### PR TITLE
feat(data-apps): support limit 'all' in app data deliveries

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -1239,18 +1239,28 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
     const setup = ({
         download,
         fileStorageEnabled = false,
+        rerun,
     }: {
         download?: (args: { queryUuid: string }) => Promise<{
             fileUrl: string;
             s3FileUrl?: string;
         }>;
         fileStorageEnabled?: boolean;
+        rerun?: (args: { queryUuid: string }) => Promise<{
+            queryUuid: string;
+        }>;
     } = {}) => {
         const downloadSyncQueryResults = vi.fn(
             download ??
                 (async ({ queryUuid }: { queryUuid: string }) => ({
                     fileUrl: `https://files.example.com/${queryUuid}`,
                     s3FileUrl: `s3://bucket/${queryUuid}`,
+                })),
+        );
+        const executeAsyncUnboundedRerunFromQueryHistory = vi.fn(
+            rerun ??
+                (async ({ queryUuid }: { queryUuid: string }) => ({
+                    queryUuid: `${queryUuid}-rerun`,
                 })),
         );
         const findAppByUuid = vi.fn().mockResolvedValue(APP_ROW);
@@ -1278,10 +1288,17 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
             }),
             asyncQueryService: asDep<'asyncQueryService'>({
                 downloadSyncQueryResults,
+                executeAsyncUnboundedRerunFromQueryHistory,
             }),
             slackClient: asDep<'slackClient'>({ isEnabled: false }),
         });
-        return { task, downloadSyncQueryResults, findAppByUuid, trackAccount };
+        return {
+            task,
+            downloadSyncQueryResults,
+            executeAsyncUnboundedRerunFromQueryHistory,
+            findAppByUuid,
+            trackAccount,
+        };
     };
 
     it('downloads every ready query and names the files after the capture labels', async () => {
@@ -1593,6 +1610,112 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
                 error: 'storage unavailable',
             },
         ]);
+    });
+
+    describe('limit: all — unbounded rerun of limit-hit queries', () => {
+        const manifestWithOneLimitHit = () =>
+            manifestOf([
+                readyItem({
+                    label: 'Revenue',
+                    queryUuid: 'query-a',
+                    rowCount: 42,
+                    limitReached: false,
+                }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Orders',
+                    queryUuid: 'query-b',
+                    order: 1,
+                    rowCount: 5000,
+                    limitReached: true,
+                }),
+            ]);
+
+        it('re-runs only limit-reached entries, leaving under-limit entries untouched', async () => {
+            const { task, executeAsyncUnboundedRerunFromQueryHistory } =
+                setup();
+
+            await callGetNotificationPageData(
+                task,
+                appScheduler({ options: { formatted: true, limit: 'all' } }),
+                manifestWithOneLimitHit(),
+            );
+
+            expect(
+                executeAsyncUnboundedRerunFromQueryHistory,
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                executeAsyncUnboundedRerunFromQueryHistory.mock.calls[0][0],
+            ).toMatchObject({
+                projectUuid: 'project-1',
+                queryUuid: 'query-b',
+            });
+        });
+
+        it('never re-runs anything when the scheduler limit is table', async () => {
+            const { task, executeAsyncUnboundedRerunFromQueryHistory } =
+                setup();
+
+            await callGetNotificationPageData(
+                task,
+                appScheduler(),
+                manifestWithOneLimitHit(),
+            );
+
+            expect(
+                executeAsyncUnboundedRerunFromQueryHistory,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('downloads the rerun queryUuid, and drops the limit notice, when the rerun succeeds', async () => {
+            const { task, downloadSyncQueryResults } = setup();
+
+            const page = await callGetNotificationPageData(
+                task,
+                appScheduler({ options: { formatted: true, limit: 'all' } }),
+                manifestWithOneLimitHit(),
+            );
+
+            expect(downloadSyncQueryResults).toHaveBeenCalledTimes(2);
+            expect(downloadSyncQueryResults.mock.calls[1][0]).toMatchObject({
+                queryUuid: 'query-b-rerun',
+            });
+            expect(page.csvUrls).toHaveLength(2);
+            expect(page.notices ?? []).toEqual([]);
+            expect(page.failures ?? []).toEqual([]);
+        });
+
+        it('delivers the capped file and keeps the notice when the rerun fails, reporting an APP_QUERY rerun failure', async () => {
+            const { task, downloadSyncQueryResults } = setup({
+                rerun: async () => {
+                    throw new Error('warehouse timeout');
+                },
+            });
+
+            const page = await callGetNotificationPageData(
+                task,
+                appScheduler({ options: { formatted: true, limit: 'all' } }),
+                manifestWithOneLimitHit(),
+            );
+
+            // The capped item still downloads under its original queryUuid.
+            expect(downloadSyncQueryResults.mock.calls[1][0]).toMatchObject({
+                queryUuid: 'query-b',
+            });
+            expect(page.csvUrls).toHaveLength(2);
+            expect(page.notices).toEqual([
+                { type: 'limit_reached', label: 'Orders', rowCount: 5000 },
+            ]);
+            expect(page.failures).toEqual([
+                {
+                    type: PartialFailureType.APP_QUERY,
+                    stage: 'rerun',
+                    captureKey: 'v1:b',
+                    label: 'Orders',
+                    error: expect.stringContaining('warehouse timeout'),
+                },
+            ]);
+        });
     });
 
     it('throws when the render captured no successful queries', async () => {

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -1716,6 +1716,86 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
                 },
             ]);
         });
+
+        it('falls back to the capped download when the rerun succeeded but its own download fails, reporting a rerun failure', async () => {
+            const { task, downloadSyncQueryResults } = setup({
+                download: async ({ queryUuid }) => {
+                    if (queryUuid === 'query-b-rerun') {
+                        throw new Error('poll timeout');
+                    }
+                    return {
+                        fileUrl: `https://files.example.com/${queryUuid}`,
+                    };
+                },
+            });
+
+            const page = await callGetNotificationPageData(
+                task,
+                appScheduler({ options: { formatted: true, limit: 'all' } }),
+                manifestWithOneLimitHit(),
+            );
+
+            // The rerun result download is attempted first, then the
+            // fallback to the still-valid capped original.
+            expect(downloadSyncQueryResults).toHaveBeenCalledTimes(3);
+            expect(downloadSyncQueryResults.mock.calls[1][0]).toMatchObject({
+                queryUuid: 'query-b-rerun',
+            });
+            expect(downloadSyncQueryResults.mock.calls[2][0]).toMatchObject({
+                queryUuid: 'query-b',
+            });
+            expect(page.csvUrls).toHaveLength(2);
+            expect(page.notices).toEqual([
+                { type: 'limit_reached', label: 'Orders', rowCount: 5000 },
+            ]);
+            expect(page.failures).toEqual([
+                {
+                    type: PartialFailureType.APP_QUERY,
+                    stage: 'rerun',
+                    captureKey: 'v1:b',
+                    label: 'Orders',
+                    error: expect.stringContaining('poll timeout'),
+                },
+            ]);
+        });
+
+        it('reports a single download failure, not a double-counted rerun failure, when both the rerun result and the capped fallback fail to download', async () => {
+            const { task, downloadSyncQueryResults } = setup({
+                download: async ({ queryUuid }) => {
+                    if (queryUuid === 'query-b-rerun') {
+                        throw new Error('poll timeout');
+                    }
+                    if (queryUuid === 'query-b') {
+                        throw new Error('capped result also gone');
+                    }
+                    return {
+                        fileUrl: `https://files.example.com/${queryUuid}`,
+                    };
+                },
+            });
+
+            const page = await callGetNotificationPageData(
+                task,
+                appScheduler({ options: { formatted: true, limit: 'all' } }),
+                manifestWithOneLimitHit(),
+            );
+
+            expect(downloadSyncQueryResults).toHaveBeenCalledTimes(3);
+            expect(page.csvUrls).toHaveLength(1);
+            expect(page.csvUrls?.[0].chartName).toBe('Revenue');
+            // No notice (the item never shipped) and no extra 'rerun'
+            // failure alongside the 'download' one.
+            expect(page.notices ?? []).toEqual([]);
+            expect(page.failures).toEqual([
+                {
+                    type: PartialFailureType.APP_QUERY,
+                    stage: 'download',
+                    captureKey: 'v1:b',
+                    label: 'Orders',
+                    error: expect.stringContaining('poll timeout'),
+                },
+            ]);
+        });
     });
 
     it('throws when the render captured no successful queries', async () => {

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -1240,15 +1240,28 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
         download,
         fileStorageEnabled = false,
         rerun,
+        rerunAppliedLimit = 10000,
+        queryRowCount = 100,
+        getQueryHistory,
     }: {
         download?: (args: { queryUuid: string }) => Promise<{
             fileUrl: string;
             s3FileUrl?: string;
         }>;
         fileStorageEnabled?: boolean;
-        rerun?: (args: { queryUuid: string }) => Promise<{
+        rerun?: (args: {
             queryUuid: string;
-        }>;
+        }) => Promise<
+            | { outcome: 'executed'; queryUuid: string; appliedLimit: number }
+            | { outcome: 'noImprovementPossible' }
+        >;
+        // Default rerun outcome's applied limit, when `rerun` isn't overridden.
+        rerunAppliedLimit?: number;
+        // Default getAsyncQueryHistory row count, when `getQueryHistory` isn't overridden.
+        queryRowCount?: number | null;
+        getQueryHistory?: (args: {
+            queryUuid: string;
+        }) => Promise<{ totalRowCount: number | null }>;
     } = {}) => {
         const downloadSyncQueryResults = vi.fn(
             download ??
@@ -1260,8 +1273,13 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
         const executeAsyncUnboundedRerunFromQueryHistory = vi.fn(
             rerun ??
                 (async ({ queryUuid }: { queryUuid: string }) => ({
+                    outcome: 'executed' as const,
                     queryUuid: `${queryUuid}-rerun`,
+                    appliedLimit: rerunAppliedLimit,
                 })),
+        );
+        const getAsyncQueryHistory = vi.fn(
+            getQueryHistory ?? (async () => ({ totalRowCount: queryRowCount })),
         );
         const findAppByUuid = vi.fn().mockResolvedValue(APP_ROW);
         const trackAccount = vi.fn();
@@ -1289,6 +1307,7 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
             asyncQueryService: asDep<'asyncQueryService'>({
                 downloadSyncQueryResults,
                 executeAsyncUnboundedRerunFromQueryHistory,
+                getAsyncQueryHistory,
             }),
             slackClient: asDep<'slackClient'>({ isEnabled: false }),
         });
