### PR TITLE
feat(data-apps): sync app delivery queries to Google Sheets

### DIFF
--- a/packages/backend/src/clients/Google/GoogleDriveClient.test.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.test.ts
@@ -1,5 +1,20 @@
-import { DimensionType, FieldType } from '@lightdash/common';
+import {
+    DimensionType,
+    FieldType,
+    GoogleSheetsQuotaError,
+} from '@lightdash/common';
+import { google } from 'googleapis';
 import { GoogleDriveClient } from './GoogleDriveClient';
+
+vi.mock('googleapis', () => ({
+    google: {
+        auth: {
+            fromJSON: vi.fn(),
+            GoogleAuth: vi.fn(),
+        },
+        sheets: vi.fn(),
+    },
+}));
 
 describe('GoogleDriveClient', () => {
     describe('formatRow', () => {
@@ -158,6 +173,79 @@ describe('GoogleDriveClient', () => {
                 [['Total revenue'], [120]],
                 undefined,
             );
+        });
+    });
+
+    // gaxios never retries our requests (nothing sets `retry`/`retryConfig`
+    // on them) — Retry-After only reaches the caller if we extract it here.
+    describe('quota errors', () => {
+        const makeClient = () =>
+            new GoogleDriveClient({
+                lightdashConfig: {
+                    auth: {
+                        google: {
+                            oauth2ClientId: 'client-id',
+                            oauth2ClientSecret: 'client-secret',
+                        },
+                    },
+                },
+            } as never);
+
+        beforeEach(() => {
+            vi.mocked(google.auth.fromJSON).mockReturnValue({} as never);
+            // Constructed via `new` in getCredentials — an arrow function
+            // implementation isn't constructable.
+            vi.mocked(google.auth.GoogleAuth).mockImplementation(
+                function MockGoogleAuth(this: object) {
+                    return this;
+                } as never,
+            );
+        });
+
+        test('carries a Retry-After header as retryAfterMs on the thrown GoogleSheetsQuotaError', async () => {
+            const get = vi.fn().mockRejectedValue({
+                message: 'Quota exceeded for quota metric Write requests',
+                response: { headers: { 'retry-after': '7' } },
+            });
+            vi.mocked(google.sheets).mockReturnValue({
+                spreadsheets: { get },
+            } as never);
+
+            const client = makeClient();
+
+            await expect(
+                client.assertFileIsGoogleSheet('refresh-token', 'file-id'),
+            ).rejects.toMatchObject({
+                name: 'GoogleSheetsQuotaError',
+                data: { retryAfterMs: 7000 },
+            });
+        });
+
+        test('leaves retryAfterMs undefined when there is no Retry-After header', async () => {
+            const get = vi.fn().mockRejectedValue({
+                message: 'Quota exceeded for quota metric Write requests',
+                response: { headers: {} },
+            });
+            vi.mocked(google.sheets).mockReturnValue({
+                spreadsheets: { get },
+            } as never);
+
+            const client = makeClient();
+
+            let caught: unknown;
+            try {
+                await client.assertFileIsGoogleSheet(
+                    'refresh-token',
+                    'file-id',
+                );
+            } catch (e) {
+                caught = e;
+            }
+
+            expect(caught).toBeInstanceOf(GoogleSheetsQuotaError);
+            expect(
+                (caught as GoogleSheetsQuotaError).data.retryAfterMs,
+            ).toBeUndefined();
         });
     });
 });

--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -129,11 +129,23 @@ export class GoogleDriveClient {
             // Detect quota/rate limit errors - these should be retried, not permanently disabled
             // like: Write requests per minute per user
             if (err?.message && err.message.includes('Quota exceeded')) {
-                throw new GoogleSheetsQuotaError(getErrorMessage(err));
+                throw new GoogleSheetsQuotaError(getErrorMessage(err), {
+                    retryAfterMs: GoogleDriveClient.parseRetryAfterMs(err),
+                });
             }
 
             throw new UnexpectedGoogleSheetsError(getErrorMessage(err));
         }
+    }
+
+    // Google doesn't always set Retry-After on quota errors, but honor it
+    // when present rather than only ever guessing with backoff.
+    private static parseRetryAfterMs(err: AnyType): number | undefined {
+        const header = err?.response?.headers?.['retry-after'];
+        const seconds = Number(header);
+        return header !== undefined && Number.isFinite(seconds) && seconds > 0
+            ? seconds * 1000
+            : undefined;
     }
 
     async createNewTab(refreshToken: string, fileId: string, tabName: string) {

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -33,8 +33,13 @@ import type { ExecutionContextInfo } from '../logging/winston';
 import SchedulerTask, {
     buildItemMapFromColumns,
     buildSchedulerLogContext,
+    computeGsheetsPacingDelayMs,
     dedupeArtifactFilename,
     GSHEET_UPLOAD_MAX_ATTEMPTS,
+    GSHEET_UPLOAD_QUOTA_BRIDGE_SCHEDULE_MS,
+    GSHEETS_WRITES_PER_APP_ITEM,
+    GSHEETS_WRITES_PER_MINUTE_BUDGET,
+    processSequentiallyWithPacing,
     retryTransientGoogleSheetsWrite,
     setSchedulerJobLogContext,
 } from './SchedulerTask';
@@ -596,6 +601,112 @@ describe('retryTransientGoogleSheetsWrite', () => {
         await retryTransientGoogleSheetsWrite(write);
 
         expect(vi.mocked(sleep)).toHaveBeenCalledWith(2000);
+    });
+
+    // The app branch's background syncs have nobody watching, unlike the
+    // interactive ad-hoc export flow (default schedule) — they can afford to
+    // wait out a full quota-window refill (~60s) when Google gives no
+    // Retry-After to follow.
+    describe('with the app branch quota-bridge schedule', () => {
+        it('reaches a cumulative wait of at least 65s across attempts when Google never sends Retry-After', async () => {
+            vi.mocked(sleep).mockClear();
+            const write = vi
+                .fn()
+                .mockRejectedValue(new GoogleSheetsQuotaError());
+
+            await expect(
+                retryTransientGoogleSheetsWrite(
+                    write,
+                    undefined,
+                    GSHEET_UPLOAD_QUOTA_BRIDGE_SCHEDULE_MS,
+                ),
+            ).rejects.toThrow(GoogleSheetsQuotaError);
+
+            const cumulativeWaitMs = vi
+                .mocked(sleep)
+                .mock.calls.reduce((sum, [ms]) => sum + (ms as number), 0);
+            expect(cumulativeWaitMs).toBeGreaterThanOrEqual(65000);
+            expect(write).toHaveBeenCalledTimes(
+                GSHEET_UPLOAD_QUOTA_BRIDGE_SCHEDULE_MS.length + 1,
+            );
+        });
+
+        it('still honors a Retry-After hint ahead of the quota-bridge schedule, capped at the ceiling', async () => {
+            vi.mocked(sleep).mockClear();
+            const write = vi
+                .fn()
+                .mockRejectedValueOnce(
+                    new GoogleSheetsQuotaError('quota', {
+                        retryAfterMs: 5000,
+                    }),
+                )
+                .mockResolvedValueOnce(undefined);
+
+            await retryTransientGoogleSheetsWrite(
+                write,
+                undefined,
+                GSHEET_UPLOAD_QUOTA_BRIDGE_SCHEDULE_MS,
+            );
+
+            // Not the schedule's first entry (2000) — the honored hint wins.
+            expect(vi.mocked(sleep)).toHaveBeenCalledWith(5000);
+        });
+    });
+});
+
+describe('computeGsheetsPacingDelayMs', () => {
+    it('spreads writesPerItem writes across a minute at the given budget', () => {
+        // 60_000 * 3 / 55, rounded up so the sustained rate never exceeds budget.
+        expect(computeGsheetsPacingDelayMs(3, 55)).toBe(3273);
+    });
+
+    it('defaults to GSHEETS_WRITES_PER_MINUTE_BUDGET when no budget is given', () => {
+        expect(computeGsheetsPacingDelayMs(3)).toBe(
+            Math.ceil((60_000 * 3) / GSHEETS_WRITES_PER_MINUTE_BUDGET),
+        );
+    });
+});
+
+describe('processSequentiallyWithPacing', () => {
+    it('never sleeps when the pacing delay is 0, regardless of item count', async () => {
+        const sleepFn = vi.fn().mockResolvedValue(undefined);
+        const processItem = vi.fn().mockResolvedValue(undefined);
+
+        await processSequentiallyWithPacing([1, 2, 3], 0, processItem, sleepFn);
+
+        expect(sleepFn).not.toHaveBeenCalled();
+        expect(processItem).toHaveBeenCalledTimes(3);
+    });
+
+    it('never sleeps before the first item, only between items', async () => {
+        const sleepFn = vi.fn().mockResolvedValue(undefined);
+        const processItem = vi.fn().mockResolvedValue(undefined);
+
+        await processSequentiallyWithPacing(
+            [1, 2, 3],
+            100,
+            processItem,
+            sleepFn,
+        );
+
+        expect(sleepFn).toHaveBeenCalledTimes(2);
+        expect(sleepFn).toHaveBeenCalledWith(100);
+    });
+
+    it('processes items in order, one at a time', async () => {
+        const order: number[] = [];
+        const sleepFn = vi.fn().mockResolvedValue(undefined);
+
+        await processSequentiallyWithPacing(
+            [1, 2, 3],
+            50,
+            async (item) => {
+                order.push(item);
+            },
+            sleepFn,
+        );
+
+        expect(order).toEqual([1, 2, 3]);
     });
 });
 
@@ -2500,6 +2611,80 @@ describe('uploadGsheets — app branch', () => {
         expect(logSchedulerJob).toHaveBeenLastCalledWith(
             expect.objectContaining({ status: 'completed' }),
         );
+    });
+
+    // Proactive pacing (writes(N) = 3N + 3 vs GSHEETS_WRITES_PER_MINUTE_BUDGET)
+    // — a large manifest bursting every write instantly would blow the
+    // per-minute quota before any single write even fails, so item
+    // processing is spaced apart up front rather than relying solely on
+    // reactive retry.
+    describe('write-quota pacing', () => {
+        const manyReadyItems = (count: number) =>
+            Array.from({ length: count }, (_, i) =>
+                readyItem({
+                    captureKey: `v1:item-${i}`,
+                    label: `Query ${i}`,
+                    queryUuid: `query-${i}`,
+                    order: i,
+                }),
+            );
+
+        it('adds zero pacing delay for a small manifest under the budget', async () => {
+            vi.mocked(sleep).mockClear();
+            const { run } = setup({
+                manifest: manifestOf(manyReadyItems(2)),
+            });
+
+            await run();
+
+            // 2 items -> 3*2+3=9 planned writes, nowhere near the 55 budget —
+            // no retries either, so sleep should never be called at all.
+            expect(vi.mocked(sleep)).not.toHaveBeenCalled();
+        });
+
+        it('engages pacing with the computed delay for a 20-query manifest', async () => {
+            vi.mocked(sleep).mockClear();
+            const { run } = setup({
+                manifest: manifestOf(manyReadyItems(20)),
+            });
+
+            await run();
+
+            // 20 items -> 3*20+3=63 planned writes, over the 55 budget.
+            const expectedDelay = computeGsheetsPacingDelayMs(
+                GSHEETS_WRITES_PER_APP_ITEM,
+            );
+            const pacingCalls = vi
+                .mocked(sleep)
+                .mock.calls.filter(([ms]) => ms === expectedDelay);
+            // Pacing sleeps between items only: 19 gaps for 20 items.
+            expect(pacingCalls).toHaveLength(19);
+        });
+
+        it('keeps the sustained write rate under budget for a 50-query manifest (MAX_DELIVERY_QUERIES)', async () => {
+            vi.mocked(sleep).mockClear();
+            const { run } = setup({
+                manifest: manifestOf(manyReadyItems(50)),
+            });
+
+            await run();
+
+            const expectedDelay = computeGsheetsPacingDelayMs(
+                GSHEETS_WRITES_PER_APP_ITEM,
+            );
+            const pacingCalls = vi
+                .mocked(sleep)
+                .mock.calls.filter(([ms]) => ms === expectedDelay);
+            expect(pacingCalls).toHaveLength(49);
+
+            // The delay actually used keeps the sustained item-write rate at
+            // or under the budget, by construction of the pacing formula.
+            const sustainedWritesPerMinute =
+                (60_000 / expectedDelay) * GSHEETS_WRITES_PER_APP_ITEM;
+            expect(sustainedWritesPerMinute).toBeLessThanOrEqual(
+                GSHEETS_WRITES_PER_MINUTE_BUDGET,
+            );
+        });
     });
 });
 

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -2144,7 +2144,10 @@ describe('uploadGsheets — app branch', () => {
         expect(appendCsvToSheet.mock.calls[0][3]).toBe('Sales.Q1');
     });
 
