### PR TITLE
fix(release-safety): repair SQL-linter latent defects and stale design comments

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -289,11 +289,9 @@ jobs:
         id: lint
         run: |
           set -euo pipefail
-          if tsx scripts/sql-migration-lint.ts --last-tag "${{ needs.changes.outputs.base_sha }}" | grep -q '"breaking": true'; then
-            echo "breaking=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "breaking=false" >> "$GITHUB_OUTPUT"
-          fi
+          tsx scripts/sql-migration-lint.ts --last-tag "${{ needs.changes.outputs.base_sha }}" > /tmp/sql-lint.json
+          BREAKING=$(node -e 'const r=JSON.parse(require("fs").readFileSync("/tmp/sql-lint.json","utf8"));process.stdout.write(String(r.breaking===true))')
+          echo "breaking=${BREAKING}" >> "$GITHUB_OUTPUT"
 
       - name: Render PR comment
         run: |

--- a/release.config.js
+++ b/release.config.js
@@ -83,11 +83,11 @@ module.exports = {
         // sides instead, and neither caller should silently get the other's
         // comparison. Without it the REST surface is reported as not checked.
         //
-        // --ai-review activates the gated AI migration review (P6). It only fires
-        // on the ~10% of releases with migrations, only when the deterministic SQL
-        // linter did not already prove a break, and only when ANTHROPIC_API_KEY is
-        // set in the release job. Any degrade leaves the honest "unknown" verdict;
-        // it never fails the release.
+        // --ai-review activates the gated AI rolling-update review (P6). It runs
+        // on every migration-bearing release and on flagged REST/MCP breaks; a
+        // definitive verdict can clear or confirm the deterministic floor. It is
+        // gated on ANTHROPIC_API_KEY in the release job. Any degrade leaves the
+        // floor or honest "unknown" verdict intact; it never fails the release.
         [
             '@semantic-release/exec',
             {

--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -47,14 +47,18 @@ test('counts only ADDED timestamped migration files', () => {
     assert.strictEqual(res.ee, false);
 });
 
-test('does NOT count modified/renamed/copied historical migrations', () => {
+test('records modified/renamed historical migrations as warnings without counting them', () => {
     const res = detectMigrations([
         change('M', `${CORE}/20210713230243_users.ts`),
-        change('R100', `${CORE}/20210713230243_users.ts`),
+        change('R100', `${CORE}/20210714230243_roles.ts`),
         change('C75', `${CORE}/20210713230243_users.ts`),
     ]);
     assert.strictEqual(res.present, false);
     assert.strictEqual(res.count, 0);
+    assert.deepStrictEqual(res.modifiedHistorical, [
+        '20210713230243_users.ts',
+        '20210714230243_roles.ts',
+    ]);
 });
 
 test('records deleted historical migrations as a warning, not a count', () => {
@@ -120,6 +124,7 @@ test('migration-bearing release => rollingUpdateSafe "unknown", Recreate', () =>
             files: ['x.ts'],
             ee: false,
             deletedHistorical: [],
+            modifiedHistorical: [],
         },
     });
     assert.strictEqual(m.compatibility.rollingUpdateSafe, 'unknown');
@@ -136,6 +141,7 @@ test('no-migration release => rollingUpdateSafe true, RollingUpdate', () => {
             files: [],
             ee: false,
             deletedHistorical: [],
+            modifiedHistorical: [],
         },
     });
     assert.strictEqual(m.compatibility.rollingUpdateSafe, true);
@@ -163,6 +169,7 @@ test('marker shape: schemaVersion, capabilities, api unchecked stubs', () => {
             files: ['x.ts'],
             ee: false,
             deletedHistorical: [],
+            modifiedHistorical: [],
         },
     });
     assert.strictEqual(m.schemaVersion, MARKER_SCHEMA_VERSION);
@@ -182,6 +189,7 @@ test('notes always disclose the blind spot', () => {
             files: [],
             ee: false,
             deletedHistorical: [],
+            modifiedHistorical: [],
         },
     });
     assert.ok(/does NOT/i.test(m.compatibility.notes));
@@ -192,7 +200,7 @@ test('notes always disclose the blind spot', () => {
 test('aiReview flips a migration-bearing release to its verdict + adds capability', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: true, count: 1, files: ['x.ts'], ee: false, deletedHistorical: [] },
+        migrations: { present: true, count: 1, files: ['x.ts'], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         aiReview: {
             rollingUpdateSafe: true,
             recommendedStrategy: 'RollingUpdate',
@@ -208,7 +216,7 @@ test('aiReview flips a migration-bearing release to its verdict + adds capabilit
 test('aiReview "breaking" verdict sets rollingUpdateSafe false', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: true, count: 1, files: ['x.ts'], ee: false, deletedHistorical: [] },
+        migrations: { present: true, count: 1, files: ['x.ts'], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         aiReview: {
             rollingUpdateSafe: false,
             recommendedStrategy: 'Recreate',
@@ -222,7 +230,7 @@ test('aiReview "breaking" verdict sets rollingUpdateSafe false', () => {
 test('aiReview is ignored on a no-migration release (never invents a verdict)', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [] },
+        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         aiReview: {
             rollingUpdateSafe: false,
             recommendedStrategy: 'Recreate',
@@ -238,7 +246,7 @@ test('aiReview is ignored on a no-migration release (never invents a verdict)', 
 test('checked restApi populates api.rest + adds "rest" capability', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [] },
+        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         restApi: {
             checked: true,
             breaking: true,
@@ -254,7 +262,7 @@ test('checked restApi populates api.rest + adds "rest" capability', () => {
 test('checked-but-clean restApi => breaking false, "rest" capability present', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [] },
+        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         restApi: { checked: true, breaking: false, changes: [] },
     });
     assert.strictEqual(m.api.rest.checked, true);
@@ -265,7 +273,7 @@ test('checked-but-clean restApi => breaking false, "rest" capability present', (
 test('unchecked restApi leaves the stub and does NOT claim the capability', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [] },
+        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         restApi: { checked: false, breaking: false, changes: [] },
     });
     assert.strictEqual(m.api.rest.checked, false);
@@ -275,7 +283,7 @@ test('unchecked restApi leaves the stub and does NOT claim the capability', () =
 test('null restApi behaves like the unchecked stub (back-compat)', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [] },
+        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         restApi: null,
     });
     assert.strictEqual(m.api.rest.checked, false);
@@ -285,7 +293,7 @@ test('null restApi behaves like the unchecked stub (back-compat)', () => {
 test('restApi and aiReview compose: capabilities carry both', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: true, count: 1, files: ['x.ts'], ee: false, deletedHistorical: [] },
+        migrations: { present: true, count: 1, files: ['x.ts'], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         aiReview: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', summary: 'safe.' },
         restApi: { checked: true, breaking: false, changes: [] },
     });
@@ -296,7 +304,7 @@ test('restApi and aiReview compose: capabilities carry both', () => {
 
 // --- sqlLint (deterministic floor) -------------------------------------------
 
-const migPresent = { present: true as const, count: 1, files: ['x.ts'], ee: false, deletedHistorical: [] };
+const migPresent = { present: true as const, count: 1, files: ['x.ts'], ee: false, deletedHistorical: [], modifiedHistorical: [] };
 
 test('sqlLint breaking sets rollingUpdateSafe false + adds "sql-lint" capability (no AI)', () => {
     const m = buildMarker({
@@ -427,7 +435,7 @@ test('sqlLint that did not run claims no capability and changes nothing', () => 
 test('sqlLint is ignored on a no-migration release (never invents a verdict)', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [] },
+        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         sqlLint: { ran: true, breaking: true, findings: ['should be ignored'] },
     });
     assert.strictEqual(m.compatibility.rollingUpdateSafe, true); // no-migration base value
@@ -439,7 +447,7 @@ test('sqlLint is ignored on a no-migration release (never invents a verdict)', (
 test('checked mcpApi populates api.mcp + adds "mcp" capability', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [] },
+        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         mcpApi: { checked: true, breaking: true, changes: ['MCP tool `x` removed'] },
     });
     assert.strictEqual(m.api.mcp.checked, true);
@@ -451,14 +459,14 @@ test('checked mcpApi populates api.mcp + adds "mcp" capability', () => {
 test('unchecked/null mcpApi leaves the stub and does NOT claim the capability', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [] },
+        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         mcpApi: { checked: false, breaking: false, changes: [] },
     });
     assert.strictEqual(m.api.mcp.checked, false);
     assert.ok(!m.capabilities.includes('mcp'));
     const m2 = buildMarker({
         ...base,
-        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [] },
+        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         mcpApi: null,
     });
     assert.ok(!m2.capabilities.includes('mcp'));
@@ -466,7 +474,7 @@ test('unchecked/null mcpApi leaves the stub and does NOT claim the capability', 
 
 // --- AI validates non-migration breaks (REST/MCP) ----------------------------
 
-const noMig = { present: false as const, count: 0, files: [], ee: false, deletedHistorical: [] };
+const noMig = { present: false as const, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] };
 
 test('REST break with NO migration → base "unknown" (cautious), not silently safe', () => {
     const m = buildMarker({
@@ -546,7 +554,7 @@ test('a clean REST surface does NOT make a no-migration release "unknown"', () =
 test('consulted upgrade override folds into the upgrade block + adds "upgrade" capability', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [] },
+        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         upgrade: {
             consulted: true,
             minPreviousVersion: '0.3200.0',
@@ -563,7 +571,7 @@ test('consulted upgrade override folds into the upgrade block + adds "upgrade" c
 test('consulted-but-default upgrade => stub values, "upgrade" capability still present', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [] },
+        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         upgrade: { consulted: true, minPreviousVersion: null, requiredStop: false, note: null },
     });
     assert.strictEqual(m.upgrade.requiredStop, false);
@@ -573,14 +581,14 @@ test('consulted-but-default upgrade => stub values, "upgrade" capability still p
 test('unconsulted/null upgrade leaves the stub and does NOT claim the capability', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [] },
+        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         upgrade: { consulted: false, minPreviousVersion: null, requiredStop: false, note: null },
     });
     assert.strictEqual(m.upgrade.requiredStop, false);
     assert.ok(!m.capabilities.includes('upgrade'));
     const m2 = buildMarker({
         ...base,
-        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [] },
+        migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         upgrade: null,
     });
     assert.ok(!m2.capabilities.includes('upgrade'));
@@ -589,7 +597,7 @@ test('unconsulted/null upgrade leaves the stub and does NOT claim the capability
 test('all phases compose: capabilities ordered migrations, sql-lint, ai-review, rest, mcp, upgrade', () => {
     const m = buildMarker({
         ...base,
-        migrations: { present: true, count: 1, files: ['x.ts'], ee: false, deletedHistorical: [] },
+        migrations: { present: true, count: 1, files: ['x.ts'], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         sqlLint: { ran: true, breaking: false, findings: [] },
         aiReview: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', summary: 'breaks.' },
         restApi: { checked: true, breaking: true, changes: ['GET /x — removed'] },

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -60,6 +60,8 @@ export interface MigrationsResult {
     ee: boolean;
     /** historical migrations deleted in this range — an anti-pattern, surfaced as a warning */
     deletedHistorical: string[];
+    /** historical migrations modified/renamed in this range — surfaced as a warning */
+    modifiedHistorical: string[];
 }
 
 export interface ApiSurface {
@@ -122,12 +124,13 @@ const BLIND_SPOT_NOTE =
 
 /**
  * PURE. Classify a list of git changes (scoped to the migration dirs) into a
- * migrations result. Counts ADDED timestamped files only — modified/renamed
- * historical migrations are not counted; deletions are surfaced as a warning.
+ * migrations result. Counts ADDED timestamped files only — modified, renamed,
+ * and deleted historical migrations are surfaced as warnings, not counted.
  */
 export function detectMigrations(changes: GitChange[]): MigrationsResult {
     const added: string[] = [];
     const deletedHistorical: string[] = [];
+    const modifiedHistorical: string[] = [];
 
     for (const change of changes) {
         const base = path.basename(change.path);
@@ -137,13 +140,16 @@ export function detectMigrations(changes: GitChange[]): MigrationsResult {
             added.push(change.path);
         } else if (code === 'D') {
             deletedHistorical.push(change.path);
+        } else if (code === 'M' || code === 'R') {
+            modifiedHistorical.push(change.path);
         }
-        // M (modified) and R/C (renamed/copied) historical migrations are not
-        // counted as new migrations.
+        // Modified, renamed, and copied historical migrations are not counted as
+        // new migrations.
     }
 
     added.sort();
     deletedHistorical.sort();
+    modifiedHistorical.sort();
 
     const ee = added.some((p) => p.startsWith(EE_MIGRATION_DIR));
 
@@ -153,6 +159,7 @@ export function detectMigrations(changes: GitChange[]): MigrationsResult {
         files: added.map((p) => path.basename(p)),
         ee,
         deletedHistorical: deletedHistorical.map((p) => path.basename(p)),
+        modifiedHistorical: modifiedHistorical.map((p) => path.basename(p)),
     };
 }
 
@@ -171,9 +178,10 @@ export interface BuildMarkerInput {
     /**
      * Optional result of the deterministic SQL-shape migration linter — the
      * non-LLM floor under the AI review. Applied only when migrations.present ===
-     * true. A "breaking" finding is AUTHORITATIVE (sets rollingUpdateSafe false
-     * and wins over the AI review); a clean run leaves the verdict for the AI /
-     * the honest "unknown" default. Adds "sql-lint" to capabilities when it ran.
+     * true. A "breaking" finding sets the floor; a definitive AI verdict can
+     * clear or confirm it, while "unknown" leaves it in place. A clean run leaves
+     * the verdict for the AI / honest "unknown" default. Adds "sql-lint" to
+     * capabilities when it ran.
      */
     sqlLint?: SqlLintSummary | null;
     /**
@@ -632,6 +640,12 @@ async function main(): Promise<void> {
             console.warn(
                 `[release-safety] WARNING: historical migrations deleted in ${range}: ` +
                     migrations.deletedHistorical.join(', '),
+            );
+        }
+        if (migrations.modifiedHistorical.length > 0) {
+            console.warn(
+                `[release-safety] WARNING: historical migrations modified in ${range}: ` +
+                    migrations.modifiedHistorical.join(', '),
             );
         }
     } else {

--- a/scripts/mcp-tools-diff.ts
+++ b/scripts/mcp-tools-diff.ts
@@ -3,8 +3,9 @@
  *
  * Populates the release-safety marker's `api.mcp` block by diffing a committed
  * snapshot of the MCP tool surface (`packages/common/src/schemas/json/mcp-tools-1.0.json`,
- * produced by `scripts/gen-mcp-tools-snapshot.ts` and regenerated in
- * `postgenerate-api`) between the PREVIOUS release tag and HEAD.
+ * produced by `packages/common/src/schemas/generateMcpToolsSnapshot.ts` via the
+ * root `generate:mcp-tools-snapshot` script in `postgenerate-api`) between the
+ * PREVIOUS release tag and HEAD.
  *
  * The snapshot is the DECLARED MCP tool set (`mcpToolDefinitions` from
  * `@lightdash/common`, the superset of every MCP-available tool) — not the

--- a/scripts/rest-api-diff.ts
+++ b/scripts/rest-api-diff.ts
@@ -6,9 +6,10 @@
  * the PREVIOUS release tag and HEAD with `oasdiff breaking`. A non-empty
  * breaking list means a consumer of the REST API may break across this upgrade.
  *
- * This is the DETERMINISTIC sibling of the P6 AI migration review: oasdiff parses
- * both specs into a semantic OpenAPI model and compares them, so JSON key ordering
- * is irrelevant and the result is reproducible. It runs whenever `oasdiff` is
+ * This is a deterministic detector whose flagged breaking changes are handed
+ * downstream to the AI rolling-update review for validation. oasdiff parses both
+ * specs into a semantic OpenAPI model and compares them, so JSON key ordering is
+ * irrelevant and the result is reproducible. It runs whenever `oasdiff` is
  * available (on PATH or via `OASDIFF_BIN`) and the caller named both sides of the
  * comparison — which specs to diff is never inferred, see the generator.
  *

--- a/scripts/sql-migration-lint.test.ts
+++ b/scripts/sql-migration-lint.test.ts
@@ -92,6 +92,57 @@ test('raw SQL column type change is flagged', () => {
     assert.ok(rules(src).includes('raw-alter-type'));
 });
 
+test('block comments containing destructive SQL and method text are ignored', () => {
+    const src = `export async function up(knex){
+  /* await knex.raw('ALTER TABLE users DROP COLUMN legacy');
+     await knex.schema.alterTable('users', t => t.dropColumn('legacy')); */
+}`;
+    assert.deepStrictEqual(rules(src), []);
+});
+
+test('raw SQL DROP COLUMN reports the line inside the raw call', () => {
+    const src = `export async function up(knex){
+  await knex.raw('ALTER TABLE users DROP COLUMN legacy');
+}`;
+    const found = lintSource(src);
+    assert.strictEqual(found[0]?.rule, 'raw-drop-column');
+    assert.strictEqual(found[0]?.line, 2);
+});
+
+test('plain strings containing destructive SQL are ignored', () => {
+    const src = `export async function up(){ const example = 'ALTER TABLE users DROP COLUMN legacy'; }`;
+    assert.deepStrictEqual(rules(src), []);
+});
+
+test('multi-line raw SQL reports a later RENAME TO line', () => {
+    const src = `export async function up(knex){
+  await knex.raw(\`
+    ALTER TABLE users
+    RENAME TO app_users
+  \`);
+}`;
+    const found = lintSource(src).find((f) => f.rule === 'raw-rename-to');
+    assert.strictEqual(found?.line, 4);
+});
+
+test('dropNullable on an existing column is flagged with its object name', () => {
+    const src = `export async function up(knex){
+  await knex.schema.alterTable('saved_queries_versions', (table) => {
+    table.dropNullable('timezone');
+  });
+}`;
+    const found = lintSource(src);
+    assert.strictEqual(found[0]?.rule, 'drop-nullable');
+    assert.strictEqual(found[0]?.object, 'timezone');
+});
+
+test('notNullable inside a block comment is ignored', () => {
+    const src = `export async function up(knex){
+  /* await knex.schema.alterTable('users', t => t.string('email').notNullable()); */
+}`;
+    assert.deepStrictEqual(rules(src), []);
+});
+
 // --- only the up() body is scanned -------------------------------------------
 
 test('destructive ops in down() only are NOT flagged', () => {

--- a/scripts/sql-migration-lint.ts
+++ b/scripts/sql-migration-lint.ts
@@ -13,16 +13,25 @@
  * and is fully deterministic — so it can run on every migration-bearing release
  * for free and its verdict is reproducible (unlike the AI review).
  *
- * Precedence: a linter "breaking" finding is AUTHORITATIVE — it sets
- * `rollingUpdateSafe = false` and the generator skips the AI review entirely (no
- * point paying for a tool-loop to confirm what a regex proved). The AI review is
- * still the only thing that can reach `true`. Bias is intentionally toward
- * over-flagging: a false "breaking" only costs an unnecessary Recreate, the same
- * cautious direction the whole marker leans. It is a FLOOR, not a complete check
- * — code-only/config-only breaks and subtle data-backfill breaks remain the AI's
- * and the blind-spot note's job.
+ * Precedence: deterministic detectors (this linter, the REST diff, and the MCP
+ * snapshot diff) always run first, and a breaking result sets the marker's floor.
+ * The AI rolling-update review then validates every migration-bearing release and
+ * flagged REST/MCP break. A definitive verdict can clear or confirm that floor;
+ * an inconclusive "unknown" never downgrades a deterministic break. Bias is
+ * intentionally toward over-flagging, but a false Recreate means real operator
+ * downtime — the downstream AI layer exists to clear those false positives. This
+ * linter is a FLOOR, not a complete check: code/config-only breaks and subtle
+ * data-backfill breaks remain the AI review's and the blind-spot note's job.
  *
- * CLI:  npx tsx scripts/sql-migration-lint.ts --last-tag 0.3260.2
+ * Known limitations:
+ *   - `down()` bodies are not scanned, so rollback safety is unexamined.
+ *   - Modified or renamed historical migrations are not linted; only added files
+ *     are scanned.
+ *   - PR preview merge-base ranges can include already-merged migrations in
+ *     criss-cross merge histories.
+ *
+ * CLI: stdout contains only the final JSON; diagnostics are written to stderr.
+ *       npx tsx scripts/sql-migration-lint.ts --last-tag 0.3260.2
  */
 import * as fs from 'fs';
 import { addedMigrationPaths } from './ai-migration-review';
@@ -50,6 +59,7 @@ export interface SqlLintResult {
  *  first string-literal argument, for expand-version tracing. */
 const METHOD_RULES: { rule: string; re: RegExp; message: string; objectRe?: RegExp }[] = [
     { rule: 'drop-column', re: /\.dropColumns?\s*\(/, message: 'drops a column the previous version may still read/write', objectRe: /\.dropColumns?\s*\(\s*['"]([^'"]+)['"]/ },
+    { rule: 'drop-nullable', re: /\.dropNullable\s*\(/, message: 'enforces NOT NULL on an existing column (old code may still write NULL)', objectRe: /\.dropNullable\s*\(\s*['"]([^'"]+)['"]/ },
     { rule: 'rename-column', re: /\.renameColumn\s*\(/, message: 'renames a column the previous version still references', objectRe: /\.renameColumn\s*\(\s*['"]([^'"]+)['"]/ },
     { rule: 'drop-table', re: /\.dropTable(?:IfExists)?\s*\(/, message: 'drops a table the previous version still references', objectRe: /\.dropTable(?:IfExists)?\s*\(\s*['"]([^'"]+)['"]/ },
     { rule: 'rename-table', re: /\.renameTable\s*\(/, message: 'renames a table the previous version still references', objectRe: /\.renameTable\s*\(\s*['"]([^'"]+)['"]/ },
@@ -73,9 +83,54 @@ function upPortion(source: string): string {
     return m >= 0 ? source.slice(0, m) : source;
 }
 
-/** Strip line comments per line (keeps line numbers stable); drop block comments crudely. */
+/**
+ * Replace block-comment content with spaces while preserving newlines and source
+ * offsets. Best-effort only: `/*` inside string literals is treated as a comment.
+ */
+function stripBlockComments(source: string): string {
+    const chars = source.split('');
+    let start = source.indexOf('/*');
+    while (start >= 0) {
+        const close = source.indexOf('*/', start + 2);
+        const end = close >= 0 ? close + 2 : source.length;
+        for (let i = start; i < end; i += 1) {
+            if (chars[i] !== '\n') chars[i] = ' ';
+        }
+        start = source.indexOf('/*', end);
+    }
+    return chars.join('');
+}
+
+/** Strip line comments per line (keeps line numbers stable). */
 function stripLineComment(line: string): string {
     return line.replace(/\/\/.*$/, '');
+}
+
+/**
+ * Best-effort spans for `.raw(` calls. Parentheses inside quoted/backtick content
+ * still affect depth; an unbalanced call extends to EOF.
+ */
+function rawSpans(source: string): Array<{ start: number; end: number }> {
+    const spans: Array<{ start: number; end: number }> = [];
+    let occurrence = source.indexOf('.raw(');
+    while (occurrence >= 0) {
+        const start = occurrence + '.raw'.length;
+        let depth = 0;
+        let end = source.length;
+        for (let i = start; i < source.length; i += 1) {
+            if (source[i] === '(') depth += 1;
+            if (source[i] === ')') {
+                depth -= 1;
+                if (depth === 0) {
+                    end = i + 1;
+                    break;
+                }
+            }
+        }
+        spans.push({ start, end });
+        occurrence = source.indexOf('.raw(', occurrence + '.raw('.length);
+    }
+    return spans;
 }
 
 function lineOfIndex(source: string, index: number): number {
@@ -96,27 +151,43 @@ function lineOfIndex(source: string, index: number): number {
  *   - RAW_RULES: destructive raw SQL, only inside statements calling `.raw(`.
  */
 export function lintSource(source: string): Omit<SqlLintFinding, 'file'>[] {
-    const up = upPortion(source);
+    const up = stripBlockComments(upPortion(source));
     const findings: Omit<SqlLintFinding, 'file'>[] = [];
 
-    // Line-scanned rules: destructive Knex builder calls + raw-SQL phrases. The
-    // raw phrases require whitespace (e.g. `drop column`), so they never collide
-    // with the Knex method names (`dropColumn`) — only real SQL text matches.
+    // Destructive Knex builder calls are line-scanned after removing comments.
     const lines = up.split('\n');
     lines.forEach((rawLine, i) => {
         const line = stripLineComment(rawLine);
-        for (const { rule, re, message, objectRe } of [...METHOD_RULES, ...RAW_RULES] as {
-            rule: string;
-            re: RegExp;
-            message: string;
-            objectRe?: RegExp;
-        }[]) {
+        for (const { rule, re, message, objectRe } of METHOD_RULES) {
             if (re.test(line)) {
                 const object = objectRe ? line.match(objectRe)?.[1] : undefined;
                 findings.push({ line: i + 1, rule, message, snippet: rawLine.trim().slice(0, 200), object });
             }
         }
     });
+
+    // Raw-SQL phrases are scanned only inside `.raw(` call spans. Blank line
+    // comments while preserving offsets so commented-out calls stay inert.
+    const rawSource = up
+        .split('\n')
+        .map((line) => line.replace(/\/\/.*$/, (comment) => ' '.repeat(comment.length)))
+        .join('\n');
+    for (const { start, end } of rawSpans(rawSource)) {
+        const span = rawSource.slice(start, end);
+        for (const { rule, re, message } of RAW_RULES) {
+            const match = span.match(re);
+            if (match?.index !== undefined) {
+                const index = start + match.index;
+                const line = lineOfIndex(rawSource, index);
+                findings.push({
+                    line,
+                    rule,
+                    message,
+                    snippet: lines[line - 1]?.trim().slice(0, 200) ?? '',
+                });
+            }
+        }
+    }
 
     // NOT NULL without default — context-aware, because splitting on `;` is
     // unreliable inside a createTable callback. For each `.notNullable(`:
@@ -202,7 +273,7 @@ function arg(name: string): string | undefined {
 function main(): void {
     const lastTag = arg('last-tag') ?? arg('previous-version');
     if (!lastTag) throw new Error('--last-tag (or --previous-version) is required');
-    const result = lintMigrations({ lastTag, log: (m) => console.log(`[sql-migration-lint] ${m}`) });
+    const result = lintMigrations({ lastTag, log: (m) => console.error(`[sql-migration-lint] ${m}`) });
     console.log(JSON.stringify({ ran: result.ran, breaking: result.breaking, findings: renderFindings(result.findings) }, null, 2));
 }
 


### PR DESCRIPTION
## What

Fixes the eight defects catalogued on the ticket in `scripts/sql-migration-lint.ts` and its surrounding docs:

- **Block comments are now stripped** before scanning (offset-preserving, so line numbers stay stable) — commented-out DDL and `.notNullable()` no longer produce findings.
- **Raw-SQL rules are scoped to `.raw(` call spans** as the comments always claimed — a string literal or comment containing "drop column" is no longer a finding.
- **New `drop-nullable` rule**: `.dropNullable()` enforces NOT NULL on an existing column; previously this shape produced zero findings.
- **Modified/renamed historical migrations** are now surfaced as a generator warning (mirroring the existing deleted-historical warning); previously `M`/`R` statuses were silently dropped.
- **Machine-readable CLI**: diagnostics go to stderr, stdout is pure JSON — and the brittle `grep '"breaking": true'` against pretty-printed JSON in `release-safety-pr.yml` is replaced with an actual `JSON.parse`.
- **Stale design comments rewritten** to describe the shipped precedence model (deterministic detectors set the floor; the AI rolling-update review validates downstream and only a definitive verdict overrides; "unknown" never downgrades a deterministic break) — in the linter header, `release.config.js`, and `rest-api-diff.ts`. The old text claimed the linter was authoritative and skipped the AI review, which is the opposite of what shipped and had already misled a design review.
- **Correct generator path** in `mcp-tools-diff.ts` (`packages/common/src/schemas/generateMcpToolsSnapshot.ts`, not a nonexistent script).
- **Known limitations documented** in the header: `down()` unscanned, historical-migration edits unlinted, criss-cross merge-base ranges.

## Tests

`sql-migration-lint.test.ts` grows 15 → 21 (block comments, raw-span scoping incl. multi-line raw templates with correct line attribution, plain-string negatives, `drop-nullable`); `gen-release-safety.test.ts` covers `modifiedHistorical`. Full suite: 151 tests across the 7 files, all passing.

One deliberate trade-off: several identical raw-SQL violations inside a single `.raw()` span now collapse to one finding per rule (the breaking verdict is unaffected; the AI review receives the full file regardless).

Closes: SPK-706