### PR TITLE
refactor(deep-research): drop the persisted report chart data path

### DIFF
--- a/packages/backend/src/ee/database/entities/aiDeepResearch.ts
+++ b/packages/backend/src/ee/database/entities/aiDeepResearch.ts
@@ -1,6 +1,5 @@
 import {
     type AiDeepResearchBudget,
-    type AiDeepResearchChartDataMap,
     type AiDeepResearchEntryPoint,
     type AiDeepResearchEventPayload,
     type AiDeepResearchEventType,
@@ -27,7 +26,6 @@ export type DbAiDeepResearchRun = {
     terminal_reason: AiDeepResearchTerminalReason | null;
     entry_point: AiDeepResearchEntryPoint;
     result_markdown: string | null;
-    result_chart_data: AiDeepResearchChartDataMap | null;
     report_expires_at: Date | null;
     report_expired_at: Date | null;
     budget_snapshot: AiDeepResearchBudget;
@@ -75,7 +73,6 @@ export type AiDeepResearchRunsTable = Knex.CompositeTableType<
             | 'status'
             | 'terminal_reason'
             | 'result_markdown'
-            | 'result_chart_data'
             | 'report_expires_at'
             | 'report_expired_at'
             | 'error_message'

--- a/packages/backend/src/ee/database/migrations/20260807120000_drop_deep_research_result_chart_data.ts
+++ b/packages/backend/src/ee/database/migrations/20260807120000_drop_deep_research_result_chart_data.ts
@@ -1,0 +1,25 @@
+import { type Knex } from 'knex';
+
+const TABLE = 'ai_deep_research_runs';
+const COLUMN = 'result_chart_data';
+
+/**
+ * Report charts are derived on demand from the execution each `<chart>`
+ * reference names, so this column has had nothing to hold: every write since
+ * the chart rework set it null and the read paths that consulted it are gone.
+ */
+export async function up(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(TABLE, COLUMN)) {
+        await knex.schema.alterTable(TABLE, (table) => {
+            table.dropColumn(COLUMN);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasColumn(TABLE, COLUMN))) {
+        await knex.schema.alterTable(TABLE, (table) => {
+            table.jsonb(COLUMN).nullable();
+        });
+    }
+}

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
@@ -528,8 +528,8 @@ describe('AiDeepResearchRunModel', () => {
         expect(tracker.history.update.at(-1)?.sql).toContain(
             '"result_markdown" = $1',
         );
-        expect(tracker.history.update.at(-1)?.sql).toContain(
-            '"result_chart_data" = $2',
+        expect(tracker.history.update.at(-1)?.sql).not.toContain(
+            'result_chart_data',
         );
     });
 });

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -7,7 +7,6 @@ import {
     findDeepResearchChartRefs,
     getErrorMessage,
     type AiDeepResearchBudget,
-    type AiDeepResearchChartDataMap,
     type AiDeepResearchEntryPoint,
     type AiDeepResearchEventPayload,
     type AiDeepResearchEventPayloadMap,
@@ -168,7 +167,6 @@ export class AiDeepResearchRunModel {
         database: Queryable,
         promptUuid: string,
         resultMarkdown: string | null,
-        resultChartData: AiDeepResearchChartDataMap | null,
     ): Promise<TerminalMetrics> {
         const [toolCalls, toolResults, toolCallErrors] = await Promise.all([
             database<AiAgentToolCallTable>(AiAgentToolCallTableName)
@@ -237,7 +235,7 @@ export class AiDeepResearchRunModel {
                     : countDeepResearchFindings(resultMarkdown),
             chart_count:
                 resultMarkdown === null
-                    ? Object.keys(resultChartData ?? {}).length
+                    ? 0
                     : findDeepResearchChartRefs(resultMarkdown).length,
         };
     }
@@ -661,7 +659,6 @@ export class AiDeepResearchRunModel {
                 transaction,
                 currentRun.prompt_uuid,
                 resultMarkdown,
-                null,
             );
             const [run] = await transaction<AiDeepResearchRunsTable>(
                 AiDeepResearchRunsTableName,
@@ -673,7 +670,6 @@ export class AiDeepResearchRunModel {
                     status,
                     terminal_reason: terminalReason,
                     result_markdown: resultMarkdown,
-                    result_chart_data: null,
                     report_expires_at: transaction.raw(
                         "now() + (? * interval '1 day')",
                         [AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS],
@@ -753,7 +749,6 @@ export class AiDeepResearchRunModel {
                 transaction,
                 currentRun.prompt_uuid,
                 null,
-                null,
             );
             const [run] = await transaction<AiDeepResearchRunsTable>(
                 AiDeepResearchRunsTableName,
@@ -811,7 +806,6 @@ export class AiDeepResearchRunModel {
             const metrics = await AiDeepResearchRunModel.getTerminalMetrics(
                 transaction,
                 currentRun.prompt_uuid,
-                null,
                 null,
             );
             const [run] = await transaction<AiDeepResearchRunsTable>(
@@ -874,7 +868,6 @@ export class AiDeepResearchRunModel {
                 const metrics = await AiDeepResearchRunModel.getTerminalMetrics(
                     transaction,
                     queuedRun.prompt_uuid,
-                    null,
                     null,
                 );
                 const [runWithMetrics] =
@@ -1033,7 +1026,6 @@ export class AiDeepResearchRunModel {
                             transaction,
                             run.prompt_uuid,
                             null,
-                            null,
                         );
                     const [updatedRun] =
                         await transaction<AiDeepResearchRunsTable>(
@@ -1099,11 +1091,7 @@ export class AiDeepResearchRunModel {
                             ),
                     ),
             )
-            .where((query) =>
-                query
-                    .whereNotNull('result_markdown')
-                    .orWhereNotNull('result_chart_data'),
-            )
+            .whereNotNull('result_markdown')
             .orderByRaw(
                 "coalesce(report_expires_at, completed_at + interval '30 days') asc",
             )
@@ -1127,13 +1115,7 @@ export class AiDeepResearchRunModel {
                                     .whereRaw(
                                         "coalesce(report_expires_at, completed_at + interval '30 days') <= now()",
                                     )
-                                    .where((query) =>
-                                        query
-                                            .whereNotNull('result_markdown')
-                                            .orWhereNotNull(
-                                                'result_chart_data',
-                                            ),
-                                    )
+                                    .whereNotNull('result_markdown')
                                     .forUpdate()
                                     .first();
                             if (!lockedCandidate) {
@@ -1215,7 +1197,6 @@ export class AiDeepResearchRunModel {
                                     )
                                     .update({
                                         result_markdown: null,
-                                        result_chart_data: null,
                                         report_expires_at: transaction.raw(
                                             "coalesce(report_expires_at, completed_at + interval '30 days')",
                                         ) as unknown as Date,

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -118,7 +118,6 @@ const run = (
     terminal_reason: null,
     entry_point: 'ask_ai',
     result_markdown: null,
-    result_chart_data: null,
     report_expires_at: null,
     report_expired_at: null,
     budget_snapshot: budget,

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -209,7 +209,6 @@ const runRow = (overrides: Record<string, unknown> = {}) => ({
     status: 'queued',
     entry_point: 'ask_ai',
     result_markdown: null,
-    result_chart_data: null,
     report_expires_at: null,
     report_expired_at: null,
     budget_snapshot: budget,
@@ -938,9 +937,6 @@ describe('AiDeepResearchService', () => {
                             cancellation_requested_at: new Date(),
                             completed_at: new Date(),
                             result_markdown: 'Private result',
-                            result_chart_data: {
-                                private: { source: 'inline' },
-                            },
                         }),
                     ),
                 },
@@ -961,7 +957,6 @@ describe('AiDeepResearchService', () => {
             expect(run.status).toBe('cancelled');
             expect(run.cancellationRequestedAt).not.toBeNull();
             expect(run.resultMarkdown).toBeNull();
-            expect(run.resultChartData).toBeNull();
             expect(run.executionContextSnapshot).toBeNull();
             expect(
                 aiAgentService.assertDeepResearchAccess,
@@ -1005,9 +1000,6 @@ describe('AiDeepResearchService', () => {
                             status: 'completed',
                             completed_at: new Date('2026-06-01T00:00:00.000Z'),
                             result_markdown: 'Expired private report',
-                            result_chart_data: {
-                                private: { source: 'inline' },
-                            },
                             report_expires_at: reportExpiresAt,
                         }),
                     ),
@@ -1021,7 +1013,6 @@ describe('AiDeepResearchService', () => {
             );
 
             expect(run.resultMarkdown).toBeNull();
-            expect(run.resultChartData).toBeNull();
             expect(run.reportExpiresAt).toBe(reportExpiresAt.toISOString());
             expect(run.reportExpiredAt).toBeNull();
             expect(run.isReportExpired).toBe(true);
@@ -1893,12 +1884,17 @@ describe('AiDeepResearchService', () => {
     });
 
     describe('refreshChart', () => {
-        const chartDataEntry = {
-            source: 'warehouse' as const,
-            title: chart.title,
-            chartConfig: chart.chartConfig,
+        const refreshQueryHistory = {
             queryUuid: chart.queryUuid,
-            derivedFrom: null,
+            createdAt: new Date('2026-07-14T12:00:00.000Z'),
+            context: QueryExecutionContext.AI,
+            projectUuid: 'project-1',
+            organizationUuid: 'org-1',
+            createdByUserUuid: 'user-1',
+            createdByActorType: 'session',
+            status: QueryHistoryStatus.READY,
+            resultsFileName: 'evidence.jsonl',
+            resultsExpiresAt: new Date('2099-07-15T12:00:00.000Z'),
             metricQuery: {
                 exploreName: 'orders',
                 dimensions: ['orders_order_month'],
@@ -1911,25 +1907,32 @@ describe('AiDeepResearchService', () => {
                 timezone: 'Europe/London',
             },
             fields: {},
-            snapshot: null,
         };
 
-        it('re-executes the stored metric query behind a report chart', async () => {
+        it('re-executes the metric query behind a referenced report chart', async () => {
             const { service, asyncQueryService } = buildService({
                 model: {
-                    findByUuidScoped: vi.fn().mockResolvedValue(
-                        runRow({
-                            result_chart_data: {
-                                [chart.queryUuid]: chartDataEntry,
-                            },
-                        }),
-                    ),
+                    findByUuidScoped: vi
+                        .fn()
+                        .mockResolvedValue(
+                            runRow({ result_markdown: chartReportMarkdown }),
+                        ),
+                },
+                aiAgentModel: {
+                    getToolCallsAndResultsForPrompt: vi
+                        .fn()
+                        .mockResolvedValue(chartProvenance()),
+                },
+                queryHistoryModel: {
+                    getByQueryUuid: vi
+                        .fn()
+                        .mockResolvedValue(refreshQueryHistory),
                 },
                 asyncQueryService: {
                     executeAsyncMetricQuery: vi.fn().mockResolvedValue({
                         queryUuid: 'query-2',
                         cacheMetadata: { cacheHit: true },
-                        metricQuery: chartDataEntry.metricQuery,
+                        metricQuery: refreshQueryHistory.metricQuery,
                         fields: {},
                         warnings: [],
                     }),
@@ -1949,7 +1952,7 @@ describe('AiDeepResearchService', () => {
             ).toHaveBeenCalledWith({
                 account: {},
                 projectUuid: 'project-1',
-                metricQuery: chartDataEntry.metricQuery,
+                metricQuery: refreshQueryHistory.metricQuery,
                 context: QueryExecutionContext.AI,
             });
             expect(result).toEqual({
@@ -1958,7 +1961,7 @@ describe('AiDeepResearchService', () => {
                 query: {
                     queryUuid: 'query-2',
                     cacheMetadata: { cacheHit: true },
-                    metricQuery: chartDataEntry.metricQuery,
+                    metricQuery: refreshQueryHistory.metricQuery,
                     fields: {},
                     warnings: [],
                     parameterReferences: [],
@@ -1975,9 +1978,7 @@ describe('AiDeepResearchService', () => {
         it('rejects a chart key that is not part of the persisted report', async () => {
             const { service, asyncQueryService } = buildService({
                 model: {
-                    findByUuidScoped: vi
-                        .fn()
-                        .mockResolvedValue(runRow({ result_chart_data: {} })),
+                    findByUuidScoped: vi.fn().mockResolvedValue(runRow()),
                 },
             });
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -25,7 +25,6 @@ import {
     type Account,
     type AiDeepResearchBudget,
     type AiDeepResearchChartData,
-    type AiDeepResearchChartDataMap,
     type AiDeepResearchEntryPoint,
     type AiDeepResearchEvent,
     type AiDeepResearchEventPayloadMap,
@@ -229,10 +228,7 @@ const getReportExpiresAt = (row: DbAiDeepResearchRun): Date | null => {
     if (row.report_expires_at) {
         return row.report_expires_at;
     }
-    if (
-        row.completed_at &&
-        (row.result_markdown !== null || row.result_chart_data !== null)
-    ) {
+    if (row.completed_at && row.result_markdown !== null) {
         return new Date(row.completed_at.getTime() + 30 * 24 * 60 * 60 * 1_000);
     }
     return null;
@@ -253,7 +249,6 @@ const toRun = (row: DbAiDeepResearchRun): AiDeepResearchRun => {
         prompt: row.prompt,
         status: row.status,
         resultMarkdown: isReportExpired ? null : row.result_markdown,
-        resultChartData: isReportExpired ? null : row.result_chart_data,
         reportExpiresAt: reportExpiresAt?.toISOString() ?? null,
         reportExpiredAt: row.report_expired_at?.toISOString() ?? null,
         isReportExpired,
@@ -863,14 +858,12 @@ export class AiDeepResearchService extends BaseService {
                 `Deep Research chart ${args.chartKey} not found`,
             );
         }
-        const chart =
-            run.result_chart_data?.[args.chartKey] ??
-            (await this.getChart({
-                user: args.user,
-                projectUuid: args.projectUuid,
-                aiDeepResearchRunUuid: args.aiDeepResearchRunUuid,
-                queryUuid: args.chartKey,
-            }));
+        const chart = await this.getChart({
+            user: args.user,
+            projectUuid: args.projectUuid,
+            aiDeepResearchRunUuid: args.aiDeepResearchRunUuid,
+            queryUuid: args.chartKey,
+        });
 
         const query = await this.asyncQueryService.executeAsyncMetricQuery({
             account: args.account,
@@ -1003,7 +996,6 @@ export class AiDeepResearchService extends BaseService {
             ...toRun({
                 ...run,
                 result_markdown: null,
-                result_chart_data: null,
             }),
             executionContextSnapshot: null,
         };

--- a/packages/common/src/ee/aiDeepResearch/markdown.test.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.test.ts
@@ -2,7 +2,6 @@ import {
     aiDeepResearchChartDefinitionSchema,
     applyDeepResearchChartRefs,
     countDeepResearchFindings,
-    findDeepResearchChartBlocks,
     findDeepResearchChartRefs,
     lintDeepResearchReport,
     renderDeepResearchChartRefs,
@@ -375,18 +374,5 @@ describe('chart definition validation', () => {
                 ),
             ).toBe(true);
         }
-    });
-});
-
-describe('legacy chart fences', () => {
-    it('still parses legacy fenced blocks for migration', () => {
-        const legacy = `\`\`\`chart\n${JSON.stringify({
-            queryUuid: UUID_A,
-            title: 'Legacy',
-            chartConfig,
-        })}\n\`\`\``;
-        const matches = findDeepResearchChartBlocks(legacy);
-        expect(matches).toHaveLength(1);
-        expect(matches[0].block?.queryUuid).toBe(UUID_A);
     });
 });

--- a/packages/common/src/ee/aiDeepResearch/markdown.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
-import { getErrorMessage } from '../../types/errors';
 import {
     AI_DEEP_RESEARCH_CONFIDENCE_LEVELS,
     type AiDeepResearchChartConfig,
 } from './types';
 
-export const AI_DEEP_RESEARCH_CHART_LANGUAGE = 'chart';
 export const AI_DEEP_RESEARCH_MAX_CHARTS = 8;
 export const AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS = 300;
 export const AI_DEEP_RESEARCH_MAX_REPORT_MARKDOWN_CHARS = 60_000;
@@ -153,30 +151,6 @@ export const getDeepResearchChartRefMarkdown = (
         title,
     )}" description="${encodeHtmlAttribute(description)}">`;
 
-// ---------------------------------------------------------------------------
-// Legacy fenced ```chart blocks. Kept for the data migration that converts
-// previously persisted reports to chart references; new reports never
-// contain them (the lint rejects fences).
-// ---------------------------------------------------------------------------
-
-export const legacyDeepResearchChartBlockSchema = z.object({
-    queryUuid: z.string().uuid(),
-    title: z.string().min(1),
-    chartConfig: chartConfigSchema,
-});
-
-export type LegacyAiDeepResearchChartBlock = z.infer<
-    typeof legacyDeepResearchChartBlockSchema
->;
-
-export type AiDeepResearchChartBlockMatch = {
-    start: number;
-    end: number;
-    raw: string;
-    block: LegacyAiDeepResearchChartBlock | null;
-    error: string | null;
-};
-
 type FencedBlock = {
     start: number;
     end: number;
@@ -244,45 +218,6 @@ const scanFencedBlocks = (markdown: string): FencedBlock[] => {
 
     return blocks;
 };
-
-const toChartBlockMatch = (
-    markdown: string,
-    { start, end, body }: FencedBlock,
-): AiDeepResearchChartBlockMatch => {
-    const raw = markdown.slice(start, end);
-    let parsedJson: unknown;
-    try {
-        parsedJson = JSON.parse(body);
-    } catch (e) {
-        return {
-            start,
-            end,
-            raw,
-            block: null,
-            error: `Chart block is not valid JSON: ${getErrorMessage(e)}`,
-        };
-    }
-    const result = legacyDeepResearchChartBlockSchema.safeParse(parsedJson);
-    if (!result.success) {
-        return {
-            start,
-            end,
-            raw,
-            block: null,
-            error: result.error.issues
-                .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
-                .join('; '),
-        };
-    }
-    return { start, end, raw, block: result.data, error: null };
-};
-
-export const findDeepResearchChartBlocks = (
-    markdown: string,
-): AiDeepResearchChartBlockMatch[] =>
-    scanFencedBlocks(markdown)
-        .filter((block) => block.lang === AI_DEEP_RESEARCH_CHART_LANGUAGE)
-        .map((block) => toChartBlockMatch(markdown, block));
 
 /** Splices char ranges out of a markdown document, back to front. */
 export const spliceDeepResearchRanges = (

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -241,9 +241,9 @@ export type AiDeepResearchChartSnapshot = {
 };
 
 /**
- * Everything the UI needs to render one report chart, keyed by chart key in
- * `AiDeepResearchRun.resultChartData`. Written entirely by the backend at
- * publish time; the markdown only carries compact <chart> references.
+ * Everything the UI needs to render one report chart. Derived on demand from
+ * the execution the chart references; the markdown only carries compact
+ * <chart> references.
  */
 export type AiDeepResearchChartData = {
     source: 'warehouse';
@@ -257,11 +257,6 @@ export type AiDeepResearchChartData = {
     /** Null only for reports persisted before snapshots existed. */
     snapshot: AiDeepResearchChartSnapshot | null;
 };
-
-export type AiDeepResearchChartDataMap = Record<
-    string,
-    AiDeepResearchChartData
->;
 
 export const AI_DEEP_RESEARCH_EVENT_TYPES = [
     'status_changed',
@@ -361,8 +356,6 @@ export type AiDeepResearchRun = {
     status: AiDeepResearchRunStatus;
     /** The report narrative with compact <chart> references. */
     resultMarkdown: string | null;
-    /** Render data for each referenced chart, keyed by chart key. */
-    resultChartData: AiDeepResearchChartDataMap | null;
     reportExpiresAt: string | null;
     reportExpiredAt: string | null;
     isReportExpired: boolean;

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.test.tsx
@@ -27,7 +27,6 @@ describe('DeepResearchMarkdownReport', () => {
         renderWithProviders(
             <DeepResearchMarkdownReport
                 markdown={`## Finding\n\n<chart id="${queryUuid}" title="Revenue trend" description="Revenue by month.">`}
-                chartData={null}
                 projectUuid="project-1"
                 runUuid="run-1"
             />,

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
@@ -1,7 +1,6 @@
 import {
     AI_DEEP_RESEARCH_MARKDOWN_TAGS,
     renderDeepResearchChartRefs,
-    type AiDeepResearchChartDataMap,
     type AiDeepResearchConfidence,
 } from '@lightdash/common';
 import { Badge, Group, Text } from '@mantine/core';
@@ -26,7 +25,6 @@ import styles from './DeepResearchReport.module.css';
 const DeepResearchReportContext = createContext<{
     projectUuid: string;
     runUuid: string;
-    chartData: AiDeepResearchChartDataMap | null;
 } | null>(null);
 
 const CONFIDENCE_COLORS: Record<AiDeepResearchConfidence, string> = {
@@ -110,7 +108,6 @@ const ReportLink: FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
 
     if (linkHref?.startsWith(CHART_HREF_PREFIX)) {
         const chartKey = linkHref.slice(CHART_HREF_PREFIX.length);
-        const chart = context?.chartData?.[chartKey];
         if (!context) {
             return (
                 <Callout variant="warning" title="Chart unavailable">
@@ -118,21 +115,11 @@ const ReportLink: FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
                 </Callout>
             );
         }
-        if (!chart) {
-            return (
-                <QueryBackedChart
-                    projectUuid={context.projectUuid}
-                    runUuid={context.runUuid}
-                    queryUuid={chartKey}
-                />
-            );
-        }
         return (
-            <DeepResearchChartTile
-                chartKey={chartKey}
-                chart={chart}
+            <QueryBackedChart
                 projectUuid={context.projectUuid}
                 runUuid={context.runUuid}
+                queryUuid={chartKey}
             />
         );
     }
@@ -195,7 +182,6 @@ const MARKDOWN_COMPONENTS: StreamdownProps['components'] = {
 
 type Props = {
     markdown: string;
-    chartData: AiDeepResearchChartDataMap | null;
     projectUuid: string;
     runUuid: string;
 };
@@ -208,7 +194,6 @@ type Props = {
  */
 export const DeepResearchMarkdownReport: FC<Props> = ({
     markdown,
-    chartData,
     projectUuid,
     runUuid,
 }) => {
@@ -217,8 +202,8 @@ export const DeepResearchMarkdownReport: FC<Props> = ({
         [markdown],
     );
     const contextValue = useMemo(
-        () => ({ projectUuid, runUuid, chartData }),
-        [projectUuid, runUuid, chartData],
+        () => ({ projectUuid, runUuid }),
+        [projectUuid, runUuid],
     );
     return (
         <DeepResearchReportContext.Provider value={contextValue}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -5,6 +5,15 @@ import { renderWithProviders } from '../../../../../testing/testUtils';
 import { deepResearchRunFixture } from '../../deepResearch/fixtures';
 import { DeepResearchReport } from './DeepResearchReport';
 
+// Report charts are fetched per reference rather than persisted with the run,
+// so the flow test has to resolve that query to place the chart.
+const mocks = vi.hoisted(() => ({ useChartQuery: vi.fn() }));
+
+vi.mock('../../hooks/useDeepResearch', async (importOriginal) => ({
+    ...(await importOriginal<object>()),
+    useDeepResearchChartQuery: mocks.useChartQuery,
+}));
+
 vi.mock('./DeepResearchChartTile', () => ({
     DeepResearchChartTile: ({ chart }: { chart: { title: string } }) => (
         <div data-testid="deep-research-chart">{chart.title}</div>
@@ -27,6 +36,10 @@ describe('DeepResearchReport', () => {
     });
 
     it('renders the markdown as one flow with the chart between setup and interpretation', async () => {
+        mocks.useChartQuery.mockReturnValue({
+            isLoading: false,
+            data: { title: 'Enterprise retention by incident exposure' },
+        });
         renderReport();
 
         await waitFor(() =>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -226,7 +226,6 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                             </Box>
                             <DeepResearchMarkdownReport
                                 markdown={run.resultMarkdown}
-                                chartData={run.resultChartData}
                                 projectUuid={run.projectUuid}
                                 runUuid={run.uuid}
                             />

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
@@ -181,7 +181,6 @@ describe('DeepResearchRunCard', () => {
                 run={{
                     ...deepResearchRunFixture,
                     resultMarkdown: null,
-                    resultChartData: null,
                     findingCount: 0,
                     isReportExpired: true,
                     reportExpiredAt: '2026-07-30T09:18:00.000Z',

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
@@ -1,9 +1,3 @@
-import {
-    DimensionType,
-    FieldType,
-    MetricType,
-    type AiDeepResearchChartDataMap,
-} from '@lightdash/common';
 import { type DeepResearchRunView } from './types';
 
 const deepResearchChartQueryUuid = '7c4b40ba-79f8-4fd2-9c43-223eca8fa76f';
@@ -64,61 +58,6 @@ Weekly active seats rose, but the increase was strongest among healthy retained 
 1. [Q2 enterprise incident review](https://example.com/incident-review) — identifies repeated export failures for the affected accounts
 `;
 
-const numberMetric = (name: string, label: string) => ({
-    name,
-    label,
-    table: 'renewals',
-    tableLabel: 'Renewals',
-    sql: '',
-    hidden: false,
-    fieldType: FieldType.METRIC as const,
-    type: MetricType.NUMBER,
-});
-
-const deepResearchChartDataFixture: AiDeepResearchChartDataMap = {
-    [deepResearchChartQueryUuid]: {
-        source: 'warehouse',
-        title: deepResearchChartFixture.title,
-        chartConfig: deepResearchChartFixture.chartConfig,
-        queryUuid: deepResearchChartQueryUuid,
-        metricQuery: {
-            exploreName: 'renewals',
-            dimensions: ['incident_exposure'],
-            metrics: ['renewed_arr', 'churned_arr'],
-            filters: {},
-            sorts: [],
-            limit: 500,
-            tableCalculations: [],
-            additionalMetrics: [],
-        },
-        fields: {
-            incident_exposure: {
-                name: 'incident_exposure',
-                label: 'Incident exposure',
-                table: 'renewals',
-                tableLabel: 'Renewals',
-                sql: '',
-                hidden: false,
-                fieldType: FieldType.DIMENSION as const,
-                type: DimensionType.STRING,
-            },
-            renewed_arr: numberMetric('renewed_arr', 'Renewed ARR'),
-            churned_arr: numberMetric('churned_arr', 'Churned ARR'),
-        },
-        snapshot: {
-            takenAt: '2026-07-15T09:18:00.000Z',
-            rowCount: 3,
-            truncated: false,
-            columnOrder: ['incident_exposure', 'renewed_arr', 'churned_arr'],
-            rows: [
-                ['No incidents', 4_200_000, 150_000],
-                ['One incident', 1_600_000, 420_000],
-                ['Repeated incidents', 380_000, 1_900_000],
-            ],
-        },
-    },
-};
-
 export const deepResearchRunFixture: DeepResearchRunView = {
     uuid: 'run-quarterly-retention',
     projectUuid: 'project-1',
@@ -151,7 +90,6 @@ export const deepResearchRunFixture: DeepResearchRunView = {
         },
     ],
     resultMarkdown: deepResearchReportMarkdownFixture,
-    resultChartData: deepResearchChartDataFixture,
     reportExpiresAt: '2026-08-29T09:18:00.000Z',
     reportExpiredAt: null,
     isReportExpired: false,

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
@@ -171,7 +171,6 @@ export const adaptDeepResearchRun = ({
         actionRequired: null,
         latestEvents: getLatestEvents(events),
         resultMarkdown: run.resultMarkdown,
-        resultChartData: run.resultChartData,
         reportExpiresAt: run.reportExpiresAt,
         reportExpiredAt: run.reportExpiredAt,
         isReportExpired: run.isReportExpired,

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
@@ -1,5 +1,3 @@
-import { type AiDeepResearchChartDataMap } from '@lightdash/common';
-
 export type DeepResearchRunStatus =
     | 'queued'
     | 'running'
@@ -45,7 +43,6 @@ export type DeepResearchRunView = {
     /** The report narrative with compact <chart> references. */
     resultMarkdown: string | null;
     /** Render data for each referenced chart, keyed by chart key. */
-    resultChartData: AiDeepResearchChartDataMap | null;
     reportExpiresAt: string | null;
     reportExpiredAt: string | null;
     isReportExpired: boolean;


### PR DESCRIPTION
Follow-up to #26991, which made the server derive every report chart on demand from the execution its `<chart>` reference names. That left `result_chart_data` and its plumbing with nothing to do.

## Why this is dead, not merely unused

- **Nothing writes it.** Every runtime path sets `result_chart_data: null`. The only code that ever populated it was the backfill in `20260717150000_deep_research_chart_snapshots.ts`.
- **Nothing needs it.** It is null on every row in the dev DB (0 of 25, against 17 with markdown), and confirmed to hold no real production data.
- **Its readers were dead branches.** `DeepResearchMarkdownReport` chose between a snapshot tile and a query-backed tile; with the map always null, every chart already rendered through the query-backed path. `refreshChart` consulted the map before falling back to derivation, so it always fell back.

The legacy fenced ```chart parser goes too. Its last caller was the lint rule removed in #26991. The migration that justified keeping it carries its own frozen copy, as migrations must.

## What changes

```
column        ai_deep_research_runs.result_chart_data      dropped
api           AiDeepResearchRun.resultChartData            removed
              AiDeepResearchChartDataMap                   removed
frontend      snapshot render branch + run fixture         removed
common        legacy fenced ```chart parser                removed
```

## Two consequences worth flagging

**`refreshChart` is now stricter.** It always derives, so it enforces the same "must be referenced in the published report" gate as `getChart`. Previously a chart key present in the snapshot map would refresh without that check. Nothing relied on the looser behaviour — the map was always empty — but it is a real behaviour change, and its test was seeding the snapshot to take the removed fast path. It now exercises derivation end to end.

**A frontend flow test was asserting a synchronous render.** Charts arrive via an async query, so the test needed the chart-query hook mocked rather than reading a chart out of the fixture.

## On sequencing

I considered splitting this into code-removal now and the column drop in a later release, per expand/contract. That is over-cautious here: the rule protects data and live traffic, and this column has never held a byte on any path the current code runs. The residual rollback risk was one expiry-job predicate on a Beta, EE, feature-flagged surface, and splitting would likely have left the column in place indefinitely. The real gate was whether production still held backfilled data inside its 30-day retention — it does not.

## Test plan

- Migration applied, rolled back (column restored), and re-applied against the dev DB
- `pnpm -F common test` — 3381 pass
- backend EE suite — 2768 pass
- frontend suite — 2245 pass
- typecheck + lint clean on common, backend, frontend
- **Live run after the drop** (`9b288f98`): completed, 5 findings, 1 chart. That chart fetches through `GET .../charts/{queryUuid}` as a real line chart ("Weekly Checkout Completions & Revenue"), and `POST .../refresh` re-executes it successfully through the derivation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## API breaking change — deliberate

`allow-api-breaking-change`

`oasdiff` flags four removals, all of the same field and nothing else:

```
[response-required-property-removed]
  results/items/resultChartData   (200)
  results/resultChartData         (202)
  results/resultChartData         (200) x2
```

Accepted deliberately. The field is `null` on every run ever recorded, so no consumer can depend on its value — only on the key being present. Deep Research is a Beta, EE, feature-flagged surface, and the only known consumer is this repo's own frontend, updated in the same PR. Keeping the field as a permanently empty response property would preserve exactly the vestigial surface this PR removes.
