### PR TITLE
feat: add agent data scope project settings page (PROD-9479)

### DIFF
--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -15,6 +15,7 @@ import {
     useRoutes,
     type RouteObject,
 } from 'react-router';
+import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 import SettingsEmbed from '../../ee/features/embed/SettingsEmbed';
 import PullRequestsPage from '../../features/pullRequests/components/PullRequestsPage';
 import RecentlyDeletedPage from '../../features/recentlyDeleted/components/RecentlyDeletedPage';
@@ -44,6 +45,7 @@ import { UpdateProjectConnection } from '../ProjectConnection';
 import ProjectParameters from '../ProjectParameters';
 import ProjectPreviewExpiration from '../ProjectPreviewExpiration';
 import ProjectTablesConfiguration from '../ProjectTablesConfiguration/ProjectTablesConfiguration';
+import SettingsAgentDataScope from '../SettingsAgentDataScope';
 import SettingsQueryTimezone from '../SettingsQueryTimezone';
 import SettingsScheduler from '../SettingsScheduler';
 import SettingsUsageAnalytics from '../SettingsUsageAnalytics';
@@ -82,6 +84,11 @@ const ProjectSettings: FC = () => {
     const { data: organization } = useOrganization();
 
     const isSoftDeleteEnabled = health.data?.softDelete?.enabled ?? false;
+    const aiOrganizationSettingsQuery = useAiOrganizationSettings();
+    const isAiCopilotEnabledOrTrial =
+        aiOrganizationSettingsQuery.isSuccess &&
+        (aiOrganizationSettingsQuery.data.isCopilotEnabled ||
+            aiOrganizationSettingsQuery.data.isTrial);
     const isPgWireEnabled = organization?.pgWire?.enabled ?? false;
     // Only relevant when the project's code lives in a Git provider, since the
     // section lists PRs opened against that repo.
@@ -247,6 +254,25 @@ const ProjectSettings: FC = () => {
                     </ProjectSettingsPage>
                 ),
             },
