### PR TITLE
fix: authorize AI generation endpoints

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -420,6 +420,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     dashboardSummaryModel: models.getDashboardSummaryModel(),
                     savedChartModel: models.getSavedChartModel(),
                     projectService: repository.getProjectService(),
+                    spacePermissionService:
+                        repository.getSpacePermissionService(),
                     asyncQueryService: repository.getAsyncQueryService(),
                     featureFlagService: repository.getFeatureFlagService(),
                     openAi: new OpenAi(

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -720,18 +720,15 @@ export class AiService extends BaseService {
             projectUuid,
             fromSession(user),
         );
-        const abilitySubject =
-            payload.mode === 'convert-sql'
-                ? subject('CustomSqlTableCalculations', {
-                      organizationUuid: project.organizationUuid,
-                      projectUuid,
-                  })
-                : subject('Explore', {
-                      organizationUuid: project.organizationUuid,
-                      projectUuid,
-                  });
-
-        if (this.createAuditedAbility(user).cannot('manage', abilitySubject)) {
+        if (
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('Explore', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -1,4 +1,5 @@
 import { type TokenUsage } from '@langchain/core/language_models/base';
+import { subject } from '@casl/ability';
 import {
     CommercialFeatureFlags,
     DashboardDAO,
@@ -32,6 +33,7 @@ import { LightdashConfig } from '../../../config/parseConfig';
 import { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
 import { SavedChartModel } from '../../../models/SavedChartModel';
 import { AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
+import { BaseService } from '../../../services/BaseService';
 import { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { ProjectService } from '../../../services/ProjectService/ProjectService';
 import {
@@ -92,7 +94,7 @@ type Dependencies = {
     orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
 };
 
-export class AiService {
+export class AiService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
 
     private readonly analytics: LightdashAnalytics;
@@ -114,6 +116,7 @@ export class AiService {
     private readonly orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
 
     constructor(dependencies: Dependencies) {
+        super();
         this.analytics = dependencies.analytics;
         this.dashboardModel = dependencies.dashboardModel;
         this.dashboardSummaryModel = dependencies.dashboardSummaryModel;
@@ -503,6 +506,22 @@ export class AiService {
         projectUuid: string,
         payload: GenerateChartMetadataRequest,
     ): Promise<GeneratedChartMetadata> {
+        const project = await this.projectService.getProject(
+            projectUuid,
+            fromSession(user),
+        );
+        if (
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('Explore', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
         const modelOptions = await this.getAmbientAiModel(user, {
             projectUuid,
         });

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -36,6 +36,7 @@ import { AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQuer
 import { BaseService } from '../../../services/BaseService';
 import { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { ProjectService } from '../../../services/ProjectService/ProjectService';
+import { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
 import {
     ConvertSqlToFormulaGenerated,
     CustomVizGenerated,
@@ -87,6 +88,7 @@ type Dependencies = {
     dashboardSummaryModel: DashboardSummaryModel;
     savedChartModel: SavedChartModel;
     projectService: ProjectService;
+    spacePermissionService: SpacePermissionService;
     asyncQueryService: AsyncQueryService;
     openAi: OpenAi;
     lightdashConfig: LightdashConfig;
@@ -107,6 +109,8 @@ export class AiService extends BaseService {
 
     private readonly projectService: ProjectService;
 
+    private readonly spacePermissionService: SpacePermissionService;
+
     private readonly asyncQueryService: AsyncQueryService;
 
     private readonly openAi: OpenAi;
@@ -122,6 +126,7 @@ export class AiService extends BaseService {
         this.dashboardSummaryModel = dependencies.dashboardSummaryModel;
         this.savedChartModel = dependencies.savedChartModel;
         this.projectService = dependencies.projectService;
+        this.spacePermissionService = dependencies.spacePermissionService;
         this.asyncQueryService = dependencies.asyncQueryService;
         this.openAi = dependencies.openAi;
         this.lightdashConfig = dependencies.lightdashConfig;
@@ -265,6 +270,42 @@ export class AiService extends BaseService {
         return Promise.all(chartResultPromises);
     }
 
+    private async getDashboardWithViewAccess(
+        user: SessionUser,
+        projectUuid: string,
+        dashboardUuidOrSlug: string,
+    ) {
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuidOrSlug,
+            { projectUuid },
+        );
+        const spaceContext =
+            await this.spacePermissionService.getSpaceAccessContext(
+                user.userUuid,
+                dashboard.spaceUuid,
+            );
+
+        if (
+            this.createAuditedAbility(user).cannot(
+                'view',
+                subject('Dashboard', {
+                    ...dashboard,
+                    ...spaceContext,
+                    metadata: {
+                        dashboardUuid: dashboard.uuid,
+                        dashboardName: dashboard.name,
+                    },
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                "You don't have access to the space this dashboard belongs to",
+            );
+        }
+
+        return dashboard;
+    }
+
     async createChartSummary(chartData: ChartPromptData) {
         const fieldInsights = chartData.columns
             .map((col) => fieldDesc(col, chartData.fields[col]))
@@ -295,6 +336,22 @@ export class AiService extends BaseService {
         }[];
         currentVizConfig: string;
     }) {
+        const project = await this.projectService.getProject(
+            projectUuid,
+            fromSession(user),
+        );
+        if (
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('Explore', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
         const aiCustomVizFlag = await this.featureFlagService.get({
             user,
             featureFlagId: FeatureFlags.AiCustomViz,
@@ -367,12 +424,13 @@ export class AiService extends BaseService {
         dashboardUuid: string,
         opts: Pick<DashboardSummary, 'context' | 'tone' | 'audiences'>,
     ) {
-        await this.throwOnFeatureDisabled(user);
         const startTime = new Date().getTime();
-        const dashboard = await this.dashboardModel.getByIdOrSlug(
+        const dashboard = await this.getDashboardWithViewAccess(
+            user,
+            projectUuid,
             dashboardUuid,
-            { projectUuid },
         );
+        await this.throwOnFeatureDisabled(user);
         const dashboardCharts = await this.getDashboardChartsResults(
             user,
             dashboard,
@@ -472,18 +530,17 @@ export class AiService extends BaseService {
         return dashboardSummary;
     }
 
-    // TODO: user permissions
     async getDashboardSummary(
         user: SessionUser,
         projectUuid: string,
         dashboardUuidOrSlug: string,
     ) {
-        await this.throwOnFeatureDisabled(user);
-
-        const dashboard = await this.dashboardModel.getByIdOrSlug(
+        const dashboard = await this.getDashboardWithViewAccess(
+            user,
+            projectUuid,
             dashboardUuidOrSlug,
-            { projectUuid },
         );
+        await this.throwOnFeatureDisabled(user);
         const dashboardSummary =
             await this.dashboardSummaryModel.getByDashboardUuid(dashboard.uuid);
 
@@ -554,13 +611,25 @@ export class AiService extends BaseService {
         projectUuid: string,
         payload: GenerateTableCalculationRequest,
     ): Promise<GeneratedTableCalculation> {
-        const modelOptions = await this.getAmbientAiModel(user, {
-            projectUuid,
-        });
         const project = await this.projectService.getProject(
             projectUuid,
             fromSession(user),
         );
+        if (
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('CustomSqlTableCalculations', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const modelOptions = await this.getAmbientAiModel(user, {
+            projectUuid,
+        });
         const warehouseType = project.warehouseConnection?.type;
 
         if (!warehouseType) {
@@ -599,13 +668,25 @@ export class AiService extends BaseService {
         projectUuid: string,
         payload: GenerateCustomDimensionRequest,
     ): Promise<GeneratedCustomDimension> {
-        const modelOptions = await this.getAmbientAiModel(user, {
-            projectUuid,
-        });
         const project = await this.projectService.getProject(
             projectUuid,
             fromSession(user),
         );
+        if (
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('CustomFields', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const modelOptions = await this.getAmbientAiModel(user, {
+            projectUuid,
+        });
         const warehouseType = project.warehouseConnection?.type;
 
         if (!warehouseType) {
@@ -635,10 +716,28 @@ export class AiService extends BaseService {
         projectUuid: string,
         payload: GenerateFormulaTableCalculationRequest,
     ): Promise<GeneratedFormulaTableCalculation> {
+        const project = await this.projectService.getProject(
+            projectUuid,
+            fromSession(user),
+        );
+        const abilitySubject =
+            payload.mode === 'convert-sql'
+                ? subject('CustomSqlTableCalculations', {
+                      organizationUuid: project.organizationUuid,
+                      projectUuid,
+                  })
+                : subject('Explore', {
+                      organizationUuid: project.organizationUuid,
+                      projectUuid,
+                  });
+
+        if (this.createAuditedAbility(user).cannot('manage', abilitySubject)) {
+            throw new ForbiddenError();
+        }
+
         const modelOptions = await this.getAmbientAiModel(user, {
             projectUuid,
         });
-
         const result = await generateFormulaTableCalculationFromContext(
             modelOptions,
             payload,
@@ -679,10 +778,25 @@ export class AiService extends BaseService {
         projectUuid: string,
         payload: GenerateTooltipRequest,
     ): Promise<GeneratedTooltip> {
+        const project = await this.projectService.getProject(
+            projectUuid,
+            fromSession(user),
+        );
+        if (
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('Explore', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
         const modelOptions = await this.getAmbientAiModel(user, {
             projectUuid,
         });
-
         const result = await generateTooltipFromContext(modelOptions, {
             prompt: payload.prompt,
             fieldsContext: payload.fieldsContext,

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -1,5 +1,5 @@
-import { type TokenUsage } from '@langchain/core/language_models/base';
 import { subject } from '@casl/ability';
+import { type TokenUsage } from '@langchain/core/language_models/base';
 import {
     CommercialFeatureFlags,
     DashboardDAO,


### PR DESCRIPTION
## Summary
Enforces project access and domain-specific permissions before public AI generation endpoints can resolve feature entitlements or execute models.
Adds dashboard space-aware view authorization for reading and creating AI summaries, while preserving the existing viewer-facing behavior.
No test files were changed; local tests could not run because the mandatory workspace setup remains stuck in its dependency-install phase.

Closes: PROD-9497

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/79dad656-1fbf-4066-af40-03e0fa1dd871)