### PR TITLE
feat(release-safety): validate every generated marker against its JSON Schema

### DIFF
--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -11,6 +11,8 @@ import {
     GitChange,
     MARKER_SCHEMA_VERSION,
     ownExpandContractFloor,
+    ReleaseSafetyMarker,
+    validateMarker,
 } from './gen-release-safety';
 
 let passed = 0;
@@ -790,6 +792,62 @@ test('requiredStops list surfaces verbatim on the marker; defaults to []', () =>
     assert.deepStrictEqual(m.upgrade.requiredStops, ['0.3280.0', '0.3290.0']);
     const m2 = buildMarker({ ...base, migrations: noMig });
     assert.deepStrictEqual(m2.upgrade.requiredStops, []);
+});
+
+// --- marker schema enforcement ----------------------------------------------
+
+test('representative no-migration marker validates against the real schema', () => {
+    const marker = buildMarker({ ...base, migrations: noMig });
+    assert.deepStrictEqual(validateMarker(marker), []);
+});
+
+test('representative linter-breaking migration marker validates against the real schema', () => {
+    const marker = buildMarker({
+        ...base,
+        migrations: migPresent,
+        sqlLint: {
+            ran: true,
+            breaking: true,
+            findings: ['migration.ts:1 drops a column [drop-column]'],
+        },
+    });
+    assert.deepStrictEqual(validateMarker(marker), []);
+});
+
+test('representative AI-cleared marker validates against the real schema', () => {
+    const marker = buildMarker({
+        ...base,
+        migrations: migPresent,
+        sqlLint: {
+            ran: true,
+            breaking: true,
+            findings: ['migration.ts:1 drops a column [drop-column]'],
+        },
+        aiReview: {
+            rollingUpdateSafe: true,
+            recommendedStrategy: 'RollingUpdate',
+            summary: 'The previous release no longer uses the column.',
+        },
+    });
+    assert.deepStrictEqual(validateMarker(marker), []);
+});
+
+test('marker schema rejects an extra top-level field', () => {
+    const marker = buildMarker({ ...base, migrations: noMig });
+    const invalid = { ...marker, unexpected: true } as ReleaseSafetyMarker;
+    assert.match(validateMarker(invalid)[0], /unexpected: additional property not allowed/);
+});
+
+test('marker schema rejects an invalid recommended strategy', () => {
+    const marker = buildMarker({ ...base, migrations: noMig });
+    const invalid = {
+        ...marker,
+        compatibility: {
+            ...marker.compatibility,
+            recommendedStrategy: 'sideways',
+        },
+    } as unknown as ReleaseSafetyMarker;
+    assert.match(validateMarker(invalid)[0], /compatibility\.recommendedStrategy.*not in enum/);
 });
 
 // --- report ------------------------------------------------------------------

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -20,6 +20,7 @@ import { lintMigrations, renderFindings, SqlLintFinding } from './sql-migration-
 import { compareVersions, findExpandFloor } from './expand-version';
 import { diffRestApi, SPEC_PATH } from './rest-api-diff';
 import { diffMcpTools } from './mcp-tools-diff';
