### PR TITLE
feat(autopilot): detect expiring service accounts and tokens

### DIFF
--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -29,9 +29,12 @@ import {
     type DbManagedAgentSettings,
 } from '../database/entities/managedAgent';
 import {
+    expiringPersonalAccessTokensSql,
+    expiringServiceAccountsSql,
     inactiveUsersSql,
     orphanedContentSql,
     unusedAgentsSql,
+    type CredentialExpiryStatus,
     type InactiveUserActivitySource,
     type OrphanedContentOwnerStatus,
     type UnusedAgentReason,
@@ -736,6 +739,96 @@ export class ManagedAgentModel {
             ownerStatus: r.owner_status,
             lastViewedAt: r.last_viewed_at,
         }));
+    }
+
+    async getExpiringServiceAccounts(
+        organizationUuid: string,
+        horizonDays: number,
+        limit: number = 30,
+    ): Promise<
+        Array<{
+            serviceAccountUuid: string;
+            description: string;
+            scopes: string[];
+            status: CredentialExpiryStatus;
+            expiresAt: Date;
+            lastUsedAt: Date | null;
+            rotatedAt: Date | null;
+            createdAt: Date;
+            createdByName: string | null;
+        }>
+    > {
+        const rows = await this.database.raw<{
+            rows: Array<{
+                service_account_uuid: string;
+                description: string;
+                scopes: string[];
+                status: CredentialExpiryStatus;
+                expires_at: Date;
+                last_used_at: Date | null;
+                rotated_at: Date | null;
+                created_at: Date;
+                created_by_name: string | null;
+            }>;
+        }>(expiringServiceAccountsSql(), [
+            horizonDays,
+            organizationUuid,
+            limit,
+        ]);
+
+        return rows.rows.map((r) => ({
+            serviceAccountUuid: r.service_account_uuid,
+            description: r.description,
+            scopes: r.scopes,
+            status: r.status,
+            expiresAt: r.expires_at,
+            lastUsedAt: r.last_used_at,
+            rotatedAt: r.rotated_at,
+            createdAt: r.created_at,
+            createdByName: r.created_by_name,
+        }));
+    }
+
+    // Counts only: the owner is the only person who can rotate a personal
+    // token, and Autopilot findings are readable by every project viewer.
+    async getExpiringPersonalAccessTokenCounts(
+        projectUuid: string,
+        organizationUuid: string,
+        horizonDays: number,
+    ): Promise<{
+        expiredCount: number;
+        expiringSoonCount: number;
+        ownersAffected: number;
+    }> {
+        const membership = await this.database.raw<{
+            rows: Array<{ user_uuid: string }>;
+        }>(usersInProjectSql(projectUuid, organizationUuid));
+        const memberUuids = membership.rows.map((row) => row.user_uuid);
+        if (memberUuids.length === 0) {
+            return {
+                expiredCount: 0,
+                expiringSoonCount: 0,
+                ownersAffected: 0,
+            };
+        }
+
+        const rows = await this.database.raw<{
+            rows: Array<{
+                expired_count: string;
+                expiring_soon_count: string;
+                owners_affected: string;
+            }>;
+        }>(expiringPersonalAccessTokensSql(), [
+            horizonDays,
+            memberUuids.join(','),
+        ]);
+
+        const row = rows.rows[0];
+        return {
+            expiredCount: Number(row?.expired_count ?? 0),
+            expiringSoonCount: Number(row?.expiring_soon_count ?? 0),
+            ownersAffected: Number(row?.owners_affected ?? 0),
+        };
     }
 
     // Traffic is counted in prompts rather than threads, so an agent someone

--- a/packages/backend/src/ee/models/ManagedAgentModelSql.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModelSql.ts
@@ -9,6 +9,8 @@ export type InactiveUserActivitySource =
 
 export type OrphanedContentOwnerStatus = 'deactivated' | 'left_org';
 
+export type CredentialExpiryStatus = 'expired' | 'expiring_soon';
+
 export type UnusedAgentReason =
     | 'never_used'
     | 'no_recent_use'
@@ -266,4 +268,61 @@ WHERE COALESCE(act.recent_prompts, 0) < params.min_prompts
   )
 ORDER BY COALESCE(act.recent_prompts, 0) ASC, a.created_at ASC
 LIMIT ?;
