### PR TITLE
feat: add rotate-lightdash-secret maintenance command

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -41,6 +41,7 @@
         "seed": "knex seed:run --knexfile src/knexfile.ts",
         "seed-production": "knex seed:run --knexfile dist/knexfile.js",
         "reseed-encrypted-credentials": "tsx --tsconfig tsconfig.scripts.json src/scripts/reseed-encrypted-credentials.ts",
+        "rotate-lightdash-secret": "tsx --tsconfig tsconfig.scripts.json src/scripts/rotate-lightdash-secret/index.ts",
         "rollback-last": "knex migrate:down --knexfile src/knexfile.ts",
         "rollback-all": "knex migrate:rollback --all --knexfile src/knexfile.ts",
         "rollback-all-production": "knex migrate:rollback --all --knexfile dist/knexfile.js",

--- a/packages/backend/src/scripts/rotate-lightdash-secret/cli.test.ts
+++ b/packages/backend/src/scripts/rotate-lightdash-secret/cli.test.ts
@@ -1,0 +1,110 @@
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { type LightdashSecrets } from '../../config/parseConfig';
+import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import { runRotationCli } from './cli';
+
+const secrets = (active: string, ...fallbacks: string[]): LightdashSecrets => ({
+    active,
+    fallbacks,
+    all: [active, ...fallbacks],
+});
+
+const encryptionFor = (keyring: LightdashSecrets) =>
+    new EncryptionUtil({
+        lightdashConfig: {
+            lightdashSecret: keyring.active,
+            lightdashSecrets: keyring,
+        },
+    });
+
+const rotatedSecrets = secrets('new secret', 'old secret');
+
+const database = knex({ client: MockClient, dialect: 'pg' });
+const context = {
+    database: database as unknown as Knex,
+    encryptionUtil: encryptionFor(rotatedSecrets),
+    lightdashSecrets: rotatedSecrets,
+};
+
+const TABLE_PRESENT = [{ table_name: 'present' }];
+
+let tracker: Tracker;
+
+beforeAll(() => {
+    tracker = getTracker();
+});
+
+afterEach(() => {
+    tracker.reset();
+});
+
+describe('runRotationCli', () => {
+    test('returns a non-zero exit code when a value is unreadable', async () => {
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on.any(/graphile_worker\.jobs/).response({ rows: [] });
+        tracker.on.select('user_oauth_grants').response([
+            {
+                user_oauth_grant_uuid: 'grant-bad',
+                encrypted_refresh_token: encryptionFor(
+                    secrets('unknown secret'),
+                ).encrypt('lost'),
+            },
+        ]);
+        tracker.on.select('personal_access_tokens').response([]);
+        tracker.on.select('service_accounts').response([]);
+
+        const lines: string[] = [];
+        const exitCode = await runRotationCli(
+            ['--table', 'user_oauth_grants'],
+            context,
+            (line) => lines.push(line),
+        );
+
+        expect(exitCode).toEqual(1);
+        const output = lines.join('\n');
+        expect(output).toContain(
+            'unreadable user_oauth_grants.encrypted_refresh_token at user_oauth_grant_uuid=grant-bad',
+        );
+        expect(output).toContain(
+            '1 ciphertext value(s) are unreadable with every configured secret',
+        );
+    });
+
+    test('returns a zero exit code when everything has converged', async () => {
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on.any(/graphile_worker\.jobs/).response({ rows: [] });
+        tracker.on.select('user_oauth_grants').response([
+            {
+                user_oauth_grant_uuid: 'grant-1',
+                encrypted_refresh_token: context.encryptionUtil.encrypt('ok'),
+            },
+        ]);
+        tracker.on.select('personal_access_tokens').response([]);
+        tracker.on.select('service_accounts').response([]);
+
+        const lines: string[] = [];
+        const exitCode = await runRotationCli(
+            ['--table', 'user_oauth_grants'],
+            context,
+            (line) => lines.push(line),
+        );
+
+        expect(exitCode).toEqual(0);
+        expect(lines.join('\n')).toContain(
+            'No blockers found by this command.',
+        );
+    });
+
+    test('rejects an unknown argument', async () => {
+        await expect(
+            runRotationCli(['--frobnicate'], context, () => {}),
+        ).rejects.toThrow('Unknown argument: --frobnicate');
+    });
+
+    test('rejects an invalid batch size', async () => {
+        await expect(
+            runRotationCli(['--batch-size', '0'], context, () => {}),
+        ).rejects.toThrow('--batch-size must be a positive integer');
+    });
+});

