### PR TITLE
fix: usage analytics 500 when project has no legacy-role users

### DIFF
--- a/packages/backend/src/ee/models/ManagedAgentModel.test.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.test.ts
@@ -1,0 +1,49 @@
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import { ManagedAgentModel } from './ManagedAgentModel';
+
+const projectUuid = '11111111-1111-4111-8111-111111111111';
+const organizationUuid = '22222222-2222-4222-8222-222222222222';
+
+describe('ManagedAgentModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const encryptionUtil = new EncryptionUtil({
+        lightdashConfig: {
+            lightdashSecret: 'test-secret',
+            lightdashSecrets: {
+                active: 'test-secret',
+                fallbacks: [],
+                all: ['test-secret'],
+            },
+        },
+    });
+    const model = new ManagedAgentModel({
+        database: database as unknown as Knex,
+        encryptionUtil,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('skips the inactivity query when the project population is empty', async () => {
+        tracker.on
+            .any(/DISTINCT ON \(users\.user_uuid\)/i)
+            .response({ rows: [] });
+        tracker.on.any(() => true).response({ rows: [] });
+
+        await expect(
+            model.getInactiveUsers(projectUuid, organizationUuid, 30),
+        ).resolves.toEqual([]);
+
+        const executedSql = tracker.history.all.map((query) => query.sql);
+        expect(executedSql).toHaveLength(1);
+        expect(executedSql[0]).not.toContain("user_uuid in ('')");
+    });
+});

