### PR TITLE
feat(autopilot): filter and search the actions table

### DIFF
--- a/packages/backend/src/ee/controllers/managedAgentController.ts
+++ b/packages/backend/src/ee/controllers/managedAgentController.ts
@@ -6,6 +6,7 @@ import {
     ManagedAgentRun,
     ManagedAgentRunsListResponse,
     ManagedAgentSettings,
+    ManagedAgentTargetType,
     UpdateManagedAgentSettings,
 } from '@lightdash/common';
 import {
@@ -136,18 +137,47 @@ export class ManagedAgentController extends BaseController {
         @Path() projectUuid: string,
         @Query() date?: string,
         @Query() actionType?: string,
+        @Query() actionTypes?: string[],
+        @Query() targetTypes?: string[],
+        @Query() search?: string,
+        @Query() dateFrom?: string,
+        @Query() dateTo?: string,
         @Query() sessionId?: string,
         @Query() runUuid?: string,
+        @Query() limit?: number,
     ): Promise<{ status: 'ok'; results: ManagedAgentAction[] }> {
         assertRegisteredAccount(req.account);
+        const validActionTypes = [
+            ...(actionTypes ?? []),
+            ...(actionType ? [actionType] : []),
+        ].filter((type): type is ManagedAgentActionType =>
+            Object.values(ManagedAgentActionType).includes(
+                type as ManagedAgentActionType,
+            ),
+        );
+        const validTargetTypes = (targetTypes ?? []).filter(
+            (type): type is ManagedAgentTargetType =>
+                Object.values(ManagedAgentTargetType).includes(
+                    type as ManagedAgentTargetType,
+                ),
+        );
         const results = await this.getManagedAgentService().getActions(
             toSessionUser(req.account),
             projectUuid,
             {
                 date,
-                actionType: actionType as ManagedAgentActionType | undefined,
+                dateFrom,
+                dateTo,
+                actionTypes:
+                    validActionTypes.length > 0 ? validActionTypes : undefined,
+                targetTypes:
+                    validTargetTypes.length > 0 ? validTargetTypes : undefined,
+                search: search?.trim() ? search.trim() : undefined,
                 sessionId,
                 runUuid,
+                limit: limit
+                    ? Math.min(Math.max(Math.floor(limit), 1), 500)
+                    : undefined,
             },
         );
         this.setStatus(200);

--- a/packages/backend/src/ee/controllers/managedAgentController.ts
+++ b/packages/backend/src/ee/controllers/managedAgentController.ts
@@ -175,9 +175,10 @@ export class ManagedAgentController extends BaseController {
                 search: search?.trim() ? search.trim() : undefined,
                 sessionId,
                 runUuid,
-                limit: limit
-                    ? Math.min(Math.max(Math.floor(limit), 1), 500)
-                    : undefined,
+                limit:
+                    limit !== undefined && Number.isFinite(limit)
+                        ? Math.min(Math.max(Math.floor(limit), 1), 500)
+                        : undefined,
             },
         );
         this.setStatus(200);

--- a/packages/backend/src/ee/controllers/managedAgentController.ts
+++ b/packages/backend/src/ee/controllers/managedAgentController.ts
@@ -172,7 +172,11 @@ export class ManagedAgentController extends BaseController {
                     validActionTypes.length > 0 ? validActionTypes : undefined,
                 targetTypes:
                     validTargetTypes.length > 0 ? validTargetTypes : undefined,
-                search: search?.trim() ? search.trim() : undefined,
+                // Cap the ILIKE needle so user input cannot produce an
+                // arbitrarily large pattern
+                search: search?.trim()
+                    ? search.trim().slice(0, 200)
+                    : undefined,
                 sessionId,
                 runUuid,
                 limit:

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -474,10 +474,15 @@ export class ManagedAgentModel {
                 [filters.dateTo],
             );
         }
-        if (filters.actionTypes && filters.actionTypes.length > 0) {
+        // Legacy single actionType is still part of the filters contract
+        const actionTypes = [
+            ...(filters.actionTypes ?? []),
+            ...(filters.actionType ? [filters.actionType] : []),
+        ];
+        if (actionTypes.length > 0) {
             query = query.whereIn(
                 `${ManagedAgentActionsTableName}.action_type`,
-                filters.actionTypes,
+                actionTypes,
             );
         }
         if (filters.targetTypes && filters.targetTypes.length > 0) {

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -462,11 +462,49 @@ export class ManagedAgentModel {
                 [filters.date],
             );
         }
-        if (filters.actionType) {
-            query = query.where(
-                `${ManagedAgentActionsTableName}.action_type`,
-                filters.actionType,
+        if (filters.dateFrom) {
+            query = query.whereRaw(
+                `${ManagedAgentActionsTableName}.created_at::date >= ?`,
+                [filters.dateFrom],
             );
+        }
+        if (filters.dateTo) {
+            query = query.whereRaw(
+                `${ManagedAgentActionsTableName}.created_at::date <= ?`,
+                [filters.dateTo],
+            );
+        }
+        if (filters.actionTypes && filters.actionTypes.length > 0) {
+            query = query.whereIn(
+                `${ManagedAgentActionsTableName}.action_type`,
+                filters.actionTypes,
+            );
+        }
+        if (filters.targetTypes && filters.targetTypes.length > 0) {
+            query = query.whereIn(
+                `${ManagedAgentActionsTableName}.target_type`,
+                filters.targetTypes,
+            );
+        }
+        if (filters.search) {
+            const pattern = `%${filters.search.replace(
+                /[\\%_]/g,
+                (match) => `\\${match}`,
+            )}%`;
+            query = query.andWhere((builder) => {
+                void builder
+                    .whereILike(
+                        `${ManagedAgentActionsTableName}.description`,
+                        pattern,
+                    )
+                    .orWhereILike(
+                        `${ManagedAgentActionsTableName}.target_name`,
+                        pattern,
+                    );
+            });
+        }
+        if (filters.limit) {
+            query = query.limit(filters.limit);
         }
         if (filters.sessionId) {
             query = query.where(

--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -334,6 +334,8 @@ export type ManagedAgentActionFilters = {
     date?: string;
     dateFrom?: string;
     dateTo?: string;
+    /** @deprecated Use `actionTypes`. Still accepted and merged into it. */
+    actionType?: ManagedAgentActionType;
     actionTypes?: ManagedAgentActionType[];
     targetTypes?: ManagedAgentTargetType[];
     search?: string;

--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -332,7 +332,12 @@ export type ApiManagedAgentRunsListResponse =
 
 export type ManagedAgentActionFilters = {
     date?: string;
-    actionType?: ManagedAgentActionType;
+    dateFrom?: string;
+    dateTo?: string;
+    actionTypes?: ManagedAgentActionType[];
+    targetTypes?: ManagedAgentTargetType[];
+    search?: string;
     sessionId?: string;
     runUuid?: string;
+    limit?: number;
 };

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -598,8 +598,11 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
     {
         path: 'autopilot',
         lazy: async () => {
-            const { ManagedAgentActivityPage } =
-                await import('./ee/features/managedAgent/ManagedAgentActivityPage');
+            const ManagedAgentActivityPage = await loadLazyRouteDefault(
+                './ee/features/managedAgent/ManagedAgentActivityPage',
+                () =>
+                    import('./ee/features/managedAgent/ManagedAgentActivityPage'),
+            );
             return { Component: ManagedAgentActivityPage };
         },
     },

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -783,3 +783,75 @@
 .reasoningMarkdown [data-streamdown='code-block'] pre {
     font-size: 11px;
 }
+
+.dayHeaderRow td {
+    padding: 12px 12px 4px;
+    border-bottom: none;
+    background-color: transparent;
+}
+
+.filterBar {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 8px 10px;
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+}
+
+.filterSearch {
+    flex: 1;
+    min-width: 160px;
+    max-width: 320px;
+}
+
+.filterDivider {
+    align-self: stretch;
+    margin-block: 4px;
+    height: auto;
+}
+
+/* Omnibar-style filter chips: subtle buttons that summarize their state */
+.filterChip :global(.mantine-Button-section)[data-position='left'] {
+    margin-inline-end: 6px;
+}
+
+.filterChip :global(.mantine-Button-section)[data-position='right'] {
+    margin-inline-start: 4px;
+}
+
+.filterChip[data-expanded],
+.filterChip.filterChipActive {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-ldDark-5)
+    );
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldGray-9)
+    );
+}
+
+.filterChipClear {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--mantine-radius-sm);
+    cursor: pointer;
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-7)
+    );
+}
+
+.filterChipClear:hover {
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldGray-9)
+    );
+}

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -13,6 +13,7 @@ import {
     type ManagedAgentRun,
     ManagedAgentRunStatus,
     ManagedAgentScheduleOption,
+    ManagedAgentTargetType,
     type UpdateManagedAgentPolicy,
     type UpdateManagedAgentSpaceScope,
     type Project,
@@ -24,6 +25,7 @@ import {
     Anchor,
     Box,
     Button,
+    Divider,
     Group,
     Loader,
     Menu,
@@ -33,16 +35,21 @@ import {
     Switch,
     Table,
     Text,
+    TextInput,
     Title,
     Tooltip,
     UnstyledButton,
 } from '@mantine/core';
+import { useDebouncedValue, useDisclosure } from '@mantine/hooks';
 import {
     IconAdjustments,
     IconAlertTriangle,
     IconArrowBackUp,
     IconBrandSlack,
+    IconCalendar,
     IconChartBar,
+    IconCheck,
+    IconChevronDown,
     IconChevronRight,
     IconCircleCheck,
     IconClock,
@@ -54,6 +61,7 @@ import {
     IconHash,
     IconLayoutDashboard,
     IconPlayerPlay,
+    IconSearch,
     IconSelector,
     IconSettings,
     IconTarget,
@@ -64,6 +72,7 @@ import {
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { format, formatDistanceToNowStrict } from 'date-fns';
 import {
+    Fragment,
     useCallback,
     useEffect,
     useMemo,
@@ -76,6 +85,8 @@ import { useParams } from 'react-router';
 import { lightdashApi } from '../../../api';
 import { AiMarkdown } from '../../../components/common/AiMarkdown';
 import { CategoryBadge } from '../../../components/common/CategoryBadge';
+import CalendarRangePicker from '../../../components/common/DatePickers/CalendarRangePicker';
+import { type CalendarDateRange } from '../../../components/common/DatePickers/types';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { NumberInput } from '../../../components/common/NumberInput';
 import { NAVBAR_HEIGHT } from '../../../components/common/Page/constants';
@@ -91,7 +102,10 @@ import { useProject } from '../../../hooks/useProject';
 import { useChartVersion, useSavedQuery } from '../../../hooks/useSavedQuery';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import useApp from '../../../providers/App/useApp';
-import { useManagedAgentActions } from './hooks/useManagedAgentActions';
+import {
+    useManagedAgentActions,
+    type ManagedAgentActionQueryFilters,
+} from './hooks/useManagedAgentActions';
 import { useManagedAgentLatestRun } from './hooks/useManagedAgentLatestRun';
 import { useManagedAgentRuns } from './hooks/useManagedAgentRuns';
 import { useManagedAgentSettings } from './hooks/useManagedAgentSettings';
@@ -2234,7 +2248,392 @@ const QuietRunsGroup: FC<{
 // --- Page ---
 
 // ts-unused-exports:disable-next-line
-export const ManagedAgentActivityPage: FC = () => {
+// --- Action filters ---
+
+const ACTION_TYPE_OPTIONS = Object.entries(ACTION_CONFIG).map(
+    ([value, config]) => ({ value, label: config.label }),
+);
+
+const TARGET_TYPE_OPTIONS = [
+    { value: ManagedAgentTargetType.CHART, label: 'Charts' },
+    { value: ManagedAgentTargetType.DASHBOARD, label: 'Dashboards' },
+    { value: ManagedAgentTargetType.SPACE, label: 'Spaces' },
+    { value: ManagedAgentTargetType.PROJECT, label: 'Project' },
+];
+
+type ActionFiltersState = {
+    search: string;
+    actionTypes: ManagedAgentActionType[];
+    targetTypes: ManagedAgentTargetType[];
+    dateRange: CalendarDateRange;
+};
+
+const EMPTY_ACTION_FILTERS: ActionFiltersState = {
+    search: '',
+    actionTypes: [],
+    targetTypes: [],
+    dateRange: [null, null],
+};
+
+const hasActiveActionFilters = (filters: ActionFiltersState): boolean =>
+    filters.search.trim() !== '' ||
+    filters.actionTypes.length > 0 ||
+    filters.targetTypes.length > 0 ||
+    filters.dateRange[0] !== null ||
+    filters.dateRange[1] !== null;
+
+// Omnibar-style filter chip: a subtle button whose caret becomes an X that
+// clears just this filter without opening the menu behind it.
+const FilterChipRightSection: FC<{
+    isActive: boolean;
+    onClear: () => void;
+}> = ({ isActive, onClear }) =>
+    isActive ? (
+        <Box
+            component="span"
+            role="button"
+            aria-label="Clear filter"
+            className={classes.filterChipClear}
+            onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+            onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                e.preventDefault();
+                onClear();
+            }}
+        >
+            <MantineIcon icon={IconX} strokeWidth={1.5} />
+        </Box>
+    ) : (
+        <MantineIcon icon={IconChevronDown} strokeWidth={1.5} />
+    );
+
+const filterChipProps = (isActive: boolean) =>
+    ({
+        size: 'compact-xs',
+        variant: 'subtle',
+        radius: 'md',
+        className: isActive
+            ? `${classes.filterChip} ${classes.filterChipActive}`
+            : classes.filterChip,
+    }) as const;
+
+const FilterChipMultiSelect: FC<{
+    label: string;
+    options: Array<{ value: string; label: string }>;
+    selected: string[];
+    onChange: (selected: string[]) => void;
+}> = ({ label, options, selected, onChange }) => {
+    const selectedLabels = options
+        .filter((option) => selected.includes(option.value))
+        .map((option) => option.label);
+    const summary =
+        selectedLabels.length === 0
+            ? label
+            : selectedLabels.length === 1
+              ? selectedLabels[0]
+              : `${selectedLabels[0]} +${selectedLabels.length - 1}`;
+
+    const chipButton = (
+        <Button
+            rightSection={
+                <FilterChipRightSection
+                    isActive={selected.length > 0}
+                    onClear={() => onChange([])}
+                />
+            }
+            {...filterChipProps(selected.length > 0)}
+        >
+            {summary}
+        </Button>
+    );
+
+    return (
+        <Menu position="bottom-start" shadow="md" closeOnItemClick={false}>
+            <Menu.Target>
+                {selectedLabels.length > 1 ? (
+                    <Tooltip label={selectedLabels.join(', ')} withinPortal>
+                        {chipButton}
+                    </Tooltip>
+                ) : (
+                    chipButton
+                )}
+            </Menu.Target>
+            <Menu.Dropdown>
+                {options.map((option) => {
+                    const isSelected = selected.includes(option.value);
+                    return (
+                        <Menu.Item
+                            key={option.value}
+                            leftSection={
+                                <MantineIcon
+                                    icon={IconCheck}
+                                    style={{
+                                        visibility: isSelected
+                                            ? 'visible'
+                                            : 'hidden',
+                                    }}
+                                />
+                            }
+                            onClick={() =>
+                                onChange(
+                                    isSelected
+                                        ? selected.filter(
+                                              (value) => value !== option.value,
+                                          )
+                                        : [...selected, option.value],
+                                )
+                            }
+                        >
+                            {option.label}
+                        </Menu.Item>
+                    );
+                })}
+            </Menu.Dropdown>
+        </Menu>
+    );
+};
+
+const formatDateRangeLabel = ([from, to]: CalendarDateRange): string => {
+    const fmt = (date: Date) => format(date, 'MMM d, yyyy');
+    if (from && to) {
+        return from.getTime() === to.getTime()
+            ? fmt(from)
+            : `${format(from, 'MMM d')} – ${fmt(to)}`;
+    }
+    if (from) return `From ${fmt(from)}`;
+    if (to) return `To ${fmt(to)}`;
+    return 'Date range';
+};
+
+const FilterChipDateRange: FC<{
+    value: CalendarDateRange;
+    onChange: (value: CalendarDateRange) => void;
+}> = ({ value, onChange }) => {
+    const [isOpen, menuHandlers] = useDisclosure(false);
+    const isActive = value[0] !== null || value[1] !== null;
+    return (
+        <Menu
+            position="bottom-start"
+            shadow="md"
+            opened={isOpen}
+            onOpen={menuHandlers.open}
+            onClose={menuHandlers.close}
+        >
+            <Menu.Target>
+                <Button
+                    leftSection={
+                        <MantineIcon icon={IconCalendar} strokeWidth={1.5} />
+                    }
+                    rightSection={
+                        <FilterChipRightSection
+                            isActive={isActive}
+                            onClear={() => onChange([null, null])}
+                        />
+                    }
+                    {...filterChipProps(isActive)}
+                >
+                    {formatDateRangeLabel(value)}
+                </Button>
+            </Menu.Target>
+            <Menu.Dropdown>
+                <CalendarRangePicker
+                    allowSingleDateInRange
+                    maxDate={new Date()}
+                    value={value}
+                    onChange={(range) => {
+                        onChange(range);
+                        if (range[0] && range[1]) {
+                            menuHandlers.close();
+                        }
+                    }}
+                />
+            </Menu.Dropdown>
+        </Menu>
+    );
+};
+
+const ActionFilterBar: FC<{
+    filters: ActionFiltersState;
+    onChange: (filters: ActionFiltersState) => void;
+}> = ({ filters, onChange }) => {
+    const isActive = hasActiveActionFilters(filters);
+    return (
+        <Box className={classes.filterBar}>
+            <TextInput
+                className={classes.filterSearch}
+                size="xs"
+                radius="md"
+                placeholder="Search actions…"
+                leftSection={<IconSearch size={14} />}
+                value={filters.search}
+                onChange={(event) =>
+                    onChange({ ...filters, search: event.currentTarget.value })
+                }
+            />
+            <Divider orientation="vertical" className={classes.filterDivider} />
+            <FilterChipMultiSelect
+                label="Action"
+                options={ACTION_TYPE_OPTIONS}
+                selected={filters.actionTypes}
+                onChange={(selected) =>
+                    onChange({
+                        ...filters,
+                        actionTypes: selected as ManagedAgentActionType[],
+                    })
+                }
+            />
+            <FilterChipMultiSelect
+                label="Content"
+                options={TARGET_TYPE_OPTIONS}
+                selected={filters.targetTypes}
+                onChange={(selected) =>
+                    onChange({
+                        ...filters,
+                        targetTypes: selected as ManagedAgentTargetType[],
+                    })
+                }
+            />
+            <FilterChipDateRange
+                value={filters.dateRange}
+                onChange={(dateRange) => onChange({ ...filters, dateRange })}
+            />
+            {isActive && (
+                <Button
+                    size="compact-xs"
+                    variant="subtle"
+                    color="gray"
+                    radius="xl"
+                    ml="auto"
+                    leftSection={<MantineIcon icon={IconX} size="sm" />}
+                    onClick={() => onChange(EMPTY_ACTION_FILTERS)}
+                >
+                    Clear
+                </Button>
+            )}
+        </Box>
+    );
+};
+
+const FilteredActionsView: FC<{
+    filters: ActionFiltersState;
+    debouncedSearch: string;
+    selectedActionUuid: string | null;
+    onSelectAction: (action: ManagedAgentAction) => void;
+}> = ({ filters, debouncedSearch, selectedActionUuid, onSelectAction }) => {
+    const queryFilters = useMemo<ManagedAgentActionQueryFilters>(
+        () => ({
+            search: debouncedSearch.trim() || undefined,
+            actionTypes:
+                filters.actionTypes.length > 0
+                    ? filters.actionTypes
+                    : undefined,
+            targetTypes:
+                filters.targetTypes.length > 0
+                    ? filters.targetTypes
+                    : undefined,
+            dateFrom: filters.dateRange[0]
+                ? format(filters.dateRange[0], 'yyyy-MM-dd')
+                : undefined,
+            dateTo: filters.dateRange[1]
+                ? format(filters.dateRange[1], 'yyyy-MM-dd')
+                : undefined,
+        }),
+        [
+            debouncedSearch,
+            filters.actionTypes,
+            filters.targetTypes,
+            filters.dateRange,
+        ],
+    );
+    const { data: actions, isLoading } = useManagedAgentActions({
+        filters: queryFilters,
+    });
+
+    const dayGroups = useMemo(() => {
+        const groups: Array<{ day: string; actions: ManagedAgentAction[] }> =
+            [];
+        (actions ?? []).forEach((action) => {
+            const day = format(new Date(action.createdAt), 'MMM d, yyyy');
+            const lastGroup = groups[groups.length - 1];
+            if (lastGroup && lastGroup.day === day) {
+                lastGroup.actions.push(action);
+            } else {
+                groups.push({ day, actions: [action] });
+            }
+        });
+        return groups;
+    }, [actions]);
+
+    return (
+        <Table className={classes.table}>
+            <Table.Thead>
+                <Table.Tr>
+                    <Table.Th w={140}>Action</Table.Th>
+                    <Table.Th w={260}>Name</Table.Th>
+                    <Table.Th>Message</Table.Th>
+                </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+                {isLoading ? (
+                    <Table.Tr>
+                        <Table.Td colSpan={3}>
+                            <Group gap="xs" justify="center" py="md">
+                                <Loader size={8} type="dots" color="dark" />
+                                <Text fz="xs" c="dimmed">
+                                    Searching actions…
+                                </Text>
+                            </Group>
+                        </Table.Td>
+                    </Table.Tr>
+                ) : dayGroups.length === 0 ? (
+                    <Table.Tr>
+                        <Table.Td colSpan={3}>
+                            <Stack gap={2} align="center" py="lg">
+                                <Text fw={500} fz="sm">
+                                    No matching actions
+                                </Text>
+                                <Text fz="xs" c="dimmed">
+                                    Try widening the date range or clearing a
+                                    filter.
+                                </Text>
+                            </Stack>
+                        </Table.Td>
+                    </Table.Tr>
+                ) : (
+                    dayGroups.map((group) => (
+                        <Fragment key={group.day}>
+                            <Table.Tr className={classes.dayHeaderRow}>
+                                <Table.Td colSpan={3}>
+                                    <Text
+                                        fz={11}
+                                        fw={700}
+                                        tt="uppercase"
+                                        c="dimmed"
+                                        lts={0.4}
+                                    >
+                                        {group.day}
+                                    </Text>
+                                </Table.Td>
+                            </Table.Tr>
+                            {group.actions.map((action) => (
+                                <ActionRow
+                                    key={action.actionUuid}
+                                    action={action}
+                                    selected={
+                                        selectedActionUuid === action.actionUuid
+                                    }
+                                    onSelect={onSelectAction}
+                                />
+                            ))}
+                        </Fragment>
+                    ))
+                )}
+            </Table.Tbody>
+        </Table>
+    );
+};
+
+const ManagedAgentActivityPage: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
     const { user } = useApp();
@@ -2308,6 +2707,10 @@ export const ManagedAgentActivityPage: FC = () => {
     ]);
     const [selected, setSelected] = useState<ManagedAgentAction | null>(null);
     const [settingsOpen, setSettingsOpen] = useState(false);
+    const [actionFilters, setActionFilters] =
+        useState<ActionFiltersState>(EMPTY_ACTION_FILTERS);
+    const [debouncedSearch] = useDebouncedValue(actionFilters.search, 300);
+    const filtersActive = hasActiveActionFilters(actionFilters);
     const [openQuietGroups, setOpenQuietGroups] = useState<Set<string>>(
         new Set(),
     );
@@ -2481,94 +2884,114 @@ export const ManagedAgentActivityPage: FC = () => {
                                 </Box>
                             ) : (
                                 <Box className={classes.tableWrapper}>
-                                    <Table className={classes.table}>
-                                        <Table.Thead>
-                                            <Table.Tr>
-                                                <Table.Th w={140}>
-                                                    Action
-                                                </Table.Th>
-                                                <Table.Th w={260}>
-                                                    Name
-                                                </Table.Th>
-                                                <Table.Th>Message</Table.Th>
-                                            </Table.Tr>
-                                        </Table.Thead>
-                                        {displayRows.map((row) => {
-                                            if (row.type === 'quietGroup') {
+                                    <ActionFilterBar
+                                        filters={actionFilters}
+                                        onChange={setActionFilters}
+                                    />
+                                    {filtersActive ? (
+                                        <FilteredActionsView
+                                            filters={actionFilters}
+                                            debouncedSearch={debouncedSearch}
+                                            selectedActionUuid={
+                                                selected?.actionUuid ?? null
+                                            }
+                                            onSelectAction={(action) => {
+                                                setSettingsOpen(false);
+                                                setSelected(action);
+                                            }}
+                                        />
+                                    ) : (
+                                        <Table className={classes.table}>
+                                            <Table.Thead>
+                                                <Table.Tr>
+                                                    <Table.Th w={140}>
+                                                        Action
+                                                    </Table.Th>
+                                                    <Table.Th w={260}>
+                                                        Name
+                                                    </Table.Th>
+                                                    <Table.Th>Message</Table.Th>
+                                                </Table.Tr>
+                                            </Table.Thead>
+                                            {displayRows.map((row) => {
+                                                if (row.type === 'quietGroup') {
+                                                    return (
+                                                        <QuietRunsGroup
+                                                            key={`quiet-${row.groupId}`}
+                                                            runs={row.runs}
+                                                            isOpen={openQuietGroups.has(
+                                                                row.groupId,
+                                                            )}
+                                                            onToggle={() =>
+                                                                toggleQuietGroup(
+                                                                    row.groupId,
+                                                                )
+                                                            }
+                                                        />
+                                                    );
+                                                }
+                                                const { run } = row;
+                                                const isLive =
+                                                    run.status ===
+                                                    ManagedAgentRunStatus.STARTED;
                                                 return (
-                                                    <QuietRunsGroup
-                                                        key={`quiet-${row.groupId}`}
-                                                        runs={row.runs}
-                                                        isOpen={openQuietGroups.has(
-                                                            row.groupId,
+                                                    <RunRow
+                                                        key={run.runUuid}
+                                                        run={run}
+                                                        isOpen={isRunOpen(
+                                                            run.runUuid,
+                                                            isLive,
                                                         )}
                                                         onToggle={() =>
-                                                            toggleQuietGroup(
-                                                                row.groupId,
+                                                            toggleRun(
+                                                                run.runUuid,
+                                                                isLive,
+                                                            )
+                                                        }
+                                                        selectedActionUuid={
+                                                            selected?.actionUuid ??
+                                                            null
+                                                        }
+                                                        onSelectAction={(
+                                                            action,
+                                                        ) =>
+                                                            handleSelectAction(
+                                                                action,
+                                                                run.runUuid,
                                                             )
                                                         }
                                                     />
                                                 );
-                                            }
-                                            const { run } = row;
-                                            const isLive =
-                                                run.status ===
-                                                ManagedAgentRunStatus.STARTED;
-                                            return (
-                                                <RunRow
-                                                    key={run.runUuid}
-                                                    run={run}
-                                                    isOpen={isRunOpen(
-                                                        run.runUuid,
-                                                        isLive,
-                                                    )}
-                                                    onToggle={() =>
-                                                        toggleRun(
-                                                            run.runUuid,
-                                                            isLive,
-                                                        )
-                                                    }
-                                                    selectedActionUuid={
-                                                        selected?.actionUuid ??
-                                                        null
-                                                    }
-                                                    onSelectAction={(action) =>
-                                                        handleSelectAction(
-                                                            action,
-                                                            run.runUuid,
-                                                        )
-                                                    }
-                                                />
-                                            );
-                                        })}
-                                        {hasNextPage && (
-                                            <Table.Tbody>
-                                                <Table.Tr
-                                                    className={
-                                                        classes.showMoreRow
-                                                    }
-                                                >
-                                                    <Table.Td colSpan={3}>
-                                                        <UnstyledButton
-                                                            className={
-                                                                classes.showMoreButton
-                                                            }
-                                                            onClick={() =>
-                                                                void fetchNextPage()
-                                                            }
-                                                            disabled={
-                                                                isFetchingNextPage
-                                                            }
-                                                        >
-                                                            {isFetchingNextPage
-                                                                ? 'Loading…'
-                                                                : 'Load older runs'}
-                                                        </UnstyledButton>
-                                                    </Table.Td>
-                                                </Table.Tr>
-                                            </Table.Tbody>
-                                        )}
-                                    </Table>
+                                            })}
+                                            {hasNextPage && (
+                                                <Table.Tbody>
+                                                    <Table.Tr
+                                                        className={
+                                                            classes.showMoreRow
+                                                        }
+                                                    >
+                                                        <Table.Td colSpan={3}>
+                                                            <UnstyledButton
+                                                                className={
+                                                                    classes.showMoreButton
+                                                                }
+                                                                onClick={() =>
+                                                                    void fetchNextPage()
+                                                                }
+                                                                disabled={
+                                                                    isFetchingNextPage
+                                                                }
+                                                            >
+                                                                {isFetchingNextPage
+                                                                    ? 'Loading…'
+                                                                    : 'Load older runs'}
+                                                            </UnstyledButton>
+                                                        </Table.Td>
+                                                    </Table.Tr>
+                                                </Table.Tbody>
+                                            )}
+                                        </Table>
+                                    )}
                                 </Box>
                             )}
                         </Stack>
@@ -2622,3 +3045,5 @@ export const ManagedAgentActivityPage: FC = () => {
         </Stack>
     );
 };
+
+export default ManagedAgentActivityPage;

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -2464,7 +2464,7 @@ const ActionFilterBar: FC<{
                 size="xs"
                 radius="md"
                 placeholder="Search actions…"
-                leftSection={<IconSearch size={14} />}
+                leftSection={<MantineIcon icon={IconSearch} size={14} />}
                 value={filters.search}
                 onChange={(event) =>
                     onChange({ ...filters, search: event.currentTarget.value })

--- a/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentActions.ts
+++ b/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentActions.ts
@@ -1,14 +1,32 @@
-import { type ManagedAgentAction } from '@lightdash/common';
+import {
+    type ManagedAgentAction,
+    type ManagedAgentActionType,
+    type ManagedAgentTargetType,
+} from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router';
 import { lightdashApi } from '../../../../api';
 
+export type ManagedAgentActionQueryFilters = {
+    search?: string;
+    actionTypes?: ManagedAgentActionType[];
+    targetTypes?: ManagedAgentTargetType[];
+    dateFrom?: string;
+    dateTo?: string;
+};
+
 const getActions = async (
     projectUuid: string,
     runUuid?: string,
+    filters?: ManagedAgentActionQueryFilters,
 ): Promise<ManagedAgentAction[]> => {
     const params = new URLSearchParams();
     if (runUuid) params.set('runUuid', runUuid);
+    if (filters?.search) params.set('search', filters.search);
+    filters?.actionTypes?.forEach((type) => params.append('actionTypes', type));
+    filters?.targetTypes?.forEach((type) => params.append('targetTypes', type));
+    if (filters?.dateFrom) params.set('dateFrom', filters.dateFrom);
+    if (filters?.dateTo) params.set('dateTo', filters.dateTo);
     const qs = params.toString();
     return lightdashApi<ManagedAgentAction[]>({
         url: `/projects/${projectUuid}/managed-agent/actions${qs ? `?${qs}` : ''}`,
@@ -18,16 +36,25 @@ const getActions = async (
 };
 
 export const useManagedAgentActions = (
-    opts: { enabled?: boolean; fastPoll?: boolean; runUuid?: string } = {},
+    opts: {
+        enabled?: boolean;
+        fastPoll?: boolean;
+        runUuid?: string;
+        filters?: ManagedAgentActionQueryFilters;
+    } = {},
 ) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const isEnabled = opts.enabled ?? true;
     return useQuery<ManagedAgentAction[]>({
-        queryKey: opts.runUuid
-            ? ['managed-agent-actions', projectUuid, opts.runUuid]
-            : ['managed-agent-actions', projectUuid],
-        queryFn: () => getActions(projectUuid!, opts.runUuid),
+        queryKey: [
+            'managed-agent-actions',
+            projectUuid,
+            ...(opts.runUuid ? [opts.runUuid] : []),
+            ...(opts.filters ? [opts.filters] : []),
+        ],
+        queryFn: () => getActions(projectUuid!, opts.runUuid, opts.filters),
         enabled: !!projectUuid && isEnabled,
+        keepPreviousData: !!opts.filters,
         refetchInterval: isEnabled ? (opts.fastPoll ? 3000 : 30000) : false,
     });
 };


### PR DESCRIPTION
Linear: [PROD-7436](https://linear.app/lightdash/issue/PROD-7436/filter-and-search-autopilot-actions-table)

Adds filtering and search to the Autopilot actions table, per the ticket: time range, action type, free text, and content type.

## Frontend

A filter toolbar inside the activity table card, following the omnibar filter-chip pattern: a capped-width debounced search, a vertical divider, then chip-style menus for action type and content type that summarize their state ("Flagged stale +2" with the full list on hover, checkmarked items in the menu, and an active chip whose caret becomes an X clearing just that filter), plus a calendar-menu date range chip with a readable label. With no filters active, the run-grouped view is completely untouched. Any active filter switches to a flat, server-filtered list of actions grouped by day headers; clicking a row still opens the detail sidebar. Iterated live against seeded dev data with screenshots at each step.

The page component is now a default export loaded through `loadLazyRouteDefault` (chunk-error handling), matching every other lazy route.

## Backend

`GET /managed-agent/actions` gains `dateFrom`/`dateTo` (inclusive date bounds), `actionTypes[]`, `targetTypes[]` (validated against the enums, unknown values dropped), `search` (case-insensitive ILIKE over description and target name, with `%`/`_`/`\` escaped), and a clamped `limit`. The legacy single `actionType` query param is still accepted and folded into `actionTypes`, so existing callers are unaffected.

## Validation

All filter dimensions were exercised against the dev database with seeded Autopilot activity (17 actions across 7 runs, 18-day spread): type and target filters return exactly matching rows, search is case-insensitive and wildcard-safe (a `%`/`_` needle matches nothing rather than everything), date bounds are inclusive and exclude out-of-range rows, and combined filters compose. Frontend/backend/common typecheck, lint, and unused-exports all pass.

## Regression analysis

- With no filters the actions request is byte-identical to before (same URL, same query key shape), and the runs view renders unchanged.
- `ManagedAgentActionFilters` dropped the single `actionType` field in favor of `actionTypes[]`; its only consumers (controller and model) were updated in this PR, and the HTTP-level `actionType` param remains accepted.
- The page's named export became a default export; Routes.tsx was its only importer and is updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eEGQShbuDQNkCFx5k5w9m