### PR TITLE
fix: inform user of org level scopes when updating custom role project scopes

### DIFF
--- a/docs/authentication-and-roles.md
+++ b/docs/authentication-and-roles.md
@@ -83,9 +83,10 @@ Two assignment surfaces:
    `project_memberships.role_uuid` to a custom role uuid. Used today by both
    human users and project-scoped automation.
 2. **Organization-level custom roles**. Set
-   `organization_memberships.role_uuid`. The same `roles` row can be assigned
-   either way — there's no project-vs-org distinction at the role level, only
-   at the assignment.
+   `organization_memberships.role_uuid`. A role carries a `level`
+   (`'project' | 'organization'`) that decides which scopes it may hold and
+   where it may be assigned; `RolesService` rejects a mismatch at both
+   scope-assignment and role-assignment time.
 
 The custom-roles UI under **Settings → Custom roles** edits both surfaces
 through the same controllers (`CustomRolesController`, `OrganizationRolesController`).
@@ -261,23 +262,48 @@ does." The trade-off is the project-level no-op above: an admin clone
 assigned at the project level will still show org-management toggles
 ticked, but those toggles are dead at runtime in that context.
 
-### Known UX gap (revisit)
+### How the role builder avoids the trap
 
-The role builder shows **all** scopes regardless of intended assignment
-level. An admin who toggles `manage:OrganizationMemberProfile` on a
-project-only role gets nothing — no error, no warning, just no effect.
-Possible future improvements (none implemented today):
+Every scope declares a `level`, and the role builder only offers the
+scopes assignable at the role's own level
+(`getScopesByGroup` → `isScopeAssignableAtLevel`). On a project-level
+role the org-management scopes aren't listed at all, and the selector
+says how many are hidden and why. `RolesService.validateScopesLevel`
+enforces the same rule server-side, so the API can't create the
+silent-no-op combination either.
 
-- Mark each scope's "applicable level" (`project | org | both`) and
-  filter the role-builder UI by intended assignment context.
-- Two distinct role flavors at the API level — "project role" vs
-  "org role" — each with its own scope catalog.
-- Inline hint in the role builder ("only effective at org assignment")
-  when an org-only scope is toggled.
+The residual trap is the one described above: a role that already holds
+org scopes (an admin duplicate, or a role built before level filtering)
+still shows those toggles ticked while assigned at the project level,
+where they're dead.
 
-Each option trades simplicity (one shared role-builder UI) for
-discoverability. The current design preserves the simpler UX at the cost
-of the silent-no-op trap.
+## Enabling the roadmap for a non-admin
+
+The enterprise roadmap (**Settings → Roadmap**) is gated on the CASL
+check `view Roadmap` against the user's own organization, plus the
+`OrganizationRoadmap` feature flag. Organization admins get the scope
+from their system role; **it is deliberately not granted to any other
+system role**, so every other user needs an explicit grant. The recipe:
+
+1. Enterprise license key configured, plus custom roles enabled
+   (`CUSTOM_ROLES_ENABLED=true` or the `custom-roles` flag). Without
+   both, the role assignment silently falls back to the user's system
+   role and the grant does nothing.
+2. **Settings → Roles** → duplicate the role the user should keep (e.g.
+   Viewer) and pick the **organization** level. An org-level custom role
+   *replaces* the user's system-role org abilities rather than adding to
+   them, so the duplicate has to carry everything they already had.
+3. Toggle **View Roadmap** (Organization Management group) and save.
+4. Assign the new role to the user **at the organization level**
+   (Settings → Users → change role; `UpsertOrganizationUserRoleAssignment`).
+   Assigning it on a project grants nothing — `view:Roadmap` builds a
+   `{ projectUuid }` condition that can never match the `{ organizationUuid }`
+   -keyed `Roadmap` subject.
+
+The user then sees the Roadmap nav item and
+`GET /api/v1/org/roadmap` returns data; anyone without the scope gets no
+nav item and a 403. Coverage lives in
+`packages/common/src/authorization/roadmapAccess.test.ts`.
 
 ## Code references
 

