### PR TITLE
feat: inline delete icon for custom metrics in explore sidebar

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -35,6 +35,7 @@ import MantineIcon from '../../common/MantineIcon';
 import classes from './SelectedFieldsSection.module.css';
 import TreeSingleNodeActions from './TableTree/Tree/TreeSingleNodeActions';
 import { type NodeItem } from './TableTree/Tree/types';
+import { useCustomMetricDelete } from './useCustomMetricDelete';
 
 export type SelectedField = {
     fieldId: string;
@@ -88,7 +89,11 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
         (isFiltered || isHover) &&
         !isAdditionalMetric(item) &&
         isFilterableField(item);
-    const showDeleteAction = isHover && isAdditionalMetric(item);
+    const { showDeleteAction, handleDeleteClick } = useCustomMetricDelete({
+        item,
+        fieldId,
+        isHover,
+    });
 
     const description =
         isField(item) || isAdditionalMetric(item)
@@ -117,15 +122,6 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
             e.stopPropagation();
         },
         [isFiltered, addFilter, item, track],
-    );
-
-    const handleDeleteClick = useCallback(
-        (e: React.MouseEvent<HTMLButtonElement>) => {
-            e.stopPropagation();
-            track({ name: EventName.REMOVE_CUSTOM_METRIC_CLICKED });
-            dispatch(explorerActions.removeAdditionalMetric(fieldId));
-        },
-        [dispatch, fieldId, track],
     );
 
     const onOpenDescriptionView = useCallback(() => {

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -8,7 +8,7 @@ import {
     type FilterableField,
 } from '@lightdash/common';
 import { UnstyledButton, ActionIcon, Tooltip } from '@mantine/core';
-import { IconFilter } from '@tabler/icons-react';
+import { IconFilter, IconTrash } from '@tabler/icons-react';
 import {
     Fragment,
     memo,
@@ -88,6 +88,7 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
         (isFiltered || isHover) &&
         !isAdditionalMetric(item) &&
         isFilterableField(item);
+    const showDeleteAction = isHover && isAdditionalMetric(item);
 
     const description =
         isField(item) || isAdditionalMetric(item)
@@ -116,6 +117,15 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
             e.stopPropagation();
         },
         [isFiltered, addFilter, item, track],
+    );
+
+    const handleDeleteClick = useCallback(
+        (e: React.MouseEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+            track({ name: EventName.REMOVE_CUSTOM_METRIC_CLICKED });
+            dispatch(explorerActions.removeAdditionalMetric(fieldId));
+        },
+        [dispatch, fieldId, track],
     );
 
     const onOpenDescriptionView = useCallback(() => {
@@ -167,6 +177,17 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                             onClick={handleFilterClick}
                         >
                             <MantineIcon icon={IconFilter} />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
+                {showDeleteAction && (
+                    <Tooltip withinPortal label="Delete custom metric">
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            onClick={handleDeleteClick}
+                        >
+                            <MantineIcon icon={IconTrash} />
                         </ActionIcon>
                     </Tooltip>
                 )}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -33,6 +33,7 @@ import {
     IconFilter,
     IconHierarchyOff,
     IconInfoCircle,
+    IconTrash,
 } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import { useToggle } from 'react-use';
@@ -289,6 +290,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
         (isFiltered || isHover) &&
         !isAdditionalMetric(item) &&
         isFilterableField(item);
+    const showDeleteAction = isHover && isAdditionalMetric(item);
 
     const timeIntervalLabel =
         isDimension(item) &&
@@ -310,6 +312,14 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
             e.stopPropagation();
         },
         [isFiltered, addFilter, item, track],
+    );
+    const handleDeleteClick = useCallback(
+        (e: React.MouseEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+            track({ name: EventName.REMOVE_CUSTOM_METRIC_CLICKED });
+            dispatch(explorerActions.removeAdditionalMetric(fieldId));
+        },
+        [dispatch, fieldId, track],
     );
     const handleClick = useCallback(() => {
         onItemClick(node.key, item);
@@ -438,18 +448,14 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                         position="right"
                         radius="md"
                         /**
-                         * Regular fields show a filter ActionIcon on hover that
-                         * eats ~28px of the row, narrowing the HoverCard target.
-                         * Custom metrics and custom dimensions never render that
-                         * icon, so their target is wider and the popover ends up
-                         * further right at the same offset. Shave ~28px off to
-                         * align both.
+                         * Regular fields show a filter ActionIcon on hover and
+                         * custom metrics a delete ActionIcon, each eating ~28px
+                         * of the row and narrowing the HoverCard target.
+                         * Custom dimensions never render an inline icon, so
+                         * their target is wider and the popover ends up further
+                         * right at the same offset. Shave ~28px off to align.
                          */
-                        offset={
-                            isAdditionalMetric(item) || isCustomDimension(item)
-                                ? 36
-                                : 70
-                        }
+                        offset={isCustomDimension(item) ? 36 : 70}
                     >
                         <HoverCard.Target>
                             <Text truncate fz="sm" style={{ flexGrow: 1 }}>
@@ -517,6 +523,20 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                             >
                                 <MantineIcon
                                     icon={IconFilter}
+                                    style={{ flexShrink: 0 }}
+                                />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
+                    {showDeleteAction && (
+                        <Tooltip withinPortal label="Delete custom metric">
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                onClick={handleDeleteClick}
+                            >
+                                <MantineIcon
+                                    icon={IconTrash}
                                     style={{ flexShrink: 0 }}
                                 />
                             </ActionIcon>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -57,6 +57,7 @@ import {
 } from '../../../../../utils/fieldColors';
 import FieldIcon from '../../../../common/Filters/FieldIcon';
 import MantineIcon from '../../../../common/MantineIcon';
+import { useCustomMetricDelete } from '../../useCustomMetricDelete';
 import { ItemDetailPreview } from '../ItemDetailPreview';
 import { MAX_GROUP_DEPTH } from './constants';
 import styles from './TreeSingleNode.module.css';
@@ -290,7 +291,11 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
         (isFiltered || isHover) &&
         !isAdditionalMetric(item) &&
         isFilterableField(item);
-    const showDeleteAction = isHover && isAdditionalMetric(item);
+    const { showDeleteAction, handleDeleteClick } = useCustomMetricDelete({
+        item,
+        fieldId,
+        isHover,
+    });
 
     const timeIntervalLabel =
         isDimension(item) &&
@@ -312,14 +317,6 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
             e.stopPropagation();
         },
         [isFiltered, addFilter, item, track],
-    );
-    const handleDeleteClick = useCallback(
-        (e: React.MouseEvent<HTMLButtonElement>) => {
-            e.stopPropagation();
-            track({ name: EventName.REMOVE_CUSTOM_METRIC_CLICKED });
-            dispatch(explorerActions.removeAdditionalMetric(fieldId));
-        },
-        [dispatch, fieldId, track],
     );
     const handleClick = useCallback(() => {
         onItemClick(node.key, item);

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -273,7 +273,7 @@ const TreeSingleNodeActions: FC<Props> = ({
                                 );
                             }}
                         >
-                            Remove custom metric
+                            Delete custom metric
                         </Menu.Item>
                     </>
                 ) : null}
@@ -402,7 +402,7 @@ const TreeSingleNodeActions: FC<Props> = ({
                                     );
                                 }}
                             >
-                                Remove custom dimension
+                                Delete custom dimension
                             </Menu.Item>
                         )}
                     </>