+`;
+
+/**
+ * Service accounts are organization-wide: there is no project column to scope
+ * them by. Credentials with no expiry set are never reported, since there is
+ * nothing to act on. Revocation deletes the row, so it is not observable here.
+ *
+ * Parameters: horizon_days, organization_uuid, limit
+ */
+export const expiringServiceAccountsSql = () => `
+WITH params AS (
+  SELECT now() + make_interval(days => ?) AS expiry_horizon
+)
+SELECT
+  sa.service_account_uuid,
+  sa.description,
+  sa.scopes,
+  sa.expires_at,
+  sa.last_used_at,
+  sa.rotated_at,
+  sa.created_at,
+  creator.first_name || ' ' || creator.last_name AS created_by_name,
+  CASE
+    WHEN sa.expires_at <= now() THEN 'expired'
+    ELSE 'expiring_soon'
+  END AS status
+FROM service_accounts sa
+  CROSS JOIN params
+  LEFT JOIN users creator ON creator.user_uuid = sa.created_by_user_uuid
+WHERE sa.organization_uuid = ?
+  AND sa.expires_at IS NOT NULL
+  AND sa.expires_at <= params.expiry_horizon
+ORDER BY sa.expires_at ASC
+LIMIT ?;
+`;
+
+/**
+ * Personal tokens are reported as counts only. Their owner is the only person
+ * who can rotate one, and Autopilot findings are readable by anyone who can
+ * view the project.
+ *
+ * Parameters: horizon_days, member_uuids
+ */
+export const expiringPersonalAccessTokensSql = () => `
+WITH params AS (
+  SELECT now() + make_interval(days => ?) AS expiry_horizon
+)
+SELECT
+  COUNT(*) FILTER (WHERE pat.expires_at <= now()) AS expired_count,
+  COUNT(*) FILTER (WHERE pat.expires_at > now()) AS expiring_soon_count,
+  COUNT(DISTINCT u.user_uuid) AS owners_affected
+FROM personal_access_tokens pat
+  CROSS JOIN params
+  JOIN users u ON u.user_id = pat.created_by_user_id
+WHERE u.user_uuid = ANY(string_to_array(?, ',')::uuid[])
+  AND pat.expires_at IS NOT NULL
+  AND pat.expires_at <= params.expiry_horizon;
 `;

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -57,6 +57,7 @@ import {
 import { ManagedAgentModel } from '../../models/ManagedAgentModel';
 import type { ServiceAccountModel } from '../../models/ServiceAccountModel';
 import {
+    buildManagedAgentToolListResult,
     formatManagedAgentToolListResult,
     getManagedAgentToolResultLimit,
     summarizeManagedAgentBrokenContent,
@@ -2037,6 +2038,8 @@ export class ManagedAgentService extends BaseService {
                 return this.handleGetOrphanedContent(actor, projectUuid, input);
             case 'get_unused_agents':
                 return this.handleGetUnusedAgents(projectUuid, input);
+            case 'get_credential_health':
+                return this.handleGetCredentialHealth(projectUuid, input);
             case 'reverse_own_action':
                 return this.handleReverseOwnAction(actor, projectUuid, input);
             default:
@@ -3279,6 +3282,56 @@ chartConfig:
                 min_prompts_threshold: minPrompts,
             })),
         );
+    }
+
+    private static readonly DEFAULT_CREDENTIAL_HORIZON_DAYS = 14;
+
+    private async handleGetCredentialHealth(
+        projectUuid: string,
+        input: Record<string, unknown>,
+    ): Promise<string> {
+        const horizonDays =
+            (input.horizon_days as number) ??
+            ManagedAgentService.DEFAULT_CREDENTIAL_HORIZON_DAYS;
+        const limit = getManagedAgentToolResultLimit(input.limit, 30);
+
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const [serviceAccounts, personalAccessTokens] = await Promise.all([
+            this.managedAgentModel.getExpiringServiceAccounts(
+                organizationUuid,
+                horizonDays,
+                limit,
+            ),
+            this.managedAgentModel.getExpiringPersonalAccessTokenCounts(
+                projectUuid,
+                organizationUuid,
+                horizonDays,
+            ),
+        ]);
+
+        return JSON.stringify({
+            horizon_days: horizonDays,
+            service_accounts: buildManagedAgentToolListResult(
+                serviceAccounts.map((account) => ({
+                    service_account_uuid: account.serviceAccountUuid,
+                    description: account.description,
+                    status: account.status,
+                    scopes: account.scopes,
+                    expires_at: account.expiresAt,
+                    last_used_at: account.lastUsedAt,
+                    rotated_at: account.rotatedAt,
+                    created_at: account.createdAt,
+                    created_by: account.createdByName,
+                })),
+                limit,
+            ),
+            personal_access_tokens: {
+                expired_count: personalAccessTokens.expiredCount,
+                expiring_soon_count: personalAccessTokens.expiringSoonCount,
+                owners_affected: personalAccessTokens.ownersAffected,
+            },
+        });
     }
 
     private async handleReverseOwnAction(

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
@@ -210,8 +210,37 @@ describe('renderManagedAgentConfig with policy', () => {
         expect(config.system).toContain(
             'NEVER delete, disable, or edit an agent',
         );
-        expect(config.system).toContain('### 7. Insights');
-        expect(config.system).toContain('### 8. Slack Summary');
+    });
+
+    it('keeps the credential tool in every aggression mode and with content capabilities off', () => {
+        (['observe', 'flag', 'cleanup'] as const).forEach((aggression) => {
+            const config = renderManagedAgentConfig({
+                ...baseArgs,
+                policy: { ...DEFAULT_MANAGED_AGENT_POLICY, aggression },
+            });
+            expect(customToolNames(config)).toContain('get_credential_health');
+        });
+
+        const noContentCapabilities = renderManagedAgentConfig({
+            ...baseArgs,
+            toolSettings: {
+                createContent: false,
+                modifyExistingContent: false,
+            },
+        });
+        expect(customToolNames(noContentCapabilities)).toContain(
+            'get_credential_health',
+        );
+    });
+
+    it('forbids naming personal token owners in credential findings', () => {
+        const config = renderManagedAgentConfig(baseArgs);
+        expect(config.system).toContain('### 7. Credential Health');
+        expect(config.system).toContain(
+            'NEVER name or guess at individual token owners',
+        );
+        expect(config.system).toContain('### 8. Insights');
+        expect(config.system).toContain('### 9. Slack Summary');
     });
 
     it('changes the config hash when policy changes', () => {

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -172,13 +172,21 @@ Call get_unused_agents. Reporting-only: record what you find with log_insight an
 - An admin_only agent has a small audience by design; do not read its low traffic as a discoverability problem
 - If it returns nothing, skip this step
 
-### 7. Insights
+### 7. Credential Health
+Call get_credential_health. Reporting-only: record what you find with log_insight and NEVER attempt to rotate, delete, or use a credential.
+- Service accounts are organization-wide, so say that rather than implying they belong to this project
+- An expired credential that was used recently is an active breakage; an expired one that was never used is just cleanup. Use last_used_at to tell those apart, because they need different urgency
+- Report personal access tokens as the counts the tool returns. NEVER name or guess at individual token owners: anyone who can view this project can read your findings, and only the owner can rotate their own token
+- Recommend rotation in the organization settings; never quote scopes as if they were project permissions
+- If nothing is expiring, skip this step
+
+### 8. Insights
 Call get_popular_content.
 - Surface content that is popular but not pinned
 - Surface content with high views but restricted access (private space)
 - If nothing noteworthy, skip this step
 
-### 8. Slack Summary
+### 9. Slack Summary
 After the run is complete, call write_slack_summary exactly once with the final summary you want posted to Slack. Use the "lightdash-agent-slack-messaging" skill to match Lightdash's Slack tone of voice
 `;
 };
