### PR TITLE
fix(charts): hide stacked bar labels that cannot fit their segment

### DIFF
--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -409,6 +409,7 @@ export type EChartsSeries = {
         formatter?: (param: { data: Record<string, unknown> }) => string;
         textBorderColor?: string;
         textBorderWidth?: number;
+        showOverlappingLabels?: boolean;
     };
     labelLayout?:
         | {
@@ -427,6 +428,7 @@ export type EChartsSeries = {
                     x?: number;
                     y?: number;
                     fontSize?: number;
+                    hideOverlap?: boolean;
                     labelLinePoints?: number[][];
                 }
               | undefined);

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -252,6 +252,10 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                                             : {
                                                   show: true,
                                                   position: value as any,
+                                                  showOverlappingLabels:
+                                                      seriesGroup[0].label
+                                                          ?.showOverlappingLabels ??
+                                                      false,
                                               },
                                 });
                             }}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -354,6 +354,10 @@ const SingleSeriesConfiguration: FC<Props> = ({
                                                       series.label
                                                           ?.showSeriesName ??
                                                       false,
+                                                  showOverlappingLabels:
+                                                      series.label
+                                                          ?.showOverlappingLabels ??
+                                                      false,
                                               },
                                 });
                             }}

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -50,6 +50,13 @@ dayjs.extend(timezonePlugin);
 vi.mock('./../../providers/TrackingProvider');
 
 describe('getCartesianLabelLayout', () => {
+    const rect = (width: number, height: number) => ({
+        x: 0,
+        y: 0,
+        width,
+        height,
+    });
+
     test('shows every top label in grouped bar charts', () => {
         expect(
             getCartesianLabelLayout({
@@ -57,37 +64,50 @@ describe('getCartesianLabelLayout', () => {
                 isStacked: false,
                 seriesType: CartesianSeriesType.BAR,
                 position: 'top',
+                showOverlappingLabels: false,
+                flipAxes: false,
             }),
         ).toEqual({ hideOverlap: false });
     });
 
     test.each([
         {
+            name: 'single bar series',
             isGroupedBarChart: false,
             isStacked: false,
             seriesType: CartesianSeriesType.BAR,
             position: 'top' as const,
         },
         {
+            name: 'stacked bars keeping their configured position',
             isGroupedBarChart: true,
             isStacked: true,
             seriesType: CartesianSeriesType.BAR,
             position: 'top' as const,
         },
         {
+            name: 'grouped bars with inside labels',
             isGroupedBarChart: true,
             isStacked: false,
             seriesType: CartesianSeriesType.BAR,
             position: 'inside' as const,
         },
         {
+            name: 'line series',
             isGroupedBarChart: true,
             isStacked: false,
             seriesType: CartesianSeriesType.LINE,
             position: 'top' as const,
         },
+        {
+            name: 'series without a label position',
+            isGroupedBarChart: true,
+            isStacked: true,
+            seriesType: CartesianSeriesType.BAR,
+            position: undefined,
+        },
     ])(
-        'hides overlapping labels for non-affected series layouts',
+        'hides overlapping labels for $name',
         ({ isGroupedBarChart, isStacked, seriesType, position }) => {
             expect(
                 getCartesianLabelLayout({
@@ -95,10 +115,108 @@ describe('getCartesianLabelLayout', () => {
                     isStacked,
                     seriesType,
                     position,
+                    showOverlappingLabels: false,
+                    flipAxes: false,
                 }),
             ).toEqual({ hideOverlap: true });
         },
     );
+
+    test('only fit-checks labels that are anchored inside their segment', () => {
+        expect(
+            getCartesianLabelLayout({
+                isGroupedBarChart: false,
+                isStacked: true,
+                seriesType: CartesianSeriesType.BAR,
+                position: 'bottom',
+                showOverlappingLabels: true,
+                flipAxes: false,
+            }),
+        ).toEqual({ hideOverlap: true });
+    });
+
+    describe('labels anchored inside a stacked bar segment', () => {
+        const layout = (
+            overrides: Partial<
+                Parameters<typeof getCartesianLabelLayout>[0]
+            > = {},
+        ) => {
+            const result = getCartesianLabelLayout({
+                isGroupedBarChart: false,
+                isStacked: true,
+                seriesType: CartesianSeriesType.BAR,
+                position: 'insideTop',
+                showOverlappingLabels: false,
+                flipAxes: false,
+                ...overrides,
+            });
+            expect(typeof result).toBe('function');
+            if (typeof result !== 'function') {
+                throw new Error('expected a labelLayout callback');
+            }
+            return result;
+        };
+
+        // A 12px label needs 12 + MIN_LABEL_SEGMENT_SLACK of segment to fit.
+        const label = rect(12, 12);
+
+        test('keeps labels that fit inside their segment', () => {
+            expect(layout()({ rect: rect(4, 40), labelRect: label })).toEqual({
+                hideOverlap: true,
+            });
+        });
+
+        test('keeps labels in a segment exactly tall enough', () => {
+            expect(layout()({ rect: rect(4, 16), labelRect: label })).toEqual({
+                hideOverlap: true,
+            });
+        });
+
+        test('moves labels off canvas one pixel below the fit threshold', () => {
+            expect(layout()({ rect: rect(40, 15), labelRect: label })).toEqual({
+                x: -1e5,
+                y: -1e5,
+            });
+        });
+
+        test('moves labels off canvas when the segment has no height', () => {
+            expect(layout()({ rect: rect(40, 0), labelRect: label })).toEqual({
+                x: -1e5,
+                y: -1e5,
+            });
+        });
+
+        test('still hides labels that cannot fit when overlapping labels are forced', () => {
+            expect(
+                layout({ showOverlappingLabels: true })({
+                    rect: rect(40, 4),
+                    labelRect: label,
+                }),
+            ).toEqual({ x: -1e5, y: -1e5 });
+        });
+
+        test('stops hiding fitting labels on overlap when they are forced', () => {
+            expect(
+                layout({ showOverlappingLabels: true })({
+                    rect: rect(4, 40),
+                    labelRect: label,
+                }),
+            ).toEqual({ hideOverlap: false });
+        });
+
+        test('measures the width axis on horizontal charts', () => {
+            const horizontal = layout({
+                flipAxes: true,
+                position: 'insideRight',
+            });
+            expect(horizontal({ rect: rect(40, 4), labelRect: label })).toEqual(
+                { hideOverlap: true },
+            );
+            expect(horizontal({ rect: rect(4, 40), labelRect: label })).toEqual(
+                { x: -1e5, y: -1e5 },
+            );
+        });
+    });
 });
 
 describe('getCartesianLabelPosition', () => {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -968,24 +968,58 @@ const isStack100Normalized = (series: Series) =>
     !!series.stack &&
     (series.type === CartesianSeriesType.BAR || !!series.areaStyle);
 
+const MIN_LABEL_SEGMENT_SLACK = 4;
+// `labelLayout` cannot hide a label, and a zero font size still paints the
+// label's background chip, so park it far enough off canvas that the position
+// tween on the next render leaves the viewport within a frame.
+const OFF_CANVAS_LABEL_COORDINATE = -1e5;
+
 export const getCartesianLabelLayout = ({
     isGroupedBarChart,
     isStacked,
     seriesType,
     position,
+    showOverlappingLabels,
+    flipAxes,
 }: {
     isGroupedBarChart: boolean;
     isStacked: boolean;
     seriesType: CartesianSeriesType;
+    /** Position actually applied, after stacked segments resolve to `inside*`. */
     position: EChartsLabelPosition | undefined;
-}) => ({
-    hideOverlap: !(
-        isGroupedBarChart &&
-        !isStacked &&
+    showOverlappingLabels: boolean;
+    flipAxes: boolean;
+}): NonNullable<EChartsSeries['labelLayout']> => {
+    const isInsideStackedBar =
+        isStacked &&
         seriesType === CartesianSeriesType.BAR &&
-        position === 'top'
-    ),
-});
+        (position?.startsWith('inside') ?? false);
+
+    if (isInsideStackedBar) {
+        // A segment too short to contain its own label paints it over the
+        // neighbouring segment — over the category axis at the base of a stack.
+        return ({ rect, labelRect }) => {
+            const segmentSize = flipAxes ? rect.width : rect.height;
+            const labelSize = flipAxes ? labelRect.width : labelRect.height;
+
+            return labelSize + MIN_LABEL_SEGMENT_SLACK <= segmentSize
+                ? { hideOverlap: !showOverlappingLabels }
+                : {
+                      x: OFF_CANVAS_LABEL_COORDINATE,
+                      y: OFF_CANVAS_LABEL_COORDINATE,
+                  };
+        };
+    }
+
+    return {
+        hideOverlap: !(
+            isGroupedBarChart &&
+            !isStacked &&
+            seriesType === CartesianSeriesType.BAR &&
+            position === 'top'
+        ),
+    };
+};
 
 /**
  * ECharts paints each series after the previous one, so a stacked segment's
@@ -1020,54 +1054,6 @@ export const getCartesianLabelPosition = ({
         return position === 'right' ? 'insideRight' : position;
     }
     return position === 'top' ? 'insideTop' : position;
-};
-
-/**
- * Create a labelLayout configuration for stacked bar charts.
- * When showOverlappingLabels is enabled, uses smaller font for labels that don't fit
- * in small segments to keep them visible.
- *
- * @param isStacked - Whether the series is part of a stack
- * @param flipAxes - Whether the chart is horizontal (flipped)
- * @param showOverlappingLabels - Force display labels even when they don't fit
- */
-const createStackedBarLabelLayout = ({
-    isStacked,
-    flipAxes,
-    showOverlappingLabels,
-}: {
-    isStacked: boolean;
-    flipAxes: boolean;
-    showOverlappingLabels: boolean;
-}):
-    | { hideOverlap: boolean }
-    | ((params: {
-          rect: { x: number; y: number; width: number; height: number };
-          labelRect: { x: number; y: number; width: number; height: number };
-      }) => { fontSize?: number } | undefined) => {
-    // Only apply small-font treatment when showOverlappingLabels is enabled for stacked bars
-    if (!isStacked || !showOverlappingLabels) {
-        return { hideOverlap: true };
-    }
-
-    // Return callback function for dynamic font sizing
-    return (params) => {
-        const { rect, labelRect } = params;
-
-        // Check if label fits inside the segment at normal size
-        const segmentSize = flipAxes ? rect.width : rect.height;
-        const labelSize = flipAxes ? labelRect.width : labelRect.height;
-        const padding = 4;
-
-        const labelFits = labelSize + padding <= segmentSize;
-
-        if (labelFits) {
-            return undefined; // Keep default size
-        }
-
-        // Label doesn't fit - use smaller font
-        return { fontSize: 8 };
-    };
 };
 
 const getPivotSeries = ({
@@ -1199,11 +1185,6 @@ const getPivotSeries = ({
                         },
                     }),
             },
-            labelLayout: createStackedBarLabelLayout({
-                isStacked: !!series.stack,
-                flipAxes: !!flipAxes,
-                showOverlappingLabels: !!series.label?.showOverlappingLabels,
-            }),
         }),
     };
 };
