### PR TITLE
feat(autopilot): detect inactive project members

### DIFF
--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -16,6 +16,7 @@ import {
     type UpdateManagedAgentSettings,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
+import { usersInProjectSql } from '../../models/AnalyticsModelSql';
 import type { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
     ManagedAgentActionsTableName,
@@ -27,6 +28,10 @@ import {
     type DbManagedAgentRun,
     type DbManagedAgentSettings,
 } from '../database/entities/managedAgent';
+import {
+    inactiveUsersSql,
+    type InactiveUserActivitySource,
+} from './ManagedAgentModelSql';
 
 export class ManagedAgentModel {
     private readonly database: Knex;
@@ -620,6 +625,64 @@ export class ManagedAgentModel {
             )
             .first();
         return row?.last_modified_at ?? null;
+    }
+
+    // Last-seen is the newest of the three project-scoped signals we record for
+    // a human: viewing a chart, viewing a dashboard, running a query.
+    async getInactiveUsers(
+        projectUuid: string,
+        organizationUuid: string,
+        inactiveDays: number,
+        limit: number = 30,
+    ): Promise<
+        Array<{
+            userUuid: string;
+            userName: string;
+            email: string | null;
+            role: string;
+            lastActiveAt: Date | null;
+            lastActiveSource: InactiveUserActivitySource | null;
+        }>
+    > {
+        const membership = await this.database.raw<{
+            rows: Array<{ user_uuid: string; role: string }>;
+        }>(usersInProjectSql(projectUuid, organizationUuid));
+        const memberUuids = membership.rows.map((row) => row.user_uuid);
+        if (memberUuids.length === 0) return [];
+
+        const roleByUserUuid = new Map(
+            membership.rows.map((row) => [row.user_uuid, row.role]),
+        );
+        const memberUuidList = memberUuids.join(',');
+
+        const rows = await this.database.raw<{
+            rows: Array<{
+                user_uuid: string;
+                user_name: string;
+                email: string | null;
+                last_active_at: Date | null;
+                last_active_source: InactiveUserActivitySource | null;
+            }>;
+        }>(inactiveUsersSql(), [
+            memberUuidList,
+            projectUuid,
+            memberUuidList,
+            projectUuid,
+            memberUuidList,
+            projectUuid,
+            memberUuidList,
+            inactiveDays,
+            limit,
+        ]);
+
+        return rows.rows.map((r) => ({
+            userUuid: r.user_uuid,
+            userName: r.user_name,
+            email: r.email,
+            role: roleByUserUuid.get(r.user_uuid) ?? 'unknown',
+            lastActiveAt: r.last_active_at,
+            lastActiveSource: r.last_active_source,
+        }));
     }
 
     async getSlowQueries(

--- a/packages/backend/src/ee/models/ManagedAgentModelSql.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModelSql.ts
@@ -1,0 +1,61 @@
+import { DashboardsTableName } from '../../database/entities/dashboards';
+import { SavedChartsTableName } from '../../database/entities/savedCharts';
+import { SpaceTableName } from '../../database/entities/spaces';
+
+export type InactiveUserActivitySource =
+    | 'chart_view'
+    | 'dashboard_view'
+    | 'query';
+
+/**
+ * Parameters: member_uuids, project_uuid, member_uuids, project_uuid,
+ * member_uuids, project_uuid, member_uuids, inactive_days, limit
+ */
+export const inactiveUsersSql = () => `
+WITH activity AS (
+  SELECT cv.user_uuid, cv.timestamp, 'chart_view' AS source
+  FROM analytics_chart_views cv
+  JOIN ${SavedChartsTableName} sq ON sq.saved_query_uuid = cv.chart_uuid AND sq.deleted_at IS NULL
+  JOIN ${SpaceTableName} s ON s.space_id = sq.space_id AND s.deleted_at IS NULL
+  JOIN projects p ON p.project_id = s.project_id
+  WHERE cv.user_uuid = ANY(string_to_array(?, ',')::uuid[]) AND p.project_uuid = ?
+
+  UNION ALL
+
+  SELECT dv.user_uuid, dv.timestamp, 'dashboard_view' AS source
+  FROM analytics_dashboard_views dv
+  JOIN ${DashboardsTableName} d ON d.dashboard_uuid = dv.dashboard_uuid AND d.deleted_at IS NULL
+  JOIN ${SpaceTableName} s ON s.space_id = d.space_id AND s.deleted_at IS NULL
+  JOIN projects p ON p.project_id = s.project_id
+  WHERE dv.user_uuid = ANY(string_to_array(?, ',')::uuid[]) AND p.project_uuid = ?
+
+  UNION ALL
+
+  SELECT qh.created_by_user_uuid AS user_uuid, qh.created_at AS timestamp, 'query' AS source
+  FROM query_history qh
+  WHERE qh.created_by_user_uuid = ANY(string_to_array(?, ',')::uuid[]) AND qh.project_uuid = ?
+),
+latest AS (
+  SELECT DISTINCT ON (user_uuid) user_uuid, timestamp, source
+  FROM activity
+  ORDER BY user_uuid, timestamp DESC
+)
+SELECT
+  u.user_uuid,
+  u.first_name || ' ' || u.last_name AS user_name,
+  e.email,
+  latest.timestamp AS last_active_at,
+  latest.source AS last_active_source
+FROM users u
+  LEFT JOIN emails e ON e.user_id = u.user_id AND e.is_primary = true
+  LEFT JOIN latest ON latest.user_uuid = u.user_uuid
+WHERE u.user_uuid = ANY(string_to_array(?, ',')::uuid[])
+  AND u.is_active = true
+  AND u.is_internal = false
+  AND (
+    latest.timestamp IS NULL
+    OR latest.timestamp < now() - make_interval(days => ?)
+  )
+ORDER BY latest.timestamp ASC NULLS FIRST
+LIMIT ?;
+`;

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -2031,6 +2031,8 @@ export class ManagedAgentService extends BaseService {
                 return this.handleGetUserQuestions(actor, projectUuid, input);
             case 'get_slow_queries':
                 return this.handleGetSlowQueries(actor, projectUuid, input);
+            case 'get_inactive_users':
+                return this.handleGetInactiveUsers(projectUuid, input);
             case 'reverse_own_action':
                 return this.handleReverseOwnAction(actor, projectUuid, input);
             default:
@@ -3139,6 +3141,41 @@ chartConfig:
                 dashboard_uuid: q.dashboardUuid,
                 dashboard_name: q.dashboardName,
                 ran_at: q.createdAt,
+            })),
+        );
+    }
+
+    private static readonly DEFAULT_INACTIVE_USER_DAYS = 90;
+
+    private async handleGetInactiveUsers(
+        projectUuid: string,
+        input: Record<string, unknown>,
+    ): Promise<string> {
+        const inactiveDays =
+            (input.inactive_days as number) ??
+            ManagedAgentService.DEFAULT_INACTIVE_USER_DAYS;
+        const limit = getManagedAgentToolResultLimit(input.limit, 30);
+
+        // Org comes from the project, never the actor: membership drives who
+        // counts as a member, and the wrong org would silently change the set.
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const users = await this.managedAgentModel.getInactiveUsers(
+            projectUuid,
+            organizationUuid,
+            inactiveDays,
+            limit,
+        );
+
+        return formatManagedAgentToolListResult(
+            users.map((user) => ({
+                user_uuid: user.userUuid,
+                name: user.userName,
+                email: user.email,
+                role: user.role,
+                last_active_at: user.lastActiveAt,
+                last_active_source: user.lastActiveSource,
+                inactive_days_threshold: inactiveDays,
             })),
         );
     }

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
@@ -150,6 +150,35 @@ describe('renderManagedAgentConfig with policy', () => {
         expect(optedOut.system).toContain('treated like any other content');
     });
 
