### PR TITLE
fix(backend): validate custom metric SQL on ad-hoc query execution

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -645,24 +645,63 @@ export class SavedChartModel {
     }
 
     /**
+     * A query over one persisted-SQL child table, joined up to its saved chart's
+     * space and scoped to a project + explore, excluding soft-deleted charts and
+     * spaces. Dashboard-tile charts (null space_id) drop out via the inner join
+     * to spaces. Callers add the table-specific `whereIn` + `distinct`.
+     */
+    private provenanceBaseQuery(
+        childTable: string,
+        projectUuid: string,
+        exploreName: string,
+    ) {
+        return this.database(childTable)
+            .innerJoin(
+                SavedChartVersionsTableName,
+                `${SavedChartVersionsTableName}.saved_queries_version_id`,
+                `${childTable}.saved_queries_version_id`,
+            )
+            .innerJoin(
+                SavedChartsTableName,
+                `${SavedChartsTableName}.saved_query_id`,
+                `${SavedChartVersionsTableName}.saved_query_id`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${SavedChartsTableName}.space_id`,
+            )
+            .where(`${SavedChartsTableName}.project_uuid`, projectUuid)
+            .where(`${SavedChartVersionsTableName}.explore_name`, exploreName)
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`);
+    }
+
+    /**
      * Finds the spaces of saved charts that already persist the given custom SQL,
      * scoped to a project + explore. Used to authorize re-running unmodified
      * saved-chart SQL from the ad-hoc query path without granting SQL-authoring
      * scopes. Callers must still check that the returned spaces are viewable.
      *
      * Matching is byte-exact on the persisted raw SQL (plus table binding for
-     * custom dimensions, since identical SQL resolves differently against another
-     * table). Dashboard-tile charts (null space_id) are excluded by the inner
-     * join to spaces.
+     * custom dimensions and additional metrics, since identical SQL resolves
+     * differently against another table). Dashboard-tile charts (null space_id)
+     * are excluded by the inner join to spaces.
      */
     async findCustomSqlProvenance(args: {
         projectUuid: string;
         exploreName: string;
         tableCalculationSqls: string[];
         customSqlDimensions: { sql: string; table: string }[];
+        additionalMetrics: { sql: string; table: string }[];
     }): Promise<{
         tableCalculations: { sql: string; spaceUuid: string }[];
         customSqlDimensions: {
+            sql: string;
+            table: string;
+            spaceUuid: string;
+        }[];
+        additionalMetrics: {
             sql: string;
             table: string;
             spaceUuid: string;
@@ -673,37 +712,17 @@ export class SavedChartModel {
             exploreName,
             tableCalculationSqls,
             customSqlDimensions,
+            additionalMetrics,
         } = args;
 
         const tableCalculations =
             tableCalculationSqls.length === 0
                 ? []
-                : await this.database(SavedChartTableCalculationTableName)
-                      .innerJoin(
-                          SavedChartVersionsTableName,
-                          `${SavedChartVersionsTableName}.saved_queries_version_id`,
-                          `${SavedChartTableCalculationTableName}.saved_queries_version_id`,
-                      )
-                      .innerJoin(
-                          SavedChartsTableName,
-                          `${SavedChartsTableName}.saved_query_id`,
-                          `${SavedChartVersionsTableName}.saved_query_id`,
-                      )
-                      .innerJoin(
-                          SpaceTableName,
-                          `${SpaceTableName}.space_id`,
-                          `${SavedChartsTableName}.space_id`,
-                      )
-                      .where(
-                          `${SavedChartsTableName}.project_uuid`,
-                          projectUuid,
-                      )
-                      .where(
-                          `${SavedChartVersionsTableName}.explore_name`,
-                          exploreName,
-                      )
-                      .whereNull(`${SavedChartsTableName}.deleted_at`)
-                      .whereNull(`${SpaceTableName}.deleted_at`)
+                : await this.provenanceBaseQuery(
+                      SavedChartTableCalculationTableName,
+                      projectUuid,
+                      exploreName,
+                  )
                       .whereIn(
                           `${SavedChartTableCalculationTableName}.calculation_raw_sql`,
                           tableCalculationSqls,
@@ -716,32 +735,11 @@ export class SavedChartModel {
         const customSqlDimensionMatches =
             customSqlDimensions.length === 0
                 ? []
-                : await this.database(SavedChartCustomSqlDimensionsTableName)
-                      .innerJoin(
-                          SavedChartVersionsTableName,
-                          `${SavedChartVersionsTableName}.saved_queries_version_id`,
-                          `${SavedChartCustomSqlDimensionsTableName}.saved_queries_version_id`,
-                      )
-                      .innerJoin(
-                          SavedChartsTableName,
-                          `${SavedChartsTableName}.saved_query_id`,
-                          `${SavedChartVersionsTableName}.saved_query_id`,
-                      )
-                      .innerJoin(
-                          SpaceTableName,
-                          `${SpaceTableName}.space_id`,
-                          `${SavedChartsTableName}.space_id`,
-                      )
-                      .where(
-                          `${SavedChartsTableName}.project_uuid`,
-                          projectUuid,
-                      )
-                      .where(
-                          `${SavedChartVersionsTableName}.explore_name`,
-                          exploreName,
-                      )
-                      .whereNull(`${SavedChartsTableName}.deleted_at`)
-                      .whereNull(`${SpaceTableName}.deleted_at`)
+                : await this.provenanceBaseQuery(
+                      SavedChartCustomSqlDimensionsTableName,
+                      projectUuid,
+                      exploreName,
+                  )
                       .whereIn(
                           [
                               `${SavedChartCustomSqlDimensionsTableName}.sql`,
@@ -755,9 +753,31 @@ export class SavedChartModel {
                           `${SpaceTableName}.space_uuid as spaceUuid`,
                       );
 
+        const additionalMetricMatches =
+            additionalMetrics.length === 0
+                ? []
+                : await this.provenanceBaseQuery(
+                      SavedChartAdditionalMetricTableName,
+                      projectUuid,
+                      exploreName,
+                  )
+                      .whereIn(
+                          [
+                              `${SavedChartAdditionalMetricTableName}.sql`,
+                              `${SavedChartAdditionalMetricTableName}.table`,
+                          ],
+                          additionalMetrics.map((m) => [m.sql, m.table]),
+                      )
+                      .distinct(
+                          `${SavedChartAdditionalMetricTableName}.sql as sql`,
+                          `${SavedChartAdditionalMetricTableName}.table as table`,
+                          `${SpaceTableName}.space_uuid as spaceUuid`,
+                      );
+
         return {
             tableCalculations,
             customSqlDimensions: customSqlDimensionMatches,
+            additionalMetrics: additionalMetricMatches,
         };
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -252,6 +252,11 @@ const savedChartModel = {
             table: string;
             spaceUuid: string;
         }[],
+        additionalMetrics: [] as {
+            sql: string;
+            table: string;
+            spaceUuid: string;
+        }[],
     })),
 };
 const jobModel = {
@@ -4051,6 +4056,12 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
         metricQuery: {
             tableCalculations?: (typeof sqlTableCalculation)[];
             customDimensions?: (typeof sqlCustomDimension)[];
+            additionalMetrics?: {
+                name: string;
+                table: string;
+                type: MetricType;
+                sql: string;
+            }[];
         };
     };
     const assertCustomSql = (svc: ProjectService, args: CustomSqlAuthArgs) =>
@@ -4137,6 +4148,7 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
         savedChartModel.findCustomSqlProvenance.mockResolvedValue({
             tableCalculations: [],
             customSqlDimensions: [],
+            additionalMetrics: [],
         });
     });
 