--- a/packages/frontend/src/components/Explorer/ExploreTree/useCustomMetricDelete.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/useCustomMetricDelete.ts
@@ -1,0 +1,38 @@
+import { isAdditionalMetric } from '@lightdash/common';
+import { useCallback } from 'react';
+import {
+    explorerActions,
+    useExplorerDispatch,
+} from '../../../features/explorer/store';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
+import { type NodeItem } from './TableTree/Tree/types';
+
+type Args = {
+    item: NodeItem;
+    fieldId: string;
+    isHover: boolean;
+};
+
+/**
+ * Inline delete affordance for custom metric rows in the explore sidebar
+ * (pinned Selected section and tree). Deleting is the same action as the
+ * overflow menu's "Delete custom metric" item.
+ */
+export const useCustomMetricDelete = ({ item, fieldId, isHover }: Args) => {
+    const dispatch = useExplorerDispatch();
+    const { track } = useTracking();
+
+    const showDeleteAction = isHover && isAdditionalMetric(item);
+
+    const handleDeleteClick = useCallback(
+        (e: React.MouseEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+            track({ name: EventName.REMOVE_CUSTOM_METRIC_CLICKED });
+            dispatch(explorerActions.removeAdditionalMetric(fieldId));
+        },
+        [dispatch, fieldId, track],
+    );
+
+    return { showDeleteAction, handleDeleteClick };
+};


### PR DESCRIPTION
## Description

Customer feedback from an enterprise onboarding session: users creating custom metrics in the explorer couldn't find a clear way to delete them. The only delete path was the hover-only `…` overflow menu — and its label said "Remove custom metric" even though it permanently deletes.

### Changes

- **Inline delete icon on hover** for custom metric rows, in both places they appear in the explore sidebar:
  - the pinned **Selected** section (where a just-created custom metric lands, since it's auto-selected) — `SelectedFieldsSection.tsx`
  - the tree's **Custom metrics** section — `TreeSingleNode.tsx`

  The trash `ActionIcon` mirrors the existing hover filter icon on regular fields, shows a "Delete custom metric" tooltip, dispatches the same `removeAdditionalMetric` action as the menu item (incl. tracking), and stops propagation so it doesn't toggle selection. It also appears for missing/broken custom metrics, which are the ones users most need to clean up.
- **Consistent remove vs delete vocabulary**: sidebar overflow items renamed "Remove custom metric" → "Delete custom metric" and "Remove custom dimension" → "Delete custom dimension", matching the results-table column menu where "Remove" means take-out-of-view and "Delete" means destroy.
- Adjusted the `HoverCard` offset in `TreeSingleNode` since custom metrics now render a hover icon like regular fields (custom dimensions keep the narrow offset).

### Out of scope

- Confirmation modal before delete (parity with existing menu behaviour).
- Inline delete for custom dimensions (delete visibility is permission-gated for custom SQL dimensions; needs its own pass).

## How to test

1. Open any explore, hover a numeric dimension → `…` → create a custom metric (e.g. Max).
2. The metric appears in the pinned Selected section — hovering it shows a trash icon with a "Delete custom metric" tooltip; clicking deletes it without toggling selection.
3. Deselect a custom metric (click its Selected row) — hovering it in the tree's "Custom metrics" section shows the same trash icon.
4. The `…` menu on custom metric / custom dimension rows now reads "Delete custom metric" / "Delete custom dimension".

Verified end-to-end on a local instance with a Playwright recording (7/7 checks passing): create → hover shows icon + tooltip → menu label renamed → deselect → tree icon → one-click delete.

Closes: PROD-9719

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFzffL3LJYYxwiwM8iPFS3