+    it('keeps get_inactive_users in every aggression mode', () => {
+        (['observe', 'flag', 'cleanup'] as const).forEach((aggression) => {
+            const config = renderManagedAgentConfig({
+                ...baseArgs,
+                policy: { ...DEFAULT_MANAGED_AGENT_POLICY, aggression },
+            });
+            expect(customToolNames(config)).toContain('get_inactive_users');
+        });
+    });
+
+    it('keeps get_inactive_users when content capabilities are off', () => {
+        const config = renderManagedAgentConfig({
+            ...baseArgs,
+            toolSettings: {
+                createContent: false,
+                modifyExistingContent: false,
+            },
+        });
+        expect(customToolNames(config)).toContain('get_inactive_users');
+    });
+
+    it('tells the agent that inactive-user findings are reporting-only', () => {
+        const config = renderManagedAgentConfig(baseArgs);
+        expect(config.system).toContain('### 5. People & Ownership');
+        expect(config.system).toContain(
+            'NEVER flag, delete, or otherwise act on a person or their content',
+        );
+    });
+
     it('changes the config hash when policy changes', () => {
         const a = getManagedAgentConfigHash(renderManagedAgentConfig(baseArgs));
         const b = getManagedAgentConfigHash(

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -158,13 +158,19 @@ CRITICAL: chartConfig.type must be "cartesian" (for line/bar/area), "table", "bi
 
 Max 3 charts per run. Skip if nothing warrants creation.
 
-### 5. Insights
+### 5. People & Ownership
+Call get_inactive_users. This is reporting-only: record what you find with log_insight and NEVER flag, delete, or otherwise act on a person or their content.
+- Group by how long they've been quiet and say which signal you used
+- Frame it as a seat and ownership review for admins, never as a judgement about the person
+- If it returns nothing, say so briefly or skip
+
+### 6. Insights
 Call get_popular_content.
 - Surface content that is popular but not pinned
 - Surface content with high views but restricted access (private space)
 - If nothing noteworthy, skip this step
 
-### 6. Slack Summary
+### 7. Slack Summary
 After the run is complete, call write_slack_summary exactly once with the final summary you want posted to Slack. Use the "lightdash-agent-slack-messaging" skill to match Lightdash's Slack tone of voice
 `;
 };
@@ -569,6 +575,27 @@ export const managedAgentConfig: AgentCreateParams = {
                 type: 'object',
             },
             name: 'get_slow_queries',
+            type: 'custom',
+        },
+        {
+            description:
+                'Get users with access to this project who have shown no activity in it recently. Activity means viewing a chart, viewing a dashboard, or running a query. Returns user_uuid, name, email, role, last_active_at, and last_active_source (the signal the decision was based on), oldest first. Reporting only: never flag or delete anything based on this.',
+            input_schema: {
+                properties: {
+                    inactive_days: {
+                        description:
+                            'Days without activity before a user counts as inactive (default 90)',
+                        type: 'number',
+                    },
+                    limit: {
+                        description: 'Max users to return (default 30)',
+                        type: 'number',
+                    },
+                },
+                required: [],
+                type: 'object',
+            },
+            name: 'get_inactive_users',
             type: 'custom',
         },
         {

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -148,7 +148,7 @@ const CAPABILITY_GROUPS = [
         key: 'readOnly',
         label: 'Read content',
         description:
-            'Reads project health signals, recent Autopilot actions, stale charts and dashboards, broken content, chart definitions, user questions, popular content, preview projects, and slow query history.',
+            'Reads project health signals, recent Autopilot actions, stale charts and dashboards, broken content, chart definitions, user questions, popular content, preview projects, slow query history, and inactive project members.',
         locked: true,
     },
     {


### PR DESCRIPTION
Closes PROD-9407. First of two: PR #26954 adds orphaned-content detection on top.

Adds a read-only `get_inactive_users` tool to the Autopilot loop. It returns members with access to the project who show no activity in it within a configurable window (default 90 days), oldest first.

**What counts as activity.** The newest of three project-scoped signals: viewing a chart, viewing a dashboard, running a query. Each row carries `last_active_at` and `last_active_source`, so a run summary can state which signal the call rests on instead of asserting inactivity without evidence — the ticket asked for the last-seen signal to be visible.

**Membership** reuses the existing `usersInProjectSql` rather than re-deriving org role, project membership and group access. One definition of "user in this project", not two that can drift.

**Reporting-only, enforced in three places.** The tool is absent from both `aggressionDisabledTools` and `managedAgentCapabilityTools`, so it survives every aggression level and capability toggle; the description says never flag or delete on this basis; and the new prompt step frames it as a seat and ownership review for admins, explicitly not a judgement about the person.

The window is a tool input rather than a policy field, so it does not appear in the settings panel. Whether every detection threshold belongs in the policy UI is a separate decision.

**Regression analysis.** Purely additive on the backend: one new SQL helper file, one new model method, one new tool, one new dispatch case. No existing query, tool, handler or policy field is touched, so every current Autopilot behaviour is unchanged. The prompt change renumbers the old steps 5 and 6 to 6 and 7 to make room for the new step — content is untouched, only the headings shift. The frontend change is one sentence in the locked read-capability description. The one shared surface is the agent config hash, which changes because the prompt and tool list changed; that is the intended trigger for re-provisioning the Anthropic agent, and `agent.test.ts` already covers hash sensitivity.

Verified with `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`, oxlint, oxfmt, and `agent.test.ts` (12 passing, 3 new). The SQL was run against a dev database: it returned the four never-active seed users and correctly excluded the one with view history. Not exercised through a live Autopilot run.
