### PR TITLE
feat(autopilot): detect AI agents with no traffic

### DIFF
--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -31,8 +31,11 @@ import {
 import {
     inactiveUsersSql,
     orphanedContentSql,
+    unusedAgentsSql,
     type InactiveUserActivitySource,
     type OrphanedContentOwnerStatus,
+    type UnusedAgentReason,
+    type UnusedAgentRoutingSignal,
 } from './ManagedAgentModelSql';
 
 export class ManagedAgentModel {
@@ -732,6 +735,82 @@ export class ManagedAgentModel {
             ownerName: r.owner_name,
             ownerStatus: r.owner_status,
             lastViewedAt: r.last_viewed_at,
+        }));
+    }
+
+    // Traffic is counted in prompts rather than threads, so an agent someone
+    // opened and never spoke to does not read as used.
+    async getUnusedAgents(
+        projectUuid: string,
+        organizationUuid: string,
+        windowDays: number,
+        minPrompts: number,
+        limit: number = 30,
+    ): Promise<
+        Array<{
+            agentUuid: string;
+            agentName: string;
+            createdAt: Date;
+            adminOnly: boolean;
+            totalThreads: number;
+            recentThreads: number;
+            totalPrompts: number;
+            recentPrompts: number;
+            recentAnswered: number;
+            recentAskers: number;
+            lastUsedAt: Date | null;
+            reason: UnusedAgentReason;
+            routingSignal: UnusedAgentRoutingSignal;
+            routedCandidateCount: number;
+            routedSuggestedCount: number;
+            routedChosenCount: number;
+        }>
+    > {
+        const rows = await this.database.raw<{
+            rows: Array<{
+                agent_uuid: string;
+                agent_name: string;
+                created_at: Date;
+                admin_only: boolean;
+                total_threads: string;
+                recent_threads: string;
+                total_prompts: string;
+                recent_prompts: string;
+                recent_answered: string;
+                recent_askers: string;
+                last_used_at: Date | null;
+                reason: UnusedAgentReason;
+                routing_signal: UnusedAgentRoutingSignal;
+                routed_candidate_count: string;
+                routed_suggested_count: string;
+                routed_chosen_count: string;
+            }>;
+        }>(unusedAgentsSql(), [
+            windowDays,
+            minPrompts,
+            projectUuid,
+            organizationUuid,
+            projectUuid,
+            limit,
+        ]);
+
+        return rows.rows.map((r) => ({
+            agentUuid: r.agent_uuid,
+            agentName: r.agent_name,
+            createdAt: r.created_at,
+            adminOnly: r.admin_only,
+            totalThreads: Number(r.total_threads),
+            recentThreads: Number(r.recent_threads),
+            totalPrompts: Number(r.total_prompts),
+            recentPrompts: Number(r.recent_prompts),
+            recentAnswered: Number(r.recent_answered),
+            recentAskers: Number(r.recent_askers),
+            lastUsedAt: r.last_used_at,
+            reason: r.reason,
+            routingSignal: r.routing_signal,
+            routedCandidateCount: Number(r.routed_candidate_count),
+            routedSuggestedCount: Number(r.routed_suggested_count),
+            routedChosenCount: Number(r.routed_chosen_count),
         }));
     }
 

--- a/packages/backend/src/ee/models/ManagedAgentModelSql.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModelSql.ts
@@ -9,6 +9,19 @@ export type InactiveUserActivitySource =
 
 export type OrphanedContentOwnerStatus = 'deactivated' | 'left_org';
 
