### PR TITLE
fix(frontend): left-align validator table headers

### DIFF
--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/ValidatorTable.module.css
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/ValidatorTable.module.css
@@ -40,7 +40,6 @@
     }
     font-weight: 600;
     font-size: var(--mantine-font-size-xs);
-    justify-content: center;
     border-top: none;
     border-left: none;
     border-right: none;


### PR DESCRIPTION
### Description

Left-align the Project Validator table headers so they match the alignment of the row content.

The validator-specific header styles were overriding the shared `ContentTable` left alignment with `justify-content: center`. Removing that override restores the table's existing alignment convention without changing column sizing or behavior.

### Screenshots

Before
<img width="2274" height="350" alt="before" src="https://github.com/user-attachments/assets/3de8ac13-2a2e-4994-af0c-17892ac49e97" />


After
<img width="2274" height="350" alt="after" src="https://github.com/user-attachments/assets/405e35d7-e25a-4814-baf1-4742c4d5bb38" />