--- a/docs/authentication-and-roles.md
+++ b/docs/authentication-and-roles.md
@@ -83,9 +83,10 @@ Two assignment surfaces:
    `project_memberships.role_uuid` to a custom role uuid. Used today by both
    human users and project-scoped automation.
 2. **Organization-level custom roles**. Set
-   `organization_memberships.role_uuid`. The same `roles` row can be assigned
-   either way — there's no project-vs-org distinction at the role level, only
-   at the assignment.
+   `organization_memberships.role_uuid`. A role carries a `level`
+   (`'project' | 'organization'`) that decides which scopes it may hold and
+   where it may be assigned; `RolesService` rejects a mismatch at both
+   scope-assignment and role-assignment time.
 
 The custom-roles UI under **Settings → Custom roles** edits both surfaces
 through the same controllers (`CustomRolesController`, `OrganizationRolesController`).
@@ -240,23 +241,48 @@ does." The trade-off is the project-level no-op above: an admin clone
 assigned at the project level will still show org-management toggles
 ticked, but those toggles are dead at runtime in that context.
 
-### Known UX gap (revisit)
+### How the role builder avoids the trap
 
-The role builder shows **all** scopes regardless of intended assignment
-level. An admin who toggles `manage:OrganizationMemberProfile` on a
-project-only role gets nothing — no error, no warning, just no effect.
-Possible future improvements (none implemented today):
+Every scope declares a `level`, and the role builder only offers the
+scopes assignable at the role's own level
+(`getScopesByGroup` → `isScopeAssignableAtLevel`). On a project-level
+role the org-management scopes aren't listed at all, and the selector
+says how many are hidden and why. `RolesService.validateScopesLevel`
+enforces the same rule server-side, so the API can't create the
+silent-no-op combination either.
 
-- Mark each scope's "applicable level" (`project | org | both`) and
-  filter the role-builder UI by intended assignment context.
-- Two distinct role flavors at the API level — "project role" vs
-  "org role" — each with its own scope catalog.
-- Inline hint in the role builder ("only effective at org assignment")
-  when an org-only scope is toggled.
+The residual trap is the one described above: a role that already holds
+org scopes (an admin duplicate, or a role built before level filtering)
+still shows those toggles ticked while assigned at the project level,
+where they're dead.
 
-Each option trades simplicity (one shared role-builder UI) for
-discoverability. The current design preserves the simpler UX at the cost
-of the silent-no-op trap.
+## Enabling the roadmap for a non-admin
+
+The enterprise roadmap (**Settings → Roadmap**) is gated on the CASL
+check `view Roadmap` against the user's own organization, plus the
+`OrganizationRoadmap` feature flag. Organization admins get the scope
+from their system role; **it is deliberately not granted to any other
+system role**, so every other user needs an explicit grant. The recipe:
+
+1. Enterprise license key configured, plus custom roles enabled
+   (`CUSTOM_ROLES_ENABLED=true` or the `custom-roles` flag). Without
+   both, the role assignment silently falls back to the user's system
+   role and the grant does nothing.
+2. **Settings → Roles** → duplicate the role the user should keep (e.g.
+   Viewer) and pick the **organization** level. An org-level custom role
+   *replaces* the user's system-role org abilities rather than adding to
+   them, so the duplicate has to carry everything they already had.
+3. Toggle **View Roadmap** (Organization Management group) and save.
+4. Assign the new role to the user **at the organization level**
+   (Settings → Users → change role; `UpsertOrganizationUserRoleAssignment`).
+   Assigning it on a project grants nothing — `view:Roadmap` builds a
+   `{ projectUuid }` condition that can never match the `{ organizationUuid }`
+   -keyed `Roadmap` subject.
+
+The user then sees the Roadmap nav item and
+`GET /api/v1/org/roadmap` returns data; anyone without the scope gets no
+nav item and a 403. Coverage lives in
+`packages/common/src/authorization/roadmapAccess.test.ts`.
 
 ## Code references
 

--- a/docs/authentication-and-roles.md
+++ b/docs/authentication-and-roles.md
@@ -289,16 +289,22 @@ system role**, so every other user needs an explicit grant. The recipe:
    (`CUSTOM_ROLES_ENABLED=true` or the `custom-roles` flag). Without
    both, the role assignment silently falls back to the user's system
    role and the grant does nothing.
