### PR TITLE
feat: parse LIGHTDASH_SECRET_FALLBACKS into an immutable secret keyring

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -128,6 +128,11 @@ export const lightdashConfigMock: LightdashConfig = {
         enabled: false,
     },
     lightdashSecret: 'look away this is a secret',
+    lightdashSecrets: {
+        active: 'look away this is a secret',
+        fallbacks: [],
+        all: ['look away this is a secret'],
+    },
     logging: {
         level: 'debug',
         format: 'pretty',

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -332,6 +332,137 @@ test('Should prefer an explicit Slack state secret', () => {
     expect(parseConfig().slack?.stateSecret).toEqual('slack-specific-secret');
 });
 
+describe('LIGHTDASH_SECRET_FALLBACKS keyring', () => {
+    test('defaults to no fallbacks when the variable is unset', () => {
+        expect(parseConfig().lightdashSecrets).toEqual({
+            active: 'not very secret',
+            fallbacks: [],
+            all: ['not very secret'],
+        });
+    });
+
+    test('keeps lightdashSecret equal to the active secret', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = '["old secret"]';
+        const config = parseConfig();
+        expect(config.lightdashSecret).toEqual(config.lightdashSecrets.active);
+    });
+
+    test('parses ordered fallbacks with active first in all', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = '["old", "older"]';
+        expect(parseConfig().lightdashSecrets).toEqual({
+            active: 'not very secret',
+            fallbacks: ['old', 'older'],
+            all: ['not very secret', 'old', 'older'],
+        });
+    });
+
+    test('preserves secret bytes exactly, including commas and whitespace', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS =
+            '["  old secret, with comma  ", "\\ttabbed\\n"]';
+        expect(parseConfig().lightdashSecrets.fallbacks).toEqual([
+            '  old secret, with comma  ',
+            '\ttabbed\n',
+        ]);
+    });
+
+    test('accepts an empty array', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = '[]';
+        expect(parseConfig().lightdashSecrets.fallbacks).toEqual([]);
+    });
+
+    test('rejects malformed JSON', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = 'old,older';
+        expect(() => parseConfig()).toThrowError(ParseError);
+    });
+
+    test('rejects JSON that is not an array', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = '{"secret": "old"}';
+        expect(() => parseConfig()).toThrowError(ParseError);
+    });
+
+    test('rejects empty string entries', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = '["old", ""]';
+        expect(() => parseConfig()).toThrowError(
+            /Entry at position 1 must be a non-empty string/,
+        );
+    });
+
+    test('rejects non-string entries', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = '["old", 123]';
+        expect(() => parseConfig()).toThrowError(
+            /Entry at position 1 must be a non-empty string/,
+        );
+    });
+
+    test('rejects more than three fallbacks', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = '["a", "b", "c", "d"]';
+        expect(() => parseConfig()).toThrowError(
+            /At most 3 fallback secrets are supported, but found 4/,
+        );
+    });
+
+    test('rejects a fallback that duplicates the active secret', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = '["old", "not very secret"]';
+        expect(() => parseConfig()).toThrowError(
+            /Entry at position 1 duplicates LIGHTDASH_SECRET/,
+        );
+    });
+
+    test('rejects duplicate fallback entries', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = '["old", "old"]';
+        expect(() => parseConfig()).toThrowError(
+            /Entry at position 1 duplicates the entry at position 0/,
+        );
+    });
+
+    test('never includes secret material in parsing errors', () => {
+        process.env.LIGHTDASH_SECRET = 'active-secret-value';
+        process.env.LIGHTDASH_SECRET_FALLBACKS =
+            '["fallback-secret-value", "fallback-secret-value"]';
+        try {
+            parseConfig();
+            expect.unreachable('parseConfig should have thrown');
+        } catch (error) {
+            expect((error as Error).message).not.toContain(
+                'active-secret-value',
+            );
+            expect((error as Error).message).not.toContain(
+                'fallback-secret-value',
+            );
+        }
+    });
+
+    test('freezes the keyring object and arrays', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = '["old"]';
+        const { lightdashSecrets } = parseConfig();
+        expect(Object.isFrozen(lightdashSecrets)).toBe(true);
+        expect(Object.isFrozen(lightdashSecrets.fallbacks)).toBe(true);
+        expect(Object.isFrozen(lightdashSecrets.all)).toBe(true);
+    });
+
+    test('requires an explicit Slack state secret when fallbacks and Slack are configured', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = '["old"]';
+        process.env.SLACK_CLIENT_ID = 'slack-client-id';
+        expect(() => parseConfig()).toThrowError(
+            /SLACK_STATE_SECRET must be set explicitly/,
+        );
+    });
+
+    test('accepts fallbacks with Slack when the state secret is explicit', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = '["old"]';
+        process.env.SLACK_CLIENT_ID = 'slack-client-id';
+        process.env.SLACK_STATE_SECRET = 'explicit-state-secret';
+        expect(parseConfig().slack?.stateSecret).toEqual(
+            'explicit-state-secret',
+        );
+    });
+
+    test('accepts fallbacks without Slack configured', () => {
+        process.env.LIGHTDASH_SECRET_FALLBACKS = '["old"]';
+        expect(() => parseConfig()).not.toThrow();
+    });
+});
+
 test('Should parse bedrock inference profile prefix from env', () => {
     process.env.BEDROCK_API_KEY = 'test-bedrock-key';
     process.env.BEDROCK_REGION = 'ap-northeast-1';

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -178,6 +178,65 @@ const getArrayFromCommaSeparatedList = (envVar: string) => {
 const getProviderCustomHeaders = (envVar: string): Record<string, string> =>
     getStringRecordFromEnvironmentVariable(envVar) ?? {};
 
+const MAX_LIGHTDASH_SECRET_FALLBACKS = 3;
+
+// Secret bytes must round-trip unchanged, so entries are never trimmed or
+// normalized, and error messages must never include secret material.
+export const parseLightdashSecretFallbacks = (
+    activeSecret: string,
+): string[] => {
+    const raw = process.env.LIGHTDASH_SECRET_FALLBACKS;
+    if (raw === undefined) {
+        return [];
+    }
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        throw new ParseError(
+            `Cannot parse environment variable "LIGHTDASH_SECRET_FALLBACKS". Must be a JSON array of strings, e.g. '["previous secret"]'`,
+            {},
+        );
+    }
+    if (!Array.isArray(parsed)) {
+        throw new ParseError(
+            `Cannot parse environment variable "LIGHTDASH_SECRET_FALLBACKS". Must be a JSON array of strings`,
+            {},
+        );
+    }
+    if (parsed.length > MAX_LIGHTDASH_SECRET_FALLBACKS) {
+        throw new ParseError(
+            `Cannot parse environment variable "LIGHTDASH_SECRET_FALLBACKS". At most ${MAX_LIGHTDASH_SECRET_FALLBACKS} fallback secrets are supported, but found ${parsed.length}`,
+            {},
+        );
+    }
+    parsed.forEach((entry, index) => {
+        if (typeof entry !== 'string' || entry.length === 0) {
+            throw new ParseError(
+                `Cannot parse environment variable "LIGHTDASH_SECRET_FALLBACKS". Entry at position ${index} must be a non-empty string`,
+                {},
+            );
+        }
+    });
+    const fallbacks = parsed as string[];
+    fallbacks.forEach((secret, index) => {
+        if (secret === activeSecret) {
+            throw new ParseError(
+                `Cannot parse environment variable "LIGHTDASH_SECRET_FALLBACKS". Entry at position ${index} duplicates LIGHTDASH_SECRET`,
+                {},
+            );
+        }
+        const firstIndex = fallbacks.indexOf(secret);
+        if (firstIndex !== index) {
+            throw new ParseError(
+                `Cannot parse environment variable "LIGHTDASH_SECRET_FALLBACKS". Entry at position ${index} duplicates the entry at position ${firstIndex}`,
+                {},
+            );
+        }
+    });
+    return fallbacks;
+};
+
 export const getHexColorsFromEnvironmentVariable = (
     colorPalette: string | undefined,
 ): string[] | undefined => {
@@ -1301,8 +1360,16 @@ export type MultiProjectSetupEntry = {
     };
 };
 
+export type LightdashSecrets = {
+    readonly active: string;
+    readonly fallbacks: readonly string[];
+    readonly all: readonly string[];
+};
+
 export type LightdashConfig = {
+    /** Always equals `lightdashSecrets.active`; kept for compatibility */
     lightdashSecret: string;
+    lightdashSecrets: LightdashSecrets;
     secureCookies: boolean;
     cookieSameSite?: 'lax' | 'none';
     security: {
@@ -2369,6 +2436,23 @@ export const parseConfig = (): LightdashConfig => {
             {},
         );
     }
+    const lightdashSecretFallbacks =
+        parseLightdashSecretFallbacks(lightdashSecret);
+    const lightdashSecrets: LightdashSecrets = Object.freeze({
+        active: lightdashSecret,
+        fallbacks: Object.freeze([...lightdashSecretFallbacks]),
+        all: Object.freeze([lightdashSecret, ...lightdashSecretFallbacks]),
+    });
+    if (
+        lightdashSecretFallbacks.length > 0 &&
+        process.env.SLACK_CLIENT_ID &&
+        !process.env.SLACK_STATE_SECRET
+    ) {
+        throw new ParseError(
+            'SLACK_STATE_SECRET must be set explicitly when LIGHTDASH_SECRET_FALLBACKS is configured and Slack is enabled. Set it to the pre-rotation LIGHTDASH_SECRET so already-issued Slack OAuth state remains valid.',
+            {},
+        );
+    }
     const lightdashMode = process.env.LIGHTDASH_MODE;
     if (lightdashMode !== undefined && !isLightdashMode(lightdashMode)) {
         throw new ParseError(
@@ -2610,6 +2694,7 @@ export const parseConfig = (): LightdashConfig => {
             },
         },
         lightdashSecret,
+        lightdashSecrets,
         secureCookies,
         cookiesMaxAgeHours: getIntegerFromEnvironmentVariable(
             'COOKIES_MAX_AGE_HOURS',


### PR DESCRIPTION
Adds an ordered, immutable secret keyring to `LightdashConfig`. `LIGHTDASH_SECRET` remains the active secret; `LIGHTDASH_SECRET_FALLBACKS` (a JSON string array, capped at three) keeps previous secrets available during a rotation. Parsing is lossless for secret bytes, validation never echoes secret material, and configuring fallbacks alongside Slack requires an explicit `SLACK_STATE_SECRET` so in-flight OAuth state survives the rotation.

First layer of the LIGHTDASH_SECRET rotation stack.

Relates: PROD-9721