### PR TITLE
feat: add per-project agent SQL scope storage and API (PROD-9479)

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -55,6 +55,7 @@ import {
     UpdateProjectMember,
     UserWarehouseCredentials,
     VirtualViewAsCode,
+    type AgentSqlScope,
     type ApiCalculateSubtotalsResponse,
     type ApiCreateDashboardResponse,
     type ApiCreateDashboardWithChartsResponse,
@@ -74,11 +75,13 @@ import {
     type DuplicateDashboardParams,
     type ProjectSummary,
     type Tag,
+    type UpdateAgentSqlScope,
     type UpdateMultipleDashboards,
     type UpdatePreviewExpirationProjectSettings,
     type UpdatePreviewExpiresAt,
     type UpdateQueryTimezoneSettings,
     type UpdateSchedulerSettings,
+    type UUID,
 } from '@lightdash/common';
 import {
     Body,
@@ -1297,6 +1300,59 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
                 throw e;
             }
         }
+
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
+     * Get the agent SQL scope for a project
+     * @summary Get agent SQL scope
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('{projectUuid}/agentSqlScope')
+    @OperationId('getAgentSqlScope')
+    async getAgentSqlScope(
+        @Path() projectUuid: UUID,
+        @Request() req: express.Request,
+    ): Promise<{ status: 'ok'; results: AgentSqlScope | null }> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+
+        return {
+            status: 'ok',
+            results: await this.services
+                .getProjectService()
+                .getAgentSqlScope(req.account, projectUuid),
+        };
+    }
+
+    /**
+     * Update the agent SQL scope for a project
+     * @summary Update agent SQL scope
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Updated')
+    @Patch('{projectUuid}/agentSqlScope')
+    @OperationId('updateAgentSqlScope')
+    async updateAgentSqlScope(
+        @Path() projectUuid: UUID,
+        @Body() body: UpdateAgentSqlScope,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+
+        await this.services
+            .getProjectService()
+            .updateAgentSqlScope(req.account, projectUuid, body);
 
         return {
             status: 'ok',

--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -1,4 +1,5 @@
 import {
+    AgentSqlScope,
     AnyType,
     DbtProjectType,
     GroupType,
@@ -42,6 +43,7 @@ export type DbProject = {
     default_preview_expiration_hours: number;
     max_preview_expiration_hours: number;
     provisioning_source: string | null;
+    agent_sql_scope: AgentSqlScope | null;
 };
 
 type CreateDbProject = Pick<
@@ -86,6 +88,7 @@ type UpdateDbProject = Partial<
         | 'default_preview_expiration_hours'
         | 'max_preview_expiration_hours'
         | 'provisioning_source'
+        | 'agent_sql_scope'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20260804190000_add_agent_sql_scope_to_projects.ts
+++ b/packages/backend/src/database/migrations/20260804190000_add_agent_sql_scope_to_projects.ts
@@ -1,0 +1,19 @@
+import { type Knex } from 'knex';
+
+const PROJECTS_TABLE = 'projects';
+const AGENT_SQL_SCOPE = 'agent_sql_scope';
+
+// Restricts which schemas/catalogs the AI agent may read via raw SQL.
+// NULL means unrestricted, which is the behaviour every existing project
+// keeps after this migration.
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(PROJECTS_TABLE, (table) => {
+        table.jsonb(AGENT_SQL_SCOPE).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(PROJECTS_TABLE, (table) => {
+        table.dropColumn(AGENT_SQL_SCOPE);
+    });
+}

--- a/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
@@ -120,6 +120,7 @@ export const expectedProject: Project = {
     colorPaletteUuid: null,
     expiresAt: null,
     provisioningSource: null,
+    agentSqlScope: null,
 };
 
 const metricFilter: MetricFilterRule = {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1,4 +1,5 @@
 import {
+    AgentSqlScope,
     AlreadyExistsError,
     AnyType,
     AthenaAuthenticationType,
@@ -934,6 +935,7 @@ export class ProjectModel {
                   color_palette_uuid: string | null;
                   expires_at: Date | null;
                   provisioning_source: string | null;
+                  agent_sql_scope: AgentSqlScope | null;
               }
             | {
                   name: string;
@@ -958,6 +960,7 @@ export class ProjectModel {
                   color_palette_uuid: string | null;
                   expires_at: Date | null;
                   provisioning_source: string | null;
+                  agent_sql_scope: AgentSqlScope | null;
               }
         )[];
         return wrapSentryTransaction(
@@ -1045,6 +1048,9 @@ export class ProjectModel {
                         this.database
                             .ref('provisioning_source')
                             .withSchema(ProjectTableName),
+                        this.database
+                            .ref('agent_sql_scope')
+                            .withSchema(ProjectTableName),
                     ])
                     .select<QueryResult>()
                     .where('projects.project_uuid', projectUuid);
@@ -1098,6 +1104,7 @@ export class ProjectModel {
                     colorPaletteUuid: project.color_palette_uuid ?? null,
                     expiresAt: project.expires_at ?? null,
                     provisioningSource: project.provisioning_source ?? null,
+                    agentSqlScope: project.agent_sql_scope ?? null,
                 };
 
                 // If project uses organization warehouse credentials, load them
@@ -1331,6 +1338,7 @@ export class ProjectModel {
             colorPaletteUuid: project.colorPaletteUuid ?? null,
             expiresAt: project.expiresAt,
             provisioningSource: project.provisioningSource ?? null,
+            agentSqlScope: project.agentSqlScope ?? null,
         };
     }
 
@@ -4098,6 +4106,59 @@ export class ProjectModel {
                 project.organization_warehouse_credentials_uuid,
             queryTimezone: project.query_timezone,
         };
+    }
+
+    async getAgentSqlScope(projectUuid: string): Promise<AgentSqlScope | null> {
+        const [project] = await this.database(ProjectTableName)
+            .select('agent_sql_scope')
+            .where('project_uuid', projectUuid);
+
+        if (!project) {
+            throw new NotFoundError(
+                `Cannot find project with id: ${projectUuid}`,
+            );
+        }
+
+        return project.agent_sql_scope ?? null;
+    }
+
+    async updateAgentSqlScope(
+        projectUuid: string,
+        agentSqlScope: AgentSqlScope | null,
+    ): Promise<void> {
+        // Empty everywhere means "unrestricted", stored as NULL so there is
+        // exactly one representation of the default. An allow list is not
+        // required: a scope may consist only of exclusions.
+        const isEmpty =
+            !agentSqlScope ||
+            (agentSqlScope.schemas.length === 0 &&
+                !agentSqlScope.catalogs?.length &&
+                !agentSqlScope.deniedSchemas?.length &&
+                !agentSqlScope.deniedCatalogs?.length);
+        const normalised = isEmpty
+            ? null
+            : {
+                  schemas: agentSqlScope!.schemas,
+                  ...(agentSqlScope!.catalogs?.length
+                      ? { catalogs: agentSqlScope!.catalogs }
+                      : {}),
+                  ...(agentSqlScope!.deniedSchemas?.length
+                      ? { deniedSchemas: agentSqlScope!.deniedSchemas }
+                      : {}),
+                  ...(agentSqlScope!.deniedCatalogs?.length
+                      ? { deniedCatalogs: agentSqlScope!.deniedCatalogs }
+                      : {}),
+              };
+
+        const updated = await this.database(ProjectTableName)
+            .update({ agent_sql_scope: normalised })
+            .where('project_uuid', projectUuid);
+
+        if (updated === 0) {
+            throw new NotFoundError(
+                `Cannot find project with id: ${projectUuid}`,
+            );
+        }
     }
 
     async getQueryTimezone(projectUuid: string): Promise<string | null> {

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -387,6 +387,7 @@ export const projectWithSensitiveFields: Project = {
     hasDefaultUserSpaces: false,
     colorPaletteUuid: null,
     expiresAt: null,
+    agentSqlScope: null,
 };
 
 export const projectSummary: ProjectSummary = {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -177,6 +177,7 @@ import {
     TablesConfiguration,
     TableSelectionType,
     UnexpectedServerError,
+    UpdateAgentSqlScope,
     UpdateDefaultUserSpaces,
     UpdateMetadata,
     UpdateProject,
@@ -195,6 +196,7 @@ import {
     WarehouseTablesCatalog,
     WarehouseTableSchema,
     WarehouseTypes,
+    type AgentSqlScope,
     type ApiCreateProjectResults,
     type CreateDatabricksCredentials,
     type DataTimezonePreviewRequest,
@@ -9855,6 +9857,62 @@ export class ProjectService extends BaseService {
         }
 
         return updatedProject;
+    }
+
+    async getAgentSqlScope(
+        account: RegisteredAccount,
+        projectUuid: string,
+    ): Promise<AgentSqlScope | null> {
+        const project = await this.projectModel.getSummary(projectUuid);
+
+        const auditedAbility = this.createAuditedAbility(account);
+        if (auditedAbility.cannot('update', subject('Project', project))) {
+            throw new ForbiddenError();
+        }
+
+        return this.projectModel.getAgentSqlScope(projectUuid);
+    }
+
+    async updateAgentSqlScope(
+        account: RegisteredAccount,
+        projectUuid: string,
+        { agentSqlScope }: UpdateAgentSqlScope,
+    ): Promise<void> {
+        const project = await this.projectModel.getSummary(projectUuid);
+
+        const auditedAbility = this.createAuditedAbility(account);
+        if (auditedAbility.cannot('update', subject('Project', project))) {
+            throw new ForbiddenError();
+        }
+
+        if (agentSqlScope) {
+            const blank = [
+                ...agentSqlScope.schemas,
+                ...(agentSqlScope.catalogs ?? []),
+                ...(agentSqlScope.deniedSchemas ?? []),
+                ...(agentSqlScope.deniedCatalogs ?? []),
+            ].some((name) => name.trim() === '');
+            if (blank) {
+                throw new ParameterError(
+                    'Schema and catalog names cannot be blank',
+                );
+            }
+        }
+
+        await this.projectModel.updateAgentSqlScope(projectUuid, agentSqlScope);
+
+        this.analytics.track({
+            event: 'agent_sql_scope.updated',
+            userId: account.user.id,
+            properties: {
+                projectId: projectUuid,
+                organizationUuid: project.organizationUuid,
+                schemaCount: agentSqlScope?.schemas.length ?? 0,
+                catalogCount: agentSqlScope?.catalogs?.length ?? 0,
+                deniedSchemaCount: agentSqlScope?.deniedSchemas?.length ?? 0,
+                deniedCatalogCount: agentSqlScope?.deniedCatalogs?.length ?? 0,
+            },
+        });
     }
 
     async updateQueryTimezone(

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -208,6 +208,7 @@ export {
     WarehouseTypes,
 } from './types/projects';
 export type {
+    AgentSqlScope,
     ApiEnsurePlaygroundProjectResponse,
     ApiGetProjectGroupAccesses,
     ApiProjectResponse,
@@ -290,6 +291,7 @@ export type {
     TrinoCredentials,
     UpdateProjectDbtSource,
     UpdateProjectDetails,
+    UpdateAgentSqlScope,
     UpdateQueryTimezoneSettings,
     UpdateSchedulerSettings,
     WarehouseCredentials,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -792,6 +792,7 @@ export type CreateProject = Omit<
     | 'colorPaletteUuid'
     | 'expiresAt'
     | 'provisioningSource'
+    | 'agentSqlScope'
 > & {
     warehouseConnection: CreateWarehouseCredentials;
     copyWarehouseConnectionFromUpstreamProject?: boolean;
@@ -830,6 +831,7 @@ export type UpdateProject = Omit<
     | 'hasDefaultUserSpaces'
     | 'colorPaletteUuid'
     | 'expiresAt'
+    | 'agentSqlScope'
 > & {
     warehouseConnection: CreateWarehouseCredentials;
 };

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -1181,6 +1181,7 @@ export type Project = {
     colorPaletteUuid: string | null;
     expiresAt: Date | null;
     provisioningSource?: string | null;
+    agentSqlScope: AgentSqlScope | null;
 };
 
 export type ProjectSummary = Pick<
@@ -1254,4 +1255,39 @@ export type UpdateSchedulerSettings = {
 export type UpdateQueryTimezoneSettings = {
     queryTimezone?: string | null;
     useProjectTimezoneInFilters?: boolean;
+};
+
+/**
+ * Restricts which part of the warehouse the AI agent may read via raw SQL.
+ *
+ * Null (or an empty `schemas` list) means unrestricted — the agent can reach
+ * anything the project's warehouse connection can reach, which is the
+ * behaviour for every project that has not configured a scope.
+ *
+ * This is a correctness control rather than a security boundary: raw SQL
+ * already requires `manage SqlRunner`, so the same data is reachable through
+ * the SQL Runner regardless. It exists so an agent can be kept off schemas a
+ * customer knows are wrong to answer from, such as a retired dbt project
+ * living in the same catalog as the current one.
+ */
+export type AgentSqlScope = {
+    /** Schemas the agent may read. Empty means every schema is allowed. */
+    schemas: string[];
+    /** Catalogs/databases the agent may read. Empty means any catalog. */
+    catalogs?: string[];
+    /**
+     * Schemas the agent may never read. Takes precedence over the allow list.
+     *
+     * Denying is often the better fit: an allow list goes stale the moment a
+     * new schema is created (the agent silently cannot see the new models),
+     * whereas "everything except the retired project" keeps working as the
+     * warehouse grows.
+     */
+    deniedSchemas?: string[];
+    /** Catalogs/databases the agent may never read. Takes precedence. */
+    deniedCatalogs?: string[];
+};
+
+export type UpdateAgentSqlScope = {
+    agentSqlScope: AgentSqlScope | null;
 };


### PR DESCRIPTION
Part 1 of 3 splitting #26844 (stacked: #this ← enforcement ← settings UI).

Adds the `AgentSqlScope` type (allowed/denied schemas and catalogs), a `projects.agent_sql_scope` column + migration, model/service plumbing, and project endpoints to read and update the scope. No behavior change yet — enforcement lands in the next PR of the stack.

Linear: PROD-9479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHhBNPi5J7Yq8fkpgGAXzz