### PR TITLE
docs: add Leaflet local data app tutorial

### DIFF
--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -22,6 +22,7 @@ You are editing a Lightdash **data app** that was created or downloaded with the
 ## Library boundaries — build with what's preinstalled
 
 - The app builds against a **fixed template dependency set** — see `package.json` (React, Recharts, d3 + d3-cloud/d3-sankey, Radix primitives, Tailwind, lucide-react, date-fns, html-to-image, jspdf, and more). **Design within this set**; it covers almost all data-app needs.
+- For an interactive geographic or tile map, consider **Leaflet** when it is already declared in `package.json` or the user confirms custom dependencies are enabled. Read `references/leaflet.md` before changing dependencies or map code — it covers the required public-image connection, manifest link, exact-origin tile URLs, and Leaflet's bundled marker-image gotcha.
 - Adding new npm packages only works when the Lightdash organization has custom dependencies enabled — **assume it does not**. When disabled, upload rejects new dependency declarations. Do not attempt `pnpm add` to find out; ask the user whether their organization has custom dependencies enabled before considering a new library.
 - Do **not** work around a missing library by vendoring its source into `src/`, inlining minified code, or fetching code at runtime. If the template set genuinely cannot express what's asked, say so and let the user decide.
 

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/references/leaflet.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/references/leaflet.md
@@ -1,0 +1,113 @@
+# Leaflet maps in locally developed data apps
+
+> Read this when the app needs an interactive geographic or raster-tile map and Leaflet is available or the user has confirmed that custom dependencies are enabled.
+
+Leaflet is not part of the standard data-app dependency set. Use it only when `package.json` already declares `leaflet`, or after the user confirms that their organization permits custom dependencies. Do not load Leaflet from a CDN or vendor its source into `src/`.
+
+## 1. Add Leaflet only when custom dependencies are allowed
+
+If Leaflet is missing, follow the parent skill's dependency workflow and update both dependency files:
+
+```bash
+sfw pnpm add leaflet@1.9.4
+```
+
+Use `pnpm add leaflet@1.9.4` when Socket Firewall is unavailable. Keep lifecycle scripts disabled. Do not hand-edit only `package.json`: upload requires the matching `pnpm-lock.yaml`.
+
+## 2. Configure the public tile origin
+
+Deployed data apps deny arbitrary browser images. A project admin must create a linked external connection that opts the tile server's exact HTTPS origin into the app's image policy.
+
+In **Project settings → Data app connections**, create or edit a connection with:
+
+- **Origin:** the exact tile origin, with no path—for example `https://a.tile.openstreetmap.org`.
+- **Authentication:** `None`.
+- **Allowed methods:** `GET`.
+- **Allow public images in linked apps:** enabled.
+- No credential or custom authorization header. Public browser images cannot use them.
+
+The browser requests tiles directly. Connection path rules, custom headers, response limits, and rate limits do not apply to those image requests. Never enable this for private or credentialed tile servers, and never put Lightdash data or secrets in tile URLs.
+
+The allowlist is exact-origin, not wildcard-based. Prefer a tile URL pinned to one hostname:
+
+```ts
+const TILE_URL = 'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png';
+```
+
+Do not use `https://{s}.tile.openstreetmap.org/...` unless every possible subdomain has its own linked, public-image-enabled connection. Otherwise some tiles work while others are blocked by CSP.
+
+Link the existing connection in `lightdash-app.yml`, using its stable project slug:
+
+```yaml
+externalConnections:
+    - alias: osm_tiles
+      connectionSlug: openstreetmap-tiles
+```
+
+The alias is required for the app link even when the code only renders images and never calls `externalFetch`. If the connection does not exist in the target project or the uploader cannot manage connections, upload warns and skips the link; stop and report that instead of weakening the app.
+
+For a code-managed connection, set the same policy in `lightdash/external-connections/<slug>.yml`: `authType: none`, `origin` equal to the exact HTTPS tile origin, `allowBrowserImages: true`, and `allowedMethods: [GET]`. Upload that connection before uploading the app, then reference its `slug` as `connectionSlug` in the app manifest.
+
+## 3. Import Leaflet and its marker assets
+
+Import the stylesheet and explicitly configure all default marker URLs at module scope, before creating a map:
+
+```tsx
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import markerIconUrl from 'leaflet/dist/images/marker-icon.png';
+import markerIconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
+import markerShadowUrl from 'leaflet/dist/images/marker-shadow.png';
+
+L.Icon.Default.mergeOptions({
+    iconUrl: markerIconUrl,
+    iconRetinaUrl: markerIconRetinaUrl,
+    shadowUrl: markerShadowUrl,
+});
+```
+
+This is required even though `leaflet.css` is imported. Vite may inline Leaflet's CSS marker image, which defeats Leaflet 1.9's legacy path detection; Leaflet then requests bare `marker-icon-2x.png` and `marker-shadow.png` paths from the app preview URL. Explicit imports let Vite bundle the small PNGs and avoid those 404s. These marker files are local library assets and do not need another external connection.
+
+## 4. Mount and clean up the map in React
+
+Give the container an explicit height and remove the map during effect cleanup. The template renders under React Strict Mode, so missing cleanup commonly causes `Map container is already initialized` during development.
+
+```tsx
+import { useEffect, useRef } from 'react';
+
+export function Map() {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        if (!containerRef.current) return undefined;
+
+        const map = L.map(containerRef.current).setView([41.3874, 2.1686], 11);
+        L.tileLayer(TILE_URL, {
+            attribution: '&copy; OpenStreetMap contributors',
+            maxZoom: 19,
+        }).addTo(map);
+        L.marker([41.3874, 2.1686]).addTo(map);
+
+        return () => map.remove();
+    }, []);
+
+    return <div ref={containerRef} className="h-[480px] w-full" />;
+}
+```
+
+If the map starts inside a hidden tab, dialog, or resizable panel, call `map.invalidateSize()` after that container becomes visible or changes size. Always follow the tile provider's attribution, licensing, rate, and production-usage requirements.
+
+## 5. Validate locally and after upload
+
+1. Run `lightdash apps validate --build` to check the custom dependency and production bundle.
+2. Run `lightdash apps preview`. Local preview resolves public image origins from the manifest's linked remote connections and applies them to its image CSP. This is narrower than `externalFetch`, which remains host-mediated and must be tested after upload.
+3. In the browser network panel, confirm tile requests return successfully and there are no requests for bare `marker-icon.png`, `marker-icon-2x.png`, or `marker-shadow.png` paths.
+4. Upload the app and verify the deployed preview, which is the authoritative CSP check.
+
+| Symptom                                | Likely cause                                                                             | Fix                                                                                                                  |
+| -------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Tile request blocked by `img-src`      | Connection is missing, unlinked, public images are disabled, or the URL's origin differs | Match the exact HTTPS origin, enable public images, link its slug, and restart local preview or upload a new version |
+| Only some tiles load                   | A `{s}` URL rotates across origins                                                       | Pin the tile URL to one configured hostname, or configure and link every hostname                                    |
+| Marker or shadow is broken             | Leaflet default image path detection failed after bundling                               | Import all three marker PNGs and call `L.Icon.Default.mergeOptions` at module scope                                  |
+| Map area is blank or zero-height       | Leaflet CSS is missing or the container has no height                                    | Import `leaflet.css` and give the map container an explicit height                                                   |
+| `Map container is already initialized` | React effect did not remove the previous map                                             | Return `map.remove()` from the effect                                                                                |