@@ -4179,6 +4191,7 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
         savedChartModel.findCustomSqlProvenance.mockResolvedValue({
             tableCalculations: [{ sql: sqlTableCalculation.sql, spaceUuid }],
             customSqlDimensions: [],
+            additionalMetrics: [],
         });
         await expect(
             assertCustomSql(service, {
@@ -4193,6 +4206,7 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
         savedChartModel.findCustomSqlProvenance.mockResolvedValue({
             tableCalculations: [{ sql: sqlTableCalculation.sql, spaceUuid }],
             customSqlDimensions: [],
+            additionalMetrics: [],
         });
         await expect(
             assertCustomSql(service, {
@@ -4223,6 +4237,7 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
                     spaceUuid,
                 },
             ],
+            additionalMetrics: [],
         });
         await expect(
             assertCustomSql(service, {
@@ -4243,6 +4258,7 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
                     spaceUuid,
                 },
             ],
+            additionalMetrics: [],
         });
         await expect(
             assertCustomSql(service, {
@@ -4257,6 +4273,7 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
         savedChartModel.findCustomSqlProvenance.mockResolvedValue({
             tableCalculations: [{ sql: sqlTableCalculation.sql, spaceUuid }],
             customSqlDimensions: [],
+            additionalMetrics: [],
         });
         await expect(
             assertCustomSql(service, {
@@ -4266,5 +4283,137 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
             }),
         ).rejects.toThrow(ForbiddenError);
         expect(savedChartModel.findCustomSqlProvenance).not.toHaveBeenCalled();
+    });
+
+    // --- additional metrics (PR2) ---
+
+    const fieldRefSql = '${TABLE}.amount';
+    const metricSubquerySql =
+        '(SELECT count(*) FROM information_schema.tables)';
+    const exploreWithFieldSql = {
+        ...validExplore,
+        tables: {
+            ...validExplore.tables,
+            a: {
+                ...validExplore.tables.a,
+                dimensions: {
+                    ...validExplore.tables.a.dimensions,
+                    dim1: {
+                        ...validExplore.tables.a.dimensions.dim1,
+                        sql: fieldRefSql,
+                    },
+                },
+            },
+        },
+    };
+    const additionalMetric = (sql: string, table = 'a', name = 'am1') => [
+        { name, table, type: MetricType.NUMBER, sql },
+    ];
+    const spyExplore = () =>
+        vi
+            .spyOn(service, 'getExplore')
+            .mockClear()
+            .mockResolvedValue(exploreWithFieldSql as unknown as Explore);
+
+    it('allows a custom metric whose SQL is a modelled field, without scope or provenance', async () => {
+        spyExplore();
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: noScopeAccount,
+                metricQuery: {
+                    additionalMetrics: additionalMetric(fieldRefSql),
+                },
+            }),
+        ).resolves.toBeUndefined();
+        expect(savedChartModel.findCustomSqlProvenance).not.toHaveBeenCalled();
+    });
+
+    it('allows any custom metric SQL for a user with manage:CustomFields, without loading the explore', async () => {
+        const exploreSpy = spyExplore();
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: authorAccount,
+                metricQuery: {
+                    additionalMetrics: additionalMetric(metricSubquerySql),
+                },
+            }),
+        ).resolves.toBeUndefined();
+        expect(exploreSpy).not.toHaveBeenCalled();
+        expect(savedChartModel.findCustomSqlProvenance).not.toHaveBeenCalled();
+    });
+
+    it('rejects hand-authored custom metric SQL with no scope and no provenance', async () => {
+        spyExplore();
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: noScopeAccount,
+                metricQuery: {
+                    additionalMetrics: additionalMetric(metricSubquerySql),
+                },
+            }),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
+    });
+
+    it('allows hand-authored custom metric SQL that matches a viewable saved chart', async () => {
+        spyExplore();
+        savedChartModel.findCustomSqlProvenance.mockResolvedValue({
+            tableCalculations: [],
+            customSqlDimensions: [],
+            additionalMetrics: [
+                { sql: metricSubquerySql, table: 'a', spaceUuid },
+            ],
+        });
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: noScopeAccount,
+                metricQuery: {
+                    additionalMetrics: additionalMetric(metricSubquerySql),
+                },
+            }),
+        ).resolves.toBeUndefined();
+    });
+
+    it('rejects a custom metric matching persisted SQL under a different table binding', async () => {
+        spyExplore();
+        savedChartModel.findCustomSqlProvenance.mockResolvedValue({
+            tableCalculations: [],
+            customSqlDimensions: [],
+            additionalMetrics: [
+                { sql: metricSubquerySql, table: 'b', spaceUuid },
+            ],
+        });
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: noScopeAccount,
+                metricQuery: {
+                    additionalMetrics: additionalMetric(metricSubquerySql, 'a'),
+                },
+            }),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
+    });
+
+    it('rejects a custom metric whose matching chart is not viewable', async () => {
+        spyExplore();
+        savedChartModel.findCustomSqlProvenance.mockResolvedValue({
+            tableCalculations: [],
+            customSqlDimensions: [],
+            additionalMetrics: [
+                { sql: metricSubquerySql, table: 'a', spaceUuid },
+            ],
+        });
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: restrictedAccount,
+                metricQuery: {
+                    additionalMetrics: additionalMetric(metricSubquerySql),
+                },
+            }),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
     });
 });

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4597,12 +4597,46 @@ export class ProjectService extends BaseService {
     }
 
     /**
-     * Custom SQL table calculations and custom SQL dimensions are authoring
-     * features gated behind manage:CustomSqlTableCalculations / manage:CustomFields.
-     * The ad-hoc query and compile endpoints accept a client-supplied metric query,
-     * so without this check a user who is denied those scopes could still run
-     * arbitrary warehouse SQL by embedding it in tableCalculations[].sql or
-     * customDimensions[].sql, bypassing the semantic layer.
+     * The set of raw SQL definitions of every modelled dimension and metric in an
+     * explore. A custom metric whose SQL equals one of these is the ordinary
+     * (viewer-available) custom-metric feature, not injected SQL.
+     */
+    private async getExploreFieldSqlSet(
+        account: Account,
+        projectUuid: string,
+        exploreName: string,
+    ): Promise<Set<string>> {
+        const explore = await this.getExplore(
+            account,
+            projectUuid,
+            exploreName,
+        );
+        const fieldSqls = new Set<string>();
+        for (const table of Object.values(explore.tables)) {
+            for (const dimension of Object.values(table.dimensions)) {
+                if (dimension.sql) fieldSqls.add(dimension.sql);
+            }
+            for (const metric of Object.values(table.metrics)) {
+                if (metric.sql) fieldSqls.add(metric.sql);
+            }
+        }
+        return fieldSqls;
+    }
+
+    /**
+     * Custom SQL table calculations, custom SQL dimensions, and custom metrics are
+     * authoring features gated behind manage:CustomSqlTableCalculations (table
+     * calculations) or manage:CustomFields (dimensions and metrics). The ad-hoc
+     * query and compile endpoints accept a client-supplied metric query, so
+     * without this check a user denied those scopes could still run arbitrary
+     * warehouse SQL by embedding it in tableCalculations[].sql,
+     * customDimensions[].sql, or additionalMetrics[].sql, bypassing the semantic
+     * layer.
+     *
+     * Custom metrics are a viewer-available feature: a metric whose SQL is exactly
+     * a modelled field's definition (the only shape the UI produces, plus
+     * period-over-period metrics) is always allowed without a scope. Only a metric
+     * with hand-authored SQL is gated like a custom SQL dimension.
      *
      * A caller who lacks the scope may still run SQL that is byte-identical to SQL
      * already persisted in a saved chart they can view (same project + explore), so
@@ -4623,7 +4657,7 @@ export class ProjectService extends BaseService {
         exploreName: string;
         metricQuery: Pick<
             MetricQuery,
-            'tableCalculations' | 'customDimensions'
+            'tableCalculations' | 'customDimensions' | 'additionalMetrics'
         >;
     }): Promise<void> {
         const sqlTableCalculations = (
@@ -4632,9 +4666,11 @@ export class ProjectService extends BaseService {
         const sqlCustomDimensions = (metricQuery.customDimensions ?? []).filter(
             isCustomSqlDimension,
         );
+        const additionalMetrics = metricQuery.additionalMetrics ?? [];
         if (
             sqlTableCalculations.length === 0 &&
-            sqlCustomDimensions.length === 0
+            sqlCustomDimensions.length === 0 &&
+            additionalMetrics.length === 0
         ) {
             return;
         }
@@ -4647,7 +4683,7 @@ export class ProjectService extends BaseService {
                 projectUuid,
             }),
         );
-        const canAuthorCustomDimensions = auditedAbility.can(
+        const canAuthorCustomFields = auditedAbility.can(
             'manage',
             subject('CustomFields', { organizationUuid, projectUuid }),
         );
@@ -4655,21 +4691,36 @@ export class ProjectService extends BaseService {
         const tableCalculationsToAuthorize = canAuthorTableCalculations
             ? []
             : sqlTableCalculations;
-        const customDimensionsToAuthorize = canAuthorCustomDimensions
+        const customDimensionsToAuthorize = canAuthorCustomFields
             ? []
             : sqlCustomDimensions;
+        // Custom metrics that are a plain modelled-field reference are always
+        // allowed; only hand-authored SQL needs the scope or a provenance match.
+        let additionalMetricsToAuthorize: typeof additionalMetrics = [];
+        if (additionalMetrics.length > 0 && !canAuthorCustomFields) {
+            const knownFieldSqls = await this.getExploreFieldSqlSet(
+                account,
+                projectUuid,
+                exploreName,
+            );
+            additionalMetricsToAuthorize = additionalMetrics.filter(
+                (metric) => !knownFieldSqls.has(metric.sql),
+            );
+        }
         if (
             tableCalculationsToAuthorize.length === 0 &&
-            customDimensionsToAuthorize.length === 0
+            customDimensionsToAuthorize.length === 0 &&
+            additionalMetricsToAuthorize.length === 0
         ) {
             return;
         }
 
-        const customDimensionKey = (item: { table: string; sql: string }) =>
+        const sqlTableKey = (item: { table: string; sql: string }) =>
             `${item.table}\0${item.sql}`;
 
         let viewableTableCalculationSqls = new Set<string>();
         let viewableCustomDimensionKeys = new Set<string>();
+        let viewableAdditionalMetricKeys = new Set<string>();
         // The provenance exemption trusts saved-chart SQL the caller can view.
         // Never extend it to JWT/embed callers.
         if (account.isRegisteredUser()) {
@@ -4683,12 +4734,16 @@ export class ProjectService extends BaseService {
                     customSqlDimensions: customDimensionsToAuthorize.map(
                         (cd) => ({ sql: cd.sql, table: cd.table }),
                     ),
+                    additionalMetrics: additionalMetricsToAuthorize.map(
+                        (metric) => ({ sql: metric.sql, table: metric.table }),
+                    ),
                 });
 
             const candidateSpaceUuids = [
                 ...new Set([
                     ...provenance.tableCalculations.map((r) => r.spaceUuid),
                     ...provenance.customSqlDimensions.map((r) => r.spaceUuid),
+                    ...provenance.additionalMetrics.map((r) => r.spaceUuid),
                 ]),
             ];
             const viewableSpaceUuids =
@@ -4718,7 +4773,12 @@ export class ProjectService extends BaseService {
             viewableCustomDimensionKeys = new Set(
                 provenance.customSqlDimensions
                     .filter((r) => viewableSpaceUuids.has(r.spaceUuid))
-                    .map(customDimensionKey),
+                    .map(sqlTableKey),
+            );
+            viewableAdditionalMetricKeys = new Set(
+                provenance.additionalMetrics
+                    .filter((r) => viewableSpaceUuids.has(r.spaceUuid))
+                    .map(sqlTableKey),
             );
         }
 
@@ -4733,11 +4793,16 @@ export class ProjectService extends BaseService {
         }
         if (
             customDimensionsToAuthorize.some(
-                (cd) =>
-                    !viewableCustomDimensionKeys.has(customDimensionKey(cd)),
+                (cd) => !viewableCustomDimensionKeys.has(sqlTableKey(cd)),
+            ) ||
+            additionalMetricsToAuthorize.some(
+                (metric) =>
+                    !viewableAdditionalMetricKeys.has(sqlTableKey(metric)),
             )
         ) {
-            throw new CustomSqlQueryForbiddenError();
+            throw new CustomSqlQueryForbiddenError(
+                'User cannot run queries with custom SQL fields',
+            );
         }
     }
 


### PR DESCRIPTION
Closes part 2 of [PROD-9722](https://linear.app/lightdash/issue/PROD-9722). Stacks on #26962.

## What this fixes

`additionalMetrics[].sql` was the third client-supplied SQL sink on the ad-hoc query and compile endpoints. #26962 closed table calculations and custom SQL dimensions; this closes the last one, so a user denied the custom-field scopes can no longer run arbitrary warehouse SQL through a custom metric. Same three entry points as #26962 (`executeAsyncMetricQuery`, `compileQuery`, `runMetricQuery`).

## How

Custom metrics are viewer-available, so this is not a blanket gate. A metric's SQL is authorized when any of:

1. it matches a modelled field's definition — every metric the UI produces (the modal copies a base field's SQL) and period-over-period metrics;
2. the caller holds `manage:CustomFields` — same scope that gates custom SQL dimensions;
3. it byte-matches a metric in a saved chart the caller can view (provenance) — so saved charts keep running in Explore edit mode.

Extends the guard from #26962: `findCustomSqlProvenance` now covers additional metrics (matched on SQL + table), plus the field-definition check.

## Accepted tradeoff (reviewed with the team)

A **new** custom-metric with hand-authored SQL, created via SDK/API/chart-as-code by a caller **without** `manage:CustomFields`, is rejected. The UI cannot produce such a metric, and the field-match + provenance allowances cover UI metrics, period-over-period, and re-running saved charts — so no in-product flow breaks. Verified against production: expression/multi-column metrics exist but are copies of modelled fields (which pass the field-match) or persisted in charts (which pass provenance).

## Test plan

- [x] `pnpm -F backend lint` / `typecheck` — clean
- [x] Backend ProjectService suite — 126 pass (6 new additional-metric tests)
- [x] Live: editor sub-select metric → `403`; legit `SUM(${TABLE}.amount)` → runs; admin → runs; re-running a saved custom-SQL metric → runs, modifying it → `403`
- [x] #26962 regression matrix still green
