### PR TITLE
feat: add v3 agent read routes and mutation guards

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,5 @@
+# Context Map
+
+Bounded contexts and where their glossaries live.
+
+- **Agents v3** — agent conversation persistence (threads, messages, parts): [docs/agents-v3/CONTEXT.md](docs/agents-v3/CONTEXT.md)

--- a/docs/agents-v3/CONTEXT.md
+++ b/docs/agents-v3/CONTEXT.md
@@ -1,0 +1,86 @@
+# Agents v3 — Context
+
+Glossary of canonical terms for agent conversation persistence. Terms only — no implementation detail.
+
+## Terms
+
+### Thread
+A single agent conversation, scoped to an organization/project and optionally an agent. The stable identity all conversation consumers reference. Canonical term — "session" is not used except when quoting external systems (OpenCode/Pi/Codex call this a session).
+
+### Storage version
+The immutable format (v1 legacy or v3) a Thread's history is persisted in, fixed at thread creation. A thread is never hybrid: v1 threads remain readable and read-only; new feature-flagged threads are v3.
+
+### Message (v3)
+A single unit within a Thread with exactly one Role. Content lives entirely in its Parts. System prompts are derived from agent configuration at run time and are never persisted as Messages; tool activity and reasoning belong to assistant Messages as Parts.
+
+### Role
+The kind of a Message: `user`, `assistant`, or `compaction`. The first two are speakers; `compaction` marks an in-band boundary row, not an utterance. Model-level `system`/`tool` messages are synthesized by adapters.
+
+### Part (v3)
+An ordered, typed unit of Message content. The only place conversation content is persisted. Canonical types: `text`, `reasoning`, `tool`, `file`, `artifact`, `step-start`, `source`, `compaction`. The set is extensible in code without migration; each type declares model-visible vs UI-only. `viz` is not a part type — visualization output is deprecated in favor of Artifacts.
+
+### Artifact part
+A Part referencing a specific artifact version produced during an assistant Message. A Message may contain any number of Artifact parts, ordered like any other Part.
+
+### Steer
+A user utterance arriving while a run is active. Persisted as an ordinary user Message; its position in the thread order captures the mid-run timing. Not a distinct entity in v3.
+
+### Pinned context
+User-selected chart/dashboard references attached to a user Message when it is sent. Rides in Message metadata, never in Parts; rendered as reference chips. Model exposure is a server-side prompt concern.
+
+### Context message
+A user Message ingested from the surrounding Slack conversation under thread-access consent, rather than addressed to the agent. Authored by no resolved Lightdash user (`created_by_user_uuid` is null); the true Slack author is recorded in the Slack satellite. An ordinary user Message in every other respect.
+
+### Frozen message
+An assistant Message whose run has reached a terminal state. Its content (and Parts) never changes afterwards; only Annotations may be added. The sole sanctioned exception is Redaction.
+
+### Annotation
+Post-hoc data attached to a Message without changing its content — feedback, scores, visibility flags. Lives beside Messages, never inside them.
+
+### Redaction
+A privileged, audited, repository-layer overwrite of Part payloads in place — rows, identifiers, and ordering preserved, never row deletion. The sole sanctioned exception to Frozen message immutability; because Forks inherit prefixes logically, redacting a parent redacts every descendant. Not built at launch. Distinct from edit (a Fork) and from visibility Annotations.
+
+### Provider metadata
+Opaque, provider-namespaced JSON returned by a model provider and stored losslessly inside a Part's payload — including reasoning signatures and encrypted reasoning blobs. Never promoted to schema columns; replayed only to the provider that produced it.
+
+### Run status
+The mutable lifecycle of an assistant Message's run: `in_progress`, `completed`, `error`, or `canceled`. A projection beside content, kept live by heartbeat; reaching a terminal value is what freezes the Message. Never derived from timestamps at read time.
+
+### Healing at freeze
+The terminal-status transition that moves any tool Part still mid-lifecycle to its interrupted error state, so persisted history is always well-formed and read adapters never synthesize missing results.
+
+### Tool approval
+A segment of the tool Part lifecycle (`approval-requested` → `approval-responded` → execution or `output-denied`) persisted in the Part and replayable to the model. Tool-agnostic, covering MCP tools. The deciding user and time live in a satellite record, never in the frozen Part.
+
+### Transient part
+Stream-only content (keepalives, step progress) that is never persisted. Anything durable must be a first-class typed Part; no generic data part exists.
+
+### Envelope
+A versioned jsonb value on an assistant or compaction Message row recording run facts outside content: `model_config` (what actually ran), `token_usage`, and `error` (named machine code + user-facing message, present only on `error` status).
+
+### Compaction row
+An in-band Message with role `compaction`, appended at its own thread_seq when earlier history is summarized; never rewrites anything. Its `compaction` Part holds the summary (model- and UI-visible) and the exact summarizer input for audit (invisible); its Envelope records summarizer cost. Replay: the latest compaction row on the composed path wins — emit its summary as a tag-wrapped user message, then only rows after it; earlier rows stay on disk. Forks inherit it iff the fork point is at or after its seq. Triggered between turns only, client-side, best-effort: a failed summarize writes nothing.
+
+### Lineage
+The immutable, creation-time relationship linking a Thread to the Thread it descends from. Two kinds: Spawn and Fork. Threads form a tree; a Thread without lineage is a root. Each Thread stays strictly linear inside. Every Thread in a lineage tree shares the root's organization/project/agent scope, fixed at creation; the tree is deleted as a unit (cascade on the parent link), so a dangling inherited prefix is impossible. Lineage never grants read access in either direction.
+
+### Fork
+A new Thread that logically inherits a prefix of another Thread's history — nothing is copied. The only way to regenerate or branch history; Messages themselves never carry branch structure. Forks are first-class Threads; only non-Spawn Threads may be forked.
+
+### Spawn
+A Thread created by a parent run's delegate tool call to execute a sub-agent. Inherits no parent history; its first user Message is the agent-authored task prompt. Hidden from Thread lists, reachable only through its parent; shares the root Thread's scoping and lifecycle. Each execution attempt is its own Spawn.
+
+### Anchor
+The exact tool Part (Message + tool call id) in a parent Thread that a Spawn descends from. Several Spawn attempts may share one Anchor.
+
+### Deep research run
+An orchestrated multi-phase research execution (planner → parallel investigators → judge) whose lifecycle — status, budgets, cancellation, report expiry — lives on a satellite run record beside the Thread, never in Messages. On v3, the judge phase runs as the parent Thread's assistant Message; planner and investigator phases are Spawns created deterministically by the executor with their context packed into each task prompt — never by model delegation. The report stays on the run record; the frozen Message carries only a reference Part.
+
+### Read adapter (v1)
+The quarantined module that projects immutable v1 turn aggregates into the v3 wire shape — the only code that reads v1 rows. Order within a v1 turn is synthesized deterministically (chronological, uuid tiebreak); content is lossless. A view, never a write path.
+
+### Read-only thread
+A thread whose transcript is frozen for conversation mutations (send, steer, interrupt, generate) for the current viewer; annotations and thread management (feedback, rename, delete) remain allowed. All v1 threads are read-only; other causes exist (Slack-driven threads, viewing another user's thread). Clients learn this from a computed, viewer-specific `readOnly` capability plus a reason code — never by branching on Storage version.
+
+### Turn (v1)
+Legacy v1 aggregate (`ai_prompt`): one row holding both a user prompt and the assistant response under a single identity. Superseded in v3 by Messages.

--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -428,6 +428,14 @@ import {
     AiAgentUserPreferencesTableName,
 } from '../ee/database/entities/aiAgentUserPreferences';
 import {
+    AiMessagePartTable,
+    AiMessagePartTableName,
+    AiThreadMessageSequenceTable,
+    AiThreadMessageSequenceTableName,
+    AiThreadMessageTable,
+    AiThreadMessageTableName,
+} from '../ee/database/entities/aiAgentV3';
+import {
     AiArtifactsTable,
     AiArtifactsTableName,
     AiArtifactVersionsTable,
@@ -624,6 +632,9 @@ declare module 'knex/types/tables' {
         [PullRequestsTableName]: PullRequestsTable;
         [DashboardTileCommentsTableName]: DashboardTileCommentsTable;
         [AiThreadTableName]: AiThreadTable;
+        [AiThreadMessageSequenceTableName]: AiThreadMessageSequenceTable;
+        [AiThreadMessageTableName]: AiThreadMessageTable;
+        [AiMessagePartTableName]: AiMessagePartTable;
         [AiThreadShareTableName]: AiThreadShareTable;
         [AiSlackThreadTableName]: AiSlackThreadTable;
         [AiWebAppThreadTableName]: AiWebAppThreadTable;

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -40,6 +40,8 @@ import {
     ApiAiAgentThreadSummaryListResponse,
     ApiAiAgentThreadWorkstreamsResponse,
     ApiAiAgentV3ChatRequest,
+    ApiAiAgentV3ThreadResponse,
+    ApiAiAgentV3ThreadSummaryListResponse,
     ApiAiAgentVerifiedArtifactsResponse,
     ApiAiAgentVerifiedQuestionsResponse,
     ApiAiMcpGithubAvailabilityResponse,
@@ -74,6 +76,7 @@ import {
     KnexPaginateArgs,
     ParameterError,
     type UUID,
+    type UUIDAnyVersion,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import {
@@ -149,6 +152,50 @@ export class AiAgentController extends BaseController {
         req.res?.on('close', handleClientDisconnect);
         req.res?.on('error', handleClientDisconnect);
         req.on('aborted', handleClientDisconnect);
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/v3/{agentUuid}/threads')
+    @OperationId('listAgentThreadsV3')
+    async listAgentThreadsV3(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUIDAnyVersion,
+        @Query() allUsers?: boolean,
+    ): Promise<ApiAiAgentV3ThreadSummaryListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().listAgentThreadsV3(
+                toSessionUser(req.account),
+                { projectUuid, agentUuid, allUsers },
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/v3/{agentUuid}/threads/{threadUuid}')
+    @OperationId('getAgentThreadV3')
+    async getAgentThreadV3(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUIDAnyVersion,
+        @Path() threadUuid: UUID,
+    ): Promise<ApiAiAgentV3ThreadResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().getAgentThreadV3(
+                toSessionUser(req.account),
+                projectUuid,
+                agentUuid,
+                threadUuid,
+            ),
+        };
     }
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
@@ -1219,12 +1266,12 @@ export class AiAgentController extends BaseController {
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Post('/{agentUuid}/threads/{threadUuid}/chat')
+    @Post('/v3/{agentUuid}/threads/{threadUuid}/chat')
     @OperationId('streamAgentThreadV3Response')
     async streamAgentThreadV3Response(
         @Request() req: express.Request,
         @Path() projectUuid: UUID,
-        @Path() agentUuid: UUID,
+        @Path() agentUuid: UUIDAnyVersion,
         @Path() threadUuid: UUID,
         @Body() body: ApiAiAgentV3ChatRequest,
     ): Promise<void> {
@@ -1235,6 +1282,50 @@ export class AiAgentController extends BaseController {
                 { agentUuid, threadUuid, body },
             );
         this.pipeAgentStream(req, stream);
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post(
+        '/v3/{agentUuid}/threads/{threadUuid}/messages/{messageUuid}/interrupt',
+    )
+    @OperationId('interruptAgentThreadMessageV3')
+    async interruptAgentThreadMessageV3(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUIDAnyVersion,
+        @Path() threadUuid: UUID,
+        @Path() messageUuid: UUIDAnyVersion,
+    ): Promise<ApiAiAgentThreadMessageInterruptResponse> {
+        assertRegisteredAccount(req.account);
+        await this.getAiAgentService().interruptAgentThreadMessageV3(
+            toSessionUser(req.account),
+            { agentUuid, threadUuid, messageUuid },
+        );
+        this.setStatus(200);
+        return { status: 'ok', results: { interrupted: true } };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/v3/{agentUuid}/threads/{threadUuid}/messages/{messageUuid}/steers')
+    @OperationId('createAgentThreadMessageSteerV3')
+    async createAgentThreadMessageSteerV3(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUIDAnyVersion,
+        @Path() threadUuid: UUID,
+        @Path() messageUuid: UUIDAnyVersion,
+        @Body() body: ApiCreateAiAgentThreadMessageSteer,
+    ): Promise<ApiAiAgentThreadMessageSteerResponse> {
+        assertRegisteredAccount(req.account);
+        const steer =
+            await this.getAiAgentService().createAgentThreadMessageSteerV3(
+                toSessionUser(req.account),
+                { agentUuid, threadUuid, messageUuid, message: body.message },
+            );
+        this.setStatus(200);
+        return { status: 'ok', results: { steer } };
     }
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -39,6 +39,7 @@ import {
     ApiAiAgentThreadStreamRequest,
     ApiAiAgentThreadSummaryListResponse,
     ApiAiAgentThreadWorkstreamsResponse,
+    ApiAiAgentV3ChatRequest,
     ApiAiAgentVerifiedArtifactsResponse,
     ApiAiAgentVerifiedQuestionsResponse,
     ApiAiMcpGithubAvailabilityResponse,
@@ -106,6 +107,50 @@ import { type AiAgentService } from '../services/AiAgentService/AiAgentService';
 @Route('/api/v1/projects/{projectUuid}/aiAgents')
 @Response<ApiErrorPayload>('default', 'Error')
 export class AiAgentController extends BaseController {
+    private pipeAgentStream(
+        req: express.Request,
+        stream: Awaited<
+            ReturnType<AiAgentService['streamAgentThreadResponse']>
+        >,
+    ): void {
+        stream.pipeUIMessageStreamToResponse(req.res!);
+        let hasConsumed = false;
+        const isStreamTimeoutError = (error: unknown) =>
+            error instanceof Error &&
+            (error.name === 'BodyTimeoutError' ||
+                (error.name === 'TypeError' && error.message === 'terminated'));
+        const handleClientDisconnect = (err: Error | undefined) => {
+            if (hasConsumed) return;
+            hasConsumed = true;
+            Logger.info(
+                `Client disconnected ${
+                    err ? `with error: ${err.message}` : ''
+                }, consuming stream`,
+            );
+            if (err && !isStreamTimeoutError(err)) {
+                Sentry.captureException(err, {
+                    tags: { errorType: 'AiAgentStreamError' },
+                });
+            }
+            void stream.consumeStream({
+                onError: (error) => {
+                    Logger.error(`Error consuming stream ${String(error)}`);
+                    if (!isStreamTimeoutError(error)) {
+                        Sentry.captureException(error, {
+                            tags: { errorType: 'AiAgentStreamError' },
+                        });
+                    }
+                },
+            });
+        };
+        req.res?.on('finish', () => {
+            hasConsumed = true;
+        });
+        req.res?.on('close', handleClientDisconnect);
+        req.res?.on('error', handleClientDisconnect);
+        req.on('aborted', handleClientDisconnect);
+    }
+
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('/')
@@ -1169,54 +1214,27 @@ export class AiAgentController extends BaseController {
                       );
                   })();
 
-        /**
-         * @ref https://github.com/lukeautry/tsoa/issues/44#issuecomment-357784246
-         * Hack to get the response object from the request
-         */
-        stream.pipeUIMessageStreamToResponse(req.res!);
+        this.pipeAgentStream(req, stream);
+    }
 
-        // If client disconnects, continue consuming the stream so side-effects complete
-        let hasConsumed = false;
-        const isStreamTimeoutError = (error: unknown) =>
-            error instanceof Error &&
-            (error.name === 'BodyTimeoutError' ||
-                (error.name === 'TypeError' && error.message === 'terminated'));
-
-        const handleClientDisconnect = (err: Error | undefined) => {
-            if (hasConsumed) return;
-            hasConsumed = true;
-            Logger.info(
-                `Client disconnected ${
-                    err ? `with error: ${err.message}` : ''
-                }, consuming stream`,
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads/{threadUuid}/chat')
+    @OperationId('streamAgentThreadV3Response')
+    async streamAgentThreadV3Response(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUID,
+        @Path() threadUuid: UUID,
+        @Body() body: ApiAiAgentV3ChatRequest,
+    ): Promise<void> {
+        assertRegisteredAccount(req.account);
+        const stream =
+            await this.getAiAgentService().streamAgentThreadV3Response(
+                toSessionUser(req.account),
+                { agentUuid, threadUuid, body },
             );
-            if (err && !isStreamTimeoutError(err)) {
-                Sentry.captureException(err, {
-                    tags: {
-                        errorType: 'AiAgentStreamError',
-                    },
-                });
-            }
-            void stream.consumeStream({
-                onError: (error) => {
-                    Logger.error(`Error consuming stream ${String(error)}`);
-                    if (!isStreamTimeoutError(error)) {
-                        Sentry.captureException(error, {
-                            tags: {
-                                errorType: 'AiAgentStreamError',
-                            },
-                        });
-                    }
-                },
-            });
-        };
-        req.res?.on('finish', () => {
-            // If the request is finished, we can stop consuming the stream
-            hasConsumed = true;
-        });
-        req.res?.on('close', handleClientDisconnect);
-        req.res?.on('error', handleClientDisconnect);
-        req.on('aborted', handleClientDisconnect);
+        this.pipeAgentStream(req, stream);
     }
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -12,7 +12,11 @@ import {
     type DataAppModelVisibility,
 } from '@lightdash/common';
 import { Knex } from 'knex';
-import type { AiAgentStorageVersion, AiThreadLineageKind } from './aiAgentV3';
+import type {
+    AiAgentStorageVersion,
+    AiCanonicalContextEntityType,
+    AiThreadLineageKind,
+} from './aiAgentV3';
 
 export const AiThreadTableName = 'ai_thread';
 
@@ -424,6 +428,17 @@ export type AiAgentToolCallErrorTable = Knex.CompositeTableType<
 >;
 
 export const AiAgentToolResultTableName = 'ai_agent_tool_result';
+const AI_AGENT_TOOL_RESULT_ERROR_STATUS = 'error';
+
+export type AiAgentToolResultMetadata = Record<string, unknown>;
+export type AiAgentToolResultErrorMetadata = AiAgentToolResultMetadata & {
+    status: typeof AI_AGENT_TOOL_RESULT_ERROR_STATUS;
+};
+
+export const isAiAgentToolResultError = (
+    metadata: AiAgentToolResultMetadata | null,
+): metadata is AiAgentToolResultErrorMetadata =>
+    metadata?.status === AI_AGENT_TOOL_RESULT_ERROR_STATUS;
 
 export type DbAiAgentToolResult = {
     ai_agent_tool_result_uuid: string;
@@ -431,7 +446,7 @@ export type DbAiAgentToolResult = {
     tool_call_id: string;
     tool_name: string;
     result: string;
-    metadata: object | null;
+    metadata: AiAgentToolResultMetadata | null;
     created_at: Date;
     // TODO add updated_at
 };
@@ -448,21 +463,11 @@ export type AiAgentToolResultTable = Knex.CompositeTableType<
 
 export const AiPromptContextTableName = 'ai_prompt_context';
 
-export type AiPromptContextEntityType =
-    | 'chart'
-    | 'dashboard'
-    | 'thread'
-    | 'file'
-    | 'repository'
-    | 'pull_request'
-    | 'proposed_change'
-    | 'review_finding'
-    | 'preview_environment';
+export type AiPromptContextEntityType = AiCanonicalContextEntityType;
 
-export type DbAiPromptContext = {
+type DbAiPromptContextBase = {
     ai_prompt_context_uuid: string;
     ai_prompt_uuid: string;
-    entity_type: AiPromptContextEntityType;
     // UUID-keyed entities (chart/dashboard/thread) store their uuid here;
     // string-keyed entities (file/repository) leave it null and use entity_ref.
     entity_uuid: string | null;
@@ -471,12 +476,27 @@ export type DbAiPromptContext = {
     entity_ref: string | null;
     pinned_version_uuid: string | null;
     display_name: string | null;
-    runtime_overrides:
-        | AiChartRuntimeOverrides
-        | AiDashboardRuntimeOverrides
-        | null;
     created_at: Date;
 };
+
+export type DbAiPromptContext = DbAiPromptContextBase &
+    (
+        | {
+              entity_type: 'chart';
+              runtime_overrides: AiChartRuntimeOverrides | null;
+          }
+        | {
+              entity_type: 'dashboard';
+              runtime_overrides: AiDashboardRuntimeOverrides | null;
+          }
+        | {
+              entity_type: Exclude<
+                  AiPromptContextEntityType,
+                  'chart' | 'dashboard'
+              >;
+              runtime_overrides: null;
+          }
+    );
 
 export type AiPromptContextTable = Knex.CompositeTableType<
     DbAiPromptContext,

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -12,6 +12,7 @@ import {
     type DataAppModelVisibility,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import type { AiAgentStorageVersion, AiThreadLineageKind } from './aiAgentV3';
 
 export const AiThreadTableName = 'ai_thread';
 
@@ -29,6 +30,12 @@ export type DbAiThread = {
     title: string | null;
     title_generated_at: Date | null;
     sql_auto_approved_at: Date | null;
+    storage_version: AiAgentStorageVersion;
+    parent_thread_uuid: string | null;
+    lineage_kind: AiThreadLineageKind | null;
+    parent_message_uuid: string | null;
+    parent_tool_call_id: string | null;
+    fork_boundary_seq: number | null;
 };
 
 export type AiThreadTable = Knex.CompositeTableType<
@@ -36,7 +43,18 @@ export type AiThreadTable = Knex.CompositeTableType<
     Pick<
         DbAiThread,
         'organization_uuid' | 'project_uuid' | 'created_from' | 'agent_uuid'
-    >,
+    > &
+        Partial<
+            Pick<
+                DbAiThread,
+                | 'storage_version'
+                | 'parent_thread_uuid'
+                | 'lineage_kind'
+                | 'parent_message_uuid'
+                | 'parent_tool_call_id'
+                | 'fork_boundary_seq'
+            >
+        >,
     Partial<
         Pick<
             DbAiThread,

--- a/packages/backend/src/ee/database/entities/aiAgentV3.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentV3.ts
@@ -1,4 +1,8 @@
-import { type AiThreadCreatedFrom } from '@lightdash/common';
+import {
+    type AiChartRuntimeOverrides,
+    type AiDashboardRuntimeOverrides,
+    type AiThreadCreatedFrom,
+} from '@lightdash/common';
 import { type Knex } from 'knex';
 
 export const AiThreadMessageSequenceTableName = 'ai_thread_message_sequence';
@@ -48,6 +52,20 @@ export const AI_MESSAGE_PART_TYPES = [
 ] as const;
 export type AiMessagePartType = (typeof AI_MESSAGE_PART_TYPES)[number];
 export type AiMessagePartTypeOrUnknown = AiMessagePartType | (string & {});
+
+export const AI_CONTEXT_ENTITY_TYPES = [
+    'chart',
+    'dashboard',
+    'thread',
+    'file',
+    'repository',
+    'pull_request',
+    'proposed_change',
+    'review_finding',
+    'preview_environment',
+] as const;
+export type AiCanonicalContextEntityType =
+    (typeof AI_CONTEXT_ENTITY_TYPES)[number];
 
 export const AI_TOOL_PART_STATES = [
     'input-streaming',
@@ -249,7 +267,7 @@ export type AiV3PartWrite =
           artifactVersionUuid?: never;
       });
 
-export type AiV3CanonicalPart = {
+export type AiCanonicalPart = {
     uuid: string;
     type: AiMessagePartTypeOrUnknown;
     payloadVersion: number;
@@ -258,10 +276,71 @@ export type AiV3CanonicalPart = {
     artifactVersionUuid: string | null;
 };
 
-export type AiV3CanonicalMessage = {
+type AiCanonicalContextBase = {
+    uuid: string;
+    entityUuid: string | null;
+    entityRef: string | null;
+    pinnedVersionUuid: string | null;
+    displayName: string | null;
+    createdAt: string;
+};
+
+export type AiCanonicalContext = AiCanonicalContextBase &
+    (
+        | {
+              entityType: 'chart';
+              runtimeOverrides: AiChartRuntimeOverrides | null;
+          }
+        | {
+              entityType: 'dashboard';
+              runtimeOverrides: AiDashboardRuntimeOverrides | null;
+          }
+        | {
+              entityType: Exclude<
+                  AiCanonicalContextEntityType,
+                  'chart' | 'dashboard'
+              >;
+              runtimeOverrides: null;
+          }
+    );
+
+export type AiCanonicalReferencedArtifact = {
+    artifactVersionUuid: string;
+    artifactUuid: string;
+    projectUuid: string;
+    similarityScore: number | null;
+    versionNumber: number;
+    title: string | null;
+    description: string | null;
+    artifactType: string;
+    createdAt: string;
+};
+
+export type AiCanonicalLegacyMetadata =
+    | {
+          type: 'response';
+          vizConfigOutput: unknown;
+          filtersOutput: unknown;
+          metricQuery: unknown;
+          savedQueryUuid: string | null;
+          humanScore: number | null;
+          humanFeedback: string | null;
+          referencedArtifacts: AiCanonicalReferencedArtifact[];
+          interrupts: {
+              createdByUserUuid: string | null;
+              createdAt: string;
+          }[];
+      }
+    | {
+          type: 'steer';
+          consumedAt: string | null;
+          consumedStep: number | null;
+      };
+
+export type AiCanonicalMessage = {
     uuid: string;
     role: AiThreadMessageRole;
-    parts: AiV3CanonicalPart[];
+    parts: AiCanonicalPart[];
     metadata: {
         createdAt: string;
         createdByUserUuid: string | null;
@@ -270,16 +349,22 @@ export type AiV3CanonicalMessage = {
         modelConfig: AiModelConfigEnvelope | null;
         tokenUsage: AiTokenUsageEnvelope | null;
         error: AiRunErrorEnvelope | null;
+        hidden: boolean;
+        context: AiCanonicalContext[];
+        legacy: AiCanonicalLegacyMetadata | null;
     };
 };
 
-export type AiV3CanonicalThread = {
+export type AiCanonicalThread = {
     uuid: string;
-    storageVersion: 3;
+    storageVersion: AiAgentStorageVersion;
     organizationUuid: string;
     projectUuid: string;
     agentUuid: string | null;
     createdAt: string;
+    updatedAt: string | null;
+    createdFrom: AiThreadCreatedFrom;
+    title: string | null;
     lineage: AiV3ThreadLineage;
-    messages: AiV3CanonicalMessage[];
+    messages: AiCanonicalMessage[];
 };

--- a/packages/backend/src/ee/database/entities/aiAgentV3.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentV3.ts
@@ -242,6 +242,7 @@ export type CreateAiV3Thread = {
     agentUuid: string | null;
     createdFrom: AiThreadCreatedFrom;
     lineage: AiV3ThreadLineage;
+    ownerUserUuid?: string;
 };
 
 type AiV3PartWriteBase = {

--- a/packages/backend/src/ee/database/entities/aiAgentV3.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentV3.ts
@@ -1,0 +1,285 @@
+import { type AiThreadCreatedFrom } from '@lightdash/common';
+import { type Knex } from 'knex';
+
+export const AiThreadMessageSequenceTableName = 'ai_thread_message_sequence';
+export const AiThreadMessageTableName = 'ai_thread_message';
+export const AiMessagePartTableName = 'ai_message_part';
+
+export const AI_AGENT_STORAGE_VERSIONS = [1, 3] as const;
+export type AiAgentStorageVersion = (typeof AI_AGENT_STORAGE_VERSIONS)[number];
+
+export const AI_THREAD_LINEAGE_KINDS = ['spawn', 'fork'] as const;
+export type AiThreadLineageKind = (typeof AI_THREAD_LINEAGE_KINDS)[number];
+
+export const AI_THREAD_MESSAGE_ROLES = [
+    'user',
+    'assistant',
+    'compaction',
+] as const;
+export type AiThreadMessageRole = (typeof AI_THREAD_MESSAGE_ROLES)[number];
+
+export const AI_ASSISTANT_MESSAGE_STATUSES = [
+    'in_progress',
+    'completed',
+    'error',
+    'canceled',
+] as const;
+export type AiAssistantMessageStatus =
+    (typeof AI_ASSISTANT_MESSAGE_STATUSES)[number];
+export type AiAssistantMessageTerminalStatus = Exclude<
+    AiAssistantMessageStatus,
+    'in_progress'
+>;
+export const AI_ASSISTANT_MESSAGE_TERMINAL_STATUSES = [
+    'completed',
+    'error',
+    'canceled',
+] as const satisfies readonly AiAssistantMessageTerminalStatus[];
+
+export const AI_MESSAGE_PART_TYPES = [
+    'text',
+    'reasoning',
+    'tool',
+    'file',
+    'artifact',
+    'step-start',
+    'source',
+    'compaction',
+] as const;
+export type AiMessagePartType = (typeof AI_MESSAGE_PART_TYPES)[number];
+export type AiMessagePartTypeOrUnknown = AiMessagePartType | (string & {});
+
+export const AI_TOOL_PART_STATES = [
+    'input-streaming',
+    'input-available',
+    'approval-requested',
+    'approval-responded',
+    'output-available',
+    'output-error',
+    'output-denied',
+] as const;
+export type AiToolPartState = (typeof AI_TOOL_PART_STATES)[number];
+export const AI_TOOL_PART_TERMINAL_STATES = [
+    'output-available',
+    'output-error',
+    'output-denied',
+] as const satisfies readonly AiToolPartState[];
+export const AI_TOOL_PART_INTERRUPTED_STATE =
+    'output-error' as const satisfies AiToolPartState;
+
+export const MODEL_VISIBLE_AI_MESSAGE_PART_TYPES = [
+    'text',
+    'reasoning',
+    'tool',
+    'file',
+    'compaction',
+] as const satisfies readonly AiMessagePartType[];
+
+export const NON_USER_AI_MESSAGE_PART_TYPES = [
+    'reasoning',
+    'tool',
+    'artifact',
+    'step-start',
+    'compaction',
+] as const satisfies readonly AiMessagePartType[];
+
+export type AiModelConfigEnvelope = {
+    version: number;
+    modelName: string;
+    modelProvider: string;
+    reasoning: {
+        enabled: boolean;
+        effort: string | null;
+        budgetTokens: number | null;
+    };
+    limits: {
+        maxSteps: number | null;
+        maxOutputTokens: number | null;
+    };
+    sampling: {
+        temperature: number | null;
+        topP: number | null;
+    };
+    providerOptions: Record<string, unknown> | null;
+};
+
+export type AiTokenUsageEnvelope = {
+    version: number;
+    inputTokens: number | null;
+    outputTokens: number | null;
+    totalTokens: number | null;
+    reasoningTokens: number | null;
+    cachedInputTokens: number | null;
+};
+
+export type AiRunErrorEnvelope = {
+    version: number;
+    name: string;
+    message: string;
+    data: Record<string, unknown> | null;
+};
+
+export type DbAiThreadMessageSequence = {
+    ai_thread_uuid: string;
+    next_thread_seq: number;
+};
+
+export type AiThreadMessageSequenceTable = Knex.CompositeTableType<
+    DbAiThreadMessageSequence,
+    Pick<DbAiThreadMessageSequence, 'ai_thread_uuid'> &
+        Partial<Pick<DbAiThreadMessageSequence, 'next_thread_seq'>>,
+    Pick<DbAiThreadMessageSequence, 'next_thread_seq'>
+>;
+
+export type DbAiThreadMessage = {
+    ai_thread_message_uuid: string;
+    ai_thread_uuid: string;
+    thread_seq: number;
+    role: AiThreadMessageRole;
+    created_by_user_uuid: string | null;
+    status: AiAssistantMessageStatus | null;
+    last_heartbeat_at: Date | null;
+    model_config: AiModelConfigEnvelope | null;
+    token_usage: AiTokenUsageEnvelope | null;
+    error: AiRunErrorEnvelope | null;
+    created_at: Date;
+};
+
+type AiThreadMessageHeartbeatWrite = {
+    last_heartbeat_at?: Date | Knex.Raw;
+};
+
+type AiThreadMessageInsert = Pick<
+    DbAiThreadMessage,
+    'ai_thread_uuid' | 'thread_seq' | 'role'
+> &
+    Partial<
+        Pick<
+            DbAiThreadMessage,
+            | 'created_by_user_uuid'
+            | 'status'
+            | 'model_config'
+            | 'token_usage'
+            | 'error'
+            | 'created_at'
+        >
+    > &
+    AiThreadMessageHeartbeatWrite;
+
+type AiThreadMessageUpdate = Partial<
+    Pick<DbAiThreadMessage, 'status' | 'token_usage' | 'error'>
+> &
+    AiThreadMessageHeartbeatWrite;
+
+export type AiThreadMessageTable = Knex.CompositeTableType<
+    DbAiThreadMessage,
+    AiThreadMessageInsert,
+    AiThreadMessageUpdate
+>;
+
+export type DbAiMessagePart = {
+    ai_message_part_uuid: string;
+    ai_thread_message_uuid: string;
+    part_index: number;
+    type: AiMessagePartTypeOrUnknown;
+    payload_version: number;
+    payload: Record<string, unknown>;
+    tool_call_id: string | null;
+    ai_artifact_version_uuid: string | null;
+    created_at: Date;
+};
+
+export type AiMessagePartTable = Knex.CompositeTableType<
+    DbAiMessagePart,
+    Pick<
+        DbAiMessagePart,
+        'ai_thread_message_uuid' | 'part_index' | 'payload_version' | 'payload'
+    > & {
+        type: AiMessagePartType;
+    } & Partial<
+            Pick<DbAiMessagePart, 'tool_call_id' | 'ai_artifact_version_uuid'>
+        >,
+    Partial<Pick<DbAiMessagePart, 'payload_version'>> & {
+        payload?: Record<string, unknown> | Knex.Raw;
+    }
+>;
+
+export type AiV3ThreadLineage =
+    | null
+    | {
+          kind: 'spawn';
+          parentThreadUuid: string;
+          parentMessageUuid: string;
+          parentToolCallId: string;
+      }
+    | {
+          kind: 'fork';
+          parentThreadUuid: string;
+          forkBoundarySeq: number;
+      };
+
+export type CreateAiV3Thread = {
+    organizationUuid: string;
+    projectUuid: string;
+    agentUuid: string | null;
+    createdFrom: AiThreadCreatedFrom;
+    lineage: AiV3ThreadLineage;
+};
+
+type AiV3PartWriteBase = {
+    partIndex: number;
+    payloadVersion: number;
+    payload: Record<string, unknown>;
+};
+
+export type AiV3PartWrite =
+    | (AiV3PartWriteBase & {
+          type: 'tool';
+          toolCallId: string;
+          artifactVersionUuid?: never;
+      })
+    | (AiV3PartWriteBase & {
+          type: 'artifact';
+          artifactVersionUuid: string;
+          toolCallId?: never;
+      })
+    | (AiV3PartWriteBase & {
+          type: Exclude<AiMessagePartType, 'tool' | 'artifact'>;
+          toolCallId?: never;
+          artifactVersionUuid?: never;
+      });
+
+export type AiV3CanonicalPart = {
+    uuid: string;
+    type: AiMessagePartTypeOrUnknown;
+    payloadVersion: number;
+    payload: Record<string, unknown>;
+    toolCallId: string | null;
+    artifactVersionUuid: string | null;
+};
+
+export type AiV3CanonicalMessage = {
+    uuid: string;
+    role: AiThreadMessageRole;
+    parts: AiV3CanonicalPart[];
+    metadata: {
+        createdAt: string;
+        createdByUserUuid: string | null;
+        status: AiAssistantMessageStatus | null;
+        lastHeartbeatAt: string | null;
+        modelConfig: AiModelConfigEnvelope | null;
+        tokenUsage: AiTokenUsageEnvelope | null;
+        error: AiRunErrorEnvelope | null;
+    };
+};
+
+export type AiV3CanonicalThread = {
+    uuid: string;
+    storageVersion: 3;
+    organizationUuid: string;
+    projectUuid: string;
+    agentUuid: string | null;
+    createdAt: string;
+    lineage: AiV3ThreadLineage;
+    messages: AiV3CanonicalMessage[];
+};

--- a/packages/backend/src/ee/database/entities/aiAgentV3.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentV3.ts
@@ -1,7 +1,14 @@
 import {
+    AI_AGENT_V3_PART_TYPES,
+    type AiAgentV3LegacyMetadata,
+    type AiAgentV3ModelConfig,
+    type AiAgentV3ReferencedArtifact,
+    type AiAgentV3RunError,
+    type AiAgentV3TokenUsage,
     type AiChartRuntimeOverrides,
     type AiDashboardRuntimeOverrides,
     type AiThreadCreatedFrom,
+    type AiAgentStorageVersion as CommonAiAgentStorageVersion,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 
@@ -9,8 +16,10 @@ export const AiThreadMessageSequenceTableName = 'ai_thread_message_sequence';
 export const AiThreadMessageTableName = 'ai_thread_message';
 export const AiMessagePartTableName = 'ai_message_part';
 
-export const AI_AGENT_STORAGE_VERSIONS = [1, 3] as const;
-export type AiAgentStorageVersion = (typeof AI_AGENT_STORAGE_VERSIONS)[number];
+export const AI_AGENT_STORAGE_VERSIONS = [
+    1, 3,
+] as const satisfies readonly CommonAiAgentStorageVersion[];
+export type AiAgentStorageVersion = CommonAiAgentStorageVersion;
 
 export const AI_THREAD_LINEAGE_KINDS = ['spawn', 'fork'] as const;
 export type AiThreadLineageKind = (typeof AI_THREAD_LINEAGE_KINDS)[number];
@@ -40,16 +49,7 @@ export const AI_ASSISTANT_MESSAGE_TERMINAL_STATUSES = [
     'canceled',
 ] as const satisfies readonly AiAssistantMessageTerminalStatus[];
 
-export const AI_MESSAGE_PART_TYPES = [
-    'text',
-    'reasoning',
-    'tool',
-    'file',
-    'artifact',
-    'step-start',
-    'source',
-    'compaction',
-] as const;
+export const AI_MESSAGE_PART_TYPES = AI_AGENT_V3_PART_TYPES;
 export type AiMessagePartType = (typeof AI_MESSAGE_PART_TYPES)[number];
 export type AiMessagePartTypeOrUnknown = AiMessagePartType | (string & {});
 
@@ -101,41 +101,9 @@ export const NON_USER_AI_MESSAGE_PART_TYPES = [
     'compaction',
 ] as const satisfies readonly AiMessagePartType[];
 
-export type AiModelConfigEnvelope = {
-    version: number;
-    modelName: string;
-    modelProvider: string;
-    reasoning: {
-        enabled: boolean;
-        effort: string | null;
-        budgetTokens: number | null;
-    };
-    limits: {
-        maxSteps: number | null;
-        maxOutputTokens: number | null;
-    };
-    sampling: {
-        temperature: number | null;
-        topP: number | null;
-    };
-    providerOptions: Record<string, unknown> | null;
-};
-
-export type AiTokenUsageEnvelope = {
-    version: number;
-    inputTokens: number | null;
-    outputTokens: number | null;
-    totalTokens: number | null;
-    reasoningTokens: number | null;
-    cachedInputTokens: number | null;
-};
-
-export type AiRunErrorEnvelope = {
-    version: number;
-    name: string;
-    message: string;
-    data: Record<string, unknown> | null;
-};
+export type AiModelConfigEnvelope = AiAgentV3ModelConfig;
+export type AiTokenUsageEnvelope = AiAgentV3TokenUsage;
+export type AiRunErrorEnvelope = AiAgentV3RunError;
 
 export type DbAiThreadMessageSequence = {
     ai_thread_uuid: string;
@@ -305,38 +273,8 @@ export type AiCanonicalContext = AiCanonicalContextBase &
           }
     );
 
-export type AiCanonicalReferencedArtifact = {
-    artifactVersionUuid: string;
-    artifactUuid: string;
-    projectUuid: string;
-    similarityScore: number | null;
-    versionNumber: number;
-    title: string | null;
-    description: string | null;
-    artifactType: string;
-    createdAt: string;
-};
-
-export type AiCanonicalLegacyMetadata =
-    | {
-          type: 'response';
-          vizConfigOutput: unknown;
-          filtersOutput: unknown;
-          metricQuery: unknown;
-          savedQueryUuid: string | null;
-          humanScore: number | null;
-          humanFeedback: string | null;
-          referencedArtifacts: AiCanonicalReferencedArtifact[];
-          interrupts: {
-              createdByUserUuid: string | null;
-              createdAt: string;
-          }[];
-      }
-    | {
-          type: 'steer';
-          consumedAt: string | null;
-          consumedStep: number | null;
-      };
+export type AiCanonicalReferencedArtifact = AiAgentV3ReferencedArtifact;
+export type AiCanonicalLegacyMetadata = AiAgentV3LegacyMetadata;
 
 export type AiCanonicalMessage = {
     uuid: string;

--- a/packages/backend/src/ee/database/migrations/20260806080000_add_ai_agent_v3_storage.ts
+++ b/packages/backend/src/ee/database/migrations/20260806080000_add_ai_agent_v3_storage.ts
@@ -1,0 +1,157 @@
+import { type Knex } from 'knex';
+
+const AiThreadTableName = 'ai_thread';
+const AiArtifactVersionsTableName = 'ai_artifact_versions';
+const AiThreadMessageSequenceTableName = 'ai_thread_message_sequence';
+const AiThreadMessageTableName = 'ai_thread_message';
+const AiMessagePartTableName = 'ai_message_part';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table.smallint('storage_version').notNullable().defaultTo(1);
+        table
+            .uuid('parent_thread_uuid')
+            .nullable()
+            .references('ai_thread_uuid')
+            .inTable(AiThreadTableName)
+            .onDelete('CASCADE')
+            .index();
+        table.text('lineage_kind').nullable();
+        // foreign key added once ai_thread_message exists
+        table.uuid('parent_message_uuid').nullable().index();
+        table.text('parent_tool_call_id').nullable();
+        table.integer('fork_boundary_seq').nullable();
+    });
+    await knex.raw(`
+        ALTER TABLE ${AiThreadTableName}
+        ADD CONSTRAINT ai_thread_lineage_shape_check CHECK (
+            (lineage_kind IS NULL
+                AND parent_thread_uuid IS NULL
+                AND parent_message_uuid IS NULL
+                AND parent_tool_call_id IS NULL
+                AND fork_boundary_seq IS NULL)
+            OR (lineage_kind = 'spawn'
+                AND parent_thread_uuid IS NOT NULL
+                AND parent_message_uuid IS NOT NULL
+                AND parent_tool_call_id IS NOT NULL
+                AND fork_boundary_seq IS NULL)
+            OR (lineage_kind = 'fork'
+                AND parent_thread_uuid IS NOT NULL
+                AND parent_message_uuid IS NULL
+                AND parent_tool_call_id IS NULL
+                AND fork_boundary_seq IS NOT NULL)
+        )
+    `);
+
+    await knex.schema.createTable(AiThreadMessageSequenceTableName, (table) => {
+        table
+            .uuid('ai_thread_uuid')
+            .primary()
+            .references('ai_thread_uuid')
+            .inTable(AiThreadTableName)
+            .onDelete('CASCADE');
+        table.integer('next_thread_seq').notNullable().defaultTo(1);
+    });
+
+    await knex.schema.createTable(AiThreadMessageTableName, (table) => {
+        table
+            .uuid('ai_thread_message_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_thread_uuid')
+            .notNullable()
+            .references('ai_thread_uuid')
+            .inTable(AiThreadTableName)
+            .onDelete('CASCADE');
+        table.integer('thread_seq').notNullable();
+        table.text('role').notNullable();
+        table
+            .uuid('created_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL')
+            .index();
+        table.text('status').nullable();
+        table.timestamp('last_heartbeat_at', { useTz: false }).nullable();
+        table.jsonb('model_config').nullable();
+        table.jsonb('token_usage').nullable();
+        table.jsonb('error').nullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        // also indexes the ai_thread_uuid foreign key
+        table.unique(['ai_thread_uuid', 'thread_seq']);
+    });
+    await knex.raw(`
+        ALTER TABLE ${AiThreadMessageTableName}
+        ADD CONSTRAINT ai_thread_message_role_status_check
+            CHECK ((role = 'assistant') = (status IS NOT NULL))
+    `);
+
+    await knex.schema.createTable(AiMessagePartTableName, (table) => {
+        table
+            .uuid('ai_message_part_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_thread_message_uuid')
+            .notNullable()
+            .references('ai_thread_message_uuid')
+            .inTable(AiThreadMessageTableName)
+            .onDelete('CASCADE');
+        table.integer('part_index').notNullable();
+        table.text('type').notNullable();
+        table.integer('payload_version').notNullable();
+        table.jsonb('payload').notNullable();
+        table.text('tool_call_id').nullable();
+        table
+            .uuid('ai_artifact_version_uuid')
+            .nullable()
+            .references('ai_artifact_version_uuid')
+            .inTable(AiArtifactVersionsTableName)
+            .onDelete('CASCADE')
+            .index();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        // also indexes the ai_thread_message_uuid foreign key
+        table.unique(['ai_thread_message_uuid', 'part_index']);
+        table.unique(['ai_thread_message_uuid', 'tool_call_id']);
+    });
+    await knex.raw(`
+        ALTER TABLE ${AiMessagePartTableName}
+        ADD CONSTRAINT ai_message_part_tool_call_shape_check
+            CHECK (tool_call_id IS NULL OR type = 'tool'),
+        ADD CONSTRAINT ai_message_part_artifact_version_shape_check
+            CHECK (ai_artifact_version_uuid IS NULL OR type = 'artifact')
+    `);
+
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table
+            .foreign('parent_message_uuid')
+            .references('ai_thread_message_uuid')
+            .inTable(AiThreadMessageTableName)
+            .onDelete('CASCADE');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // dropping the columns also drops their checks, indexes and foreign keys
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table.dropColumns(
+            'storage_version',
+            'parent_thread_uuid',
+            'lineage_kind',
+            'parent_message_uuid',
+            'parent_tool_call_id',
+            'fork_boundary_seq',
+        );
+    });
+    await knex.schema.dropTableIfExists(AiMessagePartTableName);
+    await knex.schema.dropTableIfExists(AiThreadMessageTableName);
+    await knex.schema.dropTableIfExists(AiThreadMessageSequenceTableName);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -34,6 +34,8 @@ import { AiAgentMemoryModel } from './models/AiAgentMemoryModel';
 import { AiAgentModel } from './models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from './models/AiAgentReviewClassifierModel';
 import { AiAgentReviewNotificationModel } from './models/AiAgentReviewNotificationModel';
+import { AiAgentThreadRepository } from './models/AiAgentThreadRepository';
+import { AiAgentV1ReadAdapter } from './models/AiAgentV1ReadAdapter';
 import { AiAgentV3Model } from './models/AiAgentV3Model';
 import { AiDeepResearchRunModel } from './models/AiDeepResearchRunModel';
 import { AiOrganizationSettingsModel } from './models/AiOrganizationSettingsModel';
@@ -1115,6 +1117,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     database,
                     lightdashConfig,
                     encryptionUtil: utils.getEncryptionUtil(),
+                }),
+            aiAgentThreadRepository: ({ database, repository }) =>
+                new AiAgentThreadRepository({
+                    database,
+                    v1ReadAdapter: new AiAgentV1ReadAdapter({ database }),
+                    v3Model: repository.getAiAgentV3Model<AiAgentV3Model>(),
                 }),
             aiAgentV3Model: ({ database }) => new AiAgentV3Model({ database }),
             aiAgentMemoryModel: ({ database }) =>

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -34,6 +34,7 @@ import { AiAgentMemoryModel } from './models/AiAgentMemoryModel';
 import { AiAgentModel } from './models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from './models/AiAgentReviewClassifierModel';
 import { AiAgentReviewNotificationModel } from './models/AiAgentReviewNotificationModel';
+import { AiAgentV3Model } from './models/AiAgentV3Model';
 import { AiDeepResearchRunModel } from './models/AiDeepResearchRunModel';
 import { AiOrganizationSettingsModel } from './models/AiOrganizationSettingsModel';
 import { AiRouterModel } from './models/AiRouterModel';
@@ -1115,6 +1116,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     lightdashConfig,
                     encryptionUtil: utils.getEncryptionUtil(),
                 }),
+            aiAgentV3Model: ({ database }) => new AiAgentV3Model({ database }),
             aiAgentMemoryModel: ({ database }) =>
                 new AiAgentMemoryModel({ database }),
             aiAgentDocumentModel: ({ database }) =>

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -493,6 +493,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     analytics: context.lightdashAnalytics,
                     userModel: models.getUserModel(),
                     aiAgentModel: models.getAiAgentModel(),
+                    aiAgentV3Model: models.getAiAgentV3Model<AiAgentV3Model>(),
+                    aiAgentThreadRepository:
+                        models.getAiAgentThreadRepository<AiAgentThreadRepository>(),
                     aiAgentMemoryModel:
                         models.getAiAgentMemoryModel<AiAgentMemoryModel>(),
                     aiAgentDocumentModel:

--- a/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
@@ -1,4 +1,9 @@
-import { SEED_ORG_1, SEED_ORG_1_ADMIN, SEED_PROJECT } from '@lightdash/common';
+import {
+    AiDuplicateSlackPromptError,
+    SEED_ORG_1,
+    SEED_ORG_1_ADMIN,
+    SEED_PROJECT,
+} from '@lightdash/common';
 import { type Knex } from 'knex';
 import { getModels, getTestContext } from '../../vitest.setup.integration';
 import { AiPromptTableName, AiThreadTableName } from '../database/entities/ai';
@@ -337,5 +342,39 @@ describe('AiAgentModel prompt activity', () => {
         expect(await getThreadUpdatedAt(cloneThreadUuid)).toEqual(
             clonedPrompt?.created_at,
         );
+    });
+
+    it('serializes duplicate v1 Slack prompt delivery', async () => {
+        const suffix = crypto.randomUUID();
+        const threadUuid = await model.createSlackThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            createdFrom: 'slack',
+            slackUserId: 'U123',
+            slackChannelId: `C-${suffix}`,
+            slackThreadTs: `thread-${suffix}`,
+            agentUuid: null,
+        });
+        threadUuids.add(threadUuid);
+        const prompt = {
+            threadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            prompt: 'same event',
+            slackUserId: 'U123',
+            slackChannelId: `C-${suffix}`,
+            promptSlackTs: `prompt-${suffix}`,
+        };
+
+        const results = await Promise.allSettled([
+            model.createSlackPrompt(prompt),
+            model.createSlackPrompt(prompt),
+        ]);
+
+        expect(
+            results.filter(({ status }) => status === 'fulfilled'),
+        ).toHaveLength(1);
+        expect(
+            results.filter((result) => result.status === 'rejected')[0],
+        ).toMatchObject({ reason: expect.any(AiDuplicateSlackPromptError) });
     });
 });

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -6299,7 +6299,7 @@ export class AiAgentModel {
             }
             default:
                 return assertUnreachable(
-                    row.entity_type,
+                    row,
                     `Unknown ai_prompt_context.entity_type`,
                 );
         }

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -85,6 +85,7 @@ import {
     type AgentAsCodeEvaluation,
     type AiAgent,
     type AiAgentIntegration,
+    type AiAgentStorageVersion,
     type AiChartRuntimeOverrides,
     type AiDashboardRuntimeOverrides,
     type VerifiedContentListItem,
@@ -193,6 +194,7 @@ import {
 } from '../database/entities/aiEvals';
 import { type SqlApprovalDecision } from '../services/ai/tools/sqlApprovals';
 import { AiAgentReviewClassifierModel } from './AiAgentReviewClassifierModel';
+import { getAiAgentThreadOwnerExpression } from './aiAgentThreadOwner';
 
 export type AiPromptResponseState = {
     respondedAt: string | null;
@@ -2899,16 +2901,21 @@ export class AiAgentModel {
               projectUuid: string;
               agentUuid: string | null;
               ownerUserUuid: string | null;
+              storageVersion: AiAgentStorageVersion;
           }
         | undefined
     > {
+        const ownerExpression = getAiAgentThreadOwnerExpression({
+            webAppOwner: `${AiWebAppThreadTableName}.user_uuid`,
+            firstPromptOwner: 'first_prompt.created_by_user_uuid',
+        });
         const row = await this.database(AiThreadTableName)
             .joinRaw(
                 `left join lateral (
                     select created_by_user_uuid
                     from ${AiPromptTableName}
                     where ${AiPromptTableName}.ai_thread_uuid = ${AiThreadTableName}.ai_thread_uuid
-                    order by created_at asc
+                    order by created_at asc, ai_prompt_uuid asc
                     limit 1
                 ) as first_prompt on true`,
             )
@@ -2925,14 +2932,14 @@ export class AiAgentModel {
                     project_uuid: string;
                     agent_uuid: string | null;
                     owner_user_uuid: string | null;
+                    storage_version: AiAgentStorageVersion;
                 }[]
             >(
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiThreadTableName}.project_uuid`,
                 `${AiThreadTableName}.agent_uuid`,
-                this.database.raw(
-                    `COALESCE(first_prompt.created_by_user_uuid, ${AiWebAppThreadTableName}.user_uuid) as owner_user_uuid`,
-                ),
+                `${AiThreadTableName}.storage_version`,
+                this.database.raw(`${ownerExpression} as owner_user_uuid`),
             )
             .first();
 
@@ -2942,6 +2949,7 @@ export class AiAgentModel {
             projectUuid: row.project_uuid,
             agentUuid: row.agent_uuid,
             ownerUserUuid: row.owner_user_uuid,
+            storageVersion: row.storage_version,
         };
     }
 

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -30,6 +30,7 @@ import {
     AiAgentUserPreferences,
     AiArtifact,
     AiClonedThreadCreatedFrom,
+    AiDuplicateSlackPromptError,
     AiEvalRunResultAssessment,
     AiMcpCredentialScope,
     AiMcpServer,
@@ -4814,59 +4815,89 @@ export class AiAgentModel {
         );
     }
 
+    // Serialises concurrent deliveries of the same Slack event so redeliveries queue
+    // behind the first writer instead of racing the Slack unique constraints.
+    // Key must stay byte-identical to AiAgentV3Model's — v1 and v3 serialise against each other.
+    private static async lockSlackChannel(
+        trx: Knex.Transaction,
+        slackChannelId: string,
+    ): Promise<void> {
+        await trx.raw('SELECT pg_advisory_xact_lock(hashtext(?))', [
+            slackChannelId,
+        ]);
+    }
+
+    // Callers treat a duplicate Slack prompt as "already answered" and stay silent,
+    // so the raw constraint violation must never escape a Slack write.
+    private static toSlackPromptWriteError(error: unknown): unknown {
+        return isUniqueConstraintViolation(error)
+            ? new AiDuplicateSlackPromptError('Slack prompt already exists')
+            : error;
+    }
+
     async createSlackThread(data: CreateSlackThread) {
-        return this.database.transaction(async (trx) => {
-            const [row] = await trx(AiThreadTableName)
-                .insert({
-                    organization_uuid: data.organizationUuid,
-                    project_uuid: data.projectUuid,
-                    created_from: data.createdFrom,
-                    agent_uuid: data.agentUuid,
-                })
-                .returning('ai_thread_uuid');
-            if (row === undefined) {
-                throw new Error('Failed to create thread');
-            }
-            await trx(AiSlackThreadTableName).insert({
-                ai_thread_uuid: row.ai_thread_uuid,
-                slack_user_id: data.slackUserId,
-                slack_channel_id: data.slackChannelId,
-                slack_thread_ts: data.slackThreadTs,
+        try {
+            return await this.database.transaction(async (trx) => {
+                const [row] = await trx(AiThreadTableName)
+                    .insert({
+                        organization_uuid: data.organizationUuid,
+                        project_uuid: data.projectUuid,
+                        created_from: data.createdFrom,
+                        agent_uuid: data.agentUuid,
+                    })
+                    .returning('ai_thread_uuid');
+                if (row === undefined) {
+                    throw new Error('Failed to create thread');
+                }
+                await trx(AiSlackThreadTableName).insert({
+                    ai_thread_uuid: row.ai_thread_uuid,
+                    slack_user_id: data.slackUserId,
+                    slack_channel_id: data.slackChannelId,
+                    slack_thread_ts: data.slackThreadTs,
+                });
+                return row.ai_thread_uuid;
             });
-            return row.ai_thread_uuid;
-        });
+        } catch (error) {
+            throw AiAgentModel.toSlackPromptWriteError(error);
+        }
     }
 
     async createSlackPrompt(data: CreateSlackPrompt) {
-        return this.database.transaction(async (trx) => {
-            const [row] = await trx(AiPromptTableName)
-                .insert({
-                    ai_thread_uuid: data.threadUuid,
-                    created_by_user_uuid: data.createdByUserUuid,
-                    prompt: data.prompt,
-                    model_config: data.modelConfig,
-                })
-                .returning(['ai_prompt_uuid', 'created_at']);
+        try {
+            return await this.database.transaction(async (trx) => {
+                await AiAgentModel.lockSlackChannel(trx, data.slackChannelId);
 
-            if (row === undefined) {
-                throw new Error('Failed to create prompt');
-            }
+                const [row] = await trx(AiPromptTableName)
+                    .insert({
+                        ai_thread_uuid: data.threadUuid,
+                        created_by_user_uuid: data.createdByUserUuid,
+                        prompt: data.prompt,
+                        model_config: data.modelConfig,
+                    })
+                    .returning(['ai_prompt_uuid', 'created_at']);
 
-            await AiAgentModel.bumpThreadUpdatedAt(
-                data.threadUuid,
-                row.created_at,
-                { trx },
-            );
+                if (row === undefined) {
+                    throw new Error('Failed to create prompt');
+                }
 
-            await trx(AiSlackPromptTableName).insert({
-                ai_prompt_uuid: row.ai_prompt_uuid,
-                slack_user_id: data.slackUserId,
-                slack_channel_id: data.slackChannelId,
-                prompt_slack_ts: data.promptSlackTs,
+                await AiAgentModel.bumpThreadUpdatedAt(
+                    data.threadUuid,
+                    row.created_at,
+                    { trx },
+                );
+
+                await trx(AiSlackPromptTableName).insert({
+                    ai_prompt_uuid: row.ai_prompt_uuid,
+                    slack_user_id: data.slackUserId,
+                    slack_channel_id: data.slackChannelId,
+                    prompt_slack_ts: data.promptSlackTs,
+                });
+
+                return row.ai_prompt_uuid;
             });
-
-            return row.ai_prompt_uuid;
-        });
+        } catch (error) {
+            throw AiAgentModel.toSlackPromptWriteError(error);
+        }
     }
 
     async updateModelResponse(

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -7030,7 +7030,7 @@ export class AiAgentModel {
     async createArtifact(
         data: {
             threadUuid: string;
-            promptUuid: string;
+            promptUuid: string | null;
             artifactType: 'chart' | 'dashboard';
             title?: string;
             description?: string;
@@ -7103,7 +7103,7 @@ export class AiAgentModel {
     async createArtifactVersion(
         data: {
             artifactUuid: string;
-            promptUuid: string;
+            promptUuid: string | null;
             title?: string;
             description?: string;
             vizConfig: Record<string, unknown>;
@@ -7188,7 +7188,7 @@ export class AiAgentModel {
 
     async createOrUpdateArtifact(data: {
         threadUuid: string;
-        promptUuid: string;
+        promptUuid: string | null;
         artifactType: 'chart' | 'dashboard';
         title?: string;
         description?: string;

--- a/packages/backend/src/ee/models/AiAgentThreadRepository.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentThreadRepository.integration.test.ts
@@ -197,4 +197,54 @@ describe('AiAgentThreadRepository', () => {
             ],
         });
     });
+
+    it('rejects conversation mutations through the wrong storage API', async () => {
+        const [legacyThread] = await database(AiThreadTableName)
+            .insert({
+                organization_uuid: SEED_ORG_1.organization_uuid,
+                project_uuid: SEED_PROJECT.project_uuid,
+                agent_uuid: null,
+                created_from: 'web_app',
+            })
+            .returning('ai_thread_uuid');
+        threadUuids.add(legacyThread.ai_thread_uuid);
+        const v3Thread = await v3Model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: null,
+        });
+        threadUuids.add(v3Thread.uuid);
+
+        await expect(
+            repository.assertMutationStorageVersion(
+                legacyThread.ai_thread_uuid,
+                3,
+            ),
+        ).rejects.toMatchObject({
+            name: 'ReadOnlyThreadError',
+            statusCode: 409,
+            data: {
+                threadUuid: legacyThread.ai_thread_uuid,
+                storageVersion: 1,
+            },
+        });
+        await expect(
+            repository.assertMutationStorageVersion(v3Thread.uuid, 1),
+        ).rejects.toMatchObject({
+            name: 'ReadOnlyThreadError',
+            statusCode: 409,
+            data: { threadUuid: v3Thread.uuid, storageVersion: 3 },
+        });
+        await expect(
+            repository.assertMutationStorageVersion(
+                legacyThread.ai_thread_uuid,
+                1,
+            ),
+        ).resolves.toBeUndefined();
+        await expect(
+            repository.assertMutationStorageVersion(v3Thread.uuid, 3),
+        ).resolves.toBeUndefined();
+    });
 });

--- a/packages/backend/src/ee/models/AiAgentThreadRepository.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentThreadRepository.integration.test.ts
@@ -1,0 +1,200 @@
+import { SEED_ORG_1, SEED_ORG_1_ADMIN, SEED_PROJECT } from '@lightdash/common';
+import { type Knex } from 'knex';
+import { getTestContext } from '../../vitest.setup.integration';
+import {
+    AiAgentToolCallTableName,
+    AiAgentToolResultTableName,
+    AiPromptContextTableName,
+    AiPromptSteerTableName,
+    AiPromptTableName,
+    AiThreadTableName,
+} from '../database/entities/ai';
+import { AiAgentThreadRepository } from './AiAgentThreadRepository';
+import { AiAgentV1ReadAdapter } from './AiAgentV1ReadAdapter';
+import { AiAgentV3Model } from './AiAgentV3Model';
+
+describe('AiAgentThreadRepository', () => {
+    let database: Knex;
+    let repository: AiAgentThreadRepository;
+    let v3Model: AiAgentV3Model;
+    const threadUuids = new Set<string>();
+
+    beforeAll(() => {
+        database = getTestContext().db;
+        v3Model = new AiAgentV3Model({ database });
+        repository = new AiAgentThreadRepository({
+            database,
+            v1ReadAdapter: new AiAgentV1ReadAdapter({ database }),
+            v3Model,
+        });
+    });
+
+    afterEach(async () => {
+        if (threadUuids.size > 0) {
+            await database(AiThreadTableName)
+                .whereIn('ai_thread_uuid', [...threadUuids])
+                .delete();
+        }
+        threadUuids.clear();
+    });
+
+    it('reads v1 rows through the adapter and v3 rows natively', async () => {
+        const [legacyThread] = await database(AiThreadTableName)
+            .insert({
+                organization_uuid: SEED_ORG_1.organization_uuid,
+                project_uuid: SEED_PROJECT.project_uuid,
+                agent_uuid: null,
+                created_from: 'web_app',
+            })
+            .returning('ai_thread_uuid');
+        threadUuids.add(legacyThread.ai_thread_uuid);
+        const [prompt] = await database(AiPromptTableName)
+            .insert({
+                ai_thread_uuid: legacyThread.ai_thread_uuid,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                prompt: 'What is revenue?',
+            })
+            .returning('ai_prompt_uuid');
+        await database(AiPromptTableName)
+            .where('ai_prompt_uuid', prompt.ai_prompt_uuid)
+            .update({
+                response: 'Revenue is 42',
+                viz_config_output: { type: 'bar' },
+                filters_output: { dimensions: ['orders.status'] },
+                metric_query: { metrics: ['orders.total'] },
+                human_score: 1,
+                human_feedback: 'Useful answer',
+                responded_at: database.fn.now(),
+            });
+        const [context] = await database(AiPromptContextTableName)
+            .insert({
+                ai_prompt_uuid: prompt.ai_prompt_uuid,
+                entity_type: 'chart',
+                entity_uuid: '00000000-0000-4000-8000-000000000001',
+                display_name: 'Revenue chart',
+            })
+            .returning('ai_prompt_context_uuid');
+        await database(AiAgentToolCallTableName).insert({
+            ai_prompt_uuid: prompt.ai_prompt_uuid,
+            tool_call_id: 'revenue-call',
+            tool_name: 'runQuery',
+            tool_args: { metric: 'revenue' },
+            ai_mcp_server_uuid: null,
+            parent_tool_call_id: null,
+        });
+        await database(AiAgentToolResultTableName).insert({
+            ai_prompt_uuid: prompt.ai_prompt_uuid,
+            tool_call_id: 'revenue-call',
+            tool_name: 'runQuery',
+            result: '42',
+            metadata: { status: 'success' },
+        });
+        await database(AiPromptSteerTableName).insert({
+            ai_prompt_uuid: prompt.ai_prompt_uuid,
+            created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            message: 'Use gross revenue',
+        });
+
+        const legacyRead = await repository.getThread(
+            legacyThread.ai_thread_uuid,
+        );
+
+        expect(legacyRead).toMatchObject({
+            uuid: legacyThread.ai_thread_uuid,
+            storageVersion: 1,
+            messages: [
+                {
+                    role: 'user',
+                    metadata: {
+                        context: [
+                            {
+                                uuid: context.ai_prompt_context_uuid,
+                                entityType: 'chart',
+                                entityUuid:
+                                    '00000000-0000-4000-8000-000000000001',
+                                displayName: 'Revenue chart',
+                            },
+                        ],
+                    },
+                    parts: [
+                        {
+                            type: 'text',
+                            payload: { text: 'What is revenue?' },
+                        },
+                    ],
+                },
+                {
+                    role: 'assistant',
+                    metadata: {
+                        legacy: {
+                            vizConfigOutput: { type: 'bar' },
+                            filtersOutput: {
+                                dimensions: ['orders.status'],
+                            },
+                            metricQuery: { metrics: ['orders.total'] },
+                            humanScore: 1,
+                            humanFeedback: 'Useful answer',
+                        },
+                    },
+                    parts: [
+                        {
+                            type: 'tool',
+                            toolCallId: 'revenue-call',
+                            payload: {
+                                state: 'output-available',
+                                output: '42',
+                            },
+                        },
+                        {
+                            type: 'text',
+                            payload: { text: 'Revenue is 42' },
+                        },
+                    ],
+                },
+                {
+                    role: 'user',
+                    parts: [
+                        {
+                            type: 'text',
+                            payload: { text: 'Use gross revenue' },
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const v3Thread = await v3Model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: null,
+        });
+        threadUuids.add(v3Thread.uuid);
+        await v3Model.appendUserMessage({
+            threadUuid: v3Thread.uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'text',
+                    payloadVersion: 1,
+                    payload: { text: 'Native v3' },
+                },
+            ],
+        });
+
+        await expect(
+            repository.getThread(v3Thread.uuid),
+        ).resolves.toMatchObject({
+            uuid: v3Thread.uuid,
+            storageVersion: 3,
+            messages: [
+                {
+                    role: 'user',
+                    parts: [{ type: 'text', payload: { text: 'Native v3' } }],
+                },
+            ],
+        });
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentThreadRepository.ts
+++ b/packages/backend/src/ee/models/AiAgentThreadRepository.ts
@@ -1,7 +1,10 @@
 import { assertUnreachable, NotFoundError } from '@lightdash/common';
 import { type Knex } from 'knex';
 import { AiThreadTableName } from '../database/entities/ai';
-import { type AiCanonicalThread } from '../database/entities/aiAgentV3';
+import {
+    type AiAgentStorageVersion,
+    type AiCanonicalThread,
+} from '../database/entities/aiAgentV3';
 import { AiAgentV1ReadAdapter } from './AiAgentV1ReadAdapter';
 import { AiAgentV3Model } from './AiAgentV3Model';
 
@@ -45,5 +48,18 @@ export class AiAgentThreadRepository {
                     'Unsupported thread storage version',
                 );
         }
+    }
+
+    async getStorageVersion(
+        threadUuid: string,
+    ): Promise<AiAgentStorageVersion> {
+        const thread = await this.database(AiThreadTableName)
+            .select('storage_version')
+            .where('ai_thread_uuid', threadUuid)
+            .first();
+        if (thread === undefined) {
+            throw new NotFoundError('Thread not found');
+        }
+        return thread.storage_version;
     }
 }

--- a/packages/backend/src/ee/models/AiAgentThreadRepository.ts
+++ b/packages/backend/src/ee/models/AiAgentThreadRepository.ts
@@ -1,12 +1,28 @@
-import { assertUnreachable, NotFoundError } from '@lightdash/common';
+import {
+    assertUnreachable,
+    NotFoundError,
+    ReadOnlyThreadError,
+    type AiAgentV3ThreadSummary,
+} from '@lightdash/common';
 import { type Knex } from 'knex';
-import { AiThreadTableName } from '../database/entities/ai';
+import { UserTableName } from '../../database/entities/users';
+import {
+    AiPromptTableName,
+    AiThreadTableName,
+    AiWebAppThreadTableName,
+} from '../database/entities/ai';
 import {
     type AiAgentStorageVersion,
     type AiCanonicalThread,
 } from '../database/entities/aiAgentV3';
+import { getAiAgentThreadOwnerExpression } from './aiAgentThreadOwner';
 import { AiAgentV1ReadAdapter } from './AiAgentV1ReadAdapter';
 import { AiAgentV3Model } from './AiAgentV3Model';
+
+export type AiAgentThreadHeader = Omit<
+    AiAgentV3ThreadSummary,
+    'readOnly' | 'readOnlyReason'
+>;
 
 export class AiAgentThreadRepository {
     private readonly database: Knex;
@@ -50,6 +66,105 @@ export class AiAgentThreadRepository {
         }
     }
 
+    async listThreadHeaders({
+        organizationUuid,
+        agentUuid,
+        ownerUserUuid,
+    }: {
+        organizationUuid: string;
+        agentUuid: string;
+        ownerUserUuid: string | null;
+    }): Promise<AiAgentThreadHeader[]> {
+        const ownerExpression = getAiAgentThreadOwnerExpression({
+            webAppOwner: `${AiWebAppThreadTableName}.user_uuid`,
+            firstPromptOwner: `(
+                SELECT created_by_user_uuid
+                FROM ${AiPromptTableName}
+                WHERE ${AiPromptTableName}.ai_thread_uuid = ${AiThreadTableName}.ai_thread_uuid
+                ORDER BY created_at, ai_prompt_uuid
+                LIMIT 1
+            )`,
+        });
+        const query = this.database(AiThreadTableName)
+            .leftJoin(
+                AiWebAppThreadTableName,
+                `${AiThreadTableName}.ai_thread_uuid`,
+                `${AiWebAppThreadTableName}.ai_thread_uuid`,
+            )
+            .leftJoin(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                this.database.raw(ownerExpression),
+            )
+            .where(`${AiThreadTableName}.organization_uuid`, organizationUuid)
+            .where(`${AiThreadTableName}.agent_uuid`, agentUuid)
+            .whereIn(`${AiThreadTableName}.created_from`, ['web_app', 'slack'])
+            .where((builder) =>
+                builder
+                    .whereNull(`${AiThreadTableName}.lineage_kind`)
+                    .orWhereNot(`${AiThreadTableName}.lineage_kind`, 'spawn'),
+            )
+            .select<
+                {
+                    ai_thread_uuid: string;
+                    storage_version: AiAgentStorageVersion;
+                    agent_uuid: string;
+                    created_at: Date;
+                    created_from: AiCanonicalThread['createdFrom'];
+                    title: string | null;
+                    owner_user_uuid: string | null;
+                    user_name: string | null;
+                }[]
+            >(
+                `${AiThreadTableName}.ai_thread_uuid`,
+                `${AiThreadTableName}.storage_version`,
+                `${AiThreadTableName}.agent_uuid`,
+                `${AiThreadTableName}.created_at`,
+                `${AiThreadTableName}.created_from`,
+                `${AiThreadTableName}.title`,
+                this.database.raw(`${ownerExpression} AS owner_user_uuid`),
+                this.database.raw(
+                    `NULLIF(TRIM(CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name)), '') AS user_name`,
+                ),
+            )
+            .orderBy(`${AiThreadTableName}.created_at`, 'desc');
+
+        if (ownerUserUuid !== null) {
+            void query.whereRaw(`${ownerExpression} = ?`, [ownerUserUuid]);
+        }
+
+        const rows = await query;
+        const [v1FirstMessages, v3FirstMessages] = await Promise.all([
+            this.v1ReadAdapter.listFirstMessages(
+                rows
+                    .filter((row) => row.storage_version === 1)
+                    .map((row) => row.ai_thread_uuid),
+            ),
+            this.v3Model.listFirstMessages(
+                rows
+                    .filter((row) => row.storage_version === 3)
+                    .map((row) => row.ai_thread_uuid),
+            ),
+        ]);
+        return rows.map((row) => ({
+            uuid: row.ai_thread_uuid,
+            storageVersion: row.storage_version,
+            agentUuid: row.agent_uuid,
+            createdAt: row.created_at.toISOString(),
+            createdFrom: row.created_from,
+            title: row.title,
+            firstMessage:
+                (row.storage_version === 1
+                    ? v1FirstMessages
+                    : v3FirstMessages
+                ).get(row.ai_thread_uuid) ?? null,
+            user: {
+                uuid: row.owner_user_uuid,
+                name: row.user_name ?? 'Unknown user',
+            },
+        }));
+    }
+
     async getStorageVersion(
         threadUuid: string,
     ): Promise<AiAgentStorageVersion> {
@@ -61,5 +176,17 @@ export class AiAgentThreadRepository {
             throw new NotFoundError('Thread not found');
         }
         return thread.storage_version;
+    }
+
+    async assertMutationStorageVersion(
+        threadUuid: string,
+        expectedStorageVersion: AiAgentStorageVersion,
+        knownStorageVersion: AiAgentStorageVersion | null = null,
+    ): Promise<void> {
+        const storageVersion =
+            knownStorageVersion ?? (await this.getStorageVersion(threadUuid));
+        if (storageVersion !== expectedStorageVersion) {
+            throw new ReadOnlyThreadError(threadUuid, storageVersion);
+        }
     }
 }

--- a/packages/backend/src/ee/models/AiAgentThreadRepository.ts
+++ b/packages/backend/src/ee/models/AiAgentThreadRepository.ts
@@ -1,0 +1,49 @@
+import { assertUnreachable, NotFoundError } from '@lightdash/common';
+import { type Knex } from 'knex';
+import { AiThreadTableName } from '../database/entities/ai';
+import { type AiCanonicalThread } from '../database/entities/aiAgentV3';
+import { AiAgentV1ReadAdapter } from './AiAgentV1ReadAdapter';
+import { AiAgentV3Model } from './AiAgentV3Model';
+
+export class AiAgentThreadRepository {
+    private readonly database: Knex;
+
+    private readonly v1ReadAdapter: AiAgentV1ReadAdapter;
+
+    private readonly v3Model: AiAgentV3Model;
+
+    constructor({
+        database,
+        v1ReadAdapter,
+        v3Model,
+    }: {
+        database: Knex;
+        v1ReadAdapter: AiAgentV1ReadAdapter;
+        v3Model: AiAgentV3Model;
+    }) {
+        this.database = database;
+        this.v1ReadAdapter = v1ReadAdapter;
+        this.v3Model = v3Model;
+    }
+
+    async getThread(threadUuid: string): Promise<AiCanonicalThread> {
+        const thread = await this.database(AiThreadTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .first();
+        if (thread === undefined) {
+            throw new NotFoundError('Thread not found');
+        }
+
+        switch (thread.storage_version) {
+            case 1:
+                return this.v1ReadAdapter.getThread(thread);
+            case 3:
+                return this.v3Model.getThreadFromRow(thread);
+            default:
+                return assertUnreachable(
+                    thread.storage_version,
+                    'Unsupported thread storage version',
+                );
+        }
+    }
+}

--- a/packages/backend/src/ee/models/AiAgentV1ReadAdapter.test.ts
+++ b/packages/backend/src/ee/models/AiAgentV1ReadAdapter.test.ts
@@ -1,0 +1,581 @@
+import { projectV1Thread, type V1ThreadRows } from './AiAgentV1ReadAdapter';
+
+const threadUuid = '00000000-0000-4000-8000-000000000001';
+const promptUuid = '00000000-0000-4000-8000-000000000002';
+
+describe('projectV1Thread', () => {
+    it('projects a legacy turn into deterministic canonical messages', () => {
+        const rows: V1ThreadRows = {
+            thread: {
+                ai_thread_uuid: threadUuid,
+                organization_uuid: '00000000-0000-4000-8000-000000000003',
+                project_uuid: '00000000-0000-4000-8000-000000000004',
+                agent_uuid: null,
+                created_at: new Date('2026-01-01T00:00:00.000Z'),
+                updated_at: new Date('2026-01-01T00:00:09.000Z'),
+                created_from: 'web_app',
+                title: 'Revenue thread',
+                storage_version: 1,
+            },
+            prompts: [
+                {
+                    ai_prompt_uuid: promptUuid,
+                    created_at: new Date('2026-01-01T00:00:01.000Z'),
+                    created_by_user_uuid:
+                        '00000000-0000-4000-8000-000000000005',
+                    prompt: 'Show revenue',
+                    response: 'Revenue is 42',
+                    error_message: null,
+                    responded_at: new Date('2026-01-01T00:00:09.000Z'),
+                    model_config: {
+                        modelName: 'claude-sonnet-4-5',
+                        modelProvider: 'anthropic',
+                    },
+                    token_usage: { totalTokens: 12 },
+                    viz_config_output: { type: 'bar' },
+                    filters_output: { dimensions: ['orders.status'] },
+                    metric_query: { metrics: ['orders.total'] },
+                    saved_query_uuid: '00000000-0000-4000-8000-000000000006',
+                    human_score: 1,
+                    human_feedback: 'Useful answer',
+                    hidden: false,
+                },
+            ],
+            reasonings: [
+                {
+                    ai_agent_reasoning_uuid:
+                        '00000000-0000-4000-8000-000000000012',
+                    ai_prompt_uuid: promptUuid,
+                    reasoning_id: 'reasoning-1',
+                    text: 'I should query orders',
+                    created_at: new Date('2026-01-01T00:00:02.000Z'),
+                },
+            ],
+            toolCalls: [
+                {
+                    ai_agent_tool_call_uuid:
+                        '00000000-0000-4000-8000-000000000011',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'call-success',
+                    tool_name: 'runQuery',
+                    tool_args: { metric: 'revenue' },
+                    parent_tool_call_id: null,
+                    ai_mcp_server_uuid: '00000000-0000-4000-8000-000000000007',
+                    created_at: new Date('2026-01-01T00:00:02.000Z'),
+                },
+                {
+                    ai_agent_tool_call_uuid:
+                        '00000000-0000-4000-8000-000000000014',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'call-error',
+                    tool_name: 'runSql',
+                    tool_args: { sql: 'bad sql' },
+                    parent_tool_call_id: null,
+                    ai_mcp_server_uuid: null,
+                    created_at: new Date('2026-01-01T00:00:04.000Z'),
+                },
+            ],
+            toolResults: [
+                {
+                    ai_agent_tool_result_uuid:
+                        '00000000-0000-4000-8000-000000000023',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'call-success',
+                    tool_name: 'runQuery',
+                    result: '{"rows":[{"revenue":43}]}',
+                    metadata: { status: 'success' },
+                    created_at: new Date('2026-01-01T00:00:03.500Z'),
+                },
+                {
+                    ai_agent_tool_result_uuid:
+                        '00000000-0000-4000-8000-000000000021',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'call-success',
+                    tool_name: 'runQuery',
+                    result: '{"rows":[{"revenue":42}]}',
+                    metadata: { status: 'success' },
+                    created_at: new Date('2026-01-01T00:00:03.000Z'),
+                },
+                {
+                    ai_agent_tool_result_uuid:
+                        '00000000-0000-4000-8000-000000000022',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'call-error',
+                    tool_name: 'runSql',
+                    result: 'syntax error',
+                    metadata: { status: 'error', errorCode: 'invalid_sql' },
+                    created_at: new Date('2026-01-01T00:00:05.000Z'),
+                },
+                {
+                    ai_agent_tool_result_uuid:
+                        '00000000-0000-4000-8000-000000000024',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'orphan-result',
+                    tool_name: 'legacyTool',
+                    result: 'orphan output',
+                    metadata: { status: 'success' },
+                    created_at: new Date('2026-01-01T00:00:05.500Z'),
+                },
+            ],
+            toolCallErrors: [
+                {
+                    ai_agent_tool_call_error_uuid:
+                        '00000000-0000-4000-8000-000000000013',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'invalid-call',
+                    tool_name: 'runSql',
+                    error_message: 'Invalid tool input',
+                    raw_args: '{"sql":',
+                    created_at: new Date('2026-01-01T00:00:03.000Z'),
+                },
+            ],
+            steers: [
+                {
+                    ai_prompt_steer_uuid:
+                        '00000000-0000-4000-8000-000000000031',
+                    ai_prompt_uuid: promptUuid,
+                    created_by_user_uuid:
+                        '00000000-0000-4000-8000-000000000005',
+                    message: 'Use gross revenue',
+                    created_at: new Date('2026-01-01T00:00:06.000Z'),
+                    consumed_at: new Date('2026-01-01T00:00:06.500Z'),
+                    consumed_step: 2,
+                },
+            ],
+            interrupts: [],
+            artifacts: [
+                {
+                    ai_artifact_version_uuid:
+                        '00000000-0000-4000-8000-000000000041',
+                    ai_artifact_uuid: '00000000-0000-4000-8000-000000000042',
+                    ai_prompt_uuid: promptUuid,
+                    version_number: 1,
+                    title: 'Revenue chart',
+                    description: null,
+                    artifact_type: 'chart' as const,
+                    created_at: new Date('2026-01-01T00:00:07.000Z'),
+                },
+            ],
+            contexts: [
+                {
+                    ai_prompt_context_uuid:
+                        '00000000-0000-4000-8000-000000000051',
+                    ai_prompt_uuid: promptUuid,
+                    entity_type: 'chart',
+                    entity_uuid: '00000000-0000-4000-8000-000000000052',
+                    entity_ref: null,
+                    pinned_version_uuid: '00000000-0000-4000-8000-000000000053',
+                    display_name: 'Revenue chart',
+                    runtime_overrides: {},
+                    created_at: new Date('2026-01-01T00:00:08.000Z'),
+                },
+            ],
+            referencedArtifacts: [
+                {
+                    ai_prompt_uuid: promptUuid,
+                    ai_artifact_version_uuid:
+                        '00000000-0000-4000-8000-000000000061',
+                    ai_artifact_uuid: '00000000-0000-4000-8000-000000000062',
+                    project_uuid: '00000000-0000-4000-8000-000000000004',
+                    similarity_score: 0.9,
+                    version_number: 2,
+                    title: 'Prior revenue chart',
+                    description: 'Referenced input',
+                    artifact_type: 'chart',
+                    created_at: new Date('2026-01-01T00:00:00.500Z'),
+                },
+            ],
+        };
+
+        const first = projectV1Thread(rows);
+        const second = projectV1Thread({
+            ...rows,
+            toolCalls: [...rows.toolCalls].reverse(),
+            toolResults: [...rows.toolResults].reverse(),
+            toolCallErrors: [...rows.toolCallErrors].reverse(),
+        });
+
+        expect(second).toEqual(first);
+        expect(() =>
+            projectV1Thread({
+                ...rows,
+                thread: { ...rows.thread, storage_version: 3 },
+            }),
+        ).toThrow('Thread is not storage version 1');
+        expect(first).toMatchObject({
+            uuid: threadUuid,
+            storageVersion: 1,
+            createdFrom: 'web_app',
+            title: 'Revenue thread',
+            updatedAt: '2026-01-01T00:00:09.000Z',
+            messages: [
+                {
+                    uuid: promptUuid,
+                    role: 'user',
+                    parts: [
+                        { type: 'text', payload: { text: 'Show revenue' } },
+                    ],
+                    metadata: {
+                        hidden: false,
+                        context: [
+                            {
+                                uuid: '00000000-0000-4000-8000-000000000051',
+                                entityType: 'chart',
+                                entityUuid:
+                                    '00000000-0000-4000-8000-000000000052',
+                                entityRef: null,
+                                pinnedVersionUuid:
+                                    '00000000-0000-4000-8000-000000000053',
+                                displayName: 'Revenue chart',
+                                runtimeOverrides: {},
+                                createdAt: '2026-01-01T00:00:08.000Z',
+                            },
+                        ],
+                    },
+                },
+                {
+                    role: 'assistant',
+                    metadata: {
+                        status: 'completed',
+                        hidden: false,
+                        legacy: {
+                            vizConfigOutput: { type: 'bar' },
+                            filtersOutput: {
+                                dimensions: ['orders.status'],
+                            },
+                            metricQuery: { metrics: ['orders.total'] },
+                            savedQueryUuid:
+                                '00000000-0000-4000-8000-000000000006',
+                            humanScore: 1,
+                            humanFeedback: 'Useful answer',
+                            referencedArtifacts: [
+                                {
+                                    artifactVersionUuid:
+                                        '00000000-0000-4000-8000-000000000061',
+                                    artifactUuid:
+                                        '00000000-0000-4000-8000-000000000062',
+                                    projectUuid:
+                                        '00000000-0000-4000-8000-000000000004',
+                                    similarityScore: 0.9,
+                                    versionNumber: 2,
+                                    title: 'Prior revenue chart',
+                                    description: 'Referenced input',
+                                    artifactType: 'chart',
+                                    createdAt: '2026-01-01T00:00:00.500Z',
+                                },
+                            ],
+                        },
+                    },
+                    parts: [
+                        {
+                            uuid: '00000000-0000-4000-8000-000000000011',
+                            type: 'tool',
+                            toolCallId: 'call-success',
+                            payload: {
+                                state: 'output-available',
+                                toolName: 'runQuery',
+                                input: { metric: 'revenue' },
+                                output: '{"rows":[{"revenue":43}]}',
+                                metadata: { status: 'success' },
+                                mcpServerUuid:
+                                    '00000000-0000-4000-8000-000000000007',
+                                legacyResults: [
+                                    {
+                                        uuid: '00000000-0000-4000-8000-000000000021',
+                                        result: '{"rows":[{"revenue":42}]}',
+                                    },
+                                    {
+                                        uuid: '00000000-0000-4000-8000-000000000023',
+                                        result: '{"rows":[{"revenue":43}]}',
+                                    },
+                                ],
+                            },
+                        },
+                        {
+                            uuid: '00000000-0000-4000-8000-000000000012',
+                            type: 'reasoning',
+                            payload: {
+                                reasoningId: 'reasoning-1',
+                                text: 'I should query orders',
+                            },
+                        },
+                        {
+                            uuid: '00000000-0000-4000-8000-000000000013',
+                            type: 'tool',
+                            toolCallId: 'invalid-call',
+                            payload: {
+                                state: 'output-error',
+                                toolName: 'runSql',
+                                input: '{"sql":',
+                                errorText: 'Invalid tool input',
+                            },
+                        },
+                        {
+                            uuid: '00000000-0000-4000-8000-000000000014',
+                            type: 'tool',
+                            toolCallId: 'call-error',
+                            payload: {
+                                state: 'output-error',
+                                toolName: 'runSql',
+                                input: { sql: 'bad sql' },
+                                errorText: 'syntax error',
+                                metadata: {
+                                    status: 'error',
+                                    errorCode: 'invalid_sql',
+                                },
+                            },
+                        },
+                        {
+                            uuid: '00000000-0000-4000-8000-000000000024',
+                            type: 'tool',
+                            toolCallId: 'orphan-result',
+                            payload: {
+                                state: 'output-available',
+                                toolName: 'legacyTool',
+                                input: null,
+                                output: 'orphan output',
+                                metadata: { status: 'success' },
+                                legacyResultUuid:
+                                    '00000000-0000-4000-8000-000000000024',
+                            },
+                        },
+                        { type: 'text', payload: { text: 'Revenue is 42' } },
+                        {
+                            uuid: '00000000-0000-4000-8000-000000000041',
+                            type: 'artifact',
+                            artifactVersionUuid:
+                                '00000000-0000-4000-8000-000000000041',
+                        },
+                    ],
+                },
+                {
+                    uuid: '00000000-0000-4000-8000-000000000031',
+                    role: 'user',
+                    metadata: {
+                        legacy: {
+                            type: 'steer',
+                            consumedAt: '2026-01-01T00:00:06.500Z',
+                            consumedStep: 2,
+                        },
+                    },
+                    parts: [
+                        {
+                            type: 'text',
+                            payload: { text: 'Use gross revenue' },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('projects active, failed, canceled, and hidden legacy turns', () => {
+        const activePromptUuid = '00000000-0000-4000-8000-000000000061';
+        const failedPromptUuid = '00000000-0000-4000-8000-000000000062';
+        const canceledPromptUuid = '00000000-0000-4000-8000-000000000063';
+        const hiddenPromptUuid = '00000000-0000-4000-8000-000000000064';
+        const prompt = (
+            uuid: string,
+            createdAt: string,
+            overrides: Record<string, unknown> = {},
+        ) => ({
+            ai_prompt_uuid: uuid,
+            created_at: new Date(createdAt),
+            created_by_user_uuid: '00000000-0000-4000-8000-000000000005',
+            prompt: uuid,
+            response: null,
+            error_message: null,
+            responded_at: null,
+            model_config: null,
+            token_usage: null,
+            viz_config_output: null,
+            filters_output: null,
+            metric_query: null,
+            saved_query_uuid: null,
+            human_score: null,
+            human_feedback: null,
+            hidden: false,
+            ...overrides,
+        });
+        const rows: V1ThreadRows = {
+            thread: {
+                ai_thread_uuid: threadUuid,
+                organization_uuid: '00000000-0000-4000-8000-000000000003',
+                project_uuid: '00000000-0000-4000-8000-000000000004',
+                agent_uuid: null,
+                created_at: new Date('2026-01-01T00:00:00.000Z'),
+                updated_at: null,
+                created_from: 'web_app',
+                title: null,
+                storage_version: 1,
+            },
+            prompts: [
+                prompt(activePromptUuid, '2026-01-01T00:00:01.000Z'),
+                prompt(failedPromptUuid, '2026-01-01T00:00:02.000Z', {
+                    error_message: 'Provider failed',
+                }),
+                prompt(canceledPromptUuid, '2026-01-01T00:00:03.000Z', {
+                    error_message: 'Interrupted provider call',
+                }),
+                prompt(hiddenPromptUuid, '2026-01-01T00:00:04.000Z', {
+                    response: 'Hidden response',
+                    responded_at: new Date('2026-01-01T00:00:05.000Z'),
+                    hidden: true,
+                }),
+            ],
+            reasonings: [],
+            toolCalls: [
+                {
+                    ai_agent_tool_call_uuid:
+                        '00000000-0000-4000-8000-000000000071',
+                    ai_prompt_uuid: activePromptUuid,
+                    tool_call_id: 'unfinished-call',
+                    tool_name: 'runSql',
+                    tool_args: { sql: 'select 1' },
+                    parent_tool_call_id: null,
+                    ai_mcp_server_uuid: null,
+                    created_at: new Date('2026-01-01T00:00:01.250Z'),
+                },
+                {
+                    ai_agent_tool_call_uuid:
+                        '00000000-0000-4000-8000-000000000065',
+                    ai_prompt_uuid: activePromptUuid,
+                    tool_call_id: 'unfinished-call',
+                    tool_name: 'runSql',
+                    tool_args: { sql: 'select 1' },
+                    parent_tool_call_id: null,
+                    ai_mcp_server_uuid: null,
+                    created_at: new Date('2026-01-01T00:00:01.500Z'),
+                },
+            ],
+            toolResults: [],
+            toolCallErrors: [
+                {
+                    ai_agent_tool_call_error_uuid:
+                        '00000000-0000-4000-8000-000000000069',
+                    ai_prompt_uuid: failedPromptUuid,
+                    tool_call_id: 'duplicate-invalid-call',
+                    tool_name: 'runSql',
+                    error_message: 'First invalid call',
+                    raw_args: '{}',
+                    created_at: new Date('2026-01-01T00:00:02.250Z'),
+                },
+                {
+                    ai_agent_tool_call_error_uuid:
+                        '00000000-0000-4000-8000-000000000070',
+                    ai_prompt_uuid: failedPromptUuid,
+                    tool_call_id: 'duplicate-invalid-call',
+                    tool_name: 'runSql',
+                    error_message: 'Second invalid call',
+                    raw_args: '{}',
+                    created_at: new Date('2026-01-01T00:00:02.500Z'),
+                },
+            ],
+            steers: [
+                {
+                    ai_prompt_steer_uuid:
+                        '00000000-0000-4000-8000-000000000066',
+                    ai_prompt_uuid: hiddenPromptUuid,
+                    created_by_user_uuid:
+                        '00000000-0000-4000-8000-000000000005',
+                    message: 'Hidden steer',
+                    created_at: new Date('2026-01-01T00:00:04.500Z'),
+                    consumed_at: null,
+                    consumed_step: null,
+                },
+            ],
+            interrupts: [
+                {
+                    ai_prompt_interrupt_uuid:
+                        '00000000-0000-4000-8000-000000000067',
+                    ai_prompt_uuid: canceledPromptUuid,
+                    created_by_user_uuid:
+                        '00000000-0000-4000-8000-000000000005',
+                    created_at: new Date('2026-01-01T00:00:03.500Z'),
+                },
+                {
+                    ai_prompt_interrupt_uuid:
+                        '00000000-0000-4000-8000-000000000068',
+                    ai_prompt_uuid: canceledPromptUuid,
+                    created_by_user_uuid: null,
+                    created_at: new Date('2026-01-01T00:00:03.750Z'),
+                },
+            ],
+            artifacts: [],
+            contexts: [],
+            referencedArtifacts: [],
+        };
+        const projected = projectV1Thread(rows);
+        const assistantFor = (uuid: string) => {
+            const userIndex = projected.messages.findIndex(
+                (message) => message.uuid === uuid,
+            );
+            return projected.messages[userIndex + 1];
+        };
+
+        expect(assistantFor(activePromptUuid)).toMatchObject({
+            metadata: { status: 'in_progress', error: null },
+            parts: [
+                {
+                    type: 'tool',
+                    payload: {
+                        state: 'input-available',
+                        input: { sql: 'select 1' },
+                    },
+                },
+                {
+                    type: 'tool',
+                    payload: {
+                        state: 'input-available',
+                        input: { sql: 'select 1' },
+                    },
+                },
+            ],
+        });
+        expect(assistantFor(failedPromptUuid)).toMatchObject({
+            metadata: {
+                status: 'error',
+                error: { name: 'legacy_error', message: 'Provider failed' },
+            },
+        });
+        const failedToolCallIds = assistantFor(failedPromptUuid)
+            .parts.filter((part) => part.type === 'tool')
+            .map((part) => part.toolCallId);
+        expect(new Set(failedToolCallIds).size).toBe(failedToolCallIds.length);
+        expect(assistantFor(canceledPromptUuid)).toMatchObject({
+            metadata: {
+                status: 'canceled',
+                error: null,
+                legacy: {
+                    interrupts: [
+                        {
+                            createdByUserUuid:
+                                '00000000-0000-4000-8000-000000000005',
+                            createdAt: '2026-01-01T00:00:03.500Z',
+                        },
+                        {
+                            createdByUserUuid: null,
+                            createdAt: '2026-01-01T00:00:03.750Z',
+                        },
+                    ],
+                },
+            },
+        });
+        expect(assistantFor(hiddenPromptUuid)).toMatchObject({
+            metadata: { hidden: false },
+        });
+        expect(
+            projected.messages.find(
+                (message) =>
+                    message.uuid === '00000000-0000-4000-8000-000000000066',
+            ),
+        ).toMatchObject({ metadata: { hidden: true } });
+        expect(
+            projectV1Thread({
+                ...rows,
+                toolCalls: [...rows.toolCalls].reverse(),
+                toolCallErrors: [...rows.toolCallErrors].reverse(),
+            }),
+        ).toEqual(projected);
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentV1ReadAdapter.ts
+++ b/packages/backend/src/ee/models/AiAgentV1ReadAdapter.ts
@@ -1,0 +1,809 @@
+import { ConflictError } from '@lightdash/common';
+import { type Knex } from 'knex';
+import { v5 as uuidv5 } from 'uuid';
+import {
+    AiAgentReasoningTableName,
+    type DbAiAgentReasoning,
+} from '../../database/entities/aiAgentReasoning';
+import {
+    AiAgentToolCallErrorTableName,
+    AiAgentToolCallTableName,
+    AiAgentToolResultTableName,
+    AiPromptContextTableName,
+    AiPromptInterruptTableName,
+    AiPromptSteerTableName,
+    AiPromptTableName,
+    isAiAgentToolResultError,
+    type DbAiAgentToolCall,
+    type DbAiAgentToolCallError,
+    type DbAiAgentToolResult,
+    type DbAiPrompt,
+    type DbAiPromptContext,
+    type DbAiPromptInterrupt,
+    type DbAiPromptSteer,
+    type DbAiThread,
+} from '../database/entities/ai';
+import {
+    type AiAssistantMessageStatus,
+    type AiCanonicalContext,
+    type AiCanonicalMessage,
+    type AiCanonicalPart,
+    type AiCanonicalThread,
+} from '../database/entities/aiAgentV3';
+import {
+    AiArtifactsTableName,
+    AiArtifactVersionsTableName,
+    AiPromptArtifactReferencesTableName,
+    type DbAiArtifact,
+    type DbAiArtifactVersion,
+    type DbAiPromptArtifactReference,
+} from '../database/entities/aiArtifacts';
+
+const V1_READ_ADAPTER_NAMESPACE = '8858350c-5ca8-4ad6-bfa8-43b4f8d04ad7';
+
+type V1Prompt = Pick<
+    DbAiPrompt,
+    | 'ai_prompt_uuid'
+    | 'created_at'
+    | 'created_by_user_uuid'
+    | 'prompt'
+    | 'response'
+    | 'error_message'
+    | 'responded_at'
+    | 'model_config'
+    | 'token_usage'
+    | 'viz_config_output'
+    | 'filters_output'
+    | 'metric_query'
+    | 'saved_query_uuid'
+    | 'human_score'
+    | 'human_feedback'
+    | 'hidden'
+>;
+
+type V1Artifact = Pick<
+    DbAiArtifactVersion,
+    | 'ai_artifact_version_uuid'
+    | 'ai_artifact_uuid'
+    | 'ai_prompt_uuid'
+    | 'created_at'
+    | 'version_number'
+    | 'title'
+    | 'description'
+> &
+    Pick<DbAiArtifact, 'artifact_type'>;
+
+type V1ReferencedArtifact = Pick<
+    DbAiPromptArtifactReference,
+    | 'ai_prompt_uuid'
+    | 'ai_artifact_version_uuid'
+    | 'project_uuid'
+    | 'similarity_score'
+    | 'created_at'
+> &
+    Pick<
+        DbAiArtifactVersion,
+        'ai_artifact_uuid' | 'version_number' | 'title' | 'description'
+    > &
+    Pick<DbAiArtifact, 'artifact_type'>;
+
+export type V1ThreadRows = {
+    thread: Pick<
+        DbAiThread,
+        | 'ai_thread_uuid'
+        | 'organization_uuid'
+        | 'project_uuid'
+        | 'agent_uuid'
+        | 'created_at'
+        | 'updated_at'
+        | 'created_from'
+        | 'title'
+        | 'storage_version'
+    >;
+    prompts: V1Prompt[];
+    reasonings: DbAiAgentReasoning[];
+    toolCalls: DbAiAgentToolCall[];
+    toolResults: DbAiAgentToolResult[];
+    toolCallErrors: DbAiAgentToolCallError[];
+    steers: Array<
+        Pick<
+            DbAiPromptSteer,
+            | 'ai_prompt_steer_uuid'
+            | 'ai_prompt_uuid'
+            | 'created_by_user_uuid'
+            | 'message'
+            | 'created_at'
+            | 'consumed_at'
+            | 'consumed_step'
+        >
+    >;
+    interrupts: Array<
+        Pick<
+            DbAiPromptInterrupt,
+            | 'ai_prompt_interrupt_uuid'
+            | 'ai_prompt_uuid'
+            | 'created_by_user_uuid'
+            | 'created_at'
+        >
+    >;
+    artifacts: V1Artifact[];
+    contexts: DbAiPromptContext[];
+    referencedArtifacts: V1ReferencedArtifact[];
+};
+
+type V1AssistantRows = Pick<
+    V1ThreadRows,
+    'toolCalls' | 'toolResults' | 'toolCallErrors' | 'reasonings' | 'artifacts'
+>;
+
+type OrderedPart = {
+    createdAt: Date;
+    uuid: string;
+    part: AiCanonicalPart;
+};
+
+const syntheticUuid = (kind: string, sourceUuid: string) =>
+    uuidv5(`${kind}:${sourceUuid}`, V1_READ_ADAPTER_NAMESPACE);
+
+const byDateAndUuid =
+    <T>(getDate: (row: T) => Date, getUuid: (row: T) => string) =>
+    (left: T, right: T) =>
+        getDate(left).getTime() - getDate(right).getTime() ||
+        (getUuid(left) < getUuid(right)
+            ? -1
+            : Number(getUuid(left) > getUuid(right)));
+
+const sortedByDateAndUuid = <T>(
+    rows: T[],
+    getDate: (row: T) => Date,
+    getUuid: (row: T) => string,
+) => [...rows].sort(byDateAndUuid(getDate, getUuid));
+
+const assertV1Storage = (thread: V1ThreadRows['thread']) => {
+    if (thread.storage_version !== 1) {
+        throw new ConflictError('Thread is not storage version 1');
+    }
+};
+
+const groupByPromptUuid = <T extends { ai_prompt_uuid: string | null }>(
+    rows: T[],
+) => {
+    const grouped = new Map<string, T[]>();
+    rows.forEach((row) => {
+        if (row.ai_prompt_uuid === null) return;
+        const promptRows = grouped.get(row.ai_prompt_uuid) ?? [];
+        promptRows.push(row);
+        grouped.set(row.ai_prompt_uuid, promptRows);
+    });
+    return grouped;
+};
+
+const toCanonicalContext = (context: DbAiPromptContext): AiCanonicalContext => {
+    const base = {
+        uuid: context.ai_prompt_context_uuid,
+        entityUuid: context.entity_uuid,
+        entityRef: context.entity_ref,
+        pinnedVersionUuid: context.pinned_version_uuid,
+        displayName: context.display_name,
+        createdAt: context.created_at.toISOString(),
+    };
+    switch (context.entity_type) {
+        case 'chart':
+            return {
+                ...base,
+                entityType: context.entity_type,
+                runtimeOverrides: context.runtime_overrides,
+            };
+        case 'dashboard':
+            return {
+                ...base,
+                entityType: context.entity_type,
+                runtimeOverrides: context.runtime_overrides,
+            };
+        default:
+            return {
+                ...base,
+                entityType: context.entity_type,
+                runtimeOverrides: null,
+            };
+    }
+};
+
+const getPromptStatus = ({
+    prompt,
+    interrupted,
+}: {
+    prompt: V1Prompt;
+    interrupted: boolean;
+}): AiAssistantMessageStatus => {
+    if (interrupted) return 'canceled';
+    if (prompt.error_message !== null) return 'error';
+    if (prompt.response === null || prompt.responded_at === null) {
+        return 'in_progress';
+    }
+    return 'completed';
+};
+
+const canonicalPart = (
+    uuid: string,
+    type: AiCanonicalPart['type'],
+    payload: Record<string, unknown>,
+    attributes: Pick<AiCanonicalPart, 'toolCallId' | 'artifactVersionUuid'> = {
+        toolCallId: null,
+        artifactVersionUuid: null,
+    },
+): AiCanonicalPart => ({
+    uuid,
+    type,
+    payloadVersion: 1,
+    payload,
+    ...attributes,
+});
+
+const baseMetadata = ({
+    createdAt,
+    createdByUserUuid,
+    hidden,
+}: {
+    createdAt: Date;
+    createdByUserUuid: string | null;
+    hidden: boolean;
+}): AiCanonicalMessage['metadata'] => ({
+    createdAt: createdAt.toISOString(),
+    createdByUserUuid,
+    status: null,
+    lastHeartbeatAt: null,
+    modelConfig: null,
+    tokenUsage: null,
+    error: null,
+    hidden,
+    context: [],
+    legacy: null,
+});
+
+const projectAssistantParts = (
+    rows: V1AssistantRows,
+    prompt: V1Prompt,
+    status: AiAssistantMessageStatus,
+): AiCanonicalPart[] => {
+    const sortedResults = sortedByDateAndUuid(
+        rows.toolResults,
+        (result) => result.created_at,
+        (result) => result.ai_agent_tool_result_uuid,
+    );
+    const resultsByCallId = new Map<string, DbAiAgentToolResult[]>();
+    sortedResults.forEach((result) => {
+        const results = resultsByCallId.get(result.tool_call_id) ?? [];
+        results.push(result);
+        resultsByCallId.set(result.tool_call_id, results);
+    });
+    const ordered: OrderedPart[] = [];
+    const sortedToolCalls = sortedByDateAndUuid(
+        rows.toolCalls,
+        (call) => call.created_at,
+        (call) => call.ai_agent_tool_call_uuid,
+    );
+    const persistedToolCallIds = new Set(
+        sortedToolCalls.map((call) => call.tool_call_id),
+    );
+    const claimedToolCallIds = new Set<string>();
+    // Canonical tool call IDs stay unique even when legacy rows collide.
+    const uniqueToolCallId = (toolCallId: string, sourceUuid: string) => {
+        if (!claimedToolCallIds.has(toolCallId)) {
+            claimedToolCallIds.add(toolCallId);
+            return toolCallId;
+        }
+        const uniqueId = syntheticUuid('legacy-tool-call-id', sourceUuid);
+        claimedToolCallIds.add(uniqueId);
+        return uniqueId;
+    };
+    const toLegacyResult = (result: DbAiAgentToolResult) => ({
+        uuid: result.ai_agent_tool_result_uuid,
+        toolName: result.tool_name,
+        result: result.result,
+        metadata: result.metadata,
+        createdAt: result.created_at.toISOString(),
+    });
+
+    sortedToolCalls.forEach((call) => {
+        const results = resultsByCallId.get(call.tool_call_id) ?? [];
+        // The latest row is the terminal view; legacyResults preserves all rows.
+        const result = results.at(-1);
+        const resultIsError = isAiAgentToolResultError(
+            result?.metadata ?? null,
+        );
+        const basePayload = {
+            toolName: call.tool_name,
+            input: call.tool_args,
+            parentToolCallId: call.parent_tool_call_id,
+            mcpServerUuid: call.ai_mcp_server_uuid,
+            legacyResults: results.map(toLegacyResult),
+        };
+        let payload: Record<string, unknown>;
+        if (result === undefined) {
+            payload =
+                status === 'in_progress'
+                    ? {
+                          ...basePayload,
+                          state: 'input-available',
+                      }
+                    : {
+                          ...basePayload,
+                          state: 'output-error',
+                          errorText: 'Tool execution did not complete',
+                      };
+        } else if (resultIsError) {
+            payload = {
+                ...basePayload,
+                state: 'output-error',
+                errorText: result.result,
+                metadata: result.metadata,
+            };
+        } else {
+            payload = {
+                ...basePayload,
+                state: 'output-available',
+                output: result.result,
+                metadata: result.metadata,
+            };
+        }
+        ordered.push({
+            createdAt: call.created_at,
+            uuid: call.ai_agent_tool_call_uuid,
+            part: canonicalPart(call.ai_agent_tool_call_uuid, 'tool', payload, {
+                toolCallId: uniqueToolCallId(
+                    call.tool_call_id,
+                    call.ai_agent_tool_call_uuid,
+                ),
+                artifactVersionUuid: null,
+            }),
+        });
+    });
+
+    sortedResults
+        .filter((result) => !persistedToolCallIds.has(result.tool_call_id))
+        .forEach((result) => {
+            const resultIsError = isAiAgentToolResultError(result.metadata);
+            ordered.push({
+                createdAt: result.created_at,
+                uuid: result.ai_agent_tool_result_uuid,
+                part: canonicalPart(
+                    result.ai_agent_tool_result_uuid,
+                    'tool',
+                    {
+                        state: resultIsError
+                            ? 'output-error'
+                            : 'output-available',
+                        toolName: result.tool_name,
+                        input: null,
+                        ...(resultIsError
+                            ? { errorText: result.result }
+                            : { output: result.result }),
+                        metadata: result.metadata,
+                        legacyResultUuid: result.ai_agent_tool_result_uuid,
+                    },
+                    {
+                        toolCallId: uniqueToolCallId(
+                            result.tool_call_id,
+                            result.ai_agent_tool_result_uuid,
+                        ),
+                        artifactVersionUuid: null,
+                    },
+                ),
+            });
+        });
+
+    rows.reasonings.forEach((reasoning) => {
+        ordered.push({
+            createdAt: reasoning.created_at,
+            uuid: reasoning.ai_agent_reasoning_uuid,
+            part: canonicalPart(
+                reasoning.ai_agent_reasoning_uuid,
+                'reasoning',
+                {
+                    reasoningId: reasoning.reasoning_id,
+                    text: reasoning.text,
+                },
+            ),
+        });
+    });
+
+    sortedByDateAndUuid(
+        rows.toolCallErrors,
+        (error) => error.created_at,
+        (error) => error.ai_agent_tool_call_error_uuid,
+    ).forEach((error) => {
+        ordered.push({
+            createdAt: error.created_at,
+            uuid: error.ai_agent_tool_call_error_uuid,
+            part: canonicalPart(
+                error.ai_agent_tool_call_error_uuid,
+                'tool',
+                {
+                    state: 'output-error',
+                    toolName: error.tool_name,
+                    input: error.raw_args,
+                    errorText: error.error_message,
+                    legacyToolCallId: error.tool_call_id,
+                },
+                {
+                    toolCallId: uniqueToolCallId(
+                        error.tool_call_id,
+                        error.ai_agent_tool_call_error_uuid,
+                    ),
+                    artifactVersionUuid: null,
+                },
+            ),
+        });
+    });
+
+    ordered.sort(
+        byDateAndUuid(
+            (row) => row.createdAt,
+            (row) => row.uuid,
+        ),
+    );
+
+    const parts = ordered.map(({ part }) => part);
+    if (prompt.response !== null) {
+        parts.push(
+            canonicalPart(
+                syntheticUuid('assistant-text', prompt.ai_prompt_uuid),
+                'text',
+                { text: prompt.response },
+            ),
+        );
+    }
+    sortedByDateAndUuid(
+        rows.artifacts,
+        (row) => row.created_at,
+        (row) => row.ai_artifact_version_uuid,
+    ).forEach((artifact) => {
+        parts.push(
+            canonicalPart(
+                artifact.ai_artifact_version_uuid,
+                'artifact',
+                {
+                    artifactUuid: artifact.ai_artifact_uuid,
+                    versionNumber: artifact.version_number,
+                    title: artifact.title,
+                    description: artifact.description,
+                    artifactType: artifact.artifact_type,
+                },
+                {
+                    toolCallId: null,
+                    artifactVersionUuid: artifact.ai_artifact_version_uuid,
+                },
+            ),
+        );
+    });
+    return parts;
+};
+
+export const projectV1Thread = (rows: V1ThreadRows): AiCanonicalThread => {
+    assertV1Storage(rows.thread);
+    const messages: AiCanonicalMessage[] = [];
+    const toolCallsByPromptUuid = groupByPromptUuid(rows.toolCalls);
+    const toolResultsByPromptUuid = groupByPromptUuid(rows.toolResults);
+    const toolCallErrorsByPromptUuid = groupByPromptUuid(rows.toolCallErrors);
+    const reasoningsByPromptUuid = groupByPromptUuid(rows.reasonings);
+    const artifactsByPromptUuid = groupByPromptUuid(rows.artifacts);
+    const contextsByPromptUuid = groupByPromptUuid(rows.contexts);
+    const steersByPromptUuid = groupByPromptUuid(rows.steers);
+    const referencesByPromptUuid = groupByPromptUuid(rows.referencedArtifacts);
+    const interruptsByPromptUuid = groupByPromptUuid(rows.interrupts);
+
+    sortedByDateAndUuid(
+        rows.prompts,
+        (row) => row.created_at,
+        (row) => row.ai_prompt_uuid,
+    ).forEach((prompt) => {
+        messages.push({
+            uuid: prompt.ai_prompt_uuid,
+            role: 'user',
+            parts: [
+                canonicalPart(
+                    syntheticUuid('user-text', prompt.ai_prompt_uuid),
+                    'text',
+                    { text: prompt.prompt },
+                ),
+            ],
+            metadata: {
+                ...baseMetadata({
+                    createdAt: prompt.created_at,
+                    createdByUserUuid: prompt.created_by_user_uuid,
+                    hidden: prompt.hidden,
+                }),
+                context: sortedByDateAndUuid(
+                    contextsByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+                    (context) => context.created_at,
+                    (context) => context.ai_prompt_context_uuid,
+                ).map(toCanonicalContext),
+            },
+        });
+
+        const interrupts = sortedByDateAndUuid(
+            interruptsByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+            (row) => row.created_at,
+            (row) => row.ai_prompt_interrupt_uuid,
+        );
+        const status = getPromptStatus({
+            prompt,
+            interrupted: interrupts.length > 0,
+        });
+        messages.push({
+            uuid: syntheticUuid('assistant', prompt.ai_prompt_uuid),
+            role: 'assistant',
+            parts: projectAssistantParts(
+                {
+                    toolCalls:
+                        toolCallsByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+                    toolResults:
+                        toolResultsByPromptUuid.get(prompt.ai_prompt_uuid) ??
+                        [],
+                    toolCallErrors:
+                        toolCallErrorsByPromptUuid.get(prompt.ai_prompt_uuid) ??
+                        [],
+                    reasonings:
+                        reasoningsByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+                    artifacts:
+                        artifactsByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+                },
+                prompt,
+                status,
+            ),
+            metadata: {
+                ...baseMetadata({
+                    createdAt: prompt.responded_at ?? prompt.created_at,
+                    createdByUserUuid: null,
+                    hidden: false,
+                }),
+                status,
+                modelConfig: prompt.model_config
+                    ? {
+                          version: 1,
+                          ...prompt.model_config,
+                          reasoning: {
+                              enabled: false,
+                              effort: null,
+                              budgetTokens: null,
+                          },
+                          limits: {
+                              maxSteps: null,
+                              maxOutputTokens: null,
+                          },
+                          sampling: { temperature: null, topP: null },
+                          providerOptions: null,
+                      }
+                    : null,
+                tokenUsage: prompt.token_usage
+                    ? {
+                          version: 1,
+                          inputTokens: null,
+                          outputTokens: null,
+                          totalTokens: prompt.token_usage.totalTokens,
+                          reasoningTokens: null,
+                          cachedInputTokens: null,
+                      }
+                    : null,
+                error:
+                    status === 'error'
+                        ? {
+                              version: 1,
+                              name: 'legacy_error',
+                              message:
+                                  prompt.error_message ?? 'Legacy run failed',
+                              data: null,
+                          }
+                        : null,
+                legacy: {
+                    type: 'response',
+                    vizConfigOutput: prompt.viz_config_output,
+                    filtersOutput: prompt.filters_output,
+                    metricQuery: prompt.metric_query,
+                    savedQueryUuid: prompt.saved_query_uuid,
+                    humanScore: prompt.human_score,
+                    humanFeedback: prompt.human_feedback,
+                    referencedArtifacts: sortedByDateAndUuid(
+                        referencesByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+                        (reference) => reference.created_at,
+                        (reference) => reference.ai_artifact_version_uuid,
+                    ).map((reference) => ({
+                        artifactVersionUuid: reference.ai_artifact_version_uuid,
+                        artifactUuid: reference.ai_artifact_uuid,
+                        projectUuid: reference.project_uuid,
+                        similarityScore: reference.similarity_score,
+                        versionNumber: reference.version_number,
+                        title: reference.title,
+                        description: reference.description,
+                        artifactType: reference.artifact_type,
+                        createdAt: reference.created_at.toISOString(),
+                    })),
+                    interrupts: interrupts.map((interrupt) => ({
+                        createdByUserUuid: interrupt.created_by_user_uuid,
+                        createdAt: interrupt.created_at.toISOString(),
+                    })),
+                },
+            },
+        });
+
+        sortedByDateAndUuid(
+            steersByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+            (row) => row.created_at,
+            (row) => row.ai_prompt_steer_uuid,
+        ).forEach((steer) => {
+            messages.push({
+                uuid: steer.ai_prompt_steer_uuid,
+                role: 'user',
+                parts: [
+                    canonicalPart(
+                        syntheticUuid('steer-text', steer.ai_prompt_steer_uuid),
+                        'text',
+                        { text: steer.message },
+                    ),
+                ],
+                metadata: {
+                    ...baseMetadata({
+                        createdAt: steer.created_at,
+                        createdByUserUuid: steer.created_by_user_uuid,
+                        hidden: prompt.hidden,
+                    }),
+                    legacy: {
+                        type: 'steer',
+                        consumedAt: steer.consumed_at?.toISOString() ?? null,
+                        consumedStep: steer.consumed_step,
+                    },
+                },
+            });
+        });
+    });
+
+    return {
+        uuid: rows.thread.ai_thread_uuid,
+        storageVersion: 1,
+        organizationUuid: rows.thread.organization_uuid,
+        projectUuid: rows.thread.project_uuid,
+        agentUuid: rows.thread.agent_uuid,
+        createdAt: rows.thread.created_at.toISOString(),
+        updatedAt: rows.thread.updated_at?.toISOString() ?? null,
+        createdFrom: rows.thread.created_from,
+        title: rows.thread.title,
+        lineage: null,
+        messages,
+    };
+};
+
+export class AiAgentV1ReadAdapter {
+    private readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    async getThread(
+        thread: V1ThreadRows['thread'],
+    ): Promise<AiCanonicalThread> {
+        assertV1Storage(thread);
+        const prompts = await this.database(AiPromptTableName)
+            .where('ai_thread_uuid', thread.ai_thread_uuid)
+            .orderBy([{ column: 'created_at' }, { column: 'ai_prompt_uuid' }]);
+        const promptUuids = prompts.map((prompt) => prompt.ai_prompt_uuid);
+        if (promptUuids.length === 0) {
+            return projectV1Thread({
+                thread,
+                prompts,
+                reasonings: [],
+                toolCalls: [],
+                toolResults: [],
+                toolCallErrors: [],
+                steers: [],
+                interrupts: [],
+                artifacts: [],
+                contexts: [],
+                referencedArtifacts: [],
+            });
+        }
+
+        const [
+            reasonings,
+            toolCalls,
+            toolResults,
+            toolCallErrors,
+            steers,
+            interrupts,
+            contexts,
+            artifacts,
+            referencedArtifacts,
+        ] = await Promise.all([
+            this.database(AiAgentReasoningTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiAgentToolCallTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiAgentToolResultTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiAgentToolCallErrorTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiPromptSteerTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiPromptInterruptTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiPromptContextTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiArtifactVersionsTableName)
+                .join(
+                    AiArtifactsTableName,
+                    `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
+                    `${AiArtifactsTableName}.ai_artifact_uuid`,
+                )
+                .whereIn(
+                    `${AiArtifactVersionsTableName}.ai_prompt_uuid`,
+                    promptUuids,
+                )
+                .select<V1Artifact[]>(
+                    `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
+                    `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
+                    `${AiArtifactVersionsTableName}.ai_prompt_uuid`,
+                    `${AiArtifactVersionsTableName}.created_at`,
+                    `${AiArtifactVersionsTableName}.version_number`,
+                    `${AiArtifactVersionsTableName}.title`,
+                    `${AiArtifactVersionsTableName}.description`,
+                    `${AiArtifactsTableName}.artifact_type`,
+                ),
+            this.database(AiPromptArtifactReferencesTableName)
+                .join(
+                    AiArtifactVersionsTableName,
+                    `${AiPromptArtifactReferencesTableName}.ai_artifact_version_uuid`,
+                    `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
+                )
+                .join(
+                    AiArtifactsTableName,
+                    `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
+                    `${AiArtifactsTableName}.ai_artifact_uuid`,
+                )
+                .whereIn(
+                    `${AiPromptArtifactReferencesTableName}.ai_prompt_uuid`,
+                    promptUuids,
+                )
+                .select<V1ReferencedArtifact[]>({
+                    ai_prompt_uuid: `${AiPromptArtifactReferencesTableName}.ai_prompt_uuid`,
+                    ai_artifact_version_uuid: `${AiPromptArtifactReferencesTableName}.ai_artifact_version_uuid`,
+                    project_uuid: `${AiPromptArtifactReferencesTableName}.project_uuid`,
+                    similarity_score: `${AiPromptArtifactReferencesTableName}.similarity_score`,
+                    created_at: `${AiPromptArtifactReferencesTableName}.created_at`,
+                    ai_artifact_uuid: `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
+                    version_number: `${AiArtifactVersionsTableName}.version_number`,
+                    title: `${AiArtifactVersionsTableName}.title`,
+                    description: `${AiArtifactVersionsTableName}.description`,
+                    artifact_type: `${AiArtifactsTableName}.artifact_type`,
+                }),
+        ]);
+
+        return projectV1Thread({
+            thread,
+            prompts,
+            reasonings,
+            toolCalls,
+            toolResults,
+            toolCallErrors,
+            steers,
+            interrupts,
+            artifacts,
+            contexts,
+            referencedArtifacts,
+        });
+    }
+}

--- a/packages/backend/src/ee/models/AiAgentV1ReadAdapter.ts
+++ b/packages/backend/src/ee/models/AiAgentV1ReadAdapter.ts
@@ -1,4 +1,7 @@
-import { ConflictError } from '@lightdash/common';
+import {
+    ConflictError,
+    type AiAgentThreadFirstMessage,
+} from '@lightdash/common';
 import { type Knex } from 'knex';
 import { v5 as uuidv5 } from 'uuid';
 import {
@@ -678,6 +681,27 @@ export class AiAgentV1ReadAdapter {
 
     constructor({ database }: { database: Knex }) {
         this.database = database;
+    }
+
+    async listFirstMessages(
+        threadUuids: string[],
+    ): Promise<Map<string, AiAgentThreadFirstMessage>> {
+        if (threadUuids.length === 0) return new Map();
+        const rows = await this.database(AiPromptTableName)
+            .select('ai_thread_uuid', 'ai_prompt_uuid', 'prompt')
+            .whereIn('ai_thread_uuid', threadUuids)
+            .distinctOn('ai_thread_uuid')
+            .orderBy([
+                { column: 'ai_thread_uuid' },
+                { column: 'created_at' },
+                { column: 'ai_prompt_uuid' },
+            ]);
+        return new Map(
+            rows.map((row) => [
+                row.ai_thread_uuid,
+                { uuid: row.ai_prompt_uuid, message: row.prompt },
+            ]),
+        );
     }
 
     async getThread(

--- a/packages/backend/src/ee/models/AiAgentV3Model.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentV3Model.integration.test.ts
@@ -7,7 +7,10 @@ import {
 import { randomUUID } from 'crypto';
 import { type Knex } from 'knex';
 import { getTestContext } from '../../vitest.setup.integration';
-import { AiThreadTableName } from '../database/entities/ai';
+import {
+    AiThreadTableName,
+    AiWebAppThreadTableName,
+} from '../database/entities/ai';
 import {
     AiMessagePartTableName,
     AiThreadMessageSequenceTableName,
@@ -108,6 +111,26 @@ describe('AiAgentV3Model', () => {
         ).rejects.toThrow('Lineage parent must use storage version 3');
     });
 
+    it('persists web thread ownership with creation', async () => {
+        const thread = await model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: null,
+            ownerUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        rootThreadUuids.add(thread.uuid);
+
+        await expect(
+            database(AiWebAppThreadTableName)
+                .where('ai_thread_uuid', thread.uuid)
+                .first(),
+        ).resolves.toMatchObject({
+            user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+    });
+
     it('allocates unique ordered message sequences for concurrent writers', async () => {
         const thread = await createRootThread();
 
@@ -148,6 +171,121 @@ describe('AiAgentV3Model', () => {
                 parts: [textPart(0, 'missing')],
             }),
         ).rejects.toThrow('Thread not found');
+    });
+
+    it('atomically starts one run and resumes after it freezes', async () => {
+        const thread = await createRootThread();
+        const first = await model.startRun({
+            threadUuid: thread.uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            userParts: [textPart(0, 'first')],
+            modelConfig,
+        });
+
+        await expect(
+            model.startRun({
+                threadUuid: thread.uuid,
+                createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                userParts: [textPart(0, 'racing input')],
+                modelConfig,
+            }),
+        ).rejects.toThrow('This thread already has an active run');
+        await model.finishAssistantMessage({
+            messageUuid: first.assistantMessage.uuid,
+            status: 'canceled',
+            tokenUsage: null,
+            error: null,
+        });
+        const second = await model.startRun({
+            threadUuid: thread.uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            userParts: [textPart(0, 'second')],
+            modelConfig,
+        });
+
+        expect(first.userMessage.threadSeq).toBe(1);
+        expect(first.assistantMessage.threadSeq).toBe(2);
+        expect(second.userMessage.threadSeq).toBe(3);
+        expect(second.assistantMessage.threadSeq).toBe(4);
+    });
+
+    it('refreshes heartbeats only while the assistant is in progress', async () => {
+        const thread = await createRootThread();
+        const assistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        const oldHeartbeat = new Date('2020-01-01T00:00:00.000Z');
+        await database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', assistant.uuid)
+            .update({ last_heartbeat_at: oldHeartbeat });
+
+        expect(
+            await model.refreshAssistantMessageHeartbeat(assistant.uuid),
+        ).toBe(true);
+        const refreshed = await database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', assistant.uuid)
+            .first('last_heartbeat_at');
+        expect(refreshed!.last_heartbeat_at!.getTime()).toBeGreaterThan(
+            oldHeartbeat.getTime(),
+        );
+
+        await model.finishAssistantMessage({
+            messageUuid: assistant.uuid,
+            status: 'canceled',
+            tokenUsage: null,
+            error: null,
+        });
+        expect(
+            await model.refreshAssistantMessageHeartbeat(assistant.uuid),
+        ).toBe(false);
+        const frozen = await database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', assistant.uuid)
+            .first('last_heartbeat_at');
+        expect(frozen!.last_heartbeat_at).toEqual(refreshed!.last_heartbeat_at);
+    });
+
+    it('persists steers at their true sequence while the run is active', async () => {
+        const thread = await createRootThread();
+        const run = await model.startRun({
+            threadUuid: thread.uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            userParts: [textPart(0, 'question')],
+            modelConfig,
+        });
+        const steer = await model.appendSteer({
+            threadUuid: thread.uuid,
+            assistantMessageUuid: run.assistantMessage.uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            parts: [textPart(0, 'focus on revenue')],
+        });
+
+        expect(steer.threadSeq).toBe(3);
+        expect(
+            await model.getSteers({
+                threadUuid: thread.uuid,
+                assistantMessageUuid: run.assistantMessage.uuid,
+            }),
+        ).toEqual([
+            expect.objectContaining({
+                uuid: steer.uuid,
+                message: 'focus on revenue',
+            }),
+        ]);
+        await model.finishAssistantMessage({
+            messageUuid: run.assistantMessage.uuid,
+            status: 'canceled',
+            tokenUsage: null,
+            error: null,
+        });
+        await expect(
+            model.appendSteer({
+                threadUuid: thread.uuid,
+                assistantMessageUuid: run.assistantMessage.uuid,
+                createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                parts: [textPart(0, 'too late')],
+            }),
+        ).rejects.toThrow('Assistant message is frozen');
     });
 
     it('returns messages and typed parts in canonical order', async () => {

--- a/packages/backend/src/ee/models/AiAgentV3Model.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentV3Model.integration.test.ts
@@ -1,0 +1,900 @@
+import {
+    SEED_ORG_1,
+    SEED_ORG_1_ADMIN,
+    SEED_ORG_2,
+    SEED_PROJECT,
+} from '@lightdash/common';
+import { randomUUID } from 'crypto';
+import { type Knex } from 'knex';
+import { getTestContext } from '../../vitest.setup.integration';
+import { AiThreadTableName } from '../database/entities/ai';
+import {
+    AiMessagePartTableName,
+    AiThreadMessageSequenceTableName,
+    AiThreadMessageTableName,
+} from '../database/entities/aiAgentV3';
+import {
+    AiArtifactsTableName,
+    AiArtifactVersionsTableName,
+} from '../database/entities/aiArtifacts';
+import { AiAgentV3Model } from './AiAgentV3Model';
+
+const modelConfig = {
+    version: 1,
+    modelName: 'claude-sonnet-4-5',
+    modelProvider: 'anthropic',
+    reasoning: { enabled: true, effort: 'high', budgetTokens: null },
+    limits: { maxSteps: 12, maxOutputTokens: null },
+    sampling: { temperature: 0.2, topP: null },
+    providerOptions: null,
+};
+
+const textPart = (partIndex: number, text: string) => ({
+    partIndex,
+    type: 'text' as const,
+    payloadVersion: 1,
+    payload: { text },
+});
+
+describe('AiAgentV3Model', () => {
+    let database: Knex;
+    let model: AiAgentV3Model;
+    const rootThreadUuids = new Set<string>();
+
+    beforeAll(() => {
+        database = getTestContext().db;
+        model = new AiAgentV3Model({ database });
+    });
+
+    afterEach(async () => {
+        if (rootThreadUuids.size > 0) {
+            await database(AiThreadTableName)
+                .whereIn('ai_thread_uuid', [...rootThreadUuids])
+                .delete();
+        }
+        rootThreadUuids.clear();
+    });
+
+    const createRootThread = async () => {
+        const thread = await model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: null,
+        });
+        rootThreadUuids.add(thread.uuid);
+        return thread;
+    };
+
+    it('keeps legacy threads at storage version 1 and initializes v3 threads', async () => {
+        const [legacyThread] = await database(AiThreadTableName)
+            .insert({
+                organization_uuid: SEED_ORG_1.organization_uuid,
+                project_uuid: SEED_PROJECT.project_uuid,
+                agent_uuid: null,
+                created_from: 'web_app',
+            })
+            .returning(['ai_thread_uuid', 'storage_version']);
+        rootThreadUuids.add(legacyThread.ai_thread_uuid);
+
+        const v3Thread = await createRootThread();
+        const sequence = await database(AiThreadMessageSequenceTableName)
+            .where('ai_thread_uuid', v3Thread.uuid)
+            .first();
+
+        expect(legacyThread.storage_version).toBe(1);
+        expect(v3Thread.storageVersion).toBe(3);
+        expect(sequence).toMatchObject({ next_thread_seq: 1 });
+        await expect(
+            model.appendUserMessage({
+                threadUuid: legacyThread.ai_thread_uuid,
+                createdByUserUuid: null,
+                parts: [textPart(0, 'legacy write')],
+            }),
+        ).rejects.toThrow('Thread is not writable v3 storage');
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'fork',
+                    parentThreadUuid: legacyThread.ai_thread_uuid,
+                    forkBoundarySeq: 1,
+                },
+            }),
+        ).rejects.toThrow('Lineage parent must use storage version 3');
+    });
+
+    it('allocates unique ordered message sequences for concurrent writers', async () => {
+        const thread = await createRootThread();
+
+        await Promise.all(
+            Array.from({ length: 12 }, (_, index) =>
+                model.appendUserMessage({
+                    threadUuid: thread.uuid,
+                    createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    parts: [textPart(0, `message-${index}`)],
+                }),
+            ),
+        );
+
+        const rows = await database(AiThreadMessageTableName)
+            .select(['thread_seq'])
+            .where('ai_thread_uuid', thread.uuid)
+            .orderBy('thread_seq');
+        const canonical = await model.getThread(thread.uuid);
+
+        expect(rows.map((row) => row.thread_seq)).toEqual(
+            Array.from({ length: 12 }, (_, index) => index + 1),
+        );
+        expect(canonical.messages).toHaveLength(12);
+        expect(
+            new Set(
+                canonical.messages.map(
+                    (message) => message.parts[0].payload.text,
+                ),
+            ).size,
+        ).toBe(12);
+    });
+
+    it('reports a missing thread when appending a message', async () => {
+        await expect(
+            model.appendUserMessage({
+                threadUuid: randomUUID(),
+                createdByUserUuid: null,
+                parts: [textPart(0, 'missing')],
+            }),
+        ).rejects.toThrow('Thread not found');
+    });
+
+    it('returns messages and typed parts in canonical order', async () => {
+        const thread = await createRootThread();
+        const importedCreatedAt = new Date('2024-01-02T03:04:05.000Z');
+        const userMessage = await model.appendUserMessage({
+            threadUuid: thread.uuid,
+            createdByUserUuid: null,
+            createdAt: importedCreatedAt,
+            parts: [
+                textPart(2, 'third'),
+                textPart(0, 'first'),
+                {
+                    partIndex: 1,
+                    type: 'source',
+                    payloadVersion: 2,
+                    payload: { url: 'https://example.com' },
+                },
+            ],
+        });
+        const assistantMessage = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: assistantMessage.uuid,
+            parts: [textPart(0, 'answer')],
+        });
+        await expect(
+            model.appendParts({
+                messageUuid: userMessage.uuid,
+                parts: [textPart(3, 'late mutation')],
+            }),
+        ).rejects.toThrow('Message is not an assistant message');
+
+        const canonical = await model.getThread(thread.uuid);
+
+        expect(canonical).toMatchObject({
+            uuid: thread.uuid,
+            storageVersion: 3,
+            messages: [
+                {
+                    uuid: userMessage.uuid,
+                    role: 'user',
+                    metadata: {
+                        createdAt: importedCreatedAt.toISOString(),
+                        createdByUserUuid: null,
+                    },
+                    parts: [
+                        { type: 'text', payload: { text: 'first' } },
+                        {
+                            type: 'source',
+                            payloadVersion: 2,
+                            payload: { url: 'https://example.com' },
+                        },
+                        { type: 'text', payload: { text: 'third' } },
+                    ],
+                },
+                {
+                    uuid: assistantMessage.uuid,
+                    role: 'assistant',
+                    metadata: {
+                        status: 'in_progress',
+                        modelConfig,
+                    },
+                    parts: [{ type: 'text', payload: { text: 'answer' } }],
+                },
+            ],
+        });
+    });
+
+    it('scopes part indexes and provider tool call ids to each message', async () => {
+        const thread = await createRootThread();
+        const [firstMessage, secondMessage] = await Promise.all([
+            model.createAssistantMessage({
+                threadUuid: thread.uuid,
+                modelConfig,
+            }),
+            model.createAssistantMessage({
+                threadUuid: thread.uuid,
+                modelConfig,
+            }),
+        ]);
+        const part = {
+            partIndex: 0,
+            type: 'tool' as const,
+            payloadVersion: 1,
+            toolCallId: 'provider-call-id',
+            payload: { state: 'input-available', toolName: 'findExplores' },
+        };
+
+        const [[firstPart], [secondPart]] = await Promise.all([
+            model.appendParts({
+                messageUuid: firstMessage.uuid,
+                parts: [part],
+            }),
+            model.appendParts({
+                messageUuid: secondMessage.uuid,
+                parts: [part],
+            }),
+        ]);
+
+        expect(firstPart.uuid).not.toBe(secondPart.uuid);
+        await expect(
+            model.appendParts({
+                messageUuid: firstMessage.uuid,
+                parts: [{ ...part, partIndex: 1 }],
+            }),
+        ).rejects.toMatchObject({
+            constraint:
+                'ai_message_part_ai_thread_message_uuid_tool_call_id_unique',
+        });
+        await expect(
+            model.appendParts({
+                messageUuid: firstMessage.uuid,
+                parts: [textPart(0, 'duplicate index')],
+            }),
+        ).rejects.toMatchObject({
+            constraint:
+                'ai_message_part_ai_thread_message_uuid_part_index_unique',
+        });
+    });
+
+    it('updates a part while its assistant message is writable', async () => {
+        const thread = await createRootThread();
+        const assistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        const [part] = await model.appendParts({
+            messageUuid: assistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    toolCallId: 'update-part',
+                    payload: {
+                        state: 'input-available',
+                        toolName: 'findExplores',
+                    },
+                },
+            ],
+        });
+
+        const updated = await model.updatePart({
+            messageUuid: assistant.uuid,
+            partUuid: part.uuid,
+            payloadVersion: 2,
+            payload: { state: 'output-available', output: ['orders'] },
+        });
+
+        expect(updated).toMatchObject({
+            uuid: part.uuid,
+            payloadVersion: 2,
+            payload: { state: 'output-available', output: ['orders'] },
+        });
+        expect(
+            (await model.getThread(thread.uuid)).messages[0].parts[0],
+        ).toMatchObject(updated);
+        await expect(
+            model.updatePart({
+                messageUuid: assistant.uuid,
+                partUuid: randomUUID(),
+                payloadVersion: 2,
+                payload: { state: 'output-available', output: [] },
+            }),
+        ).rejects.toThrow('Message part not found');
+    });
+
+    it('enforces type-specific part references', async () => {
+        const thread = await createRootThread();
+        const assistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+
+        await expect(
+            model.appendParts({
+                messageUuid: assistant.uuid,
+                parts: [
+                    {
+                        ...textPart(0, 'invalid'),
+                        toolCallId: 'not-a-text-attribute',
+                    } as never,
+                ],
+            }),
+        ).rejects.toThrow('Tool call id is only valid on tool parts');
+        await expect(
+            model.appendParts({
+                messageUuid: assistant.uuid,
+                parts: [
+                    {
+                        partIndex: 0,
+                        type: 'tool',
+                        payloadVersion: 1,
+                        payload: {},
+                    } as never,
+                ],
+            }),
+        ).rejects.toThrow('Tool part requires a tool call id');
+        await expect(
+            model.appendParts({
+                messageUuid: assistant.uuid,
+                parts: [
+                    {
+                        partIndex: 0,
+                        type: 'artifact',
+                        payloadVersion: 1,
+                        payload: {},
+                    } as never,
+                ],
+            }),
+        ).rejects.toThrow('Artifact part requires an artifact version uuid');
+        await expect(
+            model.appendUserMessage({
+                threadUuid: thread.uuid,
+                createdByUserUuid: null,
+                parts: [
+                    {
+                        partIndex: 0,
+                        type: 'reasoning',
+                        payloadVersion: 1,
+                        payload: {},
+                    },
+                ],
+            }),
+        ).rejects.toThrow('reasoning parts are not valid on user messages');
+        await expect(
+            model.appendParts({
+                messageUuid: assistant.uuid,
+                parts: [
+                    {
+                        partIndex: 0,
+                        type: 'compaction',
+                        payloadVersion: 1,
+                        payload: { summary: 'not an assistant part' },
+                    },
+                ],
+            }),
+        ).rejects.toThrow(
+            'compaction parts are not valid on assistant messages',
+        );
+        await expect(
+            database(AiMessagePartTableName).insert({
+                ai_thread_message_uuid: assistant.uuid,
+                part_index: 10,
+                type: 'text',
+                payload_version: 1,
+                payload: {},
+                tool_call_id: 'invalid-text-reference',
+            }),
+        ).rejects.toMatchObject({
+            constraint: 'ai_message_part_tool_call_shape_check',
+        });
+        await expect(
+            database(AiMessagePartTableName).insert({
+                ai_thread_message_uuid: assistant.uuid,
+                part_index: 11,
+                type: 'text',
+                payload_version: 1,
+                payload: {},
+                ai_artifact_version_uuid: randomUUID(),
+            }),
+        ).rejects.toMatchObject({
+            constraint: 'ai_message_part_artifact_version_shape_check',
+        });
+        await expect(
+            model.appendUserMessage({
+                threadUuid: thread.uuid,
+                createdByUserUuid: null,
+                parts: [],
+            }),
+        ).rejects.toThrow('User message requires content');
+    });
+
+    it('deletes artifact parts when their version is deleted', async () => {
+        const thread = await createRootThread();
+        const [artifact] = await database(AiArtifactsTableName)
+            .insert({ ai_thread_uuid: thread.uuid, artifact_type: 'chart' })
+            .returning('ai_artifact_uuid');
+        const [version] = await database(AiArtifactVersionsTableName)
+            .insert({
+                ai_artifact_uuid: artifact.ai_artifact_uuid,
+                version_number: 1,
+            })
+            .returning('ai_artifact_version_uuid');
+        const assistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        const [part] = await model.appendParts({
+            messageUuid: assistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'artifact',
+                    payloadVersion: 1,
+                    payload: {},
+                    artifactVersionUuid: version.ai_artifact_version_uuid,
+                },
+            ],
+        });
+
+        await database(AiArtifactVersionsTableName)
+            .where('ai_artifact_version_uuid', version.ai_artifact_version_uuid)
+            .delete();
+
+        expect(
+            await database(AiMessagePartTableName)
+                .where('ai_message_part_uuid', part.uuid)
+                .first(),
+        ).toBeUndefined();
+    });
+
+    it('freezes terminal assistant messages and heals active tool parts', async () => {
+        const thread = await createRootThread();
+        const assistantMessage = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        const [toolPart] = await model.appendParts({
+            messageUuid: assistantMessage.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    toolCallId: 'call-1',
+                    payload: {
+                        state: 'input-available',
+                        toolName: 'findExplores',
+                        input: {},
+                    },
+                },
+            ],
+        });
+
+        await model.finishAssistantMessage({
+            messageUuid: assistantMessage.uuid,
+            status: 'canceled',
+            tokenUsage: {
+                version: 1,
+                inputTokens: 12,
+                outputTokens: 3,
+                totalTokens: 15,
+                reasoningTokens: 1,
+                cachedInputTokens: 2,
+            },
+            error: null,
+        });
+
+        await expect(
+            model.appendParts({
+                messageUuid: assistantMessage.uuid,
+                parts: [textPart(1, 'late')],
+            }),
+        ).rejects.toThrow('Assistant message is frozen');
+        await expect(
+            model.updatePart({
+                messageUuid: assistantMessage.uuid,
+                partUuid: toolPart.uuid,
+                payloadVersion: 2,
+                payload: { state: 'output-available', output: 'late' },
+            }),
+        ).rejects.toThrow('Assistant message is frozen');
+
+        const canonical = await model.getThread(thread.uuid);
+        expect(canonical.messages[0]).toMatchObject({
+            metadata: {
+                status: 'canceled',
+                tokenUsage: { totalTokens: 15 },
+            },
+            parts: [
+                {
+                    uuid: toolPart.uuid,
+                    payload: {
+                        state: 'output-error',
+                        error: {
+                            name: 'interrupted',
+                            message: 'Tool execution was interrupted',
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
+    it('requires model-visible content before completion', async () => {
+        const thread = await createRootThread();
+        const assistantMessage = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: assistantMessage.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'step-start',
+                    payloadVersion: 1,
+                    payload: {},
+                },
+            ],
+        });
+
+        await expect(
+            model.finishAssistantMessage({
+                messageUuid: assistantMessage.uuid,
+                status: 'completed',
+                tokenUsage: null,
+                error: null,
+            }),
+        ).rejects.toThrow('Completed assistant message requires content');
+
+        await model.appendParts({
+            messageUuid: assistantMessage.uuid,
+            parts: [textPart(1, 'done')],
+        });
+        await model.finishAssistantMessage({
+            messageUuid: assistantMessage.uuid,
+            status: 'completed',
+            tokenUsage: null,
+            error: null,
+        });
+
+        expect(
+            (await model.getThread(thread.uuid)).messages[0].metadata.status,
+        ).toBe('completed');
+    });
+
+    it('persists versioned run envelopes and validates error transitions', async () => {
+        const thread = await createRootThread();
+        const assistantMessage = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        const error = {
+            version: 1,
+            name: 'provider_error',
+            message: 'Provider failed',
+            data: { retryable: true },
+        };
+
+        await expect(
+            model.finishAssistantMessage({
+                messageUuid: assistantMessage.uuid,
+                status: 'error',
+                tokenUsage: null,
+                error: null,
+            }),
+        ).rejects.toThrow('Error status requires an error envelope');
+        await expect(
+            model.finishAssistantMessage({
+                messageUuid: assistantMessage.uuid,
+                status: 'canceled',
+                tokenUsage: null,
+                error,
+            }),
+        ).rejects.toThrow('Error envelope requires error status');
+
+        await model.finishAssistantMessage({
+            messageUuid: assistantMessage.uuid,
+            status: 'error',
+            tokenUsage: null,
+            error,
+        });
+
+        expect(
+            (await model.getThread(thread.uuid)).messages[0].metadata,
+        ).toMatchObject({
+            status: 'error',
+            modelConfig,
+            error,
+        });
+    });
+
+    it('enforces lineage shape, scope, anchors, and fork boundaries', async () => {
+        const root = await createRootThread();
+        await expect(
+            database(AiThreadMessageTableName).insert({
+                ai_thread_uuid: root.uuid,
+                thread_seq: 999,
+                role: 'user',
+                status: 'in_progress',
+            } as never),
+        ).rejects.toMatchObject({
+            constraint: 'ai_thread_message_role_status_check',
+        });
+        await expect(
+            database(AiThreadTableName)
+                .where('ai_thread_uuid', root.uuid)
+                .update({ lineage_kind: 'fork' } as never),
+        ).rejects.toMatchObject({
+            constraint: 'ai_thread_lineage_shape_check',
+        });
+        const assistant = await model.createAssistantMessage({
+            threadUuid: root.uuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: assistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    toolCallId: 'delegate-1',
+                    payload: { state: 'input-available', toolName: 'delegate' },
+                },
+            ],
+        });
+        const userToolMessage = await model.appendUserMessage({
+            threadUuid: root.uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            parts: [textPart(0, 'user message during run')],
+        });
+        await database(AiMessagePartTableName).insert({
+            ai_thread_message_uuid: userToolMessage.uuid,
+            part_index: 1,
+            type: 'tool',
+            payload_version: 1,
+            tool_call_id: 'user-tool',
+            payload: { state: 'input-available', toolName: 'delegate' },
+        });
+
+        const spawn = await model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: {
+                kind: 'spawn',
+                parentThreadUuid: root.uuid,
+                parentMessageUuid: assistant.uuid,
+                parentToolCallId: 'delegate-1',
+            },
+        });
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'fork',
+                    parentThreadUuid: root.uuid,
+                    forkBoundarySeq: assistant.threadSeq,
+                },
+            }),
+        ).rejects.toThrow('Fork boundary assistant message must be frozen');
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'fork',
+                    parentThreadUuid: root.uuid,
+                    forkBoundarySeq: userToolMessage.threadSeq,
+                },
+            }),
+        ).rejects.toThrow('Fork prefix contains an active assistant message');
+        await model.finishAssistantMessage({
+            messageUuid: assistant.uuid,
+            status: 'canceled',
+            tokenUsage: null,
+            error: null,
+        });
+        const fork = await model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: {
+                kind: 'fork',
+                parentThreadUuid: root.uuid,
+                forkBoundarySeq: userToolMessage.threadSeq,
+            },
+        });
+
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_2.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'fork',
+                    parentThreadUuid: root.uuid,
+                    forkBoundarySeq: assistant.threadSeq,
+                },
+            }),
+        ).rejects.toThrow('Lineage scope must match its parent');
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'fork',
+                    parentThreadUuid: root.uuid,
+                    forkBoundarySeq: 999,
+                },
+            }),
+        ).rejects.toThrow('Fork boundary does not exist');
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'spawn',
+                    parentThreadUuid: root.uuid,
+                    parentMessageUuid: assistant.uuid,
+                    parentToolCallId: 'missing',
+                },
+            }),
+        ).rejects.toThrow('Spawn anchor does not exist');
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'spawn',
+                    parentThreadUuid: root.uuid,
+                    parentMessageUuid: userToolMessage.uuid,
+                    parentToolCallId: 'user-tool',
+                },
+            }),
+        ).rejects.toThrow('Spawn anchor does not exist');
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'fork',
+                    parentThreadUuid: spawn.uuid,
+                    forkBoundarySeq: 1,
+                },
+            }),
+        ).rejects.toThrow('Spawn threads cannot be forked');
+
+        expect(spawn.lineage).toMatchObject({ kind: 'spawn' });
+        expect(fork.lineage).toMatchObject({ kind: 'fork' });
+    });
+
+    it('cascades deletion through the entire lineage tree', async () => {
+        const root = await createRootThread();
+        const rootAssistant = await model.createAssistantMessage({
+            threadUuid: root.uuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: rootAssistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    toolCallId: 'delegate-root',
+                    payload: { state: 'input-available', toolName: 'delegate' },
+                },
+            ],
+        });
+        await model.finishAssistantMessage({
+            messageUuid: rootAssistant.uuid,
+            status: 'canceled',
+            tokenUsage: null,
+            error: null,
+        });
+        const child = await model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: {
+                kind: 'fork',
+                parentThreadUuid: root.uuid,
+                forkBoundarySeq: rootAssistant.threadSeq,
+            },
+        });
+        const childAssistant = await model.createAssistantMessage({
+            threadUuid: child.uuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: childAssistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    toolCallId: 'delegate-child',
+                    payload: { state: 'input-available', toolName: 'delegate' },
+                },
+            ],
+        });
+        const grandchild = await model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: {
+                kind: 'spawn',
+                parentThreadUuid: child.uuid,
+                parentMessageUuid: childAssistant.uuid,
+                parentToolCallId: 'delegate-child',
+            },
+        });
+
+        await database(AiThreadTableName)
+            .where('ai_thread_uuid', root.uuid)
+            .delete();
+
+        const [threads, messages, parts] = await Promise.all([
+            database(AiThreadTableName)
+                .select('ai_thread_uuid')
+                .whereIn('ai_thread_uuid', [
+                    root.uuid,
+                    child.uuid,
+                    grandchild.uuid,
+                ]),
+            database(AiThreadMessageTableName)
+                .select('ai_thread_message_uuid')
+                .whereIn('ai_thread_uuid', [
+                    root.uuid,
+                    child.uuid,
+                    grandchild.uuid,
+                ]),
+            database(AiMessagePartTableName)
+                .select('ai_message_part_uuid')
+                .whereIn('ai_thread_message_uuid', [
+                    rootAssistant.uuid,
+                    childAssistant.uuid,
+                ]),
+        ]);
+
+        expect(threads).toHaveLength(0);
+        expect(messages).toHaveLength(0);
+        expect(parts).toHaveLength(0);
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentV3Model.ts
+++ b/packages/backend/src/ee/models/AiAgentV3Model.ts
@@ -4,6 +4,7 @@ import {
     NotFoundError,
     ParameterError,
     UnexpectedServerError,
+    type AiAgentThreadFirstMessage,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 import {
@@ -51,6 +52,53 @@ export class AiAgentV3Model {
 
     constructor({ database }: Dependencies) {
         this.database = database;
+    }
+
+    async listFirstMessages(
+        threadUuids: string[],
+    ): Promise<Map<string, AiAgentThreadFirstMessage>> {
+        if (threadUuids.length === 0) return new Map();
+        const rows = await this.database(AiThreadMessageTableName)
+            .innerJoin(
+                AiMessagePartTableName,
+                `${AiMessagePartTableName}.ai_thread_message_uuid`,
+                `${AiThreadMessageTableName}.ai_thread_message_uuid`,
+            )
+            .select<
+                {
+                    ai_thread_uuid: string;
+                    ai_thread_message_uuid: string;
+                    payload: Record<string, unknown>;
+                }[]
+            >(
+                `${AiThreadMessageTableName}.ai_thread_uuid`,
+                `${AiThreadMessageTableName}.ai_thread_message_uuid`,
+                `${AiMessagePartTableName}.payload`,
+            )
+            .whereIn(`${AiThreadMessageTableName}.ai_thread_uuid`, threadUuids)
+            .where(`${AiThreadMessageTableName}.role`, 'user')
+            .where(`${AiMessagePartTableName}.type`, 'text')
+            .distinctOn(`${AiThreadMessageTableName}.ai_thread_uuid`)
+            .orderBy([
+                { column: `${AiThreadMessageTableName}.ai_thread_uuid` },
+                { column: `${AiThreadMessageTableName}.thread_seq` },
+                { column: `${AiMessagePartTableName}.part_index` },
+            ]);
+        return new Map(
+            rows.flatMap((row) =>
+                typeof row.payload.text === 'string'
+                    ? [
+                          [
+                              row.ai_thread_uuid,
+                              {
+                                  uuid: row.ai_thread_message_uuid,
+                                  message: row.payload.text,
+                              },
+                          ] as const,
+                      ]
+                    : [],
+            ),
+        );
     }
 
     private static toLineage(row: DbAiThread): AiV3ThreadLineage {

--- a/packages/backend/src/ee/models/AiAgentV3Model.ts
+++ b/packages/backend/src/ee/models/AiAgentV3Model.ts
@@ -6,7 +6,11 @@ import {
     UnexpectedServerError,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
-import { AiThreadTableName, type DbAiThread } from '../database/entities/ai';
+import {
+    AiThreadTableName,
+    AiWebAppThreadTableName,
+    type DbAiThread,
+} from '../database/entities/ai';
 import {
     AI_ASSISTANT_MESSAGE_TERMINAL_STATUSES,
     AI_TOOL_PART_INTERRUPTED_STATE,
@@ -357,6 +361,13 @@ export class AiAgentV3Model {
             await trx(AiThreadMessageSequenceTableName).insert({
                 ai_thread_uuid: thread.ai_thread_uuid,
             });
+            if (data.ownerUserUuid) {
+                await trx(AiWebAppThreadTableName).insert({
+                    ai_thread_uuid: thread.ai_thread_uuid,
+                    user_uuid: data.ownerUserUuid,
+                    embed_space_uuid: null,
+                });
+            }
 
             return {
                 uuid: thread.ai_thread_uuid,
@@ -420,6 +431,58 @@ export class AiAgentV3Model {
         });
     }
 
+    async appendSteer({
+        threadUuid,
+        assistantMessageUuid,
+        createdByUserUuid,
+        parts,
+    }: {
+        threadUuid: string;
+        assistantMessageUuid: string;
+        createdByUserUuid: string;
+        parts: AiV3PartWrite[];
+    }): Promise<CreatedMessage> {
+        if (parts.length === 0) {
+            throw new ParameterError('Steer message requires content');
+        }
+        AiAgentV3Model.assertPartWrites(parts, 'user');
+        return this.database.transaction(async (trx) => {
+            const assistant = await AiAgentV3Model.getWritableAssistantMessage(
+                trx,
+                assistantMessageUuid,
+            );
+            if (assistant.ai_thread_uuid !== threadUuid) {
+                throw new NotFoundError('Assistant message not found');
+            }
+            const threadSeq = await AiAgentV3Model.allocateThreadSeq(
+                trx,
+                threadUuid,
+            );
+            const [message] = await trx(AiThreadMessageTableName)
+                .insert({
+                    ai_thread_uuid: threadUuid,
+                    thread_seq: threadSeq,
+                    role: 'user',
+                    created_by_user_uuid: createdByUserUuid,
+                })
+                .returning(['ai_thread_message_uuid', 'created_at']);
+            if (message === undefined) {
+                throw new UnexpectedServerError(
+                    'Failed to append steer message',
+                );
+            }
+            await AiAgentV3Model.insertParts(
+                trx,
+                message.ai_thread_message_uuid,
+                parts,
+            );
+            await trx(AiThreadTableName)
+                .where('ai_thread_uuid', threadUuid)
+                .update({ updated_at: message.created_at });
+            return { uuid: message.ai_thread_message_uuid, threadSeq };
+        });
+    }
+
     async createAssistantMessage({
         threadUuid,
         modelConfig,
@@ -454,6 +517,99 @@ export class AiAgentV3Model {
         });
     }
 
+    async startRun({
+        threadUuid,
+        createdByUserUuid,
+        userParts,
+        modelConfig,
+    }: {
+        threadUuid: string;
+        createdByUserUuid: string;
+        userParts: AiV3PartWrite[];
+        modelConfig: AiModelConfigEnvelope;
+    }): Promise<{
+        userMessage: CreatedMessage;
+        assistantMessage: CreatedMessage;
+    }> {
+        if (userParts.length === 0) {
+            throw new ParameterError('User message requires content');
+        }
+        AiAgentV3Model.assertPartWrites(userParts, 'user');
+        return this.database.transaction(async (trx) => {
+            await trx(AiThreadMessageSequenceTableName)
+                .where('ai_thread_uuid', threadUuid)
+                .forUpdate()
+                .first();
+            const activeAssistant = await trx(AiThreadMessageTableName)
+                .where('ai_thread_uuid', threadUuid)
+                .where('role', 'assistant')
+                .where('status', 'in_progress')
+                .first();
+            if (activeAssistant !== undefined) {
+                throw new ConflictError(
+                    'This thread already has an active run',
+                );
+            }
+
+            const userThreadSeq = await AiAgentV3Model.allocateThreadSeq(
+                trx,
+                threadUuid,
+            );
+            const [userMessage] = await trx(AiThreadMessageTableName)
+                .insert({
+                    ai_thread_uuid: threadUuid,
+                    thread_seq: userThreadSeq,
+                    role: 'user',
+                    created_by_user_uuid: createdByUserUuid,
+                })
+                .returning(['ai_thread_message_uuid', 'created_at']);
+            if (userMessage === undefined) {
+                throw new UnexpectedServerError(
+                    'Failed to append user message',
+                );
+            }
+            await AiAgentV3Model.insertParts(
+                trx,
+                userMessage.ai_thread_message_uuid,
+                userParts,
+            );
+
+            const assistantThreadSeq = await AiAgentV3Model.allocateThreadSeq(
+                trx,
+                threadUuid,
+            );
+            const [assistantMessage] = await trx(AiThreadMessageTableName)
+                .insert({
+                    ai_thread_uuid: threadUuid,
+                    thread_seq: assistantThreadSeq,
+                    role: 'assistant',
+                    status: 'in_progress',
+                    last_heartbeat_at: trx.fn.now(),
+                    model_config: modelConfig,
+                })
+                .returning('ai_thread_message_uuid');
+            if (assistantMessage === undefined) {
+                throw new UnexpectedServerError(
+                    'Failed to create assistant message',
+                );
+            }
+            await trx(AiThreadTableName)
+                .where('ai_thread_uuid', threadUuid)
+                .update({ updated_at: userMessage.created_at });
+
+            return {
+                userMessage: {
+                    uuid: userMessage.ai_thread_message_uuid,
+                    threadSeq: userThreadSeq,
+                },
+                assistantMessage: {
+                    uuid: assistantMessage.ai_thread_message_uuid,
+                    threadSeq: assistantThreadSeq,
+                },
+            };
+        });
+    }
+
     async appendParts({
         messageUuid,
         parts,
@@ -466,6 +622,81 @@ export class AiAgentV3Model {
             await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
             return AiAgentV3Model.insertParts(trx, messageUuid, parts);
         });
+    }
+
+    async refreshAssistantMessageHeartbeat(
+        messageUuid: string,
+    ): Promise<boolean> {
+        const updated = await this.database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', messageUuid)
+            .where('role', 'assistant')
+            .where('status', 'in_progress')
+            .update({ last_heartbeat_at: this.database.fn.now() });
+        return updated === 1;
+    }
+
+    async isAssistantMessageInProgress(messageUuid: string): Promise<boolean> {
+        const message = await this.database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', messageUuid)
+            .where('role', 'assistant')
+            .where('status', 'in_progress')
+            .first('ai_thread_message_uuid');
+        return message !== undefined;
+    }
+
+    async getSteers({
+        threadUuid,
+        assistantMessageUuid,
+    }: {
+        threadUuid: string;
+        assistantMessageUuid: string;
+    }): Promise<Array<{ uuid: string; message: string; createdAt: string }>> {
+        const assistant = await this.database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', assistantMessageUuid)
+            .where('ai_thread_uuid', threadUuid)
+            .where('role', 'assistant')
+            .first('thread_seq');
+        if (!assistant) throw new NotFoundError('Assistant message not found');
+        const rows = await this.database(AiThreadMessageTableName)
+            .innerJoin(
+                AiMessagePartTableName,
+                `${AiMessagePartTableName}.ai_thread_message_uuid`,
+                `${AiThreadMessageTableName}.ai_thread_message_uuid`,
+            )
+            .where(`${AiThreadMessageTableName}.ai_thread_uuid`, threadUuid)
+            .where(`${AiThreadMessageTableName}.role`, 'user')
+            .where(
+                `${AiThreadMessageTableName}.thread_seq`,
+                '>',
+                assistant.thread_seq,
+            )
+            .where(`${AiMessagePartTableName}.type`, 'text')
+            .orderBy(`${AiThreadMessageTableName}.thread_seq`)
+            .orderBy(`${AiMessagePartTableName}.part_index`)
+            .select<
+                Array<{
+                    uuid: string;
+                    created_at: Date;
+                    payload: Record<string, unknown>;
+                }>
+            >({
+                uuid: `${AiThreadMessageTableName}.ai_thread_message_uuid`,
+                created_at: `${AiThreadMessageTableName}.created_at`,
+                payload: `${AiMessagePartTableName}.payload`,
+            });
+        const grouped = new Map<
+            string,
+            { uuid: string; message: string; createdAt: string }
+        >();
+        rows.forEach((row) => {
+            const current = grouped.get(row.uuid);
+            grouped.set(row.uuid, {
+                uuid: row.uuid,
+                message: `${current?.message ?? ''}${String(row.payload.text ?? '')}`,
+                createdAt: row.created_at.toISOString(),
+            });
+        });
+        return [...grouped.values()];
     }
 
     async updatePart({

--- a/packages/backend/src/ee/models/AiAgentV3Model.ts
+++ b/packages/backend/src/ee/models/AiAgentV3Model.ts
@@ -1,0 +1,619 @@
+import {
+    assertUnreachable,
+    ConflictError,
+    NotFoundError,
+    ParameterError,
+    UnexpectedServerError,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import { AiThreadTableName, type DbAiThread } from '../database/entities/ai';
+import {
+    AI_ASSISTANT_MESSAGE_TERMINAL_STATUSES,
+    AI_TOOL_PART_INTERRUPTED_STATE,
+    AI_TOOL_PART_TERMINAL_STATES,
+    AiMessagePartTableName,
+    AiThreadMessageSequenceTableName,
+    AiThreadMessageTableName,
+    MODEL_VISIBLE_AI_MESSAGE_PART_TYPES,
+    NON_USER_AI_MESSAGE_PART_TYPES,
+    type AiAssistantMessageTerminalStatus,
+    type AiModelConfigEnvelope,
+    type AiRunErrorEnvelope,
+    type AiTokenUsageEnvelope,
+    type AiV3CanonicalPart,
+    type AiV3CanonicalThread,
+    type AiV3PartWrite,
+    type AiV3ThreadLineage,
+    type CreateAiV3Thread,
+    type DbAiMessagePart,
+    type DbAiThreadMessage,
+} from '../database/entities/aiAgentV3';
+
+type Dependencies = {
+    database: Knex;
+};
+
+type CreatedMessage = {
+    uuid: string;
+    threadSeq: number;
+};
+
+const TERMINAL_TOOL_STATE_PLACEHOLDERS = AI_TOOL_PART_TERMINAL_STATES.map(
+    () => '?',
+).join(', ');
+
+export class AiAgentV3Model {
+    private readonly database: Knex;
+
+    constructor({ database }: Dependencies) {
+        this.database = database;
+    }
+
+    private static toLineage(row: DbAiThread): AiV3ThreadLineage {
+        switch (row.lineage_kind) {
+            case null:
+                return null;
+            case 'spawn':
+                if (
+                    row.parent_thread_uuid === null ||
+                    row.parent_message_uuid === null ||
+                    row.parent_tool_call_id === null
+                ) {
+                    throw new UnexpectedServerError('Invalid spawn lineage');
+                }
+                return {
+                    kind: 'spawn',
+                    parentThreadUuid: row.parent_thread_uuid,
+                    parentMessageUuid: row.parent_message_uuid,
+                    parentToolCallId: row.parent_tool_call_id,
+                };
+            case 'fork':
+                if (
+                    row.parent_thread_uuid === null ||
+                    row.fork_boundary_seq === null
+                ) {
+                    throw new UnexpectedServerError('Invalid fork lineage');
+                }
+                return {
+                    kind: 'fork',
+                    parentThreadUuid: row.parent_thread_uuid,
+                    forkBoundarySeq: row.fork_boundary_seq,
+                };
+            default:
+                return assertUnreachable(
+                    row.lineage_kind,
+                    'Invalid lineage kind',
+                );
+        }
+    }
+
+    private static assertLineageScope(
+        parent: DbAiThread,
+        data: CreateAiV3Thread,
+    ): void {
+        if (
+            parent.organization_uuid !== data.organizationUuid ||
+            parent.project_uuid !== data.projectUuid ||
+            parent.agent_uuid !== data.agentUuid
+        ) {
+            throw new ParameterError('Lineage scope must match its parent');
+        }
+        if (parent.storage_version !== 3) {
+            throw new ParameterError(
+                'Lineage parent must use storage version 3',
+            );
+        }
+    }
+
+    private static async allocateThreadSeq(
+        trx: Knex.Transaction,
+        threadUuid: string,
+    ): Promise<number> {
+        const [row] = await trx(AiThreadMessageSequenceTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .increment('next_thread_seq', 1)
+            .returning('next_thread_seq');
+        if (row === undefined) {
+            const thread = await trx(AiThreadTableName)
+                .where('ai_thread_uuid', threadUuid)
+                .first();
+            if (thread === undefined) {
+                throw new NotFoundError('Thread not found');
+            }
+            throw new ConflictError('Thread is not writable v3 storage');
+        }
+        return row.next_thread_seq - 1;
+    }
+
+    private static assertPartWrites(
+        parts: AiV3PartWrite[],
+        role: 'user' | 'assistant',
+    ): void {
+        parts.forEach((part) => {
+            if (
+                role === 'user' &&
+                NON_USER_AI_MESSAGE_PART_TYPES.some(
+                    (partType) => partType === part.type,
+                )
+            ) {
+                throw new ParameterError(
+                    `${part.type} parts are not valid on user messages`,
+                );
+            }
+            if (role === 'assistant' && part.type === 'compaction') {
+                throw new ParameterError(
+                    'compaction parts are not valid on assistant messages',
+                );
+            }
+            if (part.type === 'tool' && !part.toolCallId) {
+                throw new ParameterError('Tool part requires a tool call id');
+            }
+            if (part.type === 'artifact' && !part.artifactVersionUuid) {
+                throw new ParameterError(
+                    'Artifact part requires an artifact version uuid',
+                );
+            }
+            if (
+                part.type !== 'tool' &&
+                'toolCallId' in part &&
+                part.toolCallId !== undefined
+            ) {
+                throw new ParameterError(
+                    'Tool call id is only valid on tool parts',
+                );
+            }
+            if (
+                part.type !== 'artifact' &&
+                'artifactVersionUuid' in part &&
+                part.artifactVersionUuid !== undefined
+            ) {
+                throw new ParameterError(
+                    'Artifact version uuid is only valid on artifact parts',
+                );
+            }
+        });
+    }
+
+    private static async insertParts(
+        trx: Knex.Transaction,
+        messageUuid: string,
+        parts: AiV3PartWrite[],
+    ): Promise<AiV3CanonicalPart[]> {
+        if (parts.length === 0) return [];
+        const rows = await trx(AiMessagePartTableName)
+            .insert(
+                parts.map((part) => ({
+                    ai_thread_message_uuid: messageUuid,
+                    part_index: part.partIndex,
+                    type: part.type,
+                    payload_version: part.payloadVersion,
+                    payload: part.payload,
+                    tool_call_id: part.toolCallId,
+                    ai_artifact_version_uuid: part.artifactVersionUuid,
+                })),
+            )
+            .returning('*');
+        return rows.map(AiAgentV3Model.toCanonicalPart);
+    }
+
+    private static toCanonicalPart(part: DbAiMessagePart): AiV3CanonicalPart {
+        return {
+            uuid: part.ai_message_part_uuid,
+            type: part.type,
+            payloadVersion: part.payload_version,
+            payload: part.payload,
+            toolCallId: part.tool_call_id,
+            artifactVersionUuid: part.ai_artifact_version_uuid,
+        };
+    }
+
+    private static async getWritableAssistantMessage(
+        trx: Knex.Transaction,
+        messageUuid: string,
+    ): Promise<DbAiThreadMessage> {
+        const message = await trx(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', messageUuid)
+            .forUpdate()
+            .first();
+        if (message === undefined) {
+            throw new NotFoundError('Assistant message not found');
+        }
+        if (message.role !== 'assistant') {
+            throw new ConflictError('Message is not an assistant message');
+        }
+        if (message.status !== 'in_progress') {
+            throw new ConflictError('Assistant message is frozen');
+        }
+        return message;
+    }
+
+    async createThread(data: CreateAiV3Thread) {
+        return this.database.transaction(async (trx) => {
+            let parent: DbAiThread | undefined;
+            if (data.lineage !== null) {
+                parent = await trx(AiThreadTableName)
+                    .where('ai_thread_uuid', data.lineage.parentThreadUuid)
+                    .first();
+                if (parent === undefined) {
+                    throw new NotFoundError('Lineage parent thread not found');
+                }
+                AiAgentV3Model.assertLineageScope(parent, data);
+
+                switch (data.lineage.kind) {
+                    case 'spawn': {
+                        const anchor = await trx(AiThreadMessageTableName)
+                            .innerJoin(
+                                AiMessagePartTableName,
+                                `${AiMessagePartTableName}.ai_thread_message_uuid`,
+                                `${AiThreadMessageTableName}.ai_thread_message_uuid`,
+                            )
+                            .where(
+                                `${AiThreadMessageTableName}.ai_thread_message_uuid`,
+                                data.lineage.parentMessageUuid,
+                            )
+                            .where(
+                                `${AiThreadMessageTableName}.ai_thread_uuid`,
+                                data.lineage.parentThreadUuid,
+                            )
+                            .where(
+                                `${AiThreadMessageTableName}.role`,
+                                'assistant',
+                            )
+                            .where(`${AiMessagePartTableName}.type`, 'tool')
+                            .where(
+                                `${AiMessagePartTableName}.tool_call_id`,
+                                data.lineage.parentToolCallId,
+                            )
+                            .first();
+                        if (anchor === undefined) {
+                            throw new ParameterError(
+                                'Spawn anchor does not exist',
+                            );
+                        }
+                        break;
+                    }
+                    case 'fork': {
+                        if (parent.lineage_kind === 'spawn') {
+                            throw new ParameterError(
+                                'Spawn threads cannot be forked',
+                            );
+                        }
+                        const boundary = await trx(AiThreadMessageTableName)
+                            .where(
+                                'ai_thread_uuid',
+                                data.lineage.parentThreadUuid,
+                            )
+                            .where('thread_seq', data.lineage.forkBoundarySeq)
+                            .first();
+                        if (boundary === undefined) {
+                            throw new ParameterError(
+                                'Fork boundary does not exist',
+                            );
+                        }
+                        if (
+                            boundary.role === 'assistant' &&
+                            !AI_ASSISTANT_MESSAGE_TERMINAL_STATUSES.some(
+                                (status) => status === boundary.status,
+                            )
+                        ) {
+                            throw new ParameterError(
+                                'Fork boundary assistant message must be frozen',
+                            );
+                        }
+                        const activeAssistantInPrefix = await trx(
+                            AiThreadMessageTableName,
+                        )
+                            .where(
+                                'ai_thread_uuid',
+                                data.lineage.parentThreadUuid,
+                            )
+                            .where(
+                                'thread_seq',
+                                '<=',
+                                data.lineage.forkBoundarySeq,
+                            )
+                            .where('role', 'assistant')
+                            .where('status', 'in_progress')
+                            .first();
+                        if (activeAssistantInPrefix !== undefined) {
+                            throw new ParameterError(
+                                'Fork prefix contains an active assistant message',
+                            );
+                        }
+                        break;
+                    }
+                    default:
+                        assertUnreachable(data.lineage, 'Invalid lineage');
+                }
+            }
+
+            const { lineage } = data;
+            const [thread] = await trx(AiThreadTableName)
+                .insert({
+                    organization_uuid: data.organizationUuid,
+                    project_uuid: data.projectUuid,
+                    agent_uuid: data.agentUuid,
+                    created_from: data.createdFrom,
+                    storage_version: 3,
+                    parent_thread_uuid: lineage?.parentThreadUuid,
+                    lineage_kind: lineage?.kind,
+                    parent_message_uuid:
+                        lineage?.kind === 'spawn'
+                            ? lineage.parentMessageUuid
+                            : undefined,
+                    parent_tool_call_id:
+                        lineage?.kind === 'spawn'
+                            ? lineage.parentToolCallId
+                            : undefined,
+                    fork_boundary_seq:
+                        lineage?.kind === 'fork'
+                            ? lineage.forkBoundarySeq
+                            : undefined,
+                })
+                .returning('*');
+            if (thread === undefined) {
+                throw new UnexpectedServerError('Failed to create v3 thread');
+            }
+            await trx(AiThreadMessageSequenceTableName).insert({
+                ai_thread_uuid: thread.ai_thread_uuid,
+            });
+
+            return {
+                uuid: thread.ai_thread_uuid,
+                storageVersion: 3 as const,
+                lineage: AiAgentV3Model.toLineage(thread),
+            };
+        });
+    }
+
+    async appendUserMessage({
+        threadUuid,
+        createdByUserUuid,
+        createdAt,
+        parts,
+    }: {
+        threadUuid: string;
+        createdByUserUuid: string | null;
+        createdAt?: Date;
+        parts: AiV3PartWrite[];
+    }): Promise<CreatedMessage> {
+        if (parts.length === 0) {
+            throw new ParameterError('User message requires content');
+        }
+        AiAgentV3Model.assertPartWrites(parts, 'user');
+        return this.database.transaction(async (trx) => {
+            const threadSeq = await AiAgentV3Model.allocateThreadSeq(
+                trx,
+                threadUuid,
+            );
+            const [message] = await trx(AiThreadMessageTableName)
+                .insert({
+                    ai_thread_uuid: threadUuid,
+                    thread_seq: threadSeq,
+                    role: 'user',
+                    created_by_user_uuid: createdByUserUuid,
+                    created_at: createdAt,
+                })
+                .returning(['ai_thread_message_uuid', 'created_at']);
+            if (message === undefined) {
+                throw new UnexpectedServerError(
+                    'Failed to append user message',
+                );
+            }
+            await AiAgentV3Model.insertParts(
+                trx,
+                message.ai_thread_message_uuid,
+                parts,
+            );
+            await trx(AiThreadTableName)
+                .where('ai_thread_uuid', threadUuid)
+                .update({
+                    updated_at: trx.raw('GREATEST(??, ?)', [
+                        'updated_at',
+                        message.created_at,
+                    ]),
+                });
+            return {
+                uuid: message.ai_thread_message_uuid,
+                threadSeq,
+            };
+        });
+    }
+
+    async createAssistantMessage({
+        threadUuid,
+        modelConfig,
+    }: {
+        threadUuid: string;
+        modelConfig: AiModelConfigEnvelope;
+    }): Promise<CreatedMessage> {
+        return this.database.transaction(async (trx) => {
+            const threadSeq = await AiAgentV3Model.allocateThreadSeq(
+                trx,
+                threadUuid,
+            );
+            const [message] = await trx(AiThreadMessageTableName)
+                .insert({
+                    ai_thread_uuid: threadUuid,
+                    thread_seq: threadSeq,
+                    role: 'assistant',
+                    status: 'in_progress',
+                    last_heartbeat_at: trx.fn.now(),
+                    model_config: modelConfig,
+                })
+                .returning('ai_thread_message_uuid');
+            if (message === undefined) {
+                throw new UnexpectedServerError(
+                    'Failed to create assistant message',
+                );
+            }
+            return {
+                uuid: message.ai_thread_message_uuid,
+                threadSeq,
+            };
+        });
+    }
+
+    async appendParts({
+        messageUuid,
+        parts,
+    }: {
+        messageUuid: string;
+        parts: AiV3PartWrite[];
+    }): Promise<AiV3CanonicalPart[]> {
+        AiAgentV3Model.assertPartWrites(parts, 'assistant');
+        return this.database.transaction(async (trx) => {
+            await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
+            return AiAgentV3Model.insertParts(trx, messageUuid, parts);
+        });
+    }
+
+    async updatePart({
+        messageUuid,
+        partUuid,
+        payloadVersion,
+        payload,
+    }: {
+        messageUuid: string;
+        partUuid: string;
+        payloadVersion: number;
+        payload: Record<string, unknown>;
+    }): Promise<AiV3CanonicalPart> {
+        return this.database.transaction(async (trx) => {
+            await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
+            const [part] = await trx(AiMessagePartTableName)
+                .where('ai_message_part_uuid', partUuid)
+                .where('ai_thread_message_uuid', messageUuid)
+                .update({
+                    payload_version: payloadVersion,
+                    payload,
+                })
+                .returning('*');
+            if (part === undefined) {
+                throw new NotFoundError('Message part not found');
+            }
+            return AiAgentV3Model.toCanonicalPart(part);
+        });
+    }
+
+    async finishAssistantMessage({
+        messageUuid,
+        status,
+        tokenUsage,
+        error,
+    }: {
+        messageUuid: string;
+        status: AiAssistantMessageTerminalStatus;
+        tokenUsage: AiTokenUsageEnvelope | null;
+        error: AiRunErrorEnvelope | null;
+    }): Promise<void> {
+        if (status === 'error' && error === null) {
+            throw new ParameterError('Error status requires an error envelope');
+        }
+        if (status !== 'error' && error !== null) {
+            throw new ParameterError('Error envelope requires error status');
+        }
+        await this.database.transaction(async (trx) => {
+            await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
+            if (status === 'completed') {
+                const visiblePart = await trx(AiMessagePartTableName)
+                    .where('ai_thread_message_uuid', messageUuid)
+                    .whereIn('type', [...MODEL_VISIBLE_AI_MESSAGE_PART_TYPES])
+                    .first();
+                if (visiblePart === undefined) {
+                    throw new ConflictError(
+                        'Completed assistant message requires content',
+                    );
+                }
+            }
+
+            await trx(AiMessagePartTableName)
+                .where('ai_thread_message_uuid', messageUuid)
+                .where('type', 'tool')
+                .whereRaw(
+                    `COALESCE(payload->>'state', '') NOT IN (${TERMINAL_TOOL_STATE_PLACEHOLDERS})`,
+                    [...AI_TOOL_PART_TERMINAL_STATES],
+                )
+                .update({
+                    payload: trx.raw('payload || ?::jsonb', [
+                        JSON.stringify({
+                            state: AI_TOOL_PART_INTERRUPTED_STATE,
+                            error: {
+                                name: 'interrupted',
+                                message: 'Tool execution was interrupted',
+                            },
+                        }),
+                    ]),
+                });
+            await trx(AiThreadMessageTableName)
+                .where('ai_thread_message_uuid', messageUuid)
+                .update({
+                    status,
+                    token_usage: tokenUsage,
+                    error,
+                });
+        });
+    }
+
+    async getThread(threadUuid: string): Promise<AiV3CanonicalThread> {
+        const thread = await this.database(AiThreadTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .first();
+        if (thread === undefined) {
+            throw new NotFoundError('Thread not found');
+        }
+        if (thread.storage_version !== 3) {
+            throw new ConflictError('Thread is not storage version 3');
+        }
+
+        const messages = await this.database(AiThreadMessageTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .orderBy('thread_seq');
+        const messageUuids = messages.map(
+            (message) => message.ai_thread_message_uuid,
+        );
+        const parts =
+            messageUuids.length === 0
+                ? []
+                : await this.database(AiMessagePartTableName)
+                      .whereIn('ai_thread_message_uuid', messageUuids)
+                      .orderBy([
+                          { column: 'ai_thread_message_uuid' },
+                          { column: 'part_index' },
+                      ]);
+        const partsByMessageUuid = new Map<string, AiV3CanonicalPart[]>();
+        parts.forEach((part) => {
+            const messageParts =
+                partsByMessageUuid.get(part.ai_thread_message_uuid) ?? [];
+            messageParts.push(AiAgentV3Model.toCanonicalPart(part));
+            partsByMessageUuid.set(part.ai_thread_message_uuid, messageParts);
+        });
+
+        return {
+            uuid: thread.ai_thread_uuid,
+            storageVersion: 3,
+            organizationUuid: thread.organization_uuid,
+            projectUuid: thread.project_uuid,
+            agentUuid: thread.agent_uuid,
+            createdAt: thread.created_at.toISOString(),
+            lineage: AiAgentV3Model.toLineage(thread),
+            messages: messages.map((message) => ({
+                uuid: message.ai_thread_message_uuid,
+                role: message.role,
+                parts:
+                    partsByMessageUuid.get(message.ai_thread_message_uuid) ??
+                    [],
+                metadata: {
+                    createdAt: message.created_at.toISOString(),
+                    createdByUserUuid: message.created_by_user_uuid,
+                    status: message.status,
+                    lastHeartbeatAt:
+                        message.last_heartbeat_at?.toISOString() ?? null,
+                    modelConfig: message.model_config,
+                    tokenUsage: message.token_usage,
+                    error: message.error,
+                },
+            })),
+        };
+    }
+}

--- a/packages/backend/src/ee/models/AiAgentV3Model.ts
+++ b/packages/backend/src/ee/models/AiAgentV3Model.ts
@@ -17,11 +17,11 @@ import {
     MODEL_VISIBLE_AI_MESSAGE_PART_TYPES,
     NON_USER_AI_MESSAGE_PART_TYPES,
     type AiAssistantMessageTerminalStatus,
+    type AiCanonicalPart,
+    type AiCanonicalThread,
     type AiModelConfigEnvelope,
     type AiRunErrorEnvelope,
     type AiTokenUsageEnvelope,
-    type AiV3CanonicalPart,
-    type AiV3CanonicalThread,
     type AiV3PartWrite,
     type AiV3ThreadLineage,
     type CreateAiV3Thread,
@@ -178,7 +178,7 @@ export class AiAgentV3Model {
         trx: Knex.Transaction,
         messageUuid: string,
         parts: AiV3PartWrite[],
-    ): Promise<AiV3CanonicalPart[]> {
+    ): Promise<AiCanonicalPart[]> {
         if (parts.length === 0) return [];
         const rows = await trx(AiMessagePartTableName)
             .insert(
@@ -196,7 +196,7 @@ export class AiAgentV3Model {
         return rows.map(AiAgentV3Model.toCanonicalPart);
     }
 
-    private static toCanonicalPart(part: DbAiMessagePart): AiV3CanonicalPart {
+    private static toCanonicalPart(part: DbAiMessagePart): AiCanonicalPart {
         return {
             uuid: part.ai_message_part_uuid,
             type: part.type,
@@ -460,7 +460,7 @@ export class AiAgentV3Model {
     }: {
         messageUuid: string;
         parts: AiV3PartWrite[];
-    }): Promise<AiV3CanonicalPart[]> {
+    }): Promise<AiCanonicalPart[]> {
         AiAgentV3Model.assertPartWrites(parts, 'assistant');
         return this.database.transaction(async (trx) => {
             await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
@@ -478,7 +478,7 @@ export class AiAgentV3Model {
         partUuid: string;
         payloadVersion: number;
         payload: Record<string, unknown>;
-    }): Promise<AiV3CanonicalPart> {
+    }): Promise<AiCanonicalPart> {
         return this.database.transaction(async (trx) => {
             await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
             const [part] = await trx(AiMessagePartTableName)
@@ -555,19 +555,23 @@ export class AiAgentV3Model {
         });
     }
 
-    async getThread(threadUuid: string): Promise<AiV3CanonicalThread> {
+    async getThread(threadUuid: string): Promise<AiCanonicalThread> {
         const thread = await this.database(AiThreadTableName)
             .where('ai_thread_uuid', threadUuid)
             .first();
         if (thread === undefined) {
             throw new NotFoundError('Thread not found');
         }
+        return this.getThreadFromRow(thread);
+    }
+
+    async getThreadFromRow(thread: DbAiThread): Promise<AiCanonicalThread> {
         if (thread.storage_version !== 3) {
             throw new ConflictError('Thread is not storage version 3');
         }
 
         const messages = await this.database(AiThreadMessageTableName)
-            .where('ai_thread_uuid', threadUuid)
+            .where('ai_thread_uuid', thread.ai_thread_uuid)
             .orderBy('thread_seq');
         const messageUuids = messages.map(
             (message) => message.ai_thread_message_uuid,
@@ -581,7 +585,7 @@ export class AiAgentV3Model {
                           { column: 'ai_thread_message_uuid' },
                           { column: 'part_index' },
                       ]);
-        const partsByMessageUuid = new Map<string, AiV3CanonicalPart[]>();
+        const partsByMessageUuid = new Map<string, AiCanonicalPart[]>();
         parts.forEach((part) => {
             const messageParts =
                 partsByMessageUuid.get(part.ai_thread_message_uuid) ?? [];
@@ -596,6 +600,9 @@ export class AiAgentV3Model {
             projectUuid: thread.project_uuid,
             agentUuid: thread.agent_uuid,
             createdAt: thread.created_at.toISOString(),
+            updatedAt: thread.updated_at?.toISOString() ?? null,
+            createdFrom: thread.created_from,
+            title: thread.title,
             lineage: AiAgentV3Model.toLineage(thread),
             messages: messages.map((message) => ({
                 uuid: message.ai_thread_message_uuid,
@@ -612,6 +619,9 @@ export class AiAgentV3Model {
                     modelConfig: message.model_config,
                     tokenUsage: message.token_usage,
                     error: message.error,
+                    hidden: false,
+                    context: [],
+                    legacy: null,
                 },
             })),
         };

--- a/packages/backend/src/ee/models/aiAgentThreadOwner.ts
+++ b/packages/backend/src/ee/models/aiAgentThreadOwner.ts
@@ -1,0 +1,7 @@
+export const getAiAgentThreadOwnerExpression = ({
+    webAppOwner,
+    firstPromptOwner,
+}: {
+    webAppOwner: string;
+    firstPromptOwner: string;
+}) => `COALESCE(${webAppOwner}, ${firstPromptOwner})`;

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -381,7 +381,7 @@ const makeService = ({
             ...projectModel,
         },
         aiAgentService: {
-            generateAgentThreadResponse: vi
+            generateAgentThreadResponseInternal: vi
                 .fn()
                 .mockResolvedValue('Opened a pull request.'),
             ...aiAgentService,
@@ -2347,7 +2347,7 @@ describe('AiAgentAdminService.runReviewItemWritebackJob', () => {
             createRemediationEvent: vi.fn().mockResolvedValue(undefined),
         };
         const aiAgentService = {
-            generateAgentThreadResponse: vi
+            generateAgentThreadResponseInternal: vi
                 .fn()
                 .mockResolvedValue('Opened a pull request.'),
         };
@@ -2360,7 +2360,9 @@ describe('AiAgentAdminService.runReviewItemWritebackJob', () => {
 
         // The build-fix thread (not the headless sandbox) opens the PR, pinning
         // the editDbtProject tool on the opening turn.
-        expect(aiAgentService.generateAgentThreadResponse).toHaveBeenCalledWith(
+        expect(
+            aiAgentService.generateAgentThreadResponseInternal,
+        ).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({
                 threadUuid: WORK_THREAD_UUID,

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -2086,21 +2086,24 @@ export class AiAgentAdminService extends BaseService {
                         'Build-fix thread was not created for this remediation',
                     );
                 }
-                await this.aiAgentService.generateAgentThreadResponse(user, {
-                    agentUuid,
-                    threadUuid: workThreadUuid,
-                    autoApproveSql: true,
-                    // Force the writeback tool on the opening turn so the run
-                    // always opens a PR rather than just discussing the fix.
-                    toolHints: ['editDbtProject'],
-                    forceToolHints: true,
-                    // The review flow owns preview + verification (below), so the
-                    // tool must not also create its own preview project.
-                    suppressWritebackPreview: true,
-                    onStepProgress: (message) => {
-                        void setProgress(message);
+                await this.aiAgentService.generateAgentThreadResponseInternal(
+                    user,
+                    {
+                        agentUuid,
+                        threadUuid: workThreadUuid,
+                        autoApproveSql: true,
+                        // Force the writeback tool on the opening turn so the run
+                        // always opens a PR rather than just discussing the fix.
+                        toolHints: ['editDbtProject'],
+                        forceToolHints: true,
+                        // The review flow owns preview + verification (below), so the
+                        // tool must not also create its own preview project.
+                        suppressWritebackPreview: true,
+                        onStepProgress: (message) => {
+                            void setProgress(message);
+                        },
                     },
-                });
+                );
                 const writebackPrs =
                     await this.aiAgentReviewClassifierModel.getThreadWritebackPullRequests(
                         [workThreadUuid],

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.readRoutes.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.readRoutes.integration.test.ts
@@ -1,0 +1,393 @@
+import { SEED_ORG_1_EDITOR, SEED_PROJECT } from '@lightdash/common';
+import {
+    getModels,
+    getServices,
+    getTestContext,
+    type IntegrationTestContext,
+} from '../../../vitest.setup.integration';
+import { AiAgentV3Model } from '../../models/AiAgentV3Model';
+
+const modelConfig = {
+    version: 1,
+    modelName: 'claude-sonnet-4-5',
+    modelProvider: 'anthropic',
+    reasoning: { enabled: true, effort: 'high', budgetTokens: null },
+    limits: { maxSteps: 12, maxOutputTokens: null },
+    sampling: { temperature: 0.2, topP: null },
+    providerOptions: null,
+};
+
+describe('AiAgentService v3 thread API', () => {
+    let context: IntegrationTestContext;
+    let agentUuid: string;
+
+    beforeAll(async () => {
+        context = getTestContext();
+        const agent = await getServices(context.app).aiAgentService.createAgent(
+            context.testUser,
+            {
+                name: `V3 read routes ${crypto.randomUUID().slice(0, 8)}`,
+                description: null,
+                projectUuid: SEED_PROJECT.project_uuid,
+                tags: null,
+                integrations: [],
+                instruction: '',
+                groupAccess: [],
+                userAccess: [],
+                spaceAccess: [],
+                imageUrl: null,
+                enableDataAccess: true,
+                enableSelfImprovement: false,
+                version: 2,
+            },
+        );
+        agentUuid = agent.uuid;
+    });
+
+    afterAll(async () => {
+        await getServices(context.app).aiAgentService.deleteAgent(
+            context.testUser,
+            agentUuid,
+        );
+    });
+
+    const createLegacyThread = async ({
+        ownerUserUuid = context.testUser.userUuid,
+        promptUserUuid = ownerUserUuid,
+    }: {
+        ownerUserUuid?: string;
+        promptUserUuid?: string;
+    } = {}) => {
+        const model = getModels(context.app).aiAgentModel;
+        const threadUuid = await model.createWebAppThread({
+            organizationUuid: context.testUser.organizationUuid!,
+            projectUuid: SEED_PROJECT.project_uuid,
+            userUuid: ownerUserUuid,
+            createdFrom: 'web_app',
+            agentUuid,
+        });
+        await model.createWebAppPrompt({
+            threadUuid,
+            createdByUserUuid: promptUserUuid,
+            prompt: 'Legacy question',
+        });
+        return threadUuid;
+    };
+
+    const createV3Thread = async ({
+        createdFrom = 'web_app',
+        ownerUserUuid = context.testUser.userUuid,
+    }: {
+        createdFrom?: 'web_app' | 'slack';
+        ownerUserUuid?: string;
+    } = {}) => {
+        const model = new AiAgentV3Model({ database: context.db });
+        const thread = await model.createThread({
+            organizationUuid: context.testUser.organizationUuid!,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid,
+            createdFrom,
+            lineage: null,
+            ownerUserUuid,
+        });
+        await model.appendUserMessage({
+            threadUuid: thread.uuid,
+            createdByUserUuid: ownerUserUuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'text',
+                    payloadVersion: 1,
+                    payload: { text: 'V3 question' },
+                },
+            ],
+        });
+        return thread.uuid;
+    };
+
+    const createOwnerlessV3Thread = async () => {
+        const model = new AiAgentV3Model({ database: context.db });
+        const thread = await model.createThread({
+            organizationUuid: context.testUser.organizationUuid!,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid,
+            createdFrom: 'web_app',
+            lineage: null,
+        });
+        await model.appendUserMessage({
+            threadUuid: thread.uuid,
+            createdByUserUuid: context.testUser.userUuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'text',
+                    payloadVersion: 1,
+                    payload: { text: 'Ownerless question' },
+                },
+            ],
+        });
+        return thread.uuid;
+    };
+
+    it('serves v1 and v3 threads in one wire shape with viewer capabilities', async () => {
+        const service = getServices(context.app).aiAgentService;
+        const legacyThreadUuid = await createLegacyThread();
+        const mixedOwnerLegacyThreadUuid = await createLegacyThread({
+            promptUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+        });
+        const v3ThreadUuid = await createV3Thread();
+        const slackThreadUuid = await createV3Thread({
+            createdFrom: 'slack',
+        });
+        const otherOwnerThreadUuid = await createV3Thread({
+            ownerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+        });
+        const ownerlessThreadUuid = await createOwnerlessV3Thread();
+        const model = new AiAgentV3Model({ database: context.db });
+        const assistant = await model.createAssistantMessage({
+            threadUuid: v3ThreadUuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: assistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    payload: { state: 'output-available' },
+                    toolCallId: 'spawn-tool-call',
+                },
+            ],
+        });
+        const [spawnThread, forkThread] = await Promise.all([
+            model.createThread({
+                organizationUuid: context.testUser.organizationUuid!,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'spawn',
+                    parentThreadUuid: v3ThreadUuid,
+                    parentMessageUuid: assistant.uuid,
+                    parentToolCallId: 'spawn-tool-call',
+                },
+                ownerUserUuid: context.testUser.userUuid,
+            }),
+            model.createThread({
+                organizationUuid: context.testUser.organizationUuid!,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'fork',
+                    parentThreadUuid: v3ThreadUuid,
+                    forkBoundarySeq: 1,
+                },
+                ownerUserUuid: context.testUser.userUuid,
+            }),
+        ]);
+
+        const [legacy, v3, slack, otherOwner, ownerless] = await Promise.all([
+            service.getAgentThreadV3(
+                context.testUser,
+                SEED_PROJECT.project_uuid,
+                agentUuid,
+                legacyThreadUuid,
+            ),
+            service.getAgentThreadV3(
+                context.testUser,
+                SEED_PROJECT.project_uuid,
+                agentUuid,
+                v3ThreadUuid,
+            ),
+            service.getAgentThreadV3(
+                context.testUser,
+                SEED_PROJECT.project_uuid,
+                agentUuid,
+                slackThreadUuid,
+            ),
+            service.getAgentThreadV3(
+                context.testUser,
+                SEED_PROJECT.project_uuid,
+                agentUuid,
+                otherOwnerThreadUuid,
+            ),
+            service.getAgentThreadV3(
+                context.testUser,
+                SEED_PROJECT.project_uuid,
+                agentUuid,
+                ownerlessThreadUuid,
+            ),
+        ]);
+
+        expect(legacy).toMatchObject({
+            storageVersion: 1,
+            readOnly: true,
+            readOnlyReason: 'legacy',
+        });
+        expect(v3).toMatchObject({
+            storageVersion: 3,
+            readOnly: false,
+            readOnlyReason: null,
+        });
+        expect(slack).toMatchObject({
+            storageVersion: 3,
+            readOnly: true,
+            readOnlyReason: 'slack',
+        });
+        expect(otherOwner).toMatchObject({
+            storageVersion: 3,
+            readOnly: true,
+            readOnlyReason: 'not_owner',
+        });
+        expect(ownerless).toMatchObject({
+            storageVersion: 3,
+            readOnly: true,
+            readOnlyReason: 'not_owner',
+        });
+        [legacy.messages[0], v3.messages[0]].forEach((message) => {
+            expect(message).toEqual(
+                expect.objectContaining({
+                    uuid: expect.any(String),
+                    role: 'user',
+                    parts: expect.any(Array),
+                    metadata: expect.any(Object),
+                }),
+            );
+        });
+
+        const summaries = await service.listAgentThreadsV3(context.testUser, {
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid,
+            allUsers: true,
+        });
+        expect(summaries).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    uuid: legacyThreadUuid,
+                    storageVersion: 1,
+                    readOnlyReason: 'legacy',
+                    firstMessage: expect.objectContaining({
+                        message: 'Legacy question',
+                    }),
+                }),
+                expect.objectContaining({
+                    uuid: mixedOwnerLegacyThreadUuid,
+                    user: expect.objectContaining({
+                        uuid: context.testUser.userUuid,
+                    }),
+                }),
+                expect.objectContaining({
+                    uuid: v3ThreadUuid,
+                    storageVersion: 3,
+                    readOnly: false,
+                    firstMessage: expect.objectContaining({
+                        message: 'V3 question',
+                    }),
+                }),
+                expect.objectContaining({
+                    uuid: otherOwnerThreadUuid,
+                    readOnlyReason: 'not_owner',
+                }),
+                expect.objectContaining({
+                    uuid: ownerlessThreadUuid,
+                    user: expect.objectContaining({ uuid: null }),
+                    readOnlyReason: 'not_owner',
+                }),
+                expect.objectContaining({ uuid: forkThread.uuid }),
+            ]),
+        );
+        await expect(
+            getModels(context.app).aiAgentModel.findThreadOwnership({
+                organizationUuid: context.testUser.organizationUuid!,
+                threadUuid: mixedOwnerLegacyThreadUuid,
+            }),
+        ).resolves.toMatchObject({
+            ownerUserUuid: context.testUser.userUuid,
+        });
+        expect(summaries).not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ uuid: spawnThread.uuid }),
+            ]),
+        );
+
+        await expect(
+            service.listAgentThreadsV3(context.testUser, {
+                projectUuid: crypto.randomUUID(),
+                agentUuid,
+                allUsers: true,
+            }),
+        ).rejects.toMatchObject({ name: 'NotFoundError' });
+    });
+
+    it('guards conversation mutations in both directions', async () => {
+        const service = getServices(context.app).aiAgentService;
+        const legacyThreadUuid = await createLegacyThread();
+        const v3ThreadUuid = await createV3Thread();
+        const expectReadOnly = (promise: Promise<unknown>) =>
+            expect(promise).rejects.toMatchObject({
+                name: 'ReadOnlyThreadError',
+                statusCode: 409,
+            });
+
+        await expectReadOnly(
+            service.streamAgentThreadV3Response(context.testUser, {
+                agentUuid,
+                threadUuid: legacyThreadUuid,
+                body: { message: 'Blocked' },
+            }),
+        );
+        await expectReadOnly(
+            service.createAgentThreadMessage(
+                context.testUser,
+                agentUuid,
+                v3ThreadUuid,
+                { prompt: 'Blocked' },
+            ),
+        );
+        await expectReadOnly(
+            service.streamAgentThreadResponse(context.testUser, {
+                agentUuid,
+                threadUuid: v3ThreadUuid,
+                toolHints: [],
+            }),
+        );
+        await expectReadOnly(
+            service.generateAgentThreadResponse(context.testUser, {
+                agentUuid,
+                threadUuid: v3ThreadUuid,
+            }),
+        );
+        await expectReadOnly(
+            service.interruptAgentThreadMessageV3(context.testUser, {
+                agentUuid,
+                threadUuid: legacyThreadUuid,
+                messageUuid: crypto.randomUUID(),
+            }),
+        );
+        await expectReadOnly(
+            service.interruptAgentThreadMessage(context.testUser, {
+                agentUuid,
+                threadUuid: v3ThreadUuid,
+                messageUuid: crypto.randomUUID(),
+            }),
+        );
+        await expectReadOnly(
+            service.createAgentThreadMessageSteerV3(context.testUser, {
+                agentUuid,
+                threadUuid: legacyThreadUuid,
+                messageUuid: crypto.randomUUID(),
+                message: 'Blocked',
+            }),
+        );
+        await expectReadOnly(
+            service.createAgentThreadMessageSteer(context.testUser, {
+                agentUuid,
+                threadUuid: v3ThreadUuid,
+                messageUuid: crypto.randomUUID(),
+                message: 'Blocked',
+            }),
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.shutdown.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.shutdown.test.ts
@@ -42,6 +42,15 @@ type PrivateService = {
         options: PromptResolutionOptions,
     ) => Promise<unknown>;
     generateOrStreamAgentResponse: (...args: unknown[]) => Promise<unknown>;
+    prepareAgentThreadV3Response: (...args: unknown[]) => Promise<unknown>;
+    activeV3Runs: Map<
+        string,
+        {
+            threadUuid: string;
+            abortController: AbortController;
+            persistence: { fail: ReturnType<typeof vi.fn> };
+        }
+    >;
 };
 
 const pendingState: AiPromptResponseState = {
@@ -237,5 +246,69 @@ describe('AiAgentService streamed prompt shutdown', () => {
         expect(failPendingPrompts).not.toHaveBeenCalled();
         service.endStreamPreparation();
         vi.useRealTimers();
+    });
+
+    it('rejects new v3 runs and freezes active ones during shutdown', async () => {
+        const { instance, service, failPendingPrompts } = buildService();
+        const privateService = instance as unknown as PrivateService;
+        const abortController = new AbortController();
+        const fail = vi.fn().mockResolvedValue(undefined);
+        privateService.activeV3Runs.set('message-uuid', {
+            threadUuid: 'thread-uuid',
+            abortController,
+            persistence: { fail },
+        });
+
+        await service.failInFlightStreamedPrompts();
+
+        expect(abortController.signal.aborted).toBe(true);
+        expect(fail).toHaveBeenCalledWith(
+            expect.any(Error),
+            'The server restarted while generating this response. Please try again.',
+        );
+        expect(failPendingPrompts).not.toHaveBeenCalled();
+        await expect(
+            instance.streamAgentThreadV3Response({} as never, {
+                agentUuid: 'agent-uuid',
+                threadUuid: 'thread-uuid',
+                body: { message: 'hello' },
+            }),
+        ).rejects.toThrow('The server is restarting');
+    });
+
+    it('waits for v3 admission before snapshotting active runs', async () => {
+        const { instance, service } = buildService();
+        const privateService = instance as unknown as PrivateService;
+        const preparation = createDeferred();
+        const abortController = new AbortController();
+        const fail = vi.fn().mockResolvedValue(undefined);
+        vi.spyOn(
+            privateService,
+            'prepareAgentThreadV3Response',
+        ).mockImplementation(async () => {
+            await preparation.promise;
+            privateService.activeV3Runs.set('message-uuid', {
+                threadUuid: 'thread-uuid',
+                abortController,
+                persistence: { fail },
+            });
+            return {};
+        });
+
+        const stream = instance.streamAgentThreadV3Response({} as never, {
+            agentUuid: 'agent-uuid',
+            threadUuid: 'thread-uuid',
+            body: { message: 'hello' },
+        });
+        await Promise.resolve();
+        const shutdown = service.failInFlightStreamedPrompts();
+        await Promise.resolve();
+        expect(fail).not.toHaveBeenCalled();
+
+        preparation.resolve();
+        await Promise.all([stream, shutdown]);
+
+        expect(abortController.signal.aborted).toBe(true);
+        expect(fail).toHaveBeenCalledOnce();
     });
 });

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.shutdown.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.shutdown.test.ts
@@ -110,7 +110,7 @@ describe('AiAgentService streamed prompt shutdown', () => {
             };
         });
 
-        const stream = instance.streamAgentThreadResponse(
+        const stream = instance.streamAgentThreadResponseInternal(
             { organizationUuid: 'organization-uuid' } as never,
             {
                 agentUuid: 'agent-uuid',
@@ -145,7 +145,7 @@ describe('AiAgentService streamed prompt shutdown', () => {
         });
 
         await expect(
-            instance.streamAgentThreadResponse(
+            instance.streamAgentThreadResponseInternal(
                 { organizationUuid: 'organization-uuid' } as never,
                 {
                     agentUuid: 'agent-uuid',

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -44,6 +44,7 @@ import {
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQuery,
     ApiAiAgentThreadShareResponse,
+    ApiAiAgentV3ChatRequest,
     ApiAiMcpOAuthCredentialRequest,
     ApiAppendEvaluationRequest,
     ApiCreateAiAgent,
@@ -223,6 +224,10 @@ import { ShareService } from '../../../services/ShareService/ShareService';
 import { SpaceService } from '../../../services/SpaceService/SpaceService';
 import { wrapSentryTransaction } from '../../../utils';
 import { validatePublicHttpUrl } from '../../../utils/ssrfProtection';
+import {
+    type AiCanonicalThread,
+    type AiModelConfigEnvelope,
+} from '../../database/entities/aiAgentV3';
 import { type DbAiDeepResearchEvent } from '../../database/entities/aiDeepResearch';
 import { AiAgentDocumentModel } from '../../models/AiAgentDocumentModel';
 import { AiAgentMemoryModel } from '../../models/AiAgentMemoryModel';
@@ -238,6 +243,8 @@ import {
 } from '../../models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from '../../models/AiAgentReviewClassifierModel';
 import { AiAgentReviewNotificationModel } from '../../models/AiAgentReviewNotificationModel';
+import { AiAgentThreadRepository } from '../../models/AiAgentThreadRepository';
+import { AiAgentV3Model } from '../../models/AiAgentV3Model';
 import {
     AiDeepResearchRunModel,
     type AiDeepResearchRunContextRow,
@@ -264,8 +271,13 @@ import {
     SUGGESTION_FALLBACK_CHIPS,
     type SuggestionPromptContext,
 } from '../ai/agents/suggestionGenerator';
+import { getAiAgentModelName } from '../ai/agents/telemetry';
 import { generateThreadTitle as generateTitleFromMessages } from '../ai/agents/titleGenerator';
 import { AiAgentMcpRuntimeClient } from '../ai/AiAgentMcpRuntimeClient';
+import {
+    AiAgentV3RunPersistence,
+    getAiRunErrorEnvelope,
+} from '../ai/AiAgentV3RunPersistence';
 import { Compaction } from '../ai/compaction';
 import {
     filterModelsForOrg,
@@ -276,6 +288,7 @@ import {
     presetToModelOption,
 } from '../ai/models';
 import { OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
+import { projectV3ThreadToModelMessages } from '../ai/projectV3ThreadToModelMessages';
 import {
     requestingUserRoleFromCustomRole,
     requestingUserRoleFromSystemRole,
@@ -401,6 +414,13 @@ type AgentResponseStream = {
     consumeStream: StreamTextResult<ToolSet, Output.Output>['consumeStream'];
 };
 
+type V3RunContext = {
+    persistence: AiAgentV3RunPersistence;
+    abortSignal: AbortSignal;
+    isInterrupted: () => Promise<boolean>;
+    consumeSteers: (stepNumber: number) => Promise<AiPromptSteer[]>;
+};
+
 const MAX_AI_PROMPT_CONTEXT_ITEMS = 10;
 const AI_AGENT_SHUTDOWN_ERROR_MESSAGE =
     'The server restarted while generating this response. Please try again.';
@@ -425,6 +445,8 @@ const ALLOWED_AGENT_AVATAR_MIME_TYPES = new Set([
 // wrong" even though the backend job completes and opens the PR. 15s sits
 // comfortably under the usual 30-60s idle timeouts.
 const STREAM_KEEPALIVE_INTERVAL_MS = 15_000;
+const V3_RUN_HEARTBEAT_INTERVAL_MS = 15_000;
+const V3_RUN_STOP_TIMEOUT_MS = 5_000;
 const MAX_MCP_BEARER_TOKEN_LENGTH = 8192;
 
 type GenerateAgentExecutionOptions =
@@ -467,6 +489,8 @@ type EmbedAiAgentRuntimeOptions = {
 
 type AiAgentServiceDependencies = {
     aiAgentModel: AiAgentModel;
+    aiAgentV3Model: AiAgentV3Model;
+    aiAgentThreadRepository: AiAgentThreadRepository;
     aiAgentMemoryModel: AiAgentMemoryModel;
     aiAgentDocumentModel: AiAgentDocumentModel;
     aiDeepResearchRunModel: Pick<
@@ -698,6 +722,19 @@ function validateGeneratedSuggestion(
 
 export class AiAgentService extends BaseService {
     private readonly aiAgentModel: AiAgentModel;
+
+    private readonly aiAgentV3Model: AiAgentV3Model;
+
+    private readonly aiAgentThreadRepository: AiAgentThreadRepository;
+
+    private readonly activeV3Runs = new Map<
+        string,
+        {
+            threadUuid: string;
+            abortController: AbortController;
+            persistence: AiAgentV3RunPersistence;
+        }
+    >();
 
     private readonly inFlightStreamPrompts = new Map<
         string,
@@ -1057,6 +1094,8 @@ export class AiAgentService extends BaseService {
     constructor(dependencies: AiAgentServiceDependencies) {
         super();
         this.aiAgentModel = dependencies.aiAgentModel;
+        this.aiAgentV3Model = dependencies.aiAgentV3Model;
+        this.aiAgentThreadRepository = dependencies.aiAgentThreadRepository;
         this.aiAgentMemoryModel = dependencies.aiAgentMemoryModel;
         this.aiAgentDocumentModel = dependencies.aiAgentDocumentModel;
         this.aiDeepResearchRunModel = dependencies.aiDeepResearchRunModel;
@@ -1488,6 +1527,7 @@ export class AiAgentService extends BaseService {
         const { writeActions, content } = account.authentication.data;
         const spaceUuid = writeActions?.spaceUuid;
 
+        // Non-web and embed pipelines still use their v1 executors.
         if (
             content.type !== 'aiAgent' ||
             !spaceUuid ||
@@ -2814,15 +2854,6 @@ export class AiAgentService extends BaseService {
               )
             : undefined;
 
-        const threadUuid = await this.aiAgentModel.createWebAppThread({
-            organizationUuid,
-            projectUuid: agent.projectUuid,
-            userUuid: user.userUuid,
-            createdFrom,
-            agentUuid,
-            embedSpaceUuid: runtimeOptions?.embedSpaceUuid,
-        });
-
         const aiOrganizationSettings =
             body.modelConfig || agent.modelConfig
                 ? undefined
@@ -2832,6 +2863,85 @@ export class AiAgentService extends BaseService {
             agent.modelConfig ??
             aiOrganizationSettings?.defaultAiAgentModelConfig ??
             undefined;
+
+        const { enabled: aiAgentV3Enabled } = await this.featureFlagService.get(
+            {
+                user,
+                featureFlagId: FeatureFlags.AiAgentV3,
+            },
+        );
+        if (
+            aiAgentV3Enabled &&
+            createdFrom === 'web_app' &&
+            runtimeOptions === undefined
+        ) {
+            const created = await this.aiAgentV3Model.createThread({
+                organizationUuid,
+                projectUuid: agent.projectUuid,
+                agentUuid,
+                createdFrom,
+                lineage: null,
+                ownerUserUuid: user.userUuid,
+            });
+            const firstMessage = body.prompt
+                ? await this.aiAgentV3Model.appendUserMessage({
+                      threadUuid: created.uuid,
+                      createdByUserUuid: user.userUuid,
+                      parts: [
+                          {
+                              partIndex: 0,
+                              type: 'text',
+                              payloadVersion: 1,
+                              payload: { text: body.prompt },
+                          },
+                      ],
+                  })
+                : null;
+            if (body.prompt) {
+                this.analytics.track<AiAgentPromptCreatedEvent>({
+                    event: 'ai_agent_prompt.created',
+                    userId: user.userUuid,
+                    properties: {
+                        organizationId: organizationUuid,
+                        projectId: agent.projectUuid,
+                        aiAgentId: agentUuid,
+                        threadId: created.uuid,
+                        context: 'web_app',
+                        ...AiAgentService.getPinnedContextAnalyticsProperties(
+                            context,
+                        ),
+                    },
+                });
+            }
+            const canonical = await this.aiAgentV3Model.getThread(created.uuid);
+            return {
+                uuid: created.uuid,
+                agentUuid,
+                createdAt: canonical.createdAt,
+                createdFrom,
+                title: null,
+                titleGeneratedAt: null,
+                firstMessage: {
+                    uuid: firstMessage?.uuid ?? '',
+                    message: body.prompt ?? '',
+                },
+                user: {
+                    uuid: user.userUuid,
+                    name: [user.firstName, user.lastName]
+                        .filter(Boolean)
+                        .join(' '),
+                },
+            };
+        }
+
+        const threadUuid = await this.aiAgentModel.createWebAppThread({
+            organizationUuid,
+            projectUuid: agent.projectUuid,
+            userUuid: user.userUuid,
+            createdFrom,
+            agentUuid,
+            embedSpaceUuid: runtimeOptions?.embedSpaceUuid,
+        });
 
         if (body.prompt) {
             await this.aiAgentModel.createWebAppPrompt({
@@ -5269,6 +5379,266 @@ export class AiAgentService extends BaseService {
         }
     }
 
+    private async getAccessibleV3Thread(
+        user: SessionUser,
+        agentUuid: string,
+        threadUuid: string,
+    ): Promise<{
+        agent: AiAgent;
+        thread: AiCanonicalThread;
+        ownerUuid: string;
+    }> {
+        if (!user.organizationUuid) throw new ForbiddenError();
+        const [agent, thread] = await Promise.all([
+            this.aiAgentModel.getAgent({
+                organizationUuid: user.organizationUuid,
+                agentUuid,
+            }),
+            this.aiAgentThreadRepository.getThread(threadUuid),
+        ]);
+        if (!agent) throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        if (
+            thread.storageVersion !== 3 ||
+            thread.organizationUuid !== user.organizationUuid ||
+            thread.projectUuid !== agent.projectUuid ||
+            thread.agentUuid !== agentUuid
+        ) {
+            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        }
+        const ownership = await this.aiAgentModel.findThreadOwnership({
+            organizationUuid: user.organizationUuid,
+            threadUuid,
+        });
+        const ownerUuid = ownership?.ownerUserUuid;
+        if (!ownerUuid)
+            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            agent,
+            ownerUuid,
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to use this agent thread',
+            );
+        }
+        return { agent, thread, ownerUuid };
+    }
+
+    async streamAgentThreadV3Response(
+        user: SessionUser,
+        options: {
+            agentUuid: string;
+            threadUuid: string;
+            body: ApiAiAgentV3ChatRequest;
+        },
+    ): Promise<AgentResponseStream> {
+        this.beginStreamPreparation();
+        try {
+            return await this.prepareAgentThreadV3Response(user, options);
+        } finally {
+            this.endStreamPreparation();
+        }
+    }
+
+    private async prepareAgentThreadV3Response(
+        user: SessionUser,
+        {
+            agentUuid,
+            threadUuid,
+            body,
+        }: {
+            agentUuid: string;
+            threadUuid: string;
+            body: ApiAiAgentV3ChatRequest;
+        },
+    ): Promise<AgentResponseStream> {
+        const message = body.message.trim();
+        if (!message) throw new ParameterError('Message is required');
+        if (!(await this.getIsCopilotEnabled(user))) {
+            throw new ForbiddenError('Copilot is not enabled');
+        }
+
+        const { agent, thread, ownerUuid } = await this.getAccessibleV3Thread(
+            user,
+            agentUuid,
+            threadUuid,
+        );
+        if (body.toolHints && body.toolHints.length > 0) {
+            this.analytics.track<AiAgentSuggestionSubmitEvent>({
+                event: 'ai_agent.suggestion_submit',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: thread.organizationUuid,
+                    projectId: thread.projectUuid,
+                    agentId: agentUuid,
+                    toolHints: body.toolHints,
+                },
+            });
+        }
+        if (
+            thread.messages.some(
+                (item) =>
+                    item.role === 'assistant' &&
+                    item.metadata.status === 'in_progress',
+            )
+        ) {
+            throw new ConflictError('This thread already has an active run');
+        }
+
+        const organizationSettings =
+            body.modelConfig || agent.modelConfig
+                ? undefined
+                : await this.aiOrganizationSettingsService.getSettings(user);
+        const modelConfig =
+            body.modelConfig ??
+            agent.modelConfig ??
+            organizationSettings?.defaultAiAgentModelConfig ??
+            null;
+        const copilotConfig =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                thread.organizationUuid,
+            );
+        const modelProperties = getModel(copilotConfig, {
+            enableReasoning: modelConfig?.reasoning,
+            modelName: modelConfig?.modelName,
+            provider: modelConfig?.modelProvider as AnyType,
+        });
+        const modelEnvelope: AiModelConfigEnvelope = {
+            version: 1,
+            modelName: getAiAgentModelName(modelProperties.model),
+            modelProvider:
+                modelConfig?.modelProvider ?? copilotConfig.defaultProvider,
+            reasoning: {
+                enabled: modelConfig?.reasoning ?? false,
+                effort: null,
+                budgetTokens: null,
+            },
+            limits: {
+                maxSteps: DEFAULT_AGENT_MAX_STEPS,
+                maxOutputTokens:
+                    modelProperties.callOptions.maxOutputTokens ?? null,
+            },
+            sampling: {
+                temperature: modelProperties.callOptions.temperature ?? null,
+                topP: modelProperties.callOptions.topP ?? null,
+            },
+            providerOptions: modelProperties.providerOptions ?? null,
+        };
+        const started = await this.aiAgentV3Model.startRun({
+            threadUuid,
+            createdByUserUuid: user.userUuid,
+            userParts: [
+                {
+                    partIndex: 0,
+                    type: 'text',
+                    payloadVersion: 1,
+                    payload: { text: message },
+                },
+            ],
+            modelConfig: modelEnvelope,
+        });
+        const abortController = new AbortController();
+        const persistence = new AiAgentV3RunPersistence(
+            this.aiAgentV3Model,
+            started.assistantMessage.uuid,
+            () => abortController.signal.aborted,
+            () => {
+                if (
+                    this.activeV3Runs.get(started.assistantMessage.uuid)
+                        ?.persistence === persistence
+                ) {
+                    this.activeV3Runs.delete(started.assistantMessage.uuid);
+                }
+            },
+            () => abortController.abort(),
+        );
+        this.activeV3Runs.set(started.assistantMessage.uuid, {
+            threadUuid,
+            abortController,
+            persistence,
+        });
+        try {
+            persistence.startHeartbeat(V3_RUN_HEARTBEAT_INTERVAL_MS);
+
+            const canonical = await this.aiAgentV3Model.getThread(threadUuid);
+            const prompt: AiWebAppPrompt = {
+                organizationUuid: thread.organizationUuid,
+                projectUuid: thread.projectUuid,
+                agentUuid,
+                promptUuid: started.assistantMessage.uuid,
+                threadUuid,
+                createdByUserUuid: user.userUuid,
+                userUuid: ownerUuid,
+                prompt: message,
+                createdAt: new Date(),
+                response: null,
+                errorMessage: null,
+                humanScore: null,
+                modelConfig,
+            };
+            const auditedAbility = this.createAuditedAbility(user);
+            const canManageAgent = auditedAbility.can(
+                'manage',
+                subject('AiAgent', {
+                    organizationUuid: thread.organizationUuid,
+                    projectUuid: thread.projectUuid,
+                    metadata: { agentUuid, threadUuid },
+                }),
+            );
+            const run: V3RunContext = {
+                persistence,
+                abortSignal: abortController.signal,
+                isInterrupted: async () =>
+                    abortController.signal.aborted ||
+                    !(await this.aiAgentV3Model.isAssistantMessageInProgress(
+                        started.assistantMessage.uuid,
+                    )),
+                consumeSteers: (() => {
+                    const consumed = new Set<string>();
+                    return async (stepNumber) => {
+                        const steers = await this.aiAgentV3Model.getSteers({
+                            threadUuid,
+                            assistantMessageUuid: started.assistantMessage.uuid,
+                        });
+                        return steers.flatMap((steer) => {
+                            if (consumed.has(steer.uuid)) return [];
+                            consumed.add(steer.uuid);
+                            return [
+                                {
+                                    ...steer,
+                                    promptUuid: started.assistantMessage.uuid,
+                                    consumedAt: new Date().toISOString(),
+                                    consumedStep: stepNumber,
+                                },
+                            ];
+                        });
+                    };
+                })(),
+            };
+
+            return await this.generateOrStreamAgentResponse(
+                user,
+                {
+                    messageHistory: projectV3ThreadToModelMessages(canonical),
+                    compactionSummary: null,
+                },
+                {
+                    prompt,
+                    stream: true,
+                    canManageAgent,
+                    enableSqlMode: body.enableSqlMode,
+                    autoApproveSql: body.autoApproveSql,
+                    toolHints: body.toolHints,
+                    v3Run: run,
+                },
+            );
+        } catch (error) {
+            await persistence.fail(error, getUserFacingErrorMessage(error));
+            throw error;
+        }
+    }
+
     async failInFlightStreamedPrompts(): Promise<void> {
         if (!this.shutdownPromise) {
             this.isShuttingDown = true;
@@ -5296,6 +5666,47 @@ export class AiAgentService extends BaseService {
                 Logger.warn(
                     '[AiAgent][Shutdown] Timed out waiting for terminal prompt updates',
                 );
+            }
+        }
+
+        const v3Runs = [...this.activeV3Runs.entries()];
+        if (v3Runs.length > 0) {
+            const failures = v3Runs.map(([, run]) =>
+                run.persistence.fail(
+                    new Error(AI_AGENT_SHUTDOWN_ERROR_MESSAGE),
+                    AI_AGENT_SHUTDOWN_ERROR_MESSAGE,
+                ),
+            );
+            v3Runs.forEach(([, run]) => run.abortController.abort());
+            try {
+                await this.withShutdownTimeout(Promise.all(failures));
+            } catch {
+                Logger.warn(
+                    '[AiAgent][Shutdown] Timed out draining v3 agent runs',
+                );
+                try {
+                    await this.withShutdownTimeout(
+                        Promise.allSettled(
+                            v3Runs.map(([messageUuid]) =>
+                                this.aiAgentV3Model.finishAssistantMessage({
+                                    messageUuid,
+                                    status: 'error',
+                                    tokenUsage: null,
+                                    error: getAiRunErrorEnvelope(
+                                        new Error(
+                                            AI_AGENT_SHUTDOWN_ERROR_MESSAGE,
+                                        ),
+                                        AI_AGENT_SHUTDOWN_ERROR_MESSAGE,
+                                    ),
+                                }),
+                            ),
+                        ),
+                    );
+                } catch {
+                    Logger.error(
+                        '[AiAgent][Shutdown] Failed to freeze v3 agent runs',
+                    );
+                }
             }
         }
 
@@ -5361,6 +5772,75 @@ export class AiAgentService extends BaseService {
     ): Promise<void> {
         if (!user.organizationUuid) {
             throw new ForbiddenError();
+        }
+
+        const storageVersion =
+            await this.aiAgentThreadRepository.getStorageVersion(threadUuid);
+        if (storageVersion === 3) {
+            const { thread: canonical } = await this.getAccessibleV3Thread(
+                user,
+                agentUuid,
+                threadUuid,
+            );
+            const message = canonical.messages.find(
+                (item) =>
+                    item.uuid === messageUuid && item.role === 'assistant',
+            );
+            if (!message) {
+                throw new NotFoundError(`Prompt not found: ${messageUuid}`);
+            }
+            if (message.metadata.status !== 'in_progress') {
+                throw new ConflictError('Assistant message is frozen');
+            }
+            const run = this.activeV3Runs.get(messageUuid);
+            if (run?.threadUuid === threadUuid) {
+                run.abortController.abort();
+                let timeout: ReturnType<typeof setTimeout> | undefined;
+                const terminal = await Promise.race([
+                    run.persistence.waitForTerminal().then(() => true),
+                    new Promise<false>((resolve) => {
+                        timeout = setTimeout(
+                            () => resolve(false),
+                            V3_RUN_STOP_TIMEOUT_MS,
+                        );
+                    }),
+                ]);
+                if (timeout) clearTimeout(timeout);
+                if (!terminal) {
+                    try {
+                        await this.aiAgentV3Model.finishAssistantMessage({
+                            messageUuid,
+                            status: 'canceled',
+                            tokenUsage: null,
+                            error: null,
+                        });
+                    } catch (error) {
+                        if (
+                            !(error instanceof ConflictError) ||
+                            error.message !== 'Assistant message is frozen'
+                        ) {
+                            throw error;
+                        }
+                    }
+                }
+            } else {
+                try {
+                    await this.aiAgentV3Model.finishAssistantMessage({
+                        messageUuid,
+                        status: 'canceled',
+                        tokenUsage: null,
+                        error: null,
+                    });
+                } catch (error) {
+                    if (
+                        !(error instanceof ConflictError) ||
+                        error.message !== 'Assistant message is frozen'
+                    ) {
+                        throw error;
+                    }
+                }
+            }
+            return;
         }
 
         const prompt = await this.aiAgentModel.findWebAppPrompt(messageUuid);
@@ -5429,6 +5909,54 @@ export class AiAgentService extends BaseService {
         const trimmedMessage = message.trim();
         if (trimmedMessage.length === 0) {
             throw new ParameterError('Steer message is required');
+        }
+
+        const storageVersion =
+            await this.aiAgentThreadRepository.getStorageVersion(threadUuid);
+        if (storageVersion === 3) {
+            const { thread: canonical } = await this.getAccessibleV3Thread(
+                user,
+                agentUuid,
+                threadUuid,
+            );
+            const assistant = canonical.messages.find(
+                (item) =>
+                    item.uuid === messageUuid && item.role === 'assistant',
+            );
+            if (!assistant) {
+                throw new NotFoundError(`Prompt not found: ${messageUuid}`);
+            }
+            const run = this.activeV3Runs.get(messageUuid);
+            if (
+                assistant.metadata.status !== 'in_progress' ||
+                (run !== undefined &&
+                    (run.threadUuid !== threadUuid ||
+                        run.abortController.signal.aborted))
+            ) {
+                throw new ParameterError('Cannot steer an inactive run');
+            }
+            const created = await this.aiAgentV3Model.appendSteer({
+                threadUuid,
+                assistantMessageUuid: messageUuid,
+                createdByUserUuid: user.userUuid,
+                parts: [
+                    {
+                        partIndex: 0,
+                        type: 'text',
+                        payloadVersion: 1,
+                        payload: { text: trimmedMessage },
+                    },
+                ],
+            });
+            const steer: AiPromptSteer = {
+                uuid: created.uuid,
+                promptUuid: messageUuid,
+                message: trimmedMessage,
+                createdAt: new Date().toISOString(),
+                consumedAt: null,
+                consumedStep: null,
+            };
+            return steer;
         }
 
         const prompt = await this.aiAgentModel.findWebAppPrompt(messageUuid);
@@ -8259,6 +8787,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
             suppressWritebackPreview?: boolean;
             onWarehouseQuery?: () => void | Promise<void>;
+            v3Run?: V3RunContext;
+            v3Prompt?: AiWebAppPrompt;
         },
     ) {
         const { projectUuid, organizationUuid } = prompt;
@@ -8368,6 +8898,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         };
 
         const getPrompt: GetPromptFn = async () => {
+            if (options?.v3Prompt) return options.v3Prompt;
             const webOrSlackPrompt = isSlackPrompt(prompt)
                 ? await this.aiAgentModel.findSlackPrompt(prompt.promptUuid)
                 : await this.aiAgentModel.findWebAppPrompt(prompt.promptUuid);
@@ -8977,15 +9508,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             storeToolResults,
             storeReasoning,
             isPromptInterrupted: (promptUuid: string) =>
-                this.aiAgentModel.hasAiPromptInterrupt(promptUuid),
+                options?.v3Run
+                    ? options.v3Run.isInterrupted()
+                    : this.aiAgentModel.hasAiPromptInterrupt(promptUuid),
             consumePromptSteers: (args: {
                 promptUuid: string;
                 stepNumber: number;
             }) =>
-                this.aiAgentModel.consumeUnconsumedPromptSteers({
-                    promptUuid: args.promptUuid,
-                    stepNumber: args.stepNumber,
-                }),
+                options?.v3Run
+                    ? options.v3Run.consumeSteers(args.stepNumber)
+                    : this.aiAgentModel.consumeUnconsumedPromptSteers({
+                          promptUuid: args.promptUuid,
+                          stepNumber: args.stepNumber,
+                      }),
             searchFieldValues: toolsRuntime.searchFieldValues,
             editDbtProject,
             editProjectContext,
@@ -9019,6 +9554,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 progressStatus?: 'in_progress' | 'complete' | 'error',
             ) => void | Promise<void>;
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
+            v3Run?: V3RunContext;
         },
     ): Promise<AgentResponseStream>;
     async generateOrStreamAgentResponse(
@@ -9091,6 +9627,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             ) => void | Promise<void>;
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
             execution?: GenerateAgentExecutionOptions;
+            v3Run?: V3RunContext;
         } & (
             | {
                   prompt: AiWebAppPrompt;
@@ -9133,9 +9670,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         const stepProgressEmitter =
             stream && !isSlackPrompt(prompt) ? new EventEmitter() : undefined;
         const aiAgentMemoryEnabled =
-            await this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(
+            options.v3Run === undefined &&
+            (await this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(
                 user,
-            );
+            ));
 
         const {
             listExplores,
@@ -9210,6 +9748,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 responseExecution.mode === 'deep_research'
                     ? responseExecution.onWarehouseQuery
                     : undefined,
+            v3Run: options.v3Run,
+            v3Prompt:
+                options.v3Run && !isSlackPrompt(prompt) ? prompt : undefined,
         });
 
         const agentSettings = await this.getAgentSettings(user, prompt);
@@ -9242,7 +9783,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 threadUuid: prompt.threadUuid,
                 preflightCanUseRawSql: responseExecution.canUseRawSql,
             }));
-        let canRunSql = enableSqlMode && canUseRawSql;
+        let canRunSql =
+            enableSqlMode && canUseRawSql && options.v3Run === undefined;
         // Fail closed when CASL would evaluate against the installer.
         if (canRunSql && !hasTrustedPromptUserIdentity) {
             this.logger.info(
@@ -9350,7 +9892,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 user,
                 featureFlagId: FeatureFlags.AiGrepFields,
             });
-        let aiWritebackEnabled = hasTrustedPromptUserIdentity;
+        let aiWritebackEnabled =
+            hasTrustedPromptUserIdentity && options.v3Run === undefined;
         if (!aiWritebackEnabled) {
             this.logger.info(
                 `Disabling editDbtProject for Slack prompt ${prompt.promptUuid} because aiRequireOAuth is off.`,
@@ -9380,6 +9923,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 featureFlagId: FeatureFlags.CodingAgent,
             },
         );
+        codingAgentEnabled &&= options.v3Run === undefined;
         if (codingAgentEnabled && !hasTrustedPromptUserIdentity) {
             this.logger.info(
                 `Disabling editRepo for Slack prompt ${prompt.promptUuid} because aiRequireOAuth is off.`,
@@ -9658,6 +10202,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             toolHints: options.toolHints ?? [],
             forceToolHints: options.forceToolHints ?? false,
             execution,
+            abortSignal: options.v3Run?.abortSignal,
         };
 
         const mcpToolSetup: AgentMcpToolSetup =
@@ -9743,10 +10288,18 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             sendFile,
             sendSlackBlocks,
             updateSlackMessage,
-            storeToolCall,
-            storeToolCallError,
-            storeToolResults,
-            storeReasoning,
+            storeToolCall: options.v3Run
+                ? async () => undefined
+                : storeToolCall,
+            storeToolCallError: options.v3Run
+                ? async () => undefined
+                : storeToolCallError,
+            storeToolResults: options.v3Run
+                ? async () => undefined
+                : storeToolResults,
+            storeReasoning: options.v3Run
+                ? async () => undefined
+                : storeReasoning,
             isPromptInterrupted,
             consumePromptSteers,
             searchFieldValues,
@@ -9766,6 +10319,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             updatePrompt: (
                 update: UpdateSlackResponse | UpdateWebAppResponse,
             ) => {
+                if (options.v3Run) return Promise.resolve();
                 const updatePromise = this.persistTrackedPromptUpdate(update);
                 if (!updatePromise) {
                     return Promise.resolve();
@@ -9880,8 +10434,17 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             ) => this.analytics.track(event),
 
             createOrUpdateArtifact: async (data) => {
-                const artifact =
-                    await this.aiAgentModel.createOrUpdateArtifact(data);
+                const artifact = await this.aiAgentModel.createOrUpdateArtifact(
+                    {
+                        ...data,
+                        promptUuid: options.v3Run ? null : data.promptUuid,
+                    },
+                );
+                if (options.v3Run) {
+                    await options.v3Run.persistence.appendArtifact(
+                        artifact.versionUuid,
+                    );
+                }
 
                 return artifact;
             },
@@ -9922,6 +10485,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     );
                 },
             },
+            streamPersistence: options.v3Run?.persistence,
         };
 
         if (!stream) {
@@ -10006,7 +10570,30 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     );
                 }
 
-                writer.merge(result.toUIMessageStream());
+                const v3Persistence = options.v3Run?.persistence;
+                const messageStream = result.toUIMessageStream(
+                    v3Persistence
+                        ? {
+                              generateMessageId: () => prompt.promptUuid,
+                              sendSources: true,
+                          }
+                        : undefined,
+                );
+                if (!v3Persistence) {
+                    writer.merge(messageStream);
+                    return;
+                }
+                writer.merge(
+                    messageStream.pipeThrough(
+                        new TransformStream({
+                            transform: async (chunk, controller) => {
+                                if (await v3Persistence.waitForUiChunk(chunk)) {
+                                    controller.enqueue(chunk);
+                                }
+                            },
+                        }),
+                    ),
+                );
             },
             onFinish: () => {
                 clearKeepalive();

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -20,6 +20,8 @@ import {
     AiAgentThreadWorkstream,
     AiAgentUser,
     AiAgentUserPreferences,
+    AiAgentV3Thread,
+    AiAgentV3ThreadSummary,
     AiAgentVizConfig,
     AiAgentWithContext,
     AiDuplicateSlackPromptError,
@@ -97,6 +99,7 @@ import {
     PullRequestProvider,
     QueryExecutionContext,
     ReadinessScore,
+    ReadOnlyThreadError,
     serializeDashboardFiltersForAiContext,
     ShareUrl,
     SlackPrompt,
@@ -114,6 +117,7 @@ import {
     type AgentSuggestionTool,
     type AiAgentEditDbtProjectPipelineJobPayload,
     type AiAgentModelConfig,
+    type AiAgentStorageVersion,
     type AiClonedThreadCreatedFrom,
     type AiDeepResearchBudget,
     type AiDeepResearchEventPayloadMap,
@@ -386,6 +390,7 @@ import { type WritebackPreviewService } from '../AiWritebackService/WritebackPre
 import { PreviewDeploySetupService } from '../PreviewDeploySetupService/PreviewDeploySetupService';
 import { ProjectContextService } from '../ProjectContextService/ProjectContextService';
 import { canAccessAiAgent, canAccessAiAgentThread } from './aiAgentAccess';
+import { getAiAgentThreadReadOnly } from './aiAgentThreadReadOnly';
 import {
     canGeneratePostResponseSuggestions,
     filterSuggestionsByEnabledTools,
@@ -469,6 +474,33 @@ type GenerateAgentExecutionOptions =
           research: AiDeepResearchExecutionRole;
           parentToolCallId?: string | null;
       };
+
+type StreamAgentThreadResponseOptions = {
+    agentUuid: string;
+    threadUuid: string;
+    enableSqlMode?: boolean;
+    autoApproveSql?: boolean;
+    toolHints: string[];
+    runtimeOptions?: EmbedAiAgentRuntimeOptions;
+};
+
+type GenerateAgentThreadResponseOptions = {
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid?: string;
+    autoApproveSql?: boolean;
+    toolHints?: string[];
+    forceToolHints?: boolean;
+    onStepProgress?: (
+        progress: string,
+        toolName?: string,
+        progressId?: string,
+        progressStatus?: 'in_progress' | 'complete' | 'error',
+    ) => void | Promise<void>;
+    suppressWritebackPreview?: boolean;
+    isReviewRemediationWorkThread?: boolean;
+    execution?: GenerateAgentExecutionOptions;
+};
 
 export const shouldIncludeAttachedMcpServers = (
     executionMode: GenerateAgentExecutionOptions['mode'],
@@ -1082,7 +1114,7 @@ export class AiAgentService extends BaseService {
         const hasAccess = await this.checkAgentThreadAccess(
             user,
             threadAgent,
-            ownership.ownerUserUuid ?? '',
+            ownership.ownerUserUuid,
         );
         if (!hasAccess) {
             throw new ForbiddenError(
@@ -1507,7 +1539,7 @@ export class AiAgentService extends BaseService {
     private async checkAgentThreadAccess(
         user: SessionUser,
         agent: AiAgent,
-        threadUserUuid: string,
+        threadUserUuid: string | null,
     ): Promise<boolean> {
         return canAccessAiAgentThread(user, agent, threadUserUuid, {
             auditedAbility: this.createAuditedAbility(user),
@@ -2474,6 +2506,69 @@ export class AiAgentService extends BaseService {
         });
     }
 
+    async listAgentThreadsV3(
+        user: SessionUser,
+        {
+            projectUuid,
+            agentUuid,
+            allUsers,
+        }: {
+            projectUuid: string;
+            agentUuid: string;
+            allUsers?: boolean;
+        },
+    ): Promise<AiAgentV3ThreadSummary[]> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) throw new ForbiddenError();
+        if (!(await this.getIsCopilotEnabled(user))) {
+            throw new ForbiddenError('Copilot is not enabled');
+        }
+
+        const agent = await this.aiAgentModel.getAgent({
+            organizationUuid,
+            agentUuid,
+        });
+        if (!agent || agent.projectUuid !== projectUuid) {
+            throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+        if (!(await this.checkAgentAccess(user, agent))) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access this agent',
+            );
+        }
+
+        const canViewAllThreads =
+            allUsers === true &&
+            this.createAuditedAbility(user).can(
+                'manage',
+                subject('AiAgent', {
+                    organizationUuid,
+                    projectUuid: agent.projectUuid,
+                    metadata: { agentUuid, agentName: agent.name },
+                }),
+            );
+        if (allUsers && !canViewAllThreads) {
+            throw new ForbiddenError(
+                'Insufficient permissions to view all agent threads',
+            );
+        }
+
+        const headers = await this.aiAgentThreadRepository.listThreadHeaders({
+            organizationUuid,
+            agentUuid,
+            ownerUserUuid: canViewAllThreads ? null : user.userUuid,
+        });
+        return headers.map((thread) => ({
+            ...thread,
+            ...getAiAgentThreadReadOnly({
+                storageVersion: thread.storageVersion,
+                createdFrom: thread.createdFrom,
+                ownerUserUuid: thread.user.uuid,
+                viewerUserUuid: user.userUuid,
+            }),
+        }));
+    }
+
     async listProjectThreads(
         user: SessionUser,
         projectUuid: string,
@@ -3021,7 +3116,7 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        return this.generateAgentThreadResponse(user, {
+        return this.generateAgentThreadResponseInternal(user, {
             agentUuid,
             threadUuid: thread.uuid,
         });
@@ -3043,6 +3138,8 @@ export class AiAgentService extends BaseService {
         if (!isCopilotEnabled) {
             throw new ForbiddenError('Copilot is not enabled');
         }
+
+        await this.assertMutableV1Thread(user, agentUuid, threadUuid);
 
         const agent = await this.aiAgentModel.getAgent({
             organizationUuid,
@@ -5241,7 +5338,7 @@ export class AiAgentService extends BaseService {
         return terminalUpdatePromise;
     }
 
-    async streamAgentThreadResponse(
+    async streamAgentThreadResponseInternal(
         user: SessionUser,
         {
             agentUuid,
@@ -5250,14 +5347,7 @@ export class AiAgentService extends BaseService {
             autoApproveSql,
             toolHints,
             runtimeOptions,
-        }: {
-            agentUuid: string;
-            threadUuid: string;
-            enableSqlMode?: boolean;
-            autoApproveSql?: boolean;
-            toolHints: string[];
-            runtimeOptions?: EmbedAiAgentRuntimeOptions;
-        },
+        }: StreamAgentThreadResponseOptions,
     ): Promise<AgentResponseStream> {
         let isPreparing = false;
         let trackedPromptUuid: string | undefined;
@@ -5379,39 +5469,47 @@ export class AiAgentService extends BaseService {
         }
     }
 
-    private async getAccessibleV3Thread(
+    async streamAgentThreadResponse(
+        user: SessionUser,
+        options: StreamAgentThreadResponseOptions,
+    ): Promise<AgentResponseStream> {
+        await this.assertMutableV1Thread(
+            user,
+            options.agentUuid,
+            options.threadUuid,
+        );
+        return this.streamAgentThreadResponseInternal(user, options);
+    }
+
+    private async getAccessibleThreadMetadata(
         user: SessionUser,
         agentUuid: string,
         threadUuid: string,
     ): Promise<{
         agent: AiAgent;
-        thread: AiCanonicalThread;
-        ownerUuid: string;
+        ownerUuid: string | null;
+        storageVersion: AiAgentStorageVersion;
     }> {
         if (!user.organizationUuid) throw new ForbiddenError();
-        const [agent, thread] = await Promise.all([
+        const [agent, ownership] = await Promise.all([
             this.aiAgentModel.getAgent({
                 organizationUuid: user.organizationUuid,
                 agentUuid,
             }),
-            this.aiAgentThreadRepository.getThread(threadUuid),
+            this.aiAgentModel.findThreadOwnership({
+                organizationUuid: user.organizationUuid,
+                threadUuid,
+            }),
         ]);
         if (!agent) throw new NotFoundError(`Agent not found: ${agentUuid}`);
         if (
-            thread.storageVersion !== 3 ||
-            thread.organizationUuid !== user.organizationUuid ||
-            thread.projectUuid !== agent.projectUuid ||
-            thread.agentUuid !== agentUuid
+            !ownership ||
+            ownership.projectUuid !== agent.projectUuid ||
+            ownership.agentUuid !== agentUuid
         ) {
             throw new NotFoundError(`Thread not found: ${threadUuid}`);
         }
-        const ownership = await this.aiAgentModel.findThreadOwnership({
-            organizationUuid: user.organizationUuid,
-            threadUuid,
-        });
-        const ownerUuid = ownership?.ownerUserUuid;
-        if (!ownerUuid)
-            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        const ownerUuid = ownership.ownerUserUuid;
         const hasAccess = await this.checkAgentThreadAccess(
             user,
             agent,
@@ -5422,7 +5520,119 @@ export class AiAgentService extends BaseService {
                 'Insufficient permissions to use this agent thread',
             );
         }
-        return { agent, thread, ownerUuid };
+        return {
+            agent,
+            ownerUuid,
+            storageVersion: ownership.storageVersion,
+        };
+    }
+
+    private async getAccessibleCanonicalThread(
+        user: SessionUser,
+        agentUuid: string,
+        threadUuid: string,
+    ): Promise<{
+        agent: AiAgent;
+        thread: AiCanonicalThread;
+        ownerUuid: string | null;
+    }> {
+        const [metadata, thread] = await Promise.all([
+            this.getAccessibleThreadMetadata(user, agentUuid, threadUuid),
+            this.aiAgentThreadRepository.getThread(threadUuid),
+        ]);
+        if (
+            thread.projectUuid !== metadata.agent.projectUuid ||
+            thread.agentUuid !== agentUuid ||
+            thread.storageVersion !== metadata.storageVersion
+        ) {
+            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        }
+        return {
+            agent: metadata.agent,
+            thread,
+            ownerUuid: metadata.ownerUuid,
+        };
+    }
+
+    private async getMutableV3Thread(
+        user: SessionUser,
+        agentUuid: string,
+        threadUuid: string,
+    ): Promise<{
+        agent: AiAgent;
+        thread: AiCanonicalThread;
+        ownerUuid: string;
+    }> {
+        const accessible = await this.getAccessibleCanonicalThread(
+            user,
+            agentUuid,
+            threadUuid,
+        );
+        await this.aiAgentThreadRepository.assertMutationStorageVersion(
+            threadUuid,
+            3,
+            accessible.thread.storageVersion,
+        );
+        const capability = getAiAgentThreadReadOnly({
+            storageVersion: accessible.thread.storageVersion,
+            createdFrom: accessible.thread.createdFrom,
+            ownerUserUuid: accessible.ownerUuid,
+            viewerUserUuid: user.userUuid,
+        });
+        if (capability.readOnly || accessible.ownerUuid === null) {
+            throw new ReadOnlyThreadError(
+                threadUuid,
+                accessible.thread.storageVersion,
+            );
+        }
+        return { ...accessible, ownerUuid: accessible.ownerUuid };
+    }
+
+    private async assertMutableV1Thread(
+        user: SessionUser,
+        agentUuid: string,
+        threadUuid: string,
+    ): Promise<void> {
+        const accessible = await this.getAccessibleThreadMetadata(
+            user,
+            agentUuid,
+            threadUuid,
+        );
+        await this.aiAgentThreadRepository.assertMutationStorageVersion(
+            threadUuid,
+            1,
+            accessible.storageVersion,
+        );
+    }
+
+    async getAgentThreadV3(
+        user: SessionUser,
+        projectUuid: string,
+        agentUuid: string,
+        threadUuid: string,
+    ): Promise<AiAgentV3Thread> {
+        if (!(await this.getIsCopilotEnabled(user))) {
+            throw new ForbiddenError('Copilot is not enabled');
+        }
+        const { agent, thread, ownerUuid } =
+            await this.getAccessibleCanonicalThread(
+                user,
+                agentUuid,
+                threadUuid,
+            );
+        if (agent.projectUuid !== projectUuid) {
+            throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+        const result = {
+            ...thread,
+            ...getAiAgentThreadReadOnly({
+                storageVersion: thread.storageVersion,
+                createdFrom: thread.createdFrom,
+                ownerUserUuid: ownerUuid,
+                viewerUserUuid: user.userUuid,
+            }),
+        } satisfies AiAgentV3Thread;
+        return result;
     }
 
     async streamAgentThreadV3Response(
@@ -5459,7 +5669,7 @@ export class AiAgentService extends BaseService {
             throw new ForbiddenError('Copilot is not enabled');
         }
 
-        const { agent, thread, ownerUuid } = await this.getAccessibleV3Thread(
+        const { agent, thread, ownerUuid } = await this.getMutableV3Thread(
             user,
             agentUuid,
             threadUuid,
@@ -5758,7 +5968,7 @@ export class AiAgentService extends BaseService {
         }
     }
 
-    async interruptAgentThreadMessage(
+    async interruptAgentThreadMessageV3(
         user: SessionUser,
         {
             agentUuid,
@@ -5774,56 +5984,35 @@ export class AiAgentService extends BaseService {
             throw new ForbiddenError();
         }
 
-        const storageVersion =
-            await this.aiAgentThreadRepository.getStorageVersion(threadUuid);
-        if (storageVersion === 3) {
-            const { thread: canonical } = await this.getAccessibleV3Thread(
-                user,
-                agentUuid,
-                threadUuid,
-            );
-            const message = canonical.messages.find(
-                (item) =>
-                    item.uuid === messageUuid && item.role === 'assistant',
-            );
-            if (!message) {
-                throw new NotFoundError(`Prompt not found: ${messageUuid}`);
-            }
-            if (message.metadata.status !== 'in_progress') {
-                throw new ConflictError('Assistant message is frozen');
-            }
-            const run = this.activeV3Runs.get(messageUuid);
-            if (run?.threadUuid === threadUuid) {
-                run.abortController.abort();
-                let timeout: ReturnType<typeof setTimeout> | undefined;
-                const terminal = await Promise.race([
-                    run.persistence.waitForTerminal().then(() => true),
-                    new Promise<false>((resolve) => {
-                        timeout = setTimeout(
-                            () => resolve(false),
-                            V3_RUN_STOP_TIMEOUT_MS,
-                        );
-                    }),
-                ]);
-                if (timeout) clearTimeout(timeout);
-                if (!terminal) {
-                    try {
-                        await this.aiAgentV3Model.finishAssistantMessage({
-                            messageUuid,
-                            status: 'canceled',
-                            tokenUsage: null,
-                            error: null,
-                        });
-                    } catch (error) {
-                        if (
-                            !(error instanceof ConflictError) ||
-                            error.message !== 'Assistant message is frozen'
-                        ) {
-                            throw error;
-                        }
-                    }
-                }
-            } else {
+        const { thread: canonical } = await this.getMutableV3Thread(
+            user,
+            agentUuid,
+            threadUuid,
+        );
+        const message = canonical.messages.find(
+            (item) => item.uuid === messageUuid && item.role === 'assistant',
+        );
+        if (!message) {
+            throw new NotFoundError(`Prompt not found: ${messageUuid}`);
+        }
+        if (message.metadata.status !== 'in_progress') {
+            throw new ConflictError('Assistant message is frozen');
+        }
+        const run = this.activeV3Runs.get(messageUuid);
+        if (run?.threadUuid === threadUuid) {
+            run.abortController.abort();
+            let timeout: ReturnType<typeof setTimeout> | undefined;
+            const terminal = await Promise.race([
+                run.persistence.waitForTerminal().then(() => true),
+                new Promise<false>((resolve) => {
+                    timeout = setTimeout(
+                        () => resolve(false),
+                        V3_RUN_STOP_TIMEOUT_MS,
+                    );
+                }),
+            ]);
+            if (timeout) clearTimeout(timeout);
+            if (!terminal) {
                 try {
                     await this.aiAgentV3Model.finishAssistantMessage({
                         messageUuid,
@@ -5840,8 +6029,39 @@ export class AiAgentService extends BaseService {
                     }
                 }
             }
-            return;
+        } else {
+            try {
+                await this.aiAgentV3Model.finishAssistantMessage({
+                    messageUuid,
+                    status: 'canceled',
+                    tokenUsage: null,
+                    error: null,
+                });
+            } catch (error) {
+                if (
+                    !(error instanceof ConflictError) ||
+                    error.message !== 'Assistant message is frozen'
+                ) {
+                    throw error;
+                }
+            }
         }
+    }
+
+    async interruptAgentThreadMessage(
+        user: SessionUser,
+        {
+            agentUuid,
+            threadUuid,
+            messageUuid,
+        }: {
+            agentUuid: string;
+            threadUuid: string;
+            messageUuid: string;
+        },
+    ): Promise<void> {
+        if (!user.organizationUuid) throw new ForbiddenError();
+        await this.assertMutableV1Thread(user, agentUuid, threadUuid);
 
         const prompt = await this.aiAgentModel.findWebAppPrompt(messageUuid);
 
@@ -5888,7 +6108,7 @@ export class AiAgentService extends BaseService {
         });
     }
 
-    async createAgentThreadMessageSteer(
+    async createAgentThreadMessageSteerV3(
         user: SessionUser,
         {
             agentUuid,
@@ -5911,53 +6131,69 @@ export class AiAgentService extends BaseService {
             throw new ParameterError('Steer message is required');
         }
 
-        const storageVersion =
-            await this.aiAgentThreadRepository.getStorageVersion(threadUuid);
-        if (storageVersion === 3) {
-            const { thread: canonical } = await this.getAccessibleV3Thread(
-                user,
-                agentUuid,
-                threadUuid,
-            );
-            const assistant = canonical.messages.find(
-                (item) =>
-                    item.uuid === messageUuid && item.role === 'assistant',
-            );
-            if (!assistant) {
-                throw new NotFoundError(`Prompt not found: ${messageUuid}`);
-            }
-            const run = this.activeV3Runs.get(messageUuid);
-            if (
-                assistant.metadata.status !== 'in_progress' ||
-                (run !== undefined &&
-                    (run.threadUuid !== threadUuid ||
-                        run.abortController.signal.aborted))
-            ) {
-                throw new ParameterError('Cannot steer an inactive run');
-            }
-            const created = await this.aiAgentV3Model.appendSteer({
-                threadUuid,
-                assistantMessageUuid: messageUuid,
-                createdByUserUuid: user.userUuid,
-                parts: [
-                    {
-                        partIndex: 0,
-                        type: 'text',
-                        payloadVersion: 1,
-                        payload: { text: trimmedMessage },
-                    },
-                ],
-            });
-            const steer: AiPromptSteer = {
-                uuid: created.uuid,
-                promptUuid: messageUuid,
-                message: trimmedMessage,
-                createdAt: new Date().toISOString(),
-                consumedAt: null,
-                consumedStep: null,
-            };
-            return steer;
+        const { thread: canonical } = await this.getMutableV3Thread(
+            user,
+            agentUuid,
+            threadUuid,
+        );
+        const assistant = canonical.messages.find(
+            (item) => item.uuid === messageUuid && item.role === 'assistant',
+        );
+        if (!assistant) {
+            throw new NotFoundError(`Prompt not found: ${messageUuid}`);
         }
+        const run = this.activeV3Runs.get(messageUuid);
+        if (
+            assistant.metadata.status !== 'in_progress' ||
+            (run !== undefined &&
+                (run.threadUuid !== threadUuid ||
+                    run.abortController.signal.aborted))
+        ) {
+            throw new ParameterError('Cannot steer an inactive run');
+        }
+        const created = await this.aiAgentV3Model.appendSteer({
+            threadUuid,
+            assistantMessageUuid: messageUuid,
+            createdByUserUuid: user.userUuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'text',
+                    payloadVersion: 1,
+                    payload: { text: trimmedMessage },
+                },
+            ],
+        });
+        return {
+            uuid: created.uuid,
+            promptUuid: messageUuid,
+            message: trimmedMessage,
+            createdAt: new Date().toISOString(),
+            consumedAt: null,
+            consumedStep: null,
+        };
+    }
+
+    async createAgentThreadMessageSteer(
+        user: SessionUser,
+        {
+            agentUuid,
+            threadUuid,
+            messageUuid,
+            message,
+        }: {
+            agentUuid: string;
+            threadUuid: string;
+            messageUuid: string;
+            message: string;
+        },
+    ): Promise<AiPromptSteer> {
+        if (!user.organizationUuid) throw new ForbiddenError();
+        const trimmedMessage = message.trim();
+        if (trimmedMessage.length === 0) {
+            throw new ParameterError('Steer message is required');
+        }
+        await this.assertMutableV1Thread(user, agentUuid, threadUuid);
 
         const prompt = await this.aiAgentModel.findWebAppPrompt(messageUuid);
 
@@ -6261,7 +6497,7 @@ export class AiAgentService extends BaseService {
         });
     }
 
-    async generateAgentThreadResponse(
+    async generateAgentThreadResponseInternal(
         user: SessionUser,
         {
             agentUuid,
@@ -6274,25 +6510,7 @@ export class AiAgentService extends BaseService {
             suppressWritebackPreview,
             isReviewRemediationWorkThread,
             execution = { mode: 'standard' },
-        }: {
-            agentUuid: string;
-            threadUuid: string;
-            promptUuid?: string;
-            autoApproveSql?: boolean;
-            toolHints?: string[];
-            forceToolHints?: boolean;
-            onStepProgress?: (
-                progress: string,
-                toolName?: string,
-                progressId?: string,
-                progressStatus?: 'in_progress' | 'complete' | 'error',
-            ) => void | Promise<void>;
-            suppressWritebackPreview?: boolean;
-            // Enables the work-thread-only editProjectContext tool so the agent
-            // can open/change the project_context PR from this thread.
-            isReviewRemediationWorkThread?: boolean;
-            execution?: GenerateAgentExecutionOptions;
-        },
+        }: GenerateAgentThreadResponseOptions,
     ): Promise<string> {
         try {
             const {
@@ -6385,6 +6603,18 @@ export class AiAgentService extends BaseService {
             evidencePack,
             reason,
         });
+    }
+
+    async generateAgentThreadResponse(
+        user: SessionUser,
+        options: GenerateAgentThreadResponseOptions,
+    ): Promise<string> {
+        await this.assertMutableV1Thread(
+            user,
+            options.agentUuid,
+            options.threadUuid,
+        );
+        return this.generateAgentThreadResponseInternal(user, options);
     }
 
     async generateThreadTitle(
@@ -16069,7 +16299,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             organizationUuid,
         );
 
-        await this.generateAgentThreadResponse(sessionUser, {
+        await this.generateAgentThreadResponseInternal(sessionUser, {
             agentUuid,
             threadUuid,
             autoApproveSql: true,
@@ -16105,7 +16335,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 );
 
             // Generate the agent response
-            await this.generateAgentThreadResponse(sessionUser, {
+            await this.generateAgentThreadResponseInternal(sessionUser, {
                 agentUuid,
                 threadUuid,
                 autoApproveSql: true,

--- a/packages/backend/src/ee/services/AiAgentService/aiAgentAccess.ts
+++ b/packages/backend/src/ee/services/AiAgentService/aiAgentAccess.ts
@@ -57,7 +57,7 @@ export const canAccessAiAgent = async (
 export const canAccessAiAgentThread = async (
     user: SessionUser,
     agent: AiAgent,
-    threadUserUuid: string,
+    threadUserUuid: string | null,
     dependencies: AccessDependencies,
 ): Promise<boolean> => {
     if (!(await canAccessAiAgent(user, agent, dependencies))) return false;

--- a/packages/backend/src/ee/services/AiAgentService/aiAgentThreadReadOnly.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/aiAgentThreadReadOnly.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { getAiAgentThreadReadOnly } from './aiAgentThreadReadOnly';
+
+describe('getAiAgentThreadReadOnly', () => {
+    it.each([
+        {
+            name: 'legacy thread',
+            input: {
+                storageVersion: 1 as const,
+                createdFrom: 'web_app' as const,
+                ownerUserUuid: 'viewer',
+                viewerUserUuid: 'viewer',
+            },
+            expected: { readOnly: true, readOnlyReason: 'legacy' },
+        },
+        {
+            name: 'Slack thread',
+            input: {
+                storageVersion: 3 as const,
+                createdFrom: 'slack' as const,
+                ownerUserUuid: 'viewer',
+                viewerUserUuid: 'viewer',
+            },
+            expected: { readOnly: true, readOnlyReason: 'slack' },
+        },
+        {
+            name: "another user's thread",
+            input: {
+                storageVersion: 3 as const,
+                createdFrom: 'web_app' as const,
+                ownerUserUuid: 'owner',
+                viewerUserUuid: 'viewer',
+            },
+            expected: { readOnly: true, readOnlyReason: 'not_owner' },
+        },
+        {
+            name: "viewer's v3 web thread",
+            input: {
+                storageVersion: 3 as const,
+                createdFrom: 'web_app' as const,
+                ownerUserUuid: 'viewer',
+                viewerUserUuid: 'viewer',
+            },
+            expected: { readOnly: false, readOnlyReason: null },
+        },
+    ])('computes capability for $name', ({ input, expected }) => {
+        expect(getAiAgentThreadReadOnly(input)).toEqual(expected);
+    });
+
+    it('reports legacy before other read-only reasons', () => {
+        expect(
+            getAiAgentThreadReadOnly({
+                storageVersion: 1,
+                createdFrom: 'slack',
+                ownerUserUuid: 'owner',
+                viewerUserUuid: 'viewer',
+            }),
+        ).toEqual({ readOnly: true, readOnlyReason: 'legacy' });
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/aiAgentThreadReadOnly.ts
+++ b/packages/backend/src/ee/services/AiAgentService/aiAgentThreadReadOnly.ts
@@ -1,0 +1,28 @@
+import {
+    type AiAgentStorageVersion,
+    type AiAgentThreadCapability,
+    type AiThreadCreatedFrom,
+} from '@lightdash/common';
+
+export const getAiAgentThreadReadOnly = ({
+    storageVersion,
+    createdFrom,
+    ownerUserUuid,
+    viewerUserUuid,
+}: {
+    storageVersion: AiAgentStorageVersion;
+    createdFrom: AiThreadCreatedFrom;
+    ownerUserUuid: string | null;
+    viewerUserUuid: string;
+}): AiAgentThreadCapability => {
+    if (storageVersion === 1) {
+        return { readOnly: true, readOnlyReason: 'legacy' };
+    }
+    if (createdFrom === 'slack') {
+        return { readOnly: true, readOnlyReason: 'slack' };
+    }
+    if (ownerUserUuid !== viewerUserUuid) {
+        return { readOnly: true, readOnlyReason: 'not_owner' };
+    }
+    return { readOnly: false, readOnlyReason: null };
+};

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -305,7 +305,7 @@ const buildExecutor = ({
     const executor = new AiDeepResearchExecutor({
         aiAgentService: {
             assertDeepResearchAccess: vi.fn().mockResolvedValue(undefined),
-            generateAgentThreadResponse,
+            generateAgentThreadResponseInternal: generateAgentThreadResponse,
             generateDeepResearchReport,
         },
         aiAgentModel: aiAgentModel as AnyType,

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
@@ -56,7 +56,7 @@ type Dependencies = {
     aiAgentService: Pick<
         AiAgentService,
         | 'assertDeepResearchAccess'
-        | 'generateAgentThreadResponse'
+        | 'generateAgentThreadResponseInternal'
         | 'generateDeepResearchReport'
     >;
     /**
@@ -489,7 +489,7 @@ export class AiDeepResearchExecutor {
             let findings: AiDeepResearchWorkerFindings | null = null;
             let failureReason: string | null = null;
             try {
-                await this.dependencies.aiAgentService.generateAgentThreadResponse(
+                await this.dependencies.aiAgentService.generateAgentThreadResponseInternal(
                     user,
                     {
                         agentUuid: run.agent_uuid,
@@ -540,32 +540,35 @@ export class AiDeepResearchExecutor {
         };
 
         const runCoordinator = () =>
-            this.dependencies.aiAgentService.generateAgentThreadResponse(user, {
-                agentUuid: run.agent_uuid,
-                threadUuid: run.ai_thread_uuid,
-                promptUuid: run.prompt_uuid,
-                autoApproveSql: true,
-                execution: {
-                    mode: 'deep_research',
-                    runUuid: run.ai_deep_research_run_uuid,
-                    phase: 'planning',
-                    budget,
-                    canUseRawSql:
-                        run.execution_context_snapshot.effectivePermissions
-                            .canRunSql,
-                    abortSignal: runSignal,
-                    initialTokenUsage: tokens,
-                    onStepUsage: trackUsage,
-                    onWarehouseQuery: trackWarehouseQuery,
-                    onExecutionContextResolved: (snapshot) =>
-                        this.dependencies.aiDeepResearchRunModel.updateExecutionContextSnapshot(
-                            run.ai_deep_research_run_uuid,
-                            snapshot,
-                        ),
-                    research: { role: 'coordinator', runTask: runWorker },
+            this.dependencies.aiAgentService.generateAgentThreadResponseInternal(
+                user,
+                {
+                    agentUuid: run.agent_uuid,
+                    threadUuid: run.ai_thread_uuid,
+                    promptUuid: run.prompt_uuid,
+                    autoApproveSql: true,
+                    execution: {
+                        mode: 'deep_research',
+                        runUuid: run.ai_deep_research_run_uuid,
+                        phase: 'planning',
+                        budget,
+                        canUseRawSql:
+                            run.execution_context_snapshot.effectivePermissions
+                                .canRunSql,
+                        abortSignal: runSignal,
+                        initialTokenUsage: tokens,
+                        onStepUsage: trackUsage,
+                        onWarehouseQuery: trackWarehouseQuery,
+                        onExecutionContextResolved: (snapshot) =>
+                            this.dependencies.aiDeepResearchRunModel.updateExecutionContextSnapshot(
+                                run.ai_deep_research_run_uuid,
+                                snapshot,
+                            ),
+                        research: { role: 'coordinator', runTask: runWorker },
+                    },
+                    onStepProgress: makeStepProgressHandler(getCoordinatorPhase),
                 },
-                onStepProgress: makeStepProgressHandler(getCoordinatorPhase),
-            });
+            );
 
         /**
          * The report is always written here, from evidence the server rebuilt

--- a/packages/backend/src/ee/services/ai/AiAgentV3RunPersistence.test.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentV3RunPersistence.test.ts
@@ -1,0 +1,305 @@
+import { ConflictError } from '@lightdash/common';
+import { APICallError } from 'ai';
+import { expect, it, vi } from 'vitest';
+import {
+    AiAgentV3RunPersistence,
+    getAiRunErrorEnvelope,
+} from './AiAgentV3RunPersistence';
+
+const buildModel = () => {
+    const parts: Array<{ uuid: string; payload: Record<string, unknown> }> = [];
+    return {
+        parts,
+        appendParts: vi.fn(async ({ parts: writes }) =>
+            writes.map((write: { payload: Record<string, unknown> }) => {
+                const part = {
+                    uuid: `part-${parts.length}`,
+                    payload: write.payload,
+                };
+                parts.push(part);
+                return part;
+            }),
+        ),
+        updatePart: vi.fn(async ({ partUuid, payload }) => {
+            const part = parts.find(({ uuid }) => uuid === partUuid)!;
+            part.payload = payload;
+            return { ...part, payloadVersion: 1 };
+        }),
+        finishAssistantMessage: vi.fn(async () => undefined),
+        refreshAssistantMessageHeartbeat: vi.fn(async () => true),
+    };
+};
+
+it('persists interleaved text, reasoning, and tool chunks in first-seen order', async () => {
+    const model = buildModel();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+    );
+
+    const firstChunkAck = persistence.waitForUiChunk({
+        type: 'text-delta',
+        id: 't1',
+        delta: 'Hello ',
+    });
+    await persistence.onChunk({ type: 'text-delta', id: 't1', text: 'Hello ' });
+    await expect(firstChunkAck).resolves.toBe(true);
+    await persistence.onChunk({
+        type: 'reasoning-delta',
+        id: 'r1',
+        text: 'think',
+    });
+    await persistence.onChunk({ type: 'text-delta', id: 't1', text: 'world' });
+    await persistence.onChunk({
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'findExplores',
+        input: { query: 'orders' },
+    });
+    await persistence.onChunk({
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'findExplores',
+        output: ['orders'],
+    });
+
+    expect(model.parts.map(({ payload }) => payload)).toEqual([
+        { text: 'Hello world' },
+        { text: 'think' },
+        {
+            state: 'output-available',
+            toolName: 'findExplores',
+            input: { query: 'orders' },
+            output: ['orders'],
+        },
+    ]);
+});
+
+it('freezes cancellation after queued partial content', async () => {
+    const model = buildModel();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => true,
+    );
+    persistence.recordUsage({
+        inputTokens: 10,
+        outputTokens: 4,
+        totalTokens: 14,
+        reasoningTokens: 1,
+        cachedInputTokens: 3,
+        inputTokenDetails: {
+            noCacheTokens: undefined,
+            cacheReadTokens: undefined,
+            cacheWriteTokens: undefined,
+        },
+        outputTokenDetails: {
+            textTokens: undefined,
+            reasoningTokens: 1,
+        },
+    });
+
+    const partial = persistence.onChunk({
+        type: 'text-delta',
+        id: 't1',
+        text: 'partial',
+    });
+    const canceled = persistence.cancel();
+    await Promise.all([partial, canceled]);
+
+    expect(model.parts).toHaveLength(1);
+    expect(model.finishAssistantMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+            status: 'canceled',
+            error: null,
+            tokenUsage: expect.objectContaining({ totalTokens: 14 }),
+        }),
+    );
+});
+
+it('refreshes heartbeats until the run freezes', async () => {
+    vi.useFakeTimers();
+    const model = buildModel();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+    );
+    persistence.startHeartbeat(1_000);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(model.refreshAssistantMessageHeartbeat).toHaveBeenCalledTimes(2);
+    await persistence.cancel();
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(model.refreshAssistantMessageHeartbeat).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+});
+
+it('can persist a terminal error after a failed chunk write', async () => {
+    const model = buildModel();
+    model.appendParts.mockRejectedValueOnce(new Error('write failed'));
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+    );
+
+    await expect(
+        persistence.onChunk({
+            type: 'text-delta',
+            id: 't1',
+            text: 'partial',
+        }),
+    ).rejects.toThrow('write failed');
+    await persistence.fail(new Error('stream failed'), 'Stream failed');
+
+    expect(model.finishAssistantMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'error' }),
+    );
+});
+
+it('classifies failure from abort state when it is enqueued', async () => {
+    const model = buildModel();
+    let canceled = false;
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => canceled,
+    );
+
+    const failed = persistence.fail(
+        new Error('server restarting'),
+        'Server restarting',
+    );
+    canceled = true;
+    await failed;
+
+    expect(model.finishAssistantMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+            status: 'error',
+            error: expect.objectContaining({
+                name: 'stream_error',
+                message: 'Server restarting',
+            }),
+        }),
+    );
+});
+
+it('classifies completion from abort state when it is enqueued', async () => {
+    const model = buildModel();
+    let canceled = false;
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => canceled,
+    );
+    await persistence.onChunk({
+        type: 'text-delta',
+        id: 't1',
+        text: 'complete',
+    });
+
+    const completed = persistence.complete();
+    canceled = true;
+    await completed;
+
+    expect(model.finishAssistantMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'completed', error: null }),
+    );
+});
+
+it('stops cleanly when another server freezes the message', async () => {
+    const model = buildModel();
+    model.appendParts.mockRejectedValueOnce(
+        new ConflictError('Assistant message is frozen'),
+    );
+    const onTerminal = vi.fn();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+        onTerminal,
+    );
+
+    const chunkAck = persistence.waitForUiChunk({
+        type: 'text-delta',
+        id: 't1',
+        delta: 'late chunk',
+    });
+    await persistence.onChunk({
+        type: 'text-delta',
+        id: 't1',
+        text: 'late chunk',
+    });
+    await expect(chunkAck).resolves.toBe(false);
+    await persistence.fail(new Error('aborted'), 'Aborted');
+
+    expect(onTerminal).toHaveBeenCalledOnce();
+    expect(model.finishAssistantMessage).not.toHaveBeenCalled();
+});
+
+it('aborts local generation when another server freezes the message', async () => {
+    const model = buildModel();
+    model.appendParts.mockRejectedValueOnce(
+        new ConflictError('Assistant message is frozen'),
+    );
+    const onFrozen = vi.fn();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+        undefined,
+        onFrozen,
+    );
+
+    await persistence.onChunk({
+        type: 'text-delta',
+        id: 't1',
+        text: 'late chunk',
+    });
+
+    expect(onFrozen).toHaveBeenCalledOnce();
+});
+
+it('drops unmatched UI chunks instead of hanging the stream', async () => {
+    vi.useFakeTimers();
+    const persistence = new AiAgentV3RunPersistence(
+        buildModel() as never,
+        'assistant',
+        () => false,
+    );
+
+    const result = persistence.waitForUiChunk({
+        type: 'text-delta',
+        id: 't1',
+        delta: 'unmatched',
+    });
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toBe(false);
+    vi.useRealTimers();
+});
+
+it('uses stable error names', () => {
+    expect(
+        getAiRunErrorEnvelope(
+            new APICallError({
+                message: 'provider failed',
+                url: 'https://example.com',
+                requestBodyValues: {},
+                statusCode: 500,
+                responseHeaders: {},
+                responseBody: 'failed',
+                isRetryable: false,
+            }),
+            'Provider failed',
+        ).name,
+    ).toBe('provider_error');
+    expect(
+        getAiRunErrorEnvelope(
+            new Error('maximum context window exceeded'),
+            'Too long',
+        ).name,
+    ).toBe('context_overflow');
+});

--- a/packages/backend/src/ee/services/ai/AiAgentV3RunPersistence.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentV3RunPersistence.ts
@@ -1,0 +1,538 @@
+import { ConflictError } from '@lightdash/common';
+import { APICallError, type LanguageModelUsage } from 'ai';
+import {
+    type AiRunErrorEnvelope,
+    type AiTokenUsageEnvelope,
+    type AiV3PartWrite,
+} from '../../database/entities/aiAgentV3';
+import { type AiAgentV3Model } from '../../models/AiAgentV3Model';
+
+type PersistedPart = {
+    uuid: string;
+    partIndex: number;
+    type: AiV3PartWrite['type'];
+    toolCallId?: string;
+    payload: Record<string, unknown>;
+};
+
+type StreamChunk =
+    | {
+          type: 'text-delta' | 'reasoning-delta';
+          id: string;
+          text: string;
+          providerMetadata?: Record<string, unknown>;
+      }
+    | {
+          type: 'tool-input-start';
+          id: string;
+          toolName: string;
+          providerMetadata?: Record<string, unknown>;
+          providerExecuted?: boolean;
+          dynamic?: boolean;
+          title?: string;
+      }
+    | {
+          type: 'tool-input-delta';
+          id: string;
+          delta: string;
+          providerMetadata?: Record<string, unknown>;
+      }
+    | {
+          type: 'tool-call';
+          toolCallId: string;
+          toolName: string;
+          input: unknown;
+          providerMetadata?: Record<string, unknown>;
+          providerExecuted?: boolean;
+          dynamic?: boolean;
+          invalid?: boolean;
+          error?: unknown;
+      }
+    | {
+          type: 'tool-result';
+          toolCallId: string;
+          toolName: string;
+          output: unknown;
+          providerMetadata?: Record<string, unknown>;
+          preliminary?: boolean;
+      }
+    | ({ type: 'source' } & Record<string, unknown>)
+    | { type: 'raw'; rawValue: unknown };
+
+type Model = Pick<
+    AiAgentV3Model,
+    | 'appendParts'
+    | 'updatePart'
+    | 'finishAssistantMessage'
+    | 'refreshAssistantMessageHeartbeat'
+>;
+
+const UI_CHUNK_ACK_TIMEOUT_MS = 30_000;
+
+const usageEnvelope = (
+    usage: LanguageModelUsage | undefined,
+): AiTokenUsageEnvelope | null =>
+    usage
+        ? {
+              version: 1,
+              inputTokens: usage.inputTokens ?? null,
+              outputTokens: usage.outputTokens ?? null,
+              totalTokens: usage.totalTokens ?? null,
+              reasoningTokens: usage.reasoningTokens ?? null,
+              cachedInputTokens: usage.cachedInputTokens ?? null,
+          }
+        : null;
+
+export const getAiRunErrorEnvelope = (
+    error: unknown,
+    message: string,
+): AiRunErrorEnvelope => {
+    let name = 'stream_error';
+    if (APICallError.isInstance(error)) name = 'provider_error';
+    if (error instanceof Error && error.name === 'AiAgentStepCapReachedError') {
+        name = 'step_cap_reached';
+    }
+    if (error instanceof Error && error.name === 'AiAgentEmptyResponseError') {
+        name = 'empty_response';
+    }
+    if (
+        error instanceof Error &&
+        /context.{0,20}(length|window)|maximum context/i.test(error.message)
+    ) {
+        name = 'context_overflow';
+    }
+    return { version: 1, name, message, data: null };
+};
+
+export class AiAgentV3RunPersistence {
+    private readonly parts = new Map<string, PersistedPart>();
+
+    private nextPartIndex = 0;
+
+    private queue: Promise<void> = Promise.resolve();
+
+    private terminal = false;
+
+    private heartbeat: ReturnType<typeof setInterval> | undefined;
+
+    private tokenUsage: AiTokenUsageEnvelope | null = null;
+
+    private resolveTerminal!: () => void;
+
+    private readonly terminalPromise = new Promise<void>((resolve) => {
+        this.resolveTerminal = resolve;
+    });
+
+    private readonly chunkAckResults = new Map<string, boolean[]>();
+
+    private readonly chunkAckWaiters = new Map<
+        string,
+        Array<(persisted: boolean) => void>
+    >();
+
+    constructor(
+        private readonly model: Model,
+        private readonly messageUuid: string,
+        private readonly isCanceled: () => boolean,
+        private readonly onTerminal?: () => void,
+        private readonly onFrozen?: () => void,
+    ) {}
+
+    private markTerminal(): void {
+        if (this.terminal) return;
+        this.terminal = true;
+        this.stopHeartbeat();
+        this.onTerminal?.();
+        this.resolveTerminal();
+    }
+
+    waitForTerminal(): Promise<void> {
+        return this.terminalPromise;
+    }
+
+    private static chunkAckKey(value: unknown): string | null {
+        const chunk = value as {
+            type?: unknown;
+            id?: unknown;
+            text?: unknown;
+            delta?: unknown;
+        };
+        if (
+            (chunk.type !== 'text-delta' && chunk.type !== 'reasoning-delta') ||
+            typeof chunk.id !== 'string'
+        ) {
+            return null;
+        }
+        const content =
+            typeof chunk.text === 'string' ? chunk.text : chunk.delta;
+        return typeof content === 'string'
+            ? `${chunk.type}:${chunk.id}:${content}`
+            : null;
+    }
+
+    private acknowledgeChunk(key: string, persisted: boolean): void {
+        const waiters = this.chunkAckWaiters.get(key);
+        const waiter = waiters?.shift();
+        if (waiter) {
+            if (waiters?.length === 0) this.chunkAckWaiters.delete(key);
+            waiter(persisted);
+            return;
+        }
+        const results = this.chunkAckResults.get(key) ?? [];
+        results.push(persisted);
+        this.chunkAckResults.set(key, results);
+    }
+
+    waitForUiChunk(value: unknown): Promise<boolean> {
+        const key = AiAgentV3RunPersistence.chunkAckKey(value);
+        if (!key) return Promise.resolve(true);
+        const results = this.chunkAckResults.get(key);
+        const result = results?.shift();
+        if (result !== undefined) {
+            if (results?.length === 0) this.chunkAckResults.delete(key);
+            return Promise.resolve(result);
+        }
+        return new Promise<boolean>((resolve) => {
+            const waiters = this.chunkAckWaiters.get(key) ?? [];
+            const state: { timeout?: ReturnType<typeof setTimeout> } = {};
+            const waiter = (persisted: boolean) => {
+                if (state.timeout) clearTimeout(state.timeout);
+                resolve(persisted);
+            };
+            state.timeout = setTimeout(() => {
+                const pending = this.chunkAckWaiters.get(key);
+                const index = pending?.indexOf(waiter) ?? -1;
+                if (index >= 0) pending?.splice(index, 1);
+                if (pending?.length === 0) this.chunkAckWaiters.delete(key);
+                resolve(false);
+            }, UI_CHUNK_ACK_TIMEOUT_MS);
+            waiters.push(waiter);
+            this.chunkAckWaiters.set(key, waiters);
+        });
+    }
+
+    recordUsage(usage: LanguageModelUsage): void {
+        const next = usageEnvelope(usage);
+        if (!next) return;
+        const previous = this.tokenUsage;
+        const sum = (left: number | null, right: number | null) =>
+            left === null && right === null ? null : (left ?? 0) + (right ?? 0);
+        this.tokenUsage = previous
+            ? {
+                  version: 1,
+                  inputTokens: sum(previous.inputTokens, next.inputTokens),
+                  outputTokens: sum(previous.outputTokens, next.outputTokens),
+                  totalTokens: sum(previous.totalTokens, next.totalTokens),
+                  reasoningTokens: sum(
+                      previous.reasoningTokens,
+                      next.reasoningTokens,
+                  ),
+                  cachedInputTokens: sum(
+                      previous.cachedInputTokens,
+                      next.cachedInputTokens,
+                  ),
+              }
+            : next;
+    }
+
+    startHeartbeat(intervalMs: number): void {
+        this.heartbeat = setInterval(() => {
+            void this.model
+                .refreshAssistantMessageHeartbeat(this.messageUuid)
+                .then((updated) => {
+                    if (!updated) this.stopHeartbeat();
+                })
+                .catch(() => this.stopHeartbeat());
+        }, intervalMs);
+    }
+
+    private stopHeartbeat(): void {
+        if (this.heartbeat) clearInterval(this.heartbeat);
+        this.heartbeat = undefined;
+    }
+
+    private enqueue(operation: () => Promise<void>): Promise<void> {
+        const result = this.queue.then(async () => {
+            try {
+                await operation();
+            } catch (error) {
+                if (
+                    error instanceof ConflictError &&
+                    error.message === 'Assistant message is frozen'
+                ) {
+                    this.onFrozen?.();
+                    this.markTerminal();
+                    return;
+                }
+                throw error;
+            }
+        });
+        this.queue = result.catch(() => undefined);
+        return result;
+    }
+
+    private async createPart(
+        key: string,
+        type: AiV3PartWrite['type'],
+        payload: Record<string, unknown>,
+        toolCallId?: string,
+        artifactVersionUuid?: string,
+    ): Promise<PersistedPart> {
+        const partIndex = this.nextPartIndex;
+        this.nextPartIndex += 1;
+        const write = {
+            partIndex,
+            type,
+            payloadVersion: 1,
+            payload,
+            ...(toolCallId ? { toolCallId } : {}),
+            ...(artifactVersionUuid ? { artifactVersionUuid } : {}),
+        } as AiV3PartWrite;
+        const [created] = await this.model.appendParts({
+            messageUuid: this.messageUuid,
+            parts: [write],
+        });
+        const part = {
+            uuid: created.uuid,
+            partIndex,
+            type,
+            toolCallId,
+            payload,
+        };
+        this.parts.set(key, part);
+        return part;
+    }
+
+    private async updatePart(
+        part: PersistedPart,
+        payload: Record<string, unknown>,
+    ): Promise<void> {
+        await this.model.updatePart({
+            messageUuid: this.messageUuid,
+            partUuid: part.uuid,
+            payloadVersion: 1,
+            payload,
+        });
+        const stored = [...this.parts.values()].find(
+            ({ uuid }) => uuid === part.uuid,
+        );
+        if (stored) stored.payload = payload;
+    }
+
+    async onChunk(value: unknown): Promise<void> {
+        const chunk = value as StreamChunk;
+        const ackKey = AiAgentV3RunPersistence.chunkAckKey(chunk);
+        let persisted = false;
+        try {
+            await this.enqueue(async () => {
+                if (this.terminal) return;
+                switch (chunk.type) {
+                    case 'text-delta':
+                    case 'reasoning-delta': {
+                        const type =
+                            chunk.type === 'text-delta' ? 'text' : 'reasoning';
+                        const part = this.parts.get(chunk.id);
+                        const payload = {
+                            ...(part?.payload ?? {}),
+                            text: `${String(part?.payload.text ?? '')}${chunk.text}`,
+                            ...(chunk.providerMetadata
+                                ? { providerMetadata: chunk.providerMetadata }
+                                : {}),
+                        };
+                        if (part) await this.updatePart(part, payload);
+                        else await this.createPart(chunk.id, type, payload);
+                        persisted = true;
+                        return;
+                    }
+                    case 'tool-input-start': {
+                        await this.createPart(
+                            chunk.id,
+                            'tool',
+                            {
+                                state: 'input-streaming',
+                                toolName: chunk.toolName,
+                                rawInput: '',
+                                ...(chunk.providerMetadata
+                                    ? {
+                                          providerMetadata:
+                                              chunk.providerMetadata,
+                                      }
+                                    : {}),
+                                ...(chunk.providerExecuted !== undefined
+                                    ? {
+                                          providerExecuted:
+                                              chunk.providerExecuted,
+                                      }
+                                    : {}),
+                                ...(chunk.dynamic !== undefined
+                                    ? { dynamic: chunk.dynamic }
+                                    : {}),
+                                ...(chunk.title ? { title: chunk.title } : {}),
+                            },
+                            chunk.id,
+                        );
+                        return;
+                    }
+                    case 'tool-input-delta': {
+                        const part = this.parts.get(chunk.id);
+                        if (!part) return;
+                        await this.updatePart(part, {
+                            ...part.payload,
+                            rawInput: `${String(part.payload.rawInput ?? '')}${chunk.delta}`,
+                            ...(chunk.providerMetadata
+                                ? { providerMetadata: chunk.providerMetadata }
+                                : {}),
+                        });
+                        return;
+                    }
+                    case 'tool-call': {
+                        const part = this.parts.get(chunk.toolCallId);
+                        const payload = chunk.invalid
+                            ? {
+                                  state: 'output-error',
+                                  toolName: chunk.toolName,
+                                  input: chunk.input,
+                                  error: {
+                                      name: 'invalid_tool_call',
+                                      message:
+                                          chunk.error instanceof Error
+                                              ? chunk.error.message
+                                              : String(
+                                                    chunk.error ??
+                                                        'Invalid tool call',
+                                                ),
+                                  },
+                              }
+                            : {
+                                  state: 'input-available',
+                                  toolName: chunk.toolName,
+                                  input: chunk.input,
+                              };
+                        const enriched = {
+                            ...payload,
+                            ...(chunk.providerMetadata
+                                ? { providerMetadata: chunk.providerMetadata }
+                                : {}),
+                            ...(chunk.providerExecuted !== undefined
+                                ? { providerExecuted: chunk.providerExecuted }
+                                : {}),
+                            ...(chunk.dynamic !== undefined
+                                ? { dynamic: chunk.dynamic }
+                                : {}),
+                        };
+                        if (part) await this.updatePart(part, enriched);
+                        else
+                            await this.createPart(
+                                chunk.toolCallId,
+                                'tool',
+                                enriched,
+                                chunk.toolCallId,
+                            );
+                        return;
+                    }
+                    case 'tool-result': {
+                        if (chunk.preliminary) return;
+                        const part = this.parts.get(chunk.toolCallId);
+                        const payload = {
+                            ...(part?.payload ?? { toolName: chunk.toolName }),
+                            state: 'output-available',
+                            output: chunk.output,
+                            ...(chunk.providerMetadata
+                                ? { providerMetadata: chunk.providerMetadata }
+                                : {}),
+                        };
+                        if (part) await this.updatePart(part, payload);
+                        else
+                            await this.createPart(
+                                chunk.toolCallId,
+                                'tool',
+                                payload,
+                                chunk.toolCallId,
+                            );
+                        return;
+                    }
+                    case 'source': {
+                        const { type: _type, ...source } = chunk;
+                        await this.createPart(
+                            `source:${this.nextPartIndex}`,
+                            'source',
+                            source,
+                        );
+                        return;
+                    }
+                    case 'raw':
+                        return;
+                    default:
+                        return;
+                }
+            });
+        } finally {
+            if (ackKey) this.acknowledgeChunk(ackKey, persisted);
+        }
+    }
+
+    async appendArtifact(artifactVersionUuid: string): Promise<void> {
+        return this.enqueue(async () => {
+            if (this.terminal) return;
+            await this.createPart(
+                `artifact:${artifactVersionUuid}`,
+                'artifact',
+                {},
+                undefined,
+                artifactVersionUuid,
+            );
+        });
+    }
+
+    async complete(usage?: LanguageModelUsage): Promise<void> {
+        const canceled = this.isCanceled();
+        return this.enqueue(async () => {
+            if (this.terminal) return;
+            try {
+                await this.model.finishAssistantMessage({
+                    messageUuid: this.messageUuid,
+                    status: canceled ? 'canceled' : 'completed',
+                    tokenUsage: usageEnvelope(usage) ?? this.tokenUsage,
+                    error: null,
+                });
+            } finally {
+                this.markTerminal();
+            }
+        });
+    }
+
+    async cancel(): Promise<void> {
+        return this.enqueue(async () => {
+            if (this.terminal) return;
+            try {
+                await this.model.finishAssistantMessage({
+                    messageUuid: this.messageUuid,
+                    status: 'canceled',
+                    tokenUsage: this.tokenUsage,
+                    error: null,
+                });
+            } finally {
+                this.markTerminal();
+            }
+        });
+    }
+
+    async fail(error: unknown, message: string): Promise<void> {
+        const canceled = this.isCanceled();
+        return this.enqueue(async () => {
+            if (this.terminal) return;
+            try {
+                await this.model.finishAssistantMessage({
+                    messageUuid: this.messageUuid,
+                    status: canceled ? 'canceled' : 'error',
+                    tokenUsage: this.tokenUsage,
+                    error: canceled
+                        ? null
+                        : getAiRunErrorEnvelope(error, message),
+                });
+            } finally {
+                this.markTerminal();
+            }
+        });
+    }
+}

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -163,6 +163,7 @@ export const DEEP_RESEARCH_WORKER_TOOL_NAMES = new Set([
 ]);
 
 const PERSIST_TIMEOUT_MS = 10_000;
+const V3_STREAM_CHUNK_SIZE = 128;
 
 /**
  * Decorates updatePrompt with the stream-close contract: awaiting it never
@@ -1786,6 +1787,7 @@ export const streamAgentResponse = async ({
         const result = streamText({
             ...defaultAgentOptions,
             ...args.callOptions,
+            abortSignal: args.abortSignal,
             prepareStep,
             stopWhen: [
                 stepCountIs(args.execution.maxSteps),
@@ -1796,7 +1798,8 @@ export const streamAgentResponse = async ({
             tools,
             messages,
             experimental_context: new AgentContext(availableExplores),
-            onChunk: (event) => {
+            onChunk: async (event) => {
+                await dependencies.streamPersistence?.onChunk(event.chunk);
                 // Track time to first chunk (any type) - only once
                 if (firstChunkTime === null) {
                     firstChunkTime = Date.now();
@@ -1998,6 +2001,7 @@ export const streamAgentResponse = async ({
                 }
             },
             onStepFinish: (step) => {
+                dependencies.streamPersistence?.recordUsage(step.usage);
                 if (step.reasoningText && step.reasoningText.length > 0) {
                     logger(
                         'On Step Finish',
@@ -2072,14 +2076,24 @@ export const streamAgentResponse = async ({
                             },
                         });
                     }
-                    await persistPrompt({
-                        promptUuid: args.promptUuid,
-                        errorMessage:
-                            getUserFacingErrorMessage(emptyResponseError),
-                        tokenUsage: {
-                            totalTokens: usage.totalTokens ?? 0,
-                        },
-                    });
+                    const message =
+                        getUserFacingErrorMessage(emptyResponseError);
+                    if (dependencies.streamPersistence) {
+                        await dependencies.streamPersistence.fail(
+                            emptyResponseError,
+                            message,
+                        );
+                    } else {
+                        await persistPrompt({
+                            promptUuid: args.promptUuid,
+                            errorMessage: message,
+                            tokenUsage: {
+                                totalTokens: usage.totalTokens ?? 0,
+                            },
+                        });
+                    }
+                } else if (dependencies.streamPersistence) {
+                    await dependencies.streamPersistence.complete(totalUsage);
                 } else {
                     await persistPrompt({
                         response: completeResponse,
@@ -2127,7 +2141,12 @@ export const streamAgentResponse = async ({
             },
             experimental_transform: smoothStream({
                 delayInMs: 20,
-                chunking: 'word',
+                chunking: dependencies.streamPersistence
+                    ? (buffer) =>
+                          buffer.length >= V3_STREAM_CHUNK_SIZE
+                              ? buffer.slice(0, V3_STREAM_CHUNK_SIZE)
+                              : null
+                    : 'word',
             }),
             onError: async ({ error }) => {
                 console.error(error);
@@ -2150,11 +2169,22 @@ export const streamAgentResponse = async ({
                     args.keyManagement,
                 );
 
-                await persistPrompt({
-                    promptUuid: args.promptUuid,
-                    errorMessage: userFacingMessage,
-                });
+                if (dependencies.streamPersistence) {
+                    await dependencies.streamPersistence.fail(
+                        error,
+                        userFacingMessage,
+                    );
+                } else {
+                    await persistPrompt({
+                        promptUuid: args.promptUuid,
+                        errorMessage: userFacingMessage,
+                    });
+                }
 
+                void cleanupMcpClients();
+            },
+            onAbort: async () => {
+                await dependencies.streamPersistence?.cancel();
                 void cleanupMcpClients();
             },
             experimental_telemetry: telemetry,
@@ -2182,10 +2212,14 @@ export const streamAgentResponse = async ({
             args.keyManagement,
         );
 
-        await dependencies.updatePrompt({
-            promptUuid: args.promptUuid,
-            errorMessage: userFacingMessage,
-        });
+        if (dependencies.streamPersistence) {
+            await dependencies.streamPersistence.fail(error, userFacingMessage);
+        } else {
+            await dependencies.updatePrompt({
+                promptUuid: args.promptUuid,
+                errorMessage: userFacingMessage,
+            });
+        }
 
         await cleanupMcpClients();
         throw error;

--- a/packages/backend/src/ee/services/ai/agents/tests/utils/testHelpers.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/testHelpers.ts
@@ -42,13 +42,14 @@ export const promptAndGetToolCalls = async (
         messageUuid = message.uuid;
     }
 
-    const response = await services.aiAgentService.generateAgentThreadResponse(
-        context.testUser,
-        {
-            agentUuid: createdAgent.uuid,
-            threadUuid: threadUuidToUse,
-        },
-    );
+    const response =
+        await services.aiAgentService.generateAgentThreadResponseInternal(
+            context.testUser,
+            {
+                agentUuid: createdAgent.uuid,
+                threadUuid: threadUuidToUse,
+            },
+        );
 
     const toolCalls = await context
         .db<DbAiAgentToolCall>('ai_agent_tool_call')

--- a/packages/backend/src/ee/services/ai/projectV3ThreadToModelMessages.test.ts
+++ b/packages/backend/src/ee/services/ai/projectV3ThreadToModelMessages.test.ts
@@ -1,0 +1,158 @@
+import { expect, it } from 'vitest';
+import { type AiCanonicalThread } from '../../database/entities/aiAgentV3';
+import { projectV3ThreadToModelMessages } from './projectV3ThreadToModelMessages';
+
+const thread = (
+    messages: AiCanonicalThread['messages'],
+): AiCanonicalThread => ({
+    uuid: 'thread',
+    storageVersion: 3,
+    organizationUuid: 'org',
+    projectUuid: 'project',
+    agentUuid: 'agent',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: null,
+    createdFrom: 'web_app',
+    title: null,
+    lineage: null,
+    messages,
+});
+
+const metadata = {
+    createdAt: '2026-01-01T00:00:00.000Z',
+    createdByUserUuid: null,
+    status: null,
+    lastHeartbeatAt: null,
+    modelConfig: null,
+    tokenUsage: null,
+    error: null,
+    hidden: false,
+    context: [],
+    legacy: null,
+};
+
+it('replays persisted text and tool activity without system messages', () => {
+    expect(
+        projectV3ThreadToModelMessages(
+            thread([
+                {
+                    uuid: 'user',
+                    role: 'user',
+                    metadata,
+                    parts: [
+                        {
+                            uuid: 'user-text',
+                            type: 'text',
+                            payloadVersion: 1,
+                            payload: { text: 'question' },
+                            toolCallId: null,
+                            artifactVersionUuid: null,
+                        },
+                    ],
+                },
+                {
+                    uuid: 'assistant',
+                    role: 'assistant',
+                    metadata: { ...metadata, status: 'completed' },
+                    parts: [
+                        {
+                            uuid: 'intro',
+                            type: 'text',
+                            payloadVersion: 1,
+                            payload: { text: 'Checking.' },
+                            toolCallId: null,
+                            artifactVersionUuid: null,
+                        },
+                        {
+                            uuid: 'tool',
+                            type: 'tool',
+                            payloadVersion: 1,
+                            payload: {
+                                state: 'output-available',
+                                toolName: 'findExplores',
+                                input: { query: 'orders' },
+                                output: ['orders'],
+                            },
+                            toolCallId: 'call-1',
+                            artifactVersionUuid: null,
+                        },
+                        {
+                            uuid: 'answer',
+                            type: 'text',
+                            payloadVersion: 1,
+                            payload: { text: 'Found it.' },
+                            toolCallId: null,
+                            artifactVersionUuid: null,
+                        },
+                    ],
+                },
+            ]),
+        ),
+    ).toEqual([
+        { role: 'user', content: 'question' },
+        {
+            role: 'assistant',
+            content: [
+                {
+                    type: 'text',
+                    text: 'Checking.',
+                    providerOptions: undefined,
+                },
+                {
+                    type: 'tool-call',
+                    toolCallId: 'call-1',
+                    toolName: 'findExplores',
+                    input: { query: 'orders' },
+                    providerOptions: undefined,
+                    providerExecuted: undefined,
+                },
+            ],
+        },
+        {
+            role: 'tool',
+            content: [
+                {
+                    type: 'tool-result',
+                    toolCallId: 'call-1',
+                    toolName: 'findExplores',
+                    output: { type: 'json', value: ['orders'] },
+                    providerOptions: undefined,
+                },
+            ],
+        },
+        {
+            role: 'assistant',
+            content: [
+                {
+                    type: 'text',
+                    text: 'Found it.',
+                    providerOptions: undefined,
+                },
+            ],
+        },
+    ]);
+});
+
+it('does not replay an in-progress assistant message', () => {
+    expect(
+        projectV3ThreadToModelMessages(
+            thread([
+                {
+                    uuid: 'assistant',
+                    role: 'assistant',
+                    metadata: { ...metadata, status: 'in_progress' },
+                    parts: [
+                        {
+                            uuid: 'partial',
+                            type: 'text',
+                            payloadVersion: 1,
+                            payload: { text: 'partial' },
+                            toolCallId: null,
+                            artifactVersionUuid: null,
+                        },
+                    ],
+                },
+            ]),
+        ),
+    ).toEqual([]);
+});

--- a/packages/backend/src/ee/services/ai/projectV3ThreadToModelMessages.ts
+++ b/packages/backend/src/ee/services/ai/projectV3ThreadToModelMessages.ts
@@ -1,0 +1,113 @@
+import {
+    type AssistantModelMessage,
+    type JSONValue,
+    type ModelMessage,
+} from 'ai';
+import { type AiCanonicalThread } from '../../database/entities/aiAgentV3';
+
+const providerOptions = (payload: Record<string, unknown>) =>
+    payload.providerMetadata as
+        | Record<string, Record<string, JSONValue>>
+        | undefined;
+
+const toolOutput = (payload: Record<string, unknown>) => {
+    if (payload.state === 'output-denied') {
+        return { type: 'execution-denied' as const, reason: 'Denied by user' };
+    }
+    const value =
+        payload.state === 'output-error'
+            ? { error: payload.error ?? { name: 'tool_error' } }
+            : payload.output;
+    return value === undefined
+        ? { type: 'text' as const, value: '' }
+        : { type: 'json' as const, value: value as JSONValue };
+};
+
+export const projectV3ThreadToModelMessages = (
+    thread: AiCanonicalThread,
+): ModelMessage[] => {
+    const messages: ModelMessage[] = [];
+
+    thread.messages.forEach((message) => {
+        if (message.role === 'compaction') {
+            return;
+        }
+
+        if (message.role === 'user') {
+            const text = message.parts
+                .filter((part) => part.type === 'text')
+                .map((part) => part.payload.text)
+                .filter((part): part is string => typeof part === 'string')
+                .join('');
+            if (text) messages.push({ role: 'user', content: text });
+            return;
+        }
+
+        if (message.metadata.status === 'in_progress') return;
+        let assistantContent: Exclude<
+            AssistantModelMessage['content'],
+            string
+        > = [];
+        const flushAssistant = () => {
+            if (assistantContent.length === 0) return;
+            messages.push({ role: 'assistant', content: assistantContent });
+            assistantContent = [];
+        };
+
+        message.parts.forEach((part) => {
+            switch (part.type) {
+                case 'text':
+                case 'reasoning': {
+                    if (typeof part.payload.text !== 'string') return;
+                    assistantContent.push({
+                        type: part.type === 'text' ? 'text' : 'reasoning',
+                        text: part.payload.text,
+                        providerOptions: providerOptions(part.payload),
+                    });
+                    return;
+                }
+                case 'tool': {
+                    const { toolName, state } = part.payload;
+                    if (
+                        !part.toolCallId ||
+                        typeof toolName !== 'string' ||
+                        typeof state !== 'string'
+                    ) {
+                        return;
+                    }
+                    assistantContent.push({
+                        type: 'tool-call',
+                        toolCallId: part.toolCallId,
+                        toolName,
+                        input: part.payload.input ?? {},
+                        providerOptions: providerOptions(part.payload),
+                        providerExecuted:
+                            typeof part.payload.providerExecuted === 'boolean'
+                                ? part.payload.providerExecuted
+                                : undefined,
+                    });
+                    if (!state.startsWith('output-')) return;
+                    flushAssistant();
+                    messages.push({
+                        role: 'tool',
+                        content: [
+                            {
+                                type: 'tool-result',
+                                toolCallId: part.toolCallId,
+                                toolName,
+                                output: toolOutput(part.payload),
+                                providerOptions: providerOptions(part.payload),
+                            },
+                        ],
+                    });
+                    return;
+                }
+                default:
+                    return;
+            }
+        });
+        flushAssistant();
+    });
+
+    return messages;
+};

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -18,7 +18,7 @@ import {
 } from '@lightdash/common';
 // eslint-disable-next-line import/extensions
 import { type OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
-import { ModelMessage } from 'ai';
+import { ModelMessage, type LanguageModelUsage } from 'ai';
 import {
     AiKeyManagement,
     type AiUsageTokens,
@@ -263,6 +263,7 @@ export type AiAgentArgs = AnyAiModel & {
     canManageAgent: boolean;
     toolHints: string[];
     execution: AiAgentExecutionConfig;
+    abortSignal?: AbortSignal;
     /**
      * When true, the first tool hint is *forced* on the opening step
      * (toolChoice), not just suggested — used by the review Build-fix run to
@@ -347,6 +348,13 @@ export type AiAgentDependencies = {
     isThreadSqlAutoApproved: IsThreadSqlAutoApprovedFn;
     loadSkill: LoadAgentSkillFn;
     perf: PerformanceMetrics;
+    streamPersistence?: {
+        onChunk: (chunk: unknown) => Promise<void>;
+        recordUsage: (usage: LanguageModelUsage) => void;
+        complete: (usage?: LanguageModelUsage) => Promise<void>;
+        fail: (error: unknown, message: string) => Promise<void>;
+        cancel: () => Promise<void>;
+    };
 };
 
 export type AiGenerateAgentResponseArgs = AiAgentArgs;

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -152,6 +152,7 @@ export type ModelManifest = {
     /** An implementation signature for these models are not available at this stage */
     aiAgentMemoryModel: unknown;
     aiAgentModel: unknown;
+    aiAgentThreadRepository: unknown;
     aiAgentV3Model: unknown;
     homepageRecommendedActionSkipsModel: unknown;
     projectHomepageModel: unknown;
@@ -822,6 +823,10 @@ export class ModelRepository
 
     public getAiAgentModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentModel');
+    }
+
+    public getAiAgentThreadRepository<ModelImplT>(): ModelImplT {
+        return this.getModel('aiAgentThreadRepository');
     }
 
     public getAiAgentV3Model<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -152,6 +152,7 @@ export type ModelManifest = {
     /** An implementation signature for these models are not available at this stage */
     aiAgentMemoryModel: unknown;
     aiAgentModel: unknown;
+    aiAgentV3Model: unknown;
     homepageRecommendedActionSkipsModel: unknown;
     projectHomepageModel: unknown;
     aiAgentDocumentModel: unknown;
@@ -821,6 +822,10 @@ export class ModelRepository
 
     public getAiAgentModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentModel');
+    }
+
+    public getAiAgentV3Model<ModelImplT>(): ModelImplT {
+        return this.getModel('aiAgentV3Model');
     }
 
     public getAiAgentMemoryModel<ModelImplT>(): ModelImplT {

--- a/packages/common/src/ee/AiAgent/groupIntoTurns.test.ts
+++ b/packages/common/src/ee/AiAgent/groupIntoTurns.test.ts
@@ -1,0 +1,100 @@
+import { groupIntoTurns, type TurnGroupingMessage } from './groupIntoTurns';
+
+type Message = TurnGroupingMessage & { uuid: string };
+
+const message = (
+    uuid: string,
+    role: Message['role'],
+    hidden = false,
+): Message => ({ uuid, role, metadata: { hidden } });
+
+describe('groupIntoTurns', () => {
+    it('attaches steers and omits hidden assistant turns', () => {
+        const firstUser = message('first-user', 'user');
+        const firstAssistant = message('first-assistant', 'assistant');
+        const firstSteer = message('first-steer', 'user');
+        const secondSteer = message('second-steer', 'user');
+        const hiddenUser = message('hidden-user', 'user', true);
+        const hiddenAssistant = message('hidden-assistant', 'assistant', true);
+        const secondUser = message('second-user', 'user');
+        const secondAssistant = message('second-assistant', 'assistant');
+
+        expect(
+            groupIntoTurns([
+                firstUser,
+                firstAssistant,
+                firstSteer,
+                secondSteer,
+                hiddenUser,
+                hiddenAssistant,
+                secondUser,
+                secondAssistant,
+            ]),
+        ).toEqual([
+            {
+                userMessage: firstUser,
+                assistantMessage: firstAssistant,
+                steerMessages: [firstSteer, secondSteer],
+            },
+            {
+                userMessage: secondUser,
+                assistantMessage: secondAssistant,
+                steerMessages: [],
+            },
+        ]);
+    });
+
+    it('keeps a visible assistant reply when its user message is hidden', () => {
+        const hiddenUser = message('hidden-user', 'user', true);
+        const assistant = message('assistant', 'assistant');
+
+        expect(groupIntoTurns([hiddenUser, assistant])).toEqual([
+            {
+                userMessage: hiddenUser,
+                assistantMessage: assistant,
+                steerMessages: [],
+            },
+        ]);
+    });
+
+    it('attaches trailing user messages to the active turn', () => {
+        const firstUser = message('first-user', 'user');
+        const activeAssistant = message('active-assistant', 'assistant');
+        const activeSteer = message('active-steer', 'user');
+
+        expect(
+            groupIntoTurns([firstUser, activeAssistant, activeSteer]),
+        ).toEqual([
+            {
+                userMessage: firstUser,
+                assistantMessage: activeAssistant,
+                steerMessages: [activeSteer],
+            },
+        ]);
+    });
+
+    it('preserves initial user messages before the answered turn', () => {
+        const contextMessage = message('context', 'user');
+        const userMessage = message('user', 'user');
+        const assistantMessage = message('assistant', 'assistant');
+
+        expect(
+            groupIntoTurns([contextMessage, userMessage, assistantMessage]),
+        ).toEqual([
+            {
+                userMessage: contextMessage,
+                assistantMessage: null,
+                steerMessages: [],
+            },
+            {
+                userMessage,
+                assistantMessage,
+                steerMessages: [],
+            },
+        ]);
+    });
+
+    it('ignores assistant messages without a preceding user message', () => {
+        expect(groupIntoTurns([message('assistant', 'assistant')])).toEqual([]);
+    });
+});

--- a/packages/common/src/ee/AiAgent/groupIntoTurns.ts
+++ b/packages/common/src/ee/AiAgent/groupIntoTurns.ts
@@ -1,0 +1,96 @@
+import assertUnreachable from '../../utils/assertUnreachable';
+
+export type TurnGroupingMessage = {
+    role: 'user' | 'assistant' | 'compaction';
+    metadata: { hidden: boolean };
+};
+
+type UserMessage<T extends TurnGroupingMessage> = T & { role: 'user' };
+type AssistantMessage<T extends TurnGroupingMessage> = T & {
+    role: 'assistant';
+};
+
+const isUserMessage = <T extends TurnGroupingMessage>(
+    message: T,
+): message is UserMessage<T> => message.role === 'user';
+
+const isAssistantMessage = <T extends TurnGroupingMessage>(
+    message: T,
+): message is AssistantMessage<T> => message.role === 'assistant';
+
+export type AiTurnGroup<T extends TurnGroupingMessage> = {
+    userMessage: UserMessage<T>;
+    assistantMessage: AssistantMessage<T> | null;
+    steerMessages: UserMessage<T>[];
+};
+
+const appendPendingUserTurns = <T extends TurnGroupingMessage>(
+    turns: AiTurnGroup<T>[],
+    pendingUsers: UserMessage<T>[],
+) => {
+    pendingUsers.forEach((userMessage) => {
+        turns.push({
+            userMessage,
+            assistantMessage: null,
+            steerMessages: [],
+        });
+    });
+};
+
+export const groupIntoTurns = <T extends TurnGroupingMessage>(
+    messages: T[],
+): AiTurnGroup<T>[] => {
+    const turns: AiTurnGroup<T>[] = [];
+    let pendingUsers: UserMessage<T>[] = [];
+
+    messages.forEach((message) => {
+        switch (message.role) {
+            case 'compaction':
+                return;
+            case 'user':
+                if (isUserMessage(message)) pendingUsers.push(message);
+                return;
+            case 'assistant': {
+                if (!isAssistantMessage(message)) return;
+                // Earlier pending users are steers for the previous active turn.
+                const userMessage = pendingUsers.pop();
+                if (userMessage === undefined) return;
+                const previousTurn = turns.at(-1);
+                if (previousTurn !== undefined) {
+                    previousTurn.steerMessages.push(...pendingUsers);
+                } else {
+                    appendPendingUserTurns(turns, pendingUsers);
+                }
+                turns.push({
+                    userMessage,
+                    assistantMessage: message,
+                    steerMessages: [],
+                });
+                pendingUsers = [];
+                return;
+            }
+            default:
+                assertUnreachable(message.role, 'Unknown message role');
+        }
+    });
+
+    const lastTurn = turns.at(-1);
+    if (lastTurn !== undefined) {
+        lastTurn.steerMessages.push(...pendingUsers);
+    } else {
+        appendPendingUserTurns(turns, pendingUsers);
+    }
+
+    return turns
+        .filter((turn) =>
+            turn.assistantMessage !== null
+                ? !turn.assistantMessage.metadata.hidden
+                : !turn.userMessage.metadata.hidden,
+        )
+        .map((turn) => ({
+            ...turn,
+            steerMessages: turn.steerMessages.filter(
+                (steer) => !steer.metadata.hidden,
+            ),
+        }));
+};

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -782,6 +782,14 @@ export type ApiAiAgentThreadStreamRequest = {
     toolHints?: string[];
 };
 
+export type ApiAiAgentV3ChatRequest = {
+    message: string;
+    modelConfig?: AiAgentModelConfig;
+    enableSqlMode?: boolean;
+    autoApproveSql?: boolean;
+    toolHints?: string[];
+};
+
 export type ApiAiAgentSqlApprovalResponse = ApiSuccess<{
     decision: 'approved' | 'rejected';
 }>;

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -49,6 +49,7 @@ export * from './schemas/agentSuggestions';
 export * from './types';
 export * from './utils';
 export * from './validators';
+export * from './v3ThreadTypes';
 
 export type AiMcpServerAuthType = 'none' | 'bearer' | 'oauth';
 export type AiMcpCredentialScope = 'shared' | 'user';

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -1237,3 +1237,4 @@ export type AiModelOption = {
 };
 
 export type ApiAiAgentModelOptionsResponse = ApiSuccess<AiModelOption[]>;
+export * from './groupIntoTurns';

--- a/packages/common/src/ee/AiAgent/v3ThreadTypes.ts
+++ b/packages/common/src/ee/AiAgent/v3ThreadTypes.ts
@@ -1,0 +1,188 @@
+import {
+    type AiChartRuntimeOverrides,
+    type AiDashboardRuntimeOverrides,
+    type AiThreadCreatedFrom,
+} from './requestTypes';
+
+export type AiAgentStorageVersion = 1 | 3;
+export type AiAgentThreadReadOnlyReason = 'legacy' | 'slack' | 'not_owner';
+export type AiAgentThreadFirstMessage = { uuid: string; message: string };
+export const AI_AGENT_V3_PART_TYPES = [
+    'text',
+    'reasoning',
+    'tool',
+    'file',
+    'artifact',
+    'step-start',
+    'source',
+    'compaction',
+] as const;
+export type AiAgentV3KnownPartType = (typeof AI_AGENT_V3_PART_TYPES)[number];
+// Reads preserve future persisted types while known types remain discriminable.
+export type AiAgentV3PartType = AiAgentV3KnownPartType | (string & {});
+
+export type AiAgentThreadCapability =
+    | { readOnly: false; readOnlyReason: null }
+    | {
+          readOnly: true;
+          readOnlyReason: AiAgentThreadReadOnlyReason;
+      };
+
+export type AiAgentV3ModelConfig = {
+    version: number;
+    modelName: string;
+    modelProvider: string;
+    reasoning: {
+        enabled: boolean;
+        effort: string | null;
+        budgetTokens: number | null;
+    };
+    limits: {
+        maxSteps: number | null;
+        maxOutputTokens: number | null;
+    };
+    sampling: {
+        temperature: number | null;
+        topP: number | null;
+    };
+    providerOptions: Record<string, unknown> | null;
+};
+
+export type AiAgentV3TokenUsage = {
+    version: number;
+    inputTokens: number | null;
+    outputTokens: number | null;
+    totalTokens: number | null;
+    reasoningTokens: number | null;
+    cachedInputTokens: number | null;
+};
+
+export type AiAgentV3RunError = {
+    version: number;
+    name: string;
+    message: string;
+    data: Record<string, unknown> | null;
+};
+
+export type AiAgentV3ReferencedArtifact = {
+    artifactVersionUuid: string;
+    artifactUuid: string;
+    projectUuid: string;
+    similarityScore: number | null;
+    versionNumber: number;
+    title: string | null;
+    description: string | null;
+    artifactType: string;
+    createdAt: string;
+};
+
+export type AiAgentV3LegacyMetadata =
+    | {
+          type: 'response';
+          vizConfigOutput: unknown;
+          filtersOutput: unknown;
+          metricQuery: unknown;
+          savedQueryUuid: string | null;
+          humanScore: number | null;
+          humanFeedback: string | null;
+          referencedArtifacts: AiAgentV3ReferencedArtifact[];
+          interrupts: {
+              createdByUserUuid: string | null;
+              createdAt: string;
+          }[];
+      }
+    | {
+          type: 'steer';
+          consumedAt: string | null;
+          consumedStep: number | null;
+      };
+
+export type AiAgentV3ThreadLineage =
+    | null
+    | {
+          kind: 'spawn';
+          parentThreadUuid: string;
+          parentMessageUuid: string;
+          parentToolCallId: string;
+      }
+    | {
+          kind: 'fork';
+          parentThreadUuid: string;
+          forkBoundarySeq: number;
+      };
+
+export type AiAgentV3Part = {
+    uuid: string;
+    type: AiAgentV3PartType;
+    payloadVersion: number;
+    payload: Record<string, unknown>;
+    toolCallId: string | null;
+    artifactVersionUuid: string | null;
+};
+
+export type AiAgentV3Context = {
+    uuid: string;
+    entityType: string;
+    entityUuid: string | null;
+    entityRef: string | null;
+    pinnedVersionUuid: string | null;
+    displayName: string | null;
+    createdAt: string;
+    runtimeOverrides:
+        | AiChartRuntimeOverrides
+        | AiDashboardRuntimeOverrides
+        | null;
+};
+
+export type AiAgentV3Message = {
+    uuid: string;
+    role: 'user' | 'assistant' | 'compaction';
+    parts: AiAgentV3Part[];
+    metadata: {
+        createdAt: string;
+        createdByUserUuid: string | null;
+        status: 'in_progress' | 'completed' | 'error' | 'canceled' | null;
+        lastHeartbeatAt: string | null;
+        modelConfig: AiAgentV3ModelConfig | null;
+        tokenUsage: AiAgentV3TokenUsage | null;
+        error: AiAgentV3RunError | null;
+        hidden: boolean;
+        context: AiAgentV3Context[];
+        legacy: AiAgentV3LegacyMetadata | null;
+    };
+};
+
+export type AiAgentV3Thread = AiAgentThreadCapability & {
+    uuid: string;
+    storageVersion: AiAgentStorageVersion;
+    organizationUuid: string;
+    projectUuid: string;
+    agentUuid: string | null;
+    createdAt: string;
+    updatedAt: string | null;
+    createdFrom: AiThreadCreatedFrom;
+    title: string | null;
+    lineage: AiAgentV3ThreadLineage;
+    messages: AiAgentV3Message[];
+};
+
+export type AiAgentV3ThreadSummary = AiAgentThreadCapability & {
+    uuid: string;
+    storageVersion: AiAgentStorageVersion;
+    agentUuid: string;
+    createdAt: string;
+    createdFrom: AiThreadCreatedFrom;
+    title: string | null;
+    firstMessage: AiAgentThreadFirstMessage | null;
+    user: { uuid: string | null; name: string };
+};
+
+export type ApiAiAgentV3ThreadResponse = {
+    status: 'ok';
+    results: AiAgentV3Thread;
+};
+
+export type ApiAiAgentV3ThreadSummaryListResponse = {
+    status: 'ok';
+    results: AiAgentV3ThreadSummary[];
+};

--- a/packages/common/src/types/api/uuid.ts
+++ b/packages/common/src/types/api/uuid.ts
@@ -7,6 +7,13 @@
 export type UUID = string;
 
 /**
+ * Stringified UUID of any RFC 4122 version.
+ * @pattern [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}
+ * @format uuid
+ */
+export type UUIDAnyVersion = string;
+
+/**
  * A resource UUID or its URL slug. Resolve to a real UUID before using as a key.
  */
 export type UuidOrSlug = string;

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -400,6 +400,17 @@ export class ConflictError extends LightdashError {
     }
 }
 
+export class ReadOnlyThreadError extends LightdashError {
+    constructor(threadUuid: string, storageVersion: 1 | 3) {
+        super({
+            message: 'Thread cannot be mutated through this API',
+            name: 'ReadOnlyThreadError',
+            statusCode: 409,
+            data: { threadUuid, storageVersion },
+        });
+    }
+}
+
 export class MissingConfigError extends LightdashError {
     constructor(message: string) {
         super({

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -141,6 +141,9 @@ export enum FeatureFlags {
     /** Enable project-scoped AI agent memory runtime. */
     AiAgentMemory = 'ai-agent-memory',
 
+    /** Persist newly created AI agent threads with the v3 conversation model. */
+    AiAgentV3 = 'ai-agent-v3',
+
     /**
      * Enable the Hexbin (H3 hexagonal binning) layer type for Map charts.
      * Gates the option in the Map Type segmented control. Existing charts


### PR DESCRIPTION
Closes: [ZAP-801](https://linear.app/lightdash/issue/ZAP-801/v3-read-routes-readonly-capability-bidirectional-mutation-guards)

### Description:
- Add v3 thread list/detail reads over v1 and v3 storage in one canonical wire shape.
- Expose viewer-specific read-only capability and reasons.
- Guard all legacy/v3 mutation paths bidirectionally with 409 responses.
- Preserve authoritative ownership, ownerless policy, and spawn/fork visibility.

### Verification:
- Common and backend typechecks; targeted lint and formatting.
- Backend unit suite: 399 files, 5,977 passed, 1 skipped.
- Read-route integration: 2 passed, including mixed-owner and lineage behavior.
- Independent review: CLEAN.
- Behavioral API E2E: canonical v1/v3 reads, all 8 guards, byte-stable DB, 17 Jaeger traces, zero 5xx.