### PR TITLE
fix: substitute user attributes in sum_distinct/average_distinct SQL

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -2480,6 +2480,181 @@ LIMIT 10`;
             );
         });
 
+        test('sum_distinct should replace user attributes in the dedup CTE', () => {
+            const explore: Explore = {
+                ...EXPLORE_WITH_SUM_DISTINCT,
+                tables: {
+                    ...EXPLORE_WITH_SUM_DISTINCT.tables,
+                    orders: {
+                        ...EXPLORE_WITH_SUM_DISTINCT.tables.orders,
+                        metrics: {
+                            ...EXPLORE_WITH_SUM_DISTINCT.tables.orders.metrics,
+                            total_revenue: {
+                                ...EXPLORE_WITH_SUM_DISTINCT.tables.orders
+                                    .metrics.total_revenue,
+                                compiledValueSql: `CASE WHEN \${ld.user.email} = 'mock@lightdash.com' THEN "orders".amount ELSE NULL END`,
+                            },
+                        },
+                    },
+                },
+            };
+
+            const result = buildQuery({
+                explore,
+                compiledMetricQuery: METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            expect(result.query).not.toContain('${ld.user.email}');
+            expect(result.query).toContain(
+                `CASE WHEN 'mock@lightdash.com' = 'mock@lightdash.com' THEN "orders".amount ELSE NULL END AS __dd_val`,
+            );
+            expect(result.query).toContain(
+                `ORDER BY CASE WHEN 'mock@lightdash.com' = 'mock@lightdash.com' THEN "orders".amount ELSE NULL END) AS __dd_rn`,
+            );
+        });
+
+        test('sum_distinct should replace non-intrinsic user attributes in the dedup CTE', () => {
+            const explore: Explore = {
+                ...EXPLORE_WITH_SUM_DISTINCT,
+                tables: {
+                    ...EXPLORE_WITH_SUM_DISTINCT.tables,
+                    orders: {
+                        ...EXPLORE_WITH_SUM_DISTINCT.tables.orders,
+                        metrics: {
+                            ...EXPLORE_WITH_SUM_DISTINCT.tables.orders.metrics,
+                            total_revenue: {
+                                ...EXPLORE_WITH_SUM_DISTINCT.tables.orders
+                                    .metrics.total_revenue,
+                                compiledValueSql: `CASE WHEN \${lightdash.attributes.department} = 'ops' THEN "orders".amount ELSE NULL END`,
+                            },
+                        },
+                    },
+                },
+            };
+
+            const result = buildQuery({
+                explore,
+                compiledMetricQuery: METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
+                warehouseSqlBuilder: warehouseClientMock,
+                userAttributes: { department: ['ops'] },
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            expect(result.query).not.toContain(
+                '${lightdash.attributes.department}',
+            );
+            expect(result.query).toContain(
+                `CASE WHEN 'ops' = 'ops' THEN "orders".amount ELSE NULL END AS __dd_val`,
+            );
+        });
+
+        test('sum_distinct should throw when a user attribute in the dedup CTE is missing', () => {
+            const explore: Explore = {
+                ...EXPLORE_WITH_SUM_DISTINCT,
+                tables: {
+                    ...EXPLORE_WITH_SUM_DISTINCT.tables,
+                    orders: {
+                        ...EXPLORE_WITH_SUM_DISTINCT.tables.orders,
+                        metrics: {
+                            ...EXPLORE_WITH_SUM_DISTINCT.tables.orders.metrics,
+                            total_revenue: {
+                                ...EXPLORE_WITH_SUM_DISTINCT.tables.orders
+                                    .metrics.total_revenue,
+                                compiledDistinctKeys: [
+                                    `CASE WHEN \${lightdash.attributes.nonexistent} = 'x' THEN "orders".line_item_id ELSE NULL END`,
+                                ],
+                            },
+                        },
+                    },
+                },
+            };
+
+            expect(
+                () =>
+                    buildQuery({
+                        explore,
+                        compiledMetricQuery: METRIC_QUERY_SUM_DISTINCT_NO_DIMS,
+                        warehouseSqlBuilder: warehouseClientMock,
+                        userAttributes: {},
+                        intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                        timezone: QUERY_BUILDER_UTC_TIMEZONE,
+                    }).query,
+            ).toThrow(ForbiddenError);
+        });
+
+        test('sum_distinct should replace user attributes in distinct keys', () => {
+            const explore: Explore = {
+                ...EXPLORE_WITH_SUM_DISTINCT,
+                tables: {
+                    ...EXPLORE_WITH_SUM_DISTINCT.tables,
+                    orders: {
+                        ...EXPLORE_WITH_SUM_DISTINCT.tables.orders,
+                        metrics: {
+                            ...EXPLORE_WITH_SUM_DISTINCT.tables.orders.metrics,
+                            total_revenue: {
+                                ...EXPLORE_WITH_SUM_DISTINCT.tables.orders
+                                    .metrics.total_revenue,
+                                compiledDistinctKeys: [
+                                    `CASE WHEN \${ld.user.email} = 'mock@lightdash.com' THEN "orders".line_item_id ELSE NULL END`,
+                                ],
+                            },
+                        },
+                    },
+                },
+            };
+
+            const result = buildQuery({
+                explore,
+                compiledMetricQuery: METRIC_QUERY_SUM_DISTINCT_NO_DIMS,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            expect(result.query).not.toContain('${ld.user.email}');
+            expect(result.query).toContain(
+                `PARTITION BY CASE WHEN 'mock@lightdash.com' = 'mock@lightdash.com' THEN "orders".line_item_id ELSE NULL END ORDER BY`,
+            );
+        });
+
+        test('average_distinct should replace user attributes in the dedup CTE', () => {
+            const explore: Explore = {
+                ...EXPLORE_WITH_AVERAGE_DISTINCT,
+                tables: {
+                    ...EXPLORE_WITH_AVERAGE_DISTINCT.tables,
+                    orders: {
+                        ...EXPLORE_WITH_AVERAGE_DISTINCT.tables.orders,
+                        metrics: {
+                            ...EXPLORE_WITH_AVERAGE_DISTINCT.tables.orders
+                                .metrics,
+                            avg_shipping_cost: {
+                                ...EXPLORE_WITH_AVERAGE_DISTINCT.tables.orders
+                                    .metrics.avg_shipping_cost,
+                                compiledValueSql: `CASE WHEN \${ld.user.email} = 'mock@lightdash.com' THEN "orders".shipping_cost ELSE NULL END`,
+                            },
+                        },
+                    },
+                },
+            };
+
+            const result = buildQuery({
+                explore,
+                compiledMetricQuery: METRIC_QUERY_AVERAGE_DISTINCT_NO_DIMS,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            expect(result.query).not.toContain('${ld.user.email}');
+            expect(result.query).toContain(
+                `CASE WHEN 'mock@lightdash.com' = 'mock@lightdash.com' THEN "orders".shipping_cost ELSE NULL END AS __dd_val`,
+            );
+        });
+
         test('average_distinct should generate CTE with FLOAT division', () => {
             const result = buildQuery({
                 explore: EXPLORE_WITH_AVERAGE_DISTINCT,

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -3573,6 +3573,14 @@ export class MetricQueryBuilder {
             }
             return s;
         };
+        const replaceUserAttributesInSql = (sql: string) =>
+            replaceUserAttributesAsStrings(
+                sql,
+                this.args.intrinsicUserAttributes,
+                this.args.userAttributes ?? {},
+                warehouseSqlBuilder,
+                { noWrap: true },
+            );
         const dimensionAlias = Object.keys(dimensionSelects).map(
             (alias) => `${fieldQuoteChar}${alias}${fieldQuoteChar}`,
         );
@@ -3599,12 +3607,16 @@ export class MetricQueryBuilder {
                 const ddCteName = `dd_${snakeCaseName(metricId)}`;
                 // Re-evaluate any relative date metric filters at query time; the
                 // baked predicate lives inside compiledValueSql for distinct metrics.
-                const valueSql = this.swapRelativeDateMetricFilters(
-                    metric,
-                    metric.compiledValueSql,
+                const valueSql = replaceUserAttributesInSql(
+                    this.swapRelativeDateMetricFilters(
+                        metric,
+                        metric.compiledValueSql,
+                    ),
                 );
 
-                const partitionExprs = [...metric.compiledDistinctKeys];
+                const partitionExprs = metric.compiledDistinctKeys.map(
+                    replaceUserAttributesInSql,
+                );
                 for (const dimensionExpr of dimensionExprs) {
                     if (
                         !partitionExprs.some(


### PR DESCRIPTION
Closes #27011

## Summary

Selecting a `sum_distinct` or `average_distinct` metric whose `sql:` references `${lightdash.user.email}` (or `${lightdash.attributes.*}`) fails with a warehouse syntax error — Trino: `mismatched input '$'`, Postgres: `syntax error at or near "$"` — because the raw token reaches the warehouse unsubstituted. The same expression on a plain `sum` metric works.

Only distinct metrics are affected; regular dimension/metric selects have substituted user attributes since #23119.

## Root cause

Distinct metrics don't go through the regular metric-select path. Their SQL is embedded by `buildDistinctMetricCtes` into a dedup CTE, and that builder never called `replaceUserAttributesAsStrings`:

```
replaceUserAttributesAsStrings call sites (MetricQueryBuilder.ts)
  covered:  table sqlWhere · dimension selects · metric selects (#23119) · join sql_on · bin-join exprs
  missed:   __dd_val value SQL · ROW_NUMBER() ORDER BY · PARTITION BY distinct keys   <- this PR
```

#23119 fixed the dimension/metric select paths; the distinct CTE builder shipped earlier (#20181, #20832) and was missed.

## Fix

`buildDistinctMetricCtes` now passes the metric's value SQL (which feeds both `__dd_val` and the `ROW_NUMBER() ... ORDER BY`) and each distinct key (`PARTITION BY`) through `replaceUserAttributesAsStrings` with the same options as the regular metric-select path — including the warehouse `escapeString` escaping added in #24604. A missing attribute now throws `ForbiddenError`, matching the `sql_filter` path, instead of leaking the raw token to the warehouse.

- `packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts` — local `replaceUserAttributesInSql` helper applied to `valueSql` and `compiledDistinctKeys` in `buildDistinctMetricCtes`.
- `packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts` — 5 regression tests in the dedup suite: value substitution (`__dd_val` + `ORDER BY`) for both metric types, `PARTITION BY` key substitution, non-intrinsic `${lightdash.attributes.*}` values, and the missing-attribute throw.
- Out of scope: other CTE paths that embed metric SQL without substitution (nested aggregations, period-over-period, custom bins) — same class of miss, tracked separately to keep this fix reviewable.

## Before

Compiled SQL for a `sum_distinct` metric with `sql: CASE WHEN ${lightdash.user.email} = 'demo@lightdash.com' THEN ${TABLE}.amount ELSE NULL END`:

```sql
CASE WHEN ${lightdash.user.email} = 'demo@lightdash.com' THEN "payments".amount ELSE NULL END AS __dd_val,
ROW_NUMBER() OVER (PARTITION BY ("payments".payment_id), ... ORDER BY CASE WHEN ${lightdash.user.email} = ...) AS __dd_rn
```

Running it: `WarehouseQueryError: syntax error at or near "$"`.

## After

```sql
CASE WHEN 'demo@lightdash.com' = 'demo@lightdash.com' THEN "payments".amount ELSE NULL END AS __dd_val,
ROW_NUMBER() OVER (... ORDER BY CASE WHEN 'demo@lightdash.com' = 'demo@lightdash.com' THEN ...) AS __dd_rn
```

Query returns deduplicated rows as expected.

## Test plan

- [x] `pnpm -F backend typecheck && pnpm -F backend lint`
- [x] `vitest run src/utils/QueryBuilder` — 618 tests pass (5 new regression tests; the first was written before the fix and failed with the raw token in `__dd_val`)
- [x] Manual: local dev instance, temporary `sum_distinct` metric with `${lightdash.user.email}` in the jaffle-shop project — before the fix `compileQuery` shows the raw token and `runQuery` fails with the warehouse error; after the fix the SQL is substituted and the query returns deduplicated rows
- [x] Manual: existing dedup behavior unchanged — full `MetricQueryBuilder` suite (213) and QueryBuilder snapshot suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)