### PR TITLE
fix(backend): enforce custom SQL scopes on ad-hoc query execution

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -88,6 +88,7 @@ import {
     SavedChartCustomDimensionsTableName,
     SavedChartCustomSqlDimensionsTableName,
     SavedChartsTableName,
+    SavedChartTableCalculationTableName,
     SavedChartVersionFieldsTableName,
     SavedChartVersionsTableName,
 } from '../database/entities/savedCharts';
@@ -641,6 +642,123 @@ export class SavedChartModel {
         this.database = args.database;
         this.lightdashConfig = args.lightdashConfig;
         this.contentVerificationModel = args.contentVerificationModel;
+    }
+
+    /**
+     * Finds the spaces of saved charts that already persist the given custom SQL,
+     * scoped to a project + explore. Used to authorize re-running unmodified
+     * saved-chart SQL from the ad-hoc query path without granting SQL-authoring
+     * scopes. Callers must still check that the returned spaces are viewable.
+     *
+     * Matching is byte-exact on the persisted raw SQL (plus table binding for
+     * custom dimensions, since identical SQL resolves differently against another
+     * table). Dashboard-tile charts (null space_id) are excluded by the inner
+     * join to spaces.
+     */
+    async findCustomSqlProvenance(args: {
+        projectUuid: string;
+        exploreName: string;
+        tableCalculationSqls: string[];
+        customSqlDimensions: { sql: string; table: string }[];
+    }): Promise<{
+        tableCalculations: { sql: string; spaceUuid: string }[];
+        customSqlDimensions: {
+            sql: string;
+            table: string;
+            spaceUuid: string;
+        }[];
+    }> {
+        const {
+            projectUuid,
+            exploreName,
+            tableCalculationSqls,
+            customSqlDimensions,
+        } = args;
+
+        const tableCalculations =
+            tableCalculationSqls.length === 0
+                ? []
+                : await this.database(SavedChartTableCalculationTableName)
+                      .innerJoin(
+                          SavedChartVersionsTableName,
+                          `${SavedChartVersionsTableName}.saved_queries_version_id`,
+                          `${SavedChartTableCalculationTableName}.saved_queries_version_id`,
+                      )
+                      .innerJoin(
+                          SavedChartsTableName,
+                          `${SavedChartsTableName}.saved_query_id`,
+                          `${SavedChartVersionsTableName}.saved_query_id`,
+                      )
+                      .innerJoin(
+                          SpaceTableName,
+                          `${SpaceTableName}.space_id`,
+                          `${SavedChartsTableName}.space_id`,
+                      )
+                      .where(
+                          `${SavedChartsTableName}.project_uuid`,
+                          projectUuid,
+                      )
+                      .where(
+                          `${SavedChartVersionsTableName}.explore_name`,
+                          exploreName,
+                      )
+                      .whereNull(`${SavedChartsTableName}.deleted_at`)
+                      .whereNull(`${SpaceTableName}.deleted_at`)
+                      .whereIn(
+                          `${SavedChartTableCalculationTableName}.calculation_raw_sql`,
+                          tableCalculationSqls,
+                      )
+                      .distinct(
+                          `${SavedChartTableCalculationTableName}.calculation_raw_sql as sql`,
+                          `${SpaceTableName}.space_uuid as spaceUuid`,
+                      );
+
+        const customSqlDimensionMatches =
+            customSqlDimensions.length === 0
+                ? []
+                : await this.database(SavedChartCustomSqlDimensionsTableName)
+                      .innerJoin(
+                          SavedChartVersionsTableName,
+                          `${SavedChartVersionsTableName}.saved_queries_version_id`,
+                          `${SavedChartCustomSqlDimensionsTableName}.saved_queries_version_id`,
+                      )
+                      .innerJoin(
+                          SavedChartsTableName,
+                          `${SavedChartsTableName}.saved_query_id`,
+                          `${SavedChartVersionsTableName}.saved_query_id`,
+                      )
+                      .innerJoin(
+                          SpaceTableName,
+                          `${SpaceTableName}.space_id`,
+                          `${SavedChartsTableName}.space_id`,
+                      )
+                      .where(
+                          `${SavedChartsTableName}.project_uuid`,
+                          projectUuid,
+                      )
+                      .where(
+                          `${SavedChartVersionsTableName}.explore_name`,
+                          exploreName,
+                      )
+                      .whereNull(`${SavedChartsTableName}.deleted_at`)
+                      .whereNull(`${SpaceTableName}.deleted_at`)
+                      .whereIn(
+                          [
+                              `${SavedChartCustomSqlDimensionsTableName}.sql`,
+                              `${SavedChartCustomSqlDimensionsTableName}.table`,
+                          ],
+                          customSqlDimensions.map((d) => [d.sql, d.table]),
+                      )
+                      .distinct(
+                          `${SavedChartCustomSqlDimensionsTableName}.sql as sql`,
+                          `${SavedChartCustomSqlDimensionsTableName}.table as table`,
+                          `${SpaceTableName}.space_uuid as spaceUuid`,
+                      );
+
+        return {
+            tableCalculations,
+            customSqlDimensions: customSqlDimensionMatches,
+        };
     }
 
     async resolveColorPalette(args: {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4437,6 +4437,14 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
+        await this.assertCustomSqlAuthorizedForQuery({
+            account,
+            projectUuid,
+            organizationUuid,
+            exploreName: inputMetricQuery.exploreName,
+            metricQuery: inputMetricQuery,
+        });
+
         return this.runAsyncMetricQueryWithoutPermissionCheck(
             args,
             organizationUuid,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -61,6 +61,8 @@ export const user: SessionUser = {
         { subject: 'Job', action: ['view'] },
         { subject: 'SqlRunner', action: ['manage'] },
         { subject: 'Explore', action: ['manage'] },
+        { subject: 'CustomSqlTableCalculations', action: ['manage'] },
+        { subject: 'CustomFields', action: ['manage'] },
     ]),
     isActive: true,
     abilityRules: [],

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -1,5 +1,7 @@
 import { Ability } from '@casl/ability';
 import {
+    CustomDimensionType,
+    CustomSqlQueryForbiddenError,
     DbtProjectType,
     DbtVersionOptionLatest,
     DefaultSupportedDbtVersion,
@@ -243,6 +245,14 @@ const onboardingModel = {
 const savedChartModel = {
     getAllSpaces: vi.fn(async () => spacesWithSavedCharts),
     find: vi.fn(async () => [] as ChartSummary[]),
+    findCustomSqlProvenance: vi.fn(async () => ({
+        tableCalculations: [] as { sql: string; spaceUuid: string }[],
+        customSqlDimensions: [] as {
+            sql: string;
+            table: string;
+            spaceUuid: string;
+        }[],
+    })),
 };
 const jobModel = {
     create: vi.fn(async () => undefined),
@@ -4010,5 +4020,251 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
         await expect(
             projectService.resolveCompileAdapter(baseArgs),
         ).rejects.toThrow(ParameterError);
+    });
+});
+
+describe('assertCustomSqlAuthorizedForQuery', () => {
+    const { projectUuid } = defaultProject;
+    const organizationUuid = 'organizationUuid';
+    const exploreName = 'valid_explore';
+    const spaceUuid = 'space-1';
+
+    const sqlTableCalculation = {
+        name: 'tc',
+        displayName: 'tc',
+        sql: '(SELECT count(*) FROM information_schema.tables)',
+    };
+    const sqlCustomDimension = {
+        id: 'cd',
+        name: 'cd',
+        table: 'a',
+        type: CustomDimensionType.SQL,
+        sql: '(SELECT count(*) FROM information_schema.columns)',
+        dimensionType: DimensionType.NUMBER,
+    };
+
+    type CustomSqlAuthArgs = {
+        account: ReturnType<typeof buildAccount>;
+        projectUuid: string;
+        organizationUuid: string;
+        exploreName: string;
+        metricQuery: {
+            tableCalculations?: (typeof sqlTableCalculation)[];
+            customDimensions?: (typeof sqlCustomDimension)[];
+        };
+    };
+    const assertCustomSql = (svc: ProjectService, args: CustomSqlAuthArgs) =>
+        (
+            svc as unknown as {
+                assertCustomSqlAuthorizedForQuery: (
+                    a: CustomSqlAuthArgs,
+                ) => Promise<void>;
+            }
+        ).assertCustomSqlAuthorizedForQuery(args);
+
+    const accountWithAbility = (
+        rules: ConstructorParameters<typeof Ability<PossibleAbilities>>[0],
+        {
+            accountType = 'session',
+            userType = 'registered',
+        }: Parameters<typeof buildAccount>[0] = {},
+    ) => {
+        const base = buildAccount({ accountType, userType });
+        return {
+            ...base,
+            user: {
+                ...base.user,
+                ability: new Ability<PossibleAbilities>(rules),
+            },
+        } as ReturnType<typeof buildAccount>;
+    };
+
+    const authorAccount = accountWithAbility([
+        { subject: 'Project', action: 'view' },
+        { subject: 'Space', action: 'view' },
+        { subject: 'CustomSqlTableCalculations', action: 'manage' },
+        { subject: 'CustomFields', action: 'manage' },
+    ]);
+    const noScopeAccount = accountWithAbility([
+        { subject: 'Project', action: 'view' },
+        { subject: 'Space', action: 'view' },
+    ]);
+    const restrictedAccount = accountWithAbility([
+        { subject: 'Project', action: 'view' },
+        {
+            subject: 'Space',
+            action: 'view',
+            conditions: { projectUuid: 'different-project' },
+        },
+    ]);
+    const jwtAccount = accountWithAbility(
+        [
+            { subject: 'Project', action: 'view' },
+            { subject: 'Space', action: 'view' },
+        ],
+        { accountType: 'jwt', userType: 'anonymous' },
+    );
+
+    const spacePermissionService = {
+        getSpacesAccessContext: vi.fn(
+            async (_userUuid: string, spaceUuids: string[]) =>
+                Object.fromEntries(
+                    spaceUuids.map((s) => [
+                        s,
+                        {
+                            organizationUuid,
+                            projectUuid,
+                            inheritsFromOrgOrProject: true,
+                            access: [],
+                        },
+                    ]),
+                ),
+        ),
+    } as unknown as SpacePermissionService;
+
+    const service = getMockedProjectService(lightdashConfigMock, {
+        spacePermissionService,
+    });
+
+    const baseArgs = {
+        projectUuid,
+        organizationUuid,
+        exploreName,
+    };
+
+    beforeEach(() => {
+        savedChartModel.findCustomSqlProvenance.mockReset();
+        savedChartModel.findCustomSqlProvenance.mockResolvedValue({
+            tableCalculations: [],
+            customSqlDimensions: [],
+        });
+    });
+
+    it('resolves and skips the provenance lookup when there is no custom SQL', async () => {
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: noScopeAccount,
+                metricQuery: {},
+            }),
+        ).resolves.toBeUndefined();
+        expect(savedChartModel.findCustomSqlProvenance).not.toHaveBeenCalled();
+    });
+
+    it('allows a user with the authoring scopes without a provenance lookup', async () => {
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: authorAccount,
+                metricQuery: {
+                    tableCalculations: [sqlTableCalculation],
+                    customDimensions: [sqlCustomDimension],
+                },
+            }),
+        ).resolves.toBeUndefined();
+        expect(savedChartModel.findCustomSqlProvenance).not.toHaveBeenCalled();
+    });
+
+    it('rejects a SQL table calculation with no matching saved chart', async () => {
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: noScopeAccount,
+                metricQuery: { tableCalculations: [sqlTableCalculation] },
+            }),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('allows a SQL table calculation that matches a viewable saved chart', async () => {
+        savedChartModel.findCustomSqlProvenance.mockResolvedValue({
+            tableCalculations: [{ sql: sqlTableCalculation.sql, spaceUuid }],
+            customSqlDimensions: [],
+        });
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: noScopeAccount,
+                metricQuery: { tableCalculations: [sqlTableCalculation] },
+            }),
+        ).resolves.toBeUndefined();
+    });
+
+    it('rejects a SQL table calculation whose only matching chart is not viewable', async () => {
+        savedChartModel.findCustomSqlProvenance.mockResolvedValue({
+            tableCalculations: [{ sql: sqlTableCalculation.sql, spaceUuid }],
+            customSqlDimensions: [],
+        });
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: restrictedAccount,
+                metricQuery: { tableCalculations: [sqlTableCalculation] },
+            }),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('rejects a custom SQL dimension with no matching saved chart', async () => {
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: noScopeAccount,
+                metricQuery: { customDimensions: [sqlCustomDimension] },
+            }),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
+    });
+
+    it('allows a custom SQL dimension that matches a viewable saved chart', async () => {
+        savedChartModel.findCustomSqlProvenance.mockResolvedValue({
+            tableCalculations: [],
+            customSqlDimensions: [
+                {
+                    sql: sqlCustomDimension.sql,
+                    table: sqlCustomDimension.table,
+                    spaceUuid,
+                },
+            ],
+        });
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: noScopeAccount,
+                metricQuery: { customDimensions: [sqlCustomDimension] },
+            }),
+        ).resolves.toBeUndefined();
+    });
+
+    it('rejects a custom SQL dimension when only the SQL matches but the table binding differs', async () => {
+        savedChartModel.findCustomSqlProvenance.mockResolvedValue({
+            tableCalculations: [],
+            customSqlDimensions: [
+                {
+                    sql: sqlCustomDimension.sql,
+                    table: 'a_different_table',
+                    spaceUuid,
+                },
+            ],
+        });
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: noScopeAccount,
+                metricQuery: { customDimensions: [sqlCustomDimension] },
+            }),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
+    });
+
+    it('never grants the provenance exemption to JWT/embed callers', async () => {
+        savedChartModel.findCustomSqlProvenance.mockResolvedValue({
+            tableCalculations: [{ sql: sqlTableCalculation.sql, spaceUuid }],
+            customSqlDimensions: [],
+        });
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: jwtAccount,
+                metricQuery: { tableCalculations: [sqlTableCalculation] },
+            }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(savedChartModel.findCustomSqlProvenance).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -99,12 +99,14 @@ import {
     hasIntersection,
     hasWarehouseCredentials,
     isCartesianChartConfig,
+    isCustomSqlDimension,
     isDateItem,
     isExploreError,
     isFilterableDimension,
     isJwtUser,
     isNotNull,
     isReservedParameterName,
+    isSqlTableCalculation,
     isUserWithOrg,
     isValidTimezone,
     ItemsMap,
@@ -4594,6 +4596,151 @@ export class ProjectService extends BaseService {
         return getAvailableParameterDefinitions(projectParameters, explore);
     }
 
+    /**
+     * Custom SQL table calculations and custom SQL dimensions are authoring
+     * features gated behind manage:CustomSqlTableCalculations / manage:CustomFields.
+     * The ad-hoc query and compile endpoints accept a client-supplied metric query,
+     * so without this check a user who is denied those scopes could still run
+     * arbitrary warehouse SQL by embedding it in tableCalculations[].sql or
+     * customDimensions[].sql, bypassing the semantic layer.
+     *
+     * A caller who lacks the scope may still run SQL that is byte-identical to SQL
+     * already persisted in a saved chart they can view (same project + explore), so
+     * editors can re-run and filter existing saved charts in Explore edit mode
+     * without gaining authoring rights. The exemption is only granted to registered
+     * users, never to JWT/embed callers.
+     */
+    protected async assertCustomSqlAuthorizedForQuery({
+        account,
+        projectUuid,
+        organizationUuid,
+        exploreName,
+        metricQuery,
+    }: {
+        account: Account;
+        projectUuid: string;
+        organizationUuid: string;
+        exploreName: string;
+        metricQuery: Pick<
+            MetricQuery,
+            'tableCalculations' | 'customDimensions'
+        >;
+    }): Promise<void> {
+        const sqlTableCalculations = (
+            metricQuery.tableCalculations ?? []
+        ).filter(isSqlTableCalculation);
+        const sqlCustomDimensions = (metricQuery.customDimensions ?? []).filter(
+            isCustomSqlDimension,
+        );
+        if (
+            sqlTableCalculations.length === 0 &&
+            sqlCustomDimensions.length === 0
+        ) {
+            return;
+        }
+
+        const auditedAbility = this.createAuditedAbility(account);
+        const canAuthorTableCalculations = auditedAbility.can(
+            'manage',
+            subject('CustomSqlTableCalculations', {
+                organizationUuid,
+                projectUuid,
+            }),
+        );
+        const canAuthorCustomDimensions = auditedAbility.can(
+            'manage',
+            subject('CustomFields', { organizationUuid, projectUuid }),
+        );
+
+        const tableCalculationsToAuthorize = canAuthorTableCalculations
+            ? []
+            : sqlTableCalculations;
+        const customDimensionsToAuthorize = canAuthorCustomDimensions
+            ? []
+            : sqlCustomDimensions;
+        if (
+            tableCalculationsToAuthorize.length === 0 &&
+            customDimensionsToAuthorize.length === 0
+        ) {
+            return;
+        }
+
+        const customDimensionKey = (item: { table: string; sql: string }) =>
+            `${item.table}\0${item.sql}`;
+
+        let viewableTableCalculationSqls = new Set<string>();
+        let viewableCustomDimensionKeys = new Set<string>();
+        // The provenance exemption trusts saved-chart SQL the caller can view.
+        // Never extend it to JWT/embed callers.
+        if (account.isRegisteredUser()) {
+            const provenance =
+                await this.savedChartModel.findCustomSqlProvenance({
+                    projectUuid,
+                    exploreName,
+                    tableCalculationSqls: tableCalculationsToAuthorize.map(
+                        (tc) => tc.sql,
+                    ),
+                    customSqlDimensions: customDimensionsToAuthorize.map(
+                        (cd) => ({ sql: cd.sql, table: cd.table }),
+                    ),
+                });
+
+            const candidateSpaceUuids = [
+                ...new Set([
+                    ...provenance.tableCalculations.map((r) => r.spaceUuid),
+                    ...provenance.customSqlDimensions.map((r) => r.spaceUuid),
+                ]),
+            ];
+            const viewableSpaceUuids =
+                candidateSpaceUuids.length === 0
+                    ? new Set<string>()
+                    : new Set(
+                          Object.entries(
+                              await this.spacePermissionService.getSpacesAccessContext(
+                                  account.user.id,
+                                  candidateSpaceUuids,
+                              ),
+                          )
+                              .filter(([, ctx]) =>
+                                  auditedAbility.can(
+                                      'view',
+                                      subject('Space', ctx),
+                                  ),
+                              )
+                              .map(([spaceUuid]) => spaceUuid),
+                      );
+
+            viewableTableCalculationSqls = new Set(
+                provenance.tableCalculations
+                    .filter((r) => viewableSpaceUuids.has(r.spaceUuid))
+                    .map((r) => r.sql),
+            );
+            viewableCustomDimensionKeys = new Set(
+                provenance.customSqlDimensions
+                    .filter((r) => viewableSpaceUuids.has(r.spaceUuid))
+                    .map(customDimensionKey),
+            );
+        }
+
+        if (
+            tableCalculationsToAuthorize.some(
+                (tc) => !viewableTableCalculationSqls.has(tc.sql),
+            )
+        ) {
+            throw new ForbiddenError(
+                'User cannot run queries with custom SQL table calculations',
+            );
+        }
+        if (
+            customDimensionsToAuthorize.some(
+                (cd) =>
+                    !viewableCustomDimensionKeys.has(customDimensionKey(cd)),
+            )
+        ) {
+            throw new CustomSqlQueryForbiddenError();
+        }
+    }
+
     async compileQuery(
         args: {
             account: Account;
@@ -4635,6 +4782,17 @@ export class ProjectService extends BaseService {
             'explore' in args
                 ? args.explore
                 : await this.getExplore(account, projectUuid, args.exploreName);
+
+        // Authorize custom SQL against the explore the query actually runs on
+        // (the resolved source explore), not the client-supplied
+        // metricQuery.exploreName, which may differ.
+        await this.assertCustomSqlAuthorizedForQuery({
+            account,
+            projectUuid,
+            organizationUuid,
+            exploreName: sourceExplore.name,
+            metricQuery,
+        });
 
         // Pre-aggregate routing: compile against the pre-agg explore when cache is enabled and there's a match
         let explore = sourceExplore;
@@ -5658,6 +5816,14 @@ export class ProjectService extends BaseService {
                     ) {
                         throw new ForbiddenError();
                     }
+
+                    await this.assertCustomSqlAuthorizedForQuery({
+                        account,
+                        projectUuid,
+                        organizationUuid,
+                        exploreName,
+                        metricQuery,
+                    });
 
                     const { maxLimit, csvCellsLimit } =
                         await resolveOrganizationExportLimits(


### PR DESCRIPTION
Closes part 1 of [PROD-9722](https://linear.app/lightdash/issue/PROD-9722).

## What this fixes

The ad-hoc metric-query and compile endpoints only checked `view` access before compiling a client-supplied metric query. A user denied the custom-SQL authoring scopes could still submit `tableCalculations[].sql` or `customDimensions[].sql` in an ad-hoc query, so that SQL reached the warehouse without an authoring check — the execution-side counterpart of the create-time gap closed in #26519.

| Path | Today | After this PR |
| --- | --- | --- |
| `AsyncQueryService.executeAsyncMetricQuery()` | Checks `view Explore` only | Also requires `manage:CustomSqlTableCalculations` / `manage:CustomFields` when the query carries SQL table calculations / custom SQL dimensions |
| `ProjectService.compileQuery()` | Checks `view Project` only | Same guard, against the resolved explore |
| `ProjectService.runMetricQuery()` (deprecated `runQuery`, Postgres wire) | Checks `view Project` only | Same guard |

## How

New guard `assertCustomSqlAuthorizedForQuery` on `ProjectService` (inherited by `AsyncQueryService`). It reuses `isSqlTableCalculation` / `isCustomSqlDimension` from `@lightdash/common` and the existing `CustomSqlTableCalculations` / `CustomFields` CASL checks, throwing `ForbiddenError` / `CustomSqlQueryForbiddenError`.

**Provenance exemption.** A caller without the scope may still run SQL that is byte-identical to SQL already persisted in a saved chart they can view, on the same project + explore (custom dimensions also match on their table binding). This preserves Explore edit mode: an editor re-running or filtering an existing saved chart routes through the ad-hoc endpoint carrying that chart's SQL, and must not be blocked. New or modified SQL is not exempt, and the exemption is granted to registered users only — never JWT/embed callers. Backed by a new `SavedChartModel.findCustomSqlProvenance` lookup.

## Who's affected

| User class | Holds the scopes? | Affected? |
| --- | --- | --- |
| Service accounts (CI/CD, default org-admin) | Yes | No |
| Developer / Admin system roles | Yes | No |
| Editor / Viewer re-running an existing saved chart's SQL | No | No — provenance exemption |
| Editor / Viewer authoring new SQL in an ad-hoc query | No | **Yes** — now `403`. This is the gap being closed. |
| JWT / embed callers | n/a | New SQL blocked; no provenance exemption |

Explore edit mode and the SDK/CLI query paths re-run persisted SQL, which the exemption covers. No known customer configuration relies on running newly-authored SQL without the authoring scope.

## Test plan

- [x] `pnpm -F backend lint` — clean
- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F backend` ProjectService suite — 120 pass (9 new authorization tests + regression)
- [x] Manual (editor denied SQL Runner): injected table calc / custom SQL dimension on `/query/metric-query` and `/compileQuery` → `403`
- [x] Manual: editor re-running an existing saved chart's SQL (table calc + custom dimension) → still works; modified SQL, or the same SQL on a different explore / table binding → `403`
- [x] Manual (admin, has scope) → unaffected

## Follow-up in the same Linear thread

- **PR 2** — extend the same authoring-scope handling to `additionalMetrics[].sql`. It needs a different approach because that field also backs the standard custom-metric feature available to editors/viewers, so it can't be gated the same way — it needs validation that the SQL references known fields rather than an authoring-scope check.
