### PR TITLE
fix(data-apps): resolve app slugs to uuids in the builder and app-detail endpoint

### DIFF
--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -450,12 +450,12 @@ export class AppGenerateController extends BaseController {
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Get('/{appUuid}')
+    @Get('/{appUuidOrSlug}')
     @OperationId('getApp')
     async getApp(
         @Request() req: express.Request,
         @Path() projectUuid: string,
-        @Path() appUuid: string,
+        @Path() appUuidOrSlug: UuidOrSlug,
         @Query() beforeVersion?: number,
         @Query() limit?: number,
     ): Promise<ApiGetAppResponse> {
@@ -463,7 +463,7 @@ export class AppGenerateController extends BaseController {
         const result = await this.getAppGenerateService().getAppVersions(
             toSessionUser(req.account),
             projectUuid,
-            appUuid,
+            appUuidOrSlug,
             { beforeVersion, limit },
         );
         return {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -793,6 +793,7 @@ describe('AppGenerateService data app vizs', () => {
             ...overrides,
         });
         const appModel = {
+            getAppByUuidOrSlug: vi.fn().mockResolvedValue({ app_id: 'app-1' }),
             getAppWithVersions: vi.fn().mockResolvedValue({
                 name: 'a',
                 description: '',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7479,7 +7479,7 @@ export class AppGenerateService extends BaseService {
     async getAppVersions(
         user: SessionUser,
         projectUuid: string,
-        appUuid: string,
+        appUuidOrSlug: string,
         opts: { beforeVersion?: number; limit?: number },
     ): Promise<{
         appUuid: string;
@@ -7514,6 +7514,14 @@ export class AppGenerateService extends BaseService {
         latestReadyVersion: number | null;
     }> {
         await this.assertDataAppsEnabled(user);
+
+        // Resolve to the real uuid before any query — the raw arg may be a
+        // slug and must never reach a uuid-typed filter.
+        const resolvedApp = await this.appModel.getAppByUuidOrSlug(
+            projectUuid,
+            appUuidOrSlug,
+        );
+        const appUuid = resolvedApp.app_id;
 
         const {
             name,

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -71,7 +71,7 @@ import {
     useNavigate,
     useParams,
 } from 'react-router';
-import { v4 as uuid4 } from 'uuid';
+import { validate as isUuidString, v4 as uuid4 } from 'uuid';
 import { AiMarkdown } from '../components/common/AiMarkdown';
 import Callout from '../components/common/Callout';
 import MantineIcon from '../components/common/MantineIcon';
@@ -729,9 +729,12 @@ const AppGenerate: FC = () => {
     // Maps prompt text → dashboard name so it survives the local→server transition
     const sentDashboardByPrompt = useRef(new Map<string, string>());
     // Track appUuid in local state so polling starts immediately after creation
-    // (before the URL param updates via replaceState)
+    // (before the URL param updates via replaceState). The URL param may be a
+    // slug — never seed it here: only `useGetApp` accepts a slug, and every
+    // other endpoint needs the canonical uuid it returns. Until that arrives,
+    // activeAppUuid stays undefined and the uuid-keyed hooks stay idle.
     const [activeAppUuid, setActiveAppUuid] = useState<string | undefined>(
-        urlAppUuid,
+        isUuidString(urlAppUuid ?? '') ? urlAppUuid : undefined,
     );
     // Connections already linked to this app — shown as an "available" pill so
     // the user knows what the generated app can call via client.externalFetch.
@@ -797,7 +800,11 @@ const AppGenerate: FC = () => {
     useEffect(() => {
         const prev = prevUrlAppUuid.current;
         prevUrlAppUuid.current = urlAppUuid;
-        setActiveAppUuid(urlAppUuid);
+        // Slug URLs resolve to the canonical uuid via useGetApp; see the
+        // activeAppUuid declaration.
+        setActiveAppUuid(
+            isUuidString(urlAppUuid ?? '') ? urlAppUuid : undefined,
+        );
 
         // Post-submit redirect: undefined → new uuid. Don't clear state.
         if (!prev && urlAppUuid) return;
@@ -861,6 +868,16 @@ const AppGenerate: FC = () => {
         hasNextPage,
         isFetchingNextPage,
     } = useGetApp(projectUuid, activeAppUuid ?? urlAppUuid);
+
+    // The URL may reference the app by slug; the API resolves it and returns
+    // the canonical uuid. Adopt it so every downstream call (iterate, polling,
+    // thumbnails, connections) hits the uuid-only endpoints with a real uuid.
+    const canonicalAppUuid = appData?.pages[0]?.appUuid;
+    useEffect(() => {
+        if (canonicalAppUuid && activeAppUuid !== canonicalAppUuid) {
+            setActiveAppUuid(canonicalAppUuid);
+        }
+    }, [canonicalAppUuid, activeAppUuid]);
 
     // Derive app name/description/space/creator from fetched data
     const appName = appData?.pages?.[0]?.name ?? '';


### PR DESCRIPTION
## Summary

Opening the app builder by slug URL (`/projects/…/apps/<slug>`) 500ed: the app-detail endpoint declared `@Path() appUuid: string` and passed the raw value into the uuid-typed `apps.app_id` filter, so Postgres rejected it with `invalid input syntax for type uuid`. The slug rollout made these URLs reachable (shared/bookmarked links), but only the `/download` endpoint had resolution.

**Backend** — per the CLAUDE.md uuid-or-slug contract: the route is now `GET /{appUuidOrSlug}` typed `UuidOrSlug`, and `getAppVersions` resolves via `getAppByUuidOrSlug` before any uuid-keyed query (mirroring `/download`). Unknown refs now 404 (`App not found`) instead of 500.

**Frontend** — the builder seeded `activeAppUuid` straight from the URL param, so on a slug URL every downstream call (iterate, preview-token, external-connections, thumbnails…) forwarded the slug into uuid-only endpoints. `activeAppUuid` now never holds a slug: it seeds only when the URL param is uuid-shaped, and adopts the canonical `appUuid` returned by the (slug-capable) getApp query once loaded. The uuid-keyed hooks stay idle until then, so a slug never reaches a uuid-only endpoint.

The remaining hardening — typing the controller's ~16 uuid-only app params as `UUID` so a stray slug gets a clean 422 at the boundary — is left as a follow-up to keep this focused.

## Testing

- API: slug ref → 200, uuid ref → 200, unknown ref → 404 (was 500 for slug and unknown).
- Browser, from the slug URL: the builder loads fully, the preview iframe runs on the canonical uuid, and the api access log shows exactly one slug-keyed request (the resolving getApp call) — external-connections/preview-token all go out with the uuid. Before the frontend change, those fired with the slug and errored on first render.
- Backend and frontend typecheck clean; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
