### PR TITLE
feat: enforce the agent SQL scope in agent SQL and discovery (PROD-9479)

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -8331,6 +8331,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     ) {
         const { projectUuid, organizationUuid } = prompt;
         const runtimeAgentSettings = await this.getAgentSettings(user, prompt);
+        const sqlScope = await this.projectModel.getAgentSqlScope(projectUuid);
         const toolsRuntime = this.aiAgentToolsService.createRuntime({
             user,
             account: fromSession(user),
@@ -8343,6 +8344,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             spaceAccess:
                 options?.runtimeOptions?.spaceAccess ??
                 runtimeAgentSettings.spaceAccess,
+            sqlScope,
             userAttributeOverrides:
                 options?.runtimeOptions?.userAttributeOverrides,
             agentUuid: runtimeAgentSettings.uuid,
@@ -9371,6 +9373,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
               null
             : null;
 
+        const agentSqlScope = canRunSql
+            ? await this.projectModel.getAgentSqlScope(prompt.projectUuid)
+            : null;
+
         const knowledgeDocuments =
             await this.aiAgentDocumentModel.findAllContextForAgent({
                 organizationUuid: user.organizationUuid,
@@ -9693,6 +9699,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 : null,
             warehouseType,
             warehouseSchema,
+            sqlScope: agentSqlScope,
             availableSkills,
             modelReasoningEnabled: prompt.modelConfig?.reasoning ?? null,
 

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -33,6 +33,7 @@ import {
     TimeoutError,
     UserAttributeValueMap,
     WarehouseQueryError,
+    type AgentSqlScope,
     type AiAgentDocumentSummary,
     type ChartAsCode,
     type DashboardAsCode,
@@ -116,6 +117,12 @@ import {
     populateCustomMetricsSQL,
 } from '../ai/utils/populateCustomMetricsSQL';
 import { getExploreRequiredFilters } from '../ai/utils/requiredFilters';
+import {
+    filterWarehouseCatalogToScope,
+    findSqlScopeViolations,
+    formatSqlScopeError,
+    isSchemaInScope,
+} from '../ai/utils/sqlScope';
 import { PreviewDeploySetupService } from '../PreviewDeploySetupService/PreviewDeploySetupService';
 import type { SchedulerAiAugmentationService } from '../SchedulerAiAugmentationService/SchedulerAiAugmentationService';
 
@@ -141,6 +148,7 @@ export type AiAgentToolsRuntimeContext = {
     defaultQueryExecutionContext: QueryExecutionContext;
     tags: string[] | null;
     spaceAccess: string[] | null;
+    sqlScope?: AgentSqlScope | null;
     userAttributeOverrides?: UserAttributeValueMap;
     agentUuid?: string;
     threadUuid?: string;
@@ -1978,6 +1986,27 @@ export class AiAgentToolsService extends BaseService {
             `${AiAgentToolsService.transactionPrefix(context)}.runSqlJob`,
             { sql: sql.slice(0, 500), limit },
             async () => {
+                // Authoritative scope check. The runSql tool also checks, so
+                // the model gets a well-worded error it can act on; this one
+                // is what actually guarantees the query never reaches the
+                // warehouse, whatever the tool layer does.
+                const violations = findSqlScopeViolations(
+                    sql,
+                    context.sqlScope,
+                );
+                if (violations.length > 0 && context.sqlScope) {
+                    this.logger.warn(
+                        `Blocked out-of-scope agent SQL for project ${
+                            context.projectUuid
+                        } (agent ${context.agentUuid ?? 'unknown'}): ${violations
+                            .map((v) => v.reference)
+                            .join(', ')}`,
+                    );
+                    throw new ForbiddenError(
+                        formatSqlScopeError(violations, context.sqlScope),
+                    );
+                }
+
                 await context.onWarehouseQuery?.();
                 const { queryUuid } =
                     await this.asyncQueryService.executeAsyncSqlQuery({
@@ -2060,11 +2089,13 @@ export class AiAgentToolsService extends BaseService {
         return wrapSentryTransaction(
             `${AiAgentToolsService.transactionPrefix(context)}.listWarehouseTables`,
             { projectUuid: context.projectUuid },
-            () =>
-                this.projectService.getWarehouseTables(
+            async () => {
+                const catalog = await this.projectService.getWarehouseTables(
                     context.user,
                     context.projectUuid,
-                ),
+                );
+                return filterWarehouseCatalogToScope(catalog, context.sqlScope);
+            },
         );
     }
 
@@ -2092,6 +2123,24 @@ export class AiAgentToolsService extends BaseService {
                           null
                         : null;
                 }
+                if (
+                    resolvedSchema &&
+                    !isSchemaInScope(context.sqlScope, resolvedSchema)
+                ) {
+                    throw new ForbiddenError(
+                        formatSqlScopeError(
+                            [
+                                {
+                                    kind: 'schema',
+                                    reference: `${resolvedSchema}.${table}`,
+                                    schema: resolvedSchema,
+                                },
+                            ],
+                            context.sqlScope!,
+                        ),
+                    );
+                }
+
                 const fields = await this.projectService.getWarehouseFields(
                     context.user,
                     context.projectUuid,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -811,6 +811,7 @@ export const getAgentTools = (
               createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
               maxQueryLimit: args.runSqlMaxLimit,
               enableDataAccess: args.enableDataAccess,
+              sqlScope: args.sqlScope,
               autoApproveSql: args.autoApproveSql,
               autoApproveSqlUserUuid: args.autoApproveSqlUserUuid,
               useSlackStreamCard: args.useSlackStreamCard,
@@ -1318,6 +1319,7 @@ const getAgentMessages = (
         canRunSql: args.canRunSql,
         warehouseType: args.warehouseType,
         warehouseSchema: args.warehouseSchema,
+        sqlScope: args.sqlScope,
         runSqlMaxLimit: args.runSqlMaxLimit,
         unauthenticatedMcpServerNames: getUnauthenticatedMcpServerNames(
             args,

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -3,6 +3,7 @@ import {
     AiWritebackAttribution,
     Explore,
     WarehouseTypes,
+    type AgentSqlScope,
 } from '@lightdash/common';
 import { SystemModelMessage } from 'ai';
 import moment from 'moment';
@@ -68,6 +69,7 @@ export const getSystemPromptV2 = (args: {
     canRunSql?: boolean;
     warehouseType?: WarehouseTypes | null;
     warehouseSchema?: string | null;
+    sqlScope?: AgentSqlScope | null;
     // runSql's own max, quoted in its prompt section.
     runSqlMaxLimit?: number;
     unauthenticatedMcpServerNames?: string[];
@@ -93,6 +95,7 @@ export const getSystemPromptV2 = (args: {
         canRunSql = false,
         warehouseType = null,
         warehouseSchema = null,
+        sqlScope = null,
         runSqlMaxLimit,
         unauthenticatedMcpServerNames = [],
         mcpServers = [],
@@ -254,6 +257,7 @@ export const getSystemPromptV2 = (args: {
                 ? getRunSqlSection({
                       warehouseType,
                       warehouseSchema,
+                      sqlScope,
                       runSqlMaxLimit,
                   })
                 : '',

--- a/packages/backend/src/ee/services/ai/prompts/systemV2RunSql.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2RunSql.ts
@@ -2,6 +2,7 @@ import {
     DEFAULT_RUN_SQL_LIMIT,
     DEFAULT_RUN_SQL_MAX_LIMIT,
     WarehouseTypes,
+    type AgentSqlScope,
 } from '@lightdash/common';
 
 const WAREHOUSE_HINTS: Record<WarehouseTypes, string> = {
@@ -28,16 +29,51 @@ const WAREHOUSE_HINTS: Record<WarehouseTypes, string> = {
 export const getRunSqlSection = ({
     warehouseType,
     warehouseSchema,
+    sqlScope,
     // Configurable per instance, so a literal here would contradict the tool schema.
     runSqlMaxLimit = DEFAULT_RUN_SQL_MAX_LIMIT,
 }: {
     warehouseType: WarehouseTypes | null;
     warehouseSchema: string | null;
+    sqlScope?: AgentSqlScope | null;
     runSqlMaxLimit?: number;
 }) => {
     const warehouseLine = warehouseType
         ? `**Warehouse:** ${warehouseType}. ${WAREHOUSE_HINTS[warehouseType] ?? ''}`
         : 'Use the SQL dialect of the connected warehouse.';
+
+    // When any scope is configured the qualification rules apply, because the
+    // guard cannot classify a bare table name or a comma-join operand.
+    const SCOPE_RULES =
+        'The server REJECTS any query reading outside this scope — a rejected query is a wasted turn, so never try. Every table must be schema-qualified, and comma-join syntax (`FROM a, b`) is rejected: use explicit JOIN. If the data the user asked for is out of scope, say so plainly instead of substituting a different table.';
+
+    const list = (values: string[]) => values.map((v) => `\`${v}\``).join(', ');
+
+    const allowedSchemas = sqlScope?.schemas.length ? sqlScope.schemas : null;
+    const deniedSchemas = sqlScope?.deniedSchemas?.length
+        ? sqlScope.deniedSchemas
+        : null;
+
+    const scopeParts = [
+        allowedSchemas
+            ? `**Allowed schemas for this project:** ${list(allowedSchemas)}.`
+            : null,
+        sqlScope?.catalogs?.length
+            ? `**Allowed catalogs for this project:** ${list(
+                  sqlScope.catalogs,
+              )}. Qualify every table as catalog.schema.table — two-part references are rejected because their catalog cannot be verified.`
+            : null,
+        deniedSchemas
+            ? `**Never read these schemas:** ${list(deniedSchemas)}.`
+            : null,
+        sqlScope?.deniedCatalogs?.length
+            ? `**Never read these catalogs:** ${list(sqlScope.deniedCatalogs)}.`
+            : null,
+    ].filter((part): part is string => part !== null);
+
+    const scopeLine = scopeParts.length
+        ? `${scopeParts.join(' ')} ${SCOPE_RULES}`
+        : null;
 
     const schemaLine = warehouseSchema
         ? `**Default schema for this project:** \`${warehouseSchema}\`. ALWAYS qualify your tables with this schema (e.g. \`${warehouseSchema}.fm_work_orders\`). Bare table names will fail.`
@@ -100,7 +136,9 @@ Every \`runSql\` call costs the user an approval click. Treat each one as if you
 
 NEVER guess column names across multiple \`runSql\` calls. Discovery is free; SQL costs an approval click.
 
-**5. Schema qualification on the first attempt.** ${schemaLine}
+**5. Schema qualification on the first attempt.** ${
+        scopeLine ? `${schemaLine} ${scopeLine}` : schemaLine
+    }
 
 **6. Write SQL like the user will read it.** Comment non-trivial logic, use meaningful aliases, format CTEs clearly. The user is about to read every character before clicking Approve.
 

--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -15,10 +15,14 @@ type MakeToolOptions = {
     enableDataAccess?: boolean;
 };
 
-const executeRunSql = (tool: RunSqlTool, toolCallId: string = 'tool-call-1') =>
+const executeRunSql = (
+    tool: RunSqlTool,
+    toolCallId: string = 'tool-call-1',
+    sql: string = 'select 1 as answer',
+) =>
     tool.execute!(
         {
-            sql: 'select 1 as answer',
+            sql,
             limit: 500,
         },
         {
@@ -61,9 +65,11 @@ const makeTool = ({
     enableDataAccess = true,
     useSlackStreamCard = false,
     prompt = makePrompt(),
+    sqlScope = null,
 }: MakeToolOptions & {
     useSlackStreamCard?: boolean;
     prompt?: AiWebAppPrompt | SlackPrompt;
+    sqlScope?: { schemas: string[]; catalogs?: string[] } | null;
 } = {}) => {
     const dependencies = {
         updateProgress: vi.fn().mockResolvedValue(undefined),
@@ -87,6 +93,7 @@ const makeTool = ({
         maxQueryLimit,
         enableDataAccess,
         useSlackStreamCard,
+        sqlScope,
     };
 
     return {
@@ -328,5 +335,72 @@ describe('getRunSql', () => {
                 }),
             ]);
         });
+    });
+});
+
+describe('getRunSql agent SQL scope', () => {
+    it('runs a query against a schema inside the scope', async () => {
+        const { tool, dependencies } = makeTool({
+            autoApproveSql: true,
+            sqlScope: { schemas: ['jaffle'] },
+        });
+
+        const output = await executeRunSql(
+            tool,
+            'tool-call-1',
+            'SELECT id FROM jaffle.orders',
+        );
+
+        expect(dependencies.runSqlJob).toHaveBeenCalled();
+        expect(output.metadata?.status).toBe('success');
+    });
+
+    it('refuses a query against a schema outside the scope', async () => {
+        const { tool, dependencies } = makeTool({
+            autoApproveSql: true,
+            sqlScope: { schemas: ['jaffle'] },
+        });
+
+        const output = await executeRunSql(
+            tool,
+            'tool-call-1',
+            'SELECT id FROM jaffle_old.stale_orders',
+        );
+
+        expect(dependencies.runSqlJob).not.toHaveBeenCalled();
+        expect(output.metadata?.status).toBe('error');
+        expect(output.result).toContain('jaffle_old');
+    });
+
+    it('refuses before asking the user to approve, so a blocked query costs no approval click', async () => {
+        const waitForSqlApproval = vi.fn().mockResolvedValue('approved');
+        const { tool, dependencies } = makeTool({
+            waitForSqlApproval,
+            sqlScope: { schemas: ['jaffle'] },
+        });
+
+        await executeRunSql(
+            tool,
+            'tool-call-1',
+            'SELECT id FROM jaffle_old.stale_orders',
+        );
+
+        expect(waitForSqlApproval).not.toHaveBeenCalled();
+        expect(dependencies.updateProgress).not.toHaveBeenCalledWith(
+            'Awaiting approval to run SQL...',
+        );
+    });
+
+    it('leaves queries unrestricted when no scope is configured', async () => {
+        const { tool, dependencies } = makeTool({ autoApproveSql: true });
+
+        const output = await executeRunSql(
+            tool,
+            'tool-call-1',
+            'SELECT id FROM anything.at.all',
+        );
+
+        expect(dependencies.runSqlJob).toHaveBeenCalled();
+        expect(output.metadata?.status).toBe('success');
     });
 });

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -21,6 +21,11 @@ import type {
     WaitForSqlApprovalFn,
 } from '../types/aiAgentDependencies';
 import { serializeData } from '../utils/serializeData';
+import {
+    findSqlScopeViolations,
+    formatSqlScopeError,
+    type SqlScope,
+} from '../utils/sqlScope';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 import { renderBlocks, type SectionState } from './slackSqlAggregate';
 
@@ -38,6 +43,7 @@ type Dependencies = {
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     maxQueryLimit: number;
     enableDataAccess: boolean;
+    sqlScope?: SqlScope | null;
     autoApproveSql?: boolean;
     autoApproveSqlUserUuid?: string | null;
     useSlackStreamCard?: boolean;
@@ -99,6 +105,7 @@ export const getRunSql = ({
     createOrUpdateArtifact,
     maxQueryLimit,
     enableDataAccess,
+    sqlScope = null,
     autoApproveSql = false,
     autoApproveSqlUserUuid = null,
     useSlackStreamCard = false,
@@ -183,6 +190,14 @@ export const getRunSql = ({
 
             // Pre-section errors (bad SQL shape) — no Slack message exists
             // yet, just return the error to the agent.
+            const scopeViolations = findSqlScopeViolations(sql, sqlScope);
+            if (scopeViolations.length > 0 && sqlScope) {
+                return persistResumeResult({
+                    result: formatSqlScopeError(scopeViolations, sqlScope),
+                    metadata: { status: 'error' },
+                });
+            }
+
             try {
                 validateSelectOnly(sql);
             } catch (e) {

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -7,6 +7,7 @@ import {
     AiWritebackAttribution,
     ProjectContextEntry,
     WarehouseTypes,
+    type AgentSqlScope,
     type AiDeepResearchActivity,
     type AiDeepResearchExecutionContextSnapshot,
     type AiDeepResearchPhase,
@@ -257,6 +258,7 @@ export type AiAgentArgs = AnyAiModel & {
     getDashboardChartsPageSize: number;
     maxQueryLimit: number;
     runSqlMaxLimit: number;
+    sqlScope?: AgentSqlScope | null;
     /** Rows of a query result written into model context; the query keeps the rest. */
     maxContextRows: number;
     siteUrl: string;

--- a/packages/backend/src/ee/services/ai/utils/scopedSqlContexts.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/scopedSqlContexts.test.ts
@@ -1,0 +1,25 @@
+import { QueryExecutionContext } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { isAgentScopedQueryContext } from './scopedSqlContexts';
+
+describe('isAgentScopedQueryContext', () => {
+    it('scopes SQL the AI agent runs', () => {
+        expect(isAgentScopedQueryContext(QueryExecutionContext.AI)).toBe(true);
+    });
+
+    it('scopes SQL run through the MCP run_sql tool', () => {
+        expect(
+            isAgentScopedQueryContext(QueryExecutionContext.MCP_RUN_SQL),
+        ).toBe(true);
+    });
+
+    it('leaves the human SQL Runner unrestricted', () => {
+        expect(
+            isAgentScopedQueryContext(QueryExecutionContext.SQL_RUNNER),
+        ).toBe(false);
+    });
+
+    it('leaves an unknown context unrestricted rather than breaking it', () => {
+        expect(isAgentScopedQueryContext(undefined)).toBe(false);
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/scopedSqlContexts.ts
+++ b/packages/backend/src/ee/services/ai/utils/scopedSqlContexts.ts
@@ -1,0 +1,23 @@
+import { QueryExecutionContext } from '@lightdash/common';
+
+/**
+ * Query execution contexts whose raw SQL is subject to the project's agent SQL
+ * scope.
+ *
+ * The human SQL Runner is deliberately absent: the scope narrows what an agent
+ * will read, it does not narrow what a person with `manage SqlRunner` may
+ * query. Restricting the SQL Runner here would silently shrink a surface
+ * customers rely on.
+ *
+ * Both agent-facing entry points funnel through
+ * `AsyncQueryService.executeAsyncSqlQuery`, so gating there rather than at each
+ * caller means a new agent SQL path cannot be added without inheriting the
+ * scope.
+ */
+const AGENT_SCOPED_QUERY_CONTEXTS: ReadonlySet<QueryExecutionContext> = new Set(
+    [QueryExecutionContext.AI, QueryExecutionContext.MCP_RUN_SQL],
+);
+
+export const isAgentScopedQueryContext = (
+    context: QueryExecutionContext | undefined,
+): boolean => !!context && AGENT_SCOPED_QUERY_CONTEXTS.has(context);

--- a/packages/backend/src/ee/services/ai/utils/sqlScope.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/sqlScope.test.ts
@@ -1,0 +1,537 @@
+import { describe, expect, it } from 'vitest';
+import {
+    filterWarehouseCatalogToScope,
+    findSqlScopeViolations,
+    formatSqlScopeError,
+    isSchemaInScope,
+    type SqlScope,
+} from './sqlScope';
+
+const scope: SqlScope = { schemas: ['jaffle'] };
+const catalogScope: SqlScope = { schemas: ['jaffle'], catalogs: ['prod'] };
+
+const kinds = (sql: string, s: SqlScope = scope) =>
+    findSqlScopeViolations(sql, s).map((v) => v.kind);
+
+describe('findSqlScopeViolations', () => {
+    describe('when no scope is configured', () => {
+        it('allows a query against any schema', () => {
+            expect(
+                kinds('SELECT * FROM anything.at.all', { schemas: [] }),
+            ).toEqual([]);
+        });
+    });
+
+    describe('schema qualification', () => {
+        it('allows a table in an allowed schema', () => {
+            expect(kinds('SELECT * FROM jaffle.orders')).toEqual([]);
+        });
+
+        it('blocks a table in a schema outside the scope', () => {
+            expect(kinds('SELECT * FROM jaffle_old.stale_orders')).toEqual([
+                'schema',
+            ]);
+        });
+
+        it('blocks a PostgreSQL ONLY table outside the scope', () => {
+            expect(kinds('SELECT * FROM ONLY jaffle_old.stale_orders')).toEqual(
+                ['schema'],
+            );
+        });
+
+        it('reports which schema was rejected', () => {
+            const [violation] = findSqlScopeViolations(
+                'SELECT * FROM jaffle_old.stale_orders',
+                scope,
+            );
+            expect(violation).toEqual({
+                kind: 'schema',
+                reference: 'jaffle_old.stale_orders',
+                schema: 'jaffle_old',
+            });
+        });
+
+        it('blocks an unqualified table name', () => {
+            expect(kinds('SELECT * FROM orders')).toEqual(['unqualified']);
+        });
+
+        it('matches schema names case-insensitively', () => {
+            expect(kinds('select * from JAFFLE.ORDERS')).toEqual([]);
+        });
+    });
+
+    describe('quoted identifiers', () => {
+        it('allows a backtick-quoted table in an allowed schema', () => {
+            expect(kinds('SELECT * FROM `jaffle`.`orders`')).toEqual([]);
+        });
+
+        it('blocks a backtick-quoted table outside the scope', () => {
+            expect(kinds('SELECT * FROM `legacy`.`orders`')).toEqual([
+                'schema',
+            ]);
+        });
+
+        it('allows a double-quoted table in an allowed schema', () => {
+            expect(kinds('SELECT * FROM "jaffle"."orders"')).toEqual([]);
+        });
+
+        it('fails closed on an identifier containing a space', () => {
+            expect(kinds('SELECT * FROM "my schema".orders')).toEqual([
+                'unqualified',
+            ]);
+        });
+    });
+
+    describe('three-part references', () => {
+        it('allows an allowed catalog and schema', () => {
+            expect(
+                kinds('SELECT * FROM prod.jaffle.orders', catalogScope),
+            ).toEqual([]);
+        });
+
+        it('blocks a catalog outside the scope', () => {
+            expect(
+                kinds('SELECT * FROM legacy.jaffle.orders', catalogScope),
+            ).toEqual(['catalog']);
+        });
+
+        it('blocks a schema outside the scope even in an allowed catalog', () => {
+            expect(
+                kinds('SELECT * FROM prod.finance_pii.salaries', catalogScope),
+            ).toEqual(['schema']);
+        });
+
+        it('ignores the catalog when no catalogs are configured', () => {
+            expect(kinds('SELECT * FROM any_catalog.jaffle.orders')).toEqual(
+                [],
+            );
+        });
+    });
+
+    describe('catalog allow list and two-part references', () => {
+        // A two-part reference runs in the connection's default catalog, which
+        // may not be in the allow list — so under an allow list the guard
+        // requires full qualification rather than trusting the default.
+        it('rejects a two-part reference when a catalog allow list is configured', () => {
+            expect(kinds('SELECT * FROM jaffle.orders', catalogScope)).toEqual([
+                'catalog_unqualified',
+            ]);
+        });
+
+        it('reports the schema violation first when both apply', () => {
+            expect(kinds('SELECT * FROM secret.orders', catalogScope)).toEqual([
+                'schema',
+            ]);
+        });
+
+        it('does not require catalog qualification without an allow list', () => {
+            expect(kinds('SELECT * FROM jaffle.orders')).toEqual([]);
+        });
+
+        it('does not require catalog qualification under a catalog deny list', () => {
+            expect(
+                kinds('SELECT * FROM jaffle.orders', {
+                    schemas: [],
+                    deniedCatalogs: ['legacy'],
+                }),
+            ).toEqual([]);
+        });
+    });
+
+    describe('CTEs', () => {
+        it('allows a reference to a CTE defined in the query', () => {
+            expect(
+                kinds(
+                    'WITH o AS (SELECT * FROM jaffle.orders) SELECT * FROM o',
+                ),
+            ).toEqual([]);
+        });
+
+        it('blocks a CTE whose own source is outside the scope', () => {
+            expect(
+                kinds('WITH o AS (SELECT * FROM jaffle_old.x) SELECT * FROM o'),
+            ).toEqual(['schema']);
+        });
+
+        it('allows a RECURSIVE CTE', () => {
+            expect(
+                kinds(
+                    'WITH RECURSIVE t AS (SELECT * FROM jaffle.orders) SELECT * FROM t',
+                ),
+            ).toEqual([]);
+        });
+    });
+
+    describe('joins', () => {
+        it('allows a join where both sides are in scope', () => {
+            expect(
+                kinds('SELECT * FROM jaffle.a JOIN jaffle.b ON a.id = b.id'),
+            ).toEqual([]);
+        });
+
+        it('blocks a LEFT JOIN onto a schema outside the scope', () => {
+            expect(
+                kinds(
+                    'SELECT * FROM jaffle.a LEFT JOIN secret.b ON a.id = b.id',
+                ),
+            ).toEqual(['schema']);
+        });
+
+        it('blocks comma-join syntax, whose operands cannot be read reliably', () => {
+            expect(kinds('SELECT * FROM jaffle.a, jaffle_old.b')).toEqual([
+                'comma_join',
+            ]);
+        });
+
+        it('blocks aliased comma-join syntax', () => {
+            expect(
+                kinds('SELECT * FROM jaffle.a AS x, jaffle_old.b AS y'),
+            ).toEqual(['comma_join']);
+        });
+
+        it('does not mistake a comma in the SELECT list for a comma join', () => {
+            expect(kinds('SELECT a, b FROM jaffle.orders')).toEqual([]);
+        });
+
+        it('does not mistake a comma inside a function call for a comma join', () => {
+            expect(
+                kinds('SELECT COALESCE(a, b) FROM jaffle.orders WHERE x = 1'),
+            ).toEqual([]);
+        });
+    });
+
+    describe('subqueries and table functions', () => {
+        it('allows a subquery whose source is in scope', () => {
+            expect(
+                kinds('SELECT * FROM (SELECT * FROM jaffle.orders) t'),
+            ).toEqual([]);
+        });
+
+        it('blocks a subquery hiding a source outside the scope', () => {
+            expect(
+                kinds('SELECT * FROM (SELECT * FROM other.orders) t'),
+            ).toEqual(['schema']);
+        });
+
+        it('blocks a source outside the scope inside a WHERE subquery', () => {
+            expect(
+                kinds(
+                    'SELECT * FROM jaffle.orders WHERE id IN (SELECT id FROM other.z)',
+                ),
+            ).toEqual(['schema']);
+        });
+
+        it('allows a table function', () => {
+            expect(kinds('SELECT * FROM generate_series(1, 10)')).toEqual([]);
+        });
+
+        it('allows UNNEST', () => {
+            expect(kinds('SELECT * FROM UNNEST(ARRAY[1, 2])')).toEqual([]);
+        });
+    });
+
+    describe('comments and string literals', () => {
+        it('ignores a schema named in a line comment', () => {
+            expect(
+                kinds(
+                    '-- do not use jaffle_old.x\nSELECT * FROM jaffle.orders',
+                ),
+            ).toEqual([]);
+        });
+
+        it('ignores a schema named in a block comment', () => {
+            expect(
+                kinds(
+                    '/* jaffle_old.x is retired */ SELECT * FROM jaffle.orders',
+                ),
+            ).toEqual([]);
+        });
+
+        it('ignores a schema named in a string literal', () => {
+            expect(
+                kinds(
+                    "SELECT * FROM jaffle.orders WHERE note = 'jaffle_old.x'",
+                ),
+            ).toEqual([]);
+        });
+    });
+
+    describe('multiple violations', () => {
+        it('reports every offending reference', () => {
+            expect(
+                kinds('SELECT * FROM old_a.t1 JOIN old_b.t2 ON t1.id = t2.id'),
+            ).toEqual(['schema', 'schema']);
+        });
+    });
+});
+
+describe('isSchemaInScope', () => {
+    it('allows any schema when no scope is configured', () => {
+        expect(isSchemaInScope({ schemas: [] }, 'anything')).toBe(true);
+    });
+
+    it('allows a schema in the scope', () => {
+        expect(isSchemaInScope(scope, 'jaffle')).toBe(true);
+    });
+
+    it('rejects a schema outside the scope', () => {
+        expect(isSchemaInScope(scope, 'jaffle_old')).toBe(false);
+    });
+
+    it('matches case-insensitively', () => {
+        expect(isSchemaInScope(scope, 'JAFFLE')).toBe(true);
+    });
+
+    it('rejects a catalog outside the scope', () => {
+        expect(isSchemaInScope(catalogScope, 'jaffle', 'legacy')).toBe(false);
+    });
+
+    it('allows an in-scope catalog and schema', () => {
+        expect(isSchemaInScope(catalogScope, 'jaffle', 'prod')).toBe(true);
+    });
+
+    it('ignores the catalog when no catalogs are configured', () => {
+        expect(isSchemaInScope(scope, 'jaffle', 'anything')).toBe(true);
+    });
+});
+
+describe('formatSqlScopeError', () => {
+    it('names the offending schema and the allowed schemas', () => {
+        const message = formatSqlScopeError(
+            findSqlScopeViolations('SELECT * FROM jaffle_old.x', scope),
+            scope,
+        );
+        expect(message).toContain('jaffle_old');
+        expect(message).toContain('Allowed schemas: jaffle');
+    });
+
+    it('tells the agent not to retry or silently substitute a table', () => {
+        const message = formatSqlScopeError(
+            findSqlScopeViolations('SELECT * FROM jaffle_old.x', scope),
+            scope,
+        );
+        expect(message).toContain('Do NOT retry');
+        expect(message).toContain('do NOT substitute');
+    });
+
+    it('explains how to fix an unqualified reference', () => {
+        const message = formatSqlScopeError(
+            findSqlScopeViolations('SELECT * FROM orders', scope),
+            scope,
+        );
+        expect(message).toContain('not schema-qualified');
+    });
+
+    it('explains how to fix a catalog-unqualified reference', () => {
+        const message = formatSqlScopeError(
+            findSqlScopeViolations('SELECT * FROM jaffle.orders', catalogScope),
+            catalogScope,
+        );
+        expect(message).toContain('catalog.schema.table');
+        expect(message).toContain('Allowed catalogs: prod');
+    });
+
+    it('explains how to fix a comma join', () => {
+        const message = formatSqlScopeError(
+            findSqlScopeViolations('SELECT * FROM jaffle.a, jaffle.b', scope),
+            scope,
+        );
+        expect(message).toContain('explicit JOIN');
+    });
+});
+
+describe('filterWarehouseCatalogToScope', () => {
+    const catalog = {
+        prod: {
+            jaffle: { orders: {}, customers: {} },
+            jaffle_old: { stale_orders: {} },
+        },
+        legacy: {
+            jaffle: { ancient_orders: {} },
+        },
+    };
+
+    it('returns the catalog untouched when no scope is configured', () => {
+        expect(filterWarehouseCatalogToScope(catalog, { schemas: [] })).toEqual(
+            catalog,
+        );
+    });
+
+    it('drops schemas outside the scope', () => {
+        expect(
+            filterWarehouseCatalogToScope(catalog, { schemas: ['jaffle'] }),
+        ).toEqual({
+            prod: { jaffle: { orders: {}, customers: {} } },
+            legacy: { jaffle: { ancient_orders: {} } },
+        });
+    });
+
+    it('drops catalogs outside the scope', () => {
+        expect(
+            filterWarehouseCatalogToScope(catalog, {
+                schemas: ['jaffle'],
+                catalogs: ['prod'],
+            }),
+        ).toEqual({ prod: { jaffle: { orders: {}, customers: {} } } });
+    });
+
+    it('omits a database whose every schema was filtered out', () => {
+        expect(
+            filterWarehouseCatalogToScope(catalog, { schemas: ['jaffle_old'] }),
+        ).toEqual({ prod: { jaffle_old: { stale_orders: {} } } });
+    });
+
+    it('matches schema and catalog names case-insensitively', () => {
+        expect(
+            filterWarehouseCatalogToScope(catalog, {
+                schemas: ['JAFFLE'],
+                catalogs: ['PROD'],
+            }),
+        ).toEqual({ prod: { jaffle: { orders: {}, customers: {} } } });
+    });
+
+    it('returns an empty catalog when nothing is in scope', () => {
+        expect(
+            filterWarehouseCatalogToScope(catalog, {
+                schemas: ['nonexistent'],
+            }),
+        ).toEqual({});
+    });
+});
+
+describe('denied schemas and catalogs', () => {
+    const denyOnly: SqlScope = { schemas: [], deniedSchemas: ['jaffle_old'] };
+
+    it('treats a deny-only scope as configured', () => {
+        expect(kinds('SELECT * FROM jaffle_old.x', denyOnly)).toEqual([
+            'denied_schema',
+        ]);
+    });
+
+    it('allows any other schema under a deny-only scope', () => {
+        expect(kinds('SELECT * FROM anything.x', denyOnly)).toEqual([]);
+    });
+
+    it('still requires qualification under a deny-only scope', () => {
+        expect(kinds('SELECT * FROM orders', denyOnly)).toEqual([
+            'unqualified',
+        ]);
+    });
+
+    it('lets a denied schema override the allow list', () => {
+        expect(
+            kinds('SELECT * FROM jaffle.x', {
+                schemas: ['jaffle'],
+                deniedSchemas: ['jaffle'],
+            }),
+        ).toEqual(['denied_schema']);
+    });
+
+    it('denies a catalog regardless of the schema', () => {
+        expect(
+            kinds('SELECT * FROM legacy.jaffle.x', {
+                schemas: [],
+                deniedCatalogs: ['legacy'],
+            }),
+        ).toEqual(['denied_catalog']);
+    });
+
+    it('matches denied names case-insensitively', () => {
+        expect(kinds('SELECT * FROM JAFFLE_OLD.x', denyOnly)).toEqual([
+            'denied_schema',
+        ]);
+    });
+
+    it('reports the denied schema by name', () => {
+        const [violation] = findSqlScopeViolations(
+            'SELECT * FROM jaffle_old.x',
+            denyOnly,
+        );
+        expect(violation).toEqual({
+            kind: 'denied_schema',
+            reference: 'jaffle_old.x',
+            schema: 'jaffle_old',
+        });
+    });
+});
+
+describe('isSchemaInScope with deny lists', () => {
+    it('rejects a denied schema even when the allow list is empty', () => {
+        expect(
+            isSchemaInScope({ schemas: [], deniedSchemas: ['old'] }, 'old'),
+        ).toBe(false);
+    });
+
+    it('allows a schema that is neither allowed-listed nor denied', () => {
+        expect(
+            isSchemaInScope({ schemas: [], deniedSchemas: ['old'] }, 'new'),
+        ).toBe(true);
+    });
+
+    it('rejects a denied catalog', () => {
+        expect(
+            isSchemaInScope(
+                { schemas: [], deniedCatalogs: ['legacy'] },
+                'jaffle',
+                'legacy',
+            ),
+        ).toBe(false);
+    });
+});
+
+describe('filterWarehouseCatalogToScope with deny lists', () => {
+    const catalog = {
+        prod: { jaffle: { orders: {} }, jaffle_old: { stale: {} } },
+        legacy: { jaffle: { ancient: {} } },
+    };
+
+    it('drops only the denied schema, keeping everything else', () => {
+        expect(
+            filterWarehouseCatalogToScope(catalog, {
+                schemas: [],
+                deniedSchemas: ['jaffle_old'],
+            }),
+        ).toEqual({
+            prod: { jaffle: { orders: {} } },
+            legacy: { jaffle: { ancient: {} } },
+        });
+    });
+
+    it('drops a denied catalog entirely', () => {
+        expect(
+            filterWarehouseCatalogToScope(catalog, {
+                schemas: [],
+                deniedCatalogs: ['legacy'],
+            }),
+        ).toEqual({
+            prod: { jaffle: { orders: {} }, jaffle_old: { stale: {} } },
+        });
+    });
+});
+
+describe('formatSqlScopeError with deny lists', () => {
+    it('says the schema is excluded rather than not-allowed', () => {
+        const scopeWithDeny: SqlScope = {
+            schemas: [],
+            deniedSchemas: ['jaffle_old'],
+        };
+        const message = formatSqlScopeError(
+            findSqlScopeViolations('SELECT * FROM jaffle_old.x', scopeWithDeny),
+            scopeWithDeny,
+        );
+        expect(message).toContain('excluded');
+        expect(message).toContain('jaffle_old');
+    });
+
+    it('does not claim an allow list when there is none', () => {
+        const scopeWithDeny: SqlScope = {
+            schemas: [],
+            deniedSchemas: ['jaffle_old'],
+        };
+        const message = formatSqlScopeError(
+            findSqlScopeViolations('SELECT * FROM jaffle_old.x', scopeWithDeny),
+            scopeWithDeny,
+        );
+        expect(message).not.toContain('Allowed schemas:');
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/sqlScope.ts
+++ b/packages/backend/src/ee/services/ai/utils/sqlScope.ts
@@ -1,0 +1,299 @@
+/**
+ * Restricts which part of the warehouse the AI agent may read.
+ *
+ * This is a correctness control, not a security boundary. `runSql` already
+ * requires the prompting user to hold `manage SqlRunner`, so anything the
+ * agent can reach the user can reach through the SQL Runner anyway — a gap
+ * here grants nobody anything they did not already have. What it buys is
+ * keeping the agent off schemas the customer knows are wrong to answer from
+ * (a retired dbt project, another team's models, a raw landing zone).
+ *
+ * Enforcement is lexical rather than a full parse, because a real parser
+ * would need to cover nine warehouse dialects. The rules below are chosen so
+ * that anything the lexer cannot confidently classify is rejected rather than
+ * allowed.
+ */
+
+import {
+    assertUnreachable,
+    type AgentSqlScope,
+    type WarehouseTablesCatalog,
+} from '@lightdash/common';
+
+// Comments and single-quoted literals are blanked before any analysis, so a
+// schema merely *named* in a comment or a string can't trip the guard. Kept
+// byte-identical to the equivalent in runSql.ts.
+const SQL_COMMENTS_AND_STRINGS = /--[^\n]*|\/\*[\s\S]*?\*\/|'(?:[^']|'')*'/g;
+
+// Identifiers that may legitimately follow FROM/JOIN without naming a table.
+const NON_TABLE_KEYWORDS = new Set([
+    'lateral',
+    'unnest',
+    'only',
+    'table',
+    'values',
+]);
+
+// `<name> AS (` — CTE definitions. Also matches WINDOW definitions, which is
+// harmless: a window name is never used as a table reference.
+const CTE_DEFINITION = /\b([a-zA-Z_][\w$]*)\s+AS\s*\(/gi;
+
+// FROM/JOIN followed by an identifier chain. The trailing `(` capture
+// distinguishes a table function (`FROM generate_series(...)`) from a table.
+const TABLE_REFERENCE = /\b(FROM|JOIN)\s+(?:ONLY\s+)?([\w$."`[\]]+)\s*(\()?/gi;
+
+// Keywords that end the FROM clause's table list.
+const FROM_CLAUSE_TERMINATOR =
+    /^(WHERE|GROUP|ORDER|HAVING|LIMIT|WINDOW|QUALIFY|UNION|INTERSECT|EXCEPT|JOIN|LEFT|RIGHT|INNER|FULL|CROSS|ON|USING)$/i;
+
+// Alias of the shared project-level type so the guard and the stored config
+// can never drift apart.
+export type SqlScope = AgentSqlScope;
+
+export type SqlScopeViolation =
+    | { kind: 'unqualified'; reference: string }
+    | { kind: 'catalog_unqualified'; reference: string }
+    | { kind: 'comma_join'; reference: string }
+    | { kind: 'unparseable'; reference: string }
+    | { kind: 'schema'; reference: string; schema: string }
+    | { kind: 'catalog'; reference: string; catalog: string }
+    | { kind: 'denied_schema'; reference: string; schema: string }
+    | { kind: 'denied_catalog'; reference: string; catalog: string };
+
+const unquote = (part: string) =>
+    part.replace(/^["`[]|["`\]]$/g, '').toLowerCase();
+
+const lowerSet = (values: string[] | undefined) =>
+    values?.length ? new Set(values.map((v) => v.toLowerCase())) : null;
+
+export const isSqlScopeConfigured = (scope: SqlScope | null | undefined) =>
+    !!scope &&
+    (scope.schemas.length > 0 ||
+        !!scope.catalogs?.length ||
+        !!scope.deniedSchemas?.length ||
+        !!scope.deniedCatalogs?.length);
+
+/**
+ * Whether a schema (optionally in a given catalog) is readable by the agent.
+ * Used by the discovery tools, which know the schema directly and so need no
+ * lexical analysis.
+ */
+export const isSchemaInScope = (
+    scope: SqlScope | null | undefined,
+    schema: string,
+    catalog?: string,
+): boolean => {
+    if (!isSqlScopeConfigured(scope)) return true;
+
+    // Denials win over the allow list, so an operator can allow a broad set and
+    // carve one schema out of it without restating everything else.
+    const deniedSchemas = lowerSet(scope!.deniedSchemas);
+    if (deniedSchemas?.has(schema.toLowerCase())) return false;
+
+    const deniedCatalogs = lowerSet(scope!.deniedCatalogs);
+    if (catalog !== undefined && deniedCatalogs?.has(catalog.toLowerCase()))
+        return false;
+
+    const catalogs = lowerSet(scope!.catalogs);
+    if (
+        catalog !== undefined &&
+        catalogs &&
+        !catalogs.has(catalog.toLowerCase())
+    )
+        return false;
+
+    // An empty allow list means "everything not denied".
+    const allowedSchemas = lowerSet(scope!.schemas);
+    if (!allowedSchemas) return true;
+    return allowedSchemas.has(schema.toLowerCase());
+};
+
+/**
+ * Removes everything the agent may not read from the warehouse catalog it is
+ * shown. Out-of-scope objects must be undiscoverable, not merely unqueryable:
+ * if the agent can see a retired schema it will propose tables from it, and
+ * the user will see them named in the conversation before anything is blocked.
+ */
+export const filterWarehouseCatalogToScope = (
+    catalog: WarehouseTablesCatalog,
+    scope: SqlScope | null | undefined,
+): WarehouseTablesCatalog => {
+    if (!isSqlScopeConfigured(scope)) return catalog;
+
+    return Object.entries(catalog).reduce<WarehouseTablesCatalog>(
+        (acc, [database, schemas]) => {
+            const allowed = Object.entries(schemas).filter(([schema]) =>
+                isSchemaInScope(scope, schema, database),
+            );
+            if (allowed.length > 0) {
+                acc[database] = Object.fromEntries(allowed);
+            }
+            return acc;
+        },
+        {},
+    );
+};
+
+/**
+ * A comma at paren-depth zero inside a FROM clause is a legacy implicit join.
+ * We reject rather than resolve it: the operands after the comma are easy to
+ * miss lexically, so failing closed is the safe posture. Explicit JOIN is what
+ * the system prompt asks the agent for anyway.
+ */
+const hasTopLevelCommaInFromClause = (
+    sql: string,
+    startIndex: number,
+): boolean => {
+    let depth = 0;
+    let word = '';
+
+    for (let i = startIndex; i < sql.length; i += 1) {
+        const ch = sql[i];
+
+        if (/[\w$]/.test(ch)) {
+            word += ch;
+        } else {
+            if (depth === 0 && word && FROM_CLAUSE_TERMINATOR.test(word))
+                return false;
+            word = '';
+
+            if (ch === '(') depth += 1;
+            else if (ch === ')') {
+                // Closing the subquery that contains this FROM — clause is over.
+                if (depth === 0) return false;
+                depth -= 1;
+            } else if (ch === ';') return false;
+            else if (ch === ',' && depth === 0) return true;
+        }
+    }
+
+    return false;
+};
+
+export const findSqlScopeViolations = (
+    sql: string,
+    scope: SqlScope | null | undefined,
+): SqlScopeViolation[] => {
+    if (!isSqlScopeConfigured(scope)) return [];
+
+    const stripped = sql.replace(SQL_COMMENTS_AND_STRINGS, ' ');
+
+    const cteNames = new Set(
+        [...stripped.matchAll(CTE_DEFINITION)].map((m) => m[1].toLowerCase()),
+    );
+    const allowedSchemas = lowerSet(scope!.schemas);
+    const allowedCatalogs = lowerSet(scope!.catalogs);
+    const deniedSchemas = lowerSet(scope!.deniedSchemas);
+    const deniedCatalogs = lowerSet(scope!.deniedCatalogs);
+
+    const classifySchema = (
+        reference: string,
+        schema: string,
+    ): SqlScopeViolation | null => {
+        if (deniedSchemas?.has(schema))
+            return { kind: 'denied_schema', reference, schema };
+        if (allowedSchemas && !allowedSchemas.has(schema))
+            return { kind: 'schema', reference, schema };
+        return null;
+    };
+
+    const classify = (match: RegExpMatchArray): SqlScopeViolation | null => {
+        const [full, keyword, reference, isFunctionCall] = match;
+        if (isFunctionCall) return null;
+
+        if (
+            keyword.toUpperCase() === 'FROM' &&
+            hasTopLevelCommaInFromClause(
+                stripped,
+                (match.index ?? 0) + full.length,
+            )
+        ) {
+            return { kind: 'comma_join', reference };
+        }
+
+        const parts = reference
+            .split('.')
+            .filter((p) => p !== '')
+            .map(unquote);
+
+        if (parts.length === 1) {
+            const [name] = parts;
+            if (cteNames.has(name) || NON_TABLE_KEYWORDS.has(name)) return null;
+            return { kind: 'unqualified', reference };
+        }
+        if (parts.length === 2) {
+            const [schema] = parts;
+            const schemaViolation = classifySchema(reference, schema);
+            if (schemaViolation) return schemaViolation;
+            // A two-part reference runs in the connection's default catalog,
+            // which the lexer cannot know — under a catalog allow list that
+            // makes it unclassifiable, so it is rejected rather than allowed.
+            // Denied catalogs don't force qualification: they name specific
+            // catalogs to avoid, not a claim about what the default is.
+            if (allowedCatalogs) {
+                return { kind: 'catalog_unqualified', reference };
+            }
+            return null;
+        }
+        if (parts.length === 3) {
+            const [catalog, schema] = parts;
+            if (deniedCatalogs?.has(catalog)) {
+                return { kind: 'denied_catalog', reference, catalog };
+            }
+            if (allowedCatalogs && !allowedCatalogs.has(catalog)) {
+                return { kind: 'catalog', reference, catalog };
+            }
+            return classifySchema(reference, schema);
+        }
+        return { kind: 'unparseable', reference };
+    };
+
+    return [...stripped.matchAll(TABLE_REFERENCE)]
+        .map(classify)
+        .filter((v): v is SqlScopeViolation => v !== null);
+};
+
+const describeViolation = (violation: SqlScopeViolation): string => {
+    switch (violation.kind) {
+        case 'schema':
+            return `- \`${violation.reference}\` reads from schema \`${violation.schema}\`, which is not in scope.`;
+        case 'catalog':
+            return `- \`${violation.reference}\` reads from catalog \`${violation.catalog}\`, which is not in scope.`;
+        case 'denied_schema':
+            return `- \`${violation.reference}\` reads from schema \`${violation.schema}\`, which is explicitly excluded from this project's agent scope.`;
+        case 'denied_catalog':
+            return `- \`${violation.reference}\` reads from catalog \`${violation.catalog}\`, which is explicitly excluded from this project's agent scope.`;
+        case 'unqualified':
+            return `- \`${violation.reference}\` is not schema-qualified. Qualify every table with its schema.`;
+        case 'catalog_unqualified':
+            return `- \`${violation.reference}\` does not name a catalog, and this project's agent scope allows only specific catalogs. Qualify every table as catalog.schema.table.`;
+        case 'comma_join':
+            return `- \`${violation.reference}\` uses comma-join syntax. Use explicit JOIN instead.`;
+        case 'unparseable':
+            return `- \`${violation.reference}\` could not be resolved to a schema-qualified table.`;
+        default:
+            return assertUnreachable(violation, 'Unknown SQL scope violation');
+    }
+};
+
+export const formatSqlScopeError = (
+    violations: SqlScopeViolation[],
+    scope: SqlScope,
+): string =>
+    [
+        "This query was blocked because it reads outside this project's allowed data scope.",
+        ...violations.map(describeViolation),
+        ...(scope.schemas.length
+            ? [`Allowed schemas: ${scope.schemas.join(', ')}.`]
+            : []),
+        ...(scope.catalogs?.length
+            ? [`Allowed catalogs: ${scope.catalogs.join(', ')}.`]
+            : []),
+        ...(scope.deniedSchemas?.length
+            ? [`Excluded schemas: ${scope.deniedSchemas.join(', ')}.`]
+            : []),
+        ...(scope.deniedCatalogs?.length
+            ? [`Excluded catalogs: ${scope.deniedCatalogs.join(', ')}.`]
+            : []),
+        'Rewrite the query against an allowed schema. Do NOT retry this query, and do NOT substitute a different table without telling the user — if the data you need is not in an allowed schema, say so plainly.',
+    ].join('\n');

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -134,6 +134,11 @@ import type { INatsClient } from '../../clients/NatsClient';
 import { createLocalParquetUploadStream } from '../../clients/ResultsFileStorageClients/LocalParquetUploadStream';
 import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import type { DbProjectParameter } from '../../database/entities/projectParameters';
+import { isAgentScopedQueryContext } from '../../ee/services/ai/utils/scopedSqlContexts';
+import {
+    findSqlScopeViolations,
+    formatSqlScopeError,
+} from '../../ee/services/ai/utils/sqlScope';
 import { getDuckdbRuntimeConfig } from '../../ee/services/AsyncQueryService/getDuckdbRuntimeConfig';
 import Logger from '../../logging/logger';
 import { measureTime } from '../../logging/measureTime';
@@ -6046,6 +6051,27 @@ export class AsyncQueryService extends ProjectService {
         ) {
             throw new ForbiddenError();
         }
+
+        // Agent-run SQL is additionally constrained to the project's agent SQL
+        // scope. Both the AI agent and the MCP run_sql tool land here, so this
+        // is the one place a new agent SQL path cannot bypass. The human SQL
+        // Runner is deliberately not scoped.
+        if (isAgentScopedQueryContext(context)) {
+            const sqlScope =
+                await this.projectModel.getAgentSqlScope(projectUuid);
+            const violations = findSqlScopeViolations(sql, sqlScope);
+            if (violations.length > 0 && sqlScope) {
+                this.logger.warn('Blocked out-of-scope agent SQL', {
+                    projectUuid,
+                    context,
+                    references: violations.map((v) => v.reference),
+                });
+                throw new ForbiddenError(
+                    formatSqlScopeError(violations, sqlScope),
+                );
+            }
+        }
+
         // Combine default parameter values with request parameters first
         const combinedParameters = await this.combineParameters(
             projectUuid,


### PR DESCRIPTION
Part 2 of 3 splitting #26844 (stacked on #27015).

Adds the lexical SQL scope guard — allow/deny lists for schemas and catalogs, fail-closed on unqualified or unparseable references, catalog qualification required under a catalog allow list — and applies it in the runSql tool and system prompts, filters the discovery catalog so out-of-scope objects are undiscoverable, and enforces the scope at the shared AsyncQueryService chokepoint every agent SQL path passes through.

Carries the resolution of the Graphite thread from #26844: the catalog allow-list bypass via two-part references is closed by requiring `catalog.schema.table` qualification, rather than forbidding catalogs-without-schemas (which wouldn't have closed the gap).

Linear: PROD-9479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHhBNPi5J7Yq8fkpgGAXzz