### PR TITLE
feat(autopilot): detect content whose owner has left

### DIFF
--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -30,7 +30,9 @@ import {
 } from '../database/entities/managedAgent';
 import {
     inactiveUsersSql,
+    orphanedContentSql,
     type InactiveUserActivitySource,
+    type OrphanedContentOwnerStatus,
 } from './ManagedAgentModelSql';
 
 export class ManagedAgentModel {
@@ -682,6 +684,54 @@ export class ManagedAgentModel {
             role: roleByUserUuid.get(r.user_uuid) ?? 'unknown',
             lastActiveAt: r.last_active_at,
             lastActiveSource: r.last_active_source,
+        }));
+    }
+
+    // Owner follows the same convention the stale-content queries use: a chart's
+    // last version author, a dashboard's first version author.
+    async getOrphanedContent(
+        projectUuid: string,
+        organizationUuid: string,
+        limit: number = 30,
+    ): Promise<
+        Array<{
+            contentType: 'chart' | 'dashboard';
+            contentUuid: string;
+            contentName: string;
+            spaceUuid: string | null;
+            ownerUserUuid: string;
+            ownerName: string;
+            ownerStatus: OrphanedContentOwnerStatus;
+            lastViewedAt: Date | null;
+        }>
+    > {
+        const rows = await this.database.raw<{
+            rows: Array<{
+                content_type: 'chart' | 'dashboard';
+                content_uuid: string;
+                content_name: string;
+                space_uuid: string | null;
+                owner_user_uuid: string;
+                owner_name: string;
+                owner_status: OrphanedContentOwnerStatus;
+                last_viewed_at: Date | null;
+            }>;
+        }>(orphanedContentSql(), [
+            organizationUuid,
+            projectUuid,
+            projectUuid,
+            limit,
+        ]);
+
+        return rows.rows.map((r) => ({
+            contentType: r.content_type,
+            contentUuid: r.content_uuid,
+            contentName: r.content_name,
+            spaceUuid: r.space_uuid,
+            ownerUserUuid: r.owner_user_uuid,
+            ownerName: r.owner_name,
+            ownerStatus: r.owner_status,
+            lastViewedAt: r.last_viewed_at,
         }));
     }
 

--- a/packages/backend/src/ee/models/ManagedAgentModelSql.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModelSql.ts
@@ -7,6 +7,8 @@ export type InactiveUserActivitySource =
     | 'dashboard_view'
     | 'query';
 
