### PR TITLE
fix: serialise concurrent Slack prompt writes on the v1 path

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
@@ -1,4 +1,9 @@
-import { SEED_ORG_1, SEED_ORG_1_ADMIN, SEED_PROJECT } from '@lightdash/common';
+import {
+    AiDuplicateSlackPromptError,
+    SEED_ORG_1,
+    SEED_ORG_1_ADMIN,
+    SEED_PROJECT,
+} from '@lightdash/common';
 import { type Knex } from 'knex';
 import { getModels, getTestContext } from '../../vitest.setup.integration';
 import { AiPromptTableName, AiThreadTableName } from '../database/entities/ai';
@@ -337,5 +342,39 @@ describe('AiAgentModel prompt activity', () => {
         expect(await getThreadUpdatedAt(cloneThreadUuid)).toEqual(
             clonedPrompt?.created_at,
         );
+    });
+
+    it('serializes duplicate v1 Slack prompt delivery', async () => {
+        const suffix = crypto.randomUUID();
+        const threadUuid = await model.createSlackThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            createdFrom: 'slack',
+            slackUserId: 'U123',
+            slackChannelId: `C-${suffix}`,
+            slackThreadTs: `thread-${suffix}`,
+            agentUuid: null,
+        });
+        threadUuids.add(threadUuid);
+        const prompt = {
+            threadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            prompt: 'same event',
+            slackUserId: 'U123',
+            slackChannelId: `C-${suffix}`,
+            promptSlackTs: `prompt-${suffix}`,
+        };
+
+        const results = await Promise.allSettled([
+            model.createSlackPrompt(prompt),
+            model.createSlackPrompt(prompt),
+        ]);
+
+        expect(
+            results.filter(({ status }) => status === 'fulfilled'),
+        ).toHaveLength(1);
+        expect(
+            results.filter((result) => result.status === 'rejected')[0],
+        ).toMatchObject({ reason: expect.any(AiDuplicateSlackPromptError) });
     });
 });

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -30,6 +30,7 @@ import {
     AiAgentUserPreferences,
     AiArtifact,
     AiClonedThreadCreatedFrom,
+    AiDuplicateSlackPromptError,
     AiEvalRunResultAssessment,
     AiMcpCredentialScope,
     AiMcpServer,
@@ -4814,59 +4815,88 @@ export class AiAgentModel {
         );
     }
 
