### PR TITLE
feat(data-apps): validate dynamic table filters

### DIFF
--- a/packages/common/src/ee/apps/dataReferenceChecker.test.ts
+++ b/packages/common/src/ee/apps/dataReferenceChecker.test.ts
@@ -398,6 +398,26 @@ describe.each(indexes)('checkDataAppDataReferences (%s)', (_, index) => {
             }),
         ]);
     });
+
+    it('validates every statically resolved global filter field candidate', () => {
+        const ref: ExtractedGlobalFilterReference = {
+            kind: 'globalFilter',
+            explore: 'orders',
+            field: null,
+            fields: ['region', 'regoin', 'total_revenue'],
+            unresolved: [],
+            location: { path: 'src/ResultsTable.tsx', line: 42, column: 21 },
+        };
+
+        const errors = checkDataAppDataReferences([ref], index);
+
+        expect(errors).toEqual([
+            expect.objectContaining({
+                errorType: ValidationErrorType.Filter,
+                error: "Global filter field 'regoin' not found in explore 'orders' — did you mean 'region'?",
+            }),
+        ]);
+    });
 });
 
 describe('buildDataAppExploreIndexFromModelFiles', () => {

--- a/packages/common/src/ee/apps/dataReferenceChecker.ts
+++ b/packages/common/src/ee/apps/dataReferenceChecker.ts
@@ -497,18 +497,26 @@ class DataAppReferenceChecker {
     }
 
     private checkGlobalFilter(ref: ExtractedGlobalFilterReference): void {
+        let fieldRefs: string[] = [];
+        if (ref.fields && ref.fields.length > 0) {
+            fieldRefs = ref.fields;
+        } else if (ref.field !== null) {
+            fieldRefs = [ref.field];
+        }
         if (ref.explore === null) {
-            if (ref.field !== null && ref.field.includes('.')) {
-                const id = ref.field.replace('.', '_');
+            for (const fieldRef of fieldRefs.filter((field) =>
+                field.includes('.'),
+            )) {
+                const id = fieldRef.replace('.', '_');
                 if (
                     !this.allDimensionIds.has(id) &&
                     !this.allMetricIds.has(id)
                 ) {
                     this.errors.push({
                         errorType: ValidationErrorType.Filter,
-                        error: `Global filter field '${ref.field}' not found in any explore`,
+                        error: `Global filter field '${fieldRef}' not found in any explore`,
                         modelName: null,
-                        fieldName: ref.field,
+                        fieldName: fieldRef,
                         location: ref.location,
                     });
                 }
@@ -520,8 +528,8 @@ class DataAppReferenceChecker {
             this.pushMissingExplore(ref.explore, ref.location);
             return;
         }
-        if (ref.field !== null) {
-            const id = qualifyFieldRef(ref.explore, ref.field);
+        for (const fieldRef of fieldRefs) {
+            const id = qualifyFieldRef(ref.explore, fieldRef);
             if (!fields.dimensionIds.has(id) && !fields.metricIds.has(id)) {
                 const closest = findClosest(id, [
                     ...fields.dimensionIds,
@@ -532,9 +540,9 @@ class DataAppReferenceChecker {
                     : '';
                 this.errors.push({
                     errorType: ValidationErrorType.Filter,
-                    error: `Global filter field '${ref.field}' not found in explore '${ref.explore}'${suggestion}`,
+                    error: `Global filter field '${fieldRef}' not found in explore '${ref.explore}'${suggestion}`,
                     modelName: ref.explore,
-                    fieldName: ref.field,
+                    fieldName: fieldRef,
                     location: ref.location,
                 });
             }

--- a/packages/common/src/ee/apps/dataReferences.test.ts
+++ b/packages/common/src/ee/apps/dataReferences.test.ts
@@ -543,7 +543,95 @@ describe('extractDataAppDataReferences', () => {
             expect(filters[0]).toMatchObject({
                 explore: 'orders',
                 field: 'customer_segment',
+                fields: ['customer_segment'],
                 unresolved: [],
+            });
+        });
+
+        it('resolves query result column names through map callbacks and state', () => {
+            const result = extractDataAppDataReferences(
+                app(`
+                    import { useMemo, useState } from 'react';
+                    import { query, useLightdash } from '@lightdash/query-sdk';
+                    import { useGlobalFilters } from '@/lib/filters';
+
+                    const EXPLORE = 'orders';
+                    const baseQuery = query(EXPLORE)
+                        .dimensions(['customer_segment', 'order_date'])
+                        .metrics(['total_revenue']);
+
+                    function ResultsTable() {
+                        const { filtersFor, addFilter } = useGlobalFilters();
+                        const q = useMemo(
+                            () => baseQuery.filters(filtersFor(EXPLORE)),
+                            [filtersFor],
+                        );
+                        const { columns } = useLightdash(q);
+                        const [menuState, setMenuState] = useState(null);
+                        return (
+                            <>
+                                {columns
+                                    .filter((col) => col.name !== 'order_date')
+                                    .map((col) => (
+                                        <button onClick={() => setMenuState({ col })}>
+                                            {col.name}
+                                        </button>
+                                    ))}
+                                {menuState && (
+                                    <button onClick={() => addFilter({
+                                        field: menuState.col.name,
+                                        operator: 'equals',
+                                        value: 'value',
+                                        explore: EXPLORE,
+                                    })} />
+                                )}
+                            </>
+                        );
+                    }
+                `),
+            );
+            const [filter] = result.references.filter(
+                (ref): ref is ExtractedGlobalFilterReference =>
+                    ref.kind === 'globalFilter',
+            );
+            expect(filter).toMatchObject({
+                explore: 'orders',
+                field: null,
+                fields: ['customer_segment', 'order_date', 'total_revenue'],
+                unresolved: [],
+            });
+            expect(result.stats).toMatchObject({
+                callSites: 2,
+                fullyResolved: 2,
+                partiallyResolved: 0,
+                unresolved: 0,
+            });
+        });
+
+        it('does not treat arbitrary runtime name properties as query columns', () => {
+            const result = extractDataAppDataReferences(
+                app(`
+                    import { useGlobalFilters } from '@/lib/filters';
+                    function Menu({ item }) {
+                        const { addFilter } = useGlobalFilters();
+                        return () => addFilter({
+                            field: item.name,
+                            operator: 'equals',
+                            value: 'value',
+                            explore: 'orders',
+                        });
+                    }
+                `),
+            );
+            const [filter] = result.references.filter(
+                (ref): ref is ExtractedGlobalFilterReference =>
+                    ref.kind === 'globalFilter',
+            );
+            expect(filter).toMatchObject({
+                explore: 'orders',
+                field: null,
+                fields: [],
+                unresolved: ['field'],
             });
         });
 

--- a/packages/common/src/ee/apps/dataReferences.ts
+++ b/packages/common/src/ee/apps/dataReferences.ts
@@ -10,7 +10,7 @@ import type * as t from '@babel/types';
 
 // Bump when the extractor learns new patterns so persisted results can be
 // detected as stale and re-extracted.
-export const DATA_REFERENCE_EXTRACTOR_VERSION = 2;
+export const DATA_REFERENCE_EXTRACTOR_VERSION = 3;
 
 export type DataAppSourceFile = {
     path: string; // relative to the bundle root, forward slashes
@@ -82,7 +82,10 @@ export type GlobalFilterReferenceUnresolvedPart = 'explore' | 'field';
 export type ExtractedGlobalFilterReference = {
     kind: 'globalFilter';
     explore: string | null;
+    /** Preserved for compatibility; non-null when exactly one field resolves. */
     field: string | null;
+    /** Conservative field candidates when static analysis resolves one or more. */
+    fields?: string[];
     unresolved: GlobalFilterReferenceUnresolvedPart[];
     location: DataReferenceLocation;
 };
@@ -138,7 +141,8 @@ export function computeDataReferenceStats(
                 (ref.kind === 'query' && ref.explore !== null) ||
                 (ref.kind === 'savedChart' && ref.chartUuid !== null) ||
                 (ref.kind === 'externalFetch' && ref.alias !== null) ||
-                (ref.kind === 'globalFilter' && ref.field !== null);
+                (ref.kind === 'globalFilter' &&
+                    ((ref.fields?.length ?? 0) > 0 || ref.field !== null));
             if (identityKnown) partiallyResolved += 1;
             else unresolved += 1;
         }
@@ -155,19 +159,28 @@ const SDK_MODULE = '@lightdash/query-sdk';
 const MAX_RESOLUTION_DEPTH = 12;
 const PARSEABLE_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx'];
 
+type ScopedNode = { node: t.Node; scope: Scope };
+
 type Binding =
     | { kind: 'init'; init: t.Node | null; scope: Scope }
     | { kind: 'import'; source: string; imported: string; module: ModuleInfo }
     | {
           kind: 'useState';
           init: t.Node | null;
-          setterArgs: t.Node[];
+          setterArgs: ScopedNode[];
           setterEscapes: boolean;
           scope: Scope;
       }
     | { kind: 'stateSetter'; target: Extract<Binding, { kind: 'useState' }> }
     // Destructured property of a call result: `const { addFilter } = useGlobalFilters()`.
-    | { kind: 'callProp'; calleeName: string; prop: string }
+    | {
+          kind: 'callProp';
+          calleeName: string;
+          prop: string;
+          call: t.CallExpression | t.OptionalCallExpression;
+          scope: Scope;
+      }
+    | { kind: 'arrayElement'; source: ScopedNode }
     | { kind: 'opaque' };
 
 type Scope = {
@@ -403,6 +416,10 @@ class DataReferenceExtractor {
      *  (useState setter args) must be complete before anything resolves. */
     private readonly pending: (() => void)[] = [];
 
+    /** Global filters resolve after query references so SDK column metadata
+     *  can inherit the query's complete result-field set. */
+    private readonly latePending: (() => void)[] = [];
+
     extract(files: DataAppSourceFile[]): DataAppDataReferences {
         const parseable = files.filter((f) =>
             PARSEABLE_EXTENSIONS.some((ext) => f.path.endsWith(ext)),
@@ -414,6 +431,7 @@ class DataReferenceExtractor {
             }
         }
         for (const resolve of this.pending) resolve();
+        for (const resolve of this.latePending) resolve();
 
         const references = [
             ...[...this.queryRefs.values()].map(
@@ -630,6 +648,8 @@ class DataReferenceExtractor {
                                 kind: 'callProp',
                                 calleeName: callee.name,
                                 prop: key,
+                                call: initExpr,
+                                scope,
                             });
                             bound = true;
                         }
@@ -778,6 +798,27 @@ class DataReferenceExtractor {
 
     // -- Walk ---------------------------------------------------------------
 
+    private getArrayElementSource(
+        node: t.Node,
+        scope: Scope,
+        parent: t.Node | null,
+        parentKey: string | null,
+    ): ScopedNode | null {
+        if (
+            parentKey !== 'arguments' ||
+            !parent ||
+            !isCall(parent) ||
+            parent.arguments[0] !== node
+        ) {
+            return null;
+        }
+        const callee = unwrapExpression(parent.callee);
+        if (!isMember(callee) || memberPropertyName(callee) !== 'map') {
+            return null;
+        }
+        return { node: callee.object, scope };
+    }
+
     private walk(
         node: t.Node,
         scope: Scope,
@@ -810,9 +851,25 @@ class DataReferenceExtractor {
                 module: scope.module,
                 bindings: new Map(),
             };
-            for (const param of node.params) {
+            const arrayElementSource = this.getArrayElementSource(
+                node,
+                scope,
+                parent,
+                parentKey,
+            );
+            for (const [index, param] of node.params.entries()) {
                 for (const name of patternNames(param)) {
-                    childScope.bindings.set(name, { kind: 'opaque' });
+                    childScope.bindings.set(
+                        name,
+                        index === 0 &&
+                            param.type === 'Identifier' &&
+                            arrayElementSource
+                            ? {
+                                  kind: 'arrayElement',
+                                  source: arrayElementSource,
+                              }
+                            : { kind: 'opaque' },
+                    );
                 }
             }
         } else if (
@@ -898,7 +955,7 @@ class DataReferenceExtractor {
                     ) {
                         binding.target.setterEscapes = true;
                     } else if (arg.type !== 'SpreadElement') {
-                        binding.target.setterArgs.push(arg);
+                        binding.target.setterArgs.push({ node: arg, scope });
                     } else {
                         binding.target.setterEscapes = true;
                     }
@@ -1454,7 +1511,7 @@ class DataReferenceExtractor {
         scope: Scope,
     ): void {
         this.processedCalls.add(call);
-        this.pending.push(() => this.resolveAddFilter(call, scope));
+        this.latePending.push(() => this.resolveAddFilter(call, scope));
     }
 
     private resolveAddFilter(
@@ -1464,6 +1521,7 @@ class DataReferenceExtractor {
         const arg = call.arguments[0];
         const unresolved = new Set<GlobalFilterReferenceUnresolvedPart>();
         let field: string | null = null;
+        let fields: string[] = [];
         let explore: string | null = null;
         if (arg && isNode(arg) && arg.type === 'ObjectExpression') {
             let fieldSeen = false;
@@ -1473,9 +1531,16 @@ class DataReferenceExtractor {
                     const key = objectPropertyKeyName(prop);
                     if (key === 'field') {
                         fieldSeen = true;
-                        field = singleValue(
-                            this.resolveStrings(prop.value, scope, 0),
+                        const resolved = this.resolveGlobalFilterFields(
+                            prop.value,
+                            scope,
+                            0,
                         );
+                        fields = [...resolved.values].sort();
+                        field = singleValue(resolved);
+                        if (!resolved.complete || fields.length === 0) {
+                            unresolved.add('field');
+                        }
                     } else if (key === 'explore') {
                         exploreSeen = true;
                         explore = singleValue(
@@ -1484,7 +1549,7 @@ class DataReferenceExtractor {
                     }
                 }
             }
-            if (!fieldSeen || field === null) unresolved.add('field');
+            if (!fieldSeen) unresolved.add('field');
             if (!exploreSeen || explore === null) unresolved.add('explore');
         } else {
             unresolved.add('field');
@@ -1494,6 +1559,7 @@ class DataReferenceExtractor {
             kind: 'globalFilter',
             explore,
             field,
+            fields,
             unresolved: [...unresolved].sort(),
             location: nodeLocation(call, scope.module.path),
         });
@@ -1563,6 +1629,183 @@ class DataReferenceExtractor {
         }
         const returned = functionReturnExpressions(factory);
         return returned.length === 1 ? returned[0] : null;
+    }
+
+    private resolveGlobalFilterFields(
+        node: t.Node,
+        scope: Scope,
+        depth: number,
+    ): ResolvedStrings {
+        const resolved = this.resolveStrings(node, scope, depth);
+        if (resolved.complete || resolved.values.size > 0) return resolved;
+        return this.resolveQueryColumnFieldNames(node, scope, depth);
+    }
+
+    /** Resolve `<query column>.name` through map callbacks and React state. */
+    private resolveQueryColumnFieldNames(
+        node: t.Node,
+        scope: Scope,
+        depth: number,
+    ): ResolvedStrings {
+        if (depth > MAX_RESOLUTION_DEPTH) return unresolvedStrings();
+        const expr = unwrapExpression(node);
+        if (!isMember(expr) || memberPropertyName(expr) !== 'name') {
+            return unresolvedStrings();
+        }
+
+        return this.resolveQueryColumnValue(expr.object, scope, depth + 1);
+    }
+
+    private resolveQueryColumnValue(
+        node: t.Node,
+        scope: Scope,
+        depth: number,
+    ): ResolvedStrings {
+        if (depth > MAX_RESOLUTION_DEPTH) return unresolvedStrings();
+        const expr = unwrapExpression(node);
+        if (expr.type === 'Identifier') {
+            const binding = this.lookupBinding(expr.name, scope);
+            if (binding?.kind === 'arrayElement') {
+                return this.resolveQueryColumnArray(
+                    binding.source.node,
+                    binding.source.scope,
+                    depth + 1,
+                );
+            }
+            if (binding?.kind === 'init' && binding.init) {
+                return this.resolveQueryColumnValue(
+                    binding.init,
+                    binding.scope,
+                    depth + 1,
+                );
+            }
+            return unresolvedStrings();
+        }
+        if (isMember(expr)) {
+            const property = memberPropertyName(expr);
+            const state = unwrapExpression(expr.object);
+            if (property === null || state.type !== 'Identifier') {
+                return unresolvedStrings();
+            }
+            const binding = this.lookupBinding(state.name, scope);
+            if (binding?.kind !== 'useState') return unresolvedStrings();
+
+            const candidates: ScopedNode[] = binding.init
+                ? [
+                      { node: binding.init, scope: binding.scope },
+                      ...binding.setterArgs,
+                  ]
+                : binding.setterArgs;
+            const values = new Set<string>();
+            let complete = !binding.setterEscapes;
+            for (const candidate of candidates) {
+                const value = unwrapExpression(candidate.node);
+                if (
+                    value.type !== 'NullLiteral' &&
+                    value.type !== 'ObjectExpression'
+                ) {
+                    complete = false;
+                } else if (value.type === 'ObjectExpression') {
+                    let propertySeen = false;
+                    for (const prop of value.properties) {
+                        if (prop.type === 'SpreadElement') {
+                            complete = false;
+                        } else if (
+                            prop.type === 'ObjectProperty' &&
+                            objectPropertyKeyName(prop) === property
+                        ) {
+                            propertySeen = true;
+                            const resolved = this.resolveQueryColumnValue(
+                                prop.value,
+                                candidate.scope,
+                                depth + 1,
+                            );
+                            for (const field of resolved.values) {
+                                values.add(field);
+                            }
+                            if (!resolved.complete) complete = false;
+                        }
+                    }
+                    if (!propertySeen) complete = false;
+                }
+            }
+            if (values.size === 0) return unresolvedStrings();
+            return { values, complete };
+        }
+        return unresolvedStrings();
+    }
+
+    private resolveQueryColumnArray(
+        node: t.Node,
+        scope: Scope,
+        depth: number,
+    ): ResolvedStrings {
+        if (depth > MAX_RESOLUTION_DEPTH) return unresolvedStrings();
+        const expr = unwrapExpression(node);
+        if (isCall(expr)) {
+            const callee = unwrapExpression(expr.callee);
+            if (
+                isMember(callee) &&
+                ['filter', 'slice'].includes(memberPropertyName(callee) ?? '')
+            ) {
+                return this.resolveQueryColumnArray(
+                    callee.object,
+                    scope,
+                    depth + 1,
+                );
+            }
+            return unresolvedStrings();
+        }
+        if (expr.type === 'Identifier') {
+            const binding = this.lookupBinding(expr.name, scope);
+            if (
+                binding?.kind === 'callProp' &&
+                binding.prop === 'columns' &&
+                this.isSdkName(
+                    binding.calleeName,
+                    binding.scope,
+                    'useLightdash',
+                )
+            ) {
+                const queryArg = binding.call.arguments[0];
+                if (
+                    !queryArg ||
+                    !isNode(queryArg) ||
+                    queryArg.type === 'SpreadElement' ||
+                    queryArg.type === 'ArgumentPlaceholder'
+                ) {
+                    return unresolvedStrings();
+                }
+                const root = this.resolveChainRootThroughChain(
+                    queryArg,
+                    binding.scope,
+                    depth + 1,
+                );
+                if (!root || root.root.type !== 'query') {
+                    return unresolvedStrings();
+                }
+                const ref = this.getQueryRefForRoot(root.root);
+                return {
+                    values: new Set([
+                        ...ref.dimensions,
+                        ...ref.metrics,
+                        ...ref.localFields,
+                    ]),
+                    complete:
+                        !ref.unresolved.has('dimensions') &&
+                        !ref.unresolved.has('metrics') &&
+                        !ref.unresolved.has('localFields'),
+                };
+            }
+            if (binding?.kind === 'init' && binding.init) {
+                return this.resolveQueryColumnArray(
+                    binding.init,
+                    binding.scope,
+                    depth + 1,
+                );
+            }
+        }
+        return unresolvedStrings();
     }
 
     /** Resolves an expression to the set of string values it can take. */
@@ -1636,14 +1879,17 @@ class DataReferenceExtractor {
                 if (binding.kind === 'useState') {
                     const values = new Set<string>();
                     let complete = !binding.setterEscapes;
-                    const candidates = binding.init
-                        ? [binding.init, ...binding.setterArgs]
+                    const candidates: ScopedNode[] = binding.init
+                        ? [
+                              { node: binding.init, scope: binding.scope },
+                              ...binding.setterArgs,
+                          ]
                         : binding.setterArgs;
                     if (!binding.init) complete = false;
                     for (const candidate of candidates) {
                         const resolved = this.resolveStrings(
-                            candidate,
-                            binding.scope,
+                            candidate.node,
+                            candidate.scope,
                             depth + 1,
                         );
                         for (const value of resolved.values) values.add(value);
@@ -1933,13 +2179,16 @@ class DataReferenceExtractor {
                 // Array-valued state: resolve init + setter args as arrays.
                 const values = new Set<string>();
                 let complete = !binding.setterEscapes && binding.init !== null;
-                const candidates = binding.init
-                    ? [binding.init, ...binding.setterArgs]
+                const candidates: ScopedNode[] = binding.init
+                    ? [
+                          { node: binding.init, scope: binding.scope },
+                          ...binding.setterArgs,
+                      ]
                     : binding.setterArgs;
                 for (const candidate of candidates) {
                     const resolved = this.resolveStringArray(
-                        candidate,
-                        binding.scope,
+                        candidate.node,
+                        candidate.scope,
                         depth + 1,
                     );
                     for (const value of resolved.values) values.add(value);


### PR DESCRIPTION
## Summary

- trace Query SDK result columns through `.filter()` / `.slice()`, `.map()` callbacks, and React state objects into `addFilter({ field })`
- persist conservative field candidate sets and validate every candidate against the semantic layer
- keep existing persisted references compatible while bumping the extractor version for re-extraction

## Why

After #26944 made unresolved references visible, the F1 2026 Season Overview app showed that 3 of 9 data-reference call sites were skipped. All three were table filter menus whose field came from `menuState.col.name`.

Those columns originate from `useLightdash(query).columns`, but the extractor only resolved string values and lost that provenance across the map callback and state setter. It can safely derive the possible field names from the referenced query's dimensions, metrics, and local fields.

The extractor now carries that provenance through the known transformations and validates the conservative candidate set. Arbitrary runtime `.name` properties remain unresolved, so unknown values do not become false-green validation.

## Impact

For the F1 app, coverage improves from 6 of 9 to all 9 call sites statically analyzed. The dynamic table filters are semantically checked instead of skipped.

## Validation

- `pnpm -F common test` (129 files, 3388 passed, 1 skipped)
- `pnpm -F cli test` (41 files, 493 passed)
- focused extractor/checker tests (3 files, 68 passed)
- `pnpm -F common format`
- `pnpm -F common lint`
- `pnpm -F common typecheck`
- `pnpm -F cli format`
- `pnpm -F cli lint`
- `pnpm -F cli typecheck`
- `git diff --check`
- `ld apps validate --verbose` against F1 2026 Season Overview: all 9 call sites statically analyzed, 0 warnings