### PR TITLE
feat(data-apps): add the delivery query picker to the app scheduler form

### DIFF
--- a/packages/frontend/src/features/apps/deliveryCapture/AppDeliveryPreviewCapture.module.css
+++ b/packages/frontend/src/features/apps/deliveryCapture/AppDeliveryPreviewCapture.module.css
@@ -1,0 +1,11 @@
+/* Offscreen but laid out at a real viewport size: the app must render and
+   run its queries, it just must never be visible or interactive. */
+.offscreen {
+    position: fixed;
+    top: 0;
+    left: -12000px;
+    width: 1280px;
+    height: 800px;
+    overflow: hidden;
+    pointer-events: none;
+}

--- a/packages/frontend/src/features/apps/deliveryCapture/AppDeliveryPreviewCapture.test.tsx
+++ b/packages/frontend/src/features/apps/deliveryCapture/AppDeliveryPreviewCapture.test.tsx
@@ -1,0 +1,267 @@
+import type * as MantineHooks from '@mantine/hooks';
+import { act, waitFor } from '@testing-library/react';
+import { type ComponentProps } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { type QueryEvent } from '../hooks/useAppSdkBridge';
+import { type DeliveryCaptureAccumulator } from './deliveryCaptureAccumulator';
+
+type IframePreviewProps = {
+    src: string;
+    onScreenshotAvailabilityChange?: (available: boolean) => void;
+    onIframeLoad?: () => void;
+    onQueryEvent?: (event: QueryEvent) => void;
+    deliveryCapture?: DeliveryCaptureAccumulator;
+    invalidateCache?: boolean;
+    queryContextOverride?: string;
+};
+
+const mocks = vi.hoisted(() => ({
+    iframePreview: vi.fn((_props: IframePreviewProps) => null),
+    appQuery: {
+        data: { pages: [{ latestReadyVersion: 3 }] } as
+            | { pages: Array<{ latestReadyVersion: number | null }> }
+            | undefined,
+        isLoading: false,
+        error: undefined as { error: { message: string } } | undefined,
+    },
+    token: {
+        data: 'preview-token' as string | undefined,
+        isLoading: false,
+        error: undefined as { error: { message: string } } | undefined,
+    },
+}));
+
+vi.mock('../AppIframePreview', () => ({ default: mocks.iframePreview }));
+
+vi.mock('../hooks/useGetApp', () => ({
+    useGetApp: () => mocks.appQuery,
+}));
+
+vi.mock('../hooks/useAppPreviewToken', () => ({
+    useAppPreviewToken: () => mocks.token,
+}));
+
+vi.mock('../previewOrigin', () => ({
+    usePreviewOrigin: () => 'https://preview.example.com',
+}));
+
+// Bypasses the 1.5s quiet debounce; the debounce itself isn't under test.
+vi.mock('@mantine/hooks', async (importOriginal) => {
+    const actual = await importOriginal<typeof MantineHooks>();
+    return { ...actual, useDebouncedValue: (value: unknown) => [value] };
+});
+
+// eslint-disable-next-line import/first
+import AppDeliveryPreviewCapture from './AppDeliveryPreviewCapture';
+
+const latestIframeProps = (): IframePreviewProps => {
+    const { calls } = mocks.iframePreview.mock;
+    if (calls.length === 0) throw new Error('iframe preview never rendered');
+    return calls[calls.length - 1][0];
+};
+
+const latestCapture = (): DeliveryCaptureAccumulator => {
+    const capture = latestIframeProps().deliveryCapture;
+    if (!capture) throw new Error('no accumulator passed to the iframe');
+    return capture;
+};
+
+/** Load the iframe and announce the SDK — the baseline ready preconditions. */
+const markSdkReady = () => {
+    act(() => {
+        latestIframeProps().onIframeLoad?.();
+        latestIframeProps().onScreenshotAvailabilityChange?.(true);
+    });
+};
+
+const flushMicrotasks = async () => {
+    await act(async () => {
+        await Promise.resolve();
+    });
+};
+
+const CHART_PATH = '/api/v2/projects/project-uuid/query/chart';
+
+const queryEvent = (
+    overrides: Partial<QueryEvent> & Pick<QueryEvent, 'id' | 'status'>,
+): QueryEvent => ({
+    timestamp: Date.now(),
+    label: null,
+    exploreName: 'orders',
+    dimensions: [],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    tableCalculations: [],
+    additionalMetrics: [],
+    limit: 500,
+    queryUuid: null,
+    rowCount: null,
+    durationMs: null,
+    error: null,
+    rawMetricQuery: null,
+    ...overrides,
+});
+
+const renderCapture = (
+    overrides: Partial<ComponentProps<typeof AppDeliveryPreviewCapture>> = {},
+) => {
+    const onManifest = vi.fn();
+    const onError = vi.fn();
+    const result = renderWithProviders(
+        <AppDeliveryPreviewCapture
+            projectUuid="project-uuid"
+            appUuid="app-uuid"
+            appState={null}
+            onManifest={onManifest}
+            onError={onError}
+            {...overrides}
+        />,
+    );
+    return { onManifest, onError, ...result };
+};
+
+describe('AppDeliveryPreviewCapture', () => {
+    beforeEach(() => {
+        mocks.iframePreview.mockClear();
+        mocks.appQuery.data = { pages: [{ latestReadyVersion: 3 }] };
+        mocks.appQuery.isLoading = false;
+        mocks.appQuery.error = undefined;
+        mocks.token.data = 'preview-token';
+        mocks.token.isLoading = false;
+        mocks.token.error = undefined;
+    });
+
+    it('renders the preview without delivery stamps and seeds the app state into the URL', () => {
+        renderCapture({ appState: { tab: 'over view' } });
+
+        const props = latestIframeProps();
+        expect(props.invalidateCache).toBeUndefined();
+        expect(props.queryContextOverride).toBeUndefined();
+        expect(props.deliveryCapture).toBeDefined();
+        expect(props.src).toBe(
+            `https://preview.example.com/api/apps/app-uuid/versions/3/t/preview-token/#transport=postMessage&projectUuid=project-uuid&state=${encodeURIComponent(
+                JSON.stringify({ tab: 'over view' }),
+            )}`,
+        );
+    });
+
+    it('omits the state param when there is no app state', () => {
+        renderCapture({ appState: null });
+
+        expect(latestIframeProps().src).not.toContain('&state=');
+    });
+
+    it('emits the manifest once the app settles', async () => {
+        const { onManifest, onError } = renderCapture();
+
+        // One act: load (resets the accumulator), SDK announce, and the first
+        // query initiation — in production the 1.5s quiet debounce spans the
+        // gap between these, but the debounce is mocked synchronous here.
+        act(() => {
+            latestIframeProps().onIframeLoad?.();
+            latestIframeProps().onScreenshotAvailabilityChange?.(true);
+            latestCapture().onInitiation({
+                requestId: 'req-1',
+                method: 'POST',
+                path: CHART_PATH,
+                body: { chartUuid: 'chart-1' },
+                label: 'Revenue',
+            });
+        });
+        await flushMicrotasks();
+        // A pending capture entry withholds the manifest.
+        expect(onManifest).not.toHaveBeenCalled();
+
+        act(() => {
+            latestCapture().onPostResponse('req-1', {
+                queryUuid: 'query-1',
+                metricQuery: { exploreName: 'orders', limit: 500 },
+            });
+            latestCapture().onTerminal('query-1', {
+                status: 'ready',
+                rowCount: 42,
+            });
+        });
+
+        await waitFor(() => expect(onManifest).toHaveBeenCalledTimes(1));
+        expect(onManifest.mock.calls[0][0]).toMatchObject({
+            version: 1,
+            overflowCount: 0,
+            items: [
+                {
+                    status: 'ready',
+                    label: 'Revenue',
+                    queryUuid: 'query-1',
+                    rowCount: 42,
+                },
+            ],
+        });
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('waits for in-flight QueryEvents before emitting', async () => {
+        const { onManifest } = renderCapture();
+
+        act(() => {
+            latestIframeProps().onIframeLoad?.();
+            latestIframeProps().onScreenshotAvailabilityChange?.(true);
+            latestIframeProps().onQueryEvent?.(
+                queryEvent({ id: 'evt-1', status: 'pending' }),
+            );
+        });
+        await flushMicrotasks();
+        expect(onManifest).not.toHaveBeenCalled();
+
+        act(() => {
+            latestIframeProps().onQueryEvent?.(
+                queryEvent({ id: 'evt-1', status: 'ready' }),
+            );
+        });
+
+        await waitFor(() => expect(onManifest).toHaveBeenCalledTimes(1));
+    });
+
+    it('emits an error once on timeout and never a late manifest', async () => {
+        vi.useFakeTimers();
+        try {
+            const { onManifest, onError } = renderCapture();
+
+            act(() => {
+                vi.advanceTimersByTime(60_000);
+            });
+
+            expect(onError).toHaveBeenCalledTimes(1);
+            expect(onError).toHaveBeenCalledWith(
+                'The app took too long to run its queries',
+            );
+
+            // Settling after the timeout must not double-emit.
+            markSdkReady();
+            await act(async () => {
+                await vi.runAllTimersAsync();
+            });
+            expect(onManifest).not.toHaveBeenCalled();
+            expect(onError).toHaveBeenCalledTimes(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('emits an error when the app fails to load', () => {
+        mocks.appQuery.error = { error: { message: 'nope' } };
+        const { onManifest, onError } = renderCapture();
+
+        expect(onError).toHaveBeenCalledWith('nope');
+        expect(onManifest).not.toHaveBeenCalled();
+    });
+
+    it('emits an error when the app has no ready version', () => {
+        mocks.appQuery.data = { pages: [{ latestReadyVersion: null }] };
+        const { onError } = renderCapture();
+
+        expect(onError).toHaveBeenCalledWith('This app has no ready version');
+        expect(mocks.iframePreview).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/features/apps/deliveryCapture/AppDeliveryPreviewCapture.tsx
+++ b/packages/frontend/src/features/apps/deliveryCapture/AppDeliveryPreviewCapture.tsx
@@ -163,7 +163,10 @@ const AppDeliveryPreviewCapture: FC<Props> = ({
                 settledRef.current = true;
                 onManifestRef.current(manifest);
             })
-            .catch(() => emitError('Failed to read the captured queries'));
+            .catch(() => {
+                if (cancelled) return;
+                emitError('Failed to read the captured queries');
+            });
         return () => {
             cancelled = true;
         };

--- a/packages/frontend/src/features/apps/deliveryCapture/AppDeliveryPreviewCapture.tsx
+++ b/packages/frontend/src/features/apps/deliveryCapture/AppDeliveryPreviewCapture.tsx
@@ -1,0 +1,199 @@
+import {
+    type DeliveryCaptureManifest,
+    type SchedulerAppState,
+} from '@lightdash/common';
+import { Box } from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
+import AppIframePreview from '../AppIframePreview';
+import { useAppPreviewToken } from '../hooks/useAppPreviewToken';
+import { type QueryEvent } from '../hooks/useAppSdkBridge';
+import { useGetApp } from '../hooks/useGetApp';
+import { usePreviewOrigin } from '../previewOrigin';
+import classes from './AppDeliveryPreviewCapture.module.css';
+import { createDeliveryCaptureAccumulator } from './deliveryCaptureAccumulator';
+
+/** Mirrors MinimalApp: how long the app must stay quiet before capture. */
+const APP_QUIET_DEBOUNCE_MS = 1_500;
+
+/** Mirrors MinimalApp: treat never-announcing (old-template) SDKs as alive. */
+const SDK_ALIVE_FALLBACK_MS = 8_000;
+
+/** Whole-render budget; past this the picker falls back to "no curation". */
+const CAPTURE_TIMEOUT_MS = 60_000;
+
+type Props = {
+    projectUuid: string;
+    appUuid: string;
+    /** The to-be-saved app state; the render is seeded with it so captureKeys
+     *  match what the scheduled delivery will capture. */
+    appState: SchedulerAppState | null;
+    onManifest: (manifest: DeliveryCaptureManifest) => void;
+    onError: (message: string) => void;
+};
+
+/**
+ * Boots the app's latest ready version in a hidden offscreen iframe with the
+ * capture accumulator in preview mode (no cache-invalidation stamps) and
+ * reports the captured query manifest once the app settles. Exactly one of
+ * `onManifest`/`onError` fires, once. Readiness mirrors `MinimalApp`:
+ * SDK announce (or fallback), zero in-flight queries, zero pending capture
+ * entries, sustained for a quiet debounce.
+ */
+const AppDeliveryPreviewCapture: FC<Props> = ({
+    projectUuid,
+    appUuid,
+    appState,
+    onManifest,
+    onError,
+}) => {
+    const accumulator = useMemo(createDeliveryCaptureAccumulator, []);
+
+    const appQuery = useGetApp(projectUuid, appUuid);
+    const latestReadyVersion =
+        appQuery.data?.pages[0]?.latestReadyVersion ?? undefined;
+    const {
+        data: token,
+        isLoading: isTokenLoading,
+        error: tokenError,
+    } = useAppPreviewToken(projectUuid, appUuid, latestReadyVersion);
+    const previewOrigin = usePreviewOrigin();
+
+    const [iframeLoaded, setIframeLoaded] = useState(false);
+    const [sdkAlive, setSdkAlive] = useState(false);
+    const [sdkAliveFallback, setSdkAliveFallback] = useState(false);
+    const [activeQueryIds, setActiveQueryIds] = useState<Set<string>>(
+        () => new Set(),
+    );
+    const [pendingCaptureCount, setPendingCaptureCount] = useState(0);
+
+    // Latest callbacks in refs so the settle/timeout effects don't re-arm on
+    // every parent render; settledRef enforces the emit-once contract.
+    const settledRef = useRef(false);
+    const onManifestRef = useRef(onManifest);
+    onManifestRef.current = onManifest;
+    const onErrorRef = useRef(onError);
+    onErrorRef.current = onError;
+
+    const emitError = useCallback((message: string) => {
+        if (settledRef.current) return;
+        settledRef.current = true;
+        onErrorRef.current(message);
+    }, []);
+
+    useEffect(() => {
+        const timer = setTimeout(
+            () => emitError('The app took too long to run its queries'),
+            CAPTURE_TIMEOUT_MS,
+        );
+        return () => clearTimeout(timer);
+    }, [emitError]);
+
+    const loadError = appQuery.error ?? tokenError;
+    const hasNoReadyVersion =
+        !appQuery.isLoading &&
+        !appQuery.error &&
+        latestReadyVersion === undefined;
+    useEffect(() => {
+        if (loadError) {
+            emitError(loadError.error?.message ?? 'Failed to load the app');
+        } else if (hasNoReadyVersion) {
+            emitError('This app has no ready version');
+        }
+    }, [loadError, hasNoReadyVersion, emitError]);
+
+    const handleIframeLoad = useCallback(() => {
+        setIframeLoaded(true);
+        accumulator.reset();
+    }, [accumulator]);
+
+    const handleScreenshotAvailable = useCallback((available: boolean) => {
+        setSdkAlive(available);
+    }, []);
+
+    const handleQueryEvent = useCallback((event: QueryEvent) => {
+        setActiveQueryIds((prev) => {
+            const inFlight =
+                event.status === 'pending' || event.status === 'running';
+            if (inFlight && prev.has(event.id)) return prev;
+            if (!inFlight && !prev.has(event.id)) return prev;
+            const next = new Set(prev);
+            if (inFlight) next.add(event.id);
+            else next.delete(event.id);
+            return next;
+        });
+    }, []);
+
+    useEffect(() => {
+        if (!iframeLoaded) return;
+        const timer = setTimeout(
+            () => setSdkAliveFallback(true),
+            SDK_ALIVE_FALLBACK_MS,
+        );
+        return () => clearTimeout(timer);
+    }, [iframeLoaded]);
+
+    useEffect(
+        () => accumulator.subscribe(setPendingCaptureCount),
+        [accumulator],
+    );
+
+    const [isQuiet] = useDebouncedValue(
+        iframeLoaded &&
+            (sdkAlive || sdkAliveFallback) &&
+            activeQueryIds.size === 0 &&
+            pendingCaptureCount === 0,
+        APP_QUIET_DEBOUNCE_MS,
+    );
+
+    useEffect(() => {
+        if (!isQuiet || settledRef.current) return;
+        let cancelled = false;
+        void accumulator
+            .getManifest()
+            .then((manifest) => {
+                if (cancelled || settledRef.current) return;
+                settledRef.current = true;
+                onManifestRef.current(manifest);
+            })
+            .catch(() => emitError('Failed to read the captured queries'));
+        return () => {
+            cancelled = true;
+        };
+    }, [isQuiet, accumulator, emitError]);
+
+    if (latestReadyVersion === undefined || isTokenLoading || !token) {
+        return null;
+    }
+
+    const stateParam =
+        appState && Object.keys(appState).length > 0
+            ? `&state=${encodeURIComponent(JSON.stringify(appState))}`
+            : '';
+    const previewUrl = `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/#transport=postMessage&projectUuid=${projectUuid}${stateParam}`;
+
+    return (
+        <Box className={classes.offscreen} aria-hidden="true">
+            <AppIframePreview
+                src={previewUrl}
+                expectedPreviewOrigin={previewOrigin}
+                projectUuid={projectUuid}
+                appUuid={appUuid}
+                identityKey={`${appUuid}:${latestReadyVersion}`}
+                onIframeLoad={handleIframeLoad}
+                onQueryEvent={handleQueryEvent}
+                onScreenshotAvailabilityChange={handleScreenshotAvailable}
+                deliveryCapture={accumulator}
+            />
+        </Box>
+    );
+};
+
+export default AppDeliveryPreviewCapture;

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerAppQueriesSection.module.css
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerAppQueriesSection.module.css
@@ -5,7 +5,7 @@
 }
 
 .row {
-    padding: 8px 12px;
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
 }
 
 .row + .row {
@@ -13,7 +13,7 @@
 }
 
 .rowDetail {
-    /* Aligns detail lines under the checkbox label (16px box + 8px gap). */
-    padding-left: 24px;
-    padding-top: 4px;
+    /* Aligns detail lines under the checkbox label (1rem box + label gap). */
+    padding-left: calc(1rem + var(--mantine-spacing-xs));
+    padding-top: calc(var(--mantine-spacing-xs) / 2);
 }

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerAppQueriesSection.module.css
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerAppQueriesSection.module.css
@@ -1,0 +1,19 @@
+.rowsContainer {
+    border: 1px solid var(--mantine-color-default-border);
+    border-radius: var(--mantine-radius-md);
+    overflow: hidden;
+}
+
+.row {
+    padding: 8px 12px;
+}
+
+.row + .row {
+    border-top: 1px solid var(--mantine-color-default-border);
+}
+
+.rowDetail {
+    /* Aligns detail lines under the checkbox label (16px box + 8px gap). */
+    padding-left: 24px;
+    padding-top: 4px;
+}

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerAppQueriesSection.test.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerAppQueriesSection.test.tsx
@@ -1,0 +1,468 @@
+import {
+    SchedulerFormat,
+    type AppQuerySelection,
+    type DeliveryCaptureManifest,
+    type SchedulerAppState,
+} from '@lightdash/common';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+    type ComponentProps,
+    type FC,
+    type MutableRefObject,
+    type ReactNode,
+} from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import {
+    DEFAULT_VALUES,
+    SchedulerFormProvider,
+    useSchedulerForm,
+    type SchedulerFormValues,
+} from '../schedulerFormContext';
+
+type SchedulerForm = ReturnType<typeof useSchedulerForm>;
+
+type CaptureProps = {
+    projectUuid: string;
+    appUuid: string;
+    appState: SchedulerAppState | null;
+    onManifest: (manifest: DeliveryCaptureManifest) => void;
+    onError: (message: string) => void;
+};
+
+const mocks = vi.hoisted(() => ({
+    capture: vi.fn((_props: CaptureProps) => null),
+}));
+
+vi.mock('../../../../apps/deliveryCapture/AppDeliveryPreviewCapture', () => ({
+    default: mocks.capture,
+}));
+
+vi.mock('../../../../../hooks/useProjectUuid', () => ({
+    useProjectUuid: vi.fn(() => 'project-uuid'),
+}));
+
+// eslint-disable-next-line import/first
+import { SchedulerAppQueriesSection } from './SchedulerAppQueriesSection';
+
+const latestCaptureProps = (): CaptureProps => {
+    const { calls } = mocks.capture.mock;
+    if (calls.length === 0) throw new Error('capture never mounted');
+    return calls[calls.length - 1][0];
+};
+
+const FormWrapper: FC<{
+    initialValues: SchedulerFormValues;
+    formRef?: MutableRefObject<SchedulerForm | null>;
+    children: ReactNode;
+}> = ({ initialValues, formRef, children }) => {
+    const form = useSchedulerForm({ initialValues });
+    if (formRef) formRef.current = form;
+    return (
+        <SchedulerFormProvider form={form}>{children}</SchedulerFormProvider>
+    );
+};
+
+const AVAILABLE_APP_STATE = { tab: 'overview' };
+
+const APP_FORM_VALUES: SchedulerFormValues = {
+    ...DEFAULT_VALUES,
+    format: SchedulerFormat.CSV,
+};
+
+const renderSection = (
+    initialValues: SchedulerFormValues = APP_FORM_VALUES,
+    props: Partial<ComponentProps<typeof SchedulerAppQueriesSection>> = {},
+    formRef?: MutableRefObject<SchedulerForm | null>,
+) =>
+    renderWithProviders(
+        <FormWrapper initialValues={initialValues} formRef={formRef}>
+            <SchedulerAppQueriesSection
+                appUuid="app-uuid"
+                availableAppState={AVAILABLE_APP_STATE}
+                {...props}
+            />
+        </FormWrapper>,
+    );
+
+const manifest = (
+    items: DeliveryCaptureManifest['items'],
+    overflowCount = 0,
+): DeliveryCaptureManifest => ({ version: 1, items, overflowCount });
+
+const readyItem = (
+    overrides: Partial<
+        Extract<DeliveryCaptureManifest['items'][number], { status: 'ready' }>
+    > = {},
+) => ({
+    status: 'ready' as const,
+    captureKey: 'v1:key-a',
+    label: 'Revenue',
+    exploreName: 'orders',
+    queryUuid: 'query-a',
+    order: 0,
+    rowCount: 12,
+    limitReached: false,
+    ...overrides,
+});
+
+const selection = (
+    overrides: Partial<AppQuerySelection> = {},
+): AppQuerySelection => ({
+    captureKey: 'v1:key-a',
+    label: 'Revenue',
+    exploreName: 'orders',
+    excluded: false,
+    ...overrides,
+});
+
+const expandPicker = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByRole('button', { name: 'Choose queries' }));
+};
+
+const emitManifest = (m: DeliveryCaptureManifest) => {
+    act(() => {
+        latestCaptureProps().onManifest(m);
+    });
+};
+
+describe('SchedulerAppQueriesSection', () => {
+    beforeEach(() => {
+        mocks.capture.mockClear();
+    });
+
+    it('does not start the preview render until the picker is expanded', async () => {
+        const user = userEvent.setup();
+        renderSection();
+
+        expect(mocks.capture).not.toHaveBeenCalled();
+
+        await expandPicker(user);
+
+        expect(mocks.capture).toHaveBeenCalled();
+        expect(
+            screen.getByText('Running the app to detect its data queries…'),
+        ).toBeInTheDocument();
+    });
+
+    it('runs the render under the to-be-saved app state', async () => {
+        const user = userEvent.setup();
+        renderSection({
+            ...APP_FORM_VALUES,
+            appState: { tab: 'saved-tab' },
+        });
+
+        await expandPicker(user);
+
+        expect(latestCaptureProps()).toMatchObject({
+            projectUuid: 'project-uuid',
+            appUuid: 'app-uuid',
+            appState: { tab: 'saved-tab' },
+        });
+    });
+
+    it('falls back to the available app state when the form has none yet', async () => {
+        const user = userEvent.setup();
+        renderSection({ ...APP_FORM_VALUES, appState: null });
+
+        await expandPicker(user);
+
+        expect(latestCaptureProps().appState).toEqual(AVAILABLE_APP_STATE);
+    });
+
+    it('shows the no-curation fallback on failure and re-runs on retry', async () => {
+        const user = userEvent.setup();
+        renderSection();
+
+        await expandPicker(user);
+        act(() => {
+            latestCaptureProps().onError('boom');
+        });
+
+        expect(
+            screen.getByText("Couldn't detect this app's queries"),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'You can still save this delivery — every query the app runs will be included.',
+            ),
+        ).toBeInTheDocument();
+
+        const mountsBeforeRetry = mocks.capture.mock.calls.length;
+        await user.click(screen.getByRole('button', { name: 'Try again' }));
+
+        expect(mocks.capture.mock.calls.length).toBeGreaterThan(
+            mountsBeforeRetry,
+        );
+        expect(
+            screen.getByText('Running the app to detect its data queries…'),
+        ).toBeInTheDocument();
+    });
+
+    it('re-runs the render when re-expanded after a failure', async () => {
+        const user = userEvent.setup();
+        renderSection();
+
+        await expandPicker(user);
+        act(() => {
+            latestCaptureProps().onError('boom');
+        });
+
+        // Collapse and re-expand — a fresh render starts.
+        await expandPicker(user);
+        const mountsWhileCollapsed = mocks.capture.mock.calls.length;
+        await expandPicker(user);
+
+        expect(mocks.capture.mock.calls.length).toBeGreaterThan(
+            mountsWhileCollapsed,
+        );
+        expect(
+            screen.getByText('Running the app to detect its data queries…'),
+        ).toBeInTheDocument();
+    });
+
+    it('renders rows with indicative counts, limit and error badges, and the overflow notice', async () => {
+        const user = userEvent.setup();
+        renderSection();
+
+        await expandPicker(user);
+        emitManifest(
+            manifest(
+                [
+                    readyItem({ rowCount: 500, limitReached: true }),
+                    {
+                        status: 'error',
+                        captureKey: 'v1:key-err',
+                        label: 'Broken',
+                        exploreName: 'orders',
+                        queryUuid: null,
+                        order: 1,
+                        error: 'query exploded',
+                    },
+                ],
+                2,
+            ),
+        );
+
+        expect(screen.getByRole('checkbox', { name: /Revenue/ })).toBeChecked();
+        expect(screen.getByText('~500 rows')).toBeInTheDocument();
+        expect(screen.getByText('limit reached')).toBeInTheDocument();
+        expect(screen.getByText('error')).toBeInTheDocument();
+        expect(screen.getByText('query exploded')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Row counts come from this preview and may differ at delivery time.',
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                "2 more queries ran past the 50-query capture limit and can't be selected here.",
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('shows an empty state when the app ran no queries', async () => {
+        const user = userEvent.setup();
+        renderSection();
+
+        await expandPicker(user);
+        emitManifest(manifest([]));
+
+        expect(
+            screen.getByText('This app ran no data queries in the preview.'),
+        ).toBeInTheDocument();
+    });
+
+    it('persists a full snapshot and forces the app state on the first exclusion', async () => {
+        const formRef: MutableRefObject<SchedulerForm | null> = {
+            current: null,
+        };
+        const user = userEvent.setup();
+        renderSection({ ...APP_FORM_VALUES, appState: null }, {}, formRef);
+
+        await expandPicker(user);
+        emitManifest(
+            manifest([
+                readyItem(),
+                readyItem({
+                    captureKey: 'v1:key-b',
+                    label: 'Customers',
+                    exploreName: 'customers',
+                    queryUuid: 'query-b',
+                    order: 1,
+                }),
+            ]),
+        );
+
+        await user.click(screen.getByRole('checkbox', { name: /Revenue/ }));
+
+        // Full snapshot — every visible row, not just the toggled one.
+        expect(formRef.current?.values.appQuerySelections).toEqual([
+            {
+                captureKey: 'v1:key-a',
+                label: 'Revenue',
+                exploreName: 'orders',
+                excluded: true,
+            },
+            {
+                captureKey: 'v1:key-b',
+                label: 'Customers',
+                exploreName: 'customers',
+                excluded: false,
+            },
+        ]);
+        // Curation implies state.
+        expect(formRef.current?.values.appState).toEqual(AVAILABLE_APP_STATE);
+    });
+
+    it('keeps the snapshot when the user re-includes everything', async () => {
+        const formRef: MutableRefObject<SchedulerForm | null> = {
+            current: null,
+        };
+        const user = userEvent.setup();
+        renderSection(APP_FORM_VALUES, {}, formRef);
+
+        await expandPicker(user);
+        emitManifest(manifest([readyItem()]));
+
+        await user.click(screen.getByRole('checkbox', { name: /Revenue/ }));
+        await user.click(screen.getByRole('checkbox', { name: /Revenue/ }));
+
+        expect(formRef.current?.values.appQuerySelections).toEqual([
+            {
+                captureKey: 'v1:key-a',
+                label: 'Revenue',
+                exploreName: 'orders',
+                excluded: false,
+            },
+        ]);
+    });
+
+    it('warns when every query is excluded', async () => {
+        const user = userEvent.setup();
+        renderSection();
+
+        await expandPicker(user);
+        emitManifest(manifest([readyItem()]));
+        await user.click(screen.getByRole('checkbox', { name: /Revenue/ }));
+
+        expect(
+            screen.getByText(
+                'Every query is excluded, so this delivery would be empty. Include at least one query.',
+            ),
+        ).toBeInTheDocument();
+    });
+
+    describe('edit-mode merge', () => {
+        it('applies saved exclusions, keeps did-not-run rows, and includes new queries by default', async () => {
+            const user = userEvent.setup();
+            renderSection({
+                ...APP_FORM_VALUES,
+                appState: AVAILABLE_APP_STATE,
+                appQuerySelections: [
+                    selection({ excluded: true }),
+                    selection({
+                        captureKey: 'v1:key-gone',
+                        label: 'Gone query',
+                        exploreName: 'customers',
+                        excluded: false,
+                    }),
+                ],
+            });
+
+            await expandPicker(user);
+            emitManifest(
+                manifest([
+                    readyItem(),
+                    readyItem({
+                        captureKey: 'v1:key-new',
+                        label: 'Brand new',
+                        exploreName: 'payments',
+                        queryUuid: 'query-new',
+                        order: 1,
+                    }),
+                ]),
+            );
+
+            // Saved exclusion applies by captureKey.
+            expect(
+                screen.getByRole('checkbox', { name: /Revenue/ }),
+            ).not.toBeChecked();
+            // Fresh query not in the snapshot starts included.
+            expect(
+                screen.getByRole('checkbox', { name: /Brand new/ }),
+            ).toBeChecked();
+            // Snapshot entry that did not run stays visible and toggleable.
+            const goneCheckbox = screen.getByRole('checkbox', {
+                name: /Gone query/,
+            });
+            expect(goneCheckbox).toBeChecked();
+            expect(goneCheckbox).toBeEnabled();
+            expect(
+                screen.getByText("didn't run in preview"),
+            ).toBeInTheDocument();
+        });
+
+        it('shows the identity-changed hint for a label+explore match with a different key', async () => {
+            const user = userEvent.setup();
+            renderSection({
+                ...APP_FORM_VALUES,
+                appState: AVAILABLE_APP_STATE,
+                appQuerySelections: [selection({ excluded: true })],
+            });
+
+            await expandPicker(user);
+            emitManifest(manifest([readyItem({ captureKey: 'v1:key-a2' })]));
+
+            // Stale exclusion is not trusted — the row starts included.
+            expect(
+                screen.getByRole('checkbox', { name: /Revenue/ }),
+            ).toBeChecked();
+            expect(
+                screen.getByText(
+                    'This query changed since the delivery was last saved — its previous selection no longer applies.',
+                ),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('disables curation when there is no app state to pin', async () => {
+        const user = userEvent.setup();
+        renderSection(
+            { ...APP_FORM_VALUES, appState: null },
+            { availableAppState: null },
+        );
+
+        await expandPicker(user);
+        emitManifest(manifest([readyItem()]));
+
+        expect(
+            screen.getByRole('checkbox', { name: /Revenue/ }),
+        ).toBeDisabled();
+        expect(
+            screen.getByText(
+                'Choosing queries requires sending app state with the delivery, and this app has no state to send.',
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('summarises exclusions while collapsed', async () => {
+        const user = userEvent.setup();
+        renderSection({
+            ...APP_FORM_VALUES,
+            appQuerySelections: [
+                selection({ excluded: true }),
+                selection({ captureKey: 'v1:key-b', label: 'Customers' }),
+            ],
+        });
+
+        expect(screen.getByText('1 of 2 queries excluded')).toBeInTheDocument();
+
+        // The summary is redundant while the rows themselves are visible.
+        await expandPicker(user);
+        expect(
+            screen.queryByText('1 of 2 queries excluded'),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerAppQueriesSection.test.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerAppQueriesSection.test.tsx
@@ -465,4 +465,99 @@ describe('SchedulerAppQueriesSection', () => {
             screen.queryByText('1 of 2 queries excluded'),
         ).not.toBeInTheDocument();
     });
+
+    describe('stale-manifest invalidation', () => {
+        const LOADING_COPY = 'Running the app to detect its data queries…';
+
+        it('re-runs the render when the to-be-saved app state changes after ready', async () => {
+            const formRef: MutableRefObject<SchedulerForm | null> = {
+                current: null,
+            };
+            const user = userEvent.setup();
+            renderSection(
+                { ...APP_FORM_VALUES, appState: { tab: 'saved' } },
+                {},
+                formRef,
+            );
+
+            await expandPicker(user);
+            emitManifest(manifest([readyItem()]));
+            expect(screen.queryByText(LOADING_COPY)).not.toBeInTheDocument();
+
+            act(() => {
+                formRef.current?.setFieldValue('appState', { tab: 'other' });
+            });
+
+            // Manifest discarded, fresh render under the new state.
+            expect(screen.getByText(LOADING_COPY)).toBeInTheDocument();
+            expect(latestCaptureProps().appState).toEqual({ tab: 'other' });
+        });
+
+        it('does not re-run when the state is replaced with an equal value', async () => {
+            const formRef: MutableRefObject<SchedulerForm | null> = {
+                current: null,
+            };
+            const user = userEvent.setup();
+            renderSection(
+                { ...APP_FORM_VALUES, appState: { tab: 'saved' } },
+                {},
+                formRef,
+            );
+
+            await expandPicker(user);
+            emitManifest(manifest([readyItem()]));
+
+            // New object identity, identical content — must not invalidate.
+            act(() => {
+                formRef.current?.setFieldValue('appState', { tab: 'saved' });
+            });
+
+            expect(screen.queryByText(LOADING_COPY)).not.toBeInTheDocument();
+            expect(
+                screen.getByRole('checkbox', { name: /Revenue/ }),
+            ).toBeInTheDocument();
+        });
+
+        it('keeps exclusions across a state-triggered re-render where captureKeys still match', async () => {
+            const formRef: MutableRefObject<SchedulerForm | null> = {
+                current: null,
+            };
+            const user = userEvent.setup();
+            renderSection({ ...APP_FORM_VALUES, appState: null }, {}, formRef);
+
+            await expandPicker(user);
+            emitManifest(manifest([readyItem()]));
+            await user.click(screen.getByRole('checkbox', { name: /Revenue/ }));
+
+            // The exclusion pinned the app state — same content as the render
+            // ran under, so it must NOT trigger a re-render (loop guard).
+            expect(screen.queryByText(LOADING_COPY)).not.toBeInTheDocument();
+
+            act(() => {
+                formRef.current?.setFieldValue('appState', { tab: 'other' });
+            });
+            expect(screen.getByText(LOADING_COPY)).toBeInTheDocument();
+
+            emitManifest(
+                manifest([
+                    readyItem(),
+                    readyItem({
+                        captureKey: 'v1:key-new',
+                        label: 'Brand new',
+                        exploreName: 'payments',
+                        queryUuid: 'query-new',
+                        order: 1,
+                    }),
+                ]),
+            );
+
+            // The earlier exclusion survives the merge by captureKey.
+            expect(
+                screen.getByRole('checkbox', { name: /Revenue/ }),
+            ).not.toBeChecked();
+            expect(
+                screen.getByRole('checkbox', { name: /Brand new/ }),
+            ).toBeChecked();
+        });
+    });
 });

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerAppQueriesSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerAppQueriesSection.tsx
@@ -1,0 +1,337 @@
+import {
+    assertUnreachable,
+    MAX_DELIVERY_QUERIES,
+    type DeliveryCaptureManifest,
+    type SchedulerAppState,
+} from '@lightdash/common';
+import {
+    Badge,
+    Box,
+    Button,
+    Checkbox,
+    Group,
+    Loader,
+    Stack,
+    Text,
+} from '@mantine/core';
+import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
+import { useCallback, useMemo, useRef, useState, type FC } from 'react';
+import Callout from '../../../../../components/common/Callout';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
+import AppDeliveryPreviewCapture from '../../../../apps/deliveryCapture/AppDeliveryPreviewCapture';
+import {
+    buildAppQueryPickerRows,
+    hasExcludedQuerySelections,
+    toAppQuerySelections,
+    type AppQueryPickerRow,
+} from '../../../utils/appQuerySelections';
+import { useSchedulerFormContext } from '../schedulerFormContext';
+import classes from './SchedulerAppQueriesSection.module.css';
+import modalClasses from './SchedulerDeliveryModal.module.css';
+
+type CaptureState =
+    | { status: 'idle' }
+    | { status: 'loading'; runId: number }
+    | { status: 'ready'; manifest: DeliveryCaptureManifest }
+    | { status: 'failed' };
+
+type Props = {
+    appUuid: string;
+    /** State the "Send current app state" toggle would attach — forced on by
+     *  the first exclusion so the delivery reproduces the curated view. */
+    availableAppState: SchedulerAppState | null;
+};
+
+const RowBadges: FC<{ row: AppQueryPickerRow }> = ({ row }) => {
+    switch (row.kind) {
+        case 'ready':
+            return (
+                <>
+                    {row.rowCount !== null && (
+                        <Text size="xs" c="dimmed" flex="0 0 auto">
+                            ~{row.rowCount} rows
+                        </Text>
+                    )}
+                    {row.limitReached && (
+                        <Badge size="xs" variant="light" color="yellow">
+                            limit reached
+                        </Badge>
+                    )}
+                </>
+            );
+        case 'error':
+            return (
+                <Badge size="xs" variant="light" color="red">
+                    error
+                </Badge>
+            );
+        case 'missing':
+            return (
+                <Badge size="xs" variant="light" color="gray">
+                    didn't run in preview
+                </Badge>
+            );
+        default:
+            return assertUnreachable(row, 'Unknown picker row kind');
+    }
+};
+
+/**
+ * "Queries" sub-block of an app delivery: boots a hidden preview render on
+ * first expand, lists the captured queries, and persists a full selection
+ * snapshot into the form once the user curates. On render failure/timeout it
+ * falls back to "no curation" — every query is delivered.
+ */
+export const SchedulerAppQueriesSection: FC<Props> = ({
+    appUuid,
+    availableAppState,
+}) => {
+    const form = useSchedulerFormContext();
+    const projectUuid = useProjectUuid();
+    const [expanded, setExpanded] = useState(false);
+    const [capture, setCapture] = useState<CaptureState>({ status: 'idle' });
+    const runIdRef = useRef(0);
+
+    const selections = form.values.appQuerySelections;
+    // The state the scheduler will save if the user curates — the render must
+    // run under it so captureKeys match the scheduled delivery's.
+    const renderAppState = form.values.appState ?? availableAppState;
+    const canCurate = renderAppState !== null;
+
+    const startCapture = useCallback(() => {
+        runIdRef.current += 1;
+        setCapture({ status: 'loading', runId: runIdRef.current });
+    }, []);
+
+    const handleToggleExpanded = () => {
+        const next = !expanded;
+        setExpanded(next);
+        // Lazy start on first expand; a failed render re-runs on re-expand.
+        if (
+            next &&
+            (capture.status === 'idle' || capture.status === 'failed')
+        ) {
+            startCapture();
+        }
+    };
+
+    const handleManifest = useCallback(
+        (manifest: DeliveryCaptureManifest) =>
+            setCapture({ status: 'ready', manifest }),
+        [],
+    );
+    const handleCaptureError = useCallback(
+        () => setCapture({ status: 'failed' }),
+        [],
+    );
+
+    const rows = useMemo(
+        () =>
+            capture.status === 'ready'
+                ? buildAppQueryPickerRows(capture.manifest, selections)
+                : null,
+        [capture, selections],
+    );
+
+    const handleToggleRow = (captureKey: string) => {
+        if (rows === null) return;
+        const nextRows = rows.map((row) =>
+            row.captureKey === captureKey
+                ? { ...row, excluded: !row.excluded }
+                : row,
+        );
+        const nextSelections = toAppQuerySelections(nextRows);
+        form.setFieldValue('appQuerySelections', nextSelections);
+        // Curation implies state: the first exclusion pins the app state so
+        // the delivery reproduces the exact view the keys were captured from.
+        if (
+            hasExcludedQuerySelections(nextSelections) &&
+            form.values.appState == null &&
+            availableAppState !== null
+        ) {
+            form.setFieldValue('appState', availableAppState);
+        }
+    };
+
+    const excludedCount = selections?.filter((s) => s.excluded).length ?? 0;
+    const allExcluded =
+        rows !== null && rows.length > 0 && rows.every((row) => row.excluded);
+    const overflowCount =
+        capture.status === 'ready' ? capture.manifest.overflowCount : 0;
+    const hasIndicativeCounts =
+        rows?.some((row) => row.kind === 'ready' && row.rowCount !== null) ??
+        false;
+
+    return (
+        <Stack gap="xs">
+            <span className={modalClasses.subBlockLabel}>Queries</span>
+            <Text size="xs" c="ldGray.6">
+                Each data query the app runs becomes a file in this delivery.
+            </Text>
+            {!expanded && excludedCount > 0 && selections !== null && (
+                <Text size="xs" c="ldGray.6">
+                    {excludedCount} of {selections.length}{' '}
+                    {selections.length === 1 ? 'query' : 'queries'} excluded
+                </Text>
+            )}
+            <Button
+                type="button"
+                variant="default"
+                size="xs"
+                w="fit-content"
+                leftSection={
+                    <MantineIcon
+                        icon={expanded ? IconChevronDown : IconChevronRight}
+                        size={14}
+                    />
+                }
+                onClick={handleToggleExpanded}
+            >
+                Choose queries
+            </Button>
+
+            {expanded && capture.status === 'loading' && (
+                <Group gap="xs">
+                    <Loader size="xs" />
+                    <Text size="xs" c="dimmed">
+                        Running the app to detect its data queries…
+                    </Text>
+                </Group>
+            )}
+
+            {expanded && capture.status === 'failed' && (
+                <Callout
+                    variant="warning"
+                    title="Couldn't detect this app's queries"
+                >
+                    <Stack gap="xs" align="flex-start">
+                        <Text size="xs">
+                            You can still save this delivery — every query the
+                            app runs will be included.
+                        </Text>
+                        <Button
+                            type="button"
+                            variant="default"
+                            size="compact-xs"
+                            onClick={startCapture}
+                        >
+                            Try again
+                        </Button>
+                    </Stack>
+                </Callout>
+            )}
+
+            {expanded && rows !== null && (
+                <>
+                    {!canCurate && rows.length > 0 && (
+                        <Callout variant="info">
+                            Choosing queries requires sending app state with the
+                            delivery, and this app has no state to send.
+                        </Callout>
+                    )}
+                    {rows.length === 0 ? (
+                        <Text size="xs" c="dimmed">
+                            This app ran no data queries in the preview.
+                        </Text>
+                    ) : (
+                        <Box className={classes.rowsContainer}>
+                            {rows.map((row) => (
+                                <Box
+                                    key={row.captureKey}
+                                    className={classes.row}
+                                >
+                                    <Checkbox
+                                        size="xs"
+                                        checked={!row.excluded}
+                                        disabled={!canCurate}
+                                        onChange={() =>
+                                            handleToggleRow(row.captureKey)
+                                        }
+                                        label={
+                                            <Group gap="xs" wrap="nowrap">
+                                                <Text
+                                                    size="xs"
+                                                    fw={500}
+                                                    truncate="end"
+                                                >
+                                                    {row.label}
+                                                </Text>
+                                                <RowBadges row={row} />
+                                            </Group>
+                                        }
+                                    />
+                                    {row.kind === 'error' && (
+                                        <Text
+                                            size="xs"
+                                            c="red"
+                                            className={classes.rowDetail}
+                                        >
+                                            {row.error}
+                                        </Text>
+                                    )}
+                                    {row.kind === 'missing' && (
+                                        <Text
+                                            size="xs"
+                                            c="dimmed"
+                                            className={classes.rowDetail}
+                                        >
+                                            Saved with this delivery but didn't
+                                            run in this preview. If it doesn't
+                                            run at delivery time it's reported
+                                            as missing.
+                                        </Text>
+                                    )}
+                                    {row.kind !== 'missing' &&
+                                        row.identityChanged && (
+                                            <Text
+                                                size="xs"
+                                                c="dimmed"
+                                                className={classes.rowDetail}
+                                            >
+                                                This query changed since the
+                                                delivery was last saved — its
+                                                previous selection no longer
+                                                applies.
+                                            </Text>
+                                        )}
+                                </Box>
+                            ))}
+                        </Box>
+                    )}
+                    {hasIndicativeCounts && (
+                        <Text size="xs" c="dimmed">
+                            Row counts come from this preview and may differ at
+                            delivery time.
+                        </Text>
+                    )}
+                    {overflowCount > 0 && (
+                        <Callout variant="info">
+                            {overflowCount} more{' '}
+                            {overflowCount === 1 ? 'query' : 'queries'} ran past
+                            the {MAX_DELIVERY_QUERIES}-query capture limit and
+                            can't be selected here.
+                        </Callout>
+                    )}
+                    {allExcluded && (
+                        <Callout variant="danger">
+                            Every query is excluded, so this delivery would be
+                            empty. Include at least one query.
+                        </Callout>
+                    )}
+                </>
+            )}
+
+            {capture.status === 'loading' && projectUuid && (
+                <AppDeliveryPreviewCapture
+                    key={capture.runId}
+                    projectUuid={projectUuid}
+                    appUuid={appUuid}
+                    appState={renderAppState}
+                    onManifest={handleManifest}
+                    onError={handleCaptureError}
+                />
+            )}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerAppQueriesSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerAppQueriesSection.tsx
@@ -15,7 +15,14 @@ import {
     Text,
 } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
-import { useCallback, useMemo, useRef, useState, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import Callout from '../../../../../components/common/Callout';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
@@ -30,10 +37,16 @@ import { useSchedulerFormContext } from '../schedulerFormContext';
 import classes from './SchedulerAppQueriesSection.module.css';
 import modalClasses from './SchedulerDeliveryModal.module.css';
 
+// `stateKey` records the app state the render ran under, so a manifest can be
+// discarded when the to-be-saved state changes out from under it.
 type CaptureState =
     | { status: 'idle' }
-    | { status: 'loading'; runId: number }
-    | { status: 'ready'; manifest: DeliveryCaptureManifest }
+    | { status: 'loading'; runId: number; stateKey: string }
+    | {
+          status: 'ready';
+          manifest: DeliveryCaptureManifest;
+          stateKey: string;
+      }
     | { status: 'failed' };
 
 type Props = {
@@ -98,11 +111,35 @@ export const SchedulerAppQueriesSection: FC<Props> = ({
     // run under it so captureKeys match the scheduled delivery's.
     const renderAppState = form.values.appState ?? availableAppState;
     const canCurate = renderAppState !== null;
+    // Content comparison, not object identity — reference churn on an equal
+    // state must never invalidate a capture (that would loop the render).
+    const renderStateKey = useMemo(
+        () => JSON.stringify(renderAppState),
+        [renderAppState],
+    );
 
     const startCapture = useCallback(() => {
         runIdRef.current += 1;
-        setCapture({ status: 'loading', runId: runIdRef.current });
-    }, []);
+        setCapture({
+            status: 'loading',
+            runId: runIdRef.current,
+            stateKey: renderStateKey,
+        });
+    }, [renderStateKey]);
+
+    // A manifest captured under a different app state carries captureKeys the
+    // delivery render would never reproduce — stale exclusions silently no-op
+    // at delivery. Discard it: re-render in place while the picker is open,
+    // otherwise fall back to idle so the next expand re-runs.
+    useEffect(() => {
+        if (capture.status !== 'ready' && capture.status !== 'loading') return;
+        if (capture.stateKey === renderStateKey) return;
+        if (expanded) {
+            startCapture();
+        } else {
+            setCapture({ status: 'idle' });
+        }
+    }, [capture, renderStateKey, expanded, startCapture]);
 
     const handleToggleExpanded = () => {
         const next = !expanded;
@@ -118,7 +155,13 @@ export const SchedulerAppQueriesSection: FC<Props> = ({
 
     const handleManifest = useCallback(
         (manifest: DeliveryCaptureManifest) =>
-            setCapture({ status: 'ready', manifest }),
+            // Keep the stateKey the render actually ran under (the loading
+            // entry's), so a state change during the render still invalidates.
+            setCapture((prev) =>
+                prev.status === 'loading'
+                    ? { status: 'ready', manifest, stateKey: prev.stateKey }
+                    : prev,
+            ),
         [],
     );
     const handleCaptureError = useCallback(
@@ -165,7 +208,9 @@ export const SchedulerAppQueriesSection: FC<Props> = ({
 
     return (
         <Stack gap="xs">
-            <span className={modalClasses.subBlockLabel}>Queries</span>
+            <Text component="span" className={modalClasses.subBlockLabel}>
+                Queries
+            </Text>
             <Text size="xs" c="ldGray.6">
                 Each data query the app runs becomes a file in this delivery.
             </Text>

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
@@ -89,6 +89,7 @@ const savedCsvAppScheduler: SchedulerAndTargets = {
     savedSqlName: null,
     appUuid: 'app-uuid',
     appName: 'App',
+    appQuerySelections: null,
     options: { formatted: true, limit: 'table' },
     enabled: true,
     includeLinks: true,
@@ -181,6 +182,89 @@ describe('SchedulerDataFormatSection - app formats', () => {
         );
 
         expect(screen.getByText('Limit')).toBeInTheDocument();
+    });
+
+    describe('query picker section', () => {
+        const excludedSelections = [
+            {
+                captureKey: 'v1:key-a',
+                label: 'Revenue',
+                exploreName: 'orders',
+                excluded: true,
+            },
+        ];
+
+        it('shows the queries sub-block for csv/xlsx app deliveries only', () => {
+            renderSection(
+                { capturedQueryCount: 3 },
+                { ...DEFAULT_VALUES, format: SchedulerFormat.CSV },
+            );
+
+            expect(
+                screen.getByRole('button', { name: 'Choose queries' }),
+            ).toBeInTheDocument();
+        });
+
+        it('hides the queries sub-block for image app deliveries', () => {
+            renderSection(
+                { capturedQueryCount: 3 },
+                { ...DEFAULT_VALUES, format: SchedulerFormat.IMAGE },
+            );
+
+            expect(
+                screen.queryByRole('button', { name: 'Choose queries' }),
+            ).not.toBeInTheDocument();
+        });
+
+        it('hides the queries sub-block for non-app deliveries', () => {
+            renderSection(
+                { isApp: false, appUuid: undefined },
+                { ...DEFAULT_VALUES, format: SchedulerFormat.CSV },
+            );
+
+            expect(
+                screen.queryByRole('button', { name: 'Choose queries' }),
+            ).not.toBeInTheDocument();
+        });
+
+        it('locks the app-state checkbox on while exclusions exist', () => {
+            renderSection(
+                { currentAppState: { tab: 'overview' } },
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.CSV,
+                    appState: { tab: 'overview' },
+                    appQuerySelections: excludedSelections,
+                },
+            );
+
+            const checkbox = screen.getByRole('checkbox', {
+                name: 'Send current app state',
+            });
+            expect(checkbox).toBeChecked();
+            expect(checkbox).toBeDisabled();
+        });
+
+        it('keeps the app-state checkbox toggleable when no query is excluded', () => {
+            renderSection(
+                { currentAppState: { tab: 'overview' } },
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.CSV,
+                    appState: { tab: 'overview' },
+                    appQuerySelections: excludedSelections.map((s) => ({
+                        ...s,
+                        excluded: false,
+                    })),
+                },
+            );
+
+            expect(
+                screen.getByRole('checkbox', {
+                    name: 'Send current app state',
+                }),
+            ).toBeEnabled();
+        });
     });
 
     describe('format-switch side effect', () => {

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
@@ -227,6 +227,49 @@ describe('SchedulerDataFormatSection - app formats', () => {
             ).not.toBeInTheDocument();
         });
 
+        const imageDropWarning =
+            'This delivery has a saved query selection. Saving it as an image removes the selection — image deliveries always show the whole app.';
+
+        it('warns that saving as image drops a saved query selection', () => {
+            renderSection(
+                { capturedQueryCount: 3 },
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.IMAGE,
+                    appQuerySelections: excludedSelections,
+                },
+            );
+
+            expect(screen.getByText(imageDropWarning)).toBeInTheDocument();
+        });
+
+        it('shows no image-drop warning without a selection or outside image format', () => {
+            const { unmount } = renderSection(
+                { capturedQueryCount: 3 },
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.IMAGE,
+                    appQuerySelections: null,
+                },
+            );
+            expect(
+                screen.queryByText(imageDropWarning),
+            ).not.toBeInTheDocument();
+            unmount();
+
+            renderSection(
+                { capturedQueryCount: 3 },
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.CSV,
+                    appQuerySelections: excludedSelections,
+                },
+            );
+            expect(
+                screen.queryByText(imageDropWarning),
+            ).not.toBeInTheDocument();
+        });
+
         it('locks the app-state checkbox on while exclusions exist', () => {
             renderSection(
                 { currentAppState: { tab: 'overview' } },

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
@@ -25,6 +25,7 @@ import {
 } from '@mantine/core';
 import isEqual from 'lodash/isEqual';
 import { useMemo, type FC } from 'react';
+import Callout from '../../../../../components/common/Callout';
 import useHealth from '../../../../../hooks/health/useHealth';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { hasExcludedQuerySelections } from '../../../utils/appQuerySelections';
@@ -196,6 +197,15 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                         {appQueryCountCaption}
                     </Text>
                 )}
+                {isApp &&
+                    format === SchedulerFormat.IMAGE &&
+                    form.values.appQuerySelections !== null && (
+                        <Callout variant="warning">
+                            This delivery has a saved query selection. Saving it
+                            as an image removes the selection — image deliveries
+                            always show the whole app.
+                        </Callout>
+                    )}
                 {isImageDisabled && (
                     <Text size="xs" c="ldGray.6">
                         You must enable the

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
@@ -27,11 +27,13 @@ import isEqual from 'lodash/isEqual';
 import { useMemo, type FC } from 'react';
 import useHealth from '../../../../../hooks/health/useHealth';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
+import { hasExcludedQuerySelections } from '../../../utils/appQuerySelections';
 import { CsvFormattingOptions } from '../../CsvFormattingOptions';
 import { Limit, Values } from '../../types';
 import { useSchedulerFormContext } from '../schedulerFormContext';
 import { SchedulerFormFiltersTab } from '../SchedulerFormFiltersTab';
 import { SchedulerFormParametersTab } from '../SchedulerFormParametersTab';
+import { SchedulerAppQueriesSection } from './SchedulerAppQueriesSection';
 import classes from './SchedulerDeliveryModal.module.css';
 
 const getAppQueryCountCaption = (
@@ -106,6 +108,14 @@ export const SchedulerDataFormatSection: FC<Props> = ({
 
     const format = form.values.format;
     const appQueryCountCaption = getAppQueryCountCaption(capturedQueryCount);
+    const isAppFileFormat =
+        isApp &&
+        (format === SchedulerFormat.CSV || format === SchedulerFormat.XLSX);
+    // Exclusions pin the app state — the delivery must reproduce the exact
+    // view the selection keys were captured from.
+    const stateLockedByCuration =
+        isAppFileFormat &&
+        hasExcludedQuerySelections(form.values.appQuerySelections);
 
     return (
         <Stack gap="lg">
@@ -323,18 +333,30 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                     <Divider />
                     <Stack gap="xs">
                         <span className={classes.subBlockLabel}>App state</span>
-                        <Checkbox
-                            size="xs"
-                            label="Send current app state"
-                            description="The delivery renders the app with this state applied (selected filters, tabs, etc.) instead of its default view."
-                            checked={form.values.appState != null}
-                            onChange={(e) => {
-                                form.setFieldValue(
-                                    'appState',
-                                    e.target.checked ? availableAppState : null,
-                                );
-                            }}
-                        />
+                        <Tooltip
+                            label="Excluded queries are matched against this exact app state, so the delivery must send it. Re-include all queries to change this."
+                            position="top-start"
+                            withinPortal
+                            disabled={!stateLockedByCuration}
+                        >
+                            <Box display="flex" w="fit-content">
+                                <Checkbox
+                                    size="xs"
+                                    label="Send current app state"
+                                    description="The delivery renders the app with this state applied (selected filters, tabs, etc.) instead of its default view."
+                                    checked={form.values.appState != null}
+                                    disabled={stateLockedByCuration}
+                                    onChange={(e) => {
+                                        form.setFieldValue(
+                                            'appState',
+                                            e.target.checked
+                                                ? availableAppState
+                                                : null,
+                                        );
+                                    }}
+                                />
+                            </Box>
+                        </Tooltip>
                         {form.values.appState != null && appStateUrl && (
                             <Stack gap="xs">
                                 <Box>
@@ -388,6 +410,16 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                             </Stack>
                         )}
                     </Stack>
+                </>
+            )}
+
+            {isAppFileFormat && appUuid && (
+                <>
+                    <Divider />
+                    <SchedulerAppQueriesSection
+                        appUuid={appUuid}
+                        availableAppState={availableAppState}
+                    />
                 </>
             )}
 

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.test.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.test.ts
@@ -2,11 +2,14 @@ import {
     SchedulerFormat,
     ThresholdOperator,
     type AppQuerySelection,
+    type AppScheduler,
+    type SchedulerAndTargets,
 } from '@lightdash/common';
 import { describe, expect, test } from 'vitest';
 import {
     DEFAULT_VALUES,
     DEFAULT_VALUES_ALERT,
+    getFormValuesFromScheduler,
     transformFormValues,
 } from './schedulerFormContext';
 
@@ -112,6 +115,42 @@ describe('transformFormValues', () => {
 
             expect('appQuerySelections' in result).toBe(true);
             expect(result.appQuerySelections).toBeNull();
+        });
+
+        test('resends a curated saved scheduler verbatim when saved without opening the picker', () => {
+            // End-to-end over the edit path: hydrate the form from the saved
+            // scheduler, save untouched — the snapshot and state must survive.
+            const curatedAppScheduler: SchedulerAndTargets = {
+                schedulerUuid: 'scheduler-uuid',
+                slug: 'app-delivery',
+                name: 'App delivery',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                createdBy: 'user-uuid',
+                createdByName: 'User',
+                format: SchedulerFormat.CSV,
+                cron: '0 9 * * 1',
+                savedChartUuid: null,
+                savedChartName: null,
+                dashboardUuid: null,
+                dashboardName: null,
+                savedSqlUuid: null,
+                savedSqlName: null,
+                appUuid: 'app-uuid',
+                appName: 'App',
+                appState,
+                appQuerySelections: curatedSelections,
+                options: { formatted: true, limit: 'table' },
+                enabled: true,
+                includeLinks: true,
+                targets: [],
+            } as AppScheduler & { targets: [] };
+
+            const hydrated = getFormValuesFromScheduler(curatedAppScheduler);
+            const result = transformFormValues(hydrated, 'app');
+
+            expect(result.appQuerySelections).toEqual(curatedSelections);
+            expect(result).toMatchObject({ appState });
         });
 
         test('never adds app fields to non-app payloads', () => {

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.test.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.test.ts
@@ -1,6 +1,11 @@
-import { ThresholdOperator } from '@lightdash/common';
+import {
+    SchedulerFormat,
+    ThresholdOperator,
+    type AppQuerySelection,
+} from '@lightdash/common';
 import { describe, expect, test } from 'vitest';
 import {
+    DEFAULT_VALUES,
     DEFAULT_VALUES_ALERT,
     transformFormValues,
 } from './schedulerFormContext';
@@ -22,5 +27,105 @@ describe('transformFormValues', () => {
         );
 
         expect(result.thresholds).toEqual([]);
+    });
+
+    describe('app delivery payload', () => {
+        const appState = { tab: 'overview' };
+        const curatedSelections: AppQuerySelection[] = [
+            {
+                captureKey: 'v1:key-a',
+                label: 'Revenue',
+                exploreName: 'orders',
+                excluded: true,
+            },
+            {
+                captureKey: 'v1:key-b',
+                label: 'Customers',
+                exploreName: 'customers',
+                excluded: false,
+            },
+        ];
+
+        test('always carries an explicit appQuerySelections: null when never curated', () => {
+            const result = transformFormValues(
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.CSV,
+                    appState,
+                    appQuerySelections: null,
+                },
+                'app',
+            );
+
+            // Explicit null, not an omitted key — the model clears on omission
+            // and the form must always restate both app fields.
+            expect('appQuerySelections' in result).toBe(true);
+            expect(result.appQuerySelections).toBeNull();
+            expect(result).toMatchObject({ appState });
+        });
+
+        test('carries the curated snapshot together with the app state', () => {
+            const result = transformFormValues(
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.XLSX,
+                    appState,
+                    appQuerySelections: curatedSelections,
+                },
+                'app',
+            );
+
+            expect(result.appQuerySelections).toEqual(curatedSelections);
+            expect(result).toMatchObject({ appState });
+        });
+
+        test('keeps the full snapshot when the user curated then re-included everything', () => {
+            const allIncluded = curatedSelections.map((s) => ({
+                ...s,
+                excluded: false,
+            }));
+            const result = transformFormValues(
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.CSV,
+                    appState,
+                    appQuerySelections: allIncluded,
+                },
+                'app',
+            );
+
+            // They engaged — the snapshot persists so missing-query reporting
+            // stays active. Never collapsed back to null.
+            expect(result.appQuerySelections).toEqual(allIncluded);
+        });
+
+        test('sends null selections for image deliveries even when curated', () => {
+            const result = transformFormValues(
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.IMAGE,
+                    appState,
+                    appQuerySelections: curatedSelections,
+                },
+                'app',
+            );
+
+            expect('appQuerySelections' in result).toBe(true);
+            expect(result.appQuerySelections).toBeNull();
+        });
+
+        test('never adds app fields to non-app payloads', () => {
+            const result = transformFormValues(
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.CSV,
+                    appQuerySelections: curatedSelections,
+                },
+                'dashboard',
+            );
+
+            // The backend rejects appQuerySelections on non-app schedulers.
+            expect('appQuerySelections' in result).toBe(false);
+        });
     });
 });

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -10,6 +10,7 @@ import {
     NotificationFrequency,
     SchedulerFormat,
     ThresholdOperator,
+    type AppQuerySelection,
     type CreateSchedulerAndTargetsWithoutIds,
     type CreateSchedulerTarget,
     type Dashboard,
@@ -54,6 +55,8 @@ export interface SchedulerFormValues {
     selectedTabs?: string[] | null;
     /** App deliveries only: snapshot of the app's shareable URL state. */
     appState?: SchedulerAppState | null;
+    /** App deliveries only: curated query snapshot; null = never curated. */
+    appQuerySelections: AppQuerySelection[] | null;
     thresholds?: Array<{
         fieldId: string;
         operator: ThresholdOperator;
@@ -96,6 +99,7 @@ export const DEFAULT_VALUES: SchedulerFormValues = {
     customViewportWidth: undefined,
     selectedTabs: null,
     appState: null,
+    appQuerySelections: null,
     thresholds: [],
     includeLinks: true,
     aiAugmentation: null,
@@ -207,6 +211,9 @@ export const getFormValuesFromScheduler = (
             chartFilters: schedulerData.filters,
             parameters: schedulerData.parameters,
         }),
+        appQuerySelections: isAppScheduler(schedulerData)
+            ? (schedulerData.appQuerySelections ?? null)
+            : null,
         ...(isAppScheduler(schedulerData) && {
             appState: schedulerData.appState ?? null,
         }),
@@ -311,6 +318,13 @@ export const transformFormValues = (
         ),
         ...(resourceType === 'app' && {
             appState: values.appState ?? undefined,
+            // The model clears this on omission — send it explicitly on every
+            // save: the curated snapshot, or null outside csv/xlsx / uncurated.
+            appQuerySelections:
+                values.format === SchedulerFormat.CSV ||
+                values.format === SchedulerFormat.XLSX
+                    ? values.appQuerySelections
+                    : null,
         }),
         enabled: true,
         notificationFrequency:

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
@@ -1,4 +1,5 @@
 import {
+    SchedulerFormat,
     type ApiError,
     type CreateSchedulerAndTargetsWithoutIds,
     type ItemsMap,
@@ -29,6 +30,7 @@ import { useAiAgentButtonVisibility } from '../../../ee/features/aiCopilot/hooks
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useSavedQuery } from '../../../hooks/useSavedQuery';
 import { useSchedulerFormModal } from '../hooks/useSchedulerFormModal';
+import { areAllQuerySelectionsExcluded } from '../utils/appQuerySelections';
 import {
     getVisibleSections,
     SCHEDULER_SECTIONS,
@@ -161,6 +163,12 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
 
     // Name why the submit is blocked instead of failing silently on submit —
     // the offending field may live in a section the user isn't looking at.
+    const allAppQueriesExcluded =
+        !!isApp &&
+        (form.values.format === SchedulerFormat.CSV ||
+            form.values.format === SchedulerFormat.XLSX) &&
+        areAllQuerySelectionsExcluded(form.values.appQuerySelections);
+
     const blockedReason = !form.values.name
         ? `Give your ${isThresholdAlert ? 'alert' : 'delivery'} a name`
         : isThresholdAlert && !form.values.thresholds?.[0]?.fieldId
@@ -169,9 +177,11 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
             ? hasOnlyUnmetGroupRequirements
                 ? 'Set a value for at least one filter in each requirement group'
                 : 'Some required filters are missing values'
-            : !form.isValid()
-              ? 'Complete the required fields'
-              : null;
+            : allAppQueriesExcluded
+              ? 'Include at least one query in the delivery'
+              : !form.isValid()
+                ? 'Complete the required fields'
+                : null;
 
     const subtitle = [
         resourceName ?? dashboard?.name,

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
@@ -31,6 +31,7 @@ import {
     type SchedulerFormValues,
 } from '../components/SchedulerForm/schedulerFormContext';
 import { Limit } from '../components/types';
+import { areAllQuerySelectionsExcluded } from '../utils/appQuerySelections';
 import { getSchedulerFilterRequirements } from '../utils/filterRequirements';
 import { useScheduler, useSendNowScheduler } from './useScheduler';
 import {
@@ -194,6 +195,14 @@ export const useSchedulerFormModal = ({
             aiAugmentation: (value) =>
                 value && value.prompt.trim().length === 0
                     ? 'Instructions are required'
+                    : null,
+            // Mirrors the server's empty-delivery rejection; only csv/xlsx
+            // saves actually send the snapshot.
+            appQuerySelections: (value, values) =>
+                (values.format === SchedulerFormat.CSV ||
+                    values.format === SchedulerFormat.XLSX) &&
+                areAllQuerySelectionsExcluded(value)
+                    ? 'Include at least one query in the delivery'
                     : null,
         }),
         [dashboard?.filters],

--- a/packages/frontend/src/features/scheduler/utils/appQuerySelections.test.ts
+++ b/packages/frontend/src/features/scheduler/utils/appQuerySelections.test.ts
@@ -1,0 +1,274 @@
+import {
+    type AppQuerySelection,
+    type DeliveryCaptureManifest,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    areAllQuerySelectionsExcluded,
+    buildAppQueryPickerRows,
+    hasExcludedQuerySelections,
+    toAppQuerySelections,
+} from './appQuerySelections';
+
+const readyItem = (
+    overrides: Partial<
+        Extract<DeliveryCaptureManifest['items'][number], { status: 'ready' }>
+    > = {},
+) => ({
+    status: 'ready' as const,
+    captureKey: 'v1:key-a',
+    label: 'Revenue',
+    exploreName: 'orders',
+    queryUuid: 'query-a',
+    order: 0,
+    rowCount: 12,
+    limitReached: false,
+    ...overrides,
+});
+
+const errorItem = (
+    overrides: Partial<
+        Extract<DeliveryCaptureManifest['items'][number], { status: 'error' }>
+    > = {},
+) => ({
+    status: 'error' as const,
+    captureKey: 'v1:key-err',
+    label: 'Broken',
+    exploreName: 'orders',
+    queryUuid: null,
+    order: 1,
+    error: 'boom',
+    ...overrides,
+});
+
+const manifest = (
+    items: DeliveryCaptureManifest['items'],
+    overflowCount = 0,
+): DeliveryCaptureManifest => ({ version: 1, items, overflowCount });
+
+const selection = (
+    overrides: Partial<AppQuerySelection> = {},
+): AppQuerySelection => ({
+    captureKey: 'v1:key-a',
+    label: 'Revenue',
+    exploreName: 'orders',
+    excluded: false,
+    ...overrides,
+});
+
+describe('buildAppQueryPickerRows', () => {
+    it('includes every fresh item, unexcluded, when there is no snapshot', () => {
+        const rows = buildAppQueryPickerRows(
+            manifest([readyItem(), errorItem()]),
+            null,
+        );
+
+        expect(rows).toHaveLength(2);
+        expect(rows[0]).toMatchObject({
+            kind: 'ready',
+            captureKey: 'v1:key-a',
+            excluded: false,
+            identityChanged: false,
+            rowCount: 12,
+            limitReached: false,
+        });
+        expect(rows[1]).toMatchObject({
+            kind: 'error',
+            captureKey: 'v1:key-err',
+            excluded: false,
+            error: 'boom',
+        });
+    });
+
+    it('orders rows by capture order, not manifest array order', () => {
+        const rows = buildAppQueryPickerRows(
+            manifest([
+                readyItem({ captureKey: 'v1:key-b', order: 1, label: 'B' }),
+                readyItem({ captureKey: 'v1:key-a', order: 0, label: 'A' }),
+            ]),
+            null,
+        );
+
+        expect(rows.map((r) => r.label)).toEqual(['A', 'B']);
+    });
+
+    it('applies the saved excluded state on an exact captureKey match', () => {
+        const rows = buildAppQueryPickerRows(
+            manifest([readyItem(), errorItem()]),
+            [
+                selection({ excluded: true }),
+                selection({
+                    captureKey: 'v1:key-err',
+                    label: 'Broken',
+                    excluded: true,
+                }),
+            ],
+        );
+
+        expect(rows).toHaveLength(2);
+        expect(rows[0]).toMatchObject({
+            excluded: true,
+            identityChanged: false,
+        });
+        // Error items honour exact-match exclusions too.
+        expect(rows[1]).toMatchObject({ kind: 'error', excluded: true });
+    });
+
+    it('includes fresh items missing from the snapshot by default', () => {
+        const rows = buildAppQueryPickerRows(
+            manifest([
+                readyItem(),
+                readyItem({
+                    captureKey: 'v1:key-new',
+                    label: 'Brand new',
+                    exploreName: 'customers',
+                    order: 1,
+                }),
+            ]),
+            [selection({ excluded: true })],
+        );
+
+        expect(rows[1]).toMatchObject({
+            captureKey: 'v1:key-new',
+            excluded: false,
+            identityChanged: false,
+        });
+    });
+
+    it('renders snapshot entries that did not run as toggleable missing rows', () => {
+        const rows = buildAppQueryPickerRows(manifest([readyItem()]), [
+            selection(),
+            selection({
+                captureKey: 'v1:key-gone',
+                label: 'Gone query',
+                exploreName: 'customers',
+                excluded: true,
+            }),
+        ]);
+
+        expect(rows).toHaveLength(2);
+        expect(rows[1]).toEqual({
+            kind: 'missing',
+            captureKey: 'v1:key-gone',
+            label: 'Gone query',
+            exploreName: 'customers',
+            excluded: true,
+        });
+    });
+
+    it('flags an identity change on a label+explore match with a different key and never trusts the stale exclusion', () => {
+        const rows = buildAppQueryPickerRows(
+            manifest([readyItem({ captureKey: 'v1:key-a2' })]),
+            [selection({ excluded: true })],
+        );
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            kind: 'ready',
+            captureKey: 'v1:key-a2',
+            excluded: false,
+            identityChanged: true,
+        });
+    });
+
+    it('does not render a fuzzy-resolved stale entry as a missing row', () => {
+        const rows = buildAppQueryPickerRows(
+            manifest([readyItem({ captureKey: 'v1:key-a2' })]),
+            [selection({ excluded: true })],
+        );
+
+        expect(rows.some((row) => row.kind === 'missing')).toBe(false);
+    });
+
+    it('credits an identity-changed hint to only the first of several items sharing one stale entry', () => {
+        const rows = buildAppQueryPickerRows(
+            manifest([
+                readyItem({ captureKey: 'v1:key-a2', order: 0 }),
+                readyItem({ captureKey: 'v1:key-a3', order: 1 }),
+            ]),
+            [selection({ excluded: true })],
+        );
+
+        expect(
+            rows.map((row) => row.kind !== 'missing' && row.identityChanged),
+        ).toEqual([true, false]);
+    });
+
+    it('never fuzzy-matches error items', () => {
+        const rows = buildAppQueryPickerRows(
+            manifest([errorItem({ captureKey: 'v1:key-err2' })]),
+            [
+                selection({
+                    captureKey: 'v1:key-err',
+                    label: 'Broken',
+                    excluded: true,
+                }),
+            ],
+        );
+
+        expect(rows).toHaveLength(2);
+        expect(rows[0]).toMatchObject({
+            kind: 'error',
+            excluded: false,
+            identityChanged: false,
+        });
+        expect(rows[1]).toMatchObject({
+            kind: 'missing',
+            captureKey: 'v1:key-err',
+        });
+    });
+});
+
+describe('toAppQuerySelections', () => {
+    it('snapshots every row, including missing rows, with only the persisted fields', () => {
+        const rows = buildAppQueryPickerRows(manifest([readyItem()]), [
+            selection({
+                captureKey: 'v1:key-gone',
+                label: 'Gone query',
+                excluded: true,
+            }),
+        ]);
+
+        expect(toAppQuerySelections(rows)).toEqual([
+            {
+                captureKey: 'v1:key-a',
+                label: 'Revenue',
+                exploreName: 'orders',
+                excluded: false,
+            },
+            {
+                captureKey: 'v1:key-gone',
+                label: 'Gone query',
+                exploreName: 'orders',
+                excluded: true,
+            },
+        ]);
+    });
+});
+
+describe('selection guards', () => {
+    it('hasExcludedQuerySelections is false for null and all-included snapshots', () => {
+        expect(hasExcludedQuerySelections(null)).toBe(false);
+        expect(hasExcludedQuerySelections([selection()])).toBe(false);
+        expect(
+            hasExcludedQuerySelections([selection({ excluded: true })]),
+        ).toBe(true);
+    });
+
+    it('areAllQuerySelectionsExcluded only fires on a non-empty fully excluded snapshot', () => {
+        expect(areAllQuerySelectionsExcluded(null)).toBe(false);
+        expect(areAllQuerySelectionsExcluded([])).toBe(false);
+        expect(
+            areAllQuerySelectionsExcluded([
+                selection({ excluded: true }),
+                selection({ captureKey: 'v1:key-b' }),
+            ]),
+        ).toBe(false);
+        expect(
+            areAllQuerySelectionsExcluded([
+                selection({ excluded: true }),
+                selection({ captureKey: 'v1:key-b', excluded: true }),
+            ]),
+        ).toBe(true);
+    });
+});

--- a/packages/frontend/src/features/scheduler/utils/appQuerySelections.ts
+++ b/packages/frontend/src/features/scheduler/utils/appQuerySelections.ts
@@ -1,0 +1,154 @@
+import type {
+    AppQuerySelection,
+    DeliveryCaptureManifest,
+} from '@lightdash/common';
+
+type PickerRowBase = {
+    captureKey: string;
+    label: string;
+    exploreName: string | null;
+    excluded: boolean;
+};
+
+/**
+ * One row of the delivery query picker: a fresh preview capture item merged
+ * with the saved selection snapshot. `missing` rows are snapshot entries that
+ * did not run in the preview — kept visible and toggleable.
+ */
+export type AppQueryPickerRow =
+    | (PickerRowBase & {
+          kind: 'ready';
+          rowCount: number | null;
+          limitReached: boolean;
+          identityChanged: boolean;
+      })
+    | (PickerRowBase & {
+          kind: 'error';
+          error: string;
+          identityChanged: boolean;
+      })
+    | (PickerRowBase & { kind: 'missing' });
+
+/**
+ * Merges a fresh preview manifest with the saved snapshot. Mirrors the
+ * worker's `applyAppQuerySelections` matching rules: exact captureKey match
+ * applies the saved excluded state; a label+explore match with a different
+ * key means the query's identity changed — the stale exclusion is not
+ * trusted (the row starts included) and the row carries an inline hint.
+ */
+export const buildAppQueryPickerRows = (
+    manifest: DeliveryCaptureManifest,
+    selections: AppQuerySelection[] | null,
+): AppQueryPickerRow[] => {
+    const orderedItems = [...manifest.items].sort((a, b) => a.order - b.order);
+    if (selections === null) {
+        return orderedItems.map((item) =>
+            item.status === 'ready'
+                ? {
+                      kind: 'ready',
+                      captureKey: item.captureKey,
+                      label: item.label,
+                      exploreName: item.exploreName,
+                      excluded: false,
+                      rowCount: item.rowCount,
+                      limitReached: item.limitReached,
+                      identityChanged: false,
+                  }
+                : {
+                      kind: 'error',
+                      captureKey: item.captureKey,
+                      label: item.label,
+                      exploreName: item.exploreName,
+                      excluded: false,
+                      error: item.error,
+                      identityChanged: false,
+                  },
+        );
+    }
+
+    const byCaptureKey = new Map(selections.map((s) => [s.captureKey, s]));
+    const resolvedCaptureKeys = new Set<string>();
+    // Credit a stale entry's identity-changed hint to one row only, matching
+    // the worker's one-notice-per-stale-entry dedup.
+    const hintedStaleCaptureKeys = new Set<string>();
+
+    const freshRows: AppQueryPickerRow[] = orderedItems.map((item) => {
+        const exact = byCaptureKey.get(item.captureKey);
+        let excluded = false;
+        let identityChanged = false;
+        if (exact) {
+            resolvedCaptureKeys.add(exact.captureKey);
+            excluded = exact.excluded;
+        } else if (item.status === 'ready') {
+            // The worker only fuzzy-matches ready items; error items have no
+            // successful replacement to point at.
+            const fuzzy = selections.find(
+                (s) =>
+                    s.label === item.label &&
+                    s.exploreName === item.exploreName,
+            );
+            if (fuzzy) {
+                resolvedCaptureKeys.add(fuzzy.captureKey);
+                if (!hintedStaleCaptureKeys.has(fuzzy.captureKey)) {
+                    hintedStaleCaptureKeys.add(fuzzy.captureKey);
+                    identityChanged = true;
+                }
+            }
+        }
+        return item.status === 'ready'
+            ? {
+                  kind: 'ready',
+                  captureKey: item.captureKey,
+                  label: item.label,
+                  exploreName: item.exploreName,
+                  excluded,
+                  rowCount: item.rowCount,
+                  limitReached: item.limitReached,
+                  identityChanged,
+              }
+            : {
+                  kind: 'error',
+                  captureKey: item.captureKey,
+                  label: item.label,
+                  exploreName: item.exploreName,
+                  excluded,
+                  error: item.error,
+                  identityChanged,
+              };
+    });
+
+    const missingRows: AppQueryPickerRow[] = selections
+        .filter((s) => !resolvedCaptureKeys.has(s.captureKey))
+        .map((s) => ({
+            kind: 'missing',
+            captureKey: s.captureKey,
+            label: s.label,
+            exploreName: s.exploreName,
+            excluded: s.excluded,
+        }));
+
+    return [...freshRows, ...missingRows];
+};
+
+/** Full snapshot of every visible row — what the form persists once curated. */
+export const toAppQuerySelections = (
+    rows: AppQueryPickerRow[],
+): AppQuerySelection[] =>
+    rows.map(({ captureKey, label, exploreName, excluded }) => ({
+        captureKey,
+        label,
+        exploreName,
+        excluded,
+    }));
+
+export const hasExcludedQuerySelections = (
+    selections: AppQuerySelection[] | null,
+): boolean => selections !== null && selections.some((s) => s.excluded);
+
+/** Client-side mirror of the server's empty-delivery rejection. */
+export const areAllQuerySelectionsExcluded = (
+    selections: AppQuerySelection[] | null,
+): boolean =>
+    selections !== null &&
+    selections.length > 0 &&
+    selections.every((s) => s.excluded);


### PR DESCRIPTION
## Summary

Final PR of the app-delivery query picker stack — makes the feature user-visible and closes the ticket.

The app scheduler form (CSV/XLSX formats) gains an inspector-style list of the app's data queries with checkboxes. Unchecked queries are excluded from the delivery via the `appQuerySelections` snapshot (#26931), applied by the worker (#26935).

- **Data source**: a fresh preview capture render — the app boots in a hidden iframe under the to-be-saved state using the capture pipeline's preview mode (no cache-invalidation stamps), and the picker reads the manifest straight from the capture accumulator at quiescence. Lazy-started when the picker section opens, 60s timeout, and a failure fallback that still lets the user save uncurated. The iframe tears down on ready/error/close.
- **Rows**: label, indicative row count (preview counts are cache-served), limit-reached flag, error badge, overflow notice.
- **Edit merge**: saved exclusions apply by `captureKey`; snapshot entries that didn't run render as "did not run in preview" and stay toggleable; new queries arrive checked (include-new-by-default); identity-changed hints appear inline on label+explore/key mismatches.
- **Save semantics**: every app-scheduler save explicitly sends both `appState` and `appQuerySelections` (value or explicit null) — editing without opening the picker preserves existing curation verbatim. Any exclusion pins "send current app state" on (with an explanatory tooltip); if the pinned state changes after the manifest is ready, the capture is invalidated and re-run so exclusions can never silently target stale query identities. All-excluded is blocked client-side, mirroring the server validation. A never-touched picker saves `null` (deliver everything); curated-then-reincluded-all keeps the snapshot so missing-query reporting stays active. Switching a curated scheduler to Image format warns that the selection will be removed.

## Testing

Frontend-only diff. Apps+scheduler suites 39 files / 384 passed (+49 new tests across the capture component, picker section, format section, and form-context transform), including the full save-payload matrix, state-invalidation/loop-prevention, and an end-to-end curated-hydration test through the real form transforms. Typecheck/lint/format clean.

Closes: PROD-9380