### PR TITLE
feat(scripts): spike an upgrade-preflight prober (SPK-701)

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -7,6 +7,9 @@ import { LightdashConfig } from './parseConfig';
 
 export const lightdashConfigMock: LightdashConfig = {
     allowMultiOrgs: false,
+    preflight: {
+        probeEnabled: false,
+    },
     auth: {
         pat: {
             enabled: false,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1434,6 +1434,10 @@ export type LightdashConfig = {
         allowMissingMigrations: boolean;
     };
     allowMultiOrgs: boolean;
+    preflight: {
+        /** SPK-701 spike: opt-in gate for the read-only upgrade-preflight probe endpoint */
+        probeEnabled: boolean;
+    };
     maxPayloadSize: string;
     query: {
         maxLimit: number;
@@ -2921,6 +2925,9 @@ export const parseConfig = (): LightdashConfig => {
             ),
         },
         allowMultiOrgs: process.env.ALLOW_MULTIPLE_ORGS === 'true',
+        preflight: {
+            probeEnabled: process.env.PREFLIGHT_PROBE_ENABLED === 'true',
+        },
         maxPayloadSize: process.env.LIGHTDASH_MAX_PAYLOAD || '5mb',
         query: {
             maxLimit:

--- a/packages/backend/src/controllers/preflightController.ts
+++ b/packages/backend/src/controllers/preflightController.ts
@@ -1,0 +1,51 @@
+import {
+    ApiErrorPayload,
+    ApiPreflightProbeResponse,
+    assertRegisteredAccount,
+} from '@lightdash/common';
+import {
+    Get,
+    Hidden,
+    Middlewares,
+    OperationId,
+    Query,
+    Request,
+    Response,
+    Route,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
+import { BaseController } from './baseController';
+
+@Route('/api/v1/preflight')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Preflight')
+@Hidden()
+export class PreflightController extends BaseController {
+    /**
+     * Read-only snapshot of the instance database's upgrade-relevant state:
+     * migration lock, write counters for the given tables, and long-running
+     * transactions. Call twice and diff the counters for write rates. Requires
+     * organization admin.
+     * @summary Preflight probe
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/probe')
+    @OperationId('GetPreflightProbe')
+    async getPreflightProbe(
+        @Request() req: express.Request,
+        @Query() tables?: string,
+    ): Promise<ApiPreflightProbeResponse> {
+        assertRegisteredAccount(req.account);
+        const tableNames = (tables ?? '')
+            .split(',')
+            .map((table) => table.trim())
+            .filter(Boolean);
+        const results = await this.services
+            .getPreflightService()
+            .probe(req.account, tableNames);
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+}

--- a/packages/backend/src/controllers/preflightController.ts
+++ b/packages/backend/src/controllers/preflightController.ts
@@ -26,8 +26,12 @@ export class PreflightController extends BaseController {
     /**
      * Read-only snapshot of the instance database's upgrade-relevant state:
      * migration lock, write counters for the given tables, and long-running
-     * transactions. Call twice and diff the counters for write rates. Requires
-     * organization admin.
+     * transactions. Call twice and diff the counters for write rates. Disabled
+     * unless PREFLIGHT_PROBE_ENABLED=true; requires organization admin, and
+     * refuses multi-organization instances outright.
+     * On single-organization instances the activity snapshot includes in-flight
+     * query text (which can embed literals from other users' queries) — the
+     * audience is the instance operator.
      * @summary Preflight probe
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -40,6 +40,7 @@ import { OrganizationWarehouseCredentialsModel } from './OrganizationWarehouseCr
 import { PasswordResetLinkModel } from './PasswordResetLinkModel';
 import { PersistentDownloadFileModel } from './PersistentDownloadFileModel';
 import { PinnedListModel } from './PinnedListModel';
+import { PreflightModel } from './PreflightModel';
 import { ProjectCompileLogModel } from './ProjectCompileLogModel';
 import { ProjectDbtSourcesModel } from './ProjectDbtSourcesModel';
 import { ProjectModel } from './ProjectModel/ProjectModel';
@@ -108,6 +109,7 @@ export type ModelManifest = {
     organizationDomainVerificationModel: OrganizationDomainVerificationModel;
     organizationEmailDomainModel: OrganizationEmailDomainModel;
     organizationSettingsModel: OrganizationSettingsModel;
+    preflightModel: PreflightModel;
     organizationSsoModel: OrganizationSsoModel;
     organizationWarehouseCredentialsModel: OrganizationWarehouseCredentialsModel;
     passwordResetLinkModel: PasswordResetLinkModel;
@@ -530,6 +532,13 @@ export class ModelRepository
         return this.getModel(
             'organizationSettingsModel',
             () => new OrganizationSettingsModel({ database: this.database }),
+        );
+    }
+
+    public getPreflightModel(): PreflightModel {
+        return this.getModel(
+            'preflightModel',
+            () => new PreflightModel({ database: this.database }),
         );
     }
 

--- a/packages/backend/src/models/PreflightModel.ts
+++ b/packages/backend/src/models/PreflightModel.ts
@@ -59,7 +59,7 @@ export class PreflightModel {
         }>(
             `SELECT relname, n_tup_ins, n_tup_upd, n_tup_del, n_live_tup
              FROM pg_stat_user_tables
-             WHERE schemaname = 'public' AND relname = ANY(?)`,
+             WHERE schemaname = current_schema() AND relname = ANY(?)`,
             [tables],
         );
         return result.rows.map((row) => ({
@@ -71,7 +71,9 @@ export class PreflightModel {
         }));
     }
 
-    async getActivity(): Promise<PreflightActivityRow[]> {
+    async getActivity(options: {
+        includeQueryText: boolean;
+    }): Promise<PreflightActivityRow[]> {
         const result = await this.database.raw<{
             rows: Array<{
                 pid: number;
@@ -89,6 +91,7 @@ export class PreflightModel {
                     CASE WHEN cardinality(pg_blocking_pids(pid)) > 0 THEN pg_blocking_pids(pid) END AS blocked_by
              FROM pg_stat_activity
              WHERE pid <> pg_backend_pid()
+               AND datname = current_database()
                AND xact_start IS NOT NULL
                AND state <> 'idle'`,
         );
@@ -99,7 +102,7 @@ export class PreflightModel {
             state: row.state,
             xactAgeSeconds:
                 row.xact_age_s === null ? null : Number(row.xact_age_s),
-            query: row.query,
+            query: options.includeQueryText ? row.query : null,
             blockedBy: row.blocked_by ?? [],
         }));
     }

--- a/packages/backend/src/models/PreflightModel.ts
+++ b/packages/backend/src/models/PreflightModel.ts
@@ -31,18 +31,19 @@ export class PreflightModel {
             }
             throw error;
         }
-        const backends = await this.database.raw<{
-            rows: Array<{ n: number }>;
+        const lastMigration = await this.database.raw<{
+            rows: Array<{ age_seconds: number | null }>;
         }>(
-            `SELECT count(*)::integer AS n
-             FROM pg_stat_activity
-             WHERE state <> 'idle'
-               AND pid <> pg_backend_pid()
-               AND query ILIKE '%knex_migrations%'`,
+            `SELECT EXTRACT(EPOCH FROM now() - max(migration_time))::integer AS age_seconds
+             FROM knex_migrations`,
         );
         return {
             isLocked,
-            activeMigrationBackends: backends.rows[0]?.n ?? 0,
+            lastMigrationAgeSeconds:
+                lastMigration.rows[0]?.age_seconds === null ||
+                lastMigration.rows[0]?.age_seconds === undefined
+                    ? null
+                    : Number(lastMigration.rows[0].age_seconds),
         };
     }
 

--- a/packages/backend/src/models/PreflightModel.ts
+++ b/packages/backend/src/models/PreflightModel.ts
@@ -1,0 +1,106 @@
+import {
+    PreflightActivityRow,
+    PreflightLockState,
+    PreflightTableStats,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+
+const POSTGRES_UNDEFINED_TABLE = '42P01';
+
+export class PreflightModel {
+    private readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    async getLockState(): Promise<PreflightLockState | null> {
+        let isLocked: boolean;
+        try {
+            const result = await this.database.raw<{
+                rows: Array<{ is_locked: number }>;
+            }>('SELECT is_locked FROM knex_migrations_lock');
+            isLocked = result.rows.some((row) => Number(row.is_locked) === 1);
+        } catch (error) {
+            if (
+                error instanceof Error &&
+                'code' in error &&
+                error.code === POSTGRES_UNDEFINED_TABLE
+            ) {
+                return null;
+            }
+            throw error;
+        }
+        const backends = await this.database.raw<{
+            rows: Array<{ n: number }>;
+        }>(
+            `SELECT count(*)::integer AS n
+             FROM pg_stat_activity
+             WHERE state <> 'idle'
+               AND pid <> pg_backend_pid()
+               AND query ILIKE '%knex_migrations%'`,
+        );
+        return {
+            isLocked,
+            activeMigrationBackends: backends.rows[0]?.n ?? 0,
+        };
+    }
+
+    async getTableStats(tables: string[]): Promise<PreflightTableStats[]> {
+        if (tables.length === 0) return [];
+        const result = await this.database.raw<{
+            rows: Array<{
+                relname: string;
+                n_tup_ins: string;
+                n_tup_upd: string;
+                n_tup_del: string;
+                n_live_tup: string;
+            }>;
+        }>(
+            `SELECT relname, n_tup_ins, n_tup_upd, n_tup_del, n_live_tup
+             FROM pg_stat_user_tables
+             WHERE schemaname = 'public' AND relname = ANY(?)`,
+            [tables],
+        );
+        return result.rows.map((row) => ({
+            table: row.relname,
+            inserts: Number(row.n_tup_ins),
+            updates: Number(row.n_tup_upd),
+            deletes: Number(row.n_tup_del),
+            liveTuples: Number(row.n_live_tup),
+        }));
+    }
+
+    async getActivity(): Promise<PreflightActivityRow[]> {
+        const result = await this.database.raw<{
+            rows: Array<{
+                pid: number;
+                usename: string | null;
+                application_name: string | null;
+                state: string | null;
+                xact_age_s: number | null;
+                query: string | null;
+                blocked_by: number[] | null;
+            }>;
+        }>(
+            `SELECT pid, usename, application_name, state,
+                    EXTRACT(EPOCH FROM now() - xact_start)::integer AS xact_age_s,
+                    left(query, 160) AS query,
+                    CASE WHEN cardinality(pg_blocking_pids(pid)) > 0 THEN pg_blocking_pids(pid) END AS blocked_by
+             FROM pg_stat_activity
+             WHERE pid <> pg_backend_pid()
+               AND xact_start IS NOT NULL
+               AND state <> 'idle'`,
+        );
+        return result.rows.map((row) => ({
+            pid: row.pid,
+            userName: row.usename,
+            applicationName: row.application_name,
+            state: row.state,
+            xactAgeSeconds:
+                row.xact_age_s === null ? null : Number(row.xact_age_s),
+            query: row.query,
+            blockedBy: row.blocked_by ?? [],
+        }));
+    }
+}

--- a/packages/backend/src/services/PreflightService/PreflightService.test.ts
+++ b/packages/backend/src/services/PreflightService/PreflightService.test.ts
@@ -35,7 +35,7 @@ const buildService = (allowMultiOrgs: boolean, probeEnabled = true) => {
     const preflightModel = {
         getLockState: vi.fn(async () => ({
             isLocked: false,
-            activeMigrationBackends: 0,
+            lastMigrationAgeSeconds: 3600,
         })),
         getTableStats: vi.fn(async () => []),
         getActivity: vi.fn(async () => []),
@@ -88,7 +88,7 @@ describe('PreflightService — probe', () => {
         const probe = await service.probe(adminAccount, ['users', 'users']);
         expect(probe.lock).toEqual({
             isLocked: false,
-            activeMigrationBackends: 0,
+            lastMigrationAgeSeconds: 3600,
         });
         expect(preflightModel.getTableStats).toHaveBeenCalledWith(['users']);
         expect(preflightModel.getActivity).toHaveBeenCalledWith({

--- a/packages/backend/src/services/PreflightService/PreflightService.test.ts
+++ b/packages/backend/src/services/PreflightService/PreflightService.test.ts
@@ -1,0 +1,98 @@
+import { Ability } from '@casl/ability';
+import {
+    ForbiddenError,
+    ParameterError,
+    type PossibleAbilities,
+    type RegisteredAccount,
+} from '@lightdash/common';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { type PreflightModel } from '../../models/PreflightModel';
+import { PreflightService } from './PreflightService';
+
+const adminAccount = {
+    organization: { organizationUuid: 'org-uuid', name: 'Acme' },
+    user: {
+        id: 'user-uuid',
+        userUuid: 'user-uuid',
+        ability: new Ability<PossibleAbilities>([
+            { subject: 'Organization', action: 'manage' },
+        ]),
+    },
+    authentication: { type: 'session' },
+    isAnonymousUser: () => false,
+    isServiceAccount: () => false,
+} as unknown as RegisteredAccount;
+
+const viewerAccount = {
+    ...adminAccount,
+    user: {
+        ...adminAccount.user,
+        ability: new Ability<PossibleAbilities>([]),
+    },
+} as unknown as RegisteredAccount;
+
+const buildService = (allowMultiOrgs: boolean, probeEnabled = true) => {
+    const preflightModel = {
+        getLockState: vi.fn(async () => ({
+            isLocked: false,
+            activeMigrationBackends: 0,
+        })),
+        getTableStats: vi.fn(async () => []),
+        getActivity: vi.fn(async () => []),
+    } as unknown as PreflightModel;
+
+    const service = new PreflightService({
+        lightdashConfig: {
+            ...lightdashConfigMock,
+            allowMultiOrgs,
+            preflight: { probeEnabled },
+        },
+        preflightModel,
+    });
+    return { service, preflightModel };
+};
+
+describe('PreflightService — probe', () => {
+    it('refuses when the probe is not enabled by environment variable', async () => {
+        const { service, preflightModel } = buildService(false, false);
+        await expect(service.probe(adminAccount, ['users'])).rejects.toThrow(
+            /not enabled/,
+        );
+        expect(preflightModel.getLockState).not.toHaveBeenCalled();
+    });
+
+    it('refuses outright on multi-organization instances', async () => {
+        const { service, preflightModel } = buildService(true);
+        await expect(service.probe(adminAccount, ['users'])).rejects.toThrow(
+            ForbiddenError,
+        );
+        expect(preflightModel.getLockState).not.toHaveBeenCalled();
+    });
+
+    it('refuses non-admin accounts', async () => {
+        const { service } = buildService(false);
+        await expect(service.probe(viewerAccount, ['users'])).rejects.toThrow(
+            ForbiddenError,
+        );
+    });
+
+    it('rejects invalid table names', async () => {
+        const { service } = buildService(false);
+        await expect(
+            service.probe(adminAccount, ['users; DROP TABLE users']),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    it('probes single-org instances with query text included', async () => {
+        const { service, preflightModel } = buildService(false);
+        const probe = await service.probe(adminAccount, ['users', 'users']);
+        expect(probe.lock).toEqual({
+            isLocked: false,
+            activeMigrationBackends: 0,
+        });
+        expect(preflightModel.getTableStats).toHaveBeenCalledWith(['users']);
+        expect(preflightModel.getActivity).toHaveBeenCalledWith({
+            includeQueryText: true,
+        });
+    });
+});

--- a/packages/backend/src/services/PreflightService/PreflightService.ts
+++ b/packages/backend/src/services/PreflightService/PreflightService.ts
@@ -5,10 +5,12 @@ import {
     PreflightProbe,
     type RegisteredAccount,
 } from '@lightdash/common';
+import { LightdashConfig } from '../../config/parseConfig';
 import { PreflightModel } from '../../models/PreflightModel';
 import { BaseService } from '../BaseService';
 
 type PreflightServiceArguments = {
+    lightdashConfig: LightdashConfig;
     preflightModel: PreflightModel;
 };
 
@@ -23,10 +25,16 @@ const MAX_TABLES = 50;
  * SQL.
  */
 export class PreflightService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
     private readonly preflightModel: PreflightModel;
 
-    constructor({ preflightModel }: PreflightServiceArguments) {
+    constructor({
+        lightdashConfig,
+        preflightModel,
+    }: PreflightServiceArguments) {
         super({ serviceName: 'PreflightService' });
+        this.lightdashConfig = lightdashConfig;
         this.preflightModel = preflightModel;
     }
 
@@ -50,6 +58,16 @@ export class PreflightService extends BaseService {
         account: RegisteredAccount,
         tables: string[],
     ): Promise<PreflightProbe> {
+        if (!this.lightdashConfig.preflight.probeEnabled) {
+            throw new ForbiddenError(
+                'Preflight probe is not enabled on this instance (set PREFLIGHT_PROBE_ENABLED=true)',
+            );
+        }
+        if (this.lightdashConfig.allowMultiOrgs) {
+            throw new ForbiddenError(
+                'Preflight probe is only available on single-organization instances',
+            );
+        }
         this.assertCanManageOrganization(account);
         const uniqueTables = [...new Set(tables)];
         if (uniqueTables.length > MAX_TABLES) {
@@ -63,7 +81,9 @@ export class PreflightService extends BaseService {
         const [lock, tableStats, activity] = await Promise.all([
             this.preflightModel.getLockState(),
             this.preflightModel.getTableStats(uniqueTables),
-            this.preflightModel.getActivity(),
+            this.preflightModel.getActivity({
+                includeQueryText: !this.lightdashConfig.allowMultiOrgs,
+            }),
         ]);
         return {
             serverTime: new Date().toISOString(),

--- a/packages/backend/src/services/PreflightService/PreflightService.ts
+++ b/packages/backend/src/services/PreflightService/PreflightService.ts
@@ -1,0 +1,75 @@
+import { subject } from '@casl/ability';
+import {
+    ForbiddenError,
+    ParameterError,
+    PreflightProbe,
+    type RegisteredAccount,
+} from '@lightdash/common';
+import { PreflightModel } from '../../models/PreflightModel';
+import { BaseService } from '../BaseService';
+
+type PreflightServiceArguments = {
+    preflightModel: PreflightModel;
+};
+
+const TABLE_NAME_PATTERN = /^[a-z_][a-z0-9_]{0,62}$/;
+const MAX_TABLES = 50;
+
+/**
+ * SPK-701 spike: read-only probe of the instance database's upgrade-relevant
+ * state, for operators without direct Postgres access. Serves snapshots only —
+ * joining them with per-migration facts (and everything EXPLAIN-based) stays
+ * in the preflight consumer, so this endpoint never executes caller-supplied
+ * SQL.
+ */
+export class PreflightService extends BaseService {
+    private readonly preflightModel: PreflightModel;
+
+    constructor({ preflightModel }: PreflightServiceArguments) {
+        super({ serviceName: 'PreflightService' });
+        this.preflightModel = preflightModel;
+    }
+
+    private assertCanManageOrganization(account: RegisteredAccount): void {
+        const organizationUuid = account.organization?.organizationUuid;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
+    async probe(
+        account: RegisteredAccount,
+        tables: string[],
+    ): Promise<PreflightProbe> {
+        this.assertCanManageOrganization(account);
+        const uniqueTables = [...new Set(tables)];
+        if (uniqueTables.length > MAX_TABLES) {
+            throw new ParameterError(`Pass at most ${MAX_TABLES} tables`);
+        }
+        for (const table of uniqueTables) {
+            if (!TABLE_NAME_PATTERN.test(table)) {
+                throw new ParameterError(`Invalid table name: ${table}`);
+            }
+        }
+        const [lock, tableStats, activity] = await Promise.all([
+            this.preflightModel.getLockState(),
+            this.preflightModel.getTableStats(uniqueTables),
+            this.preflightModel.getActivity(),
+        ]);
+        return {
+            serverTime: new Date().toISOString(),
+            lock,
+            tableStats,
+            activity,
+        };
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -713,6 +713,7 @@ export class ServiceRepository
             'preflightService',
             () =>
                 new PreflightService({
+                    lightdashConfig: this.context.lightdashConfig,
                     preflightModel: this.models.getPreflightModel(),
                 }),
         );

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -57,6 +57,7 @@ import { PersistentDownloadFileService } from './PersistentDownloadFileService/P
 import { PersonalAccessTokenService } from './PersonalAccessTokenService';
 import { PinningService } from './PinningService/PinningService';
 import { PivotTableService } from './PivotTableService/PivotTableService';
+import { PreflightService } from './PreflightService/PreflightService';
 import { ProjectCompileLogService } from './ProjectCompileLogService/ProjectCompileLogService';
 import { ProjectDbtSourcesService } from './ProjectDbtSourcesService';
 import { ProjectParametersService } from './ProjectParametersService';
@@ -111,6 +112,7 @@ interface ServiceManifest {
     organizationDesignService: OrganizationDesignService;
     organizationService: OrganizationService;
     organizationSettingsService: OrganizationSettingsService;
+    preflightService: PreflightService;
     organizationSsoService: OrganizationSsoService;
     organizationDomainVerificationService: OrganizationDomainVerificationService;
     emailWhitelabelService: EmailWhitelabelService;
@@ -702,6 +704,16 @@ export class ServiceRepository
                     organizationSettingsModel:
                         this.models.getOrganizationSettingsModel(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
+                }),
+        );
+    }
+
+    public getPreflightService(): PreflightService {
+        return this.getService(
+            'preflightService',
+            () =>
+                new PreflightService({
+                    preflightModel: this.models.getPreflightModel(),
                 }),
         );
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -153,6 +153,7 @@ export * from './types/organizationBrand';
 export * from './types/organizationDomainVerification';
 export * from './types/organizationMemberProfile';
 export * from './types/organizationSettings';
+export * from './types/preflight';
 export * from './types/organizationSso';
 export * from './types/organizationWarehouseCredentials';
 export * from './types/paginateResults';

--- a/packages/common/src/types/preflight.ts
+++ b/packages/common/src/types/preflight.ts
@@ -1,0 +1,40 @@
+export type PreflightLockState = {
+    isLocked: boolean;
+    activeMigrationBackends: number;
+};
+
+export type PreflightTableStats = {
+    table: string;
+    inserts: number;
+    updates: number;
+    deletes: number;
+    liveTuples: number;
+};
+
+export type PreflightActivityRow = {
+    pid: number;
+    userName: string | null;
+    applicationName: string | null;
+    state: string | null;
+    xactAgeSeconds: number | null;
+    query: string | null;
+    blockedBy: number[];
+};
+
+/**
+ * One read-only snapshot of the instance database's upgrade-relevant state.
+ * Write rates are derived by the consumer from two snapshots — the server
+ * stays stateless and the sampling interval stays a client choice.
+ */
+export type PreflightProbe = {
+    serverTime: string;
+    /** null when the knex migration lock table does not exist */
+    lock: PreflightLockState | null;
+    tableStats: PreflightTableStats[];
+    activity: PreflightActivityRow[];
+};
+
+export type ApiPreflightProbeResponse = {
+    status: 'ok';
+    results: PreflightProbe;
+};

--- a/packages/common/src/types/preflight.ts
+++ b/packages/common/src/types/preflight.ts
@@ -1,6 +1,7 @@
 export type PreflightLockState = {
     isLocked: boolean;
-    activeMigrationBackends: number;
+    /** seconds since the newest completed migration; evidence for judging a held lock */
+    lastMigrationAgeSeconds: number | null;
 };
 
 export type PreflightTableStats = {

--- a/scripts/preflight-facts.example.json
+++ b/scripts/preflight-facts.example.json
@@ -1,0 +1,115 @@
+{
+    "schemaVersion": "1-draft",
+    "migrationFacts": [
+        {
+            "migration": "20260610120000_default_saved_chart_timezone_to_project",
+            "introducedIn": "0.3138.0",
+            "runsInTransaction": false,
+            "resumable": true,
+            "batchSize": 10000,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "saved_queries_versions",
+                    "access": [
+                        "ddl",
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock (batched UPDATE passes)",
+                        "ShareUpdateExclusiveLock (VALIDATE CONSTRAINT)",
+                        "AccessExclusiveLock (brief, ALTER COLUMN default / SET NOT NULL fast path)"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Repurposes the nullable timezone column into a NOT NULL setting column: batched ctid UPDATE flips remaining NULLs to 'project_timezone' (each pass re-scans for what is left), then CHECK NOT VALID + VALIDATE + SET NOT NULL.",
+                "estimateSql": "SELECT saved_queries_version_id FROM saved_queries_versions WHERE timezone IS NULL",
+                "planSql": "SELECT ctid FROM saved_queries_versions WHERE timezone IS NULL LIMIT 10000",
+                "supportingIndexSql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sqv_timezone_null ON saved_queries_versions (saved_queries_version_id) WHERE timezone IS NULL"
+            },
+            "notes": "Every pass re-selects the remaining NULLs by scanning the table, so passes slow down as few NULLs remain; a concurrent writer appending rows extends the drain and its IO competes with the scan. The vetted partial index makes the remaining-NULLs lookup cheap once most rows are drained."
+        },
+        {
+            "migration": "20260721112833_add_project_uuid_to_saved_queries",
+            "introducedIn": "0.3477.0",
+            "runsInTransaction": false,
+            "resumable": true,
+            "batchSize": 1000,
+            "lockTimeout": "5s",
+            "tables": [
+                {
+                    "name": "saved_queries",
+                    "access": [
+                        "ddl",
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "AccessExclusiveLock (brief, ADD COLUMN with 5s lock_timeout)",
+                        "RowExclusiveLock (batched UPDATE)"
+                    ]
+                },
+                {
+                    "name": "spaces",
+                    "access": [
+                        "read"
+                    ],
+                    "expectedLockModes": [
+                        "AccessShareLock"
+                    ]
+                },
+                {
+                    "name": "projects",
+                    "access": [
+                        "read"
+                    ],
+                    "expectedLockModes": [
+                        "AccessShareLock"
+                    ]
+                },
+                {
+                    "name": "dashboards",
+                    "access": [
+                        "read"
+                    ],
+                    "expectedLockModes": [
+                        "AccessShareLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Adds saved_queries.project_uuid and backfills it from the owning space's project (falling back to the parent dashboard's project) in committed batches of 1000; reruns skip populated rows.",
+                "estimateSql": "SELECT saved_query_id FROM saved_queries",
+                "planSql": "SELECT saved_queries.saved_query_id FROM saved_queries LEFT JOIN spaces AS direct_spaces ON direct_spaces.space_id = saved_queries.space_id LEFT JOIN projects AS direct_projects ON direct_projects.project_id = direct_spaces.project_id LEFT JOIN dashboards ON dashboards.dashboard_uuid = saved_queries.dashboard_uuid LEFT JOIN spaces AS dashboard_spaces ON dashboard_spaces.space_id = dashboards.space_id LEFT JOIN projects AS dashboard_projects ON dashboard_projects.project_id = dashboard_spaces.project_id WHERE saved_queries.saved_query_id > 0 ORDER BY saved_queries.saved_query_id LIMIT 1000",
+                "supportingIndexSql": null
+            },
+            "notes": "Expand phase; every row starts NULL so the whole table is touched. A hard-killed run leaves the global knex lock held (see stale-lock check)."
+        },
+        {
+            "migration": "20260731111612_grandfather_existing_incomplete_users_setup_complete",
+            "introducedIn": "1.51.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "users",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock (single UPDATE, row locks held until commit)"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Single-statement UPDATE users SET is_setup_complete = true WHERE is_setup_complete = false, inside the default migration transaction.",
+                "estimateSql": "SELECT user_id FROM users WHERE is_setup_complete = false",
+                "planSql": null,
+                "supportingIndexSql": null
+            },
+            "notes": "Not batched: on a large users table this holds row locks for the whole statement and the transaction blocks concurrent writers to the same rows."
+        }
+    ]
+}

--- a/scripts/preflight-facts.schema.json
+++ b/scripts/preflight-facts.schema.json
@@ -40,7 +40,7 @@
                 },
                 "supportingIndexSql": {
                     "type": ["string", "null"],
-                    "description": "Vetted pre-upgrade index DDL (CREATE INDEX CONCURRENTLY ...) that supports the backfill predicate, emitted verbatim as an operator remediation. null when no index helps (e.g. the predicate matches most of the table)."
+                    "description": "Vetted pre-upgrade index DDL that supports the backfill predicate, emitted verbatim as an operator remediation. When non-null it must be one semicolon-free statement matching ^CREATE (UNIQUE )?INDEX CONCURRENTLY (IF NOT EXISTS )?[A-Za-z0-9_\" .()=<>'!,-]+$. null when no index helps (e.g. the predicate matches most of the table)."
                 }
             }
         },

--- a/scripts/preflight-facts.schema.json
+++ b/scripts/preflight-facts.schema.json
@@ -1,0 +1,92 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://lightdash.com/schemas/preflight-facts/v1-draft.json",
+    "title": "Lightdash upgrade-preflight migration facts (draft)",
+    "description": "Per-migration facts consumed by scripts/preflight.ts (SPK-701 spike). Draft of the `migrationFacts` extension to the release-safety marker: each entry describes what one migration will do to the operator's database so the preflight prober can join it with read-only probes. All backfill SQL must be runnable against the PRE-upgrade schema — columns the migration itself adds do not exist yet on the operator's database.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["schemaVersion", "migrationFacts"],
+    "definitions": {
+        "tableFact": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "access", "expectedLockModes"],
+            "properties": {
+                "name": { "type": "string" },
+                "access": {
+                    "type": "array",
+                    "items": { "type": "string", "enum": ["read", "write", "ddl"] }
+                },
+                "expectedLockModes": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Asserted documentation joined into operator messages, not a verified lock model."
+                }
+            }
+        },
+        "backfillFact": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["description", "estimateSql", "planSql", "supportingIndexSql"],
+            "properties": {
+                "description": { "type": "string" },
+                "estimateSql": {
+                    "type": "string",
+                    "description": "Single SELECT statement enumerating the rows the backfill touches; EXPLAIN'd for the row estimate."
+                },
+                "planSql": {
+                    "type": ["string", "null"],
+                    "description": "The batch query shape, EXPLAIN'd for the index/seq-scan check; null when estimateSql is the shape."
+                },
+                "supportingIndexSql": {
+                    "type": ["string", "null"],
+                    "description": "Vetted pre-upgrade index DDL (CREATE INDEX CONCURRENTLY ...) that supports the backfill predicate, emitted verbatim as an operator remediation. null when no index helps (e.g. the predicate matches most of the table)."
+                }
+            }
+        },
+        "migrationFact": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "migration",
+                "introducedIn",
+                "runsInTransaction",
+                "resumable",
+                "batchSize",
+                "lockTimeout",
+                "tables",
+                "backfill",
+                "notes"
+            ],
+            "properties": {
+                "migration": { "type": "string" },
+                "introducedIn": {
+                    "type": "string",
+                    "description": "Release version that ships this migration; joined against the prober's --from/--to range."
+                },
+                "runsInTransaction": { "type": "boolean" },
+                "resumable": { "type": "boolean" },
+                "batchSize": { "type": ["integer", "null"], "minimum": 1 },
+                "lockTimeout": { "type": ["string", "null"] },
+                "tables": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/tableFact" }
+                },
+                "backfill": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/backfillFact" },
+                        { "type": "null" }
+                    ]
+                },
+                "notes": { "type": ["string", "null"] }
+            }
+        }
+    },
+    "properties": {
+        "schemaVersion": { "type": "string", "const": "1-draft" },
+        "migrationFacts": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/migrationFact" }
+        }
+    }
+}

