### PR TITLE
feat(data-apps): show recent apps on build page

### DIFF
--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -36,6 +36,7 @@ import {
     type DataAppActivityFilters,
     type GenerateAppRequestBody,
     type ImportAppCodeRequestBody,
+    type MyAppsSortBy,
     type UpgradeAppRequestBody,
     type UUID,
     type UuidOrSlug,
@@ -1024,6 +1025,7 @@ export class UserAppsController extends BaseController {
         @Query() excludePreviewProjects?: boolean,
         @Query() projectUuids?: string[],
         @Query() search?: string,
+        @Query() sortBy?: MyAppsSortBy,
     ): Promise<ApiMyAppsResponse> {
         assertRegisteredAccount(req.account);
         const result = await this.services
@@ -1031,7 +1033,7 @@ export class UserAppsController extends BaseController {
             .listMyApps(
                 toSessionUser(req.account),
                 page && pageSize ? { page, pageSize } : undefined,
-                { excludePreviewProjects, projectUuids, search },
+                { excludePreviewProjects, projectUuids, search, sortBy },
             );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -94,6 +94,7 @@ import {
     type LightdashProjectParameter,
     type MetricQuery,
     type ModelRequiredFilterRule,
+    type MyAppsSortBy,
     type PersistedDataAppDataReferences,
     type PromoteAppAction,
     type PromoteAppDiff,
@@ -7922,6 +7923,7 @@ export class AppGenerateService extends BaseService {
             excludePreviewProjects?: boolean;
             projectUuids?: string[];
             search?: string;
+            sortBy?: MyAppsSortBy;
         } = {},
     ): Promise<{
         data: {

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -14,6 +14,7 @@ import {
     type DataAppVizSchema,
     type KnexPaginateArgs,
     type KnexPaginatedData,
+    type MyAppsSortBy,
     type PersistedDataAppDataReferences,
 } from '@lightdash/common';
 import { Knex } from 'knex';
@@ -1210,6 +1211,7 @@ export class AppModel {
             excludePreviewProjects?: boolean;
             projectUuids?: string[];
             search?: string;
+            sortBy?: MyAppsSortBy;
         } = {},
     ): Promise<
         KnexPaginatedData<
@@ -1285,8 +1287,18 @@ export class AppModel {
                 `${SpaceTableName}.name as space_name`,
                 `${AppVersionsTableName}.version as last_version`,
                 `${AppVersionsTableName}.status as last_version_status`,
-            )
-            .orderBy(`${AppsTableName}.created_at`, 'desc');
+            );
+
+        if (options.sortBy === 'latestActivity') {
+            void query.orderByRaw('COALESCE(??, ??, ??) DESC', [
+                `${AppVersionsTableName}.status_updated_at`,
+                `${AppVersionsTableName}.created_at`,
+                `${AppsTableName}.created_at`,
+            ]);
+        } else {
+            void query.orderBy(`${AppsTableName}.created_at`, 'desc');
+        }
+        void query.orderBy(`${AppsTableName}.app_id`, 'asc');
 
         const result = await KnexPaginate.paginate(query, paginateArgs);
 

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -590,6 +590,8 @@ export type ApiAppSummary = {
     lastVersionStatus: AppVersionStatus | null;
 };
 
+export type MyAppsSortBy = 'createdAt' | 'latestActivity';
+
 /** Minimal app shape for the embed config's standalone-app allowlist picker. */
 export type EmbedProjectApp = {
     appUuid: string;

--- a/packages/frontend/src/features/apps/components/RecentAppSuggestions.module.css
+++ b/packages/frontend/src/features/apps/components/RecentAppSuggestions.module.css
@@ -1,0 +1,60 @@
+.suggestions {
+    grid-row: 3;
+    grid-column: 1;
+    align-self: start;
+    width: 100%;
+    max-width: 760px;
+    min-height: 26px;
+    margin-top: 10px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 4px;
+}
+
+.suggestion {
+    min-width: 0;
+    max-width: 100%;
+    padding: 4px 10px;
+    border: 1px solid transparent;
+    border-radius: var(--mantine-radius-xl);
+    color: var(--mantine-color-ldGray-6);
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.5;
+    text-decoration: none;
+    transition:
+        color 180ms cubic-bezier(0.22, 1, 0.36, 1),
+        border-color 180ms cubic-bezier(0.22, 1, 0.36, 1),
+        background-color 180ms cubic-bezier(0.22, 1, 0.36, 1);
+
+    &:hover,
+    &:focus-visible {
+        color: var(--mantine-color-ldGray-9);
+        border-color: var(--mantine-color-ldGray-2);
+        background: light-dark(#fff, var(--mantine-color-dark-6));
+        text-decoration: none;
+    }
+}
+
+.prefix {
+    flex: 0 0 auto;
+    opacity: 0.78;
+}
+
+.label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 600;
+}
+
+.status {
+    flex: 0 0 auto;
+    color: var(--mantine-color-ldGray-5);
+}
+
+.errorStatus {
+    color: var(--mantine-color-red-6);
+}

--- a/packages/frontend/src/features/apps/components/RecentAppSuggestions.tsx
+++ b/packages/frontend/src/features/apps/components/RecentAppSuggestions.tsx
@@ -1,0 +1,103 @@
+import {
+    getAppDisplayName,
+    isAppVersionInProgress,
+    type ApiAppSummary,
+} from '@lightdash/common';
+import { Anchor, Box, Group, Loader } from '@mantine/core';
+import { IconArrowUpRight } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
+import { useRecentApps } from '../hooks/useMyApps';
+import classes from './RecentAppSuggestions.module.css';
+
+const RECENT_APP_SUGGESTION_LIMIT = 2;
+
+const RecentAppSuggestion: FC<{
+    app: ApiAppSummary;
+    position: number;
+    onClick: (app: ApiAppSummary, position: number) => void;
+}> = ({ app, position, onClick }) => {
+    const displayName = getAppDisplayName(app.name, app.appUuid);
+    const isBuilding =
+        app.lastVersionStatus !== null &&
+        isAppVersionInProgress(app.lastVersionStatus);
+
+    return (
+        <Anchor
+            component={Link}
+            to={`/projects/${app.projectUuid}/apps/${app.appUuid}`}
+            className={classes.suggestion}
+            title={`Continue building: ${displayName}`}
+            onClick={() => onClick(app, position)}
+        >
+            <Group gap={4} wrap="nowrap">
+                {isBuilding ? (
+                    <Loader size={10} color="blue.6" />
+                ) : (
+                    <MantineIcon
+                        icon={IconArrowUpRight}
+                        size={12}
+                        color="ldGray.5"
+                    />
+                )}
+                <span className={classes.prefix}>Continue building:</span>
+                <span className={classes.label}>{displayName}</span>
+                {isBuilding && (
+                    <span className={classes.status}>
+                        · Building
+                        {app.lastVersionNumber !== null
+                            ? ` v${app.lastVersionNumber}`
+                            : ''}
+                    </span>
+                )}
+                {app.lastVersionStatus === 'error' && (
+                    <span
+                        className={`${classes.status} ${classes.errorStatus}`}
+                    >
+                        · Build failed
+                    </span>
+                )}
+            </Group>
+        </Anchor>
+    );
+};
+
+const RecentAppSuggestions: FC<{ projectUuid: string }> = ({ projectUuid }) => {
+    const { data, isLoading, isError } = useRecentApps(
+        projectUuid,
+        RECENT_APP_SUGGESTION_LIMIT,
+    );
+    const { track } = useTracking();
+    const apps = data?.data;
+
+    if (isLoading || isError || !apps || apps.length === 0) return null;
+
+    return (
+        <Box className={classes.suggestions}>
+            {apps.map((app, position) => (
+                <RecentAppSuggestion
+                    key={app.appUuid}
+                    app={app}
+                    position={position}
+                    onClick={(clickedApp, clickedPosition) => {
+                        track({
+                            name: EventName.DATA_APP_RECENT_SUGGESTION_CLICK,
+                            properties: {
+                                projectId: projectUuid,
+                                appId: clickedApp.appUuid,
+                                position: clickedPosition,
+                                status: clickedApp.lastVersionStatus,
+                                version: clickedApp.lastVersionNumber,
+                            },
+                        });
+                    }}
+                />
+            ))}
+        </Box>
+    );
+};
+
+export default RecentAppSuggestions;

--- a/packages/frontend/src/features/apps/hooks/useMyApps.ts
+++ b/packages/frontend/src/features/apps/hooks/useMyApps.ts
@@ -2,19 +2,28 @@ import {
     type ApiAppSummary,
     type ApiError,
     type ApiMyAppsResponse,
+    type MyAppsSortBy,
 } from '@lightdash/common';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
 type MyAppsResult = ApiMyAppsResponse['results'];
 
-const fetchMyApps = async (
-    page: number,
-    pageSize: number,
-    excludePreviewProjects: boolean,
-    projectUuids: string[],
-    search?: string,
-): Promise<MyAppsResult> => {
+const fetchMyApps = async ({
+    page,
+    pageSize,
+    excludePreviewProjects,
+    projectUuids,
+    search,
+    sortBy,
+}: {
+    page: number;
+    pageSize: number;
+    excludePreviewProjects: boolean;
+    projectUuids: string[];
+    search?: string;
+    sortBy?: MyAppsSortBy;
+}): Promise<MyAppsResult> => {
     const params = new URLSearchParams({
         page: String(page),
         pageSize: String(pageSize),
@@ -22,6 +31,9 @@ const fetchMyApps = async (
     });
     if (search) {
         params.set('search', search);
+    }
+    if (sortBy) {
+        params.set('sortBy', sortBy);
     }
     projectUuids.forEach((projectUuid) => {
         params.append('projectUuids', projectUuid);
@@ -53,19 +65,38 @@ export const useMyApps = (
             options.search,
         ],
         queryFn: async ({ pageParam = 1 }) =>
-            fetchMyApps(
-                pageParam as number,
-                FETCH_SIZE,
-                options.excludePreviewProjects ?? true,
-                options.projectUuids ?? [],
-                options.search,
-            ),
+            fetchMyApps({
+                page: pageParam as number,
+                pageSize: FETCH_SIZE,
+                excludePreviewProjects: options.excludePreviewProjects ?? true,
+                projectUuids: options.projectUuids ?? [],
+                search: options.search,
+            }),
         getNextPageParam: (_lastGroup, groups) => {
             const currentPage = groups.length;
             const totalPages = _lastGroup.pagination?.totalPageCount ?? 0;
             return currentPage < totalPages ? currentPage + 1 : undefined;
         },
         keepPreviousData: true,
+        refetchOnWindowFocus: false,
+    });
+
+export const useRecentApps = (
+    projectUuid: string | undefined,
+    pageSize: number,
+) =>
+    useQuery<MyAppsResult, ApiError>({
+        queryKey: ['myApps', 'recent', projectUuid, pageSize, 'latestActivity'],
+        queryFn: () =>
+            fetchMyApps({
+                page: 1,
+                pageSize,
+                excludePreviewProjects: false,
+                projectUuids: [projectUuid!],
+                sortBy: 'latestActivity',
+            }),
+        enabled: !!projectUuid,
+        staleTime: 0,
         refetchOnWindowFocus: false,
     });
 

--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -64,9 +64,15 @@
 /* The compose Panel fills the group; center the (height-capped) card
    inside it so it doesn't stretch to the full viewport height. */
 .chatPanelOuterCompose {
-    display: flex;
-    align-items: center;
+    display: grid;
+    grid-template-rows: minmax(0, 1fr) auto minmax(0, 1fr);
+    grid-template-columns: minmax(0, 760px);
     justify-content: center;
+}
+
+.chatPanelOuterCompose > .chatPanelCompose {
+    grid-row: 2;
+    grid-column: 1;
 }
 
 :global(body:has(#preview-banner)) .composeLayout,

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -114,6 +114,7 @@ import AppHeaderActions from '../features/apps/components/AppHeaderActions';
 import DataAppVizResultCard from '../features/apps/components/DataAppVizResultCard';
 import DataAppVizTestPanel from '../features/apps/components/DataAppVizTestPanel';
 import LoadingDots from '../features/apps/components/LoadingDots';
+import RecentAppSuggestions from '../features/apps/components/RecentAppSuggestions';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppFileUpload } from '../features/apps/hooks/useAppFileUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
@@ -3235,6 +3236,9 @@ const AppGenerate: FC = () => {
                             </Box>
                         )}
                     </Box>
+                    {newAppLanding && (
+                        <RecentAppSuggestions projectUuid={projectUuid} />
+                    )}
                 </Panel>
 
                 {!newAppLanding && (

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -1,4 +1,5 @@
 import {
+    type AppVersionStatus,
     type AiDeepResearchTerminalStatus,
     type CustomFormatType,
     type HomepageRecommendedActionKey,
@@ -608,6 +609,17 @@ type AiAgentSuggestionClickEvent = {
     };
 };
 
+type DataAppRecentSuggestionClickEvent = {
+    name: EventName.DATA_APP_RECENT_SUGGESTION_CLICK;
+    properties: {
+        projectId: string;
+        appId: string;
+        position: number;
+        status: AppVersionStatus | null;
+        version: number | null;
+    };
+};
+
 type ThemeToggledEvent = {
     name: EventName.THEME_TOGGLED;
     properties: {
@@ -920,6 +932,7 @@ export type EventData =
     | AiDeepResearchReportEngagedEvent
     | AiAgentSuggestionImpressionEvent
     | AiAgentSuggestionClickEvent
+    | DataAppRecentSuggestionClickEvent
     | ThemeToggledEvent
     | DashboardUiVersionToggledEvent
     | TableCalculationSaveEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -90,6 +90,7 @@ export enum EventName {
     HOMEPAGE_OPENING_SWAPPED = 'homepage_opening.swapped',
     HOMEPAGE_RECOMMENDED_ACTION_CLICKED = 'homepage_recommended_action.clicked',
     HOMEPAGE_RECOMMENDED_ACTION_SKIPPED = 'homepage_recommended_action.skipped',
+    DATA_APP_RECENT_SUGGESTION_CLICK = 'data_app.recent_suggestion_click',
     REVOKE_INVITES_BUTTON_CLICKED = 'revoke_invites_button.clicked',
     INVITE_BUTTON_CLICKED = 'invite_users_to_organisation_button.clicked',
     RUN_QUERY_BUTTON_CLICKED = 'run_query_button.clicked',


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9472/show-recently-modified-apps-on-build-page

## Summary

- show up to two creator-owned recent apps below the new Data App composer
- order suggestions by latest app-version activity and include in-progress or failed build status
- avoid reserving loading or empty-state space, and track suggestion clicks

## Why

Users can lose track of apps that are still building in the background when they return to the new-app page. This keeps their most recent apps close without treating them as part of the new-app window.

## Screenshots
<img width="1840" height="1474" alt="image" src="https://github.com/user-attachments/assets/0bbbc90a-717f-4bc7-90cb-ac72665d5eb3" />
