### PR TITLE
fix(autopilot): make policy copy match what observe mode actually does

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -186,6 +186,26 @@ const AGGRESSION_DESCRIPTIONS: Record<
         'Flags first, then soft-deletes content that stays flagged past the escalation window.',
 };
 
+// Observe mode never flags or deletes, so this only keeps recent content out
+// of the stale lists it reports on.
+const PROTECT_RECENT_LABELS: Record<ManagedAgentPolicy['aggression'], string> =
+    {
+        observe: 'Skip content newer than',
+        flag: 'Protect new content',
+        cleanup: 'Protect new content',
+    };
+
+const POLICY_SECTION_DESCRIPTIONS: Record<
+    ManagedAgentPolicy['aggression'],
+    string
+> = {
+    observe:
+        'Tune the thresholds below. In observe mode they decide what Autopilot reports, not what it changes.',
+    flag: 'Tune staleness thresholds and what Autopilot flags for review.',
+    cleanup:
+        'Tune staleness thresholds and how aggressively Autopilot cleans up.',
+};
+
 const PolicyNumberField: FC<{
     label: string;
     suffix: string;
@@ -1656,8 +1676,11 @@ const SettingsSidebar: FC<{
                                     </Text>
                                 </Group>
                                 <Text fz="xs" c="dimmed">
-                                    Tune staleness thresholds and how
-                                    aggressively Autopilot cleans up.
+                                    {
+                                        POLICY_SECTION_DESCRIPTIONS[
+                                            policy.aggression
+                                        ]
+                                    }
                                 </Text>
                             </Stack>
 
@@ -1718,7 +1741,9 @@ const SettingsSidebar: FC<{
                             <Group grow align="flex-end">
                                 <PolicyNumberField
                                     key={`protect-${policy.protectRecentDays}`}
-                                    label="Protect new content"
+                                    label={
+                                        PROTECT_RECENT_LABELS[policy.aggression]
+                                    }
                                     suffix=" days"
                                     value={policy.protectRecentDays}
                                     min={0}


### PR DESCRIPTION
Closes PROD-9688.

The ticket asked for the stale, deadline and time fields to be disabled when cleanup mode is `observe`. Only one of them is actually inert in observe mode, and it was already handled, so this is a copy fix rather than a disabling one.

**What observe mode really does.** `aggressionDisabledTools.observe` only removes `flag_content` and `soft_delete_content`. The agent still calls `get_stale_charts`, `get_stale_dashboards`, `get_preview_projects` and `get_slow_queries` and logs insights from them, so every threshold in the panel still decides what gets reported. `protectRecentDays` also filters recent content out of the stale queries in `AnalyticsModel`, not just the soft-delete guard. Disabling those inputs would have left observe runs using whatever was last saved with no way to tune them. `escalationHours` is the one genuinely cleanup-only field, and it is already hidden whenever the mode isn't `cleanup`.

**Changes** (`ManagedAgentActivityPage.tsx`, frontend only):

- The Policy section description is now per-mode. It read "Tune staleness thresholds and how aggressively Autopilot cleans up" in every mode, including one where nothing is cleaned up. Observe now says the thresholds decide what Autopilot reports rather than what it changes.
- `protectRecentDays` was labelled "Protect new content", which describes nothing in a mode that cannot flag or delete. In observe it now reads "Skip content newer than", which matches its only effect there.

Both are `Record<ManagedAgentPolicy['aggression'], string>` maps, so a new aggression level fails to compile until its copy is written.

**Regression analysis.** No behaviour change: no stored value, request, prompt or query is touched, and the flag/cleanup strings are byte-identical to what shipped, so those two modes render exactly as before. The only runtime difference is which string is read for `aggression === 'observe'`. `PolicyNumberField` takes `label` as a prop already, and the field keeps its `key={`protect-${policy.protectRecentDays}`}`, so switching modes re-labels the input without remounting it or dropping an uncommitted draft. Risk is confined to the Autopilot settings sidebar.

Verified with `pnpm -F frontend typecheck`, oxlint and oxfmt on the changed file. The page has no test file. Not exercised in a running app.
