### PR TITLE
feat(data-apps): add the Google Sheets Sync surface for data apps

### DIFF
--- a/packages/frontend/src/features/apps/components/AppHeaderActions.test.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.test.tsx
@@ -109,7 +109,7 @@ const openMenu = async () => {
     await user.click(screen.getByRole('button', { name: 'App actions' }));
 };
 
-describe('AppHeaderActions — Sync with Google Sheets entry point', () => {
+describe('AppHeaderActions — Google Sheets Sync entry point', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockedCanEdit.mockReturnValue(true);
@@ -131,7 +131,7 @@ describe('AppHeaderActions — Sync with Google Sheets entry point', () => {
         // The gate reads an async health query — findBy polls until it has
         // resolved instead of racing the first render.
         expect(
-            await screen.findByText('Sync with Google Sheets'),
+            await screen.findByText('Google Sheets Sync'),
         ).toBeInTheDocument();
         // Schedule delivery is a separate, unrelated entry.
         expect(screen.getByText('Schedule delivery')).toBeInTheDocument();
@@ -148,7 +148,7 @@ describe('AppHeaderActions — Sync with Google Sheets entry point', () => {
         await screen.findByText('Schedule delivery');
 
         expect(
-            screen.queryByText('Sync with Google Sheets'),
+            screen.queryByText('Google Sheets Sync'),
         ).not.toBeInTheDocument();
     });
 
@@ -162,7 +162,7 @@ describe('AppHeaderActions — Sync with Google Sheets entry point', () => {
         await screen.findByText('Schedule delivery');
 
         expect(
-            screen.queryByText('Sync with Google Sheets'),
+            screen.queryByText('Google Sheets Sync'),
         ).not.toBeInTheDocument();
     });
 
@@ -180,7 +180,7 @@ describe('AppHeaderActions — Sync with Google Sheets entry point', () => {
         await screen.findByText('View network');
 
         expect(
-            screen.queryByText('Sync with Google Sheets'),
+            screen.queryByText('Google Sheets Sync'),
         ).not.toBeInTheDocument();
         expect(screen.queryByText('Schedule delivery')).not.toBeInTheDocument();
     });

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.test.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.test.tsx
@@ -1,0 +1,187 @@
+import { type HealthState } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defaultAbility } from '../../../providers/Ability/constants';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { useCanEditDataApp } from '../hooks/useCanEditDataApp';
+import AppHeaderActions from './AppHeaderActions';
+
+vi.mock('react-router', () => ({
+    useNavigate: () => vi.fn(),
+}));
+vi.mock('../hooks/useCanEditDataApp', () => ({
+    useCanEditDataApp: vi.fn(),
+}));
+vi.mock('../hooks/useCanCreateDataApp', () => ({
+    useCanCreateDataApp: vi.fn(() => false),
+}));
+vi.mock('../hooks/useAppThumbnail', () => ({
+    useAppThumbnailUrl: vi.fn(() => ({ data: undefined, isError: false })),
+    useAppThumbnailDelete: vi.fn(() => ({
+        mutateAsync: vi.fn(),
+        isLoading: false,
+    })),
+}));
+vi.mock('../hooks/useDuplicateApp', () => ({
+    useDuplicateApp: vi.fn(() => ({ mutate: vi.fn(), isLoading: false })),
+}));
+vi.mock('../hooks/useUpgradeApp', () => ({
+    useUpgradeApp: vi.fn(() => ({ mutate: vi.fn(), isLoading: false })),
+}));
+vi.mock('../../../hooks/useProject', () => ({
+    useProject: vi.fn(() => ({ data: undefined })),
+}));
+// Neither modal opens during these tests (nothing clicks their triggers) —
+// stubbed only so their own heavy dependency trees never mount.
+vi.mock('../../scheduler/components/SchedulerModals', () => ({
+    AppSchedulersModal: () => null,
+}));
+vi.mock('../../sync/components', () => ({
+    AppSyncModal: () => null,
+}));
+
+const mockedCanEdit = vi.mocked(useCanEditDataApp);
+
+// Matches AppProviderMock's default user fixture (mockUserResponse) —
+// hardcoded rather than imported to avoid pulling in a __mocks__ file.
+const DEFAULT_ORG_UUID = '172a2270-000f-42be-9c68-c4752c23ae51';
+
+// AppProviderMock shallow-merges this into its full default HealthState, so a
+// partial `auth` (cast — AppHeaderActions only reads .auth.google) is enough.
+const withGoogleDriveConfigured = (): Partial<HealthState> => ({
+    auth: {
+        google: {
+            oauth2ClientId: 'client-id',
+            googleDriveApiKey: 'api-key',
+        },
+    } as HealthState['auth'],
+});
+
+const withGoogleDriveNotConfigured = (): Partial<HealthState> => ({
+    auth: {
+        google: {
+            oauth2ClientId: undefined,
+            googleDriveApiKey: undefined,
+        },
+    } as HealthState['auth'],
+});
+
+// `Can` reads the module-level `defaultAbility` singleton (via AbilityContext,
+// whose default value IS that singleton) — not AppProviderMock's `user.data`.
+// In the real app `PrivateRoute` calls `ability.update(user.abilityRules)` on
+// this same instance; tests must do the same instead of passing abilityRules
+// through renderWithProviders' `user` mock, which `Can` never reads.
+const grantGoogleSheetsAbility = () => {
+    defaultAbility.update([
+        {
+            action: 'manage',
+            subject: 'GoogleSheets',
+            conditions: { organizationUuid: DEFAULT_ORG_UUID },
+        },
+    ]);
+};
+
+const baseProps = {
+    projectUuid: 'project-1',
+    appUuid: 'app-1',
+    appName: 'My app',
+    appDescription: null,
+    appSpaceUuid: null,
+    appCreatedByUserUuid: null,
+    latestVersionNumber: 1,
+    latestVersionStatus: 'ready' as const,
+    onRefresh: vi.fn(),
+    refreshDisabled: false,
+    onViewNetwork: vi.fn(),
+    onDeleted: vi.fn(),
+    onEdit: null,
+    shareUrl: null,
+    navItem: null,
+    fullscreenToggle: null,
+    captureThumbnail: null,
+    capturePreviewScreenshot: null,
+    upgrade: null,
+};
+
+const openMenu = async () => {
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'App actions' }));
+};
+
+describe('AppHeaderActions — Sync with Google Sheets entry point', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockedCanEdit.mockReturnValue(true);
+        defaultAbility.update([]);
+    });
+
+    afterEach(() => {
+        defaultAbility.update([]);
+    });
+
+    it('shows the entry when the user can edit, Drive is configured, and GoogleSheets is granted', async () => {
+        grantGoogleSheetsAbility();
+        renderWithProviders(<AppHeaderActions {...baseProps} />, {
+            health: withGoogleDriveConfigured(),
+        });
+
+        await openMenu();
+
+        // The gate reads an async health query — findBy polls until it has
+        // resolved instead of racing the first render.
+        expect(
+            await screen.findByText('Sync with Google Sheets'),
+        ).toBeInTheDocument();
+        // Schedule delivery is a separate, unrelated entry.
+        expect(screen.getByText('Schedule delivery')).toBeInTheDocument();
+    });
+
+    it('hides the entry when Google Drive is not configured, but keeps Schedule delivery', async () => {
+        grantGoogleSheetsAbility();
+        renderWithProviders(<AppHeaderActions {...baseProps} />, {
+            health: withGoogleDriveNotConfigured(),
+        });
+
+        await openMenu();
+        // Wait for the async health query to settle before asserting absence.
+        await screen.findByText('Schedule delivery');
+
+        expect(
+            screen.queryByText('Sync with Google Sheets'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('hides the entry when the GoogleSheets ability is not granted', async () => {
+        // No grantGoogleSheetsAbility() call — defaultAbility stays empty.
+        renderWithProviders(<AppHeaderActions {...baseProps} />, {
+            health: withGoogleDriveConfigured(),
+        });
+
+        await openMenu();
+        await screen.findByText('Schedule delivery');
+
+        expect(
+            screen.queryByText('Sync with Google Sheets'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('hides the entry (and Schedule delivery) when the user cannot edit the app', async () => {
+        mockedCanEdit.mockReturnValue(false);
+        grantGoogleSheetsAbility();
+
+        renderWithProviders(<AppHeaderActions {...baseProps} />, {
+            health: withGoogleDriveConfigured(),
+        });
+
+        await openMenu();
+        // "View network" is unconditional — a stable anchor to wait on since
+        // Schedule delivery itself is hidden in this scenario.
+        await screen.findByText('View network');
+
+        expect(
+            screen.queryByText('Sync with Google Sheets'),
+        ).not.toBeInTheDocument();
+        expect(screen.queryByText('Schedule delivery')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     getAppDisplayName,
     isApiError,
@@ -17,6 +18,7 @@ import {
 import {
     IconArrowsUpDown,
     IconCamera,
+    IconCirclesRelation,
     IconCopy,
     IconDatabaseExport,
     IconDots,
@@ -40,7 +42,10 @@ import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
 import { ShareLinkButton } from '../../../components/common/ShareLinkButton';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProject } from '../../../hooks/useProject';
+import { Can } from '../../../providers/Ability';
+import useApp from '../../../providers/App/useApp';
 import { AppSchedulersModal } from '../../scheduler/components/SchedulerModals';
+import { AppSyncModal } from '../../sync/components';
 import {
     useAppThumbnailDelete,
     useAppThumbnailUrl,
@@ -149,6 +154,13 @@ const AppHeaderActions: FC<Props> = ({
     // needs `create:DataApp` — not manage rights on this app.
     const canDuplicate = useCanCreateDataApp(projectUuid);
 
+    const { user, health } = useApp();
+    // Same health check the chart/SQL chart Google Sheets Sync entries gate
+    // on — Drive picker credentials must be configured.
+    const hasGoogleDriveEnabled =
+        health.data?.auth.google.oauth2ClientId !== undefined &&
+        health.data?.auth.google.googleDriveApiKey !== undefined;
+
     // Promotion is only offered from a preview project linked to an upstream.
     const { data: project } = useProject(projectUuid);
     const isPreviewProject = !!project?.upstreamProjectUuid;
@@ -199,6 +211,7 @@ const AppHeaderActions: FC<Props> = ({
     ]);
 
     const [schedulerModalOpen, setSchedulerModalOpen] = useState(false);
+    const [syncModalOpen, setSyncModalOpen] = useState(false);
     const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false);
     const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
     const [isMoveToSpaceOpen, setIsMoveToSpaceOpen] = useState(false);
@@ -346,6 +359,27 @@ const AppHeaderActions: FC<Props> = ({
                         >
                             Schedule delivery
                         </Menu.Item>
+                    )}
+                    {canEdit && hasGoogleDriveEnabled && (
+                        <Can
+                            I="manage"
+                            this={subject('GoogleSheets', {
+                                organizationUuid: user.data?.organizationUuid,
+                                projectUuid,
+                            })}
+                        >
+                            <Menu.Item
+                                leftSection={
+                                    <MantineIcon
+                                        icon={IconCirclesRelation}
+                                        size={14}
+                                    />
+                                }
+                                onClick={() => setSyncModalOpen(true)}
+                            >
+                                Sync with Google Sheets
+                            </Menu.Item>
+                        </Can>
                     )}
                     {(canEdit || canDuplicate) && <Menu.Divider />}
                     {canEdit && upgrade && (
@@ -548,6 +582,14 @@ const AppHeaderActions: FC<Props> = ({
                     isOpen
                     onClose={() => setSchedulerModalOpen(false)}
                     capturedQueryCount={capturedQueryCount}
+                />
+            )}
+            {syncModalOpen && (
+                <AppSyncModal
+                    projectUuid={projectUuid}
+                    appUuid={appUuid}
+                    opened
+                    onClose={() => setSyncModalOpen(false)}
                 />
             )}
             {isPromoteModalOpen && (

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -377,7 +377,7 @@ const AppHeaderActions: FC<Props> = ({
                                 }
                                 onClick={() => setSyncModalOpen(true)}
                             >
-                                Sync with Google Sheets
+                                Google Sheets Sync
                             </Menu.Item>
                         </Can>
                     )}

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.filter.test.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.filter.test.ts
@@ -1,0 +1,44 @@
+import { SchedulerFormat, type SchedulerAndTargets } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { isDeliveryListScheduler } from './deliveryListFilter';
+
+const scheduler = (
+    overrides: Partial<SchedulerAndTargets>,
+): SchedulerAndTargets =>
+    ({
+        schedulerUuid: 'scheduler-uuid',
+        format: SchedulerFormat.CSV,
+        thresholds: [],
+        ...overrides,
+    }) as SchedulerAndTargets;
+
+describe('isDeliveryListScheduler', () => {
+    it('excludes gsheets syncs from the delivery list', () => {
+        expect(
+            isDeliveryListScheduler(
+                scheduler({ format: SchedulerFormat.GSHEETS }),
+                false,
+            ),
+        ).toBe(false);
+    });
+
+    it('keeps csv/xlsx/image deliveries in the delivery list', () => {
+        for (const format of [
+            SchedulerFormat.CSV,
+            SchedulerFormat.XLSX,
+            SchedulerFormat.IMAGE,
+        ]) {
+            expect(isDeliveryListScheduler(scheduler({ format }), false)).toBe(
+                true,
+            );
+        }
+    });
+
+    it('routes threshold alerts to the alert list only', () => {
+        const alert = scheduler({
+            thresholds: [{}] as SchedulerAndTargets['thresholds'],
+        });
+        expect(isDeliveryListScheduler(alert, true)).toBe(true);
+        expect(isDeliveryListScheduler(alert, false)).toBe(false);
+    });
+});

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.tsx
@@ -69,6 +69,7 @@ import ConfirmPauseSchedulerModal from '../../ConfirmPauseSchedulerModal';
 import ConfirmSendNowModal from '../../ConfirmSendNowModal';
 import { SchedulerDeleteModal } from '../../SchedulerDeleteModal';
 import { getSchedulerDeliveryType } from '../../types';
+import { isDeliveryListScheduler } from './deliveryListFilter';
 import { getNextRuns } from './nextRuns';
 import classes from './SchedulerDeliveryModal.module.css';
 
@@ -579,12 +580,9 @@ export const SchedulerList: FC<Props> = ({
 
     const schedulers = useMemo(() => {
         const all = data?.pages.flatMap((page) => page.data) ?? [];
-        return all.filter((scheduler) => {
-            const isAlert =
-                scheduler.thresholds && scheduler.thresholds.length > 0;
-            if (isThresholdAlert !== !!isAlert) return false;
-            return scheduler.format !== SchedulerFormat.GSHEETS;
-        });
+        return all.filter((scheduler) =>
+            isDeliveryListScheduler(scheduler, isThresholdAlert),
+        );
     }, [data, isThresholdAlert]);
 
     const selected =

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/deliveryListFilter.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/deliveryListFilter.ts
@@ -1,0 +1,11 @@
+import { SchedulerFormat, type SchedulerAndTargets } from '@lightdash/common';
+
+// Gsheets syncs live in the sync modal, never in the delivery/alert lists.
+export const isDeliveryListScheduler = (
+    scheduler: SchedulerAndTargets,
+    isThresholdAlert: boolean,
+): boolean => {
+    const isAlert = !!(scheduler.thresholds && scheduler.thresholds.length > 0);
+    if (isThresholdAlert !== isAlert) return false;
+    return scheduler.format !== SchedulerFormat.GSHEETS;
+};

--- a/packages/frontend/src/features/sync/components/AppSyncModal.test.tsx
+++ b/packages/frontend/src/features/sync/components/AppSyncModal.test.tsx
@@ -1,0 +1,133 @@
+import { SchedulerFormat, type AppScheduler } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { useAppSchedulers } from '../../scheduler/hooks/useAppSchedulers';
+import { AppSyncModal } from './AppSyncModal';
+
+vi.mock('../../scheduler/hooks/useAppSchedulers', () => ({
+    useAppSchedulers: vi.fn(),
+    useAppSchedulerCreateMutation: vi.fn(() => ({
+        mutate: vi.fn(),
+        isLoading: false,
+        isSuccess: false,
+    })),
+}));
+vi.mock('../../../hooks/useActiveProject', () => ({
+    useActiveProjectUuid: () => ({
+        activeProjectUuid: 'project-1',
+        isLoading: false,
+    }),
+}));
+vi.mock('../../../hooks/useProject', () => ({
+    useProject: () => ({
+        data: { schedulerTimezone: 'UTC' },
+    }),
+}));
+
+const mockedUseAppSchedulers = vi.mocked(useAppSchedulers);
+
+const baseScheduler = {
+    schedulerUuid: 'sched-1',
+    slug: 'app-sync',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    createdBy: 'user-uuid',
+    createdByName: 'User',
+    cron: '0 9 * * *',
+    savedChartUuid: null,
+    savedChartName: null,
+    dashboardUuid: null,
+    dashboardName: null,
+    savedSqlUuid: null,
+    savedSqlName: null,
+    appUuid: 'app-1',
+    appName: 'App',
+    enabled: true,
+    includeLinks: true,
+    targets: [],
+} as unknown as AppScheduler & { targets: [] };
+
+const gsheetsScheduler = {
+    ...baseScheduler,
+    schedulerUuid: 'sched-gsheets',
+    name: 'GSheets sync',
+    format: SchedulerFormat.GSHEETS,
+    options: {
+        gdriveId: 'drive-1',
+        gdriveName: 'Sheet',
+        gdriveOrganizationName: 'Acme',
+        url: 'https://docs.google.com/x',
+    },
+};
+
+const csvScheduler = {
+    ...baseScheduler,
+    schedulerUuid: 'sched-csv',
+    name: 'CSV delivery',
+    format: SchedulerFormat.CSV,
+    options: { formatted: true, limit: 'table' as const },
+};
+
+const mockAppSchedulersData = (results: (typeof baseScheduler)[]) =>
+    ({
+        data: {
+            pages: [
+                {
+                    data: results,
+                    pagination: {
+                        page: 1,
+                        pageSize: results.length || 1,
+                        totalPageCount: 1,
+                        totalResults: results.length,
+                    },
+                },
+            ],
+        },
+        hasNextPage: false,
+        fetchNextPage: vi.fn(),
+        isFetchingNextPage: false,
+    }) as unknown as ReturnType<typeof useAppSchedulers>;
+
+describe('AppSyncModal', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('shows only gsheets-format app schedulers, not csv/xlsx deliveries', () => {
+        mockedUseAppSchedulers.mockReturnValue(
+            mockAppSchedulersData([gsheetsScheduler, csvScheduler]),
+        );
+
+        renderWithProviders(
+            <AppSyncModal
+                projectUuid="project-1"
+                appUuid="app-1"
+                opened
+                onClose={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText('GSheets sync')).toBeInTheDocument();
+        expect(screen.queryByText('CSV delivery')).not.toBeInTheDocument();
+    });
+
+    it('shows the app-specific empty state when there are no gsheets syncs', () => {
+        mockedUseAppSchedulers.mockReturnValue(
+            mockAppSchedulersData([csvScheduler]),
+        );
+
+        renderWithProviders(
+            <AppSyncModal
+                projectUuid="project-1"
+                appUuid="app-1"
+                opened
+                onClose={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.getByText('This app has no Syncs set up yet'),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/sync/components/AppSyncModal.tsx
+++ b/packages/frontend/src/features/sync/components/AppSyncModal.tsx
@@ -1,0 +1,67 @@
+import { SchedulerFormat } from '@lightdash/common';
+import { useMemo, type FC } from 'react';
+import { type MantineModalProps } from '../../../components/common/MantineModal';
+import { useAppSchedulers } from '../../../features/scheduler/hooks/useAppSchedulers';
+import { SyncModalProvider } from '../providers/SyncModalProvider';
+import { SyncModalAction } from '../providers/types';
+import { useSyncModal } from '../providers/useSyncModal';
+import { SyncModalCreateOrEdit } from './SyncModalCreateOrEdit';
+import { SyncModalDelete } from './SyncModalDelete';
+import { SyncModalView } from './SyncModalView';
+
+type Props = {
+    projectUuid: string;
+    appUuid: string;
+} & Pick<MantineModalProps, 'opened' | 'onClose'>;
+
+const AppSyncModalContent: FC<Props> = ({
+    projectUuid,
+    appUuid,
+    opened,
+    onClose,
+}) => {
+    const { action } = useSyncModal();
+    // The app schedulers endpoint returns every format unfiltered (small,
+    // unpaginated list) — filter to gsheets here the same way
+    // SqlChartSyncModal filters its own unfiltered schedulers list.
+    const { data } = useAppSchedulers({ projectUuid, appUuid });
+
+    const gsheetsSchedulers = useMemo(
+        () =>
+            (data?.pages.flatMap((page) => page.data) ?? []).filter(
+                (s) => s.format === SchedulerFormat.GSHEETS,
+            ),
+        [data],
+    );
+
+    if (action === SyncModalAction.VIEW || action === SyncModalAction.DELETE) {
+        return (
+            <>
+                <SyncModalView
+                    schedulers={gsheetsSchedulers}
+                    resourceLabel="app"
+                    onClose={onClose}
+                />
+                {action === SyncModalAction.DELETE && <SyncModalDelete />}
+            </>
+        );
+    }
+
+    if (action === SyncModalAction.CREATE || action === SyncModalAction.EDIT) {
+        return (
+            <SyncModalCreateOrEdit
+                resource={{ type: 'app', projectUuid, appUuid }}
+                opened={opened}
+                onClose={onClose}
+            />
+        );
+    }
+
+    return null;
+};
+
+export const AppSyncModal: FC<Props> = (props) => (
+    <SyncModalProvider>
+        <AppSyncModalContent {...props} />
+    </SyncModalProvider>
+);

--- a/packages/frontend/src/features/sync/components/SqlChartSyncModal.tsx
+++ b/packages/frontend/src/features/sync/components/SqlChartSyncModal.tsx
@@ -38,6 +38,7 @@ const SqlChartSyncModalContent: FC<Props> = ({
             <>
                 <SyncModalView
                     schedulers={gsheetsSchedulers}
+                    resourceLabel="chart"
                     onClose={onClose}
                 />
                 {action === SyncModalAction.DELETE && <SyncModalDelete />}
@@ -48,10 +49,9 @@ const SqlChartSyncModalContent: FC<Props> = ({
     if (action === SyncModalAction.CREATE || action === SyncModalAction.EDIT) {
         return (
             <SyncModalCreateOrEdit
-                chartUuid={savedSqlUuid}
+                resource={{ type: 'sqlChart', projectUuid, savedSqlUuid }}
                 opened={opened}
                 onClose={onClose}
-                projectUuid={projectUuid}
             />
         );
     }

--- a/packages/frontend/src/features/sync/components/SyncModal.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModal.tsx
@@ -53,6 +53,7 @@ const SyncModalBaseAndManager: FC<Props> = ({ chartUuid, opened, onClose }) => {
             <>
                 <SyncModalView
                     schedulers={schedulers}
+                    resourceLabel="chart"
                     isFetchingNextPage={isFetchingNextPage}
                     onScrollBottom={handleScrollBottom}
                     onClose={onClose}
@@ -65,7 +66,7 @@ const SyncModalBaseAndManager: FC<Props> = ({ chartUuid, opened, onClose }) => {
     if (action === SyncModalAction.CREATE || action === SyncModalAction.EDIT) {
         return (
             <SyncModalCreateOrEdit
-                chartUuid={chartUuid}
+                resource={{ type: 'chart', chartUuid }}
                 opened={opened}
                 onClose={onClose}
             />

--- a/packages/frontend/src/features/sync/components/SyncModalCreateOrEdit.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalCreateOrEdit.tsx
@@ -9,17 +9,16 @@ import SuboptimalState from '../../../components/common/SuboptimalState/Suboptim
 import { useSyncModalForm } from '../hooks/useSyncModalForm';
 import { SyncModalAction } from '../providers/types';
 import { useSyncModal } from '../providers/useSyncModal';
+import { type SyncResource } from '../types';
 import { SyncModalForm } from './SyncModalForm';
 import { SyncModalFormProvider } from './syncModalFormContext';
 
 type Props = {
-    chartUuid: string;
-    projectUuid?: string;
+    resource: SyncResource;
 } & Pick<MantineModalProps, 'opened' | 'onClose'>;
 
 export const SyncModalCreateOrEdit: FC<Props> = ({
-    chartUuid,
-    projectUuid,
+    resource,
     opened,
     onClose,
 }) => {
@@ -32,7 +31,7 @@ export const SyncModalCreateOrEdit: FC<Props> = ({
         isLoadingSchedulerData,
         isSchedulerError,
         schedulerError,
-    } = useSyncModalForm(chartUuid, projectUuid);
+    } = useSyncModalForm(resource);
 
     const hasSetGoogleSheet = form.values.options.gdriveId !== '';
 
@@ -69,7 +68,11 @@ export const SyncModalCreateOrEdit: FC<Props> = ({
                     </Button>
                 }
             >
-                <SyncModalForm id={formId} onSubmit={handleSubmit} />
+                <SyncModalForm
+                    id={formId}
+                    onSubmit={handleSubmit}
+                    isApp={resource.type === 'app'}
+                />
             </MantineModal>
         </SyncModalFormProvider>
     );

--- a/packages/frontend/src/features/sync/components/SyncModalForm.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalForm.tsx
@@ -5,6 +5,7 @@ import {
     Input,
     Stack,
     Switch,
+    Text,
     TextInput,
     Tooltip,
 } from '@mantine/core';
@@ -25,9 +26,12 @@ import {
 type Props = {
     id: string;
     onSubmit: (data: SyncModalFormValues) => void;
+    /** App syncs always write one tab per captured query — there's no single
+     *  "first tab" to override, so the tab-name override doesn't apply. */
+    isApp?: boolean;
 };
 
-export const SyncModalForm: FC<Props> = ({ id, onSubmit }) => {
+export const SyncModalForm: FC<Props> = ({ id, onSubmit, isApp = false }) => {
     const { activeProjectUuid } = useActiveProjectUuid();
     const { data: project } = useProject(activeProjectUuid);
 
@@ -84,31 +88,45 @@ export const SyncModalForm: FC<Props> = ({ id, onSubmit }) => {
 
                 <SelectGoogleSheetButton />
 
-                <Group>
-                    <Switch
-                        label="Save in a new tab"
-                        {...form.getInputProps('saveInNewTab', {
-                            type: 'checkbox',
-                        })}
-                    ></Switch>
-                    <Tooltip
-                        label={`Type a tab name to save the sync in, instead of overriding the first existing tab in the Google sheet.
+                {isApp && (
+                    <Text size="xs" c="ldGray.6">
+                        Each query in the app is written to its own tab, named
+                        after the query.
+                    </Text>
+                )}
+
+                {!isApp && (
+                    <>
+                        <Group>
+                            <Switch
+                                label="Save in a new tab"
+                                {...form.getInputProps('saveInNewTab', {
+                                    type: 'checkbox',
+                                })}
+                            ></Switch>
+                            <Tooltip
+                                label={`Type a tab name to save the sync in, instead of overriding the first existing tab in the Google sheet.
                                 This will create a new tab if it doesn't exist. We will still create a tab called metadata with the Sync information.`}
-                        multiline
-                        withinPortal
-                        position="right"
-                        maw={400}
-                    >
-                        <MantineIcon icon={IconInfoCircle} color="ldGray.6" />
-                    </Tooltip>
-                </Group>
-                {form.values.saveInNewTab && (
-                    <TextInput
-                        required
-                        label="Tab name"
-                        placeholder="Sheet1"
-                        {...form.getInputProps('options.tabName')}
-                    />
+                                multiline
+                                withinPortal
+                                position="right"
+                                maw={400}
+                            >
+                                <MantineIcon
+                                    icon={IconInfoCircle}
+                                    color="ldGray.6"
+                                />
+                            </Tooltip>
+                        </Group>
+                        {form.values.saveInNewTab && (
+                            <TextInput
+                                required
+                                label="Tab name"
+                                placeholder="Sheet1"
+                                {...form.getInputProps('options.tabName')}
+                            />
+                        )}
+                    </>
                 )}
             </Stack>
         </form>

--- a/packages/frontend/src/features/sync/components/SyncModalView.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalView.tsx
@@ -109,12 +109,15 @@ const SendNowButton: FC<{ schedulerUuid: string }> = ({ schedulerUuid }) => {
 
 type Props = {
     schedulers: SchedulerAndTargets[];
+    /** Drives the empty-state copy ("This {resourceLabel} has no Syncs..."). */
+    resourceLabel: 'chart' | 'app';
     isFetchingNextPage?: boolean;
     onScrollBottom?: () => void;
 } & Pick<MantineModalProps, 'onClose'>;
 
 export const SyncModalView: FC<Props> = ({
     schedulers,
+    resourceLabel,
     isFetchingNextPage,
     onScrollBottom,
     onClose,
@@ -288,11 +291,11 @@ export const SyncModalView: FC<Props> = ({
             ) : (
                 <Group justify="center" ta="center" gap="xs" my="sm" pt="md">
                     <Text fz="sm" fw={450} c="ldGray.7">
-                        This chart has no Syncs set up yet
+                        This {resourceLabel} has no Syncs set up yet
                     </Text>
                     <Text fz="xs" fw={400} c="ldGray.6">
                         Get started by clicking 'Create new Sync' to seamlessly
-                        integrate your chart data with Google Sheets
+                        integrate your {resourceLabel} data with Google Sheets
                     </Text>
                 </Group>
             )}

--- a/packages/frontend/src/features/sync/components/index.tsx
+++ b/packages/frontend/src/features/sync/components/index.tsx
@@ -1,1 +1,2 @@
+export { AppSyncModal } from './AppSyncModal';
 export { SyncModal } from './SyncModal';

--- a/packages/frontend/src/features/sync/hooks/useSyncModalForm.test.tsx
+++ b/packages/frontend/src/features/sync/hooks/useSyncModalForm.test.tsx
@@ -1,0 +1,187 @@
+import { SchedulerFormat } from '@lightdash/common';
+import { renderHook } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAppSchedulerCreateMutation } from '../../scheduler/hooks/useAppSchedulers';
+import { useChartSchedulerCreateMutation } from '../../scheduler/hooks/useChartSchedulers';
+import { useScheduler } from '../../scheduler/hooks/useScheduler';
+import { useSchedulersUpdateMutation } from '../../scheduler/hooks/useSchedulersUpdateMutation';
+import { type SyncModalFormValues } from '../components/syncModalFormContext';
+import { SyncModalProvider } from '../providers/SyncModalProvider';
+import { useSyncModal } from '../providers/useSyncModal';
+import { type SyncResource } from '../types';
+import { useSqlChartSchedulerCreateMutation } from './useSqlChartSchedulers';
+import { useSyncModalForm } from './useSyncModalForm';
+
+// Every mutation hook is mocked, so no QueryClient/App providers are needed —
+// only SyncModalProvider, whose context useSyncModalForm reads via useSyncModal.
+vi.mock('../../scheduler/hooks/useAppSchedulers', () => ({
+    useAppSchedulerCreateMutation: vi.fn(),
+}));
+vi.mock('../../scheduler/hooks/useChartSchedulers', () => ({
+    useChartSchedulerCreateMutation: vi.fn(),
+}));
+vi.mock('../../scheduler/hooks/useScheduler', () => ({
+    useScheduler: vi.fn(),
+}));
+vi.mock('../../scheduler/hooks/useSchedulersUpdateMutation', () => ({
+    useSchedulersUpdateMutation: vi.fn(),
+}));
+vi.mock('./useSqlChartSchedulers', () => ({
+    useSqlChartSchedulerCreateMutation: vi.fn(),
+}));
+
+const mockedAppMutation = vi.mocked(useAppSchedulerCreateMutation);
+const mockedChartMutation = vi.mocked(useChartSchedulerCreateMutation);
+const mockedSqlChartMutation = vi.mocked(useSqlChartSchedulerCreateMutation);
+const mockedUseScheduler = vi.mocked(useScheduler);
+const mockedUpdateMutation = vi.mocked(useSchedulersUpdateMutation);
+
+const makeMutationResult = (mutate: ReturnType<typeof vi.fn>) =>
+    ({
+        mutate,
+        isLoading: false,
+        isSuccess: false,
+    }) as unknown as ReturnType<typeof useChartSchedulerCreateMutation>;
+
+const renderSyncModalForm = (resource: SyncResource) =>
+    renderHook(
+        () => ({
+            modal: useSyncModal(),
+            syncForm: useSyncModalForm(resource),
+        }),
+        {
+            wrapper: ({ children }: PropsWithChildren) => (
+                <SyncModalProvider>{children}</SyncModalProvider>
+            ),
+        },
+    );
+
+const formValues: SyncModalFormValues = {
+    name: 'My sync',
+    cron: '0 9 * * *',
+    timezone: undefined,
+    options: {
+        gdriveId: 'drive-1',
+        gdriveName: 'Revenue sheet',
+        gdriveOrganizationName: 'Acme',
+        url: 'https://docs.google.com/spreadsheets/x',
+        tabName: '',
+    },
+    saveInNewTab: false,
+};
+
+describe('useSyncModalForm', () => {
+    let createApp: ReturnType<typeof vi.fn>;
+    let createChart: ReturnType<typeof vi.fn>;
+    let createSqlChart: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        createApp = vi.fn();
+        createChart = vi.fn();
+        createSqlChart = vi.fn();
+
+        mockedAppMutation.mockReturnValue(makeMutationResult(createApp));
+        mockedChartMutation.mockReturnValue(makeMutationResult(createChart));
+        mockedSqlChartMutation.mockReturnValue(
+            makeMutationResult(createSqlChart),
+        );
+        mockedUpdateMutation.mockReturnValue(
+            makeMutationResult(vi.fn()) as unknown as ReturnType<
+                typeof useSchedulersUpdateMutation
+            >,
+        );
+        mockedUseScheduler.mockReturnValue({
+            data: undefined,
+            isInitialLoading: false,
+            isError: false,
+            error: null,
+        } as unknown as ReturnType<typeof useScheduler>);
+    });
+
+    it('creates an app sync with format GSHEETS, gsheets options, and no csv options', () => {
+        const { result } = renderSyncModalForm({
+            type: 'app',
+            projectUuid: 'project-1',
+            appUuid: 'app-1',
+        });
+
+        result.current.syncForm.handleSubmit(formValues);
+
+        expect(createApp).toHaveBeenCalledTimes(1);
+        const [{ resourceUuid, data }] = createApp.mock.calls[0];
+        expect(resourceUuid).toBe('app-1');
+        expect(data.format).toBe(SchedulerFormat.GSHEETS);
+        expect(data.appUuid).toBeNull();
+        expect(data.appName).toBeNull();
+        expect(data.options).toEqual({
+            gdriveId: 'drive-1',
+            gdriveName: 'Revenue sheet',
+            gdriveOrganizationName: 'Acme',
+            url: 'https://docs.google.com/spreadsheets/x',
+            tabName: undefined,
+        });
+        // No CSV/limit/values fields, and no app-state snapshot.
+        expect(data).not.toHaveProperty('limit');
+        expect(data).not.toHaveProperty('formatted');
+        expect(data).not.toHaveProperty('appState');
+        expect(data).not.toHaveProperty('message');
+
+        // Only the app mutation fires — never the chart/sql-chart ones.
+        expect(createChart).not.toHaveBeenCalled();
+        expect(createSqlChart).not.toHaveBeenCalled();
+    });
+
+    it('creates a chart sync against the chart scheduler endpoint', () => {
+        const { result } = renderSyncModalForm({
+            type: 'chart',
+            chartUuid: 'chart-1',
+        });
+
+        result.current.syncForm.handleSubmit(formValues);
+
+        expect(createChart).toHaveBeenCalledTimes(1);
+        const [{ resourceUuid, data }] = createChart.mock.calls[0];
+        expect(resourceUuid).toBe('chart-1');
+        expect(data.format).toBe(SchedulerFormat.GSHEETS);
+        expect(createApp).not.toHaveBeenCalled();
+        expect(createSqlChart).not.toHaveBeenCalled();
+    });
+
+    it('creates a SQL chart sync against the SQL chart scheduler endpoint', () => {
+        const { result } = renderSyncModalForm({
+            type: 'sqlChart',
+            projectUuid: 'project-1',
+            savedSqlUuid: 'sql-chart-1',
+        });
+
+        result.current.syncForm.handleSubmit(formValues);
+
+        expect(createSqlChart).toHaveBeenCalledTimes(1);
+        const [{ resourceUuid, data }] = createSqlChart.mock.calls[0];
+        expect(resourceUuid).toBe('sql-chart-1');
+        expect(data.format).toBe(SchedulerFormat.GSHEETS);
+        expect(createApp).not.toHaveBeenCalled();
+        expect(createChart).not.toHaveBeenCalled();
+    });
+
+    it('keeps the tab name unset when "save in a new tab" is off, including for apps', () => {
+        const { result } = renderSyncModalForm({
+            type: 'app',
+            projectUuid: 'project-1',
+            appUuid: 'app-1',
+        });
+
+        result.current.syncForm.handleSubmit({
+            ...formValues,
+            saveInNewTab: true,
+            options: { ...formValues.options, tabName: 'Sheet2' },
+        });
+
+        const [{ data }] = createApp.mock.calls[0];
+        // The app form never renders the tab-name control, but the shared
+        // payload builder still honours saveInNewTab if it were ever set.
+        expect(data.options.tabName).toBe('Sheet2');
+    });
+});

--- a/packages/frontend/src/features/sync/hooks/useSyncModalForm.ts
+++ b/packages/frontend/src/features/sync/hooks/useSyncModalForm.ts
@@ -1,5 +1,10 @@
-import { isSchedulerGsheetsOptions, SchedulerFormat } from '@lightdash/common';
+import {
+    assertUnreachable,
+    isSchedulerGsheetsOptions,
+    SchedulerFormat,
+} from '@lightdash/common';
 import { useCallback, useEffect } from 'react';
+import { useAppSchedulerCreateMutation } from '../../../features/scheduler/hooks/useAppSchedulers';
 import { useChartSchedulerCreateMutation } from '../../../features/scheduler/hooks/useChartSchedulers';
 import { useScheduler } from '../../../features/scheduler/hooks/useScheduler';
 import { useSchedulersUpdateMutation } from '../../../features/scheduler/hooks/useSchedulersUpdateMutation';
@@ -12,8 +17,9 @@ import {
 import { useSqlChartSchedulerCreateMutation } from '../hooks/useSqlChartSchedulers';
 import { SyncModalAction } from '../providers/types';
 import { useSyncModal } from '../providers/useSyncModal';
+import { type SyncResource } from '../types';
 
-export const useSyncModalForm = (chartUuid: string, projectUuid?: string) => {
+export const useSyncModalForm = (resource: SyncResource) => {
     const { action, setAction, currentSchedulerUuid } = useSyncModal();
 
     const isEditing = action === SyncModalAction.EDIT;
@@ -31,12 +37,30 @@ export const useSyncModalForm = (chartUuid: string, projectUuid?: string) => {
         isLoading: isUpdateChartSyncLoading,
         isSuccess: isUpdateChartSyncSuccess,
     } = useSchedulersUpdateMutation(currentSchedulerUuid ?? '');
+    // All three mutation hooks are called unconditionally (rules of hooks) —
+    // only the one matching `resource.type` is ever invoked.
     const chartSchedulerMutation = useChartSchedulerCreateMutation();
-    const sqlChartSchedulerMutation =
-        useSqlChartSchedulerCreateMutation(projectUuid);
-    const createMutation = projectUuid
-        ? sqlChartSchedulerMutation
-        : chartSchedulerMutation;
+    const sqlChartSchedulerMutation = useSqlChartSchedulerCreateMutation(
+        resource.type === 'sqlChart' ? resource.projectUuid : undefined,
+    );
+    const appSchedulerMutation = useAppSchedulerCreateMutation(
+        resource.type === 'app' ? resource.projectUuid : '',
+    );
+    const createMutation = (() => {
+        switch (resource.type) {
+            case 'chart':
+                return chartSchedulerMutation;
+            case 'sqlChart':
+                return sqlChartSchedulerMutation;
+            case 'app':
+                return appSchedulerMutation;
+            default:
+                return assertUnreachable(
+                    resource,
+                    `Unknown sync resource type`,
+                );
+        }
+    })();
     const {
         mutate: createChartSync,
         isLoading: isCreateChartSyncLoading,
@@ -126,14 +150,28 @@ export const useSyncModalForm = (chartUuid: string, projectUuid?: string) => {
 
             if (isEditing) {
                 updateChartSync(payload);
-            } else {
-                createChartSync({
-                    resourceUuid: chartUuid,
-                    data: payload,
-                });
+                return;
             }
+
+            const resourceUuid = (() => {
+                switch (resource.type) {
+                    case 'chart':
+                        return resource.chartUuid;
+                    case 'sqlChart':
+                        return resource.savedSqlUuid;
+                    case 'app':
+                        return resource.appUuid;
+                    default:
+                        return assertUnreachable(
+                            resource,
+                            `Unknown sync resource type`,
+                        );
+                }
+            })();
+
+            createChartSync({ resourceUuid, data: payload });
         },
-        [chartUuid, createChartSync, isEditing, updateChartSync],
+        [resource, createChartSync, isEditing, updateChartSync],
     );
 
     useEffect(() => {

--- a/packages/frontend/src/features/sync/types.ts
+++ b/packages/frontend/src/features/sync/types.ts
@@ -1,0 +1,7 @@
+// Discriminates which resource a Google Sheets sync belongs to, so the
+// create/edit form knows which scheduler endpoint to call without relying on
+// which optional fields happen to be set.
+export type SyncResource =
+    | { type: 'chart'; chartUuid: string }
+    | { type: 'sqlChart'; projectUuid: string; savedSqlUuid: string }
+    | { type: 'app'; projectUuid: string; appUuid: string };


### PR DESCRIPTION
## Summary

PR 2 of 2 for Google Sheets sync on data apps — the user-facing surface, stacked on #27033. Closes the slice.

GSheets sync is its own scope in the product (charts and SQL charts manage syncs through the `features/sync` modal family, never the scheduled-delivery modal), and apps now follow the same pattern:

- **"Google Sheets Sync" menu entry** on the app page, gated exactly like the chart and SQL-chart entries: hidden when the Google Drive integration isn't configured, and behind the `manage:GoogleSheets` ability (also enforced server-side as of #27033).
- **App variant of the sync modal** following the `SqlChartSyncModal` precedent: list/create/edit/delete syncs with the same minimal form — name, cron, destination sheet via `SelectGoogleSheetButton`. No format/limit/message controls and no app-state snapshot: syncs render the app's default state, which the backend now enforces as an invariant (GSHEETS app schedulers reject non-null `appState`), keeping the chart-shaped edit flow provably unable to clobber app-only fields.
- **Strict list separation**: syncs appear only in the sync modal, deliveries only in the delivery modal — the delivery-list GSHEETS exclusion is now pinned by a unit-tested predicate (`deliveryListFilter`). The delivery modal's format control is untouched (csv/xlsx/image).
- `SyncModalView` gains a `resourceLabel` prop so app modals don't render chart-specific empty-state copy.

## Testing

Frontend-only diff. New tests across the sync form hook, the app sync modal (create payload: app endpoint, `GSHEETS` format, gsheets options, no csv options), the menu gating, and the delivery-list exclusion predicate; targeted sync+scheduler+apps scope 352 tests passing; typecheck/lint clean.

Closes: PROD-9382