@@ -1296,6 +1315,7 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
             task,
             downloadSyncQueryResults,
             executeAsyncUnboundedRerunFromQueryHistory,
+            getAsyncQueryHistory,
             findAppByUuid,
             trackAccount,
         };
@@ -1667,8 +1687,12 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
             ).not.toHaveBeenCalled();
         });
 
-        it('downloads the rerun queryUuid, and drops the limit notice, when the rerun succeeds', async () => {
-            const { task, downloadSyncQueryResults } = setup();
+        // Pins the row-count-vs-applied-limit check: the default fixture's
+        // rerun applies a limit of 10000 and reports 100 rows back, so the
+        // rerun is genuinely complete (rowCount < appliedLimit).
+        it('downloads the rerun queryUuid, and drops the limit notice, when the rerun genuinely completes', async () => {
+            const { task, downloadSyncQueryResults, getAsyncQueryHistory } =
+                setup();
 
             const page = await callGetNotificationPageData(
                 task,
@@ -1680,8 +1704,72 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
             expect(downloadSyncQueryResults.mock.calls[1][0]).toMatchObject({
                 queryUuid: 'query-b-rerun',
             });
+            expect(getAsyncQueryHistory).toHaveBeenCalledWith(
+                expect.objectContaining({ queryUuid: 'query-b-rerun' }),
+            );
             expect(page.csvUrls).toHaveLength(2);
             expect(page.notices ?? []).toEqual([]);
+            expect(page.failures ?? []).toEqual([]);
+        });
+
+        // Wide-query case: the export's cell-based cap (e.g. floor(cells /
+        // columns) for a 25-column query) can land at or below the query's
+        // own already-captured limit. Rerunning would return no more rows,
+        // so the service reports 'noImprovementPossible' and the worker must
+        // not execute a second query at all.
+        it('never downloads a rerun result when the export limit would not improve on the captured query (wide-query case)', async () => {
+            const {
+                task,
+                downloadSyncQueryResults,
+                executeAsyncUnboundedRerunFromQueryHistory,
+            } = setup({
+                rerun: async () => ({ outcome: 'noImprovementPossible' }),
+            });
+
+            const page = await callGetNotificationPageData(
+                task,
+                appScheduler({ options: { formatted: true, limit: 'all' } }),
+                manifestWithOneLimitHit(),
+            );
+
+            expect(
+                executeAsyncUnboundedRerunFromQueryHistory,
+            ).toHaveBeenCalledTimes(1);
+            expect(downloadSyncQueryResults).toHaveBeenCalledTimes(2);
+            expect(
+                downloadSyncQueryResults.mock.calls.map(
+                    (call) => (call[0] as { queryUuid: string }).queryUuid,
+                ),
+            ).toEqual(['query-a', 'query-b']);
+            expect(page.csvUrls).toHaveLength(2);
+            expect(page.notices).toEqual([
+                { type: 'limit_reached', label: 'Orders', rowCount: 5000 },
+            ]);
+            expect(page.failures ?? []).toEqual([]);
+        });
+
+        // The rerun executes and downloads fine, but the fresh result still
+        // hit its own (larger) row cap — a bigger file, but still
+        // truthfully truncated, so the notice must survive.
+        it('keeps the limit-reached notice when the unbounded rerun itself hits the export cap', async () => {
+            const { task, downloadSyncQueryResults } = setup({
+                rerunAppliedLimit: 8000,
+                queryRowCount: 8000,
+            });
+
+            const page = await callGetNotificationPageData(
+                task,
+                appScheduler({ options: { formatted: true, limit: 'all' } }),
+                manifestWithOneLimitHit(),
+            );
+
+            expect(downloadSyncQueryResults.mock.calls[1][0]).toMatchObject({
+                queryUuid: 'query-b-rerun',
+            });
+            expect(page.csvUrls).toHaveLength(2);
+            expect(page.notices).toEqual([
+                { type: 'limit_reached', label: 'Orders', rowCount: 5000 },
+            ]);
             expect(page.failures ?? []).toEqual([]);
         });
 

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1032,6 +1032,62 @@ export default class SchedulerTask {
                             );
                         }
 
+                        // limit: 'all' upgrades limit-hit entries to complete
+                        // result sets by re-running them unbounded via their
+                        // query-history record — never a second app render.
+                        // Under-limit entries, and every entry when limit is
+                        // 'table', are left untouched.
+                        const rerunFailures: PartialFailure[] = [];
+                        const rerunQueryUuidByCaptureKey = new Map<
+                            string,
+                            string
+                        >();
+                        const rerunSucceededCaptureKeys = new Set<string>();
+                        if (csvOptions?.limit === 'all') {
+                            const limitHitItems = readyItems.filter(
+                                (item) => item.limitReached,
+                            );
+                            const rerunSettled = await Promise.allSettled(
+                                limitHitItems.map((item) =>
+                                    this.asyncQueryService.executeAsyncUnboundedRerunFromQueryHistory(
+                                        {
+                                            account,
+                                            projectUuid,
+                                            queryUuid: item.queryUuid,
+                                            context:
+                                                QueryExecutionContext.SCHEDULED_DELIVERY,
+                                            invalidateCache: true,
+                                        },
+                                    ),
+                                ),
+                            );
+                            rerunSettled.forEach((result, index) => {
+                                const item = limitHitItems[index];
+                                if (result.status === 'fulfilled') {
+                                    rerunQueryUuidByCaptureKey.set(
+                                        item.captureKey,
+                                        result.value.queryUuid,
+                                    );
+                                    rerunSucceededCaptureKeys.add(
+                                        item.captureKey,
+                                    );
+                                    return;
+                                }
+                                Logger.warn(
+                                    `Failed to re-run app delivery query "${item.label}" (${item.queryUuid}) unbounded: ${result.reason}`,
+                                );
+                                rerunFailures.push({
+                                    type: PartialFailureType.APP_QUERY,
+                                    stage: 'rerun',
+                                    captureKey: item.captureKey,
+                                    label: item.label,
+                                    error: `Could not re-run without a limit, delivered the capped result instead: ${getErrorMessage(
+                                        result.reason,
+                                    )}`,
+                                });
+                            });
+                        }
+
                         const settled = await Promise.allSettled(
                             readyItems.map((item) =>
                                 this.asyncQueryService.downloadSyncQueryResults(
@@ -1039,7 +1095,10 @@ export default class SchedulerTask {
                                         account,
                                         accessMode: downloadAccessMode,
                                         projectUuid,
-                                        queryUuid: item.queryUuid,
+                                        queryUuid:
+                                            rerunQueryUuidByCaptureKey.get(
+                                                item.captureKey,
+                                            ) ?? item.queryUuid,
                                         type: downloadFileType,
                                         onlyRaw:
                                             csvOptions?.formatted === false,
@@ -1103,7 +1162,12 @@ export default class SchedulerTask {
                             });
                             appDeliveryQueries.push({
                                 chartName: item.label,
-                                queryUuid: item.queryUuid,
+                                // The rerun replacement when one happened, so
+                                // AI augmentation reads the complete result.
+                                queryUuid:
+                                    rerunQueryUuidByCaptureKey.get(
+                                        item.captureKey,
+                                    ) ?? item.queryUuid,
                             });
                             deliveredItems.push(item);
                         });
@@ -1114,12 +1178,18 @@ export default class SchedulerTask {
                             );
                         }
 
-                        // Only for files that actually shipped — a notice about
-                        // an unattached file would just confuse recipients.
+                        // Only for files that actually shipped, and only when
+                        // still capped — a successful unbounded rerun clears
+                        // the notice, and one about an unattached file would
+                        // just confuse recipients.
                         const appNotices: DeliveryNotice[] = deliveredItems
                             .filter(
                                 (item) =>
-                                    item.limitReached && item.rowCount !== null,
+                                    item.limitReached &&
+                                    item.rowCount !== null &&
+                                    !rerunSucceededCaptureKeys.has(
+                                        item.captureKey,
+                                    ),
                             )
                             .map((item) => ({
                                 type: 'limit_reached',
@@ -1132,6 +1202,7 @@ export default class SchedulerTask {
 
                         const appFailures = [
                             ...renderFailures,
+                            ...rerunFailures,
                             ...downloadFailures,
                             ...(appCaptureManifest.overflowCount > 0
                                 ? [
@@ -4893,7 +4964,9 @@ export default class SchedulerTask {
                 });
 
                 // App deliveries: how much of the captured render actually shipped.
-                const appQueryFailures = (stage: 'render' | 'download') =>
+                const appQueryFailures = (
+                    stage: 'render' | 'download' | 'rerun',
+                ) =>
                     partialFailures.filter(
                         (failure) =>
                             failure.type === PartialFailureType.APP_QUERY &&
@@ -4905,6 +4978,7 @@ export default class SchedulerTask {
                           deliveredFileCount: page?.csvUrls?.length ?? 0,
                           renderFailureCount: appQueryFailures('render'),
                           downloadFailureCount: appQueryFailures('download'),
+                          rerunFailureCount: appQueryFailures('rerun'),
                           noticeCount: page?.notices?.length ?? 0,
                           captureOverflow: appCaptureManifest.overflowCount > 0,
                       }

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1088,24 +1088,69 @@ export default class SchedulerTask {
                             });
                         }
 
+                        const downloadItemResult = (queryUuid: string) =>
+                            this.asyncQueryService.downloadSyncQueryResults(
+                                {
+                                    account,
+                                    accessMode: downloadAccessMode,
+                                    projectUuid,
+                                    queryUuid,
+                                    type: downloadFileType,
+                                    onlyRaw: csvOptions?.formatted === false,
+                                    expirationSecondsOverride,
+                                },
+                                SCHEDULER_POLLING_OPTIONS,
+                            );
+
+                        // Downloads the rerun replacement when one exists,
+                        // falling back to the still-valid capped original if
+                        // that download fails — same end state as a
+                        // rerun-execution failure (capped file, notice kept,
+                        // 'rerun'-stage failure), never a lost file just
+                        // because the upgraded result couldn't be fetched.
+                        const downloadAppQueryItem = async (
+                            item: Extract<CapturedQuery, { status: 'ready' }>,
+                        ) => {
+                            const rerunQueryUuid =
+                                rerunQueryUuidByCaptureKey.get(item.captureKey);
+                            if (!rerunQueryUuid) {
+                                return downloadItemResult(item.queryUuid);
+                            }
+                            try {
+                                return await downloadItemResult(rerunQueryUuid);
+                            } catch (rerunDownloadError) {
+                                const fallback = await downloadItemResult(
+                                    item.queryUuid,
+                                ).catch(() => {
+                                    // Fallback also failed: report the
+                                    // original (rerun-result) download
+                                    // failure so this becomes a single,
+                                    // ordinary 'download'-stage failure with
+                                    // no file, not a double-counted one.
+                                    throw rerunDownloadError;
+                                });
+                                rerunSucceededCaptureKeys.delete(
+                                    item.captureKey,
+                                );
+                                rerunQueryUuidByCaptureKey.delete(
+                                    item.captureKey,
+                                );
+                                rerunFailures.push({
+                                    type: PartialFailureType.APP_QUERY,
+                                    stage: 'rerun',
+                                    captureKey: item.captureKey,
+                                    label: item.label,
+                                    error: `Could not retrieve the complete result set, delivered the capped result instead: ${getErrorMessage(
+                                        rerunDownloadError,
+                                    )}`,
+                                });
+                                return fallback;
+                            }
+                        };
+
                         const settled = await Promise.allSettled(
                             readyItems.map((item) =>
-                                this.asyncQueryService.downloadSyncQueryResults(
-                                    {
-                                        account,
-                                        accessMode: downloadAccessMode,
-                                        projectUuid,
-                                        queryUuid:
-                                            rerunQueryUuidByCaptureKey.get(
-                                                item.captureKey,
-                                            ) ?? item.queryUuid,
-                                        type: downloadFileType,
-                                        onlyRaw:
-                                            csvOptions?.formatted === false,
-                                        expirationSecondsOverride,
-                                    },
-                                    SCHEDULER_POLLING_OPTIONS,
-                                ),
+                                downloadAppQueryItem(item),
                             ),
                         );
 

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1038,9 +1038,9 @@ export default class SchedulerTask {
                         // Under-limit entries, and every entry when limit is
                         // 'table', are left untouched.
                         const rerunFailures: PartialFailure[] = [];
-                        const rerunQueryUuidByCaptureKey = new Map<
+                        const rerunOutcomeByCaptureKey = new Map<
                             string,
-                            string
+                            { queryUuid: string; appliedLimit: number }
                         >();
                         const rerunSucceededCaptureKeys = new Set<string>();
                         if (csvOptions?.limit === 'all') {
@@ -1063,27 +1063,38 @@ export default class SchedulerTask {
                             );
                             rerunSettled.forEach((result, index) => {
                                 const item = limitHitItems[index];
-                                if (result.status === 'fulfilled') {
-                                    rerunQueryUuidByCaptureKey.set(
-                                        item.captureKey,
-                                        result.value.queryUuid,
+                                if (result.status === 'rejected') {
+                                    Logger.warn(
+                                        `Failed to re-run app delivery query "${item.label}" (${item.queryUuid}) unbounded: ${result.reason}`,
                                     );
-                                    rerunSucceededCaptureKeys.add(
-                                        item.captureKey,
+                                    rerunFailures.push({
+                                        type: PartialFailureType.APP_QUERY,
+                                        stage: 'rerun',
+                                        captureKey: item.captureKey,
+                                        label: item.label,
+                                        error: `Could not re-run without a limit, delivered the capped result instead: ${getErrorMessage(
+                                            result.reason,
+                                        )}`,
+                                    });
+                                    return;
+                                }
+                                if (
+                                    result.value.outcome ===
+                                    'noImprovementPossible'
+                                ) {
+                                    // A wide query's cell-based export cap
+                                    // can land at or below its own captured
+                                    // limit — an "upgrade" that returns no
+                                    // more rows isn't one. Deliver the
+                                    // capped file as-is; nothing failed.
+                                    Logger.info(
+                                        `Skipping unbounded rerun for app delivery query "${item.label}" (${item.queryUuid}): the export limit would not improve on the captured result`,
                                     );
                                     return;
                                 }
-                                Logger.warn(
-                                    `Failed to re-run app delivery query "${item.label}" (${item.queryUuid}) unbounded: ${result.reason}`,
-                                );
-                                rerunFailures.push({
-                                    type: PartialFailureType.APP_QUERY,
-                                    stage: 'rerun',
-                                    captureKey: item.captureKey,
-                                    label: item.label,
-                                    error: `Could not re-run without a limit, delivered the capped result instead: ${getErrorMessage(
-                                        result.reason,
-                                    )}`,
+                                rerunOutcomeByCaptureKey.set(item.captureKey, {
+                                    queryUuid: result.value.queryUuid,
+                                    appliedLimit: result.value.appliedLimit,
                                 });
                             });
                         }
@@ -1107,19 +1118,61 @@ export default class SchedulerTask {
                         // that download fails — same end state as a
                         // rerun-execution failure (capped file, notice kept,
                         // 'rerun'-stage failure), never a lost file just
-                        // because the upgraded result couldn't be fetched.
+                        // because the upgraded result couldn't be fetched. A
+                        // rerun download that succeeds but still hit its own
+                        // (cell-based) row cap keeps the notice too — bigger
+                        // file, still truthfully truncated.
                         const downloadAppQueryItem = async (
                             item: Extract<CapturedQuery, { status: 'ready' }>,
                         ) => {
-                            const rerunQueryUuid =
-                                rerunQueryUuidByCaptureKey.get(item.captureKey);
-                            if (!rerunQueryUuid) {
-                                return downloadItemResult(item.queryUuid);
+                            const rerunOutcome = rerunOutcomeByCaptureKey.get(
+                                item.captureKey,
+                            );
+                            if (!rerunOutcome) {
+                                return {
+                                    download: await downloadItemResult(
+                                        item.queryUuid,
+                                    ),
+                                    deliveredQueryUuid: item.queryUuid,
+                                };
                             }
                             try {
-                                return await downloadItemResult(rerunQueryUuid);
+                                const download = await downloadItemResult(
+                                    rerunOutcome.queryUuid,
+                                );
+                                try {
+                                    const { totalRowCount } =
+                                        await this.asyncQueryService.getAsyncQueryHistory(
+                                            {
+                                                account,
+                                                projectUuid,
+                                                queryUuid:
+                                                    rerunOutcome.queryUuid,
+                                            },
+                                        );
+                                    if (
+                                        totalRowCount !== null &&
+                                        totalRowCount <
+                                            rerunOutcome.appliedLimit
+                                    ) {
+                                        rerunSucceededCaptureKeys.add(
+                                            item.captureKey,
+                                        );
+                                    }
+                                } catch (rowCountError) {
+                                    // Can't confirm completeness — keep the
+                                    // notice (fail closed), but the download
+                                    // we already have still ships.
+                                    Logger.warn(
+                                        `Failed to confirm the row count of the unbounded rerun for "${item.label}" (${rerunOutcome.queryUuid}), keeping the limit-reached notice: ${rowCountError}`,
+                                    );
+                                }
+                                return {
+                                    download,
+                                    deliveredQueryUuid: rerunOutcome.queryUuid,
+                                };
                             } catch (rerunDownloadError) {
-                                const fallback = await downloadItemResult(
+                                const download = await downloadItemResult(
                                     item.queryUuid,
                                 ).catch(() => {
                                     // Fallback also failed: report the
@@ -1129,12 +1182,6 @@ export default class SchedulerTask {
                                     // no file, not a double-counted one.
                                     throw rerunDownloadError;
                                 });
-                                rerunSucceededCaptureKeys.delete(
-                                    item.captureKey,
-                                );
-                                rerunQueryUuidByCaptureKey.delete(
-                                    item.captureKey,
-                                );
                                 rerunFailures.push({
                                     type: PartialFailureType.APP_QUERY,
                                     stage: 'rerun',
@@ -1144,7 +1191,10 @@ export default class SchedulerTask {
                                         rerunDownloadError,
                                     )}`,
                                 });
-                                return fallback;
+                                return {
+                                    download,
+                                    deliveredQueryUuid: item.queryUuid,
+                                };
                             }
                         };
 
@@ -1183,6 +1233,8 @@ export default class SchedulerTask {
                                 });
                                 return;
                             }
+                            const { download, deliveredQueryUuid } =
+                                result.value;
                             appCsvUrls.push({
                                 filename: dedupeArtifactFilename(
                                     downloadFileType === DownloadFileType.XLSX
@@ -1198,21 +1250,18 @@ export default class SchedulerTask {
                                           ),
                                     usedFilenames,
                                 ),
-                                path: result.value.fileUrl,
+                                path: download.fileUrl,
                                 localPath:
-                                    result.value.s3FileUrl ??
-                                    result.value.fileUrl,
+                                    download.s3FileUrl ?? download.fileUrl,
                                 chartName: item.label,
                                 truncated: false,
                             });
                             appDeliveryQueries.push({
                                 chartName: item.label,
-                                // The rerun replacement when one happened, so
-                                // AI augmentation reads the complete result.
-                                queryUuid:
-                                    rerunQueryUuidByCaptureKey.get(
-                                        item.captureKey,
-                                    ) ?? item.queryUuid,
+                                // The rerun replacement when one was actually
+                                // delivered, so AI augmentation reads
+                                // whichever result the recipient got.
+                                queryUuid: deliveredQueryUuid,
                             });
                             deliveredItems.push(item);
                         });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -4022,19 +4022,14 @@ describe('AsyncQueryService', () => {
             vi.restoreAllMocks();
         });
 
-        it('re-runs the source metricQuery with the row limit lifted', async () => {
-            const service = getMockedAsyncQueryService(lightdashConfigMock);
-            const account = buildAccount();
-
-            (
-                service.queryHistoryModel.get as import('vitest').Mock
-            ).mockResolvedValue({
+        const mockSourceQueryHistory = (sourceLimit: number) =>
+            ({
                 queryUuid: 'capped-query-uuid',
                 projectUuid,
                 organizationUuid: projectSummary.organizationUuid,
                 metricQuery: {
                     ...metricQueryMock,
-                    limit: 500,
+                    limit: sourceLimit,
                 },
                 pivotConfiguration: null,
                 requestParameters: {
@@ -4042,7 +4037,82 @@ describe('AsyncQueryService', () => {
                     query: metricQueryMock,
                     parameters: { region: 'EU' },
                 },
-            } as unknown as QueryHistory);
+            }) as unknown as QueryHistory;
+
+        // 'all' semantics: the org's cell-based cap, computed the same way
+        // for every source limit in this describe block.
+        const expectedUnboundedLimit = Math.floor(
+            lightdashConfigMock.query.csvCellsLimit /
+                (metricQueryMock.dimensions.length +
+                    metricQueryMock.metrics.length +
+                    metricQueryMock.tableCalculations.length),
+        );
+
+        it('re-runs the source metricQuery with the row limit lifted, returning the applied limit', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const account = buildAccount();
+
+            (
+                service.queryHistoryModel.get as import('vitest').Mock
+            ).mockResolvedValue(mockSourceQueryHistory(500));
+
+            const runSpy = vi
+                .spyOn(
+                    service as unknown as {
+                        runAsyncMetricQueryWithoutPermissionCheck: (
+                            ...args: unknown[]
+                        ) => Promise<unknown>;
+                    },
+                    'runAsyncMetricQueryWithoutPermissionCheck',
+                )
+                .mockResolvedValue({ queryUuid: 'rerun-query-uuid' } as never);
+
+            const result =
+                await service.executeAsyncUnboundedRerunFromQueryHistory({
+                    account,
+                    projectUuid,
+                    queryUuid: 'capped-query-uuid',
+                    context: QueryExecutionContext.SCHEDULED_DELIVERY,
+                });
+
+            expect(service.queryHistoryModel.get).toHaveBeenCalledWith(
+                'capped-query-uuid',
+                projectUuid,
+                account,
+            );
+            expect(runSpy).toHaveBeenCalledTimes(1);
+            const [runArgs] = runSpy.mock.calls[0] as [
+                { metricQuery: MetricQuery; context: QueryExecutionContext },
+            ];
+            // The numeric cap from the capped run (500) is replaced by the
+            // org's cell-based cap, not merely "not 500".
+            expect(runArgs.metricQuery.limit).toBe(expectedUnboundedLimit);
+            expect(runArgs.context).toBe(
+                QueryExecutionContext.SCHEDULED_DELIVERY,
+            );
+            expect(runSpy.mock.calls[0][0]).toEqual(
+                expect.objectContaining({
+                    parameters: { region: 'EU' },
+                    pivotConfiguration: undefined,
+                }),
+            );
+            expect(result).toEqual({
+                outcome: 'executed',
+                queryUuid: 'rerun-query-uuid',
+                appliedLimit: expectedUnboundedLimit,
+            });
+        });
+
+        // Wide-query case: a source limit already at (or above) the org's
+        // cell-based cap means rerunning can't return more rows than the
+        // capped result already has — 'All Results' must never deliver less.
+        it('skips execution and reports noImprovementPossible when the computed limit would not beat the source limit', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const account = buildAccount();
+
+            (
+                service.queryHistoryModel.get as import('vitest').Mock
+            ).mockResolvedValue(mockSourceQueryHistory(expectedUnboundedLimit));
 
             const runSpy = vi
                 .spyOn(
@@ -4055,40 +4125,16 @@ describe('AsyncQueryService', () => {
                 )
                 .mockResolvedValue({} as never);
 
-            await service.executeAsyncUnboundedRerunFromQueryHistory({
-                account,
-                projectUuid,
-                queryUuid: 'capped-query-uuid',
-                context: QueryExecutionContext.SCHEDULED_DELIVERY,
-            });
+            const result =
+                await service.executeAsyncUnboundedRerunFromQueryHistory({
+                    account,
+                    projectUuid,
+                    queryUuid: 'capped-query-uuid',
+                    context: QueryExecutionContext.SCHEDULED_DELIVERY,
+                });
 
-            expect(service.queryHistoryModel.get).toHaveBeenCalledWith(
-                'capped-query-uuid',
-                projectUuid,
-                account,
-            );
-            expect(runSpy).toHaveBeenCalledTimes(1);
-            const [runArgs] = runSpy.mock.calls[0] as [
-                { metricQuery: MetricQuery; context: QueryExecutionContext },
-            ];
-            // 'all' semantics: the numeric cap from the capped run (500) is
-            // replaced by the org's cell-based cap, not merely "not 500".
-            const expectedUnboundedLimit = Math.floor(
-                lightdashConfigMock.query.csvCellsLimit /
-                    (metricQueryMock.dimensions.length +
-                        metricQueryMock.metrics.length +
-                        metricQueryMock.tableCalculations.length),
-            );
-            expect(runArgs.metricQuery.limit).toBe(expectedUnboundedLimit);
-            expect(runArgs.context).toBe(
-                QueryExecutionContext.SCHEDULED_DELIVERY,
-            );
-            expect(runSpy.mock.calls[0][0]).toEqual(
-                expect.objectContaining({
-                    parameters: { region: 'EU' },
-                    pivotConfiguration: undefined,
-                }),
-            );
+            expect(runSpy).not.toHaveBeenCalled();
+            expect(result).toEqual({ outcome: 'noImprovementPossible' });
         });
     });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -4071,8 +4071,15 @@ describe('AsyncQueryService', () => {
             const [runArgs] = runSpy.mock.calls[0] as [
                 { metricQuery: MetricQuery; context: QueryExecutionContext },
             ];
-            // 'all' semantics: no numeric cap carried over from the capped run.
-            expect(runArgs.metricQuery.limit).not.toBe(500);
+            // 'all' semantics: the numeric cap from the capped run (500) is
+            // replaced by the org's cell-based cap, not merely "not 500".
+            const expectedUnboundedLimit = Math.floor(
+                lightdashConfigMock.query.csvCellsLimit /
+                    (metricQueryMock.dimensions.length +
+                        metricQueryMock.metrics.length +
+                        metricQueryMock.tableCalculations.length),
+            );
+            expect(runArgs.metricQuery.limit).toBe(expectedUnboundedLimit);
             expect(runArgs.context).toBe(
                 QueryExecutionContext.SCHEDULED_DELIVERY,
             );

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -4017,6 +4017,74 @@ describe('AsyncQueryService', () => {
         });
     });
 
+    describe('executeAsyncUnboundedRerunFromQueryHistory', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('re-runs the source metricQuery with the row limit lifted', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const account = buildAccount();
+
+            (
+                service.queryHistoryModel.get as import('vitest').Mock
+            ).mockResolvedValue({
+                queryUuid: 'capped-query-uuid',
+                projectUuid,
+                organizationUuid: projectSummary.organizationUuid,
+                metricQuery: {
+                    ...metricQueryMock,
+                    limit: 500,
+                },
+                pivotConfiguration: null,
+                requestParameters: {
+                    context: QueryExecutionContext.SCHEDULED_DELIVERY,
+                    query: metricQueryMock,
+                    parameters: { region: 'EU' },
+                },
+            } as unknown as QueryHistory);
+
+            const runSpy = vi
+                .spyOn(
+                    service as unknown as {
+                        runAsyncMetricQueryWithoutPermissionCheck: (
+                            ...args: unknown[]
+                        ) => Promise<unknown>;
+                    },
+                    'runAsyncMetricQueryWithoutPermissionCheck',
+                )
+                .mockResolvedValue({} as never);
+
+            await service.executeAsyncUnboundedRerunFromQueryHistory({
+                account,
+                projectUuid,
+                queryUuid: 'capped-query-uuid',
+                context: QueryExecutionContext.SCHEDULED_DELIVERY,
+            });
+
+            expect(service.queryHistoryModel.get).toHaveBeenCalledWith(
+                'capped-query-uuid',
+                projectUuid,
+                account,
+            );
+            expect(runSpy).toHaveBeenCalledTimes(1);
+            const [runArgs] = runSpy.mock.calls[0] as [
+                { metricQuery: MetricQuery; context: QueryExecutionContext },
+            ];
+            // 'all' semantics: no numeric cap carried over from the capped run.
+            expect(runArgs.metricQuery.limit).not.toBe(500);
+            expect(runArgs.context).toBe(
+                QueryExecutionContext.SCHEDULED_DELIVERY,
+            );
+            expect(runSpy.mock.calls[0][0]).toEqual(
+                expect.objectContaining({
+                    parameters: { region: 'EU' },
+                    pivotConfiguration: undefined,
+                }),
+            );
+        });
+    });
+
     describe('executeAsyncSavedChartQuery pivotDimensions wiring', () => {
         const pivotColumn = 'a_dim1';
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -219,6 +219,7 @@ import {
     type RunAsyncPreAggregateQueryArgs,
     type RunAsyncWarehouseQueryArgs,
     type ScheduleDownloadAsyncQueryResultsArgs,
+    type UnboundedRerunFromQueryHistoryResult,
 } from './types';
 
 // NULL pivot keys collide with the unsuffixed base column when joined
@@ -4662,6 +4663,13 @@ export class AsyncQueryService extends ProjectService {
      * the resolved LIMIT, so the cache key already differs) — it matches
      * every other scheduled-delivery execution path in SchedulerTask, which
      * all invalidate the cache on the same "never serve stale data" policy.
+     *
+     * Does NOT execute when the computed unbounded limit wouldn't beat the
+     * source's own limit (a wide query's cell-based cap can land at or below
+     * it) — the caller must keep delivering the already-capped result in
+     * that case, not a same-or-smaller "upgrade". The applied limit is
+     * returned alongside the new queryUuid so the caller can, after
+     * downloading, tell whether the rerun itself still hit that cap.
      */
     async executeAsyncUnboundedRerunFromQueryHistory({
         account,
@@ -4675,7 +4683,7 @@ export class AsyncQueryService extends ProjectService {
         queryUuid: string;
         context: QueryExecutionContext;
         invalidateCache?: boolean;
-    }): Promise<ApiExecuteAsyncMetricQueryResults> {
+    }): Promise<UnboundedRerunFromQueryHistoryResult> {
         assertIsAccountWithOrg(account);
 
         const [source, { organizationUuid }] = await Promise.all([
@@ -4690,26 +4698,39 @@ export class AsyncQueryService extends ProjectService {
                 organizationUuid,
             );
 
-        return this.runAsyncMetricQueryWithoutPermissionCheck(
-            {
-                account,
-                projectUuid,
-                context,
-                metricQuery: applyMetricQueryLimit(
-                    source.metricQuery,
-                    null,
-                    csvCellsLimit,
-                    maxLimit,
-                ),
-                pivotConfiguration: source.pivotConfiguration ?? undefined,
-                parameters: source.requestParameters?.parameters,
-                dateZoom: getDateZoomFromRequestParameters(
-                    source.requestParameters,
-                ),
-                invalidateCache,
-            },
-            organizationUuid,
+        const unboundedMetricQuery = applyMetricQueryLimit(
+            source.metricQuery,
+            null,
+            csvCellsLimit,
+            maxLimit,
         );
+
+        if (unboundedMetricQuery.limit <= source.metricQuery.limit) {
+            return { outcome: 'noImprovementPossible' };
+        }
+
+        const { queryUuid: rerunQueryUuid } =
+            await this.runAsyncMetricQueryWithoutPermissionCheck(
+                {
+                    account,
+                    projectUuid,
+                    context,
+                    metricQuery: unboundedMetricQuery,
+                    pivotConfiguration: source.pivotConfiguration ?? undefined,
+                    parameters: source.requestParameters?.parameters,
+                    dateZoom: getDateZoomFromRequestParameters(
+                        source.requestParameters,
+                    ),
+                    invalidateCache,
+                },
+                organizationUuid,
+            );
+
+        return {
+            outcome: 'executed',
+            queryUuid: rerunQueryUuid,
+            appliedLimit: unboundedMetricQuery.limit,
+        };
     }
 
     /**

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4657,7 +4657,11 @@ export class AsyncQueryService extends ProjectService {
      * analytics for free. `queryHistoryModel.get` enforces the source belongs
      * to this project and account, which authorizes the rerun — same as
      * `executeAsyncCalculateTotalFromQueryHistory` — so no separate CASL
-     * explore check is needed.
+     * explore check is needed. `invalidateCache: true` isn't needed to avoid
+     * colliding with the capped run's cache entry (the compiled SQL embeds
+     * the resolved LIMIT, so the cache key already differs) — it matches
+     * every other scheduled-delivery execution path in SchedulerTask, which
+     * all invalidate the cache on the same "never serve stale data" policy.
      */
     async executeAsyncUnboundedRerunFromQueryHistory({
         account,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4649,6 +4649,66 @@ export class AsyncQueryService extends ProjectService {
     }
 
     /**
+     * Re-runs a previously-executed query without its row limit — used by app
+     * deliveries to upgrade a capped (limitReached) captured query to a
+     * complete result set. Reads the source's metricQuery/pivotConfiguration/
+     * parameters from query_history (never a browser-transported payload) and
+     * stores its own row, so it inherits cancellation, polling, download, and
+     * analytics for free. `queryHistoryModel.get` enforces the source belongs
+     * to this project and account, which authorizes the rerun — same as
+     * `executeAsyncCalculateTotalFromQueryHistory` — so no separate CASL
+     * explore check is needed.
+     */
+    async executeAsyncUnboundedRerunFromQueryHistory({
+        account,
+        projectUuid,
+        queryUuid,
+        context,
+        invalidateCache,
+    }: {
+        account: Account;
+        projectUuid: string;
+        queryUuid: string;
+        context: QueryExecutionContext;
+        invalidateCache?: boolean;
+    }): Promise<ApiExecuteAsyncMetricQueryResults> {
+        assertIsAccountWithOrg(account);
+
+        const [source, { organizationUuid }] = await Promise.all([
+            this.queryHistoryModel.get(queryUuid, projectUuid, account),
+            this.projectModel.getSummary(projectUuid),
+        ]);
+
+        const { csvCellsLimit, maxLimit } =
+            await resolveOrganizationExportLimits(
+                this.organizationSettingsModel,
+                this.lightdashConfig.query,
+                organizationUuid,
+            );
+
+        return this.runAsyncMetricQueryWithoutPermissionCheck(
+            {
+                account,
+                projectUuid,
+                context,
+                metricQuery: applyMetricQueryLimit(
+                    source.metricQuery,
+                    null,
+                    csvCellsLimit,
+                    maxLimit,
+                ),
+                pivotConfiguration: source.pivotConfiguration ?? undefined,
+                parameters: source.requestParameters?.parameters,
+                dateZoom: getDateZoomFromRequestParameters(
+                    source.requestParameters,
+                ),
+                invalidateCache,
+            },
+            organizationUuid,
+        );
+    }
+
+    /**
      * Calculate totals for a previously-executed async query referenced by
      * its queryUuid. The source query's metricQuery + pivotConfiguration are
      * read from query_history; this endpoint stores its own row in query_history

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -135,6 +135,20 @@ export type ExecuteAsyncQueryReturn = {
     cacheMetadata: CacheMetadata;
 };
 
+// The export's cell-based cap (floor(csvCellsLimit / columnCount)) can land
+// at or below a wide query's own already-applied limit — rerunning would
+// then return no more rows than the capped result already has, so the
+// caller must skip execution rather than deliver a same-or-smaller "upgrade".
+export type UnboundedRerunFromQueryHistoryResult =
+    | {
+          outcome: 'executed';
+          queryUuid: string;
+          appliedLimit: number;
+      }
+    | {
+          outcome: 'noImprovementPossible';
+      };
+
 export type PreAggregationRouteMode = 'required' | 'opportunistic';
 
 export type PreAggregationRoute = {

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -389,7 +389,7 @@ describe('SchedulerService', () => {
                 },
             );
 
-            test('rejects a send-now app payload with a csv limit other than table', async () => {
+            test('rejects a send-now app payload with a numeric csv limit', async () => {
                 const { appSendService, appSendSchedulerClient } =
                     buildAppSendService();
 
@@ -398,7 +398,7 @@ describe('SchedulerService', () => {
                         appSendActor,
                         appSendPayload(SchedulerFormat.CSV, {
                             formatted: true,
-                            limit: 'all',
+                            limit: 500,
                         }),
                     ),
                 ).rejects.toThrowError(ParameterError);
@@ -417,6 +417,30 @@ describe('SchedulerService', () => {
                     appSendPayload(SchedulerFormat.CSV, {
                         formatted: true,
                         limit: 'table',
+                    }),
+                );
+
+                expect(
+                    appSendSchedulerClient.addScheduledDeliveryJob,
+                ).toHaveBeenCalledWith(
+                    expect.any(Date),
+                    expect.objectContaining({
+                        format: SchedulerFormat.CSV,
+                        appUuid: sendAppUuid,
+                    }),
+                    undefined,
+                );
+            });
+
+            test('accepts a send-now csv app payload with limit all', async () => {
+                const { appSendService, appSendSchedulerClient } =
+                    buildAppSendService();
+
+                await appSendService.sendScheduler(
+                    appSendActor,
+                    appSendPayload(SchedulerFormat.CSV, {
+                        formatted: true,
+                        limit: 'all',
                     }),
                 );
 
@@ -897,8 +921,8 @@ describe('SchedulerService', () => {
             },
         );
 
-        test.each(['all', 500])(
-            'should reject a csv limit of %s',
+        test.each([500, 0, -1])(
+            'should reject a numeric csv limit of %s',
             async (limit) => {
                 const { appService, appSchedulerModel } = buildAppService();
 
@@ -918,6 +942,26 @@ describe('SchedulerService', () => {
                 ).not.toHaveBeenCalled();
             },
         );
+
+        test('should accept a csv limit of all', async () => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await appService.createAppScheduler(
+                appActor,
+                appUuid,
+                appSchedulerPayload(SchedulerFormat.CSV, {
+                    formatted: true,
+                    limit: 'all',
+                }),
+            );
+
+            expect(appSchedulerModel.createScheduler).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    format: SchedulerFormat.CSV,
+                    appUuid,
+                }),
+            );
+        });
 
         // The generic PATCH /schedulers path is the only way to edit an app
         // scheduler, so the format gate has to hold there too.
@@ -1008,7 +1052,7 @@ describe('SchedulerService', () => {
             ).not.toHaveBeenCalled();
         });
 
-        test('should reject a csv limit change on the generic update path', async () => {
+        test('should reject a numeric csv limit change on the generic update path', async () => {
             const { appUpdateService, appUpdateSchedulerModel } =
                 buildAppUpdateService();
 
@@ -1018,7 +1062,7 @@ describe('SchedulerService', () => {
                     'schedulerUuid',
                     appUpdatePayload(SchedulerFormat.CSV, {
                         formatted: true,
-                        limit: 'all',
+                        limit: 500,
                     }),
                 ),
             ).rejects.toThrowError(ParameterError);
@@ -1026,6 +1070,29 @@ describe('SchedulerService', () => {
             expect(
                 appUpdateSchedulerModel.updateScheduler,
             ).not.toHaveBeenCalled();
+        });
+
+        test('should allow a csv limit of all on the generic update path', async () => {
+            const { appUpdateService, appUpdateSchedulerModel } =
+                buildAppUpdateService();
+
+            await appUpdateService.updateScheduler(
+                appUpdateActor(),
+                'schedulerUuid',
+                appUpdatePayload(SchedulerFormat.CSV, {
+                    formatted: true,
+                    limit: 'all',
+                }),
+            );
+
+            expect(
+                appUpdateSchedulerModel.updateScheduler,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    schedulerUuid: 'schedulerUuid',
+                    format: SchedulerFormat.CSV,
+                }),
+            );
         });
 
         test('should allow an image app scheduler update on the generic update path', async () => {

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -562,8 +562,10 @@ export class SchedulerService extends BaseService {
         }
     }
 
-    // App deliveries render the app once and materialise whatever queries it ran,
-    // so each query brings its own limit and GSheets/PDF have no equivalent yet.
+    // App deliveries render the app once and materialise whatever queries it ran.
+    // 'table' delivers each query's own (possibly capped) result; 'all' re-runs
+    // capped queries unbounded at delivery time. Numeric limits stay rejected —
+    // a single row cap makes no sense across an app's heterogeneous queries.
     private static validateAppSchedulerDelivery(scheduler: {
         format: SchedulerFormat;
         options: SchedulerOptions;
@@ -580,10 +582,11 @@ export class SchedulerService extends BaseService {
         }
         if (
             isSchedulerCsvOptions(scheduler.options) &&
-            scheduler.options.limit !== 'table'
+            scheduler.options.limit !== 'table' &&
+            scheduler.options.limit !== 'all'
         ) {
             throw new ParameterError(
-                "Data app deliveries always use each query's own limit",
+                "Data app deliveries only support the 'table' or 'all' row limit",
             );
         }
     }

--- a/packages/common/src/types/schedulerLog.ts
+++ b/packages/common/src/types/schedulerLog.ts
@@ -60,10 +60,13 @@ export type AiAugmentationPartialFailure = {
     error: string;
 };
 
-// A captured app query failed while the delivery re-ran it (render or download stage).
+// A captured app query failed during the delivery: at initial render, at
+// download, or (limit: 'all' only) while re-running a capped query unbounded —
+// 'rerun' failures still deliver the original capped file, so the caller must
+// keep the limit-reached notice for that entry.
 export type AppQueryPartialFailure = {
     type: PartialFailureType.APP_QUERY;
-    stage: 'render' | 'download';
+    stage: 'render' | 'download' | 'rerun';
     captureKey: string;
     label: string;
     error: string;

--- a/packages/frontend/src/features/scheduler/components/CsvFormattingOptions.tsx
+++ b/packages/frontend/src/features/scheduler/components/CsvFormattingOptions.tsx
@@ -22,6 +22,8 @@ import { Limit, Values } from './types';
 
 type XlsxFileLayout = NonNullable<SchedulerCsvOptions['xlsxFileLayout']>;
 
+export type LimitVariant = 'full' | 'tableOrAll';
+
 type CsvFormattingOptionsProps = {
     format: SchedulerFormat.CSV | SchedulerFormat.XLSX;
     formatted: Values;
@@ -36,8 +38,9 @@ type CsvFormattingOptionsProps = {
     onXlsxFileLayoutChange: (value: XlsxFileLayout) => void;
     /** Render the options directly (two-column grid) instead of behind a collapsible */
     inline?: boolean;
-    /** Suppresses the row-limit control — app deliveries always use each query's own limit */
-    hideLimit?: boolean;
+    /** 'tableOrAll' (app deliveries) drops the numeric Custom option — a single
+     *  row cap can't apply across an app's heterogeneous captured queries. */
+    limitVariant?: LimitVariant;
     /** Suppresses the pivot layout control — meaningless without chart config (e.g. apps) */
     hideExportPivotedData?: boolean;
 };
@@ -70,7 +73,7 @@ export const CsvFormattingOptions: FC<CsvFormattingOptionsProps> = ({
     xlsxFileLayout,
     onXlsxFileLayoutChange,
     inline = false,
-    hideLimit = false,
+    limitVariant = 'full',
     hideExportPivotedData = false,
 }) => {
     const health = useHealth();
@@ -107,35 +110,34 @@ export const CsvFormattingOptions: FC<CsvFormattingOptionsProps> = ({
                     </Stack>
                 </Radio.Group>
             )}
-            {!hideLimit && (
-                <Stack gap="xs">
-                    <Radio.Group
-                        label="Limit"
-                        value={limit}
-                        onChange={(value) => onLimitChange(value as Limit)}
-                    >
-                        <Stack gap="xxs" pt="xs">
-                            <Radio
-                                label="Results in Table"
-                                value={Limit.TABLE}
-                            />
-                            <Radio label="All Results" value={Limit.ALL} />
+            <Stack gap="xs">
+                <Radio.Group
+                    label="Limit"
+                    value={limit}
+                    onChange={(value) => onLimitChange(value as Limit)}
+                >
+                    <Stack gap="xxs" pt="xs">
+                        <Radio label="Results in Table" value={Limit.TABLE} />
+                        <Radio label="All Results" value={Limit.ALL} />
+                        {limitVariant === 'full' && (
                             <Radio label="Custom..." value={Limit.CUSTOM} />
-                        </Stack>
-                    </Radio.Group>
-                    {limit === Limit.CUSTOM && (
-                        <NumberInput
-                            w={150}
-                            min={1}
-                            required
-                            value={customLimit}
-                            onChange={(value) =>
-                                onCustomLimitChange(Number(value) || 1)
-                            }
-                        />
-                    )}
+                        )}
+                    </Stack>
+                </Radio.Group>
+                {limitVariant === 'full' && limit === Limit.CUSTOM && (
+                    <NumberInput
+                        w={150}
+                        min={1}
+                        required
+                        value={customLimit}
+                        onChange={(value) =>
+                            onCustomLimitChange(Number(value) || 1)
+                        }
+                    />
+                )}
 
-                    {(limit === Limit.ALL || limit === Limit.CUSTOM) && (
+                {limitVariant === 'full' &&
+                    (limit === Limit.ALL || limit === Limit.CUSTOM) && (
                         <i>
                             Results are limited to{' '}
                             {Number(
@@ -144,8 +146,13 @@ export const CsvFormattingOptions: FC<CsvFormattingOptionsProps> = ({
                             cells for each file
                         </i>
                     )}
-                </Stack>
-            )}
+                {limitVariant === 'tableOrAll' && limit === Limit.ALL && (
+                    <i>
+                        Queries that hit their row limit are re-run without a
+                        limit at delivery time — this may be slower.
+                    </i>
+                )}
+            </Stack>
             {format === SchedulerFormat.XLSX && (
                 <Radio.Group
                     label={

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
@@ -199,13 +199,70 @@ describe('SchedulerDataFormatSection - app formats', () => {
         expect(csvRadio).toBeChecked();
     });
 
-    it('hides the row-limit control for apps', () => {
+    it('shows only the table/all limit options for apps, no Custom', () => {
         renderSection(
             { capturedQueryCount: 3 },
             { ...DEFAULT_VALUES, format: SchedulerFormat.CSV },
         );
 
-        expect(screen.queryByText('Limit')).not.toBeInTheDocument();
+        expect(screen.getByText('Limit')).toBeInTheDocument();
+        expect(
+            screen.getByRole('radio', { name: 'Results in Table' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('radio', { name: 'All Results' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('radio', { name: 'Custom...' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('defaults the app limit control to table', () => {
+        renderSection(
+            { capturedQueryCount: 3 },
+            { ...DEFAULT_VALUES, format: SchedulerFormat.CSV },
+        );
+
+        expect(
+            screen.getByRole('radio', { name: 'Results in Table' }),
+        ).toBeChecked();
+    });
+
+    it('hints that limit-hit queries are re-run unbounded when All Results is selected for an app', async () => {
+        const user = userEvent.setup();
+        renderSection(
+            { capturedQueryCount: 3 },
+            { ...DEFAULT_VALUES, format: SchedulerFormat.CSV },
+        );
+
+        expect(
+            screen.queryByText(/re-run without a limit at delivery time/i),
+        ).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('radio', { name: 'All Results' }));
+
+        expect(
+            screen.getByText(/re-run without a limit at delivery time/i),
+        ).toBeInTheDocument();
+    });
+
+    it('round-trips a saved app scheduler with limit "all"', () => {
+        const savedWithAllLimit: SchedulerAndTargets = {
+            ...savedCsvAppScheduler,
+            options: { formatted: true, limit: 'all' },
+        };
+
+        renderSection(
+            {
+                savedSchedulerData: savedWithAllLimit,
+                capturedQueryCount: undefined,
+            },
+            getFormValuesFromScheduler(savedWithAllLimit),
+        );
+
+        expect(
+            screen.getByRole('radio', { name: 'All Results' }),
+        ).toBeChecked();
     });
 
     it('shows the row-limit control for non-app deliveries', () => {
@@ -215,6 +272,9 @@ describe('SchedulerDataFormatSection - app formats', () => {
         );
 
         expect(screen.getByText('Limit')).toBeInTheDocument();
+        expect(
+            screen.getByRole('radio', { name: 'Custom...' }),
+        ).toBeInTheDocument();
     });
 
     describe('format-switch side effect', () => {

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
@@ -363,5 +363,30 @@ describe('SchedulerDataFormatSection - app formats', () => {
                 DEFAULT_VALUES.options,
             );
         });
+
+        // Regression: a saved app scheduler with limit 'all' must survive a
+        // CSV<->XLSX toggle (e.g. checking XLSX layout options) unchanged —
+        // only entering CSV/XLSX from a non-CSV/XLSX format normalizes limit.
+        it('preserves a saved "all" limit across a csv<->xlsx toggle', async () => {
+            const formRef = createFormRef();
+            const user = userEvent.setup();
+            renderSection(
+                { capturedQueryCount: 3 },
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.CSV,
+                    options: {
+                        ...DEFAULT_VALUES.options,
+                        limit: Limit.ALL,
+                    },
+                },
+                formRef,
+            );
+
+            await user.click(screen.getByRole('radio', { name: '.xlsx' }));
+
+            expect(formRef.current?.values.format).toBe(SchedulerFormat.XLSX);
+            expect(formRef.current?.values.options.limit).toBe(Limit.ALL);
+        });
     });
 });

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
@@ -313,7 +313,7 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                                     value,
                                 )
                             }
-                            hideLimit={isApp}
+                            limitVariant={isApp ? 'tableOrAll' : 'full'}
                             hideExportPivotedData={isApp}
                         />
                     </Box>

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
@@ -138,6 +138,7 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                             w="100%"
                             value={format}
                             onChange={(value) => {
+                                const previousFormat = form.values.format;
                                 form.setFieldValue(
                                     'format',
                                     value as SchedulerFormat,
@@ -146,11 +147,23 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                                     value === SchedulerFormat.CSV ||
                                     value === SchedulerFormat.XLSX
                                 ) {
-                                    // The only limit shape the backend accepts for app deliveries.
+                                    // A CSV<->XLSX toggle already carries a
+                                    // backend-legal limit (table/all) from
+                                    // the previous format's own reset here —
+                                    // preserve it. Any other origin (e.g.
+                                    // Image, whose options never validate the
+                                    // app CSV limit) gets normalized to the
+                                    // only limit shape the backend accepts.
+                                    const wasAlreadyCsvOrXlsx =
+                                        previousFormat ===
+                                            SchedulerFormat.CSV ||
+                                        previousFormat === SchedulerFormat.XLSX;
                                     form.setFieldValue('options', {
                                         ...form.values.options,
                                         formatted: Values.FORMATTED,
-                                        limit: Limit.TABLE,
+                                        limit: wasAlreadyCsvOrXlsx
+                                            ? form.values.options.limit
+                                            : Limit.TABLE,
                                     });
                                 }
                             }}

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
@@ -147,13 +147,8 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                                     value === SchedulerFormat.CSV ||
                                     value === SchedulerFormat.XLSX
                                 ) {
-                                    // A CSV<->XLSX toggle already carries a
-                                    // backend-legal limit (table/all) from
-                                    // the previous format's own reset here —
-                                    // preserve it. Any other origin (e.g.
-                                    // Image, whose options never validate the
-                                    // app CSV limit) gets normalized to the
-                                    // only limit shape the backend accepts.
+                                    // CSV<->XLSX keeps its app-legal limit
+                                    // (table/all); other origins normalize.
                                     const wasAlreadyCsvOrXlsx =
                                         previousFormat ===
                                             SchedulerFormat.CSV ||


### PR DESCRIPTION
## Summary

App CSV/XLSX deliveries currently ship each query's own result set — a 500-row-limited table arrives capped with a "reached its query limit" notice. This adds the `limit: 'all'` option so recipients get complete result sets, matching what chart/dashboard deliveries offer.

- **Options**: app schedulers accept `limit: 'table' | 'all'`; numeric limits stay rejected (one number across an app's heterogeneous queries is meaningless). Validated on create, update, and send-now.
- **Worker**: with `'all'`, after capture and before downloads, only the captured queries whose manifest entry has `limitReached: true` are re-run — from each query's server-side query-history record (`limit: null`, context `SCHEDULED_DELIVERY`, same identity the delivery already runs under) — never a browser-transported payload, so the capture trust model is unchanged. "All" reuses the exact `metricQueryWithLimit` mechanism chart/dashboard "All Results" use (bounded by the org's `csvCellsLimit`). Under-limit queries reuse the render's results with no re-execution. Chart-query and metric-query executions share the same query-history write path, so the history-keyed rerun works uniformly.
- **Failure containment**: a failed rerun — or a rerun that succeeded but whose result couldn't be downloaded — falls back to the original capped file, keeps the limit-reached notice, and records an `APP_QUERY` partial failure with the new `'rerun'` stage. A failed upgrade never loses data the render already produced.
- **UI**: the Limit control un-hides for apps as a two-option choice (Results in Table / All Results, no custom number) with a hint that limit-hit queries are re-run at delivery time. Switching CSV↔XLSX preserves a saved `'all'`; only non-data formats normalize the limit.

## Testing

- Backend: validation matrix ('all' accepted, numbers rejected, all paths), only-limitReached-entries re-run, under-limit untouched, queryUuid replacement into download, rerun-failure and rerun-download-failure fallbacks, `'table'` zero-reruns (SchedulerTask 80/80, targeted suites 174/174)
- Frontend: two-option control, no Custom, round-trip, hint on 'all', CSV↔XLSX preservation (scheduler suites green)
- Typechecks clean on common/backend/frontend

Closes: PROD-9379