+export type OrphanedContentOwnerStatus = 'deactivated' | 'left_org';
+
 /**
  * Parameters: member_uuids, project_uuid, member_uuids, project_uuid,
  * member_uuids, project_uuid, member_uuids, inactive_days, limit
@@ -57,5 +59,78 @@ WHERE u.user_uuid = ANY(string_to_array(?, ',')::uuid[])
     OR latest.timestamp < now() - make_interval(days => ?)
   )
 ORDER BY latest.timestamp ASC NULLS FIRST
+LIMIT ?;
+`;
+
+/**
+ * Owner attribution matches the stale-content queries: a chart's last version
+ * author, a dashboard's first version author. An owner is orphaned when their
+ * account is deactivated or they no longer hold a membership in the org.
+ *
+ * Parameters: organization_uuid, project_uuid, project_uuid, limit
+ */
+export const orphanedContentSql = () => `
+WITH orphaned_owner AS (
+  SELECT
+    u.user_uuid,
+    u.first_name || ' ' || u.last_name AS owner_name,
+    CASE WHEN u.is_active = false THEN 'deactivated' ELSE 'left_org' END AS owner_status
+  FROM users u
+    LEFT JOIN organization_memberships om ON om.user_id = u.user_id
+    LEFT JOIN organizations o ON o.organization_id = om.organization_id AND o.organization_uuid = ?
+  WHERE u.is_internal = false
+  GROUP BY u.user_uuid, u.first_name, u.last_name, u.is_active
+  HAVING u.is_active = false OR COUNT(o.organization_id) = 0
+)
+SELECT
+  'chart' AS content_type,
+  sq.saved_query_uuid AS content_uuid,
+  sq.name AS content_name,
+  s.space_uuid,
+  oo.user_uuid AS owner_user_uuid,
+  oo.owner_name,
+  oo.owner_status,
+  (
+    SELECT MAX(cv.timestamp)
+    FROM analytics_chart_views cv
+    WHERE cv.chart_uuid = sq.saved_query_uuid
+  ) AS last_viewed_at
+FROM ${SavedChartsTableName} sq
+  JOIN orphaned_owner oo ON oo.user_uuid = sq.last_version_updated_by_user_uuid
+  JOIN ${SpaceTableName} s ON s.space_id = sq.space_id AND s.deleted_at IS NULL
+  JOIN projects p ON p.project_id = s.project_id
+WHERE p.project_uuid = ?
+  AND sq.deleted_at IS NULL
+
+UNION ALL
+
+SELECT
+  'dashboard' AS content_type,
+  d.dashboard_uuid AS content_uuid,
+  d.name AS content_name,
+  s.space_uuid,
+  oo.user_uuid AS owner_user_uuid,
+  oo.owner_name,
+  oo.owner_status,
+  (
+    SELECT MAX(dv.timestamp)
+    FROM analytics_dashboard_views dv
+    WHERE dv.dashboard_uuid = d.dashboard_uuid
+  ) AS last_viewed_at
+FROM ${DashboardsTableName} d
+  JOIN LATERAL (
+    SELECT dver.updated_by_user_uuid
+    FROM dashboard_versions dver
+    WHERE dver.dashboard_id = d.dashboard_id
+    ORDER BY dver.created_at ASC
+    LIMIT 1
+  ) first_version ON true
+  JOIN orphaned_owner oo ON oo.user_uuid = first_version.updated_by_user_uuid
+  JOIN ${SpaceTableName} s ON s.space_id = d.space_id AND s.deleted_at IS NULL
+  JOIN projects p ON p.project_id = s.project_id
+WHERE p.project_uuid = ?
+  AND d.deleted_at IS NULL
+
+ORDER BY owner_user_uuid, content_name
 LIMIT ?;
 `;

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -2033,6 +2033,8 @@ export class ManagedAgentService extends BaseService {
                 return this.handleGetSlowQueries(actor, projectUuid, input);
             case 'get_inactive_users':
                 return this.handleGetInactiveUsers(projectUuid, input);
+            case 'get_orphaned_content':
+                return this.handleGetOrphanedContent(actor, projectUuid, input);
             case 'reverse_own_action':
                 return this.handleReverseOwnAction(actor, projectUuid, input);
             default:
@@ -3176,6 +3178,51 @@ chartConfig:
                 last_active_at: user.lastActiveAt,
                 last_active_source: user.lastActiveSource,
                 inactive_days_threshold: inactiveDays,
+            })),
+        );
+    }
+
+    private async handleGetOrphanedContent(
+        actor: SessionUser,
+        projectUuid: string,
+        input: Record<string, unknown>,
+    ): Promise<string> {
+        const limit = getManagedAgentToolResultLimit(input.limit, 30);
+
+        // Org comes from the project, never the actor: a mismatched org makes
+        // every current member look like they left, orphaning the whole project.
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const orphaned = await this.managedAgentModel.getOrphanedContent(
+            projectUuid,
+            organizationUuid,
+            limit,
+        );
+        const { canViewChartUuid, canViewDashboardUuid } =
+            this.createContentVisibilityChecker(actor, projectUuid);
+
+        const visible = (
+            await Promise.all(
+                orphaned.map(async (item) => {
+                    const canView =
+                        item.contentType === 'chart'
+                            ? await canViewChartUuid(item.contentUuid)
+                            : await canViewDashboardUuid(item.contentUuid);
+                    return canView ? item : null;
+                }),
+            )
+        ).filter((item) => item !== null);
+
+        return formatManagedAgentToolListResult(
+            visible.map((item) => ({
+                content_type: item.contentType,
+                content_uuid: item.contentUuid,
+                content_name: item.contentName,
+                space_uuid: item.spaceUuid,
+                owner_uuid: item.ownerUserUuid,
+                owner_name: item.ownerName,
+                owner_status: item.ownerStatus,
+                last_viewed_at: item.lastViewedAt,
             })),
         );
     }

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
@@ -150,17 +150,19 @@ describe('renderManagedAgentConfig with policy', () => {
         expect(optedOut.system).toContain('treated like any other content');
     });
 
