### PR TITLE
fix(release-safety): stop the sticky PR comment freezing when the diff leaves the watched paths

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -16,30 +16,19 @@ name: Release-safety preview
 # of every PR diff, and diffing it against itself reports "no breaking changes"
 # for an API break it never looked at.
 
+# SPK-857: no `paths:` filter here, deliberately. With a trigger-level filter,
+# a PR revision whose diff leaves the watched paths stops launching the workflow
+# entirely — and the sticky comment (write-forward-only) freezes at the last
+# matching revision, describing a diff that no longer exists. Graphite restacks
+# make that a live failure mode, not a corner case. Instead the workflow always
+# runs on the watched event types; the cheap `changes` job decides in-job whether
+# the diff touches the watched surface, and when it doesn't, the `retract` job
+# corrects the frozen comment instead of leaving it standing.
 on:
   pull_request:
     # Include ready_for_review so flipping a draft to ready re-runs the preview —
     # that's the event that newly enables the AI migration review (see below).
     types: [opened, synchronize, reopened, ready_for_review]
-    # The OpenAPI surface is not a file list: TSOA derives the spec from the
-    # controllers and every type they reach, so any backend or common change can
-    # move it (this is also why `.github/file-filters.yml`'s api_schema filter is
-    # deliberately broad). Migrations and the MCP snapshot live under those two
-    # globs too; the generated swagger.json used to be listed here on its own,
-    # which is what left the REST check unreachable.
-    paths:
-      - 'packages/backend/**'
-      - 'packages/common/**'
-      - 'release-safety.overrides.json'
-      - 'scripts/gen-release-safety.ts'
-      - 'scripts/ai-migration-review.ts'
-      - 'scripts/sql-migration-lint.ts'
-      - 'scripts/rest-api-diff.ts'
-      - 'scripts/mcp-tools-diff.ts'
-      - 'scripts/upgrade-overrides.ts'
-      - 'scripts/release-safety-pr-comment.ts'
-      - '.github/file-filters.yml'
-      - '.github/workflows/release-safety-pr.yml'
 
 # Spec generation makes a run long enough that an older run could otherwise
 # finish last and overwrite the sticky comment with a stale verdict.
@@ -57,6 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
+      watched: ${{ steps.watched.outputs.watched }}
       base_sha: ${{ steps.base.outputs.sha }}
       base_short: ${{ steps.base.outputs.short }}
       openapi: ${{ steps.filter.outputs.release_safety_api }}
@@ -65,7 +55,41 @@ jobs:
         with:
           egress-policy: audit
 
+      # The watched surface — the paths that were previously the trigger-level
+      # `paths:` filter (see the `on:` comment). Checked FIRST, without a
+      # checkout: on pull_request events dorny reads the PR file list from the
+      # API, so unwatched PRs (most of the repo's traffic) pay only this one
+      # step. The filter list is inline rather than in file-filters.yml because
+      # reading that file would itself require the checkout this fast path
+      # avoids.
+      #
+      # The OpenAPI surface is not a file list: TSOA derives the spec from the
+      # controllers and every type they reach, so any backend or common change
+      # can move it (this is also why `.github/file-filters.yml`'s api_schema
+      # filter is deliberately broad). Migrations and the MCP snapshot live
+      # under those two globs too.
+      - name: Check whether the diff touches the watched surface
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+        id: watched
+        with:
+          token: ${{ github.token }}
+          filters: |
+            watched:
+              - 'packages/backend/**'
+              - 'packages/common/**'
+              - 'release-safety.overrides.json'
+              - 'scripts/gen-release-safety.ts'
+              - 'scripts/ai-migration-review.ts'
+              - 'scripts/sql-migration-lint.ts'
+              - 'scripts/rest-api-diff.ts'
+              - 'scripts/mcp-tools-diff.ts'
+              - 'scripts/upgrade-overrides.ts'
+              - 'scripts/release-safety-pr-comment.ts'
+              - '.github/file-filters.yml'
+              - '.github/workflows/release-safety-pr.yml'
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: steps.watched.outputs.watched == 'true'
         with:
           fetch-depth: 0
 
@@ -73,6 +97,7 @@ jobs:
       # diff and the comment's base label all have to describe the same comparison.
       - name: Resolve comparison base
         id: base
