### PR TITLE
fix(frontend): left-align compilation history headers

### DIFF
--- a/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
+++ b/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
@@ -273,7 +273,6 @@ const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
                 backgroundColor: theme.colors.ldGray[0],
                 fontWeight: 600,
                 fontSize: theme.fontSizes.xs,
-                justifyContent: 'center',
             },
             sx: {
                 // Removing mantine table borders for last cell


### PR DESCRIPTION
### Description

Left-align the Compilation History table headers so they match the alignment of the row content.

The table-specific header styles were overriding the shared `ContentTable` left alignment with `justifyContent: 'center'`. Removing that override restores the shared table convention without changing sorting, column sizing, or row behavior.

### Validation

Before
<img width="2274" height="350" alt="before" src="https://github.com/user-attachments/assets/b173ccfa-3648-4d6e-b3c9-94b3c01c8e72" />

After
<img width="2274" height="350" alt="after" src="https://github.com/user-attachments/assets/524e1181-829f-4676-9756-11e4477c1769" />