-    it('dedupes tab names that collide once sanitized, like the CSV app path dedupes filenames', async () => {
+    // Suffixes are derived from each item's own captureKey, not from
+    // iteration order, so identity can't drift if the set/order of same-
+    // labeled items changes between runs (see the reversed-order test below).
+    it('suffixes both occurrences of a duplicate label with a stable, captureKey-derived tag', async () => {
         const { run, createNewTab } = setup({
             manifest: manifestOf([
                 readyItem({
@@ -2168,21 +2171,112 @@ describe('uploadGsheets — app branch', () => {
             1,
             'refresh-token',
             'sheet-1',
-            'Revenue',
+            'Revenue (c9ea)',
         );
         expect(createNewTab).toHaveBeenNthCalledWith(
             2,
             'refresh-token',
             'sheet-1',
-            'Revenue (2)',
+            'Revenue (73b6)',
+        );
+    });
+
+    it('keeps duplicate-label tab names stable across a re-run with reversed item order', async () => {
+        const forwardRun = setup({
+            manifest: manifestOf([
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Revenue',
+                    queryUuid: 'query-a',
+                    order: 0,
+                }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Revenue',
+                    queryUuid: 'query-b',
+                    order: 1,
+                }),
+            ]),
+        });
+        await forwardRun.run();
+
+        // Same two items, reversed order and swapped `order` fields — as if
+        // the app declared them in a different sequence on the next sync.
+        const reversedRun = setup({
+            manifest: manifestOf([
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Revenue',
+                    queryUuid: 'query-b',
+                    order: 0,
+                }),
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Revenue',
+                    queryUuid: 'query-a',
+                    order: 1,
+                }),
+            ]),
+        });
+        await reversedRun.run();
+
+        const forwardTabNames = forwardRun.createNewTab.mock.calls.map(
+            (call) => call[2],
+        );
+        const reversedTabNames = reversedRun.createNewTab.mock.calls.map(
+            (call) => call[2],
+        );
+        // query-a's tab name is identical whether it's processed first or
+        // second, and likewise for query-b — the suffix tracks the query,
+        // not its position in this run's list.
+        expect(forwardTabNames).toEqual(['Revenue (c9ea)', 'Revenue (73b6)']);
+        expect(reversedTabNames).toEqual(['Revenue (73b6)', 'Revenue (c9ea)']);
+        expect(new Set(forwardTabNames)).toEqual(new Set(reversedTabNames));
+    });
+
+    it('keeps the plain sanitized name for a label that is unique this run, even when other labels collide', async () => {
+        const { run, createNewTab } = setup({
+            manifest: manifestOf([
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Revenue',
+                    queryUuid: 'query-a',
+                    order: 0,
+                }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Revenue',
+                    queryUuid: 'query-b',
+                    order: 1,
+                }),
+                readyItem({
+                    captureKey: 'v1:c',
+                    label: 'Orders',
+                    queryUuid: 'query-c',
+                    order: 2,
+                }),
+            ]),
+        });
+
+        await run();
+
+        expect(createNewTab).toHaveBeenNthCalledWith(
+            3,
+            'refresh-token',
+            'sheet-1',
+            'Orders',
         );
     });
 
     // Manifest items already known to have failed at render time never get a
     // tab attempt — same as the dashboard branch pre-filtering chartTiles down
     // to tiles with a live savedChartUuid before it starts iterating.