@@ -1389,11 +1370,6 @@ const getSimpleSeries = ({
                     },
                 }),
         },
-        labelLayout: createStackedBarLabelLayout({
-            isStacked: !!series.stack,
-            flipAxes: !!flipAxes,
-            showOverlappingLabels: !!series.label?.showOverlappingLabels,
-        }),
     }),
     ...(series.markLine && {
         markLine: applyReadableColorsToMarkLine(
@@ -3590,7 +3566,10 @@ const useEchartsCartesianConfig = (
                             isGroupedBarChart,
                             isStacked: validStack !== undefined,
                             seriesType: serie.type,
-                            position: serie.label.position,
+                            position: labelPosition,
+                            showOverlappingLabels:
+                                !!serie.label.showOverlappingLabels,
+                            flipAxes: isHorizontal,
                         }),
                     }),
                     // Apply reference line styling with readable colors


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9384

## Before

<img width="2800" height="1600" alt="before-stacked-top-labels" src="https://github.com/user-attachments/assets/5333717d-d30b-407d-a352-56a22fbe0070" />

<img width="2800" height="1600" alt="before-small-nonzero-segments" src="https://github.com/user-attachments/assets/4c09ffc7-1f35-40e1-8f9f-68afc28f7697" />

## After

<img width="2800" height="1600" alt="after-stacked-top-labels" src="https://github.com/user-attachments/assets/9972a935-912e-4b65-85f6-17ac9bc30408" />

