### PR TITLE
fix(release-safety): derive REST breaking from oasdiff ERR only, surface WARN as advisories

### DIFF
--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -243,19 +243,35 @@ test('aiReview is ignored on a no-migration release (never invents a verdict)', 
 
 // --- restApi (P2) ------------------------------------------------------------
 
+const emptyApiDetails = {
+    breakingCount: 0,
+    advisories: [] as string[],
+    advisoryCount: 0,
+};
+const breakingApiDetails = { ...emptyApiDetails, breakingCount: 1 };
+
 test('checked restApi populates api.rest + adds "rest" capability', () => {
     const m = buildMarker({
         ...base,
         migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         restApi: {
+            ...emptyApiDetails,
             checked: true,
             breaking: true,
             changes: ['GET /api/v1/foo — api removed without deprecation'],
+            breakingCount: 12,
+            advisories: ['GET /api/v1/foo — response enum value added'],
+            advisoryCount: 1,
         },
     });
     assert.strictEqual(m.api.rest.checked, true);
     assert.strictEqual(m.api.rest.breaking, true);
     assert.deepStrictEqual(m.api.rest.changes, ['GET /api/v1/foo — api removed without deprecation']);
+    assert.strictEqual(m.api.rest.breakingCount, 12);
+    assert.deepStrictEqual(m.api.rest.advisories, [
+        'GET /api/v1/foo — response enum value added',
+    ]);
+    assert.strictEqual(m.api.rest.advisoryCount, 1);
     assert.deepStrictEqual(m.capabilities, ['migrations', 'rest']);
 });
 
@@ -263,7 +279,7 @@ test('checked-but-clean restApi => breaking false, "rest" capability present', (
     const m = buildMarker({
         ...base,
         migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
-        restApi: { checked: true, breaking: false, changes: [] },
+        restApi: { ...emptyApiDetails, checked: true, breaking: false, changes: [] },
     });
     assert.strictEqual(m.api.rest.checked, true);
     assert.strictEqual(m.api.rest.breaking, false);
@@ -274,7 +290,7 @@ test('unchecked restApi leaves the stub and does NOT claim the capability', () =
     const m = buildMarker({
         ...base,
         migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
-        restApi: { checked: false, breaking: false, changes: [] },
+        restApi: { ...emptyApiDetails, checked: false, breaking: false, changes: [] },
     });
     assert.strictEqual(m.api.rest.checked, false);
     assert.ok(!m.capabilities.includes('rest'));
@@ -295,7 +311,7 @@ test('restApi and aiReview compose: capabilities carry both', () => {
         ...base,
         migrations: { present: true, count: 1, files: ['x.ts'], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         aiReview: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', summary: 'safe.' },
-        restApi: { checked: true, breaking: false, changes: [] },
+        restApi: { ...emptyApiDetails, checked: true, breaking: false, changes: [] },
     });
     assert.deepStrictEqual(m.capabilities, ['migrations', 'ai-review', 'rest']);
     assert.strictEqual(m.compatibility.rollingUpdateSafe, true);
@@ -448,7 +464,7 @@ test('checked mcpApi populates api.mcp + adds "mcp" capability', () => {
     const m = buildMarker({
         ...base,
         migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
-        mcpApi: { checked: true, breaking: true, changes: ['MCP tool `x` removed'] },
+        mcpApi: { ...breakingApiDetails, checked: true, breaking: true, changes: ['MCP tool `x` removed'] },
     });
     assert.strictEqual(m.api.mcp.checked, true);
     assert.strictEqual(m.api.mcp.breaking, true);
@@ -460,7 +476,7 @@ test('unchecked/null mcpApi leaves the stub and does NOT claim the capability', 
     const m = buildMarker({
         ...base,
         migrations: { present: false, count: 0, files: [], ee: false, deletedHistorical: [], modifiedHistorical: [] },
-        mcpApi: { checked: false, breaking: false, changes: [] },
+        mcpApi: { ...emptyApiDetails, checked: false, breaking: false, changes: [] },
     });
     assert.strictEqual(m.api.mcp.checked, false);
     assert.ok(!m.capabilities.includes('mcp'));
@@ -480,7 +496,7 @@ test('REST break with NO migration → base "unknown" (cautious), not silently s
     const m = buildMarker({
         ...base,
         migrations: noMig,
-        restApi: { checked: true, breaking: true, changes: ['DELETE /api/v1/foo — endpoint removed'] },
+        restApi: { ...breakingApiDetails, checked: true, breaking: true, changes: ['DELETE /api/v1/foo — endpoint removed'] },
     });
     // no migration would normally be "true"; a flagged REST break makes it unknown
     assert.strictEqual(m.compatibility.rollingUpdateSafe, 'unknown');
@@ -494,7 +510,7 @@ test('REST break + AI "safe/high" verdict → RollingUpdate (in-flight frontend 
     const m = buildMarker({
         ...base,
         migrations: noMig,
-        restApi: { checked: true, breaking: true, changes: ['DELETE /api/v1/legacy — removed'] },
+        restApi: { ...breakingApiDetails, checked: true, breaking: true, changes: ['DELETE /api/v1/legacy — removed'] },
         aiReview: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', summary: 'Endpoint is external-only; the bundled frontend never calls it.' },
     });
     assert.strictEqual(m.compatibility.rollingUpdateSafe, true);
@@ -507,7 +523,7 @@ test('REST break + AI "breaking" verdict → false (an in-flight consumer breaks
     const m = buildMarker({
         ...base,
         migrations: noMig,
-        restApi: { checked: true, breaking: true, changes: ['GET /api/v1/saved — response field removed'] },
+        restApi: { ...breakingApiDetails, checked: true, breaking: true, changes: ['GET /api/v1/saved — response field removed'] },
         aiReview: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', summary: 'The bundled frontend reads the removed field.' },
     });
     assert.strictEqual(m.compatibility.rollingUpdateSafe, false);
@@ -519,7 +535,7 @@ test('REST break + inconclusive AI ("unknown") → stays "unknown" (never assert
     const m = buildMarker({
         ...base,
         migrations: noMig,
-        restApi: { checked: true, breaking: true, changes: ['PATCH /api/v1/x — param now required'] },
+        restApi: { ...breakingApiDetails, checked: true, breaking: true, changes: ['PATCH /api/v1/x — param now required'] },
         aiReview: { rollingUpdateSafe: 'unknown', recommendedStrategy: 'Recreate', summary: 'Could not determine frontend usage.' },
     });
     assert.strictEqual(m.compatibility.rollingUpdateSafe, 'unknown');
@@ -530,7 +546,7 @@ test('MCP break with NO migration + AI "breaking" → false', () => {
     const m = buildMarker({
         ...base,
         migrations: noMig,
-        mcpApi: { checked: true, breaking: true, changes: ['MCP tool `run_query` removed'] },
+        mcpApi: { ...breakingApiDetails, checked: true, breaking: true, changes: ['MCP tool `run_query` removed'] },
         aiReview: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', summary: 'An in-flight agent session would fail the call.' },
     });
     assert.strictEqual(m.compatibility.rollingUpdateSafe, false);
@@ -541,7 +557,7 @@ test('a clean REST surface does NOT make a no-migration release "unknown"', () =
     const m = buildMarker({
         ...base,
         migrations: noMig,
-        restApi: { checked: true, breaking: false, changes: [] },
+        restApi: { ...emptyApiDetails, checked: true, breaking: false, changes: [] },
         // an aiReview passed here must be ignored — nothing was flagged to validate
         aiReview: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', summary: 'should be ignored' },
     });
@@ -600,8 +616,8 @@ test('all phases compose: capabilities ordered migrations, sql-lint, ai-review, 
         migrations: { present: true, count: 1, files: ['x.ts'], ee: false, deletedHistorical: [], modifiedHistorical: [] },
         sqlLint: { ran: true, breaking: false, findings: [] },
         aiReview: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', summary: 'breaks.' },
-        restApi: { checked: true, breaking: true, changes: ['GET /x — removed'] },
-        mcpApi: { checked: true, breaking: false, changes: [] },
+        restApi: { ...breakingApiDetails, checked: true, breaking: true, changes: ['GET /x — removed'] },
+        mcpApi: { ...emptyApiDetails, checked: true, breaking: false, changes: [] },
         upgrade: { consulted: true, minPreviousVersion: null, requiredStop: true, note: 'stop' },
     });
     assert.deepStrictEqual(m.capabilities, ['migrations', 'sql-lint', 'ai-review', 'rest', 'mcp', 'upgrade']);

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -68,6 +68,9 @@ export interface ApiSurface {
     checked: boolean;
     breaking: TriState;
     changes: string[];
+    breakingCount: number;
+    advisories: string[];
+    advisoryCount: number;
 }
 
 export interface ReleaseSafetyMarker {
@@ -393,7 +396,14 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     // means the diff didn't run — leave the unchecked stub and don't claim the
     // capability. Independent of the migration/rolling-update signal above:
     // api.rest.breaking is about REST consumers, not mid-rollout pod safety.
-    let rest: ApiSurface = { checked: false, breaking: false, changes: [] };
+    let rest: ApiSurface = {
+        checked: false,
+        breaking: false,
+        changes: [],
+        breakingCount: 0,
+        advisories: [],
+        advisoryCount: 0,
+    };
     if (restApi && restApi.checked) {
         rest = restApi;
         capabilities.push('rest');
@@ -402,7 +412,14 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     // P3: deterministic MCP tool-surface diff. Same semantics as rest:
     // `checked: false` means the diff didn't run — leave the unchecked stub and
     // don't claim the capability. About MCP tool consumers, not pod safety.
-    let mcp: ApiSurface = { checked: false, breaking: false, changes: [] };
+    let mcp: ApiSurface = {
+        checked: false,
+        breaking: false,
+        changes: [],
+        breakingCount: 0,
+        advisories: [],
+        advisoryCount: 0,
+    };
     if (input.mcpApi && input.mcpApi.checked) {
         mcp = input.mcpApi;
         capabilities.push('mcp');

--- a/scripts/mcp-tools-diff.test.ts
+++ b/scripts/mcp-tools-diff.test.ts
@@ -6,7 +6,12 @@
  * (git show + parse) is exercised by the CLI against committed snapshots.
  */
 import * as assert from 'assert';
-import { diffSnapshots, SnapshotTool, ToolsSnapshot } from './mcp-tools-diff';
+import {
+    diffMcpTools,
+    diffSnapshots,
+    SnapshotTool,
+    ToolsSnapshot,
+} from './mcp-tools-diff';
 
 let passed = 0;
 const failures: string[] = [];
@@ -35,6 +40,7 @@ test('identical snapshots => not breaking', () => {
     const r = diffSnapshots(a, a);
     assert.strictEqual(r.breaking, false);
     assert.deepStrictEqual(r.changes, []);
+    assert.strictEqual(r.breakingCount, 0);
 });
 
 test('R1: removed tool is breaking', () => {
@@ -104,6 +110,25 @@ test('multiple breaking changes accumulate, deterministic order', () => {
     assert.ok(r.changes.includes('MCP tool `a`: input `x` became required'));
     assert.ok(r.changes.includes('MCP tool `a`: input `x` type changed string → number'));
     assert.strictEqual(r.breaking, true);
+    assert.strictEqual(r.breakingCount, 4);
+});
+
+test('caps more than 50 breaking changes while preserving the total count', () => {
+    const before = snap(
+        Array.from({ length: 60 }, (_, i) => tool(`removed_${i.toString().padStart(2, '0')}`)),
+    );
+    const r = diffSnapshots(before, snap([]));
+    assert.strictEqual(r.breaking, true);
+    assert.strictEqual(r.changes.length, 51);
+    assert.match(r.changes[50], /and 10 more breaking change\(s\)/);
+    assert.strictEqual(r.breakingCount, 60);
+});
+
+test('a checked MCP diff carries no advisories', () => {
+    const r = diffMcpTools({ lastTag: 'HEAD', newRef: 'HEAD' });
+    assert.strictEqual(r.checked, true);
+    assert.deepStrictEqual(r.advisories, []);
+    assert.strictEqual(r.advisoryCount, 0);
 });
 
 test('missing/empty inputSchema is treated as no properties (no crash)', () => {

--- a/scripts/mcp-tools-diff.ts
+++ b/scripts/mcp-tools-diff.ts
@@ -38,6 +38,9 @@ export interface ApiSurface {
     checked: boolean;
     breaking: TriState;
     changes: string[];
+    breakingCount: number;
+    advisories: string[];
+    advisoryCount: number;
 }
 
 /** Repo-relative path to the committed MCP tool-surface snapshot. */
@@ -86,7 +89,8 @@ function typeLabel(t: string | string[] | undefined): string {
 
 /**
  * PURE. Conservative 4-rule breaking-change classifier over two tool snapshots.
- * Returns `breaking` + a capped, human-readable list. The four rules:
+ * Returns `breaking`, an uncapped count, and a capped human-readable list. The
+ * four rules:
  *   R1 tool removed
  *   R2 input field became required (added to `required`)
  *   R3 input field removed (a top-level property disappeared)
@@ -97,7 +101,7 @@ function typeLabel(t: string | string[] | undefined): string {
 export function diffSnapshots(
     oldSnap: ToolsSnapshot,
     newSnap: ToolsSnapshot,
-): { breaking: boolean; changes: string[] } {
+): { breaking: boolean; changes: string[]; breakingCount: number } {
     const oldByName = new Map(oldSnap.tools.map((t) => [t.name, t]));
     const newByName = new Map(newSnap.tools.map((t) => [t.name, t]));
     const changes: string[] = [];
@@ -148,10 +152,21 @@ export function diffSnapshots(
     if (changes.length > MAX_CHANGES) {
         capped.push(`… and ${changes.length - MAX_CHANGES} more breaking change(s)`);
     }
-    return { breaking: changes.length > 0, changes: capped };
+    return {
+        breaking: changes.length > 0,
+        changes: capped,
+        breakingCount: changes.length,
+    };
 }
 
-const UNCHECKED: ApiSurface = { checked: false, breaking: false, changes: [] };
+const UNCHECKED: ApiSurface = {
+    checked: false,
+    breaking: false,
+    changes: [],
+    breakingCount: 0,
+    advisories: [],
+    advisoryCount: 0,
+};
 
 /** IO: read a file at a git ref. Returns null if the path didn't exist there. */
 function showAtRef(ref: string, repoPath: string): string | null {
@@ -208,9 +223,16 @@ export function diffMcpTools(opts: DiffMcpToolsOpts): ApiSurface {
         return UNCHECKED;
     }
 
-    const { breaking, changes } = diffSnapshots(oldSnap, newSnap);
-    log(`api.mcp checked: ${breaking ? `BREAKING (${changes.length})` : 'no breaking changes'}`);
-    return { checked: true, breaking, changes };
+    const result = diffSnapshots(oldSnap, newSnap);
+    log(
+        `api.mcp checked: ${result.breakingCount} breaking, 0 advisory`,
+    );
+    return {
+        checked: true,
+        ...result,
+        advisories: [],
+        advisoryCount: 0,
+    };
 }
 
 // ---- CLI --------------------------------------------------------------------

--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -134,6 +134,59 @@ test('MCP breaking change is called out for agents/clients', () => {
     assert.ok(body.includes('| MCP tools | 1 breaking change |'));
 });
 
+test('API result prefers the uncapped breaking count over rendered change length', () => {
+    const body = renderPrComment(baseMarker({
+        api: {
+            rest: {
+                checked: true,
+                breaking: true,
+                changes: Array.from({ length: 51 }, () => 'rendered change'),
+                breakingCount: 500,
+            },
+            mcp: { checked: false, breaking: false, changes: [] },
+        },
+    }));
+    assert.ok(body.includes('| REST API | 500 breaking changes |'));
+});
+
+test('API results append advisory counts for breaking and non-breaking surfaces', () => {
+    const body = renderPrComment(baseMarker({
+        api: {
+            rest: {
+                checked: true,
+                breaking: false,
+                changes: [],
+                advisories: ['response enum value added', 'another enum value added'],
+                advisoryCount: 2,
+            },
+            mcp: {
+                checked: true,
+                breaking: true,
+                changes: ['tool removed'],
+                breakingCount: 1,
+                advisories: ['metadata changed'],
+                advisoryCount: 1,
+            },
+        },
+    }));
+    assert.ok(body.includes('| REST API | no breaking changes, 2 advisory notes |'));
+    assert.ok(body.includes('| MCP tools | 1 breaking change, 1 advisory note |'));
+});
+
+test('old markers without count or advisory fields fall back to rendered change length', () => {
+    const body = renderPrComment(baseMarker({
+        api: {
+            rest: {
+                checked: true,
+                breaking: true,
+                changes: ['first rendered change', 'second rendered change'],
+            },
+            mcp: { checked: false, breaking: false, changes: [] },
+        },
+    }));
+    assert.ok(body.includes('| REST API | 2 breaking changes |'));
+});
+
 test('required stop is surfaced in plain terms', () => {
     const body = renderPrComment(baseMarker({
         upgrade: { minPreviousVersion: '0.3200.0', requiredStop: true, note: 'Index rebuild.' },

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -29,6 +29,9 @@ interface ApiSurface {
     checked: boolean;
     breaking: TriState;
     changes: string[];
+    breakingCount?: number;
+    advisories?: string[];
+    advisoryCount?: number;
 }
 
 export interface Marker {
@@ -162,9 +165,15 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
             : 'couldn’t tell (no baseline to compare against)';
     const apiResult = (s: ApiSurface, uncheckedReason?: string): string => {
         if (!s.checked) return uncheckedReason ? `not checked — ${uncheckedReason}` : 'not checked';
-        return s.breaking === true
-            ? `${s.changes.length} breaking change${s.changes.length === 1 ? '' : 's'}`
-            : 'no breaking changes';
+        const breakingCount = s.breakingCount ?? s.changes.length;
+        const result =
+            s.breaking === true
+                ? `${breakingCount} breaking change${breakingCount === 1 ? '' : 's'}`
+                : 'no breaking changes';
+        const advisoryCount = s.advisoryCount ?? 0;
+        return advisoryCount > 0
+            ? `${result}, ${advisoryCount} advisory note${advisoryCount === 1 ? '' : 's'}`
+            : result;
     };
     const restUncheckedReason =
         opts.restStatus === 'skipped'

--- a/scripts/release-safety.schema.json
+++ b/scripts/release-safety.schema.json
@@ -33,7 +33,21 @@
                     "description": "Whether this surface was diffed for this release. false means UNKNOWN, not 'no break'."
                 },
                 "breaking": { "$ref": "#/definitions/triState" },
-                "changes": { "type": "array", "items": { "type": "string" } }
+                "changes": { "type": "array", "items": { "type": "string" } },
+                "breakingCount": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Uncapped total count of ERR-level contract-breaking findings."
+                },
+                "advisories": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "WARN-level oasdiff findings — worth a look, not contract-breaking."
+                },
+                "advisoryCount": {
+                    "type": "integer",
+                    "minimum": 0
+                }
             }
         }
     },

--- a/scripts/rest-api-diff.test.ts
+++ b/scripts/rest-api-diff.test.ts
@@ -37,6 +37,9 @@ test('empty list => not breaking, no changes', () => {
     const r = summarizeBreaking([]);
     assert.strictEqual(r.breaking, false);
     assert.deepStrictEqual(r.changes, []);
+    assert.strictEqual(r.breakingCount, 0);
+    assert.deepStrictEqual(r.advisories, []);
+    assert.strictEqual(r.advisoryCount, 0);
 });
 
 test('non-empty list => breaking true, formatted "METHOD path — text"', () => {
@@ -57,12 +60,56 @@ test('renders gracefully when operation/path are absent', () => {
     assert.deepStrictEqual(r.changes, ['something broke']);
 });
 
-test('caps the list at 50 with an explicit overflow line (never silent truncation)', () => {
-    const many = Array.from({ length: 53 }, (_, i) => item({ path: `/api/v1/r${i}` }));
+test('WARN-only items are advisory and do not make the result breaking', () => {
+    const r = summarizeBreaking([
+        item({ id: 'response-property-enum-value-added', level: 2, text: 'response enum value added' }),
+    ]);
+    assert.strictEqual(r.breaking, false);
+    assert.strictEqual(r.breakingCount, 0);
+    assert.deepStrictEqual(r.changes, []);
+    assert.deepStrictEqual(r.advisories, [
+        'GET /api/v1/foo — response enum value added',
+    ]);
+    assert.strictEqual(r.advisoryCount, 1);
+});
+
+test('mixed ERR and WARN items are split into breaking changes and advisories', () => {
+    const r = summarizeBreaking([
+        item({ level: 3, text: 'response property removed' }),
+        item({ level: 2, text: 'response enum value added' }),
+    ]);
+    assert.strictEqual(r.breaking, true);
+    assert.deepStrictEqual(r.changes, ['GET /api/v1/foo — response property removed']);
+    assert.strictEqual(r.breakingCount, 1);
+    assert.deepStrictEqual(r.advisories, ['GET /api/v1/foo — response enum value added']);
+    assert.strictEqual(r.advisoryCount, 1);
+});
+
+test('an item with no level is conservatively treated as breaking', () => {
+    const r = summarizeBreaking([item({ level: undefined })]);
+    assert.strictEqual(r.breaking, true);
+    assert.strictEqual(r.breakingCount, 1);
+    assert.deepStrictEqual(r.advisories, []);
+});
+
+test('caps 60 breaking items at 50 plus overflow while preserving the total count', () => {
+    const many = Array.from({ length: 60 }, (_, i) => item({ path: `/api/v1/r${i}` }));
     const r = summarizeBreaking(many);
     assert.strictEqual(r.breaking, true);
     assert.strictEqual(r.changes.length, 51); // 50 + overflow line
-    assert.match(r.changes[50], /and 3 more breaking change\(s\)/);
+    assert.match(r.changes[50], /and 10 more breaking change\(s\)/);
+    assert.strictEqual(r.breakingCount, 60);
+});
+
+test('caps advisories independently while preserving the total count', () => {
+    const many = Array.from({ length: 60 }, (_, i) =>
+        item({ level: 2, path: `/api/v1/r${i}` }),
+    );
+    const r = summarizeBreaking(many);
+    assert.strictEqual(r.breaking, false);
+    assert.strictEqual(r.advisories.length, 51);
+    assert.match(r.advisories[50], /and 10 more advisory note\(s\)/);
+    assert.strictEqual(r.advisoryCount, 60);
 });
 
 test('exactly 50 changes => no overflow line', () => {
@@ -91,6 +138,9 @@ test('uses an explicit working-tree spec as the new side', () => {
             checked: true,
             breaking: false,
             changes: [],
+            breakingCount: 0,
+            advisories: [],
+            advisoryCount: 0,
         });
     } finally {
         fs.rmSync(dir, { recursive: true, force: true });
@@ -117,7 +167,14 @@ test('diffs an explicitly generated spec pair, touching no git ref', () => {
             oasdiffBin: oasdiffPath,
         });
 
-        assert.deepStrictEqual(result, { checked: true, breaking: false, changes: [] });
+        assert.deepStrictEqual(result, {
+            checked: true,
+            breaking: false,
+            changes: [],
+            breakingCount: 0,
+            advisories: [],
+            advisoryCount: 0,
+        });
         assert.strictEqual(fs.readFileSync(argsLog, 'utf-8'), '{"old":true}{"new":true}');
     } finally {
         fs.rmSync(dir, { recursive: true, force: true });
@@ -138,14 +195,28 @@ test('a missing generated spec stays unchecked rather than reporting no changes'
             newSpecPath: present,
             oasdiffBin: oasdiffPath,
         });
-        assert.deepStrictEqual(missingBase, { checked: false, breaking: false, changes: [] });
+        assert.deepStrictEqual(missingBase, {
+            checked: false,
+            breaking: false,
+            changes: [],
+            breakingCount: 0,
+            advisories: [],
+            advisoryCount: 0,
+        });
 
         const missingNew = diffRestApi({
             baseSpecPath: present,
             newSpecPath: path.join(dir, 'absent.json'),
             oasdiffBin: oasdiffPath,
         });
-        assert.deepStrictEqual(missingNew, { checked: false, breaking: false, changes: [] });
+        assert.deepStrictEqual(missingNew, {
+            checked: false,
+            breaking: false,
+            changes: [],
+            breakingCount: 0,
+            advisories: [],
+            advisoryCount: 0,
+        });
     } finally {
         fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/scripts/rest-api-diff.ts
+++ b/scripts/rest-api-diff.ts
@@ -3,8 +3,11 @@
  *
  * Populates the release-safety marker's `api.rest` block by diffing the
  * generated OpenAPI spec (`packages/backend/src/generated/swagger.json`) between
- * the PREVIOUS release tag and HEAD with `oasdiff breaking`. A non-empty
- * breaking list means a consumer of the REST API may break across this upgrade.
+ * the PREVIOUS release tag and HEAD with `oasdiff breaking`. That command returns
+ * both WARN-level (2) and ERR-level (3) items. Only ERR items are consumer-
+ * breaking contract violations; WARN items — such as response enum widening,
+ * which recurs whenever a chart or scheduler type is added — are surfaced as
+ * advisories without affecting the verdict.
  *
  * This is a deterministic detector whose flagged breaking changes are handed
  * downstream to the AI rolling-update review for validation. oasdiff parses both
@@ -39,6 +42,9 @@ export interface ApiSurface {
     checked: boolean;
     breaking: TriState;
     changes: string[];
+    breakingCount: number;
+    advisories: string[];
+    advisoryCount: number;
 }
 
 export const SPEC_PATH = 'packages/backend/src/generated/swagger.json';
@@ -48,13 +54,13 @@ const MAX_CHANGES = 50;
 
 /**
  * One item from `oasdiff breaking -f json`. oasdiff's `breaking` subcommand
- * already filters to breaking-only changes (WARN=2 / ERR=3); INFO=1 additive
- * changes never appear here.
+ * returns both WARN=2 and ERR=3 items; missing levels are possible when output
+ * changes and are handled conservatively as errors.
  */
 export interface OasdiffItem {
     id: string;
     text: string;
-    level: number;
+    level?: number;
     operation?: string;
     operationId?: string;
     path?: string;
@@ -62,27 +68,49 @@ export interface OasdiffItem {
 
 /**
  * PURE. Reduce the oasdiff `breaking` JSON array into the marker's `api.rest`
- * shape. A non-empty list ⇒ `breaking: true`; each item renders as
- * "METHOD /path — text". The list is capped with an explicit overflow line so
- * the count is never silently truncated.
+ * shape. ERR-level and unlevelled items are breaking; WARN/other items are
+ * advisories. Each item renders as "METHOD /path — text". Both lists are capped
+ * independently with explicit overflow lines while their counts remain uncapped.
  */
 export function summarizeBreaking(items: OasdiffItem[]): {
     breaking: boolean;
     changes: string[];
+    breakingCount: number;
+    advisories: string[];
+    advisoryCount: number;
 } {
-    const rendered = items.map((it) => {
+    const render = (it: OasdiffItem): string => {
         const op = it.operation ? `${it.operation} ` : '';
         const p = it.path ? `${it.path} — ` : '';
         return `${op}${p}${it.text}`.trim();
-    });
-    const changes = rendered.slice(0, MAX_CHANGES);
-    if (rendered.length > MAX_CHANGES) {
-        changes.push(`… and ${rendered.length - MAX_CHANGES} more breaking change(s)`);
+    };
+    const errItems = items.filter((item) => item.level === undefined || item.level >= 3);
+    const advisoryItems = items.filter((item) => item.level !== undefined && item.level < 3);
+    const changes = errItems.slice(0, MAX_CHANGES).map(render);
+    if (errItems.length > MAX_CHANGES) {
+        changes.push(`… and ${errItems.length - MAX_CHANGES} more breaking change(s)`);
     }
-    return { breaking: items.length > 0, changes };
+    const advisories = advisoryItems.slice(0, MAX_CHANGES).map(render);
+    if (advisoryItems.length > MAX_CHANGES) {
+        advisories.push(`… and ${advisoryItems.length - MAX_CHANGES} more advisory note(s)`);
+    }
+    return {
+        breaking: errItems.length > 0,
+        changes,
+        breakingCount: errItems.length,
+        advisories,
+        advisoryCount: advisoryItems.length,
+    };
 }
 
-const UNCHECKED: ApiSurface = { checked: false, breaking: false, changes: [] };
+const UNCHECKED: ApiSurface = {
+    checked: false,
+    breaking: false,
+    changes: [],
+    breakingCount: 0,
+    advisories: [],
+    advisoryCount: 0,
+};
 
 /** Locate the oasdiff binary: explicit OASDIFF_BIN, else PATH. null if absent. */
 export function findOasdiff(): string | null {
@@ -208,9 +236,11 @@ export function diffRestApi(opts: DiffRestApiOpts): ApiSurface {
             return UNCHECKED;
         }
 
-        const { breaking, changes } = summarizeBreaking(items);
-        log(`api.rest checked: ${breaking ? `BREAKING (${items.length})` : 'no breaking changes'}`);
-        return { checked: true, breaking, changes };
+        const summary = summarizeBreaking(items);
+        log(
+            `api.rest checked: ${summary.breakingCount} breaking, ${summary.advisoryCount} advisory`,
+        );
+        return { checked: true, ...summary };
     } finally {
         fs.rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What

- `summarizeBreaking()` now splits oasdiff items by level: only **ERR (3)** items set `api.rest.breaking`; **WARN (2)** items — like `response-property-enum-value-added`, which fires on every added chart/scheduler type — surface as a new `advisories` list that never affects the verdict. Items with a missing level are conservatively treated as breaking.
- Fixes the capped-count miscount on both API surfaces: the marker carries uncapped `breakingCount`/`advisoryCount` alongside the capped rendered lists, and the PR comment renders the true totals (500 findings used to render as "51").
- `release-safety.schema.json` gains the three fields as optional properties, so markers produced before this change remain schema-valid.
- The PR comment appends ", N advisory note(s)" to the REST cell but deliberately adds no headline bullet for advisories — the point of this change is that a ⚠️ should always be worth acting on.

## Why

A PR adding a single chart type produced "51 breaking changes" — every one a response-only enum widening, which does not break consumers that tolerate unknown values, while the AI review in the same marker correctly concluded nothing breaks. Left as-is this trains everyone to ignore the ⚠️.

## Considered and rejected

Annotating response enums with `x-extensible-enum`: oasdiff's checker has **no response-side** x-extensible-enum checks (verified in its `checker/` source — only `request-property`/`request-parameter` variants exist), so the annotation would silence widening at the cost of also losing response enum-**removal** detection, and it degrades the generated spec for docs/client codegen. The severity split achieves the intended semantics without those losses. Noted on the ticket.

## Tests

`rest-api-diff.test.ts` 9 → 13 (WARN/ERR split, missing-level conservatism, independent capping, uncapped counts); `mcp-tools-diff.test.ts` and `release-safety-pr-comment.test.ts` extended for counts/advisory rendering and old-marker fallback; `gen-release-safety.test.ts` passthrough coverage. Full suite green.

Closes: SPK-696