### PR TITLE
fix(dbt): pass an explicit environment to the dbt subprocess

### DIFF
--- a/packages/backend/src/dbt/CLAUDE.md
+++ b/packages/backend/src/dbt/CLAUDE.md
@@ -14,7 +14,7 @@ import { generateProfiles } from './profiles';
 const dbtClient = new DbtCliClient({
     dbtProjectDirectory: '/path/to/dbt/project',
     dbtProfilesDirectory: '/tmp/profiles',
-    environment: process.env,
+    environment: { LIGHTDASH_DBT_PROFILE_VAR_PASSWORD: 'password' },
     dbtVersion: 'v1.8',
     useDbtLs: true,
 });
@@ -68,6 +68,8 @@ await fs.writeFile('/tmp/profiles/profiles.yml', profiles.profiles);
 
 <importantToKnow>
 - DbtCliClient supports multiple dbt versions (1.4 through 1.10) with version-specific commands
+- The dbt subprocess does NOT inherit the backend environment (`extendEnv: false`). It gets only what `dbtProcessEnvironment.ts` lists by exact name, plus the project and profile variables. Anything a dbt project can read with `env_var()` ends up in compiled explore metadata, which any project viewer can read
+- The only dbt commands we run are `deps`, `ls` and `parse`, and none of them connects to the warehouse (verified against a dead endpoint on dbt-postgres). The warehouse connection in a compile comes from the Node `warehouseClient` in `dbtBaseProjectAdapter`, not from the dbt subprocess, so the cloud credentials on that list are probably unnecessary. They are still shared while that is confirmed on the adapters that authenticate from the host; narrowing them is follow up work
 - Profiles are auto-generated from warehouse credentials and use environment variables for security
 - The client automatically modifies dbt_project.yml to set target-path to '/target'
 - DbtMetadataApiClient uses GraphQL to fetch metadata from dbt Cloud with pagination

--- a/packages/backend/src/dbt/dbtCliClient.test.ts
+++ b/packages/backend/src/dbt/dbtCliClient.test.ts
@@ -104,3 +104,56 @@ Object.values(SupportedDbtVersions).map((dbtVersion) => {
         });
     });
 });
