### PR TITLE
fix(security): sandbox the third-party Loom embed iframe

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardLoomTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardLoomTile.tsx
@@ -54,6 +54,7 @@ const LoomTile: FC<Props> = (props) => {
                 src={`https://www.loom.com/embed/${getLoomId(url)}`}
                 frameBorder="0"
                 allowFullScreen
+                sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"
                 style={{
                     flex: 1,
                 }}


### PR DESCRIPTION
## Summary

The Loom dashboard tile framed `loom.com` with no `sandbox`, so the embedded third-party page could navigate the entire Lightdash tab. This adds a sandbox that blocks top-navigation and form submission while keeping the player fully working.

react-doctor flags three `iframe-missing-sandbox` sites. **Only one of them should be sandboxed** — reasoning below.

## Why only the Loom tile

| iframe | Frames | Decision |
|---|---|---|
| `DashboardLoomTile.tsx:51` | `loom.com` — third party | **Sandboxed.** Content we don't control; cross-origin means `allow-scripts` + `allow-same-origin` cannot reach into our page |
| `sdk/index.tsx:714` | The customer's own Lightdash instance, over `postMessage` | **Left alone.** Needs `allow-scripts` + `allow-same-origin`, which on first-party content provides no real isolation — and this is the published SDK, so changing frame attributes risks breaking live customer embeds |
| `AnalyticsEmbedDashboard.tsx:22` | A Lightdash embed URL from our own API | **Left alone.** Same reasoning |

Sandboxing the latter two would be security theatre with real breakage risk. `AppIframePreview` is already correctly sandboxed and was not flagged.

## Why `allow-same-origin` is correct here (pre-empting the usual objection)

"`allow-scripts` + `allow-same-origin` defeats the sandbox" is a real rule, and it does **not** apply to a cross-origin frame. `allow-same-origin` means "don't give this document an opaque origin" — not "give it the parent's origin". Loom keeps `https://www.loom.com`, so the cross-origin barrier stands. Measured on the live page:

```
pageOrigin:                http://localhost:3000
frameOrigin:               https://www.loom.com
crossOrigin:               true
contentDocumentAccessible: false
```

The frame therefore cannot reach our DOM, our storage, or make requests as our origin — and cannot remove the sandbox attribute, since that attribute lives in *our* DOM. The anti-pattern applies when you frame **first-party** content with both tokens, which is exactly why this PR leaves `sdk/index.tsx` and `AnalyticsEmbedDashboard` alone.

Dropping `allow-same-origin` was tested: applied verbatim to the source and loaded fresh, **the Loom player renders blank** — it needs its own origin for storage/session. So the real choice is this sandbox or no sandbox, and what this one buys on a cross-origin frame is `allow-top-navigation` and `allow-forms` staying off.

## `allow-popups` is required — found by breaking it first

My initial token list was `allow-scripts allow-same-origin allow-presentation`. The player rendered fine, which is exactly why this needed a functional check rather than a visual one.

A/B in the running app, clicking the player's "open on Loom" control:

- **with that sandbox** — no popup, control silently does nothing
- **with the sandbox stripped at runtime** — opens `https://www.loom.com/share/<id>` as expected

So the first attempt shipped a silent UX regression. Adding `allow-popups allow-popups-to-escape-sandbox` restores it.

## Final state, verified in-app

```
sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"
```

- "open on Loom" control opens the share URL again
- `allow-top-navigation` — **off** (the phishing vector this closes)
- `allow-forms` — **off**
- Player renders fully: thumbnail, play control, view count, duration, chrome

## Regression analysis

The only behaviour the sandbox removes that the embed previously had is top-level navigation and form submission from inside the Loom frame. Neither is something a video embed legitimately needs, and the one control that *did* depend on escaping the frame (open on Loom) is explicitly re-permitted and re-tested. Existing Loom tiles need no migration — this is a render-time attribute.

## Test plan

- [x] `pnpm -F frontend typecheck` clean
- [x] `oxlint` clean
- [x] 267 tests pass across the touched areas
- [x] Loom tile renders and its "open on Loom" control works, verified against a real Loom embed
- [x] Confirmed `allow-top-navigation` / `allow-forms` remain off

## No Linear ticket

Opened without one deliberately, per the author's standing call for this react-doctor sweep.