--- a/packages/backend/src/scripts/rotate-lightdash-secret/cli.ts
+++ b/packages/backend/src/scripts/rotate-lightdash-secret/cli.ts
@@ -1,0 +1,118 @@
+import { CIPHERTEXT_REGISTRY } from './registry';
+import {
+    runSecretRotation,
+    type RotationContext,
+    type RotationOptions,
+} from './rotation';
+
+export const parseArguments = (argv: string[]): RotationOptions => {
+    const options: RotationOptions = {
+        execute: false,
+        batchSize: 500,
+        tables: null,
+    };
+    for (let i = 0; i < argv.length; i += 1) {
+        const argument = argv[i];
+        switch (argument) {
+            case '--execute':
+                options.execute = true;
+                break;
+            case '--batch-size': {
+                i += 1;
+                const batchSize = Number(argv[i]);
+                if (!Number.isInteger(batchSize) || batchSize < 1) {
+                    throw new Error('--batch-size must be a positive integer');
+                }
+                options.batchSize = batchSize;
+                break;
+            }
+            case '--table': {
+                i += 1;
+                const table = argv[i];
+                if (
+                    !table ||
+                    !CIPHERTEXT_REGISTRY.some((entry) => entry.table === table)
+                ) {
+                    throw new Error(
+                        `--table must be one of: ${[
+                            ...new Set(
+                                CIPHERTEXT_REGISTRY.map((entry) => entry.table),
+                            ),
+                        ].join(', ')}`,
+                    );
+                }
+                options.tables = [...(options.tables ?? []), table];
+                break;
+            }
+            default:
+                throw new Error(`Unknown argument: ${argument}`);
+        }
+    }
+    return options;
+};
+
+/** Runs the rotation and prints the report; returns the process exit code. */
+export async function runRotationCli(
+    argv: string[],
+    context: RotationContext,
+    log: (line: string) => void = console.log,
+): Promise<number> {
+    const options = parseArguments(argv);
+    const report = await runSecretRotation(context, options);
+
+    log(`Mode: ${report.mode}`);
+    log(`Configured fallbacks: ${context.lightdashSecrets.fallbacks.length}`);
+    log('\nRegistered ciphertext:');
+    report.ciphertext.forEach((result) => {
+        if (!result.tablePresent) {
+            log(`  ${result.table}.${result.column}: table absent`);
+            return;
+        }
+        log(
+            `  ${result.table}.${result.column}: scanned=${result.scanned} active=${result.active} fallback=${result.fallback} reEncrypted=${result.reEncrypted} concurrentSkips=${result.concurrentSkips} unreadable=${result.unreadablePrimaryKeys.length}`,
+        );
+        result.unreadablePrimaryKeys.forEach((primaryKey) => {
+            log(
+                `    unreadable ${result.table}.${result.column} at ${result.primaryKeyColumn}=${primaryKey}`,
+            );
+        });
+    });
+
+    const jobs = report.graphileJobs;
+    log('\nQueued createProjectWithCompile jobs:');
+    if (!jobs.schemaPresent) {
+        log('  graphile_worker.jobs absent');
+    } else {
+        log(
+            `  scanned=${jobs.scanned} active=${jobs.active} fallback=${jobs.fallback} reEncrypted=${jobs.reEncrypted} concurrentSkips=${jobs.concurrentSkips} unreadable=${jobs.unreadableJobIds.length}`,
+        );
+        jobs.unreadableJobIds.forEach((jobId) => {
+            log(`    unreadable job id ${jobId}`);
+        });
+    }
+
+    log('\nToken hashes:');
+    report.tokenHashes.forEach((result) => {
+        if (!result.tablePresent) {
+            log(`  ${result.table}: table absent`);
+            return;
+        }
+        log(
+            `  ${result.table}: total=${result.total} active=${result.active} fallback=[${result.fallback.join(', ')}] legacySha256=${result.legacySha256} unknown=${result.unknown}`,
+        );
+    });
+
+    if (report.blockers.length > 0) {
+        log('\nOld-secret removal blockers:');
+        report.blockers.forEach((blocker) => {
+            log(`  - ${blocker}`);
+        });
+        log('\nDo NOT remove a fallback secret while blockers remain.');
+    } else {
+        log(
+            '\nNo blockers found by this command. Verify the session-cookie, app-preview JWT, and signed download link waiting periods from the runbook before removing a fallback secret.',
+        );
+    }
+
+    return report.hasUnreadableValues ? 1 : 0;
+}

--- a/packages/backend/src/scripts/rotate-lightdash-secret/index.ts
+++ b/packages/backend/src/scripts/rotate-lightdash-secret/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Migrates LIGHTDASH_SECRET-derived state toward the active secret during a
+ * secret rotation, and reports every blocker that must clear before an old
+ * fallback secret can be removed.
+ *
+ * Dry-run by default: reports without modifying anything. With --execute,
+ * re-encrypts fallback-encrypted ciphertext (registered tables and queued
+ * createProjectWithCompile jobs) with the active secret using
+ * compare-and-swap updates. Never deletes unreadable values and never
+ * revokes credentials.
+ *
+ * Usage:
+ *   pnpm -F backend rotate-lightdash-secret [--execute]
+ *       [--batch-size 500] [--table <registry-table>]
+ */
+import knex from 'knex';
+import { lightdashConfig } from '../../config/lightdashConfig';
+import knexConfig from '../../knexfile';
+import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import { runRotationCli } from './cli';
+
+async function main() {
+    const database = knex(
+        knexConfig[
+            (process.env.NODE_ENV as 'production' | 'development') ||
+                'production'
+        ],
+    );
+    try {
+        process.exitCode = await runRotationCli(process.argv.slice(2), {
+            database,
+            encryptionUtil: new EncryptionUtil({ lightdashConfig }),
+            lightdashSecrets: lightdashConfig.lightdashSecrets,
+        });
+    } finally {
+        await database.destroy();
+    }
+}
+
+main().catch((error: unknown) => {
+    // Deliberately not the full message: driver errors can embed SQL and
+    // bindings, including token hashes and ciphertext
+    const name = error instanceof Error ? error.name : typeof error;
+    const code =
+        error && typeof error === 'object' && 'code' in error
+            ? `, code ${String((error as { code: unknown }).code)}`
+            : '';
+    console.error(`Secret rotation command failed: ${name}${code}`);
+    process.exit(1);
+});

--- a/packages/backend/src/scripts/rotate-lightdash-secret/registry.ts
+++ b/packages/backend/src/scripts/rotate-lightdash-secret/registry.ts
@@ -1,0 +1,109 @@
+export type CiphertextRegistryEntry = {
+    table: string;
+    primaryKeyColumn: string;
+    column: string;
+};
+
+// Every database field that stores EncryptionUtil (AES-256-GCM) ciphertext
+// derived from LIGHTDASH_SECRET. Tables are existence-checked at runtime so
+// EE-only and dormant tables are skipped on instances that lack them.
+// `dbt_cloud_integrations.service_token` is a dormant legacy field: its
+// reader was removed but the table was never dropped, so old deployments can
+// still hold ciphertext in it.
+export const CIPHERTEXT_REGISTRY: CiphertextRegistryEntry[] = [
+    {
+        table: 'projects',
+        primaryKeyColumn: 'project_id',
+        column: 'dbt_connection',
+    },
+    {
+        table: 'warehouse_credentials',
+        primaryKeyColumn: 'warehouse_credentials_id',
+        column: 'encrypted_credentials',
+    },
+    {
+        table: 'organization_warehouse_credentials',
+        primaryKeyColumn: 'organization_warehouse_credentials_uuid',
+        column: 'warehouse_connection',
+    },
+    {
+        table: 'user_warehouse_credentials',
+        primaryKeyColumn: 'user_warehouse_credentials_uuid',
+        column: 'encrypted_credentials',
+    },
+    {
+        table: 'project_dbt_sources',
+        primaryKeyColumn: 'project_dbt_source_uuid',
+        column: 'dbt_connection',
+    },
+    {
+        table: 'warehouse_connect_codes',
+        primaryKeyColumn: 'warehouse_connect_code_uuid',
+        column: 'encrypted_credentials',
+    },
+    {
+        table: 'ssh_key_pairs',
+        primaryKeyColumn: 'public_key',
+        column: 'private_key',
+    },
+    {
+        table: 'github_app_installations',
+        primaryKeyColumn: 'github_app_installation_uuid',
+        column: 'encrypted_installation_id',
+    },
+    {
+        table: 'gitlab_app_installations',
+        primaryKeyColumn: 'gitlab_app_installation_uuid',
+        column: 'encrypted_installation_id',
+    },
+    {
+        table: 'git_user_credentials',
+        primaryKeyColumn: 'git_user_credential_uuid',
+        column: 'encrypted_auth_token',
+    },
+    {
+        table: 'git_user_credentials',
+        primaryKeyColumn: 'git_user_credential_uuid',
+        column: 'encrypted_refresh_token',
+    },
+    {
+        table: 'user_oauth_grants',
+        primaryKeyColumn: 'user_oauth_grant_uuid',
+        column: 'encrypted_refresh_token',
+    },
+    {
+        table: 'organization_sso_configurations',
+        primaryKeyColumn: 'organization_sso_configuration_uuid',
+        column: 'config',
+    },
+    {
+        table: 'embedding',
+        primaryKeyColumn: 'project_uuid',
+        column: 'encoded_secret',
+    },
+    {
+        table: 'managed_agent_settings',
+        primaryKeyColumn: 'project_uuid',
+        column: 'service_account_token',
+    },
+    {
+        table: 'ai_mcp_server_credential',
+        primaryKeyColumn: 'ai_mcp_server_credential_uuid',
+        column: 'encrypted_credentials',
+    },
+    {
+        table: 'ai_organization_settings',
+        primaryKeyColumn: 'organization_uuid',
+        column: 'encrypted_provider_api_keys',
+    },
+    {
+        table: 'external_connection_secrets',
+        primaryKeyColumn: 'external_connection_uuid',
+        column: 'encrypted_payload',
+    },
+    {
+        table: 'dbt_cloud_integrations',
+        primaryKeyColumn: 'project_id',
+        column: 'service_token',
+    },
+];