+        if: steps.watched.outputs.watched == 'true'
         run: |
           set -euo pipefail
           git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
@@ -83,6 +108,7 @@ jobs:
       - name: Check for files changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
+        if: steps.watched.outputs.watched == 'true'
         with:
           token: ${{ github.token }}
           filters: .github/file-filters.yml
@@ -155,7 +181,9 @@ jobs:
     # the migration and MCP halves still have something to say, and the comment
     # reports the REST check as not run rather than silently omitting it. A failed
     # openapi-specs job stays red on its own — this job does not launder it green.
-    if: ${{ always() && needs.changes.result == 'success' }}
+    # Skipped entirely when the diff doesn't touch the watched surface — the
+    # `retract` job owns the comment in that case.
+    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.watched == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -298,6 +326,8 @@ jobs:
           tsx scripts/release-safety-pr-comment.ts \
             --marker /tmp/release-safety.json \
             --base "${{ github.event.pull_request.base.ref }} (${{ needs.changes.outputs.base_short }})" \
+            --head-sha "${{ github.event.pull_request.head.sha }}" \
+            --base-sha "${{ needs.changes.outputs.base_sha }}" \
             --rest-status "${{ steps.rest-result.outputs.status }}" \
             ${{ steps.marker.outputs.draft == 'true' && '--draft' || '' }} \
             ${{ steps.lint.outputs.breaking == 'true' && '--linter-breaking' || '--no-linter-breaking' }} \
@@ -313,10 +343,30 @@ jobs:
             const body = fs.readFileSync('/tmp/release-safety-comment.md', 'utf8');
             const marker = '<!-- release-safety-marker -->';
 
-            const { data: comments } = await github.rest.issues.listComments({
+            // This run computed a verdict for the EVENT's head. If the PR has
+            // moved on since (a newer push, or this is a manual re-run of an
+            // old run — concurrency only cancels runs that are still in
+            // progress when a newer one starts), writing would replace the
+            // current verdict with a stale one. The newer head's own run owns
+            // the comment; skip.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const eventHead = context.payload.pull_request.head.sha;
+            if (pr.head.sha !== eventHead) {
+              core.info(`PR head moved on (${eventHead.slice(0, 7)} -> ${pr.head.sha.slice(0, 7)}); not writing a stale verdict.`);
+              return;
+            }
+
+            // Paginate: the sticky comment can sit past the first page on a
+            // long PR, and missing it here would double-post a new one.
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
+              per_page: 100,
             });
             const existing = comments.find((c) => c.body.includes(marker));
 
@@ -339,3 +389,79 @@ jobs:
       - name: Fail when a REST check was handed its specs but did not run
         if: ${{ steps.rest-result.outputs.broken == 'true' }}
         run: exit 1
