### PR TITLE
feat: stage PAT and service account token lookup across the secret keyring

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1152,7 +1152,10 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
             slackAuthenticationModel: ({ database }) =>
                 new CommercialSlackAuthenticationModel({ database }),
             serviceAccountModel: ({ database }) =>
-                new ServiceAccountModel({ database }),
+                new ServiceAccountModel({
+                    database,
+                    lightdashConfig,
+                }),
             externalConnectionModel: ({ database, utils }) =>
                 new ExternalConnectionModel({
                     database,

--- a/packages/backend/src/ee/models/ServiceAccountModel.test.ts
+++ b/packages/backend/src/ee/models/ServiceAccountModel.test.ts
@@ -1,0 +1,146 @@
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { type LightdashConfig } from '../../config/parseConfig';
+import { deprecatedHash, hashWithSecret } from '../../utils/hash';
+import { ServiceAccountModel } from './ServiceAccountModel';
+
+vi.mock('../../utils/hash', () => ({
+    hash: vi.fn(async (s: string) => `bcrypt:env:${s}`),
+    hashWithSecret: vi.fn(
+        async (s: string, secret: string) => `bcrypt:${secret}:${s}`,
+    ),
+    deprecatedHash: vi.fn((s: string) => `sha256:${s}`),
+}));
+
+const lightdashConfig = {
+    lightdashSecrets: {
+        active: 'new secret',
+        fallbacks: ['old secret', 'older secret'],
+        all: ['new secret', 'old secret', 'older secret'],
+    },
+} as unknown as Pick<LightdashConfig, 'lightdashSecrets'>;
+
+const serviceAccountRow = (tokenHash: string, uuid: string = 'sa-uuid') => ({
+    service_account_uuid: uuid,
+    token_hash: tokenHash,
+    organization_uuid: 'org-uuid',
+    created_at: new Date('2024-01-01'),
+    description: 'test account',
+    expires_at: null,
+    created_by_user_uuid: null,
+    rotated_at: null,
+    rotated_by_user_uuid: null,
+    last_used_at: null,
+    scopes: [],
+    service_account_user_uuid: 'sa-user-uuid',
+    role_uuid: null,
+    creator_user_uuid: null,
+    creator_first_name: null,
+    creator_last_name: null,
+});
+
+describe('ServiceAccountModel token lookup', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new ServiceAccountModel({
+        database: database as unknown as Knex,
+        lightdashConfig,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+        vi.clearAllMocks();
+    });
+
+    test('an active-hash match performs one bcrypt hash and one query', async () => {
+        tracker.on
+            .select('service_accounts')
+            .responseOnce([serviceAccountRow('bcrypt:new secret:token')]);
+
+        const match = await model.findByToken('token');
+
+        expect(match?.uuid).toEqual('sa-uuid');
+        expect(hashWithSecret).toHaveBeenCalledTimes(1);
+        expect(hashWithSecret).toHaveBeenCalledWith('token', 'new secret');
+        expect(tracker.history.select).toHaveLength(1);
+    });
+
+    test('the first query groups the active and legacy hashes', async () => {
+        tracker.on
+            .select('service_accounts')
+            .responseOnce([serviceAccountRow('bcrypt:new secret:token')]);
+
+        await model.findByToken('token');
+
+        expect(tracker.history.select[0].bindings).toEqual(
+            expect.arrayContaining(['bcrypt:new secret:token', 'sha256:token']),
+        );
+    });
+
+    test('a legacy sha256 match performs one bcrypt hash', async () => {
+        tracker.on
+            .select('service_accounts')
+            .responseOnce([serviceAccountRow('sha256:token')]);
+
+        const match = await model.findByToken('token');
+
+        expect(hashWithSecret).toHaveBeenCalledTimes(1);
+        expect(deprecatedHash).toHaveBeenCalledWith('token');
+        expect(match?.uuid).toEqual('sa-uuid');
+    });
+
+    test('fallback hashes are derived only after a miss and matched in one grouped query', async () => {
+        tracker.on.select('service_accounts').responseOnce([]);
+        tracker.on
+            .select('service_accounts')
+            .responseOnce([serviceAccountRow('bcrypt:old secret:token')]);
+
+        const match = await model.findByToken('token');
+
+        expect(vi.mocked(hashWithSecret).mock.calls).toEqual([
+            ['token', 'new secret'],
+            ['token', 'old secret'],
+            ['token', 'older secret'],
+        ]);
+        expect(tracker.history.select).toHaveLength(2);
+        expect(tracker.history.select[1].bindings).toEqual(
+            expect.arrayContaining([
+                'bcrypt:old secret:token',
+                'bcrypt:older secret:token',
+            ]),
+        );
+        expect(match?.uuid).toEqual('sa-uuid');
+    });
+
+    test('the earliest configured fallback wins when several rows match', async () => {
+        tracker.on.select('service_accounts').responseOnce([]);
+        tracker.on
+            .select('service_accounts')
+            .responseOnce([
+                serviceAccountRow('bcrypt:older secret:token', 'older-sa-uuid'),
+                serviceAccountRow('bcrypt:old secret:token', 'old-sa-uuid'),
+            ]);
+
+        const match = await model.findByToken('token');
+
+        expect(match?.uuid).toEqual('old-sa-uuid');
+    });
+
+    test('a full miss uses a single grouped fallback query and returns undefined', async () => {
+        tracker.on.select('service_accounts').response([]);
+
+        const match = await model.findByToken('token');
+
+        expect(match).toBeUndefined();
+        expect(vi.mocked(hashWithSecret).mock.calls).toEqual([
+            ['token', 'new secret'],
+            ['token', 'old secret'],
+            ['token', 'older secret'],
+        ]);
+        expect(tracker.history.select).toHaveLength(2);
+    });
+});

--- a/packages/backend/src/ee/models/ServiceAccountModel.ts
+++ b/packages/backend/src/ee/models/ServiceAccountModel.ts
@@ -13,10 +13,11 @@ import {
 } from '@lightdash/common';
 import * as crypto from 'crypto';
 import { Knex } from 'knex';
+import { LightdashConfig } from '../../config/parseConfig';
 import { OrganizationMembershipsTableName } from '../../database/entities/organizationMemberships';
 import { RolesTableName } from '../../database/entities/roles';
 import { DbUser, UserTableName } from '../../database/entities/users';
-import { deprecatedHash, hash } from '../../utils/hash';
+import { deprecatedHash, hash, hashWithSecret } from '../../utils/hash';
 import {
     DbServiceAccounts,
     DbUpdateServiceAccount,
@@ -36,8 +37,17 @@ type DbServiceAccountWithRole = DbServiceAccounts & {
 export class ServiceAccountModel {
     private readonly database: Knex;
 
-    constructor({ database }: { database: Knex }) {
+    private readonly lightdashConfig: Pick<LightdashConfig, 'lightdashSecrets'>;
+
+    constructor({
+        database,
+        lightdashConfig,
+    }: {
+        database: Knex;
+        lightdashConfig: Pick<LightdashConfig, 'lightdashSecrets'>;
+    }) {
         this.database = database;
+        this.lightdashConfig = lightdashConfig;
     }
 
     static mapDbObjectToServiceAccount(
@@ -490,15 +500,49 @@ export class ServiceAccountModel {
         return row && ServiceAccountModel.mapDbObjectToServiceAccount(row);
     }
 
-    async getByToken(token: string): Promise<ServiceAccount> {
-        const hashedToken = await hash(token);
-        const [row] = await this.serviceAccountSelectQuery()
-            .where(`${ServiceAccountsTableName}.token_hash`, hashedToken)
-            .orWhere(
+    async findByToken(token: string): Promise<ServiceAccount | undefined> {
+        const findRowByTokenHashes = (tokenHashes: string[]) =>
+            this.serviceAccountSelectQuery().whereIn(
                 `${ServiceAccountsTableName}.token_hash`,
-                deprecatedHash(token),
-            ); // Adding old sha256 hash for backwards compatibility
-        const mappedRow = ServiceAccountModel.mapDbObjectToServiceAccount(row);
-        return mappedRow;
+                tokenHashes,
+            );
+        // Active bcrypt and legacy sha256 hashes cover every non-rotation
+        // deployment with a single bcrypt operation; fallback bcrypt hashes
+        // are only derived after a miss — concurrently (config caps fallbacks
+        // at three) — and matched with one grouped query that prefers the
+        // earliest configured fallback.
+        const activeTokenHash = await hashWithSecret(
+            token,
+            this.lightdashConfig.lightdashSecrets.active,
+        );
+        const activeRows = await findRowByTokenHashes([
+            activeTokenHash,
+            deprecatedHash(token),
+        ]);
+        let row: (typeof activeRows)[number] | undefined = activeRows[0];
+        if (row === undefined) {
+            const { fallbacks } = this.lightdashConfig.lightdashSecrets;
+            if (fallbacks.length > 0) {
+                const fallbackTokenHashes = await Promise.all(
+                    fallbacks.map((fallbackSecret) =>
+                        hashWithSecret(token, fallbackSecret),
+                    ),
+                );
+                const fallbackRows =
+                    await findRowByTokenHashes(fallbackTokenHashes);
+                row = fallbackTokenHashes
+                    .map((fallbackTokenHash) =>
+                        fallbackRows.find(
+                            (fallbackRow) =>
+                                fallbackRow.token_hash === fallbackTokenHash,
+                        ),
+                    )
+                    .find((match) => match !== undefined);
+            }
+        }
+        if (row === undefined) {
+            return undefined;
+        }
+        return ServiceAccountModel.mapDbObjectToServiceAccount(row);
     }
 }

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.test.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.test.ts
@@ -96,7 +96,7 @@ const buildService = ({
             token: 'service-account-token',
         }),
         delete: vi.fn().mockResolvedValue(undefined),
-        getByToken: vi.fn().mockResolvedValue({
+        findByToken: vi.fn().mockResolvedValue({
             uuid: SERVICE_ACCOUNT_UUID,
             description: `Autopilot (${PROJECT_UUID})`,
             scopes: serviceAccountScopes,

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -355,7 +355,10 @@ export class ManagedAgentService extends BaseService {
         serviceAccountToken: string,
     ): Promise<void> {
         const serviceAccount =
-            await this.serviceAccountModel.getByToken(serviceAccountToken);
+            await this.serviceAccountModel.findByToken(serviceAccountToken);
+        if (serviceAccount === undefined) {
+            throw new NotFoundError('Service account not found for token');
+        }
         const projectGrants =
             await this.projectModel.getServiceAccountProjectGrants(
                 serviceAccount.uuid,

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.test.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.test.ts
@@ -894,3 +894,57 @@ describe('ServiceAccountService.update', () => {
         ).not.toHaveBeenCalled();
     });
 });
+
+describe('ServiceAccountService.authenticateServiceAccount', () => {
+    const tokenMatch = () => ({
+        uuid: 'sa-uuid',
+        organizationUuid: ORG,
+        expiresAt: null,
+        lastUsedAt: null,
+        description: 'test',
+        scopes: [ServiceAccountScope.SYSTEM_MEMBER],
+    });
+
+    const buildAuthMocks = (match: AnyType) => {
+        const mocks = buildMocks();
+        mocks.serviceAccountModel.findByToken = vi
+            .fn()
+            .mockResolvedValue(match) as AnyType;
+        mocks.serviceAccountModel.updateUsedDate = vi
+            .fn()
+            .mockResolvedValue(undefined) as AnyType;
+        return mocks;
+    };
+
+    it('authenticates a matched token', async () => {
+        const mocks = buildAuthMocks(tokenMatch());
+
+        const result =
+            await buildService(mocks).authenticateServiceAccount('ldsvc_token');
+
+        expect(result?.uuid).toEqual('sa-uuid');
+        expect(mocks.serviceAccountModel.updateUsedDate).toHaveBeenCalledWith(
+            'sa-uuid',
+        );
+    });
+
+    it('returns null for an expired token', async () => {
+        const expired = tokenMatch();
+        expired.expiresAt = new Date(Date.now() - 1000) as AnyType;
+        const mocks = buildAuthMocks(expired);
+
+        const result =
+            await buildService(mocks).authenticateServiceAccount('ldsvc_token');
+
+        expect(result).toBeNull();
+    });
+
+    it('returns null for an unknown token', async () => {
+        const mocks = buildAuthMocks(undefined);
+
+        const result =
+            await buildService(mocks).authenticateServiceAccount('ldsvc_token');
+
+        expect(result).toBeNull();
+    });
+});

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -689,7 +689,7 @@ export class ServiceAccountService extends BaseService {
         if (token === '') return null;
 
         try {
-            const dbToken = await this.serviceAccountModel.getByToken(token);
+            const dbToken = await this.serviceAccountModel.findByToken(token);
             if (dbToken) {
                 // return null if expired
                 if (dbToken.expiresAt && dbToken.expiresAt < new Date()) {
@@ -732,7 +732,7 @@ export class ServiceAccountService extends BaseService {
         if (token === '') return null;
 
         try {
-            const dbToken = await this.serviceAccountModel.getByToken(token);
+            const dbToken = await this.serviceAccountModel.findByToken(token);
             if (dbToken) {
                 // return null if expired
                 if (dbToken.expiresAt && dbToken.expiresAt < new Date()) {

--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -12,17 +12,27 @@ import {
     type SessionUser,
 } from '@lightdash/common';
 import bcrypt from 'bcrypt';
-import { type Knex } from 'knex';
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
 import { type LightdashConfig } from '../config/parseConfig';
 import { EmailTableName } from '../database/entities/emails';
 import { PasswordLoginTableName } from '../database/entities/passwordLogins';
 import { UserTableName } from '../database/entities/users';
+import { hashWithSecret } from '../utils/hash';
 import { type FeatureFlagModel } from './FeatureFlagModel/FeatureFlagModel';
 import {
     mapDbUserDetailsToLightdashUser,
     UserModel,
     type DbUserDetails,
 } from './UserModel';
+
+vi.mock('../utils/hash', () => ({
+    hash: vi.fn(async (s: string) => `bcrypt:env:${s}`),
+    hashWithSecret: vi.fn(
+        async (s: string, secret: string) => `bcrypt:${secret}:${s}`,
+    ),
+    deprecatedHash: vi.fn((s: string) => `sha256:${s}`),
+}));
 
 type TestableUserModel = {
     hasAuthentication: (userUuid: string, trx?: Knex) => Promise<boolean>;
@@ -672,6 +682,154 @@ describe('UserModel', () => {
 
             expect(findSessionUser).toHaveBeenCalledTimes(2);
             expect(sessionUserCache.set).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('findSessionUserByPersonalAccessToken', () => {
+        const rotationConfig = {
+            ...lightdashConfig,
+            lightdashSecrets: {
+                active: 'new secret',
+                fallbacks: ['old secret', 'older secret'],
+                all: ['new secret', 'old secret', 'older secret'],
+            },
+        } as unknown as LightdashConfig;
+
+        const patRow = (tokenHash: string, uuid: string = 'pat-uuid') => ({
+            ...userDetails,
+            personal_access_token_uuid: uuid,
+            token_hash: tokenHash,
+            created_at: new Date('2024-01-01'),
+            rotated_at: null,
+            last_used_at: null,
+            description: 'test token',
+            expires_at: null,
+            created_by_user_id: userDetails.user_id,
+        });
+
+        const mockDatabase = knex({ client: MockClient, dialect: 'pg' });
+        let tracker: Tracker;
+
+        const createPatUserModel = () => {
+            const model = new UserModel({
+                database: mockDatabase as unknown as Knex,
+                lightdashConfig: rotationConfig,
+                featureFlagModel,
+            });
+            (
+                model as unknown as {
+                    generateUserAbilityBuilder: () => Promise<unknown>;
+                }
+            ).generateUserAbilityBuilder = vi.fn(async () => ({
+                abilityBuilder: { rules: [], build: () => ({}) },
+                lightdashUser: { userUuid: userDetails.user_uuid },
+            }));
+            return model;
+        };
+
+        beforeAll(() => {
+            tracker = getTracker();
+        });
+
+        afterEach(() => {
+            tracker.reset();
+            vi.clearAllMocks();
+        });
+
+        it('performs one bcrypt hash and one grouped query for an active match', async () => {
+            tracker.on
+                .select('users')
+                .responseOnce([patRow('bcrypt:new secret:token')]);
+
+            const result =
+                await createPatUserModel().findSessionUserByPersonalAccessToken(
+                    'token',
+                );
+
+            expect(result?.cacheHit).toBe(false);
+            expect(hashWithSecret).toHaveBeenCalledTimes(1);
+            expect(hashWithSecret).toHaveBeenCalledWith('token', 'new secret');
+            expect(tracker.history.select).toHaveLength(1);
+            expect(tracker.history.select[0].bindings).toEqual(
+                expect.arrayContaining([
+                    'bcrypt:new secret:token',
+                    'sha256:token',
+                ]),
+            );
+        });
+
+        it('matches a legacy sha256 hash without extra bcrypt work', async () => {
+            tracker.on.select('users').responseOnce([patRow('sha256:token')]);
+
+            const result =
+                await createPatUserModel().findSessionUserByPersonalAccessToken(
+                    'token',
+                );
+
+            expect(hashWithSecret).toHaveBeenCalledTimes(1);
+            expect(result?.data.personalAccessToken.uuid).toEqual('pat-uuid');
+        });
+
+        it('derives fallback hashes only after a miss and matches them in one grouped query', async () => {
+            tracker.on.select('users').responseOnce([]);
+            tracker.on
+                .select('users')
+                .responseOnce([patRow('bcrypt:old secret:token')]);
+
+            const result =
+                await createPatUserModel().findSessionUserByPersonalAccessToken(
+                    'token',
+                );
+
+            expect(vi.mocked(hashWithSecret).mock.calls).toEqual([
+                ['token', 'new secret'],
+                ['token', 'old secret'],
+                ['token', 'older secret'],
+            ]);
+            expect(tracker.history.select).toHaveLength(2);
+            expect(tracker.history.select[1].bindings).toEqual(
+                expect.arrayContaining([
+                    'bcrypt:old secret:token',
+                    'bcrypt:older secret:token',
+                ]),
+            );
+            expect(result?.data.personalAccessToken.uuid).toEqual('pat-uuid');
+        });
+
+        it('prefers the earliest configured fallback when several rows match', async () => {
+            tracker.on.select('users').responseOnce([]);
+            tracker.on
+                .select('users')
+                .responseOnce([
+                    patRow('bcrypt:older secret:token', 'older-pat-uuid'),
+                    patRow('bcrypt:old secret:token', 'old-pat-uuid'),
+                ]);
+
+            const result =
+                await createPatUserModel().findSessionUserByPersonalAccessToken(
+                    'token',
+                );
+
+            expect(result?.data.personalAccessToken.uuid).toEqual(
+                'old-pat-uuid',
+            );
+        });
+
+        it('misses with a single grouped fallback query before returning undefined', async () => {
+            tracker.on.select('users').response([]);
+
+            const result =
+                await createPatUserModel().findSessionUserByPersonalAccessToken(
+                    'token',
+                );
+
+            expect(result).toBeUndefined();
+            expect(vi.mocked(hashWithSecret).mock.calls).toEqual([
+                ['token', 'new secret'],
+                ['token', 'old secret'],
+                ['token', 'older secret'],
+            ]);
+            expect(tracker.history.select).toHaveLength(2);
         });
     });
 });

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -68,7 +68,7 @@ import {
     UserTableName,
 } from '../database/entities/users';
 import Logger from '../logging/logger';
-import { deprecatedHash, hash } from '../utils/hash';
+import { deprecatedHash, hashWithSecret } from '../utils/hash';
 import {
     CachedPatSessionUser,
     PatSessionCache,
@@ -1394,19 +1394,52 @@ export class UserModel {
         if (cached) {
             return { data: cached, cacheHit: true };
         }
-        const tokenHash = await hash(token);
-        const [row] = await userDetailsQueryBuilder(this.database)
-            .innerJoin(
-                'personal_access_tokens',
-                'personal_access_tokens.created_by_user_id',
-                'users.user_id',
-            )
-            .where('token_hash', tokenHash)
-            .orWhere('token_hash', deprecatedHash(token)) // Adding old sha256 hash for backwards compatibility
-            .select<(DbUserDetails & DbPersonalAccessToken)[]>(
-                '*',
-                'organizations.created_at as organization_created_at',
-            );
+        const findRowByTokenHashes = (tokenHashes: string[]) =>
+            userDetailsQueryBuilder(this.database)
+                .innerJoin(
+                    'personal_access_tokens',
+                    'personal_access_tokens.created_by_user_id',
+                    'users.user_id',
+                )
+                .whereIn('personal_access_tokens.token_hash', tokenHashes)
+                .select<(DbUserDetails & DbPersonalAccessToken)[]>(
+                    '*',
+                    'organizations.created_at as organization_created_at',
+                );
+        // Active bcrypt and legacy sha256 hashes cover every non-rotation
+        // deployment with a single bcrypt operation; fallback bcrypt hashes
+        // are only derived after a miss — concurrently (config caps fallbacks
+        // at three) — and matched with one grouped query that prefers the
+        // earliest configured fallback.
+        const activeTokenHash = await hashWithSecret(
+            token,
+            this.lightdashConfig.lightdashSecrets.active,
+        );
+        const activeRows = await findRowByTokenHashes([
+            activeTokenHash,
+            deprecatedHash(token),
+        ]);
+        let row: (typeof activeRows)[number] | undefined = activeRows[0];
+        if (row === undefined) {
+            const { fallbacks } = this.lightdashConfig.lightdashSecrets;
+            if (fallbacks.length > 0) {
+                const fallbackTokenHashes = await Promise.all(
+                    fallbacks.map((fallbackSecret) =>
+                        hashWithSecret(token, fallbackSecret),
+                    ),
+                );
+                const fallbackRows =
+                    await findRowByTokenHashes(fallbackTokenHashes);
+                row = fallbackTokenHashes
+                    .map((fallbackTokenHash) =>
+                        fallbackRows.find(
+                            (fallbackRow) =>
+                                fallbackRow.token_hash === fallbackTokenHash,
+                        ),
+                    )
+                    .find((match) => match !== undefined);
+            }
+        }
         if (row === undefined) {
             return undefined;
         }

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -1,6 +1,8 @@
 import { Ability } from '@casl/ability';
 import {
+    AnyType,
     AuthorizationError,
+    DeactivatedAccountError,
     defineUserAbility,
     EmailStatus,
     ExpiredError,
@@ -87,6 +89,9 @@ const userModel = {
         async () => newUser,
     ),
     findSessionUserByPrimaryEmail: vi.fn(async () => sessionUser),
+    findSessionUserByPersonalAccessToken: vi.fn<
+        UserModel['findSessionUserByPersonalAccessToken']
+    >(async () => undefined),
     findServiceAccountByUserUuid: vi.fn(async () => undefined),
     joinOrg: vi.fn(async () => sessionUser),
     hasUsers: vi.fn<UserModel['hasUsers']>(async () => false),
@@ -195,6 +200,10 @@ const organizationMemberProfileModel = {
 
 type UserServiceTestOverrides = {
     featureFlagModel?: Pick<FeatureFlagModel, 'get'>;
+    personalAccessTokenModel?: Pick<
+        PersonalAccessTokenModel,
+        'delete' | 'updateUsedDate'
+    >;
     organizationAllowedEmailDomainsModel?: Pick<
         OrganizationAllowedEmailDomainsModel,
         'findAllowedEmailDomains'
@@ -229,7 +238,9 @@ const createUserService = (
         organizationMemberProfileModel:
             organizationMemberProfileModel as unknown as OrganizationMemberProfileModel,
         organizationModel: organizationModel as unknown as OrganizationModel,
-        personalAccessTokenModel: {} as PersonalAccessTokenModel,
+        personalAccessTokenModel:
+            (overrides.personalAccessTokenModel as PersonalAccessTokenModel) ??
+            ({} as PersonalAccessTokenModel),
         organizationAllowedEmailDomainsModel:
             (overrides.organizationAllowedEmailDomainsModel as OrganizationAllowedEmailDomainsModel) ??
             (organizationAllowedEmailDomainsModel as unknown as OrganizationAllowedEmailDomainsModel),
@@ -3611,6 +3622,102 @@ describe('UserService', () => {
             expect(projectModel.ensureDefaultUserSpace).toHaveBeenCalledTimes(
                 2,
             );
+        });
+    });
+
+    describe('loginWithPersonalAccessToken', () => {
+        const patAbility = new Ability<PossibleAbilities>([
+            { subject: 'PersonalAccessToken', action: ['view'] },
+        ]);
+
+        const patLookup = (overrides: AnyType = {}) => ({
+            data: {
+                user: {
+                    ...sessionUser,
+                    ability: patAbility,
+                    ...overrides.user,
+                },
+                personalAccessToken: {
+                    uuid: 'pat-uuid',
+                    createdAt: new Date('2024-01-01'),
+                    rotatedAt: null,
+                    lastUsedAt: null,
+                    expiresAt: null,
+                    description: 'test token',
+                    ...overrides.personalAccessToken,
+                },
+            },
+            cacheHit: false,
+            ...overrides.lookup,
+        });
+
+        const buildPatMocks = () => ({
+            delete: vi.fn(async () => undefined),
+            updateUsedDate: vi.fn(async () => undefined),
+        });
+
+        it('authenticates a matched token', async () => {
+            const patModel = buildPatMocks();
+            const service = createUserService(lightdashConfigMock, {
+                personalAccessTokenModel: patModel as AnyType,
+            });
+            userModel.findSessionUserByPersonalAccessToken.mockResolvedValue(
+                patLookup() as AnyType,
+            );
+
+            const result = await service.loginWithPersonalAccessToken('token');
+
+            expect(result.userUuid).toEqual(sessionUser.userUuid);
+            expect(patModel.updateUsedDate).toHaveBeenCalledWith('pat-uuid');
+        });
+
+        it('rejects a deactivated account', async () => {
+            const patModel = buildPatMocks();
+            const service = createUserService(lightdashConfigMock, {
+                personalAccessTokenModel: patModel as AnyType,
+            });
+            userModel.findSessionUserByPersonalAccessToken.mockResolvedValue(
+                patLookup({ user: { isActive: false } }) as AnyType,
+            );
+
+            await expect(
+                service.loginWithPersonalAccessToken('token'),
+            ).rejects.toBeInstanceOf(DeactivatedAccountError);
+        });
+
+        it('rejects an unauthorized user', async () => {
+            const patModel = buildPatMocks();
+            const service = createUserService(lightdashConfigMock, {
+                personalAccessTokenModel: patModel as AnyType,
+            });
+            userModel.findSessionUserByPersonalAccessToken.mockResolvedValue(
+                patLookup({
+                    user: { ability: new Ability<PossibleAbilities>([]) },
+                }) as AnyType,
+            );
+
+            await expect(
+                service.loginWithPersonalAccessToken('token'),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+        });
+
+        it('deletes an expired token', async () => {
+            const patModel = buildPatMocks();
+            const service = createUserService(lightdashConfigMock, {
+                personalAccessTokenModel: patModel as AnyType,
+            });
+            userModel.findSessionUserByPersonalAccessToken.mockResolvedValue(
+                patLookup({
+                    personalAccessToken: {
+                        expiresAt: new Date(Date.now() - 1000),
+                    },
+                }) as AnyType,
+            );
+
+            await expect(
+                service.loginWithPersonalAccessToken('token'),
+            ).rejects.toBeInstanceOf(AuthorizationError);
+            expect(patModel.delete).toHaveBeenCalledWith('pat-uuid');
         });
     });
 });

--- a/packages/backend/src/utils/hash.test.ts
+++ b/packages/backend/src/utils/hash.test.ts
@@ -1,0 +1,61 @@
+import {
+    deprecatedHash,
+    deriveTokenHashSalt,
+    hash,
+    hashWithSecret,
+} from './hash';
+
+const ENV_KEYS = ['LIGHTDASH_SECRET'] as const;
+const savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> =
+    {};
+
+beforeEach(() => {
+    ENV_KEYS.forEach((key) => {
+        savedEnv[key] = process.env[key];
+    });
+});
+
+afterEach(() => {
+    ENV_KEYS.forEach((key) => {
+        if (savedEnv[key] === undefined) {
+            delete process.env[key];
+        } else {
+            process.env[key] = savedEnv[key];
+        }
+    });
+});
+
+describe('deriveTokenHashSalt', () => {
+    test('produces a deterministic bcrypt-format salt', () => {
+        const salt = deriveTokenHashSalt('some secret');
+        expect(salt).toMatch(/^\$2b\$10\$[./A-Za-z0-9]{22}$/);
+        expect(deriveTokenHashSalt('some secret')).toEqual(salt);
+        expect(deriveTokenHashSalt('other secret')).not.toEqual(salt);
+    });
+});
+
+describe('hashWithSecret', () => {
+    test('is deterministic per token and secret', async () => {
+        const first = await hashWithSecret('token', 'secret-a');
+        expect(await hashWithSecret('token', 'secret-a')).toEqual(first);
+        expect(await hashWithSecret('token', 'secret-b')).not.toEqual(first);
+        expect(await hashWithSecret('other', 'secret-a')).not.toEqual(first);
+    });
+});
+
+describe('hash', () => {
+    test('hashes with the LIGHTDASH_SECRET environment variable', async () => {
+        process.env.LIGHTDASH_SECRET = 'env secret';
+        expect(await hash('token')).toEqual(
+            await hashWithSecret('token', 'env secret'),
+        );
+    });
+});
+
+describe('deprecatedHash', () => {
+    test('remains the plain sha256 hex of the token', () => {
+        expect(deprecatedHash('token')).toEqual(
+            '3c469e9d6c5875d37a43f353d4f88e61fcf812c66eee3457465a40b0da4153e0',
+        );
+    });
+});

--- a/packages/backend/src/utils/hash.ts
+++ b/packages/backend/src/utils/hash.ts
@@ -1,15 +1,22 @@
 import bcrypt from 'bcrypt';
 import * as crypto from 'crypto';
 
+export function deriveTokenHashSalt(secret: string): string {
+    // Use the secret as key material to generate a consistent salt in valid
+    // bcrypt format: $2b$10$ + 22 chars from the sha256 of the secret
+    const secretHash = crypto.createHash('sha256').update(secret).digest('hex');
+    return `$2b$10$${secretHash.substring(0, 22)}`;
+}
+
+export async function hashWithSecret(
+    s: string,
+    secret: string,
+): Promise<string> {
+    return bcrypt.hash(s, deriveTokenHashSalt(secret));
+}
+
 export async function hash(s: string): Promise<string> {
-    // Use LIGHTDASH_SECRET as key material to generate a consistent salt
-    const secretHash = crypto
-        .createHash('sha256')
-        .update(process.env.LIGHTDASH_SECRET!)
-        .digest('hex');
-    // Create a valid bcrypt salt format: $2b$10$ + 22 chars from the hash
-    const salt = `$2b$10$${secretHash.substring(0, 22)}`;
-    return bcrypt.hash(s, salt);
+    return hashWithSecret(s, process.env.LIGHTDASH_SECRET!);
 }
 
 /*


### PR DESCRIPTION
Token lookup queries the active bcrypt hash and legacy sha256 hash together with a single bcrypt operation. On a miss, fallback-secret hashes are derived concurrently (config caps fallbacks at three) and matched in one grouped query that prefers the earliest configured fallback.

Token hashes are one-way, so they are never rewritten: a credential hashed under a fallback secret keeps working while that fallback stays configured and must be reissued or revoked before the fallback is removed (the rotate command reports these as removal blockers). Service-account lookup also gains a null guard instead of throwing on unknown tokens.

Relates: PROD-9721