<img width="2800" height="1600" alt="after-small-nonzero-segments" src="https://github.com/user-attachments/assets/03346504-0b5e-4450-9bd4-2a2d8c35da55" />

## Summary

In a stacked bar chart with value labels set to **Top**, segments too short to contain their label painted it on top of the category axis, hiding the axis tick labels. With a series that is mostly `0`, the axis disappeared behind a row of value badges.

Vertical and horizontal stacked bars are affected. Grouped (non-stacked) bars and line/area series are not.

## Root cause

#26890 fixed lower stacked segments losing their label — ECharts paints each series after the previous one, so a segment's `top` label sits inside the segment stacked above it and is covered by that segment's bar. The fix re-anchors those labels to `insideTop`, where they are painted with the bar they belong to.

An `inside*` anchor only works while the segment is tall enough to hold the label. It never is for a `0` segment, and often isn't for a small one:

```ts
// insideTop on a 1.7px segment, with a ~12px label:
rect      = { y: 240.5, height:  1.7 }   // the bar segment
labelRect = { y: 245.5, height: 12.2 }   // 15px below the segment's bottom edge
```

For the segment at the base of a stack, "below the segment" is the category axis.

`labelLayout` had no fit check: `getCartesianLabelLayout` returned a flat `{ hideOverlap: true }`, and ECharts' `hideOverlap` only compares labels against *other labels* — never against the axis.