+
+// Pinned to one dbt version: the environment is version independent, and the
+// matrix above would repeat these nine times for nothing.
+describe('DbtCliClient environment', () => {
+    const cliArgs = {
+        ...cliArgsWithoutVersion,
+        dbtVersion: SupportedDbtVersions.V1_10,
+    };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.mocked(fs.mkdtemp).mockResolvedValue(
+            '/tmp/dbt_target_test' as never,
+        );
+        execaMock.mockImplementation(cliMockImplementation.success);
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('does not extend the backend environment', async () => {
+        await new DbtCliClient(cliArgs).installDeps();
+        const [, , options] = execaMock.mock.calls[0];
+
+        expect(options).toMatchObject({ extendEnv: false });
+    });
+
+    it('does not hand backend secrets to dbt', async () => {
+        vi.stubEnv('LIGHTDASH_SECRET', 'not-for-dbt');
+        vi.stubEnv('PATH', '/usr/local/bin');
+
+        await new DbtCliClient(cliArgs).installDeps();
+        const [, , options] = execaMock.mock.calls[0];
+        const { env } = options as { env: Record<string, string> };
+
+        expect(env).not.toHaveProperty('LIGHTDASH_SECRET');
+        expect(Object.values(env)).not.toContain('not-for-dbt');
+        expect(env.PATH).toEqual('/usr/local/bin');
+    });
+
+    it('cannot be pointed at another target directory by a project', async () => {
+        await new DbtCliClient({
+            ...cliArgs,
+            environment: { DBT_TARGET_PATH: '/tmp/attacker' },
+        }).installDeps();
+        const [, , options] = execaMock.mock.calls[0];
+
+        expect((options as { env: Record<string, string> }).env).toMatchObject({
+            DBT_TARGET_PATH: '/tmp/dbt_target_test',
+        });
+    });
+});

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -190,9 +190,6 @@ export class DbtCliClient implements DbtClient {
             const dbtProcess = await execa(dbtExec, dbtArgs, {
                 all: true,
                 stdio: ['pipe', 'pipe', process.stderr],
-                // Anything a dbt project can read with env_var() ends up in
-                // compiled explore metadata, which any project viewer can read,
-                // so the child gets only what we put in it.
                 extendEnv: false,
                 env: getDbtProcessEnvironment({
                     processEnvironment: process.env,

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -22,6 +22,10 @@ import path from 'path';
 import Logger from '../logging/logger';
 import { traceSpan } from '../tracing/tracing';
 import { DbtClient } from '../types';
+import {
+    getDbtProcessEnvironment,
+    getMissingEnvironmentVariableHint,
+} from './dbtProcessEnvironment';
 
 type DbtCliArgs = {
     dbtProjectDirectory: string;
@@ -186,12 +190,15 @@ export class DbtCliClient implements DbtClient {
             const dbtProcess = await execa(dbtExec, dbtArgs, {
                 all: true,
                 stdio: ['pipe', 'pipe', process.stderr],
-                env: {
-                    ...this.environment,
-                    DBT_PARTIAL_PARSE: 'false', // Disable dbt from storing manifest and doing partial parses. https://docs.getdbt.com/reference/parsing#partial-parsing
-                    DBT_SEND_ANONYMOUS_USAGE_STATS: 'false', // Disable sending usage stats. https://docs.getdbt.com/reference/global-configs/usage-stats
-                    DBT_TARGET_PATH: targetPath,
-                },
+                // Anything a dbt project can read with env_var() ends up in
+                // compiled explore metadata, which any project viewer can read,
+                // so the child gets only what we put in it.
+                extendEnv: false,
+                env: getDbtProcessEnvironment({
+                    processEnvironment: process.env,
+                    projectEnvironment: this.environment,
+                    targetPath,
+                }),
             });
             return {
                 logs: DbtCliClient.parseDbtJsonLogs(dbtProcess.all),
@@ -210,10 +217,15 @@ export class DbtCliClient implements DbtClient {
                 'all' in execaError &&
                 typeof execaError.all === 'string'
             ) {
+                const missingVariablesHint = getMissingEnvironmentVariableHint(
+                    execaError.all,
+                );
                 throw new DbtError(
                     `Failed to run "${dbtExec} ${command.join(
                         ' ',
-                    )}" with dbt version "${this.dbtVersion}"`,
+                    )}" with dbt version "${this.dbtVersion}"${
+                        missingVariablesHint ? `. ${missingVariablesHint}` : ''
+                    }`,
                     DbtCliClient.parseDbtJsonLogs(execaError.all),
                 );
             }

--- a/packages/backend/src/dbt/dbtProcessEnvironment.test.ts
+++ b/packages/backend/src/dbt/dbtProcessEnvironment.test.ts
@@ -1,0 +1,115 @@
+import {
+    getDbtProcessEnvironment,
+    getMissingEnvironmentVariableHint,
+} from './dbtProcessEnvironment';
+
+const processEnvironment: NodeJS.ProcessEnv = {
+    PATH: '/usr/local/bin:/usr/bin',
+    HOME: '/root',
+    TZ: 'Europe/London',
+    HTTPS_PROXY: 'http://proxy.internal:3128',
+    REQUESTS_CA_BUNDLE: '/etc/ssl/corporate.pem',
+    AWS_ACCESS_KEY_ID: 'aws-key-id',
+    GOOGLE_APPLICATION_CREDENTIALS: '/adc.json',
+    LIGHTDASH_SECRET: 'not-for-dbt',
+    LIGHTDASH_LICENSE_KEY: 'licence-jwt',
+    PGPASSWORD: 'metadata-db-password',
+    DATABASE_CONNECTION_URI: 'postgres://user:pw@host/db',
+    ANTHROPIC_API_KEY: 'anthropic-key',
+    MY_AWS_SECRET_KEY: 'lookalike-secret',
+    UNKNOWN_VARIABLE: 'unknown',
+    EMPTY_VARIABLE: undefined,
+};
+
+const buildEnvironment = (projectEnvironment: Record<string, string> = {}) =>
+    getDbtProcessEnvironment({
+        processEnvironment,
+        projectEnvironment,
+        targetPath: '/tmp/dbt_target_test',
+    });
+
+describe('getDbtProcessEnvironment', () => {
+    it('forwards what dbt needs to run and reach the network', () => {
+        const environment = buildEnvironment();
+
+        expect(environment.PATH).toEqual('/usr/local/bin:/usr/bin');
+        expect(environment.HOME).toEqual('/root');
+        expect(environment.TZ).toEqual('Europe/London');
+        expect(environment.HTTPS_PROXY).toEqual('http://proxy.internal:3128');
+        expect(environment.REQUESTS_CA_BUNDLE).toEqual(
+            '/etc/ssl/corporate.pem',
+        );
+    });
+
+    it('forwards the credentials warehouses resolve from the host', () => {
+        const environment = buildEnvironment();
+
+        expect(environment.AWS_ACCESS_KEY_ID).toEqual('aws-key-id');
+        expect(environment.GOOGLE_APPLICATION_CREDENTIALS).toEqual('/adc.json');
+    });
+
+    it('does not forward the backend own secrets', () => {
+        const environment = buildEnvironment();
+
+        expect(environment).not.toHaveProperty('LIGHTDASH_SECRET');
+        expect(environment).not.toHaveProperty('LIGHTDASH_LICENSE_KEY');
+        expect(environment).not.toHaveProperty('PGPASSWORD');
+        expect(environment).not.toHaveProperty('DATABASE_CONNECTION_URI');
+        expect(environment).not.toHaveProperty('ANTHROPIC_API_KEY');
+        // A value smuggled under a different key would pass the checks above
+        expect(Object.values(environment)).not.toContain('not-for-dbt');
+        expect(Object.values(environment)).not.toContain('licence-jwt');
+        expect(Object.values(environment)).not.toContain(
+            'metadata-db-password',
+        );
+    });
+
+    it('matches names exactly, so lookalikes are not forwarded', () => {
+        const environment = buildEnvironment();
+
+        expect(environment).not.toHaveProperty('MY_AWS_SECRET_KEY');
+        expect(environment).not.toHaveProperty('UNKNOWN_VARIABLE');
+        expect(environment).not.toHaveProperty('EMPTY_VARIABLE');
+    });
+
+    it('keeps the Lightdash controlled dbt variables', () => {
+        const environment = buildEnvironment({
+            DBT_TARGET_PATH: '/tmp/attacker',
+        });
+
+        expect(environment.DBT_PARTIAL_PARSE).toEqual('false');
+        expect(environment.DBT_SEND_ANONYMOUS_USAGE_STATS).toEqual('false');
+        expect(environment.DBT_TARGET_PATH).toEqual('/tmp/dbt_target_test');
+    });
+
+    it('passes project variables through', () => {
+        const environment = buildEnvironment({
+            LIGHTDASH_DBT_PROFILE_VAR_PASSWORD: 'warehouse-password',
+            DBT_ENV_SECRET_GIT_TOKEN: 'project-owned-token',
+        });
+
+        expect(environment.LIGHTDASH_DBT_PROFILE_VAR_PASSWORD).toEqual(
+            'warehouse-password',
+        );
+        expect(environment.DBT_ENV_SECRET_GIT_TOKEN).toEqual(
+            'project-owned-token',
+        );
+    });
+});
+
+describe('getMissingEnvironmentVariableHint', () => {
+    it('names the variables dbt asked for', () => {
+        const hint = getMissingEnvironmentVariableHint(
+            `Env var required but not provided: 'MY_VAR'\nEnv var required but not provided: 'OTHER_VAR'`,
+        );
+
+        expect(hint).toContain('MY_VAR');
+        expect(hint).toContain('OTHER_VAR');
+    });
+
+    it('returns nothing for unrelated dbt failures', () => {
+        expect(
+            getMissingEnvironmentVariableHint('Database Error in model orders'),
+        ).toBeUndefined();
+    });
+});

--- a/packages/backend/src/dbt/dbtProcessEnvironment.test.ts
+++ b/packages/backend/src/dbt/dbtProcessEnvironment.test.ts
@@ -10,6 +10,7 @@ const processEnvironment: NodeJS.ProcessEnv = {
     HTTPS_PROXY: 'http://proxy.internal:3128',
     REQUESTS_CA_BUNDLE: '/etc/ssl/corporate.pem',
     AWS_ACCESS_KEY_ID: 'aws-key-id',
+    AWS_SECRET_ACCESS_KEY: 'host-secret',
     GOOGLE_APPLICATION_CREDENTIALS: '/adc.json',
     LIGHTDASH_SECRET: 'not-for-dbt',
     LIGHTDASH_LICENSE_KEY: 'licence-jwt',
@@ -80,6 +81,34 @@ describe('getDbtProcessEnvironment', () => {
         expect(environment.DBT_PARTIAL_PARSE).toEqual('false');
         expect(environment.DBT_SEND_ANONYMOUS_USAGE_STATS).toEqual('false');
         expect(environment.DBT_TARGET_PATH).toEqual('/tmp/dbt_target_test');
+    });
+
+    it('does not let a project redirect the runtime plumbing', () => {
+        const environment = buildEnvironment({
+            PATH: '/tmp/malicious',
+            HOME: '/tmp/malicious',
+            HTTPS_PROXY: 'http://attacker.example:8080',
+            REQUESTS_CA_BUNDLE: '/tmp/malicious.pem',
+        });
+
+        expect(environment.PATH).toEqual('/usr/local/bin:/usr/bin');
+        expect(environment.HOME).toEqual('/root');
+        expect(environment.HTTPS_PROXY).toEqual('http://proxy.internal:3128');
+        expect(environment.REQUESTS_CA_BUNDLE).toEqual(
+            '/etc/ssl/corporate.pem',
+        );
+    });
+
+    it('lets the warehouse credentials beat the host identity', () => {
+        // profiles.ts injects these for Redshift IAM with static keys, and they
+        // must win over whatever the pod itself is authenticated as
+        const environment = buildEnvironment({
+            AWS_ACCESS_KEY_ID: 'warehouse-key-id',
+            AWS_SECRET_ACCESS_KEY: 'warehouse-secret',
+        });
+
+        expect(environment.AWS_ACCESS_KEY_ID).toEqual('warehouse-key-id');
+        expect(environment.AWS_SECRET_ACCESS_KEY).toEqual('warehouse-secret');
     });
 
     it('passes project variables through', () => {

--- a/packages/backend/src/dbt/dbtProcessEnvironment.ts
+++ b/packages/backend/src/dbt/dbtProcessEnvironment.ts
@@ -1,0 +1,149 @@
+import Logger from '../logging/logger';
+
+// PATH is load bearing: getDbtExec returns bare command names and on Linux the
+// lookup happens in the child against the environment we build here. The proxy
+// and CA settings are for `dbt deps` reaching hub.getdbt.com or cloning git
+// packages. Both cases are listed because tools disagree: curl ignores
+// uppercase HTTP_PROXY, python reads lowercase first.
+const RUNTIME_ENVIRONMENT_VARIABLE_KEYS = [
+    'PATH',
+    'HOME',
+    'TMPDIR',
+    'LANG',
+    'LC_ALL',
+    'LC_CTYPE',
+    'TZ',
+    'HTTP_PROXY',
+    'HTTPS_PROXY',
+    'NO_PROXY',
+    'ALL_PROXY',
+    'http_proxy',
+    'https_proxy',
+    'no_proxy',
+    'all_proxy',
+    'REQUESTS_CA_BUNDLE',
+    'CURL_CA_BUNDLE',
+    'SSL_CERT_FILE',
+    'SSL_CERT_DIR',
+];
+
+// Credential chains, for warehouses whose adapter authenticates from the host
+// rather than from the generated profiles.yml. Exact names rather than
+// prefixes, since an AWS_ or AZURE_ prefix would also share Lightdash's own
+// AZURE_AI_API_KEY and friends.
+const CLOUD_CREDENTIAL_ENVIRONMENT_VARIABLE_KEYS = [
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_ROLE_ARN',
+    'AWS_ROLE_SESSION_NAME',
+    'AWS_WEB_IDENTITY_TOKEN_FILE',
+    'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
+    'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+    'AWS_CONTAINER_AUTHORIZATION_TOKEN',
+    'AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE',
+    'AWS_PROFILE',
+    'AWS_DEFAULT_PROFILE',
+    'AWS_SHARED_CREDENTIALS_FILE',
+    'AWS_CONFIG_FILE',
+    'AWS_REGION', // botocore prefers this one
+    'AWS_DEFAULT_REGION', // the AWS SDK used by DuckDB prefers this one
+    'AWS_CA_BUNDLE',
+    'AWS_STS_REGIONAL_ENDPOINTS',
+    'AWS_EC2_METADATA_DISABLED',
+    'AWS_EC2_METADATA_SERVICE_ENDPOINT',
+    'AWS_METADATA_SERVICE_TIMEOUT',
+    'AWS_METADATA_SERVICE_NUM_ATTEMPTS',
+    'AWS_ENDPOINT_URL',
+    'AWS_ENDPOINT_URL_S3',
+    'AWS_ENDPOINT_URL_STS',
+    'GOOGLE_APPLICATION_CREDENTIALS',
+    'CLOUDSDK_CONFIG',
+    'GOOGLE_CLOUD_PROJECT',
+    'GCLOUD_PROJECT',
+    'GOOGLE_CLOUD_QUOTA_PROJECT',
+    'GCE_METADATA_HOST',
+    'GCE_METADATA_IP',
+    'GCE_METADATA_ROOT',
+    'NO_GCE_CHECK',
+    'AZURE_TENANT_ID',
+    'AZURE_CLIENT_ID',
+    'AZURE_CLIENT_SECRET',
+    'AZURE_CLIENT_CERTIFICATE_PATH',
+    'AZURE_CLIENT_CERTIFICATE_PASSWORD',
+    'AZURE_FEDERATED_TOKEN_FILE',
+    'AZURE_AUTHORITY_HOST',
+    'MSI_ENDPOINT',
+    'MSI_SECRET',
+    'IDENTITY_ENDPOINT',
+    'IDENTITY_HEADER',
+    'IMDS_ENDPOINT',
+];
+
+const INHERITED_ENVIRONMENT_VARIABLE_KEYS = new Set([
+    ...RUNTIME_ENVIRONMENT_VARIABLE_KEYS,
+    ...CLOUD_CREDENTIAL_ENVIRONMENT_VARIABLE_KEYS,
+]);
+
+type DbtProcessEnvironmentArgs = {
+    processEnvironment: NodeJS.ProcessEnv;
+    projectEnvironment: Record<string, string>;
+    targetPath: string;
+};
+
+export const getDbtProcessEnvironment = ({
+    processEnvironment,
+    projectEnvironment,
+    targetPath,
+}: DbtProcessEnvironmentArgs): Record<string, string> => {
+    const inheritedEnvironment = Object.entries(processEnvironment).reduce<
+        Record<string, string>
+    >((acc, [key, value]) => {
+        if (
+            value === undefined ||
+            !INHERITED_ENVIRONMENT_VARIABLE_KEYS.has(key)
+        ) {
+            return acc;
+        }
+        return { ...acc, [key]: value };
+    }, {});
+
+    return {
+        ...inheritedEnvironment,
+        ...projectEnvironment,
+        DBT_PARTIAL_PARSE: 'false', // Disable dbt from storing manifest and doing partial parses. https://docs.getdbt.com/reference/parsing#partial-parsing
+        DBT_SEND_ANONYMOUS_USAGE_STATS: 'false', // Disable sending usage stats. https://docs.getdbt.com/reference/global-configs/usage-stats
+        DBT_TARGET_PATH: targetPath,
+    };
+};
+
+const MISSING_ENVIRONMENT_VARIABLE_REGEX =
+    /Env var required but not provided: '([^']+)'/g;
+
+// dbt raises rather than rendering empty when env_var() names an unset variable,
+// so point at the project setting that provides it.
+export const getMissingEnvironmentVariableHint = (
+    dbtOutput: string,
+): string | undefined => {
+    const keys = Array.from(
+        new Set(
+            Array.from(
+                dbtOutput.matchAll(MISSING_ENVIRONMENT_VARIABLE_REGEX),
+                ([, key]) => key,
+            ),
+        ),
+    );
+    if (keys.length === 0) {
+        return undefined;
+    }
+
+    Logger.warn(
+        `dbt requested environment variables that Lightdash does not share with it: ${keys.join(
+            ', ',
+        )}`,
+    );
+
+    return `Your dbt project reads ${keys.join(
+        ', ',
+    )} from the environment, which is not available during compilation. Set the values you need in your project's dbt environment variables.`;
+};

--- a/packages/backend/src/dbt/dbtProcessEnvironment.ts
+++ b/packages/backend/src/dbt/dbtProcessEnvironment.ts
@@ -108,13 +108,15 @@ export const getDbtProcessEnvironment = ({
         return { ...acc, [key]: value };
     }, {});
 
+
     return {
-        ...inheritedEnvironment,
         ...projectEnvironment,
+        ...inheritedEnvironment,
         DBT_PARTIAL_PARSE: 'false', // Disable dbt from storing manifest and doing partial parses. https://docs.getdbt.com/reference/parsing#partial-parsing
         DBT_SEND_ANONYMOUS_USAGE_STATS: 'false', // Disable sending usage stats. https://docs.getdbt.com/reference/global-configs/usage-stats
         DBT_TARGET_PATH: targetPath,
     };
+
 };
 
 const MISSING_ENVIRONMENT_VARIABLE_REGEX =

--- a/packages/backend/src/dbt/dbtProcessEnvironment.ts
+++ b/packages/backend/src/dbt/dbtProcessEnvironment.ts
@@ -80,44 +80,42 @@ const CLOUD_CREDENTIAL_ENVIRONMENT_VARIABLE_KEYS = [
     'IMDS_ENDPOINT',
 ];
 
-const INHERITED_ENVIRONMENT_VARIABLE_KEYS = new Set([
-    ...RUNTIME_ENVIRONMENT_VARIABLE_KEYS,
-    ...CLOUD_CREDENTIAL_ENVIRONMENT_VARIABLE_KEYS,
-]);
-
 type DbtProcessEnvironmentArgs = {
     processEnvironment: NodeJS.ProcessEnv;
     projectEnvironment: Record<string, string>;
     targetPath: string;
 };
 
+const inheritKeys = (
+    processEnvironment: NodeJS.ProcessEnv,
+    keys: string[],
+): Record<string, string> =>
+    keys.reduce<Record<string, string>>((acc, key) => {
+        const value = processEnvironment[key];
+        return value === undefined ? acc : { ...acc, [key]: value };
+    }, {});
+
 export const getDbtProcessEnvironment = ({
     processEnvironment,
     projectEnvironment,
     targetPath,
-}: DbtProcessEnvironmentArgs): Record<string, string> => {
-    const inheritedEnvironment = Object.entries(processEnvironment).reduce<
-        Record<string, string>
-    >((acc, [key, value]) => {
-        if (
-            value === undefined ||
-            !INHERITED_ENVIRONMENT_VARIABLE_KEYS.has(key)
-        ) {
-            return acc;
-        }
-        return { ...acc, [key]: value };
-    }, {});
-
-
-    return {
-        ...projectEnvironment,
-        ...inheritedEnvironment,
-        DBT_PARTIAL_PARSE: 'false', // Disable dbt from storing manifest and doing partial parses. https://docs.getdbt.com/reference/parsing#partial-parsing
-        DBT_SEND_ANONYMOUS_USAGE_STATS: 'false', // Disable sending usage stats. https://docs.getdbt.com/reference/global-configs/usage-stats
-        DBT_TARGET_PATH: targetPath,
-    };
-
-};
+}: DbtProcessEnvironmentArgs): Record<string, string> => ({
+    // Ambient cloud credentials sit below the project, because profiles.ts
+    // injects the warehouse's own AWS_* keys through projectEnvironment and
+    // those must beat whatever identity the host happens to carry.
+    ...inheritKeys(
+        processEnvironment,
+        CLOUD_CREDENTIAL_ENVIRONMENT_VARIABLE_KEYS,
+    ),
+    ...projectEnvironment,
+    // Runtime plumbing sits above it: PATH decides which binary runs, and the
+    // proxy and CA settings decide where dbt deps fetches from, so a project
+    // cannot redirect either.
+    ...inheritKeys(processEnvironment, RUNTIME_ENVIRONMENT_VARIABLE_KEYS),
+    DBT_PARTIAL_PARSE: 'false', // Disable dbt from storing manifest and doing partial parses. https://docs.getdbt.com/reference/parsing#partial-parsing
+    DBT_SEND_ANONYMOUS_USAGE_STATS: 'false', // Disable sending usage stats. https://docs.getdbt.com/reference/global-configs/usage-stats
+    DBT_TARGET_PATH: targetPath,
+});
 
 const MISSING_ENVIRONMENT_VARIABLE_REGEX =
     /Env var required but not provided: '([^']+)'/g;

--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -531,6 +531,17 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# The shared base snapshot stores the absolute dbt path of whichever worktree
+# built it, so a bootstrapped instance compiles against a directory that may no
+# longer exist and refresh fails on `dbt deps`.
+step "Reconcile local dbt project path"
+if ./scripts/dev-reconcile.sh local-dbt-path-fix 2>&1; then
+    :
+else
+    echo "WARN: local-dbt-path-fix reported an issue (non-fatal) — refreshing the dbt project may fail until fixed"
+fi
+
+# ---------------------------------------------------------------------------
 step "Ensure instance snapshot"
 if docker volume inspect "${LD_VOLUME_PREFIX}_postgres_data_snapshot" >/dev/null 2>&1; then
     echo "SKIP: snapshot exists"
@@ -575,6 +586,15 @@ fi
 
 # ---------------------------------------------------------------------------
 step "Start PM2"
+# The God Daemon keeps running after a worktree is deleted, and it forks every
+# child through ITS OWN pm2 install. When that install is a different version
+# (or its node_modules are gone) children die with ERR_MODULE_NOT_FOUND on
+# ProcessContainerFork.js, which surfaces only as a health timeout. Recycling
+# the daemon is safe: processes are re-added from the ecosystem config below.
+if pm2 list 2>&1 | grep -q "In-memory PM2 is out-of-date"; then
+    echo "PM2 daemon version differs from this worktree's — restarting the daemon"
+    pm2 kill >/dev/null 2>&1 || true
+fi
 RUNNING_CWD="$(pm2 jlist 2>/dev/null | INSTANCE="$LD_INSTANCE_ID" python3 -c "
 import sys, json, os
 inst = os.environ['INSTANCE']

--- a/scripts/dev-github-reconcile.cjs
+++ b/scripts/dev-github-reconcile.cjs
@@ -308,6 +308,42 @@ async function stepWarehousePortFix(client) {
   if (!fixed) console.log(`OK: warehouse credentials already point at localhost:${targetPort}`);
 }
 
+// A `dbt` project stores absolute paths, and the shared base snapshot was built
+// in whichever worktree created it. Bootstrapping carries those paths over, so
+// the first compile fails with `dbt deps` exiting instantly on a directory that
+// no longer exists.
+async function stepLocalDbtPathFix(client) {
+  const secret = need('RUNNING_SECRET');
+  const demoDir = need('DBT_DEMO_DIR');
+  const rows = await client.query(
+    "SELECT project_uuid, name, encode(dbt_connection,'hex') AS hex FROM projects WHERE dbt_connection_type = 'dbt'");
+  if (!rows.rows.length) { console.log('OK: no local dbt projects'); return; }
+  let fixed = 0;
+  for (const row of rows.rows) {
+    let conn;
+    try { conn = JSON.parse(decrypt(Buffer.from(row.hex, 'hex'), secret)); }
+    catch (_) { console.log(`WARN: project ${row.name} will not decrypt with running secret — skipping`); continue; }
+    const projectDir = `${demoDir}/dbt`;
+    const profilesDir = `${demoDir}/profiles`;
+    if (conn.project_dir === projectDir && conn.profiles_dir === profilesDir) continue;
+    // Only a demo checkout in some other worktree. Any other path is a project
+    // someone set up deliberately, including one outside the repo.
+    if (!String(conn.project_dir).endsWith('/examples/full-jaffle-shop-demo/dbt')) {
+      console.log(`SKIP: project ${row.name} project_dir=${conn.project_dir} is not a jaffle demo checkout — leaving as-is`);
+      continue;
+    }
+    const before = conn.project_dir;
+    conn.project_dir = projectDir;
+    conn.profiles_dir = profilesDir;
+    const enc = encrypt(JSON.stringify(conn), secret);
+    if (decrypt(enc, secret) !== JSON.stringify(conn)) throw new Error('round-trip check failed');
+    await client.query('UPDATE projects SET dbt_connection=$1 WHERE project_uuid=$2', [enc, row.project_uuid]);
+    console.log(`OK: project ${row.name} repointed ${before} -> ${projectDir}`);
+    fixed += 1;
+  }
+  if (!fixed) console.log(`OK: local dbt projects already point at ${demoDir}`);
+}
+
 (async () => {
   const step = process.argv[2];
   const kvs = {};
@@ -329,6 +365,7 @@ async function stepWarehousePortFix(client) {
     else if (step === 'dbt-repo-repoint') await stepDbtRepoRepoint(client, kvs);
     else if (step === 'verify-token') await stepVerifyToken(client);
     else if (step === 'warehouse-port-fix') await stepWarehousePortFix(client);
+    else if (step === 'local-dbt-path-fix') await stepLocalDbtPathFix(client);
     else { console.error(`FAIL: reconcile -- unknown step '${step}'`); process.exit(2); }
   } finally {
     await client.end();

--- a/scripts/dev-reconcile.sh
+++ b/scripts/dev-reconcile.sh
@@ -68,6 +68,7 @@ run_cjs() {
     RUNNING_SECRET="$RUNNING_SECRET" \
     GITHUB_APP_ID="$GITHUB_APP_ID" GITHUB_PRIVATE_KEY="$GITHUB_PRIVATE_KEY" \
     GH_ACCOUNT="${GH_ACCOUNT:-}" \
+    DBT_DEMO_DIR="${DBT_DEMO_DIR:-$REPO_ROOT/examples/full-jaffle-shop-demo}" \
     PGHOST=localhost PGPORT="$LD_PG_PORT" PGUSER=postgres PGPASSWORD=password PGDATABASE=postgres \
     NODE_PATH="$REPO_ROOT/packages/backend/node_modules" \
     node "$REPO_ROOT/scripts/dev-github-reconcile.cjs" "$@"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-9718

### Description:

dbt commands were spawned with execa's default `extendEnv`, so the child process inherited the backend's entire environment when only a small part of it is relevant to dbt. This builds that environment explicitly instead, from an exact-name list: `PATH`, `HOME`, `TMPDIR` and locale, the proxy and CA settings `dbt deps` needs to fetch packages, and the AWS, Google Cloud and Azure credential chain variables that warehouses resolve from the host. Project and profile environment variables are unchanged, and the dbt error now names any variable a project asked for that isn't provided, since `env_var()` raises rather than rendering empty.

Verified against the real dbt CLI on a project with two hub packages, a git-sourced package and a seed: `dbt deps`, `dbt ls` and `dbt parse` all still work, and package fetching over HTTPS and `git clone` are unaffected.

Also included: two dev-environment reconciles in `scripts/`, for a stale PM2 daemon and for local dbt project paths carried over from the shared base snapshot, both of which broke a fresh worktree's first project refresh.
