### PR TITLE
fix(migrations): make the scheduler slug backfill terminate on unresolvable rows

### DIFF
--- a/packages/backend/src/database/migrations/20260713120324_add_slug_to_scheduler.ts
+++ b/packages/backend/src/database/migrations/20260713120324_add_slug_to_scheduler.ts
@@ -87,6 +87,7 @@ async function backfillProjectUuids(knex: Knex): Promise<void> {
             ), batch AS (
                 SELECT scheduler_uuid, project_uuid
                 FROM resource_projects
+                WHERE project_uuid IS NOT NULL
                 LIMIT ${BatchSize}
             )
             UPDATE ${SchedulerTableName} AS scheduler


### PR DESCRIPTION
## Summary

The batched backfill in `20260713120324_add_slug_to_scheduler` exits only when a pass updates zero rows. A scheduler whose project resolves through a SQL chart with a NULL `project_uuid` (the column was nullable until a much later contract migration, and migrations run in filename order, so the contract can never run first) had NULL written over NULL on every pass — Postgres counts that as an updated row, the same rows re-select forever, and the migration never terminates while holding the migration lock. Every subsequent deploy then fails with "Migration table is already locked".

The fix excludes unresolvable rows from the batch **before** the limit, so they can neither hold the loop open nor starve resolvable rows out of batch slots. They are left untouched; the downstream saved-SQL contract migration is unaffected (its NOT NULL enforcement targets `saved_sql`, not these scheduler rows, and the scheduler unique index is partial and excludes them by construction).

Modifying a shipped historical migration is deliberate here: the change only executes on instances that have not yet run it — exactly the instances at risk of the hang. The release-safety marker will flag the modified historical migration; that flag is expected.

## Validation

Validated against a 2 GB / 11.5M-row database seeded at the 0.3137.0 schema carrying the triggering data shape (12 scheduler rows whose owning SQL chart has a NULL `project_uuid`). Before: non-terminating (killed after 4+ minutes with zero progress, 12 rows re-firing). After: the full 0.3137.0 → 0.3476.0 migration path completes in 32.9s, the 12 unresolvable rows are skipped and left NULL, and the downstream saved-SQL slug contract still enforces NOT NULL. The path was carried on to 1.79.0 — 393 migrations, 0 failures, migration lock free at the end.

Plus a differential check on a scratch schema: a batch containing only unresolvable rows reports `updated=0` with the fix (terminates) and `updated=1` without it (loops); resolvable rows behave identically before and after.

Follow-up tracked separately (SPK-889): rows skipped here become resolvable later in the same upgrade and deserve a reconciliation migration.

Relates: SPK-882

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDMJiJBYRWBBK92zhjVA31