--- a/packages/backend/src/scripts/rotate-lightdash-secret/rotation.test.ts
+++ b/packages/backend/src/scripts/rotate-lightdash-secret/rotation.test.ts
@@ -1,0 +1,535 @@
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { type LightdashSecrets } from '../../config/parseConfig';
+import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import { deriveTokenHashSalt, hashWithSecret } from '../../utils/hash';
+import { CIPHERTEXT_REGISTRY } from './registry';
+import {
+    classifyTokenHashes,
+    rotateQueuedCreateProjectJobs,
+    rotateRegisteredCiphertext,
+    runSecretRotation,
+} from './rotation';
+
+const secrets = (active: string, ...fallbacks: string[]): LightdashSecrets => ({
+    active,
+    fallbacks,
+    all: [active, ...fallbacks],
+});
+
+const encryptionFor = (keyring: LightdashSecrets) =>
+    new EncryptionUtil({
+        lightdashConfig: {
+            lightdashSecret: keyring.active,
+            lightdashSecrets: keyring,
+        },
+    });
+
+const oldOnly = encryptionFor(secrets('old secret'));
+const rotatedSecrets = secrets('new secret', 'old secret');
+const rotatedEncryption = encryptionFor(rotatedSecrets);
+
+const database = knex({ client: MockClient, dialect: 'pg' });
+const context = {
+    database: database as unknown as Knex,
+    encryptionUtil: rotatedEncryption,
+    lightdashSecrets: rotatedSecrets,
+};
+
+const TABLE_PRESENT = [{ table_name: 'present' }];
+
+let tracker: Tracker;
+
+beforeAll(() => {
+    tracker = getTracker();
+});
+
+afterEach(() => {
+    tracker.reset();
+});
+
+describe('ciphertext registry', () => {
+    test('contains the full 19-field inventory', () => {
+        expect(
+            CIPHERTEXT_REGISTRY.map((e) => `${e.table}.${e.column}`),
+        ).toEqual([
+            'projects.dbt_connection',
+            'warehouse_credentials.encrypted_credentials',
+            'organization_warehouse_credentials.warehouse_connection',
+            'user_warehouse_credentials.encrypted_credentials',
+            'project_dbt_sources.dbt_connection',
+            'warehouse_connect_codes.encrypted_credentials',
+            'ssh_key_pairs.private_key',
+            'github_app_installations.encrypted_installation_id',
+            'gitlab_app_installations.encrypted_installation_id',
+            'git_user_credentials.encrypted_auth_token',
+            'git_user_credentials.encrypted_refresh_token',
+            'user_oauth_grants.encrypted_refresh_token',
+            'organization_sso_configurations.config',
+            'embedding.encoded_secret',
+            'managed_agent_settings.service_account_token',
+            'ai_mcp_server_credential.encrypted_credentials',
+            'ai_organization_settings.encrypted_provider_api_keys',
+            'external_connection_secrets.encrypted_payload',
+            'dbt_cloud_integrations.service_token',
+        ]);
+    });
+});
+
+describe('rotateRegisteredCiphertext', () => {
+    const onlyOAuthGrants = {
+        execute: false,
+        batchSize: 500,
+        tables: ['user_oauth_grants'],
+    };
+
+    const grantRow = (uuid: string, ciphertext: Buffer) => ({
+        user_oauth_grant_uuid: uuid,
+        encrypted_refresh_token: ciphertext,
+    });
+
+    test('dry-run counts fallback ciphertext without updating', async () => {
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on
+            .select('user_oauth_grants')
+            .response([
+                grantRow('grant-1', oldOnly.encrypt('refresh-token')),
+                grantRow('grant-2', rotatedEncryption.encrypt('refresh-token')),
+            ]);
+
+        const [result] = await rotateRegisteredCiphertext(
+            context,
+            onlyOAuthGrants,
+        );
+
+        expect(result).toMatchObject({
+            table: 'user_oauth_grants',
+            scanned: 2,
+            active: 1,
+            fallback: 1,
+            reEncrypted: 0,
+            concurrentSkips: 0,
+            unreadablePrimaryKeys: [],
+        });
+        expect(tracker.history.update).toHaveLength(0);
+    });
+
+    test('execute re-encrypts fallback ciphertext with a compare-and-swap', async () => {
+        const fallbackCiphertext = oldOnly.encrypt('refresh-token');
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on
+            .select('user_oauth_grants')
+            .response([grantRow('grant-1', fallbackCiphertext)]);
+        tracker.on.update('user_oauth_grants').responseOnce(1);
+
+        const [result] = await rotateRegisteredCiphertext(context, {
+            ...onlyOAuthGrants,
+            execute: true,
+        });
+
+        expect(result).toMatchObject({
+            fallback: 1,
+            reEncrypted: 1,
+            concurrentSkips: 0,
+        });
+        expect(tracker.history.update).toHaveLength(1);
+        const updateBindings = tracker.history.update[0].bindings;
+        expect(updateBindings).toContain('grant-1');
+        expect(
+            updateBindings.some(
+                (binding) =>
+                    Buffer.isBuffer(binding) &&
+                    binding.equals(fallbackCiphertext),
+            ),
+        ).toBe(true);
+        const newCiphertext = updateBindings.find(
+            (binding) =>
+                Buffer.isBuffer(binding) && !binding.equals(fallbackCiphertext),
+        ) as Buffer;
+        expect(
+            encryptionFor(secrets('new secret')).decrypt(newCiphertext),
+        ).toEqual('refresh-token');
+    });
+
+    test('records a compare-and-swap miss as a concurrent skip', async () => {
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on
+            .select('user_oauth_grants')
+            .response([grantRow('grant-1', oldOnly.encrypt('refresh-token'))]);
+        tracker.on.update('user_oauth_grants').responseOnce(0);
+
+        const [result] = await rotateRegisteredCiphertext(context, {
+            ...onlyOAuthGrants,
+            execute: true,
+        });
+
+        expect(result).toMatchObject({
+            fallback: 1,
+            reEncrypted: 0,
+            concurrentSkips: 1,
+        });
+    });
+
+    test('reports unreadable ciphertext without modifying it and keeps scanning', async () => {
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on
+            .select('user_oauth_grants')
+            .response([
+                grantRow(
+                    'grant-bad',
+                    encryptionFor(secrets('unknown secret')).encrypt('lost'),
+                ),
+                grantRow('grant-2', oldOnly.encrypt('refresh-token')),
+            ]);
+        tracker.on.update('user_oauth_grants').responseOnce(1);
+
+        const [result] = await rotateRegisteredCiphertext(context, {
+            ...onlyOAuthGrants,
+            execute: true,
+        });
+
+        expect(result.unreadablePrimaryKeys).toEqual(['grant-bad']);
+        expect(result.reEncrypted).toEqual(1);
+        expect(tracker.history.update).toHaveLength(1);
+    });
+
+    test('skips absent tables without querying them', async () => {
+        tracker.on.any(/information_schema/).response(undefined);
+
+        const [result] = await rotateRegisteredCiphertext(
+            context,
+            onlyOAuthGrants,
+        );
+
+        expect(result.tablePresent).toBeFalsy();
+        expect(result.scanned).toEqual(0);
+        expect(
+            tracker.history.all.filter((query) =>
+                query.sql.includes('user_oauth_grants'),
+            ),
+        ).toHaveLength(0);
+    });
+
+    test('excludes null values in the query and paginates by primary key', async () => {
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on
+            .select('user_oauth_grants')
+            .responseOnce([
+                grantRow('grant-1', rotatedEncryption.encrypt('a')),
+                grantRow('grant-2', rotatedEncryption.encrypt('b')),
+            ]);
+        tracker.on
+            .select('user_oauth_grants')
+            .responseOnce([
+                grantRow('grant-3', rotatedEncryption.encrypt('c')),
+            ]);
+
+        const [result] = await rotateRegisteredCiphertext(context, {
+            ...onlyOAuthGrants,
+            batchSize: 2,
+        });
+
+        expect(result.scanned).toEqual(3);
+        const tableSelects = tracker.history.select.filter((query) =>
+            query.sql.includes('user_oauth_grants'),
+        );
+        expect(tableSelects).toHaveLength(2);
+        expect(tableSelects[0].sql).toContain('is not null');
+        expect(tableSelects[1].bindings).toContain('grant-2');
+    });
+
+    test('a rerun over converged ciphertext performs no updates', async () => {
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on
+            .select('user_oauth_grants')
+            .response([
+                grantRow('grant-1', rotatedEncryption.encrypt('refresh-token')),
+            ]);
+
+        const [result] = await rotateRegisteredCiphertext(context, {
+            ...onlyOAuthGrants,
+            execute: true,
+        });
+
+        expect(result).toMatchObject({ active: 1, fallback: 0 });
+        expect(tracker.history.update).toHaveLength(0);
+    });
+
+    test('lifecycle: A-active ciphertext migrates under B-active/A-fallback and reads with B only', async () => {
+        // Stage 1: pre-rotation, A ("old secret") is the only secret
+        const preRotationCiphertext = oldOnly.encrypt('warehouse-password');
+        expect(oldOnly.decrypt(preRotationCiphertext)).toEqual(
+            'warehouse-password',
+        );
+
+        // Stage 2: B active with A as fallback — run the migration
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on
+            .select('user_oauth_grants')
+            .response([grantRow('grant-1', preRotationCiphertext)]);
+        tracker.on.update('user_oauth_grants').responseOnce(1);
+
+        const [result] = await rotateRegisteredCiphertext(context, {
+            ...onlyOAuthGrants,
+            execute: true,
+        });
+        expect(result).toMatchObject({ fallback: 1, reEncrypted: 1 });
+
+        const migratedCiphertext = tracker.history.update[0].bindings.find(
+            (binding) =>
+                Buffer.isBuffer(binding) &&
+                !binding.equals(preRotationCiphertext),
+        ) as Buffer;
+
+        // Stage 3: A removed — B alone reads the value, A alone cannot
+        expect(
+            encryptionFor(secrets('new secret')).decrypt(migratedCiphertext),
+        ).toEqual('warehouse-password');
+        expect(() => oldOnly.decrypt(migratedCiphertext)).toThrow();
+    });
+});
+
+describe('rotateQueuedCreateProjectJobs', () => {
+    test('scans only unlocked jobs and re-encrypts with guarded updates', async () => {
+        const oldPayload = oldOnly.encrypt('{"name":"p"}').toString('base64');
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on
+            .any(/graphile_worker\.jobs/)
+            .responseOnce({ rows: [{ id: '7', data: oldPayload }] });
+        tracker.on.any(/graphile_worker\.jobs/).responseOnce({ rowCount: 1 });
+
+        const result = await rotateQueuedCreateProjectJobs(context, {
+            execute: true,
+            batchSize: 500,
+        });
+
+        expect(result).toMatchObject({
+            scanned: 1,
+            fallback: 1,
+            reEncrypted: 1,
+            concurrentSkips: 0,
+        });
+        const rawQueries = tracker.history.all.filter((query) =>
+            query.sql.includes('graphile_worker.jobs'),
+        );
+        expect(rawQueries[0].sql).toContain('locked_at IS NULL');
+        expect(rawQueries[0].sql).toContain('LIMIT');
+        expect(rawQueries[1].sql).toContain('locked_at IS NULL');
+        expect(rawQueries[1].sql).toContain("payload->>'data' =");
+        expect(rawQueries[1].bindings).toContain('7');
+        expect(rawQueries[1].bindings).toContain(oldPayload);
+
+        // The written value must round-trip: base64 payload back through
+        // decode + decrypt with the new secret alone
+        const rewrittenPayload = rawQueries[1].bindings.find(
+            (binding) =>
+                typeof binding === 'string' &&
+                binding !== '7' &&
+                binding !== oldPayload,
+        ) as string;
+        expect(
+            encryptionFor(secrets('new secret')).decrypt(
+                Buffer.from(rewrittenPayload, 'base64'),
+            ),
+        ).toEqual('{"name":"p"}');
+    });
+
+    test('paginates unlocked jobs by id with the configured batch size', async () => {
+        const payloadFor = (name: string) =>
+            oldOnly.encrypt(`{"name":"${name}"}`).toString('base64');
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on.any(/graphile_worker\.jobs/).responseOnce({
+            rows: [
+                { id: '1', data: payloadFor('a') },
+                { id: '2', data: payloadFor('b') },
+            ],
+        });
+        tracker.on.any(/graphile_worker\.jobs/).responseOnce({
+            rows: [{ id: '3', data: payloadFor('c') }],
+        });
+
+        const result = await rotateQueuedCreateProjectJobs(context, {
+            execute: false,
+            batchSize: 2,
+        });
+
+        expect(result).toMatchObject({ scanned: 3, fallback: 3 });
+        const selects = tracker.history.all.filter((query) =>
+            query.sql.includes('SELECT id'),
+        );
+        expect(selects).toHaveLength(2);
+        expect(selects[0].sql).not.toContain('id >');
+        expect(selects[1].sql).toContain('id >');
+        expect(selects[1].bindings).toContain('2');
+    });
+
+    test('records a concurrently changed payload as a skip', async () => {
+        const oldPayload = oldOnly.encrypt('{"name":"p"}').toString('base64');
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on
+            .any(/graphile_worker\.jobs/)
+            .responseOnce({ rows: [{ id: '7', data: oldPayload }] });
+        tracker.on.any(/graphile_worker\.jobs/).responseOnce({ rowCount: 0 });
+
+        const result = await rotateQueuedCreateProjectJobs(context, {
+            execute: true,
+            batchSize: 500,
+        });
+
+        expect(result).toMatchObject({ concurrentSkips: 1, reEncrypted: 0 });
+    });
+
+    test('reports undecryptable job payloads', async () => {
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on.any(/graphile_worker\.jobs/).responseOnce({
+            rows: [{ id: '9', data: 'bm90LWEtY2lwaGVydGV4dA==' }],
+        });
+
+        const result = await rotateQueuedCreateProjectJobs(context, {
+            execute: false,
+            batchSize: 500,
+        });
+
+        expect(result.unreadableJobIds).toEqual(['9']);
+    });
+});
+
+describe('classifyTokenHashes', () => {
+    test('classifies by canonical bcrypt prefix, legacy sha256 and unknown', async () => {
+        // 'new secret' is a secret whose raw derived salt differs from the
+        // canonical prefix bcrypt stores, which is exactly why sentinel
+        // hashes are required for classification.
+        const activeHash = await hashWithSecret('token-a', 'new secret');
+        expect(activeHash.startsWith(deriveTokenHashSalt('new secret'))).toBe(
+            false,
+        );
+        const fallbackHash = await hashWithSecret('token-b', 'old secret');
+        const legacyHash =
+            '3c469e9d6c5875d37a43f353d4f88e61fcf812c66eee3457465a40b0da4153e0';
+
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on
+            .select('personal_access_tokens')
+            .response([
+                { token_hash: activeHash },
+                { token_hash: fallbackHash },
+                { token_hash: legacyHash },
+                { token_hash: 'garbage' },
+            ]);
+        tracker.on
+            .select('service_accounts')
+            .response([{ token_hash: fallbackHash }]);
+
+        const [patResult, serviceAccountResult] = await classifyTokenHashes(
+            context,
+            { batchSize: 500 },
+        );
+
+        expect(patResult).toMatchObject({
+            table: 'personal_access_tokens',
+            total: 4,
+            active: 1,
+            fallback: [1],
+            legacySha256: 1,
+            unknown: 1,
+        });
+        expect(serviceAccountResult).toMatchObject({
+            table: 'service_accounts',
+            total: 1,
+            active: 0,
+            fallback: [1],
+        });
+    });
+
+    test('reports absent token tables without querying them', async () => {
+        tracker.on.any(/information_schema/).response(undefined);
+
+        const results = await classifyTokenHashes(context, { batchSize: 500 });
+
+        expect(results).toHaveLength(2);
+        expect(results[0].tablePresent).toBeFalsy();
+        expect(results[0].total).toEqual(0);
+    });
+
+    test('paginates token hashes by primary key with the configured batch size', async () => {
+        const fallbackHash = await hashWithSecret('token', 'old secret');
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on.select('personal_access_tokens').responseOnce([
+            { token_hash: fallbackHash, personal_access_token_uuid: 'pat-1' },
+            { token_hash: fallbackHash, personal_access_token_uuid: 'pat-2' },
+        ]);
+        tracker.on.select('personal_access_tokens').responseOnce([
+            {
+                token_hash: fallbackHash,
+                personal_access_token_uuid: 'pat-3',
+            },
+        ]);
+        tracker.on.select('service_accounts').response([]);
+
+        const [patResult] = await classifyTokenHashes(context, {
+            batchSize: 2,
+        });
+
+        expect(patResult).toMatchObject({ total: 3, fallback: [3] });
+        const patSelects = tracker.history.select.filter((query) =>
+            query.sql.includes('personal_access_tokens'),
+        );
+        expect(patSelects).toHaveLength(2);
+        expect(patSelects[0].sql).toContain('limit');
+        expect(patSelects[1].bindings).toContain('pat-2');
+    });
+});
+
+describe('runSecretRotation blockers', () => {
+    test('reports blockers for pending fallback state', async () => {
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on.any(/graphile_worker\.jobs/).response({ rows: [] });
+        tracker.on.select('user_oauth_grants').response([
+            {
+                user_oauth_grant_uuid: 'grant-1',
+                encrypted_refresh_token: oldOnly.encrypt('refresh-token'),
+            },
+        ]);
+        tracker.on.select('personal_access_tokens').response([]);
+        tracker.on
+            .select('service_accounts')
+            .response([
+                { token_hash: await hashWithSecret('token', 'old secret') },
+            ]);
+
+        const report = await runSecretRotation(context, {
+            execute: false,
+            batchSize: 500,
+            tables: ['user_oauth_grants'],
+        });
+
+        expect(report.hasUnreadableValues).toBe(false);
+        expect(report.blockers).toEqual([
+            '1 registered ciphertext value(s) still require a fallback secret',
+            '1 token hash(es) still derive from a fallback secret; reissue or revoke the credentials before removing the fallback',
+        ]);
+    });
+
+    test('reports no blockers when everything has converged', async () => {
+        tracker.on.any(/information_schema/).response(TABLE_PRESENT);
+        tracker.on.any(/graphile_worker\.jobs/).response({ rows: [] });
+        tracker.on.select('user_oauth_grants').response([
+            {
+                user_oauth_grant_uuid: 'grant-1',
+                encrypted_refresh_token:
+                    rotatedEncryption.encrypt('refresh-token'),
+            },
+        ]);
+        tracker.on.select('personal_access_tokens').response([]);
+        tracker.on.select('service_accounts').response([]);
+
+        const report = await runSecretRotation(context, {
+            execute: false,
+            batchSize: 500,
+            tables: ['user_oauth_grants'],
+        });
+
+        expect(report.blockers).toEqual([]);
+        expect(report.hasUnreadableValues).toBe(false);
+    });
+});

