### PR TITLE
feat: validate data app references from the CLI

### DIFF
--- a/packages/backend/src/database/entities/validation.ts
+++ b/packages/backend/src/database/entities/validation.ts
@@ -20,6 +20,7 @@ export type DbValidationTable = {
     model_name: string | null;
     saved_chart_uuid: string | null;
     dashboard_uuid: string | null;
+    app_uuid: string | null;
     job_id: string | null;
     source: ValidationSourceType | null;
 };

--- a/packages/backend/src/database/migrations/20260806150000_add_app_uuid_to_validations.ts
+++ b/packages/backend/src/database/migrations/20260806150000_add_app_uuid_to_validations.ts
@@ -1,0 +1,22 @@
+import { type Knex } from 'knex';
+
+const AppsTableName = 'apps';
+const ValidationTableName = 'validations';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ValidationTableName, (table) => {
+        table
+            .uuid('app_uuid')
+            .nullable()
+            .references('app_id')
+            .inTable(AppsTableName)
+            .onDelete('CASCADE')
+            .index();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ValidationTableName, (table) => {
+        table.dropColumn('app_uuid');
+    });
+}

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -938,6 +938,25 @@ export class AppModel {
             });
     }
 
+    async findAppsForValidation(
+        projectUuid: string,
+    ): Promise<
+        Array<
+            Pick<DbApp, 'app_id' | 'name'> &
+                Pick<DbAppVersion, 'data_references'>
+        >
+    > {
+        return this.joinLatestReadyVersion(this.database(AppsTableName))
+            .where(`${AppsTableName}.project_uuid`, projectUuid)
+            .whereNull(`${AppsTableName}.deleted_at`)
+            .whereNotNull(`${AppVersionsTableName}.app_version_id`)
+            .select(
+                `${AppsTableName}.app_id`,
+                `${AppsTableName}.name`,
+                `${AppVersionsTableName}.data_references`,
+            );
+    }
+
     /**
      * A page of the project's bindable data app vizs — only those whose latest
      * ready version has generated a schema, so pagination counts are exact.

--- a/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
@@ -1,6 +1,7 @@
 import { DashboardFilterValidationErrorType } from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { AppsTableName } from '../../database/entities/apps';
 import { DashboardsTableName } from '../../database/entities/dashboards';
 import { SavedChartsTableName } from '../../database/entities/savedCharts';
 import { ValidationTableName } from '../../database/entities/validation';
@@ -72,9 +73,10 @@ describe('ValidationModel', () => {
             const joinedContentQueries = tracker.history.select.filter(
                 ({ sql }) =>
                     sql.includes(`join "${SavedChartsTableName}"`) ||
-                    sql.includes(`join "${DashboardsTableName}"`),
+                    sql.includes(`join "${DashboardsTableName}"`) ||
+                    sql.includes(`join "${AppsTableName}"`),
             );
-            expect(joinedContentQueries).toHaveLength(2);
+            expect(joinedContentQueries).toHaveLength(3);
             joinedContentQueries.forEach(({ sql }) => {
                 expect(sql).toContain(
                     `"${ValidationTableName}"."project_uuid"`,

--- a/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
@@ -1,7 +1,10 @@
 import { DashboardFilterValidationErrorType } from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
-import { AppsTableName } from '../../database/entities/apps';
+import {
+    AppsTableName,
+    AppVersionsTableName,
+} from '../../database/entities/apps';
 import { DashboardsTableName } from '../../database/entities/dashboards';
 import { SavedChartsTableName } from '../../database/entities/savedCharts';
 import { ValidationTableName } from '../../database/entities/validation';
@@ -82,6 +85,30 @@ describe('ValidationModel', () => {
                     `"${ValidationTableName}"."project_uuid"`,
                 );
             });
+        });
+
+        it('reads data app update metadata from the latest version regardless of status', async () => {
+            tracker.on.select(({ sql }) => sql.length > 0).response([]);
+
+            await model.get('22222222-2222-4222-8222-222222222222');
+
+            const appQuery = tracker.history.select.find(({ sql }) =>
+                sql.includes(`join "${AppsTableName}"`),
+            );
+            expect(appQuery).toBeDefined();
+            expect(appQuery!.sql).toContain(
+                `distinct on ("app_id") "app_id", "created_at", "created_by_user_uuid" from "${AppVersionsTableName}"`,
+            );
+            expect(appQuery!.sql).toContain(
+                'order by "app_id" asc, "version" desc',
+            );
+            expect(appQuery!.sql).not.toContain('where "status"');
+            expect(appQuery!.sql).toContain(
+                '"latest_app_version"."created_at" as "last_updated_at"',
+            );
+            expect(appQuery!.sql).toContain(
+                '"app_version_author"."first_name"',
+            );
         });
     });
 

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -20,7 +20,11 @@ import {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { DatabaseError } from 'pg';
-import { AppsTableName, type DbApp } from '../../database/entities/apps';
+import {
+    AppsTableName,
+    AppVersionsTableName,
+    type DbApp,
+} from '../../database/entities/apps';
 import {
     DashboardsTableName,
     DashboardTable,
@@ -67,11 +71,23 @@ type ValidationModelArguments = {
     database: Knex;
 };
 
+const LATEST_APP_VERSION_ALIAS = 'latest_app_version';
+const APP_VERSION_AUTHOR_ALIAS = 'app_version_author';
+
 export class ValidationModel {
     private database: Knex;
 
     constructor(args: ValidationModelArguments) {
         this.database = args.database;
+    }
+
+    private getLatestAppVersionQuery() {
+        return this.database(AppVersionsTableName)
+            .distinctOn('app_id')
+            .select('app_id', 'created_at', 'created_by_user_uuid')
+            .orderBy('app_id')
+            .orderBy('version', 'desc')
+            .as(LATEST_APP_VERSION_ALIAS);
     }
 
     async create({
@@ -587,6 +603,16 @@ export class ValidationModel {
                     `${ValidationTableName}.app_uuid`,
                 ).andOnNull(`${AppsTableName}.deleted_at`);
             })
+            .innerJoin(
+                this.getLatestAppVersionQuery(),
+                `${LATEST_APP_VERSION_ALIAS}.app_id`,
+                `${AppsTableName}.app_id`,
+            )
+            .leftJoin(
+                `${UserTableName} as ${APP_VERSION_AUTHOR_ALIAS}`,
+                `${APP_VERSION_AUTHOR_ALIAS}.user_uuid`,
+                `${LATEST_APP_VERSION_ALIAS}.created_by_user_uuid`,
+            )
             .where(`${ValidationTableName}.project_uuid`, projectUuid)
             .andWhere((queryBuilder) => {
                 if (jobId) {
@@ -600,11 +626,21 @@ export class ValidationModel {
                 ValidationSourceType.DataApp,
             )
             .select<
-                Array<DbValidationTable & Pick<DbApp, 'name' | 'space_uuid'>>
+                Array<
+                    DbValidationTable &
+                        Pick<DbApp, 'name' | 'space_uuid'> & {
+                            last_updated_at: Date;
+                            first_name: string | null;
+                            last_name: string | null;
+                        }
+                >
             >([
                 `${ValidationTableName}.*`,
                 `${AppsTableName}.name`,
                 `${AppsTableName}.space_uuid`,
+                `${LATEST_APP_VERSION_ALIAS}.created_at as last_updated_at`,
+                `${APP_VERSION_AUTHOR_ALIAS}.first_name`,
+                `${APP_VERSION_AUTHOR_ALIAS}.last_name`,
             ]);
 
         const appValidationErrors: ValidationErrorDataAppResponse[] =
@@ -621,6 +657,10 @@ export class ValidationModel {
                 fieldName: validationError.field_name ?? undefined,
                 modelName: validationError.model_name ?? undefined,
                 spaceUuid: validationError.space_uuid ?? undefined,
+                lastUpdatedBy: validationError.first_name
+                    ? `${validationError.first_name} ${validationError.last_name}`
+                    : undefined,
+                lastUpdatedAt: validationError.last_updated_at,
             }));
 
         return [
@@ -700,6 +740,10 @@ export class ValidationModel {
                 appUuid: row.app_uuid!,
                 name: row.resource_name || 'Data app does not exist',
                 spaceUuid: row.space_uuid ?? undefined,
+                lastUpdatedBy: row.first_name
+                    ? `${row.first_name} ${row.last_name}`
+                    : undefined,
+                lastUpdatedAt: row.last_updated_at ?? undefined,
             };
         }
 
@@ -1157,6 +1201,16 @@ export class ValidationModel {
                     `${ValidationTableName}.app_uuid`,
                 ).andOnNull(`${AppsTableName}.deleted_at`);
             })
+            .innerJoin(
+                this.getLatestAppVersionQuery(),
+                `${LATEST_APP_VERSION_ALIAS}.app_id`,
+                `${AppsTableName}.app_id`,
+            )
+            .leftJoin(
+                `${UserTableName} as ${APP_VERSION_AUTHOR_ALIAS}`,
+                `${APP_VERSION_AUTHOR_ALIAS}.user_uuid`,
+                `${LATEST_APP_VERSION_ALIAS}.created_by_user_uuid`,
+            )
             .where(`${ValidationTableName}.project_uuid`, projectUuid)
             .andWhere(
                 `${ValidationTableName}.source`,
@@ -1179,9 +1233,9 @@ export class ValidationModel {
                 `${ValidationTableName}.app_uuid`,
                 `${AppsTableName}.name as resource_name`,
                 this.database.raw('NULL::integer as views_count'),
-                this.database.raw('NULL::timestamp as last_updated_at'),
-                this.database.raw('NULL::text as first_name'),
-                this.database.raw('NULL::text as last_name'),
+                `${LATEST_APP_VERSION_ALIAS}.created_at as last_updated_at`,
+                `${APP_VERSION_AUTHOR_ALIAS}.first_name`,
+                `${APP_VERSION_AUTHOR_ALIAS}.last_name`,
                 `${AppsTableName}.space_uuid`,
                 this.database.raw('NULL::text as last_version_chart_kind'),
             ]);

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -4,12 +4,14 @@ import {
     DashboardFilterValidationErrorType,
     isChartValidationError,
     isDashboardValidationError,
+    isDataAppValidationError,
     isTableValidationError,
     KnexPaginateArgs,
     KnexPaginatedData,
     NotFoundError,
     ValidationErrorChartResponse,
     ValidationErrorDashboardResponse,
+    ValidationErrorDataAppResponse,
     ValidationErrorTableResponse,
     ValidationErrorType,
     ValidationResponse,
@@ -18,6 +20,7 @@ import {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { DatabaseError } from 'pg';
+import { AppsTableName, type DbApp } from '../../database/entities/apps';
 import {
     DashboardsTableName,
     DashboardTable,
@@ -50,6 +53,7 @@ type NormalizedValidationRow = {
     model_name: string | null;
     saved_chart_uuid: string | null;
     dashboard_uuid: string | null;
+    app_uuid: string | null;
     resource_name: string | null;
     views_count: number | null;
     last_updated_at: Date | null;
@@ -121,6 +125,11 @@ export class ValidationModel {
                             chart_name: validation.chartName ?? null,
                             model_name: validation.name,
                         }),
+                        ...(isDataAppValidationError(validation) && {
+                            app_uuid: validation.appUuid,
+                            field_name: validation.fieldName ?? null,
+                            model_name: validation.modelName ?? null,
+                        }),
                     })),
                 );
             } catch (error: unknown) {
@@ -129,6 +138,7 @@ export class ValidationModel {
                     'validations_project_uuid_foreign',
                     'validations_saved_chart_uuid_foreign',
                     'validations_dashboard_uuid_foreign',
+                    'validations_app_uuid_foreign',
                 ];
                 if (
                     error instanceof DatabaseError &&
@@ -137,7 +147,7 @@ export class ValidationModel {
                     handledConstraints.includes(error.constraint)
                 ) {
                     Logger.warn(
-                        `Failed to insert validations: Foreign key constraint violation (${error.constraint}). This may happen if the project, chart, or dashboard was deleted during validation.`,
+                        `Failed to insert validations: Foreign key constraint violation (${error.constraint}). This may happen if the project, chart, dashboard, or data app was deleted during validation.`,
                     );
                     return;
                 }
@@ -569,10 +579,55 @@ export class ValidationModel {
                 source: ValidationSourceType.Table,
             }));
 
+        const appValidationErrorsRows = await this.database(ValidationTableName)
+            .innerJoin(AppsTableName, function nonDeletedAppJoin() {
+                this.on(
+                    `${AppsTableName}.app_id`,
+                    '=',
+                    `${ValidationTableName}.app_uuid`,
+                ).andOnNull(`${AppsTableName}.deleted_at`);
+            })
+            .where(`${ValidationTableName}.project_uuid`, projectUuid)
+            .andWhere((queryBuilder) => {
+                if (jobId) {
+                    void queryBuilder.where('job_id', jobId);
+                } else {
+                    void queryBuilder.whereNull('job_id');
+                }
+            })
+            .andWhere(
+                `${ValidationTableName}.source`,
+                ValidationSourceType.DataApp,
+            )
+            .select<
+                Array<DbValidationTable & Pick<DbApp, 'name' | 'space_uuid'>>
+            >([
+                `${ValidationTableName}.*`,
+                `${AppsTableName}.name`,
+                `${AppsTableName}.space_uuid`,
+            ]);
+
+        const appValidationErrors: ValidationErrorDataAppResponse[] =
+            appValidationErrorsRows.map((validationError) => ({
+                validationUuid: validationError.validation_uuid,
+                validationId: validationError.validation_id,
+                createdAt: validationError.created_at,
+                projectUuid: validationError.project_uuid,
+                error: validationError.error,
+                errorType: validationError.error_type,
+                source: ValidationSourceType.DataApp,
+                appUuid: validationError.app_uuid!,
+                name: validationError.name,
+                fieldName: validationError.field_name ?? undefined,
+                modelName: validationError.model_name ?? undefined,
+                spaceUuid: validationError.space_uuid ?? undefined,
+            }));
+
         return [
             ...tableValidationErrors,
             ...chartValidationErrors,
             ...dashboardValidationErrors,
+            ...appValidationErrors,
         ];
     }
 
@@ -628,6 +683,23 @@ export class ValidationModel {
                 chartName: row.chart_name ?? undefined,
                 tableName: parsedError.tableName,
                 dashboardFilterErrorType: parsedError.dashboardFilterErrorType,
+            };
+        }
+
+        if (row.source === ValidationSourceType.DataApp) {
+            return {
+                validationUuid: row.validation_uuid,
+                validationId: row.validation_id,
+                createdAt: row.created_at,
+                projectUuid: row.project_uuid,
+                error: row.error,
+                errorType: row.error_type,
+                source: ValidationSourceType.DataApp,
+                fieldName: row.field_name ?? undefined,
+                modelName: row.model_name ?? undefined,
+                appUuid: row.app_uuid!,
+                name: row.resource_name || 'Data app does not exist',
+                spaceUuid: row.space_uuid ?? undefined,
             };
         }
 
@@ -720,6 +792,7 @@ export class ValidationModel {
                 `${ValidationTableName}.model_name`,
                 `${ValidationTableName}.saved_chart_uuid`,
                 `${ValidationTableName}.dashboard_uuid`,
+                `${ValidationTableName}.app_uuid`,
                 this.database.raw(
                     `COALESCE(${SavedChartsTableName}.name, ${ValidationTableName}.chart_name, 'Chart does not exist') as resource_name`,
                 ),
@@ -774,6 +847,7 @@ export class ValidationModel {
                 `${ValidationTableName}.model_name`,
                 `${ValidationTableName}.saved_chart_uuid`,
                 `${ValidationTableName}.dashboard_uuid`,
+                `${ValidationTableName}.app_uuid`,
                 this.database.raw(
                     `COALESCE(${DashboardsTableName}.name, ${ValidationTableName}.model_name, 'Dashboard does not exist') as resource_name`,
                 ),
@@ -808,6 +882,7 @@ export class ValidationModel {
                 `${ValidationTableName}.model_name`,
                 `${ValidationTableName}.saved_chart_uuid`,
                 `${ValidationTableName}.dashboard_uuid`,
+                `${ValidationTableName}.app_uuid`,
                 this.database.raw(
                     `${ValidationTableName}.model_name as resource_name`,
                 ),
@@ -859,6 +934,7 @@ export class ValidationModel {
             errorTypes?: ValidationErrorType[];
             includeChartConfigWarnings?: boolean;
             allowedSpaceUuids?: string[] | 'all';
+            allowedAppUuids?: string[] | 'all';
             jobId?: string;
         },
     ): Promise<KnexPaginatedData<ValidationResponse[]>> {
@@ -870,6 +946,7 @@ export class ValidationModel {
             errorTypes,
             includeChartConfigWarnings = false,
             allowedSpaceUuids = 'all',
+            allowedAppUuids = 'all',
             jobId,
         } = options ?? {};
 
@@ -929,6 +1006,7 @@ export class ValidationModel {
                 `${ValidationTableName}.model_name`,
                 `${ValidationTableName}.saved_chart_uuid`,
                 `${ValidationTableName}.dashboard_uuid`,
+                `${ValidationTableName}.app_uuid`,
                 this.database.raw(
                     `COALESCE(${SavedChartsTableName}.name, ${ValidationTableName}.chart_name, 'Chart does not exist') as resource_name`,
                 ),
@@ -1004,6 +1082,7 @@ export class ValidationModel {
                 `${ValidationTableName}.model_name`,
                 `${ValidationTableName}.saved_chart_uuid`,
                 `${ValidationTableName}.dashboard_uuid`,
+                `${ValidationTableName}.app_uuid`,
                 this.database.raw(
                     `COALESCE(${DashboardsTableName}.name, ${ValidationTableName}.model_name, 'Dashboard does not exist') as resource_name`,
                 ),
@@ -1056,6 +1135,7 @@ export class ValidationModel {
                 `${ValidationTableName}.model_name`,
                 `${ValidationTableName}.saved_chart_uuid`,
                 `${ValidationTableName}.dashboard_uuid`,
+                `${ValidationTableName}.app_uuid`,
                 this.database.raw(
                     `${ValidationTableName}.model_name as resource_name`,
                 ),
@@ -1068,6 +1148,43 @@ export class ValidationModel {
             ])
             .distinctOn(`${ValidationTableName}.error`)
             .orderBy(`${ValidationTableName}.error`, 'asc');
+
+        const appSubquery = this.database(ValidationTableName)
+            .innerJoin(AppsTableName, function nonDeletedAppJoin() {
+                this.on(
+                    `${AppsTableName}.app_id`,
+                    '=',
+                    `${ValidationTableName}.app_uuid`,
+                ).andOnNull(`${AppsTableName}.deleted_at`);
+            })
+            .where(`${ValidationTableName}.project_uuid`, projectUuid)
+            .andWhere(
+                `${ValidationTableName}.source`,
+                ValidationSourceType.DataApp,
+            )
+            .andWhere(jobFilter)
+            .select([
+                `${ValidationTableName}.validation_uuid`,
+                `${ValidationTableName}.validation_id`,
+                `${ValidationTableName}.created_at`,
+                `${ValidationTableName}.project_uuid`,
+                `${ValidationTableName}.error`,
+                `${ValidationTableName}.error_type`,
+                `${ValidationTableName}.source`,
+                `${ValidationTableName}.field_name`,
+                `${ValidationTableName}.chart_name`,
+                `${ValidationTableName}.model_name`,
+                `${ValidationTableName}.saved_chart_uuid`,
+                `${ValidationTableName}.dashboard_uuid`,
+                `${ValidationTableName}.app_uuid`,
+                `${AppsTableName}.name as resource_name`,
+                this.database.raw('NULL::integer as views_count'),
+                this.database.raw('NULL::timestamp as last_updated_at'),
+                this.database.raw('NULL::text as first_name'),
+                this.database.raw('NULL::text as last_name'),
+                `${AppsTableName}.space_uuid`,
+                this.database.raw('NULL::text as last_version_chart_kind'),
+            ]);
 
         const sortColumnMap: Record<string, string> = {
             name: 'resource_name',
@@ -1082,10 +1199,11 @@ export class ValidationModel {
                 .with('chart_errors', chartSubquery)
                 .with('dashboard_errors', dashboardSubquery)
                 .with('table_errors', tableSubquery)
+                .with('app_errors', appSubquery)
                 .with(
                     'all_errors',
                     this.database.raw(
-                        'SELECT * FROM chart_errors UNION ALL SELECT * FROM dashboard_errors UNION ALL SELECT * FROM table_errors',
+                        'SELECT * FROM chart_errors UNION ALL SELECT * FROM dashboard_errors UNION ALL SELECT * FROM table_errors UNION ALL SELECT * FROM app_errors',
                     ),
                 )
                 .from('all_errors')
@@ -1119,11 +1237,50 @@ export class ValidationModel {
                                 );
                         });
                     }
-                    if (allowedSpaceUuids !== 'all') {
+                    if (
+                        allowedSpaceUuids !== 'all' ||
+                        allowedAppUuids !== 'all'
+                    ) {
                         void qb.where((inner) => {
-                            void inner
-                                .whereIn('space_uuid', allowedSpaceUuids)
-                                .orWhere('source', ValidationSourceType.Table);
+                            void inner.where(
+                                'source',
+                                ValidationSourceType.Table,
+                            );
+
+                            if (allowedSpaceUuids === 'all') {
+                                void inner.orWhereNot(
+                                    'source',
+                                    ValidationSourceType.DataApp,
+                                );
+                            } else {
+                                void inner.orWhere((nonAppContent) => {
+                                    void nonAppContent
+                                        .whereNot(
+                                            'source',
+                                            ValidationSourceType.DataApp,
+                                        )
+                                        .whereIn(
+                                            'space_uuid',
+                                            allowedSpaceUuids,
+                                        );
+                                });
+                            }
+
+                            if (allowedAppUuids === 'all') {
+                                void inner.orWhere(
+                                    'source',
+                                    ValidationSourceType.DataApp,
+                                );
+                            } else if (allowedAppUuids.length > 0) {
+                                void inner.orWhere((appContent) => {
+                                    void appContent
+                                        .where(
+                                            'source',
+                                            ValidationSourceType.DataApp,
+                                        )
+                                        .whereIn('app_uuid', allowedAppUuids);
+                                });
+                            }
                         });
                     }
                 })

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -58,6 +58,7 @@ import {
     isDashboardScheduler,
     isDashboardSqlChartTile,
     isDashboardValidationError,
+    isDataAppValidationError,
     isSchedulerCsvOptions,
     isSchedulerGsheetsOptions,
     isSchedulerImageOptions,
@@ -2764,6 +2765,8 @@ export default class SchedulerTask {
                     return validation.chartUuid;
                 if (isDashboardValidationError(validation))
                     return validation.dashboardUuid;
+                if (isDataAppValidationError(validation))
+                    return validation.appUuid;
 
                 return validation.name;
             });

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1164,6 +1164,7 @@ export class ServiceRepository
                 new ValidationService({
                     lightdashConfig: this.context.lightdashConfig,
                     analytics: this.context.lightdashAnalytics,
+                    appModel: this.models.getAppModel(),
                     projectModel: this.models.getProjectModel(),
                     savedChartModel: this.models.getSavedChartModel(),
                     validationModel: this.models.getValidationModel(),

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -3,6 +3,7 @@ import {
     AbilityAction,
     AnyType,
     FilterOperator,
+    OrganizationMemberRole,
     TableCalculationTemplateType,
     TableSelectionType,
     ValidationErrorType,
@@ -12,6 +13,7 @@ import {
 } from '@lightdash/common';
 import { validateWarehouseColumnReferences } from '@lightdash/warehouses';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { AppModel } from '../../models/AppModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -80,6 +82,12 @@ const validationModel = {
     create: vi.fn(async () => {}),
     get: vi.fn(async () => []),
 };
+const appModel = {
+    findAppsForValidation: vi.fn(
+        async (): ReturnType<AppModel['findAppsForValidation']> => [],
+    ),
+    listAppsByProject: vi.fn(async (): Promise<AnyType[]> => []),
+};
 const dashboardModel = {
     findDashboardsForValidation: vi.fn(async () => [dashboardForValidation]),
     getByIdOrSlug: vi.fn(async () => ({
@@ -90,21 +98,27 @@ const dashboardModel = {
         projectUuid: 'projectUuid',
     })),
 };
+const spaceModel = {
+    find: vi.fn(async () => []),
+};
 const spacePermissionService = {
     getSpaceAccessContext: vi.fn(async () => ({
         inheritsFromOrgOrProject: false,
         access: [],
     })),
+    getSpacesAccessContext: vi.fn(async () => ({})),
+    getAccessibleSpaceUuids: vi.fn(async () => []),
 };
 describe('validation', () => {
     const validationService = new ValidationService({
         analytics: analyticsMock,
         validationModel: validationModel as unknown as ValidationModel,
         projectModel: projectModel as unknown as ProjectModel,
+        appModel: appModel as unknown as AppModel,
         savedChartModel: savedChartModel as unknown as SavedChartModel,
         dashboardModel: dashboardModel as unknown as DashboardModel,
         lightdashConfig: config,
-        spaceModel: {} as SpaceModel,
+        spaceModel: spaceModel as unknown as SpaceModel,
         schedulerClient: {} as SchedulerClient,
         spacePermissionService:
             spacePermissionService as unknown as SpacePermissionService,
@@ -371,6 +385,202 @@ describe('validation', () => {
         ];
 
         expect(errors.map((error) => error.error)).toEqual(expectedErrors);
+    });
+
+    it('validates definite data app reference errors and ignores unavailable extraction data', async () => {
+        appModel.findAppsForValidation.mockResolvedValueOnce([
+            {
+                app_id: 'broken-app-uuid',
+                name: 'Broken app',
+                data_references: {
+                    references: [
+                        {
+                            kind: 'query',
+                            explore: 'missing_explore',
+                            dimensions: [],
+                            metrics: [],
+                            dimensionFilterFields: [],
+                            metricFilterFields: [],
+                            sortFields: [],
+                            parameterKeys: [],
+                            localFields: [],
+                            unresolved: [],
+                            location: {
+                                path: 'src/App.tsx',
+                                line: 10,
+                                column: 5,
+                            },
+                        },
+                        {
+                            kind: 'query',
+                            explore: 'unavailable_explore',
+                            dimensions: [],
+                            metrics: [],
+                            dimensionFilterFields: [],
+                            metricFilterFields: [],
+                            sortFields: [],
+                            parameterKeys: [],
+                            localFields: [],
+                            unresolved: [],
+                            location: {
+                                path: 'src/App.tsx',
+                                line: 20,
+                                column: 5,
+                            },
+                        },
+                    ],
+                    parseErrors: [],
+                    stats: {
+                        callSites: 2,
+                        fullyResolved: 2,
+                        partiallyResolved: 0,
+                        unresolved: 0,
+                    },
+                },
+            },
+            {
+                app_id: 'legacy-app-uuid',
+                name: 'Legacy app',
+                data_references: null,
+            },
+            {
+                app_id: 'parse-warning-app-uuid',
+                name: 'Parse warning app',
+                data_references: {
+                    references: [],
+                    parseErrors: [
+                        {
+                            path: 'src/App.tsx',
+                            message: 'Could not parse source',
+                        },
+                    ],
+                    stats: {
+                        callSites: 0,
+                        fullyResolved: 0,
+                        partiallyResolved: 0,
+                        unresolved: 0,
+                    },
+                },
+            },
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            [
+                explore,
+                {
+                    ...exploreError,
+                    name: 'unavailable_explore',
+                },
+            ],
+            new Set([ValidationTarget.APPS]),
+        );
+
+        expect(errors).toEqual([
+            expect.objectContaining({
+                appUuid: 'broken-app-uuid',
+                name: 'Broken app',
+                source: ValidationSourceType.DataApp,
+                errorType: ValidationErrorType.Model,
+                error: "Explore 'missing_explore' does not exist",
+                modelName: 'missing_explore',
+            }),
+        ]);
+    });
+
+    it('reveals only owned personal data app validations to non-admins', async () => {
+        appModel.listAppsByProject.mockResolvedValueOnce([
+            {
+                app_id: 'owned-app-uuid',
+                space_uuid: null,
+                created_by_user_uuid: user.userUuid,
+            },
+            {
+                app_id: 'private-app-uuid',
+                space_uuid: null,
+                created_by_user_uuid: 'another-user-uuid',
+            },
+        ]);
+        const nonAdminUser = {
+            ...user,
+            role: OrganizationMemberRole.DEVELOPER,
+            ability: new Ability<[AbilityAction, AnyType]>([
+                {
+                    subject: 'DataApp',
+                    action: ['view'],
+                    conditions: {
+                        projectUuid: 'projectUuid',
+                        createdByUserUuid: user.userUuid,
+                    },
+                },
+            ]),
+        };
+        const validationBase = {
+            validationId: null,
+            createdAt: new Date(),
+            projectUuid: 'projectUuid',
+            error: "Explore 'missing_explore' does not exist",
+            errorType: ValidationErrorType.Model,
+            source: ValidationSourceType.DataApp,
+        } as const;
+
+        const result = await validationService.hidePrivateContent(
+            nonAdminUser,
+            'projectUuid',
+            [
+                {
+                    ...validationBase,
+                    validationUuid: 'owned-validation-uuid',
+                    appUuid: 'owned-app-uuid',
+                    name: 'Owned app',
+                },
+                {
+                    ...validationBase,
+                    validationUuid: 'private-validation-uuid',
+                    appUuid: 'private-app-uuid',
+                    name: 'Private app',
+                },
+            ],
+        );
+
+        expect(result).toEqual([
+            expect.objectContaining({
+                appUuid: 'owned-app-uuid',
+                name: 'Owned app',
+            }),
+            expect.objectContaining({
+                appUuid: undefined,
+                name: 'Private content',
+            }),
+        ]);
+    });
+
+    it('does not validate data apps against an explore-scoped compilation', async () => {
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            [explore],
+            new Set([ValidationTarget.APPS]),
+            true,
+        );
+
+        expect(errors).toEqual([]);
+        expect(appModel.findAppsForValidation).not.toHaveBeenCalled();
+    });
+
+    it('does not validate data apps unless they are explicitly targeted', async () => {
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            [explore],
+        );
+
+        expect(errors).not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    source: ValidationSourceType.DataApp,
+                }),
+            ]),
+        );
+        expect(appModel.findAppsForValidation).not.toHaveBeenCalled();
     });
 
     it('Should validate only charts in project', async () => {

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -1,10 +1,13 @@
 import { subject } from '@casl/ability';
 import {
     assertUnreachable,
+    buildDataAppExploreIndexFromExplores,
+    checkDataAppDataReferences,
     CompiledField,
     convertFieldRefToFieldId,
     CreateChartValidation,
     CreateDashboardValidation,
+    CreateDataAppValidation,
     CreateTableValidation,
     CreateValidation,
     DashboardTileTarget,
@@ -21,6 +24,7 @@ import {
     isChartValidationError,
     isDashboardFieldTarget,
     isDashboardValidationError,
+    isDataAppValidationError,
     isExploreError,
     isSqlTableCalculation,
     isTableValidationError,
@@ -43,6 +47,7 @@ import {
 import * as Sentry from '@sentry/node';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
+import { AppModel } from '../../models/AppModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -58,6 +63,7 @@ type ValidationServiceArguments = {
     analytics: LightdashAnalytics;
     validationModel: ValidationModel;
     projectModel: ProjectModel;
+    appModel: AppModel;
     savedChartModel: SavedChartModel;
     dashboardModel: DashboardModel;
     spaceModel: SpaceModel;
@@ -168,6 +174,8 @@ export class ValidationService extends BaseService {
 
     projectModel: ProjectModel;
 
+    appModel: AppModel;
+
     savedChartModel: SavedChartModel;
 
     dashboardModel: DashboardModel;
@@ -185,6 +193,7 @@ export class ValidationService extends BaseService {
         analytics,
         validationModel,
         projectModel,
+        appModel,
         savedChartModel,
         dashboardModel,
         spaceModel,
@@ -196,6 +205,7 @@ export class ValidationService extends BaseService {
         this.lightdashConfig = lightdashConfig;
         this.analytics = analytics;
         this.projectModel = projectModel;
+        this.appModel = appModel;
         this.savedChartModel = savedChartModel;
         this.validationModel = validationModel;
         this.dashboardModel = dashboardModel;
@@ -939,6 +949,47 @@ export class ValidationService extends BaseService {
         return results;
     }
 
+    private async validateDataApps(
+        projectUuid: string,
+        explores: (Explore | ExploreError)[],
+    ): Promise<CreateDataAppValidation[]> {
+        const apps = await this.appModel.findAppsForValidation(projectUuid);
+        const exploreIndex = buildDataAppExploreIndexFromExplores(
+            explores.filter(
+                (explore): explore is Explore => !isExploreError(explore),
+            ),
+        );
+        const unavailableExploreNames = new Set(
+            explores.flatMap((explore) =>
+                isExploreError(explore) && explore.name ? [explore.name] : [],
+            ),
+        );
+
+        return apps.flatMap((app) => {
+            if (app.data_references === null) return [];
+
+            return checkDataAppDataReferences(
+                app.data_references.references,
+                exploreIndex,
+            )
+                .filter(
+                    (error) =>
+                        !error.modelName ||
+                        !unavailableExploreNames.has(error.modelName),
+                )
+                .map((error) => ({
+                    appUuid: app.app_id,
+                    name: app.name,
+                    projectUuid,
+                    source: ValidationSourceType.DataApp,
+                    error: error.error,
+                    errorType: error.errorType,
+                    fieldName: error.fieldName ?? undefined,
+                    modelName: error.modelName ?? undefined,
+                }));
+        });
+    }
+
     async generateValidation(
         projectUuid: string,
         compiledExplores?: (Explore | ExploreError)[],
@@ -1073,7 +1124,19 @@ export class ValidationService extends BaseService {
                   )
                 : [];
 
-        return [...tableErrors, ...chartErrors, ...dashboardErrors];
+        const dataAppErrors =
+            !onlyValidateExploresInArgs &&
+            hasValidationTargets &&
+            validationTargets.has(ValidationTarget.APPS)
+                ? await this.validateDataApps(projectUuid, explores)
+                : [];
+
+        return [
+            ...tableErrors,
+            ...chartErrors,
+            ...dashboardErrors,
+            ...dataAppErrors,
+        ];
     }
 
     async validate(
@@ -1157,19 +1220,42 @@ export class ValidationService extends BaseService {
                 spaceUuids,
             );
 
+        const allowedAppUuids = await this.resolveAllowedAppUuids(
+            user,
+            projectUuid,
+            user.organizationUuid!,
+            allowedSpaceUuids,
+        );
+        const allowedAppUuidSet = new Set(
+            allowedAppUuids === 'all' ? [] : allowedAppUuids,
+        );
+
         // Filter private content to developers
-        return Promise.all(
-            validations.map(async (validation) => {
-                // Table validations are project-level, not space-specific
-                // Anyone with project access can see them
-                if (
-                    !isDashboardValidationError(validation) &&
-                    !isChartValidationError(validation) &&
-                    isTableValidationError(validation)
-                ) {
+        return validations.map((validation) => {
+            if (isDataAppValidationError(validation)) {
+                if (!validation.appUuid) {
+                    return {
+                        ...validation,
+                        appUuid: undefined,
+                        name: 'Deleted content',
+                    };
+                }
+
+                if (allowedAppUuidSet.has(validation.appUuid)) {
                     return validation;
                 }
 
+                return {
+                    ...validation,
+                    appUuid: undefined,
+                    name: 'Private content',
+                };
+            }
+
+            if (
+                isChartValidationError(validation) ||
+                isDashboardValidationError(validation)
+            ) {
                 const isDeleted =
                     (isDashboardValidationError(validation) &&
                         !validation.dashboardUuid) ||
@@ -1198,8 +1284,79 @@ export class ValidationService extends BaseService {
                     dashboardUuid: undefined,
                     name: 'Private content',
                 };
-            }),
+            }
+
+            // Table validations are project-level, not space-specific.
+            return validation;
+        });
+    }
+
+    private async resolveAllowedAppUuids(
+        user: SessionUser,
+        projectUuid: string,
+        organizationUuid: string,
+        allowedSpaceUuids: string[] | 'all',
+    ): Promise<string[] | 'all'> {
+        if (user.role === OrganizationMemberRole.ADMIN) return 'all';
+
+        const apps = await this.appModel.listAppsByProject(projectUuid);
+        const allowedSpaceUuidSet = new Set(
+            allowedSpaceUuids === 'all' ? [] : allowedSpaceUuids,
         );
+        const auditedAbility = this.createAuditedAbility(user);
+        const appSpaceUuids = [
+            ...new Set(
+                apps.flatMap((app) =>
+                    app.space_uuid !== null &&
+                    (allowedSpaceUuids === 'all' ||
+                        allowedSpaceUuidSet.has(app.space_uuid))
+                        ? [app.space_uuid]
+                        : [],
+                ),
+            ),
+        ];
+        const spaceAccessContexts =
+            appSpaceUuids.length > 0
+                ? await this.spacePermissionService.getSpacesAccessContext(
+                      user.userUuid,
+                      appSpaceUuids,
+                  )
+                : {};
+
+        return apps
+            .filter((app) => {
+                if (app.space_uuid !== null) {
+                    if (
+                        allowedSpaceUuids !== 'all' &&
+                        !allowedSpaceUuidSet.has(app.space_uuid)
+                    ) {
+                        return false;
+                    }
+
+                    const spaceAccessContext =
+                        spaceAccessContexts[app.space_uuid];
+                    return (
+                        spaceAccessContext !== undefined &&
+                        auditedAbility.can(
+                            'view',
+                            subject('DataApp', {
+                                ...spaceAccessContext,
+                                createdByUserUuid: app.created_by_user_uuid,
+                            }),
+                        )
+                    );
+                }
+
+                return auditedAbility.can(
+                    'view',
+                    subject('DataApp', {
+                        organizationUuid,
+                        projectUuid,
+                        createdByUserUuid: app.created_by_user_uuid,
+                    }),
+                );
+            })
+            .map((app) => app.app_id);
     }
 
     async get(
@@ -1231,7 +1388,8 @@ export class ValidationService extends BaseService {
 
         // Filter out orphaned validations (content was deleted)
         const validations = allValidations.filter((validation) => {
-            // Keep table validations (they don't reference charts/dashboards)
+            // Table validations are project-level. Data app rows have already
+            // been joined against a non-deleted app by the model.
             if (
                 !isDashboardValidationError(validation) &&
                 !isChartValidationError(validation)
@@ -1256,6 +1414,7 @@ export class ValidationService extends BaseService {
                     ('chartUuid' in validation && validation.chartUuid) ||
                     ('dashboardUuid' in validation &&
                         validation.dashboardUuid) ||
+                    ('appUuid' in validation && validation.appUuid) ||
                     validation.name,
             );
 
@@ -1379,6 +1538,13 @@ export class ValidationService extends BaseService {
                 );
         }
 
+        const allowedAppUuids = await this.resolveAllowedAppUuids(
+            user,
+            projectUuid,
+            projectSummary.organizationUuid,
+            allowedSpaceUuids,
+        );
+
         const result = await this.validationModel.getPaginated(
             projectUuid,
             paginateArgs,
@@ -1390,6 +1556,7 @@ export class ValidationService extends BaseService {
                 errorTypes: options?.errorTypes,
                 includeChartConfigWarnings: options?.includeChartConfigWarnings,
                 allowedSpaceUuids,
+                allowedAppUuids,
                 jobId: options?.jobId,
             },
         );
@@ -1400,6 +1567,7 @@ export class ValidationService extends BaseService {
                     ('chartUuid' in validation && validation.chartUuid) ||
                     ('dashboardUuid' in validation &&
                         validation.dashboardUuid) ||
+                    ('appUuid' in validation && validation.appUuid) ||
                     validation.name,
             );
 

--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -392,6 +392,7 @@ type CliValidateCompleted = BaseTrack & {
         tableErrors: number;
         chartErrors: number;
         dashboardErrors: number;
+        appErrors: number;
     };
 };
 type CliValidateError = BaseTrack & {

--- a/packages/cli/src/handlers/validate.test.ts
+++ b/packages/cli/src/handlers/validate.test.ts
@@ -173,4 +173,45 @@ describe('validateHandler warehouse column validation', () => {
         );
         expect(skipWarnings()).toEqual([]);
     });
+
+    test('skips data app validation when dbt selection produces a partial semantic layer', async () => {
+        await validateHandler({
+            ...baseOptions,
+            only: [ValidationTarget.CHARTS, ValidationTarget.APPS],
+            select: ['orders'],
+        });
+
+        const validationRequest = vi
+            .mocked(lightdashApi)
+            .mock.calls.find(
+                ([request]) =>
+                    request.method === 'POST' &&
+                    request.url.endsWith('/validate'),
+            );
+        expect(validationRequest).toBeDefined();
+        expect(JSON.parse(String(validationRequest![0].body))).toEqual(
+            expect.objectContaining({
+                validationTargets: [ValidationTarget.CHARTS],
+            }),
+        );
+        expect(
+            errorOutput.some((line) =>
+                line.includes('Skipping data app validation'),
+            ),
+        ).toBe(true);
+    });
+
+    test('rejects apps-only validation against a partial semantic layer', async () => {
+        await expect(
+            validateHandler({
+                ...baseOptions,
+                only: [ValidationTarget.APPS],
+                select: ['orders'],
+            }),
+        ).rejects.toThrow(
+            'Data app validation requires a full project compile',
+        );
+
+        expect(compile).not.toHaveBeenCalled();
+    });
 });

--- a/packages/cli/src/handlers/validate.test.ts
+++ b/packages/cli/src/handlers/validate.test.ts
@@ -1,4 +1,9 @@
-import { SchedulerJobStatus, ValidationTarget } from '@lightdash/common';
+import {
+    SchedulerJobStatus,
+    ValidationErrorType,
+    ValidationSourceType,
+    ValidationTarget,
+} from '@lightdash/common';
 import { compile } from './compile';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
 import { validateHandler } from './validate';
@@ -213,5 +218,47 @@ describe('validateHandler warehouse column validation', () => {
         );
 
         expect(compile).not.toHaveBeenCalled();
+    });
+
+    test('prints the latest data app version author and date', async () => {
+        vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+        vi.mocked(lightdashApi).mockImplementation(async ({ method, url }) => {
+            if (method === 'POST' && url.endsWith('/validate')) {
+                return { jobId: 'test-job-id' };
+            }
+            if (url.includes('/schedulers/job/')) {
+                return {
+                    status: SchedulerJobStatus.COMPLETED,
+                    details: null,
+                };
+            }
+            if (url.includes('/validate?jobId=')) {
+                return [
+                    {
+                        validationUuid: 'validation-uuid',
+                        validationId: null,
+                        createdAt: new Date('2026-08-07T09:00:00Z'),
+                        projectUuid: 'test-project-uuid',
+                        name: 'Broken data app',
+                        error: 'Dimension does not exist',
+                        errorType: ValidationErrorType.Dimension,
+                        source: ValidationSourceType.DataApp,
+                        appUuid: 'app-uuid',
+                        lastUpdatedBy: 'Ada Lovelace',
+                        lastUpdatedAt: new Date('2026-08-06T15:30:00Z'),
+                    },
+                ];
+            }
+            throw new Error(`Unexpected API call: ${method} ${url}`);
+        });
+
+        await validateHandler({
+            ...baseOptions,
+            only: [ValidationTarget.APPS],
+        });
+
+        const output = errorOutput.join('\n');
+        expect(output).toContain('Ada Lovelace');
+        expect(output).toContain('2026-08-06');
     });
 });

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -9,6 +9,7 @@ import {
     getErrorMessage,
     isChartValidationError,
     isDashboardValidationError,
+    isDataAppValidationError,
     isTableValidationError,
     ParameterError,
     SchedulerJobStatus,
@@ -175,7 +176,42 @@ export const validateHandler = async (
             projectUuid,
         );
 
-    const validationTargets = options.only ? options.only : [];
+    let validationTargets = options.only ? [...options.only] : [];
+    const hasPartialModelSelection =
+        Boolean(options.select?.length) ||
+        Boolean(options.models?.length) ||
+        Boolean(options.exclude?.length) ||
+        Boolean(options.selector);
+    const includesDataAppValidation =
+        validationTargets.length === 0 ||
+        validationTargets.includes(ValidationTarget.APPS);
+
+    if (hasPartialModelSelection && includesDataAppValidation) {
+        if (
+            validationTargets.length === 1 &&
+            validationTargets[0] === ValidationTarget.APPS
+        ) {
+            throw new ParameterError(
+                'Data app validation requires a full project compile. Remove the dbt model selection flags to use --only apps.',
+            );
+        }
+
+        validationTargets =
+            validationTargets.length === 0
+                ? [
+                      ValidationTarget.TABLES,
+                      ValidationTarget.CHARTS,
+                      ValidationTarget.DASHBOARDS,
+                  ]
+                : validationTargets.filter(
+                      (target) => target !== ValidationTarget.APPS,
+                  );
+        console.error(
+            styles.warning(
+                '> Skipping data app validation because dbt model selection flags produce a partial semantic layer',
+            ),
+        );
+    }
 
     await LightdashAnalytics.track({
         event: 'validate.started',
@@ -275,6 +311,7 @@ export const validateHandler = async (
         const tableErrors = validation.filter(isTableValidationError);
         const chartErrors = validation.filter(isChartValidationError);
         const dashboardErrors = validation.filter(isDashboardValidationError);
+        const appErrors = validation.filter(isDataAppValidationError);
 
         await LightdashAnalytics.track({
             event: 'validate.completed',
@@ -292,6 +329,7 @@ export const validateHandler = async (
                 tableErrors: tableErrors.length,
                 chartErrors: chartErrors.length,
                 dashboardErrors: dashboardErrors.length,
+                appErrors: appErrors.length,
             },
         });
 
@@ -351,6 +389,15 @@ export const validateHandler = async (
             ) {
                 console.error(
                     `- Dashboards: ${styleTotalErrors(dashboardErrors.length)}`,
+                );
+            }
+
+            if (
+                !hasValidationTargets ||
+                validationTargetsSet.has(ValidationTarget.APPS)
+            ) {
+                console.error(
+                    `- Data apps: ${styleTotalErrors(appErrors.length)}`,
                 );
             }
 

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -424,11 +424,15 @@ export const validateHandler = async (
                         : v.error,
                 ),
                 'last updated by':
-                    isChartValidationError(v) || isDashboardValidationError(v)
+                    isChartValidationError(v) ||
+                    isDashboardValidationError(v) ||
+                    isDataAppValidationError(v)
                         ? styles.secondary(v.lastUpdatedBy)
                         : '',
                 'last updated at':
-                    isChartValidationError(v) || isDashboardValidationError(v)
+                    isChartValidationError(v) ||
+                    isDashboardValidationError(v) ||
+                    isDataAppValidationError(v)
                         ? styles.secondary(formatDate(v.lastUpdatedAt))
                         : '',
             }));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1403,11 +1403,11 @@ program
     )
     .option(
         '--include-spaces <spaceSlugs...>',
-        'Only report validation errors for charts and dashboards in these spaces (and their sub-spaces). Spaces must be visible to your credentials',
+        'Only report validation errors for charts, dashboards, and data apps in these spaces (and their sub-spaces). Spaces must be visible to your credentials',
     )
     .option(
         '--exclude-spaces <spaceSlugs...>',
-        'Skip validation errors for charts and dashboards in these spaces (and their sub-spaces). Spaces must be visible to your credentials',
+        'Skip validation errors for charts, dashboards, and data apps in these spaces (and their sub-spaces). Spaces must be visible to your credentials',
     )
     .option(
         '--no-partial-compilation',

--- a/packages/common/src/types/validation.ts
+++ b/packages/common/src/types/validation.ts
@@ -51,6 +51,8 @@ export type ValidationErrorDataAppResponse = ValidationResponseBase & {
     appUuid: string | undefined; // NOTE: can be undefined if private content
     fieldName?: string;
     modelName?: string;
+    lastUpdatedBy?: string;
+    lastUpdatedAt?: Date;
 };
 
 export type ValidationResponse =

--- a/packages/common/src/types/validation.ts
+++ b/packages/common/src/types/validation.ts
@@ -46,10 +46,18 @@ export type ValidationErrorTableResponse = Omit<
     name: string | undefined;
 };
 
+export type ValidationErrorDataAppResponse = ValidationResponseBase & {
+    source: ValidationSourceType.DataApp;
+    appUuid: string | undefined; // NOTE: can be undefined if private content
+    fieldName?: string;
+    modelName?: string;
+};
+
 export type ValidationResponse =
     | ValidationErrorChartResponse
     | ValidationErrorDashboardResponse
-    | ValidationErrorTableResponse;
+    | ValidationErrorTableResponse
+    | ValidationErrorDataAppResponse;
 
 export type CreateTableValidation = Pick<
     ValidationErrorTableResponse,
@@ -82,10 +90,26 @@ export type CreateDashboardValidation = Pick<
     | 'source'
 >;
 
+export type CreateDataAppValidation = Omit<
+    Pick<
+        ValidationErrorDataAppResponse,
+        | 'appUuid'
+        | 'error'
+        | 'errorType'
+        | 'fieldName'
+        | 'modelName'
+        | 'name'
+        | 'projectUuid'
+        | 'source'
+    >,
+    'appUuid'
+> & { appUuid: string };
+
 export type CreateValidation =
     | CreateTableValidation
     | CreateChartValidation
-    | CreateDashboardValidation;
+    | CreateDashboardValidation
+    | CreateDataAppValidation;
 
 /** @deprecated Use ApiPaginatedValidateResponse with GET /validate/list instead */
 export type ApiValidateResponse = {
@@ -137,6 +161,7 @@ export enum DashboardFilterValidationErrorType {
 export enum ValidationSourceType {
     Chart = 'chart',
     Dashboard = 'dashboard',
+    DataApp = 'data_app',
     Table = 'table',
 }
 
@@ -154,6 +179,11 @@ export const isDashboardValidationError = (
     error: ValidationResponse | CreateValidation,
 ): error is ValidationErrorDashboardResponse | CreateDashboardValidation =>
     error.source === ValidationSourceType.Dashboard;
+
+export const isDataAppValidationError = (
+    error: ValidationResponse | CreateValidation,
+): error is ValidationErrorDataAppResponse | CreateDataAppValidation =>
+    error.source === ValidationSourceType.DataApp;
 
 /**
  * Checks if a dashboard validation error is fixable via rename.
@@ -174,6 +204,7 @@ export const isFixableDashboardValidationError = (
             DashboardFilterValidationErrorType.FieldTableMismatch);
 
 export enum ValidationTarget {
+    APPS = 'apps',
     CHARTS = 'charts',
     DASHBOARDS = 'dashboards',
     TABLES = 'tables',


### PR DESCRIPTION
## What changed

- add data apps as an explicit project-validation target
- validate persisted references from each app's latest ready version
- persist and return app-owned validation errors with permission-aware masking
- add `lightdash validate --only apps` reporting and analytics
- skip data app validation for partial dbt selections and explore-scoped compilations

## Why

Data apps can keep references to explores and fields that later disappear, but project validation currently treats only tables, charts, and dashboards as resources. This adds a deliberately opt-in CLI MVP without changing existing Settings validation runs.

Only definite semantic reference errors are surfaced. Legacy versions without extraction data, parser/coverage warnings, and references to explores that failed compilation are skipped to avoid false positives.

A stacked follow-up PR will enable the default Settings validation path and add the validator UI treatment.

## Validation

- common, backend, CLI, and frontend typechecks
- backend ValidationService and ValidationModel tests
- CLI validate handler tests
- targeted oxfmt and oxlint
- TSOA API generation
- `git diff --check`

[PROD-9449](https://linear.app/lightdash/issue/PROD-9449/data-apps-first-class-resource-in-project-validation-validationservice)