+            // Only registered when the instance has AI agents at all — same
+            // gate as the AI agents navigation section.
+            ...(isAiCopilotEnabledOrTrial
+                ? [
+                      {
+                          path: `/agentDataScope`,
+                          element: (
+                              <ProjectSettingsPage
+                                  title="Agent data scope"
+                                  description="Limit which schemas an AI agent can read when it writes raw SQL."
+                              >
+                                  <SettingsAgentDataScope
+                                      projectUuid={projectUuid}
+                                  />
+                              </ProjectSettingsPage>
+                          ),
+                      },
+                  ]
+                : []),
             {
                 path: `/queryTimezone`,
                 element: (
@@ -408,6 +434,7 @@ const ProjectSettings: FC = () => {
         isGitProject,
         user.data?.ability,
         canManageExternalConnections,
+        isAiCopilotEnabledOrTrial,
     ]);
     const routesElements = useRoutes(routes);
 

--- a/packages/frontend/src/components/SettingsAgentDataScope/SettingsAgentDataScope.module.css
+++ b/packages/frontend/src/components/SettingsAgentDataScope/SettingsAgentDataScope.module.css
@@ -1,0 +1,3 @@
+.compactInput {
+    padding-block: var(--mantine-spacing-xxs) !important;
+}

--- a/packages/frontend/src/components/SettingsAgentDataScope/index.tsx
+++ b/packages/frontend/src/components/SettingsAgentDataScope/index.tsx
@@ -1,0 +1,311 @@
+import { getErrorMessage, isApiError } from '@lightdash/common';
+import {
+    Button,
+    Group,
+    LoadingOverlay,
+    MultiSelect,
+    type MultiSelectProps,
+    Paper,
+    Stack,
+    Text,
+    Title,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { IconLock } from '@tabler/icons-react';
+import isEqual from 'lodash/isEqual';
+import { useCallback, useMemo, type FC } from 'react';
+import { useTables } from '../../features/sqlRunner/hooks/useTables';
+import useToaster from '../../hooks/toaster/useToaster';
+import {
+    useAgentSqlScope,
+    useProjectUpdateAgentSqlScope,
+} from '../../hooks/useProject';
+import Callout from '../common/Callout';
+import MantineIcon from '../common/MantineIcon';
+import { SettingsCard } from '../common/Settings/SettingsCard';
+import classes from './SettingsAgentDataScope.module.css';
+
+type SettingsAgentDataScopeProps = {
+    projectUuid: string;
+};
+
+type AgentDataScopeFormValues = {
+    schemas: string[];
+    catalogs: string[];
+    deniedSchemas: string[];
+    deniedCatalogs: string[];
+};
+
+const sorted = (values: Iterable<string>) => [...new Set(values)].sort();
+
+const compactMultiSelectClassNames: MultiSelectProps['classNames'] = {
+    input: classes.compactInput,
+};
+
+const AgentDataScopeForm: FC<{
+    isLoading: boolean;
+    initialValues: AgentDataScopeFormValues;
+    schemaOptions: string[];
+    catalogOptions: string[];
+    onSubmit: (values: AgentDataScopeFormValues) => void;
+}> = ({
+    isLoading,
+    initialValues,
+    schemaOptions,
+    catalogOptions,
+    onSubmit,
+}) => {
+    const form = useForm<AgentDataScopeFormValues>({ initialValues });
+
+    const hasChanged = (
+        ['schemas', 'catalogs', 'deniedSchemas', 'deniedCatalogs'] as const
+    ).some((key) => !isEqual(sorted(form.values[key]), initialValues[key]));
+
+    // An empty schema list is the "no restriction" default, and a catalog
+    // restriction on its own would be meaningless, so the catalog picker only
+    // opens once at least one schema is chosen.
+    const catalogsDisabled = form.values.schemas.length === 0;
+
+    return (
+        <form onSubmit={form.onSubmit(onSubmit)}>
+            <Stack gap="md">
+                <MultiSelect
+                    variant="subtle"
+                    size="xs"
+                    classNames={compactMultiSelectClassNames}
+                    label="Allowed schemas"
+                    description="The agent can only read from these. Empty means no restriction."
+                    placeholder={
+                        form.values.schemas.length === 0
+                            ? 'All schemas (no restriction)'
+                            : undefined
+                    }
+                    data={schemaOptions}
+                    searchable
+                    clearable
+                    {...form.getInputProps('schemas')}
+                />
+
+                <MultiSelect
+                    variant="subtle"
+                    size="xs"
+                    classNames={compactMultiSelectClassNames}
+                    label="Allowed catalogs"
+                    description="Optional. Restricts which catalogs/databases the schemas above may be read from."
+                    placeholder={
+                        form.values.catalogs.length === 0
+                            ? 'Any catalog'
+                            : undefined
+                    }
+                    data={catalogOptions}
+                    disabled={catalogsDisabled}
+                    searchable
+                    clearable
+                    {...form.getInputProps('catalogs')}
+                />
+
+                <MultiSelect
+                    variant="subtle"
+                    size="xs"
+                    classNames={compactMultiSelectClassNames}
+                    label="Excluded schemas"
+                    description="The agent can never read these, even if the allow list above would permit them."
+                    placeholder={
+                        form.values.deniedSchemas.length === 0
+                            ? 'Nothing excluded'
+                            : undefined
+                    }
+                    data={schemaOptions}
+                    searchable
+                    clearable
+                    {...form.getInputProps('deniedSchemas')}
+                />
+
+                <MultiSelect
+                    variant="subtle"
+                    size="xs"
+                    classNames={compactMultiSelectClassNames}
+                    label="Excluded catalogs"
+                    description="Optional. The agent can never read these catalogs/databases."
+                    placeholder={
+                        form.values.deniedCatalogs.length === 0
+                            ? 'Nothing excluded'
+                            : undefined
+                    }
+                    data={catalogOptions}
+                    searchable
+                    clearable
+                    {...form.getInputProps('deniedCatalogs')}
+                />
+            </Stack>
+
+            <Group justify="flex-end" gap="xs" mt="md">
+                <Button
+                    type="button"
+                    variant="default"
+                    size="xs"
+                    disabled={!hasChanged || isLoading}
+                    onClick={() => form.reset()}
+                >
+                    Cancel
+                </Button>
+                <Button
+                    type="submit"
+                    size="xs"
+                    disabled={!hasChanged}
+                    loading={isLoading}
+                >
+                    Save changes
+                </Button>
+            </Group>
+        </form>
+    );
+};
+
+const SettingsAgentDataScope: FC<SettingsAgentDataScopeProps> = ({
+    projectUuid,
+}) => {
+    const { showToastError, showToastSuccess } = useToaster();
+    const { data: scope, isInitialLoading: isLoadingScope } =
+        useAgentSqlScope(projectUuid);
+    // The catalog is the source of truth for what exists, so admins pick real
+    // schemas rather than typing names that silently match nothing.
+    const { data: catalog, isInitialLoading: isLoadingCatalog } = useTables({
+        projectUuid,
+    });
+    const mutation = useProjectUpdateAgentSqlScope(projectUuid);
+
+    const isLoading = isLoadingScope || isLoadingCatalog;
+
+    const initialValues = useMemo<AgentDataScopeFormValues>(
+        () => ({
+            schemas: sorted(scope?.schemas ?? []),
+            catalogs: sorted(scope?.catalogs ?? []),
+            deniedSchemas: sorted(scope?.deniedSchemas ?? []),
+            deniedCatalogs: sorted(scope?.deniedCatalogs ?? []),
+        }),
+        [scope],
+    );
+
+    const { schemaOptions, catalogOptions } = useMemo(() => {
+        const databases = Object.keys(catalog ?? {});
+        const schemaNames = new Set<string>();
+        Object.values(catalog ?? {}).forEach((db) => {
+            Object.keys(db).forEach((schema) => schemaNames.add(schema));
+        });
+        // Keep any saved value that no longer exists in the warehouse visible,
+        // otherwise editing an unrelated field would silently drop it.
+        return {
+            schemaOptions: sorted([
+                ...schemaNames,
+                ...initialValues.schemas,
+                ...initialValues.deniedSchemas,
+            ]),
+            catalogOptions: sorted([
+                ...databases,
+                ...initialValues.catalogs,
+                ...initialValues.deniedCatalogs,
+            ]),
+        };
+    }, [catalog, initialValues]);
+
+    const handleSubmit = useCallback(
+        async (values: AgentDataScopeFormValues) => {
+            try {
+                const isEmpty = (
+                    [
+                        'schemas',
+                        'catalogs',
+                        'deniedSchemas',
+                        'deniedCatalogs',
+                    ] as const
+                ).every((key) => values[key].length === 0);
+
+                await mutation.mutateAsync({
+                    agentSqlScope: isEmpty
+                        ? null
+                        : {
+                              schemas: sorted(values.schemas),
+                              catalogs: sorted(values.catalogs),
+                              deniedSchemas: sorted(values.deniedSchemas),
+                              deniedCatalogs: sorted(values.deniedCatalogs),
+                          },
+                });
+                showToastSuccess({
+                    title: `Successfully updated the agent's data scope`,
+                });
+            } catch (e) {
+                showToastError({
+                    title: `Failed to update the agent's data scope`,
+                    subtitle: isApiError(e)
+                        ? e.error.message
+                        : getErrorMessage(e),
+                });
+            }
+        },
+        [mutation, showToastError, showToastSuccess],
+    );
+
+    return (
+        <SettingsCard p="xl" pos="relative">
+            <LoadingOverlay visible={isLoading} />
+
+            <Stack gap="lg">
+                <Group align="flex-start" gap="xs" wrap="nowrap">
+                    <Paper p="xxs" withBorder radius="sm">
+                        <MantineIcon icon={IconLock} size="md" />
+                    </Paper>
+                    <Stack gap={2}>
+                        <Title order={5} c="ldGray.9" fw={700}>
+                            Warehouse access
+                        </Title>
+                        <Text size="xs" c="dimmed">
+                            Control which warehouse schemas and catalogs AI
+                            agents can query with SQL.
+                        </Text>
+                    </Stack>
+                </Group>
+
+                <Callout
+                    variant="info"
+                    color="gray"
+                    title="How agent data scope works"
+                >
+                    <Text fz="xs">
+                        Leave every field empty to let AI agents query the
+                        entire warehouse connection.
+                    </Text>
+                    <Text fz="xs" mt="xs">
+                        Use exclusions to block known schemas or catalogs. Use
+                        allow lists when agents should query only an approved
+                        set; newly added schemas are not included automatically.
+                    </Text>
+                    <Text fz="xs" mt="xs">
+                        Agents query the semantic layer by default; direct SQL
+                        requires approval for every query and is available only
+                        to users with SQL Runner access. These rules apply to AI
+                        agents only. They do not change warehouse permissions or
+                        restrict SQL Runner users. Use warehouse grants to
+                        enforce security.
+                    </Text>
+                </Callout>
+
+                {!isLoading && (
+                    // Remounting when the saved scope changes resets the form to
+                    // it — the React-recommended way to reset state on new data,
+                    // rather than syncing state in an effect.
+                    <AgentDataScopeForm
+                        key={JSON.stringify(initialValues)}
+                        isLoading={mutation.isLoading}
+                        initialValues={initialValues}
+                        schemaOptions={schemaOptions}
+                        catalogOptions={catalogOptions}
+                        onSubmit={handleSubmit}
+                    />
+                )}
+            </Stack>
+        </SettingsCard>
+    );
+};
+
+export default SettingsAgentDataScope;

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -44,6 +44,7 @@ import {
     IconUsers,
 } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, useState } from 'react';
+import { Link } from 'react-router';
 import { z } from 'zod';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
@@ -690,30 +691,43 @@ export const AiAgentFormSetup = ({
                             })}
                             disabled={!form.values.enableDataAccess}
                         />
