### PR TITLE
feat: decrypt with the ordered secret keyring in EncryptionUtil

### DIFF
--- a/packages/backend/src/models/UserOAuthGrantsModel.test.ts
+++ b/packages/backend/src/models/UserOAuthGrantsModel.test.ts
@@ -14,7 +14,14 @@ const providerEmail = 'shared@example.com';
 describe('UserOAuthGrantsModel', () => {
     const database = knex({ client: MockClient, dialect: 'pg' });
     const encryptionUtil = new EncryptionUtil({
-        lightdashConfig: { lightdashSecret: 'test-secret' },
+        lightdashConfig: {
+            lightdashSecret: 'test-secret',
+            lightdashSecrets: {
+                active: 'test-secret',
+                fallbacks: [],
+                all: ['test-secret'],
+            },
+        },
     });
     const userModel = {
         getRefreshToken: vi.fn<UserModel['getRefreshToken']>(

--- a/packages/backend/src/utils/EncryptionUtil/EncryptionUtil.test.ts
+++ b/packages/backend/src/utils/EncryptionUtil/EncryptionUtil.test.ts
@@ -1,9 +1,109 @@
 import { EncryptionUtil } from './EncryptionUtil';
 
+const configWithSecrets = (active: string, ...fallbacks: string[]) => ({
+    lightdashSecret: active,
+    lightdashSecrets: {
+        active,
+        fallbacks,
+        all: [active, ...fallbacks],
+    },
+});
+
 test('Message is unchanged by encryption and decryption', () => {
     const service = new EncryptionUtil({
-        lightdashConfig: { lightdashSecret: 'secret' },
+        lightdashConfig: configWithSecrets('secret'),
     });
     const message = 'extremely secret';
     expect(service.decrypt(service.encrypt(message))).toStrictEqual(message);
+});
+
+describe('secret keyring', () => {
+    const message = 'extremely secret';
+    const oldOnly = new EncryptionUtil({
+        lightdashConfig: configWithSecrets('old secret'),
+    });
+    const newOnly = new EncryptionUtil({
+        lightdashConfig: configWithSecrets('new secret'),
+    });
+    const newActiveOldFallback = new EncryptionUtil({
+        lightdashConfig: configWithSecrets('new secret', 'old secret'),
+    });
+    const oldActiveNewFallback = new EncryptionUtil({
+        lightdashConfig: configWithSecrets('old secret', 'new secret'),
+    });
+
+    test('encrypt uses only the active secret', () => {
+        const encrypted = newActiveOldFallback.encrypt(message);
+        expect(newOnly.decrypt(encrypted)).toStrictEqual(message);
+        expect(() => oldOnly.decrypt(encrypted)).toThrow();
+    });
+
+    test('decrypts fallback ciphertext under both orderings', () => {
+        const oldCiphertext = oldOnly.encrypt(message);
+        const newCiphertext = newOnly.encrypt(message);
+        expect(newActiveOldFallback.decrypt(oldCiphertext)).toStrictEqual(
+            message,
+        );
+        expect(newActiveOldFallback.decrypt(newCiphertext)).toStrictEqual(
+            message,
+        );
+        expect(oldActiveNewFallback.decrypt(oldCiphertext)).toStrictEqual(
+            message,
+        );
+        expect(oldActiveNewFallback.decrypt(newCiphertext)).toStrictEqual(
+            message,
+        );
+    });
+
+    test('decryptWithMeta reports the active key', () => {
+        const encrypted = newActiveOldFallback.encrypt(message);
+        expect(newActiveOldFallback.decryptWithMeta(encrypted)).toStrictEqual({
+            value: message,
+            keySource: { type: 'active' },
+        });
+    });
+
+    test('decryptWithMeta reports the fallback index', () => {
+        const withTwoFallbacks = new EncryptionUtil({
+            lightdashConfig: configWithSecrets(
+                'new secret',
+                'unrelated secret',
+                'old secret',
+            ),
+        });
+        expect(
+            withTwoFallbacks.decryptWithMeta(oldOnly.encrypt(message)),
+        ).toStrictEqual({
+            value: message,
+            keySource: { type: 'fallback', index: 1 },
+        });
+    });
+
+    test('rethrows the active attempt error when no candidate matches', () => {
+        const encrypted = new EncryptionUtil({
+            lightdashConfig: configWithSecrets('unknown secret'),
+        }).encrypt(message);
+        let activeOnlyError: unknown;
+        try {
+            newOnly.decrypt(encrypted);
+        } catch (error) {
+            activeOnlyError = error;
+        }
+        expect(activeOnlyError).toBeInstanceOf(Error);
+        expect(() => newActiveOldFallback.decrypt(encrypted)).toThrowError(
+            (activeOnlyError as Error).message,
+        );
+    });
+
+    test('rejects tampered ciphertext', () => {
+        const encrypted = newActiveOldFallback.encrypt(message);
+        encrypted[encrypted.length - 1] = 255 - encrypted[encrypted.length - 1];
+        expect(() => newActiveOldFallback.decrypt(encrypted)).toThrow();
+    });
+
+    test('rejects a malformed envelope', () => {
+        expect(() =>
+            newActiveOldFallback.decrypt(Buffer.from('too short')),
+        ).toThrow();
+    });
 });

--- a/packages/backend/src/utils/EncryptionUtil/EncryptionUtil.ts
+++ b/packages/backend/src/utils/EncryptionUtil/EncryptionUtil.ts
@@ -7,11 +7,26 @@ import {
 import { LightdashConfig } from '../../config/parseConfig';
 
 type EncryptionUtilArguments = {
-    lightdashConfig: Pick<LightdashConfig, 'lightdashSecret'>;
+    lightdashConfig: Pick<
+        LightdashConfig,
+        'lightdashSecret' | 'lightdashSecrets'
+    >;
+};
+
+export type DecryptionKeySource =
+    | { type: 'active' }
+    | { type: 'fallback'; index: number };
+
+export type DecryptionResult = {
+    value: string;
+    keySource: DecryptionKeySource;
 };
 
 export class EncryptionUtil {
-    lightdashConfig: Pick<LightdashConfig, 'lightdashSecret'>;
+    lightdashConfig: Pick<
+        LightdashConfig,
+        'lightdashSecret' | 'lightdashSecrets'
+    >;
 
     algorithm: 'aes-256-gcm' = 'aes-256-gcm';
 
@@ -50,7 +65,7 @@ export class EncryptionUtil {
         const iv = randomBytes(this.ivLength);
         const salt = randomBytes(this.saltLength);
         const key = pbkdf2Sync(
-            this.lightdashConfig.lightdashSecret,
+            this.lightdashConfig.lightdashSecrets.active,
             salt,
             this.keyIterations,
             this.keyLength,
@@ -68,26 +83,50 @@ export class EncryptionUtil {
     }
 
     decrypt(encrypted: Buffer): string {
+        return this.decryptWithMeta(encrypted).value;
+    }
+
+    // Tries the active secret first, then each fallback in order. When every
+    // candidate fails, the active attempt's error is rethrown so existing
+    // catch behavior and error grouping are preserved.
+    decryptWithMeta(encrypted: Buffer): DecryptionResult {
         const salt = encrypted.slice(this.saltOffset, this.tagOffset);
         const tag = encrypted.slice(this.tagOffset, this.ivOffset);
         const iv = encrypted.slice(this.ivOffset, this.messageOffset);
         const encryptedMessage = encrypted.slice(this.messageOffset);
-        const key = pbkdf2Sync(
-            this.lightdashConfig.lightdashSecret,
-            salt,
-            this.keyIterations,
-            this.keyLength,
-            this.keyDigest,
-        );
-        const decipher = createDecipheriv(this.algorithm, key, iv, {
-            authTagLength: this.aesAuthTagLength,
-        });
-        decipher.setAuthTag(tag);
-        const message = `${decipher.update(
-            encryptedMessage,
-            undefined,
-            this.inputEncoding,
-        )}${decipher.final()}`;
-        return message;
+        const candidates = this.lightdashConfig.lightdashSecrets.all;
+        let activeError: unknown;
+        for (let i = 0; i < candidates.length; i += 1) {
+            try {
+                const key = pbkdf2Sync(
+                    candidates[i],
+                    salt,
+                    this.keyIterations,
+                    this.keyLength,
+                    this.keyDigest,
+                );
+                const decipher = createDecipheriv(this.algorithm, key, iv, {
+                    authTagLength: this.aesAuthTagLength,
+                });
+                decipher.setAuthTag(tag);
+                const value = `${decipher.update(
+                    encryptedMessage,
+                    undefined,
+                    this.inputEncoding,
+                )}${decipher.final()}`;
+                return {
+                    value,
+                    keySource:
+                        i === 0
+                            ? { type: 'active' }
+                            : { type: 'fallback', index: i - 1 },
+                };
+            } catch (error) {
+                if (i === 0) {
+                    activeError = error;
+                }
+            }
+        }
+        throw activeError;
     }
 }


### PR DESCRIPTION
EncryptionUtil now encrypts with the active secret only and decrypts by attempting each configured secret in active-first order, so ciphertext written before a rotation stays readable while the old secret remains configured as a fallback. `decryptWithMeta` exposes which key matched so migration tooling can tell converged from pending ciphertext. When every candidate fails, the active attempt's error is rethrown to preserve existing catch behavior.

Relates: PROD-9721