--- a/packages/backend/src/scripts/rotate-lightdash-secret/rotation.ts
+++ b/packages/backend/src/scripts/rotate-lightdash-secret/rotation.ts
@@ -1,0 +1,479 @@
+import { Knex } from 'knex';
+import { LightdashSecrets } from '../../config/parseConfig';
+import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import { hashWithSecret } from '../../utils/hash';
+import { CIPHERTEXT_REGISTRY, CiphertextRegistryEntry } from './registry';
+
+export type RotationOptions = {
+    execute: boolean;
+    batchSize: number;
+    /** Registry table filter; null means every registered table */
+    tables: string[] | null;
+};
+
+export type CiphertextScanResult = {
+    table: string;
+    column: string;
+    primaryKeyColumn: string;
+    tablePresent: boolean;
+    scanned: number;
+    active: number;
+    fallback: number;
+    reEncrypted: number;
+    concurrentSkips: number;
+    /** Primary keys of rows whose ciphertext no configured secret can read */
+    unreadablePrimaryKeys: string[];
+};
+
+export type GraphileJobsScanResult = {
+    schemaPresent: boolean;
+    scanned: number;
+    active: number;
+    fallback: number;
+    reEncrypted: number;
+    concurrentSkips: number;
+    unreadableJobIds: string[];
+};
+
+export type TokenHashClassification = {
+    table: string;
+    tablePresent: boolean;
+    total: number;
+    active: number;
+    /** Count per configured fallback, in keyring order */
+    fallback: number[];
+    legacySha256: number;
+    unknown: number;
+};
+
+export type SecretRotationReport = {
+    mode: 'dry-run' | 'execute';
+    ciphertext: CiphertextScanResult[];
+    graphileJobs: GraphileJobsScanResult;
+    tokenHashes: TokenHashClassification[];
+    blockers: string[];
+    hasUnreadableValues: boolean;
+};
+
+export type RotationContext = {
+    database: Knex;
+    encryptionUtil: EncryptionUtil;
+    lightdashSecrets: LightdashSecrets;
+};
+
+const CREATE_PROJECT_TASK = 'createProjectWithCompile';
+const LEGACY_SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const BCRYPT_PREFIX_LENGTH = '$2b$10$'.length + 22;
+const CLASSIFICATION_SENTINEL = 'lightdash-secret-rotation-sentinel';
+
+// Both bounds stay small so combined connection demand (table scans times
+// per-page updates) never exhausts the default knex pool.
+const TABLE_SCAN_CONCURRENCY = 2;
+const UPDATE_CONCURRENCY = 4;
+
+const TOKEN_HASH_TABLES: ReadonlyArray<{
+    table: string;
+    primaryKeyColumn: string;
+}> = [
+    {
+        table: 'personal_access_tokens',
+        primaryKeyColumn: 'personal_access_token_uuid',
+    },
+    { table: 'service_accounts', primaryKeyColumn: 'service_account_uuid' },
+];
+
+// Runs at most `concurrency` handlers in flight and preserves input order in
+// the results. Workers advance through a shared index by recursing instead of
+// looping, so independent work is parallel without unbounded fan-out.
+async function mapWithBoundedConcurrency<Item, Result>(
+    items: readonly Item[],
+    concurrency: number,
+    handle: (item: Item) => Promise<Result>,
+): Promise<Result[]> {
+    const results = new Array<Result>(items.length);
+    let nextIndex = 0;
+    const worker = async (): Promise<void> => {
+        const index = nextIndex;
+        nextIndex += 1;
+        if (index >= items.length) {
+            return;
+        }
+        results[index] = await handle(items[index]);
+        await worker();
+    };
+    await Promise.all(
+        Array.from({ length: Math.min(concurrency, items.length) }, () =>
+            worker(),
+        ),
+    );
+    return results;
+}
+
+// Async cursor pagination: fetches pages of at most `batchSize` rows ordered
+// by a stable key and handles each page before fetching the next, keeping
+// memory and query duration bounded on large tables.
+async function forEachPage<Row>(
+    batchSize: number,
+    fetchPage: (cursor: unknown) => Promise<Row[]>,
+    getCursor: (row: Row) => unknown,
+    handlePage: (rows: Row[]) => Promise<void>,
+): Promise<void> {
+    const step = async (cursor: unknown): Promise<void> => {
+        const rows = await fetchPage(cursor);
+        if (rows.length === 0) {
+            return;
+        }
+        await handlePage(rows);
+        if (rows.length < batchSize) {
+            return;
+        }
+        await step(getCursor(rows[rows.length - 1]));
+    };
+    await step(null);
+}
+
+async function scanRegistryEntry(
+    { database, encryptionUtil }: RotationContext,
+    entry: CiphertextRegistryEntry,
+    options: Pick<RotationOptions, 'execute' | 'batchSize'>,
+): Promise<CiphertextScanResult> {
+    const result: CiphertextScanResult = {
+        table: entry.table,
+        column: entry.column,
+        primaryKeyColumn: entry.primaryKeyColumn,
+        tablePresent: await database.schema.hasTable(entry.table),
+        scanned: 0,
+        active: 0,
+        fallback: 0,
+        reEncrypted: 0,
+        concurrentSkips: 0,
+        unreadablePrimaryKeys: [],
+    };
+    if (!result.tablePresent) {
+        return result;
+    }
+    await forEachPage<Record<string, unknown>>(
+        options.batchSize,
+        async (cursor) => {
+            const query = database(entry.table)
+                .select([entry.primaryKeyColumn, entry.column])
+                .whereNotNull(entry.column)
+                .orderBy(entry.primaryKeyColumn, 'asc')
+                .limit(options.batchSize);
+            if (cursor !== null) {
+                void query.where(entry.primaryKeyColumn, '>', cursor as never);
+            }
+            const rows: Record<string, unknown>[] = await query;
+            return rows;
+        },
+        (row) => row[entry.primaryKeyColumn],
+        async (rows) => {
+            const pendingReEncryptions: {
+                primaryKey: unknown;
+                ciphertext: Buffer;
+                plaintext: string;
+            }[] = [];
+            for (const row of rows) {
+                const primaryKey = row[entry.primaryKeyColumn];
+                const ciphertext = row[entry.column] as Buffer;
+                result.scanned += 1;
+                let decrypted = null;
+                try {
+                    decrypted = encryptionUtil.decryptWithMeta(ciphertext);
+                } catch {
+                    result.unreadablePrimaryKeys.push(String(primaryKey));
+                }
+                if (decrypted !== null) {
+                    if (decrypted.keySource.type === 'active') {
+                        result.active += 1;
+                    } else {
+                        result.fallback += 1;
+                        if (options.execute) {
+                            pendingReEncryptions.push({
+                                primaryKey,
+                                ciphertext,
+                                plaintext: decrypted.value,
+                            });
+                        }
+                    }
+                }
+            }
+            await mapWithBoundedConcurrency(
+                pendingReEncryptions,
+                UPDATE_CONCURRENCY,
+                async ({ primaryKey, ciphertext, plaintext }) => {
+                    const updatedRows = await database(entry.table)
+                        .where(entry.primaryKeyColumn, primaryKey as never)
+                        .andWhere(entry.column, ciphertext)
+                        .update({
+                            [entry.column]: encryptionUtil.encrypt(plaintext),
+                        });
+                    if (updatedRows === 0) {
+                        result.concurrentSkips += 1;
+                    } else {
+                        result.reEncrypted += 1;
+                    }
+                },
+            );
+        },
+    );
+    return result;
+}
+
+export async function rotateRegisteredCiphertext(
+    context: RotationContext,
+    options: RotationOptions,
+): Promise<CiphertextScanResult[]> {
+    const entries = CIPHERTEXT_REGISTRY.filter(
+        (entry) =>
+            options.tables === null || options.tables.includes(entry.table),
+    );
+    return mapWithBoundedConcurrency(entries, TABLE_SCAN_CONCURRENCY, (entry) =>
+        scanRegistryEntry(context, entry, options),
+    );
+}
+
+export async function rotateQueuedCreateProjectJobs(
+    { database, encryptionUtil }: RotationContext,
+    options: Pick<RotationOptions, 'execute' | 'batchSize'>,
+): Promise<GraphileJobsScanResult> {
+    const result: GraphileJobsScanResult = {
+        schemaPresent: await database.schema
+            .withSchema('graphile_worker')
+            .hasTable('jobs'),
+        scanned: 0,
+        active: 0,
+        fallback: 0,
+        reEncrypted: 0,
+        concurrentSkips: 0,
+        unreadableJobIds: [],
+    };
+    if (!result.schemaPresent) {
+        return result;
+    }
+    type JobRow = { id: string; data: string | null };
+    await forEachPage<JobRow>(
+        options.batchSize,
+        async (cursor) => {
+            // Only unlocked jobs: a locked job is being processed by a worker
+            // and must not be modified underneath it.
+            const { rows } = (await database.raw(
+                `SELECT id, payload->>'data' AS data
+                 FROM graphile_worker.jobs
+                 WHERE task_identifier = ? AND locked_at IS NULL${
+                     cursor !== null ? ' AND id > ?' : ''
+                 }
+                 ORDER BY id ASC
+                 LIMIT ?`,
+                cursor !== null
+                    ? [CREATE_PROJECT_TASK, cursor as string, options.batchSize]
+                    : [CREATE_PROJECT_TASK, options.batchSize],
+            )) as { rows: JobRow[] };
+            return rows;
+        },
+        (row) => row.id,
+        async (rows) => {
+            const pendingReEncryptions: {
+                id: string;
+                data: string;
+                plaintext: string;
+            }[] = [];
+            for (const row of rows.filter((jobRow) => jobRow.data)) {
+                result.scanned += 1;
+                let decrypted = null;
+                try {
+                    decrypted = encryptionUtil.decryptWithMeta(
+                        Buffer.from(row.data as string, 'base64'),
+                    );
+                } catch {
+                    result.unreadableJobIds.push(String(row.id));
+                }
+                if (decrypted !== null) {
+                    if (decrypted.keySource.type === 'active') {
+                        result.active += 1;
+                    } else {
+                        result.fallback += 1;
+                        if (options.execute) {
+                            pendingReEncryptions.push({
+                                id: row.id,
+                                data: row.data as string,
+                                plaintext: decrypted.value,
+                            });
+                        }
+                    }
+                }
+            }
+            await mapWithBoundedConcurrency(
+                pendingReEncryptions,
+                UPDATE_CONCURRENCY,
+                async ({ id, data, plaintext }) => {
+                    const reEncrypted = encryptionUtil
+                        .encrypt(plaintext)
+                        .toString('base64');
+                    const updateResult = (await database.raw(
+                        `UPDATE graphile_worker.jobs
+                         SET payload = jsonb_set(payload::jsonb, '{data}', to_jsonb(?::text), true)
+                         WHERE id = ? AND locked_at IS NULL AND payload->>'data' = ?`,
+                        [reEncrypted, id, data],
+                    )) as { rowCount: number };
+                    if (updateResult.rowCount === 0) {
+                        result.concurrentSkips += 1;
+                    } else {
+                        result.reEncrypted += 1;
+                    }
+                },
+            );
+        },
+    );
+    return result;
+}
+
+// Classifies stored bcrypt hashes by their canonical 29-character prefix
+// ($2b$10$ + 22 salt chars). The prefix comes from a real bcrypt output per
+// candidate secret because bcrypt canonicalizes the supplied salt: the raw
+// derived salt string can differ from what bcrypt stores.
+export async function classifyTokenHashes(
+    { database, lightdashSecrets }: RotationContext,
+    options: Pick<RotationOptions, 'batchSize'>,
+): Promise<TokenHashClassification[]> {
+    const candidatePrefixes = await Promise.all(
+        lightdashSecrets.all.map(async (secret) =>
+            (await hashWithSecret(CLASSIFICATION_SENTINEL, secret)).slice(
+                0,
+                BCRYPT_PREFIX_LENGTH,
+            ),
+        ),
+    );
+    return mapWithBoundedConcurrency(
+        TOKEN_HASH_TABLES,
+        TABLE_SCAN_CONCURRENCY,
+        async ({ table, primaryKeyColumn }) => {
+            const result: TokenHashClassification = {
+                table,
+                tablePresent: await database.schema.hasTable(table),
+                total: 0,
+                active: 0,
+                fallback: lightdashSecrets.fallbacks.map(() => 0),
+                legacySha256: 0,
+                unknown: 0,
+            };
+            if (!result.tablePresent) {
+                return result;
+            }
+            await forEachPage<Record<string, unknown>>(
+                options.batchSize,
+                async (cursor) => {
+                    const query = database(table)
+                        .select('token_hash', primaryKeyColumn)
+                        .orderBy(primaryKeyColumn, 'asc')
+                        .limit(options.batchSize);
+                    if (cursor !== null) {
+                        void query.where(
+                            primaryKeyColumn,
+                            '>',
+                            cursor as never,
+                        );
+                    }
+                    const rows: Record<string, unknown>[] = await query;
+                    return rows;
+                },
+                (row) => row[primaryKeyColumn],
+                async (rows) => {
+                    for (const row of rows) {
+                        result.total += 1;
+                        const tokenHash = row.token_hash as string;
+                        const candidateIndex = candidatePrefixes.findIndex(
+                            (prefix) => tokenHash.startsWith(prefix),
+                        );
+                        if (candidateIndex === 0) {
+                            result.active += 1;
+                        } else if (candidateIndex > 0) {
+                            result.fallback[candidateIndex - 1] += 1;
+                        } else if (LEGACY_SHA256_PATTERN.test(tokenHash)) {
+                            result.legacySha256 += 1;
+                        } else {
+                            result.unknown += 1;
+                        }
+                    }
+                },
+            );
+            return result;
+        },
+    );
+}
+
+const collectBlockers = (
+    report: Omit<SecretRotationReport, 'blockers' | 'hasUnreadableValues'>,
+): string[] => {
+    const blockers: string[] = [];
+    const fallbackCiphertext = report.ciphertext.reduce(
+        (sum, r) => sum + r.fallback - r.reEncrypted,
+        0,
+    );
+    if (fallbackCiphertext > 0) {
+        blockers.push(
+            `${fallbackCiphertext} registered ciphertext value(s) still require a fallback secret`,
+        );
+    }
+    const unreadable = report.ciphertext.reduce(
+        (sum, r) => sum + r.unreadablePrimaryKeys.length,
+        0,
+    );
+    if (unreadable > 0) {
+        blockers.push(
+            `${unreadable} ciphertext value(s) are unreadable with every configured secret`,
+        );
+    }
+    const concurrentSkips =
+        report.ciphertext.reduce((sum, r) => sum + r.concurrentSkips, 0) +
+        report.graphileJobs.concurrentSkips;
+    if (concurrentSkips > 0) {
+        blockers.push(
+            `${concurrentSkips} concurrent skip(s); rerun until a dry-run reports zero`,
+        );
+    }
+    const fallbackJobs =
+        report.graphileJobs.fallback - report.graphileJobs.reEncrypted;
+    if (fallbackJobs > 0) {
+        blockers.push(
+            `${fallbackJobs} queued ${CREATE_PROJECT_TASK} job(s) still require a fallback secret`,
+        );
+    }
+    if (report.graphileJobs.unreadableJobIds.length > 0) {
+        blockers.push(
+            `${report.graphileJobs.unreadableJobIds.length} queued ${CREATE_PROJECT_TASK} job(s) are unreadable with every configured secret`,
+        );
+    }
+    const fallbackTokenHashes = report.tokenHashes.reduce(
+        (sum, r) => sum + r.fallback.reduce((a, b) => a + b, 0),
+        0,
+    );
+    if (fallbackTokenHashes > 0) {
+        blockers.push(
+            `${fallbackTokenHashes} token hash(es) still derive from a fallback secret; reissue or revoke the credentials before removing the fallback`,
+        );
+    }
+    return blockers;
+};
+
+export async function runSecretRotation(
+    context: RotationContext,
+    options: RotationOptions,
+): Promise<SecretRotationReport> {
+    const ciphertext = await rotateRegisteredCiphertext(context, options);
+    const graphileJobs = await rotateQueuedCreateProjectJobs(context, options);
+    const tokenHashes = await classifyTokenHashes(context, options);
+    const partialReport = {
+        mode: options.execute ? ('execute' as const) : ('dry-run' as const),
+        ciphertext,
+        graphileJobs,
+        tokenHashes,
+    };
+    return {
+        ...partialReport,
+        blockers: collectBlockers(partialReport),
+        hasUnreadableValues:
+            ciphertext.some((r) => r.unreadablePrimaryKeys.length > 0) ||
+            graphileJobs.unreadableJobIds.length > 0,
+    };
+}


### PR DESCRIPTION
Adds a `rotate-lightdash-secret` maintenance command (dry-run by default, `--execute` to migrate) that moves secret-derived state toward the active secret and reports every blocker gating old-secret removal:

- Re-encrypts the registered ciphertext inventory (19 fields) and unlocked queued `createProjectWithCompile` job payloads with compare-and-swap updates, paginating by stable primary key with a validated batch size and bounded update concurrency.
- Classifies PAT and service-account hashes by canonical per-candidate sentinel bcrypt prefixes. Token hashes are never rewritten (they are one-way); credentials still classified under a fallback are reported as removal blockers and must be reissued or revoked.
- Unreadable values are reported, never modified, and produce a non-zero exit after the full report.

Signed download links are deliberately not scanned: they stop working once the secret that signed them is no longer configured, and their bounded lifetime (3 days by default, configurable per channel) is covered by a time-based removal gate in the runbook instead of a database report.

test-all

Relates: PROD-9721