-2. **Settings → Roles** → duplicate the role the user should keep (e.g.
-   Viewer) and pick the **organization** level. An org-level custom role
-   *replaces* the user's system-role org abilities rather than adding to
-   them, so the duplicate has to carry everything they already had.
-3. Toggle **View Roadmap** (Organization Management group) and save.
-4. Assign the new role to the user **at the organization level**
-   (Settings → Users → change role; `UpsertOrganizationUserRoleAssignment`).
-   Assigning it on a project grants nothing — `view:Roadmap` builds a
-   `{ projectUuid }` condition that can never match the `{ organizationUuid }`
-   -keyed `Roadmap` subject.
+2. **Settings → Roles** → create an **organization**-level role holding
+   just **View Roadmap** (Organization Management group), and save.
+3. Add that role to the user's organization role set alongside the
+   system role they already have (Settings → Users → role cell;
+   `ReplaceOrganizationUserRoleSet`). Extra roles are unioned on top of
+   the primary slot, so the user keeps everything their system role
+   grants and gains the roadmap.
+4. Assign it **at the organization level**. On a project it grants
+   nothing — `view:Roadmap` builds a `{ projectUuid }` condition that
+   can never match the `{ organizationUuid }`-keyed `Roadmap` subject.
+
+Releases before role sets have only the single
+`organization_memberships.role_uuid` slot, where a custom role *replaces*
+the system role's org abilities. There the recipe is to duplicate the
+role the user should keep, toggle **View Roadmap** on the duplicate, and
+assign it with `UpsertOrganizationUserRoleAssignment`.
 
 The user then sees the Roadmap nav item and
 `GET /api/v1/org/roadmap` returns data; anyone without the scope gets no

--- a/packages/common/src/authorization/roadmapAccess.test.ts
+++ b/packages/common/src/authorization/roadmapAccess.test.ts
@@ -1,0 +1,163 @@
+import { subject } from '@casl/ability';
+import { OrganizationMemberRole } from '../types/organizationMemberProfile';
+import { ProjectMemberRole } from '../types/projectMemberRole';
+import { getUserAbilityBuilder } from './index';
+
+const ORG_UUID = 'roadmap-org-uuid';
+const PROJECT_UUID = 'roadmap-project-uuid';
+const USER_UUID = 'roadmap-user-uuid';
+const CUSTOM_ROLE_UUID = '44444444-4444-4444-a444-444444444444';
+
+const PERMISSIONS_CONFIG = {
+    pat: { enabled: false, allowedOrgRoles: [] },
+};
+
+const canViewRoadmap = ({
+    role = OrganizationMemberRole.MEMBER,
+    orgRoleUuid,
+    projectRoleUuid,
+    scopes = ['view:Roadmap'],
+    customRolesEnabled = true,
+    isEnterprise = true,
+}: {
+    role?: OrganizationMemberRole;
+    orgRoleUuid?: string;
+    projectRoleUuid?: string;
+    scopes?: string[];
+    customRolesEnabled?: boolean;
+    isEnterprise?: boolean;
+}): boolean => {
+    const { builder } = getUserAbilityBuilder({
+        user: {
+            role,
+            organizationUuid: ORG_UUID,
+            userUuid: USER_UUID,
+            roleUuid: orgRoleUuid,
+        },
+        projectProfiles: projectRoleUuid
+            ? [
+                  {
+                      projectUuid: PROJECT_UUID,
+                      role: ProjectMemberRole.VIEWER,
+                      userUuid: USER_UUID,
+                      roleUuid: projectRoleUuid,
+                  },
+              ]
+            : [],
+        permissionsConfig: PERMISSIONS_CONFIG,
+        customRoleScopes: { [CUSTOM_ROLE_UUID]: scopes },
+        customRolesEnabled,
+        isEnterprise,
+    });
+
+    return builder
+        .build()
+        .can('view', subject('Roadmap', { organizationUuid: ORG_UUID }));
+};
+
+describe('Roadmap access', () => {
+    describe('System roles', () => {
+        it('grants the organization admin access', () => {
+            expect(canViewRoadmap({ role: OrganizationMemberRole.ADMIN })).toBe(
+                true,
+            );
+        });
+
+        it.each([
+            OrganizationMemberRole.MEMBER,
+            OrganizationMemberRole.VIEWER,
+            OrganizationMemberRole.INTERACTIVE_VIEWER,
+            OrganizationMemberRole.EDITOR,
+            OrganizationMemberRole.DEVELOPER,
+        ])('denies %s — access stays explicit-grant only', (role) => {
+            expect(canViewRoadmap({ role })).toBe(false);
+        });
+    });
+
+    describe('Organization-level custom role', () => {
+        it('grants a non-admin the roadmap when the role includes view:Roadmap', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    orgRoleUuid: CUSTOM_ROLE_UUID,
+                }),
+            ).toBe(true);
+        });
+
+        it('denies a non-admin when the role omits view:Roadmap', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    orgRoleUuid: CUSTOM_ROLE_UUID,
+                    scopes: ['view:Dashboard', 'view:Project'],
+                }),
+            ).toBe(false);
+        });
+
+        it('scopes the grant to the assigning organization', () => {
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.VIEWER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: CUSTOM_ROLE_UUID,
+                },
+                projectProfiles: [],
+                permissionsConfig: PERMISSIONS_CONFIG,
+                customRoleScopes: { [CUSTOM_ROLE_UUID]: ['view:Roadmap'] },
+                customRolesEnabled: true,
+                isEnterprise: true,
+            });
+
+            expect(
+                builder.build().can(
+                    'view',
+                    subject('Roadmap', {
+                        organizationUuid: 'another-organization',
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('denies when custom roles are disabled — the assignment falls back to the system role', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    orgRoleUuid: CUSTOM_ROLE_UUID,
+                    customRolesEnabled: false,
+                }),
+            ).toBe(false);
+        });
+
+        it('denies without an enterprise license — view:Roadmap is an enterprise scope', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    orgRoleUuid: CUSTOM_ROLE_UUID,
+                    isEnterprise: false,
+                }),
+            ).toBe(false);
+        });
+
+        it('replaces the system role, so an admin assigned a role without view:Roadmap loses it', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.ADMIN,
+                    orgRoleUuid: CUSTOM_ROLE_UUID,
+                    scopes: ['view:Dashboard'],
+                }),
+            ).toBe(false);
+        });
+    });
+
+    describe('Project-level assignment', () => {
+        it('grants nothing — view:Roadmap builds a projectUuid condition that never matches the org-keyed subject', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    projectRoleUuid: CUSTOM_ROLE_UUID,
+                }),
+            ).toBe(false);
+        });
+    });
+});

