### PR TITLE
fix: gate Slack channel linking before the system-agent fallback

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -12508,14 +12508,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     // Offers only agents the user can manage — linking mutates agent config.
     // A single manageable agent is linked immediately (no one-option dropdown)
     // and returned so the caller can answer the question in the same pass.
+    // Callers must gate on resolveAgentForUnmappedSlackChannel first, which
+    // enforces the explicit-linking setting.
     private async showChannelLinkAgentPicker(args: {
         organizationUuid: string;
         userUuid: string;
         channelId: string;
         threadTs: string;
         say: SayFn;
-        client: WebClient;
-        slackUserId: string;
         // Reuses the multi-agent channel "filter agents by project" setting.
         visibleProjectUuids?: string[] | null;
     }): Promise<AiAgent | undefined> {
@@ -12525,25 +12525,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             channelId,
             threadTs,
             say,
-            client,
-            slackUserId,
             visibleProjectUuids,
         } = args;
         const { siteUrl } = this.lightdashConfig;
-
-        if (
-            await this.aiOrganizationSettingsService.isExplicitSlackChannelLinkingRequired(
-                organizationUuid,
-            )
-        ) {
-            await client.chat.postEphemeral({
-                channel: channelId,
-                user: slackUserId,
-                thread_ts: threadTs,
-                text: this.getExplicitSlackChannelLinkingMessage(),
-            });
-            return undefined;
-        }
 
         // Drop deleted projects so a stale filter doesn't hide every agent.
         const validProjectUuids = visibleProjectUuids?.length
@@ -12657,6 +12641,80 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             thread_ts: threadTs,
         });
         return undefined;
