### PR TITLE
fix(frontend): gate theme settings by manage permission

### DIFF
--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -292,7 +292,7 @@ export const useSettingsNavigation = (
         if (isDataAppsEnabled) {
             const dataAppChildren: SettingsNavigationItem[] = [];
 
-            if (ability?.can('view', 'OrganizationDesign')) {
+            if (ability?.can('manage', 'OrganizationDesign')) {
                 dataAppChildren.push({
                     label: 'Themes',
                     to: '/generalSettings/dataApps/themes',

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -493,12 +493,12 @@ const Settings: FC = () => {
         }
 
         if (dataAppsFlag?.enabled) {
-            const canViewThemes =
-                user?.ability.can('view', 'OrganizationDesign') ?? false;
+            const canManageThemes =
+                user?.ability.can('manage', 'OrganizationDesign') ?? false;
             const canViewActivity =
                 user?.ability.can('manage', 'Organization') ?? false;
 
-            if (canViewThemes) {
+            if (canManageThemes) {
                 allowedRoutes.push({
                     path: '/dataApps/themes',
                     element: <DesignListPage />,
@@ -511,13 +511,13 @@ const Settings: FC = () => {
                 });
             }
             // Land on whichever sub-page the user can actually reach.
-            if (canViewThemes || canViewActivity) {
+            if (canManageThemes || canViewActivity) {
                 allowedRoutes.push({
                     path: '/dataApps',
                     element: (
                         <Navigate
                             to={
-                                canViewThemes
+                                canManageThemes
                                     ? '/generalSettings/dataApps/themes'
                                     : '/generalSettings/dataApps/activity'
                             }


### PR DESCRIPTION
## What changed

- require `manage:OrganizationDesign` before showing the Themes settings navigation item
- register the Themes settings route only for users with the same management permission
- preserve `view:OrganizationDesign` access where themes are consumed by Data Apps

## Why

Viewer users intentionally have read access to organization themes so Data Apps can consume them. The organization Themes settings surface incorrectly used that read permission too, exposing the page and its management actions even though the backend correctly rejected writes.

This aligns the frontend settings boundary with the existing backend management permission.

## Validation

- `pnpm exec oxfmt --check src/pages/Settings.tsx src/hooks/settings/useSettingsNavigation.ts`
- focused `oxlint` on both changed files
- `pnpm -F frontend typecheck`
- `git diff --check`
- repository pre-commit checks

Linear: [GLITCH-657](https://linear.app/lightdash/issue/GLITCH-657/gate-org-theme-settings-behind-correct-frontend-permission-checks)