--- a/packages/common/src/authorization/roadmapAccess.test.ts
+++ b/packages/common/src/authorization/roadmapAccess.test.ts
@@ -7,6 +7,7 @@ const ORG_UUID = 'roadmap-org-uuid';
 const PROJECT_UUID = 'roadmap-project-uuid';
 const USER_UUID = 'roadmap-user-uuid';
 const CUSTOM_ROLE_UUID = '44444444-4444-4444-a444-444444444444';
+const EXTRA_ROLE_UUID = '55555555-5555-4555-a555-555555555555';
 
 const PERMISSIONS_CONFIG = {
     pat: { enabled: false, allowedOrgRoles: [] },
@@ -15,14 +16,18 @@ const PERMISSIONS_CONFIG = {
 const canViewRoadmap = ({
     role = OrganizationMemberRole.MEMBER,
     orgRoleUuid,
+    orgExtraRoleUuids = [],
     projectRoleUuid,
+    projectExtraRoleUuids,
     scopes = ['view:Roadmap'],
     customRolesEnabled = true,
     isEnterprise = true,
 }: {
     role?: OrganizationMemberRole;
     orgRoleUuid?: string;
+    orgExtraRoleUuids?: string[];
     projectRoleUuid?: string;
+    projectExtraRoleUuids?: string[];
     scopes?: string[];
     customRolesEnabled?: boolean;
     isEnterprise?: boolean;
@@ -34,18 +39,24 @@ const canViewRoadmap = ({
             userUuid: USER_UUID,
             roleUuid: orgRoleUuid,
         },
-        projectProfiles: projectRoleUuid
-            ? [
-                  {
-                      projectUuid: PROJECT_UUID,
-                      role: ProjectMemberRole.VIEWER,
-                      userUuid: USER_UUID,
-                      roleUuid: projectRoleUuid,
-                  },
-              ]
-            : [],
+        orgExtraRoleUuids,
+        projectProfiles:
+            projectRoleUuid || projectExtraRoleUuids
+                ? [
+                      {
+                          projectUuid: PROJECT_UUID,
+                          role: ProjectMemberRole.VIEWER,
+                          userUuid: USER_UUID,
+                          roleUuid: projectRoleUuid,
+                          extraRoleUuids: projectExtraRoleUuids,
+                      },
+                  ]
+                : [],
         permissionsConfig: PERMISSIONS_CONFIG,
-        customRoleScopes: { [CUSTOM_ROLE_UUID]: scopes },
+        customRoleScopes: {
+            [CUSTOM_ROLE_UUID]: scopes,
+            [EXTRA_ROLE_UUID]: ['view:Roadmap'],
+        },
         customRolesEnabled,
         isEnterprise,
     });
@@ -150,12 +161,63 @@ describe('Roadmap access', () => {
         });
     });
 
+    describe('Organization role set (extra custom role)', () => {
+        it('grants a non-admin while keeping their system role in the primary slot', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    orgExtraRoleUuids: [EXTRA_ROLE_UUID],
+                }),
+            ).toBe(true);
+        });
+
+        it('widens a custom primary slot that omits view:Roadmap', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    orgRoleUuid: CUSTOM_ROLE_UUID,
+                    scopes: ['view:Dashboard'],
+                    orgExtraRoleUuids: [EXTRA_ROLE_UUID],
+                }),
+            ).toBe(true);
+        });
+
+        it('denies when custom roles are disabled — extra roles are skipped', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    orgExtraRoleUuids: [EXTRA_ROLE_UUID],
+                    customRolesEnabled: false,
+                }),
+            ).toBe(false);
+        });
+
+        it('denies without an enterprise license', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    orgExtraRoleUuids: [EXTRA_ROLE_UUID],
+                    isEnterprise: false,
+                }),
+            ).toBe(false);
+        });
+    });
+
     describe('Project-level assignment', () => {
         it('grants nothing — view:Roadmap builds a projectUuid condition that never matches the org-keyed subject', () => {
             expect(
                 canViewRoadmap({
                     role: OrganizationMemberRole.VIEWER,
                     projectRoleUuid: CUSTOM_ROLE_UUID,
+                }),
+            ).toBe(false);
+        });
+
+        it('grants nothing as a project extra role either', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    projectExtraRoleUuids: [EXTRA_ROLE_UUID],
                 }),
             ).toBe(false);
         });

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
@@ -1,4 +1,7 @@
-import { type RoleLevel } from '@lightdash/common';
+import {
+    getOrganizationOnlyScopes,
+    type RoleLevel,
+} from '@lightdash/common';
 import {
     Badge,
     Box,
@@ -424,6 +427,11 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({
         );
     }, [selectedGroupKey, filteredScopes]);
 