--- a/scripts/preflight.test.ts
+++ b/scripts/preflight.test.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {
     ActivityRow,
+    analyzeUpgradeStrategy,
     assertSafeApiBaseUrl,
     executionSeconds,
     parseNumericFlag,
@@ -283,16 +284,42 @@ test('large single-transaction backfill warns; batched resumable one is ok', () 
     assert.match(batched.summary, /batches of 1000, resumable \(~2,000 passes\)/);
 });
 
-test('a measured scan turns the window advice into a number and names the k8s knobs', () => {
+test('a measured scan turns the window advice into a number', () => {
     const slow = analyzeRowEstimate(fact(), explainFixture(2_000_000), 100000, 300);
     assert.match(slow.summary, /measured ~5 min on this instance/);
     assert.match(slow.action ?? '', /window of at least ~5 min/);
-    assert.match(slow.action ?? '', /recommendedStrategy \(Recreate/);
-    assert.match(slow.action ?? '', /activeDeadlineSeconds/);
 
     const fast = analyzeRowEstimate(fact(), explainFixture(2_000_000), 100000, 0.4);
     assert.doesNotMatch(fast.action ?? '', /at least <1s/);
     assert.match(fast.action ?? '', /scan measured <1s here, but the single-transaction UPDATE/);
+});
+
+test('strategy advice fires whenever the range contains DDL, as info not warn', () => {
+    const ddlFact = fact({
+        tables: [
+            { name: 'saved_queries', access: ['ddl', 'write'], expectedLockModes: [] },
+            { name: 'spaces', access: ['read'], expectedLockModes: [] },
+        ],
+    });
+    const findings = analyzeUpgradeStrategy([ddlFact, fact()]);
+    assert.strictEqual(findings.length, 1);
+    assert.strictEqual(findings[0].severity, 'info');
+    assert.strictEqual(findings[0].actionKind, 'plan');
+    assert.match(findings[0].summary, /"saved_queries"/);
+    assert.doesNotMatch(findings[0].summary, /"spaces"/);
+    assert.match(findings[0].action ?? '', /strategy Recreate/);
+    assert.match(findings[0].action ?? '', /activeDeadlineSeconds/);
+    assert.match(findings[0].action ?? '', /stale lock/);
+});
+
+test('no DDL in range means no strategy finding, and info does not degrade the verdict', () => {
+    assert.deepStrictEqual(analyzeUpgradeStrategy([fact()]), []);
+    const report = buildReport('1.50.0', '1.60.0', [], [
+        { check: 'strategy', severity: 'info', migration: null, table: null, summary: 's', action: 'plan it', actionKind: 'plan', data: {} },
+        { check: 'activity', severity: 'ok', migration: null, table: null, summary: 'fine', action: null, actionKind: null, data: {} },
+    ]);
+    assert.strictEqual(report.verdict, 'ok');
+    assert.deepStrictEqual(report.planItems, ['plan it']);
 });
 
 test('formatSeconds picks sensible units', () => {
@@ -429,8 +456,7 @@ test('operator-fixable findings are remediate; migration-intrinsic ones are plan
 
     const bigTxn = analyzeRowEstimate(fact(), explainFixture(2_000_000), 100000, null);
     assert.strictEqual(bigTxn.actionKind, 'plan');
-    assert.match(bigTxn.action ?? '', /Recreate/);
-    assert.match(bigTxn.action ?? '', /eviction/);
+    assert.match(bigTxn.action ?? '', /maintenance window/);
     const seq = analyzeSeqScans(fact(), explainFixture(500, 'users'), new Map([['users', 2_000_000]]), 100000, 500, null);
     assert.strictEqual(seq[0].actionKind, 'plan');
 });

--- a/scripts/preflight.test.ts
+++ b/scripts/preflight.test.ts
@@ -10,8 +10,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {
     ActivityRow,
+    assertSafeApiBaseUrl,
     executionSeconds,
+    parseNumericFlag,
     formatSeconds,
+    makePsqlRunner,
     analyzeActivity,
     analyzeLock,
     analyzeRowEstimate,
@@ -430,6 +433,29 @@ test('operator-fixable findings are remediate; migration-intrinsic ones are plan
     assert.match(bigTxn.action ?? '', /eviction/);
     const seq = analyzeSeqScans(fact(), explainFixture(500, 'users'), new Map([['users', 2_000_000]]), 100000, 500, null);
     assert.strictEqual(seq[0].actionKind, 'plan');
+});
+
+// --- transport guards --------------------------------------------------------
+
+test('http API URLs are rejected unless local or explicitly allowed', () => {
+    assert.throws(() => assertSafeApiBaseUrl('http://lightdash.internal:8080', false), /cleartext/);
+    assert.doesNotThrow(() => assertSafeApiBaseUrl('http://localhost:8120', false));
+    assert.doesNotThrow(() => assertSafeApiBaseUrl('http://lightdash.internal:8080', true));
+    assert.doesNotThrow(() => assertSafeApiBaseUrl('https://lightdash.example.com', false));
+    assert.throws(() => assertSafeApiBaseUrl('not a url', false), /not a valid URL/);
+});
+
+test('malformed numeric flags fail loudly instead of producing a false clear verdict', () => {
+    assert.strictEqual(parseNumericFlag('--interval', null, 10), 10);
+    assert.strictEqual(parseNumericFlag('--interval', '15', 10), 15);
+    assert.throws(() => parseNumericFlag('--interval', 'abc', 10), /positive number/);
+    assert.throws(() => parseNumericFlag('--interval', '-5', 10), /positive number/);
+    assert.throws(() => parseNumericFlag('--interval', '0', 10), /positive number/);
+});
+
+test('quoted --psql commands fail loudly instead of splitting silently', () => {
+    assert.throws(() => makePsqlRunner('psql "dbname=my db"'), /does not understand quoting/);
+    assert.doesNotThrow(() => makePsqlRunner('docker exec db psql -U postgres'));
 });
 
 // -----------------------------------------------------------------------------

--- a/scripts/preflight.test.ts
+++ b/scripts/preflight.test.ts
@@ -1,0 +1,442 @@
+/**
+ * Unit tests for the PURE core of the SPK-701 preflight prober.
+ * Run: `npx tsx scripts/preflight.test.ts`
+ *
+ * The psql IO shell is exercised manually against a dev instance (see the
+ * spike write-up); everything here runs on fixtures.
+ */
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    ActivityRow,
+    executionSeconds,
+    formatSeconds,
+    analyzeActivity,
+    analyzeLock,
+    analyzeRowEstimate,
+    analyzeSeqScans,
+    analyzeWriteRates,
+    buildReport,
+    computeWriteRates,
+    Finding,
+    flattenPlan,
+    MigrationFact,
+    parseFactsFile,
+    selectFacts,
+    StatRow,
+    topPlanRows,
+} from './preflight';
+
+let passed = 0;
+const failures: string[] = [];
+
+function test(name: string, fn: () => void): void {
+    try {
+        fn();
+        passed += 1;
+    } catch (err) {
+        failures.push(`${name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+
+const fact = (overrides: Partial<MigrationFact> = {}): MigrationFact => ({
+    migration: '20260101000000_test_migration',
+    introducedIn: '1.50.0',
+    runsInTransaction: true,
+    resumable: false,
+    batchSize: null,
+    lockTimeout: null,
+    tables: [{ name: 'users', access: ['write'], expectedLockModes: ['RowExclusiveLock'] }],
+    backfill: {
+        description: 'test',
+        estimateSql: 'SELECT user_id FROM users WHERE is_setup_complete = false',
+        planSql: null,
+        supportingIndexSql: null,
+    },
+    notes: null,
+    ...overrides,
+});
+
+const explainFixture = (planRows: number, relation = 'users') => [
+    {
+        Plan: {
+            'Node Type': 'Seq Scan',
+            'Relation Name': relation,
+            'Plan Rows': planRows,
+        },
+    },
+];
+
+// --- parseFactsFile ----------------------------------------------------------
+
+const validFactsFile = (facts: MigrationFact[]): string =>
+    JSON.stringify({ schemaVersion: '1-draft', migrationFacts: facts });
+
+test('parseFactsFile rejects a file without migrationFacts', () => {
+    assert.throws(() => parseFactsFile('{"schemaVersion":"1-draft"}'), /migrationFacts/);
+});
+
+test('the shipped example facts file validates against the schema', () => {
+    const raw = fs.readFileSync(
+        path.join(__dirname, 'preflight-facts.example.json'),
+        'utf-8',
+    );
+    assert.strictEqual(parseFactsFile(raw).migrationFacts.length, 3);
+});
+
+test('schema rejects an unknown table access value', () => {
+    const bad = fact({
+        tables: [{ name: 'users', access: ['readwrite' as never], expectedLockModes: [] }],
+    });
+    assert.throws(() => parseFactsFile(validFactsFile([bad])), /not in enum/);
+});
+
+test('schema rejects unknown properties on a fact', () => {
+    const bad = { ...fact(), surprise: true } as unknown as MigrationFact;
+    assert.throws(() => parseFactsFile(validFactsFile([bad])), /additional property not allowed/);
+});
+
+test('schema rejects a wrong schemaVersion', () => {
+    assert.throws(
+        () => parseFactsFile('{"schemaVersion":"2","migrationFacts":[]}'),
+        /does not equal const/,
+    );
+});
+
+test('parseFactsFile rejects multi-statement backfill SQL', () => {
+    const file = JSON.stringify({
+        schemaVersion: '1-draft',
+        migrationFacts: [
+            {
+                ...fact(),
+                backfill: {
+                    description: 'x',
+                    estimateSql: 'SELECT 1; COMMIT; DROP TABLE users',
+                    planSql: null,
+                    supportingIndexSql: null,
+                },
+            },
+        ],
+    });
+    assert.throws(() => parseFactsFile(file), /single statement/);
+});
+
+test('parseFactsFile rejects a fact without a version', () => {
+    assert.throws(
+        () => parseFactsFile('{"migrationFacts":[{"migration":"x"}]}'),
+        /introducedIn/,
+    );
+});
+
+// --- selectFacts -------------------------------------------------------------
+
+test('selectFacts takes migrations strictly after from, up to and including to', () => {
+    const facts = [
+        fact({ migration: 'a', introducedIn: '1.50.0' }),
+        fact({ migration: 'b', introducedIn: '1.51.0' }),
+        fact({ migration: 'c', introducedIn: '1.60.0' }),
+        fact({ migration: 'd', introducedIn: '1.61.0' }),
+    ];
+    assert.deepStrictEqual(
+        selectFacts(facts, '1.50.0', '1.60.0').map((f) => f.migration),
+        ['b', 'c'],
+    );
+});
+
+test('selectFacts orders versions numerically, not lexically', () => {
+    const facts = [fact({ migration: 'a', introducedIn: '0.3477.0' })];
+    assert.strictEqual(selectFacts(facts, '0.3476.2', '0.3480.0').length, 1);
+    assert.strictEqual(selectFacts(facts, '0.3477.0', '0.3480.0').length, 0);
+});
+
+// --- analyzeLock -------------------------------------------------------------
+
+test('free lock is ok', () => {
+    const f = analyzeLock([{ index: 1, is_locked: 0 }], 0);
+    assert.strictEqual(f.severity, 'ok');
+});
+
+test('held lock with no migration backend is a stale-lock blocker with a clear action', () => {
+    const f = analyzeLock([{ index: 1, is_locked: 1 }], 0);
+    assert.strictEqual(f.severity, 'blocker');
+    assert.match(f.action ?? '', /UPDATE knex_migrations_lock SET is_locked = 0/);
+});
+
+test('held lock with an active migration backend reports a live run, not a stale lock', () => {
+    const f = analyzeLock([{ index: 1, is_locked: 1 }], 1);
+    assert.strictEqual(f.severity, 'blocker');
+    assert.match(f.summary, /active migration/);
+});
+
+test('missing lock table degrades to a warning', () => {
+    assert.strictEqual(analyzeLock(null, 0).severity, 'warn');
+});
+
+// --- computeWriteRates -------------------------------------------------------
+
+const stat = (over: Partial<StatRow>): StatRow => ({
+    relname: 'users',
+    n_tup_ins: 0,
+    n_tup_upd: 0,
+    n_tup_del: 0,
+    n_live_tup: 1000,
+    ...over,
+});
+
+test('write rate is the summed counter delta scaled to rows/min', () => {
+    const rates = computeWriteRates(
+        [stat({ n_tup_ins: 100, n_tup_upd: 50 })],
+        [stat({ n_tup_ins: 160, n_tup_upd: 70 })],
+        30,
+    );
+    assert.strictEqual(rates[0].rowsPerMin, 160); // 80 rows in 30s
+});
+
+test('a stats reset (counters going backwards) clamps to zero instead of negative', () => {
+    const rates = computeWriteRates(
+        [stat({ n_tup_ins: 5000 })],
+        [stat({ n_tup_ins: 10 })],
+        10,
+    );
+    assert.strictEqual(rates[0].rowsPerMin, 0);
+});
+
+test('a table absent from the first sample reports zero rate, not NaN', () => {
+    const rates = computeWriteRates([], [stat({ n_tup_ins: 100 })], 10);
+    assert.strictEqual(rates[0].rowsPerMin, 0);
+});
+
+// --- analyzeWriteRates -------------------------------------------------------
+
+test('busy mutated table warns with a pause action; quiet table is ok', () => {
+    const findings = analyzeWriteRates(
+        [fact()],
+        [
+            {
+                table: 'users',
+                rowsPerMin: 500,
+                inserts: 100,
+                updates: 0,
+                deletes: 0,
+                liveTuples: 2_000_000,
+            },
+        ],
+        10,
+    );
+    assert.strictEqual(findings.length, 1);
+    assert.strictEqual(findings[0].severity, 'warn');
+    assert.match(findings[0].action ?? '', /pause/i);
+});
+
+test('read-only joined tables are not rated', () => {
+    const f = fact({
+        tables: [{ name: 'projects', access: ['read'], expectedLockModes: [] }],
+    });
+    assert.strictEqual(analyzeWriteRates([f], [], 10).length, 0);
+});
+
+test('a mutated table missing from pg_stat warns about schema drift', () => {
+    const findings = analyzeWriteRates([fact()], [], 10);
+    assert.strictEqual(findings[0].severity, 'warn');
+    assert.match(findings[0].summary, /not found/);
+});
+
+// --- EXPLAIN analysis --------------------------------------------------------
+
+test('topPlanRows reads the top plan node estimate', () => {
+    assert.strictEqual(topPlanRows(explainFixture(123456)), 123456);
+    assert.strictEqual(topPlanRows({ not: 'a plan' }), null);
+});
+
+test('flattenPlan walks nested plans', () => {
+    const nested = {
+        'Node Type': 'Limit',
+        Plans: [
+            {
+                'Node Type': 'Hash Join',
+                Plans: [
+                    { 'Node Type': 'Seq Scan', 'Relation Name': 'saved_queries' },
+                    { 'Node Type': 'Index Scan', 'Relation Name': 'spaces' },
+                ],
+            },
+        ],
+    };
+    assert.strictEqual(flattenPlan(nested).length, 4);
+});
+
+test('large single-transaction backfill warns; batched resumable one is ok', () => {
+    const single = analyzeRowEstimate(fact(), explainFixture(2_000_000), 100000, null);
+    assert.strictEqual(single.severity, 'warn');
+    assert.match(single.summary, /2,000,000 rows/);
+
+    const batched = analyzeRowEstimate(
+        fact({ runsInTransaction: false, resumable: true, batchSize: 1000 }),
+        explainFixture(2_000_000),
+        100000,
+        null,
+    );
+    assert.strictEqual(batched.severity, 'ok');
+    assert.match(batched.summary, /batches of 1000, resumable \(~2,000 passes\)/);
+});
+
+test('a measured scan turns the window advice into a number and names the k8s knobs', () => {
+    const slow = analyzeRowEstimate(fact(), explainFixture(2_000_000), 100000, 300);
+    assert.match(slow.summary, /measured ~5 min on this instance/);
+    assert.match(slow.action ?? '', /window of at least ~5 min/);
+    assert.match(slow.action ?? '', /recommendedStrategy \(Recreate/);
+    assert.match(slow.action ?? '', /activeDeadlineSeconds/);
+
+    const fast = analyzeRowEstimate(fact(), explainFixture(2_000_000), 100000, 0.4);
+    assert.doesNotMatch(fast.action ?? '', /at least <1s/);
+    assert.match(fast.action ?? '', /scan measured <1s here, but the single-transaction UPDATE/);
+});
+
+test('formatSeconds picks sensible units', () => {
+    assert.strictEqual(formatSeconds(0.3), '<1s');
+    assert.strictEqual(formatSeconds(45), '~45s');
+    assert.strictEqual(formatSeconds(300), '~5 min');
+});
+
+test('executionSeconds reads EXPLAIN ANALYZE output', () => {
+    assert.strictEqual(executionSeconds([{ 'Execution Time': 1234 }]), 1.234);
+    assert.strictEqual(executionSeconds({ nope: true }), null);
+});
+
+test('seq scan on a large table warns; small table stays quiet', () => {
+    const big = analyzeSeqScans(
+        fact(),
+        explainFixture(500, 'users'),
+        new Map([['users', 2_000_000]]),
+        100000,
+        500,
+        null,
+    );
+    assert.strictEqual(big.length, 1);
+    assert.match(big[0].summary, /seq-scans "users"/);
+
+    const small = analyzeSeqScans(
+        fact(),
+        explainFixture(500, 'users'),
+        new Map([['users', 91]]),
+        100000,
+        500,
+        null,
+    );
+    assert.strictEqual(small.length, 0);
+});
+
+test('predicate matching most of the table suppresses index advice — the scan is the work', () => {
+    const findings = analyzeSeqScans(
+        fact(),
+        explainFixture(1_900_000, 'users'),
+        new Map([['users', 2_000_000]]),
+        100000,
+        1_900_000,
+        8,
+    );
+    assert.strictEqual(findings.length, 1);
+    assert.match(findings[0].summary, /no index can help/);
+    assert.match(findings[0].summary, /~95% of "users"/);
+    assert.strictEqual(findings[0].actionKind, 'plan');
+    assert.doesNotMatch(findings[0].action ?? '', /index/i);
+});
+
+test('a vetted supporting index becomes a runnable remediation', () => {
+    const withIndex = fact();
+    (withIndex.backfill as { supportingIndexSql: string | null }).supportingIndexSql =
+        'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_x ON users (user_id) WHERE is_setup_complete = false';
+    const findings = analyzeSeqScans(
+        withIndex,
+        explainFixture(100_000, 'users'),
+        new Map([['users', 2_000_000]]),
+        100000,
+        100_000,
+        8,
+    );
+    assert.strictEqual(findings.length, 1);
+    assert.strictEqual(findings[0].actionKind, 'remediate');
+    assert.match(findings[0].action ?? '', /run: CREATE INDEX CONCURRENTLY/);
+    assert.match(findings[0].action ?? '', /re-run preflight/);
+});
+
+// --- analyzeActivity ---------------------------------------------------------
+
+const activity = (over: Partial<ActivityRow>): ActivityRow => ({
+    pid: 4242,
+    usename: 'postgres',
+    application_name: 'upload-cron',
+    state: 'idle in transaction',
+    xact_age_s: 10,
+    query: 'INSERT INTO uploads ...',
+    blocked_by: null,
+    ...over,
+});
+
+test('a lock wait is a blocker naming the blocking pids', () => {
+    const findings = analyzeActivity([activity({ blocked_by: [99] })], 300);
+    assert.strictEqual(findings[0].severity, 'blocker');
+    assert.match(findings[0].summary, /pid\(s\) 99/);
+});
+
+test('a long-open transaction warns; short ones do not', () => {
+    const long = analyzeActivity([activity({ xact_age_s: 1800 })], 300);
+    assert.strictEqual(long[0].severity, 'warn');
+    assert.match(long[0].summary, /30 min/);
+
+    const short = analyzeActivity([activity({ xact_age_s: 5 })], 300);
+    assert.strictEqual(short[0].severity, 'ok');
+});
+
+// --- buildReport -------------------------------------------------------------
+
+test('report sorts blockers first, splits actions by kind, and aggregates the verdict', () => {
+    const findings: Finding[] = [
+        { check: 'write-rate', severity: 'ok', migration: null, table: 'users', summary: 'quiet', action: null, actionKind: null, data: {} },
+        { check: 'row-estimate', severity: 'warn', migration: null, table: 'users', summary: 'huge', action: 'plan a window', actionKind: 'plan', data: {} },
+        { check: 'write-rate', severity: 'warn', migration: null, table: 'users', summary: 'busy', action: 'pause the writer', actionKind: 'remediate', data: {} },
+        { check: 'stale-lock', severity: 'blocker', migration: null, table: null, summary: 'stale', action: 'clear the lock', actionKind: 'remediate', data: {} },
+    ];
+    const report = buildReport('1.50.0', '1.60.0', [fact()], findings);
+    assert.strictEqual(report.verdict, 'blocker');
+    assert.deepStrictEqual(report.remediateNow, ['clear the lock', 'pause the writer']);
+    assert.deepStrictEqual(report.planItems, ['plan a window']);
+    assert.strictEqual(report.findings[0].check, 'stale-lock');
+});
+
+test('all-ok findings give an ok verdict and empty remediation/plan lists', () => {
+    const report = buildReport('1.50.0', '1.60.0', [], [
+        { check: 'activity', severity: 'ok', migration: null, table: null, summary: 'fine', action: null, actionKind: null, data: {} },
+    ]);
+    assert.strictEqual(report.verdict, 'ok');
+    assert.deepStrictEqual(report.remediateNow, []);
+    assert.deepStrictEqual(report.planItems, []);
+});
+
+test('operator-fixable findings are remediate; migration-intrinsic ones are plan', () => {
+    assert.strictEqual(analyzeLock([{ index: 1, is_locked: 1 }], 0).actionKind, 'remediate');
+    const busy = analyzeWriteRates(
+        [fact()],
+        [{ table: 'users', rowsPerMin: 500, inserts: 100, updates: 0, deletes: 0, liveTuples: 2_000_000 }],
+        10,
+    );
+    assert.strictEqual(busy[0].actionKind, 'remediate');
+    const longTxn = analyzeActivity([activity({ xact_age_s: 1800 })], 300);
+    assert.strictEqual(longTxn[0].actionKind, 'remediate');
+
+    const bigTxn = analyzeRowEstimate(fact(), explainFixture(2_000_000), 100000, null);
+    assert.strictEqual(bigTxn.actionKind, 'plan');
+    assert.match(bigTxn.action ?? '', /Recreate/);
+    assert.match(bigTxn.action ?? '', /eviction/);
+    const seq = analyzeSeqScans(fact(), explainFixture(500, 'users'), new Map([['users', 2_000_000]]), 100000, 500, null);
+    assert.strictEqual(seq[0].actionKind, 'plan');
+});
+
+// -----------------------------------------------------------------------------
+
+if (failures.length > 0) {
+    console.error(`${failures.length} test(s) failed:`);
+    for (const failure of failures) console.error(`  ✖ ${failure}`);
+    process.exit(1);
+}
+console.log(`preflight: ${passed} tests passed`);

--- a/scripts/preflight.test.ts
+++ b/scripts/preflight.test.ts
@@ -21,12 +21,16 @@ import {
     analyzeRowEstimate,
     analyzeSeqScans,
     analyzeWriteRates,
+    BackfillFact,
+    buildReadOnlyPsqlPayload,
     buildReport,
     computeWriteRates,
     Finding,
     flattenPlan,
     MigrationFact,
+    parseArgs,
     parseFactsFile,
+    parseIntegerFlag,
     selectFacts,
     StatRow,
     topPlanRows,
@@ -126,6 +130,34 @@ test('parseFactsFile rejects multi-statement backfill SQL', () => {
     assert.throws(() => parseFactsFile(file), /single statement/);
 });
 
+test('parseFactsFile rejects semicolons in supporting index SQL', () => {
+    const withIndex = fact();
+    (withIndex.backfill as BackfillFact).supportingIndexSql =
+        'CREATE INDEX CONCURRENTLY idx_x ON users (user_id); DROP TABLE users';
+    assert.throws(() => parseFactsFile(validFactsFile([withIndex])), /single statement/);
+});
+
+test('parseFactsFile rejects supporting SQL that is not CREATE INDEX CONCURRENTLY', () => {
+    const withIndex = fact();
+    (withIndex.backfill as BackfillFact).supportingIndexSql =
+        'CREATE INDEX idx_x ON users (user_id)';
+    assert.throws(
+        () => parseFactsFile(validFactsFile([withIndex])),
+        /CREATE \[UNIQUE\] INDEX CONCURRENTLY/,
+    );
+});
+
+test('parseFactsFile accepts the committed supporting index DDL', () => {
+    const parsed = parseFactsFile(
+        fs.readFileSync(path.join(__dirname, 'preflight-facts.example.json'), 'utf-8'),
+    );
+    assert.match(
+        parsed.migrationFacts.find((migration) => migration.backfill?.supportingIndexSql)
+            ?.backfill?.supportingIndexSql ?? '',
+        /^CREATE INDEX CONCURRENTLY/,
+    );
+});
+
 test('parseFactsFile rejects a fact without a version', () => {
     assert.throws(
         () => parseFactsFile('{"migrationFacts":[{"migration":"x"}]}'),
@@ -157,24 +189,30 @@ test('selectFacts orders versions numerically, not lexically', () => {
 // --- analyzeLock -------------------------------------------------------------
 
 test('free lock is ok', () => {
-    const f = analyzeLock([{ index: 1, is_locked: 0 }], 0);
+    const f = analyzeLock([{ index: 1, is_locked: 0 }], null);
     assert.strictEqual(f.severity, 'ok');
 });
 
-test('held lock with no migration backend is a stale-lock blocker with a clear action', () => {
-    const f = analyzeLock([{ index: 1, is_locked: 1 }], 0);
+test('held lock never claims staleness and gives a guarded knex-compatible repair', () => {
+    const f = analyzeLock([{ index: 1, is_locked: 1 }], 3600);
     assert.strictEqual(f.severity, 'blocker');
-    assert.match(f.action ?? '', /UPDATE knex_migrations_lock SET is_locked = 0/);
+    assert.match(f.summary, /cannot prove whether a migration is live/i);
+    assert.doesNotMatch(f.summary, /stale lock from/);
+    assert.match(f.action ?? '', /confirm no migration job or container is running/);
+    assert.match(f.action ?? '', /DELETE FROM knex_migrations_lock/);
+    assert.match(
+        f.action ?? '',
+        /INSERT INTO knex_migrations_lock \(is_locked\) VALUES \(0\)/,
+    );
 });
 
-test('held lock with an active migration backend reports a live run, not a stale lock', () => {
-    const f = analyzeLock([{ index: 1, is_locked: 1 }], 1);
-    assert.strictEqual(f.severity, 'blocker');
-    assert.match(f.summary, /active migration/);
+test('held lock reports when last-migration evidence is unavailable', () => {
+    const f = analyzeLock([{ index: 1, is_locked: 1 }], null);
+    assert.match(f.summary, /completed-migration age is unavailable/);
 });
 
 test('missing lock table degrades to a warning', () => {
-    assert.strictEqual(analyzeLock(null, 0).severity, 'warn');
+    assert.strictEqual(analyzeLock(null, null).severity, 'warn');
 });
 
 // --- computeWriteRates -------------------------------------------------------
@@ -339,7 +377,6 @@ test('seq scan on a large table warns; small table stays quiet', () => {
         explainFixture(500, 'users'),
         new Map([['users', 2_000_000]]),
         100000,
-        500,
         null,
     );
     assert.strictEqual(big.length, 1);
@@ -350,7 +387,6 @@ test('seq scan on a large table warns; small table stays quiet', () => {
         explainFixture(500, 'users'),
         new Map([['users', 91]]),
         100000,
-        500,
         null,
     );
     assert.strictEqual(small.length, 0);
@@ -362,7 +398,6 @@ test('predicate matching most of the table suppresses index advice — the scan 
         explainFixture(1_900_000, 'users'),
         new Map([['users', 2_000_000]]),
         100000,
-        1_900_000,
         8,
     );
     assert.strictEqual(findings.length, 1);
@@ -379,15 +414,38 @@ test('a vetted supporting index becomes a runnable remediation', () => {
     const findings = analyzeSeqScans(
         withIndex,
         explainFixture(100_000, 'users'),
-        new Map([['users', 2_000_000]]),
+        new Map([['users', 300_000]]),
         100000,
-        100_000,
         8,
     );
     assert.strictEqual(findings.length, 1);
     assert.strictEqual(findings[0].actionKind, 'remediate');
-    assert.match(findings[0].action ?? '', /run: CREATE INDEX CONCURRENTLY/);
-    assert.match(findings[0].action ?? '', /re-run preflight/);
+    assert.match(findings[0].summary, /~33% of "users"/);
+    assert.strictEqual(findings[0].data.fraction, 1 / 3);
+    assert.match(findings[0].action ?? '', /review this index DDL with your DBA/);
+    assert.match(findings[0].action ?? '', /re-run preflight afterwards/);
+});
+
+test('a joined-table seq scan makes no target-row percentage or index DDL claim', () => {
+    const withIndex = fact({
+        tables: [
+            { name: 'users', access: ['write'], expectedLockModes: [] },
+            { name: 'organizations', access: ['read'], expectedLockModes: [] },
+        ],
+    });
+    (withIndex.backfill as BackfillFact).supportingIndexSql =
+        'CREATE INDEX CONCURRENTLY idx_x ON users (user_id)';
+    const findings = analyzeSeqScans(
+        withIndex,
+        explainFixture(900_000, 'organizations'),
+        new Map([['organizations', 300_000]]),
+        100000,
+        null,
+    );
+    assert.strictEqual(findings.length, 1);
+    assert.doesNotMatch(findings[0].summary, /%/);
+    assert.doesNotMatch(findings[0].summary, /900,000/);
+    assert.doesNotMatch(findings[0].action ?? '', /CREATE INDEX/);
 });
 
 // --- analyzeActivity ---------------------------------------------------------
@@ -444,7 +502,7 @@ test('all-ok findings give an ok verdict and empty remediation/plan lists', () =
 });
 
 test('operator-fixable findings are remediate; migration-intrinsic ones are plan', () => {
-    assert.strictEqual(analyzeLock([{ index: 1, is_locked: 1 }], 0).actionKind, 'remediate');
+    assert.strictEqual(analyzeLock([{ index: 1, is_locked: 1 }], null).actionKind, 'remediate');
     const busy = analyzeWriteRates(
         [fact()],
         [{ table: 'users', rowsPerMin: 500, inserts: 100, updates: 0, deletes: 0, liveTuples: 2_000_000 }],
@@ -457,7 +515,7 @@ test('operator-fixable findings are remediate; migration-intrinsic ones are plan
     const bigTxn = analyzeRowEstimate(fact(), explainFixture(2_000_000), 100000, null);
     assert.strictEqual(bigTxn.actionKind, 'plan');
     assert.match(bigTxn.action ?? '', /maintenance window/);
-    const seq = analyzeSeqScans(fact(), explainFixture(500, 'users'), new Map([['users', 2_000_000]]), 100000, 500, null);
+    const seq = analyzeSeqScans(fact(), explainFixture(500, 'users'), new Map([['users', 2_000_000]]), 100000, null);
     assert.strictEqual(seq[0].actionKind, 'plan');
 });
 
@@ -477,6 +535,25 @@ test('malformed numeric flags fail loudly instead of producing a false clear ver
     assert.throws(() => parseNumericFlag('--interval', 'abc', 10), /positive number/);
     assert.throws(() => parseNumericFlag('--interval', '-5', 10), /positive number/);
     assert.throws(() => parseNumericFlag('--interval', '0', 10), /positive number/);
+    assert.strictEqual(parseIntegerFlag('--probe-timeout', '30', 10), 30);
+    assert.throws(() => parseIntegerFlag('--probe-timeout', '1.5', 10), /positive integer/);
+});
+
+test('measurement is opt-in and probe timeout defaults to 30 seconds', () => {
+    const required = ['--facts', 'facts.json', '--from', '1.0.0', '--to', '2.0.0'];
+    const defaults = parseArgs(required);
+    assert.strictEqual(defaults.measure, false);
+    assert.strictEqual(defaults.probeTimeoutSeconds, 30);
+    const optedIn = parseArgs([...required, '--measure', '--probe-timeout', '45']);
+    assert.strictEqual(optedIn.measure, true);
+    assert.strictEqual(optedIn.probeTimeoutSeconds, 45);
+});
+
+test('every read-only psql payload sets the local statement timeout', () => {
+    assert.strictEqual(
+        buildReadOnlyPsqlPayload('SELECT 1', 30),
+        "BEGIN TRANSACTION READ ONLY; SET LOCAL statement_timeout = '30s'; SELECT 1; ROLLBACK;",
+    );
 });
 
 test('quoted --psql commands fail loudly instead of splitting silently', () => {

--- a/scripts/preflight.ts
+++ b/scripts/preflight.ts
@@ -572,6 +572,63 @@ export function renderHuman(report: PreflightReport): string {
 
 // --- IO shell -----------------------------------------------------------------
 
+interface ApiProbe {
+    serverTime: string;
+    lock: { isLocked: boolean; activeMigrationBackends: number } | null;
+    tableStats: Array<{
+        table: string;
+        inserts: number;
+        updates: number;
+        deletes: number;
+        liveTuples: number;
+    }>;
+    activity: Array<{
+        pid: number;
+        userName: string | null;
+        applicationName: string | null;
+        state: string | null;
+        xactAgeSeconds: number | null;
+        query: string | null;
+        blockedBy: number[];
+    }>;
+}
+
+async function fetchApiProbe(
+    baseUrl: string,
+    apiKey: string,
+    tables: string[],
+): Promise<ApiProbe> {
+    const url = `${baseUrl.replace(/\/$/, '')}/api/v1/preflight/probe?tables=${encodeURIComponent(tables.join(','))}`;
+    const response = await fetch(url, {
+        headers: { Authorization: `ApiKey ${apiKey}` },
+    });
+    if (!response.ok) {
+        throw new Error(`probe endpoint returned ${response.status}: ${(await response.text()).slice(0, 200)}`);
+    }
+    const body = (await response.json()) as { status: string; results: ApiProbe };
+    return body.results;
+}
+
+const statRowsFromProbe = (probe: ApiProbe): StatRow[] =>
+    probe.tableStats.map((t) => ({
+        relname: t.table,
+        n_tup_ins: t.inserts,
+        n_tup_upd: t.updates,
+        n_tup_del: t.deletes,
+        n_live_tup: t.liveTuples,
+    }));
+
+const activityRowsFromProbe = (probe: ApiProbe): ActivityRow[] =>
+    probe.activity.map((a) => ({
+        pid: a.pid,
+        usename: a.userName,
+        application_name: a.applicationName,
+        state: a.state,
+        xact_age_s: a.xactAgeSeconds,
+        query: a.query,
+        blocked_by: a.blockedBy.length > 0 ? a.blockedBy : null,
+    }));
+
 interface PsqlRunner {
     json: (sql: string) => unknown;
     explain: (sql: string) => unknown;
@@ -611,6 +668,7 @@ interface CliArgs {
     largeRowThreshold: number;
     longTxnThresholdSeconds: number;
     measure: boolean;
+    api: string | null;
 }
 
 function parseArgs(argv: string[]): CliArgs {
@@ -623,7 +681,7 @@ function parseArgs(argv: string[]): CliArgs {
     const to = get('--to');
     if (!facts || !from || !to) {
         throw new Error(
-            'usage: preflight.ts --facts <file> --from <current version> --to <target version> [--psql "<cmd>"] [--interval <s>] [--json] [--no-measure]',
+            'usage: preflight.ts --facts <file> --from <current version> --to <target version> [--psql "<cmd>" | --api <baseUrl>] [--interval <s>] [--json] [--no-measure]',
         );
     }
     return {
@@ -637,13 +695,68 @@ function parseArgs(argv: string[]): CliArgs {
         largeRowThreshold: Number(get('--large-row-threshold') ?? 100000),
         longTxnThresholdSeconds: Number(get('--long-txn-threshold') ?? 300),
         measure: !argv.includes('--no-measure'),
+        api: get('--api'),
     };
+}
+
+async function runApiMode(args: CliArgs, facts: MigrationFact[]): Promise<Finding[]> {
+    const apiKey = process.env.LIGHTDASH_API_KEY;
+    if (!apiKey) {
+        throw new Error('--api mode needs LIGHTDASH_API_KEY in the environment');
+    }
+    const baseUrl = args.api as string;
+    const findings: Finding[] = [];
+    const tableNames = [...new Set(facts.flatMap((f) => f.tables.map((t) => t.name)))];
+
+    const before = await fetchApiProbe(baseUrl, apiKey, tableNames);
+    process.stderr.write(
+        `[preflight] sampling write activity via ${baseUrl} for ${args.intervalSeconds}s across ${tableNames.length} table(s)...\n`,
+    );
+    await sleep(args.intervalSeconds * 1000);
+    const after = await fetchApiProbe(baseUrl, apiKey, tableNames);
+
+    const lockRows: LockRow[] | null = after.lock
+        ? [{ index: 1, is_locked: after.lock.isLocked ? 1 : 0 }]
+        : null;
+    findings.push(analyzeLock(lockRows, after.lock?.activeMigrationBackends ?? 0));
+
+    const rates = computeWriteRates(
+        statRowsFromProbe(before),
+        statRowsFromProbe(after),
+        args.intervalSeconds,
+    );
+    findings.push(...analyzeWriteRates(facts, rates, args.writeRateThreshold));
+
+    findings.push(...analyzeActivity(activityRowsFromProbe(after), args.longTxnThresholdSeconds));
+
+    const skipped = facts.filter((f) => f.backfill !== null);
+    if (skipped.length > 0) {
+        findings.push({
+            check: 'row-estimate',
+            severity: 'warn',
+            migration: null,
+            table: null,
+            summary: `EXPLAIN-based checks (row estimates, index/plan shape, measured durations) skipped in API mode for ${skipped.length} backfill(s) — they need facts SQL executed against the database, which this endpoint deliberately does not do`,
+            action: 'run preflight with direct database access for full coverage, or wait for server-side verified-facts probing (open design question)',
+            actionKind: 'plan',
+            data: { skippedMigrations: skipped.map((f) => f.migration) },
+        });
+    }
+    return findings;
 }
 
 async function main(): Promise<void> {
     const args = parseArgs(process.argv.slice(2));
     const factsFile = parseFactsFile(fs.readFileSync(args.facts, 'utf-8'));
     const facts = selectFacts(factsFile.migrationFacts, args.from, args.to);
+
+    if (args.api !== null) {
+        const apiFindings = await runApiMode(args, facts);
+        const apiReport = buildReport(args.from, args.to, facts, apiFindings);
+        console.log(args.json ? JSON.stringify(apiReport, null, 2) : renderHuman(apiReport));
+        process.exit(apiReport.verdict === 'blocker' ? 2 : apiReport.verdict === 'warn' ? 1 : 0);
+    }
+
     const db = makePsqlRunner(args.psql);
     const findings: Finding[] = [];
 

--- a/scripts/preflight.ts
+++ b/scripts/preflight.ts
@@ -106,7 +106,7 @@ export function selectFacts(
 
 // --- findings ---------------------------------------------------------------
 
-export type Severity = 'ok' | 'warn' | 'blocker';
+export type Severity = 'ok' | 'info' | 'warn' | 'blocker';
 
 /**
  * remediate — the operator can fix it in place before the upgrade and verify by
@@ -116,7 +116,7 @@ export type Severity = 'ok' | 'warn' | 'blocker';
 export type ActionKind = 'remediate' | 'plan' | null;
 
 export interface Finding {
-    check: 'stale-lock' | 'write-rate' | 'row-estimate' | 'plan' | 'activity';
+    check: 'stale-lock' | 'write-rate' | 'row-estimate' | 'plan' | 'activity' | 'strategy';
     severity: Severity;
     migration: string | null;
     table: string | null;
@@ -126,7 +126,12 @@ export interface Finding {
     data: Record<string, unknown>;
 }
 
-const SEVERITY_ORDER: Record<Severity, number> = { blocker: 0, warn: 1, ok: 2 };
+const SEVERITY_ORDER: Record<Severity, number> = {
+    blocker: 0,
+    warn: 1,
+    info: 2,
+    ok: 3,
+};
 
 // --- stale migration lock ---------------------------------------------------
 
@@ -358,16 +363,14 @@ export function analyzeRowEstimate(
             : scanSeconds >= 60
               ? `of at least ${formatSeconds(scanSeconds)} — reading the target rows alone measured that here, and the UPDATE holds row locks for longer`
               : `— the target-row scan measured ${formatSeconds(scanSeconds)} here, but the single-transaction UPDATE on ~${num(rows)} rows holds row locks until commit`;
+    const windowAction = `schedule a maintenance window ${windowSize}`;
     return {
         check: 'row-estimate',
         severity: big && fact.runsInTransaction ? 'warn' : 'ok',
         migration: fact.migration,
         table: fact.tables.find((t) => t.access.includes('write'))?.name ?? null,
         summary: `backfill touches ~${num(rows)} rows here, ${transactional}${measured}`,
-        action:
-            big && fact.runsInTransaction
-                ? `schedule a maintenance window ${windowSize}; upgrade with the marker's recommendedStrategy (Recreate: no old pods serving mid-migration) and protect the migration job from eviction (raise activeDeadlineSeconds, set a PriorityClass) — a job killed mid-backfill is what leaves stale locks behind`
-                : null,
+        action: big && fact.runsInTransaction ? windowAction : null,
         actionKind: big && fact.runsInTransaction ? 'plan' : null,
         data: { estimatedRows: rows, passes, scanSeconds },
     };
@@ -427,6 +430,39 @@ export function analyzeSeqScans(
         }
     }
     return findings;
+}
+
+// --- upgrade strategy --------------------------------------------------------
+
+/**
+ * Fires whenever the range contains DDL, independent of any measured hazard:
+ * old pods keep querying the tables being altered, the ALTER queues behind
+ * them, and everything else then queues behind the ALTER — the advice must
+ * surface even on a quiet instance.
+ */
+export function analyzeUpgradeStrategy(facts: MigrationFact[]): Finding[] {
+    const ddlTables = [
+        ...new Set(
+            facts.flatMap((fact) =>
+                fact.tables
+                    .filter((table) => table.access.includes('ddl'))
+                    .map((table) => table.name),
+            ),
+        ),
+    ];
+    if (ddlTables.length === 0) return [];
+    return [
+        {
+            check: 'strategy',
+            severity: 'info',
+            migration: null,
+            table: null,
+            summary: `this range runs DDL against ${ddlTables.map((t) => `"${t}"`).join(', ')} — live pods keep querying those tables, an ALTER TABLE queues behind them, and every later query queues behind the ALTER`,
+            action: `upgrade with strategy Recreate (stop old pods before migrations run — the marker's recommendedStrategy), pause schedulers/crons that write to those tables, and protect the migration job from eviction (raise activeDeadlineSeconds, set a PriorityClass) — a job killed mid-migration is what leaves the stale lock behind`,
+            actionKind: 'plan',
+            data: { ddlTables },
+        },
+    ];
 }
 
 // --- activity / locks --------------------------------------------------------
@@ -531,6 +567,7 @@ export function buildReport(
 const SEVERITY_ICON: Record<Severity, string> = {
     blocker: '✖',
     warn: '⚠',
+    info: 'ℹ',
     ok: '✓',
 };
 
@@ -778,6 +815,8 @@ async function runApiMode(args: CliArgs, facts: MigrationFact[]): Promise<Findin
 
     findings.push(...analyzeActivity(activityRowsFromProbe(after), args.longTxnThresholdSeconds));
 
+    findings.push(...analyzeUpgradeStrategy(facts));
+
     const skipped = facts.filter((f) => f.backfill !== null);
     if (skipped.length > 0) {
         findings.push({
@@ -819,6 +858,7 @@ async function main(): Promise<void> {
         `SELECT count(*)::integer AS n FROM pg_stat_activity WHERE state <> 'idle' AND pid <> pg_backend_pid() AND query ILIKE '%knex_migrations%'`,
     ) as Array<{ n: number }>;
     findings.push(analyzeLock(lockRows, migrationBackends[0]?.n ?? 0));
+    findings.push(...analyzeUpgradeStrategy(facts));
 
     const tableNames = [
         ...new Set(facts.flatMap((f) => f.tables.map((t) => t.name))),

--- a/scripts/preflight.ts
+++ b/scripts/preflight.ts
@@ -7,7 +7,7 @@
  * plan for the upgrade window instead of a bare verdict.
  *
  * Checks:
- *   - stale `knex_migrations_lock` row (blocks every future migration run)
+ *   - held `knex_migrations_lock` row (blocks every future migration run)
  *   - write rate on tables the selected migrations write/DDL, from two
  *     samples of pg_stat_user_tables
  *   - per-backfill row estimates via EXPLAIN (FORMAT JSON) — never COUNT(*)
@@ -21,7 +21,7 @@
  *
  * Run:
  *   npx tsx scripts/preflight.ts --facts <facts.json> --from 1.50.0 --to 1.60.0 \
- *     [--psql "psql -h host -U user -d db"] [--interval 10] [--json]
+ *     [--psql "psql -h host -U user -d db"] [--interval 10] [--probe-timeout 30] [--measure] [--json]
  */
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
@@ -68,6 +68,9 @@ export interface FactsFile {
 
 export const FACTS_SCHEMA_PATH = path.join(__dirname, 'preflight-facts.schema.json');
 
+const SUPPORTING_INDEX_SQL_PATTERN =
+    /^CREATE (UNIQUE )?INDEX CONCURRENTLY (IF NOT EXISTS )?[A-Za-z0-9_" .()=<>'!,-]+$/;
+
 export function parseFactsFile(raw: string): FactsFile {
     const parsed = JSON.parse(raw) as unknown;
     const schema = JSON.parse(fs.readFileSync(FACTS_SCHEMA_PATH, 'utf-8')) as Record<
@@ -86,6 +89,21 @@ export function parseFactsFile(raw: string): FactsFile {
                     `backfill SQL for "${fact.migration}" contains ';' — facts SQL must be a single statement (it runs inside a READ ONLY transaction and must not be able to end it)`,
                 );
             }
+        }
+        const supportingIndexSql = fact.backfill?.supportingIndexSql;
+        if (supportingIndexSql?.includes(';')) {
+            throw new Error(
+                `supportingIndexSql for "${fact.migration}" contains ';' — index DDL must be a single statement`,
+            );
+        }
+        if (
+            supportingIndexSql !== null &&
+            supportingIndexSql !== undefined &&
+            !SUPPORTING_INDEX_SQL_PATTERN.test(supportingIndexSql)
+        ) {
+            throw new Error(
+                `supportingIndexSql for "${fact.migration}" must be a single CREATE [UNIQUE] INDEX CONCURRENTLY statement using only the supported SQL characters`,
+            );
         }
     }
     return factsFile;
@@ -142,7 +160,7 @@ export interface LockRow {
 
 export function analyzeLock(
     lockRows: LockRow[] | null,
-    activeMigrationBackends: number,
+    lastMigrationAgeSeconds: number | null,
 ): Finding {
     if (lockRows === null) {
         return {
@@ -166,31 +184,22 @@ export function analyzeLock(
             summary: 'migration lock is free',
             action: null,
             actionKind: null,
-            data: { activeMigrationBackends },
+            data: { lastMigrationAgeSeconds },
         };
     }
-    if (activeMigrationBackends > 0) {
-        return {
-            check: 'stale-lock',
-            severity: 'blocker',
-            migration: null,
-            table: 'knex_migrations_lock',
-            summary: `migration lock is held and ${activeMigrationBackends} backend(s) look like an active migration run — another upgrade may be in progress`,
-            action: 'wait for the running migration to finish, then re-run preflight',
-            actionKind: 'remediate',
-            data: { activeMigrationBackends },
-        };
-    }
+    const migrationEvidence =
+        lastMigrationAgeSeconds === null
+            ? 'the latest completed-migration age is unavailable'
+            : `the latest completed migration was ${formatSeconds(lastMigrationAgeSeconds)} ago`;
     return {
         check: 'stale-lock',
         severity: 'blocker',
         migration: null,
         table: 'knex_migrations_lock',
-        summary:
-            'migration lock is held but no backend is running migrations — stale lock from a failed/killed migration run; every future migration will fail with "Migration table is already locked"',
-        action: 'run: UPDATE knex_migrations_lock SET is_locked = 0; — then re-run preflight to confirm the lock reads free',
+        summary: `migration lock is held; ${migrationEvidence}, and recent table write activity is reported separately — this tool cannot prove whether a migration is live`,
+        action: 'first confirm no migration job or container is running (check kubectl get jobs and your scheduler); only then clear and repair the lock with: DELETE FROM knex_migrations_lock; INSERT INTO knex_migrations_lock (is_locked) VALUES (0); — then re-run preflight',
         actionKind: 'remediate',
-        data: { activeMigrationBackends },
+        data: { lastMigrationAgeSeconds },
     };
 }
 
@@ -384,24 +393,29 @@ export function analyzeSeqScans(
     explainJson: unknown,
     liveTuplesByTable: Map<string, number>,
     largeRowThreshold: number,
-    estimatedRows: number | null,
     scanSeconds: number | null,
 ): Finding[] {
     if (!Array.isArray(explainJson)) return [];
     const plan = (explainJson[0] as { Plan?: PlanNode } | undefined)?.Plan;
     if (!plan) return [];
     const findings: Finding[] = [];
-    const measured =
-        scanSeconds !== null
-            ? `; one full scan measured ${formatSeconds(scanSeconds)} on this instance`
-            : '';
+    const writtenTable = fact.tables.find((table) => table.access.includes('write'))?.name;
     for (const node of flattenPlan(plan)) {
         if (node['Node Type'] !== 'Seq Scan' || !node['Relation Name']) continue;
         const table = node['Relation Name'];
         const liveTuples = liveTuplesByTable.get(table) ?? 0;
         if (liveTuples < largeRowThreshold) continue;
+        const scansWrittenTable = table === writtenTable;
+        const estimatedRows =
+            scansWrittenTable && typeof node['Plan Rows'] === 'number'
+                ? node['Plan Rows']
+                : null;
         const fraction =
             estimatedRows !== null && liveTuples > 0 ? estimatedRows / liveTuples : null;
+        const measured =
+            scansWrittenTable && scanSeconds !== null
+                ? `; the target-row scan measured ${formatSeconds(scanSeconds)} on this instance`
+                : '';
         const base = { check: 'plan' as const, severity: 'warn' as const, migration: fact.migration, table };
         if (fraction !== null && fraction >= INDEX_USELESS_FRACTION) {
             findings.push({
@@ -411,21 +425,27 @@ export function analyzeSeqScans(
                 actionKind: 'plan',
                 data: { liveTuples, estimatedRows, fraction, scanSeconds },
             });
-        } else if (fact.backfill?.supportingIndexSql) {
+        } else if (scansWrittenTable && fact.backfill?.supportingIndexSql) {
             findings.push({
                 ...base,
-                summary: `the backfill seq-scans "${table}" (~${num(liveTuples)} live rows) to reach ~${estimatedRows === null ? '?' : num(estimatedRows)} target rows — no usable index on this instance, but the facts carry a vetted one${measured}`,
-                action: `run: ${fact.backfill.supportingIndexSql}; — CONCURRENTLY does not block writes; then re-run preflight: this finding disappears once the planner uses the index`,
+                summary: `the backfill's predicate matches ${fraction === null ? 'an unknown fraction' : `~${Math.round(fraction * 100)}%`} of "${table}" (${estimatedRows === null ? '?' : num(estimatedRows)} of ${num(liveTuples)} rows) — no usable index on this instance, but the facts carry a vetted one${measured}`,
+                action: `review this index DDL with your DBA, then run it: ${fact.backfill.supportingIndexSql} — CONCURRENTLY does not block writes; re-run preflight afterwards`,
                 actionKind: 'remediate',
                 data: { liveTuples, estimatedRows, fraction, scanSeconds },
             });
         } else {
+            const targetFraction =
+                scansWrittenTable && fraction !== null
+                    ? `; its predicate matches ~${Math.round(fraction * 100)}% (${num(estimatedRows as number)} of ${num(liveTuples)} rows)`
+                    : '';
             findings.push({
                 ...base,
-                summary: `the backfill seq-scans "${table}" (~${num(liveTuples)} live rows) — no usable index for its predicate on this instance, and the facts carry no vetted one${measured}`,
-                action: `expect ${scanSeconds !== null ? formatSeconds(scanSeconds) : 'a full-table scan'}${fact.batchSize ? ' of scan work PER PASS in the worst case' : ' of scan time'}; check the release notes for a supporting index, or accept the scan`,
+                summary: `the backfill seq-scans "${table}" (~${num(liveTuples)} live rows)${targetFraction} — no usable index for this relation on this instance${scansWrittenTable ? ', and the facts carry no vetted one' : ''}${measured}`,
+                action: `expect ${scanSeconds !== null && scansWrittenTable ? `${formatSeconds(scanSeconds)} of measured target-scan time` : 'a full-table scan'}${fact.batchSize ? ' per pass in the worst case' : ''}; check the release notes for a supporting index, or accept the scan`,
                 actionKind: 'plan',
-                data: { liveTuples, estimatedRows, fraction, scanSeconds },
+                data: scansWrittenTable
+                    ? { liveTuples, estimatedRows, fraction, scanSeconds }
+                    : { liveTuples },
             });
         }
     }
@@ -611,7 +631,7 @@ export function renderHuman(report: PreflightReport): string {
 
 interface ApiProbe {
     serverTime: string;
-    lock: { isLocked: boolean; activeMigrationBackends: number } | null;
+    lock: { isLocked: boolean; lastMigrationAgeSeconds: number | null } | null;
     tableStats: Array<{
         table: string;
         inserts: number;
@@ -687,7 +707,17 @@ interface PsqlRunner {
     explainAnalyze: (sql: string) => unknown;
 }
 
-export function makePsqlRunner(psqlCommand: string): PsqlRunner {
+export function buildReadOnlyPsqlPayload(
+    sql: string,
+    statementTimeoutSeconds: number,
+): string {
+    return `BEGIN TRANSACTION READ ONLY; SET LOCAL statement_timeout = '${statementTimeoutSeconds}s'; ${sql}; ROLLBACK;`;
+}
+
+export function makePsqlRunner(
+    psqlCommand: string,
+    statementTimeoutSeconds = 30,
+): PsqlRunner {
     if (/['"\\]/.test(psqlCommand)) {
         throw new Error(
             '--psql is split on whitespace and does not understand quoting — pass a bare executable plus simple flags (quotes/backslashes would be passed through literally)',
@@ -700,7 +730,7 @@ export function makePsqlRunner(psqlCommand: string): PsqlRunner {
             stdio: ['ignore', 'pipe', 'pipe'],
         });
     const readOnly = (sql: string): string =>
-        `BEGIN TRANSACTION READ ONLY; ${sql}; ROLLBACK;`;
+        buildReadOnlyPsqlPayload(sql, statementTimeoutSeconds);
     return {
         json: (sql: string) => {
             const wrapped = `SELECT COALESCE(json_agg(row_to_json(t)), '[]'::json) FROM (${sql}) AS t`;
@@ -714,7 +744,7 @@ export function makePsqlRunner(psqlCommand: string): PsqlRunner {
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-interface CliArgs {
+export interface CliArgs {
     facts: string;
     from: string;
     to: string;
@@ -724,6 +754,7 @@ interface CliArgs {
     writeRateThreshold: number;
     largeRowThreshold: number;
     longTxnThresholdSeconds: number;
+    probeTimeoutSeconds: number;
     measure: boolean;
     api: string | null;
     allowInsecure: boolean;
@@ -742,7 +773,19 @@ export function parseNumericFlag(
     return value;
 }
 
-function parseArgs(argv: string[]): CliArgs {
+export function parseIntegerFlag(
+    name: string,
+    raw: string | null,
+    fallback: number,
+): number {
+    const value = parseNumericFlag(name, raw, fallback);
+    if (!Number.isInteger(value)) {
+        throw new Error(`${name} must be a positive integer, got "${raw}"`);
+    }
+    return value;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
     const get = (flag: string): string | null => {
         const i = argv.indexOf(flag);
         const value = i >= 0 && i + 1 < argv.length ? argv[i + 1] : null;
@@ -753,7 +796,7 @@ function parseArgs(argv: string[]): CliArgs {
     const to = get('--to');
     if (!facts || !from || !to) {
         throw new Error(
-            'usage: preflight.ts --facts <file> --from <current version> --to <target version> [--psql "<cmd>" | --api <baseUrl>] [--interval <s>] [--json] [--no-measure]',
+            'usage: preflight.ts --facts <file> --from <current version> --to <target version> [--psql "<cmd>" | --api <baseUrl>] [--interval <s>] [--probe-timeout <s>] [--measure] [--json]',
         );
     }
     return {
@@ -778,7 +821,12 @@ function parseArgs(argv: string[]): CliArgs {
             get('--long-txn-threshold'),
             300,
         ),
-        measure: !argv.includes('--no-measure'),
+        probeTimeoutSeconds: parseIntegerFlag(
+            '--probe-timeout',
+            get('--probe-timeout'),
+            30,
+        ),
+        measure: argv.includes('--measure'),
         api: get('--api'),
         allowInsecure: argv.includes('--allow-insecure'),
     };
@@ -804,7 +852,7 @@ async function runApiMode(args: CliArgs, facts: MigrationFact[]): Promise<Findin
     const lockRows: LockRow[] | null = after.lock
         ? [{ index: 1, is_locked: after.lock.isLocked ? 1 : 0 }]
         : null;
-    findings.push(analyzeLock(lockRows, after.lock?.activeMigrationBackends ?? 0));
+    findings.push(analyzeLock(lockRows, after.lock?.lastMigrationAgeSeconds ?? null));
 
     const rates = computeWriteRates(
         statRowsFromProbe(before),
@@ -824,7 +872,7 @@ async function runApiMode(args: CliArgs, facts: MigrationFact[]): Promise<Findin
             severity: 'warn',
             migration: null,
             table: null,
-            summary: `EXPLAIN-based checks (row estimates, index/plan shape, measured durations) skipped in API mode for ${skipped.length} backfill(s) — they need facts SQL executed against the database, which this endpoint deliberately does not do`,
+            summary: `EXPLAIN-based checks (row estimates and index/plan shape${args.measure ? ', including requested duration measurements' : ''}) skipped in API mode for ${skipped.length} backfill(s) — they need facts SQL executed against the database, which this endpoint deliberately does not do`,
             action: 'run preflight with direct database access for full coverage, or wait for server-side verified-facts probing (open design question)',
             actionKind: 'plan',
             data: { skippedMigrations: skipped.map((f) => f.migration) },
@@ -845,7 +893,7 @@ async function main(): Promise<void> {
         process.exit(apiReport.verdict === 'blocker' ? 2 : apiReport.verdict === 'warn' ? 1 : 0);
     }
 
-    const db = makePsqlRunner(args.psql);
+    const db = makePsqlRunner(args.psql, args.probeTimeoutSeconds);
     const findings: Finding[] = [];
 
     let lockRows: LockRow[] | null;
@@ -854,10 +902,18 @@ async function main(): Promise<void> {
     } catch {
         lockRows = null;
     }
-    const migrationBackends = db.json(
-        `SELECT count(*)::integer AS n FROM pg_stat_activity WHERE state <> 'idle' AND pid <> pg_backend_pid() AND query ILIKE '%knex_migrations%'`,
-    ) as Array<{ n: number }>;
-    findings.push(analyzeLock(lockRows, migrationBackends[0]?.n ?? 0));
+    let lastMigrationAgeSeconds: number | null = null;
+    if (lockRows?.some((row) => Number(row.is_locked) === 1)) {
+        try {
+            const lastMigration = db.json(
+                'SELECT EXTRACT(EPOCH FROM now() - max(migration_time))::integer AS age_seconds FROM knex_migrations',
+            ) as Array<{ age_seconds: number | null }>;
+            lastMigrationAgeSeconds = lastMigration[0]?.age_seconds ?? null;
+        } catch {
+            lastMigrationAgeSeconds = null;
+        }
+    }
+    findings.push(analyzeLock(lockRows, lastMigrationAgeSeconds));
     findings.push(...analyzeUpgradeStrategy(facts));
 
     const tableNames = [
@@ -882,7 +938,6 @@ async function main(): Promise<void> {
         if (!fact.backfill) continue;
         try {
             const estimate = db.explain(fact.backfill.estimateSql);
-            const estimatedRows = topPlanRows(estimate);
             let scanSeconds: number | null = null;
             if (args.measure) {
                 try {
@@ -903,7 +958,6 @@ async function main(): Promise<void> {
                     planJson,
                     liveTuplesByTable,
                     args.largeRowThreshold,
-                    estimatedRows,
                     scanSeconds,
                 ),
             );

--- a/scripts/preflight.ts
+++ b/scripts/preflight.ts
@@ -1,0 +1,749 @@
+/**
+ * SPK-701 SPIKE — upgrade preflight prober.
+ *
+ * Joins per-migration facts (a draft `migrationFacts` extension of the
+ * release-safety marker, hand-authored fixtures for now) with read-only
+ * queries against the operator's Postgres, and emits a concrete operator
+ * plan for the upgrade window instead of a bare verdict.
+ *
+ * Checks:
+ *   - stale `knex_migrations_lock` row (blocks every future migration run)
+ *   - write rate on tables the selected migrations write/DDL, from two
+ *     samples of pg_stat_user_tables
+ *   - per-backfill row estimates via EXPLAIN (FORMAT JSON) — never COUNT(*)
+ *   - plan shape: seq scans on large tables in the backfill query
+ *   - long-running transactions and lock waits in pg_stat_activity
+ *
+ * PURE core (fact selection, analysis, report building) + thin IO shell that
+ * shells out to psql (`--psql` makes the transport configurable; every query
+ * runs inside BEGIN TRANSACTION READ ONLY). Prototype: NOT wired into the CLI
+ * package — delivery form is the open design question this spike informs.
+ *
+ * Run:
+ *   npx tsx scripts/preflight.ts --facts <facts.json> --from 1.50.0 --to 1.60.0 \
+ *     [--psql "psql -h host -U user -d db"] [--interval 10] [--json]
+ */
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { compareVersions } from './expand-version';
+import { validateAgainstSchema } from './json-schema-lite';
+
+// --- facts (draft migrationFacts schema) ------------------------------------
+
+export type TableAccess = 'read' | 'write' | 'ddl';
+
+export interface TableFact {
+    name: string;
+    access: TableAccess[];
+    expectedLockModes: string[];
+}
+
+export interface BackfillFact {
+    description: string;
+    /** SELECT enumerating the rows the backfill touches; MUST be runnable against the PRE-upgrade schema */
+    estimateSql: string;
+    /** the batch query shape for plan/index analysis (pre-upgrade-runnable); null when estimateSql is the shape */
+    planSql: string | null;
+    /** vetted pre-upgrade index DDL (CREATE INDEX CONCURRENTLY ...) that supports the backfill predicate; null when no index helps */
+    supportingIndexSql: string | null;
+}
+
+export interface MigrationFact {
+    migration: string;
+    introducedIn: string;
+    runsInTransaction: boolean;
+    resumable: boolean;
+    batchSize: number | null;
+    lockTimeout: string | null;
+    tables: TableFact[];
+    backfill: BackfillFact | null;
+    notes: string | null;
+}
+
+export interface FactsFile {
+    schemaVersion: string;
+    migrationFacts: MigrationFact[];
+}
+
+export const FACTS_SCHEMA_PATH = path.join(__dirname, 'preflight-facts.schema.json');
+
+export function parseFactsFile(raw: string): FactsFile {
+    const parsed = JSON.parse(raw) as unknown;
+    const schema = JSON.parse(fs.readFileSync(FACTS_SCHEMA_PATH, 'utf-8')) as Record<
+        string,
+        unknown
+    >;
+    const schemaErrors = validateAgainstSchema(parsed, schema);
+    if (schemaErrors.length > 0) {
+        throw new Error(`facts file does not match its schema:\n  ${schemaErrors.join('\n  ')}`);
+    }
+    const factsFile = parsed as FactsFile;
+    for (const fact of factsFile.migrationFacts) {
+        for (const sql of [fact.backfill?.estimateSql, fact.backfill?.planSql]) {
+            if (sql !== null && sql !== undefined && sql.includes(';')) {
+                throw new Error(
+                    `backfill SQL for "${fact.migration}" contains ';' — facts SQL must be a single statement (it runs inside a READ ONLY transaction and must not be able to end it)`,
+                );
+            }
+        }
+    }
+    return factsFile;
+}
+
+/** migrations the upgrade will run: introduced after `from`, at or before `to` */
+export function selectFacts(
+    facts: MigrationFact[],
+    from: string,
+    to: string,
+): MigrationFact[] {
+    return facts.filter(
+        (f) =>
+            compareVersions(f.introducedIn, from) > 0 &&
+            compareVersions(f.introducedIn, to) <= 0,
+    );
+}
+
+// --- findings ---------------------------------------------------------------
+
+export type Severity = 'ok' | 'warn' | 'blocker';
+
+/**
+ * remediate — the operator can fix it in place before the upgrade and verify by
+ * re-running preflight. plan — intrinsic to the migration + this database's
+ * shape; cannot be fixed, only consciously planned around.
+ */
+export type ActionKind = 'remediate' | 'plan' | null;
+
+export interface Finding {
+    check: 'stale-lock' | 'write-rate' | 'row-estimate' | 'plan' | 'activity';
+    severity: Severity;
+    migration: string | null;
+    table: string | null;
+    summary: string;
+    action: string | null;
+    actionKind: ActionKind;
+    data: Record<string, unknown>;
+}
+
+const SEVERITY_ORDER: Record<Severity, number> = { blocker: 0, warn: 1, ok: 2 };
+
+// --- stale migration lock ---------------------------------------------------
+
+export interface LockRow {
+    index: number;
+    is_locked: number;
+}
+
+export function analyzeLock(
+    lockRows: LockRow[] | null,
+    activeMigrationBackends: number,
+): Finding {
+    if (lockRows === null) {
+        return {
+            check: 'stale-lock',
+            severity: 'warn',
+            migration: null,
+            table: 'knex_migrations_lock',
+            summary: 'knex_migrations_lock table not found — cannot verify migration lock state',
+            action: null,
+            actionKind: null,
+            data: {},
+        };
+    }
+    const locked = lockRows.some((r) => Number(r.is_locked) === 1);
+    if (!locked) {
+        return {
+            check: 'stale-lock',
+            severity: 'ok',
+            migration: null,
+            table: 'knex_migrations_lock',
+            summary: 'migration lock is free',
+            action: null,
+            actionKind: null,
+            data: { activeMigrationBackends },
+        };
+    }
+    if (activeMigrationBackends > 0) {
+        return {
+            check: 'stale-lock',
+            severity: 'blocker',
+            migration: null,
+            table: 'knex_migrations_lock',
+            summary: `migration lock is held and ${activeMigrationBackends} backend(s) look like an active migration run — another upgrade may be in progress`,
+            action: 'wait for the running migration to finish, then re-run preflight',
+            actionKind: 'remediate',
+            data: { activeMigrationBackends },
+        };
+    }
+    return {
+        check: 'stale-lock',
+        severity: 'blocker',
+        migration: null,
+        table: 'knex_migrations_lock',
+        summary:
+            'migration lock is held but no backend is running migrations — stale lock from a failed/killed migration run; every future migration will fail with "Migration table is already locked"',
+        action: 'run: UPDATE knex_migrations_lock SET is_locked = 0; — then re-run preflight to confirm the lock reads free',
+        actionKind: 'remediate',
+        data: { activeMigrationBackends },
+    };
+}
+
+// --- write rate -------------------------------------------------------------
+
+export interface StatRow {
+    relname: string;
+    n_tup_ins: number;
+    n_tup_upd: number;
+    n_tup_del: number;
+    n_live_tup: number;
+}
+
+export interface WriteRate {
+    table: string;
+    rowsPerMin: number;
+    inserts: number;
+    updates: number;
+    deletes: number;
+    liveTuples: number;
+}
+
+export function computeWriteRates(
+    before: StatRow[],
+    after: StatRow[],
+    intervalSeconds: number,
+): WriteRate[] {
+    const beforeByTable = new Map(before.map((r) => [r.relname, r]));
+    return after.map((a) => {
+        const b = beforeByTable.get(a.relname);
+        const delta = (x: number, y: number) => Math.max(0, x - y);
+        const inserts = b ? delta(Number(a.n_tup_ins), Number(b.n_tup_ins)) : 0;
+        const updates = b ? delta(Number(a.n_tup_upd), Number(b.n_tup_upd)) : 0;
+        const deletes = b ? delta(Number(a.n_tup_del), Number(b.n_tup_del)) : 0;
+        const total = inserts + updates + deletes;
+        return {
+            table: a.relname,
+            rowsPerMin: intervalSeconds > 0 ? Math.round((total * 60) / intervalSeconds) : 0,
+            inserts,
+            updates,
+            deletes,
+            liveTuples: Number(a.n_live_tup),
+        };
+    });
+}
+
+export function analyzeWriteRates(
+    facts: MigrationFact[],
+    rates: WriteRate[],
+    thresholdRowsPerMin: number,
+): Finding[] {
+    const rateByTable = new Map(rates.map((r) => [r.table, r]));
+    const findings: Finding[] = [];
+    const seen = new Set<string>();
+    for (const fact of facts) {
+        for (const table of fact.tables) {
+            const mutating = table.access.some((a) => a === 'write' || a === 'ddl');
+            if (!mutating || seen.has(table.name)) continue;
+            seen.add(table.name);
+            const rate = rateByTable.get(table.name);
+            if (!rate) {
+                findings.push({
+                    check: 'write-rate',
+                    severity: 'warn',
+                    migration: fact.migration,
+                    table: table.name,
+                    summary: `table "${table.name}" not found in pg_stat_user_tables — schema drift?`,
+                    action: null,
+                    actionKind: null,
+                    data: {},
+                });
+                continue;
+            }
+            if (rate.rowsPerMin >= thresholdRowsPerMin) {
+                findings.push({
+                    check: 'write-rate',
+                    severity: 'warn',
+                    migration: fact.migration,
+                    table: table.name,
+                    summary: `something is writing to "${table.name}" at ~${rate.rowsPerMin} rows/min (${rate.inserts} ins / ${rate.updates} upd / ${rate.deletes} del in the sample) while the upgrade wants ${table.access.join('+')} on it${table.expectedLockModes.length > 0 ? ` (${table.expectedLockModes.join(', ')})` : ''}`,
+                    action: `pause the writer (cron/integration) on "${table.name}", then re-run preflight to confirm the table reads quiet`,
+                    actionKind: 'remediate',
+                    data: { rate },
+                });
+            } else {
+                findings.push({
+                    check: 'write-rate',
+                    severity: 'ok',
+                    migration: fact.migration,
+                    table: table.name,
+                    summary: `"${table.name}" is quiet (~${rate.rowsPerMin} rows/min)`,
+                    action: null,
+                    actionKind: null,
+                    data: { rate },
+                });
+            }
+        }
+    }
+    return findings;
+}
+
+// --- EXPLAIN analysis --------------------------------------------------------
+
+interface PlanNode {
+    'Node Type': string;
+    'Relation Name'?: string;
+    'Plan Rows'?: number;
+    Plans?: PlanNode[];
+}
+
+export function flattenPlan(node: PlanNode): PlanNode[] {
+    return [node, ...(node.Plans ?? []).flatMap(flattenPlan)];
+}
+
+export function topPlanRows(explainJson: unknown): number | null {
+    if (!Array.isArray(explainJson)) return null;
+    const plan = (explainJson[0] as { Plan?: PlanNode } | undefined)?.Plan;
+    return plan?.['Plan Rows'] ?? null;
+}
+
+export function executionSeconds(explainAnalyzeJson: unknown): number | null {
+    if (!Array.isArray(explainAnalyzeJson)) return null;
+    const ms = (explainAnalyzeJson[0] as { 'Execution Time'?: number } | undefined)?.[
+        'Execution Time'
+    ];
+    return typeof ms === 'number' ? ms / 1000 : null;
+}
+
+export function formatSeconds(seconds: number): string {
+    if (seconds < 1) return '<1s';
+    if (seconds < 90) return `~${Math.round(seconds)}s`;
+    return `~${Math.round(seconds / 60)} min`;
+}
+
+const num = (n: number): string => n.toLocaleString('en-US');
+
+export function analyzeRowEstimate(
+    fact: MigrationFact,
+    explainJson: unknown,
+    largeRowThreshold: number,
+    scanSeconds: number | null,
+): Finding {
+    const rows = topPlanRows(explainJson);
+    if (rows === null) {
+        return {
+            check: 'row-estimate',
+            severity: 'warn',
+            migration: fact.migration,
+            table: null,
+            summary: `could not read a row estimate for the "${fact.migration}" backfill`,
+            action: null,
+            actionKind: null,
+            data: { explainJson },
+        };
+    }
+    const big = rows >= largeRowThreshold;
+    const passes = fact.batchSize ? Math.max(1, Math.ceil(rows / fact.batchSize)) : 1;
+    const measured =
+        scanSeconds !== null
+            ? `; one scan of the target rows measured ${formatSeconds(scanSeconds)} on this instance`
+            : '';
+    const transactional = fact.runsInTransaction
+        ? 'in a single transaction'
+        : fact.batchSize
+          ? `in batches of ${fact.batchSize}${fact.resumable ? ', resumable' : ''}${passes > 1 ? ` (~${num(passes)} passes)` : ''}`
+          : 'outside a transaction';
+    const windowSize =
+        scanSeconds === null
+            ? `sized for ~${num(rows)} rows — row locks are held until commit`
+            : scanSeconds >= 60
+              ? `of at least ${formatSeconds(scanSeconds)} — reading the target rows alone measured that here, and the UPDATE holds row locks for longer`
+              : `— the target-row scan measured ${formatSeconds(scanSeconds)} here, but the single-transaction UPDATE on ~${num(rows)} rows holds row locks until commit`;
+    return {
+        check: 'row-estimate',
+        severity: big && fact.runsInTransaction ? 'warn' : 'ok',
+        migration: fact.migration,
+        table: fact.tables.find((t) => t.access.includes('write'))?.name ?? null,
+        summary: `backfill touches ~${num(rows)} rows here, ${transactional}${measured}`,
+        action:
+            big && fact.runsInTransaction
+                ? `schedule a maintenance window ${windowSize}; upgrade with the marker's recommendedStrategy (Recreate: no old pods serving mid-migration) and protect the migration job from eviction (raise activeDeadlineSeconds, set a PriorityClass) — a job killed mid-backfill is what leaves stale locks behind`
+                : null,
+        actionKind: big && fact.runsInTransaction ? 'plan' : null,
+        data: { estimatedRows: rows, passes, scanSeconds },
+    };
+}
+
+/** above this fraction of the table, an index cannot beat the scan — the scan IS the work */
+const INDEX_USELESS_FRACTION = 0.5;
+
+export function analyzeSeqScans(
+    fact: MigrationFact,
+    explainJson: unknown,
+    liveTuplesByTable: Map<string, number>,
+    largeRowThreshold: number,
+    estimatedRows: number | null,
+    scanSeconds: number | null,
+): Finding[] {
+    if (!Array.isArray(explainJson)) return [];
+    const plan = (explainJson[0] as { Plan?: PlanNode } | undefined)?.Plan;
+    if (!plan) return [];
+    const findings: Finding[] = [];
+    const measured =
+        scanSeconds !== null
+            ? `; one full scan measured ${formatSeconds(scanSeconds)} on this instance`
+            : '';
+    for (const node of flattenPlan(plan)) {
+        if (node['Node Type'] !== 'Seq Scan' || !node['Relation Name']) continue;
+        const table = node['Relation Name'];
+        const liveTuples = liveTuplesByTable.get(table) ?? 0;
+        if (liveTuples < largeRowThreshold) continue;
+        const fraction =
+            estimatedRows !== null && liveTuples > 0 ? estimatedRows / liveTuples : null;
+        const base = { check: 'plan' as const, severity: 'warn' as const, migration: fact.migration, table };
+        if (fraction !== null && fraction >= INDEX_USELESS_FRACTION) {
+            findings.push({
+                ...base,
+                summary: `the backfill's predicate matches ~${Math.round(fraction * 100)}% of "${table}" (${num(estimatedRows as number)} of ${num(liveTuples)} rows) — no index can help; the scan is the work${measured}`,
+                action: `size the window for the update work on ~${num(estimatedRows as number)} rows${scanSeconds !== null ? ` (the scan itself measured ${formatSeconds(scanSeconds)} here)` : ''}`,
+                actionKind: 'plan',
+                data: { liveTuples, estimatedRows, fraction, scanSeconds },
+            });
+        } else if (fact.backfill?.supportingIndexSql) {
+            findings.push({
+                ...base,
+                summary: `the backfill seq-scans "${table}" (~${num(liveTuples)} live rows) to reach ~${estimatedRows === null ? '?' : num(estimatedRows)} target rows — no usable index on this instance, but the facts carry a vetted one${measured}`,
+                action: `run: ${fact.backfill.supportingIndexSql}; — CONCURRENTLY does not block writes; then re-run preflight: this finding disappears once the planner uses the index`,
+                actionKind: 'remediate',
+                data: { liveTuples, estimatedRows, fraction, scanSeconds },
+            });
+        } else {
+            findings.push({
+                ...base,
+                summary: `the backfill seq-scans "${table}" (~${num(liveTuples)} live rows) — no usable index for its predicate on this instance, and the facts carry no vetted one${measured}`,
+                action: `expect ${scanSeconds !== null ? formatSeconds(scanSeconds) : 'a full-table scan'}${fact.batchSize ? ' of scan work PER PASS in the worst case' : ' of scan time'}; check the release notes for a supporting index, or accept the scan`,
+                actionKind: 'plan',
+                data: { liveTuples, estimatedRows, fraction, scanSeconds },
+            });
+        }
+    }
+    return findings;
+}
+
+// --- activity / locks --------------------------------------------------------
+
+export interface ActivityRow {
+    pid: number;
+    usename: string | null;
+    application_name: string | null;
+    state: string | null;
+    xact_age_s: number | null;
+    query: string | null;
+    blocked_by: number[] | null;
+}
+
+export function analyzeActivity(
+    rows: ActivityRow[],
+    longTxnThresholdSeconds: number,
+): Finding[] {
+    const findings: Finding[] = [];
+    for (const row of rows) {
+        const blockedBy = row.blocked_by ?? [];
+        if (blockedBy.length > 0) {
+            findings.push({
+                check: 'activity',
+                severity: 'blocker',
+                migration: null,
+                table: null,
+                summary: `pid ${row.pid} (${row.application_name || row.usename || 'unknown'}) is waiting on a lock held by pid(s) ${blockedBy.join(', ')} — the migration would queue behind the same locks`,
+                action: `inspect and end the blocking session(s), then re-run preflight: SELECT pg_terminate_backend(pid) once you know what it is`,
+                actionKind: 'remediate',
+                data: { pid: row.pid, blockedBy, query: row.query },
+            });
+        } else if ((row.xact_age_s ?? 0) >= longTxnThresholdSeconds) {
+            findings.push({
+                check: 'activity',
+                severity: 'warn',
+                migration: null,
+                table: null,
+                summary: `pid ${row.pid} (${row.application_name || row.usename || 'unknown'}) has held a transaction open for ${Math.round(Number(row.xact_age_s) / 60)} min — any ALTER TABLE will queue behind it and block everything else`,
+                action: 'let this session finish (or terminate it), then re-run preflight',
+                actionKind: 'remediate',
+                data: { pid: row.pid, xactAgeSeconds: row.xact_age_s, query: row.query },
+            });
+        }
+    }
+    if (findings.length === 0) {
+        findings.push({
+            check: 'activity',
+            severity: 'ok',
+            migration: null,
+            table: null,
+            summary: 'no long-running transactions or lock waits',
+            action: null,
+            actionKind: null,
+            data: {},
+        });
+    }
+    return findings;
+}
+
+// --- report ------------------------------------------------------------------
+
+export interface PreflightReport {
+    from: string;
+    to: string;
+    migrations: string[];
+    findings: Finding[];
+    remediateNow: string[];
+    planItems: string[];
+    verdict: Severity;
+}
+
+export function buildReport(
+    from: string,
+    to: string,
+    facts: MigrationFact[],
+    findings: Finding[],
+): PreflightReport {
+    const sorted = [...findings].sort(
+        (a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity],
+    );
+    const actions = (kind: 'remediate' | 'plan') =>
+        sorted
+            .filter((f) => f.action !== null && f.actionKind === kind)
+            .map((f) => f.action as string);
+    const verdict = sorted.some((f) => f.severity === 'blocker')
+        ? 'blocker'
+        : sorted.some((f) => f.severity === 'warn')
+          ? 'warn'
+          : 'ok';
+    return {
+        from,
+        to,
+        migrations: facts.map((f) => f.migration),
+        findings: sorted,
+        remediateNow: actions('remediate'),
+        planItems: actions('plan'),
+        verdict,
+    };
+}
+
+const SEVERITY_ICON: Record<Severity, string> = {
+    blocker: '✖',
+    warn: '⚠',
+    ok: '✓',
+};
+
+export function renderHuman(report: PreflightReport): string {
+    const lines: string[] = [];
+    lines.push(`Upgrade preflight: ${report.from} → ${report.to}`);
+    lines.push(
+        `Migrations with facts in range: ${report.migrations.length === 0 ? '(none)' : ''}`,
+    );
+    for (const m of report.migrations) lines.push(`  - ${m}`);
+    lines.push('');
+    for (const f of report.findings) {
+        lines.push(`${SEVERITY_ICON[f.severity]} [${f.check}] ${f.summary}`);
+        if (f.action) lines.push(`    → ${f.action}`);
+    }
+    lines.push('');
+    if (report.remediateNow.length === 0 && report.planItems.length === 0) {
+        lines.push('No preparation needed — clear to upgrade.');
+    }
+    if (report.remediateNow.length > 0) {
+        lines.push('REMEDIATE NOW — fix these, then re-run preflight to verify:');
+        report.remediateNow.forEach((step, i) => lines.push(`  ${i + 1}. ${step}`));
+        lines.push('');
+    }
+    if (report.planItems.length > 0) {
+        lines.push('PLAN DIFFERENTLY — these cannot be fixed in place, only planned around:');
+        report.planItems.forEach((step, i) => lines.push(`  ${i + 1}. ${step}`));
+        lines.push('');
+    }
+    lines.push(
+        'The loop: remediate → re-run preflight → upgrade only when the run is clean,',
+        'or when every remaining warning is a plan item you have consciously accepted.',
+        'Exit codes gate automation: 0 clean / 1 warnings / 2 blockers.',
+    );
+    lines.push('');
+    lines.push(`Verdict: ${report.verdict.toUpperCase()}`);
+    return lines.join('\n');
+}
+
+// --- IO shell -----------------------------------------------------------------
+
+interface PsqlRunner {
+    json: (sql: string) => unknown;
+    explain: (sql: string) => unknown;
+    explainAnalyze: (sql: string) => unknown;
+}
+
+export function makePsqlRunner(psqlCommand: string): PsqlRunner {
+    const argv = psqlCommand.split(/\s+/).filter(Boolean);
+    const run = (payload: string): string =>
+        execFileSync(argv[0], [...argv.slice(1), '-X', '-q', '-A', '-t', '-v', 'ON_ERROR_STOP=1', '-c', payload], {
+            encoding: 'utf-8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+    const readOnly = (sql: string): string =>
+        `BEGIN TRANSACTION READ ONLY; ${sql}; ROLLBACK;`;
+    return {
+        json: (sql: string) => {
+            const wrapped = `SELECT COALESCE(json_agg(row_to_json(t)), '[]'::json) FROM (${sql}) AS t`;
+            return JSON.parse(run(readOnly(wrapped)).trim());
+        },
+        explain: (sql: string) => JSON.parse(run(readOnly(`EXPLAIN (FORMAT JSON) ${sql}`)).trim()),
+        explainAnalyze: (sql: string) =>
+            JSON.parse(run(readOnly(`EXPLAIN (ANALYZE, TIMING OFF, FORMAT JSON) ${sql}`)).trim()),
+    };
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+interface CliArgs {
+    facts: string;
+    from: string;
+    to: string;
+    psql: string;
+    intervalSeconds: number;
+    json: boolean;
+    writeRateThreshold: number;
+    largeRowThreshold: number;
+    longTxnThresholdSeconds: number;
+    measure: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+    const get = (flag: string): string | null => {
+        const i = argv.indexOf(flag);
+        return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null;
+    };
+    const facts = get('--facts');
+    const from = get('--from');
+    const to = get('--to');
+    if (!facts || !from || !to) {
+        throw new Error(
+            'usage: preflight.ts --facts <file> --from <current version> --to <target version> [--psql "<cmd>"] [--interval <s>] [--json] [--no-measure]',
+        );
+    }
+    return {
+        facts,
+        from,
+        to,
+        psql: get('--psql') ?? 'psql',
+        intervalSeconds: Number(get('--interval') ?? 10),
+        json: argv.includes('--json'),
+        writeRateThreshold: Number(get('--write-rate-threshold') ?? 10),
+        largeRowThreshold: Number(get('--large-row-threshold') ?? 100000),
+        longTxnThresholdSeconds: Number(get('--long-txn-threshold') ?? 300),
+        measure: !argv.includes('--no-measure'),
+    };
+}
+
+async function main(): Promise<void> {
+    const args = parseArgs(process.argv.slice(2));
+    const factsFile = parseFactsFile(fs.readFileSync(args.facts, 'utf-8'));
+    const facts = selectFacts(factsFile.migrationFacts, args.from, args.to);
+    const db = makePsqlRunner(args.psql);
+    const findings: Finding[] = [];
+
+    let lockRows: LockRow[] | null;
+    try {
+        lockRows = db.json('SELECT "index", is_locked FROM knex_migrations_lock') as LockRow[];
+    } catch {
+        lockRows = null;
+    }
+    const migrationBackends = db.json(
+        `SELECT count(*)::integer AS n FROM pg_stat_activity WHERE state <> 'idle' AND pid <> pg_backend_pid() AND query ILIKE '%knex_migrations%'`,
+    ) as Array<{ n: number }>;
+    findings.push(analyzeLock(lockRows, migrationBackends[0]?.n ?? 0));
+
+    const tableNames = [
+        ...new Set(facts.flatMap((f) => f.tables.map((t) => t.name))),
+    ];
+    let liveTuplesByTable = new Map<string, number>();
+    if (tableNames.length > 0) {
+        const quoted = tableNames.map((t) => `'${t.replace(/'/g, "''")}'`).join(', ');
+        const statSql = `SELECT relname, n_tup_ins, n_tup_upd, n_tup_del, n_live_tup FROM pg_stat_user_tables WHERE schemaname = 'public' AND relname IN (${quoted})`;
+        const before = db.json(statSql) as StatRow[];
+        process.stderr.write(
+            `[preflight] sampling write activity for ${args.intervalSeconds}s across ${tableNames.length} table(s)...\n`,
+        );
+        await sleep(args.intervalSeconds * 1000);
+        const after = db.json(statSql) as StatRow[];
+        const rates = computeWriteRates(before, after, args.intervalSeconds);
+        liveTuplesByTable = new Map(rates.map((r) => [r.table, r.liveTuples]));
+        findings.push(...analyzeWriteRates(facts, rates, args.writeRateThreshold));
+    }
+
+    for (const fact of facts) {
+        if (!fact.backfill) continue;
+        try {
+            const estimate = db.explain(fact.backfill.estimateSql);
+            const estimatedRows = topPlanRows(estimate);
+            let scanSeconds: number | null = null;
+            if (args.measure) {
+                try {
+                    scanSeconds = executionSeconds(db.explainAnalyze(fact.backfill.estimateSql));
+                } catch {
+                    scanSeconds = null;
+                }
+            }
+            findings.push(
+                analyzeRowEstimate(fact, estimate, args.largeRowThreshold, scanSeconds),
+            );
+            const planJson = fact.backfill.planSql
+                ? db.explain(fact.backfill.planSql)
+                : estimate;
+            findings.push(
+                ...analyzeSeqScans(
+                    fact,
+                    planJson,
+                    liveTuplesByTable,
+                    args.largeRowThreshold,
+                    estimatedRows,
+                    scanSeconds,
+                ),
+            );
+        } catch (err) {
+            findings.push({
+                check: 'row-estimate',
+                severity: 'warn',
+                migration: fact.migration,
+                table: null,
+                summary: `backfill estimate query failed for "${fact.migration}" — facts may not match this schema version: ${err instanceof Error ? err.message.split('\n')[0] : String(err)}`,
+                action: null,
+                actionKind: null,
+                data: {},
+            });
+        }
+    }
+
+    const activity = db.json(
+        `SELECT pid, usename, application_name, state,
+                EXTRACT(EPOCH FROM now() - xact_start)::integer AS xact_age_s,
+                left(query, 160) AS query,
+                CASE WHEN cardinality(pg_blocking_pids(pid)) > 0 THEN pg_blocking_pids(pid) END AS blocked_by
+         FROM pg_stat_activity
+         WHERE pid <> pg_backend_pid() AND xact_start IS NOT NULL AND state <> 'idle'`,
+    ) as ActivityRow[];
+    findings.push(...analyzeActivity(activity, args.longTxnThresholdSeconds));
+
+    const report = buildReport(args.from, args.to, facts, findings);
+    if (args.json) {
+        console.log(JSON.stringify(report, null, 2));
+    } else {
+        console.log(renderHuman(report));
+    }
+    process.exit(report.verdict === 'blocker' ? 2 : report.verdict === 'warn' ? 1 : 0);
+}
+
+const isCliInvocation =
+    require.main === module || process.argv[1]?.endsWith('preflight.ts') === true;
+
+if (isCliInvocation) {
+    main().catch((err) => {
+        console.error(`[preflight] FAILED: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(3);
+    });
+}

--- a/scripts/preflight.ts
+++ b/scripts/preflight.ts
@@ -593,6 +593,21 @@ interface ApiProbe {
     }>;
 }
 
+export function assertSafeApiBaseUrl(baseUrl: string, allowInsecure: boolean): void {
+    let parsed: URL;
+    try {
+        parsed = new URL(baseUrl);
+    } catch {
+        throw new Error(`--api is not a valid URL: ${baseUrl}`);
+    }
+    const isLocal = ['localhost', '127.0.0.1', '::1'].includes(parsed.hostname);
+    if (parsed.protocol !== 'https:' && !isLocal && !allowInsecure) {
+        throw new Error(
+            `--api uses ${parsed.protocol}// — the API key would travel in cleartext. Use https, or pass --allow-insecure if you accept that`,
+        );
+    }
+}
+
 async function fetchApiProbe(
     baseUrl: string,
     apiKey: string,
@@ -636,6 +651,11 @@ interface PsqlRunner {
 }
 
 export function makePsqlRunner(psqlCommand: string): PsqlRunner {
+    if (/['"\\]/.test(psqlCommand)) {
+        throw new Error(
+            '--psql is split on whitespace and does not understand quoting — pass a bare executable plus simple flags (quotes/backslashes would be passed through literally)',
+        );
+    }
     const argv = psqlCommand.split(/\s+/).filter(Boolean);
     const run = (payload: string): string =>
         execFileSync(argv[0], [...argv.slice(1), '-X', '-q', '-A', '-t', '-v', 'ON_ERROR_STOP=1', '-c', payload], {
@@ -669,12 +689,27 @@ interface CliArgs {
     longTxnThresholdSeconds: number;
     measure: boolean;
     api: string | null;
+    allowInsecure: boolean;
+}
+
+export function parseNumericFlag(
+    name: string,
+    raw: string | null,
+    fallback: number,
+): number {
+    if (raw === null) return fallback;
+    const value = Number(raw);
+    if (!Number.isFinite(value) || value <= 0) {
+        throw new Error(`${name} must be a positive number, got "${raw}"`);
+    }
+    return value;
 }
 
 function parseArgs(argv: string[]): CliArgs {
     const get = (flag: string): string | null => {
         const i = argv.indexOf(flag);
-        return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null;
+        const value = i >= 0 && i + 1 < argv.length ? argv[i + 1] : null;
+        return value !== null && value.startsWith('--') ? null : value;
     };
     const facts = get('--facts');
     const from = get('--from');
@@ -689,13 +724,26 @@ function parseArgs(argv: string[]): CliArgs {
         from,
         to,
         psql: get('--psql') ?? 'psql',
-        intervalSeconds: Number(get('--interval') ?? 10),
+        intervalSeconds: parseNumericFlag('--interval', get('--interval'), 10),
         json: argv.includes('--json'),
-        writeRateThreshold: Number(get('--write-rate-threshold') ?? 10),
-        largeRowThreshold: Number(get('--large-row-threshold') ?? 100000),
-        longTxnThresholdSeconds: Number(get('--long-txn-threshold') ?? 300),
+        writeRateThreshold: parseNumericFlag(
+            '--write-rate-threshold',
+            get('--write-rate-threshold'),
+            10,
+        ),
+        largeRowThreshold: parseNumericFlag(
+            '--large-row-threshold',
+            get('--large-row-threshold'),
+            100000,
+        ),
+        longTxnThresholdSeconds: parseNumericFlag(
+            '--long-txn-threshold',
+            get('--long-txn-threshold'),
+            300,
+        ),
         measure: !argv.includes('--no-measure'),
         api: get('--api'),
+        allowInsecure: argv.includes('--allow-insecure'),
     };
 }
 
@@ -705,6 +753,7 @@ async function runApiMode(args: CliArgs, facts: MigrationFact[]): Promise<Findin
         throw new Error('--api mode needs LIGHTDASH_API_KEY in the environment');
     }
     const baseUrl = args.api as string;
+    assertSafeApiBaseUrl(baseUrl, args.allowInsecure);
     const findings: Finding[] = [];
     const tableNames = [...new Set(facts.flatMap((f) => f.tables.map((t) => t.name)))];
 
@@ -777,7 +826,7 @@ async function main(): Promise<void> {
     let liveTuplesByTable = new Map<string, number>();
     if (tableNames.length > 0) {
         const quoted = tableNames.map((t) => `'${t.replace(/'/g, "''")}'`).join(', ');
-        const statSql = `SELECT relname, n_tup_ins, n_tup_upd, n_tup_del, n_live_tup FROM pg_stat_user_tables WHERE schemaname = 'public' AND relname IN (${quoted})`;
+        const statSql = `SELECT relname, n_tup_ins, n_tup_upd, n_tup_del, n_live_tup FROM pg_stat_user_tables WHERE schemaname = current_schema() AND relname IN (${quoted})`;
         const before = db.json(statSql) as StatRow[];
         process.stderr.write(
             `[preflight] sampling write activity for ${args.intervalSeconds}s across ${tableNames.length} table(s)...\n`,


### PR DESCRIPTION
## Summary

Spike prototype for `lightdash preflight`: a dependency-free tsx script (`scripts/preflight.ts`, same family as the release-safety generators) that joins per-migration facts — a draft `migrationFacts` extension of the release-safety marker, hand-authored here for three real migrations (including the batched timezone backfill from a recent self-hosted incident) and schema-validated at load against `scripts/preflight-facts.schema.json` using the stack's `json-schema-lite` validator, with the single-statement SQL rule kept as a semantic check on top — with **read-only** queries against an operator's Postgres, and tells the operator what to do about the findings instead of emitting a bare verdict.

Checks: stale `knex_migrations_lock` detection, write-rate sampling on tables the migrations touch (`pg_stat_user_tables`), EXPLAIN-based backfill row estimates (never `COUNT(*)`), seq-scan-on-large-table detection, and long-running-transaction / lock-wait discovery. Every query runs inside `BEGIN TRANSACTION READ ONLY`.

Findings with actions carry an `actionKind` that splits the output into an explicit operator loop:

- **REMEDIATE NOW** — fixable in place, verified by re-running preflight: clear the stale lock (exact SQL emitted), pause the named writer job, finish/terminate the long-open transaction or blocking session.
- **PLAN DIFFERENTLY** — intrinsic to the migration + this database's shape: a large single-transaction backfill or unindexed scan means sizing a maintenance window, upgrading with strategy Recreate, and raising the migration job's eviction/timeout protection (a job killed mid-backfill is what leaves stale locks behind).
- The output closes with the loop instruction: remediate → re-run → upgrade only when clean or when every remaining warning is a consciously accepted plan item. Exit codes 0/1/2 (ok/warn/blocker) gate automation; `--json` exposes `remediateNow`/`planItems`.
- Actions are operator-actionable, not vibes: durations are **measured** (one timed read-only scan of each backfill's target rows, `--no-measure` to skip) so window advice carries numbers from the operator's own hardware; index advice is either **runnable vetted DDL** from the facts file (`supportingIndexSql`, `CREATE INDEX CONCURRENTLY`, self-verifying on re-run) or suppressed entirely when the predicate matches most of the table and no index can help; deploy advice names the marker's `recommendedStrategy` and the concrete k8s knobs (`activeDeadlineSeconds`, PriorityClass).

## Probe endpoint (second commit)

Self-hosted operators often cannot reach their instance's Postgres directly — in the motivating incident, running diagnostic SQL needed platform-team involvement. `GET /api/v1/preflight/probe` (off by default — `PREFLIGHT_PROBE_ENABLED=true` opts in; org-admin only; refuses multi-org instances outright; hidden from docs) returns one read-only snapshot of upgrade-relevant state: migration-lock status + active migration backends, per-table write counters and live tuples for a validated table list, and long-running transactions/lock waits. Consumers call it twice and diff the counters, so the server stays stateless and the sampling interval is a client choice. `scripts/preflight.ts --api <baseUrl>` (with `LIGHTDASH_API_KEY`) runs the lock, write-rate, and activity checks through it — no database credentials needed. The endpoint deliberately never executes caller-supplied SQL: EXPLAIN-based checks are reported as an explicit coverage-gap finding in API mode, with server-side probing of signature-verified facts as the documented follow-on design question.

## Scope notes

- **Draft on purpose** — SPK-701 implementation is gated on design-partner validation; this branch exists to make that conversation concrete. Do not merge as-is.
- Deliberately NOT wired into `packages/cli` (delivery form — CLI vs Helm hook vs k8s Job — is the open design question) and deliberately does NOT touch `scripts/release-safety.schema.json` — the branch now sits on top of the M1 stack (base: `feature/spk-858`) and `migrationFacts` would fold into the marker schema as an additive array validated by the same mechanism.
- Motivated by a recent incident at a self-hosted customer where a routine migration met a huge table, a concurrent writer cron, and a stale migration lock — all knowable pre-upgrade with one read-only probe.

## Testing

- `npx tsx scripts/preflight.test.ts` — 33 unit tests over the pure core (facts schema validation, fact selection, lock analysis, measured-duration wording, index-advice suppression and remediation, write-rate math incl. counter resets, EXPLAIN plan walking, activity analysis, remediate/plan classification, report building). Also green as part of `npm run test:release-safety` (the file is in that glob on this base).
- Demo verified against a dev instance with a manufactured scenario shaped like that incident (2M-row `saved_queries_versions` with undrained backfill rows + a looping content-upload writer on the same table + stale lock + long-open transaction), run as the full operator loop: dirty run exits 2 with four REMEDIATE NOW items (including the vetted index DDL) and two plan items; after remediation — index created, writer paused, lock cleared, txn ended — the re-run exits 1 with only the accepted plan items and the index finding verifies itself by disappearing. A batched/resumable fixture migration correctly reads as safe throughout.

Relates: SPK-701

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDMJiJBYRWBBK92zhjVA31