--- a/packages/cli/src/handlers/apps/scaffolding.test.ts
+++ b/packages/cli/src/handlers/apps/scaffolding.test.ts
@@ -77,6 +77,16 @@ describe('buildStaticAuthoringFiles', () => {
         expect(byPath(`.claude/skills/${skill}/SKILL.md`)).toBeDefined();
     });
 
+    it('ships the Leaflet local-development reference', () => {
+        const skillPath =
+            '.claude/skills/developing-data-apps-locally/SKILL.md';
+        const referencePath =
+            '.claude/skills/developing-data-apps-locally/references/leaflet.md';
+
+        expect(text(skillPath)).toContain('references/leaflet.md');
+        expect(text(referencePath)).toContain('L.Icon.Default.mergeOptions');
+    });
+
     it('pins the SDK to a concrete version in package.json', () => {
         expect(text('package.json')).toContain(
             '"@lightdash/query-sdk": "0.3275.0"',

--- a/packages/cli/src/handlers/apps/scaffolding.ts
+++ b/packages/cli/src/handlers/apps/scaffolding.ts
@@ -164,14 +164,17 @@ export const buildStaticAuthoringFiles = (args: {
         ).toString('base64'),
     });
 
-    // 3. authoring/developing-data-apps-locally/SKILL.md
-    //    → .claude/skills/developing-data-apps-locally/SKILL.md
-    files.push({
-        path: '.claude/skills/developing-data-apps-locally/SKILL.md',
-        contentBase64: readFileSync(
-            path.join(authoringDir, 'developing-data-apps-locally', 'SKILL.md'),
-        ).toString('base64'),
-    });
+    // 3. Local-authoring skill and its progressively loaded references.
+    const localSkillDir = path.join(
+        authoringDir,
+        'developing-data-apps-locally',
+    );
+    for (const file of walkDir(localSkillDir, localSkillDir, new Set())) {
+        files.push({
+            ...file,
+            path: `.claude/skills/developing-data-apps-locally/${file.path}`,
+        });
+    }
 
     // 4. AGENTS.md.tmpl → AGENTS.md
     files.push({


### PR DESCRIPTION
Depends on #26959.

### Description

Adds a progressively loaded Leaflet tutorial to the `developing-data-apps-locally` skill used by locally created and downloaded data apps.

The main skill contains one routing sentence for interactive mapping. The focused reference covers:

- the custom-dependency gate, lockfile update, and lifecycle-script policy;
- creating a no-auth, `GET`-only public-image connection for the exact tile origin;
- linking the connection through `lightdash-app.yml`;
- avoiding `{s}` tile-host rotation when only one exact origin is configured;
- importing Leaflet CSS and explicitly bundling all three default marker assets;
- React Strict Mode cleanup, explicit map height, resizing, attribution, and provider policies;
- local build/preview, deployed verification, and symptom-based troubleshooting.

The CLI scaffolder now copies the complete local-development skill directory so its `references/` files ship with new local app workspaces.

### Validation

- `pnpm -F cli exec vitest run --config vitest.config.ts src/handlers/apps/scaffolding.test.ts` — 19 passed.
- `pnpm -F cli typecheck` — passed.
- Commit-time targeted lint and formatting hooks — passed.