+
+  # SPK-857: when the current diff no longer touches the watched surface, an
+  # existing sticky comment is describing a revision that no longer exists —
+  # retract it instead of letting the frozen verdict stand (observed both ways:
+  # a stale ❓ that told the author to mark ready for a re-run that could never
+  # start, and a stale ✅ describing a migration that had left the diff). Only
+  # ever UPDATES an existing comment; a PR that never had one gets no noise.
+  retract:
+    name: Retract a stale verdict
+    needs: changes
+    if: ${{ needs.changes.result == 'success' && needs.changes.outputs.watched != 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Retract the sticky comment if one exists
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const marker = '<!-- release-safety-marker -->';
+            const retracted = '<!-- release-safety-retracted -->';
+            const headSha = context.payload.pull_request.head.sha;
+            const short = headSha.slice(0, 7);
+
+            // Same stale-run guard as the post step: only the run for the PR's
+            // CURRENT head may touch the comment.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            if (pr.head.sha !== headSha) {
+              core.info(`PR head moved on (${short} -> ${pr.head.sha.slice(0, 7)}); leaving the comment to the newer run.`);
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (!existing) {
+              core.info('No sticky comment to retract.');
+              return;
+            }
+            // Already retracted AND naming the current head — nothing to say.
+            // A retraction naming an older head still gets refreshed so its
+            // "current diff" reference never goes stale.
+            if (existing.body.includes(retracted) && existing.body.includes(`\`${short}\``)) {
+              core.info('Sticky comment is already retracted for this head.');
+              return;
+            }
+            const body = [
+              marker,
+              retracted,
+              '## 🛡️ Upgrade safety for self-hosted customers',
+              '',
+              `- ✅ **No database or API surface in this PR's current diff.** An earlier revision of this PR touched files that affect self-hosted upgrades, and this comment described that revision. The current diff (commit \`${short}\`) no longer touches any of them, so that verdict has been retracted.`,
+              '',
+              '---',
+              '<sub>Automated upgrade-safety check. If a later revision touches the database or API surface again, a fresh verdict will replace this notice.</sub>',
+              '',
+            ].join('\n');
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+            core.info(`Retracted the stale verdict (head ${short}).`);

--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -3,7 +3,12 @@
  * Run: `npx tsx scripts/release-safety-pr-comment.test.ts`
  */
 import * as assert from 'assert';
-import { COMMENT_MARKER, Marker, renderPrComment } from './release-safety-pr-comment';
+import {
+    COMMENT_MARKER,
+    DESCRIBES_STAMP_RE,
+    Marker,
+    renderPrComment,
+} from './release-safety-pr-comment';
 
 let passed = 0;
 const failures: string[] = [];
@@ -279,6 +284,38 @@ test('raw JSON is embedded in a collapsed details block', () => {
     const body = renderPrComment(baseMarker());
     assert.ok(body.includes('<details><summary>Technical details (raw JSON)</summary>'));
     assert.ok(body.includes('"rollingUpdateSafe"'));
+});
+
+// --- describes-stamp (SPK-857) ------------------------------------------------
+
+test('headSha+baseSha emit a machine-readable stamp the regex parses back', () => {
+    const body = renderPrComment(baseMarker(), {
+        baseLabel: 'main (0abc123)',
+        headSha: 'deadbeefcafe4567deadbeefcafe4567deadbeef',
+        baseSha: '0abc1234',
+    });
+    const m = body.match(DESCRIBES_STAMP_RE);
+    assert.ok(m, 'stamp missing');
+    assert.strictEqual(m?.[1], 'deadbeefcafe4567deadbeefcafe4567deadbeef');
+    assert.strictEqual(m?.[2], '0abc1234');
+});
+
+test('stamped comment carries a visible short-sha note on the base line', () => {
+    const body = renderPrComment(baseMarker(), {
+        baseLabel: 'main (0abc123)',
+        headSha: 'deadbeefcafe4567deadbeefcafe4567deadbeef',
+        baseSha: '0abc1234',
+    });
+    assert.ok(body.includes('This verdict describes commit `deadbee`.'));
+});
+
+test('no stamp is emitted when headSha/baseSha are absent or partial', () => {
+    assert.ok(!DESCRIBES_STAMP_RE.test(renderPrComment(baseMarker())));
+    assert.ok(
+        !DESCRIBES_STAMP_RE.test(
+            renderPrComment(baseMarker(), { headSha: 'deadbeef' }),
+        ),
+    );
 });
 
 if (failures.length > 0) {

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -16,12 +16,27 @@
  * prints the comment body.
  *
  * CLI:  npx tsx scripts/release-safety-pr-comment.ts --marker /tmp/rs.json [--base main]
- *         [--rest-status ran|skipped|failed] [--out /tmp/body.md]
+ *         [--rest-status ran|skipped|failed] [--head-sha <sha> --base-sha <sha>]
+ *         [--out /tmp/body.md]
  */
 import * as fs from 'fs';
 
 /** Hidden anchor used to find-and-update the single sticky comment. */
 export const COMMENT_MARKER = '<!-- release-safety-marker -->';
+
+/**
+ * Hidden stamp naming the exact revision pair the comment describes. Written
+ * next to the anchor; the workflow reads it back to tell a current verdict from
+ * a frozen one (SPK-857) — a sticky comment survives pushes that stop matching
+ * the watched paths, so without the stamp a stale verdict is indistinguishable
+ * from a fresh one.
+ */
+export const DESCRIBES_STAMP_RE =
+    /<!-- release-safety-describes head:([0-9a-f]{7,40}) base:([0-9a-f]{7,40}) -->/;
+
+export function describesStamp(headSha: string, baseSha: string): string {
+    return `<!-- release-safety-describes head:${headSha} base:${baseSha} -->`;
+}
 
 type TriState = boolean | 'unknown';
 
@@ -71,6 +86,15 @@ export interface RenderOpts {
      * OpenAPI specs it needed — the second is a broken check, not a clean bill.
      */
     restStatus?: 'ran' | 'skipped' | 'failed';
+    /**
+     * Head commit this verdict was computed for. Rendered as a hidden
+     * machine-readable stamp plus a visible note, so a comment frozen by a later
+     * diff change is identifiable on sight (SPK-857). Both must be full or
+     * abbreviated hex SHAs; the stamp is emitted only when both are present.
+     */
+    headSha?: string;
+    /** Merge-base the verdict compared against (pairs with headSha). */
+    baseSha?: string;
 }
 
 const LINTER_NOTE_PREFIX = 'Migration linter detected breaking';
@@ -221,11 +245,20 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
     }
 
     // ---- assemble -----------------------------------------------------------
-    const baseLine = opts.baseLabel ? `> Comparing against \`${opts.baseLabel}\`.\n` : '';
+    const stamped = Boolean(opts.headSha && opts.baseSha);
+    const describes = stamped
+        ? ` This verdict describes commit \`${(opts.headSha as string).slice(0, 7)}\`.`
+        : '';
+    const baseLine = opts.baseLabel
+        ? `> Comparing against \`${opts.baseLabel}\`.${describes}\n`
+        : '';
     const rawJson = JSON.stringify(marker, null, 2);
 
     return [
         COMMENT_MARKER,
+        ...(stamped
+            ? [describesStamp(opts.headSha as string, opts.baseSha as string)]
+            : []),
         '## 🛡️ Upgrade safety for self-hosted customers',
         baseLine,
         head.map((l) => `- ${l}`).join('\n'),
@@ -265,6 +298,8 @@ function main(): void {
     const body = renderPrComment(marker, {
         baseLabel: arg('base'),
         restStatus: restStatus as RenderOpts['restStatus'],
+        headSha: arg('head-sha'),
+        baseSha: arg('base-sha'),
         draft: process.argv.includes('--draft'),
         linterBreaking: process.argv.includes('--linter-breaking')
             ? true


### PR DESCRIPTION
## What

- Removes the trigger-level `paths:` filter from `release-safety-pr.yml` — the workflow now always runs on the watched event types. A cheap first step (dorny/paths-filter in API mode, no checkout) classifies the diff; unwatched PRs (most repo traffic) pay one API call and skip checkout, base resolution, and every heavy job.
- New `retract` job: when the current diff no longer touches the watched surface but a sticky verdict exists, the comment is **updated to an explicit retraction** naming the current head. It never creates a comment, so PRs that never had a verdict get no noise.
- Every verdict comment now carries a hidden machine stamp `<!-- release-safety-describes head:<sha> base:<sha> -->` plus a visible "This verdict describes commit `abc1234`" note, so a frozen verdict is identifiable on sight and by tooling (the stamp is what SPK-858 builds its short-circuit on).
- Hardening from an adversarial review of the change: both comment-writing paths now (a) skip the write when the PR's current head differs from the event's head — a manual re-run of an old run can no longer overwrite the current verdict with a stale one (concurrency only cancels runs in progress when a newer one starts), and (b) paginate the comment listing, so a sticky comment past page one can no longer double-post or dodge retraction. The retraction notice also refreshes itself when the head moves again.

## Why

The sticky comment is write-forward-only, and Graphite restacks routinely carry a mid-stack PR's diff out of the watched paths after the parent merges. Audit of merged PRs found both failure directions live: a ❓ verdict whose author marked ready as instructed — with the invited re-run silenced by the very diff change that made the verdict stale — and a ✅ describing a migration that was no longer in the PR. Both happened to be benign; the mechanism has no such guarantee, and the artifact's credibility is the product.

## Notes

- Base-branch changes still don't re-trigger (they fire `edited`, which isn't in the trigger types) — that's SPK-858, stacked directly on this.
- Renderer covered by 3 new tests (25 total in that file); full suite green. Real proof is this stack's own PRs: they touch the workflow, so the restructured preview runs on them.

Closes: SPK-857