### PR TITLE
feat: verify sessions, JWTs and headless HMACs with the secret keyring

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -59,6 +59,7 @@ import { databricksPassportStrategy } from './controllers/authentication/strateg
 import { slackPassportStrategy } from './controllers/authentication/strategies/slackStrategy';
 import { snowflakePassportStrategy } from './controllers/authentication/strategies/snowflakeStrategy';
 import { errorHandler, scimErrorHandler } from './errors';
+import { buildExpressSessionOptions } from './expressSessionOptions';
 import { RegisterRoutes } from './generated/routes';
 import apiSpec from './generated/swagger.json';
 import Logger from './logging/logger';
@@ -664,7 +665,7 @@ export default class App {
                 '/api/apps',
                 createAppPreviewRouter(
                     this.lightdashConfig.appRuntime,
-                    this.lightdashConfig.lightdashSecret,
+                    this.lightdashConfig.lightdashSecrets,
                     previewFrameAncestors,
                     (p) => {
                         void analyticsModel.addAppViewEvent(
@@ -689,29 +690,13 @@ export default class App {
         expressApp.use(express.urlencoded({ extended: false }));
 
         expressApp.use(
-            expressSession({
-                name:
-                    process.env.NODE_ENV === 'development' &&
-                    process.env.DEV_SCOPED_COOKIE_NAMES_ENABLED === 'true'
-                        ? `connect.sid.${this.port}`
-                        : 'connect.sid',
-                secret: this.lightdashConfig.lightdashSecret,
-                proxy: this.lightdashConfig.trustProxy,
-                rolling: true,
-                cookie: {
-                    maxAge:
-                        (this.lightdashConfig.cookiesMaxAgeHours || 24) *
-                        60 *
-                        60 *
-                        1000, // in ms
-                    secure: this.lightdashConfig.secureCookies,
-                    httpOnly: true,
-                    sameSite: this.lightdashConfig.cookieSameSite,
-                },
-                resave: false,
-                saveUninitialized: false,
-                store,
-            }),
+            expressSession(
+                buildExpressSessionOptions(
+                    this.lightdashConfig,
+                    store,
+                    this.port,
+                ),
+            ),
         );
         expressApp.use(flash());
         expressApp.use(passport.initialize());

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -57,6 +57,12 @@ const makeDataAppVizRow = (overrides: Record<string, unknown> = {}) => ({
     ...overrides,
 });
 
+const testLightdashSecrets = {
+    active: 'test-secret',
+    fallbacks: [],
+    all: ['test-secret'],
+};
+
 function buildService(
     appModel: unknown,
     overrides: {
@@ -65,7 +71,10 @@ function buildService(
     } = {},
 ) {
     const service = new AppGenerateService({
-        lightdashConfig: { lightdashSecret: 'test-secret' } as never,
+        lightdashConfig: {
+            lightdashSecret: 'test-secret',
+            lightdashSecrets: testLightdashSecrets,
+        } as never,
         analytics: {} as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
@@ -723,7 +732,12 @@ describe('AppGenerateService data app vizs', () => {
                 2,
             );
             expect(
-                verifyPreviewToken(token, 'test-secret', 'data-app-viz-1', 2),
+                verifyPreviewToken(
+                    token,
+                    testLightdashSecrets,
+                    'data-app-viz-1',
+                    2,
+                ),
             ).toMatchObject({
                 ok: true,
                 payload: {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7827,7 +7827,7 @@ export class AppGenerateService extends BaseService {
         );
 
         return mintPreviewToken(
-            this.lightdashConfig.lightdashSecret,
+            this.lightdashConfig.lightdashSecrets,
             dataAppViz.app_id,
             version,
             user.userUuid,
@@ -7879,7 +7879,7 @@ export class AppGenerateService extends BaseService {
         );
 
         return mintPreviewToken(
-            this.lightdashConfig.lightdashSecret,
+            this.lightdashConfig.lightdashSecrets,
             dataAppViz.app_id,
             version,
             user.userUuid,
@@ -8562,7 +8562,7 @@ export class AppGenerateService extends BaseService {
         await this.assertCanViewApp(user, app);
 
         return mintPreviewToken(
-            this.lightdashConfig.lightdashSecret,
+            this.lightdashConfig.lightdashSecrets,
             appUuid,
             version,
             user.userUuid,
@@ -8657,7 +8657,7 @@ export class AppGenerateService extends BaseService {
         }
 
         const token = mintPreviewToken(
-            this.lightdashConfig.lightdashSecret,
+            this.lightdashConfig.lightdashSecrets,
             appUuid,
             latestReady.version,
             account.user.id,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
@@ -97,6 +97,12 @@ const chartAccount = () =>
 const dashboardAccount = () =>
     makeAccount({ type: 'dashboard', dashboardUuid: 'dashboard-1' });
 
+const testLightdashSecrets = {
+    active: 'test-secret',
+    fallbacks: [],
+    all: ['test-secret'],
+};
+
 const buildService = ({
     appModel = {},
     savedChartModel = {},
@@ -115,6 +121,7 @@ const buildService = ({
         lightdashConfig: {
             ...EmbedServiceArgumentsMock.lightdashConfig,
             lightdashSecret: 'test-secret',
+            lightdashSecrets: testLightdashSecrets,
         },
         appModel,
         savedChartModel,
@@ -412,7 +419,12 @@ describe('EmbedService data app viz rendering', () => {
 
         expect(appModel.getVersion).toHaveBeenCalledWith(DATA_APP_VIZ_UUID, 2);
         expect(
-            verifyPreviewToken(token, 'test-secret', DATA_APP_VIZ_UUID, 2),
+            verifyPreviewToken(
+                token,
+                testLightdashSecrets,
+                DATA_APP_VIZ_UUID,
+                2,
+            ),
         ).toMatchObject({
             ok: true,
             payload: {

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1873,7 +1873,7 @@ export class EmbedService extends BaseService {
             version,
         );
         return mintPreviewToken(
-            this.lightdashConfig.lightdashSecret,
+            this.lightdashConfig.lightdashSecrets,
             dataAppViz.app_id,
             version,
             account.user.id,

--- a/packages/backend/src/expressSessionOptions.test.ts
+++ b/packages/backend/src/expressSessionOptions.test.ts
@@ -1,0 +1,186 @@
+import express from 'express';
+import expressSession, { MemoryStore, Store } from 'express-session';
+import http, { Server } from 'http';
+import { AddressInfo } from 'net';
+import { LightdashSecrets } from './config/parseConfig';
+import { buildExpressSessionOptions } from './expressSessionOptions';
+
+const OLD_SECRET = 'old secret';
+const NEW_SECRET = 'new secret';
+
+const keyring = (active: string, fallbacks: string[]): LightdashSecrets =>
+    Object.freeze({
+        active,
+        fallbacks: Object.freeze([...fallbacks]),
+        all: Object.freeze([active, ...fallbacks]),
+    });
+
+const preRotation = keyring(OLD_SECRET, []);
+const overlap = keyring(NEW_SECRET, [OLD_SECRET]);
+const postRemoval = keyring(NEW_SECRET, []);
+
+const buildApp = (secrets: LightdashSecrets, store: Store) => {
+    const app = express();
+    app.use(
+        expressSession(
+            buildExpressSessionOptions(
+                {
+                    lightdashSecrets: secrets,
+                    trustProxy: false,
+                    cookiesMaxAgeHours: 1,
+                    secureCookies: false,
+                    cookieSameSite: 'lax',
+                },
+                store,
+                8080,
+            ),
+        ),
+    );
+    app.get('/login', (req, res) => {
+        req.session.oauth = { returnTo: 'logged-in' };
+        res.json({ status: 'ok' });
+    });
+    app.get('/whoami', (req, res) => {
+        res.json({ returnTo: req.session.oauth?.returnTo ?? null });
+    });
+    return app;
+};
+
+type RunningServer = { url: string; close: () => Promise<void> };
+
+const startServer = async (app: express.Express): Promise<RunningServer> => {
+    const server: Server = app.listen(0, '127.0.0.1');
+    await new Promise<void>((resolve) => {
+        server.once('listening', resolve);
+    });
+    const { port } = server.address() as AddressInfo;
+    return {
+        url: `http://127.0.0.1:${port}`,
+        close: () =>
+            new Promise<void>((resolve, reject) => {
+                server.close((err) => (err ? reject(err) : resolve()));
+            }),
+    };
+};
+
+type HttpResult = { body: string; setCookie: string | undefined };
+
+// Plain node:http because the vitest setup stubs global fetch
+const httpGet = (url: string, cookie?: string): Promise<HttpResult> =>
+    new Promise((resolve, reject) => {
+        const request = http.get(
+            url,
+            { headers: cookie ? { cookie } : {} },
+            (response) => {
+                let body = '';
+                response.on('data', (chunk) => {
+                    body += chunk;
+                });
+                response.on('end', () => {
+                    resolve({
+                        body,
+                        setCookie:
+                            response.headers['set-cookie']?.[0]?.split(';')[0],
+                    });
+                });
+            },
+        );
+        request.on('error', reject);
+    });
+
+const login = async (server: RunningServer): Promise<string> => {
+    const { setCookie } = await httpGet(`${server.url}/login`);
+    if (!setCookie) {
+        throw new Error('expected a session cookie to be set');
+    }
+    return setCookie;
+};
+
+const whoami = async (server: RunningServer, cookie: string) => {
+    const { body, setCookie } = await httpGet(`${server.url}/whoami`, cookie);
+    return {
+        body: JSON.parse(body) as { returnTo: string | null },
+        reSignedCookie: setCookie,
+    };
+};
+
+describe('session cookies across secret rotation keyrings', () => {
+    let store: Store;
+    let servers: RunningServer[];
+
+    const serve = async (secrets: LightdashSecrets) => {
+        const server = await startServer(buildApp(secrets, store));
+        servers.push(server);
+        return server;
+    };
+
+    beforeEach(() => {
+        store = new MemoryStore();
+        servers = [];
+    });
+
+    afterEach(async () => {
+        await Promise.all(servers.map((server) => server.close()));
+    });
+
+    test('a pre-rotation cookie stays valid while the old secret is a fallback', async () => {
+        const oldApp = await serve(preRotation);
+        const overlapApp = await serve(overlap);
+
+        const cookie = await login(oldApp);
+        const { body } = await whoami(overlapApp, cookie);
+
+        expect(body.returnTo).toEqual('logged-in');
+    });
+
+    test('overlap-era cookies are signed with the active secret, not the fallback', async () => {
+        const overlapApp = await serve(overlap);
+        const newOnlyApp = await serve(postRemoval);
+        const oldOnlyApp = await serve(preRotation);
+
+        const cookie = await login(overlapApp);
+
+        // Valid where only the new secret is configured...
+        const { body: withNewSecret } = await whoami(newOnlyApp, cookie);
+        expect(withNewSecret.returnTo).toEqual('logged-in');
+
+        // ...and invalid where only the old secret is configured
+        const { body: withOldSecret } = await whoami(oldOnlyApp, cookie);
+        expect(withOldSecret.returnTo).toBeNull();
+    });
+
+    test('touching a pre-rotation session re-signs its cookie with the active secret', async () => {
+        const oldApp = await serve(preRotation);
+        const overlapApp = await serve(overlap);
+        const newOnlyApp = await serve(postRemoval);
+
+        const oldCookie = await login(oldApp);
+        const { reSignedCookie } = await whoami(overlapApp, oldCookie);
+
+        expect(reSignedCookie).toBeDefined();
+        const { body } = await whoami(newOnlyApp, reSignedCookie!);
+        expect(body.returnTo).toEqual('logged-in');
+    });
+
+    test('removing the old secret invalidates cookies still signed with it', async () => {
+        const oldApp = await serve(preRotation);
+        const newOnlyApp = await serve(postRemoval);
+
+        const cookie = await login(oldApp);
+        const { body } = await whoami(newOnlyApp, cookie);
+
+        expect(body.returnTo).toBeNull();
+    });
+
+    test('a tampered signature is rejected in every keyring', async () => {
+        const overlapApp = await serve(overlap);
+
+        const cookie = await login(overlapApp);
+        const tampered = cookie.endsWith('0')
+            ? `${cookie.slice(0, -1)}1`
+            : `${cookie.slice(0, -1)}0`;
+        const { body } = await whoami(overlapApp, tampered);
+
+        expect(body.returnTo).toBeNull();
+    });
+});

--- a/packages/backend/src/expressSessionOptions.ts
+++ b/packages/backend/src/expressSessionOptions.ts
@@ -1,0 +1,37 @@
+import { SessionOptions, Store } from 'express-session';
+import { LightdashConfig } from './config/parseConfig';
+
+type SessionRelevantConfig = Pick<
+    LightdashConfig,
+    | 'lightdashSecrets'
+    | 'trustProxy'
+    | 'cookiesMaxAgeHours'
+    | 'secureCookies'
+    | 'cookieSameSite'
+>;
+
+export const buildExpressSessionOptions = (
+    lightdashConfig: SessionRelevantConfig,
+    store: Store,
+    port: string | number,
+): SessionOptions => ({
+    name:
+        process.env.NODE_ENV === 'development' &&
+        process.env.DEV_SCOPED_COOKIE_NAMES_ENABLED === 'true'
+            ? `connect.sid.${port}`
+            : 'connect.sid',
+    // Active secret signs new cookies; fallbacks keep sessions
+    // signed before a secret rotation verifiable until expiry
+    secret: [...lightdashConfig.lightdashSecrets.all],
+    proxy: lightdashConfig.trustProxy,
+    rolling: true,
+    cookie: {
+        maxAge: (lightdashConfig.cookiesMaxAgeHours || 24) * 60 * 60 * 1000, // in ms
+        secure: lightdashConfig.secureCookies,
+        httpOnly: true,
+        sameSite: lightdashConfig.cookieSameSite,
+    },
+    resave: false,
+    saveUninitialized: false,
+    store,
+});

--- a/packages/backend/src/routers/appPreviewRouter.ts
+++ b/packages/backend/src/routers/appPreviewRouter.ts
@@ -2,7 +2,10 @@ import { GetObjectCommand, S3, S3ServiceException } from '@aws-sdk/client-s3';
 import express, { type Router } from 'express';
 import path from 'path';
 import { validate as isValidUuid } from 'uuid';
-import { type AppRuntimeConfig } from '../config/parseConfig';
+import {
+    type AppRuntimeConfig,
+    type LightdashSecrets,
+} from '../config/parseConfig';
 import Logger from '../logging/logger';
 import {
     verifyPreviewToken,
@@ -106,7 +109,7 @@ const isPlausibleToken = (token: string): boolean =>
 
 export const createAppPreviewRouter = (
     config: AppRuntimeConfig,
-    lightdashSecret: string,
+    lightdashSecrets: LightdashSecrets,
     /**
      * Frame-ancestor allowlist applied to every preview iframe. Matches the
      * `/embed/*` policy (`'self' https://*`) plus the explicit domains in
@@ -258,7 +261,7 @@ export const createAppPreviewRouter = (
 
         const result = verifyPreviewToken(
             token,
-            lightdashSecret,
+            lightdashSecrets,
             appUuid,
             versionNum,
         );

--- a/packages/backend/src/routers/appPreviewToken.test.ts
+++ b/packages/backend/src/routers/appPreviewToken.test.ts
@@ -1,0 +1,112 @@
+import { mintPreviewToken, verifyPreviewToken } from './appPreviewToken';
+
+const secrets = (active: string, ...fallbacks: string[]) => ({
+    active,
+    fallbacks,
+    all: [active, ...fallbacks],
+});
+
+const oldOnly = secrets('old secret');
+const newOnly = secrets('new secret');
+const newActiveOldFallback = secrets('new secret', 'old secret');
+const oldActiveNewFallback = secrets('old secret', 'new secret');
+
+const appUuid = '0b7a5a1e-6a70-4c65-8b0f-8c1a9c2f1a11';
+const mint = (keyring: ReturnType<typeof secrets>) =>
+    mintPreviewToken(
+        keyring,
+        appUuid,
+        3,
+        'user-uuid',
+        'organization-uuid',
+        'project-uuid',
+    );
+
+describe('app preview tokens across secret rotation', () => {
+    test('mints with the active secret only', () => {
+        const token = mint(newActiveOldFallback);
+        expect(verifyPreviewToken(token, newOnly, appUuid, 3).ok).toBe(true);
+        expect(verifyPreviewToken(token, oldOnly, appUuid, 3).ok).toBe(false);
+    });
+
+    test('verifies tokens from either secret under both orderings', () => {
+        const oldToken = mint(oldOnly);
+        const newToken = mint(newOnly);
+        for (const keyring of [newActiveOldFallback, oldActiveNewFallback]) {
+            expect(verifyPreviewToken(oldToken, keyring, appUuid, 3).ok).toBe(
+                true,
+            );
+            expect(verifyPreviewToken(newToken, keyring, appUuid, 3).ok).toBe(
+                true,
+            );
+        }
+    });
+
+    test('returns the payload on success', () => {
+        const result = verifyPreviewToken(
+            mint(oldOnly),
+            newActiveOldFallback,
+            appUuid,
+            3,
+        );
+        expect(result).toMatchObject({
+            ok: true,
+            payload: {
+                appUuid,
+                version: 3,
+                userUuid: 'user-uuid',
+                organizationUuid: 'organization-uuid',
+                projectUuid: 'project-uuid',
+            },
+        });
+    });
+
+    test('rejects tokens signed with an unknown secret', () => {
+        const token = mint(secrets('unknown secret'));
+        expect(
+            verifyPreviewToken(token, newActiveOldFallback, appUuid, 3),
+        ).toEqual({
+            ok: false,
+            status: 403,
+            message: 'Invalid or expired preview token',
+        });
+    });
+
+    test('rejects a missing token', () => {
+        expect(
+            verifyPreviewToken(undefined, newActiveOldFallback, appUuid, 3),
+        ).toEqual({
+            ok: false,
+            status: 401,
+            message: 'Missing preview token',
+        });
+    });
+
+    test('rejects a mismatched app or version', () => {
+        const token = mint(newActiveOldFallback);
+        expect(
+            verifyPreviewToken(token, newActiveOldFallback, appUuid, 4).ok,
+        ).toBe(false);
+        expect(
+            verifyPreviewToken(
+                token,
+                newActiveOldFallback,
+                '11111111-1111-4111-8111-111111111111',
+                3,
+            ).ok,
+        ).toBe(false);
+    });
+
+    test('rejects an expired token even with a fallback configured', () => {
+        vi.useFakeTimers();
+        try {
+            const token = mint(oldOnly);
+            vi.advanceTimersByTime(2 * 60 * 60 * 1000);
+            expect(
+                verifyPreviewToken(token, newActiveOldFallback, appUuid, 3).ok,
+            ).toBe(false);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/packages/backend/src/routers/appPreviewToken.ts
+++ b/packages/backend/src/routers/appPreviewToken.ts
@@ -1,5 +1,6 @@
 import { createHmac } from 'crypto';
 import jwt from 'jsonwebtoken';
+import { LightdashSecrets } from '../config/parseConfig';
 
 const PREVIEW_TOKEN_TYPE = 'app-preview';
 const PREVIEW_TOKEN_MAX_AGE_SECONDS = 3600; // 1 hour
@@ -27,7 +28,7 @@ export const deriveSigningKey = (lightdashSecret: string): Buffer =>
  * Mints a short-lived JWT for accessing a specific app version's preview.
  */
 export const mintPreviewToken = (
-    lightdashSecret: string,
+    lightdashSecrets: LightdashSecrets,
     appUuid: string,
     version: number,
     userUuid: string,
@@ -43,7 +44,7 @@ export const mintPreviewToken = (
             organizationUuid,
             projectUuid,
         } satisfies PreviewTokenPayload,
-        deriveSigningKey(lightdashSecret),
+        deriveSigningKey(lightdashSecrets.active),
         {
             expiresIn: PREVIEW_TOKEN_MAX_AGE_SECONDS,
             issuer: PREVIEW_TOKEN_ISSUER,
@@ -63,7 +64,7 @@ export type VerifyPreviewTokenResult = VerifySuccess | VerifyFailure;
  */
 export const verifyPreviewToken = (
     token: string | undefined,
-    lightdashSecret: string,
+    lightdashSecrets: LightdashSecrets,
     appUuid: string,
     version: number,
 ): VerifyPreviewTokenResult => {
@@ -71,35 +72,44 @@ export const verifyPreviewToken = (
         return { ok: false, status: 401, message: 'Missing preview token' };
     }
 
-    try {
-        const decoded = jwt.verify(token, deriveSigningKey(lightdashSecret), {
-            algorithms: ['HS256'],
-            issuer: PREVIEW_TOKEN_ISSUER,
-            audience: PREVIEW_TOKEN_AUDIENCE,
-        });
+    // Tokens are minted with the active secret only; fallback candidates keep
+    // tokens issued before a secret rotation valid until they expire.
+    for (const candidateSecret of lightdashSecrets.all) {
+        try {
+            const decoded = jwt.verify(
+                token,
+                deriveSigningKey(candidateSecret),
+                {
+                    algorithms: ['HS256'],
+                    issuer: PREVIEW_TOKEN_ISSUER,
+                    audience: PREVIEW_TOKEN_AUDIENCE,
+                },
+            );
 
-        if (
-            typeof decoded === 'string' ||
-            decoded.type !== PREVIEW_TOKEN_TYPE ||
-            decoded.appUuid !== appUuid ||
-            decoded.version !== version
-        ) {
+            if (
+                typeof decoded === 'string' ||
+                decoded.type !== PREVIEW_TOKEN_TYPE ||
+                decoded.appUuid !== appUuid ||
+                decoded.version !== version
+            ) {
+                return {
+                    ok: false,
+                    status: 403,
+                    message: 'Invalid or expired preview token',
+                };
+            }
+
             return {
-                ok: false,
-                status: 403,
-                message: 'Invalid or expired preview token',
+                ok: true,
+                payload: decoded as PreviewTokenPayload,
             };
+        } catch {
+            // try the next candidate secret
         }
-
-        return {
-            ok: true,
-            payload: decoded as PreviewTokenPayload,
-        };
-    } catch {
-        return {
-            ok: false,
-            status: 403,
-            message: 'Invalid or expired preview token',
-        };
     }
+    return {
+        ok: false,
+        status: 403,
+        message: 'Invalid or expired preview token',
+    };
 };

--- a/packages/backend/src/routers/headlessBrowser.test.ts
+++ b/packages/backend/src/routers/headlessBrowser.test.ts
@@ -1,0 +1,93 @@
+import { createHmac } from 'crypto';
+import {
+    getAuthenticationToken,
+    isValidAuthenticationToken,
+} from './headlessBrowser';
+
+vi.mock('../config/lightdashConfig', async () => {
+    const { lightdashConfigMock } =
+        await import('../config/lightdashConfig.mock');
+    return {
+        lightdashConfig: {
+            ...lightdashConfigMock,
+            lightdashSecrets: {
+                active: 'new secret',
+                fallbacks: ['old secret'],
+                all: ['new secret', 'old secret'],
+            },
+        },
+    };
+});
+
+const hmacFor = (secret: string, value: string) =>
+    createHmac('sha512', secret).update(value).digest('hex');
+
+describe('headless browser authentication token', () => {
+    const userUuid = 'a2c62b2d-8bb7-44b8-8d65-dbc9d78e79f0';
+
+    test('generates tokens with the active secret only', () => {
+        expect(getAuthenticationToken(userUuid)).toEqual(
+            hmacFor('new secret', userUuid),
+        );
+    });
+
+    test('accepts a token derived from the active secret', () => {
+        expect(
+            isValidAuthenticationToken(
+                userUuid,
+                hmacFor('new secret', userUuid),
+            ),
+        ).toBe(true);
+    });
+
+    test('accepts a token derived from a fallback secret', () => {
+        expect(
+            isValidAuthenticationToken(
+                userUuid,
+                hmacFor('old secret', userUuid),
+            ),
+        ).toBe(true);
+    });
+
+    test('accepts a valid token in uppercase hex', () => {
+        expect(
+            isValidAuthenticationToken(
+                userUuid,
+                hmacFor('new secret', userUuid).toUpperCase(),
+            ),
+        ).toBe(true);
+    });
+
+    test('rejects a token derived from an unknown secret', () => {
+        expect(
+            isValidAuthenticationToken(
+                userUuid,
+                hmacFor('unknown secret', userUuid),
+            ),
+        ).toBe(false);
+    });
+
+    test('rejects a token derived for a different value', () => {
+        expect(
+            isValidAuthenticationToken(
+                userUuid,
+                hmacFor('new secret', 'other-user-uuid'),
+            ),
+        ).toBe(false);
+    });
+
+    test.each([
+        ['undefined', undefined],
+        ['null', null],
+        ['a number', 123],
+        ['an object', { token: 'nested' }],
+        ['an array', ['a'.repeat(128)]],
+        ['an empty string', ''],
+        ['a short hex string', 'ab'.repeat(63)],
+        ['an odd-length hex string', 'a'.repeat(127)],
+        ['a long hex string', 'ab'.repeat(65)],
+        ['a non-hex string of the right length', 'z'.repeat(128)],
+    ])('rejects %s without throwing', (_label, token) => {
+        expect(isValidAuthenticationToken(userUuid, token)).toBe(false);
+    });
+});

--- a/packages/backend/src/routers/headlessBrowser.ts
+++ b/packages/backend/src/routers/headlessBrowser.ts
@@ -5,7 +5,7 @@ import {
     getObjectValue,
 } from '@lightdash/common';
 import { sign } from 'cookie-signature';
-import { createHmac } from 'crypto';
+import { createHmac, timingSafeEqual } from 'crypto';
 import express, { type Router } from 'express';
 import playwright from 'playwright';
 import { lightdashConfig } from '../config/lightdashConfig';
@@ -16,17 +16,43 @@ export const headlessBrowserRouter: Router = express.Router({
 });
 
 export const getAuthenticationToken = (value: string) =>
-    createHmac('sha512', lightdashConfig.lightdashSecret)
+    createHmac('sha512', lightdashConfig.lightdashSecrets.active)
         .update(value)
         .digest('hex');
+
+const SHA512_HMAC_HEX_PATTERN = /^[0-9a-f]{128}$/i;
+
+// The token is attacker-controlled: validate shape before the timing-safe
+// comparison, and compare every candidate secret without an early exit so
+// neither malformed input nor candidate ordering changes observable behavior.
+export const isValidAuthenticationToken = (
+    value: string,
+    token: unknown,
+): boolean => {
+    if (typeof token !== 'string' || !SHA512_HMAC_HEX_PATTERN.test(token)) {
+        return false;
+    }
+    const tokenBytes = Buffer.from(token, 'hex');
+    return lightdashConfig.lightdashSecrets.all.reduce(
+        (matched, candidateSecret) => {
+            const expected = createHmac('sha512', candidateSecret)
+                .update(value)
+                .digest();
+            if (expected.length !== tokenBytes.length) {
+                return matched;
+            }
+            return timingSafeEqual(expected, tokenBytes) || matched;
+        },
+        false,
+    );
+};
 
 headlessBrowserRouter.post('/login/:userUuid', async (req, res, next) => {
     try {
         const userUuid = getObjectValue(req.params, 'userUuid');
         Logger.debug(`Headless browser login request for user ${userUuid}`);
-        const hash = getAuthenticationToken(userUuid);
 
-        if (hash !== req.body.token) {
+        if (!isValidAuthenticationToken(userUuid, req.body?.token)) {
             throw new ForbiddenError();
         }
 
@@ -65,7 +91,7 @@ headlessBrowserRouter.post('/login/:userUuid', async (req, res, next) => {
                 );
                 const value = `s:${sign(
                     req.session.id,
-                    lightdashConfig.lightdashSecret,
+                    lightdashConfig.lightdashSecrets.active,
                 )}`;
 
                 res.setHeader('Set-Cookie', [

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.test.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.test.ts
@@ -33,6 +33,7 @@ const baseData = {
 
 const createService = (
     configOverrides: Partial<LightdashConfig['persistentDownloadUrls']> = {},
+    lightdashSecrets: LightdashConfig['lightdashSecrets'] = lightdashConfigMock.lightdashSecrets,
 ) =>
     new PersistentDownloadFileService({
         analytics: {
@@ -40,6 +41,7 @@ const createService = (
         } as unknown as LightdashAnalytics,
         lightdashConfig: {
             ...lightdashConfigMock,
+            lightdashSecrets,
             persistentDownloadUrls: {
                 ...lightdashConfigMock.persistentDownloadUrls,
                 enabled: true,
@@ -423,6 +425,82 @@ describe('PersistentDownloadFileService', () => {
                     ),
                 ),
             ).resolves.toMatchObject({ fileType: 'csv' });
+        });
+
+        it('accepts tokens across a secret rotation in both orderings', async () => {
+            const oldOnly = createService(undefined, {
+                active: 'old secret',
+                fallbacks: [],
+                all: ['old secret'],
+            });
+            const newActiveOldFallback = createService(undefined, {
+                active: 'new secret',
+                fallbacks: ['old secret'],
+                all: ['new secret', 'old secret'],
+            });
+            const oldActiveNewFallback = createService(undefined, {
+                active: 'old secret',
+                fallbacks: ['new secret'],
+                all: ['old secret', 'new secret'],
+            });
+
+            const signedUrl = new URL(
+                await oldOnly.createPersistentUrl({
+                    ...baseData,
+                    accessMode: PersistentDownloadFileAccessMode.SIGNED,
+                }),
+            );
+            const fileId = signedUrl.pathname.split('/').at(-1)!;
+            const downloadToken = signedUrl.searchParams.get('downloadToken')!;
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.SIGNED, {
+                    nanoid: fileId,
+                }),
+            );
+
+            await expect(
+                newActiveOldFallback.getFileStream(
+                    fileId,
+                    requestContext(undefined, downloadToken),
+                ),
+            ).resolves.toMatchObject({ fileType: 'csv' });
+            await expect(
+                oldActiveNewFallback.getFileStream(
+                    fileId,
+                    requestContext(undefined, downloadToken),
+                ),
+            ).resolves.toMatchObject({ fileType: 'csv' });
+        });
+
+        it('rejects a token signed with a secret outside the keyring', async () => {
+            const unknownSecretService = createService(undefined, {
+                active: 'unknown secret',
+                fallbacks: [],
+                all: ['unknown secret'],
+            });
+            const signedUrl = new URL(
+                await unknownSecretService.createPersistentUrl({
+                    ...baseData,
+                    accessMode: PersistentDownloadFileAccessMode.SIGNED,
+                }),
+            );
+            const fileId = signedUrl.pathname.split('/').at(-1)!;
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.SIGNED, {
+                    nanoid: fileId,
+                }),
+            );
+
+            await expect(
+                createService().getFileStream(
+                    fileId,
+                    requestContext(
+                        undefined,
+                        signedUrl.searchParams.get('downloadToken')!,
+                    ),
+                ),
+            ).rejects.toThrow(NotFoundError);
+            expect(mockS3GetFileStream).not.toHaveBeenCalled();
         });
 
         it('rejects a token bound to another file', async () => {

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
@@ -170,7 +170,7 @@ export class PersistentDownloadFileService extends BaseService {
                         fileId: fileNanoid,
                     } satisfies DownloadTokenPayload,
                     deriveDownloadSigningKey(
-                        this.lightdashConfig.lightdashSecret,
+                        this.lightdashConfig.lightdashSecrets.active,
                     ),
                     {
                         expiresIn: Math.max(1, expirationSeconds),
@@ -269,28 +269,33 @@ export class PersistentDownloadFileService extends BaseService {
             );
         };
         const hasValidDownloadToken = (): boolean => {
-            if (!requestContext.downloadToken) return false;
+            const { downloadToken } = requestContext;
+            if (!downloadToken) return false;
 
-            try {
-                const decoded = jwt.verify(
-                    requestContext.downloadToken,
-                    deriveDownloadSigningKey(
-                        this.lightdashConfig.lightdashSecret,
-                    ),
-                    {
-                        algorithms: ['HS256'],
-                        issuer: DOWNLOAD_TOKEN_ISSUER,
-                        audience: DOWNLOAD_TOKEN_AUDIENCE,
-                    },
-                );
-                return (
-                    typeof decoded !== 'string' &&
-                    decoded.type === DOWNLOAD_TOKEN_TYPE &&
-                    decoded.fileId === fileNanoid
-                );
-            } catch {
-                return false;
-            }
+            // Tokens are minted with the active secret only; fallback
+            // candidates keep links signed before a rotation valid.
+            return this.lightdashConfig.lightdashSecrets.all.some(
+                (candidateSecret) => {
+                    try {
+                        const decoded = jwt.verify(
+                            downloadToken,
+                            deriveDownloadSigningKey(candidateSecret),
+                            {
+                                algorithms: ['HS256'],
+                                issuer: DOWNLOAD_TOKEN_ISSUER,
+                                audience: DOWNLOAD_TOKEN_AUDIENCE,
+                            },
+                        );
+                        return (
+                            typeof decoded !== 'string' &&
+                            decoded.type === DOWNLOAD_TOKEN_TYPE &&
+                            decoded.fileId === fileNanoid
+                        );
+                    } catch {
+                        return false;
+                    }
+                },
+            );
         };
         let isAuthorized: boolean;
 


### PR DESCRIPTION
Applies the secret keyring to the signing surfaces:

- Express sessions sign new cookies with the active secret while fallbacks keep pre-rotation sessions valid until expiry; the session options are extracted into a testable module with a real-HTTP regression suite covering the full rotation lifecycle (fallback verification, active-first signing, rolling re-sign, removal-gate invalidation, tampering).
- App-preview and persistent-download JWTs mint with the active secret and verify against every candidate.
- Headless-browser HMAC verification validates token shape before a timing-safe comparison against every candidate, so malformed input fails authorization instead of throwing.

Relates: PROD-9721