+    const organizationOnlyScopeCount = useMemo(
+        () => getOrganizationOnlyScopes().length,
+        [],
+    );
+
     const totalScopes = allGroupedScopes.reduce(
         (acc, group) => acc + group.scopes.length,
         0,
@@ -510,13 +518,24 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({
                     />
                 </Group>
                 <Group justify="space-between">
-                    <Text fz="sm" c="dimmed">
-                        {selectedCount} of {totalScopes}{' '}
-                        <Text span fw={600} inherit>
-                            {level}
-                        </Text>{' '}
-                        permissions selected
-                    </Text>
+                    <Stack gap="two">
+                        <Text fz="sm" c="dimmed">
+                            {selectedCount} of {totalScopes}{' '}
+                            <Text span fw={600} inherit>
+                                {level}
+                            </Text>{' '}
+                            permissions selected
+                        </Text>
+                        {level === 'project' ? (
+                            <Text fz="xs" c="dimmed">
+                                {organizationOnlyScopeCount}{' '}
+                                organization-level permissions, including
+                                viewing the roadmap, are hidden here. They only
+                                take effect on an organization-level role
+                                assigned to a user at the organization level.
+                            </Text>
+                        ) : null}
+                    </Stack>
                     <Group gap="xs">
                         <Button
                             variant="subtle"

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
@@ -1,4 +1,7 @@
-import { type RoleLevel } from '@lightdash/common';
+import {
+    getOrganizationOnlyScopes,
+    type RoleLevel,
+} from '@lightdash/common';
 import {
     Badge,
     Box,
@@ -429,6 +432,11 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({
         );
     }, [selectedGroupKey, filteredScopes]);
 
+    const organizationOnlyScopeCount = useMemo(
+        () => getOrganizationOnlyScopes().length,
+        [],
+    );
+
     const totalScopes = allGroupedScopes.reduce(
         (acc, group) => acc + group.scopes.length,
         0,
@@ -515,13 +523,24 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({
                     />
                 </Group>
                 <Group justify="space-between">
-                    <Text fz="sm" c="dimmed">
-                        {selectedCount} of {totalScopes}{' '}
-                        <Text span fw={600} inherit>
-                            {level}
-                        </Text>{' '}
-                        permissions selected
-                    </Text>
+                    <Stack gap="two">
+                        <Text fz="sm" c="dimmed">
+                            {selectedCount} of {totalScopes}{' '}
+                            <Text span fw={600} inherit>
+                                {level}
+                            </Text>{' '}
+                            permissions selected
+                        </Text>
+                        {level === 'project' ? (
+                            <Text fz="xs" c="dimmed">
+                                {organizationOnlyScopeCount}{' '}
+                                organization-level permissions, including
+                                viewing the roadmap, are hidden here. They only
+                                take effect on an organization-level role
+                                assigned to a user at the organization level.
+                            </Text>
+                        ) : null}
+                    </Stack>
                     <Group gap="xs">
                         <Button
                             variant="subtle"

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
@@ -515,7 +515,7 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({
                     />
                 </Group>
                 <Group justify="space-between">
-                    <Stack gap="two">
+                    <Stack gap="xs">
                         <Text fz="sm" c="dimmed">
                             {selectedCount} of {totalScopes}{' '}
                             <Text span fw={600} inherit>

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
@@ -1,7 +1,4 @@
-import {
-    getOrganizationOnlyScopes,
-    type RoleLevel,
-} from '@lightdash/common';
+import { getOrganizationOnlyScopes, type RoleLevel } from '@lightdash/common';
 import {
     Badge,
     Box,
@@ -528,11 +525,10 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({
                         </Text>
                         {level === 'project' ? (
                             <Text fz="xs" c="dimmed">
-                                {organizationOnlyScopeCount}{' '}
-                                organization-level permissions, including
-                                viewing the roadmap, are hidden here. They only
-                                take effect on an organization-level role
-                                assigned to a user at the organization level.
+                                {organizationOnlyScopeCount} organization-level
+                                permissions are hidden here. They only take
+                                effect on an organization-level role assigned at
+                                the organization level.
                             </Text>
                         ) : null}
                     </Stack>


### PR DESCRIPTION
### Description:

The `view:Roadmap` scope already exists and the plumbing already works — no new scope, and no system role gains the roadmap by default. What was missing is coverage that the intended grant path actually holds, plus something to hand to CS.

- `packages/common/src/authorization/roadmapAccess.test.ts` — asserts, through `getUserAbilityBuilder`, that an org-level custom role containing `view:Roadmap` grants a non-admin the roadmap; that the same role assigned at **project** level grants nothing (the `{ projectUuid }` condition can never match the org-keyed subject); that the enterprise-license and custom-roles gates both deny; and that admin keeps access while viewer / interactive viewer / editor / developer still don't have it.
- Role builder: on a project-level role, the scope selector now says how many organization-level permissions are hidden and that they only take effect on an org-level role assigned at the org level. (They were already filtered out of the list — there was just no explanation.)
- `docs/authentication-and-roles.md`: added the enablement recipe (license + `CUSTOM_ROLES_ENABLED`, duplicate the user's role at organization level, toggle View Roadmap, assign at org level), and refreshed two stale claims — the role builder does filter by level now, and roles do carry a `level`.

Not verified against a live EE instance (no licensed instance available in this environment); verification is at the ability layer, which is what both the endpoint and the nav item gate on.
