### PR TITLE
fix(deep-research): let the server own report charts so they can publish

### DIFF
--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -79,7 +79,6 @@ The monthly trend was stable.
 ## Conclusion
 
 - Revenue remained stable.`,
-    charts: [],
 };
 
 const taskInput = (index: number) => ({
@@ -151,11 +150,13 @@ const toolProvenance = ({
     toolCallId,
     toolArgs,
     result,
+    metadata = { status: 'success' },
 }: {
     toolName: string;
     toolCallId: string;
     toolArgs: object;
     result: string;
+    metadata?: object;
 }) =>
     ({
         toolCall: {
@@ -177,7 +178,7 @@ const toolProvenance = ({
             toolCallId,
             createdAt: new Date(),
             result,
-            metadata: { status: 'success' },
+            metadata,
             toolType: toolName.startsWith('mcp_') ? 'mcp' : 'built-in',
             toolName,
         },
@@ -261,6 +262,7 @@ const evidencePack = (
             rowCount: 12,
             rowsCsv: 'Month,Revenue\n2026-01,100',
             truncated: false,
+            chartable: true,
         },
     ],
     workerFindings: [],
@@ -421,7 +423,10 @@ describe('AiDeepResearchExecutor', () => {
                         toolName: 'runSql',
                         toolCallId: 'query-1',
                         toolArgs: {},
-                        result: JSON.stringify({ queryUuid }),
+                        // A warehouse tool's result is the text the model
+                        // reads, not JSON; the execution id is in metadata.
+                        result: `Returned 30 rows. This execution's queryUuid is ${queryUuid}; use exactly this value to reference it.`,
+                        metadata: { status: 'success', queryUuid },
                     }),
                     reportSubmission(),
                 ],
@@ -952,7 +957,6 @@ describe('AiDeepResearchExecutor', () => {
                 reportSubmission('report-valid'),
                 reportSubmission('report-invalid', {
                     markdown: 'No structured report',
-                    charts: [],
                 }),
             ],
         });

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
@@ -78,37 +78,24 @@ type Dependencies = {
     userService: Pick<UserService, 'getAccountByUserUuidAndOrg'>;
 };
 
-const parseJson = (value: string): unknown => {
-    try {
-        return JSON.parse(value) as unknown;
-    } catch {
-        return value;
-    }
-};
-
-const findStringValues = (value: unknown, key: string): string[] => {
-    if (Array.isArray(value)) {
-        return value.flatMap((item) => findStringValues(item, key));
-    }
-    if (value === null || typeof value !== 'object') {
-        return [];
-    }
-
-    return Object.entries(value).flatMap(([entryKey, entryValue]) => [
-        ...(entryKey === key && typeof entryValue === 'string'
-            ? [entryValue]
-            : []),
-        ...findStringValues(entryValue, key),
-    ]);
-};
-
+/**
+ * The execution id lives in the tool result's metadata. A warehouse tool's
+ * `result` is the text the model reads — prose and CSV, not JSON — so it has no
+ * `queryUuid` field to read even though it names the uuid in a sentence.
+ */
 const getQueryUuids = (provenance: ToolProvenance[]): string[] => [
     ...new Set(
-        provenance.flatMap(({ toolResult }) =>
-            toolResult && isDeepResearchWarehouseTool(toolResult.toolName)
-                ? findStringValues(parseJson(toolResult.result), 'queryUuid')
-                : [],
-        ),
+        provenance.flatMap(({ toolResult }) => {
+            const metadata = toolResult?.metadata;
+            return toolResult &&
+                isDeepResearchWarehouseTool(toolResult.toolName) &&
+                metadata !== null &&
+                typeof metadata === 'object' &&
+                'queryUuid' in metadata &&
+                typeof metadata.queryUuid === 'string'
+                ? [metadata.queryUuid]
+                : [];
+        }),
     ),
 ];
 
@@ -127,7 +114,6 @@ ${reason}
 ## Conclusion
 
 - Run Deep Research again to continue investigating: ${run.prompt}`,
-    charts: [],
 });
 
 const getActivity = (toolName: string): AiDeepResearchActivity => {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -114,7 +114,7 @@ The baseline trend is stable.
 - Revenue held steady.
 `;
 
