### PR TITLE
feat(explore): add fullscreen toggle to the standalone chart view

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -495,13 +495,15 @@ const SavedChartsHeader: FC = () => {
                     {savedChart && projectUuid && (
                         <>
                             <Group gap={4}>
-                                <TitleBreadCrumbs
-                                    projectUuid={projectUuid}
-                                    spaceUuid={savedChart.spaceUuid}
-                                    spaceName={savedChart.spaceName}
-                                    dashboardUuid={savedChart.dashboardUuid}
-                                    dashboardName={savedChart.dashboardName}
-                                />
+                                {!isFullscreen && (
+                                    <TitleBreadCrumbs
+                                        projectUuid={projectUuid}
+                                        spaceUuid={savedChart.spaceUuid}
+                                        spaceName={savedChart.spaceName}
+                                        dashboardUuid={savedChart.dashboardUuid}
+                                        dashboardName={savedChart.dashboardName}
+                                    />
+                                )}
                                 <Title
                                     c="ldDark.9"
                                     order={5}
@@ -569,28 +571,30 @@ const SavedChartsHeader: FC = () => {
                                 onClose={() => setIsRenamingChart(false)}
                                 onConfirm={() => setIsRenamingChart(false)}
                             />
-                            <Group gap="xs">
-                                <UpdatedInfo
-                                    updatedAt={savedChart.updatedAt}
-                                    user={savedChart.updatedByUser}
-                                    partiallyBold={false}
-                                />
-                                <ResourceInfoPopup
-                                    resourceUuid={savedChart.uuid}
-                                    projectUuid={projectUuid}
-                                    title={savedChart.name}
-                                    description={savedChart.description}
-                                    slug={savedChart.slug}
-                                    updatedAt={savedChart.updatedAt}
-                                    spaceName={savedChart.spaceName}
-                                    spaceUuid={savedChart.spaceUuid}
-                                    viewStats={chartViewStats.data?.views}
-                                    firstViewedAt={
-                                        chartViewStats.data?.firstViewedAt
-                                    }
-                                    withChartData={true}
-                                />
-                            </Group>
+                            {!isFullscreen && (
+                                <Group gap="xs">
+                                    <UpdatedInfo
+                                        updatedAt={savedChart.updatedAt}
+                                        user={savedChart.updatedByUser}
+                                        partiallyBold={false}
+                                    />
+                                    <ResourceInfoPopup
+                                        resourceUuid={savedChart.uuid}
+                                        projectUuid={projectUuid}
+                                        title={savedChart.name}
+                                        description={savedChart.description}
+                                        slug={savedChart.slug}
+                                        updatedAt={savedChart.updatedAt}
+                                        spaceName={savedChart.spaceName}
+                                        spaceUuid={savedChart.spaceUuid}
+                                        viewStats={chartViewStats.data?.views}
+                                        firstViewedAt={
+                                            chartViewStats.data?.firstViewedAt
+                                        }
+                                        withChartData={true}
+                                    />
+                                </Group>
+                            )}
                         </>
                     )}
                 </div>

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -34,6 +34,8 @@ import {
     IconFolderSymlink,
     IconHistory,
     IconLayoutGridAdd,
+    IconMaximize,
+    IconMinimize,
     IconPencil,
     IconPin,
     IconPinnedOff,
@@ -98,6 +100,7 @@ import {
     defaultState,
 } from '../../../providers/Explorer/defaultState';
 import { ExplorerSection } from '../../../providers/Explorer/types';
+import useNativeFullscreenToggle from '../../../providers/Fullscreen/useNativeFullscreenToggle';
 import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
@@ -173,6 +176,12 @@ const SavedChartsHeader: FC = () => {
         () => favorites?.some((f) => f.data.uuid === savedChart?.uuid) ?? false,
         [favorites, savedChart?.uuid],
     );
+
+    const {
+        enabled: isFullscreenEnabled,
+        isFullscreen,
+        handleToggleFullscreen,
+    } = useNativeFullscreenToggle();
 
     const { clearDashboardStorage } = useDashboardStorage();
     const [isRenamingChart, setIsRenamingChart] = useState(false);
@@ -358,6 +367,17 @@ const SavedChartsHeader: FC = () => {
             projectUuid,
         }),
     );
+
+    // Chart actions are hidden in fullscreen so the chart owns the viewport
+    const showChartActions =
+        !isFullscreen &&
+        (userCanManageChart ||
+            userCanCreateDeliveriesAndAlerts ||
+            userCanManageExplore ||
+            userCanViewContentAsCode);
+
+    const showFullscreenToggle =
+        !isEditMode && isFullscreenEnabled && document.fullscreenEnabled;
 
     const canManageContentVerification =
         user.data?.ability?.can(
@@ -574,84 +594,124 @@ const SavedChartsHeader: FC = () => {
                         </>
                     )}
                 </div>
-                {(userCanManageChart ||
-                    userCanCreateDeliveriesAndAlerts ||
-                    userCanManageExplore ||
-                    userCanViewContentAsCode) && (
-                    <Group gap="xs">
-                        {userCanManageExplore && !isEditMode && (
-                            <ExploreFromHereButton />
-                        )}
-                        {userCanManageChart && (
-                            <>
-                                {/* TODO: Extract this into a separate component, depending on the mode: viewing or editing */}
-                                {!isEditMode ? (
-                                    <>
-                                        <Button
-                                            variant="default"
-                                            size="xs"
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconPencil}
-                                                />
-                                            }
-                                            onClick={() =>
-                                                navigate({
-                                                    pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.uuid}/edit`,
-                                                })
-                                            }
-                                        >
-                                            Edit chart
-                                        </Button>
-                                        <ShareShortLinkButton
-                                            disabled={!isValidQuery}
-                                        />
-                                    </>
-                                ) : (
-                                    <>
-                                        <SaveChartButton
-                                            onSaveModalOpenChange={
-                                                setIsSaveModalOpen
-                                            }
-                                            verificationSavePrompt={
-                                                verificationSavePrompt
-                                            }
-                                        />
-                                        <Button
-                                            variant="default"
-                                            size="xs"
-                                            disabled={
-                                                isFromDashboard &&
-                                                !hasUnsavedChanges
-                                            }
-                                            onClick={handleCancelClick}
-                                        >
-                                            Cancel{' '}
-                                            {isFromDashboard ? 'changes' : ''}
-                                        </Button>
-
-                                        {isFromDashboard && (
-                                            <Tooltip
-                                                offset={-1}
-                                                label="Return to dashboard"
-                                                withinPortal
-                                                position="bottom"
-                                            >
-                                                <ActionIcon
-                                                    variant="default"
-                                                    onClick={handleGoBackClick}
-                                                >
+                <Group gap="xs">
+                    {showChartActions && (
+                        <>
+                            {userCanManageExplore && !isEditMode && (
+                                <ExploreFromHereButton />
+                            )}
+                            {userCanManageChart && (
+                                <>
+                                    {/* TODO: Extract this into a separate component, depending on the mode: viewing or editing */}
+                                    {!isEditMode ? (
+                                        <>
+                                            <Button
+                                                variant="default"
+                                                size="xs"
+                                                leftSection={
                                                     <MantineIcon
-                                                        icon={IconArrowBack}
+                                                        icon={IconPencil}
                                                     />
-                                                </ActionIcon>
-                                            </Tooltip>
-                                        )}
-                                    </>
-                                )}
-                            </>
-                        )}
-                        {/* TODO: Refactor this into its own component */}
+                                                }
+                                                onClick={() =>
+                                                    navigate({
+                                                        pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.uuid}/edit`,
+                                                    })
+                                                }
+                                            >
+                                                Edit chart
+                                            </Button>
+                                            <ShareShortLinkButton
+                                                disabled={!isValidQuery}
+                                            />
+                                        </>
+                                    ) : (
+                                        <>
+                                            <SaveChartButton
+                                                onSaveModalOpenChange={
+                                                    setIsSaveModalOpen
+                                                }
+                                                verificationSavePrompt={
+                                                    verificationSavePrompt
+                                                }
+                                            />
+                                            <Button
+                                                variant="default"
+                                                size="xs"
+                                                disabled={
+                                                    isFromDashboard &&
+                                                    !hasUnsavedChanges
+                                                }
+                                                onClick={handleCancelClick}
+                                            >
+                                                Cancel{' '}
+                                                {isFromDashboard
+                                                    ? 'changes'
+                                                    : ''}
+                                            </Button>
+
+                                            {isFromDashboard && (
+                                                <Tooltip
+                                                    offset={-1}
+                                                    label="Return to dashboard"
+                                                    withinPortal
+                                                    position="bottom"
+                                                >
+                                                    <ActionIcon
+                                                        variant="default"
+                                                        onClick={
+                                                            handleGoBackClick
+                                                        }
+                                                    >
+                                                        <MantineIcon
+                                                            icon={IconArrowBack}
+                                                        />
+                                                    </ActionIcon>
+                                                </Tooltip>
+                                            )}
+                                        </>
+                                    )}
+                                </>
+                            )}
+                        </>
+                    )}
+                    {showFullscreenToggle && (
+                        <Tooltip
+                            label={
+                                isFullscreen
+                                    ? 'Exit Fullscreen Mode'
+                                    : 'Enter Fullscreen Mode'
+                            }
+                            withinPortal
+                            position="bottom"
+                            openDelay={200}
+                            transitionProps={{
+                                transition: 'fade',
+                                duration: 150,
+                            }}
+                        >
+                            <ActionIcon
+                                aria-label={
+                                    isFullscreen
+                                        ? 'Exit Fullscreen Mode'
+                                        : 'Enter Fullscreen Mode'
+                                }
+                                variant="default"
+                                radius="md"
+                                onClick={handleToggleFullscreen}
+                            >
+                                <MantineIcon
+                                    icon={
+                                        isFullscreen
+                                            ? IconMinimize
+                                            : IconMaximize
+                                    }
+                                />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
+                    {/* TODO: Refactor this into its own component */}
+                    {showChartActions && (
                         <Menu
                             position="bottom"
                             withArrow
@@ -950,8 +1010,8 @@ const SavedChartsHeader: FC = () => {
                                 </ActionIcon>
                             </Menu.Target>
                         </Menu>
-                    </Group>
-                )}
+                    )}
+                </Group>
             </PageHeader>
 
             {savedChart && isAddToDashboardModalOpen && projectUuid && (

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -50,6 +50,7 @@ import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { ExplorerSection } from '../../../providers/Explorer/types';
+import useFullscreen from '../../../providers/Fullscreen/useFullscreen';
 import ChartDownloadMenu from '../../common/ChartDownload/ChartDownloadMenu';
 import CollapsableCard from '../../common/CollapsableCard/CollapsableCard';
 import { COLLAPSABLE_CARD_BUTTON_PROPS } from '../../common/CollapsableCard/constants';
@@ -87,6 +88,8 @@ const VisualizationCard: FC<Props> = memo((props) => {
     const { data: org } = useOrganization();
     const colorScheme = useComputedColorScheme();
     const dispatch = useExplorerDispatch();
+    // In fullscreen the chart card header is hidden so the chart owns the viewport
+    const { isFullscreen } = useFullscreen();
 
     // Get savedChart from Redux
     const savedChart = useExplorerSelector(selectSavedChart);
@@ -189,7 +192,11 @@ const VisualizationCard: FC<Props> = memo((props) => {
         [dispatch],
     );
 
-    const isOpen = useExplorerSelector(selectIsVisualizationExpanded);
+    const isVisualizationExpanded = useExplorerSelector(
+        selectIsVisualizationExpanded,
+    );
+    // Without the heading there is no way to expand the card, so force it open
+    const isOpen = isVisualizationExpanded || isFullscreen;
     const isEditMode = useExplorerSelector(selectIsEditMode);
     const isVisualizationConfigOpen = useExplorerSelector(
         selectIsVisualizationConfigOpen,
@@ -361,6 +368,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
                     title="Chart"
                     isOpen={isOpen}
                     isVisualizationCard
+                    hideHeading={isFullscreen}
                     onToggle={toggleSection}
                     headerElement={
                         isOpen && (

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -39,6 +39,7 @@ import { useExplore } from '../../hooks/useExplore';
 import { useExplorerQuery } from '../../hooks/useExplorerQuery';
 import { useProjectUuid } from '../../hooks/useProjectUuid';
 import { Can } from '../../providers/Ability';
+import useFullscreen from '../../providers/Fullscreen/useFullscreen';
 import ScreenshotReadyIndicator from '../common/ScreenshotReadyIndicator';
 import { DrillDownModal } from '../MetricQueryData/DrillDownModal';
 import MetricQueryDataProvider from '../MetricQueryData/MetricQueryDataProvider';
@@ -232,6 +233,10 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
 
         const { data: org } = useOrganization();
 
+        // In fullscreen only the visualization is shown, so it can use the
+        // whole viewport
+        const { isFullscreen } = useFullscreen();
+
         return (
             <MetricQueryDataProvider
                 tableName={tableName}
@@ -249,15 +254,17 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                             !savedChart && <RefreshDbtButton />
                         ))}
 
-                    {!!tableName && hasReferencedUserParameters && (
-                        <ParametersCard
-                            parameterReferences={
-                                parameterReferencesFromRedux ?? undefined
-                            }
-                        />
-                    )}
+                    {!isFullscreen &&
+                        !!tableName &&
+                        hasReferencedUserParameters && (
+                            <ParametersCard
+                                parameterReferences={
+                                    parameterReferencesFromRedux ?? undefined
+                                }
+                            />
+                        )}
 
-                    <FiltersCard />
+                    {!isFullscreen && <FiltersCard />}
 
                     <VisualizationCard
                         projectUuid={projectUuid}
@@ -265,17 +272,23 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                         onScreenshotError={handleScreenshotError}
                     />
 
-                    <ResultsCard />
+                    {!isFullscreen && (
+                        <>
+                            <ResultsCard />
 
-                    <Can
-                        I="manage"
-                        this={subject('Explore', {
-                            organizationUuid: org?.organizationUuid,
-                            projectUuid,
-                        })}
-                    >
-                        {!!projectUuid && <SqlCard projectUuid={projectUuid} />}
-                    </Can>
+                            <Can
+                                I="manage"
+                                this={subject('Explore', {
+                                    organizationUuid: org?.organizationUuid,
+                                    projectUuid,
+                                })}
+                            >
+                                {!!projectUuid && (
+                                    <SqlCard projectUuid={projectUuid} />
+                                )}
+                            </Can>
+                        </>
+                    )}
                 </Stack>
 
                 {/* These use the metricQueryDataProvider context */}

--- a/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
+++ b/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
@@ -16,10 +16,12 @@ interface CollapsableCardProps {
     headerElement?: React.ReactNode;
     rightHeaderElement?: React.ReactNode;
     isVisualizationCard?: boolean;
+    hideHeading?: boolean;
 }
 
 const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
     isVisualizationCard = false,
+    hideHeading = false,
     children,
     onToggle,
     isOpen = false,
@@ -55,74 +57,78 @@ const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
             }}
             shadow="subtle"
         >
-            <Flex
-                ref={headingRef}
-                gap="xxs"
-                align="center"
-                mr="xs"
-                h="xxl"
-                w="100%"
-                onClick={onClickHeading}
-                className={
-                    disabled
-                        ? classes.inactiveCardHeading
-                        : classes.activeCardHeading
-                }
-            >
-                <Tooltip
-                    position="top-start"
-                    disabled={!toggleTooltip}
-                    label={toggleTooltip}
+            {!hideHeading && (
+                <Flex
+                    ref={headingRef}
+                    gap="xxs"
+                    align="center"
+                    mr="xs"
+                    h="xxl"
+                    w="100%"
+                    onClick={onClickHeading}
+                    className={
+                        disabled
+                            ? classes.inactiveCardHeading
+                            : classes.activeCardHeading
+                    }
                 >
-                    <Button
-                        data-testid={`${title}-card-expand`}
-                        variant="subtle"
-                        color="gray"
-                        w="xxl"
-                        h="xxl"
-                        p={0}
-                        onClick={
-                            disabled
-                                ? undefined
-                                : (e: MouseEvent) => {
-                                      e.stopPropagation();
-                                      handleToggle(!isOpen);
-                                  }
-                        }
-                        className={
-                            disabled ? classes.disabledButton : undefined
-                        }
+                    <Tooltip
+                        position="top-start"
+                        disabled={!toggleTooltip}
+                        label={toggleTooltip}
                     >
-                        <MantineIcon
-                            icon={isOpen ? IconChevronDown : IconChevronRight}
-                        />
-                    </Button>
-                </Tooltip>
-                <Group>
-                    <Title order={5} fw={500} fz="sm">
-                        {title}
-                    </Title>
-                    <Group
-                        gap="xs"
-                        onClick={(e: MouseEvent) => e.stopPropagation()}
-                    >
-                        {headerElement}
-                    </Group>
-                </Group>
-                {rightHeaderElement && (
-                    <>
-                        <Box flex={1} />
+                        <Button
+                            data-testid={`${title}-card-expand`}
+                            variant="subtle"
+                            color="gray"
+                            w="xxl"
+                            h="xxl"
+                            p={0}
+                            onClick={
+                                disabled
+                                    ? undefined
+                                    : (e: MouseEvent) => {
+                                          e.stopPropagation();
+                                          handleToggle(!isOpen);
+                                      }
+                            }
+                            className={
+                                disabled ? classes.disabledButton : undefined
+                            }
+                        >
+                            <MantineIcon
+                                icon={
+                                    isOpen ? IconChevronDown : IconChevronRight
+                                }
+                            />
+                        </Button>
+                    </Tooltip>
+                    <Group>
+                        <Title order={5} fw={500} fz="sm">
+                            {title}
+                        </Title>
                         <Group
                             gap="xs"
-                            pos="relative"
-                            right={2}
                             onClick={(e: MouseEvent) => e.stopPropagation()}
                         >
-                            {rightHeaderElement}
+                            {headerElement}
                         </Group>
-                    </>
-                )}
-            </Flex>
+                    </Group>
+                    {rightHeaderElement && (
+                        <>
+                            <Box flex={1} />
+                            <Group
+                                gap="xs"
+                                pos="relative"
+                                right={2}
+                                onClick={(e: MouseEvent) => e.stopPropagation()}
+                            >
+                                {rightHeaderElement}
+                            </Group>
+                        </>
+                    )}
+                </Flex>
+            )}
 
             {isOpen && (
                 <Flex


### PR DESCRIPTION
Closes: lightdash/lightdash#26965

### Description:

Adds the fullscreen toggle to the saved chart (standalone) view, reusing the same `useNativeFullscreenToggle` hook, icons and tooltip as the dashboard and data app headers, so entering/exiting feels identical.

While fullscreen: the navbar hides itself (existing behaviour of the fullscreen provider), the chart actions in the header are hidden — leaving just the title and the exit button — and the Explorer only renders the visualization card (parameters, filters, results and SQL cards are hidden) so the chart, table charts included, takes the whole viewport.

The toggle is only shown in view mode, and it now sits outside the permission-gated action group so viewers without edit/export permissions get it too.

Not verified in a running app — no local stack available in this environment; checked with frontend typecheck and lint.