-                        <Switch
-                            variant="subtle"
-                            label={
-                                <Group gap="xs">
-                                    <Text fz="sm" fw={500}>
-                                        Enable SQL Runner by default
-                                    </Text>
-                                    <Tooltip
-                                        label="SQL Runner is only available to users whose role includes SQL Runner access (project developers and admins by default). This setting never grants permission: users without access cannot use SQL Runner, whether this is on or off."
-                                        withArrow
-                                        withinPortal
-                                        multiline
-                                        position="right"
-                                        maw="300px"
-                                    >
-                                        <MantineIcon icon={IconInfoCircle} />
-                                    </Tooltip>
-                                </Group>
-                            }
-                            description="Let the agent query your warehouse directly when it helps answer a question. Users can still turn SQL Runner on or off for each conversation."
-                            {...form.getInputProps('enableSqlMode', {
-                                type: 'checkbox',
-                            })}
-                        />
+                        <Stack gap={2}>
+                            <Switch
+                                variant="subtle"
+                                label={
+                                    <Group gap="xs">
+                                        <Text fz="sm" fw={500}>
+                                            Enable SQL Runner by default
+                                        </Text>
+                                        <Tooltip
+                                            label="SQL Runner is only available to users whose role includes SQL Runner access (project developers and admins by default). This setting never grants permission: users without access cannot use SQL Runner, whether this is on or off."
+                                            withArrow
+                                            withinPortal
+                                            multiline
+                                            position="right"
+                                            maw="300px"
+                                        >
+                                            <MantineIcon
+                                                icon={IconInfoCircle}
+                                            />
+                                        </Tooltip>
+                                    </Group>
+                                }
+                                description="Let the agent query your warehouse directly when it helps answer a question. Users can still turn SQL Runner on or off for each conversation."
+                                {...form.getInputProps('enableSqlMode', {
+                                    type: 'checkbox',
+                                })}
+                            />
+                            <Anchor
+                                component={Link}
+                                to={`/generalSettings/projectManagement/${projectUuid}/agentDataScope`}
+                                fz="xs"
+                                ml={50}
+                            >
+                                Configure which schemas and tables agent can
+                                query
+                            </Anchor>
+                        </Stack>
 
                         <Divider />
 

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -640,6 +640,27 @@ export const useSettingsNavigation = (
                     children: [],
                     exact: true,
                 },
