### PR TITLE
fix(frontend): stop mutating prop and hook-result arrays when sorting

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -386,7 +386,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
             return items;
         }
 
-        return items.sort((a, b) => {
+        return [...items].sort((a, b) => {
             return [...columnSorts.entries()].reduce(
                 (acc, [columnId, sortDirection]) => {
                     const column = columns.find((c) => c.id === columnId);

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -586,16 +586,6 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
         showGuidedSetup ? dashboardProjectUuid : undefined,
     );
 
-    const sortedTiles = dashboardTiles?.sort((a, b) => {
-        if (a.y === b.y) {
-            // If 'y' is the same, sort by 'x'
-            return a.x - b.x;
-        } else {
-            // Otherwise, sort by 'y'
-            return a.y - b.y;
-        }
-    });
-
     const firstSortedTabUuid = sortedTabs?.[0]?.uuid;
     const isActiveTile = useCallback(
         (tile: DashboardTile) => {
@@ -641,7 +631,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
         dashboardTemporaryFilters.dimensions.length;
     const totalParametersCount = Object.keys(activeTabParameters).length;
 
-    const currentTabHasTiles = !!sortedTiles?.some((tile) =>
+    const currentTabHasTiles = !!dashboardTiles?.some((tile) =>
         isActiveTile(tile),
     );
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -3867,7 +3867,7 @@ const useEchartsCartesianConfig = (
             }, []);
 
             // ! good candidate for deduplication, we loop over the result set in many places in this file - should mostly impact very large datasets
-            const sorted = sortedResults.sort((a, b) => {
+            const sorted = sortedResults.slice().sort((a, b) => {
                 const totalA =
                     stackTotalEntries.find(
                         (entry) => entry[0] === a[xFieldId],

--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -81,7 +81,7 @@ const useEchartsPieConfig = (
         // Calculate total for percentage calculation
         const total = data.reduce((sum, { value }) => sum + value, 0);
 
-        return data
+        return [...data]
             .sort(
                 ({ name: nameA }, { name: nameB }) =>
                     sortedGroupLabels.indexOf(nameA) -


### PR DESCRIPTION
## Summary

Four places called `.sort()` in place on an array owned by something else — a prop, React context, or a `useMemo` result. Each one mutates state shared across renders and components, so the sort's side effect leaks well beyond the code doing the sorting.

Found by `react-doctor` (`no-mutating-array-method-on-prop-or-hook-result`). All four were traced to their owning array before changing anything; none are false positives.

## The four sites

| File | What it mutated |
|---|---|
| `components/common/ResourceView/ResourceViewList/index.tsx:389` | The `items` **prop**, sorted inside a `useMemo` — mutates the parent's array |
| `features/dashboardTabs/index.tsx:589` | The `dashboardTiles` **context** array, sorted during render |
| `hooks/echarts/useEchartsCartesianConfig.ts:3870` | A `useMemo` result |
| `hooks/echarts/useEchartsPieConfig.ts:84` | The chart config's `data` array |

Three become copy-then-sort. The fourth is deleted outright — see below.

## Two things worth a reviewer's attention

**1. The dashboard tile sort is removed, not copied.** `sortedTiles` had exactly one consumer, an order-independent `.some(isActiveTile)`. The sort never affected anything the variable was used for; its only real effect was mutating the context array. Copying an array on every render just to discard the order would be waste, so the sort is gone and the `.some()` now runs on `dashboardTiles` directly.

That's a behaviour change, so here's why it's safe. **The sort was already redundant for loaded dashboards**: `DashboardModel` returns tiles ordered by `y_offset, x_offset, tab_uuid, dashboard_tile_uuid` (`DashboardModel.ts:1117`, `:2303`) — the same ordering this sort computed — and `DashboardProvider.tsx:1648` sets them into context straight from the response. Array order was already y-then-x before the sort ran.

Independently of that, array order doesn't drive layout: every tile gets a layout entry keyed `i: tile.uuid` with absolute x/y/w/h (`gridUtils.ts:59-69`), so there's no auto-placement fallback, and with no `compactType` set RGL's vertical compaction sorts layout items by row/column internally rather than by children order.

**2. `.slice()` rather than spread in the cartesian hook.** `[...sortedResults]` was the obvious fix and it fails typecheck. `sortedResults` is `A[] | B[]`, and spreading collapses that to `(A | B)[]`, which kills the per-branch narrowing that `a[xFieldId]` relies on. `.slice()` preserves the union of array types. Worth knowing because the correct copy-then-sort 35 lines below at :3905 *does* use spread — it only gets away with it because it narrows explicitly via `EMPTY_X_AXIS in a`.

## Regression analysis

The risk in a change like this is the inverse of the bug: some consumer was silently relying on the accidental mutation to see a sorted array.

- **`ResourceViewList`** — the sorted result is returned from the `useMemo` and consumed from there. No other reader of `items` depended on the parent's array having been reordered.
- **`dashboardTiles`** — read in several other places in `dashboardTabs/index.tsx` (tab mapping, visible-tile filtering, parameter collection, delete/duplicate) plus `pages/Dashboard.tsx`. All are filters, lookups, or `.some()`/`.map()` calls that don't depend on ordering. The save payload (`tiles: dashboardTiles`) carries `x`/`y` per tile, so array order doesn't affect what's persisted.

  **One honest caveat, edit mode only:** the local updaters can leave array order out of sync with visual order — `handleUpdateTiles` maps over tiles in place while x/y change (`Dashboard.tsx:415`), and `appendNewTilesToBottom` and tab-duplication (`dashboardTabs/index.tsx:874`) append at the end. The old in-place sort would eventually re-sync DOM order to visual order; this no longer happens. That affects keyboard tab order and screen-reader reading order after a drag or an add in edit mode. Layout is unaffected.

  I'd call this a wash rather than a regression, because the old behaviour wasn't reliable either: `visibleTiles`' memo runs at line 465, *before* where the sort was at 589, so within any given render the memo saw the previous render's ordering — and in the hidden-tabs branch it returns a fresh filtered array that never got re-sorted at all. Deterministic-if-imperfect beats non-deterministic. Flagging it so the trade-off is visible rather than buried.
- **Both echarts hooks** — the sorted copy is consumed immediately in the same expression, so nothing downstream can observe the difference.

## Test plan

- [x] `pnpm -F frontend typecheck` clean
- [x] `oxlint` clean on all four files
- [x] 249 tests pass across `hooks/echarts`, `features/dashboardTabs`, `components/common/ResourceView`
- [x] 128 further tests pass across `pages`, `providers/Dashboard`, `dashboardTabs`, `dashboardFilters` (19 files)
- [x] `react-doctor` re-run: 0 remaining `no-mutating-array-method-on-prop-or-hook-result` findings (was 4)
- [x] Verified in the running app, A/B against `main` — see below

## No Linear ticket

Opened without one deliberately, confirmed with the author. This came out of an ad-hoc `react-doctor` sweep rather than planned work. Happy to file a Spark issue retroactively if the team would rather these be tracked — SPK-699 was filed from the dead-code section of the same report.


## Verified in-app against `main`

Ran the same drag (top-left tile dragged down, forcing array order to diverge from visual order) on this branch and on `main`, on a 9-tile dashboard, measuring `getBoundingClientRect()` per tile. Changes were discarded, not saved.

**Every tile lands at the identical pixel position on both branches:**

| tile | `main` (top,left) | this branch |
|---|---|---|
| b0132c9e | 931, 18 | 931, 18 |
| 2940b49e | 151, 761 | 151, 761 |
| 8991111c | 736, 18 | 736, 18 |
| d843aea9 | 1516, 18 | 1516, 18 |
| f4483755 | 931, 1009 | 931, 1009 |
| ecafd63a | 2101, 18 | 2101, 18 |
| b7ff3c38 | 2296, 18 | 2296, 18 |
| cfdcbfdf | 2296, 761 | 2296, 761 |
| 33b3caa2 | 2881, 18 | 2881, 18 |

Zero overlapping and zero collapsed tiles on both. Computed visual order identical on both. On first load, DOM order matched the DB's `y_offset, x_offset` ordering exactly on both — confirming the sort was a no-op for loaded dashboards.

**This weakens the edit-mode caveat above, in the change's favour.** After the drag, `main`'s DOM order is `2940b49e, 8991111c, f4483755, b0132c9e, …` — but `f4483755` is at left 1009 and `b0132c9e` at left 18, both at top 931, so `main` has them backwards relative to reading order. It sorted the *previous* render's coordinates. `main` isn't giving up a correct DOM order here; it's giving up an incorrect one, and this branch replaces it with a stable one.


### Tabbed dashboards

The run above used the non-tabbed grid (no seeded dashboard has tabs). Seeded a temporary tabbed dashboard to cover the other path — 2 tabs, 7 markdown tiles, supplied in deliberately scrambled array order — then deleted it.

- **On load**, DOM order came back normalized to `y,x` on both branches despite the scrambled input, confirming the backend ORDER BY is what determines order.
- **Drag, 3 trials per branch** under an identical protocol (same reload, same settle time, same 720px drag): fully deterministic and **identical on both** — the dragged tile lands at `591,18` on every trial, all other tiles unmoved, zero overlaps.
- **Tab switching** on this branch: Tab A renders its 5 tiles, Tab B its 2, and an added empty Tab C shows the empty state. That exercises `currentTabHasTiles` — the line this PR actually changed — in both the has-tiles and no-tiles cases.

One note on method: a first, uncontrolled tabbed run showed the dragged tile landing at `1176` on this branch vs `591` on `main`. That was an artifact of differing page-settle time and `goto` vs `reload`, not a behavioural difference — under the repeated controlled protocol both branches agree on every trial.
