### PR TITLE
ci(release-safety): run the release-safety script tests in CI

### DIFF
--- a/.github/workflows/release-safety-tests.yml
+++ b/.github/workflows/release-safety-tests.yml
@@ -1,0 +1,47 @@
+name: Release-safety script tests
+
+# SPK-859: the release-safety scripts carry a self-contained node:assert test
+# suite (scripts/*.test.ts) that pins the marker's verdict-precedence rules.
+# They are deliberately outside the jest/vitest project config, so no other CI
+# job runs them — this workflow is their only harness.
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - 'package.json'
+      - '.github/workflows/release-safety-tests.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  release-safety-tests:
+    name: Run scripts/*.test.ts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install tsx
+        run: sfw npm install -g tsx@4.19.4
+
+      - name: Run release-safety script tests
+        run: npm run test:release-safety

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
         "fix-lint": "turbo run fix-lint --filter=@lightdash/common --filter=@lightdash/warehouses --filter=backend --filter=@lightdash/frontend --filter=e2e --filter=@lightdash/cli --filter=api-tests",
         "fix-format": "turbo run fix-format --filter=@lightdash/common --filter=@lightdash/warehouses --filter=backend --filter=@lightdash/frontend --filter=e2e --filter=@lightdash/cli --filter=api-tests",
         "test": "turbo run test --filter=@lightdash/common --filter=@lightdash/warehouses --filter=backend --filter=@lightdash/frontend --filter=e2e --filter=@lightdash/cli --filter=api-tests --filter=@lightdash/query-sdk",
+        "test:release-safety": "for f in scripts/*.test.ts; do npx tsx \"$f\" || exit 1; done",
         "dev": "pnpm -r --stream --parallel -F common -F warehouses -F backend -F frontend run dev",
         "build": "turbo run build --filter=@lightdash/common --filter=@lightdash/warehouses --filter=backend --filter=@lightdash/frontend",
         "build-published-packages": "pnpm -r --stream --sequential -F common -F warehouses -F query-sdk -F cli -F formula build && pnpm frontend-build-sdk",


### PR DESCRIPTION
## What

- Adds a `test:release-safety` root script that runs every `scripts/*.test.ts` via tsx (145 self-contained `node:assert` tests across 7 files).
- Adds a dedicated `release-safety-tests.yml` workflow, path-filtered on `scripts/**`, that runs the script on PRs.

## Why

The release-safety scripts carry a thorough test suite pinning the marker's verdict-precedence rules (linter floor → AI validation → honest unknown), the overrides fold, and the SQL linter's positives/negatives — but nothing invoked them: they are deliberately outside the jest/vitest project config, and no workflow ran them. A regression in the precedence ladder would ship green.

This lands first in the stack so every later slice has the suite as its safety net.

## Notes

- No framework migration: the tests stay self-contained `node:assert` scripts, run via `tsx` (pinned to the same version `release-safety-pr.yml` uses).
- `ai-migration-review.ts` remains the one script without a test file (its pure helpers are testable) — left as a follow-up, noted on the ticket.

Closes: SPK-859