### PR TITLE
fix: prevent onboarding redirect loop for users without project creation permission

### DIFF
--- a/packages/frontend/src/components/AppRoute.test.tsx
+++ b/packages/frontend/src/components/AppRoute.test.tsx
@@ -1,17 +1,38 @@
+import { Ability } from '@casl/ability';
 import { MantineProvider } from '@mantine/core';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import AppRoute from './AppRoute';
 
+const organizationUuid = '172a2270-000f-42be-9c68-c4752c23ae51';
+
 const state = vi.hoisted(() => ({
     needsProject: true,
     isHomepageBuilderEnabled: true,
     isNewOnboardingEnabled: true,
+    canCreateProject: true,
 }));
 
 vi.mock('../providers/App/useApp', () => ({
     default: () => ({
         health: { isInitialLoading: false, error: null, data: {} },
+        user: {
+            isInitialLoading: false,
+            data: {
+                organizationUuid,
+                ability: new Ability(
+                    state.canCreateProject
+                        ? [
+                              {
+                                  action: 'create',
+                                  subject: 'Project',
+                                  conditions: { organizationUuid },
+                              },
+                          ]
+                        : [],
+                ),
+            },
+        },
     }),
 }));
 
@@ -72,6 +93,7 @@ describe('AppRoute', () => {
         state.needsProject = true;
         state.isHomepageBuilderEnabled = true;
         state.isNewOnboardingEnabled = true;
+        state.canCreateProject = true;
     });
 
     it('sends an organization with the homepage builder to the get started page', () => {
@@ -107,5 +129,23 @@ describe('AppRoute', () => {
         renderAppRoute();
 
         expect(screen.getByText('app')).toBeInTheDocument();
+    });
+
+    it('renders its children for a user who cannot create a project', () => {
+        state.canCreateProject = false;
+        renderAppRoute();
+
+        expect(screen.getByText('app')).toBeInTheDocument();
+        expect(screen.queryByText('get started')).not.toBeInTheDocument();
+    });
+
+    it('keeps the legacy project creation redirect away from users who cannot create a project', () => {
+        state.canCreateProject = false;
+        state.isNewOnboardingEnabled = false;
+        state.isHomepageBuilderEnabled = false;
+        renderAppRoute();
+
+        expect(screen.getByText('app')).toBeInTheDocument();
+        expect(screen.queryByText('create project')).not.toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/components/AppRoute.tsx
+++ b/packages/frontend/src/components/AppRoute.tsx
@@ -1,4 +1,5 @@
-import { FeatureFlags } from '@lightdash/common';
+import { subject } from '@casl/ability';
+import { FeatureFlags, ProjectType } from '@lightdash/common';
 import { type FC } from 'react';
 import { Navigate, useLocation } from 'react-router';
 import { useHomepageBuilderFlag } from '../ee/features/homepageBuilder/hooks/useProjectHomepage';
@@ -9,7 +10,7 @@ import ErrorState from './common/ErrorState';
 import PageSpinner from './PageSpinner';
 
 const AppRoute: FC<React.PropsWithChildren> = ({ children }) => {
-    const { health } = useApp();
+    const { health, user } = useApp();
     const location = useLocation();
     const orgRequest = useOrganization();
     const homepageBuilderFlag = useHomepageBuilderFlag();
@@ -28,18 +29,35 @@ const AppRoute: FC<React.PropsWithChildren> = ({ children }) => {
     }
 
     if (orgRequest?.data?.needsProject) {
-        if (homepageBuilderFlag.isLoading || orgSetupPageFlag.isLoading) {
+        if (
+            homepageBuilderFlag.isLoading ||
+            orgSetupPageFlag.isLoading ||
+            user.isInitialLoading
+        ) {
             return <PageSpinner />;
         }
-        const isNewOnboardingEnabled = orgSetupPageFlag.data?.enabled ?? false;
-        const showGetStarted =
-            homepageBuilderFlag.isEnabled && isNewOnboardingEnabled;
-        const pathname = showGetStarted
-            ? '/get-started'
-            : isNewOnboardingEnabled
-              ? '/onboarding/data-source'
-              : '/createProject';
-        return <Navigate to={{ pathname }} state={{ from: location }} />;
+
+        const canCreateProject =
+            user.data?.ability.can(
+                'create',
+                subject('Project', {
+                    organizationUuid: user.data.organizationUuid,
+                    type: ProjectType.DEFAULT,
+                }),
+            ) ?? false;
+
+        if (canCreateProject) {
+            const isNewOnboardingEnabled =
+                orgSetupPageFlag.data?.enabled ?? false;
+            const showGetStarted =
+                homepageBuilderFlag.isEnabled && isNewOnboardingEnabled;
+            const pathname = showGetStarted
+                ? '/get-started'
+                : isNewOnboardingEnabled
+                  ? '/onboarding/data-source'
+                  : '/createProject';
+            return <Navigate to={{ pathname }} state={{ from: location }} />;
+        }
     }
 
     return <>{children}</>;

--- a/packages/frontend/src/components/ForbiddenPanel.test.tsx
+++ b/packages/frontend/src/components/ForbiddenPanel.test.tsx
@@ -1,0 +1,80 @@
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import ForbiddenPanel from './ForbiddenPanel';
+
+const state = vi.hoisted(() => ({
+    needsProject: false,
+    isInitialLoading: false,
+}));
+
+vi.mock('../hooks/organization/useOrganization', () => ({
+    useOrganization: () => ({
+        data: { needsProject: state.needsProject },
+        isInitialLoading: state.isInitialLoading,
+    }),
+}));
+
+vi.mock('../providers/Ability', () => ({
+    Can: ({
+        children,
+    }: {
+        children: (isAllowed: boolean) => React.ReactNode;
+    }) => children(false),
+}));
+
+const renderForbiddenPanel = (subject?: string) =>
+    render(
+        <MantineProvider env="test">
+            <MemoryRouter>
+                <ForbiddenPanel subject={subject} />
+            </MemoryRouter>
+        </MantineProvider>,
+    );
+
+const GENERIC_TITLE = "You don't have access";
+const NO_PROJECT_TITLE = "Your organization doesn't have a project yet";
+
+describe('ForbiddenPanel', () => {
+    beforeEach(() => {
+        state.needsProject = false;
+        state.isInitialLoading = false;
+    });
+
+    it('explains the missing project when the organization has none', () => {
+        state.needsProject = true;
+        renderForbiddenPanel();
+
+        expect(screen.getByText(NO_PROJECT_TITLE)).toBeInTheDocument();
+        expect(
+            screen.getByText(/A project connects Lightdash to your data/),
+        ).toBeInTheDocument();
+        expect(screen.queryByText(GENERIC_TITLE)).not.toBeInTheDocument();
+    });
+
+    it('keeps the generic access message when the organization has a project', () => {
+        renderForbiddenPanel();
+
+        expect(screen.getByText(GENERIC_TITLE)).toBeInTheDocument();
+        expect(
+            screen.getByText('Please contact the admin to request access.'),
+        ).toBeInTheDocument();
+        expect(screen.queryByText(NO_PROJECT_TITLE)).not.toBeInTheDocument();
+    });
+
+    it('names the subject in the generic access message', () => {
+        renderForbiddenPanel('project');
+
+        expect(
+            screen.getByText("You don't have access to this project"),
+        ).toBeInTheDocument();
+    });
+
+    it('shows neither message while the organization is still loading', () => {
+        state.isInitialLoading = true;
+        renderForbiddenPanel();
+
+        expect(screen.queryByText(GENERIC_TITLE)).not.toBeInTheDocument();
+        expect(screen.queryByText(NO_PROJECT_TITLE)).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/ForbiddenPanel.tsx
+++ b/packages/frontend/src/components/ForbiddenPanel.tsx
@@ -2,10 +2,56 @@ import { Anchor, Box } from '@mantine/core';
 import { IconLock } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
+import { useOrganization } from '../hooks/organization/useOrganization';
 import { Can } from '../providers/Ability';
 import SuboptimalState from './common/SuboptimalState/SuboptimalState';
 
 const ForbiddenPanel: FC<{ subject?: string }> = ({ subject }) => {
+    const orgRequest = useOrganization();
+
+    const createProjectLink = (
+        <Can I="create" a={'Project'}>
+            {(isAllowed) => {
+                return (
+                    isAllowed && (
+                        <Anchor component={Link} to="/createProject">
+                            Or create a new project.
+                        </Anchor>
+                    )
+                );
+            }}
+        </Can>
+    );
+
+    if (orgRequest.isInitialLoading) {
+        return (
+            <Box mt="30vh">
+                <SuboptimalState loading />
+            </Box>
+        );
+    }
+
+    if (orgRequest.data?.needsProject) {
+        return (
+            <Box mt="30vh">
+                <SuboptimalState
+                    title="Your organization doesn't have a project yet"
+                    description={
+                        <>
+                            {' '}
+                            <p>
+                                A project connects Lightdash to your data. Ask
+                                an organization admin to finish setting one up.
+                            </p>
+                            {createProjectLink}
+                        </>
+                    }
+                    icon={IconLock}
+                />
+            </Box>
+        );
+    }
+
     return (
         <Box mt="30vh">
             <SuboptimalState
@@ -16,20 +62,7 @@ const ForbiddenPanel: FC<{ subject?: string }> = ({ subject }) => {
                     <>
                         {' '}
                         <p>Please contact the admin to request access.</p>
-                        <Can I="create" a={'Project'}>
-                            {(isAllowed) => {
-                                return (
-                                    isAllowed && (
-                                        <Anchor
-                                            component={Link}
-                                            to="/createProject"
-                                        >
-                                            Or create a new project.
-                                        </Anchor>
-                                    )
-                                );
-                            }}
-                        </Can>
+                        {createProjectLink}
                     </>
                 }
                 icon={IconLock}

--- a/packages/frontend/src/pages/OnboardingDataSource.test.tsx
+++ b/packages/frontend/src/pages/OnboardingDataSource.test.tsx
@@ -1,6 +1,6 @@
 import { FeatureFlags, type HealthState } from '@lightdash/common';
 import { screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { renderWithProviders } from '../testing/testUtils';
@@ -38,6 +38,24 @@ const renderDataSourcePicker = (isGoogleAuthEnabled: boolean) =>
         { health: healthWithGoogleAuth(isGoogleAuthEnabled) },
     );
 
+const renderWithoutProjectCreation = () =>
+    renderWithProviders(
+        <MemoryRouter initialEntries={['/onboarding/data-source']}>
+            <Routes>
+                <Route
+                    path="/onboarding/data-source"
+                    element={<OnboardingDataSource />}
+                />
+                <Route path="/" element={<div>home</div>} />
+                <Route path="/no-access" element={<div>no access</div>} />
+            </Routes>
+        </MemoryRouter>,
+        {
+            health: healthWithGoogleAuth(false),
+            user: { abilityRules: [] },
+        },
+    );
+
 describe('OnboardingDataSource', () => {
     beforeEach(() => {
         vi.mocked(useServerFeatureFlag).mockReturnValue({
@@ -68,5 +86,12 @@ describe('OnboardingDataSource', () => {
             screen.queryByText('Sign in with Google to connect'),
         ).not.toBeInTheDocument();
         expect(screen.getByText('Connect with SSO')).toBeInTheDocument();
+    });
+
+    it('sends a user who cannot create a project to the no access page', async () => {
+        renderWithoutProjectCreation();
+
+        expect(await screen.findByText('no access')).toBeInTheDocument();
+        expect(screen.queryByText('home')).not.toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/pages/OnboardingDataSource.tsx
+++ b/packages/frontend/src/pages/OnboardingDataSource.tsx
@@ -62,8 +62,8 @@ const POPULAR_WAREHOUSES: { key: WarehouseTypes; subtitle: string }[] = [
     },
 ];
 
-const popularKeys: SelectedWarehouse[] = POPULAR_WAREHOUSES.map(
-    (warehouse) => warehouse.key,
+const popularKeys = new Set<SelectedWarehouse>(
+    POPULAR_WAREHOUSES.map((warehouse) => warehouse.key),
 );
 
 const BIGQUERY_SERVICE_ACCOUNT_SUBTITLE = 'Connect with a service account';
@@ -87,7 +87,7 @@ const getPopularWarehouses = (isGoogleSsoAvailable: boolean) =>
     }).filter((warehouse) => warehouse !== undefined);
 
 const allWarehouses = orderedWarehouses.filter(
-    (warehouse) => !popularKeys.includes(warehouse.key),
+    (warehouse) => !popularKeys.has(warehouse.key),
 );
 
 const OTHER_ROUTE_PARAM = 'other';
@@ -301,7 +301,7 @@ const OnboardingDataSource: FC = () => {
     );
 
     if (!canCreateProject) {
-        return <Navigate to="/" replace />;
+        return <Navigate to="/no-access" replace />;
     }
 
     return <OnboardingDataSourceContent key={guard.user.userUuid} />;


### PR DESCRIPTION
## Problem

Users in an organization that has no project yet, and who do **not** have the create-project permission, were caught in an infinite client-side redirect loop:

- `AppRoute` sees `needsProject` and redirects `/` → `/onboarding/data-source` (or `/get-started` / `/createProject`) **without checking whether the user is allowed to create a project**.
- `OnboardingDataSource` checks the ability, finds the user cannot create a project, and bounces them back with `<Navigate to="/" replace />`.

The two guards therefore redirect into each other forever. Safari enforces a History API rate limit (more than 100 `history.replaceState` calls in 10 seconds) and throws `SecurityError`, crashing the page; Chrome spins silently instead. Reported via Sentry issue `LIGHTDASH-FRONTEND-5FP`.

## Fix

Three parts. The first two break the loop at both ends; the third makes the page users now land on tell the truth.

1. **`AppRoute`** now evaluates the same CASL predicate the onboarding page uses — `ability.can('create', subject('Project', { organizationUuid, type: DEFAULT }))` — and only performs the onboarding/project-creation redirect when the user can actually create a project. Otherwise it falls through to its children; `Projects` already routes users with no accessible project to `/no-access`. The `needsProject` spinner guard also waits on the user query so the ability is never evaluated against undefined data.
2. **`OnboardingDataSource`** now bounces non-creators to `/no-access` instead of `/`, so the cycle is structurally impossible even via a deep link.
3. **`ForbiddenPanel`** gains an organization-aware empty state. The generic "You don't have access / Please contact the admin to request access" copy is misleading for this cohort: nothing is being withheld from them, their organization simply has not finished setting up. When the organization still needs a project, the panel now says "Your organization doesn't have a project yet" / "A project connects Lightdash to your data. Ask an organization admin to finish setting one up." It holds on a loader while the organization query resolves, so the generic copy never flashes first, and every other case keeps the existing copy verbatim. `/no-project-access` shares this component and intentionally inherits the same message.

`/no-access` is not wrapped in `AppRoute`, so the fall-through terminates rather than re-entering the guard.

Also included: a `react-doctor` diagnostic on one of the touched files (`popularKeys` array scanned with `.includes()` in a filter) — converted to a `Set` lookup. Unrelated to the bug, but the file is touched by this PR.

## Test plan

**Automated** — extended the existing suites and added one for `ForbiddenPanel`. Every new test was confirmed red before its corresponding change and green after:

- `AppRoute.test.tsx`: `needsProject` + user *without* create-Project ability → children render, no redirect (covering both the new-onboarding and legacy `/createProject` paths).
- `AppRoute.test.tsx`: `needsProject` + user *with* the ability → the existing redirects still happen (unchanged behaviour).
- `OnboardingDataSource.test.tsx`: non-creator → navigates to `/no-access`, not `/`.
- `ForbiddenPanel.test.tsx`: organization needing a project → new title and description, generic title absent; organization with a project → generic copy unchanged; `subject` prop still named in the generic copy; nothing rendered while the organization query is loading.

```
pnpm -F frontend exec vitest run src/components/ForbiddenPanel.test.tsx \
  src/components/AppRoute.test.tsx src/pages/OnboardingDataSource.test.tsx
  Test Files  3 passed (3)   Tests  14 passed (14)
pnpm -F frontend typecheck   # clean
pnpm -F frontend run linter <touched paths>   # 0 warnings, 0 errors
```

**Manual** — local EE instance with the new-onboarding feature flags:

1. Signed up a fresh user into a brand-new organization and completed organization setup, leaving the org with **zero projects**.
2. Demoted that user to `viewer` in `organization_memberships` (confirmed via `GET /api/v1/user`: `role: viewer`, no `create`/`Project` ability rules).
3. Loaded `/` → lands on `/no-access` and **stays** there: URL sampled over several seconds shows no flicker, `history.length` does not grow, no `SecurityError`, and the network log shows a single pass of `/api/v1/user` + `/org/projects` rather than a redirect storm.
4. Deep-linked directly to `/onboarding/data-source` → also lands on `/no-access` (part 2 of the fix).
5. Re-checked after the copy change: the same viewer now sees "Your organization doesn't have a project yet" rather than the generic access message, with no create-project link (correct, they cannot create one).

Before the fix, both of those entry points looped between `/` and the onboarding page.

Linear: SPK-881
