### PR TITLE
feat(autopilot): propose pre-aggregate candidates from query history

### DIFF
--- a/packages/backend/src/ee/clients/ManagedAgentClient.test.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.test.ts
@@ -38,6 +38,7 @@ const createClient = () =>
         lightdashConfig: {
             siteUrl: SITE_URL,
             managedAgent: { anthropicApiKey: 'anthropic-api-key' },
+            preAggregates: { enabled: false },
         },
     } as AnyType);
 

--- a/packages/backend/src/ee/clients/ManagedAgentClient.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.ts
@@ -81,6 +81,8 @@ export class ManagedAgentClient {
             skillIds,
             toolSettings,
             policy,
+            preAggregatesEnabled:
+                this.config.lightdashConfig.preAggregates.enabled,
         });
         return {
             ...renderedAgentConfig,

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -31,6 +31,9 @@ import {
 import {
     inactiveUsersSql,
     orphanedContentSql,
+    preAggCandidateExploresSql,
+    preAggMissStatsSql,
+    preAggQueryShapesSql,
     unusedAgentsSql,
     type InactiveUserActivitySource,
     type OrphanedContentOwnerStatus,
@@ -811,6 +814,132 @@ export class ManagedAgentModel {
             routedCandidateCount: Number(r.routed_candidate_count),
             routedSuggestedCount: Number(r.routed_suggested_count),
             routedChosenCount: Number(r.routed_chosen_count),
+        }));
+    }
+
+    async getPreAggCandidateExplores(
+        projectUuid: string,
+        windowDays: number,
+        minQueries: number,
+        limit: number = 10,
+    ): Promise<
+        Array<{
+            exploreName: string;
+            queryCount: number;
+            distinctUsers: number;
+            totalExecutionMs: number;
+            avgExecutionMs: number;
+            p95ExecutionMs: number;
+            preAggHitCount: number;
+            contextCounts: Record<string, number>;
+        }>
+    > {
+        const rows = await this.database.raw<{
+            rows: Array<{
+                explore_name: string;
+                query_count: string;
+                distinct_users: string;
+                total_execution_ms: string;
+                avg_execution_ms: string;
+                p95_execution_ms: string;
+                preagg_hit_count: string;
+                context_counts: Record<string, number> | null;
+            }>;
+        }>(preAggCandidateExploresSql(), [
+            windowDays,
+            minQueries,
+            projectUuid,
+            limit,
+        ]);
+
+        return rows.rows.map((r) => ({
+            exploreName: r.explore_name,
+            queryCount: Number(r.query_count),
+            distinctUsers: Number(r.distinct_users),
+            totalExecutionMs: Number(r.total_execution_ms),
+            avgExecutionMs: Number(r.avg_execution_ms),
+            p95ExecutionMs: Number(r.p95_execution_ms),
+            preAggHitCount: Number(r.preagg_hit_count),
+            contextCounts: r.context_counts ?? {},
+        }));
+    }
+
+    async getPreAggQueryShapes(
+        projectUuid: string,
+        exploreNames: string[],
+        windowDays: number,
+        shapesPerExplore: number,
+    ): Promise<
+        Array<{
+            exploreName: string;
+            dimensionFieldIds: string[];
+            metricFieldIds: string[];
+            filterFieldIds: string[];
+            hasCustomFields: boolean;
+            queryCount: number;
+            avgExecutionMs: number;
+            totalExecutionMs: number;
+        }>
+    > {
+        if (exploreNames.length === 0) {
+            return [];
+        }
+
+        const rows = await this.database.raw<{
+            rows: Array<{
+                explore_name: string;
+                dimension_field_ids: string[];
+                metric_field_ids: string[];
+                filter_field_id_sets: string[][];
+                has_custom_fields: boolean;
+                query_count: string;
+                avg_execution_ms: string;
+                total_execution_ms: string;
+            }>;
+        }>(preAggQueryShapesSql(), [
+            windowDays,
+            projectUuid,
+            exploreNames.join(','),
+            shapesPerExplore,
+        ]);
+
+        return rows.rows.map((r) => ({
+            exploreName: r.explore_name,
+            dimensionFieldIds: r.dimension_field_ids,
+            metricFieldIds: r.metric_field_ids,
+            filterFieldIds: Array.from(new Set(r.filter_field_id_sets.flat())),
+            hasCustomFields: r.has_custom_fields,
+            queryCount: Number(r.query_count),
+            avgExecutionMs: Number(r.avg_execution_ms),
+            totalExecutionMs: Number(r.total_execution_ms),
+        }));
+    }
+
+    async getPreAggMissStats(
+        projectUuid: string,
+        windowDays: number,
+    ): Promise<
+        Array<{
+            exploreName: string;
+            missReason: string | null;
+            hitCount: number;
+            missCount: number;
+        }>
+    > {
+        const rows = await this.database.raw<{
+            rows: Array<{
+                explore_name: string;
+                miss_reason: string | null;
+                hit_count: string;
+                miss_count: string;
+            }>;
+        }>(preAggMissStatsSql(), [windowDays, projectUuid]);
+
+        return rows.rows.map((r) => ({
+            exploreName: r.explore_name,
+            missReason: r.miss_reason,
+            hitCount: Number(r.hit_count),
+            missCount: Number(r.miss_count),
         }));
     }
 