+    }
+
+    /**
+     * A mention landed in a regular channel with no agent mapped to it.
+     *
+     * Order matters: the explicit-linking setting must be evaluated before the
+     * system-agent fallback, otherwise the fallback silently auto-creates and
+     * answers as a system agent in channels an admin deliberately locked down.
+     *
+     * @returns the agent to answer with, or 'handled' when the user has already
+     * been told what to do next and the caller should stop.
+     */
+    private async resolveAgentForUnmappedSlackChannel(args: {
+        organizationUuid: string;
+        userUuid: string;
+        channelId: string;
+        threadTs: string;
+        say: SayFn;
+        client: WebClient;
+        slackUserId: string;
+        promptText: string;
+        visibleProjectUuids: string[] | null | undefined;
+    }): Promise<AiAgent | 'handled'> {
+        const {
+            organizationUuid,
+            userUuid,
+            channelId,
+            threadTs,
+            say,
+            client,
+            slackUserId,
+            promptText,
+            visibleProjectUuids,
+        } = args;
+
+        if (
+            await this.aiOrganizationSettingsService.isExplicitSlackChannelLinkingRequired(
+                organizationUuid,
+            )
+        ) {
+            await client.chat.postEphemeral({
+                channel: channelId,
+                user: slackUserId,
+                thread_ts: threadTs,
+                text: this.getExplicitSlackChannelLinkingMessage(),
+            });
+            return 'handled';
+        }
+
+        const fallback = await this.resolveSystemAgentForSlack({
+            organizationUuid,
+            userUuid,
+            projectUuids: undefined,
+            say,
+            slackChannelId: channelId,
+            threadTs,
+            promptText,
+        });
+        if (fallback === 'handled') {
+            return 'handled';
+        }
+        if (fallback) {
+            return fallback;
+        }
+
+        const linkedAgent = await this.showChannelLinkAgentPicker({
+            organizationUuid,
+            userUuid,
+            channelId,
+            threadTs,
+            say,
+            visibleProjectUuids,
+        });
+        return linkedAgent ?? 'handled';
     }
 
     /**
@@ -14514,20 +14572,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 if (!(e instanceof AiAgentNotFoundError)) {
                     throw e;
                 }
-                const fallback = await this.resolveSystemAgentForSlack({
-                    organizationUuid,
-                    userUuid,
-                    projectUuids: undefined,
-                    say,
-                    slackChannelId: channelId,
-                    threadTs: threadTs || messageTs,
-                    promptText: originalMessageText,
-                });
-                if (fallback === 'handled') {
-                    return;
-                }
-                if (!fallback) {
-                    agentConfig = await this.showChannelLinkAgentPicker({
+                const resolved = await this.resolveAgentForUnmappedSlackChannel(
+                    {
                         organizationUuid,
                         userUuid,
                         channelId,
@@ -14535,15 +14581,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         say,
                         client,
                         slackUserId,
+                        promptText: originalMessageText,
                         visibleProjectUuids:
                             slackSettings.aiMultiAgentProjectUuids,
-                    });
-                    if (!agentConfig) {
-                        return;
-                    }
-                } else {
-                    agentConfig = fallback;
+                    },
+                );
+                if (resolved === 'handled') {
+                    return;
                 }
+                agentConfig = resolved;
             }
         }
 
@@ -14781,25 +14827,13 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             slackChannelId: event.channel,
                         });
                 } catch (e) {
-                    // No agent mapped to this channel: system-agent fallback
-                    // (AiSlackSystemAgentFallback) first, else offer to link an agent.
+                    // No agent mapped to this channel: explicit-linking gate,
+                    // then system-agent fallback, else offer to link an agent.
                     if (!(e instanceof AiAgentNotFoundError)) {
                         throw e;
                     }
-                    const fallback = await this.resolveSystemAgentForSlack({
-                        organizationUuid,
-                        userUuid,
-                        projectUuids: undefined,
-                        say,
-                        slackChannelId: event.channel,
-                        threadTs: event.thread_ts ?? event.ts,
-                        promptText: event.text ?? '',
-                    });
-                    if (fallback === 'handled') {
-                        return;
-                    }
-                    if (!fallback) {
-                        agentConfig = await this.showChannelLinkAgentPicker({
+                    const resolved =
+                        await this.resolveAgentForUnmappedSlackChannel({
                             organizationUuid,
                             userUuid,
                             channelId: event.channel,
@@ -14807,15 +14841,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             say,
                             client,
                             slackUserId: event.user,
+                            promptText: event.text ?? '',
                             visibleProjectUuids:
                                 slackSettings.aiMultiAgentProjectUuids,
                         });
-                        if (!agentConfig) {
-                            return;
-                        }
-                    } else {
-                        agentConfig = fallback;
+                    if (resolved === 'handled') {
+                        return;
                     }
+                    agentConfig = resolved;
                 }
             }
 

--- a/packages/backend/src/ee/services/AiAgentService/slackChannelLinkStrictMode.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/slackChannelLinkStrictMode.test.ts
@@ -1,5 +1,6 @@
 import {
     defineUserAbility,
+    FeatureFlags,
     OrganizationMemberRole,
     type SessionUser,
 } from '@lightdash/common';
@@ -49,14 +50,20 @@ const agent = {
 
 const buildService = ({
     requireExplicitLinking,
+    systemAgentFallbackEnabled = false,
 }: {
     requireExplicitLinking: boolean;
+    systemAgentFallbackEnabled?: boolean;
 }) => {
     const aiAgentModel = {
         getAgent: vi.fn().mockResolvedValue(agent),
         findAllAgents: vi.fn().mockResolvedValue([agent]),
         addSlackChannelIntegration: vi.fn().mockResolvedValue(undefined),
         findLastUsedProjectUuid: vi.fn().mockResolvedValue(null),
+        getOrCreateSystemAgent: vi.fn().mockResolvedValue(agent),
+        findThreadUuidBySlackChannelIdAndThreadTs: vi
+            .fn()
+            .mockResolvedValue(undefined),
     };
     const service = new AiAgentService({
         aiAgentModel,
@@ -67,7 +74,12 @@ const buildService = ({
             getSummary: vi.fn().mockResolvedValue({ name: 'Jaffle Shop' }),
         },
         featureFlagService: {
-            get: vi.fn().mockResolvedValue({ enabled: true }),
+            get: vi.fn().mockImplementation(async ({ featureFlagId }) => ({
+                enabled:
+                    featureFlagId === FeatureFlags.AiSlackSystemAgentFallback
+                        ? systemAgentFallbackEnabled
+                        : true,
+            })),
         },
         aiOrganizationSettingsService: {
             isExplicitSlackChannelLinkingRequired: vi
@@ -81,7 +93,7 @@ const buildService = ({
     return { service, aiAgentModel };
 };
 
-const buildPickerArgs = () => {
+const buildUnmappedChannelArgs = () => {
     const say = vi.fn().mockResolvedValue(undefined);
     const postEphemeral = vi.fn().mockResolvedValue(undefined);
     const client = { chat: { postEphemeral } };
@@ -94,6 +106,8 @@ const buildPickerArgs = () => {
             say,
             client,
             slackUserId: SLACK_USER_ID,
+            promptText: 'how many orders did we get last week?',
+            visibleProjectUuids: undefined,
         },
         say,
         postEphemeral,
@@ -137,17 +151,23 @@ describe('linkAgentToSlackChannel strict mode', () => {
     });
 });
 
-describe('showChannelLinkAgentPicker strict mode', () => {
-    it('posts an ephemeral pointing at agent settings and links nothing', async () => {
+describe('resolveAgentForUnmappedSlackChannel strict mode', () => {
+    it('posts an ephemeral and skips the system-agent fallback when strict mode is on', async () => {
         const { service, aiAgentModel } = buildService({
             requireExplicitLinking: true,
+            systemAgentFallbackEnabled: true,
         });
-        const { args, say, postEphemeral } = buildPickerArgs();
+        const { args, say, postEphemeral } = buildUnmappedChannelArgs();
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = await (service as any).showChannelLinkAgentPicker(args);
+        const result = await (
+            service as unknown as {
+                resolveAgentForUnmappedSlackChannel: (
+                    a: typeof args,
+                ) => Promise<unknown>;
+            }
+        ).resolveAgentForUnmappedSlackChannel(args);
 
-        expect(result).toBeUndefined();
+        expect(result).toBe('handled');
         expect(postEphemeral).toHaveBeenCalledWith(
             expect.objectContaining({
                 channel: CHANNEL_ID,
@@ -156,21 +176,27 @@ describe('showChannelLinkAgentPicker strict mode', () => {
                 text: expect.stringContaining(`${SITE_URL}/ai-agents`),
             }),
         );
+        expect(aiAgentModel.getOrCreateSystemAgent).not.toHaveBeenCalled();
         expect(aiAgentModel.addSlackChannelIntegration).not.toHaveBeenCalled();
         expect(aiAgentModel.findAllAgents).not.toHaveBeenCalled();
         expect(say).not.toHaveBeenCalled();
     });
 
-    it('still auto-links the single manageable agent when strict mode is off', async () => {
+    it('auto-links the single manageable agent when strict mode is off', async () => {
         const { service, aiAgentModel } = buildService({
             requireExplicitLinking: false,
         });
-        const { args, say, postEphemeral } = buildPickerArgs();
+        const { args, say, postEphemeral } = buildUnmappedChannelArgs();
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = await (service as any).showChannelLinkAgentPicker(args);
+        const result = await (
+            service as unknown as {
+                resolveAgentForUnmappedSlackChannel: (
+                    a: typeof args,
+                ) => Promise<{ uuid: string }>;
+            }
+        ).resolveAgentForUnmappedSlackChannel(args);
 
-        expect(result?.uuid).toBe(AGENT_UUID);
+        expect(result.uuid).toBe(AGENT_UUID);
         expect(aiAgentModel.addSlackChannelIntegration).toHaveBeenCalledWith({
             organizationUuid: ORGANIZATION_UUID,
             agentUuid: AGENT_UUID,


### PR DESCRIPTION
## The bug

When someone mentions the Lightdash bot in a regular Slack channel with no linked AI agent, Lightdash has three possible policies:

1. If the organization requires explicit channel linking, privately tell the user that an admin must configure the channel.
2. Otherwise, if the system-agent fallback is enabled, use the built-in `Lightdash Assistant`.
3. Otherwise, let the user link an available agent or explain that none are available.

Previously, `handleAppMention` tried the system-agent fallback before the channel-link picker, while the `require_explicit_slack_channel_linking` check lived inside that picker.

With `ai-slack-system-agent-fallback` enabled, execution never reached the explicit-linking check. The admin setting was effectively ignored: instead of the private 🔒 "ask an admin" message, Lightdash created a system agent and answered the question.

## The fix

This PR introduces `resolveAgentForUnmappedSlackChannel`, which applies the policies in the intended order:

1. Enforce explicit channel linking and stop after posting the private 🔒 message.
2. Try the system-agent fallback.
3. Fall back to the normal agent-linking flow.

Both the direct Slack mention path and the post-OAuth replay path now use this resolver, so they cannot bypass the organization setting.

This also preserves the fallback-off behavior for unmapped channels: users can select an agent, a single manageable agent can be linked automatically, and the existing zero-agent messages remain reachable.

## Notes

Pre-existing bug on `main` — not introduced by the v3 stack above it.

No Linear ticket for this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