## Fix

A stacked segment shows its value label only when the segment can hold it; otherwise the label is not drawn.

```
Before                              After
                                    
 45 ┤     ▓▓                         45 ┤     ▓▓
    │     ▓▓                            │     ▓▓
    │  ██ ██                            │  ██ ██
  0 ┼──██─██──                        0 ┼──██─██──
    ⓪⓪⓪⓪⓪⓪⓪⓪⓪   <- labels over          2023-03  2023-06
    2023-03 2023-06   the axis labels
```

- `useEchartsCartesianConfig.ts` — `getCartesianLabelLayout` returns a `labelLayout` callback for inside-anchored stacked bar segments. Labels that fit are unchanged; labels that cannot fit are moved off canvas. ECharts' `LabelLayoutOption` has no `show`/`ignore`, and `fontSize: 0` still paints the label's background chip, so moving it is the only way to drop it.
- `useEchartsCartesianConfig.ts` — merges `createStackedBarLabelLayout` into the same function. It was dead code: the final series mapping overwrote `labelLayout` whenever labels were shown, so the **Show overlapping labels** checkbox had no effect. It now controls `hideOverlap` for labels that fit. It deliberately cannot force a label that has nowhere to go — otherwise the setting could reintroduce this bug.
- `SingleSeriesConfiguration.tsx`, `GroupedSeriesConfiguration.tsx` — keep `showOverlappingLabels` when the value-label position changes. Both handlers rebuilt `label` from scratch and dropped it, silently resetting the setting.
- `packages/common` — `EChartsSeries` gains `label.showOverlappingLabels` and `hideOverlap` on the `labelLayout` callback return. Render-only type; no API or chart-as-code schema change.

Out of scope: non-stacked bars with an explicitly chosen `Inside` position hit the same overflow, but they are not re-anchored by us and their labels stay readable over empty plot space.

## Test plan

- [x] `pnpm -F frontend typecheck && pnpm -F common typecheck && pnpm -F frontend lint && pnpm -F common lint`
- [x] `pnpm -F frontend exec vitest run src/hooks/echarts src/components/VisualizationConfigs` — 327 pass, 10 added for the fit predicate (boundary, zero-height, forced, flipped axes)
- [x] Mutation-checked the new tests: flipping `<=` to `<`, reading `width` on a vertical chart, and zeroing the slack constant each fail
- [x] Manual: ticket repro — stacked bars with a `0` series and with a small non-zero series, labels set to Top; axis tick labels readable, labels that fit unchanged
- [x] Manual: grouped bars with Top labels still label every bar (#26679 preserved); stack-end segments keep their label above the stack
- [x] Manual: horizontal stack, small viewport, reference-line labels, and **Show overlapping labels** on and off

🤖 Generated with [Claude Code](https://claude.com/claude-code)