### PR TITLE
fix(release-safety): recompute the verdict when a PR's base branch changes

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -28,7 +28,13 @@ on:
   pull_request:
     # Include ready_for_review so flipping a draft to ready re-runs the preview —
     # that's the event that newly enables the AI migration review (see below).
-    types: [opened, synchronize, reopened, ready_for_review]
+    # Include edited (SPK-858) because changing a PR's BASE branch fires
+    # `edited`, not `synchronize` — re-parenting a Graphite PR onto main changes
+    # the effective merge-base diff with no push at all, and without this event
+    # the comment keeps showing a pre-reparent verdict. Title/body edits fire
+    # `edited` too; the `changes` job short-circuits those via the comment's
+    # describes-stamp instead of re-running the heavy jobs.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 # Spec generation makes a run long enough that an older run could otherwise
 # finish last and overwrite the sticky comment with a stale verdict.
@@ -50,6 +56,10 @@ jobs:
       base_sha: ${{ steps.base.outputs.sha }}
       base_short: ${{ steps.base.outputs.short }}
       openapi: ${{ steps.filter.outputs.release_safety_api }}
+      # 'true' only on an `edited` event whose head+base the sticky comment
+      # already describes — empty when the fresh step is skipped, so downstream
+      # `!= 'true'` gates default to running.
+      fresh: ${{ steps.fresh.outputs.fresh }}
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -88,6 +98,35 @@ jobs:
               - '.github/file-filters.yml'
               - '.github/workflows/release-safety-pr.yml'
 
+      # SPK-858: an `edited` event that changed neither the base nor the diff
+      # (title/body edits are the overwhelming majority) should not re-run the
+      # heavy jobs. Freshness is judged against WHAT THE COMMENT DESCRIBES (its
+      # stamp) rather than against the event payload: with cancel-in-progress
+      # concurrency, a title edit can cancel an in-flight synchronize run — the
+      # stamp comparison makes the replacement run recompute exactly when the
+      # comment is stale, and skip only when it is current. Only `edited` may
+      # short-circuit: ready_for_review must recompute even on an unchanged diff
+      # (it newly enables the AI review), and pushes always recompute.
+      - name: Read the sticky comment's describes-stamp
+        id: sticky
+        if: github.event.action == 'edited' && steps.watched.outputs.watched == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const marker = '<!-- release-safety-marker -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            const m = existing?.body.match(
+              /<!-- release-safety-describes head:([0-9a-f]{7,40}) base:([0-9a-f]{7,40}) -->/,
+            );
+            core.setOutput('head', m ? m[1] : '');
+            core.setOutput('base', m ? m[2] : '');
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.watched.outputs.watched == 'true'
         with:
@@ -113,10 +152,24 @@ jobs:
           token: ${{ github.token }}
           filters: .github/file-filters.yml
 
+      - name: Decide whether this edited event can short-circuit
+        id: fresh
+        if: github.event.action == 'edited' && steps.watched.outputs.watched == 'true'
+        run: |
+          set -euo pipefail
+          if [ -n "${{ steps.sticky.outputs.head }}" ] \
+            && [ "${{ steps.sticky.outputs.head }}" = "${{ github.event.pull_request.head.sha }}" ] \
+            && [ "${{ steps.sticky.outputs.base }}" = "${{ steps.base.outputs.sha }}" ]; then
+            echo "The sticky comment already describes this head+base; skipping recompute."
+            echo "fresh=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fresh=false" >> "$GITHUB_OUTPUT"
+          fi
+
   openapi-specs:
     name: Generate OpenAPI specs
     needs: changes
-    if: needs.changes.outputs.openapi == 'true'
+    if: needs.changes.outputs.openapi == 'true' && needs.changes.outputs.fresh != 'true'
     runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 30
     env:
@@ -182,8 +235,9 @@ jobs:
     # reports the REST check as not run rather than silently omitting it. A failed
     # openapi-specs job stays red on its own — this job does not launder it green.
     # Skipped entirely when the diff doesn't touch the watched surface — the
-    # `retract` job owns the comment in that case.
-    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.watched == 'true' }}
+    # `retract` job owns the comment in that case — and on an `edited` event
+    # whose head+base the comment already describes (SPK-858).
+    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.watched == 'true' && needs.changes.outputs.fresh != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## What

- Adds `edited` to `release-safety-pr.yml`'s trigger types: changing a PR's **base branch** fires `pull_request(edited)`, not `synchronize`, so a Graphite re-parent onto main changed the effective merge-base diff with no recompute at all (verified on a merged PR: at both `base_ref_changed` moments, the only workflow that woke was the one with `edited` in its triggers).
- Title/body edits — the overwhelming majority of `edited` events — short-circuit cheaply: the `changes` job reads the sticky comment's describes-stamp (from SPK-857), and when it already names the current head **and** merge-base, the heavy jobs skip (`fresh=true`). A base change alters the merge-base, so the stamp mismatches and the verdict recomputes.
- Freshness is judged against **what the comment describes**, not the event payload — this also heals a cancel-in-progress race: a title edit arriving mid-`synchronize`-run cancels that run, and the stamp check makes the replacement `edited` run do the full recompute the cancelled run never finished. Only `edited` may short-circuit: `ready_for_review` must always recompute (it newly enables the AI review with an unchanged diff).

## Why

Unlike the paths-filter freeze (SPK-857), whose observed instances were benign, this direction has no benign bias: a re-parent can *add* a migration or API change the frozen comment has never seen, and the comment keeps showing the pre-reparent verdict.

## Notes

Stacks directly on SPK-857 — the trigger-level `paths:` filter it removed would otherwise still have suppressed `edited` events on PRs whose diff left the watched paths, and the short-circuit is built on 857's stamp.

Closes: SPK-858