+import { validateAgainstSchema } from './json-schema-lite';
 import {
     CarriedFloor,
     CarriedFloorKind,
@@ -33,6 +34,15 @@ import {
 } from './upgrade-overrides';
 
 export const MARKER_SCHEMA_VERSION = '1';
+
+export function validateMarker(marker: ReleaseSafetyMarker): string[] {
+    const schemaPath = path.join(__dirname, 'release-safety.schema.json');
+    const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf-8')) as unknown;
+    if (typeof schema !== 'object' || schema === null || Array.isArray(schema)) {
+        throw new Error(`${schemaPath} must contain a JSON object schema`);
+    }
+    return validateAgainstSchema(marker, schema as Record<string, unknown>);
+}
 
 const MIGRATION_DIRS = [
     'packages/backend/src/database/migrations',
@@ -835,6 +845,12 @@ async function main(): Promise<void> {
         carriedFloor,
         requiredStops,
     });
+    const markerErrors = validateMarker(marker);
+    if (markerErrors.length > 0) {
+        throw new Error(
+            `release-safety marker failed schema validation:\n${markerErrors.join('\n')}`,
+        );
+    }
 
     // Persist THIS release's own auto-derived expand/contract floor into the
     // committed overrides so EVERY future release carries it forward automatically

--- a/scripts/json-schema-lite.test.ts
+++ b/scripts/json-schema-lite.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for the dependency-free release-safety JSON-Schema subset.
+ * Run: `npx tsx scripts/json-schema-lite.test.ts`
+ */
+import * as assert from 'assert';
+import { validateAgainstSchema } from './json-schema-lite';
+
+let passed = 0;
+const failures: string[] = [];
+
+function test(name: string, fn: () => void): void {
+    try {
+        fn();
+        passed += 1;
+    } catch (err) {
+        failures.push(`${name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+
+const errors = (data: unknown, schema: Record<string, unknown>): string[] =>
+    validateAgainstSchema(data, schema);
+
+test('type accepts supported JSON types and rejects the wrong type', () => {
+    const fixtures: Array<[unknown, string]> = [
+        [{}, 'object'],
+        [[], 'array'],
+        ['x', 'string'],
+        [1, 'integer'],
+        [1.5, 'number'],
+        [true, 'boolean'],
+        [null, 'null'],
+    ];
+    for (const [value, type] of fixtures) assert.deepStrictEqual(errors(value, { type }), []);
+    assert.match(errors('1', { type: 'integer' })[0], /expected type integer/);
+});
+
+test('type arrays accept null and reject values outside the union', () => {
+    const schema = { type: ['string', 'null'] };
+    assert.deepStrictEqual(errors(null, schema), []);
+    assert.deepStrictEqual(errors('value', schema), []);
+    assert.match(errors(false, schema)[0], /expected type string\|null/);
+});
+
+test('const and enum accept matching values and reject non-members including null', () => {
+    assert.deepStrictEqual(errors('1', { const: '1' }), []);
+    assert.match(errors('2', { const: '1' })[0], /does not equal const/);
+    assert.deepStrictEqual(errors(null, { enum: ['x', null] }), []);
+    assert.match(errors('y', { enum: ['x', null] })[0], /not in enum/);
+});
+
+test('properties, required, and additionalProperties false validate object shape', () => {
+    const schema = {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+        required: ['name'],
+        additionalProperties: false,
+    };
+    assert.deepStrictEqual(errors({ name: 'ok' }, schema), []);
+    assert.match(errors({ name: 1 }, schema)[0], /name: expected type string/);
+    assert.match(errors({}, schema)[0], /name: required property missing/);
+    assert.match(errors({ name: 'ok', extra: true }, schema)[0], /extra: additional property/);
+});
+
+test('additionalProperties schema validates every dynamic property', () => {
+    const schema = {
+        type: 'object',
+        additionalProperties: { type: 'integer', minimum: 0 },
+    };
+    assert.deepStrictEqual(errors({ one: 1, two: 2 }, schema), []);
+    assert.match(errors({ bad: -1 }, schema)[0], /bad: value -1 is less than minimum 0/);
+});
+
+test('items validates array entries and reports indexed nested paths', () => {
+    const schema = {
+        type: 'array',
+        items: {
+            type: 'object',
+            properties: { enabled: { type: 'boolean' } },
+            required: ['enabled'],
+        },
+    };
+    assert.deepStrictEqual(errors([{ enabled: true }], schema), []);
+    assert.match(errors([{ enabled: 'yes' }], schema)[0], /\$\[0\]\.enabled/);
+});
+
+test('oneOf requires exactly one matching schema', () => {
+    const schema = { oneOf: [{ type: 'string' }, { type: 'boolean' }] };
+    assert.deepStrictEqual(errors('ok', schema), []);
+    assert.match(errors(1, schema)[0], /matched 0/);
+    assert.match(errors(1, { oneOf: [{ type: 'number' }, { type: 'integer' }] })[0], /matched 2/);
+});
+
+test('$ref resolves definitions against the root schema', () => {
+    const root = {
+        definitions: { label: { type: 'string', enum: ['safe'] } },
+        $ref: '#/definitions/label',
+    };
+    assert.deepStrictEqual(errors('safe', root), []);
+    assert.match(errors('unsafe', root)[0], /not in enum/);
+});
+
+test('$ref accepts an explicit root schema for a schema fragment', () => {
+    const root = { definitions: { count: { type: 'integer', minimum: 1 } } };
+    const schema = { $ref: '#/definitions/count' };
+    assert.deepStrictEqual(validateAgainstSchema(1, schema, root), []);
+    assert.match(validateAgainstSchema(0, schema, root)[0], /minimum 1/);
+});
+
+test('ignored metadata keywords do not affect validation', () => {
+    const schema = {
+        $schema: 'draft-07',
+        $id: 'test',
+        title: 'Title',
+        description: 'Description',
+        format: 'date-time',
+        default: 'x',
+        type: 'string',
+    };
+    assert.deepStrictEqual(errors('anything', schema), []);
+});
+
+test('unsupported schema keywords throw even in an unvisited branch', () => {
+    assert.throws(
+        () => errors({}, { type: 'object', properties: { unused: { type: 'string', pattern: '^x' } } }),
+        /unsupported schema construct: pattern/,
+    );
+});
+
+if (failures.length > 0) {
+    console.error(`\n❌ ${failures.length} failed, ${passed} passed:\n`);
+    for (const failure of failures) console.error(`  - ${failure}`);
+    process.exit(1);
+}
+console.log(`✅ ${passed} tests passed`);

--- a/scripts/json-schema-lite.ts
+++ b/scripts/json-schema-lite.ts
@@ -1,0 +1,218 @@
+/**
+ * Dependency-free validator for the JSON-Schema subset used by release safety.
+ * The relevant CI jobs install only `tsx`, so this deliberately avoids a general
+ * schema package. Unsupported schema evolution throws instead of silently
+ * weakening validation; this is not a general JSON-Schema implementation.
+ */
+
+type Schema = Record<string, unknown>;
+
+const IGNORED_KEYWORDS = new Set([
+    '$schema',
+    '$id',
+    'title',
+    'description',
+    'format',
+    'default',
+]);
+
+const SUPPORTED_KEYWORDS = new Set([
+    'type',
+    'const',
+    'enum',
+    'properties',
+    'required',
+    'additionalProperties',
+    'items',
+    'oneOf',
+    '$ref',
+    'minimum',
+    'definitions',
+]);
+
+const SUPPORTED_TYPES = new Set([
+    'object',
+    'array',
+    'string',
+    'integer',
+    'number',
+    'boolean',
+    'null',
+]);
+
+function isRecord(value: unknown): value is Schema {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function assertSupportedSchema(schema: Schema): void {
+    for (const keyword of Object.keys(schema)) {
+        if (!SUPPORTED_KEYWORDS.has(keyword) && !IGNORED_KEYWORDS.has(keyword)) {
+            throw new Error(`unsupported schema construct: ${keyword}`);
+        }
+    }
+
+    const type = schema.type;
+    const types = Array.isArray(type) ? type : type === undefined ? [] : [type];
+    if (types.some((entry) => typeof entry !== 'string' || !SUPPORTED_TYPES.has(entry))) {
+        throw new Error('unsupported schema construct: type');
+    }
+
+    const visitMap = (value: unknown): void => {
+        if (!isRecord(value)) return;
+        for (const child of Object.values(value)) {
+            if (isRecord(child)) assertSupportedSchema(child);
+        }
+    };
+    visitMap(schema.properties);
+    visitMap(schema.definitions);
+
+    if (schema.items !== undefined) {
+        if (!isRecord(schema.items)) throw new Error('unsupported schema construct: items');
+        assertSupportedSchema(schema.items);
+    }
+    if (schema.oneOf !== undefined) {
+        if (!Array.isArray(schema.oneOf) || schema.oneOf.some((entry) => !isRecord(entry))) {
+            throw new Error('unsupported schema construct: oneOf');
+        }
+        for (const child of schema.oneOf) assertSupportedSchema(child as Schema);
+    }
+    if (
+        schema.additionalProperties !== undefined &&
+        schema.additionalProperties !== false
+    ) {
+        if (!isRecord(schema.additionalProperties)) {
+            throw new Error('unsupported schema construct: additionalProperties');
+        }
+        assertSupportedSchema(schema.additionalProperties);
+    }
+}
+
+function valueType(value: unknown): string {
+    if (value === null) return 'null';
+    if (Array.isArray(value)) return 'array';
+    if (typeof value === 'number' && Number.isInteger(value)) return 'integer';
+    return typeof value;
+}
+
+function matchesType(value: unknown, type: string): boolean {
+    switch (type) {
+        case 'object':
+            return isRecord(value);
+        case 'array':
+            return Array.isArray(value);
+        case 'integer':
+            return typeof value === 'number' && Number.isInteger(value);
+        case 'number':
+            return typeof value === 'number';
+        case 'null':
+            return value === null;
+        default:
+            return typeof value === type;
+    }
+}
+
+function childPath(parent: string, key: string): string {
+    if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)) {
+        return parent === '$' ? key : `${parent}.${key}`;
+    }
+    return `${parent === '$' ? '' : parent}[${JSON.stringify(key)}]`;
+}
+
+function display(value: unknown): string {
+    return JSON.stringify(value) ?? String(value);
+}
+
+function resolveRef(ref: unknown, rootSchema: Schema): Schema {
+    if (typeof ref !== 'string') throw new Error('unsupported schema construct: $ref');
+    const match = ref.match(/^#\/definitions\/([^/]+)$/);
+    if (!match) throw new Error(`unsupported schema construct: $ref ${ref}`);
+    const definitions = rootSchema.definitions;
+    const resolved = isRecord(definitions) ? definitions[match[1]] : undefined;
+    if (!isRecord(resolved)) throw new Error(`unresolved schema reference: ${ref}`);
+    return resolved;
+}
+
+function validateNode(
+    data: unknown,
+    schema: Schema,
+    rootSchema: Schema,
+    path: string,
+): string[] {
+    if (schema.$ref !== undefined) {
+        return validateNode(data, resolveRef(schema.$ref, rootSchema), rootSchema, path);
+    }
+
+    const errors: string[] = [];
+    if (schema.oneOf !== undefined) {
+        const matches = (schema.oneOf as Schema[]).filter(
+            (candidate) => validateNode(data, candidate, rootSchema, path).length === 0,
+        ).length;
+        if (matches !== 1) {
+            errors.push(`${path}: value must match exactly one oneOf schema (matched ${matches})`);
+        }
+    }
+
+    if (schema.type !== undefined) {
+        const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+        if (!(types as string[]).some((type) => matchesType(data, type))) {
+            errors.push(`${path}: expected type ${(types as string[]).join('|')}, got ${valueType(data)}`);
+            return errors;
+        }
+    }
+
+    if ('const' in schema && !Object.is(data, schema.const)) {
+        errors.push(`${path}: value ${display(data)} does not equal const ${display(schema.const)}`);
+    }
+    if (Array.isArray(schema.enum) && !schema.enum.some((entry) => Object.is(data, entry))) {
+        errors.push(`${path}: value ${display(data)} not in enum ${display(schema.enum)}`);
+    }
+    if (typeof data === 'number' && typeof schema.minimum === 'number' && data < schema.minimum) {
+        errors.push(`${path}: value ${data} is less than minimum ${schema.minimum}`);
+    }
+
+    if (isRecord(data)) {
+        const properties = isRecord(schema.properties) ? schema.properties : {};
+        if (Array.isArray(schema.required)) {
+            for (const key of schema.required) {
+                if (typeof key === 'string' && !Object.prototype.hasOwnProperty.call(data, key)) {
+                    errors.push(`${childPath(path, key)}: required property missing`);
+                }
+            }
+        }
+        for (const [key, value] of Object.entries(data)) {
+            const propertySchema = properties[key];
+            if (isRecord(propertySchema)) {
+                errors.push(...validateNode(value, propertySchema, rootSchema, childPath(path, key)));
+            } else if (schema.additionalProperties === false) {
+                errors.push(`${childPath(path, key)}: additional property not allowed`);
+            } else if (isRecord(schema.additionalProperties)) {
+                errors.push(
+                    ...validateNode(
+                        value,
+                        schema.additionalProperties,
+                        rootSchema,
+                        childPath(path, key),
+                    ),
+                );
+            }
+        }
+    }
+
+    if (Array.isArray(data) && isRecord(schema.items)) {
+        data.forEach((item, index) => {
+            errors.push(...validateNode(item, schema.items as Schema, rootSchema, `${path}[${index}]`));
+        });
+    }
+
+    return errors;
+}
+
+export function validateAgainstSchema(
+    data: unknown,
+    schema: Record<string, unknown>,
+    rootSchema: Record<string, unknown> = schema,
+): string[] {
+    assertSupportedSchema(rootSchema);
+    if (schema !== rootSchema) assertSupportedSchema(schema);
+    return validateNode(data, schema, rootSchema, '$');
+}

--- a/scripts/upgrade-overrides.test.ts
+++ b/scripts/upgrade-overrides.test.ts
@@ -9,6 +9,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { validateAgainstSchema } from './json-schema-lite';
 import {
     carriedUpgradeFloor,
     loadUpgradeOverrides,
@@ -199,6 +200,64 @@ test('rejects a wrong-typed minPreviousVersion', () =>
     throws(() => validateOverrides({ default: { minPreviousVersion: 3 } }), /minPreviousVersion must be a string or null/));
 test('rejects a non-object versions map', () =>
     throws(() => validateOverrides({ versions: [] }), /versions must be an object/));
+
+test('validateOverrides agrees with the real overrides schema', () => {
+    const schemaPath = path.join(__dirname, 'release-safety-overrides.schema.json');
+    const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf-8')) as Record<
+        string,
+        unknown
+    >;
+    const corpus: Array<{ name: string; fixture: unknown }> = [
+        { name: 'empty object', fixture: {} },
+        { name: 'default only', fixture: { default: { requiredStop: false } } },
+        {
+            name: 'version with all fields',
+            fixture: {
+                versions: {
+                    '0.3300.0': {
+                        minPreviousVersion: '0.3200.0',
+                        requiredStop: true,
+                        note: 'Stop here.',
+                    },
+                },
+            },
+        },
+        { name: '$schema key', fixture: { $schema: './release-safety-overrides.schema.json' } },
+        {
+            name: 'null fields',
+            fixture: { default: { minPreviousVersion: null, note: null } },
+        },
+        { name: 'array root', fixture: [] },
+        { name: 'unknown top-level key', fixture: { unknown: true } },
+        { name: 'unknown block field', fixture: { default: { unknown: true } } },
+        {
+            name: 'wrong minPreviousVersion type',
+            fixture: { default: { minPreviousVersion: 1 } },
+        },
+        {
+            name: 'wrong requiredStop type',
+            fixture: { default: { requiredStop: 'yes' } },
+        },
+        { name: 'wrong note type', fixture: { default: { note: false } } },
+        { name: 'versions array', fixture: { versions: [] } },
+        { name: 'version block string', fixture: { versions: { '0.3300.0': 'stop' } } },
+    ];
+
+    for (const { name, fixture } of corpus) {
+        let manualThrows = false;
+        try {
+            validateOverrides(fixture);
+        } catch {
+            manualThrows = true;
+        }
+        const schemaRejects = validateAgainstSchema(fixture, schema).length > 0;
+        assert.strictEqual(
+            manualThrows,
+            schemaRejects,
+            `${name}: validateOverrides=${manualThrows ? 'reject' : 'accept'}, schema=${schemaRejects ? 'reject' : 'accept'}`,
+        );
+    }
+});
 
 // --- recordDerivedFloor (IO: persist a floor for future releases) ------------
 


### PR DESCRIPTION
## What

- New `scripts/json-schema-lite.ts`: a small dependency-free validator for the JSON-Schema subset the two release-safety schemas use (type/const/enum/properties/required/additionalProperties/items/oneOf/$ref-to-definitions/minimum). It throws `unsupported schema construct` on anything outside that subset — including in unvisited branches, via a schema preflight — so future schema evolution fails loud instead of silently not validating. Dependency-free because the CI jobs that run these scripts install only `tsx`, no node_modules.
- `gen-release-safety.ts` validates every assembled marker against `release-safety.schema.json` (script-dir anchored) before writing or printing, and throws with the full error list on mismatch — failing both the release and the PR preview. Exposed as `validateMarker()` for tests.
- New agreement suite pins the hand-written `validateOverrides` to `release-safety-overrides.schema.json`: 13 valid/invalid fixtures, asserting the validator throws **iff** the schema rejects — exact agreement in both directions, so the two can no longer drift independently.

## Why

`release-safety.schema.json` is the contract we're about to tell self-hosted operators to gate CI/CD on (SPK-709), and nothing in the repo referenced it. `checked: true` claims are only worth something if the artifact provably matches its published contract at generation time.

## Notes

- Publishing the schema at its `$id` URL (ticket point 3) is docs/infra work, out of scope here — noted on the ticket.
- Tests: 11 new validator tests, 5 new generator validation tests, 13-fixture agreement suite. Full suite: 177 tests across 8 files, green. Generator smoke run writes a valid marker with validation live.

Closes: SPK-861