### PR TITLE
fix(charts): measure axis label width with textContent, not innerHTML

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1514,7 +1514,7 @@ const calculateWidthText = (text: string | undefined): number => {
     span.style.top = '0px';
     span.style.position = 'absolute';
     span.style.whiteSpace = 'no-wrap';
-    span.innerHTML = text;
+    span.textContent = text;
 
     const width = Math.ceil(span.clientWidth);
     span.remove();


### PR DESCRIPTION
## Summary

`calculateWidthText` in `useEchartsCartesianConfig.ts` measures how wide an axis label will render. It appended a span to `document.body` and then assigned `span.innerHTML = text`. That text is query result data, so warehouse values reached an HTML sink.

Flagged by react-doctor (`dangerous-html-sink`). Verified rather than taken on trust.

## The data path is real

`getCategoryAxisTickLabelWidth` maps `getLongestLabelsForAxis({ rows: resultsData?.rows, axisIds })` through `calculateWidthText`. Row values from the warehouse go straight into `innerHTML`. The other call sites (`formatTick(tickMax/tickMin)`, `longestValueXAxisBottom/Top`) are the same shape.

## The sink executes

Reproduced the function's exact shape in the running app — create span, append to body, assign `innerHTML`, read `clientWidth`, `remove()`. An inline `onerror` still fired (`firedAfterRemove: true`). The immediate `span.remove()` does **not** cancel a pending handler, so the removal is not a mitigation.

Threat model: needs attacker-influenced warehouse data or dbt field labels. For a BI tool rendering third-party-ingested data (customer names, support tickets, anything user-submitted upstream) that is a realistic stored-XSS path.

## `innerHTML` was also measuring wrong

ECharts renders axis labels to SVG/canvas (`renderer: 'svg' | 'canvas'` in `SimpleChart/index.tsx:342`), never HTML, and the only formatters here are `'{value}%'` — ECharts template syntax. So a label containing markup is **drawn literally** by the chart, but `innerHTML` was parsing it away before measuring.

Measured both against canvas `measureText`, which is what the chart actually draws:

| label | `innerHTML` | `textContent` | canvas truth |
|---|---:|---:|---:|
| `Completed` | 62 | 62 | 59 |
| `bank_transfer` | 78 | 78 | 74 |
| `2024-01-15` | 65 | 65 | 62 |
| `Smith & Sons` | 75 | 75 | 73 |
| `Q1 <2024>` | 63 | 63 | 61 |
| `Tom & Jerry <Ltd>` | **69** | **106** | **99** |
| `&amp;` | **8** | **36** | **35** |
| `<b>bold</b>` | **25** | **76** | **68** |

Identical for every ordinary label — no behaviour change for normal data. They diverge only on markup or entities, and there `innerHTML` **under**-measured badly (it parsed `<Ltd>` as a tag and dropped it), reserving 69px of axis gutter for text drawn at 99px. That is clipped labels today. `textContent` lands within a few px of truth in every case.

The residual ~5% gap (62 vs 59) is span-vs-canvas font metrics and applies uniformly before and after.

## Organic before/after on a real chart

Seeded a warehouse dimension value containing markup (`Tom & Jerry <Ltd> Payments`, replacing `coupon` in `jaffle.payments`), re-ran the query, and measured the same horizontal bar chart on `main` and on this branch. Data was reverted and the query cache re-run afterwards.

Measuring the rotated Y-axis title against the longest tick label:

| | axis title right edge | longest label left edge | result |
|---|---:|---:|---|
| `main` (`innerHTML`) | 90px | 69px | **21px overlap** |
| this branch (`textContent`) | 53px | 69px | 16px clearance |

On `main` the axis title "Payment method" is drawn *on top of* the tick label, because `innerHTML` parsed `<Ltd>` away and measured the label ~37px narrower than it renders. With `textContent` the title sits clear of the labels.

This is the concrete user-visible bug the fix resolves, beyond the security issue: any dimension value containing something that parses as a tag collides the axis title into the tick labels.

## Blast radius: what actually consumes this number

`calculateWidthText` has six call sites, all in `useEchartsCartesianConfig.ts`, and every one of them ends up in an axis **`nameGap`** — the distance between the axis *title* and the axis line:

| Path | Consumer | When it applies |
|---|---|---|
| `getValueAxisTickLabelWidth` / `getCategoryAxisTickLabelWidth` → `leftYaxisGap` / `rightYaxisGap` (:2136, :2150) | `defaultNameGap` for the left/right axis (:2306, :2341) | Always, for Y axes |
| `longestLabelWidth` (:2228, :2284) | `nameGap = width × sin(rotate) + 15` in `getCartesianAxisFormatterConfig` | **Only when the user sets axis label rotation.** Unused otherwise |
| `leftValueLabelGutter` (:2254) | Extra left gutter | Only bar charts with flipped axes and value labels positioned `left` |

It does **not** size the plot area, position tick labels, or touch the data — ECharts computes those itself. The worst a wrong number here can do is put the axis title too close to or too far from the axis.

`calculateWidthText` is referenced nowhere else in the codebase, so the HTML-based custom tooltip feature is unaffected.

## Charts render to SVG and draw labels literally

Confirmed on a live chart: the renderer is SVG and axis labels are `<text>` nodes. Replacing tick label text with markup shows the chart drawing it verbatim — `<b>bold</b>` renders as those characters rather than bold, `&amp;` renders as five characters rather than `&`.

That is the whole argument for `textContent`: the chart never parses HTML, so measuring a parsed version was measuring a string that is never drawn. For numeric axes the two are identical by construction (numbers contain no markup), and for plain text categories they measure identically too, as the table above shows.

## History

The line arrived via `cd8f76e613` ("visualization provider refactor", #7943) as carry-along, not a deliberate decision to measure HTML.

## Caveat

The execution proof ran against the dev build. A production CSP blocking inline handlers would blunt exploitability — worth confirming before assigning a severity. The measurement bug is unaffected by CSP either way.

## Test plan

- [x] `pnpm -F frontend typecheck` clean
- [x] `oxlint` clean
- [x] 244 echarts tests pass
- [x] Sink execution and width comparison both measured in the running app

## No Linear ticket

Opened without one deliberately, per the author's standing call for this react-doctor sweep. Happy to file retroactively.