-const report = { markdown: reportMarkdown, charts: [] };
+const report = { markdown: reportMarkdown };
 
 const persistedMetrics = {
     duration_ms: 5_000,
@@ -137,7 +137,7 @@ const chartReportMarkdown = reportMarkdown.replace(
     `The baseline trend is stable.\n\n${chartRef}`,
 );
 
-const chartReport = { markdown: chartReportMarkdown, charts: [chart] };
+const chartReport = { markdown: chartReportMarkdown };
 
 const chartToolArgs = {
     title: chart.title,
@@ -1388,6 +1388,11 @@ describe('AiDeepResearchService', () => {
                     report: chartReport,
                     warehouseQueryUuids: [chart.queryUuid],
                 }),
+                aiAgentModel: {
+                    getToolCallsAndResultsForPrompt: vi
+                        .fn()
+                        .mockResolvedValue(chartProvenance()),
+                },
                 queryHistoryModel: {
                     getByQueryUuid: vi.fn().mockResolvedValue(verifiedQuery),
                 },
@@ -1402,30 +1407,34 @@ describe('AiDeepResearchService', () => {
         });
 
         it('accepts a chart that references a verified table calculation', async () => {
-            const tableCalculationChart = {
-                ...chart,
-                chartConfig: {
-                    ...chart.chartConfig,
-                    secondaryYAxisMetric: 'running_pct',
-                    secondaryYAxisLabel: 'Cumulative revenue',
-                },
-            };
-            const tableCalculationMarkdown = chartReportMarkdown.replace(
-                chart.title,
-                tableCalculationChart.title,
-            );
             const { service, model } = buildService({
                 executor: vi.fn().mockResolvedValue({
                     status: 'completed',
-                    report: {
-                        markdown: tableCalculationMarkdown,
-                        charts: [tableCalculationChart],
-                    },
-                    warehouseQueryUuids: [tableCalculationChart.queryUuid],
+                    report: chartReport,
+                    warehouseQueryUuids: [chart.queryUuid],
                 }),
+                aiAgentModel: {
+                    getToolCallsAndResultsForPrompt: vi.fn().mockResolvedValue([
+                        {
+                            ...chartProvenance()[0],
+                            toolCall: {
+                                ...chartProvenance()[0].toolCall,
+                                toolArgs: {
+                                    ...chartToolArgs,
+                                    chartConfig: {
+                                        ...chart.chartConfig,
+                                        secondaryYAxisMetric: 'running_pct',
+                                        secondaryYAxisLabel:
+                                            'Cumulative revenue',
+                                    },
+                                },
+                            },
+                        },
+                    ]),
+                },
                 queryHistoryModel: {
                     getByQueryUuid: vi.fn().mockResolvedValue({
-                        queryUuid: tableCalculationChart.queryUuid,
+                        queryUuid: chart.queryUuid,
                         createdAt: new Date('2026-07-14T12:00:00.000Z'),
                         context: QueryExecutionContext.MCP_RUN_METRIC_QUERY,
                         projectUuid: 'project-1',
@@ -1453,7 +1462,31 @@ describe('AiDeepResearchService', () => {
 
             expect(model.markCompleted).toHaveBeenCalledWith(
                 'run-1',
-                tableCalculationMarkdown,
+                chartReportMarkdown,
+            );
+        });
+
+        it('drops a reference to an execution this run never charted', async () => {
+            const { service, model, queryHistoryModel } = buildService({
+                executor: vi.fn().mockResolvedValue({
+                    status: 'completed',
+                    report: chartReport,
+                    warehouseQueryUuids: [chart.queryUuid],
+                }),
+            });
+
+            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
+
+            // No generateVisualization call means no chart to derive, so the
+            // reference is dropped before query history is ever consulted.
+            expect(queryHistoryModel.getByQueryUuid).not.toHaveBeenCalled();
+            expect(model.markCompleted).toHaveBeenCalledWith(
+                'run-1',
+                expect.not.stringContaining(chart.queryUuid),
+            );
+            expect(model.markCompleted).toHaveBeenCalledWith(
+                'run-1',
+                expect.stringContaining('The baseline trend is stable.'),
             );
         });
 
@@ -1464,6 +1497,11 @@ describe('AiDeepResearchService', () => {
                     report: chartReport,
                     warehouseQueryUuids: [],
                 }),
+                aiAgentModel: {
+                    getToolCallsAndResultsForPrompt: vi
+                        .fn()
+                        .mockResolvedValue(chartProvenance()),
+                },
             });
 
             await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
@@ -1489,6 +1527,11 @@ describe('AiDeepResearchService', () => {
                     report: chartReport,
                     warehouseQueryUuids: [chart.queryUuid],
                 }),
+                aiAgentModel: {
+                    getToolCallsAndResultsForPrompt: vi
+                        .fn()
+                        .mockResolvedValue(chartProvenance()),
+                },
                 queryHistoryModel: {
                     getByQueryUuid: vi.fn().mockResolvedValue({
                         queryUuid: chart.queryUuid,
@@ -1680,8 +1723,36 @@ describe('AiDeepResearchService', () => {
                 // its 20-row slice as the whole result.
                 rowCount: 400,
                 truncated: true,
+                // The execution carries a chart config, so the finalizer is
+                // told it may reference this queryUuid as a chart.
+                chartable: true,
             });
             expect(pack.queries[0].rowsCsv).toContain('2026-01');
+        });
+
+        it('marks an execution with no chart config as not chartable', async () => {
+            const { service } = buildEvidenceService({
+                aiAgentModel: {
+                    getToolCallsAndResultsForPrompt: vi.fn().mockResolvedValue([
+                        {
+                            ...chartProvenance()[0],
+                            toolCall: {
+                                ...chartProvenance()[0].toolCall,
+                                toolName: 'lightdash__run_metric_query',
+                                toolArgs: {
+                                    ...chartToolArgs,
+                                    chartConfig: null,
+                                },
+                            },
+                        },
+                    ]),
+                },
+            });
+
+            const pack = await service.buildEvidencePack(runRow() as AnyType);
+
+            expect(pack.queries).toHaveLength(1);
+            expect(pack.queries[0].chartable).toBe(false);
         });
 
         it('refuses evidence tagged for a different run', async () => {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -3,10 +3,12 @@ import {
     AI_DEEP_RESEARCH_DEFAULT_LIMITS,
     AI_DEEP_RESEARCH_EVIDENCE_MAX_QUERIES,
     AI_DEEP_RESEARCH_EVIDENCE_MAX_ROWS,
+    AI_DEEP_RESEARCH_MAX_CHARTS,
     AI_DEEP_RESEARCH_MAX_WORKERS,
     AI_DEEP_RESEARCH_WORKER_FINDINGS_TOOL_NAME,
     aiDeepResearchWorkerFindingsInputSchema,
     AiResultType,
+    applyDeepResearchChartRefs,
     ConflictError,
     FeatureFlags,
     findDeepResearchChartRefs,
@@ -18,14 +20,12 @@ import {
     ParameterError,
     QueryExecutionContext,
     QueryHistoryStatus,
-    removeDeepResearchChartRefs,
     toolRunQueryArgsSchema,
     UnexpectedServerError,
     type Account,
     type AiDeepResearchBudget,
     type AiDeepResearchChartData,
     type AiDeepResearchChartDataMap,
-    type AiDeepResearchChartDefinition,
     type AiDeepResearchEntryPoint,
     type AiDeepResearchEvent,
     type AiDeepResearchEventPayloadMap,
@@ -120,7 +120,6 @@ const isChartConfigCompatible = (
 
 export type AiDeepResearchSubmittedReport = {
     markdown: string;
-    charts: AiDeepResearchChartDefinition[];
 };
 
 export type AiDeepResearchExecutorResult =
@@ -1142,81 +1141,121 @@ export class AiDeepResearchService extends BaseService {
     }
 
     /**
-     * A chart whose evidence cannot be verified is dropped from the report,
-     * never allowed to discard it: the narrative is the deliverable, and losing
-     * a finished report over one chart is the worse failure.
+     * The model only names the executions it wants charted; the chart itself is
+     * derived here from the execution the server already holds. A reference the
+     * server cannot back is spliced out of the markdown, never allowed to
+     * discard the report: the narrative is the deliverable.
      */
     private async prepareEvidenceReport(
         run: DbAiDeepResearchRun,
         report: AiDeepResearchSubmittedReport,
         runQueryUuids: Set<string>,
     ): Promise<{ markdown: string }> {
-        const omittedKeys = new Set<string>();
+        const derivable = await this.getRunWarehouseCharts(run);
+        const requestedKeys = [
+            ...new Set(
+                findDeepResearchChartRefs(report.markdown).map(
+                    ({ key }) => key,
+                ),
+            ),
+        ].slice(0, AI_DEEP_RESEARCH_MAX_CHARTS);
 
-        await Promise.all(
-            report.charts.map(async (chart) => {
+        const verified = await Promise.all(
+            requestedKeys.map(async (key) => {
+                const candidate = derivable.get(key);
+                if (!candidate) {
+                    return null;
+                }
                 try {
                     const entry = await this.buildWarehouseChartData(
                         run,
-                        chart,
+                        candidate.chart,
                         runQueryUuids,
                     );
-                    if (!entry) {
-                        omittedKeys.add(chart.queryUuid);
-                    }
+                    return entry
+                        ? ([
+                              key,
+                              {
+                                  title: entry.title,
+                                  description: candidate.description,
+                              },
+                          ] as const)
+                        : null;
                 } catch (error) {
                     this.logger.error(
-                        `Deep Research run ${run.ai_deep_research_run_uuid} could not prepare chart ${chart.queryUuid}: ${getErrorMessage(error)}`,
+                        `Deep Research run ${run.ai_deep_research_run_uuid} could not prepare chart ${key}: ${getErrorMessage(error)}`,
                     );
-                    omittedKeys.add(chart.queryUuid);
+                    return null;
                 }
             }),
         );
 
-        if (omittedKeys.size > 0) {
+        const published = new Map(
+            verified.flatMap((entry) => (entry ? [entry] : [])),
+        );
+        const omittedKeys = requestedKeys.filter((key) => !published.has(key));
+        if (omittedKeys.length > 0) {
             this.logger.warn(
-                `Deep Research run ${run.ai_deep_research_run_uuid} published without unverifiable chart(s): ${[
-                    ...omittedKeys,
-                ].join(', ')}`,
+                `Deep Research run ${run.ai_deep_research_run_uuid} published without unbackable chart(s): ${omittedKeys.join(
+                    ', ',
+                )}`,
             );
         }
         return {
-            markdown: removeDeepResearchChartRefs(report.markdown, omittedKeys),
+            markdown: applyDeepResearchChartRefs(report.markdown, published),
         };
+    }
+
+    /**
+     * Every chart this run could publish, keyed by the execution behind it. A
+     * worker's calls are children tagged with this run; the coordinator's are
+     * top-level. Anything tagged for another run is refused even when it shares
+     * this prompt.
+     */
+    private async getRunWarehouseCharts(
+        run: DbAiDeepResearchRun,
+    ): Promise<
+        Map<
+            string,
+            { chart: AiDeepResearchWarehouseChart; description: string }
+        >
+    > {
+        const provenance =
+            await this.aiAgentModel.getToolCallsAndResultsForPrompt(
+                run.prompt_uuid,
+                { includeSubagentToolCalls: true },
+            );
+
+        return new Map(
+            provenance.flatMap(({ toolCall, toolResult }) => {
+                const queryUuid = toolResult
+                    ? getQueryUuidFromMetadata(toolResult.metadata)
+                    : null;
+                if (
+                    toolCall.toolName !== 'generateVisualization' ||
+                    queryUuid === null ||
+                    (toolCall.parentToolCallId !== null &&
+                        !toolCall.parentToolCallId.startsWith(
+                            `deep-research:${run.ai_deep_research_run_uuid}:`,
+                        ))
+                ) {
+                    return [];
+                }
+                const resolved = resolveDeepResearchWarehouseChart(
+                    toolCall.toolArgs,
+                    queryUuid,
+                );
+                return resolved ? [[queryUuid, resolved] as const] : [];
+            }),
+        );
     }
 
     private async findRunWarehouseChart(
         run: DbAiDeepResearchRun,
         queryUuid: string,
     ): Promise<AiDeepResearchWarehouseChart | null> {
-        const provenance =
-            await this.aiAgentModel.getToolCallsAndResultsForPrompt(
-                run.prompt_uuid,
-                { includeSubagentToolCalls: true },
-            );
-        // A worker's calls are children tagged with this run; the
-        // coordinator's are top-level. Anything tagged for another run is
-        // refused even when it shares this prompt.
-        const match = provenance.find(
-            ({ toolCall, toolResult }) =>
-                toolCall.toolName === 'generateVisualization' &&
-                (toolCall.parentToolCallId === null ||
-                    toolCall.parentToolCallId.startsWith(
-                        `deep-research:${run.ai_deep_research_run_uuid}:`,
-                    )) &&
-                toolResult !== null &&
-                getQueryUuidFromMetadata(toolResult.metadata) === queryUuid,
-        );
-        if (!match) {
-            return null;
-        }
-
-        return (
-            resolveDeepResearchWarehouseChart(
-                match.toolCall.toolArgs,
-                queryUuid,
-            )?.chart ?? null
-        );
+        const charts = await this.getRunWarehouseCharts(run);
+        return charts.get(queryUuid)?.chart ?? null;
     }
 
     /**
@@ -1333,6 +1372,9 @@ export class AiDeepResearchService extends BaseService {
                 truncated:
                     (queryHistory.totalRowCount ?? page.rows.length) >
                     AI_DEEP_RESEARCH_EVIDENCE_MAX_ROWS,
+                chartable:
+                    resolveDeepResearchWarehouseChart(toolArgs, queryUuid) !==
+                    null,
             };
         } catch (error) {
             // A single unreadable result must not cost the whole pack.

--- a/packages/backend/src/ee/services/ai/agents/reportFinalizer.ts
+++ b/packages/backend/src/ee/services/ai/agents/reportFinalizer.ts
@@ -1,9 +1,7 @@
 import {
     aiDeepResearchReportInputSchema,
     aiDeepResearchReportSchema,
-    findDeepResearchChartRefs,
     getErrorMessage,
-    removeDeepResearchChartRefs,
     type AiDeepResearchEvidencePack,
     type AiDeepResearchSubmittedReport,
 } from '@lightdash/common';
@@ -147,8 +145,8 @@ export const generateDeepResearchReport = async (
         return second.report;
     }
 
-    // Formatting rules must not cost a grounded report. Drop the charts —
-    // the part the rules are about — and keep the narrative.
+    // Formatting rules must not cost a grounded report: publish the narrative
+    // the model did produce rather than nothing.
     const salvageable = second.raw ?? first.raw;
     if (!salvageable) {
         throw new Error(
@@ -156,17 +154,7 @@ export const generateDeepResearchReport = async (
         );
     }
     Logger.warn(
-        `[AiDeepResearch] Publishing report without charts after lint failure: ${second.issues}`,
+        `[AiDeepResearch] Publishing report that failed the markdown lint: ${second.issues}`,
     );
-    return {
-        markdown: removeDeepResearchChartRefs(
-            salvageable.markdown,
-            new Set(
-                findDeepResearchChartRefs(salvageable.markdown).map(
-                    (ref) => ref.key,
-                ),
-            ),
-        ),
-        charts: [],
-    };
+    return { markdown: salvageable.markdown };
 };

--- a/packages/backend/src/ee/services/ai/prompts/deepResearch.ts
+++ b/packages/backend/src/ee/services/ai/prompts/deepResearch.ts
@@ -1,7 +1,4 @@
-import {
-    AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS,
-    AI_DEEP_RESEARCH_MAX_CHARTS,
-} from '@lightdash/common';
+import { AI_DEEP_RESEARCH_MAX_CHARTS } from '@lightdash/common';
 
 export const AI_DEEP_RESEARCH_INSTRUCTIONS = `You are running a Deep Research investigation using this agent's full configured context and tools.
 
@@ -9,7 +6,7 @@ Plan broadly, investigate competing explanations, validate important claims, and
 
 # Report format
 
-The report is ONE markdown document plus a charts array, written at the end of the run from the evidence gathered during it.
+The report is ONE markdown document, written at the end of the run from the evidence gathered during it.
 
 Structure:
 - Start with a 2-4 sentence introduction before any heading that answers the user's question directly and states your overall confidence.
@@ -19,11 +16,9 @@ Structure:
 - Cite external evidence inline with markers such as [1], and list each source in a final "## Sources" section.
 
 Charts:
-- Every chart is warehouse-backed by one query from this run. Its queryUuid must be copied exactly from the "This execution's queryUuid is ..." line in that query's result — never composed, guessed, or reused from anywhere else. There is no way to chart data a query did not return, so run a query for anything worth charting.
-- A chart's queryUuid is also its id in the markdown. Define it in the charts argument and reference it exactly once as <chart id="<queryUuid>" title="<chart title>" description="<standalone summary>">, using that same queryUuid verbatim as the id — not a slug, name, or any other label. For example a chart whose queryUuid is 681831ec-b696-4cda-85ef-de7b6ddae850 is referenced as <chart id="681831ec-b696-4cda-85ef-de7b6ddae850" title="Weekly orders" description="Orders fell from the week of Dec 15.">.
-- Reference at most one chart per finding section, and reference every chart you define exactly once. Use the same title in the markdown reference as in the charts argument, and never define the same queryUuid twice.
-- Keep each chart description at most ${AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS} characters.
-- Include no more than ${AI_DEEP_RESEARCH_MAX_CHARTS} charts. A report with zero charts is valid.
+- You do not design charts. To show one, write <chart id="<queryUuid>"> on its own line where it belongs in the narrative, using the queryUuid of an execution marked chartable in the evidence. For example: <chart id="681831ec-b696-4cda-85ef-de7b6ddae850">.
+- The id must be a queryUuid copied verbatim from the evidence — not a slug, name, or any other label. The server builds the chart from that execution and fills in its title and description; a reference it cannot back is dropped and costs nothing else.
+- Show a chart wherever one makes a finding easier to see — a trend over time, a comparison across categories, a breakdown behind a total. Reference each execution at most once, and include no more than ${AI_DEEP_RESEARCH_MAX_CHARTS} charts.
 
 Callouts:
 - Use only paired <warning>, <info>, <tip>, <note>, and <confidence> tags.

--- a/packages/common/src/ee/aiDeepResearch/evidence.ts
+++ b/packages/common/src/ee/aiDeepResearch/evidence.ts
@@ -20,6 +20,8 @@ export type AiDeepResearchEvidenceQuery = {
     /** Up to AI_DEEP_RESEARCH_EVIDENCE_MAX_ROWS rows, as CSV. */
     rowsCsv: string;
     truncated: boolean;
+    /** Whether the server can derive a chart for this execution. */
+    chartable: boolean;
 };
 
 /**

--- a/packages/common/src/ee/aiDeepResearch/markdown.test.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.test.ts
@@ -1,11 +1,10 @@
 import {
     aiDeepResearchChartDefinitionSchema,
+    applyDeepResearchChartRefs,
     countDeepResearchFindings,
     findDeepResearchChartBlocks,
     findDeepResearchChartRefs,
-    getDeepResearchChartKey,
     lintDeepResearchReport,
-    removeDeepResearchChartRefs,
     renderDeepResearchChartRefs,
     spliceDeepResearchRanges,
     type AiDeepResearchChartDefinition,
@@ -18,6 +17,10 @@ const chartTag = (
     title = 'Revenue by month',
     description = 'Revenue rose steadily until spring.',
 ) => `<chart id="${id}" title="${title}" description="${description}">`;
+
+const published = (
+    entries: Array<[string, { title: string; description: string }]>,
+) => new Map(entries);
 
 const chartConfig = {
     defaultVizType: 'bar' as const,
@@ -73,6 +76,25 @@ describe('findDeepResearchChartRefs', () => {
         );
     });
 
+    it('accepts a tag carrying only an id, because the server owns the rest', () => {
+        const refs = findDeepResearchChartRefs(`<chart id="${UUID_A}">`);
+        expect(refs).toHaveLength(1);
+        expect(refs[0]).toMatchObject({
+            key: UUID_A,
+            title: '',
+            description: '',
+        });
+    });
+
+    it('ignores a tag with no usable id', () => {
+        expect(
+            findDeepResearchChartRefs('<chart title="No id here">'),
+        ).toHaveLength(0);
+        expect(
+            findDeepResearchChartRefs('<chart id="not a uuid!">'),
+        ).toHaveLength(0);
+    });
+
     it('ignores references inside code fences', () => {
         const refs = findDeepResearchChartRefs(
             `\`\`\`md\n${chartTag('abc')}\n\`\`\`\n\n${chartTag('xyz-1')}`,
@@ -117,10 +139,11 @@ describe('findDeepResearchChartRefs', () => {
         expect(rendered).not.toContain('[Revenue ](https://attacker.example)');
     });
 
-    it('decodes HTML entities before validating description length', () => {
-        const description = '&amp;'.repeat(300);
+    it('decodes HTML entities and truncates over-long descriptions', () => {
         const refs = findDeepResearchChartRefs(
-            `<chart id="${UUID_A}" title="Revenue &amp; margin" description="${description}">`,
+            `<chart id="${UUID_A}" title="Revenue &amp; margin" description="${'&amp;'.repeat(
+                400,
+            )}">`,
         );
 
         expect(refs[0]).toMatchObject({
@@ -130,11 +153,30 @@ describe('findDeepResearchChartRefs', () => {
     });
 });
 
-describe('removeDeepResearchChartRefs', () => {
-    it('drops only the named charts and keeps the narrative', () => {
+describe('applyDeepResearchChartRefs', () => {
+    it('rewrites a published reference with the title and description the server derived', () => {
+        const result = applyDeepResearchChartRefs(
+            `<chart id="${UUID_A}" title="Model guess" description="Model guess.">`,
+            published([
+                [
+                    UUID_A,
+                    { title: 'Server title', description: 'Server text.' },
+                ],
+            ]),
+        );
+
+        expect(result.trim()).toBe(
+            `<chart id="${UUID_A}" title="Server title" description="Server text.">`,
+        );
+    });
+
+    it('drops references the server could not back and keeps the narrative', () => {
         const markdown = `a ${chartTag('k1', 'X')} b ${chartTag('k2', 'Y')} c`;
 
-        const result = removeDeepResearchChartRefs(markdown, new Set(['k1']));
+        const result = applyDeepResearchChartRefs(
+            markdown,
+            published([['k2', { title: 'Kept', description: 'Still here.' }]]),
+        );
 
         expect(result).not.toContain('id="k1"');
         expect(result).toContain('id="k2"');
@@ -142,21 +184,34 @@ describe('removeDeepResearchChartRefs', () => {
         expect(result).toContain(' c');
     });
 
-    it('returns the report untouched when nothing was omitted', () => {
-        expect(removeDeepResearchChartRefs(validReport, new Set())).toBe(
-            validReport,
-        );
-    });
-
-    it('leaves a readable report when every chart is dropped', () => {
-        const result = removeDeepResearchChartRefs(
-            validReport,
-            new Set([UUID_A]),
-        );
+    it('leaves a readable report when nothing could be published', () => {
+        const result = applyDeepResearchChartRefs(validReport, published([]));
 
         expect(findDeepResearchChartRefs(result)).toEqual([]);
         expect(result).toContain('The dip aligns with contract renewals.');
         expect(result).toContain('## Conclusion');
+    });
+
+    it('keeps only the first reference to the same chart', () => {
+        const markdown = `${chartTag(UUID_A)}\n\n${chartTag(UUID_A, 'Again')}`;
+
+        const result = applyDeepResearchChartRefs(
+            markdown,
+            published([[UUID_A, { title: 'Once', description: 'Only once.' }]]),
+        );
+
+        expect(findDeepResearchChartRefs(result)).toHaveLength(1);
+    });
+
+    it('removes malformed chart tags rather than leaving them in the report', () => {
+        const result = applyDeepResearchChartRefs(
+            `before <chart title="No id"> after`,
+            published([]),
+        );
+
+        expect(result).not.toContain('<chart');
+        expect(result).toContain('before');
+        expect(result).toContain('after');
     });
 });
 
@@ -184,179 +239,28 @@ describe('countDeepResearchFindings', () => {
     });
 });
 
-describe('chart definition schemas', () => {
-    it('keys a chart by the execution it is evidence of', () => {
-        expect(getDeepResearchChartKey(warehouseChart(UUID_A))).toBe(UUID_A);
-    });
-
-    it('rejects a chart that is not warehouse-backed', () => {
-        const result = aiDeepResearchChartDefinitionSchema.safeParse({
-            source: 'inline',
-            key: 'tickets-per-1k',
-            title: 'Derived ratio',
-            chartConfig,
-        });
-        expect(result.success).toBe(false);
-    });
-});
-
 describe('lintDeepResearchReport', () => {
     it('accepts a valid report', () => {
-        expect(
-            lintDeepResearchReport(validReport, [warehouseChart(UUID_A)]),
-        ).toEqual([]);
+        expect(lintDeepResearchReport(validReport)).toEqual([]);
     });
 
-    it('requires every defined chart to be referenced exactly once', () => {
-        const errors = lintDeepResearchReport(validReport, [
-            warehouseChart(UUID_A),
-            warehouseChart(UUID_B, 'Orphan chart'),
-        ]);
-        expect(
-            errors.some(
-                (e) => e.includes(UUID_B) && e.includes('exactly once'),
-            ),
-        ).toBe(true);
-    });
+    it('never fails a report over its charts', () => {
+        const markdown = validReport
+            .replace(
+                'The dip aligns with contract renewals.',
+                `The dip aligns with contract renewals.\n\n${chartTag(
+                    UUID_A,
+                    'Duplicate',
+                )}\n\n${chartTag(UUID_B, 'Second')}\n\n<chart id="not a uuid!">`,
+            )
+            .replace(chartTag(UUID_A), chartTag(UUID_A, 'T', 'x'.repeat(400)));
 
-    it('rejects references to undefined charts', () => {
-        const errors = lintDeepResearchReport(validReport, []);
-        expect(
-            errors.some(
-                (e) =>
-                    e.includes(UUID_A) && e.includes('no chart with that key'),
-            ),
-        ).toBe(true);
-    });
-
-    it('rejects a chart referenced twice', () => {
-        const markdown = validReport.replace(
-            'The dip aligns with contract renewals.',
-            `The dip aligns with contract renewals.\n\n${chartTag(
-                UUID_A,
-                'Again',
-            )}`,
-        );
-        const errors = lintDeepResearchReport(markdown, [
-            warehouseChart(UUID_A),
-        ]);
-        expect(errors.some((e) => e.includes('found 2 references'))).toBe(true);
-    });
-
-    it('rejects more than one chart reference in a finding section', () => {
-        const markdown = validReport.replace(
-            'The dip aligns with contract renewals.',
-            `The dip aligns with contract renewals.\n\n${chartTag(
-                UUID_B,
-                'Second',
-            )}`,
-        );
-        const errors = lintDeepResearchReport(markdown, [
-            warehouseChart(UUID_A),
-            warehouseChart(UUID_B, 'Second'),
-        ]);
-        expect(
-            errors.some(
-                (e) =>
-                    e.includes('Baseline revenue trend') &&
-                    e.includes('at most one chart per finding'),
-            ),
-        ).toBe(true);
-    });
-
-    it('accepts one chart in each of two finding sections', () => {
-        const markdown = validReport.replace(
-            '## Conclusion',
-            `## Second finding\n\n<confidence level="medium">ok</confidence>\n\nMore prose.\n\n${chartTag(
-                UUID_B,
-                'Second',
-            )}\n\n## Conclusion`,
-        );
-        expect(
-            lintDeepResearchReport(markdown, [
-                warehouseChart(UUID_A),
-                warehouseChart(UUID_B, 'Second'),
-            ]),
-        ).toEqual([]);
-    });
-
-    it('rejects duplicate chart keys', () => {
-        const errors = lintDeepResearchReport(validReport, [
-            warehouseChart(UUID_A),
-            warehouseChart(UUID_A, 'Duplicate'),
-        ]);
-        expect(errors.some((e) => e.includes('defined 2 times'))).toBe(true);
-    });
-
-    it('rejects more than the maximum number of charts', () => {
-        const charts = Array.from({ length: 9 }, (_, i) =>
-            warehouseChart(`33333333-3333-4333-8333-33333333333${i}`),
-        );
-        const errors = lintDeepResearchReport(validReport, charts);
-        expect(errors.some((e) => e.includes('at most 8'))).toBe(true);
-    });
-
-    it('rejects legacy chart code fences', () => {
-        const markdown = validReport.replace(
-            chartTag(UUID_A),
-            `\`\`\`chart\n{"queryUuid":"${UUID_A}"}\n\`\`\``,
-        );
-        const errors = lintDeepResearchReport(markdown, [
-            warehouseChart(UUID_A),
-        ]);
-        expect(errors.some((e) => e.includes('Do not embed ```chart'))).toBe(
-            true,
-        );
-    });
-
-    it('rejects descriptions longer than 300 characters', () => {
-        const markdown = validReport.replace(
-            chartTag(UUID_A),
-            chartTag(UUID_A, 'Revenue by month', 'x'.repeat(301)),
-        );
-        const errors = lintDeepResearchReport(markdown, [
-            warehouseChart(UUID_A),
-        ]);
-        expect(
-            errors.some(
-                (error) =>
-                    error.includes('description') && error.includes('300'),
-            ),
-        ).toBe(true);
-    });
-
-    it('accepts descriptions exactly 300 characters long', () => {
-        const markdown = validReport.replace(
-            chartTag(UUID_A),
-            chartTag(UUID_A, 'Revenue by month', 'x'.repeat(300)),
-        );
-        expect(
-            lintDeepResearchReport(markdown, [warehouseChart(UUID_A)]),
-        ).toEqual([]);
-    });
-
-    it('requires the tag and chart definition to use the same title', () => {
-        const markdown = validReport.replace(
-            chartTag(UUID_A),
-            chartTag(UUID_A, 'Different title'),
-        );
-        const errors = lintDeepResearchReport(markdown, [
-            warehouseChart(UUID_A),
-        ]);
-
-        expect(
-            errors.some(
-                (error) =>
-                    error.includes('Different title') &&
-                    error.includes('Revenue by month'),
-            ),
-        ).toBe(true);
+        expect(lintDeepResearchReport(markdown)).toEqual([]);
     });
 
     it('requires intro prose before the first heading', () => {
         const errors = lintDeepResearchReport(
             validReport.replace(/^.*\n\n## Baseline/, '## Baseline'),
-            [warehouseChart(UUID_A)],
         );
         expect(errors.some((e) => e.includes('introduction'))).toBe(true);
     });
@@ -364,7 +268,6 @@ describe('lintDeepResearchReport', () => {
     it('requires a conclusion section', () => {
         const errors = lintDeepResearchReport(
             validReport.replace('## Conclusion', '## Wrap up'),
-            [warehouseChart(UUID_A)],
         );
         expect(errors.some((e) => e.includes('## Conclusion'))).toBe(true);
     });
@@ -375,7 +278,6 @@ describe('lintDeepResearchReport', () => {
                 '<confidence level="high">Complete order history since 2022.</confidence>\n\n',
                 '',
             ),
-            [warehouseChart(UUID_A)],
         );
         expect(
             errors.some(
@@ -390,7 +292,6 @@ describe('lintDeepResearchReport', () => {
                 'Revenue grew steadily until spring.',
                 '<confidence level="low">extra</confidence>\n\nRevenue grew steadily until spring.',
             ),
-            [warehouseChart(UUID_A)],
         );
         expect(errors.some((e) => e.includes('found 2'))).toBe(true);
     });
@@ -398,7 +299,6 @@ describe('lintDeepResearchReport', () => {
     it('rejects invalid confidence levels', () => {
         const errors = lintDeepResearchReport(
             validReport.replace('level="high"', 'level="certain"'),
-            [warehouseChart(UUID_A)],
         );
         expect(errors.some((e) => e.includes('invalid level'))).toBe(true);
     });
@@ -406,7 +306,6 @@ describe('lintDeepResearchReport', () => {
     it('rejects disallowed html tags', () => {
         const errors = lintDeepResearchReport(
             `${validReport}\n<script>alert(1)</script>\n`,
-            [warehouseChart(UUID_A)],
         );
         expect(errors.some((e) => e.includes('script'))).toBe(true);
     });
@@ -417,7 +316,6 @@ describe('lintDeepResearchReport', () => {
                 'Revenue grew steadily until spring.',
                 'Revenue grew steadily until spring.\n\n```sql\n-- <script> ## Not a heading\nSELECT 1;\n```',
             ),
-            [warehouseChart(UUID_A)],
         );
         expect(errors).toEqual([]);
     });
@@ -428,7 +326,6 @@ describe('lintDeepResearchReport', () => {
                 'The dip aligns with contract renewals.',
                 '<note>\n\nThe dip aligns with contract renewals.',
             ),
-            [warehouseChart(UUID_A)],
         );
         expect(errors.some((e) => e.includes('Unbalanced <note>'))).toBe(true);
     });
@@ -439,7 +336,6 @@ describe('lintDeepResearchReport', () => {
                 'The dip aligns with contract renewals.',
                 'The dip aligns with contract renewals [1].',
             ),
-            [warehouseChart(UUID_A)],
         );
         expect(errors.some((e) => e.includes('## Sources'))).toBe(true);
     });
@@ -450,13 +346,22 @@ describe('lintDeepResearchReport', () => {
                 'The dip aligns with contract renewals.',
                 'The dip aligns with contract renewals [1].',
             )}\n## Sources\n\n1. [Benchmarks](https://example.com) — baseline\n`,
-            [warehouseChart(UUID_A)],
         );
         expect(errors).toEqual([]);
     });
 });
 
 describe('chart definition validation', () => {
+    it('rejects a chart that is not warehouse-backed', () => {
+        const result = aiDeepResearchChartDefinitionSchema.safeParse({
+            source: 'inline',
+            key: 'tickets-per-1k',
+            title: 'Derived ratio',
+            chartConfig,
+        });
+        expect(result.success).toBe(false);
+    });
+
     it('rejects grouped chart configs', () => {
         const result = aiDeepResearchChartDefinitionSchema.safeParse({
             ...warehouseChart(UUID_A),

--- a/packages/common/src/ee/aiDeepResearch/markdown.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.ts
@@ -85,10 +85,6 @@ export type AiDeepResearchChartDefinition = z.infer<
     typeof aiDeepResearchChartDefinitionSchema
 >;
 
-export const getDeepResearchChartKey = (
-    chart: AiDeepResearchChartDefinition,
-): string => chart.queryUuid;
-
 // ---------------------------------------------------------------------------
 // Chart references: chart data is stored separately, while the markdown keeps
 // compact metadata that lets an LLM understand the chart without reading it.
@@ -139,6 +135,13 @@ export type AiDeepResearchChartRef = {
     start: number;
     end: number;
     raw: string;
+};
+
+/** Every `<chart>` tag in the markdown, whether or not it parses into a ref. */
+type AiDeepResearchChartTag = {
+    ref: AiDeepResearchChartRef | null;
+    start: number;
+    end: number;
 };
 
 export const getDeepResearchChartRefMarkdown = (
@@ -313,11 +316,16 @@ const maskFencedBlocks = (markdown: string): string => {
     );
 };
 
-export const findDeepResearchChartRefs = (
+/**
+ * The id is the only attribute the model has to get right: it names an
+ * execution the server already holds. Title and description are optional
+ * because the server rewrites them from that execution at publish time.
+ */
+const findDeepResearchChartTags = (
     markdown: string,
-): AiDeepResearchChartRef[] => {
+): AiDeepResearchChartTag[] => {
     const masked = maskFencedBlocks(markdown);
-    const refs: AiDeepResearchChartRef[] = [];
+    const tags: AiDeepResearchChartTag[] = [];
     for (
         let match = CHART_REF_RE.exec(masked);
         match !== null;
@@ -325,51 +333,72 @@ export const findDeepResearchChartRefs = (
     ) {
         const attributes = Object.fromEntries(
             [...match[1].matchAll(CHART_ATTRIBUTE_RE)].map(
-                ([, name, value]) => [name, value],
+                ([, name, value]) => [name, decodeHtmlEntities(value)],
             ),
         );
-        const id = attributes.id && decodeHtmlEntities(attributes.id);
-        const title = attributes.title && decodeHtmlEntities(attributes.title);
-        const description =
-            attributes.description &&
-            decodeHtmlEntities(attributes.description);
-        const isValid =
-            id &&
-            /^[A-Za-z0-9-]+$/.test(id) &&
-            title &&
-            description &&
-            description.length <= AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS;
-        if (isValid) {
-            refs.push({
-                key: id,
-                title,
-                description,
-                start: match.index,
-                end: match.index + match[0].length,
-                raw: markdown.slice(match.index, match.index + match[0].length),
-            });
-        }
+        const start = match.index;
+        const end = match.index + match[0].length;
+        const { id } = attributes;
+        tags.push({
+            start,
+            end,
+            ref:
+                id && /^[A-Za-z0-9-]+$/.test(id)
+                    ? {
+                          key: id,
+                          title: attributes.title ?? '',
+                          description: (attributes.description ?? '').slice(
+                              0,
+                              AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS,
+                          ),
+                          start,
+                          end,
+                          raw: markdown.slice(start, end),
+                      }
+                    : null,
+        });
     }
-    return refs;
+    return tags;
 };
 
-/**
- * Drops the `<chart>` references whose data could not be published, leaving the
- * surrounding narrative intact. A chart that cannot be verified must cost the
- * report that chart, never the whole report.
- */
-export const removeDeepResearchChartRefs = (
+export const findDeepResearchChartRefs = (
     markdown: string,
-    keys: ReadonlySet<string>,
-): string =>
-    keys.size === 0
-        ? markdown
-        : spliceDeepResearchRanges(
-              markdown,
-              findDeepResearchChartRefs(markdown)
-                  .filter((ref) => keys.has(ref.key))
-                  .map((match) => ({ match, replacement: '' })),
-          );
+): AiDeepResearchChartRef[] =>
+    findDeepResearchChartTags(markdown).flatMap(({ ref }) =>
+        ref ? [ref] : [],
+    );
+
+/**
+ * Rewrites the markdown so it contains exactly the charts the server published:
+ * each retained tag is replaced with its canonical form, and every other
+ * `<chart>` tag — unknown id, unverifiable execution, duplicate, malformed — is
+ * spliced out. A chart the server cannot back costs the report that chart,
+ * never the narrative around it.
+ */
+export const applyDeepResearchChartRefs = (
+    markdown: string,
+    published: ReadonlyMap<string, { title: string; description: string }>,
+): string => {
+    const rendered = new Set<string>();
+    return spliceDeepResearchRanges(
+        markdown,
+        findDeepResearchChartTags(markdown).map((tag) => {
+            const chart = tag.ref ? published.get(tag.ref.key) : undefined;
+            if (!tag.ref || !chart || rendered.has(tag.ref.key)) {
+                return { match: tag, replacement: '' };
+            }
+            rendered.add(tag.ref.key);
+            return {
+                match: tag,
+                replacement: getDeepResearchChartRefMarkdown(
+                    chart.title,
+                    tag.ref.key,
+                    chart.description,
+                ),
+            };
+        }),
+    );
+};
 
 export const renderDeepResearchChartRefs = (markdown: string): string =>
     spliceDeepResearchRanges(
@@ -486,15 +515,11 @@ const lintHtmlTags = (masked: string): string[] => {
 };
 
 /**
- * Validates a submitted report: the markdown structure and the referential
- * integrity between chart definitions (tool arguments) and the
- * <chart> references in the markdown. Returns actionable errors
- * the agent can self-correct from.
+ * Validates the structure of a submitted report. Chart references are
+ * deliberately not linted: the server owns them and drops the ones it cannot
+ * back, so a chart problem can never cost the report.
  */
-export const lintDeepResearchReport = (
-    markdown: string,
-    charts: AiDeepResearchChartDefinition[],
-): string[] => {
+export const lintDeepResearchReport = (markdown: string): string[] => {
     const errors: string[] = [];
     const masked = maskFencedBlocks(markdown);
     const { preamble, sections } = splitSections(masked);
@@ -542,80 +567,6 @@ export const lintDeepResearchReport = (
         });
     });
 
-    // Charts are tool arguments referenced by compact <chart> tags;
-    // fenced ```chart blocks are the legacy form and are rejected.
-    if (findDeepResearchChartBlocks(markdown).length > 0) {
-        errors.push(
-            'Do not embed ```chart code fences in the markdown; define charts in the `charts` argument and reference each one inline with a <chart id="..." title="..." description="..."> tag.',
-        );
-    }
-
-    if (charts.length > AI_DEEP_RESEARCH_MAX_CHARTS) {
-        errors.push(
-            `The report defines ${charts.length} charts; use at most ${AI_DEEP_RESEARCH_MAX_CHARTS}.`,
-        );
-    }
-
-    const keyCounts = new Map<string, number>();
-    const chartTitles = new Map<string, string>();
-    charts.forEach((chart) => {
-        const key = getDeepResearchChartKey(chart);
-        keyCounts.set(key, (keyCounts.get(key) ?? 0) + 1);
-        chartTitles.set(key, chart.title);
-    });
-    keyCounts.forEach((count, key) => {
-        if (count > 1) {
-            errors.push(
-                `Chart key ${key} is defined ${count} times; every chart needs a unique queryUuid or key.`,
-            );
-        }
-    });
-
-    const refs = findDeepResearchChartRefs(markdown);
-    const chartTagCount = masked.match(/<chart\b[^>]*>/g)?.length ?? 0;
-    if (chartTagCount !== refs.length) {
-        errors.push(
-            `Every <chart> tag must have a valid id, a non-empty title, and a non-empty description of at most ${AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS} characters.`,
-        );
-    }
-    const refCounts = new Map<string, number>();
-    refs.forEach((ref) => {
-        refCounts.set(ref.key, (refCounts.get(ref.key) ?? 0) + 1);
-        const chartTitle = chartTitles.get(ref.key);
-        if (chartTitle !== undefined && ref.title !== chartTitle) {
-            errors.push(
-                `Chart ${ref.key} has title "${ref.title}" in the markdown but "${chartTitle}" in the charts argument; use the same title in both places.`,
-            );
-        }
-    });
-
-    keyCounts.forEach((_, key) => {
-        const refCount = refCounts.get(key) ?? 0;
-        if (refCount !== 1) {
-            errors.push(
-                `Chart ${key} must be referenced exactly once in the markdown as <chart id="${key}" title="..." description="..."> (found ${refCount} references).`,
-            );
-        }
-    });
-    refCounts.forEach((_, key) => {
-        if (!keyCounts.has(key)) {
-            errors.push(
-                `The markdown references chart ${key} but no chart with that key is defined in the charts argument.`,
-            );
-        }
-    });
-
-    findingSections.forEach(({ title, start, end }) => {
-        const refsInSection = refs.filter(
-            (ref) => ref.start >= start && ref.start < end,
-        ).length;
-        if (refsInSection > 1) {
-            errors.push(
-                `Finding section "${title}" references ${refsInSection} charts; reference at most one chart per finding and split additional charts into their own finding sections.`,
-            );
-        }
-    });
-
     errors.push(...lintHtmlTags(masked));
 
     const hasCitations = /\[\d+\]/.test(masked);
@@ -633,24 +584,18 @@ export const lintDeepResearchReport = (
 
 export const aiDeepResearchReportInputSchema = z.object({
     markdown: z.string().min(1).max(AI_DEEP_RESEARCH_MAX_REPORT_MARKDOWN_CHARS),
-    charts: z
-        .array(aiDeepResearchChartDefinitionSchema)
-        .max(AI_DEEP_RESEARCH_MAX_CHARTS)
-        .default([]),
 });
 
 export const aiDeepResearchReportSchema =
-    aiDeepResearchReportInputSchema.superRefine(
-        ({ markdown, charts }, context) => {
-            for (const message of lintDeepResearchReport(markdown, charts)) {
-                context.addIssue({
-                    code: 'custom',
-                    path: ['markdown'],
-                    message,
-                });
-            }
-        },
-    );
+    aiDeepResearchReportInputSchema.superRefine(({ markdown }, context) => {
+        for (const message of lintDeepResearchReport(markdown)) {
+            context.addIssue({
+                code: 'custom',
+                path: ['markdown'],
+                message,
+            });
+        }
+    });
 
 export type AiDeepResearchSubmittedReport = z.infer<
     typeof aiDeepResearchReportSchema


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9727

Deep Research has never published a chart. Every run in the feature's history has `chart_count = 0` — before the PROD-9678 stack and after it. Reports are text-only and always have been.

There were two independent causes. Fixing either one alone leaves `chart_count` at 0, which is why the first live run of this branch still published nothing.

## Root cause 1 — the model would not author a chart

Landing one chart meant satisfying about ten rules at once, split across three places:

```
markdown          id must be the exact queryUuid, referenced exactly once,
                  at most one per finding section, title identical to the
                  charts argument, description <= 300 chars
charts argument   queryUuid from this run, never reused, ~12 required-but-
                  nullable chartConfig fields, groupBy must be null
server            execution belongs to this run, right actor type, created
                  after the run started, results unexpired, config fields
                  present in the verified metricQuery
```

Any single miss cost the chart, and the format explicitly said a report with zero charts is valid. The model took the safe route every time.

**The model no longer authors charts.** It writes `<chart id="<queryUuid>">` and nothing else. The server derives the title, description, and config from the `generateVisualization` execution behind that id, verifies it, and rewrites the tag in canonical form. The `charts` argument is gone from the generated object, and the lint has no chart rules left — so a chart problem can no longer cost a report. Anything the server cannot back (unknown id, unverifiable execution, duplicate, malformed tag) is spliced out of the markdown.

## Root cause 2 — the server would have dropped it anyway

`getQueryUuids` built the run's set of verified executions like this:

```ts
findStringValues(parseJson(toolResult.result), 'queryUuid')
```

That looks for a `queryUuid` **field**. But a warehouse tool's `result` is the text the model reads — prose and CSV:

> `Returned all 30 rows... This execution's queryUuid is 1dbe2787-...; use exactly this value to reference it.`

There is no field to find, so the set was **always empty** and every chart failed the first gate in `buildWarehouseChartData` before a single real check ran. The uuid is in `toolResult.metadata`, where `buildEvidencePack` and `getRunWarehouseCharts` already read it.

This was latent rather than new: with no run ever referencing a chart, the empty set was never consulted. Its unit test concealed it by fabricating `result: JSON.stringify({ queryUuid })` — a shape production never emits. The fixture now carries the real prose result plus metadata, so the old scraping fails it.

## Verification

Same question, same agent, three runs:

```
                      baseline      after fix 1     after both
chart refs emitted           0              5              5
charts published             0              0              5
findings                     5              5              5
status               completed      completed      completed
```

Run `06906bba` published five charts, each with a server-derived title. Every one fetches through `GET .../charts/{queryUuid}` with a real `metricQuery` and fields:

```
d3b25645... -> ok funnel     Purchase Funnel by Stage
5ade45dc... -> ok table      Weekly Top-of-Funnel Traffic vs Completions
6bfb92e1... -> ok table      Weekly Checkout-to-Completion Conversion Rate
c7e0a2c1... -> ok table      Funnel by Device Type
7ee49ebf... -> ok table      Weekly Completions by Product Category
```

An execution from the same run that the report does not reference still returns 404, so the read path stays gated on the published report rather than run membership alone.

## Notes for review

- Publish and read now derive charts through one `getRunWarehouseCharts`. Previously publish trusted the model's `chartConfig` while `getChart` re-derived from tool args — the two could disagree about the same chart.
- The "no ```chart code fences" lint rule went with the other chart rules. A legacy fence now renders as a code block instead of failing the report.
- Four of the five charts above render as `table` because `resolveDeepResearchWarehouseChart` coerces any grouped config to a table (snapshots are unpivoted). That is pre-existing and out of scope here; worth a follow-up if grouped charts should render as charts.

## Test plan

- `pnpm -F common test` — 3382 pass
- backend EE suite — 2768 pass
- frontend aiCopilot — 271 pass
- typecheck + lint clean on common, backend, frontend
- Three live runs against the dev instance, as tabulated above

🤖 Generated with [Claude Code](https://claude.com/claude-code)