+export type UnusedAgentReason =
+    | 'never_used'
+    | 'no_recent_use'
+    | 'only_failed_sessions'
+    | 'low_traffic';
+
+export type UnusedAgentRoutingSignal =
+    | 'router_disabled'
+    | 'never_a_candidate'
+    | 'candidate_never_suggested'
+    | 'suggested_never_chosen'
+    | 'routed';
+
 /**
  * Parameters: member_uuids, project_uuid, member_uuids, project_uuid,
  * member_uuids, project_uuid, member_uuids, inactive_days, limit
@@ -132,5 +145,125 @@ WHERE p.project_uuid = ?
   AND d.deleted_at IS NULL
 
 ORDER BY owner_user_uuid, content_name
+LIMIT ?;
+`;
+
+/**
+ * Traffic is measured in prompts, not threads: an opened conversation that was
+ * never asked anything is not use. Agents younger than the window are excluded
+ * because they have not had the chance to earn traffic yet.
+ *
+ * Parameters: window_days, min_prompts, project_uuid, organization_uuid,
+ * project_uuid, limit
+ */
+export const unusedAgentsSql = () => `
+WITH params AS (
+  SELECT
+    now() - make_interval(days => ?) AS window_start,
+    ?::int AS min_prompts
+),
+agents AS (
+  SELECT a.ai_agent_uuid, a.name, a.created_at, a.admin_only
+  FROM ai_agent a, params
+  WHERE a.project_uuid = ?
+    AND a.is_system = false
+    AND a.created_at <= params.window_start
+),
+router_enabled AS (
+  SELECT EXISTS (
+    SELECT 1
+    FROM ai_router r
+    WHERE r.organization_uuid = ?
+      AND r.enabled = true
+      AND ?::uuid = ANY(r.project_uuids)
+  ) AS enabled
+),
+activity AS (
+  SELECT
+    t.agent_uuid,
+    COUNT(DISTINCT t.ai_thread_uuid) AS total_threads,
+    COUNT(DISTINCT t.ai_thread_uuid) FILTER (
+      WHERE t.created_at >= params.window_start
+    ) AS recent_threads,
+    COUNT(p.ai_prompt_uuid) AS total_prompts,
+    COUNT(p.ai_prompt_uuid) FILTER (
+      WHERE p.created_at >= params.window_start
+    ) AS recent_prompts,
+    COUNT(p.ai_prompt_uuid) FILTER (
+      WHERE p.created_at >= params.window_start
+        AND p.responded_at IS NOT NULL
+        AND p.error_message IS NULL
+    ) AS recent_answered,
+    COUNT(DISTINCT p.created_by_user_uuid) FILTER (
+      WHERE p.created_at >= params.window_start
+    ) AS recent_askers,
+    MAX(p.created_at) AS last_used_at
+  FROM ai_thread t
+    JOIN agents a ON a.ai_agent_uuid = t.agent_uuid
+    LEFT JOIN ai_prompt p ON p.ai_thread_uuid = t.ai_thread_uuid
+    CROSS JOIN params
+  GROUP BY t.agent_uuid
+),
+routing AS (
+  SELECT
+    a.ai_agent_uuid AS agent_uuid,
+    COUNT(rd.ai_router_decision_uuid) FILTER (
+      WHERE a.ai_agent_uuid = ANY(rd.candidate_agent_uuids)
+    ) AS candidate_count,
+    COUNT(rd.ai_router_decision_uuid) FILTER (
+      WHERE rd.suggested_agent_uuid = a.ai_agent_uuid
+    ) AS suggested_count,
+    COUNT(rd.ai_router_decision_uuid) FILTER (
+      WHERE rd.chosen_agent_uuid = a.ai_agent_uuid
+    ) AS chosen_count
+  FROM agents a
+    CROSS JOIN params
+    LEFT JOIN ai_router_decision rd
+      ON rd.created_at >= params.window_start
+      AND (
+        rd.suggested_agent_uuid = a.ai_agent_uuid
+        OR rd.chosen_agent_uuid = a.ai_agent_uuid
+        OR a.ai_agent_uuid = ANY(rd.candidate_agent_uuids)
+      )
+  GROUP BY a.ai_agent_uuid
+)
+SELECT
+  a.ai_agent_uuid AS agent_uuid,
+  a.name AS agent_name,
+  a.created_at,
+  a.admin_only,
+  COALESCE(act.total_threads, 0) AS total_threads,
+  COALESCE(act.recent_threads, 0) AS recent_threads,
+  COALESCE(act.total_prompts, 0) AS total_prompts,
+  COALESCE(act.recent_prompts, 0) AS recent_prompts,
+  COALESCE(act.recent_answered, 0) AS recent_answered,
+  COALESCE(act.recent_askers, 0) AS recent_askers,
+  act.last_used_at,
+  CASE
+    WHEN COALESCE(act.total_prompts, 0) = 0 THEN 'never_used'
+    WHEN COALESCE(act.recent_prompts, 0) = 0 THEN 'no_recent_use'
+    WHEN COALESCE(act.recent_answered, 0) = 0 THEN 'only_failed_sessions'
+    ELSE 'low_traffic'
+  END AS reason,
+  CASE
+    WHEN NOT (SELECT enabled FROM router_enabled) THEN 'router_disabled'
+    WHEN COALESCE(r.candidate_count, 0) = 0 THEN 'never_a_candidate'
+    WHEN COALESCE(r.suggested_count, 0) = 0 THEN 'candidate_never_suggested'
+    WHEN COALESCE(r.chosen_count, 0) = 0 THEN 'suggested_never_chosen'
+    ELSE 'routed'
+  END AS routing_signal,
+  COALESCE(r.candidate_count, 0) AS routed_candidate_count,
+  COALESCE(r.suggested_count, 0) AS routed_suggested_count,
+  COALESCE(r.chosen_count, 0) AS routed_chosen_count
+FROM agents a
+  CROSS JOIN params
+  LEFT JOIN activity act ON act.agent_uuid = a.ai_agent_uuid
+  LEFT JOIN routing r ON r.agent_uuid = a.ai_agent_uuid
+WHERE COALESCE(act.recent_prompts, 0) < params.min_prompts
+  OR (
+    COALESCE(act.recent_prompts, 0) > 0
+    AND COALESCE(act.recent_answered, 0) = 0
+  )
+ORDER BY COALESCE(act.recent_prompts, 0) ASC, a.created_at ASC
 LIMIT ?;
 `;

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -2035,6 +2035,8 @@ export class ManagedAgentService extends BaseService {
                 return this.handleGetInactiveUsers(projectUuid, input);
             case 'get_orphaned_content':
                 return this.handleGetOrphanedContent(actor, projectUuid, input);
+            case 'get_unused_agents':
+                return this.handleGetUnusedAgents(projectUuid, input);
             case 'reverse_own_action':
                 return this.handleReverseOwnAction(actor, projectUuid, input);
             default:
@@ -3223,6 +3225,58 @@ chartConfig:
                 owner_name: item.ownerName,
                 owner_status: item.ownerStatus,
                 last_viewed_at: item.lastViewedAt,
+            })),
+        );
+    }
+
+    private static readonly DEFAULT_UNUSED_AGENT_WINDOW_DAYS = 30;
+
+    private static readonly DEFAULT_UNUSED_AGENT_MIN_PROMPTS = 5;
+
+    private async handleGetUnusedAgents(
+        projectUuid: string,
+        input: Record<string, unknown>,
+    ): Promise<string> {
+        const windowDays =
+            (input.window_days as number) ??
+            ManagedAgentService.DEFAULT_UNUSED_AGENT_WINDOW_DAYS;
+        const minPrompts =
+            (input.min_prompts as number) ??
+            ManagedAgentService.DEFAULT_UNUSED_AGENT_MIN_PROMPTS;
+        const limit = getManagedAgentToolResultLimit(input.limit, 30);
+
+        // Org comes from the project: the router is org-scoped, and the wrong
+        // org would report every agent as unrouted.
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const agents = await this.managedAgentModel.getUnusedAgents(
+            projectUuid,
+            organizationUuid,
+            windowDays,
+            minPrompts,
+            limit,
+        );
+
+        return formatManagedAgentToolListResult(
+            agents.map((agent) => ({
+                agent_uuid: agent.agentUuid,
+                name: agent.agentName,
+                created_at: agent.createdAt,
+                admin_only: agent.adminOnly,
+                reason: agent.reason,
+                routing_signal: agent.routingSignal,
+                last_used_at: agent.lastUsedAt,
+                threads_total: agent.totalThreads,
+                threads_in_window: agent.recentThreads,
+                prompts_total: agent.totalPrompts,
+                prompts_in_window: agent.recentPrompts,
+                answered_prompts_in_window: agent.recentAnswered,
+                distinct_askers_in_window: agent.recentAskers,
+                router_candidate_count: agent.routedCandidateCount,
+                router_suggested_count: agent.routedSuggestedCount,
+                router_chosen_count: agent.routedChosenCount,
+                window_days: windowDays,
+                min_prompts_threshold: minPrompts,
             })),
         );
     }

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
@@ -183,6 +183,37 @@ describe('renderManagedAgentConfig with policy', () => {
         );
     });
 