+                // Only meaningful when the instance has AI agents at all —
+                // same gate as the org-level AI agents section.
+                ...(isAiCopilotEnabledOrTrial
+                    ? [
+                          {
+                              label: 'Agent data scope',
+                              to: `${base}/agentDataScope`,
+                              icon: IconDatabaseCog,
+                              keywords: [
+                                  'ai',
+                                  'agent',
+                                  'sql',
+                                  'schema',
+                                  'catalog',
+                                  'scope',
+                              ],
+                              children: [],
+                              exact: true,
+                          },
+                      ]
+                    : []),
                 {
                     label: 'Compilation history',
                     to: `${base}/compilationHistory`,

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -1,4 +1,5 @@
 import {
+    type AgentSqlScope,
     type ApiDataTimezonePreviewResults,
     type ApiCreateProjectResults,
     type ApiError,
@@ -8,6 +9,7 @@ import {
     type DataTimezonePreviewRequest,
     type MostPopularAndRecentlyUpdated,
     type Project,
+    type UpdateAgentSqlScope,
     type UpdateDefaultUserSpaces,
     type UpdateProject,
     type UpdateQueryTimezoneSettings,
@@ -275,6 +277,43 @@ export const useProjectUpdateQueryTimezoneSettings = (uuid: string) => {
         {
             mutationKey: ['project_query_timezone_settings_update', uuid],
             onSuccess: async () => {
+                await queryClient.invalidateQueries(['project', uuid]);
+            },
+        },
+    );
+};
+
+const getAgentSqlScope = async (uuid: string) =>
+    lightdashApi<AgentSqlScope | null>({
+        url: `/projects/${uuid}/agentSqlScope`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useAgentSqlScope = (uuid: string) =>
+    useQuery<AgentSqlScope | null, ApiError>({
+        queryKey: ['project_agent_sql_scope', uuid],
+        queryFn: () => getAgentSqlScope(uuid),
+    });
+
+const updateAgentSqlScope = async (uuid: string, data: UpdateAgentSqlScope) =>
+    lightdashApi<undefined>({
+        url: `/projects/${uuid}/agentSqlScope`,
+        method: 'PATCH',
+        body: JSON.stringify(data),
+    });
+
+export const useProjectUpdateAgentSqlScope = (uuid: string) => {
+    const queryClient = useQueryClient();
+    return useMutation<undefined, ApiError, UpdateAgentSqlScope>(
+        (data) => updateAgentSqlScope(uuid, data),
+        {
+            mutationKey: ['project_agent_sql_scope_update', uuid],
+            onSuccess: async () => {
+                await queryClient.invalidateQueries([
+                    'project_agent_sql_scope',
+                    uuid,
+                ]);
                 await queryClient.invalidateQueries(['project', uuid]);
             },
         },


### PR DESCRIPTION
Part 3 of 3 splitting #26844 (stacked on the enforcement PR).

Project settings page for the agent SQL scope: allow/exclude multi-selects for schemas and catalogs sourced from the warehouse catalog (saved values that no longer exist stay visible), an explanatory alert clarifying this is a correctness control rather than a security boundary, and the nav item + route hidden when the instance has no AI agents (same gate as the AI agents settings section).

Linear: PROD-9479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHhBNPi5J7Yq8fkpgGAXzz