--- a/packages/backend/src/models/AnalyticsModel.test.ts
+++ b/packages/backend/src/models/AnalyticsModel.test.ts
@@ -1,0 +1,81 @@
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { AnalyticsModel } from './AnalyticsModel';
+import { usersInProjectSql } from './AnalyticsModelSql';
+
+const projectUuid = '11111111-1111-4111-8111-111111111111';
+const organizationUuid = '22222222-2222-4222-8222-222222222222';
+
+describe('AnalyticsModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new AnalyticsModel({
+        database: database as unknown as Knex,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('includes organization custom-role users in the project population', () => {
+        const sql = usersInProjectSql(projectUuid, organizationUuid).replace(
+            /\s+/g,
+            ' ',
+        );
+
+        expect(sql).toContain(
+            "organization_memberships.role != 'member' OR organization_memberships.role_uuid IS NOT NULL",
+        );
+    });
+
+    it('skips user-filtered queries when the project population is empty', async () => {
+        tracker.on
+            .any(/DISTINCT ON \(users\.user_uuid\)/i)
+            .response({ rows: [] });
+        tracker.on
+            .any(/100 \* COUNT\(DISTINCT\(user_uuid\)\) \/ 0/i)
+            .response({ rows: [{ count: '0' }] });
+        tracker.on
+            .any(/FROM public\.analytics_dashboard_views dv/i)
+            .response({ rows: [] });
+        tracker.on.any(/WITH RankedResults AS/i).response({ rows: [] });
+        tracker.on
+            .any(/FROM public\.analytics_chart_views/i)
+            .response({ rows: [] });
+        tracker.on.any(() => true).response({ rows: [] });
+
+        await expect(
+            model.getUserActivity(projectUuid, organizationUuid),
+        ).resolves.toEqual({
+            numberUsers: 0,
+            numberInteractiveViewers: 0,
+            numberViewers: 0,
+            numberEditors: 0,
+            numberAdmins: 0,
+            numberWeeklyQueryingUsers: 0,
+            tableMostQueries: [],
+            tableMostCreatedCharts: [],
+            tableNoQueries: [],
+            chartWeeklyQueryingUsers: [],
+            chartWeeklyAverageQueries: [],
+            dashboardViews: [],
+            userMostViewedDashboards: [],
+            chartViews: [],
+        });
+
+        const executedSql = tracker.history.all.map((query) => query.sql);
+        expect(executedSql).toHaveLength(4);
+        expect(executedSql).not.toEqual(
+            expect.arrayContaining([
+                expect.stringContaining("user_uuid in ('')"),
+            ]),
+        );
+        expect(executedSql).not.toEqual(
+            expect.arrayContaining([expect.stringContaining('/ 0')]),
+        );
+    });
+});

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -197,34 +197,59 @@ export class AnalyticsModel {
         const usersInProject: { user_uuid: string; role: string }[] =
             usersInProjectQuery.rows;
         const userUuids = usersInProject.map((user) => user.user_uuid);
+        const parseUsersWithCount = (
+            userData: DbUserWithCount,
+        ): UserWithCount => ({
+            userUuid: userData.user_uuid,
+            firstName: userData.first_name,
+            lastName: userData.last_name,
+            count: userData.count || undefined,
+        });
+        let numberWeeklyQueryingUsers = 0;
+        let tableMostQueries: UserWithCount[] = [];
+        let tableMostCreatedCharts: UserWithCount[] = [];
+        let tableNoQueries: UserWithCount[] = [];
+        let chartWeeklyQueryingUsers: UserActivity['chartWeeklyQueryingUsers'] =
+            [];
+        let chartWeeklyAverageQueries: UserActivity['chartWeeklyAverageQueries'] =
+            [];
 
-        const numberWeeklyQueryingUsersQuery = await this.database.raw(
-            numberWeeklyQueryingUsersSql(userUuids, projectUuid),
-        );
-        const numberWeeklyQueryingUsers: number = parseInt(
-            numberWeeklyQueryingUsersQuery.rows[0].count,
-            10,
-        );
+        if (userUuids.length > 0) {
+            const numberWeeklyQueryingUsersQuery = await this.database.raw(
+                numberWeeklyQueryingUsersSql(userUuids, projectUuid),
+            );
+            numberWeeklyQueryingUsers = parseInt(
+                numberWeeklyQueryingUsersQuery.rows[0].count,
+                10,
+            );
 
-        const tableMostQueries = await this.database.raw(
-            tableMostQueriesSql(userUuids, projectUuid),
-        );
+            const tableMostQueriesQuery = await this.database.raw(
+                tableMostQueriesSql(userUuids, projectUuid),
+            );
+            tableMostQueries =
+                tableMostQueriesQuery.rows.map(parseUsersWithCount);
 
-        const tableMostCreatedCharts = await this.database.raw(
-            tableMostCreatedChartsSql(userUuids, projectUuid),
-        );
+            const tableMostCreatedChartsQuery = await this.database.raw(
+                tableMostCreatedChartsSql(userUuids, projectUuid),
+            );
+            tableMostCreatedCharts =
+                tableMostCreatedChartsQuery.rows.map(parseUsersWithCount);
 
-        const tableNoQueries = await this.database.raw(
-            tableNoQueriesSql(userUuids, projectUuid),
-        );
+            const tableNoQueriesQuery = await this.database.raw(
+                tableNoQueriesSql(userUuids, projectUuid),
+            );
+            tableNoQueries = tableNoQueriesQuery.rows.map(parseUsersWithCount);
 
-        const chartWeeklyQueryingUsers = await this.database.raw(
-            chartWeeklyQueryingUsersSql(userUuids, projectUuid),
-        );
+            const chartWeeklyQueryingUsersQuery = await this.database.raw(
+                chartWeeklyQueryingUsersSql(userUuids, projectUuid),
+            );
+            chartWeeklyQueryingUsers = chartWeeklyQueryingUsersQuery.rows;
 
-        const chartWeeklyAverageQueries = await this.database.raw(
-            chartWeeklyAverageQueriesSql(userUuids, projectUuid),
-        );
+            const chartWeeklyAverageQueriesQuery = await this.database.raw(
+                chartWeeklyAverageQueriesSql(userUuids, projectUuid),
+            );
+            chartWeeklyAverageQueries = chartWeeklyAverageQueriesQuery.rows;
+        }
 
         const dashboardViews = await this.database.raw(
             dashboardViewsSql(projectUuid),
@@ -241,14 +266,6 @@ export class AnalyticsModel {
             }[];
         }>(userMostViewedDashboardSql(projectUuid));
         const chartViews = await this.database.raw(chartViewsSql(projectUuid));
-        const parseUsersWithCount = (
-            userData: DbUserWithCount,
-        ): UserWithCount => ({
-            userUuid: userData.user_uuid,
-            firstName: userData.first_name,
-            lastName: userData.last_name,
-            count: userData.count || undefined,
-        });
 
         return {
             numberUsers: usersInProject.length,
@@ -268,12 +285,11 @@ export class AnalyticsModel {
                 (user) => user.role === OrganizationMemberRole.ADMIN,
             ).length,
             numberWeeklyQueryingUsers,
-            tableMostQueries: tableMostQueries.rows.map(parseUsersWithCount),
-            tableMostCreatedCharts:
-                tableMostCreatedCharts.rows.map(parseUsersWithCount),
-            tableNoQueries: tableNoQueries.rows.map(parseUsersWithCount),
-            chartWeeklyQueryingUsers: chartWeeklyQueryingUsers.rows,
-            chartWeeklyAverageQueries: chartWeeklyAverageQueries.rows,
+            tableMostQueries,
+            tableMostCreatedCharts,
+            tableNoQueries,
+            chartWeeklyQueryingUsers,
+            chartWeeklyAverageQueries,
             dashboardViews: dashboardViews.rows,
             userMostViewedDashboards: userMostViewedDashboards.rows.map(
                 (row) => ({

--- a/packages/backend/src/models/AnalyticsModelSql.ts
+++ b/packages/backend/src/models/AnalyticsModelSql.ts
@@ -21,7 +21,8 @@ WHERE
   emails.is_primary = true
   AND users.is_internal = false
   AND (
-      (organization_memberships.role != 'member'
+      ((organization_memberships.role != 'member'
+        OR organization_memberships.role_uuid IS NOT NULL)
         AND organization_uuid = '${organizationUuid}')
   OR
       (projects.project_uuid = '${projectUuid}')


### PR DESCRIPTION
## Summary

The user activity endpoint (`GET /api/v1/analytics/user-activity/:projectUuid`) returned a 500 for organizations that migrated to custom roles, leaving the Usage Analytics page stuck on an endless loading spinner.

Custom role assignment intentionally parks the legacy `organization_memberships.role` column at `member` and stores the real role in `role_uuid`. `usersInProjectSql` predates custom roles and only counted users via `role != 'member'`, explicit project memberships, or group access — so for org-level custom-role users it returned an empty list. The downstream SQL builders then interpolated that empty list into `100 * COUNT(...) / 0` (division by zero) and `user_uuid in ('')`, which Postgres rejects with `22P02: invalid input syntax for type uuid`.

## Changes

- `usersInProjectSql`: org-membership branch now also matches `role_uuid IS NOT NULL`, so org-level custom-role holders count as project users (org-level custom roles emit org-wide CASL rules, the same reach as legacy non-member roles).
- `AnalyticsModel.getUserActivity`: when the project population is empty, skip every user-filtered query and return zeros/empty arrays instead of interpolating an empty uuid list into SQL. Project-scoped queries (dashboard/chart views) still run.
- Regression tests for both consumers of `usersInProjectSql` (`AnalyticsModel` and the managed agent's inactive-user detection, which already had an empty-population guard).

## Known limitation

Custom-role users are counted in `numberUsers` but not in the legacy per-role counters (viewers/editors/admins) — custom roles don't map onto the legacy enum buckets. Follow-up scope if we want role breakdowns for custom-role orgs.

## Testing

- `pnpm -F backend exec vitest run src/models/AnalyticsModel.test.ts src/ee/models/ManagedAgentModel.test.ts` — 3 passing
- Backend typecheck + lint of touched paths
- The patched population query was validated read-only against the affected production database: returns the expected user set where the old query returned zero rows

Linear: SPK-890

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrvTca2FWGQ8eo6aygy2Rs