+    it('keeps the unused-agent tool in every aggression mode and with content capabilities off', () => {
+        (['observe', 'flag', 'cleanup'] as const).forEach((aggression) => {
+            const config = renderManagedAgentConfig({
+                ...baseArgs,
+                policy: { ...DEFAULT_MANAGED_AGENT_POLICY, aggression },
+            });
+            expect(customToolNames(config)).toContain('get_unused_agents');
+        });
+
+        const noContentCapabilities = renderManagedAgentConfig({
+            ...baseArgs,
+            toolSettings: {
+                createContent: false,
+                modifyExistingContent: false,
+            },
+        });
+        expect(customToolNames(noContentCapabilities)).toContain(
+            'get_unused_agents',
+        );
+    });
+
+    it('tells the agent that unused-agent findings are reporting-only', () => {
+        const config = renderManagedAgentConfig(baseArgs);
+        expect(config.system).toContain('### 6. AI Agent Usage');
+        expect(config.system).toContain(
+            'NEVER delete, disable, or edit an agent',
+        );
+        expect(config.system).toContain('### 7. Insights');
+        expect(config.system).toContain('### 8. Slack Summary');
+    });
+
     it('changes the config hash when policy changes', () => {
         const a = getManagedAgentConfigHash(renderManagedAgentConfig(baseArgs));
         const b = getManagedAgentConfigHash(

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -164,13 +164,21 @@ Call get_inactive_users and get_orphaned_content. Both are reporting-only: recor
 - Orphaned content: group by former owner so admins can reassign in one pass. Leaving the company does not make content stale, so do not recommend deletion on those grounds alone
 - If either returns nothing, say so briefly or skip
 
-### 6. Insights
+### 6. AI Agent Usage
+Call get_unused_agents. Reporting-only: record what you find with log_insight and NEVER delete, disable, or edit an agent.
+- Lead with the reason field. never_used, no_recent_use, only_failed_sessions and low_traffic call for different advice, so do not blur them into "unused"
+- Use routing_signal to say why traffic may not be arriving: never_a_candidate and candidate_never_suggested point at the agent's name, description and tags rather than at the agent being unwanted; suggested_never_chosen means users are overriding the router
+- only_failed_sessions is a reliability problem, not a popularity one. Say so, and never suggest retiring an agent on that basis
+- An admin_only agent has a small audience by design; do not read its low traffic as a discoverability problem
+- If it returns nothing, skip this step
+
+### 7. Insights
 Call get_popular_content.
 - Surface content that is popular but not pinned
 - Surface content with high views but restricted access (private space)
 - If nothing noteworthy, skip this step
 
-### 7. Slack Summary
+### 8. Slack Summary
 After the run is complete, call write_slack_summary exactly once with the final summary you want posted to Slack. Use the "lightdash-agent-slack-messaging" skill to match Lightdash's Slack tone of voice
 `;
 };
@@ -612,6 +620,32 @@ export const managedAgentConfig: AgentCreateParams = {
                 type: 'object',
             },
             name: 'get_orphaned_content',
+            type: 'custom',
+        },
+        {
+            description:
+                'Get AI agents in this project that are getting little or no traffic. Traffic is counted as user prompts, so an opened conversation nobody spoke in does not count as use. Agents created inside the window and the auto-provisioned system agent are excluded. Returns name, reason (never_used, no_recent_use, only_failed_sessions, low_traffic), routing_signal (router_disabled, never_a_candidate, candidate_never_suggested, suggested_never_chosen, routed), last_used_at, prompt and thread counts, and router counts. Reporting only: never delete or disable an agent based on this.',
+            input_schema: {
+                properties: {
+                    limit: {
+                        description: 'Max agents to return (default 30)',
+                        type: 'number',
+                    },
+                    min_prompts: {
+                        description:
+                            'Prompts in the window below which an agent counts as low traffic (default 5)',
+                        type: 'number',
+                    },
+                    window_days: {
+                        description:
+                            'Days of activity to look at (default 30). Agents younger than this are excluded',
+                        type: 'number',
+                    },
+                },
+                required: [],
+                type: 'object',
+            },
+            name: 'get_unused_agents',
             type: 'custom',
         },
         {

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -148,7 +148,7 @@ const CAPABILITY_GROUPS = [
         key: 'readOnly',
         label: 'Read content',
         description:
-            'Reads project health signals, recent Autopilot actions, stale charts and dashboards, broken content, chart definitions, user questions, popular content, preview projects, slow query history, inactive project members, and content whose owner has left.',
+            'Reads project health signals, recent Autopilot actions, stale charts and dashboards, broken content, chart definitions, user questions, popular content, preview projects, slow query history, inactive project members, content whose owner has left, and AI agents with little or no traffic.',
         locked: true,
     },
     {


### PR DESCRIPTION
Closes PROD-9412. Completes the detection pack started by #26953 (inactive users) and #26954 (orphaned owners).

Adds a read-only `get_unused_agents` tool. It returns AI agents in the project that are getting little or no traffic, with a reason for the verdict and a separate signal for why traffic may not be arriving.

**Traffic is prompts, not threads.** An opened conversation nobody spoke in is not use, so counting threads would let a bounce register as traffic. Thread counts are still returned alongside prompt counts, which keeps the "opened once and abandoned" case visible without letting it count as usage.

**Two fields, not one verdict.** `reason` says what kind of unused this is — `never_used`, `no_recent_use`, `only_failed_sessions`, `low_traffic` — and `routing_signal` says why traffic may not be arriving: `router_disabled`, `never_a_candidate`, `candidate_never_suggested`, `suggested_never_chosen`, `routed`. The routing signal comes from `ai_router_decision`'s candidate array, suggestion and choice, which is what separates "nobody wants this agent" from "the router never puts it forward". Collapsing the two into a single "unused" label would have lost exactly the distinction that tells an admin whether to retire the agent or rewrite its description.

**Failed sessions are not a popularity problem.** An agent whose prompts all error gets `only_failed_sessions` rather than being counted as used or lumped in with low traffic. The tool description and the prompt step both rule out recommending retirement on that basis.

**Two exclusions.** The auto-provisioned system agent is skipped, because an admin did not choose to create it and "consider disabling it" is not actionable. Agents younger than the window are skipped too — no traffic in 30 days is not a claim you can make about a 5-day-old agent. Both are enforced in SQL, not left to the model.

**Reporting-only, enforced in three places,** matching the two detections that came before it: absent from `aggressionDisabledTools` and `managedAgentCapabilityTools` so it survives every aggression level and capability toggle, a tool description that rules out acting on the result, and a prompt step that says never delete, disable, or edit an agent.

**Regression analysis.** Additive in the same shape as the two parents: one SQL helper, one model method, one tool, one dispatch case. No existing query, tool, handler or policy field is touched, so every current Autopilot behaviour is unchanged. The prompt change inserts a new step 6 and renumbers Insights to 7 and Slack Summary to 8 — the content of those two steps is untouched, only the headings shift. The frontend change is one sentence in the locked read-capability description. The one shared surface is the agent config hash, which changes because the prompt and tool list changed; that is the intended trigger for re-provisioning the Anthropic agent, and `agent.test.ts` covers hash sensitivity.

Worth a reviewer's eye: the routing CTE joins `ai_router_decision` on an OR across suggested, chosen and the candidate array, and `candidate_agent_uuids` has no GIN index. Decision volume is low today, so this is fine, but it is the part of the query that would need an index first if router traffic grows. Also note the thresholds are tool inputs rather than policy fields, so they do not appear in the settings panel — same call as the inactive-user window, and whether detection thresholds belong in the policy UI is still a separate decision.

Verified with `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`, oxlint, oxfmt, and `agent.test.ts` (14 passing, 2 new). The SQL was run against a dev database inside a transaction seeded to hit every branch and then rolled back: all four reasons and all five routing signals resolved correctly, the healthy agent and the system agent were excluded, and a genuinely recent agent was correctly dropped by the age filter. Not exercised through a live Autopilot run.