-    it('skips error manifest items and only builds tabs for ready items', async () => {
-        const { run, createNewTab, appendCsvToSheet } = setup({
+    // A capture error is a runtime query failure (like a dashboard tile whose
+    // query throws), not a missing widget — gsheets has no partial-failure
+    // channel to report it silently, so any error item fails the whole sync
+    // instead of shipping a "successful" run quietly missing that tab.
+    it('fails the whole sync when the manifest contains any error items, naming them in the message', async () => {
+        const { run, createNewTab, appendCsvToSheet, logSchedulerJob } = setup({
             manifest: manifestOf([
                 readyItem({
                     captureKey: 'v1:a',
@@ -2198,20 +2292,36 @@ describe('uploadGsheets — app branch', () => {
             ]),
         });
 
-        await run();
-
-        expect(createNewTab).toHaveBeenCalledTimes(1);
-        expect(createNewTab).toHaveBeenCalledWith(
-            'refresh-token',
-            'sheet-1',
-            'Revenue',
+        await expect(run()).rejects.toThrow(/Broken query/);
+        expect(createNewTab).not.toHaveBeenCalled();
+        expect(appendCsvToSheet).not.toHaveBeenCalled();
+        expect(logSchedulerJob).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: 'error' }),
         );
-        expect(appendCsvToSheet).toHaveBeenCalledTimes(1);
     });
 
-    it('throws when the capture render returns no successful queries', async () => {
+    it('names every error item when there is more than one', async () => {
+        const { run } = setup({
+            manifest: manifestOf([
+                errorItem({
+                    captureKey: 'v1:a',
+                    label: 'Broken A',
+                    order: 0,
+                }),
+                errorItem({
+                    captureKey: 'v1:b',
+                    label: 'Broken B',
+                    order: 1,
+                }),
+            ]),
+        });
+
+        await expect(run()).rejects.toThrow(/Broken A.*Broken B/s);
+    });
+
+    it('throws when the capture render returns no items at all', async () => {
         const { run, createNewTab } = setup({
-            manifest: manifestOf([errorItem()]),
+            manifest: manifestOf([]),
         });
 
         await expect(run()).rejects.toThrow(/captured no successful queries/i);

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -9,10 +9,12 @@ import {
     GoogleSheetsQuotaError,
     GoogleSheetsTransientError,
     LightdashPage,
+    MAX_DELIVERY_QUERIES,
     MetricType,
     NotEnoughResults,
     PartialFailureType,
     SchedulerFormat,
+    sleep,
     ThresholdOperator,
     VizAggregationOptions,
     VizIndexType,
@@ -554,6 +556,46 @@ describe('retryTransientGoogleSheetsWrite', () => {
         await retryTransientGoogleSheetsWrite(write, onRetry);
 
         expect(onRetry.mock.calls).toEqual([[2], [3]]);
+    });
+
+    it('honors a Retry-After hint on a quota error instead of the default linear backoff', async () => {
+        vi.mocked(sleep).mockClear();
+        const write = vi
+            .fn()
+            .mockRejectedValueOnce(
+                new GoogleSheetsQuotaError('quota', { retryAfterMs: 5000 }),
+            )
+            .mockResolvedValueOnce(undefined);
+
+        await retryTransientGoogleSheetsWrite(write);
+
+        expect(vi.mocked(sleep)).toHaveBeenCalledWith(5000);
+    });
+
+    it('caps an honored Retry-After so one huge value cannot stall the job', async () => {
+        vi.mocked(sleep).mockClear();
+        const write = vi
+            .fn()
+            .mockRejectedValueOnce(
+                new GoogleSheetsQuotaError('quota', { retryAfterMs: 600000 }),
+            )
+            .mockResolvedValueOnce(undefined);
+
+        await retryTransientGoogleSheetsWrite(write);
+
+        expect(vi.mocked(sleep)).toHaveBeenCalledWith(30000);
+    });
+
+    it('falls back to the default linear backoff when the quota error carries no Retry-After', async () => {
+        vi.mocked(sleep).mockClear();
+        const write = vi
+            .fn()
+            .mockRejectedValueOnce(new GoogleSheetsQuotaError())
+            .mockResolvedValueOnce(undefined);
+
+        await retryTransientGoogleSheetsWrite(write);
+
+        expect(vi.mocked(sleep)).toHaveBeenCalledWith(2000);
     });
 });
 
@@ -2082,20 +2124,12 @@ describe('uploadGsheets — app branch', () => {
 
         await run();
 
-        expect(createNewTab).toHaveBeenCalledTimes(2);
-        expect(createNewTab).toHaveBeenNthCalledWith(
-            1,
-            'refresh-token',
-            'sheet-1',
-            'Revenue by month',
-        );
-        expect(createNewTab).toHaveBeenNthCalledWith(
-            2,
-            'refresh-token',
-            'sheet-1',
-            'Orders by status',
-        );
+        // appendCsvToSheet creates the tab itself — a separate explicit
+        // createNewTab call would just be a second write against the quota.
+        expect(createNewTab).not.toHaveBeenCalled();
         expect(appendCsvToSheet).toHaveBeenCalledTimes(2);
+        expect(appendCsvToSheet.mock.calls[0][3]).toBe('Revenue by month');
+        expect(appendCsvToSheet.mock.calls[1][3]).toBe('Orders by status');
         expect(uploadMetadata).toHaveBeenCalledWith(
             'refresh-token',
             'sheet-1',
@@ -2105,6 +2139,38 @@ describe('uploadGsheets — app branch', () => {
         );
         expect(logSchedulerJob).toHaveBeenLastCalledWith(
             expect.objectContaining({ status: 'completed' }),
+        );
+    });
+
+    // The metadata tab must list what was actually written, not the raw
+    // capture labels — a duplicate label is sanitized and suffixed before it
+    // becomes a real tab name.
+    it('lists the actual sanitized+suffixed tab names in the metadata tab for duplicate labels', async () => {
+        const { run, uploadMetadata } = setup({
+            manifest: manifestOf([
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Revenue',
+                    queryUuid: 'query-a',
+                    order: 0,
+                }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Revenue',
+                    queryUuid: 'query-b',
+                    order: 1,
+                }),
+            ]),
+        });
+
+        await run();
+
+        expect(uploadMetadata).toHaveBeenCalledWith(
+            'refresh-token',
+            'sheet-1',
+            expect.any(String),
+            ['Revenue (c9ea)', 'Revenue (73b6)'],
+            expect.stringContaining('/apps/app-1/view'),
         );
     });
 
@@ -2136,11 +2202,7 @@ describe('uploadGsheets — app branch', () => {
 
         await run();
 
-        expect(createNewTab).toHaveBeenCalledWith(
-            'refresh-token',
-            'sheet-1',
-            'Sales.Q1',
-        );
+        expect(createNewTab).not.toHaveBeenCalled();
         expect(appendCsvToSheet.mock.calls[0][3]).toBe('Sales.Q1');
     });
 
@@ -2148,7 +2210,7 @@ describe('uploadGsheets — app branch', () => {
     // iteration order, so identity can't drift if the set/order of same-
     // labeled items changes between runs (see the reversed-order test below).
     it('suffixes both occurrences of a duplicate label with a stable, captureKey-derived tag', async () => {
-        const { run, createNewTab } = setup({
+        const { run, appendCsvToSheet } = setup({
             manifest: manifestOf([
                 readyItem({
                     captureKey: 'v1:a',
@@ -2167,18 +2229,8 @@ describe('uploadGsheets — app branch', () => {
 
         await run();
 
-        expect(createNewTab).toHaveBeenNthCalledWith(
-            1,
-            'refresh-token',
-            'sheet-1',
-            'Revenue (c9ea)',
-        );
-        expect(createNewTab).toHaveBeenNthCalledWith(
-            2,
-            'refresh-token',
-            'sheet-1',
-            'Revenue (73b6)',
-        );
+        expect(appendCsvToSheet.mock.calls[0][3]).toBe('Revenue (c9ea)');
+        expect(appendCsvToSheet.mock.calls[1][3]).toBe('Revenue (73b6)');
     });
 
     it('keeps duplicate-label tab names stable across a re-run with reversed item order', async () => {
@@ -2220,11 +2272,11 @@ describe('uploadGsheets — app branch', () => {
         });
         await reversedRun.run();
 
-        const forwardTabNames = forwardRun.createNewTab.mock.calls.map(
-            (call) => call[2],
+        const forwardTabNames = forwardRun.appendCsvToSheet.mock.calls.map(
+            (call) => call[3],
         );
-        const reversedTabNames = reversedRun.createNewTab.mock.calls.map(
-            (call) => call[2],
+        const reversedTabNames = reversedRun.appendCsvToSheet.mock.calls.map(
+            (call) => call[3],
         );
         // query-a's tab name is identical whether it's processed first or
         // second, and likewise for query-b — the suffix tracks the query,
@@ -2235,7 +2287,7 @@ describe('uploadGsheets — app branch', () => {
     });
 
     it('keeps the plain sanitized name for a label that is unique this run, even when other labels collide', async () => {
-        const { run, createNewTab } = setup({
+        const { run, appendCsvToSheet } = setup({
             manifest: manifestOf([
                 readyItem({
                     captureKey: 'v1:a',
@@ -2260,12 +2312,7 @@ describe('uploadGsheets — app branch', () => {
 
         await run();
 
-        expect(createNewTab).toHaveBeenNthCalledWith(
-            3,
-            'refresh-token',
-            'sheet-1',
-            'Orders',
-        );
+        expect(appendCsvToSheet.mock.calls[2][3]).toBe('Orders');
     });
 
     // Manifest items already known to have failed at render time never get a
@@ -2328,6 +2375,30 @@ describe('uploadGsheets — app branch', () => {
         expect(createNewTab).not.toHaveBeenCalled();
     });
 
+    // Overflow queries are dropped silently at capture time — gsheets has no
+    // partial-failure channel to report that, so a dropped query would
+    // otherwise be missing a tab forever with nothing to say why.
+    it('fails the whole sync when the capture manifest overflowed, naming the dropped count and the cap', async () => {
+        const { run, createNewTab, appendCsvToSheet } = setup({
+            manifest: manifestOf([readyItem()], 3),
+        });
+
+        await expect(run()).rejects.toThrow(
+            new RegExp(`3 queries.*${MAX_DELIVERY_QUERIES}`, 's'),
+        );
+        expect(createNewTab).not.toHaveBeenCalled();
+        expect(appendCsvToSheet).not.toHaveBeenCalled();
+    });
+
+    it('does not fail when the capture manifest has no overflow', async () => {
+        const { run, appendCsvToSheet } = setup({
+            manifest: manifestOf([readyItem()], 0),
+        });
+
+        await expect(run()).resolves.toBeUndefined();
+        expect(appendCsvToSheet).toHaveBeenCalledTimes(1);
+    });
+
     // Capture is fail-closed: a rejected render fails the whole gsheets task
     // and rides its existing retry/notify-and-disable path — no partial sync.
     it('fails the whole sync when the delivery capture render fails', async () => {
@@ -2354,7 +2425,7 @@ describe('uploadGsheets — app branch', () => {
     // reduce().catch(rethrow), not the CSV app path's per-item partial
     // failures (gsheets has no notification payload to carry those through).
     it('fails the whole sync when a ready item fails during processing, and never attempts later items', async () => {
-        const { run, createNewTab } = setup({
+        const { run, appendCsvToSheet } = setup({
             manifest: manifestOf([
                 readyItem({
                     captureKey: 'v1:a',
@@ -2388,14 +2459,46 @@ describe('uploadGsheets — app branch', () => {
         });
 
         await expect(run()).rejects.toThrow(/results file missing/i);
-        // The first item's tab was already created before the second item
+        // The first item's tab was already written before the second item
         // failed; sequential processing stops there and the third item is
         // never attempted.
-        expect(createNewTab).toHaveBeenCalledTimes(1);
-        expect(createNewTab).toHaveBeenCalledWith(
-            'refresh-token',
-            'sheet-1',
-            'Fetched fine',
+        expect(appendCsvToSheet).toHaveBeenCalledTimes(1);
+        expect(appendCsvToSheet.mock.calls[0][3]).toBe('Fetched fine');
+    });
+
+    // gaxios only retries when a request opts into `retry`/`retryConfig`,
+    // which our calls never do — retryTransientGoogleSheetsWrite is the only
+    // backoff a Google Sheets write gets, so the app branch's writes must go
+    // through it the same as the ad-hoc gsheet export paths already do.
+    it('retries a quota error on the sheet write and still completes the sync', async () => {
+        const { run, appendCsvToSheet, logSchedulerJob } = setup({
+            manifest: manifestOf([readyItem()]),
+        });
+        appendCsvToSheet
+            .mockRejectedValueOnce(new GoogleSheetsQuotaError())
+            .mockResolvedValueOnce(undefined);
+
+        await run();
+
+        expect(appendCsvToSheet).toHaveBeenCalledTimes(2);
+        expect(logSchedulerJob).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: 'completed' }),
+        );
+    });
+
+    it('retries a quota error on the metadata write and still completes the sync', async () => {
+        const { run, uploadMetadata, logSchedulerJob } = setup({
+            manifest: manifestOf([readyItem()]),
+        });
+        uploadMetadata
+            .mockRejectedValueOnce(new GoogleSheetsQuotaError())
+            .mockResolvedValueOnce(undefined);
+
+        await run();
+
+        expect(uploadMetadata).toHaveBeenCalledTimes(2);
+        expect(logSchedulerJob).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: 'completed' }),
         );
     });
 });

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -1930,6 +1930,366 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
     });
 });
 
+const gsheetsAppScheduler = (overrides: Record<string, unknown> = {}) => ({
+    schedulerUuid: 'scheduler-1',
+    name: 'Daily app sync',
+    createdBy: 'user-1',
+    format: SchedulerFormat.GSHEETS,
+    savedChartUuid: null,
+    dashboardUuid: null,
+    savedSqlUuid: null,
+    appUuid: 'app-1',
+    appName: 'Sales App',
+    cron: '0 7 * * *',
+    timezone: 'UTC',
+    options: { gdriveId: 'sheet-1' },
+    thresholds: undefined,
+    filters: undefined,
+    ...overrides,
+});
+
+describe('uploadGsheets — app branch', () => {
+    const setup = ({
+        manifest = manifestOf([readyItem()]),
+        captureAppDeliveryManifest: captureOverride,
+        getRawAsyncQueryResults: getRawOverride,
+    }: {
+        manifest?: DeliveryCaptureManifest;
+        captureAppDeliveryManifest?: Mock;
+        getRawAsyncQueryResults?: (args: { queryUuid: string }) => Promise<{
+            rows: Record<string, unknown>[];
+            fields: Record<string, unknown>;
+            displayTimezone: string | null;
+        }>;
+    } = {}) => {
+        const scheduler = gsheetsAppScheduler();
+        const captureAppDeliveryManifest =
+            captureOverride ?? vi.fn().mockResolvedValue(manifest);
+        const createNewTab = vi.fn().mockResolvedValue(undefined);
+        const appendCsvToSheet = vi.fn().mockResolvedValue(undefined);
+        const uploadMetadata = vi.fn().mockResolvedValue(undefined);
+        const logSchedulerJob = vi.fn().mockResolvedValue(undefined);
+        const getRawAsyncQueryResults = vi.fn(
+            getRawOverride ??
+                (async () => ({
+                    rows: [{ orders_id: 1, orders_status: 'complete' }],
+                    fields: {},
+                    displayTimezone: null,
+                })),
+        );
+
+        const task = makeTaskWithDeps({
+            googleDriveClient: asDep<'googleDriveClient'>({
+                isEnabled: true,
+                createNewTab,
+                appendCsvToSheet,
+                uploadMetadata,
+            }),
+            schedulerService: asDep<'schedulerService'>({
+                schedulerModel: {
+                    getSchedulerAndTargets: vi
+                        .fn()
+                        .mockResolvedValue(scheduler),
+                },
+                getSchedulerDefaultTimezone: vi.fn().mockResolvedValue('UTC'),
+                appModel: {
+                    findAppByUuid: vi.fn().mockResolvedValue(APP_ROW),
+                },
+                logSchedulerJob,
+            }),
+            userService: asDep<'userService'>({
+                getSessionByUserUuid: vi.fn().mockResolvedValue({}),
+                getAccountByUserUuid: vi.fn().mockResolvedValue({
+                    user: { email: 'demo@lightdash.com' },
+                    organization: { organizationUuid: 'org-1' },
+                }),
+                getRefreshToken: vi.fn().mockResolvedValue('refresh-token'),
+            }),
+            asyncQueryService: asDep<'asyncQueryService'>({
+                getRawAsyncQueryResults,
+            }),
+            unfurlService: asDep<'unfurlService'>({
+                captureAppDeliveryManifest,
+            }),
+            analytics: asDep<'analytics'>({ track: vi.fn() }),
+            lightdashConfig: asDep<'lightdashConfig'>({
+                siteUrl: 'https://lightdash.example.com',
+                headlessBrowser: {
+                    internalLightdashHost: 'http://lightdash-dev:3000',
+                },
+            }),
+        });
+
+        const run = () =>
+            (
+                task as unknown as {
+                    uploadGsheets(
+                        jobId: string,
+                        notification: {
+                            schedulerUuid: string;
+                            scheduledTime: Date;
+                            jobGroup: string;
+                            userUuid: string;
+                            organizationUuid: string;
+                            projectUuid: string;
+                        },
+                    ): Promise<void>;
+                }
+            ).uploadGsheets('job-1', {
+                schedulerUuid: scheduler.schedulerUuid,
+                scheduledTime: new Date('2026-08-04T07:00:00Z'),
+                jobGroup: 'scheduled_delivery',
+                userUuid: 'user-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'project-1',
+            });
+
+        return {
+            scheduler,
+            run,
+            captureAppDeliveryManifest,
+            createNewTab,
+            appendCsvToSheet,
+            uploadMetadata,
+            logSchedulerJob,
+            getRawAsyncQueryResults,
+        };
+    };
+
+    it('creates one tab per ready item and writes the metadata tab with the frequency, source link and tab list', async () => {
+        const {
+            run,
+            createNewTab,
+            appendCsvToSheet,
+            uploadMetadata,
+            logSchedulerJob,
+        } = setup({
+            manifest: manifestOf([
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Revenue by month',
+                    queryUuid: 'query-a',
+                    order: 0,
+                }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Orders by status',
+                    queryUuid: 'query-b',
+                    order: 1,
+                }),
+            ]),
+        });
+
+        await run();
+
+        expect(createNewTab).toHaveBeenCalledTimes(2);
+        expect(createNewTab).toHaveBeenNthCalledWith(
+            1,
+            'refresh-token',
+            'sheet-1',
+            'Revenue by month',
+        );
+        expect(createNewTab).toHaveBeenNthCalledWith(
+            2,
+            'refresh-token',
+            'sheet-1',
+            'Orders by status',
+        );
+        expect(appendCsvToSheet).toHaveBeenCalledTimes(2);
+        expect(uploadMetadata).toHaveBeenCalledWith(
+            'refresh-token',
+            'sheet-1',
+            expect.any(String),
+            ['Revenue by month', 'Orders by status'],
+            expect.stringContaining('/apps/app-1/view'),
+        );
+        expect(logSchedulerJob).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: 'completed' }),
+        );
+    });
+
+    it('pages rows for each ready item via the completed query, unbounded', async () => {
+        const { run, getRawAsyncQueryResults } = setup({
+            manifest: manifestOf([readyItem({ queryUuid: 'query-xyz' })]),
+        });
+
+        await run();
+
+        expect(getRawAsyncQueryResults).toHaveBeenCalledTimes(1);
+        expect(getRawAsyncQueryResults.mock.calls[0][0]).toMatchObject({
+            projectUuid: 'project-1',
+            queryUuid: 'query-xyz',
+        });
+        // Same unbounded row bound the chart/dashboard gsheets branches use —
+        // no maxRows cap, unlike the AI-augmentation caller of this method.
+        expect(getRawAsyncQueryResults.mock.calls[0][0]).not.toHaveProperty(
+            'maxRows',
+        );
+    });
+
+    it('sanitizes colons out of tab names, same as the chart/dashboard branches', async () => {
+        const { run, createNewTab, appendCsvToSheet } = setup({
+            manifest: manifestOf([
+                readyItem({ label: 'Sales:Q1', queryUuid: 'query-a' }),
+            ]),
+        });
+
+        await run();
+
+        expect(createNewTab).toHaveBeenCalledWith(
+            'refresh-token',
+            'sheet-1',
+            'Sales.Q1',
+        );
+        expect(appendCsvToSheet.mock.calls[0][3]).toBe('Sales.Q1');
+    });
+
+    it('dedupes tab names that collide once sanitized, like the CSV app path dedupes filenames', async () => {
+        const { run, createNewTab } = setup({
+            manifest: manifestOf([
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Revenue',
+                    queryUuid: 'query-a',
+                    order: 0,
+                }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Revenue',
+                    queryUuid: 'query-b',
+                    order: 1,
+                }),
+            ]),
+        });
+
+        await run();
+
+        expect(createNewTab).toHaveBeenNthCalledWith(
+            1,
+            'refresh-token',
+            'sheet-1',
+            'Revenue',
+        );
+        expect(createNewTab).toHaveBeenNthCalledWith(
+            2,
+            'refresh-token',
+            'sheet-1',
+            'Revenue (2)',
+        );
+    });
+
+    // Manifest items already known to have failed at render time never get a
+    // tab attempt — same as the dashboard branch pre-filtering chartTiles down
+    // to tiles with a live savedChartUuid before it starts iterating.
+    it('skips error manifest items and only builds tabs for ready items', async () => {
+        const { run, createNewTab, appendCsvToSheet } = setup({
+            manifest: manifestOf([
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Revenue',
+                    queryUuid: 'query-a',
+                    order: 0,
+                }),
+                errorItem({
+                    captureKey: 'v1:err',
+                    label: 'Broken query',
+                    order: 1,
+                }),
+            ]),
+        });
+
+        await run();
+
+        expect(createNewTab).toHaveBeenCalledTimes(1);
+        expect(createNewTab).toHaveBeenCalledWith(
+            'refresh-token',
+            'sheet-1',
+            'Revenue',
+        );
+        expect(appendCsvToSheet).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when the capture render returns no successful queries', async () => {
+        const { run, createNewTab } = setup({
+            manifest: manifestOf([errorItem()]),
+        });
+
+        await expect(run()).rejects.toThrow(/captured no successful queries/i);
+        expect(createNewTab).not.toHaveBeenCalled();
+    });
+
+    // Capture is fail-closed: a rejected render fails the whole gsheets task
+    // and rides its existing retry/notify-and-disable path — no partial sync.
+    it('fails the whole sync when the delivery capture render fails', async () => {
+        const { run, createNewTab, appendCsvToSheet, logSchedulerJob } = setup({
+            captureAppDeliveryManifest: vi
+                .fn()
+                .mockRejectedValue(
+                    new Error('App delivery capture missing or malformed'),
+                ),
+        });
+
+        await expect(run()).rejects.toThrow(
+            /App delivery capture missing or malformed/i,
+        );
+        expect(createNewTab).not.toHaveBeenCalled();
+        expect(appendCsvToSheet).not.toHaveBeenCalled();
+        expect(logSchedulerJob).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: 'error' }),
+        );
+    });
+
+    // Any failure processing an attempted ready item (not a pre-known render
+    // error) fails the whole sync too — matching the dashboard branch's
+    // reduce().catch(rethrow), not the CSV app path's per-item partial
+    // failures (gsheets has no notification payload to carry those through).
+    it('fails the whole sync when a ready item fails during processing, and never attempts later items', async () => {
+        const { run, createNewTab } = setup({
+            manifest: manifestOf([
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Fetched fine',
+                    queryUuid: 'query-a',
+                    order: 0,
+                }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Broken during fetch',
+                    queryUuid: 'query-b',
+                    order: 1,
+                }),
+                readyItem({
+                    captureKey: 'v1:c',
+                    label: 'Never attempted',
+                    queryUuid: 'query-c',
+                    order: 2,
+                }),
+            ]),
+            getRawAsyncQueryResults: async ({ queryUuid }) => {
+                if (queryUuid === 'query-b') {
+                    throw new Error('results file missing');
+                }
+                return {
+                    rows: [{ orders_id: 1 }],
+                    fields: {},
+                    displayTimezone: null,
+                };
+            },
+        });
+
+        await expect(run()).rejects.toThrow(/results file missing/i);
+        // The first item's tab was already created before the second item
+        // failed; sequential processing stops there and the third item is
+        // never attempted.
+        expect(createNewTab).toHaveBeenCalledTimes(1);
+        expect(createNewTab).toHaveBeenCalledWith(
+            'refresh-token',
+            'sheet-1',
+            'Fetched fine',
+        );
+    });
+});
+
 describe('captureAppDeliveryQueries', () => {
     const setup = () => {
         const captureAppDeliveryManifest = vi

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -66,6 +66,7 @@ import {
     isTileInSelectedTabs,
     isVizTableConfig,
     LightdashPage,
+    MAX_DELIVERY_QUERIES,
     MAX_SAFE_INTEGER,
     MetricType,
     MissingConfigError,
@@ -322,6 +323,14 @@ export function setSchedulerJobLogContext(
 
 export const GSHEET_UPLOAD_MAX_ATTEMPTS = 3;
 const GSHEET_UPLOAD_RETRY_BASE_MS = 2000;
+// googleapis/gaxios only retries when a request opts in via `retry`/
+// `retryConfig` (see gaxios's getRetryConfig) — we never set either, so
+// nothing below us retries automatically; this bounded wait is genuinely
+// the only backoff a Google Sheets write gets. Caps how long a single
+// honored Retry-After can make us wait, so a large server-suggested delay
+// still hands off to the task's own retry/notify-and-disable path instead
+// of stalling the job.
+const GSHEET_UPLOAD_RETRY_AFTER_CEILING_MS = 30000;
 
 export async function retryTransientGoogleSheetsWrite(
     write: () => Promise<void>,
@@ -337,7 +346,17 @@ export async function retryTransientGoogleSheetsWrite(
         if (!isTransient || attempt >= GSHEET_UPLOAD_MAX_ATTEMPTS) {
             throw e;
         }
-        await sleep(GSHEET_UPLOAD_RETRY_BASE_MS * attempt);
+        // Honor a server-provided Retry-After when Google sends one;
+        // otherwise fall back to the existing linear backoff.
+        const retryAfterMs =
+            e instanceof GoogleSheetsQuotaError &&
+            typeof e.data?.retryAfterMs === 'number'
+                ? Math.min(
+                      e.data.retryAfterMs,
+                      GSHEET_UPLOAD_RETRY_AFTER_CEILING_MS,
+                  )
+                : undefined;
+        await sleep(retryAfterMs ?? GSHEET_UPLOAD_RETRY_BASE_MS * attempt);
         await onRetry(attempt + 1);
         await retryTransientGoogleSheetsWrite(write, onRetry, attempt + 1);
     }
@@ -404,7 +423,11 @@ export function dedupeArtifactFilename(
 // A short, stable-per-query suffix for a gsheets tab name — derived from the
 // item's own captureKey (fixed per query) rather than run-order, so a
 // duplicate label's tab identity survives items being added/removed/reordered
-// between syncs.
+// between syncs. If a label's duplicate *count* changes run to run (e.g. a
+// second same-labeled query is added or removed), the suffixed/unsuffixed
+// tab name changes too and the old tab is orphaned — accepted as
+// rename-equivalent behavior, the same as a renamed chart leaving its old
+// gsheets tab stale rather than deleting/renaming it.
 export function captureKeyTabSuffix(captureKey: string): string {
     return createHash('sha256').update(captureKey).digest('hex').slice(0, 4);
 }
@@ -4389,20 +4412,21 @@ export default class SchedulerTask {
                     );
                 }
 
-                await this.googleDriveClient.uploadMetadata(
-                    refreshToken,
-                    gdriveId,
-                    getHumanReadableCronExpression(
-                        scheduler.cron,
-                        scheduler.timezone ?? defaultSchedulerTimezone,
-                    ),
-                    readyItems.map((item) => item.label),
-                    deliveryUrl,
-                );
-
-                Logger.debug(
-                    `Uploading app with ${readyItems.length} queries to Google Sheets`,
-                );
+                // Overflow queries are silently dropped at capture time (see
+                // MAX_DELIVERY_QUERIES) — gsheets has no partial-failure
+                // channel to surface that, so a dropped query would
+                // otherwise be missing a tab forever with nothing to say why.
+                if (appCaptureManifest.overflowCount > 0) {
+                    throw new Error(
+                        `App delivery render dropped ${
+                            appCaptureManifest.overflowCount
+                        } ${
+                            appCaptureManifest.overflowCount === 1
+                                ? 'query'
+                                : 'queries'
+                        } from capture (limit ${MAX_DELIVERY_QUERIES})`,
+                    );
+                }
 
                 // A duplicate label's tab suffix must not depend on this
                 // run's item order/cardinality — positional numbering (like
@@ -4412,6 +4436,7 @@ export default class SchedulerTask {
                 // suffix from the item's own stable captureKey instead keeps
                 // a duplicate label's tab identity fixed run over run.
                 // Unique labels this run keep the plain sanitized name.
+                // (Duplicate-count changes across runs: see captureKeyTabSuffix.)
                 const sanitizedLabelCounts = new Map<string, number>();
                 readyItems.forEach((item) => {
                     const sanitizedLabel = item.label.replaceAll(':', '.');
@@ -4432,6 +4457,41 @@ export default class SchedulerTask {
                           )})`
                         : sanitizedLabel;
                 };
+                // The metadata tab must list what was actually written, not
+                // the raw labels — a label gets sanitized and possibly
+                // suffixed before it becomes a real tab name.
+                const readyItemTabNames = readyItems.map((item) =>
+                    tabNameForReadyItem(item),
+                );
+
+                // Write-quota arithmetic (Sheets API: 60 write requests per
+                // user per minute — developers.google.com/sheets/api/limits).
+                // Each ready item costs 3 writes below: createNewTab (called
+                // once, inside appendCsvToSheet), clearTabName, and the
+                // values.update — plus a fixed 3 writes for this one-off
+                // metadata tab. writes(N) = 3N + 3, so N=19 (60 writes) is
+                // the practical per-sync ceiling before quota errors become
+                // likely within a single job run; N=15 -> 48 writes,
+                // comfortably under. retryTransientGoogleSheetsWrite below
+                // absorbs a transient 429/500 with bounded backoff before
+                // the task's own retry/notify-and-disable path takes over.
+                const humanReadableCron = getHumanReadableCronExpression(
+                    scheduler.cron,
+                    scheduler.timezone ?? defaultSchedulerTimezone,
+                );
+                await retryTransientGoogleSheetsWrite(() =>
+                    this.googleDriveClient.uploadMetadata(
+                        refreshToken,
+                        gdriveId,
+                        humanReadableCron,
+                        readyItemTabNames,
+                        deliveryUrl,
+                    ),
+                );
+
+                Logger.debug(
+                    `Uploading app with ${readyItems.length} queries to Google Sheets`,
+                );
 
                 // We want to process all queries in sequence, so we don't load all query results in memory
                 await readyItems
@@ -4447,12 +4507,6 @@ export default class SchedulerTask {
                             );
 
                         const itemTabName = tabNameForReadyItem(item);
-                        await this.googleDriveClient.createNewTab(
-                            refreshToken,
-                            gdriveId,
-                            itemTabName,
-                        );
-
                         const columnNames =
                             rows.length > 0 ? Object.keys(rows[0]) : [];
                         const dataRows = rows.map((row) =>
@@ -4465,11 +4519,20 @@ export default class SchedulerTask {
                             ),
                         );
 
-                        await this.googleDriveClient.appendCsvToSheet(
-                            refreshToken,
-                            gdriveId,
-                            [columnNames, ...dataRows],
-                            itemTabName,
+                        // appendCsvToSheet creates the tab itself when given
+                        // a tabName — itemTabName is already fully
+                        // sanitized+deduped, so a separate explicit
+                        // createNewTab call first (like the dashboard
+                        // branch's chartTabName pattern) would just be a
+                        // second identical write request against the quota
+                        // budget above for no benefit.
+                        await retryTransientGoogleSheetsWrite(() =>
+                            this.googleDriveClient.appendCsvToSheet(
+                                refreshToken,
+                                gdriveId,
+                                [columnNames, ...dataRows],
+                                itemTabName,
+                            ),
                         );
                     }, Promise.resolve())
                     .catch((error) => {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -138,6 +138,7 @@ import {
     type SlackBatchNotificationPayload,
 } from '@lightdash/common';
 import archiver from 'archiver';
+import { createHash } from 'crypto';
 import fsSync from 'fs';
 import fs from 'fs/promises';
 import moment from 'moment';
@@ -164,6 +165,7 @@ import {
     getDashboardCsvResultsBlocks,
     getDeliveryFailureRecipientBlocks,
     getNotificationChannelErrorBlocks,
+    sanitizeText,
 } from '../clients/Slack/SlackMessageBlocks';
 import { LightdashConfig } from '../config/parseConfig';
 import type { PreAggregateModel } from '../ee/models/PreAggregateModel';
@@ -397,6 +399,14 @@ export function dedupeArtifactFilename(
     return dotIndex === -1
         ? `${filename} (${next})`
         : `${filename.slice(0, dotIndex)} (${next})${filename.slice(dotIndex)}`;
+}
+
+// A short, stable-per-query suffix for a gsheets tab name — derived from the
+// item's own captureKey (fixed per query) rather than run-order, so a
+// duplicate label's tab identity survives items being added/removed/reordered
+// between syncs.
+export function captureKeyTabSuffix(captureKey: string): string {
+    return createHash('sha256').update(captureKey).digest('hex').slice(0, 4);
 }
 
 export default class SchedulerTask {
@@ -4344,16 +4354,35 @@ export default class SchedulerTask {
                     scheduler,
                     jobId,
                 );
-                const readyItems = [...appCaptureManifest.items]
-                    .sort((a, b) => a.order - b.order)
-                    .filter(
-                        (
-                            item,
-                        ): item is Extract<
-                            CapturedQuery,
-                            { status: 'ready' }
-                        > => item.status === 'ready',
+                const sortedCapturedItems = [...appCaptureManifest.items].sort(
+                    (a, b) => a.order - b.order,
+                );
+
+                // A capture error is a runtime query failure, not a missing
+                // widget — same as a dashboard tile whose query throws. gsheets
+                // has no partial-failure channel to report it silently, so it
+                // must fail the whole sync (matching the dashboard branch's
+                // reduce().catch(rethrow)), not skip the tab and stay quiet.
+                const errorItems = sortedCapturedItems.filter(
+                    (
+                        item,
+                    ): item is Extract<CapturedQuery, { status: 'error' }> =>
+                        item.status === 'error',
+                );
+                if (errorItems.length > 0) {
+                    throw new Error(
+                        `App delivery render failed for: ${errorItems
+                            .map((item) => sanitizeText(item.label))
+                            .join(', ')}`,
                     );
+                }
+
+                const readyItems = sortedCapturedItems.filter(
+                    (
+                        item,
+                    ): item is Extract<CapturedQuery, { status: 'ready' }> =>
+                        item.status === 'ready',
+                );
                 if (readyItems.length === 0) {
                     throw new Error(
                         'App delivery render captured no successful queries',
@@ -4375,10 +4404,34 @@ export default class SchedulerTask {
                     `Uploading app with ${readyItems.length} queries to Google Sheets`,
                 );
 
-                // Different labels can sanitize to the same tab name once
-                // colons are stripped, so dedupe before creating tabs — same
-                // mechanism the CSV app path uses for file names.
-                const usedTabNames = new Map<string, number>();
+                // A duplicate label's tab suffix must not depend on this
+                // run's item order/cardinality — positional numbering (like
+                // the CSV path's dedupeArtifactFilename) would let "Revenue
+                // (2)" silently point at a different query on a later run
+                // when items are added/removed/reordered. Deriving the
+                // suffix from the item's own stable captureKey instead keeps
+                // a duplicate label's tab identity fixed run over run.
+                // Unique labels this run keep the plain sanitized name.
+                const sanitizedLabelCounts = new Map<string, number>();
+                readyItems.forEach((item) => {
+                    const sanitizedLabel = item.label.replaceAll(':', '.');
+                    sanitizedLabelCounts.set(
+                        sanitizedLabel,
+                        (sanitizedLabelCounts.get(sanitizedLabel) ?? 0) + 1,
+                    );
+                });
+                const tabNameForReadyItem = (
+                    item: (typeof readyItems)[number],
+                ) => {
+                    const sanitizedLabel = item.label.replaceAll(':', '.');
+                    const isDuplicateLabel =
+                        (sanitizedLabelCounts.get(sanitizedLabel) ?? 0) > 1;
+                    return isDuplicateLabel
+                        ? `${sanitizedLabel} (${captureKeyTabSuffix(
+                              item.captureKey,
+                          )})`
+                        : sanitizedLabel;
+                };
 
                 // We want to process all queries in sequence, so we don't load all query results in memory
                 await readyItems
@@ -4393,10 +4446,7 @@ export default class SchedulerTask {
                                 },
                             );
 
-                        const itemTabName = dedupeArtifactFilename(
-                            item.label.replaceAll(':', '.'),
-                            usedTabNames,
-                        );
+                        const itemTabName = tabNameForReadyItem(item);
                         await this.googleDriveClient.createNewTab(
                             refreshToken,
                             gdriveId,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -3917,8 +3917,13 @@ export default class SchedulerTask {
                     schedulerUuid,
                 );
 
-            const { format, savedChartUuid, dashboardUuid, thresholds } =
-                scheduler;
+            const {
+                format,
+                savedChartUuid,
+                dashboardUuid,
+                appUuid,
+                thresholds,
+            } = scheduler;
 
             const gdriveId = isSchedulerGsheetsOptions(scheduler.options)
                 ? scheduler.options.gdriveId
@@ -4307,6 +4312,120 @@ export default class SchedulerTask {
                     csvData,
                     tabName,
                 );
+            } else if (appUuid) {
+                const { url: appUrl, projectUuid: appProjectUuid } =
+                    await this.getChartOrDashboard(
+                        null,
+                        null,
+                        schedulerUuid,
+                        QueryExecutionContext.SCHEDULED_DELIVERY,
+                        null,
+                        appUuid,
+                    );
+                deliveryUrl = appendUuidQueryParam(
+                    `${appUrl}?isSync=true`,
+                    'scheduler_uuid',
+                    schedulerUuid,
+                );
+
+                const defaultSchedulerTimezone =
+                    await this.schedulerService.getSchedulerDefaultTimezone(
+                        schedulerUuid,
+                    );
+
+                const refreshToken = await this.userService.getRefreshToken(
+                    scheduler.createdBy,
+                );
+
+                // Capture once, same as the CSV/XLSX app branch — a second
+                // render could tag a different query set than the tabs we
+                // build from this one.
+                const appCaptureManifest = await this.captureAppDeliveryQueries(
+                    scheduler,
+                    jobId,
+                );
+                const readyItems = [...appCaptureManifest.items]
+                    .sort((a, b) => a.order - b.order)
+                    .filter(
+                        (
+                            item,
+                        ): item is Extract<
+                            CapturedQuery,
+                            { status: 'ready' }
+                        > => item.status === 'ready',
+                    );
+                if (readyItems.length === 0) {
+                    throw new Error(
+                        'App delivery render captured no successful queries',
+                    );
+                }
+
+                await this.googleDriveClient.uploadMetadata(
+                    refreshToken,
+                    gdriveId,
+                    getHumanReadableCronExpression(
+                        scheduler.cron,
+                        scheduler.timezone ?? defaultSchedulerTimezone,
+                    ),
+                    readyItems.map((item) => item.label),
+                    deliveryUrl,
+                );
+
+                Logger.debug(
+                    `Uploading app with ${readyItems.length} queries to Google Sheets`,
+                );
+
+                // Different labels can sanitize to the same tab name once
+                // colons are stripped, so dedupe before creating tabs — same
+                // mechanism the CSV app path uses for file names.
+                const usedTabNames = new Map<string, number>();
+
+                // We want to process all queries in sequence, so we don't load all query results in memory
+                await readyItems
+                    .reduce(async (promise, item) => {
+                        await promise;
+                        const { rows, fields, displayTimezone } =
+                            await this.asyncQueryService.getRawAsyncQueryResults(
+                                {
+                                    account: account!,
+                                    projectUuid: appProjectUuid,
+                                    queryUuid: item.queryUuid,
+                                },
+                            );
+
+                        const itemTabName = dedupeArtifactFilename(
+                            item.label.replaceAll(':', '.'),
+                            usedTabNames,
+                        );
+                        await this.googleDriveClient.createNewTab(
+                            refreshToken,
+                            gdriveId,
+                            itemTabName,
+                        );
+
+                        const columnNames =
+                            rows.length > 0 ? Object.keys(rows[0]) : [];
+                        const dataRows = rows.map((row) =>
+                            columnNames.map((col) =>
+                                GoogleDriveClient.formatCell(
+                                    row[col],
+                                    fields[col],
+                                    displayTimezone ?? undefined,
+                                ),
+                            ),
+                        );
+
+                        await this.googleDriveClient.appendCsvToSheet(
+                            refreshToken,
+                            gdriveId,
+                            [columnNames, ...dataRows],
+                            itemTabName,
+                        );
+                    }, Promise.resolve())
+                    .catch((error) => {
+                        Logger.debug('Error processing app queries:', error);
+                        throw error;
+                    });
             } else {
                 throw new UnexpectedServerError('Not implemented');
             }

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -321,8 +321,19 @@ export function setSchedulerJobLogContext(
     update({ scheduler });
 }
 
-export const GSHEET_UPLOAD_MAX_ATTEMPTS = 3;
-const GSHEET_UPLOAD_RETRY_BASE_MS = 2000;
+// Default bounded backoff for the ad-hoc "export to a new Google Sheet"
+// flow — interactive, a user is watching a spinner, so failing fast and
+// letting them retry beats a long silent wait.
+const GSHEET_UPLOAD_RETRY_SCHEDULE_MS = [2000, 4000];
+export const GSHEET_UPLOAD_MAX_ATTEMPTS =
+    GSHEET_UPLOAD_RETRY_SCHEDULE_MS.length + 1;
+// Scheduled background app syncs have nobody watching, so they can afford to
+// wait out a full Sheets write-quota window refill (~60s, see
+// GSHEETS_WRITES_PER_MINUTE_BUDGET below) when Google gives no Retry-After
+// hint to follow instead. Cumulative wait ~65s across 5 retries.
+export const GSHEET_UPLOAD_QUOTA_BRIDGE_SCHEDULE_MS = [
+    2000, 4000, 8000, 16000, 35000,
+];
 // googleapis/gaxios only retries when a request opts in via `retry`/
 // `retryConfig` (see gaxios's getRetryConfig) — we never set either, so
 // nothing below us retries automatically; this bounded wait is genuinely
@@ -335,6 +346,7 @@ const GSHEET_UPLOAD_RETRY_AFTER_CEILING_MS = 30000;
 export async function retryTransientGoogleSheetsWrite(
     write: () => Promise<void>,
     onRetry: (attempt: number) => Promise<void> = async () => {},
+    backoffScheduleMs: number[] = GSHEET_UPLOAD_RETRY_SCHEDULE_MS,
     attempt = 1,
 ): Promise<void> {
     try {
@@ -343,11 +355,11 @@ export async function retryTransientGoogleSheetsWrite(
         const isTransient =
             e instanceof GoogleSheetsTransientError ||
             e instanceof GoogleSheetsQuotaError;
-        if (!isTransient || attempt >= GSHEET_UPLOAD_MAX_ATTEMPTS) {
+        if (!isTransient || attempt > backoffScheduleMs.length) {
             throw e;
         }
         // Honor a server-provided Retry-After when Google sends one;
-        // otherwise fall back to the existing linear backoff.
+        // otherwise fall back to the caller's backoff schedule.
         const retryAfterMs =
             e instanceof GoogleSheetsQuotaError &&
             typeof e.data?.retryAfterMs === 'number'
@@ -356,9 +368,14 @@ export async function retryTransientGoogleSheetsWrite(
                       GSHEET_UPLOAD_RETRY_AFTER_CEILING_MS,
                   )
                 : undefined;
-        await sleep(retryAfterMs ?? GSHEET_UPLOAD_RETRY_BASE_MS * attempt);
+        await sleep(retryAfterMs ?? backoffScheduleMs[attempt - 1]);
         await onRetry(attempt + 1);
-        await retryTransientGoogleSheetsWrite(write, onRetry, attempt + 1);
+        await retryTransientGoogleSheetsWrite(
+            write,
+            onRetry,
+            backoffScheduleMs,
+            attempt + 1,
+        );
     }
 }
 
@@ -430,6 +447,46 @@ export function dedupeArtifactFilename(
 // gsheets tab stale rather than deleting/renaming it.
 export function captureKeyTabSuffix(captureKey: string): string {
     return createHash('sha256').update(captureKey).digest('hex').slice(0, 4);
+}
+
+// Sheets write cost of one app-delivered query in the app gsheets branch:
+// createNewTab (called once, inside appendCsvToSheet), clearTabName, and the
+// values.update.
+export const GSHEETS_WRITES_PER_APP_ITEM = 3;
+// Google's Sheets API write-requests-per-user-per-minute quota is 60
+// (developers.google.com/sheets/api/limits) — stay a safety margin under it
+// so the fixed metadata-tab writes and any concurrent activity on the same
+// account don't tip a paced run over the hard limit.
+export const GSHEETS_WRITES_PER_MINUTE_BUDGET = 55;
+
+// Per-item delay that keeps the SUSTAINED write rate at/under budget if kept
+// up indefinitely: budget writes/min <=> (60_000 / delayMs) items/min, each
+// item costing writesPerItem writes.
+export function computeGsheetsPacingDelayMs(
+    writesPerItem: number,
+    budgetPerMinute: number = GSHEETS_WRITES_PER_MINUTE_BUDGET,
+): number {
+    return Math.ceil((60_000 * writesPerItem) / budgetPerMinute);
+}
+
+// Proactively spaces item processing apart by `pacingDelayMs` (a no-op when
+// 0) instead of relying solely on reactive quota-error retries — a large
+// manifest bursting all its writes instantly would blow the per-minute quota
+// before any single write even fails. Sleep is injectable so tests don't
+// real-sleep and can assert on the exact delay used.
+export async function processSequentiallyWithPacing<T>(
+    items: T[],
+    pacingDelayMs: number,
+    processItem: (item: T) => Promise<void>,
+    sleepFn: (ms: number) => Promise<unknown> = sleep,
+): Promise<void> {
+    await items.reduce(async (promise, item, index) => {
+        await promise;
+        if (index > 0 && pacingDelayMs > 0) {
+            await sleepFn(pacingDelayMs);
+        }
+        await processItem(item);
+    }, Promise.resolve());
 }
 
 export default class SchedulerTask {
@@ -4464,29 +4521,46 @@ export default class SchedulerTask {
                     tabNameForReadyItem(item),
                 );
 
-                // Write-quota arithmetic (Sheets API: 60 write requests per
+                // Write-quota invariant (Sheets API: 60 write requests per
                 // user per minute — developers.google.com/sheets/api/limits).
-                // Each ready item costs 3 writes below: createNewTab (called
-                // once, inside appendCsvToSheet), clearTabName, and the
-                // values.update — plus a fixed 3 writes for this one-off
-                // metadata tab. writes(N) = 3N + 3, so N=19 (60 writes) is
-                // the practical per-sync ceiling before quota errors become
-                // likely within a single job run; N=15 -> 48 writes,
-                // comfortably under. retryTransientGoogleSheetsWrite below
-                // absorbs a transient 429/500 with bounded backoff before
-                // the task's own retry/notify-and-disable path takes over.
+                // Each ready item costs GSHEETS_WRITES_PER_APP_ITEM (3)
+                // writes below: createNewTab (called once, inside
+                // appendCsvToSheet), clearTabName, and the values.update —
+                // plus a fixed 3 writes for this one-off metadata tab.
+                // writes(N) = 3N + 3 scales past the quota well within
+                // MAX_DELIVERY_QUERIES (50 -> 153 writes), so a manifest of
+                // any size up to that cap is proactively paced (below) to
+                // keep the SUSTAINED rate at/under
+                // GSHEETS_WRITES_PER_MINUTE_BUDGET — this isn't just an
+                // observed ceiling, pacing plus the quota-bridging retry
+                // schedule enforce it. retryTransientGoogleSheetsWrite still
+                // absorbs any transient 429/500 that gets through with
+                // bounded backoff before the task's own retry/notify-and-
+                // disable path takes over.
+                const plannedWrites =
+                    GSHEETS_WRITES_PER_APP_ITEM * readyItems.length + 3;
+                const pacingDelayMs =
+                    plannedWrites > GSHEETS_WRITES_PER_MINUTE_BUDGET
+                        ? computeGsheetsPacingDelayMs(
+                              GSHEETS_WRITES_PER_APP_ITEM,
+                          )
+                        : 0;
+
                 const humanReadableCron = getHumanReadableCronExpression(
                     scheduler.cron,
                     scheduler.timezone ?? defaultSchedulerTimezone,
                 );
-                await retryTransientGoogleSheetsWrite(() =>
-                    this.googleDriveClient.uploadMetadata(
-                        refreshToken,
-                        gdriveId,
-                        humanReadableCron,
-                        readyItemTabNames,
-                        deliveryUrl,
-                    ),
+                await retryTransientGoogleSheetsWrite(
+                    () =>
+                        this.googleDriveClient.uploadMetadata(
+                            refreshToken,
+                            gdriveId,
+                            humanReadableCron,
+                            readyItemTabNames,
+                            deliveryUrl,
+                        ),
+                    undefined,
+                    GSHEET_UPLOAD_QUOTA_BRIDGE_SCHEDULE_MS,
                 );
 
                 Logger.debug(
@@ -4494,9 +4568,10 @@ export default class SchedulerTask {
                 );
 
                 // We want to process all queries in sequence, so we don't load all query results in memory
-                await readyItems
-                    .reduce(async (promise, item) => {
-                        await promise;
+                await processSequentiallyWithPacing(
+                    readyItems,
+                    pacingDelayMs,
+                    async (item) => {
                         const { rows, fields, displayTimezone } =
                             await this.asyncQueryService.getRawAsyncQueryResults(
                                 {
@@ -4526,19 +4601,22 @@ export default class SchedulerTask {
                         // branch's chartTabName pattern) would just be a
                         // second identical write request against the quota
                         // budget above for no benefit.
-                        await retryTransientGoogleSheetsWrite(() =>
-                            this.googleDriveClient.appendCsvToSheet(
-                                refreshToken,
-                                gdriveId,
-                                [columnNames, ...dataRows],
-                                itemTabName,
-                            ),
+                        await retryTransientGoogleSheetsWrite(
+                            () =>
+                                this.googleDriveClient.appendCsvToSheet(
+                                    refreshToken,
+                                    gdriveId,
+                                    [columnNames, ...dataRows],
+                                    itemTabName,
+                                ),
+                            undefined,
+                            GSHEET_UPLOAD_QUOTA_BRIDGE_SCHEDULE_MS,
                         );
-                    }, Promise.resolve())
-                    .catch((error) => {
-                        Logger.debug('Error processing app queries:', error);
-                        throw error;
-                    });
+                    },
+                ).catch((error) => {
+                    Logger.debug('Error processing app queries:', error);
+                    throw error;
+                });
             } else {
                 throw new UnexpectedServerError('Not implemented');
             }

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -774,6 +774,26 @@ describe('SchedulerService', () => {
                 action: ['create'],
                 conditions: { organizationUuid },
             },
+            {
+                subject: 'GoogleSheets',
+                action: ['manage'],
+                conditions: { organizationUuid },
+            },
+        ]);
+
+        // Same base grants as appActor, minus GoogleSheets — for asserting
+        // the gsheets-only ability gate.
+        const appActorWithoutGoogleSheetsAbility = buildUser([
+            {
+                subject: 'DataApp',
+                action: ['view'],
+                conditions: { organizationUuid },
+            },
+            {
+                subject: 'ScheduledDeliveries',
+                action: ['create'],
+                conditions: { organizationUuid },
+            },
         ]);
 
         // Defaults to a passing live Drive-file check, same as a real gsheets
@@ -1040,6 +1060,108 @@ describe('SchedulerService', () => {
             expect(appSchedulerModel.createScheduler).not.toHaveBeenCalled();
         });
 
+        // Gsheets syncs are stateless — enforced here so the sync edit
+        // path's clear-on-omit write to app_state stays a provable
+        // null -> null no-op instead of an accidental invariant.
+        test('should reject a gsheets delivery that carries app state', async () => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await expect(
+                appService.createAppScheduler(appActor, appUuid, {
+                    ...appSchedulerPayload(SchedulerFormat.GSHEETS, {
+                        gdriveId: 'gdrive-1',
+                        gdriveName: 'My sheet',
+                        gdriveOrganizationName: 'My org',
+                        url: 'https://docs.google.com/spreadsheets/d/gdrive-1',
+                    }),
+                    appState: { tab: 'revenue' },
+                } as unknown as Parameters<
+                    SchedulerService['createAppScheduler']
+                >[2]),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(appSchedulerModel.createScheduler).not.toHaveBeenCalled();
+        });
+
+        test('should accept a gsheets delivery with app state explicitly null', async () => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await appService.createAppScheduler(appActor, appUuid, {
+                ...appSchedulerPayload(SchedulerFormat.GSHEETS, {
+                    gdriveId: 'gdrive-1',
+                    gdriveName: 'My sheet',
+                    gdriveOrganizationName: 'My org',
+                    url: 'https://docs.google.com/spreadsheets/d/gdrive-1',
+                }),
+                appState: null,
+            } as unknown as Parameters<
+                SchedulerService['createAppScheduler']
+            >[2]);
+
+            expect(appSchedulerModel.createScheduler).toHaveBeenCalledWith(
+                expect.objectContaining({ format: SchedulerFormat.GSHEETS }),
+            );
+        });
+
+        test('should still accept app state on csv/xlsx deliveries', async () => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await appService.createAppScheduler(appActor, appUuid, {
+                ...appSchedulerPayload(SchedulerFormat.CSV, {
+                    formatted: true,
+                    limit: 'table',
+                }),
+                appState: { tab: 'revenue' },
+            } as unknown as Parameters<
+                SchedulerService['createAppScheduler']
+            >[2]);
+
+            expect(appSchedulerModel.createScheduler).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    format: SchedulerFormat.CSV,
+                    appState: { tab: 'revenue' },
+                }),
+            );
+        });
+
+        // The sync entry point already gates on this ability client-side;
+        // this makes the raw API enforce it too.
+        test('should reject gsheets creation without the GoogleSheets ability', async () => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await expect(
+                appService.createAppScheduler(
+                    appActorWithoutGoogleSheetsAbility,
+                    appUuid,
+                    appSchedulerPayload(SchedulerFormat.GSHEETS, {
+                        gdriveId: 'gdrive-1',
+                        gdriveName: 'My sheet',
+                        gdriveOrganizationName: 'My org',
+                        url: 'https://docs.google.com/spreadsheets/d/gdrive-1',
+                    }),
+                ),
+            ).rejects.toThrowError(ForbiddenError);
+
+            expect(appSchedulerModel.createScheduler).not.toHaveBeenCalled();
+        });
+
+        test('should not require the GoogleSheets ability for csv app scheduler creation', async () => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await appService.createAppScheduler(
+                appActorWithoutGoogleSheetsAbility,
+                appUuid,
+                appSchedulerPayload(SchedulerFormat.CSV, {
+                    formatted: true,
+                    limit: 'table',
+                }),
+            );
+
+            expect(appSchedulerModel.createScheduler).toHaveBeenCalledWith(
+                expect.objectContaining({ format: SchedulerFormat.CSV }),
+            );
+        });
+
         test.each([500, 0, -1])(
             'should reject a numeric csv limit of %s',
             async (limit) => {
@@ -1273,6 +1395,45 @@ describe('SchedulerService', () => {
                     format: SchedulerFormat.GSHEETS,
                 }),
             );
+        });
+
+        test('should reject a gsheets app scheduler update that carries app state', async () => {
+            const { appUpdateService, appUpdateSchedulerModel } =
+                buildAppUpdateService();
+
+            const actor = buildUser([
+                {
+                    subject: 'ScheduledDeliveries',
+                    action: ['manage'],
+                    conditions: { organizationUuid },
+                },
+                {
+                    subject: 'GoogleSheets',
+                    action: ['manage'],
+                    conditions: { organizationUuid },
+                },
+            ]);
+
+            await expect(
+                appUpdateService.updateScheduler(
+                    actor,
+                    'schedulerUuid',
+                    {
+                        ...appUpdatePayload(SchedulerFormat.GSHEETS, {
+                            gdriveId: 'gdrive-1',
+                            gdriveName: 'My sheet',
+                            gdriveOrganizationName: 'My org',
+                            url: 'https://docs.google.com/spreadsheets/d/gdrive-1',
+                        }),
+                        appState: { tab: 'revenue' },
+                    },
+                    { validateGoogleSheet: false },
+                ),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(
+                appUpdateSchedulerModel.updateScheduler,
+            ).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -902,7 +902,7 @@ describe('SchedulerService', () => {
             expect(scheduler.schedulerUuid).toBe('newSchedulerUuid');
         });
 
-        test.each([SchedulerFormat.GSHEETS, SchedulerFormat.PDF])(
+        test.each([SchedulerFormat.PDF])(
             'should reject %s deliveries',
             async (format) => {
                 const { appService, appSchedulerModel } = buildAppService();
@@ -920,6 +920,47 @@ describe('SchedulerService', () => {
                 ).not.toHaveBeenCalled();
             },
         );
+
+        // The format gate lift makes app+GSHEETS schedulers possible via API;
+        // no UI creates them yet.
+        test('should accept gsheets deliveries with valid gsheets options', async () => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await appService.createAppScheduler(
+                appActor,
+                appUuid,
+                appSchedulerPayload(SchedulerFormat.GSHEETS, {
+                    gdriveId: 'gdrive-1',
+                    gdriveName: 'My sheet',
+                    gdriveOrganizationName: 'My org',
+                    url: 'https://docs.google.com/spreadsheets/d/gdrive-1',
+                }),
+            );
+
+            expect(appSchedulerModel.createScheduler).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    format: SchedulerFormat.GSHEETS,
+                    appUuid,
+                }),
+            );
+        });
+
+        test('should reject gsheets deliveries with non-gsheets options', async () => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await expect(
+                appService.createAppScheduler(
+                    appActor,
+                    appUuid,
+                    appSchedulerPayload(SchedulerFormat.GSHEETS, {
+                        formatted: true,
+                        limit: 'table',
+                    }),
+                ),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(appSchedulerModel.createScheduler).not.toHaveBeenCalled();
+        });
 
         test.each([500, 0, -1])(
             'should reject a numeric csv limit of %s',
@@ -1111,6 +1152,47 @@ describe('SchedulerService', () => {
                 expect.objectContaining({
                     schedulerUuid: 'schedulerUuid',
                     format: SchedulerFormat.IMAGE,
+                }),
+            );
+        });
+
+        // validateGoogleSheet: false isolates the format-gate check from the
+        // live Drive file check, which isn't part of this validation matrix.
+        test('should allow a gsheets app scheduler update on the generic update path', async () => {
+            const { appUpdateService, appUpdateSchedulerModel } =
+                buildAppUpdateService();
+
+            const actor = buildUser([
+                {
+                    subject: 'ScheduledDeliveries',
+                    action: ['manage'],
+                    conditions: { organizationUuid },
+                },
+                {
+                    subject: 'GoogleSheets',
+                    action: ['manage'],
+                    conditions: { organizationUuid },
+                },
+            ]);
+
+            await appUpdateService.updateScheduler(
+                actor,
+                'schedulerUuid',
+                appUpdatePayload(SchedulerFormat.GSHEETS, {
+                    gdriveId: 'gdrive-1',
+                    gdriveName: 'My sheet',
+                    gdriveOrganizationName: 'My org',
+                    url: 'https://docs.google.com/spreadsheets/d/gdrive-1',
+                }),
+                { validateGoogleSheet: false },
+            );
+
+            expect(
+                appUpdateSchedulerModel.updateScheduler,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    schedulerUuid: 'schedulerUuid',
+                    format: SchedulerFormat.GSHEETS,
                 }),
             );
         });

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -7,6 +7,7 @@ import {
     SchedulerAndTargets,
     SchedulerFormat,
     SessionUser,
+    UnexpectedGoogleSheetsError,
     type ChartScheduler,
     type CreateSchedulerAndTargets,
     type UpdateSchedulerAndTargetsWithoutId,
@@ -775,7 +776,13 @@ describe('SchedulerService', () => {
             },
         ]);
 
-        const buildAppService = () => {
+        // Defaults to a passing live Drive-file check, same as a real gsheets
+        // file — tests that care about the check itself override it.
+        const buildAppService = ({
+            assertFileIsGoogleSheet = vi.fn().mockResolvedValue(undefined),
+        }: {
+            assertFileIsGoogleSheet?: ReturnType<typeof vi.fn>;
+        } = {}) => {
             const appSchedulerModel = {
                 createScheduler: vi.fn(async (scheduler) => ({
                     ...scheduler,
@@ -785,6 +792,7 @@ describe('SchedulerService', () => {
             const appSchedulerClient = {
                 generateDailyJobsForScheduler: vi.fn(async () => {}),
             };
+            const getRefreshToken = vi.fn().mockResolvedValue('refresh-token');
             const appService = new SchedulerService({
                 lightdashConfig: lightdashConfigMock,
                 analytics: analyticsMock,
@@ -805,13 +813,23 @@ describe('SchedulerService', () => {
                 } as unknown as SlackClient,
                 emailClient: {} as EmailClient,
                 userModel: {} as UserModel,
-                googleDriveClient: {} as GoogleDriveClient,
-                userService: {} as UserService,
+                googleDriveClient: {
+                    assertFileIsGoogleSheet,
+                } as unknown as GoogleDriveClient,
+                userService: {
+                    getRefreshToken,
+                } as unknown as UserService,
                 jobModel: {} as JobModel,
                 spacePermissionService:
                     spacePermissionService as unknown as SpacePermissionService,
             });
-            return { appService, appSchedulerModel, appSchedulerClient };
+            return {
+                appService,
+                appSchedulerModel,
+                appSchedulerClient,
+                assertFileIsGoogleSheet,
+                getRefreshToken,
+            };
         };
 
         const appSchedulerPayload = (
@@ -924,7 +942,8 @@ describe('SchedulerService', () => {
         // The format gate lift makes app+GSHEETS schedulers possible via API;
         // no UI creates them yet.
         test('should accept gsheets deliveries with valid gsheets options', async () => {
-            const { appService, appSchedulerModel } = buildAppService();
+            const { appService, appSchedulerModel, assertFileIsGoogleSheet } =
+                buildAppService();
 
             await appService.createAppScheduler(
                 appActor,
@@ -943,7 +962,66 @@ describe('SchedulerService', () => {
                     appUuid,
                 }),
             );
+            expect(assertFileIsGoogleSheet).toHaveBeenCalledWith(
+                'refresh-token',
+                'gdrive-1',
+            );
         });
+
+        // Mirrors SavedChartService.createScheduler's live check for chart
+        // gsheets schedulers, so PR 2 only has to build UI, not add
+        // creation-time validation.
+        test('should reject a gsheets delivery whose gdriveId is not a real Google Sheet', async () => {
+            const { appService, appSchedulerModel, assertFileIsGoogleSheet } =
+                buildAppService({
+                    assertFileIsGoogleSheet: vi
+                        .fn()
+                        .mockRejectedValue(
+                            new UnexpectedGoogleSheetsError(
+                                'This operation is not supported for the provided file.',
+                            ),
+                        ),
+                });
+
+            await expect(
+                appService.createAppScheduler(
+                    appActor,
+                    appUuid,
+                    appSchedulerPayload(SchedulerFormat.GSHEETS, {
+                        gdriveId: 'not-a-sheet',
+                        gdriveName: 'My sheet',
+                        gdriveOrganizationName: 'My org',
+                        url: 'https://docs.google.com/spreadsheets/d/not-a-sheet',
+                    }),
+                ),
+            ).rejects.toThrowError(UnexpectedGoogleSheetsError);
+
+            expect(assertFileIsGoogleSheet).toHaveBeenCalledWith(
+                'refresh-token',
+                'not-a-sheet',
+            );
+            expect(appSchedulerModel.createScheduler).not.toHaveBeenCalled();
+        });
+
+        test.each([
+            [SchedulerFormat.IMAGE, {}],
+            [SchedulerFormat.CSV, { formatted: true, limit: 'table' }],
+            [SchedulerFormat.XLSX, { formatted: true, limit: 'table' }],
+        ] as const)(
+            'does not run the live Drive-file check for %s app schedulers',
+            async (format, options) => {
+                const { appService, assertFileIsGoogleSheet } =
+                    buildAppService();
+
+                await appService.createAppScheduler(
+                    appActor,
+                    appUuid,
+                    appSchedulerPayload(format, options),
+                );
+
+                expect(assertFileIsGoogleSheet).not.toHaveBeenCalled();
+            },
+        );
 
         test('should reject gsheets deliveries with non-gsheets options', async () => {
             const { appService, appSchedulerModel } = buildAppService();

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -670,6 +670,9 @@ export class SchedulerService extends BaseService {
             | 'savedSqlUuid'
             | 'appUuid'
         >,
+        { validateGoogleSheet }: GoogleSheetValidationOptions = {
+            validateGoogleSheet: true,
+        },
     ): Promise<SchedulerAndTargets> {
         const app = await this.checkAppScheduledDeliveryAccess(user, appUuid);
 
@@ -685,6 +688,43 @@ export class SchedulerService extends BaseService {
         SchedulerService.validateAppState(
             'appState' in newScheduler ? newScheduler.appState : undefined,
         );
+
+        // Live-validate the target file, same as chart/dashboard scheduler
+        // creation — validateAppSchedulerDelivery above already guarantees
+        // gsheets-shaped options here, the inner check is only for narrowing.
+        if (
+            newScheduler.format === SchedulerFormat.GSHEETS &&
+            validateGoogleSheet &&
+            isSchedulerGsheetsOptions(newScheduler.options)
+        ) {
+            try {
+                const refreshToken = await this.userService.getRefreshToken(
+                    user.userUuid,
+                );
+                await this.googleDriveClient.assertFileIsGoogleSheet(
+                    refreshToken,
+                    newScheduler.options.gdriveId,
+                );
+            } catch (error) {
+                if (error instanceof UnexpectedGoogleSheetsError) {
+                    throw error; // Already has clear user-facing message
+                }
+                if (error instanceof GoogleSheetsTransientError) {
+                    throw error; // Allow transient errors to propagate for retry
+                }
+                if (error instanceof GoogleSheetsScopeError) {
+                    throw error; // Allow scope errors to propagate for frontend re-auth handling
+                }
+                if (error instanceof NotFoundError) {
+                    throw new GoogleSheetsScopeError(
+                        `Google sheet not found or you don't have permission to access it.`,
+                    );
+                }
+                throw new MissingConfigError(
+                    'Unable to validate Google Sheets file. Please ensure you have connected your Google account.',
+                );
+            }
+        }
 
         const scheduler = await this.schedulerModel.createScheduler({
             ...newScheduler,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -50,6 +50,7 @@ import {
     UpdateSchedulerAndTargetsWithoutId,
     UserSchedulersSummary,
     type Account,
+    type SchedulerAppState,
 } from '@lightdash/common';
 import cronstrue from 'cronstrue';
 import {
@@ -569,6 +570,7 @@ export class SchedulerService extends BaseService {
     private static validateAppSchedulerDelivery(scheduler: {
         format: SchedulerFormat;
         options: SchedulerOptions;
+        appState?: SchedulerAppState | null;
     }): void {
         const allowedFormats = [
             SchedulerFormat.IMAGE,
@@ -598,6 +600,19 @@ export class SchedulerService extends BaseService {
         ) {
             throw new ParameterError(
                 'Google Sheets format requires valid gsheets options',
+            );
+        }
+        // Gsheets syncs always render the app's default state. Enforcing
+        // this turns "no UI path currently writes appState onto a GSHEETS
+        // scheduler" from an accidental invariant into a real one, so
+        // updateScheduler's clear-on-omit write to app_state stays a
+        // provable null -> null no-op on every sync edit.
+        if (
+            scheduler.format === SchedulerFormat.GSHEETS &&
+            scheduler.appState != null
+        ) {
+            throw new ParameterError(
+                "Google Sheets syncs render the app's default state; app state is not supported",
             );
         }
     }
@@ -723,6 +738,24 @@ export class SchedulerService extends BaseService {
                 throw new MissingConfigError(
                     'Unable to validate Google Sheets file. Please ensure you have connected your Google account.',
                 );
+            }
+        }
+
+        // Same ability gate chart/dashboard gsheets scheduler creation
+        // requires — the sync entry point already checks this client-side,
+        // this makes the raw API enforce it too, not just the UI.
+        if (newScheduler.format === SchedulerFormat.GSHEETS) {
+            const auditedAbility = this.createAuditedAbility(user);
+            if (
+                auditedAbility.cannot(
+                    'manage',
+                    subject('GoogleSheets', {
+                        organizationUuid: app.organization_uuid,
+                        projectUuid: app.project_uuid,
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
             }
         }
 

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -574,10 +574,11 @@ export class SchedulerService extends BaseService {
             SchedulerFormat.IMAGE,
             SchedulerFormat.CSV,
             SchedulerFormat.XLSX,
+            SchedulerFormat.GSHEETS,
         ];
         if (!allowedFormats.includes(scheduler.format)) {
             throw new ParameterError(
-                'Data app schedulers support image, csv and xlsx deliveries',
+                'Data app schedulers support image, csv, xlsx and google sheets deliveries',
             );
         }
         if (
@@ -587,6 +588,16 @@ export class SchedulerService extends BaseService {
         ) {
             throw new ParameterError(
                 "Data app deliveries only support the 'table' or 'all' row limit",
+            );
+        }
+        // Gsheets syncs have no csv/limit semantics — same options shape check
+        // chart/dashboard gsheets schedulers get on the create/update paths.
+        if (
+            scheduler.format === SchedulerFormat.GSHEETS &&
+            !isSchedulerGsheetsOptions(scheduler.options)
+        ) {
+            throw new ParameterError(
+                'Google Sheets format requires valid gsheets options',
             );
         }
     }


### PR DESCRIPTION
## Summary

PR 1 of 2 for Google Sheets sync on data apps — the backend worker branch. Dark: the format gate now admits `GSHEETS` app schedulers, but no UI creates them until the sync-modal PR that follows.

- **Worker**: new app branch in the `uploadGsheets` task beside chart/dashboard/sql-chart. It captures the app's queries with the same fail-closed helper the CSV/XLSX delivery path uses (headless render, `SCHEDULED_DELIVERY` context, cache invalidation), then writes one worksheet tab per captured query — sequentially, paging rows through the async-results read path against the render's own `queryUuid`s (no re-execution) — plus the standard metadata tab linking back to the app view.
- **Failure semantics match the dashboard branch**: any error item in the captured manifest fails the whole sync, naming the failed queries — the gsheets task has no partial-failure channel, so a silent skip would mean a "successful" sync permanently missing a tab. The existing retry → notify-and-disable contract then applies.
- **Tab identity is stable across runs**: app-authored labels go through the existing sheets-side sanitization; duplicate labels get a short suffix derived from each query's stable `captureKey` rather than run-order numbering, so re-syncs overwrite the right tabs even when items are added, removed, or reordered. Cell values ride the shared formula-defusing escape path.
- **Validation**: `GSHEETS` accepted for app schedulers with gsheets options (numbers/PDF etc. still rejected), and app scheduler creation now runs the same live `assertFileIsGoogleSheet` Drive check chart sync creation performs.

## Testing

Worker tests against faked capture manifests: happy path (N queries → N tabs + metadata), label sanitization + stable duplicate suffixes (incl. reversed-order re-run), error-item fatality with named labels, capture failure fail-closed, and the validation matrix. Targeted suites 132/132; `test:dev:nowatch` 145/145; typecheck/lint clean.

Relates: PROD-9382