### PR TITLE
feat: add v3 tool approval persistence

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -434,6 +434,8 @@ import {
     AiThreadMessageSequenceTableName,
     AiThreadMessageTable,
     AiThreadMessageTableName,
+    AiToolApprovalTable,
+    AiToolApprovalTableName,
 } from '../ee/database/entities/aiAgentV3';
 import {
     AiArtifactsTable,
@@ -635,6 +637,7 @@ declare module 'knex/types/tables' {
         [AiThreadMessageSequenceTableName]: AiThreadMessageSequenceTable;
         [AiThreadMessageTableName]: AiThreadMessageTable;
         [AiMessagePartTableName]: AiMessagePartTable;
+        [AiToolApprovalTableName]: AiToolApprovalTable;
         [AiThreadShareTableName]: AiThreadShareTable;
         [AiSlackThreadTableName]: AiSlackThreadTable;
         [AiWebAppThreadTableName]: AiWebAppThreadTable;

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -39,6 +39,8 @@ import {
     ApiAiAgentThreadStreamRequest,
     ApiAiAgentThreadSummaryListResponse,
     ApiAiAgentThreadWorkstreamsResponse,
+    ApiAiAgentToolApprovalRequest,
+    ApiAiAgentToolApprovalResponse,
     ApiAiAgentV3ChatRequest,
     ApiAiAgentV3ThreadResponse,
     ApiAiAgentV3ThreadSummaryListResponse,
@@ -1213,10 +1215,50 @@ export class AiAgentController extends BaseController {
             results: await this.getAiAgentService().decideSqlApproval(
                 toSessionUser(req.account),
                 {
+                    projectUuid,
                     agentUuid,
                     threadUuid,
                     toolCallId,
                     decision: body.decision,
+                    reason: body.reason ?? null,
+                },
+            ),
+        };
+    }
+
+    /**
+     * Records a tool approval decision and resumes the run when ready.
+     * @summary Decide tool approval
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads/{threadUuid}/tool-calls/{toolCallId}/approval')
+    @OperationId('decideAgentToolApproval')
+    async decideAgentToolApproval(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUIDAnyVersion,
+        @Path() threadUuid: UUID,
+        @Path() toolCallId: string,
+        @Body() body: ApiAiAgentToolApprovalRequest,
+    ): Promise<ApiAiAgentToolApprovalResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().decideToolApproval(
+                toSessionUser(req.account),
+                {
+                    projectUuid,
+                    agentUuid,
+                    threadUuid,
+                    toolCallId,
+                    decision: body.decision,
+                    reason: body.reason ?? null,
                 },
             ),
         };

--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -292,6 +292,8 @@ export const AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW: DbAiAgentMcp
     'always_allow';
 export const AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY: DbAiAgentMcpServerToolPermissionMode =
     'always_deny';
+export const AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ASK: DbAiAgentMcpServerToolPermissionMode =
+    'ask';
 
 export type DbAiAgentMcpServerTool = {
     ai_agent_uuid: string;

--- a/packages/backend/src/ee/database/entities/aiAgentV3.test.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentV3.test.ts
@@ -1,0 +1,33 @@
+import { UnexpectedServerError } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { getAiToolApprovalPayload } from './aiAgentV3';
+
+describe('getAiToolApprovalPayload', () => {
+    it('returns null when approval is absent', () => {
+        expect(getAiToolApprovalPayload({})).toBeNull();
+    });
+
+    it('normalizes omitted optional approval fields', () => {
+        expect(
+            getAiToolApprovalPayload({ approval: { id: 'approval-1' } }),
+        ).toEqual({
+            id: 'approval-1',
+            signature: null,
+            approved: null,
+            reason: null,
+            decidedByUserUuid: null,
+            decidedAt: null,
+        });
+    });
+
+    it('rejects malformed persisted approval fields', () => {
+        expect(() =>
+            getAiToolApprovalPayload({
+                approval: { id: 'approval-1', approved: 'true' },
+            }),
+        ).toThrow(UnexpectedServerError);
+        expect(() =>
+            getAiToolApprovalPayload({ approval: { id: 42 } }),
+        ).toThrow(UnexpectedServerError);
+    });
+});

--- a/packages/backend/src/ee/database/entities/aiAgentV3.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentV3.ts
@@ -1,5 +1,6 @@
 import {
     AI_AGENT_V3_PART_TYPES,
+    UnexpectedServerError,
     type AiAgentV3LegacyMetadata,
     type AiAgentV3ModelConfig,
     type AiAgentV3ReferencedArtifact,
@@ -15,6 +16,7 @@ import { type Knex } from 'knex';
 export const AiThreadMessageSequenceTableName = 'ai_thread_message_sequence';
 export const AiThreadMessageTableName = 'ai_thread_message';
 export const AiMessagePartTableName = 'ai_message_part';
+export const AiToolApprovalTableName = 'ai_tool_approval';
 
 export const AI_AGENT_STORAGE_VERSIONS = [
     1, 3,
@@ -132,7 +134,7 @@ export type DbAiThreadMessage = {
 };
 
 type AiThreadMessageHeartbeatWrite = {
-    last_heartbeat_at?: Date | Knex.Raw;
+    last_heartbeat_at?: Date | Knex.Raw | null;
 };
 
 type AiThreadMessageInsert = Pick<
@@ -188,6 +190,86 @@ export type AiMessagePartTable = Knex.CompositeTableType<
     Partial<Pick<DbAiMessagePart, 'payload_version'>> & {
         payload?: Record<string, unknown> | Knex.Raw;
     }
+>;
+
+export type AiToolApprovalDecision = 'approved' | 'rejected';
+export const AI_TOOL_APPROVAL_DEFAULT_REASONS = {
+    approved: 'Approved by user',
+    rejected: 'Denied by user',
+} as const satisfies Record<AiToolApprovalDecision, string>;
+
+export type AiToolApprovalPayload = {
+    id: string;
+    signature: string | null;
+    approved: boolean | null;
+    reason: string | null;
+    decidedByUserUuid: string | null;
+    decidedAt: string | null;
+};
+
+export const getAiToolApprovalPayload = (
+    payload: Record<string, unknown>,
+): AiToolApprovalPayload | null => {
+    const { approval } = payload;
+    if (approval === undefined) return null;
+    if (
+        approval === null ||
+        typeof approval !== 'object' ||
+        Array.isArray(approval)
+    ) {
+        throw new UnexpectedServerError('Malformed tool approval payload');
+    }
+    const value = approval as Record<string, unknown>;
+    const { id, signature, approved, reason, decidedByUserUuid, decidedAt } =
+        value;
+    if (typeof id !== 'string') {
+        throw new UnexpectedServerError('Malformed tool approval payload');
+    }
+    const isNullableString = (
+        field: unknown,
+    ): field is string | null | undefined =>
+        field === undefined || field === null || typeof field === 'string';
+    if (
+        !isNullableString(signature) ||
+        (approved !== undefined &&
+            approved !== null &&
+            typeof approved !== 'boolean') ||
+        !isNullableString(reason) ||
+        !isNullableString(decidedByUserUuid) ||
+        !isNullableString(decidedAt)
+    ) {
+        throw new UnexpectedServerError('Malformed tool approval payload');
+    }
+    return {
+        id,
+        signature: signature ?? null,
+        approved: approved ?? null,
+        reason: reason ?? null,
+        decidedByUserUuid: decidedByUserUuid ?? null,
+        decidedAt: decidedAt ?? null,
+    };
+};
+
+export type DbAiToolApproval = {
+    ai_message_part_uuid: string;
+    approval_id: string;
+    decision: AiToolApprovalDecision;
+    reason: string | null;
+    decided_by_user_uuid: string | null;
+    decided_at: Date;
+};
+
+export type AiToolApprovalTable = Knex.CompositeTableType<
+    DbAiToolApproval,
+    Pick<
+        DbAiToolApproval,
+        | 'ai_message_part_uuid'
+        | 'approval_id'
+        | 'decision'
+        | 'reason'
+        | 'decided_by_user_uuid'
+    >,
+    never
 >;
 
 export type AiV3ThreadLineage =

--- a/packages/backend/src/ee/database/migrations/20260806090000_add_ai_tool_approval.ts
+++ b/packages/backend/src/ee/database/migrations/20260806090000_add_ai_tool_approval.ts
@@ -1,0 +1,32 @@
+import { type Knex } from 'knex';
+
+const AiToolApprovalTableName = 'ai_tool_approval';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(AiToolApprovalTableName, (table) => {
+        table
+            .uuid('ai_message_part_uuid')
+            .primary()
+            .references('ai_message_part_uuid')
+            .inTable('ai_message_part')
+            .onDelete('CASCADE');
+        table.text('approval_id').notNullable();
+        table.text('decision').notNullable();
+        table.text('reason').nullable();
+        table
+            .uuid('decided_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL')
+            .index('ai_tool_approval_decided_by_user_uuid_idx');
+        table
+            .timestamp('decided_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(AiToolApprovalTableName);
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -147,6 +147,7 @@ import {
 import {
     AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
     AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY,
+    AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ASK,
     AiAgentGroupAccessTableName,
     AiAgentInstructionVersionsTableName,
     AiAgentIntegrationTableName,
@@ -232,6 +233,7 @@ type Dependencies = {
 export {
     AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
     AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY,
+    AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ASK,
 };
 
 export type AiAgentMcpServerToolPermissionSetting = AiMcpServerTool & {
@@ -1538,7 +1540,7 @@ export class AiAgentModel {
                 `${AiAgentMcpServerToolTableName}.ai_mcp_server_uuid`,
                 attachment.ai_mcp_server_uuid,
             )
-            .andWhere(
+            .where(
                 `${AiAgentMcpServerToolTableName}.permission_mode`,
                 AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
             )

--- a/packages/backend/src/ee/models/AiAgentV3Model.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentV3Model.integration.test.ts
@@ -357,6 +357,38 @@ describe('AiAgentV3Model', () => {
         });
     });
 
+    it('ignores approval-shaped metadata on non-tool parts', async () => {
+        const thread = await createRootThread();
+        await model.appendUserMessage({
+            threadUuid: thread.uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'text',
+                    payloadVersion: 1,
+                    payload: { text: 'hello', approval: 'not-an-approval' },
+                },
+            ],
+        });
+
+        await expect(model.getThread(thread.uuid)).resolves.toMatchObject({
+            messages: [
+                {
+                    parts: [
+                        {
+                            type: 'text',
+                            payload: {
+                                text: 'hello',
+                                approval: 'not-an-approval',
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
     it('scopes part indexes and provider tool call ids to each message', async () => {
         const thread = await createRootThread();
         const [firstMessage, secondMessage] = await Promise.all([
@@ -454,6 +486,313 @@ describe('AiAgentV3Model', () => {
                 payload: { state: 'output-available', output: [] },
             }),
         ).rejects.toThrow('Message part not found');
+    });
+
+    it('durably records a tool approval decision and decider', async () => {
+        const thread = await createRootThread();
+        const assistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        const [approvalPart] = await model.appendParts({
+            messageUuid: assistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    toolCallId: 'approval-call',
+                    payload: {
+                        state: 'approval-requested',
+                        toolName: 'runSql',
+                        input: { sql: 'SELECT 1' },
+                        approval: { id: 'approval-id' },
+                    },
+                },
+            ],
+        });
+
+        const decision = await model.decideToolApproval({
+            threadUuid: thread.uuid,
+            messageUuid: assistant.uuid,
+            toolCallId: 'approval-call',
+            decision: 'rejected',
+            reason: 'Denied by user',
+            decidedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        await model.updatePart({
+            messageUuid: assistant.uuid,
+            partUuid: approvalPart!.uuid,
+            payloadVersion: 1,
+            payload: {
+                state: 'approval-requested',
+                toolName: 'runSql',
+                input: { sql: 'SELECT 1' },
+                approval: { id: 'approval-id' },
+            },
+        });
+        const reloaded = await model.getThread(thread.uuid);
+
+        expect(decision).toMatchObject({
+            decision: 'rejected',
+            messageUuid: assistant.uuid,
+            shouldResume: true,
+        });
+        expect(reloaded.messages[0]).toMatchObject({
+            metadata: { status: 'in_progress' },
+            parts: [
+                {
+                    payload: {
+                        state: 'output-denied',
+                        approval: {
+                            id: 'approval-id',
+                            approved: false,
+                            reason: 'Denied by user',
+                            decidedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                            decidedAt: expect.any(String),
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
+    it('claims a suspended approval resume only once', async () => {
+        const thread = await createRootThread();
+        const assistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+
+        await expect(
+            model.claimAssistantMessageResume(assistant.uuid),
+        ).resolves.toBe(false);
+        await model.suspendAssistantMessage(assistant.uuid, null);
+        await expect(
+            model.claimAssistantMessageResume(assistant.uuid),
+        ).resolves.toBe(true);
+        await expect(
+            model.claimAssistantMessageResume(assistant.uuid),
+        ).resolves.toBe(false);
+    });
+
+    it('resumes only after every parallel approval is decided', async () => {
+        const thread = await createRootThread();
+        const assistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: assistant.uuid,
+            parts: ['first', 'second'].map((id, partIndex) => ({
+                partIndex,
+                type: 'tool' as const,
+                payloadVersion: 1,
+                toolCallId: id,
+                payload: {
+                    state: 'approval-requested',
+                    toolName: 'runSql',
+                    input: { sql: `SELECT ${partIndex + 1}` },
+                    approval: { id: `approval-${id}` },
+                },
+            })),
+        });
+
+        const first = await model.decideToolApproval({
+            threadUuid: thread.uuid,
+            messageUuid: assistant.uuid,
+            toolCallId: 'first',
+            decision: 'approved',
+            reason: null,
+            decidedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        const second = await model.decideToolApproval({
+            threadUuid: thread.uuid,
+            messageUuid: assistant.uuid,
+            toolCallId: 'second',
+            decision: 'rejected',
+            reason: 'No second query',
+            decidedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        const duplicate = await model.decideToolApproval({
+            threadUuid: thread.uuid,
+            messageUuid: assistant.uuid,
+            toolCallId: 'second',
+            decision: 'approved',
+            reason: null,
+            decidedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+
+        expect(first).toMatchObject({ recorded: true, shouldResume: false });
+        expect(second).toMatchObject({ recorded: true, shouldResume: true });
+        expect(duplicate).toMatchObject({
+            recorded: false,
+            shouldResume: false,
+        });
+        const reloaded = await model.getThread(thread.uuid);
+        expect(reloaded.messages[0]?.parts).toMatchObject([
+            { payload: { state: 'approval-responded' } },
+            { payload: { state: 'output-denied' } },
+        ]);
+    });
+
+    it('serializes concurrent decisions for one tool part', async () => {
+        const thread = await createRootThread();
+        const assistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: assistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    toolCallId: 'concurrent-call',
+                    payload: {
+                        state: 'approval-requested',
+                        toolName: 'runSql',
+                        input: { sql: 'SELECT 1' },
+                        approval: { id: 'concurrent-approval' },
+                    },
+                },
+            ],
+        });
+
+        const decisions = await Promise.all(
+            ['approved', 'rejected'].map((decision) =>
+                model.decideToolApproval({
+                    threadUuid: thread.uuid,
+                    messageUuid: assistant.uuid,
+                    toolCallId: 'concurrent-call',
+                    decision: decision as 'approved' | 'rejected',
+                    reason: null,
+                    decidedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                }),
+            ),
+        );
+
+        expect(decisions.filter(({ recorded }) => recorded)).toHaveLength(1);
+        expect(decisions.filter(({ recorded }) => !recorded)).toHaveLength(1);
+        expect([
+            ...new Set(decisions.map(({ decision }) => decision)),
+        ]).toHaveLength(1);
+    });
+
+    it('allows provider approval ids to repeat across threads', async () => {
+        const threads = await Promise.all([
+            createRootThread(),
+            createRootThread(),
+        ]);
+        const assistants = await Promise.all(
+            threads.map((thread) =>
+                model.createAssistantMessage({
+                    threadUuid: thread.uuid,
+                    modelConfig,
+                }),
+            ),
+        );
+        await Promise.all(
+            assistants.map((assistant, index) =>
+                model.appendParts({
+                    messageUuid: assistant.uuid,
+                    parts: [
+                        {
+                            partIndex: 0,
+                            type: 'tool',
+                            payloadVersion: 1,
+                            toolCallId: `reused-call-${index}`,
+                            payload: {
+                                state: 'approval-requested',
+                                toolName: 'runSql',
+                                input: { sql: 'SELECT 1' },
+                                approval: { id: 'provider-reused-approval-id' },
+                            },
+                        },
+                    ],
+                }),
+            ),
+        );
+
+        const decisions = await Promise.all(
+            threads.map((thread, index) =>
+                model.decideToolApproval({
+                    threadUuid: thread.uuid,
+                    messageUuid: assistants[index]!.uuid,
+                    toolCallId: `reused-call-${index}`,
+                    decision: 'approved',
+                    reason: null,
+                    decidedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                }),
+            ),
+        );
+
+        expect(decisions).toMatchObject([
+            { recorded: true, shouldResume: true },
+            { recorded: true, shouldResume: true },
+        ]);
+    });
+
+    it('scopes reused tool call ids to the active message', async () => {
+        const thread = await createRootThread();
+        const firstAssistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        const appendApproval = (messageUuid: string, approvalId: string) =>
+            model.appendParts({
+                messageUuid,
+                parts: [
+                    {
+                        partIndex: 0,
+                        type: 'tool' as const,
+                        payloadVersion: 1,
+                        toolCallId: 'reused-call',
+                        payload: {
+                            state: 'approval-requested',
+                            toolName: 'runSql',
+                            input: { sql: 'SELECT 1' },
+                            approval: { id: approvalId },
+                        },
+                    },
+                ],
+            });
+        await appendApproval(firstAssistant.uuid, 'first-approval');
+        await model.decideToolApproval({
+            threadUuid: thread.uuid,
+            messageUuid: firstAssistant.uuid,
+            toolCallId: 'reused-call',
+            decision: 'rejected',
+            reason: null,
+            decidedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        await model.finishAssistantMessage({
+            messageUuid: firstAssistant.uuid,
+            status: 'completed',
+            tokenUsage: null,
+            error: null,
+        });
+
+        const secondAssistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        await appendApproval(secondAssistant.uuid, 'second-approval');
+
+        await expect(
+            model.decideToolApproval({
+                threadUuid: thread.uuid,
+                messageUuid: secondAssistant.uuid,
+                toolCallId: 'reused-call',
+                decision: 'approved',
+                reason: null,
+                decidedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).resolves.toMatchObject({
+            messageUuid: secondAssistant.uuid,
+            recorded: true,
+        });
     });
 
     it('enforces type-specific part references', async () => {

--- a/packages/backend/src/ee/models/AiAgentV3Model.ts
+++ b/packages/backend/src/ee/models/AiAgentV3Model.ts
@@ -19,6 +19,8 @@ import {
     AiMessagePartTableName,
     AiThreadMessageSequenceTableName,
     AiThreadMessageTableName,
+    AiToolApprovalTableName,
+    getAiToolApprovalPayload,
     MODEL_VISIBLE_AI_MESSAGE_PART_TYPES,
     NON_USER_AI_MESSAGE_PART_TYPES,
     type AiAssistantMessageTerminalStatus,
@@ -27,11 +29,13 @@ import {
     type AiModelConfigEnvelope,
     type AiRunErrorEnvelope,
     type AiTokenUsageEnvelope,
+    type AiToolApprovalDecision,
     type AiV3PartWrite,
     type AiV3ThreadLineage,
     type CreateAiV3Thread,
     type DbAiMessagePart,
     type DbAiThreadMessage,
+    type DbAiToolApproval,
 } from '../database/entities/aiAgentV3';
 
 type Dependencies = {
@@ -41,6 +45,14 @@ type Dependencies = {
 type CreatedMessage = {
     uuid: string;
     threadSeq: number;
+};
+
+type ToolApprovalDecisionResult = {
+    decision: AiToolApprovalDecision;
+    messageUuid: string;
+    partUuid: string;
+    recorded: boolean;
+    shouldResume: boolean;
 };
 
 const TERMINAL_TOOL_STATE_PLACEHOLDERS = AI_TOOL_PART_TERMINAL_STATES.map(
@@ -245,15 +257,34 @@ export class AiAgentV3Model {
                 })),
             )
             .returning('*');
-        return rows.map(AiAgentV3Model.toCanonicalPart);
+        return rows.map((row) => AiAgentV3Model.toCanonicalPart(row));
     }
 
-    private static toCanonicalPart(part: DbAiMessagePart): AiCanonicalPart {
+    private static toCanonicalPart(
+        part: DbAiMessagePart,
+        approval?: DbAiToolApproval,
+    ): AiCanonicalPart {
+        const persistedApproval =
+            part.type === 'tool'
+                ? getAiToolApprovalPayload(part.payload)
+                : null;
         return {
             uuid: part.ai_message_part_uuid,
             type: part.type,
             payloadVersion: part.payload_version,
-            payload: part.payload,
+            payload: approval
+                ? {
+                      ...part.payload,
+                      approval: {
+                          id: approval.approval_id,
+                          signature: persistedApproval?.signature ?? null,
+                          approved: approval.decision === 'approved',
+                          reason: approval.reason,
+                          decidedByUserUuid: approval.decided_by_user_uuid,
+                          decidedAt: approval.decided_at.toISOString(),
+                      },
+                  }
+                : part.payload,
             toolCallId: part.tool_call_id,
             artifactVersionUuid: part.ai_artifact_version_uuid,
         };
@@ -277,6 +308,58 @@ export class AiAgentV3Model {
             throw new ConflictError('Assistant message is frozen');
         }
         return message;
+    }
+
+    private static async assertHasVisibleMessagePart(
+        trx: Knex.Transaction,
+        messageUuid: string,
+    ): Promise<void> {
+        const visiblePart = await trx(AiMessagePartTableName)
+            .where('ai_thread_message_uuid', messageUuid)
+            .whereIn('type', [...MODEL_VISIBLE_AI_MESSAGE_PART_TYPES])
+            .first();
+        if (visiblePart === undefined) {
+            throw new ConflictError(
+                'Completed assistant message requires content',
+            );
+        }
+    }
+
+    private static async healNonTerminalToolParts(
+        trx: Knex.Transaction,
+        messageUuid: string,
+    ): Promise<void> {
+        await trx(AiMessagePartTableName)
+            .where('ai_thread_message_uuid', messageUuid)
+            .where('type', 'tool')
+            .whereRaw(
+                `COALESCE(payload->>'state', '') NOT IN (${TERMINAL_TOOL_STATE_PLACEHOLDERS})`,
+                [...AI_TOOL_PART_TERMINAL_STATES],
+            )
+            .update({
+                payload: trx.raw('payload || ?::jsonb', [
+                    JSON.stringify({
+                        state: AI_TOOL_PART_INTERRUPTED_STATE,
+                        error: {
+                            name: 'interrupted',
+                            message: 'Tool execution was interrupted',
+                        },
+                    }),
+                ]),
+            });
+    }
+
+    private static existingToolApprovalResult(
+        part: DbAiMessagePart,
+        approval: DbAiToolApproval,
+    ): ToolApprovalDecisionResult {
+        return {
+            decision: approval.decision,
+            messageUuid: part.ai_thread_message_uuid,
+            partUuid: part.ai_message_part_uuid,
+            recorded: false,
+            shouldResume: false,
+        };
     }
 
     async createThread(data: CreateAiV3Thread) {
@@ -683,6 +766,33 @@ export class AiAgentV3Model {
         return updated === 1;
     }
 
+    async suspendAssistantMessage(
+        messageUuid: string,
+        tokenUsage: AiTokenUsageEnvelope | null,
+    ): Promise<void> {
+        const updated = await this.database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', messageUuid)
+            .where('role', 'assistant')
+            .where('status', 'in_progress')
+            .update({
+                token_usage: tokenUsage,
+                last_heartbeat_at: null,
+            });
+        if (updated !== 1) {
+            throw new ConflictError('Assistant message is frozen');
+        }
+    }
+
+    async claimAssistantMessageResume(messageUuid: string): Promise<boolean> {
+        const updated = await this.database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', messageUuid)
+            .where('role', 'assistant')
+            .where('status', 'in_progress')
+            .whereNull('last_heartbeat_at')
+            .update({ last_heartbeat_at: this.database.fn.now() });
+        return updated === 1;
+    }
+
     async isAssistantMessageInProgress(messageUuid: string): Promise<boolean> {
         const message = await this.database(AiThreadMessageTableName)
             .where('ai_thread_message_uuid', messageUuid)
@@ -760,18 +870,157 @@ export class AiAgentV3Model {
     }): Promise<AiCanonicalPart> {
         return this.database.transaction(async (trx) => {
             await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
-            const [part] = await trx(AiMessagePartTableName)
+            const update = trx(AiMessagePartTableName)
                 .where('ai_message_part_uuid', partUuid)
-                .where('ai_thread_message_uuid', messageUuid)
+                .where('ai_thread_message_uuid', messageUuid);
+            if (payload.state === 'approval-requested') {
+                update.whereRaw("payload->>'state' IN (?, ?, ?)", [
+                    'input-streaming',
+                    'input-available',
+                    'approval-requested',
+                ]);
+            }
+            const [part] = await update
                 .update({
                     payload_version: payloadVersion,
                     payload,
                 })
                 .returning('*');
             if (part === undefined) {
+                if (payload.state === 'approval-requested') {
+                    const existing = await trx(AiMessagePartTableName)
+                        .where('ai_message_part_uuid', partUuid)
+                        .where('ai_thread_message_uuid', messageUuid)
+                        .first();
+                    if (existing !== undefined) {
+                        return AiAgentV3Model.toCanonicalPart(existing);
+                    }
+                }
                 throw new NotFoundError('Message part not found');
             }
             return AiAgentV3Model.toCanonicalPart(part);
+        });
+    }
+
+    async decideToolApproval({
+        threadUuid,
+        messageUuid,
+        toolCallId,
+        decision,
+        reason,
+        decidedByUserUuid,
+    }: {
+        threadUuid: string;
+        messageUuid: string;
+        toolCallId: string;
+        decision: AiToolApprovalDecision;
+        reason: string | null;
+        decidedByUserUuid: string;
+    }): Promise<ToolApprovalDecisionResult> {
+        return this.database.transaction(async (trx) => {
+            const row = await trx(AiMessagePartTableName)
+                .innerJoin(
+                    AiThreadMessageTableName,
+                    `${AiThreadMessageTableName}.ai_thread_message_uuid`,
+                    `${AiMessagePartTableName}.ai_thread_message_uuid`,
+                )
+                .where(`${AiThreadMessageTableName}.ai_thread_uuid`, threadUuid)
+                .where(
+                    `${AiThreadMessageTableName}.ai_thread_message_uuid`,
+                    messageUuid,
+                )
+                .where(`${AiMessagePartTableName}.tool_call_id`, toolCallId)
+                .where(`${AiMessagePartTableName}.type`, 'tool')
+                .forUpdate()
+                .first<
+                    DbAiMessagePart & {
+                        message_status: DbAiThreadMessage['status'];
+                    }
+                >(
+                    `${AiMessagePartTableName}.*`,
+                    `${AiThreadMessageTableName}.status as message_status`,
+                );
+            if (!row) throw new NotFoundError('Tool call not found');
+            if (row.message_status !== 'in_progress') {
+                const existing = await trx(AiToolApprovalTableName)
+                    .where('ai_message_part_uuid', row.ai_message_part_uuid)
+                    .first();
+                if (existing) {
+                    return AiAgentV3Model.existingToolApprovalResult(
+                        row,
+                        existing,
+                    );
+                }
+                throw new ConflictError('Assistant message is frozen');
+            }
+            const approval = getAiToolApprovalPayload(row.payload);
+            if (!approval) {
+                throw new ConflictError('Tool approval id is missing');
+            }
+            const existing = await trx(AiToolApprovalTableName)
+                .where('ai_message_part_uuid', row.ai_message_part_uuid)
+                .first();
+            if (existing) {
+                return AiAgentV3Model.existingToolApprovalResult(row, existing);
+            }
+            if (row.payload.state !== 'approval-requested') {
+                throw new ConflictError('Tool call is not awaiting approval');
+            }
+            const [inserted] = await trx(AiToolApprovalTableName)
+                .insert({
+                    ai_message_part_uuid: row.ai_message_part_uuid,
+                    approval_id: approval.id,
+                    decision,
+                    reason,
+                    decided_by_user_uuid: decidedByUserUuid,
+                })
+                .onConflict('ai_message_part_uuid')
+                .ignore()
+                .returning('*');
+            if (!inserted) {
+                const racedDecision = await trx(AiToolApprovalTableName)
+                    .where('ai_message_part_uuid', row.ai_message_part_uuid)
+                    .first();
+                if (!racedDecision) {
+                    throw new UnexpectedServerError(
+                        'Failed to read tool approval decision',
+                    );
+                }
+                return AiAgentV3Model.existingToolApprovalResult(
+                    row,
+                    racedDecision,
+                );
+            }
+
+            const state =
+                decision === 'approved'
+                    ? 'approval-responded'
+                    : 'output-denied';
+            await trx(AiMessagePartTableName)
+                .where('ai_message_part_uuid', row.ai_message_part_uuid)
+                .update({
+                    payload: {
+                        ...row.payload,
+                        state,
+                        approval: {
+                            id: approval.id,
+                            signature: approval.signature,
+                            approved: decision === 'approved',
+                        },
+                    },
+                });
+            const remainingApproval = await trx(AiMessagePartTableName)
+                .where('ai_thread_message_uuid', row.ai_thread_message_uuid)
+                .where('type', 'tool')
+                .whereRaw("payload->>'state' = ?", ['approval-requested'])
+                .first('ai_message_part_uuid');
+            return {
+                decision,
+                messageUuid: row.ai_thread_message_uuid,
+                partUuid: row.ai_message_part_uuid,
+                recorded: true,
+                shouldResume: remainingApproval === undefined,
+            };
         });
     }
 
@@ -795,35 +1044,13 @@ export class AiAgentV3Model {
         await this.database.transaction(async (trx) => {
             await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
             if (status === 'completed') {
-                const visiblePart = await trx(AiMessagePartTableName)
-                    .where('ai_thread_message_uuid', messageUuid)
-                    .whereIn('type', [...MODEL_VISIBLE_AI_MESSAGE_PART_TYPES])
-                    .first();
-                if (visiblePart === undefined) {
-                    throw new ConflictError(
-                        'Completed assistant message requires content',
-                    );
-                }
+                await AiAgentV3Model.assertHasVisibleMessagePart(
+                    trx,
+                    messageUuid,
+                );
             }
 
-            await trx(AiMessagePartTableName)
-                .where('ai_thread_message_uuid', messageUuid)
-                .where('type', 'tool')
-                .whereRaw(
-                    `COALESCE(payload->>'state', '') NOT IN (${TERMINAL_TOOL_STATE_PLACEHOLDERS})`,
-                    [...AI_TOOL_PART_TERMINAL_STATES],
-                )
-                .update({
-                    payload: trx.raw('payload || ?::jsonb', [
-                        JSON.stringify({
-                            state: AI_TOOL_PART_INTERRUPTED_STATE,
-                            error: {
-                                name: 'interrupted',
-                                message: 'Tool execution was interrupted',
-                            },
-                        }),
-                    ]),
-                });
+            await AiAgentV3Model.healNonTerminalToolParts(trx, messageUuid);
             await trx(AiThreadMessageTableName)
                 .where('ai_thread_message_uuid', messageUuid)
                 .update({
@@ -864,11 +1091,29 @@ export class AiAgentV3Model {
                           { column: 'ai_thread_message_uuid' },
                           { column: 'part_index' },
                       ]);
+        const approvals =
+            parts.length === 0
+                ? []
+                : await this.database(AiToolApprovalTableName).whereIn(
+                      'ai_message_part_uuid',
+                      parts.map((part) => part.ai_message_part_uuid),
+                  );
+        const approvalsByPartUuid = new Map(
+            approvals.map((approval) => [
+                approval.ai_message_part_uuid,
+                approval,
+            ]),
+        );
         const partsByMessageUuid = new Map<string, AiCanonicalPart[]>();
         parts.forEach((part) => {
             const messageParts =
                 partsByMessageUuid.get(part.ai_thread_message_uuid) ?? [];
-            messageParts.push(AiAgentV3Model.toCanonicalPart(part));
+            messageParts.push(
+                AiAgentV3Model.toCanonicalPart(
+                    part,
+                    approvalsByPartUuid.get(part.ai_message_part_uuid),
+                ),
+            );
             partsByMessageUuid.set(part.ai_thread_message_uuid, messageParts);
         });
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
@@ -418,6 +418,53 @@ describe('AiAgentService MCP support', () => {
             },
         ]);
 
+        await expect(
+            services.aiAgentService.updateAgentMcpServerTools(
+                context.testUser,
+                SEED_PROJECT.project_uuid,
+                agent.uuid,
+                mcpServer.uuid,
+                {
+                    toolSettings: [{ toolName: 'lookup' } as never],
+                },
+            ),
+        ).rejects.toThrow('MCP tool permission mode is required');
+
+        await expect(
+            services.aiAgentService.updateAgentMcpServerTools(
+                context.testUser,
+                SEED_PROJECT.project_uuid,
+                agent.uuid,
+                mcpServer.uuid,
+                {
+                    toolSettings: [
+                        {
+                            toolName: 'lookup',
+                            permissionMode: 'bogus',
+                        } as never,
+                    ],
+                },
+            ),
+        ).rejects.toThrow('Invalid MCP tool permission mode');
+
+        await expect(
+            services.aiAgentService.updateAgentMcpServerTools(
+                context.testUser,
+                SEED_PROJECT.project_uuid,
+                agent.uuid,
+                mcpServer.uuid,
+                {
+                    toolSettings: [
+                        {
+                            toolName: 'lookup',
+                            permissionMode: 'ask',
+                            enabled: true,
+                        },
+                    ],
+                },
+            ),
+        ).rejects.toThrow('MCP tool permission mode conflicts with enabled');
+
         availableTools = [
             {
                 name: 'lookup',

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.readRoutes.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.readRoutes.integration.test.ts
@@ -390,4 +390,122 @@ describe('AiAgentService v3 thread API', () => {
             }),
         );
     });
+
+    it('rejects approval decisions from a non-owner viewer', async () => {
+        const service = getServices(context.app).aiAgentService;
+        const threadUuid = await createV3Thread({
+            ownerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+        });
+        const model = new AiAgentV3Model({ database: context.db });
+        const assistant = await model.createAssistantMessage({
+            threadUuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: assistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    toolCallId: 'read-only-approval',
+                    payload: {
+                        state: 'approval-requested',
+                        toolName: 'runSql',
+                        input: { sql: 'SELECT 1' },
+                        approval: { id: 'read-only-approval' },
+                    },
+                },
+            ],
+        });
+
+        await expect(
+            service.decideToolApproval(context.testUser, {
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid,
+                threadUuid,
+                toolCallId: 'read-only-approval',
+                decision: 'approved',
+                reason: null,
+            }),
+        ).rejects.toMatchObject({
+            name: 'ReadOnlyThreadError',
+            statusCode: 409,
+        });
+    });
+
+    it('keeps approval decisions scoped, bounded, and idempotent after freeze', async () => {
+        const service = getServices(context.app).aiAgentService;
+        const threadUuid = await createV3Thread();
+        const model = new AiAgentV3Model({ database: context.db });
+        const assistant = await model.createAssistantMessage({
+            threadUuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: assistant.uuid,
+            parts: ['decided-call', 'pending-call'].map(
+                (toolCallId, partIndex) => ({
+                    partIndex,
+                    type: 'tool' as const,
+                    payloadVersion: 1,
+                    toolCallId,
+                    payload: {
+                        state: 'approval-requested',
+                        toolName: 'findExplores',
+                        input: {},
+                        approval: { id: `${toolCallId}-approval` },
+                    },
+                }),
+            ),
+        });
+        const decide = (
+            overrides: Partial<{
+                projectUuid: string;
+                reason: string | null;
+            }> = {},
+        ) =>
+            service.decideToolApproval(context.testUser, {
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid,
+                threadUuid,
+                toolCallId: 'decided-call',
+                decision: 'rejected',
+                reason: null,
+                ...overrides,
+            });
+
+        await expect(
+            decide({ projectUuid: crypto.randomUUID() }),
+        ).rejects.toMatchObject({ statusCode: 404 });
+        await expect(decide({ reason: 'x'.repeat(1_001) })).rejects.toThrow(
+            'Approval reason cannot exceed 1000 characters',
+        );
+        await expect(decide()).resolves.toEqual({ decision: 'rejected' });
+        await expect(model.getThread(threadUuid)).resolves.toMatchObject({
+            messages: [
+                {},
+                {
+                    parts: [
+                        {
+                            payload: {
+                                approval: {
+                                    reason: null,
+                                    decidedByUserUuid:
+                                        context.testUser.userUuid,
+                                },
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+        await model.finishAssistantMessage({
+            messageUuid: assistant.uuid,
+            status: 'completed',
+            tokenUsage: null,
+            error: null,
+        });
+        await expect(decide()).resolves.toEqual({ decision: 'rejected' });
+    });
 });

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.shutdown.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.shutdown.test.ts
@@ -43,12 +43,16 @@ type PrivateService = {
     ) => Promise<unknown>;
     generateOrStreamAgentResponse: (...args: unknown[]) => Promise<unknown>;
     prepareAgentThreadV3Response: (...args: unknown[]) => Promise<unknown>;
+    waitForActiveV3Run: (messageUuid: string) => Promise<void>;
     activeV3Runs: Map<
         string,
         {
             threadUuid: string;
             abortController: AbortController;
-            persistence: { fail: ReturnType<typeof vi.fn> };
+            persistence: {
+                fail: ReturnType<typeof vi.fn>;
+                waitForTerminal?: () => Promise<void>;
+            };
         }
     >;
 };
@@ -310,5 +314,32 @@ describe('AiAgentService streamed prompt shutdown', () => {
 
         expect(abortController.signal.aborted).toBe(true);
         expect(fail).toHaveBeenCalledOnce();
+    });
+
+    it('waits for the suspending run before resuming an approval', async () => {
+        const { instance } = buildService();
+        const privateService = instance as unknown as PrivateService;
+        const terminal = createDeferred();
+        privateService.activeV3Runs.set('message-uuid', {
+            threadUuid: 'thread-uuid',
+            abortController: new AbortController(),
+            persistence: {
+                fail: vi.fn(),
+                waitForTerminal: () => terminal.promise,
+            },
+        });
+
+        let released = false;
+        const waiting = privateService
+            .waitForActiveV3Run('message-uuid')
+            .then(() => {
+                released = true;
+            });
+        await Promise.resolve();
+        expect(released).toBe(false);
+
+        terminal.resolve();
+        await waiting;
+        expect(released).toBe(true);
     });
 });

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -229,8 +229,11 @@ import { SpaceService } from '../../../services/SpaceService/SpaceService';
 import { wrapSentryTransaction } from '../../../utils';
 import { validatePublicHttpUrl } from '../../../utils/ssrfProtection';
 import {
+    type AiCanonicalPart,
     type AiCanonicalThread,
     type AiModelConfigEnvelope,
+    type AiTokenUsageEnvelope,
+    type AiToolApprovalDecision,
 } from '../../database/entities/aiAgentV3';
 import { type DbAiDeepResearchEvent } from '../../database/entities/aiDeepResearch';
 import { AiAgentDocumentModel } from '../../models/AiAgentDocumentModel';
@@ -238,6 +241,7 @@ import { AiAgentMemoryModel } from '../../models/AiAgentMemoryModel';
 import {
     AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
     AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY,
+    AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ASK,
     AiAgentModel,
     type AiAgentMcpServerToolPermissionSetting,
     type AiAgentMcpServerToolPermissionSettingUpdate,
@@ -291,8 +295,13 @@ import {
     getModel,
     presetToModelOption,
 } from '../ai/models';
+import { isAiProvider } from '../ai/models/types';
 import { OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
-import { projectV3ThreadToModelMessages } from '../ai/projectV3ThreadToModelMessages';
+import {
+    getV3MessageRunOptions,
+    getV3TriggeringUserMessage,
+    projectV3ThreadToModelMessages,
+} from '../ai/projectV3ThreadToModelMessages';
 import {
     requestingUserRoleFromCustomRole,
     requestingUserRoleFromSystemRole,
@@ -451,7 +460,9 @@ const ALLOWED_AGENT_AVATAR_MIME_TYPES = new Set([
 // comfortably under the usual 30-60s idle timeouts.
 const STREAM_KEEPALIVE_INTERVAL_MS = 15_000;
 const V3_RUN_HEARTBEAT_INTERVAL_MS = 15_000;
+const V3_APPROVAL_RESUME_POLL_MS = 100;
 const V3_RUN_STOP_TIMEOUT_MS = 5_000;
+const MAX_TOOL_APPROVAL_REASON_LENGTH = 1_000;
 const MAX_MCP_BEARER_TOKEN_LENGTH = 8192;
 
 type GenerateAgentExecutionOptions =
@@ -2789,20 +2800,26 @@ export class AiAgentService extends BaseService {
         };
     }
 
-    async decideSqlApproval(
+    private async decideV3ToolApproval(
         user: SessionUser,
         {
+            projectUuid,
             agentUuid,
             threadUuid,
             toolCallId,
             decision,
+            expectedToolName,
+            reason,
         }: {
+            projectUuid: string;
             agentUuid: string;
             threadUuid: string;
             toolCallId: string;
-            decision: 'approved' | 'rejected';
+            decision: AiToolApprovalDecision;
+            expectedToolName: string | null;
+            reason: string | null;
         },
-    ): Promise<{ decision: 'approved' | 'rejected' }> {
+    ): Promise<{ decision: AiToolApprovalDecision }> {
         const { organizationUuid } = user;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
@@ -2811,6 +2828,168 @@ export class AiAgentService extends BaseService {
         if (!(await this.getIsCopilotEnabled(user))) {
             throw new ForbiddenError('Copilot is not enabled');
         }
+
+        const { agent, thread } = await this.getMutableV3Thread(
+            user,
+            agentUuid,
+            threadUuid,
+        );
+        if (agent.projectUuid !== projectUuid) {
+            throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+        if (
+            reason !== null &&
+            reason.length > MAX_TOOL_APPROVAL_REASON_LENGTH
+        ) {
+            throw new ParameterError(
+                `Approval reason cannot exceed ${MAX_TOOL_APPROVAL_REASON_LENGTH} characters`,
+            );
+        }
+        const matchingMessages = thread.messages.filter(
+            (message) =>
+                message.role === 'assistant' &&
+                message.parts.some((part) => part.toolCallId === toolCallId),
+        );
+        const approvalMessage =
+            matchingMessages.find(
+                (message) => message.metadata.status === 'in_progress',
+            ) ?? matchingMessages.at(-1);
+        if (!approvalMessage) {
+            throw new NotFoundError(`Tool call not found: ${toolCallId}`);
+        }
+        const toolPart = approvalMessage.parts.find(
+            (part) => part.toolCallId === toolCallId,
+        );
+        if (!toolPart) {
+            throw new NotFoundError(`Tool call not found: ${toolCallId}`);
+        }
+        const { toolName } = toolPart.payload;
+        if (expectedToolName !== null && toolName !== expectedToolName) {
+            throw new ParameterError(
+                `Tool call ${toolCallId} is not a ${expectedToolName} approval`,
+            );
+        }
+        if (toolName === 'runSql') {
+            const auditedAbility = this.createAuditedAbility(user);
+            if (
+                auditedAbility.cannot(
+                    'manage',
+                    subject('SqlRunner', {
+                        organizationUuid,
+                        projectUuid: agent.projectUuid,
+                        metadata: { agentUuid, threadUuid, toolCallId },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError(
+                    'You need the SqlRunner permission to approve SQL execution',
+                );
+            }
+        }
+        const result = await this.aiAgentV3Model.decideToolApproval({
+            threadUuid,
+            messageUuid: approvalMessage.uuid,
+            toolCallId,
+            decision,
+            reason,
+            decidedByUserUuid: user.userUuid,
+        });
+        if (result.recorded && result.shouldResume) {
+            void this.waitForActiveV3Run(result.messageUuid)
+                .then(() =>
+                    this.resumeV3ToolApproval(user, {
+                        agent,
+                        threadUuid,
+                        assistantMessageUuid: result.messageUuid,
+                    }),
+                )
+                .catch(async (error) => {
+                    try {
+                        if (
+                            await this.aiAgentV3Model.isAssistantMessageInProgress(
+                                result.messageUuid,
+                            )
+                        ) {
+                            const current =
+                                await this.aiAgentV3Model.getThread(threadUuid);
+                            const tokenUsage = current.messages.find(
+                                (message) =>
+                                    message.uuid === result.messageUuid,
+                            )?.metadata.tokenUsage;
+                            await this.aiAgentV3Model.finishAssistantMessage({
+                                messageUuid: result.messageUuid,
+                                status: 'error',
+                                tokenUsage: tokenUsage ?? null,
+                                error: getAiRunErrorEnvelope(
+                                    error,
+                                    getUserFacingErrorMessage(error),
+                                ),
+                            });
+                        }
+                    } catch (persistError) {
+                        Logger.error(
+                            `[AiAgentV3] Failed to persist resume error for ${toolCallId}`,
+                            persistError,
+                        );
+                    }
+                    Logger.error(
+                        `[AiAgentV3] Failed to resume decided tool ${toolCallId}`,
+                        error,
+                    );
+                });
+        }
+        return { decision: result.decision };
+    }
+
+    async decideToolApproval(
+        user: SessionUser,
+        args: {
+            projectUuid: string;
+            agentUuid: string;
+            threadUuid: string;
+            toolCallId: string;
+            decision: AiToolApprovalDecision;
+            reason: string | null;
+        },
+    ): Promise<{ decision: AiToolApprovalDecision }> {
+        return this.decideV3ToolApproval(user, {
+            ...args,
+            expectedToolName: null,
+        });
+    }
+
+    async decideSqlApproval(
+        user: SessionUser,
+        args: {
+            projectUuid: string;
+            agentUuid: string;
+            threadUuid: string;
+            toolCallId: string;
+            decision: AiToolApprovalDecision;
+            reason: string | null;
+        },
+    ): Promise<{ decision: AiToolApprovalDecision }> {
+        const metadata = await this.getAccessibleThreadMetadata(
+            user,
+            args.agentUuid,
+            args.threadUuid,
+        );
+        if (metadata.storageVersion === 3) {
+            return this.decideV3ToolApproval(user, {
+                ...args,
+                expectedToolName: 'runSql',
+            });
+        }
+
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        if (!(await this.getIsCopilotEnabled(user))) {
+            throw new ForbiddenError('Copilot is not enabled');
+        }
+
+        const { agentUuid, threadUuid, toolCallId, decision } = args;
 
         const context =
             await this.aiAgentModel.findSqlApprovalContext(toolCallId);
@@ -2843,6 +3022,9 @@ export class AiAgentService extends BaseService {
             agentUuid,
         });
         if (!agent) {
+            throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+        if (agent.projectUuid !== args.projectUuid) {
             throw new NotFoundError(`Agent not found: ${agentUuid}`);
         }
 
@@ -2905,6 +3087,210 @@ export class AiAgentService extends BaseService {
         }
 
         return { decision };
+    }
+
+    private createV3RunContext({
+        threadUuid,
+        assistantMessageUuid,
+        initialParts = [],
+        initialTokenUsage = null,
+    }: {
+        threadUuid: string;
+        assistantMessageUuid: string;
+        initialParts?: AiCanonicalPart[];
+        initialTokenUsage?: AiTokenUsageEnvelope | null;
+    }): { persistence: AiAgentV3RunPersistence; run: V3RunContext } {
+        if (this.activeV3Runs.has(assistantMessageUuid)) {
+            throw new ConflictError('This message already has an active run');
+        }
+        const abortController = new AbortController();
+        const persistence = new AiAgentV3RunPersistence(
+            this.aiAgentV3Model,
+            assistantMessageUuid,
+            () => abortController.signal.aborted,
+            () => {
+                if (
+                    this.activeV3Runs.get(assistantMessageUuid)?.persistence ===
+                    persistence
+                ) {
+                    this.activeV3Runs.delete(assistantMessageUuid);
+                }
+            },
+            () => abortController.abort(),
+            initialParts,
+            initialTokenUsage,
+        );
+        this.activeV3Runs.set(assistantMessageUuid, {
+            threadUuid,
+            abortController,
+            persistence,
+        });
+        persistence.startHeartbeat(V3_RUN_HEARTBEAT_INTERVAL_MS);
+        const consumed = new Set<string>();
+        return {
+            persistence,
+            run: {
+                persistence,
+                abortSignal: abortController.signal,
+                isInterrupted: async () =>
+                    abortController.signal.aborted ||
+                    !(await this.aiAgentV3Model.isAssistantMessageInProgress(
+                        assistantMessageUuid,
+                    )),
+                consumeSteers: async (stepNumber) => {
+                    const steers = await this.aiAgentV3Model.getSteers({
+                        threadUuid,
+                        assistantMessageUuid,
+                    });
+                    return steers.flatMap((steer) => {
+                        if (consumed.has(steer.uuid)) return [];
+                        consumed.add(steer.uuid);
+                        return [
+                            {
+                                ...steer,
+                                promptUuid: assistantMessageUuid,
+                                consumedAt: new Date().toISOString(),
+                                consumedStep: stepNumber,
+                            },
+                        ];
+                    });
+                },
+            },
+        };
+    }
+
+    private async waitForActiveV3Run(messageUuid: string): Promise<void> {
+        await this.activeV3Runs.get(messageUuid)?.persistence.waitForTerminal();
+    }
+
+    private async claimV3ToolApprovalResume(
+        messageUuid: string,
+    ): Promise<void> {
+        if (
+            await this.aiAgentV3Model.claimAssistantMessageResume(messageUuid)
+        ) {
+            return;
+        }
+        if (
+            !(await this.aiAgentV3Model.isAssistantMessageInProgress(
+                messageUuid,
+            ))
+        ) {
+            throw new ConflictError('Assistant message is frozen');
+        }
+        await sleep(V3_APPROVAL_RESUME_POLL_MS);
+        return this.claimV3ToolApprovalResume(messageUuid);
+    }
+
+    private async resumeV3ToolApproval(
+        user: SessionUser,
+        {
+            agent,
+            threadUuid,
+            assistantMessageUuid,
+        }: {
+            agent: AiAgent;
+            threadUuid: string;
+            assistantMessageUuid: string;
+        },
+    ): Promise<void> {
+        await this.claimV3ToolApprovalResume(assistantMessageUuid);
+        const canonical = await this.aiAgentV3Model.getThread(threadUuid);
+        const assistant = canonical.messages.find(
+            (message) => message.uuid === assistantMessageUuid,
+        );
+        const modelConfig = assistant?.metadata.modelConfig;
+        if (!assistant || !modelConfig) {
+            throw new NotFoundError('Assistant message not found');
+        }
+        const selectedModelConfig: AiAgentModelConfig = {
+            modelName: modelConfig.modelName,
+            modelProvider: modelConfig.modelProvider,
+            reasoning: modelConfig.reasoning.enabled,
+        };
+        if (!isAiProvider(selectedModelConfig.modelProvider)) {
+            throw new ParameterError('Unsupported AI model provider');
+        }
+        const copilotConfig =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                canonical.organizationUuid,
+            );
+        const modelProperties = getModel(copilotConfig, {
+            enableReasoning: selectedModelConfig.reasoning,
+            modelName: selectedModelConfig.modelName,
+            provider: selectedModelConfig.modelProvider,
+        });
+        const { persistence, run } = this.createV3RunContext({
+            threadUuid,
+            assistantMessageUuid,
+            initialParts: assistant.parts,
+            initialTokenUsage: assistant.metadata.tokenUsage,
+        });
+
+        const triggeringUserMessage = getV3TriggeringUserMessage(
+            canonical.messages,
+            assistantMessageUuid,
+        );
+        const promptText =
+            triggeringUserMessage?.parts
+                .filter((part) => part.type === 'text')
+                .map((part) => part.payload.text)
+                .filter((text): text is string => typeof text === 'string')
+                .join('') ?? '';
+        const promptUserUuid =
+            triggeringUserMessage?.metadata.createdByUserUuid ?? user.userUuid;
+        const runOptions = getV3MessageRunOptions(triggeringUserMessage);
+        const prompt: AiWebAppPrompt = {
+            organizationUuid: canonical.organizationUuid,
+            projectUuid: canonical.projectUuid,
+            agentUuid: agent.uuid,
+            promptUuid: assistantMessageUuid,
+            threadUuid,
+            createdByUserUuid: promptUserUuid,
+            userUuid: promptUserUuid,
+            prompt: promptText,
+            createdAt: new Date(
+                triggeringUserMessage?.metadata.createdAt ?? Date.now(),
+            ),
+            response: null,
+            errorMessage: null,
+            humanScore: null,
+            modelConfig: selectedModelConfig,
+        };
+        const canManageAgent = this.createAuditedAbility(user).can(
+            'manage',
+            subject('AiAgent', {
+                organizationUuid: canonical.organizationUuid,
+                projectUuid: canonical.projectUuid,
+                metadata: { agentUuid: agent.uuid, threadUuid },
+            }),
+        );
+        try {
+            const response = await this.generateOrStreamAgentResponse(
+                user,
+                {
+                    messageHistory: projectV3ThreadToModelMessages(canonical, {
+                        modelProvider: selectedModelConfig.modelProvider,
+                        includeInProgressMessageUuid: assistantMessageUuid,
+                    }),
+                    compactionSummary: null,
+                },
+                {
+                    prompt,
+                    stream: true,
+                    canManageAgent,
+                    enableSqlMode:
+                        runOptions.enableSqlMode ?? agent.enableSqlMode,
+                    autoApproveSql: false,
+                    toolHints: runOptions.toolHints,
+                    v3Run: run,
+                },
+            );
+            await response.consumeStream();
+        } catch (error) {
+            await persistence.fail(error, getUserFacingErrorMessage(error));
+            throw error;
+        }
     }
 
     async createAgentThread(
@@ -3587,11 +3973,13 @@ export class AiAgentService extends BaseService {
         projectUuid,
         agentUuid,
         includeAttachedMcpServers = true,
+        includeApprovalRequiredTools = false,
     }: {
         user: SessionUser;
         projectUuid: string;
         agentUuid: string;
         includeAttachedMcpServers?: boolean;
+        includeApprovalRequiredTools?: boolean;
     }): Promise<AiAgentMcpServer[]> {
         if (!user.organizationUuid) {
             throw new ForbiddenError('Organization not found');
@@ -3611,14 +3999,38 @@ export class AiAgentService extends BaseService {
             projectUuid,
             userUuid: user.userUuid,
             mcpServers: await Promise.all(
-                attachedServers.map(async (mcpServer) => ({
-                    ...mcpServer,
-                    enabledToolNames:
-                        await this.aiAgentModel.getEnabledMcpServerToolNames({
+                attachedServers.map(async (mcpServer) => {
+                    const toolSettings =
+                        await this.aiAgentModel.listAgentMcpServerTools({
                             agentUuid,
                             serverUuid: mcpServer.uuid,
-                        }),
-                })),
+                        });
+                    const enabledToolNames = toolSettings
+                        .filter(
+                            ({ permissionMode }) =>
+                                permissionMode ===
+                                    AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW ||
+                                (includeApprovalRequiredTools &&
+                                    permissionMode ===
+                                        AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ASK),
+                        )
+                        .map(({ toolName }) => toolName);
+                    const approvalRequiredToolNames =
+                        includeApprovalRequiredTools
+                            ? toolSettings
+                                  .filter(
+                                      ({ permissionMode }) =>
+                                          permissionMode ===
+                                          AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ASK,
+                                  )
+                                  .map(({ toolName }) => toolName)
+                            : [];
+                    return {
+                        ...mcpServer,
+                        enabledToolNames,
+                        approvalRequiredToolNames,
+                    };
+                }),
             ),
         });
     }
@@ -3854,6 +4266,7 @@ export class AiAgentService extends BaseService {
 
         return {
             ...apiTool,
+            permissionMode,
             enabled:
                 permissionMode ===
                 AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
@@ -3864,6 +4277,36 @@ export class AiAgentService extends BaseService {
         return enabled
             ? AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW
             : AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY;
+    }
+
+    private static resolveAgentMcpServerToolPermissionMode(
+        tool: ApiUpdateAiAgentMcpServerToolsRequest['toolSettings'][number],
+    ) {
+        const { permissionMode, enabled } = tool;
+        if (
+            permissionMode !== undefined &&
+            enabled !== undefined &&
+            permissionMode !==
+                AiAgentService.toAgentMcpServerToolPermissionMode(enabled)
+        ) {
+            throw new ParameterError(
+                'MCP tool permission mode conflicts with enabled',
+            );
+        }
+        switch (permissionMode) {
+            case AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW:
+            case AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY:
+            case AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ASK:
+                return permissionMode;
+            case undefined:
+                break;
+            default:
+                throw new ParameterError('Invalid MCP tool permission mode');
+        }
+        if (enabled !== undefined) {
+            return AiAgentService.toAgentMcpServerToolPermissionMode(enabled);
+        }
+        throw new ParameterError('MCP tool permission mode is required');
     }
 
     public async listAgentMcpServerTools(
@@ -3906,8 +4349,8 @@ export class AiAgentService extends BaseService {
                         {
                             toolName: tool.toolName,
                             permissionMode:
-                                AiAgentService.toAgentMcpServerToolPermissionMode(
-                                    tool.enabled,
+                                AiAgentService.resolveAgentMcpServerToolPermissionMode(
+                                    tool,
                                 ),
                         },
                     ],
@@ -5709,16 +6152,20 @@ export class AiAgentService extends BaseService {
             await this.orgAiCopilotConfigResolver.getCopilotConfig(
                 thread.organizationUuid,
             );
+        const selectedProvider =
+            modelConfig?.modelProvider ?? copilotConfig.defaultProvider;
+        if (!isAiProvider(selectedProvider)) {
+            throw new ParameterError('Unsupported AI model provider');
+        }
         const modelProperties = getModel(copilotConfig, {
             enableReasoning: modelConfig?.reasoning,
             modelName: modelConfig?.modelName,
-            provider: modelConfig?.modelProvider as AnyType,
+            provider: selectedProvider,
         });
         const modelEnvelope: AiModelConfigEnvelope = {
             version: 1,
             modelName: getAiAgentModelName(modelProperties.model),
-            modelProvider:
-                modelConfig?.modelProvider ?? copilotConfig.defaultProvider,
+            modelProvider: selectedProvider,
             reasoning: {
                 enabled: modelConfig?.reasoning ?? false,
                 effort: null,
@@ -5743,34 +6190,20 @@ export class AiAgentService extends BaseService {
                     partIndex: 0,
                     type: 'text',
                     payloadVersion: 1,
-                    payload: { text: message },
+                    payload: {
+                        text: message,
+                        toolHints: body.toolHints ?? [],
+                        enableSqlMode: body.enableSqlMode ?? null,
+                    },
                 },
             ],
             modelConfig: modelEnvelope,
         });
-        const abortController = new AbortController();
-        const persistence = new AiAgentV3RunPersistence(
-            this.aiAgentV3Model,
-            started.assistantMessage.uuid,
-            () => abortController.signal.aborted,
-            () => {
-                if (
-                    this.activeV3Runs.get(started.assistantMessage.uuid)
-                        ?.persistence === persistence
-                ) {
-                    this.activeV3Runs.delete(started.assistantMessage.uuid);
-                }
-            },
-            () => abortController.abort(),
-        );
-        this.activeV3Runs.set(started.assistantMessage.uuid, {
+        const { persistence, run } = this.createV3RunContext({
             threadUuid,
-            abortController,
-            persistence,
+            assistantMessageUuid: started.assistantMessage.uuid,
         });
         try {
-            persistence.startHeartbeat(V3_RUN_HEARTBEAT_INTERVAL_MS);
-
             const canonical = await this.aiAgentV3Model.getThread(threadUuid);
             const prompt: AiWebAppPrompt = {
                 organizationUuid: thread.organizationUuid,
@@ -5796,41 +6229,13 @@ export class AiAgentService extends BaseService {
                     metadata: { agentUuid, threadUuid },
                 }),
             );
-            const run: V3RunContext = {
-                persistence,
-                abortSignal: abortController.signal,
-                isInterrupted: async () =>
-                    abortController.signal.aborted ||
-                    !(await this.aiAgentV3Model.isAssistantMessageInProgress(
-                        started.assistantMessage.uuid,
-                    )),
-                consumeSteers: (() => {
-                    const consumed = new Set<string>();
-                    return async (stepNumber) => {
-                        const steers = await this.aiAgentV3Model.getSteers({
-                            threadUuid,
-                            assistantMessageUuid: started.assistantMessage.uuid,
-                        });
-                        return steers.flatMap((steer) => {
-                            if (consumed.has(steer.uuid)) return [];
-                            consumed.add(steer.uuid);
-                            return [
-                                {
-                                    ...steer,
-                                    promptUuid: started.assistantMessage.uuid,
-                                    consumedAt: new Date().toISOString(),
-                                    consumedStep: stepNumber,
-                                },
-                            ];
-                        });
-                    };
-                })(),
-            };
-
             return await this.generateOrStreamAgentResponse(
                 user,
                 {
-                    messageHistory: projectV3ThreadToModelMessages(canonical),
+                    messageHistory: projectV3ThreadToModelMessages(canonical, {
+                        modelProvider: selectedProvider,
+                        includeInProgressMessageUuid: null,
+                    }),
                     compactionSummary: null,
                 },
                 {
@@ -6002,7 +6407,7 @@ export class AiAgentService extends BaseService {
         if (run?.threadUuid === threadUuid) {
             run.abortController.abort();
             let timeout: ReturnType<typeof setTimeout> | undefined;
-            const terminal = await Promise.race([
+            await Promise.race([
                 run.persistence.waitForTerminal().then(() => true),
                 new Promise<false>((resolve) => {
                     timeout = setTimeout(
@@ -6012,21 +6417,19 @@ export class AiAgentService extends BaseService {
                 }),
             ]);
             if (timeout) clearTimeout(timeout);
-            if (!terminal) {
-                try {
-                    await this.aiAgentV3Model.finishAssistantMessage({
-                        messageUuid,
-                        status: 'canceled',
-                        tokenUsage: null,
-                        error: null,
-                    });
-                } catch (error) {
-                    if (
-                        !(error instanceof ConflictError) ||
-                        error.message !== 'Assistant message is frozen'
-                    ) {
-                        throw error;
-                    }
+            try {
+                await this.aiAgentV3Model.finishAssistantMessage({
+                    messageUuid,
+                    status: 'canceled',
+                    tokenUsage: null,
+                    error: null,
+                });
+            } catch (error) {
+                if (
+                    !(error instanceof ConflictError) ||
+                    error.message !== 'Assistant message is frozen'
+                ) {
+                    throw error;
                 }
             }
         } else {
@@ -10013,8 +10416,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 threadUuid: prompt.threadUuid,
                 preflightCanUseRawSql: responseExecution.canUseRawSql,
             }));
-        let canRunSql =
-            enableSqlMode && canUseRawSql && options.v3Run === undefined;
+        let canRunSql = enableSqlMode && canUseRawSql;
         // Fail closed when CASL would evaluate against the installer.
         if (canRunSql && !hasTrustedPromptUserIdentity) {
             this.logger.info(
@@ -10116,6 +10518,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     ? responseExecution.research?.role
                     : undefined,
             ),
+            includeApprovalRequiredTools: options.v3Run !== undefined,
         });
         const { enabled: grepFieldsEnabled } =
             await this.featureFlagService.get({
@@ -10359,6 +10762,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             ...modelProperties,
 
             agentSettings,
+            useNativeToolApproval: options.v3Run !== undefined,
             requestingUser,
             knowledgeDocuments,
             deepResearchRuns,
@@ -10817,6 +11221,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     messageStream.pipeThrough(
                         new TransformStream({
                             transform: async (chunk, controller) => {
+                                await v3Persistence.onUiChunk(chunk);
                                 if (await v3Persistence.waitForUiChunk(chunk)) {
                                     controller.enqueue(chunk);
                                 }

--- a/packages/backend/src/ee/services/AiAgentService/mcpBearerCredential.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/mcpBearerCredential.test.ts
@@ -189,9 +189,12 @@ const buildPreflightService = ({
         getAgentMcpServersWithSensitiveData: vi
             .fn()
             .mockResolvedValue(attachedServers),
-        getEnabledMcpServerToolNames: vi
-            .fn()
-            .mockResolvedValue(['search_issues']),
+        listAgentMcpServerTools: vi.fn().mockResolvedValue([
+            {
+                toolName: 'search_issues',
+                permissionMode: 'always_allow',
+            },
+        ]),
     });
     Object.assign(aiAgentMcpRuntimeClient, {
         attachRuntimeProviders: vi.fn(

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
@@ -36,6 +36,7 @@ const getMcpServer = (
     updatedAt: new Date(),
     resolvedCredential: null,
     resolvedCredentialScope: null,
+    approvalRequiredToolNames: [],
     ...overrides,
 });
 
@@ -270,7 +271,10 @@ describe('resolveMcpTools', () => {
 
     it('keeps healthy MCP tools when another MCP fails', async () => {
         const close = vi.fn().mockResolvedValue(undefined);
-        const healthyServer = getMcpServer({ name: 'Docs MCP' });
+        const healthyServer = getMcpServer({
+            name: 'Docs MCP',
+            approvalRequiredToolNames: ['search'],
+        });
         const brokenServer = getMcpServer({
             uuid: 'broken-server',
             name: 'Broken MCP',
@@ -312,6 +316,9 @@ describe('resolveMcpTools', () => {
         expect(result.mcpToolNameToServerUuid).toEqual({
             mcp_docs_mcp__search: healthyServer.uuid,
         });
+        expect(result.approvalRequiredToolNames).toEqual([
+            'mcp_docs_mcp__search',
+        ]);
         expect(result.unavailableMcpServers).toEqual([
             {
                 serverUuid: 'broken-server',

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
@@ -45,6 +45,7 @@ type Dependencies = {
 export type ResolvedMcpTools = {
     tools: ToolSet;
     mcpToolNameToServerUuid: Record<string, string>;
+    approvalRequiredToolNames: string[];
     unavailableMcpServers: UnavailableMcpServer[];
     closeMcpClients: () => Promise<void>;
 };
@@ -1028,10 +1029,10 @@ export class AiAgentMcpRuntimeClient {
         });
     }
 
-    attachRuntimeProviders(args: {
+    attachRuntimeProviders<T extends AiMcpServerWithSensitiveData>(args: {
         projectUuid: string;
         userUuid: string;
-        mcpServers: AiMcpServerWithSensitiveData[];
+        mcpServers: T[];
     }) {
         return args.mcpServers.map((mcpServer) => ({
             ...mcpServer,
@@ -1159,6 +1160,7 @@ export class AiAgentMcpRuntimeClient {
             return {
                 tools: {},
                 mcpToolNameToServerUuid: {},
+                approvalRequiredToolNames: [],
                 unavailableMcpServers: [],
                 closeMcpClients: async () => undefined,
             };
@@ -1168,6 +1170,7 @@ export class AiAgentMcpRuntimeClient {
         const usedToolNames = new Set<string>();
         const resolvedTools: ToolSet = {};
         const mcpToolNameToServerUuid: Record<string, string> = {};
+        const approvalRequiredToolNames: string[] = [];
         const unavailableMcpServers: UnavailableMcpServer[] = [];
 
         const serverResults = await Promise.all(
@@ -1304,6 +1307,13 @@ export class AiAgentMcpRuntimeClient {
                     usedToolNames.add(namespacedToolName);
                     mcpToolNameToServerUuid[namespacedToolName] =
                         serverResult.mcpServer.uuid;
+                    if (
+                        serverResult.mcpServer.approvalRequiredToolNames.includes(
+                            toolName,
+                        )
+                    ) {
+                        approvalRequiredToolNames.push(namespacedToolName);
+                    }
                     resolvedTools[namespacedToolName] =
                         toolDefinition as ToolSet[string];
                 }
@@ -1313,6 +1323,7 @@ export class AiAgentMcpRuntimeClient {
         return {
             tools: resolvedTools,
             mcpToolNameToServerUuid,
+            approvalRequiredToolNames,
             unavailableMcpServers,
             closeMcpClients: async () => {
                 const results = await Promise.allSettled(

--- a/packages/backend/src/ee/services/ai/AiAgentV3RunPersistence.test.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentV3RunPersistence.test.ts
@@ -27,6 +27,7 @@ const buildModel = () => {
         }),
         finishAssistantMessage: vi.fn(async () => undefined),
         refreshAssistantMessageHeartbeat: vi.fn(async () => true),
+        suspendAssistantMessage: vi.fn(async () => undefined),
     };
 };
 
@@ -76,6 +77,60 @@ it('persists interleaved text, reasoning, and tool chunks in first-seen order', 
     ]);
 });
 
+it('does not copy durable approval metadata back into a tool part', async () => {
+    const model = buildModel();
+    const payload = {
+        state: 'approval-responded',
+        toolName: 'runSql',
+        input: { sql: 'SELECT 1' },
+        approval: {
+            id: 'approval-1',
+            signature: 'signature',
+            approved: true,
+            reason: 'Approved for this query',
+            decidedByUserUuid: 'user-1',
+            decidedAt: '2026-08-06T00:00:00.000Z',
+        },
+    };
+    model.parts.push({ uuid: 'part-0', payload });
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+        undefined,
+        undefined,
+        [
+            {
+                uuid: 'part-0',
+                type: 'tool',
+                payloadVersion: 1,
+                payload,
+                toolCallId: 'call-1',
+                artifactVersionUuid: null,
+            },
+        ],
+    );
+
+    await persistence.onChunk({
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'runSql',
+        output: [{ value: 1 }],
+    });
+
+    expect(model.parts[0]?.payload).toEqual({
+        state: 'output-available',
+        toolName: 'runSql',
+        input: { sql: 'SELECT 1' },
+        output: [{ value: 1 }],
+        approval: {
+            id: 'approval-1',
+            signature: 'signature',
+            approved: true,
+        },
+    });
+});
+
 it('freezes cancellation after queued partial content', async () => {
     const model = buildModel();
     const persistence = new AiAgentV3RunPersistence(
@@ -114,6 +169,51 @@ it('freezes cancellation after queued partial content', async () => {
             status: 'canceled',
             error: null,
             tokenUsage: expect.objectContaining({ totalTokens: 14 }),
+        }),
+    );
+});
+
+it('keeps accumulated resume usage when finish usage is absent', async () => {
+    const model = buildModel();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+        undefined,
+        undefined,
+        [],
+        {
+            version: 1,
+            inputTokens: 10,
+            outputTokens: 4,
+            totalTokens: 14,
+            reasoningTokens: 1,
+            cachedInputTokens: 3,
+        },
+    );
+    persistence.recordUsage({
+        inputTokens: 2,
+        outputTokens: 1,
+        totalTokens: 3,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        inputTokenDetails: {
+            noCacheTokens: undefined,
+            cacheReadTokens: undefined,
+            cacheWriteTokens: undefined,
+        },
+        outputTokenDetails: {
+            textTokens: undefined,
+            reasoningTokens: 0,
+        },
+    });
+    await persistence.onChunk({ type: 'text-delta', id: 't1', text: 'done' });
+
+    await persistence.complete();
+
+    expect(model.finishAssistantMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+            tokenUsage: expect.objectContaining({ totalTokens: 17 }),
         }),
     );
 });
@@ -186,7 +286,7 @@ it('classifies failure from abort state when it is enqueued', async () => {
     );
 });
 
-it('classifies completion from abort state when it is enqueued', async () => {
+it('classifies completion from abort state when it executes', async () => {
     const model = buildModel();
     let canceled = false;
     const persistence = new AiAgentV3RunPersistence(
@@ -205,7 +305,7 @@ it('classifies completion from abort state when it is enqueued', async () => {
     await completed;
 
     expect(model.finishAssistantMessage).toHaveBeenCalledWith(
-        expect.objectContaining({ status: 'completed', error: null }),
+        expect.objectContaining({ status: 'canceled', error: null }),
     );
 });
 
@@ -302,4 +402,238 @@ it('uses stable error names', () => {
             'Too long',
         ).name,
     ).toBe('context_overflow');
+});
+
+it('persists an approval request and suspends without freezing it', async () => {
+    const model = buildModel();
+    const onTerminal = vi.fn();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+        onTerminal,
+    );
+
+    await persistence.onChunk({
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'runSql',
+        input: { sql: 'SELECT 1' },
+    });
+    await persistence.onUiChunk({
+        type: 'tool-approval-request',
+        approvalId: 'approval-1',
+        signature: 'signed-request',
+        toolCallId: 'call-1',
+    });
+    expect(persistence.hasPendingApproval()).toBe(true);
+    await persistence.complete();
+
+    expect(model.parts).toEqual([
+        {
+            uuid: 'part-0',
+            payload: {
+                state: 'approval-requested',
+                toolName: 'runSql',
+                input: { sql: 'SELECT 1' },
+                approval: {
+                    id: 'approval-1',
+                    signature: 'signed-request',
+                },
+            },
+        },
+    ]);
+    expect(model.finishAssistantMessage).not.toHaveBeenCalled();
+    expect(onTerminal).toHaveBeenCalledOnce();
+    expect(model.suspendAssistantMessage).toHaveBeenCalledWith(
+        'assistant',
+        null,
+    );
+});
+
+it('cancels instead of suspending a pending approval after an interrupt', async () => {
+    const model = buildModel();
+    let canceled = false;
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => canceled,
+    );
+
+    await persistence.onChunk({
+        type: 'tool-approval-request',
+        approvalId: 'approval-1',
+        signature: null,
+        toolCall: {
+            toolCallId: 'call-1',
+            toolName: 'runSql',
+            input: { sql: 'SELECT 1' },
+        },
+    });
+    const completed = persistence.complete();
+    canceled = true;
+    await completed;
+
+    expect(model.suspendAssistantMessage).not.toHaveBeenCalled();
+    expect(model.finishAssistantMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'canceled', error: null }),
+    );
+});
+
+it('cancels when interrupted while the pending approval is suspending', async () => {
+    const model = buildModel();
+    let canceled = false;
+    model.suspendAssistantMessage.mockImplementationOnce(async () => {
+        canceled = true;
+    });
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => canceled,
+    );
+
+    await persistence.onChunk({
+        type: 'tool-approval-request',
+        approvalId: 'approval-1',
+        signature: null,
+        toolCall: {
+            toolCallId: 'call-1',
+            toolName: 'runSql',
+            input: { sql: 'SELECT 1' },
+        },
+    });
+    await persistence.complete();
+
+    expect(model.suspendAssistantMessage).toHaveBeenCalledOnce();
+    expect(model.finishAssistantMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'canceled', error: null }),
+    );
+});
+
+it('ignores malformed UI persistence chunks', async () => {
+    const model = buildModel();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+    );
+
+    await persistence.onUiChunk({
+        type: 'tool-approval-request',
+        approvalId: 42,
+        toolCallId: 'call-1',
+    });
+
+    expect(model.appendParts).not.toHaveBeenCalled();
+    expect(model.updatePart).not.toHaveBeenCalled();
+});
+
+it('persists tool execution errors as structured model-visible output', async () => {
+    const model = buildModel();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+    );
+
+    await persistence.onChunk({
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'findExplores',
+        input: { query: 'orders' },
+    });
+    await persistence.onUiChunk({
+        type: 'tool-output-error',
+        toolCallId: 'call-1',
+        errorText: 'Warehouse unavailable',
+        providerMetadata: {
+            anthropic: { opaque: { nested: ['value'] } },
+        },
+    });
+
+    expect(model.parts[0]?.payload).toEqual({
+        state: 'output-error',
+        toolName: 'findExplores',
+        input: { query: 'orders' },
+        error: {
+            name: 'tool_error',
+            message: 'Warehouse unavailable',
+            data: null,
+        },
+        resultProviderMetadata: {
+            anthropic: { opaque: { nested: ['value'] } },
+        },
+    });
+});
+
+it('persists error-status tool results as model-visible errors', async () => {
+    const model = buildModel();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+    );
+
+    await persistence.onChunk({
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'runSql',
+        output: {
+            result: 'relation "missing" does not exist',
+            metadata: { status: 'error' },
+        },
+    });
+
+    expect(model.parts[0]?.payload).toEqual({
+        state: 'output-error',
+        toolName: 'runSql',
+        output: {
+            result: 'relation "missing" does not exist',
+            metadata: { status: 'error' },
+        },
+        error: {
+            name: 'tool_error',
+            message: 'relation "missing" does not exist',
+            data: null,
+        },
+    });
+});
+
+it('preserves reasoning provider metadata losslessly across deltas', async () => {
+    const model = buildModel();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+    );
+
+    await persistence.onUiChunk({
+        type: 'reasoning-start',
+        id: 'reasoning-1',
+        providerMetadata: {
+            anthropic: {
+                signature: 'signature',
+                encryptedContent: { bytes: [0, 255], empty: null },
+            },
+        },
+    });
+    await persistence.onChunk({
+        type: 'reasoning-delta',
+        id: 'reasoning-1',
+        text: 'visible',
+    });
+    await persistence.onUiChunk({
+        type: 'reasoning-end',
+        id: 'reasoning-1',
+        providerMetadata: {
+            openai: { itemId: 'reasoning-item' },
+        },
+    });
+
+    expect(model.parts[0]?.payload).toEqual({
+        text: 'visible',
+        providerMetadata: {
+            openai: { itemId: 'reasoning-item' },
+        },
+    });
 });

--- a/packages/backend/src/ee/services/ai/AiAgentV3RunPersistence.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentV3RunPersistence.ts
@@ -1,6 +1,7 @@
-import { ConflictError } from '@lightdash/common';
+import { assertUnreachable, ConflictError } from '@lightdash/common';
 import { APICallError, type LanguageModelUsage } from 'ai';
 import {
+    type AiCanonicalPart,
     type AiRunErrorEnvelope,
     type AiTokenUsageEnvelope,
     type AiV3PartWrite,
@@ -16,6 +17,11 @@ type PersistedPart = {
 };
 
 type StreamChunk =
+    | {
+          type: 'text-start' | 'text-end' | 'reasoning-start' | 'reasoning-end';
+          id: string;
+          providerMetadata?: Record<string, unknown>;
+      }
     | {
           type: 'text-delta' | 'reasoning-delta';
           id: string;
@@ -38,6 +44,11 @@ type StreamChunk =
           providerMetadata?: Record<string, unknown>;
       }
     | {
+          type: 'tool-input-end';
+          id: string;
+          providerMetadata?: Record<string, unknown>;
+      }
+    | {
           type: 'tool-call';
           toolCallId: string;
           toolName: string;
@@ -56,8 +67,108 @@ type StreamChunk =
           providerMetadata?: Record<string, unknown>;
           preliminary?: boolean;
       }
+    | {
+          type: 'tool-error';
+          toolCallId: string;
+          toolName: string;
+          input: unknown;
+          error: unknown;
+          providerMetadata?: Record<string, unknown>;
+          providerExecuted?: boolean;
+          dynamic?: boolean;
+          title?: string;
+      }
+    | {
+          type: 'tool-approval-request';
+          approvalId: string;
+          signature: string | null;
+          toolCall: {
+              toolCallId: string;
+              toolName: string;
+              input: unknown;
+              providerMetadata?: Record<string, unknown>;
+              providerExecuted?: boolean;
+              dynamic?: boolean;
+          };
+      }
     | ({ type: 'source' } & Record<string, unknown>)
     | { type: 'raw'; rawValue: unknown };
+
+type UiPersistenceChunk =
+    | Extract<
+          StreamChunk,
+          {
+              type:
+                  | 'text-start'
+                  | 'text-end'
+                  | 'reasoning-start'
+                  | 'reasoning-end';
+          }
+      >
+    | {
+          type: 'tool-approval-request';
+          approvalId: string;
+          toolCallId: string;
+          signature: string | null;
+      }
+    | {
+          type: 'tool-output-error';
+          toolCallId: string;
+          errorText: string;
+          providerMetadata?: Record<string, unknown>;
+          providerExecuted?: boolean;
+          dynamic?: boolean;
+          title?: string;
+      };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null;
+
+const withoutDurableApprovalMetadata = (
+    payload: Record<string, unknown>,
+): Record<string, unknown> => {
+    if (!isRecord(payload.approval)) return payload;
+    const {
+        reason: _reason,
+        decidedByUserUuid: _decidedByUserUuid,
+        decidedAt: _decidedAt,
+        ...approval
+    } = payload.approval;
+    return { ...payload, approval };
+};
+
+const isUiPersistenceChunk = (value: unknown): value is UiPersistenceChunk => {
+    if (!isRecord(value) || typeof value.type !== 'string') return false;
+    const hasProviderMetadata =
+        value.providerMetadata === undefined ||
+        isRecord(value.providerMetadata);
+    switch (value.type) {
+        case 'text-start':
+        case 'text-end':
+        case 'reasoning-start':
+        case 'reasoning-end':
+            return typeof value.id === 'string' && hasProviderMetadata;
+        case 'tool-approval-request':
+            return (
+                typeof value.approvalId === 'string' &&
+                typeof value.toolCallId === 'string' &&
+                (value.signature == null || typeof value.signature === 'string')
+            );
+        case 'tool-output-error':
+            return (
+                typeof value.toolCallId === 'string' &&
+                typeof value.errorText === 'string' &&
+                hasProviderMetadata &&
+                (value.providerExecuted === undefined ||
+                    typeof value.providerExecuted === 'boolean') &&
+                (value.dynamic === undefined ||
+                    typeof value.dynamic === 'boolean') &&
+                (value.title === undefined || typeof value.title === 'string')
+            );
+        default:
+            return false;
+    }
+};
 
 type Model = Pick<
     AiAgentV3Model,
@@ -65,9 +176,82 @@ type Model = Pick<
     | 'updatePart'
     | 'finishAssistantMessage'
     | 'refreshAssistantMessageHeartbeat'
+    | 'suspendAssistantMessage'
 >;
 
 const UI_CHUNK_ACK_TIMEOUT_MS = 30_000;
+
+type ToolPartMetadata = {
+    providerMetadata?: Record<string, unknown>;
+    providerExecuted?: boolean;
+    dynamic?: boolean;
+    title?: string;
+};
+
+const toolPartMetadata = (
+    chunk: ToolPartMetadata,
+    providerMetadataKey:
+        | 'providerMetadata'
+        | 'resultProviderMetadata' = 'providerMetadata',
+): Record<string, unknown> => ({
+    ...(chunk.providerMetadata
+        ? { [providerMetadataKey]: chunk.providerMetadata }
+        : {}),
+    ...(chunk.providerExecuted !== undefined
+        ? { providerExecuted: chunk.providerExecuted }
+        : {}),
+    ...(chunk.dynamic !== undefined ? { dynamic: chunk.dynamic } : {}),
+    ...(chunk.title ? { title: chunk.title } : {}),
+});
+
+const toolErrorData = (error: Record<string, unknown>) =>
+    typeof error.code === 'string' || typeof error.code === 'number'
+        ? { code: error.code }
+        : null;
+
+const structuredToolError = (error: unknown) => {
+    if (error instanceof Error) {
+        return {
+            name: error.name || 'tool_error',
+            message: error.message,
+            data: toolErrorData(error as Error & Record<string, unknown>),
+        };
+    }
+    if (typeof error === 'object' && error !== null) {
+        const value = error as Record<string, unknown>;
+        return {
+            name: typeof value.name === 'string' ? value.name : 'tool_error',
+            message:
+                typeof value.message === 'string'
+                    ? value.message
+                    : 'Tool execution failed',
+            data: toolErrorData(value),
+        };
+    }
+    return {
+        name: 'tool_error',
+        message: typeof error === 'string' ? error : 'Tool execution failed',
+        data: null,
+    };
+};
+
+const toolOutputError = (output: unknown) => {
+    if (typeof output !== 'object' || output === null) return null;
+    const value = output as Record<string, unknown>;
+    const { metadata, result } = value;
+    if (
+        typeof metadata !== 'object' ||
+        metadata === null ||
+        (metadata as Record<string, unknown>).status !== 'error'
+    ) {
+        return null;
+    }
+    return {
+        name: 'tool_error',
+        message: typeof result === 'string' ? result : 'Tool execution failed',
+        data: null,
+    };
+};
 
 const usageEnvelope = (
     usage: LanguageModelUsage | undefined,
@@ -82,6 +266,24 @@ const usageEnvelope = (
               cachedInputTokens: usage.cachedInputTokens ?? null,
           }
         : null;
+
+const sumUsage = (
+    left: AiTokenUsageEnvelope | null,
+    right: AiTokenUsageEnvelope | null,
+): AiTokenUsageEnvelope | null => {
+    if (!left) return right;
+    if (!right) return left;
+    const sum = (a: number | null, b: number | null) =>
+        a === null && b === null ? null : (a ?? 0) + (b ?? 0);
+    return {
+        version: 1,
+        inputTokens: sum(left.inputTokens, right.inputTokens),
+        outputTokens: sum(left.outputTokens, right.outputTokens),
+        totalTokens: sum(left.totalTokens, right.totalTokens),
+        reasoningTokens: sum(left.reasoningTokens, right.reasoningTokens),
+        cachedInputTokens: sum(left.cachedInputTokens, right.cachedInputTokens),
+    };
+};
 
 export const getAiRunErrorEnvelope = (
     error: unknown,
@@ -115,7 +317,13 @@ export class AiAgentV3RunPersistence {
 
     private heartbeat: ReturnType<typeof setInterval> | undefined;
 
+    private heartbeatUpdate: Promise<void> | undefined;
+
     private tokenUsage: AiTokenUsageEnvelope | null = null;
+
+    private readonly initialTokenUsage: AiTokenUsageEnvelope | null;
+
+    private pendingApproval = false;
 
     private resolveTerminal!: () => void;
 
@@ -136,7 +344,24 @@ export class AiAgentV3RunPersistence {
         private readonly isCanceled: () => boolean,
         private readonly onTerminal?: () => void,
         private readonly onFrozen?: () => void,
-    ) {}
+        initialParts: AiCanonicalPart[] = [],
+        initialTokenUsage: AiTokenUsageEnvelope | null = null,
+    ) {
+        this.initialTokenUsage = initialTokenUsage;
+        this.tokenUsage = initialTokenUsage;
+        this.nextPartIndex = initialParts.length;
+        initialParts.forEach((part, partIndex) => {
+            if (part.type === 'tool' && part.toolCallId) {
+                this.parts.set(part.toolCallId, {
+                    uuid: part.uuid,
+                    partIndex,
+                    type: 'tool',
+                    toolCallId: part.toolCallId,
+                    payload: withoutDurableApprovalMetadata(part.payload),
+                });
+            }
+        });
+    }
 
     private markTerminal(): void {
         if (this.terminal) return;
@@ -214,41 +439,36 @@ export class AiAgentV3RunPersistence {
     recordUsage(usage: LanguageModelUsage): void {
         const next = usageEnvelope(usage);
         if (!next) return;
-        const previous = this.tokenUsage;
-        const sum = (left: number | null, right: number | null) =>
-            left === null && right === null ? null : (left ?? 0) + (right ?? 0);
-        this.tokenUsage = previous
-            ? {
-                  version: 1,
-                  inputTokens: sum(previous.inputTokens, next.inputTokens),
-                  outputTokens: sum(previous.outputTokens, next.outputTokens),
-                  totalTokens: sum(previous.totalTokens, next.totalTokens),
-                  reasoningTokens: sum(
-                      previous.reasoningTokens,
-                      next.reasoningTokens,
-                  ),
-                  cachedInputTokens: sum(
-                      previous.cachedInputTokens,
-                      next.cachedInputTokens,
-                  ),
-              }
-            : next;
+        this.tokenUsage = sumUsage(this.tokenUsage, next);
+    }
+
+    hasPendingApproval(): boolean {
+        return this.pendingApproval;
     }
 
     startHeartbeat(intervalMs: number): void {
         this.heartbeat = setInterval(() => {
-            void this.model
+            if (this.heartbeatUpdate) return;
+            this.heartbeatUpdate = this.model
                 .refreshAssistantMessageHeartbeat(this.messageUuid)
                 .then((updated) => {
                     if (!updated) this.stopHeartbeat();
                 })
-                .catch(() => this.stopHeartbeat());
+                .catch(() => this.stopHeartbeat())
+                .finally(() => {
+                    this.heartbeatUpdate = undefined;
+                });
         }, intervalMs);
     }
 
     private stopHeartbeat(): void {
         if (this.heartbeat) clearInterval(this.heartbeat);
         this.heartbeat = undefined;
+    }
+
+    private async stopHeartbeatAndWait(): Promise<void> {
+        this.stopHeartbeat();
+        await this.heartbeatUpdate;
     }
 
     private enqueue(operation: () => Promise<void>): Promise<void> {
@@ -319,6 +539,18 @@ export class AiAgentV3RunPersistence {
         if (stored) stored.payload = payload;
     }
 
+    private async upsertToolPart(
+        toolCallId: string,
+        payload: Record<string, unknown>,
+    ): Promise<void> {
+        const part = this.parts.get(toolCallId);
+        if (part) {
+            await this.updatePart(part, payload);
+        } else {
+            await this.createPart(toolCallId, 'tool', payload, toolCallId);
+        }
+    }
+
     async onChunk(value: unknown): Promise<void> {
         const chunk = value as StreamChunk;
         const ackKey = AiAgentV3RunPersistence.chunkAckKey(chunk);
@@ -327,6 +559,18 @@ export class AiAgentV3RunPersistence {
             await this.enqueue(async () => {
                 if (this.terminal) return;
                 switch (chunk.type) {
+                    case 'text-start':
+                    case 'reasoning-start': {
+                        const type =
+                            chunk.type === 'text-start' ? 'text' : 'reasoning';
+                        await this.createPart(chunk.id, type, {
+                            text: '',
+                            ...(chunk.providerMetadata
+                                ? { providerMetadata: chunk.providerMetadata }
+                                : {}),
+                        });
+                        return;
+                    }
                     case 'text-delta':
                     case 'reasoning-delta': {
                         const type =
@@ -344,6 +588,16 @@ export class AiAgentV3RunPersistence {
                         persisted = true;
                         return;
                     }
+                    case 'text-end':
+                    case 'reasoning-end': {
+                        const part = this.parts.get(chunk.id);
+                        if (!part || !chunk.providerMetadata) return;
+                        await this.updatePart(part, {
+                            ...part.payload,
+                            providerMetadata: chunk.providerMetadata,
+                        });
+                        return;
+                    }
                     case 'tool-input-start': {
                         await this.createPart(
                             chunk.id,
@@ -352,22 +606,7 @@ export class AiAgentV3RunPersistence {
                                 state: 'input-streaming',
                                 toolName: chunk.toolName,
                                 rawInput: '',
-                                ...(chunk.providerMetadata
-                                    ? {
-                                          providerMetadata:
-                                              chunk.providerMetadata,
-                                      }
-                                    : {}),
-                                ...(chunk.providerExecuted !== undefined
-                                    ? {
-                                          providerExecuted:
-                                              chunk.providerExecuted,
-                                      }
-                                    : {}),
-                                ...(chunk.dynamic !== undefined
-                                    ? { dynamic: chunk.dynamic }
-                                    : {}),
-                                ...(chunk.title ? { title: chunk.title } : {}),
+                                ...toolPartMetadata(chunk),
                             },
                             chunk.id,
                         );
@@ -385,6 +624,15 @@ export class AiAgentV3RunPersistence {
                         });
                         return;
                     }
+                    case 'tool-input-end': {
+                        const part = this.parts.get(chunk.id);
+                        if (!part || !chunk.providerMetadata) return;
+                        await this.updatePart(part, {
+                            ...part.payload,
+                            providerMetadata: chunk.providerMetadata,
+                        });
+                        return;
+                    }
                     case 'tool-call': {
                         const part = this.parts.get(chunk.toolCallId);
                         const payload = chunk.invalid
@@ -392,6 +640,8 @@ export class AiAgentV3RunPersistence {
                                   state: 'output-error',
                                   toolName: chunk.toolName,
                                   input: chunk.input,
+                                  invalid: true,
+                                  rawInput: chunk.input,
                                   error: {
                                       name: 'invalid_tool_call',
                                       message:
@@ -410,45 +660,66 @@ export class AiAgentV3RunPersistence {
                               };
                         const enriched = {
                             ...payload,
-                            ...(chunk.providerMetadata
-                                ? { providerMetadata: chunk.providerMetadata }
-                                : {}),
-                            ...(chunk.providerExecuted !== undefined
-                                ? { providerExecuted: chunk.providerExecuted }
-                                : {}),
-                            ...(chunk.dynamic !== undefined
-                                ? { dynamic: chunk.dynamic }
-                                : {}),
+                            ...toolPartMetadata(chunk),
                         };
-                        if (part) await this.updatePart(part, enriched);
-                        else
-                            await this.createPart(
-                                chunk.toolCallId,
-                                'tool',
-                                enriched,
-                                chunk.toolCallId,
-                            );
+                        await this.upsertToolPart(chunk.toolCallId, enriched);
+                        return;
+                    }
+                    case 'tool-approval-request': {
+                        const { toolCall } = chunk;
+                        const part = this.parts.get(toolCall.toolCallId);
+                        const payload = {
+                            ...(part?.payload ?? {
+                                toolName: toolCall.toolName,
+                                input: toolCall.input,
+                            }),
+                            state: 'approval-requested',
+                            approval: {
+                                id: chunk.approvalId,
+                                ...(chunk.signature
+                                    ? { signature: chunk.signature }
+                                    : {}),
+                            },
+                            ...toolPartMetadata(toolCall),
+                        };
+                        await this.upsertToolPart(toolCall.toolCallId, payload);
+                        this.pendingApproval = true;
                         return;
                     }
                     case 'tool-result': {
                         if (chunk.preliminary) return;
                         const part = this.parts.get(chunk.toolCallId);
+                        const error = toolOutputError(chunk.output);
                         const payload = {
                             ...(part?.payload ?? { toolName: chunk.toolName }),
-                            state: 'output-available',
+                            state: error ? 'output-error' : 'output-available',
                             output: chunk.output,
+                            ...(error ? { error } : {}),
                             ...(chunk.providerMetadata
-                                ? { providerMetadata: chunk.providerMetadata }
+                                ? {
+                                      resultProviderMetadata:
+                                          chunk.providerMetadata,
+                                  }
                                 : {}),
                         };
-                        if (part) await this.updatePart(part, payload);
-                        else
-                            await this.createPart(
-                                chunk.toolCallId,
-                                'tool',
-                                payload,
-                                chunk.toolCallId,
-                            );
+                        await this.upsertToolPart(chunk.toolCallId, payload);
+                        return;
+                    }
+                    case 'tool-error': {
+                        const part = this.parts.get(chunk.toolCallId);
+                        const payload = {
+                            ...(part?.payload ?? {
+                                toolName: chunk.toolName,
+                                input: chunk.input,
+                            }),
+                            state: 'output-error',
+                            error: structuredToolError(chunk.error),
+                            ...toolPartMetadata(
+                                chunk,
+                                'resultProviderMetadata',
+                            ),
+                        };
+                        await this.upsertToolPart(chunk.toolCallId, payload);
                         return;
                     }
                     case 'source': {
@@ -471,6 +742,54 @@ export class AiAgentV3RunPersistence {
         }
     }
 
+    async onUiChunk(value: unknown): Promise<void> {
+        if (!isUiPersistenceChunk(value)) return;
+        const chunk = value;
+        switch (chunk.type) {
+            case 'text-start':
+            case 'text-end':
+            case 'reasoning-start':
+            case 'reasoning-end':
+                await this.onChunk(chunk);
+                return;
+            case 'tool-approval-request': {
+                const part = this.parts.get(chunk.toolCallId);
+                const toolName = part?.payload.toolName;
+                if (!part || typeof toolName !== 'string') return;
+                await this.onChunk({
+                    type: 'tool-approval-request',
+                    approvalId: chunk.approvalId,
+                    signature: chunk.signature ?? null,
+                    toolCall: {
+                        toolCallId: chunk.toolCallId,
+                        toolName,
+                        input: part.payload.input,
+                    },
+                });
+                return;
+            }
+            case 'tool-output-error': {
+                const part = this.parts.get(chunk.toolCallId);
+                const toolName = part?.payload.toolName;
+                if (!part || typeof toolName !== 'string') return;
+                await this.onChunk({
+                    type: 'tool-error',
+                    toolCallId: chunk.toolCallId,
+                    toolName,
+                    input: part.payload.input,
+                    error: chunk.errorText,
+                    providerMetadata: chunk.providerMetadata,
+                    providerExecuted: chunk.providerExecuted,
+                    dynamic: chunk.dynamic,
+                    title: chunk.title,
+                });
+                return;
+            }
+            default:
+                return assertUnreachable(chunk, 'Unknown UI chunk');
+        }
+    }
+
     async appendArtifact(artifactVersionUuid: string): Promise<void> {
         return this.enqueue(async () => {
             if (this.terminal) return;
@@ -485,14 +804,44 @@ export class AiAgentV3RunPersistence {
     }
 
     async complete(usage?: LanguageModelUsage): Promise<void> {
-        const canceled = this.isCanceled();
         return this.enqueue(async () => {
             if (this.terminal) return;
+            if (this.pendingApproval) {
+                await this.stopHeartbeatAndWait();
+                if (this.isCanceled()) {
+                    await this.model.finishAssistantMessage({
+                        messageUuid: this.messageUuid,
+                        status: 'canceled',
+                        tokenUsage: this.tokenUsage,
+                        error: null,
+                    });
+                    this.markTerminal();
+                    return;
+                }
+                await this.model.suspendAssistantMessage(
+                    this.messageUuid,
+                    this.tokenUsage,
+                );
+                if (this.isCanceled()) {
+                    await this.model.finishAssistantMessage({
+                        messageUuid: this.messageUuid,
+                        status: 'canceled',
+                        tokenUsage: this.tokenUsage,
+                        error: null,
+                    });
+                }
+                this.markTerminal();
+                return;
+            }
             try {
+                const canceled = this.isCanceled();
+                const finalUsage = usage
+                    ? sumUsage(this.initialTokenUsage, usageEnvelope(usage))
+                    : this.tokenUsage;
                 await this.model.finishAssistantMessage({
                     messageUuid: this.messageUuid,
                     status: canceled ? 'canceled' : 'completed',
-                    tokenUsage: usageEnvelope(usage) ?? this.tokenUsage,
+                    tokenUsage: finalUsage,
                     error: null,
                 });
             } finally {

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -22,8 +22,27 @@ import {
     recordAgentStepUsage,
     storeInvalidAgentToolCall,
     withEarlyToolProgress,
+    withMcpToolApprovals,
     type AgentMcpToolSetup,
 } from './agentV2';
+
+describe('withMcpToolApprovals', () => {
+    it('gates only ask-mode MCP tools on v3 runs', () => {
+        const tools = {
+            safe: { description: 'safe' },
+            destructive: { description: 'destructive' },
+        } as never;
+
+        expect(withMcpToolApprovals(tools, ['destructive'], true)).toEqual({
+            safe: { description: 'safe' },
+            destructive: {
+                description: 'destructive',
+                needsApproval: true,
+            },
+        });
+        expect(withMcpToolApprovals(tools, ['destructive'], false)).toBe(tools);
+    });
+});
 
 vi.mock('ai', async (importOriginal) => ({
     ...(await importOriginal<typeof import('ai')>()),
@@ -114,6 +133,7 @@ describe('generateAgentResponse error persistence', () => {
                 mcpToolSetup: {
                     tools: {},
                     mcpToolNameToServerUuid: {},
+                    approvalRequiredToolNames: [],
                     unavailableMcpServers: [],
                     closeMcpClients: vi.fn().mockResolvedValue(undefined),
                 },
@@ -464,6 +484,7 @@ describe('buildDeepResearchExecutionContextSnapshot', () => {
                 mcpToolNameToServerUuid: {
                     mcp_github__search_issues: 'mcp-1',
                 },
+                approvalRequiredToolNames: [],
                 unavailableMcpServers: [],
                 closeMcpClients: () => Promise.resolve(),
             },
@@ -615,6 +636,7 @@ describe('getAgentTools workstream tool gate', () => {
     const mcpStub: AgentMcpToolSetup = {
         tools: {},
         mcpToolNameToServerUuid: {},
+        approvalRequiredToolNames: [],
         unavailableMcpServers: [],
         closeMcpClients: () => Promise.resolve(),
     };

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -105,6 +105,7 @@ import {
 import { getDiscoverFields } from './discoverFields/tool';
 import { getMcpActiveTools } from './mcpToolGating';
 import { buildQueryRetryStepOverride } from './queryRetryCap';
+import { extractPendingToolApprovals } from './sqlApprovalSuspend';
 import { getAgentTelemetryConfig, getAiAgentModelName } from './telemetry';
 
 const createAiAgentLogger =
@@ -296,8 +297,26 @@ const withPreGrepCandidates = (
 export type AgentMcpToolSetup = {
     tools: ToolSet;
     mcpToolNameToServerUuid: Record<string, string>;
+    approvalRequiredToolNames: string[];
     unavailableMcpServers: UnavailableMcpServer[];
     closeMcpClients: () => Promise<void>;
+};
+
+export const withMcpToolApprovals = (
+    tools: ToolSet,
+    approvalRequiredToolNames: string[],
+    enabled: boolean,
+): ToolSet => {
+    if (!enabled || approvalRequiredToolNames.length === 0) return tools;
+    const approvalRequired = new Set(approvalRequiredToolNames);
+    return Object.fromEntries(
+        Object.entries(tools).map(([toolName, definition]) => [
+            toolName,
+            approvalRequired.has(toolName)
+                ? { ...definition, needsApproval: true }
+                : definition,
+        ]),
+    ) as ToolSet;
 };
 
 export const buildDeepResearchExecutionContextSnapshot = (
@@ -804,6 +823,7 @@ export const getAgentTools = (
               autoApproveSql: args.autoApproveSql,
               autoApproveSqlUserUuid: args.autoApproveSqlUserUuid,
               useSlackStreamCard: args.useSlackStreamCard,
+              useNativeToolApproval: args.useNativeToolApproval === true,
           })
         : null;
 
@@ -1061,7 +1081,14 @@ export const getAgentTools = (
         ...(loadMcpTools ? { loadMcpTools } : {}),
     };
 
-    const mergedTools = { ...tools, ...mcpTools };
+    // Filter first, then mark approvals, so a tool the run cannot use never
+    // shows up as an approval request.
+    const mcpToolsWithApprovals = withMcpToolApprovals(
+        mcpTools,
+        mcpToolSetup.approvalRequiredToolNames,
+        Boolean(dependencies.streamPersistence),
+    );
+    const mergedTools = { ...tools, ...mcpToolsWithApprovals };
 
     // Deep-research roles reshape the toolset: the coordinator gains delegation,
     // and a worker is cut down to the warehouse tools its one task needs so the
@@ -2047,6 +2074,29 @@ export const streamAgentResponse = async ({
                     .join('\n');
 
                 const stepCapReached = steps.length >= args.execution.maxSteps;
+                await Promise.all(
+                    steps
+                        .flatMap((step) => step.content)
+                        .filter((part) => part.type === 'tool-error')
+                        .map((part) =>
+                            dependencies.streamPersistence?.onChunk(part),
+                        ),
+                );
+                const pendingApprovals = extractPendingToolApprovals(steps);
+                await Promise.all(
+                    pendingApprovals.map((approval) =>
+                        dependencies.streamPersistence?.onChunk({
+                            type: 'tool-approval-request',
+                            approvalId: approval.approvalId,
+                            signature: approval.signature,
+                            toolCall: {
+                                toolCallId: approval.toolCallId,
+                                toolName: approval.toolName,
+                                input: approval.input,
+                            },
+                        }),
+                    ),
+                );
 
                 // The AI SDK holds the stream open until onFinish resolves, so
                 // the HTTP stream only closes once the response is persisted —
@@ -2055,7 +2105,9 @@ export const streamAgentResponse = async ({
                 // or an error message — a blank response with no error renders
                 // as an empty chat bubble with no explanation. trim() matters:
                 // steps with empty text still join into "\n" strings.
-                if (!completeResponse.trim()) {
+                if (dependencies.streamPersistence?.hasPendingApproval()) {
+                    await dependencies.streamPersistence.complete(totalUsage);
+                } else if (!completeResponse.trim()) {
                     const emptyResponseError = stepCapReached
                         ? new AiAgentStepCapReachedError(steps.length)
                         : new AiAgentEmptyResponseError(

--- a/packages/backend/src/ee/services/ai/agents/sqlApprovalSuspend.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/sqlApprovalSuspend.test.ts
@@ -1,5 +1,5 @@
 import {
-    extractPendingSqlApprovals,
+    extractPendingToolApprovals,
     sqlApprovalId,
 } from './sqlApprovalSuspend';
 
@@ -20,9 +20,10 @@ describe('SQL approval (native needsApproval)', () => {
             { content: [{ type: 'text' }] },
             { content: [approvalRequest('tc1', 'SELECT 1')] },
         ];
-        expect(extractPendingSqlApprovals(steps)).toEqual([
+        expect(extractPendingToolApprovals(steps)).toEqual([
             {
                 approvalId: 'sql-approval:tc1',
+                signature: null,
                 toolCallId: 'tc1',
                 toolName: 'runSql',
                 input: { sql: 'SELECT 1' },
@@ -32,9 +33,9 @@ describe('SQL approval (native needsApproval)', () => {
 
     it('returns empty when no approval request is present', () => {
         expect(
-            extractPendingSqlApprovals([{ content: [{ type: 'tool-call' }] }]),
+            extractPendingToolApprovals([{ content: [{ type: 'tool-call' }] }]),
         ).toEqual([]);
-        expect(extractPendingSqlApprovals([{ content: null }])).toEqual([]);
-        expect(extractPendingSqlApprovals([])).toEqual([]);
+        expect(extractPendingToolApprovals([{ content: null }])).toEqual([]);
+        expect(extractPendingToolApprovals([])).toEqual([]);
     });
 });

--- a/packages/backend/src/ee/services/ai/agents/sqlApprovalSuspend.ts
+++ b/packages/backend/src/ee/services/ai/agents/sqlApprovalSuspend.ts
@@ -1,19 +1,10 @@
-// Native AI-SDK human-in-the-loop for SQL approval. runSql declares
-// `needsApproval` on the modern Slack path: the SDK halts before executing and
-// emits a `tool-approval-request`, ending the run so the worker can be released.
-// A resume job rebuilds history with a matching `tool-approval-response` and the
-// SDK executes runSql itself.
-//
-// Because we reconstruct the message history ourselves, the approvalId is
-// derived deterministically from the toolCallId — request and response always
-// match without persisting the SDK's original id.
-
 export const sqlApprovalId = (toolCallId: string): string =>
     `sql-approval:${toolCallId}`;
 
 type ApprovalRequestPart = {
     type: 'tool-approval-request';
     approvalId: string;
+    signature: string | null;
     toolCall: {
         toolCallId: string;
         toolName: string;
@@ -25,8 +16,9 @@ type StepLike = {
     content?: ReadonlyArray<{ type?: string } | null> | null;
 };
 
-export type PendingSqlApproval = {
+export type PendingToolApproval = {
     approvalId: string;
+    signature: string | null;
     toolCallId: string;
     toolName: string;
     input: unknown;
@@ -38,15 +30,16 @@ const isApprovalRequestPart = (
 
 // Pulls pending tool-approval-requests out of a generateText result's steps.
 // When non-empty, the run suspended awaiting approval rather than finishing.
-export const extractPendingSqlApprovals = (
+export const extractPendingToolApprovals = (
     steps: ReadonlyArray<StepLike>,
-): PendingSqlApproval[] => {
-    const pending: PendingSqlApproval[] = [];
+): PendingToolApproval[] => {
+    const pending: PendingToolApproval[] = [];
     for (const step of steps) {
         for (const part of step.content ?? []) {
             if (isApprovalRequestPart(part)) {
                 pending.push({
                     approvalId: part.approvalId,
+                    signature: part.signature ?? null,
                     toolCallId: part.toolCall.toolCallId,
                     toolName: part.toolCall.toolName,
                     input: part.toolCall.input,

--- a/packages/backend/src/ee/services/ai/models/types.ts
+++ b/packages/backend/src/ee/services/ai/models/types.ts
@@ -8,6 +8,17 @@ import { AiCallAttribution } from '../utils/aiCallTelemetry';
 
 export type AiProvider = keyof AiCopilotConfigSchemaType['providers'];
 
+const AI_PROVIDERS = {
+    openai: true,
+    azure: true,
+    anthropic: true,
+    openrouter: true,
+    bedrock: true,
+} as const satisfies Record<AiProvider, true>;
+
+export const isAiProvider = (provider: string): provider is AiProvider =>
+    Object.prototype.hasOwnProperty.call(AI_PROVIDERS, provider);
+
 export type ProviderOptionsMap = {
     openai: OpenAIResponsesProviderOptions;
     azure: OpenAIResponsesProviderOptions;

--- a/packages/backend/src/ee/services/ai/projectV3ThreadToModelMessages.test.ts
+++ b/packages/backend/src/ee/services/ai/projectV3ThreadToModelMessages.test.ts
@@ -1,6 +1,10 @@
 import { expect, it } from 'vitest';
 import { type AiCanonicalThread } from '../../database/entities/aiAgentV3';
-import { projectV3ThreadToModelMessages } from './projectV3ThreadToModelMessages';
+import {
+    getV3MessageRunOptions,
+    getV3TriggeringUserMessage,
+    projectV3ThreadToModelMessages,
+} from './projectV3ThreadToModelMessages';
 
 const thread = (
     messages: AiCanonicalThread['messages'],
@@ -30,6 +34,67 @@ const metadata = {
     context: [],
     legacy: null,
 };
+
+it('reads only valid persisted tool hints', () => {
+    const message = thread([
+        {
+            uuid: 'user',
+            role: 'user',
+            metadata,
+            parts: [
+                {
+                    uuid: 'user-text',
+                    type: 'text',
+                    payloadVersion: 1,
+                    payload: {
+                        text: 'question',
+                        toolHints: ['runSql', 'findExplores'],
+                        enableSqlMode: true,
+                    },
+                    toolCallId: null,
+                    artifactVersionUuid: null,
+                },
+            ],
+        },
+    ]).messages[0];
+
+    expect(getV3MessageRunOptions(message)).toEqual({
+        toolHints: ['runSql', 'findExplores'],
+        enableSqlMode: true,
+    });
+    if (message) message.parts[0]!.payload.toolHints = ['runSql', 1];
+    expect(getV3MessageRunOptions(message)).toEqual({
+        toolHints: [],
+        enableSqlMode: true,
+    });
+});
+
+it('finds the user message that triggered an assistant before later steers', () => {
+    const { messages } = thread([
+        {
+            uuid: 'trigger',
+            role: 'user',
+            metadata,
+            parts: [],
+        },
+        {
+            uuid: 'assistant',
+            role: 'assistant',
+            metadata: { ...metadata, status: 'in_progress' },
+            parts: [],
+        },
+        {
+            uuid: 'steer',
+            role: 'user',
+            metadata,
+            parts: [],
+        },
+    ]);
+
+    expect(getV3TriggeringUserMessage(messages, 'assistant')?.uuid).toBe(
+        'trigger',
+    );
+});
 
 it('replays persisted text and tool activity without system messages', () => {
     expect(
@@ -155,4 +220,263 @@ it('does not replay an in-progress assistant message', () => {
             ]),
         ),
     ).toEqual([]);
+});
+
+it('lowers approval decisions and tool errors to model-visible messages', () => {
+    expect(
+        projectV3ThreadToModelMessages(
+            thread([
+                {
+                    uuid: 'assistant',
+                    role: 'assistant',
+                    metadata: { ...metadata, status: 'completed' },
+                    parts: [
+                        {
+                            uuid: 'denied-tool',
+                            type: 'tool',
+                            payloadVersion: 1,
+                            payload: {
+                                state: 'output-denied',
+                                toolName: 'runSql',
+                                input: { sql: 'SELECT 1' },
+                                approval: {
+                                    id: 'approval-1',
+                                    approved: false,
+                                    reason: 'Denied by user',
+                                },
+                            },
+                            toolCallId: 'call-1',
+                            artifactVersionUuid: null,
+                        },
+                        {
+                            uuid: 'failed-tool',
+                            type: 'tool',
+                            payloadVersion: 1,
+                            payload: {
+                                state: 'output-error',
+                                toolName: 'findExplores',
+                                input: { query: 42 },
+                                error: {
+                                    name: 'invalid_tool_call',
+                                    message: 'Expected a string',
+                                    data: { rawInput: '{"query":42}' },
+                                },
+                            },
+                            toolCallId: 'call-2',
+                            artifactVersionUuid: null,
+                        },
+                    ],
+                },
+            ]),
+            {
+                modelProvider: 'anthropic',
+                includeInProgressMessageUuid: null,
+            },
+        ),
+    ).toEqual([
+        {
+            role: 'assistant',
+            content: [
+                expect.objectContaining({
+                    type: 'tool-call',
+                    toolCallId: 'call-1',
+                }),
+                {
+                    type: 'tool-approval-request',
+                    approvalId: 'approval-1',
+                    toolCallId: 'call-1',
+                },
+            ],
+        },
+        {
+            role: 'tool',
+            content: [
+                {
+                    type: 'tool-approval-response',
+                    approvalId: 'approval-1',
+                    approved: false,
+                    reason: 'Denied by user',
+                    providerExecuted: undefined,
+                },
+                {
+                    type: 'tool-result',
+                    toolCallId: 'call-1',
+                    toolName: 'runSql',
+                    output: {
+                        type: 'execution-denied',
+                        reason: 'Denied by user',
+                    },
+                    providerOptions: undefined,
+                },
+            ],
+        },
+        {
+            role: 'assistant',
+            content: [
+                expect.objectContaining({
+                    type: 'tool-call',
+                    toolCallId: 'call-2',
+                }),
+            ],
+        },
+        {
+            role: 'tool',
+            content: [
+                {
+                    type: 'tool-result',
+                    toolCallId: 'call-2',
+                    toolName: 'findExplores',
+                    output: {
+                        type: 'error-json',
+                        value: {
+                            name: 'invalid_tool_call',
+                            message: 'Expected a string',
+                            data: { rawInput: '{"query":42}' },
+                        },
+                    },
+                    providerOptions: undefined,
+                },
+            ],
+        },
+    ]);
+});
+
+it('keeps resumed approval responses last after parallel calls and steers', () => {
+    const messages = projectV3ThreadToModelMessages(
+        thread([
+            {
+                uuid: 'assistant',
+                role: 'assistant',
+                metadata: { ...metadata, status: 'in_progress' },
+                parts: ['call-1', 'call-2'].map((toolCallId, index) => ({
+                    uuid: `part-${index}`,
+                    type: 'tool' as const,
+                    payloadVersion: 1,
+                    payload: {
+                        state: 'approval-responded',
+                        toolName: 'runSql',
+                        input: { sql: `SELECT ${index + 1}` },
+                        approval: {
+                            id: `approval-${index + 1}`,
+                            approved: true,
+                        },
+                    },
+                    toolCallId,
+                    artifactVersionUuid: null,
+                })),
+            },
+            {
+                uuid: 'steer',
+                role: 'user',
+                metadata,
+                parts: [
+                    {
+                        uuid: 'steer-text',
+                        type: 'text',
+                        payloadVersion: 1,
+                        payload: { text: 'Use a smaller result.' },
+                        toolCallId: null,
+                        artifactVersionUuid: null,
+                    },
+                ],
+            },
+        ]),
+        {
+            modelProvider: null,
+            includeInProgressMessageUuid: 'assistant',
+        },
+    );
+
+    expect(messages.at(-1)).toEqual({
+        role: 'tool',
+        content: [
+            expect.objectContaining({
+                type: 'tool-approval-response',
+                approvalId: 'approval-1',
+                approved: true,
+            }),
+            expect.objectContaining({
+                type: 'tool-approval-response',
+                approvalId: 'approval-2',
+                approved: true,
+            }),
+        ],
+    });
+});
+
+it('replays provider metadata only to the producing provider', () => {
+    const providerMetadata = {
+        anthropic: {
+            signature: 'signed-reasoning',
+            encryptedContent: { blob: 'opaque' },
+        },
+    };
+    const canonical = thread([
+        {
+            uuid: 'assistant',
+            role: 'assistant',
+            metadata: {
+                ...metadata,
+                status: 'completed',
+                modelConfig: {
+                    version: 1,
+                    modelName: 'claude-sonnet-4-5',
+                    modelProvider: 'anthropic',
+                    reasoning: {
+                        enabled: true,
+                        effort: null,
+                        budgetTokens: null,
+                    },
+                    limits: { maxSteps: 12, maxOutputTokens: null },
+                    sampling: { temperature: null, topP: null },
+                    providerOptions: null,
+                },
+            },
+            parts: [
+                {
+                    uuid: 'reasoning',
+                    type: 'reasoning',
+                    payloadVersion: 1,
+                    payload: { text: '', providerMetadata },
+                    toolCallId: null,
+                    artifactVersionUuid: null,
+                },
+            ],
+        },
+    ]);
+
+    expect(
+        projectV3ThreadToModelMessages(canonical, {
+            modelProvider: 'anthropic',
+            includeInProgressMessageUuid: null,
+        }),
+    ).toEqual([
+        {
+            role: 'assistant',
+            content: [
+                {
+                    type: 'reasoning',
+                    text: '',
+                    providerOptions: providerMetadata,
+                },
+            ],
+        },
+    ]);
+    expect(
+        projectV3ThreadToModelMessages(canonical, {
+            modelProvider: 'openai',
+            includeInProgressMessageUuid: null,
+        }),
+    ).toEqual([
+        {
+            role: 'assistant',
+            content: [
+                {
+                    type: 'reasoning',
+                    text: '',
+                    providerOptions: undefined,
+                },
+            ],
+        },
+    ]);
 });

--- a/packages/backend/src/ee/services/ai/projectV3ThreadToModelMessages.ts
+++ b/packages/backend/src/ee/services/ai/projectV3ThreadToModelMessages.ts
@@ -2,31 +2,116 @@ import {
     type AssistantModelMessage,
     type JSONValue,
     type ModelMessage,
+    type ToolModelMessage,
 } from 'ai';
-import { type AiCanonicalThread } from '../../database/entities/aiAgentV3';
+import {
+    AI_TOOL_APPROVAL_DEFAULT_REASONS,
+    getAiToolApprovalPayload,
+    type AiCanonicalMessage,
+    type AiCanonicalThread,
+} from '../../database/entities/aiAgentV3';
+import { type AiProvider } from './models/types';
 
-const providerOptions = (payload: Record<string, unknown>) =>
-    payload.providerMetadata as
-        | Record<string, Record<string, JSONValue>>
-        | undefined;
+type ProjectionOptions = {
+    modelProvider: AiProvider | null;
+    includeInProgressMessageUuid: string | null;
+};
+
+export const getV3TriggeringUserMessage = (
+    messages: AiCanonicalMessage[],
+    assistantMessageUuid: string,
+): AiCanonicalMessage | undefined => {
+    const assistantIndex = messages.findIndex(
+        (message) => message.uuid === assistantMessageUuid,
+    );
+    if (assistantIndex < 0) return undefined;
+    return messages
+        .slice(0, assistantIndex)
+        .reverse()
+        .find((message) => message.role === 'user');
+};
+
+const providerOptions = ({
+    payload,
+    producingProvider,
+    replayProvider,
+    key = 'providerMetadata',
+}: {
+    payload: Record<string, unknown>;
+    producingProvider: string | null;
+    replayProvider: AiProvider | null;
+    key?: 'providerMetadata' | 'resultProviderMetadata';
+}) =>
+    producingProvider !== null && producingProvider === replayProvider
+        ? (payload[key] as
+              | Record<string, Record<string, JSONValue>>
+              | undefined)
+        : undefined;
 
 const toolOutput = (payload: Record<string, unknown>) => {
     if (payload.state === 'output-denied') {
-        return { type: 'execution-denied' as const, reason: 'Denied by user' };
+        // Canonical reads merge durable decision metadata into the payload.
+        const approval = getAiToolApprovalPayload(payload);
+        return {
+            type: 'execution-denied' as const,
+            reason:
+                typeof approval?.reason === 'string'
+                    ? approval.reason
+                    : AI_TOOL_APPROVAL_DEFAULT_REASONS.rejected,
+        };
     }
-    const value =
-        payload.state === 'output-error'
-            ? { error: payload.error ?? { name: 'tool_error' } }
-            : payload.output;
+    if (payload.state === 'output-error') {
+        return {
+            type: 'error-json' as const,
+            value: (payload.error ?? {
+                name: 'tool_error',
+                message: 'Tool execution failed',
+            }) as JSONValue,
+        };
+    }
+    const value = payload.output;
     return value === undefined
         ? { type: 'text' as const, value: '' }
         : { type: 'json' as const, value: value as JSONValue };
 };
 
+const providerExecuted = (payload: Record<string, unknown>) =>
+    typeof payload.providerExecuted === 'boolean'
+        ? payload.providerExecuted
+        : undefined;
+
+export const getV3MessageRunOptions = (
+    message: AiCanonicalMessage | undefined,
+): { toolHints: string[]; enableSqlMode: boolean | undefined } => {
+    const payload = message?.parts.find(
+        (part) =>
+            part.type === 'text' &&
+            (Array.isArray(part.payload.toolHints) ||
+                typeof part.payload.enableSqlMode === 'boolean'),
+    )?.payload;
+    const toolHints = payload?.toolHints;
+    return {
+        toolHints:
+            Array.isArray(toolHints) &&
+            toolHints.every((item) => typeof item === 'string')
+                ? toolHints
+                : [],
+        enableSqlMode:
+            typeof payload?.enableSqlMode === 'boolean'
+                ? payload.enableSqlMode
+                : undefined,
+    };
+};
+
 export const projectV3ThreadToModelMessages = (
     thread: AiCanonicalThread,
+    options: ProjectionOptions = {
+        modelProvider: null,
+        includeInProgressMessageUuid: null,
+    },
 ): ModelMessage[] => {
     const messages: ModelMessage[] = [];
+    const deferredApprovalResponses: ToolModelMessage['content'] = [];
 
     thread.messages.forEach((message) => {
         if (message.role === 'compaction') {
@@ -43,7 +128,14 @@ export const projectV3ThreadToModelMessages = (
             return;
         }
 
-        if (message.metadata.status === 'in_progress') return;
+        if (
+            message.metadata.status === 'in_progress' &&
+            message.uuid !== options.includeInProgressMessageUuid
+        ) {
+            return;
+        }
+        const producingProvider =
+            message.metadata.modelConfig?.modelProvider ?? null;
         let assistantContent: Exclude<
             AssistantModelMessage['content'],
             string
@@ -62,7 +154,11 @@ export const projectV3ThreadToModelMessages = (
                     assistantContent.push({
                         type: part.type === 'text' ? 'text' : 'reasoning',
                         text: part.payload.text,
-                        providerOptions: providerOptions(part.payload),
+                        providerOptions: providerOptions({
+                            payload: part.payload,
+                            producingProvider,
+                            replayProvider: options.modelProvider,
+                        }),
                     });
                     return;
                 }
@@ -80,12 +176,75 @@ export const projectV3ThreadToModelMessages = (
                         toolCallId: part.toolCallId,
                         toolName,
                         input: part.payload.input ?? {},
-                        providerOptions: providerOptions(part.payload),
-                        providerExecuted:
-                            typeof part.payload.providerExecuted === 'boolean'
-                                ? part.payload.providerExecuted
-                                : undefined,
+                        providerOptions: providerOptions({
+                            payload: part.payload,
+                            producingProvider,
+                            replayProvider: options.modelProvider,
+                        }),
+                        providerExecuted: providerExecuted(part.payload),
                     });
+                    const approval = getAiToolApprovalPayload(part.payload);
+                    if (approval) {
+                        assistantContent.push({
+                            type: 'tool-approval-request',
+                            approvalId: approval.id,
+                            toolCallId: part.toolCallId,
+                            ...(typeof approval.signature === 'string'
+                                ? { signature: approval.signature }
+                                : {}),
+                        });
+                    }
+                    if (
+                        approval?.approved === true &&
+                        state === 'approval-responded'
+                    ) {
+                        deferredApprovalResponses.push({
+                            type: 'tool-approval-response',
+                            approvalId: approval.id,
+                            approved: true,
+                            reason: approval.reason ?? undefined,
+                            providerExecuted: providerExecuted(part.payload),
+                        });
+                        return;
+                    }
+                    if (approval && typeof approval.approved === 'boolean') {
+                        flushAssistant();
+                        messages.push({
+                            role: 'tool',
+                            content: [
+                                {
+                                    type: 'tool-approval-response',
+                                    approvalId: approval.id,
+                                    approved: approval.approved,
+                                    reason:
+                                        typeof approval.reason === 'string'
+                                            ? approval.reason
+                                            : undefined,
+                                    providerExecuted: providerExecuted(
+                                        part.payload,
+                                    ),
+                                },
+                                ...(state === 'output-denied'
+                                    ? [
+                                          {
+                                              type: 'tool-result' as const,
+                                              toolCallId: part.toolCallId,
+                                              toolName,
+                                              output: toolOutput(part.payload),
+                                              providerOptions: providerOptions({
+                                                  payload: part.payload,
+                                                  producingProvider,
+                                                  replayProvider:
+                                                      options.modelProvider,
+                                                  key: 'resultProviderMetadata',
+                                              }),
+                                          },
+                                      ]
+                                    : []),
+                            ],
+                        });
+                        if (state === 'output-denied') return;
+                    }
                     if (!state.startsWith('output-')) return;
                     flushAssistant();
                     messages.push({
@@ -96,7 +255,12 @@ export const projectV3ThreadToModelMessages = (
                                 toolCallId: part.toolCallId,
                                 toolName,
                                 output: toolOutput(part.payload),
-                                providerOptions: providerOptions(part.payload),
+                                providerOptions: providerOptions({
+                                    payload: part.payload,
+                                    producingProvider,
+                                    replayProvider: options.modelProvider,
+                                    key: 'resultProviderMetadata',
+                                }),
                             },
                         ],
                     });
@@ -108,6 +272,13 @@ export const projectV3ThreadToModelMessages = (
         });
         flushAssistant();
     });
+
+    if (deferredApprovalResponses.length > 0) {
+        messages.push({
+            role: 'tool',
+            content: deferredApprovalResponses,
+        });
+    }
 
     return messages;
 };

--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -60,9 +60,11 @@ const makeTool = ({
     maxQueryLimit = 5000,
     enableDataAccess = true,
     useSlackStreamCard = false,
+    useNativeToolApproval = false,
     prompt = makePrompt(),
 }: MakeToolOptions & {
     useSlackStreamCard?: boolean;
+    useNativeToolApproval?: boolean;
     prompt?: AiWebAppPrompt | SlackPrompt;
 } = {}) => {
     const dependencies = {
@@ -87,6 +89,7 @@ const makeTool = ({
         maxQueryLimit,
         enableDataAccess,
         useSlackStreamCard,
+        useNativeToolApproval,
     };
 
     return {
@@ -133,6 +136,22 @@ describe('getRunSql', () => {
             'Awaiting approval to run SQL...',
         );
         expect(output.metadata?.status).toBe('success');
+    });
+
+    it('uses native approval for v3 web runs', async () => {
+        const { tool } = makeTool({ useNativeToolApproval: true });
+
+        await expect(
+            typeof tool.needsApproval === 'function'
+                ? tool.needsApproval(
+                      { sql: 'select 1 as answer', limit: 500 },
+                      {
+                          messages: [],
+                          toolCallId: 'tool-call-1',
+                      },
+                  )
+                : tool.needsApproval,
+        ).resolves.toBe(true);
     });
 
     it('creates a SQL-backed chart artifact for web results', async () => {

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -41,6 +41,7 @@ type Dependencies = {
     autoApproveSql?: boolean;
     autoApproveSqlUserUuid?: string | null;
     useSlackStreamCard?: boolean;
+    useNativeToolApproval?: boolean;
 };
 
 const toolDefinition = runSqlToolDefinition.for('agent');
@@ -102,6 +103,7 @@ export const getRunSql = ({
     autoApproveSql = false,
     autoApproveSqlUserUuid = null,
     useSlackStreamCard = false,
+    useNativeToolApproval = false,
 }: Dependencies) => {
     let sqlApprovalTimedOut = false;
 
@@ -114,7 +116,9 @@ export const getRunSql = ({
     // generation and the SDK re-invokes execute once approved. Auto-approve and
     // "don't ask again" threads bypass approval entirely.
     const usesNativeApproval = async () => {
-        if (!useSlackStreamCard || autoApproveSql) return false;
+        if (autoApproveSql) return false;
+        if (useNativeToolApproval) return true;
+        if (!useSlackStreamCard) return false;
         const prompt = await getPrompt();
         return (
             isSlackPrompt(prompt) &&
@@ -139,7 +143,8 @@ export const getRunSql = ({
             // — the reply flow posted the approval card and the decision is
             // already recorded.
             const isNativeApprovalPath =
-                useSlackStreamCard && isSlack && !shouldAutoApprove;
+                useNativeToolApproval ||
+                (useSlackStreamCard && isSlack && !shouldAutoApprove);
 
             // When execute runs as a RESUME of a previously-suspended approval,
             // onStepFinish won't persist the result (the tool call was made in a

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -97,6 +97,7 @@ export type AiAgentMcpServer = AiMcpServer & {
     resolvedCredentialScope: 'shared' | 'user' | null;
     oauthProvider?: OAuthClientProvider;
     enabledToolNames?: string[];
+    approvalRequiredToolNames: string[];
 };
 
 export type UnavailableMcpServer = {
@@ -208,6 +209,7 @@ export type AiAgentArgs = AnyAiModel & {
     debugLoggingEnabled: boolean;
     telemetryEnabled: boolean;
     enableDataAccess: boolean;
+    useNativeToolApproval: boolean;
     enableSelfImprovement: boolean;
     enableContentTools: boolean;
     enableAiWriteback: boolean;
@@ -350,7 +352,9 @@ export type AiAgentDependencies = {
     perf: PerformanceMetrics;
     streamPersistence?: {
         onChunk: (chunk: unknown) => Promise<void>;
+        onUiChunk: (chunk: unknown) => Promise<void>;
         recordUsage: (usage: LanguageModelUsage) => void;
+        hasPendingApproval: () => boolean;
         complete: (usage?: LanguageModelUsage) => Promise<void>;
         fail: (error: unknown, message: string) => Promise<void>;
         cancel: () => Promise<void>;

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -99,15 +99,24 @@ export type AiMcpServerToolInput = Pick<
     | 'meta'
 >;
 
+export type AiAgentMcpServerToolPermissionMode =
+    | 'always_allow'
+    | 'ask'
+    | 'always_deny';
+
 export type AiAgentMcpServerTool = AiMcpServerTool & {
     agentUuid: string;
     enabled: boolean;
+    permissionMode: AiAgentMcpServerToolPermissionMode;
 };
 
 export type AiAgentMcpServerToolUpdate = Pick<
     AiAgentMcpServerTool,
-    'toolName' | 'enabled'
->;
+    'toolName'
+> & {
+    permissionMode?: AiAgentMcpServerToolPermissionMode;
+    enabled?: boolean;
+};
 
 export type AiAgentIntegration = {
     type: 'slack';
@@ -756,9 +765,12 @@ export type ApiAiAgentThreadMessageCreateRequest = {
     hidden?: boolean;
 };
 
-export type ApiAiAgentSqlApprovalRequest = {
+export type ApiAiAgentToolApprovalRequest = {
     decision: 'approved' | 'rejected';
+    reason?: string;
 };
+
+export type ApiAiAgentSqlApprovalRequest = ApiAiAgentToolApprovalRequest;
 
 export type ApiAiAgentThreadStreamRequest = {
     /**
@@ -791,9 +803,11 @@ export type ApiAiAgentV3ChatRequest = {
     toolHints?: string[];
 };
 
-export type ApiAiAgentSqlApprovalResponse = ApiSuccess<{
+export type ApiAiAgentToolApprovalResponse = ApiSuccess<{
     decision: 'approved' | 'rejected';
 }>;
+
+export type ApiAiAgentSqlApprovalResponse = ApiAiAgentToolApprovalResponse;
 
 export type ApiAiAgentThreadMessageInterruptResponse = ApiSuccess<{
     interrupted: true;

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
@@ -1,5 +1,8 @@
 import { isApiError } from '@lightdash/common';
 import type {
+    AiAgentMcpServerTool,
+    AiAgentMcpServerToolPermissionMode,
+    AiAgentMcpServerToolUpdate,
     ApiAiMcpGithubAvailabilityResponse,
     ApiAiMcpOAuthCredentialRequest,
     ApiAiAgentMcpServerToolListResponse,
@@ -622,6 +625,27 @@ export const useDisconnectMcpOAuthConnectionMutation = (
     });
 };
 
+// Mirrors the server: permissionMode wins, otherwise it is derived from
+// `enabled`, and `enabled` is always `permissionMode === 'always_allow'`.
+const applyOptimisticToolUpdate = (
+    tool: AiAgentMcpServerTool,
+    update: AiAgentMcpServerToolUpdate,
+): AiAgentMcpServerTool => {
+    const permissionMode: AiAgentMcpServerToolPermissionMode =
+        update.permissionMode ??
+        (update.enabled === undefined
+            ? tool.permissionMode
+            : update.enabled
+              ? 'always_allow'
+              : 'always_deny');
+
+    return {
+        ...tool,
+        permissionMode,
+        enabled: permissionMode === 'always_allow',
+    };
+};
+
 export const useUpdateAgentAiMcpServerToolsMutation = (
     projectUuid: string,
     agentUuid: string,
@@ -673,7 +697,7 @@ export const useUpdateAgentAiMcpServerToolsMutation = (
                             );
 
                             return nextSetting
-                                ? { ...tool, enabled: nextSetting.enabled }
+                                ? applyOptimisticToolUpdate(tool, nextSetting)
                                 : tool;
                         }) ?? currentTools,
                 );


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/ZAP-802/tool-approvals-model-visible-tool-errors-provider-metadata

### Description

- Persist v3 tool approvals with durable decision, reason, user, timestamp, suspend/resume, mutation guards, and SQL/MCP approval support.
- Persist tool execution failures and invalid calls as model-visible output-error parts.
- Preserve provider metadata losslessly and replay it only to the producing provider.
- Preserve request run options across approval suspension and keep frozen Parts free of satellite decider metadata.

### Verification

- Backend/common typecheck and lint.
- Focused behavioral unit tests: 29 passed; broader focused suite: 98 passed.
- API generation passed; generated files excluded.
- Full backend suite: 5,992 passed, 1 skipped; only 2 pre-existing SchedulerTaskTracer failures.
- Fresh independent Claude review: CLEAN.
- Fresh curl behavioral E2E with PostgreSQL, server logs, and Jaeger: CLEAN.

### Deferred stack scope

- ZAP-803: crashed/stale run recovery and re-drive.
- ZAP-804: compaction.
- ZAP-805: Slack v3.
- ZAP-806/807: resumed-run frontend lifecycle.