+    // Serialises concurrent deliveries of the same Slack event so redeliveries queue
+    // behind the first writer instead of racing the Slack unique constraints.
+    private static async lockSlackChannel(
+        trx: Knex.Transaction,
+        slackChannelId: string,
+    ): Promise<void> {
+        await trx.raw('SELECT pg_advisory_xact_lock(hashtext(?))', [
+            slackChannelId,
+        ]);
+    }
+
+    // Callers treat a duplicate Slack prompt as "already answered" and stay silent,
+    // so the raw constraint violation must never escape a Slack write.
+    private static toSlackPromptWriteError(error: unknown): unknown {
+        return isUniqueConstraintViolation(error)
+            ? new AiDuplicateSlackPromptError('Slack prompt already exists')
+            : error;
+    }
+
     async createSlackThread(data: CreateSlackThread) {
-        return this.database.transaction(async (trx) => {
-            const [row] = await trx(AiThreadTableName)
-                .insert({
-                    organization_uuid: data.organizationUuid,
-                    project_uuid: data.projectUuid,
-                    created_from: data.createdFrom,
-                    agent_uuid: data.agentUuid,
-                })
-                .returning('ai_thread_uuid');
-            if (row === undefined) {
-                throw new Error('Failed to create thread');
-            }
-            await trx(AiSlackThreadTableName).insert({
-                ai_thread_uuid: row.ai_thread_uuid,
-                slack_user_id: data.slackUserId,
-                slack_channel_id: data.slackChannelId,
-                slack_thread_ts: data.slackThreadTs,
+        try {
+            return await this.database.transaction(async (trx) => {
+                const [row] = await trx(AiThreadTableName)
+                    .insert({
+                        organization_uuid: data.organizationUuid,
+                        project_uuid: data.projectUuid,
+                        created_from: data.createdFrom,
+                        agent_uuid: data.agentUuid,
+                    })
+                    .returning('ai_thread_uuid');
+                if (row === undefined) {
+                    throw new Error('Failed to create thread');
+                }
+                await trx(AiSlackThreadTableName).insert({
+                    ai_thread_uuid: row.ai_thread_uuid,
+                    slack_user_id: data.slackUserId,
+                    slack_channel_id: data.slackChannelId,
+                    slack_thread_ts: data.slackThreadTs,
+                });
+                return row.ai_thread_uuid;
             });
-            return row.ai_thread_uuid;
-        });
+        } catch (error) {
+            throw AiAgentModel.toSlackPromptWriteError(error);
+        }
     }
 
     async createSlackPrompt(data: CreateSlackPrompt) {
-        return this.database.transaction(async (trx) => {
-            const [row] = await trx(AiPromptTableName)
-                .insert({
-                    ai_thread_uuid: data.threadUuid,
-                    created_by_user_uuid: data.createdByUserUuid,
-                    prompt: data.prompt,
-                    model_config: data.modelConfig,
-                })
-                .returning(['ai_prompt_uuid', 'created_at']);
+        try {
+            return await this.database.transaction(async (trx) => {
+                await AiAgentModel.lockSlackChannel(trx, data.slackChannelId);
 
-            if (row === undefined) {
-                throw new Error('Failed to create prompt');
-            }
+                const [row] = await trx(AiPromptTableName)
+                    .insert({
+                        ai_thread_uuid: data.threadUuid,
+                        created_by_user_uuid: data.createdByUserUuid,
+                        prompt: data.prompt,
+                        model_config: data.modelConfig,
+                    })
+                    .returning(['ai_prompt_uuid', 'created_at']);
 
-            await AiAgentModel.bumpThreadUpdatedAt(
-                data.threadUuid,
-                row.created_at,
-                { trx },
-            );
+                if (row === undefined) {
+                    throw new Error('Failed to create prompt');
+                }
 
-            await trx(AiSlackPromptTableName).insert({
-                ai_prompt_uuid: row.ai_prompt_uuid,
-                slack_user_id: data.slackUserId,
-                slack_channel_id: data.slackChannelId,
-                prompt_slack_ts: data.promptSlackTs,
+                await AiAgentModel.bumpThreadUpdatedAt(
+                    data.threadUuid,
+                    row.created_at,
+                    { trx },
+                );
+
+                await trx(AiSlackPromptTableName).insert({
+                    ai_prompt_uuid: row.ai_prompt_uuid,
+                    slack_user_id: data.slackUserId,
+                    slack_channel_id: data.slackChannelId,
+                    prompt_slack_ts: data.promptSlackTs,
+                });
+
+                return row.ai_prompt_uuid;
             });
-
-            return row.ai_prompt_uuid;
-        });
+        } catch (error) {
+            throw AiAgentModel.toSlackPromptWriteError(error);
+        }
     }
 
     async updateModelResponse(


### PR DESCRIPTION
## The bug

Slack can deliver the same event more than once, including concurrently. The legacy v1 path checked whether a prompt existed before inserting it, so two deliveries could both pass that check and then race to write the same `(slack_channel_id, prompt_slack_ts)` identity.

The database correctly rejected the losing insert, but `AiAgentModel.createSlackPrompt` and `createSlackThread` allowed the raw PostgreSQL unique-constraint error to escape. Their callers already treat `AiDuplicateSlackPromptError` as an expected redelivery and stay silent, so the raw error turned a harmless duplicate into a user-visible failure.

## The fix

This PR adds two private helpers to `AiAgentModel`:

- `lockSlackChannel` acquires a transaction-scoped advisory lock keyed by Slack channel. `createSlackPrompt` uses it to serialize concurrent prompt writes for that channel.
- `toSlackPromptWriteError` converts unique-constraint violations into `AiDuplicateSlackPromptError`.

`createSlackPrompt` now acquires the channel lock and maps duplicate errors. `createSlackThread` does not take the advisory lock, but it maps duplicate errors through the same helper; its existing transaction rolls back the partial thread if the Slack mapping loses a race.

The integration test starts two identical v1 prompt writes concurrently and verifies that exactly one succeeds while the other returns `AiDuplicateSlackPromptError`.

## Notes

Pre-existing bug on `main`.

No Linear ticket for this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