--- a/packages/backend/src/ee/models/ManagedAgentModelSql.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModelSql.ts
@@ -267,3 +267,156 @@ WHERE COALESCE(act.recent_prompts, 0) < params.min_prompts
 ORDER BY COALESCE(act.recent_prompts, 0) ASC, a.created_at ASC
 LIMIT ?;
 `;
+
+/**
+ * Warehouse-cost ranking of explores over the window. Only queries that
+ * actually hit the warehouse count (cache hits have no execution time), and
+ * queries already served by a pre-aggregate are counted separately so an
+ * explore that is fully covered stops looking like a candidate.
+ *
+ * Parameters: window_days, min_queries, project_uuid, limit
+ */
+export const preAggCandidateExploresSql = () => `
+WITH params AS (
+  SELECT
+    now() - make_interval(days => ?) AS window_start,
+    ?::int AS min_queries
+),
+runs AS (
+  SELECT
+    qh.metric_query->>'exploreName' AS explore_name,
+    qh.warehouse_execution_time_ms AS execution_ms,
+    qh.pre_aggregate_compiled_sql IS NOT NULL AS preagg_hit,
+    qh.created_by_user_uuid,
+    qh.context
+  FROM query_history qh
+    CROSS JOIN params
+  WHERE qh.project_uuid = ?
+    AND qh.created_at >= params.window_start
+    AND qh.status = 'ready'
+    AND qh.error IS NULL
+    AND qh.metric_query->>'exploreName' IS NOT NULL
+    AND qh.warehouse_execution_time_ms > 0
+)
+SELECT
+  r.explore_name,
+  COUNT(*) AS query_count,
+  COUNT(DISTINCT r.created_by_user_uuid) AS distinct_users,
+  SUM(r.execution_ms) AS total_execution_ms,
+  ROUND(AVG(r.execution_ms)) AS avg_execution_ms,
+  ROUND(percentile_cont(0.95) WITHIN GROUP (ORDER BY r.execution_ms)::numeric) AS p95_execution_ms,
+  COUNT(*) FILTER (WHERE r.preagg_hit) AS preagg_hit_count,
+  (
+    SELECT jsonb_object_agg(c.context, c.context_count)
+    FROM (
+      SELECT context, COUNT(*) AS context_count
+      FROM runs r2
+      WHERE r2.explore_name = r.explore_name
+      GROUP BY context
+    ) c
+  ) AS context_counts
+FROM runs r
+  CROSS JOIN params
+GROUP BY r.explore_name, params.min_queries
+HAVING COUNT(*) FILTER (WHERE NOT r.preagg_hit) >= params.min_queries
+ORDER BY SUM(r.execution_ms) DESC
+LIMIT ?;
+`;
+
+/**
+ * Most common (dimensions, metrics) combinations per explore, so a proposed
+ * pre-aggregate can cover the shapes users actually run instead of the union
+ * of everything. Shapes using table calculations, custom metrics, or custom
+ * dimensions can never hit a pre-aggregate, so they are marked rather than
+ * silently mixed in.
+ *
+ * Parameters: window_days, project_uuid, explore_names_csv, shapes_per_explore
+ */
+export const preAggQueryShapesSql = () => `
+WITH params AS (
+  SELECT now() - make_interval(days => ?) AS window_start
+),
+shapes AS (
+  SELECT
+    qh.metric_query->>'exploreName' AS explore_name,
+    (
+      SELECT COALESCE(jsonb_agg(d ORDER BY d), '[]'::jsonb)
+      FROM jsonb_array_elements_text(qh.metric_query->'dimensions') d
+    ) AS dimension_field_ids,
+    (
+      SELECT COALESCE(jsonb_agg(m ORDER BY m), '[]'::jsonb)
+      FROM jsonb_array_elements_text(qh.metric_query->'metrics') m
+    ) AS metric_field_ids,
+    (
+      COALESCE(jsonb_array_length(qh.metric_query->'tableCalculations'), 0) > 0
+      OR COALESCE(jsonb_array_length(qh.metric_query->'additionalMetrics'), 0) > 0
+      OR COALESCE(jsonb_array_length(qh.metric_query->'customDimensions'), 0) > 0
+    ) AS has_custom_fields,
+    jsonb_path_query_array(
+      COALESCE(qh.metric_query->'filters', '{}'::jsonb), '$.**.fieldId'
+    ) AS filter_field_ids,
+    qh.warehouse_execution_time_ms AS execution_ms
+  FROM query_history qh
+    CROSS JOIN params
+  WHERE qh.project_uuid = ?
+    AND qh.created_at >= params.window_start
+    AND qh.status = 'ready'
+    AND qh.error IS NULL
+    AND qh.metric_query->>'exploreName' = ANY(string_to_array(?, ','))
+    AND qh.warehouse_execution_time_ms > 0
+    AND qh.pre_aggregate_compiled_sql IS NULL
+),
+grouped AS (
+  SELECT
+    explore_name,
+    dimension_field_ids,
+    metric_field_ids,
+    has_custom_fields,
+    jsonb_agg(DISTINCT filter_field_ids) AS filter_field_id_sets,
+    COUNT(*) AS query_count,
+    ROUND(AVG(execution_ms)) AS avg_execution_ms,
+    SUM(execution_ms) AS total_execution_ms,
+    ROW_NUMBER() OVER (
+      PARTITION BY explore_name
+      ORDER BY COUNT(*) DESC, SUM(execution_ms) DESC
+    ) AS shape_rank
+  FROM shapes
+  GROUP BY explore_name, dimension_field_ids, metric_field_ids, has_custom_fields
+)
+SELECT
+  explore_name,
+  dimension_field_ids,
+  metric_field_ids,
+  has_custom_fields,
+  filter_field_id_sets,
+  query_count,
+  avg_execution_ms,
+  total_execution_ms
+FROM grouped
+WHERE shape_rank <= ?
+ORDER BY explore_name, query_count DESC;
+`;
+
+/**
+ * Hit/miss counts per explore and miss reason from the pre-aggregate match
+ * log. Distinguishes "no pre-aggregate defined" from "defined but keeps
+ * missing", which call for different fixes.
+ *
+ * Parameters: window_days, project_uuid
+ */
+export const preAggMissStatsSql = () => `
+WITH params AS (
+  SELECT (now() - make_interval(days => ?))::date AS window_start
+)
+SELECT
+  s.explore_name,
+  s.miss_reason,
+  SUM(s.hit_count) AS hit_count,
+  SUM(s.miss_count) AS miss_count
+FROM pre_aggregate_daily_stats s
+  CROSS JOIN params
+WHERE s.project_uuid = ?
+  AND s.date >= params.window_start
+GROUP BY s.explore_name, s.miss_reason
+ORDER BY s.explore_name, SUM(s.miss_count) DESC;
+`;

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -56,7 +56,9 @@ import {
 } from '../../clients/ManagedAgentClient';
 import { ManagedAgentModel } from '../../models/ManagedAgentModel';
 import type { ServiceAccountModel } from '../../models/ServiceAccountModel';
+import { buildPreAggCandidateSuggestion } from './preAggCandidates';
 import {
+    buildManagedAgentToolListResult,
     formatManagedAgentToolListResult,
     getManagedAgentToolResultLimit,
     summarizeManagedAgentBrokenContent,
@@ -2037,6 +2039,8 @@ export class ManagedAgentService extends BaseService {
                 return this.handleGetOrphanedContent(actor, projectUuid, input);
             case 'get_unused_agents':
                 return this.handleGetUnusedAgents(projectUuid, input);
+            case 'get_preagg_candidates':
+                return this.handleGetPreAggCandidates(projectUuid, input);
             case 'reverse_own_action':
                 return this.handleReverseOwnAction(actor, projectUuid, input);
             default:
@@ -3279,6 +3283,144 @@ chartConfig:
                 min_prompts_threshold: minPrompts,
             })),
         );
+    }
+
+    private static readonly DEFAULT_PREAGG_WINDOW_DAYS = 30;
+
+    private static readonly DEFAULT_PREAGG_MIN_QUERIES = 10;
+
+    // Wide enough that one dominant non-additive metric cannot crowd every
+    // additive shape out of the sample.
+    private static readonly PREAGG_SHAPES_PER_EXPLORE = 10;
+
+    private async handleGetPreAggCandidates(
+        projectUuid: string,
+        input: Record<string, unknown>,
+    ): Promise<string> {
+        if (!this.lightdashConfig.preAggregates.enabled) {
+            return JSON.stringify({
+                enabled: false,
+                message:
+                    'Pre-aggregates are not enabled on this instance, so there is nothing to check.',
+            });
+        }
+
+        const windowDays =
+            (input.window_days as number) ??
+            ManagedAgentService.DEFAULT_PREAGG_WINDOW_DAYS;
+        const minQueries =
+            (input.min_queries as number) ??
+            ManagedAgentService.DEFAULT_PREAGG_MIN_QUERIES;
+        const limit = getManagedAgentToolResultLimit(input.limit, 10);
+
+        const candidates =
+            await this.managedAgentModel.getPreAggCandidateExplores(
+                projectUuid,
+                windowDays,
+                minQueries,
+                limit,
+            );
+        if (candidates.length === 0) {
+            return formatManagedAgentToolListResult([]);
+        }
+
+        const exploreNames = candidates.map((c) => c.exploreName);
+        const [shapes, missStats, explores] = await Promise.all([
+            this.managedAgentModel.getPreAggQueryShapes(
+                projectUuid,
+                exploreNames,
+                windowDays,
+                ManagedAgentService.PREAGG_SHAPES_PER_EXPLORE,
+            ),
+            this.managedAgentModel.getPreAggMissStats(projectUuid, windowDays),
+            this.projectModel.findExploresFromCache(
+                projectUuid,
+                'name',
+                exploreNames,
+            ),
+        ]);
+
+        const results = candidates.map((candidate) => {
+            const exploreShapes = shapes.filter(
+                (shape) => shape.exploreName === candidate.exploreName,
+            );
+            const exploreMissStats = missStats.filter(
+                (stat) => stat.exploreName === candidate.exploreName,
+            );
+            const explore = explores[candidate.exploreName];
+            const suggestion =
+                explore && !('errors' in explore)
+                    ? buildPreAggCandidateSuggestion({
+                          explore,
+                          shapes: exploreShapes.map((shape) => ({
+                              dimensionFieldIds: shape.dimensionFieldIds,
+                              metricFieldIds: shape.metricFieldIds,
+                              filterFieldIds: shape.filterFieldIds,
+                              hasCustomFields: shape.hasCustomFields,
+                              queryCount: shape.queryCount,
+                          })),
+                      })
+                    : null;
+
+            return {
+                explore_name: candidate.exploreName,
+                query_count: candidate.queryCount,
+                distinct_users: candidate.distinctUsers,
+                total_warehouse_ms: candidate.totalExecutionMs,
+                avg_warehouse_ms: candidate.avgExecutionMs,
+                p95_warehouse_ms: candidate.p95ExecutionMs,
+                queries_already_served_by_preagg: candidate.preAggHitCount,
+                query_contexts: candidate.contextCounts,
+                preagg_hits_in_window: exploreMissStats.reduce(
+                    (sum, stat) => sum + stat.hitCount,
+                    0,
+                ),
+                preagg_misses_by_reason: exploreMissStats
+                    .filter((stat) => stat.missReason !== null)
+                    .map((stat) => ({
+                        reason: stat.missReason,
+                        miss_count: stat.missCount,
+                    })),
+                top_query_shapes: exploreShapes.map((shape) => ({
+                    dimensions: shape.dimensionFieldIds,
+                    metrics: shape.metricFieldIds,
+                    filter_fields: shape.filterFieldIds,
+                    uses_custom_fields: shape.hasCustomFields,
+                    query_count: shape.queryCount,
+                    avg_warehouse_ms: shape.avgExecutionMs,
+                })),
+                suggestion: suggestion
+                    ? {
+                          suggested_yaml: suggestion.suggestedYaml,
+                          no_suggestion_reason: suggestion.noSuggestionReason,
+                          time_dimension: suggestion.timeDimension,
+                          granularity: suggestion.granularity,
+                          covered_query_count: suggestion.coveredQueryCount,
+                          coverable_query_count: suggestion.coverableQueryCount,
+                          custom_field_query_count:
+                              suggestion.customFieldQueryCount,
+                          ineligible_fields: suggestion.ineligibleFields.map(
+                              (field) => ({
+                                  field_id: field.fieldId,
+                                  kind: field.kind,
+                                  reason: field.reason,
+                              }),
+                          ),
+                          unresolved_field_ids: suggestion.unresolvedFieldIds,
+                      }
+                    : {
+                          suggested_yaml: null,
+                          no_suggestion_reason:
+                              'explore_not_found_or_has_compile_errors',
+                      },
+            };
+        });
+
+        return JSON.stringify({
+            window_days: windowDays,
+            min_queries_threshold: minQueries,
+            ...buildManagedAgentToolListResult(results, limit),
+        });
     }
 
     private async handleReverseOwnAction(

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
@@ -214,6 +214,49 @@ describe('renderManagedAgentConfig with policy', () => {
         expect(config.system).toContain('### 8. Slack Summary');
     });
 
+    it('omits the pre-aggregate tool and checklist section when pre-aggregates are disabled', () => {
+        const config = renderManagedAgentConfig(baseArgs);
+        expect(customToolNames(config)).not.toContain('get_preagg_candidates');
+        expect(config.system).not.toContain('Pre-Aggregate Candidates');
+        expect(config.system).toContain('### 7. Insights');
+    });
+
+    it('includes the pre-aggregate tool and renumbers the checklist when enabled', () => {
+        (['observe', 'flag', 'cleanup'] as const).forEach((aggression) => {
+            const config = renderManagedAgentConfig({
+                ...baseArgs,
+                preAggregatesEnabled: true,
+                policy: { ...DEFAULT_MANAGED_AGENT_POLICY, aggression },
+            });
+            expect(customToolNames(config)).toContain('get_preagg_candidates');
+        });
+
+        const config = renderManagedAgentConfig({
+            ...baseArgs,
+            preAggregatesEnabled: true,
+        });
+        expect(config.system).toContain('### 7. Pre-Aggregate Candidates');
+        expect(config.system).toContain(
+            'NEVER write dbt files or change project configuration',
+        );
+        expect(config.system).toContain('Quote it verbatim in your insight');
+        expect(config.system).toContain('### 8. Insights');
+        expect(config.system).toContain('### 9. Slack Summary');
+    });
+
+    it('changes the config hash when pre-aggregate availability changes', () => {
+        const disabled = getManagedAgentConfigHash(
+            renderManagedAgentConfig(baseArgs),
+        );
+        const enabled = getManagedAgentConfigHash(
+            renderManagedAgentConfig({
+                ...baseArgs,
+                preAggregatesEnabled: true,
+            }),
+        );
+        expect(disabled).not.toBe(enabled);
+    });
+
     it('changes the config hash when policy changes', () => {
         const a = getManagedAgentConfigHash(renderManagedAgentConfig(baseArgs));
         const b = getManagedAgentConfigHash(

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -8,8 +8,63 @@ import {
 import { createHash } from 'crypto';
 import { produce } from 'immer';
 
+export type ManagedAgentPromptOptions = {
+    preAggregatesEnabled?: boolean;
+};
+
+// Tail sections number themselves so a conditional section (pre-aggregates)
+// does not force renumbering every section after it.
+const buildChecklistTailSections = (
+    options: ManagedAgentPromptOptions,
+): string => {
+    const sections: Array<{ title: string; body: string }> = [
+        {
+            title: 'AI Agent Usage',
+            body: `Call get_unused_agents. Reporting-only: record what you find with log_insight and NEVER delete, disable, or edit an agent.
+- Lead with the reason field. never_used, no_recent_use, only_failed_sessions and low_traffic call for different advice, so do not blur them into "unused"
+- Use routing_signal to say why traffic may not be arriving: never_a_candidate and candidate_never_suggested point at the agent's name, description and tags rather than at the agent being unwanted; suggested_never_chosen means users are overriding the router
+- only_failed_sessions is a reliability problem, not a popularity one. Say so, and never suggest retiring an agent on that basis
+- An admin_only agent has a small audience by design; do not read its low traffic as a discoverability problem
+- If it returns nothing, skip this step`,
+        },
+        ...(options.preAggregatesEnabled
+            ? [
+                  {
+                      title: 'Pre-Aggregate Candidates',
+                      body: `Call get_preagg_candidates. Reporting-only: record findings with log_insight and NEVER write dbt files or change project configuration.
+- Each candidate includes a suggested_yaml block already validated against this project's semantic layer. Quote it verbatim in your insight; never invent or edit pre-aggregate YAML yourself
+- Lead with the cost story: total_warehouse_ms and query_count say how much warehouse time is at stake, and covered_query_count out of coverable_query_count says how much of the observed traffic the suggestion actually serves
+- preagg_misses_by_reason distinguishes explores with no pre-aggregate from pre-aggregates that keep missing. dimension_not_in_pre_aggregate and metric_not_in_pre_aggregate mean an EXISTING pre-aggregate should be extended, not a new one added
+- ineligible_fields can never be pre-aggregated (non-additive metrics, custom SQL, user attributes). Mention them so admins understand the coverage gap; do not propose workarounds
+- Tell admins to check the materialized row count before adopting a suggestion: high-cardinality dimensions can exceed the recommended 1,000,000 row threshold. Suggest max_rows or filters when that risk looks real
+- If it returns nothing, skip this step`,
+                  },
+              ]
+            : []),
+        {
+            title: 'Insights',
+            body: `Call get_popular_content.
+- Surface content that is popular but not pinned
+- Surface content with high views but restricted access (private space)
+- If nothing noteworthy, skip this step`,
+        },
+        {
+            title: 'Slack Summary',
+            body: `After the run is complete, call write_slack_summary exactly once with the final summary you want posted to Slack. Use the "lightdash-agent-slack-messaging" skill to match Lightdash's Slack tone of voice`,
+        },
+    ];
+
+    return sections
+        .map(
+            (section, index) =>
+                `### ${index + 6}. ${section.title}\n${section.body}`,
+        )
+        .join('\n\n');
+};
+
 export const buildManagedAgentSystemPrompt = (
     policy: ManagedAgentPolicy,
+    options: ManagedAgentPromptOptions = {},
 ): string => {
     const {
         stalenessChartDays,
@@ -164,22 +219,7 @@ Call get_inactive_users and get_orphaned_content. Both are reporting-only: recor
 - Orphaned content: group by former owner so admins can reassign in one pass. Leaving the company does not make content stale, so do not recommend deletion on those grounds alone
 - If either returns nothing, say so briefly or skip
 
-### 6. AI Agent Usage
-Call get_unused_agents. Reporting-only: record what you find with log_insight and NEVER delete, disable, or edit an agent.
-- Lead with the reason field. never_used, no_recent_use, only_failed_sessions and low_traffic call for different advice, so do not blur them into "unused"
-- Use routing_signal to say why traffic may not be arriving: never_a_candidate and candidate_never_suggested point at the agent's name, description and tags rather than at the agent being unwanted; suggested_never_chosen means users are overriding the router
-- only_failed_sessions is a reliability problem, not a popularity one. Say so, and never suggest retiring an agent on that basis
-- An admin_only agent has a small audience by design; do not read its low traffic as a discoverability problem
-- If it returns nothing, skip this step
-
-### 7. Insights
-Call get_popular_content.
-- Surface content that is popular but not pinned
-- Surface content with high views but restricted access (private space)
-- If nothing noteworthy, skip this step
-
-### 8. Slack Summary
-After the run is complete, call write_slack_summary exactly once with the final summary you want posted to Slack. Use the "lightdash-agent-slack-messaging" skill to match Lightdash's Slack tone of voice
+${buildChecklistTailSections(options)}
 `;
 };
 
@@ -650,6 +690,33 @@ export const managedAgentConfig: AgentCreateParams = {
         },
         {
             description:
+                'Get explores where users burn warehouse time on repeated queries that a pre-aggregate could serve. Ranks explores by total warehouse execution time over the window, with the most common query shapes, existing pre-aggregate hit/miss stats by miss reason, and a suggested pre_aggregates YAML definition that has been validated against the project semantic layer. Queries already served by a pre-aggregate are excluded from the ranking. Reporting only: propose the YAML to admins via log_insight, never write dbt files.',
+            input_schema: {
+                properties: {
+                    limit: {
+                        description:
+                            'Max candidate explores to return (default 10)',
+                        type: 'number',
+                    },
+                    min_queries: {
+                        description:
+                            'Minimum warehouse queries in the window for an explore to qualify (default 10)',
+                        type: 'number',
+                    },
+                    window_days: {
+                        description:
+                            'Days of query history to analyze (default 30)',
+                        type: 'number',
+                    },
+                },
+                required: [],
+                type: 'object',
+            },
+            name: 'get_preagg_candidates',
+            type: 'custom',
+        },
+        {
+            description:
                 'Persist the final Slack-ready summary for this run. Call exactly once after you finish your work and have written the final Slack message.',
             input_schema: {
                 properties: {
@@ -674,6 +741,7 @@ type RenderManagedAgentConfigArgs = {
     skillIds: string[];
     toolSettings?: Record<string, boolean>;
     policy?: ManagedAgentPolicy;
+    preAggregatesEnabled?: boolean;
 };
 
 export const getManagedAgentMcpUrl = (
@@ -729,6 +797,7 @@ export const renderManagedAgentConfig = ({
     skillIds,
     toolSettings = {},
     policy,
+    preAggregatesEnabled = false,
 }: RenderManagedAgentConfigArgs): AgentCreateParams => {
     const resolvedPolicy = resolveManagedAgentPolicy(policy);
     const normalizedToolSettings =
@@ -744,12 +813,15 @@ export const renderManagedAgentConfig = ({
                 ],
         ),
         ...aggressionDisabledTools[resolvedPolicy.aggression],
+        ...(preAggregatesEnabled ? [] : ['get_preagg_candidates']),
     ]);
     const policyToolDescriptions = buildPolicyToolDescriptions(resolvedPolicy);
 
     return produce(managedAgentConfig, (draft) => {
         // eslint-disable-next-line no-param-reassign
-        draft.system = buildManagedAgentSystemPrompt(resolvedPolicy);
+        draft.system = buildManagedAgentSystemPrompt(resolvedPolicy, {
+            preAggregatesEnabled,
+        });
         // eslint-disable-next-line no-param-reassign
         draft.mcp_servers = [
             {

--- a/packages/backend/src/ee/services/ManagedAgentService/preAggCandidates.test.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/preAggCandidates.test.ts
@@ -1,0 +1,237 @@
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    SupportedDbtAdapter,
+    TimeFrames,
+    type CompiledDimension,
+    type CompiledMetric,
+    type CompiledTable,
+    type Explore,
+} from '@lightdash/common';
+import { buildPreAggCandidateSuggestion } from './preAggCandidates';
+
+const makeDimension = (
+    overrides: Partial<CompiledDimension> & Pick<CompiledDimension, 'name'>,
+): CompiledDimension => ({
+    ...overrides,
+    fieldType: FieldType.DIMENSION,
+    type: overrides.type ?? DimensionType.STRING,
+    name: overrides.name,
+    label: overrides.label ?? overrides.name,
+    table: overrides.table ?? 'orders',
+    tableLabel: overrides.tableLabel ?? 'Orders',
+    sql: overrides.sql ?? `\${TABLE}.${overrides.name}`,
+    compiledSql: overrides.compiledSql ?? `"orders".${overrides.name}`,
+    tablesReferences: overrides.tablesReferences ?? [
+        overrides.table ?? 'orders',
+    ],
+    hidden: overrides.hidden ?? false,
+});
+
+const makeMetric = (
+    overrides: Partial<CompiledMetric> & Pick<CompiledMetric, 'name' | 'type'>,
+): CompiledMetric => ({
+    ...overrides,
+    fieldType: FieldType.METRIC,
+    type: overrides.type,
+    name: overrides.name,
+    label: overrides.label ?? overrides.name,
+    table: overrides.table ?? 'orders',
+    tableLabel: overrides.tableLabel ?? 'Orders',
+    sql: overrides.sql ?? `sum(\${TABLE}.amount)`,
+    compiledSql: overrides.compiledSql ?? 'SUM("orders".amount)',
+    tablesReferences: overrides.tablesReferences ?? [
+        overrides.table ?? 'orders',
+    ],
+    hidden: overrides.hidden ?? false,
+});
+
+const makeTable = (
+    name: string,
+    dimensions: CompiledDimension[],
+    metrics: CompiledMetric[],
+): CompiledTable => ({
+    name,
+    label: name,
+    database: 'db',
+    schema: 'public',
+    sqlTable: `"public"."${name}"`,
+    dimensions: Object.fromEntries(dimensions.map((d) => [d.name, d])),
+    metrics: Object.fromEntries(metrics.map((m) => [m.name, m])),
+    lineageGraph: {},
+});
+
+const status = makeDimension({ name: 'status' });
+const orderDateBase = makeDimension({
+    name: 'order_date',
+    type: DimensionType.DATE,
+    isIntervalBase: true,
+});
+const orderDateDay = makeDimension({
+    name: 'order_date_day',
+    type: DimensionType.DATE,
+    timeInterval: TimeFrames.DAY,
+    timeIntervalBaseDimensionName: 'order_date',
+});
+const orderDateMonth = makeDimension({
+    name: 'order_date_month',
+    type: DimensionType.DATE,
+    timeInterval: TimeFrames.MONTH,
+    timeIntervalBaseDimensionName: 'order_date',
+});
+const customerName = makeDimension({
+    name: 'first_name',
+    table: 'customers',
+    tableLabel: 'Customers',
+    compiledSql: '"customers".first_name',
+    tablesReferences: ['customers'],
+});
+const totalAmount = makeMetric({
+    name: 'total_order_amount',
+    type: MetricType.SUM,
+});
+const medianAmount = makeMetric({
+    name: 'median_order_amount',
+    type: MetricType.MEDIAN,
+    sql: 'median(${TABLE}.amount)',
+    compiledSql: 'MEDIAN("orders".amount)',
+});
+
+const explore: Explore = {
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    baseTable: 'orders',
+    joinedTables: [],
+    tables: {
+        orders: makeTable(
+            'orders',
+            [status, orderDateBase, orderDateDay, orderDateMonth],
+            [totalAmount, medianAmount],
+        ),
+        customers: makeTable('customers', [customerName], []),
+    },
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+};
+
+describe('buildPreAggCandidateSuggestion', () => {
+    it('proposes a validated definition covering the observed shapes', () => {
+        const suggestion = buildPreAggCandidateSuggestion({
+            explore,
+            shapes: [
+                {
+                    dimensionFieldIds: [
+                        'orders_status',
+                        'orders_order_date_day',
+                    ],
+                    metricFieldIds: ['orders_total_order_amount'],
+                    filterFieldIds: ['customers_first_name'],
+                    hasCustomFields: false,
+                    queryCount: 40,
+                },
+                {
+                    dimensionFieldIds: ['orders_order_date_month'],
+                    metricFieldIds: ['orders_total_order_amount'],
+                    filterFieldIds: [],
+                    hasCustomFields: false,
+                    queryCount: 10,
+                },
+            ],
+        });
+
+        expect(suggestion.noSuggestionReason).toBeNull();
+        expect(suggestion.timeDimension).toBe('order_date');
+        expect(suggestion.granularity).toBe('day');
+        expect(suggestion.suggestedYaml).toBe(
+            [
+                'pre_aggregates:',
+                '  - name: orders_autopilot_candidate',
+                '    dimensions:',
+                '      - customers.first_name',
+                '      - status',
+                '    metrics:',
+                '      - total_order_amount',
+                '    time_dimension: order_date',
+                '    granularity: day',
+            ].join('\n'),
+        );
+        expect(suggestion.coveredQueryCount).toBe(50);
+        expect(suggestion.coverableQueryCount).toBe(50);
+        expect(suggestion.ineligibleFields).toEqual([]);
+    });
+
+    it('reports non-additive metrics as ineligible instead of proposing them', () => {
+        const suggestion = buildPreAggCandidateSuggestion({
+            explore,
+            shapes: [
+                {
+                    dimensionFieldIds: ['orders_status'],
+                    metricFieldIds: [
+                        'orders_total_order_amount',
+                        'orders_median_order_amount',
+                    ],
+                    filterFieldIds: [],
+                    hasCustomFields: false,
+                    queryCount: 20,
+                },
+            ],
+        });
+
+        expect(suggestion.suggestedYaml).toContain('total_order_amount');
+        expect(suggestion.suggestedYaml).not.toContain('median_order_amount');
+        expect(suggestion.ineligibleFields).toEqual([
+            {
+                fieldId: 'orders_median_order_amount',
+                kind: 'metric',
+                reason: 'non_additive_metric_type_median',
+            },
+        ]);
+        expect(suggestion.coveredQueryCount).toBe(0);
+    });
+
+    it('returns no suggestion when every shape uses custom fields', () => {
+        const suggestion = buildPreAggCandidateSuggestion({
+            explore,
+            shapes: [
+                {
+                    dimensionFieldIds: ['orders_status'],
+                    metricFieldIds: ['orders_total_order_amount'],
+                    filterFieldIds: [],
+                    hasCustomFields: true,
+                    queryCount: 15,
+                },
+            ],
+        });
+
+        expect(suggestion.suggestedYaml).toBeNull();
+        expect(suggestion.noSuggestionReason).toBe(
+            'every_observed_query_uses_custom_fields_that_cannot_hit_a_pre_aggregate',
+        );
+        expect(suggestion.customFieldQueryCount).toBe(15);
+    });
+
+    it('surfaces unknown field ids instead of failing', () => {
+        const suggestion = buildPreAggCandidateSuggestion({
+            explore,
+            shapes: [
+                {
+                    dimensionFieldIds: [
+                        'orders_status',
+                        'orders_deleted_dimension',
+                    ],
+                    metricFieldIds: ['orders_total_order_amount'],
+                    filterFieldIds: [],
+                    hasCustomFields: false,
+                    queryCount: 5,
+                },
+            ],
+        });
+
+        expect(suggestion.unresolvedFieldIds).toContain(
+            'orders_deleted_dimension',
+        );
+        expect(suggestion.suggestedYaml).not.toBeNull();
+        expect(suggestion.coveredQueryCount).toBe(0);
+    });
+});

--- a/packages/backend/src/ee/services/ManagedAgentService/preAggCandidates.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/preAggCandidates.ts
@@ -1,0 +1,437 @@
+import {
+    analyzePreAggregateDerivedDimensionEligibility,
+    analyzePreAggregateDerivedMetricEligibility,
+    getItemId,
+    isPreAggregateCompatibleMetricType,
+    parseDbtPreAggregateDef,
+    TimeFrames,
+    type CompiledDimension,
+    type CompiledMetric,
+    type Explore,
+} from '@lightdash/common';
+
+export type PreAggCandidateShape = {
+    dimensionFieldIds: string[];
+    metricFieldIds: string[];
+    filterFieldIds: string[];
+    hasCustomFields: boolean;
+    queryCount: number;
+};
+
+export type PreAggIneligibleField = {
+    fieldId: string;
+    kind: 'dimension' | 'metric';
+    reason: string;
+};
+
+export type PreAggCandidateSuggestion = {
+    suggestedYaml: string | null;
+    noSuggestionReason: string | null;
+    timeDimension: string | null;
+    granularity: string | null;
+    ineligibleFields: PreAggIneligibleField[];
+    unresolvedFieldIds: string[];
+    coveredQueryCount: number;
+    coverableQueryCount: number;
+    customFieldQueryCount: number;
+};
+
+// Frames that behave as a linear time granularity: a pre-aggregate stored at
+// one of these serves queries at the same frame or any coarser one. Ordered
+// finest to coarsest. Cyclic frames (day-of-week, month name, ...) cannot be a
+// granularity and are treated as plain dimensions.
+const LINEAR_TIME_FRAMES: TimeFrames[] = [
+    TimeFrames.MILLISECOND,
+    TimeFrames.SECOND,
+    TimeFrames.MINUTE,
+    TimeFrames.HOUR,
+    TimeFrames.DAY,
+    TimeFrames.WEEK,
+    TimeFrames.MONTH,
+    TimeFrames.QUARTER,
+    TimeFrames.YEAR,
+];
+
+const linearFrameIndex = (frame: TimeFrames): number =>
+    LINEAR_TIME_FRAMES.indexOf(frame);
+
+type IndexedField =
+    | { kind: 'dimension'; field: CompiledDimension }
+    | { kind: 'metric'; field: CompiledMetric };
+
+const indexExploreFields = (explore: Explore): Map<string, IndexedField> => {
+    const index = new Map<string, IndexedField>();
+    Object.values(explore.tables).forEach((table) => {
+        Object.values(table.dimensions).forEach((dimension) => {
+            index.set(getItemId(dimension), {
+                kind: 'dimension',
+                field: dimension,
+            });
+        });
+        Object.values(table.metrics).forEach((metric) => {
+            index.set(getItemId(metric), { kind: 'metric', field: metric });
+        });
+    });
+    return index;
+};
+
+// YAML references are bare field names on the base table and
+// "table.field" on joined tables (see examples/full-jaffle-shop-demo).
+const fieldYamlReference = (
+    explore: Explore,
+    field: CompiledDimension | CompiledMetric,
+): string =>
+    field.table === explore.baseTable
+        ? field.name
+        : `${field.table}.${field.name}`;
+
+const renderPreAggYaml = ({
+    name,
+    dimensionRefs,
+    metricRefs,
+    timeDimensionRef,
+    granularity,
+}: {
+    name: string;
+    dimensionRefs: string[];
+    metricRefs: string[];
+    timeDimensionRef: string | null;
+    granularity: TimeFrames | null;
+}): string => {
+    const lines = [
+        'pre_aggregates:',
+        `  - name: ${name}`,
+        '    dimensions:',
+        ...dimensionRefs.map((ref) => `      - ${ref}`),
+        '    metrics:',
+        ...metricRefs.map((ref) => `      - ${ref}`),
+    ];
+    if (timeDimensionRef && granularity) {
+        lines.push(`    time_dimension: ${timeDimensionRef}`);
+        lines.push(`    granularity: ${granularity.toLowerCase()}`);
+    }
+    return lines.join('\n');
+};
+
+type TimeDimensionUsage = {
+    baseFieldId: string;
+    baseName: string;
+    table: string;
+    weight: number;
+    linearFrames: TimeFrames[];
+};
+
+export const buildPreAggCandidateSuggestion = ({
+    explore,
+    shapes,
+}: {
+    explore: Explore;
+    shapes: PreAggCandidateShape[];
+}): PreAggCandidateSuggestion => {
+    const fieldIndex = indexExploreFields(explore);
+    const coverableShapes = shapes.filter((shape) => !shape.hasCustomFields);
+    const customFieldQueryCount = shapes
+        .filter((shape) => shape.hasCustomFields)
+        .reduce((sum, shape) => sum + shape.queryCount, 0);
+
+    const empty = (reason: string): PreAggCandidateSuggestion => ({
+        suggestedYaml: null,
+        noSuggestionReason: reason,
+        timeDimension: null,
+        granularity: null,
+        ineligibleFields: [],
+        unresolvedFieldIds: [],
+        coveredQueryCount: 0,
+        coverableQueryCount: coverableShapes.reduce(
+            (sum, shape) => sum + shape.queryCount,
+            0,
+        ),
+        customFieldQueryCount,
+    });
+
+    if (coverableShapes.length === 0) {
+        return empty(
+            'every_observed_query_uses_custom_fields_that_cannot_hit_a_pre_aggregate',
+        );
+    }
+
+    // Weight each field by how many queries used it, so the time dimension
+    // choice reflects real traffic.
+    const dimensionWeights = new Map<string, number>();
+    const metricWeights = new Map<string, number>();
+    coverableShapes.forEach((shape) => {
+        new Set([...shape.dimensionFieldIds, ...shape.filterFieldIds]).forEach(
+            (fieldId) => {
+                dimensionWeights.set(
+                    fieldId,
+                    (dimensionWeights.get(fieldId) ?? 0) + shape.queryCount,
+                );
+            },
+        );
+        new Set(shape.metricFieldIds).forEach((fieldId) => {
+            metricWeights.set(
+                fieldId,
+                (metricWeights.get(fieldId) ?? 0) + shape.queryCount,
+            );
+        });
+    });
+
+    const unresolvedFieldIds: string[] = [];
+    const ineligibleFields: PreAggIneligibleField[] = [];
+    const plainDimensions = new Map<string, CompiledDimension>();
+    const timeDimensionUsages = new Map<string, TimeDimensionUsage>();
+
+    dimensionWeights.forEach((weight, fieldId) => {
+        const indexed = fieldIndex.get(fieldId);
+        if (!indexed) {
+            unresolvedFieldIds.push(fieldId);
+            return;
+        }
+        if (indexed.kind === 'metric') {
+            // A filter can target a metric; metric filters are handled by the
+            // metrics list, not the dimensions list.
+            return;
+        }
+        const dimension = indexed.field;
+        const baseName = dimension.timeIntervalBaseDimensionName;
+        const interval = dimension.timeInterval;
+        if (baseName && interval && linearFrameIndex(interval) >= 0) {
+            const baseFieldId = getItemId({
+                table: dimension.table,
+                name: baseName,
+            });
+            const usage = timeDimensionUsages.get(baseFieldId) ?? {
+                baseFieldId,
+                baseName,
+                table: dimension.table,
+                weight: 0,
+                linearFrames: [],
+            };
+            usage.weight += weight;
+            usage.linearFrames.push(interval);
+            timeDimensionUsages.set(baseFieldId, usage);
+            return;
+        }
+        plainDimensions.set(fieldId, dimension);
+    });
+
+    metricWeights.forEach((_weight, fieldId) => {
+        const indexed = fieldIndex.get(fieldId);
+        if (!indexed || indexed.kind === 'dimension') {
+            unresolvedFieldIds.push(fieldId);
+        }
+    });
+
+    // Most-queried time base wins; the granularity is the finest frame
+    // observed on it, because a pre-aggregate serves that frame and coarser.
+    const chosenTimeUsage = Array.from(timeDimensionUsages.values()).sort(
+        (a, b) => b.weight - a.weight,
+    )[0];
+    const chosenGranularity = chosenTimeUsage
+        ? chosenTimeUsage.linearFrames.reduce((finest, frame) =>
+              linearFrameIndex(frame) < linearFrameIndex(finest)
+                  ? frame
+                  : finest,
+          )
+        : null;
+
+    // The chosen base is expressed via time_dimension/granularity; a filter
+    // targeting the raw base field must not duplicate it as a plain dimension.
+    if (chosenTimeUsage) {
+        plainDimensions.delete(chosenTimeUsage.baseFieldId);
+    }
+
+    // Time bases other than the chosen one stay as plain interval dimensions.
+    timeDimensionUsages.forEach((usage) => {
+        if (usage === chosenTimeUsage) {
+            return;
+        }
+        dimensionWeights.forEach((_weight, fieldId) => {
+            const indexed = fieldIndex.get(fieldId);
+            if (
+                indexed?.kind === 'dimension' &&
+                indexed.field.timeIntervalBaseDimensionName ===
+                    usage.baseName &&
+                indexed.field.table === usage.table
+            ) {
+                plainDimensions.set(fieldId, indexed.field);
+            }
+        });
+    });
+
+    const eligibleDimensions: CompiledDimension[] = [];
+    plainDimensions.forEach((dimension, fieldId) => {
+        const eligibility = analyzePreAggregateDerivedDimensionEligibility({
+            dimension,
+            tables: explore.tables,
+        });
+        if (eligibility.isEligible) {
+            eligibleDimensions.push(dimension);
+        } else {
+            ineligibleFields.push({
+                fieldId,
+                kind: 'dimension',
+                reason: eligibility.reason,
+            });
+        }
+    });
+
+    const eligibleMetrics: CompiledMetric[] = [];
+    const eligibleMetricFieldIds = new Set<string>();
+    metricWeights.forEach((_weight, fieldId) => {
+        const indexed = fieldIndex.get(fieldId);
+        if (!indexed || indexed.kind !== 'metric') {
+            return;
+        }
+        const metric = indexed.field;
+        if (!isPreAggregateCompatibleMetricType(metric.type)) {
+            ineligibleFields.push({
+                fieldId,
+                kind: 'metric',
+                reason: `non_additive_metric_type_${metric.type}`,
+            });
+            return;
+        }
+        const eligibility = analyzePreAggregateDerivedMetricEligibility({
+            metric,
+            tables: explore.tables,
+        });
+        if (eligibility.isEligible) {
+            eligibleMetrics.push(metric);
+            eligibleMetricFieldIds.add(fieldId);
+        } else {
+            ineligibleFields.push({
+                fieldId,
+                kind: 'metric',
+                reason: eligibility.reason,
+            });
+        }
+    });
+
+    if (eligibleMetrics.length === 0) {
+        return {
+            ...empty('no_eligible_metrics_in_observed_queries'),
+            ineligibleFields,
+            unresolvedFieldIds,
+        };
+    }
+    if (eligibleDimensions.length === 0 && !chosenTimeUsage) {
+        return {
+            ...empty('no_eligible_dimensions_in_observed_queries'),
+            ineligibleFields,
+            unresolvedFieldIds,
+        };
+    }
+
+    const eligibleDimensionFieldIds = new Set(
+        eligibleDimensions.map((dimension) => getItemId(dimension)),
+    );
+    const coveredIntervalFieldIds = new Set<string>();
+    if (chosenTimeUsage && chosenGranularity) {
+        fieldIndex.forEach((indexed, fieldId) => {
+            if (
+                indexed.kind === 'dimension' &&
+                indexed.field.table === chosenTimeUsage.table &&
+                indexed.field.timeIntervalBaseDimensionName ===
+                    chosenTimeUsage.baseName &&
+                indexed.field.timeInterval &&
+                linearFrameIndex(indexed.field.timeInterval) >=
+                    linearFrameIndex(chosenGranularity)
+            ) {
+                coveredIntervalFieldIds.add(fieldId);
+            }
+        });
+    }
+
+    const shapeIsCovered = (shape: PreAggCandidateShape): boolean => {
+        const dimensionFieldIds = new Set([
+            ...shape.dimensionFieldIds,
+            ...shape.filterFieldIds,
+        ]);
+        const dimensionsCovered = Array.from(dimensionFieldIds).every(
+            (fieldId) =>
+                eligibleDimensionFieldIds.has(fieldId) ||
+                coveredIntervalFieldIds.has(fieldId) ||
+                // Metric filters resolve through the metrics list
+                eligibleMetricFieldIds.has(fieldId),
+        );
+        const metricsCovered = shape.metricFieldIds.every((fieldId) =>
+            eligibleMetricFieldIds.has(fieldId),
+        );
+        return dimensionsCovered && metricsCovered;
+    };
+    const coveredQueryCount = coverableShapes
+        .filter(shapeIsCovered)
+        .reduce((sum, shape) => sum + shape.queryCount, 0);
+
+    const name = `${explore.baseTable}_autopilot_candidate`;
+    const dimensionRefs = eligibleDimensions
+        .map((dimension) => fieldYamlReference(explore, dimension))
+        .sort();
+    const metricRefs = eligibleMetrics
+        .map((metric) => fieldYamlReference(explore, metric))
+        .sort();
+    const baseTimeDimension = chosenTimeUsage
+        ? Object.values(explore.tables)
+              .flatMap((table) => Object.values(table.dimensions))
+              .find(
+                  (dimension) =>
+                      dimension.table === chosenTimeUsage.table &&
+                      dimension.name === chosenTimeUsage.baseName,
+              )
+        : undefined;
+    const timeDimensionRef =
+        baseTimeDimension && chosenGranularity
+            ? fieldYamlReference(explore, baseTimeDimension)
+            : null;
+
+    // Roundtrip through the real parser so the agent only ever quotes a
+    // definition Lightdash would accept.
+    try {
+        parseDbtPreAggregateDef(
+            {
+                name,
+                dimensions: dimensionRefs,
+                metrics: metricRefs,
+                ...(timeDimensionRef && chosenGranularity
+                    ? {
+                          time_dimension: timeDimensionRef,
+                          granularity: chosenGranularity.toLowerCase(),
+                      }
+                    : {}),
+            },
+            explore.baseTable,
+        );
+    } catch (error) {
+        return {
+            ...empty(
+                `generated_definition_failed_validation: ${
+                    error instanceof Error ? error.message : 'unknown error'
+                }`,
+            ),
+            ineligibleFields,
+            unresolvedFieldIds,
+        };
+    }
+
+    return {
+        suggestedYaml: renderPreAggYaml({
+            name,
+            dimensionRefs,
+            metricRefs,
+            timeDimensionRef,
+            granularity: chosenGranularity,
+        }),
+        noSuggestionReason: null,
+        timeDimension: timeDimensionRef,
+        granularity: chosenGranularity?.toLowerCase() ?? null,
+        ineligibleFields,
+        unresolvedFieldIds,
+        coveredQueryCount,
+        coverableQueryCount: coverableShapes.reduce(
+            (sum, shape) => sum + shape.queryCount,
+            0,
+        ),
+        customFieldQueryCount,
+    };
+};

--- a/packages/backend/src/ee/services/ManagedAgentService/toolResults.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/toolResults.ts
@@ -28,19 +28,24 @@ type ManagedAgentToolListResult<T> = {
     omitted_count: number;
 };
 
-export const formatManagedAgentToolListResult = <T>(
+export const buildManagedAgentToolListResult = <T>(
     items: T[],
     limit = MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT,
-): string => {
+): ManagedAgentToolListResult<T> => {
     const limitedItems = items.slice(0, limit);
-    return JSON.stringify({
+    return {
         items: limitedItems,
         total_count: items.length,
         returned_count: limitedItems.length,
         truncated: items.length > limitedItems.length,
         omitted_count: Math.max(items.length - limitedItems.length, 0),
-    } satisfies ManagedAgentToolListResult<T>);
+    };
 };
+
+export const formatManagedAgentToolListResult = <T>(
+    items: T[],
+    limit = MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT,
+): string => JSON.stringify(buildManagedAgentToolListResult(items, limit));
 
 type ManagedAgentBrokenContentItem = {
     uuid: string;

--- a/packages/common/src/ee/preAggregates/index.ts
+++ b/packages/common/src/ee/preAggregates/index.ts
@@ -1,3 +1,7 @@
+export {
+    getAdditivityType as getPreAggregateMetricAdditivityType,
+    isCompatible as isPreAggregateCompatibleMetricType,
+} from './additivity';
 export * from './audit';
 export {
     analyzePreAggregateDerivedDimensionEligibility,

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -148,7 +148,7 @@ const CAPABILITY_GROUPS = [
         key: 'readOnly',
         label: 'Read content',
         description:
-            'Reads project health signals, recent Autopilot actions, stale charts and dashboards, broken content, chart definitions, user questions, popular content, preview projects, slow query history, inactive project members, content whose owner has left, and AI agents with little or no traffic.',
+            'Reads project health signals, recent Autopilot actions, stale charts and dashboards, broken content, chart definitions, user questions, popular content, preview projects, slow query history, inactive project members, content whose owner has left, AI agents with little or no traffic, and pre-aggregate candidates from query patterns.',
         locked: true,
     },
     {


### PR DESCRIPTION
Linear: [PROD-9414](https://linear.app/lightdash/issue/PROD-9414/pre-aggregate-identification)

Adds a `get_preagg_candidates` Autopilot tool that turns real query history into validated pre-aggregate proposals.

## What it does

- Ranks explores by total warehouse execution time over a window (default 30 days), counting only queries that actually hit the warehouse and excluding traffic already served by a pre-aggregate.
- Extracts the dominant query shapes per explore: selected dimensions, metrics, and filter fields (filters matter because a filtered dimension must be in the pre-aggregate even when not selected). Shapes using table calculations, custom metrics, or custom dimensions are counted separately since they can never hit a pre-aggregate.
- Cross-checks the union of observed fields against the compiled explore using the real eligibility analyzers from `@lightdash/common` (`analyzePreAggregateDerived*Eligibility`, metric additivity). Non-additive metrics (median, percentile, count_distinct...) are reported as ineligible, never proposed.
- Picks the most-traffic time dimension and the finest observed linear granularity (a pre-agg at day serves day/week/month; cyclic frames like day-of-week stay plain dimensions).
- Emits a suggested `pre_aggregates:` YAML block that is round-tripped through `parseDbtPreAggregateDef` before the agent sees it, so the agent only ever quotes a definition Lightdash would accept, plus a covered/coverable query count so the value is measurable.
- Includes per-explore hit/miss stats from `pre_aggregate_daily_stats` broken down by miss reason, so the agent distinguishes "no pre-aggregate defined" from "existing pre-aggregate should be extended".

## Gating

The tool and its checklist section only render when `lightdashConfig.preAggregates.enabled` is set on the instance (license + `PRE_AGGREGATES_ENABLED` + S3 config). On disabled instances the tool is absent from the agent config entirely, and the handler double-guards.

The checklist tail sections now number themselves, so this conditional section (and future ones) no longer forces renumbering every later section and its tests.

## Reporting-only guardrails

The prompt instructs the agent to record findings via `log_insight`, quote the validated YAML verbatim, never write dbt files, and warn admins to check materialized row counts against the 1M row threshold before adopting a suggestion. Tests pin these phrases.

## Live validation

Ran the full pipeline against the local dev database (jaffle project, 90-day window): the SQL detectors surfaced real traffic, the suggestion builder produced a validated YAML block, `buildPreAggregateExplore` compiled it (proving every reference string resolves), and the real matcher (`preAggregateUtils.findMatch`) reported 42/200 recorded production-shaped queries as HITs against the generated definition, with the remaining misses correctly attributed (mostly a count_distinct metric that can never be pre-aggregated, reported as ineligible). This run surfaced and fixed three things: cache hits store `warehouse_execution_time_ms = 0` (not NULL), so the filters now use `> 0` to keep cache traffic out of the averages; a date filter targeting the raw base field no longer duplicates the chosen time dimension as a plain dimension; and the shape sample per explore was widened to 10 so one dominant non-additive metric cannot crowd every additive shape out of the sample.

## Regression analysis

- `toolResults.ts`: `formatManagedAgentToolListResult` is now a thin wrapper over a new `buildManagedAgentToolListResult`; output is byte-identical for all existing callers.
- `buildManagedAgentSystemPrompt` gained an optional options arg defaulting to `{}`; with pre-aggregates disabled the rendered prompt is character-identical to before (existing section-numbering tests pass unchanged), so persisted agent config hashes do not churn on instances without pre-aggregates.
- `@lightdash/common` adds two renamed re-exports (`getPreAggregateMetricAdditivityType`, `isPreAggregateCompatibleMetricType`); no existing export changes.
- All three SQL detectors were run against the dev database; the full backend suite (6131 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eEGQShbuDQNkCFx5k5w9m