@@ -646,6 +654,28 @@ export const managedAgentConfig: AgentCreateParams = {
                 type: 'object',
             },
             name: 'get_unused_agents',
+            type: 'custom',
+        },
+        {
+            description:
+                'Get credentials that have expired or are close to expiring. Service accounts are returned per credential (description, status, scopes, expires_at, last_used_at, rotated_at, who created it) and are organization-wide, not specific to this project. Personal access tokens are returned as counts only, never named. Credentials with no expiry date set are not returned, and revoked credentials cannot be detected because revoking deletes the record. Warehouse connections are not covered. Reporting only.',
+            input_schema: {
+                properties: {
+                    horizon_days: {
+                        description:
+                            'Report credentials expiring within this many days (default 14). Already-expired credentials are always included',
+                        type: 'number',
+                    },
+                    limit: {
+                        description:
+                            'Max service accounts to return (default 30)',
+                        type: 'number',
+                    },
+                },
+                required: [],
+                type: 'object',
+            },
+            name: 'get_credential_health',
             type: 'custom',
         },
         {

--- a/packages/backend/src/ee/services/ManagedAgentService/toolResults.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/toolResults.ts
@@ -28,19 +28,24 @@ type ManagedAgentToolListResult<T> = {
     omitted_count: number;
 };
 
-export const formatManagedAgentToolListResult = <T>(
+export const buildManagedAgentToolListResult = <T>(
     items: T[],
     limit = MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT,
-): string => {
+): ManagedAgentToolListResult<T> => {
     const limitedItems = items.slice(0, limit);
-    return JSON.stringify({
+    return {
         items: limitedItems,
         total_count: items.length,
         returned_count: limitedItems.length,
         truncated: items.length > limitedItems.length,
         omitted_count: Math.max(items.length - limitedItems.length, 0),
-    } satisfies ManagedAgentToolListResult<T>);
+    };
 };
+
+export const formatManagedAgentToolListResult = <T>(
+    items: T[],
+    limit = MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT,
+): string => JSON.stringify(buildManagedAgentToolListResult(items, limit));
 
 type ManagedAgentBrokenContentItem = {
     uuid: string;

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -148,7 +148,7 @@ const CAPABILITY_GROUPS = [
         key: 'readOnly',
         label: 'Read content',
         description:
-            'Reads project health signals, recent Autopilot actions, stale charts and dashboards, broken content, chart definitions, user questions, popular content, preview projects, slow query history, inactive project members, content whose owner has left, and AI agents with little or no traffic.',
+            'Reads project health signals, recent Autopilot actions, stale charts and dashboards, broken content, chart definitions, user questions, popular content, preview projects, slow query history, inactive project members, content whose owner has left, AI agents with little or no traffic, and expiring service accounts.',
         locked: true,
     },
     {


### PR DESCRIPTION
Closes PROD-9408. Stacked on #26968 (unused agents) — review that one first. Last of the detection pack.

Adds a read-only `get_credential_health` tool covering credentials that have expired or are close to expiring.

**Warehouse credentials are not covered, because they are not detectable.** `warehouse_credentials`, `user_warehouse_credentials` and `organization_warehouse_credentials` all store an encrypted blob with no `expires_at`, no `last_used_at` and no validity column. Any OAuth expiry lives inside the encrypted payload, so detecting it would mean decrypting every credential on every run, and only some warehouse types carry an expiry at all. The honest path for warehouse connection health is inferring it from auth failures in `query_history`, which is a different detection and a different ticket. Flagging this rather than quietly shipping two thirds of the ticket.

**Answering the ticket's open questions.** Personal token validity does not need to be inferred from failed usage: `expires_at` is a real column on `personal_access_tokens`, same as on `service_accounts`. Revocation is genuinely undetectable in both cases, because revoking deletes the row — the tool description says so rather than letting the agent imply the absence of a credential means anything. Near-expiry is in v1, and is the point: an already-expired credential is cleanup, a credential expiring on Friday is the one an admin can still act on.

**Personal tokens are reported as counts, never named.** Reading Autopilot's findings requires only `view` on the project, not admin, and the Slack summary is broader still. A service account is shared infrastructure that an admin who reads the report can rotate, so naming it is actionable. A personal token can only be rotated by its owner, so naming it would publish "Bob's prod deploy key expires Friday" to every project viewer while giving none of them anything to do. The tool therefore returns service accounts per credential and personal tokens as `expired_count` / `expiring_soon_count` / `owners_affected`, and the prompt step forbids naming or guessing at owners. The counts still support the real action, which is an admin nudging people to check their tokens.

**Expired-and-in-use is the finding that matters.** An expired credential with a recent `last_used_at` is something breaking right now; an expired one that was never used is just cleanup. Both are returned with `last_used_at` and `rotated_at`, and the prompt tells the agent to separate them rather than reporting one undifferentiated pile.

**Scoping.** Service accounts have no project column — they are organization-wide by design — so they are scoped to the project's organization and both the tool description and the prompt require the agent to say so rather than implying they belong to this project. Personal token counts are scoped to project members via `usersInProjectSql`, the same definition `get_inactive_users` uses.

**Reporting-only,** in the same three places as the rest of the pack: absent from `aggressionDisabledTools` and `managedAgentCapabilityTools`, a tool description that rules out acting, and a prompt step that forbids rotating, deleting or using a credential.

**Regression analysis.** Additive except for one small refactor: `formatManagedAgentToolListResult` is now a thin `JSON.stringify` over a new `buildManagedAgentToolListResult`, which returns the same object it always built. Every existing caller keeps the identical string output, and the existing `toolResults` tests cover that. The refactor exists because this tool returns two sections in one payload — service account rows plus token counts — and needed the list result as an object rather than a pre-stringified blob. Beyond that: two SQL helpers, two model methods, one tool, one dispatch case, no existing query or handler touched. The prompt change inserts step 7 and renumbers Insights to 8 and Slack Summary to 9, content unchanged. The frontend change is one sentence in the locked read-capability description. Config hash changes for the intended reason.

Worth a reviewer's eye: credentials with no expiry set are never reported. That is deliberate — there is no expiry event to act on — but it does mean a never-expiring, never-rotated token stays invisible to this tool, which is arguably its own finding and would need a different threshold to express. Also note SCIM tokens share the identical shape and were left out to keep a project-scoped surface from carrying org-wide security state; adding them later is a UNION branch if you decide the tradeoff is worth it.

Verified with `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`, oxlint, and the managed agent suites (21 passing, 2 new). Both SQL helpers were run against a dev database inside a transaction seeded to cover every branch and then rolled back: expired-and-recently-used, expired-and-never-used, and expiring-within-horizon service accounts were all returned with correct status, a healthy account 100 days out was excluded, and the token counts correctly excluded both a token with no expiry and a token belonging to a non-member. Not exercised through a live Autopilot run.