-    it('keeps get_inactive_users in every aggression mode', () => {
+    it('keeps the people and ownership tools in every aggression mode', () => {
         (['observe', 'flag', 'cleanup'] as const).forEach((aggression) => {
             const config = renderManagedAgentConfig({
                 ...baseArgs,
                 policy: { ...DEFAULT_MANAGED_AGENT_POLICY, aggression },
             });
-            expect(customToolNames(config)).toContain('get_inactive_users');
+            const tools = customToolNames(config);
+            expect(tools).toContain('get_inactive_users');
+            expect(tools).toContain('get_orphaned_content');
         });
     });
 
-    it('keeps get_inactive_users when content capabilities are off', () => {
+    it('keeps the people and ownership tools when content capabilities are off', () => {
         const config = renderManagedAgentConfig({
             ...baseArgs,
             toolSettings: {
@@ -168,10 +170,12 @@ describe('renderManagedAgentConfig with policy', () => {
                 modifyExistingContent: false,
             },
         });
-        expect(customToolNames(config)).toContain('get_inactive_users');
+        const tools = customToolNames(config);
+        expect(tools).toContain('get_inactive_users');
+        expect(tools).toContain('get_orphaned_content');
     });
 
-    it('tells the agent that inactive-user findings are reporting-only', () => {
+    it('tells the agent that people and ownership findings are reporting-only', () => {
         const config = renderManagedAgentConfig(baseArgs);
         expect(config.system).toContain('### 5. People & Ownership');
         expect(config.system).toContain(

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -159,10 +159,10 @@ CRITICAL: chartConfig.type must be "cartesian" (for line/bar/area), "table", "bi
 Max 3 charts per run. Skip if nothing warrants creation.
 
 ### 5. People & Ownership
-Call get_inactive_users. This is reporting-only: record what you find with log_insight and NEVER flag, delete, or otherwise act on a person or their content.
-- Group by how long they've been quiet and say which signal you used
-- Frame it as a seat and ownership review for admins, never as a judgement about the person
-- If it returns nothing, say so briefly or skip
+Call get_inactive_users and get_orphaned_content. Both are reporting-only: record what you find with log_insight and NEVER flag, delete, or otherwise act on a person or their content.
+- Inactive users: group by how long they've been quiet and say which signal you used. Frame it as a seat and ownership review for admins, never as a judgement about the person
+- Orphaned content: group by former owner so admins can reassign in one pass. Leaving the company does not make content stale, so do not recommend deletion on those grounds alone
+- If either returns nothing, say so briefly or skip
 
 ### 6. Insights
 Call get_popular_content.
@@ -596,6 +596,22 @@ export const managedAgentConfig: AgentCreateParams = {
                 type: 'object',
             },
             name: 'get_inactive_users',
+            type: 'custom',
+        },
+        {
+            description:
+                "Get charts and dashboards in this project whose owner is deactivated or has left the organization. Owner means a chart's last editor and a dashboard's original author. Returns content_type, uuid, name, space, owner name, owner_status, and last_viewed_at, grouped by owner. Reporting only: content is not stale just because its owner left, so never flag or delete based on this.",
+            input_schema: {
+                properties: {
+                    limit: {
+                        description: 'Max items to return (default 30)',
+                        type: 'number',
+                    },
+                },
+                required: [],
+                type: 'object',
+            },
+            name: 'get_orphaned_content',
             type: 'custom',
         },
         {

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -148,7 +148,7 @@ const CAPABILITY_GROUPS = [
         key: 'readOnly',
         label: 'Read content',
         description:
-            'Reads project health signals, recent Autopilot actions, stale charts and dashboards, broken content, chart definitions, user questions, popular content, preview projects, slow query history, and inactive project members.',
+            'Reads project health signals, recent Autopilot actions, stale charts and dashboards, broken content, chart definitions, user questions, popular content, preview projects, slow query history, inactive project members, and content whose owner has left.',
         locked: true,
     },
     {


### PR DESCRIPTION
Closes PROD-9409. Stacked on #26953 (inactive user detection) — review that one first.

Adds a read-only `get_orphaned_content` tool. It returns charts and dashboards whose owner is deactivated or no longer holds a membership in the organization, tagged `deactivated` or `left_org` and ordered by owner so admins can reassign in one pass rather than one item at a time.

**Owner attribution** follows the convention the stale-content queries already use: a chart's `last_version_updated_by_user_uuid`, a dashboard's first version author. Inventing a third notion of ownership here would have made the two surfaces disagree about who owns the same chart.

**Visibility.** Results run through `createContentVisibilityChecker`, the same filter `get_slow_queries` uses, so space scope and per-entity protections apply. The agent never sees content an admin excluded from its scope.

**Reporting-only, and deliberately so.** A departed owner says nothing about whether content is still used — heavily-viewed dashboards routinely outlive their author. Both the tool description and the prompt step rule out recommending deletion on those grounds, and the tool is excluded from the aggression and capability strip lists so it behaves identically in observe, flag and cleanup.

**Regression analysis.** Additive in the same shape as #26953: one SQL helper, one model method, one tool, one dispatch case, no change to any existing query or handler. The prompt edit extends the People & Ownership step introduced by the parent PR from one tool to two; the surrounding steps are untouched. The frontend change extends one sentence in the read-capability description. The config hash changes again for the same intended reason as the parent. Worth a reviewer's eye: the `orphaned_owner` CTE treats "no membership row for this org" as `left_org`, which is correct for content authors (authoring implies they were once members) but would over-report if the query were ever reused against users with no relationship to the project.

Verified with `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`, oxlint, oxfmt, and `agent.test.ts` (12 passing). Both branches in the stack were typechecked and tested independently, not just the tip. The SQL was run against a dev database, where it returned nothing on clean data; re-run inside a transaction that deactivated a seed owner, it found 108 charts and 13 dashboards for that owner, and the transaction was rolled back. Not exercised through a live Autopilot run.
