### PR TITLE
feat: show data app errors in project validation

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -567,20 +567,12 @@ describe('validation', () => {
         expect(appModel.findAppsForValidation).not.toHaveBeenCalled();
     });
 
-    it('does not validate data apps unless they are explicitly targeted', async () => {
-        const errors = await validationService.generateValidation(
-            'projectUuid',
-            [explore],
-        );
+    it('includes data apps in default project validation runs', async () => {
+        await validationService.generateValidation('projectUuid', [explore]);
 
-        expect(errors).not.toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    source: ValidationSourceType.DataApp,
-                }),
-            ]),
+        expect(appModel.findAppsForValidation).toHaveBeenCalledWith(
+            'projectUuid',
         );
-        expect(appModel.findAppsForValidation).not.toHaveBeenCalled();
     });
 
     it('Should validate only charts in project', async () => {

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -1126,8 +1126,8 @@ export class ValidationService extends BaseService {
 
         const dataAppErrors =
             !onlyValidateExploresInArgs &&
-            hasValidationTargets &&
-            validationTargets.has(ValidationTarget.APPS)
+            (!hasValidationTargets ||
+                validationTargets.has(ValidationTarget.APPS))
                 ? await this.validateDataApps(projectUuid, explores)
                 : [];
 

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.tsx
@@ -3,6 +3,7 @@ import {
     DashboardFilterValidationErrorType,
     friendlyName,
     isChartValidationError,
+    isDataAppValidationError,
     isDashboardValidationError,
     isTableValidationError,
     ValidationErrorType,
@@ -97,6 +98,10 @@ const ErrorMessageByType: FC<{
         }
 
         // Fallback for unexpected cases
+        return <Text fz={11}>{validationError.error}</Text>;
+    }
+
+    if (isDataAppValidationError(validationError)) {
         return <Text fz={11}>{validationError.error}</Text>;
     }
 

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/ValidatorTableTopToolbar.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/ValidatorTableTopToolbar.tsx
@@ -22,6 +22,7 @@ import classes from './ValidatorTableTopToolbar.module.css';
 const SOURCE_TYPE_OPTIONS = [
     { value: ValidationSourceType.Chart, label: 'Chart' },
     { value: ValidationSourceType.Dashboard, label: 'Dashboard' },
+    { value: ValidationSourceType.DataApp, label: 'Data app' },
     { value: ValidationSourceType.Table, label: 'Table' },
 ] as const;
 

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -1,5 +1,6 @@
 import {
     isChartValidationError,
+    isDataAppValidationError,
     isDashboardValidationError,
     isFixableDashboardValidationError,
     isTableValidationError,
@@ -17,7 +18,12 @@ import {
     Text,
     Tooltip,
 } from '@mantine/core';
-import { IconLayoutDashboard, IconTable, IconX } from '@tabler/icons-react';
+import {
+    IconAppWindow,
+    IconLayoutDashboard,
+    IconTable,
+    IconX,
+} from '@tabler/icons-react';
 import { useMemo, useRef, type FC } from 'react';
 import { useInfiniteScroll } from '../../../hooks/useInfiniteScroll';
 import { useDeleteValidation } from '../../../hooks/validation/useValidation';
@@ -37,20 +43,24 @@ import { ValidatorTableTopToolbar } from './ValidatorTableTopToolbar';
 const isDeleted = (validationError: ValidationResponse) =>
     (isChartValidationError(validationError) && !validationError.chartUuid) ||
     (isDashboardValidationError(validationError) &&
-        !validationError.dashboardUuid);
+        !validationError.dashboardUuid) ||
+    (isDataAppValidationError(validationError) && !validationError.appUuid);
 
 const Icon = ({ validationError }: { validationError: ValidationResponse }) => {
     if (isChartValidationError(validationError))
         return <ChartIcon chartKind={validationError.chartKind} />;
     if (isDashboardValidationError(validationError))
         return <IconBox icon={IconLayoutDashboard} color="green.8" />;
+    if (isDataAppValidationError(validationError))
+        return <IconBox icon={IconAppWindow} color="orange.6" />;
     return <IconBox icon={IconTable} color="indigo.6" />;
 };
 
 const getErrorName = (validationError: ValidationResponse) => {
     if (
         isChartValidationError(validationError) ||
-        isDashboardValidationError(validationError)
+        isDashboardValidationError(validationError) ||
+        isDataAppValidationError(validationError)
     )
         return validationError.name;
     if (isTableValidationError(validationError))
@@ -182,7 +192,9 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
                                                 {getViews(validationError) === 1
                                                     ? ''
                                                     : 's'}
-                                                {validationError.lastUpdatedBy ? (
+                                                {'lastUpdatedBy' in
+                                                    validationError &&
+                                                validationError.lastUpdatedBy ? (
                                                     <>
                                                         {' • '}
                                                         Last edited by{' '}

--- a/packages/frontend/src/components/SettingsValidator/utils/utils.ts
+++ b/packages/frontend/src/components/SettingsValidator/utils/utils.ts
@@ -1,5 +1,6 @@
 import {
     isChartValidationError,
+    isDataAppValidationError,
     isDashboardValidationError,
     type ValidationResponse,
 } from '@lightdash/common';
@@ -16,6 +17,9 @@ export const getLinkToResource = (
         validationError.dashboardUuid
     )
         return `/projects/${projectUuid}/dashboards/${validationError.dashboardUuid}/view`;
+
+    if (isDataAppValidationError(validationError) && validationError.appUuid)
+        return `/projects/${projectUuid}/apps/${validationError.appUuid}`;
 
     return;
 };


### PR DESCRIPTION
## What changed

- include data apps in default project validation runs
- render data app validation rows with an app icon and name
- show the checker's exact semantic error
- add the Data app source filter
- link validation rows to the owning app

## Why

This activates the Settings experience on top of the opt-in API/CLI support in #26971. Keeping activation separate makes the foundation independently testable while this PR stays focused on the user-visible MVP.

The UI intentionally omits source locations, extraction coverage warnings, Fix with AI, views/last-updated metadata, search/resource badges, and pinned single-validation links.

## Screenshots
<img width="2156" height="357" alt="ui-error" src="https://github.com/user-attachments/assets/5bf40dcf-59c6-442c-9d65-53ea63990159" />

<img width="1169" height="163" alt="cli-error" src="https://github.com/user-attachments/assets/6bd85846-5be4-486b-b668-49715aae976e" />



[PROD-9449](https://linear.app/lightdash/issue/PROD-9449/data-apps-first-class-resource-in-project-validation-validationservice)