### PR TITLE
fix(preflight): make coverage honest about what it has not seen

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -104,7 +104,7 @@ module.exports = {
             '@semantic-release/exec',
             {
                 prepareCmd:
-                    'npx tsx scripts/gen-migration-facts.ts --last-tag "${lastRelease.gitTag}" --out migration-facts.json',
+                    'npx tsx scripts/gen-migration-facts.ts --last-tag "${lastRelease.gitTag}" --release "${nextRelease.gitTag}" --out migration-facts.json',
             },
         ],
 

--- a/scripts/gen-migration-facts.test.ts
+++ b/scripts/gen-migration-facts.test.ts
@@ -3,8 +3,14 @@
  * Run: `npx tsx scripts/gen-migration-facts.test.ts`
  */
 import * as assert from 'assert';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
+    assertFactsPointAtRealMigrations,
     buildFactsAsset,
+    gitNameStatus,
     migrationNamesFromChanges,
     selectFactsForMigrations,
 } from './gen-migration-facts';
@@ -36,6 +42,8 @@ const fact = (migration: string): MigrationFact => ({
 
 const source = (migrationFacts: MigrationFact[]): FactsFile => ({
     schemaVersion: '1-draft',
+    release: null,
+    previousRelease: null,
     migrationsInRelease: null,
     migrationsWithoutFacts: null,
     migrationFacts,
@@ -48,6 +56,7 @@ test('only ADDED migration files count; edits, deletes and strays are ignored', 
         { status: 'M', path: 'packages/backend/src/database/migrations/20260103000000_edited.ts' },
         { status: 'D', path: 'packages/backend/src/database/migrations/20260104000000_deleted.ts' },
         { status: 'A', path: 'packages/backend/src/database/migrations/CLAUDE.md' },
+        { status: 'A', path: 'packages/backend/src/database/migrations/__tests__/20260106000000_not_a_migration.test.ts' },
     ]);
     assert.deepStrictEqual(
         [...names].sort(),
@@ -86,15 +95,25 @@ test('a release with no facts-bearing migrations selects nothing', () => {
 
 test('generated assets carry concrete release coverage', () => {
     const output = buildFactsAsset(
-        source([fact('20260101000000_one')]),
+        source([
+            fact('20260101000000_one'),
+            fact('20260103000000_enterprise'),
+        ]),
         new Set(['20260102000000_two', '20260101000000_one']),
+        new Set(['20260103000000_enterprise']),
         false,
+        '1.51.0',
+        '1.50.0',
     );
     assert.strictEqual(output.migrationsInRelease, 2);
     assert.deepStrictEqual(output.migrationsWithoutFacts, ['20260102000000_two']);
+    assert.strictEqual(output.enterpriseMigrationsInRelease, 1);
+    assert.deepStrictEqual(output.enterpriseMigrationsWithoutFacts, []);
+    assert.strictEqual(output.release, '1.51.0');
+    assert.strictEqual(output.previousRelease, '1.50.0');
     assert.deepStrictEqual(
         output.migrationFacts.map((migration) => migration.migration),
-        ['20260101000000_one'],
+        ['20260101000000_one', '20260103000000_enterprise'],
     );
     assert.doesNotThrow(() => parseFactsFile(JSON.stringify(output)));
 });
@@ -106,7 +125,10 @@ test('--all selects every authored fact while coverage still describes the relea
             fact('20260101000000_one'),
         ]),
         new Set(['20260102000000_two', '20260101000000_one']),
+        new Set(),
         true,
+        '1.51.0',
+        '1.50.0',
     );
     assert.deepStrictEqual(
         output.migrationFacts.map((migration) => migration.migration),
@@ -114,6 +136,126 @@ test('--all selects every authored fact while coverage still describes the relea
     );
     assert.strictEqual(output.migrationsInRelease, 2);
     assert.deepStrictEqual(output.migrationsWithoutFacts, ['20260102000000_two']);
+});
+
+function withTempGitRepo(run: (repo: string) => void): void {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-facts-test-'));
+    const previousCwd = process.cwd();
+    try {
+        process.chdir(repo);
+        execFileSync('git', ['init', '--quiet']);
+        execFileSync('git', ['config', 'user.email', 'test@example.com']);
+        execFileSync('git', ['config', 'user.name', 'Migration Facts Test']);
+        fs.writeFileSync('README.md', 'test\n');
+        execFileSync('git', ['add', 'README.md']);
+        execFileSync('git', ['commit', '--quiet', '-m', 'base']);
+        run(repo);
+    } finally {
+        process.chdir(previousCwd);
+        fs.rmSync(repo, { recursive: true, force: true });
+    }
+}
+
+test('--to limits the generated migration range to the supplied ref', () => {
+    withTempGitRepo((repo) => {
+        const migrationDir = path.join(
+            repo,
+            'packages/backend/src/database/migrations',
+        );
+        fs.mkdirSync(migrationDir, { recursive: true });
+        const base = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf-8' }).trim();
+        fs.writeFileSync(path.join(migrationDir, '20260101000000_one.ts'), 'export {};\n');
+        execFileSync('git', ['add', '.']);
+        execFileSync('git', ['commit', '--quiet', '-m', 'one']);
+        const to = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf-8' }).trim();
+        fs.writeFileSync(path.join(migrationDir, '20260102000000_two.ts'), 'export {};\n');
+        execFileSync('git', ['add', '.']);
+        execFileSync('git', ['commit', '--quiet', '-m', 'two']);
+
+        const atTo = migrationNamesFromChanges(
+            gitNameStatus(`${base}..${to}`, [
+                'packages/backend/src/database/migrations',
+            ]),
+        );
+        const atHead = migrationNamesFromChanges(
+            gitNameStatus(`${base}..HEAD`, [
+                'packages/backend/src/database/migrations',
+            ]),
+        );
+        assert.deepStrictEqual([...atTo], ['20260101000000_one']);
+        assert.deepStrictEqual([...atHead].sort(), [
+            '20260101000000_one',
+            '20260102000000_two',
+        ]);
+    });
+});
+
+test('migration existence is asserted against the supplied ref', () => {
+    withTempGitRepo((repo) => {
+        const migrationDir = path.join(
+            repo,
+            'packages/backend/src/database/migrations',
+        );
+        fs.mkdirSync(migrationDir, { recursive: true });
+        const migrationPath = path.join(migrationDir, '20260101000000_one.ts');
+        fs.writeFileSync(migrationPath, 'export {};\n');
+        execFileSync('git', ['add', '.']);
+        execFileSync('git', ['commit', '--quiet', '-m', 'add migration']);
+        const withMigration = execFileSync('git', ['rev-parse', 'HEAD'], {
+            encoding: 'utf-8',
+        }).trim();
+        fs.rmSync(migrationPath);
+        execFileSync('git', ['add', '.']);
+        execFileSync('git', ['commit', '--quiet', '-m', 'remove migration']);
+
+        assert.doesNotThrow(() =>
+            assertFactsPointAtRealMigrations(
+                [fact('20260101000000_one')],
+                withMigration,
+            ),
+        );
+        assert.throws(
+            () => assertFactsPointAtRealMigrations([fact('20260101000000_one')], 'HEAD'),
+            /does not match any migration file/,
+        );
+    });
+});
+
+test('a bogus corpus fact throws even when it is outside the selected range', () => {
+    withTempGitRepo((repo) => {
+        const migrationDir = path.join(
+            repo,
+            'packages/backend/src/database/migrations',
+        );
+        fs.mkdirSync(migrationDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(migrationDir, '20260101000000_one.ts'),
+            'export {};\n',
+        );
+        execFileSync('git', ['add', '.']);
+        execFileSync('git', ['commit', '--quiet', '-m', 'add migration']);
+        const corpus = [
+            fact('20260101000000_one'),
+            fact('20260199000000_bogus'),
+        ];
+        const output = buildFactsAsset(
+            source(corpus),
+            new Set(['20260101000000_one']),
+            new Set(),
+            false,
+            '1.51.0',
+            '1.50.0',
+        );
+
+        assert.deepStrictEqual(
+            output.migrationFacts.map((migration) => migration.migration),
+            ['20260101000000_one'],
+        );
+        assert.throws(
+            () => assertFactsPointAtRealMigrations(corpus, 'HEAD'),
+            /20260199000000_bogus/,
+        );
+    });
 });
 
 if (failures.length > 0) {

--- a/scripts/gen-migration-facts.ts
+++ b/scripts/gen-migration-facts.ts
@@ -22,23 +22,30 @@ import * as path from 'path';
 import { GitChange } from './gen-release-safety';
 import { FactsFile, MigrationFact, parseFactsFile } from './preflight';
 
-const MIGRATION_DIRS = [
-    'packages/backend/src/database/migrations',
-    'packages/backend/src/ee/database/migrations',
-] as const;
+const CORE_MIGRATION_DIR = 'packages/backend/src/database/migrations';
+const ENTERPRISE_MIGRATION_DIR = 'packages/backend/src/ee/database/migrations';
+const MIGRATION_DIRS = [CORE_MIGRATION_DIR, ENTERPRISE_MIGRATION_DIR] as const;
 
 const MIGRATION_FILENAME_RE = /^\d{14}_.+\.(ts|js)$/;
 
 export const DEFAULT_SOURCE = path.join(__dirname, 'migration-facts.json');
 
 /** migration names (basename, no extension) ADDED in the range */
-export function migrationNamesFromChanges(changes: GitChange[]): Set<string> {
+export function migrationNamesFromChanges(
+    changes: GitChange[],
+    migrationDirs: readonly string[] = MIGRATION_DIRS,
+): Set<string> {
     const names = new Set<string>();
     for (const change of changes) {
-        if (!change.status.startsWith('A')) continue;
-        const base = path.basename(change.path);
-        if (!MIGRATION_FILENAME_RE.test(base)) continue;
-        names.add(base.replace(/\.(ts|js)$/, ''));
+        if (
+            change.status.startsWith('A') &&
+            migrationDirs.includes(path.dirname(change.path))
+        ) {
+            const base = path.basename(change.path);
+            if (MIGRATION_FILENAME_RE.test(base)) {
+                names.add(base.replace(/\.(ts|js)$/, ''));
+            }
+        }
     }
     return names;
 }
@@ -59,17 +66,36 @@ export function selectFactsForMigrations(
 
 export function buildFactsAsset(
     source: FactsFile,
-    releaseMigrations: Set<string>,
+    coreReleaseMigrations: Set<string>,
+    enterpriseReleaseMigrations: Set<string>,
     includeAll: boolean,
+    release: string | null,
+    previousRelease: string | null,
 ): FactsFile {
-    const { selected, withoutFacts } = selectFactsForMigrations(
+    const releaseMigrations = new Set([
+        ...coreReleaseMigrations,
+        ...enterpriseReleaseMigrations,
+    ]);
+    const { selected } = selectFactsForMigrations(
         source.migrationFacts,
         releaseMigrations,
     );
+    const { withoutFacts: coreWithoutFacts } = selectFactsForMigrations(
+        source.migrationFacts,
+        coreReleaseMigrations,
+    );
+    const { withoutFacts: enterpriseWithoutFacts } = selectFactsForMigrations(
+        source.migrationFacts,
+        enterpriseReleaseMigrations,
+    );
     return {
         schemaVersion: source.schemaVersion,
-        migrationsInRelease: releaseMigrations.size,
-        migrationsWithoutFacts: withoutFacts,
+        release,
+        previousRelease,
+        migrationsInRelease: coreReleaseMigrations.size,
+        migrationsWithoutFacts: coreWithoutFacts,
+        enterpriseMigrationsInRelease: enterpriseReleaseMigrations.size,
+        enterpriseMigrationsWithoutFacts: enterpriseWithoutFacts,
         migrationFacts: includeAll
             ? [...source.migrationFacts].sort((a, b) =>
                   a.migration.localeCompare(b.migration),
@@ -78,7 +104,7 @@ export function buildFactsAsset(
     };
 }
 
-function gitNameStatus(range: string, dirs: readonly string[]): GitChange[] {
+export function gitNameStatus(range: string, dirs: readonly string[]): GitChange[] {
     const stdout = execFileSync(
         'git',
         ['diff', '--name-status', range, '--', ...dirs],
@@ -86,19 +112,32 @@ function gitNameStatus(range: string, dirs: readonly string[]): GitChange[] {
     );
     const changes: GitChange[] = [];
     for (const line of stdout.split('\n')) {
-        if (!line.trim()) continue;
-        const parts = line.split('\t');
-        changes.push({ status: parts[0], path: parts[parts.length - 1] });
+        if (line.trim()) {
+            const parts = line.split('\t');
+            changes.push({ status: parts[0], path: parts[parts.length - 1] });
+        }
     }
     return changes;
 }
 
-function assertFactsPointAtRealMigrations(facts: MigrationFact[]): void {
+export function assertFactsPointAtRealMigrations(
+    facts: MigrationFact[],
+    ref: string,
+): void {
     for (const fact of facts) {
-        const exists = MIGRATION_DIRS.some(
-            (dir) =>
-                fs.existsSync(path.join(dir, `${fact.migration}.ts`)) ||
-                fs.existsSync(path.join(dir, `${fact.migration}.js`)),
+        const exists = MIGRATION_DIRS.some((dir) =>
+            ['ts', 'js'].some((extension) => {
+                try {
+                    execFileSync(
+                        'git',
+                        ['cat-file', '-e', `${ref}:${dir}/${fact.migration}.${extension}`],
+                        { stdio: 'ignore' },
+                    );
+                    return true;
+                } catch {
+                    return false;
+                }
+            }),
         );
         if (!exists) {
             throw new Error(
@@ -123,9 +162,11 @@ function main(): void {
     };
     const lastTag = get('--last-tag');
     const out = get('--out');
+    const to = get('--to') ?? 'HEAD';
+    const release = get('--release');
     if (!lastTag || !out) {
         throw new Error(
-            'usage: gen-migration-facts.ts --last-tag <tag> --out <file> [--source <facts file>] [--all]',
+            'usage: gen-migration-facts.ts --last-tag <tag> --out <file> [--to <ref>] [--release <version>] [--source <facts file>] [--all]',
         );
     }
     if (process.env.RELEASE_SAFETY_MARKER_ENABLED !== 'true') {
@@ -136,24 +177,35 @@ function main(): void {
     }
     const source = get('--source') ?? DEFAULT_SOURCE;
     const factsFile = parseFactsFile(fs.readFileSync(source, 'utf-8'));
-    assertFactsPointAtRealMigrations(factsFile.migrationFacts);
+    assertFactsPointAtRealMigrations(factsFile.migrationFacts, 'HEAD');
 
-    const changes = gitNameStatus(`${lastTag}..HEAD`, MIGRATION_DIRS);
-    const releaseMigrations = migrationNamesFromChanges(changes);
+    const changes = gitNameStatus(`${lastTag}..${to}`, MIGRATION_DIRS);
+    const coreReleaseMigrations = migrationNamesFromChanges(changes, [CORE_MIGRATION_DIR]);
+    const enterpriseReleaseMigrations = migrationNamesFromChanges(changes, [
+        ENTERPRISE_MIGRATION_DIR,
+    ]);
     const output = buildFactsAsset(
         factsFile,
-        releaseMigrations,
+        coreReleaseMigrations,
+        enterpriseReleaseMigrations,
         argv.includes('--all'),
+        release,
+        lastTag,
     );
     for (const name of output.migrationsWithoutFacts ?? []) {
         console.log(`[migration-facts] no facts authored for ${name} (fine unless it backfills)`);
+    }
+    for (const name of output.enterpriseMigrationsWithoutFacts ?? []) {
+        console.log(
+            `[migration-facts] no facts authored for Enterprise migration ${name} (fine unless it backfills)`,
+        );
     }
 
     const json = JSON.stringify(output, null, 4);
     parseFactsFile(json);
     writeAtomic(out, `${json}\n`);
     console.log(
-        `[migration-facts] wrote ${out}: ${output.migrationFacts.length} fact(s) for ${releaseMigrations.size} migration(s) in ${lastTag}..HEAD${argv.includes('--all') ? ' (--all)' : ''}`,
+        `[migration-facts] wrote ${out}: ${output.migrationFacts.length} fact(s) for ${coreReleaseMigrations.size} core and ${enterpriseReleaseMigrations.size} Enterprise migration(s) in ${lastTag}..${to}${argv.includes('--all') ? ' (--all)' : ''}`,
     );
 }
 

--- a/scripts/migration-facts.json
+++ b/scripts/migration-facts.json
@@ -1,5 +1,7 @@
 {
     "schemaVersion": "1-draft",
+    "release": null,
+    "previousRelease": null,
     "migrationsInRelease": null,
     "migrationsWithoutFacts": null,
     "migrationFacts": [
@@ -28,7 +30,8 @@
                 "description": "Repurposes the nullable timezone column into a NOT NULL setting column: batched ctid UPDATE flips remaining NULLs to 'project_timezone' (each pass re-scans for what is left), then CHECK NOT VALID + VALIDATE + SET NOT NULL.",
                 "estimateSql": "SELECT saved_queries_version_id FROM saved_queries_versions WHERE timezone IS NULL",
                 "planSql": "SELECT ctid FROM saved_queries_versions WHERE timezone IS NULL LIMIT 10000",
-                "supportingIndexSql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sqv_timezone_null ON saved_queries_versions (saved_queries_version_id) WHERE timezone IS NULL"
+                "supportingIndexSql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sqv_timezone_null ON saved_queries_versions (saved_queries_version_id) WHERE timezone IS NULL",
+                "perPassCost": "table"
             },
             "notes": "Every pass re-selects the remaining NULLs by scanning the table, so passes slow down as few NULLs remain; a concurrent writer appending rows extends the drain and its IO competes with the scan. The vetted partial index makes the remaining-NULLs lookup cheap once most rows are drained."
         },

--- a/scripts/preflight-facts.schema.json
+++ b/scripts/preflight-facts.schema.json
@@ -5,7 +5,7 @@
     "description": "Per-migration facts consumed by scripts/preflight.ts (SPK-701 spike). Draft of the `migrationFacts` extension to the release-safety marker: each entry describes what one migration will do to the operator's database so the preflight prober can join it with read-only probes. All backfill SQL must be runnable against the PRE-upgrade schema — columns the migration itself adds do not exist yet on the operator's database.",
     "type": "object",
     "additionalProperties": false,
-    "required": ["schemaVersion", "migrationsInRelease", "migrationsWithoutFacts", "migrationFacts"],
+    "required": ["schemaVersion", "release", "previousRelease", "migrationsInRelease", "migrationsWithoutFacts", "migrationFacts"],
     "definitions": {
         "tableFact": {
             "type": "object",
@@ -41,7 +41,8 @@
                 "supportingIndexSql": {
                     "type": ["string", "null"],
                     "description": "Vetted pre-upgrade index DDL that supports the backfill predicate, emitted verbatim as an operator remediation. When non-null it must be one semicolon-free statement matching ^CREATE (UNIQUE )?INDEX CONCURRENTLY (IF NOT EXISTS )?[A-Za-z0-9_\" .()=<>'!,-]+$. null when no index helps (e.g. the predicate matches most of the table)."
-                }
+                },
+                "perPassCost": { "enum": ["remaining", "table"] }
             }
         },
         "migrationFact": {
@@ -84,6 +85,8 @@
     },
     "properties": {
         "schemaVersion": { "type": "string", "const": "1-draft" },
+        "release": { "type": ["string", "null"] },
+        "previousRelease": { "type": ["string", "null"] },
         "migrationsInRelease": {
             "type": ["integer", "null"],
             "minimum": 0,
@@ -93,6 +96,14 @@
             "type": ["array", "null"],
             "items": { "type": "string" },
             "description": "Sorted migration names in this release asset's range that have no authored facts. null only in the cumulative authoring source, where release coverage is unknown."
+        },
+        "enterpriseMigrationsInRelease": {
+            "type": ["integer", "null"],
+            "minimum": 0
+        },
+        "enterpriseMigrationsWithoutFacts": {
+            "type": ["array", "null"],
+            "items": { "type": "string" }
         },
         "migrationFacts": {
             "type": "array",

--- a/scripts/preflight.test.ts
+++ b/scripts/preflight.test.ts
@@ -319,6 +319,66 @@ test('findRangeGaps ignores duplicate and overlapping coverage', () => {
     );
 });
 
+test('findRangeGaps ignores assets outside the requested range', () => {
+    // An operator who fetches a handful of release assets but upgrades across
+    // only some of them must not be told coverage is missing for a range they
+    // never asked about — a false "coverage unknown" caps the verdict and sends
+    // them looking for assets they do not need.
+    assert.deepStrictEqual(
+        findRangeGaps(
+            [
+                { previousRelease: '1.0.0', release: '1.1.0' },
+                { previousRelease: '1.1.0', release: '1.2.0' },
+                { previousRelease: '1.2.0', release: '1.3.0' },
+                { previousRelease: '1.5.0', release: '1.6.0' },
+            ],
+            '1.0.0',
+            '1.2.0',
+        ).gaps,
+        [],
+    );
+    assert.deepStrictEqual(
+        findRangeGaps(
+            [
+                { previousRelease: '0.1.0', release: '0.2.0' },
+                { previousRelease: '1.0.0', release: '2.0.0' },
+            ],
+            '1.0.0',
+            '2.0.0',
+        ).gaps,
+        [],
+    );
+});
+
+test('findRangeGaps handles an asset nested inside a wider one', () => {
+    // The wide asset already covers the whole range; the narrow one inside it
+    // must not open a gap. Sorting these intervals by their end rather than
+    // their start is what makes that happen, in either input order.
+    for (const files of [
+        [
+            { previousRelease: '1.0.0', release: '2.0.0' },
+            { previousRelease: '1.2.0', release: '1.3.0' },
+        ],
+        [
+            { previousRelease: '1.2.0', release: '1.3.0' },
+            { previousRelease: '1.0.0', release: '2.0.0' },
+        ],
+    ]) {
+        assert.deepStrictEqual(findRangeGaps(files, '1.0.0', '2.0.0').gaps, []);
+    }
+});
+
+test('findRangeGaps clamps a trailing gap to the requested range', () => {
+    assert.deepStrictEqual(
+        findRangeGaps(
+            [{ previousRelease: '5.0.0', release: '6.0.0' }],
+            '1.0.0',
+            '2.0.0',
+        ).gaps,
+        [{ from: '1.0.0', to: '2.0.0' }],
+    );
+});
+
 // --- analyzeLock -------------------------------------------------------------
 
 test('free lock is ok', () => {
@@ -509,14 +569,49 @@ test('full-table per-pass cost warns with a plan for a large non-transactional t
     assert.match(largeTable.action ?? '', /each pass costs the same/);
     assert.strictEqual(largeTable.actionKind, 'plan');
 
-    const smallTable = analyzeRowEstimate(
+    // perPassCost only ever raises the cost estimate. A live-tuple count below
+    // the target count means the facts and the statistics disagree — usually an
+    // un-analyzed table reporting 0 — and that must not be read as "small".
+    const staleOrMissingStats = analyzeRowEstimate(
         tableSized,
         explainFixture(2_000_000),
         50_000,
         100000,
         null,
     );
-    assert.strictEqual(smallTable.severity, 'ok');
+    assert.strictEqual(staleOrMissingStats.severity, 'warn');
+
+    const noStatsAtAll = analyzeRowEstimate(
+        tableSized,
+        explainFixture(2_000_000),
+        0,
+        100000,
+        null,
+    );
+    assert.strictEqual(noStatsAtAll.severity, 'warn');
+});
+
+test('per-pass table cost never downgrades a large single-transaction backfill', () => {
+    // Regression: reading an absent or un-analyzed live-tuple count as 0 made a
+    // 50M-row single-transaction backfill report ok with no action — quieter
+    // than the same fact carries without perPassCost at all.
+    const withTableCost = fact({
+        runsInTransaction: true,
+        backfill: {
+            ...(fact().backfill as BackfillFact),
+            perPassCost: 'table',
+        },
+    });
+    const unknownStats = analyzeRowEstimate(
+        withTableCost,
+        explainFixture(50_000_000),
+        0,
+        100000,
+        null,
+    );
+    assert.strictEqual(unknownStats.severity, 'warn');
+    assert.strictEqual(unknownStats.actionKind, 'plan');
+    assert.ok(unknownStats.action);
 });
 
 test('full-table cost drives severity without repeating equal target and table counts', () => {

--- a/scripts/preflight.test.ts
+++ b/scripts/preflight.test.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {
     ActivityRow,
+    analyzeLockTimeouts,
     analyzeUpgradeStrategy,
     assertSafeApiBaseUrl,
     mergeFactsFiles,
@@ -30,6 +31,7 @@ import {
     FactsCoverage,
     FactsFile,
     flattenPlan,
+    findRangeGaps,
     MigrationFact,
     parseArgs,
     parseFactsFile,
@@ -86,6 +88,8 @@ const completeCoverage = (migrationsInRelease: number): FactsCoverage => ({
     unknownCoverageFiles: 0,
 });
 
+const completeRangeCoverage = { gaps: [], unknownReleaseFiles: 0 };
+
 const factsFile = (
     migrationFacts: MigrationFact[],
     coverage: Pick<FactsFile, 'migrationsInRelease' | 'migrationsWithoutFacts'> = {
@@ -94,6 +98,8 @@ const factsFile = (
     },
 ): FactsFile => ({
     schemaVersion: '1-draft',
+    release: null,
+    previousRelease: null,
     ...coverage,
     migrationFacts,
 });
@@ -114,6 +120,8 @@ test('the shipped facts source file validates against the schema', () => {
     );
     const parsed = parseFactsFile(raw);
     assert.strictEqual(parsed.migrationFacts.length, 3);
+    assert.strictEqual(parsed.release, null);
+    assert.strictEqual(parsed.previousRelease, null);
     assert.strictEqual(parsed.migrationsInRelease, null);
     assert.strictEqual(parsed.migrationsWithoutFacts, null);
 });
@@ -140,6 +148,8 @@ test('schema rejects a wrong schemaVersion', () => {
 test('parseFactsFile rejects multi-statement backfill SQL', () => {
     const file = JSON.stringify({
         schemaVersion: '1-draft',
+        release: null,
+        previousRelease: null,
         migrationsInRelease: null,
         migrationsWithoutFacts: null,
         migrationFacts: [
@@ -236,6 +246,77 @@ test('selectFacts orders versions numerically, not lexically', () => {
     const facts = [fact({ migration: 'a', introducedIn: '0.3477.0' })];
     assert.strictEqual(selectFacts(facts, '0.3476.2', '0.3480.0').length, 1);
     assert.strictEqual(selectFacts(facts, '0.3477.0', '0.3480.0').length, 0);
+});
+
+test('findRangeGaps reports a fully spanned range without gaps', () => {
+    assert.deepStrictEqual(
+        findRangeGaps(
+            [
+                { previousRelease: '1.0.0', release: '2.0.0' },
+                { previousRelease: '2.0.0', release: '3.0.0' },
+            ],
+            '1.0.0',
+            '3.0.0',
+        ),
+        { gaps: [], unknownReleaseFiles: 0 },
+    );
+});
+
+test('findRangeGaps reports a missing middle release', () => {
+    assert.deepStrictEqual(
+        findRangeGaps(
+            [
+                { previousRelease: '1.0.0', release: '2.0.0' },
+                { previousRelease: '3.0.0', release: '4.0.0' },
+            ],
+            '1.0.0',
+            '4.0.0',
+        ).gaps,
+        [{ from: '2.0.0', to: '3.0.0' }],
+    );
+});
+
+test('findRangeGaps reports missing head and tail ranges', () => {
+    assert.deepStrictEqual(
+        findRangeGaps(
+            [{ previousRelease: '2.0.0', release: '3.0.0' }],
+            '1.0.0',
+            '4.0.0',
+        ).gaps,
+        [
+            { from: '1.0.0', to: '2.0.0' },
+            { from: '3.0.0', to: '4.0.0' },
+        ],
+    );
+});
+
+test('findRangeGaps counts files with unknown release bounds', () => {
+    assert.deepStrictEqual(
+        findRangeGaps(
+            [
+                { previousRelease: '1.0.0', release: '3.0.0' },
+                { previousRelease: null, release: null },
+            ],
+            '1.0.0',
+            '3.0.0',
+        ),
+        { gaps: [], unknownReleaseFiles: 1 },
+    );
+});
+
+test('findRangeGaps ignores duplicate and overlapping coverage', () => {
+    assert.deepStrictEqual(
+        findRangeGaps(
+            [
+                { previousRelease: '1.0.0', release: '3.0.0' },
+                { previousRelease: '1.0.0', release: '3.0.0' },
+                { previousRelease: '2.0.0', release: '4.0.0' },
+            ],
+            '1.0.0',
+            '4.0.0',
+        ).gaps,
+        [],
+    );
 });
 
 // --- analyzeLock -------------------------------------------------------------
@@ -360,13 +441,20 @@ test('flattenPlan walks nested plans', () => {
 });
 
 test('large single-transaction backfill warns; batched resumable one is ok', () => {
-    const single = analyzeRowEstimate(fact(), explainFixture(2_000_000), 100000, null);
+    const single = analyzeRowEstimate(
+        fact(),
+        explainFixture(2_000_000),
+        2_000_000,
+        100000,
+        null,
+    );
     assert.strictEqual(single.severity, 'warn');
     assert.match(single.summary, /2,000,000 rows/);
 
     const batched = analyzeRowEstimate(
         fact({ runsInTransaction: false, resumable: true, batchSize: 1000 }),
         explainFixture(2_000_000),
+        2_000_000,
         100000,
         null,
     );
@@ -375,13 +463,85 @@ test('large single-transaction backfill warns; batched resumable one is ok', () 
 });
 
 test('a measured scan turns the window advice into a number', () => {
-    const slow = analyzeRowEstimate(fact(), explainFixture(2_000_000), 100000, 300);
+    const slow = analyzeRowEstimate(
+        fact(),
+        explainFixture(2_000_000),
+        2_000_000,
+        100000,
+        300,
+    );
     assert.match(slow.summary, /measured ~5 min on this instance/);
     assert.match(slow.action ?? '', /window of at least ~5 min/);
 
-    const fast = analyzeRowEstimate(fact(), explainFixture(2_000_000), 100000, 0.4);
+    const fast = analyzeRowEstimate(
+        fact(),
+        explainFixture(2_000_000),
+        2_000_000,
+        100000,
+        0.4,
+    );
     assert.doesNotMatch(fast.action ?? '', /at least <1s/);
     assert.match(fast.action ?? '', /scan measured <1s here, but the single-transaction UPDATE/);
+});
+
+test('full-table per-pass cost warns with a plan for a large non-transactional table', () => {
+    const tableSized = fact({
+        runsInTransaction: false,
+        resumable: true,
+        batchSize: 1000,
+        backfill: {
+            ...(fact().backfill as BackfillFact),
+            perPassCost: 'table',
+        },
+    });
+    const largeTable = analyzeRowEstimate(
+        tableSized,
+        explainFixture(8),
+        5_000_000,
+        100000,
+        null,
+    );
+    assert.strictEqual(largeTable.severity, 'warn');
+    assert.match(largeTable.summary, /repairs ~8 rows/);
+    assert.match(largeTable.summary, /all 5,000,000 rows of "users"/);
+    assert.match(largeTable.summary, /cost does not fall as the work drains/);
+    assert.match(largeTable.action ?? '', /repeated full-table passes over ~5,000,000 rows/);
+    assert.match(largeTable.action ?? '', /each pass costs the same/);
+    assert.strictEqual(largeTable.actionKind, 'plan');
+
+    const smallTable = analyzeRowEstimate(
+        tableSized,
+        explainFixture(2_000_000),
+        50_000,
+        100000,
+        null,
+    );
+    assert.strictEqual(smallTable.severity, 'ok');
+});
+
+test('full-table cost drives severity without repeating equal target and table counts', () => {
+    const tableSized = fact({
+        runsInTransaction: false,
+        resumable: true,
+        batchSize: 10000,
+        backfill: {
+            ...(fact().backfill as BackfillFact),
+            perPassCost: 'table',
+        },
+    });
+    const finding = analyzeRowEstimate(
+        tableSized,
+        explainFixture(2_000_000),
+        2_000_000,
+        100000,
+        null,
+    );
+
+    assert.strictEqual(finding.severity, 'warn');
+    assert.match(finding.summary, /backfill touches ~2,000,000 rows here/);
+    assert.doesNotMatch(finding.summary, /every pass scans or sorts/);
+    assert.doesNotMatch(finding.summary, /cost does not fall/);
+    assert.match(finding.action ?? '', /repeated full-table passes over ~2,000,000 rows/);
 });
 
 test('strategy advice fires whenever the range contains DDL, as info not warn', () => {
@@ -413,9 +573,53 @@ test('no DDL in range means no strategy finding, and info does not degrade the v
             { check: 'activity', severity: 'ok', migration: null, table: null, summary: 'fine', action: null, actionKind: null, data: {} },
         ],
         completeCoverage(0),
+        completeRangeCoverage,
     );
     assert.strictEqual(report.verdict, 'ok');
     assert.deepStrictEqual(report.planItems, ['plan it']);
+});
+
+test('missing DDL lock timeouts warn on large tables, inform on small tables, and deduplicate', () => {
+    const ddlFact = fact({
+        tables: [
+            { name: 'users', access: ['ddl'], expectedLockModes: [] },
+            { name: 'users', access: ['ddl', 'write'], expectedLockModes: [] },
+        ],
+    });
+    const large = analyzeLockTimeouts(
+        [ddlFact],
+        new Map([['users', 5_000_000]]),
+        100000,
+    );
+    assert.strictEqual(large.length, 1);
+    assert.strictEqual(large[0].severity, 'warn');
+    assert.strictEqual(large[0].actionKind, 'plan');
+    assert.match(large[0].summary, /waits without limit/);
+    assert.match(large[0].summary, /behind any live reader/);
+    assert.match(large[0].action ?? '', /every later query queues behind the waiting ALTER/);
+
+    const small = analyzeLockTimeouts(
+        [ddlFact],
+        new Map([['users', 50_000]]),
+        100000,
+    );
+    assert.strictEqual(small[0].severity, 'info');
+});
+
+test('a configured lock timeout suppresses the lock-timeout finding', () => {
+    assert.deepStrictEqual(
+        analyzeLockTimeouts(
+            [
+                fact({
+                    lockTimeout: '5s',
+                    tables: [{ name: 'users', access: ['ddl'], expectedLockModes: [] }],
+                }),
+            ],
+            new Map([['users', 5_000_000]]),
+            100000,
+        ),
+        [],
+    );
 });
 
 test('formatSeconds picks sensible units', () => {
@@ -549,6 +753,7 @@ test('report sorts blockers first, splits actions by kind, and aggregates the ve
         [fact()],
         findings,
         completeCoverage(1),
+        completeRangeCoverage,
     );
     assert.strictEqual(report.verdict, 'blocker');
     assert.deepStrictEqual(report.remediateNow, ['clear the lock', 'pause the writer']);
@@ -565,6 +770,7 @@ test('complete coverage and all-ok findings render an honest clear-to-upgrade me
             { check: 'activity', severity: 'ok', migration: null, table: null, summary: 'fine', action: null, actionKind: null, data: {} },
         ],
         completeCoverage(0),
+        completeRangeCoverage,
     );
     assert.strictEqual(report.verdict, 'ok');
     assert.deepStrictEqual(report.remediateNow, []);
@@ -586,6 +792,7 @@ test('missing facts add a coverage warning, cap the verdict, and never render cl
             migrationsWithoutFacts: ['20260102000000_missing'],
             unknownCoverageFiles: 0,
         },
+        completeRangeCoverage,
     );
     const coverage = report.findings.find((finding) => finding.check === 'coverage');
     assert.strictEqual(report.verdict, 'warn');
@@ -594,12 +801,36 @@ test('missing facts add a coverage warning, cap the verdict, and never render cl
     assert.doesNotMatch(renderHuman(report), /clear to upgrade/i);
 });
 
+test('range gaps make coverage unknown without presenting a precise denominator', () => {
+    const report = buildReport(
+        '1.50.0',
+        '1.60.0',
+        [fact()],
+        [],
+        {
+            migrationsInRelease: 2,
+            migrationsWithoutFacts: ['20260102000000_missing'],
+            unknownCoverageFiles: 0,
+        },
+        {
+            gaps: [{ from: '1.51.0', to: '1.59.0' }],
+            unknownReleaseFiles: 0,
+        },
+    );
+    const coverage = report.findings.find((finding) => finding.check === 'coverage');
+    assert.match(coverage?.summary ?? '', /coverage is unknown/);
+    assert.match(coverage?.summary ?? '', /1\.51\.0\.\.1\.59\.0/);
+    assert.doesNotMatch(coverage?.summary ?? '', /1 of 2/);
+    assert.strictEqual(coverage?.severity, 'warn');
+    assert.strictEqual(coverage?.actionKind, 'plan');
+});
+
 test('unknown facts-file coverage warns even when no known migrations are missing', () => {
     const report = buildReport('1.50.0', '1.60.0', [], [], {
         migrationsInRelease: 4,
         migrationsWithoutFacts: [],
         unknownCoverageFiles: 2,
-    });
+    }, completeRangeCoverage);
     assert.strictEqual(report.verdict, 'warn');
     assert.match(
         report.findings.find((finding) => finding.check === 'coverage')?.summary ?? '',
@@ -619,7 +850,13 @@ test('operator-fixable findings are remediate; migration-intrinsic ones are plan
     const longTxn = analyzeActivity([activity({ xact_age_s: 1800 })], 300);
     assert.strictEqual(longTxn[0].actionKind, 'remediate');
 
-    const bigTxn = analyzeRowEstimate(fact(), explainFixture(2_000_000), 100000, null);
+    const bigTxn = analyzeRowEstimate(
+        fact(),
+        explainFixture(2_000_000),
+        2_000_000,
+        100000,
+        null,
+    );
     assert.strictEqual(bigTxn.actionKind, 'plan');
     assert.match(bigTxn.action ?? '', /maintenance window/);
     const seq = analyzeSeqScans(fact(), explainFixture(500, 'users'), new Map([['users', 2_000_000]]), 100000, null);

--- a/scripts/preflight.ts
+++ b/scripts/preflight.ts
@@ -47,6 +47,7 @@ export interface BackfillFact {
     planSql: string | null;
     /** vetted pre-upgrade index DDL (CREATE INDEX CONCURRENTLY ...) that supports the backfill predicate; null when no index helps */
     supportingIndexSql: string | null;
+    /** absent means 'remaining'; optional so assets predating the field still validate */
     perPassCost?: 'remaining' | 'table';
 }
 
@@ -86,6 +87,7 @@ export interface FactsRangeCoverage {
 
 export interface MergedFactsFile extends FactsCoverage {
     schemaVersion: string;
+    enterpriseMigrationsWithoutFacts: string[];
     migrationFacts: MigrationFact[];
 }
 
@@ -141,6 +143,7 @@ export function mergeFactsFiles(files: FactsFile[]): MergedFactsFile {
     let migrationsInRelease = 0;
     const migrationsWithoutFacts: string[] = [];
     let unknownCoverageFiles = 0;
+    const enterpriseMigrationsWithoutFacts: string[] = [];
     for (const file of files) {
         if (file.schemaVersion !== schemaVersion) {
             throw new Error(
@@ -156,6 +159,9 @@ export function mergeFactsFiles(files: FactsFile[]): MergedFactsFile {
             migrationsInRelease += file.migrationsInRelease;
             migrationsWithoutFacts.push(...file.migrationsWithoutFacts);
         }
+        enterpriseMigrationsWithoutFacts.push(
+            ...(file.enterpriseMigrationsWithoutFacts ?? []),
+        );
         for (const fact of file.migrationFacts) {
             if (seen.has(fact.migration)) {
                 throw new Error(
@@ -171,6 +177,7 @@ export function mergeFactsFiles(files: FactsFile[]): MergedFactsFile {
         migrationsInRelease,
         migrationsWithoutFacts: migrationsWithoutFacts.sort(),
         unknownCoverageFiles,
+        enterpriseMigrationsWithoutFacts: enterpriseMigrationsWithoutFacts.sort(),
         migrationFacts,
     };
 }
@@ -189,16 +196,23 @@ export function findRangeGaps(
             }
             return [{ release: file.release, previousRelease: file.previousRelease }];
         })
-        .sort((a, b) => compareVersions(a.release, b.release));
+        // Sorted by where each asset STARTS: this is an interval merge, and
+        // sorting by the end lets a nested asset open a gap its enclosing one
+        // already covers.
+        .sort((a, b) => compareVersions(a.previousRelease, b.previousRelease));
     const gaps: { from: string; to: string }[] = [];
     let cursor = from;
     for (const file of knownFiles) {
-        if (compareVersions(file.previousRelease, cursor) > 0) {
-            gaps.push({ from: cursor, to: file.previousRelease });
+        // Only the requested range matters: assets past `to` cannot leave a gap
+        // in it, and assets below the cursor are already covered.
+        if (compareVersions(cursor, to) >= 0) break;
+        if (compareVersions(file.release, cursor) <= 0) continue;
+        const gapEnd =
+            compareVersions(file.previousRelease, to) > 0 ? to : file.previousRelease;
+        if (compareVersions(gapEnd, cursor) > 0) {
+            gaps.push({ from: cursor, to: gapEnd });
         }
-        if (compareVersions(file.release, cursor) > 0) {
-            cursor = file.release;
-        }
+        cursor = file.release;
     }
     if (compareVersions(cursor, to) < 0) {
         gaps.push({ from: cursor, to });
@@ -454,7 +468,11 @@ export function analyzeRowEstimate(
         };
     }
     const perPassCost = fact.backfill?.perPassCost ?? 'remaining';
-    const costRows = perPassCost === 'table' ? tableLiveTuples : rows;
+    // A full-table pass costs at least the target rows, so never let an absent
+    // or un-analyzed live-tuple count (0) rate a big backfill lower than the
+    // target count alone would.
+    const costRows =
+        perPassCost === 'table' ? Math.max(rows, tableLiveTuples) : rows;
     const big = costRows >= largeRowThreshold;
     const passes = fact.batchSize ? Math.max(1, Math.ceil(rows / fact.batchSize)) : 1;
     let measured = '';
@@ -754,6 +772,22 @@ function coverageFinding(
     };
 }
 
+export function enterpriseCoverageFinding(
+    enterpriseMigrationsWithoutFacts: string[],
+): Finding | null {
+    if (enterpriseMigrationsWithoutFacts.length === 0) return null;
+    return {
+        check: 'coverage',
+        severity: 'info',
+        migration: null,
+        table: null,
+        summary: `${enterpriseMigrationsWithoutFacts.length} Enterprise migration(s) in this range have no facts; they only run on a licensed instance, so they are not counted in the coverage verdict above`,
+        action: null,
+        actionKind: null,
+        data: { enterpriseMigrationsWithoutFacts },
+    };
+}
+
 export function buildReport(
     from: string,
     to: string,
@@ -761,10 +795,14 @@ export function buildReport(
     findings: Finding[],
     coverage: FactsCoverage,
     rangeCoverage: FactsRangeCoverage,
+    enterpriseMigrationsWithoutFacts: string[] = [],
 ): PreflightReport {
     const combinedCoverage = { ...coverage, ...rangeCoverage };
-    const coverageWarning = coverageFinding(combinedCoverage);
-    const sorted = [...findings, ...(coverageWarning ? [coverageWarning] : [])].sort(
+    const extra = [
+        coverageFinding(combinedCoverage),
+        enterpriseCoverageFinding(enterpriseMigrationsWithoutFacts),
+    ].flatMap((finding) => (finding ? [finding] : []));
+    const sorted = [...findings, ...extra].sort(
         (a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity],
     );
     const actions = (kind: 'remediate' | 'plan') =>
@@ -1127,6 +1165,7 @@ async function main(): Promise<void> {
             apiFindings,
             factsFile,
             rangeCoverage,
+            factsFile.enterpriseMigrationsWithoutFacts,
         );
         console.log(args.json ? JSON.stringify(apiReport, null, 2) : renderHuman(apiReport));
         process.exit(apiReport.verdict === 'blocker' ? 2 : apiReport.verdict === 'warn' ? 1 : 0);
@@ -1243,6 +1282,7 @@ async function main(): Promise<void> {
         findings,
         factsFile,
         rangeCoverage,
+        factsFile.enterpriseMigrationsWithoutFacts,
     );
     if (args.json) {
         console.log(JSON.stringify(report, null, 2));

--- a/scripts/preflight.ts
+++ b/scripts/preflight.ts
@@ -47,6 +47,7 @@ export interface BackfillFact {
     planSql: string | null;
     /** vetted pre-upgrade index DDL (CREATE INDEX CONCURRENTLY ...) that supports the backfill predicate; null when no index helps */
     supportingIndexSql: string | null;
+    perPassCost?: 'remaining' | 'table';
 }
 
 export interface MigrationFact {
@@ -63,8 +64,12 @@ export interface MigrationFact {
 
 export interface FactsFile {
     schemaVersion: string;
+    release: string | null;
+    previousRelease: string | null;
     migrationsInRelease: number | null;
     migrationsWithoutFacts: string[] | null;
+    enterpriseMigrationsInRelease?: number | null;
+    enterpriseMigrationsWithoutFacts?: string[] | null;
     migrationFacts: MigrationFact[];
 }
 
@@ -72,6 +77,11 @@ export interface FactsCoverage {
     migrationsInRelease: number;
     migrationsWithoutFacts: string[];
     unknownCoverageFiles: number;
+}
+
+export interface FactsRangeCoverage {
+    gaps: { from: string; to: string }[];
+    unknownReleaseFiles: number;
 }
 
 export interface MergedFactsFile extends FactsCoverage {
@@ -165,6 +175,37 @@ export function mergeFactsFiles(files: FactsFile[]): MergedFactsFile {
     };
 }
 
+export function findRangeGaps(
+    files: { release: string | null; previousRelease: string | null }[],
+    from: string,
+    to: string,
+): FactsRangeCoverage {
+    let unknownReleaseFiles = 0;
+    const knownFiles = files
+        .flatMap((file) => {
+            if (file.release === null || file.previousRelease === null) {
+                unknownReleaseFiles += 1;
+                return [];
+            }
+            return [{ release: file.release, previousRelease: file.previousRelease }];
+        })
+        .sort((a, b) => compareVersions(a.release, b.release));
+    const gaps: { from: string; to: string }[] = [];
+    let cursor = from;
+    for (const file of knownFiles) {
+        if (compareVersions(file.previousRelease, cursor) > 0) {
+            gaps.push({ from: cursor, to: file.previousRelease });
+        }
+        if (compareVersions(file.release, cursor) > 0) {
+            cursor = file.release;
+        }
+    }
+    if (compareVersions(cursor, to) < 0) {
+        gaps.push({ from: cursor, to });
+    }
+    return { gaps, unknownReleaseFiles };
+}
+
 /** migrations the upgrade will run: introduced after `from`, at or before `to` */
 export function selectFacts(
     facts: MigrationFact[],
@@ -190,7 +231,7 @@ export type Severity = 'ok' | 'info' | 'warn' | 'blocker';
 export type ActionKind = 'remediate' | 'plan' | null;
 
 export interface Finding {
-    check: 'stale-lock' | 'write-rate' | 'row-estimate' | 'plan' | 'activity' | 'strategy' | 'coverage';
+    check: 'stale-lock' | 'write-rate' | 'row-estimate' | 'plan' | 'activity' | 'strategy' | 'coverage' | 'lock-timeout';
     severity: Severity;
     migration: string | null;
     table: string | null;
@@ -395,6 +436,7 @@ const num = (n: number): string => n.toLocaleString('en-US');
 export function analyzeRowEstimate(
     fact: MigrationFact,
     explainJson: unknown,
+    tableLiveTuples: number,
     largeRowThreshold: number,
     scanSeconds: number | null,
 ): Finding {
@@ -411,12 +453,16 @@ export function analyzeRowEstimate(
             data: { explainJson },
         };
     }
-    const big = rows >= largeRowThreshold;
+    const perPassCost = fact.backfill?.perPassCost ?? 'remaining';
+    const costRows = perPassCost === 'table' ? tableLiveTuples : rows;
+    const big = costRows >= largeRowThreshold;
     const passes = fact.batchSize ? Math.max(1, Math.ceil(rows / fact.batchSize)) : 1;
-    const measured =
-        scanSeconds !== null
-            ? `; one scan of the target rows measured ${formatSeconds(scanSeconds)} on this instance`
-            : '';
+    let measured = '';
+    if (scanSeconds !== null) {
+        const measuredWork =
+            perPassCost === 'table' ? 'full-table pass' : 'scan of the target rows';
+        measured = `; one ${measuredWork} measured ${formatSeconds(scanSeconds)} on this instance`;
+    }
     const transactional = fact.runsInTransaction
         ? 'in a single transaction'
         : fact.batchSize
@@ -424,20 +470,35 @@ export function analyzeRowEstimate(
           : 'outside a transaction';
     const windowSize =
         scanSeconds === null
-            ? `sized for ~${num(rows)} rows — row locks are held until commit`
+            ? `sized for ~${num(costRows)} rows — row locks are held until commit`
             : scanSeconds >= 60
               ? `of at least ${formatSeconds(scanSeconds)} — reading the target rows alone measured that here, and the UPDATE holds row locks for longer`
               : `— the target-row scan measured ${formatSeconds(scanSeconds)} here, but the single-transaction UPDATE on ~${num(rows)} rows holds row locks until commit`;
     const windowAction = `schedule a maintenance window ${windowSize}`;
+    const perPassAction = `size the window for repeated full-table passes over ~${num(tableLiveTuples)} rows — each pass costs the same regardless of how much work is left`;
+    const showPerPassCost =
+        perPassCost === 'table' && rows < tableLiveTuples * 0.9;
+    const summary =
+        showPerPassCost
+            ? `backfill repairs ~${num(rows)} rows here, ${transactional}, but every pass scans or sorts all ${num(tableLiveTuples)} rows of "${fact.tables.find((table) => table.access.includes('write'))?.name ?? 'unknown'}" — cost does not fall as the work drains${measured}`
+            : `backfill touches ~${num(rows)} rows here, ${transactional}${measured}`;
+    const warnsForTablePasses = big && perPassCost === 'table';
+    const warnsForTransaction = big && fact.runsInTransaction;
+    let action: string | null = null;
+    if (warnsForTablePasses) {
+        action = perPassAction;
+    } else if (warnsForTransaction) {
+        action = windowAction;
+    }
     return {
         check: 'row-estimate',
-        severity: big && fact.runsInTransaction ? 'warn' : 'ok',
+        severity: warnsForTransaction || warnsForTablePasses ? 'warn' : 'ok',
         migration: fact.migration,
         table: fact.tables.find((t) => t.access.includes('write'))?.name ?? null,
-        summary: `backfill touches ~${num(rows)} rows here, ${transactional}${measured}`,
-        action: big && fact.runsInTransaction ? windowAction : null,
-        actionKind: big && fact.runsInTransaction ? 'plan' : null,
-        data: { estimatedRows: rows, passes, scanSeconds },
+        summary,
+        action,
+        actionKind: action === null ? null : 'plan',
+        data: { estimatedRows: rows, passes, scanSeconds, perPassCost, tableLiveTuples },
     };
 }
 
@@ -541,6 +602,38 @@ export function analyzeUpgradeStrategy(facts: MigrationFact[]): Finding[] {
     ];
 }
 
+export function analyzeLockTimeouts(
+    facts: MigrationFact[],
+    liveTuplesByTable: Map<string, number>,
+    largeRowThreshold: number,
+): Finding[] {
+    const findings: Finding[] = [];
+    const seen = new Set<string>();
+    for (const fact of facts) {
+        if (fact.lockTimeout === null) {
+            for (const table of fact.tables) {
+                const key = `${fact.migration}\u0000${table.name}`;
+                if (table.access.includes('ddl') && !seen.has(key)) {
+                    seen.add(key);
+                    const liveTuples = liveTuplesByTable.get(table.name) ?? 0;
+                    findings.push({
+                        check: 'lock-timeout',
+                        severity:
+                            liveTuples >= largeRowThreshold ? 'warn' : 'info',
+                        migration: fact.migration,
+                        table: table.name,
+                        summary: `migration "${fact.migration}" runs ALTER TABLE on "${table.name}"; the ALTER TABLE waits without limit for its exclusive lock behind any live reader`,
+                        action: `stop or drain queries against "${table.name}" before the upgrade, because every later query queues behind the waiting ALTER`,
+                        actionKind: 'plan',
+                        data: { liveTuples },
+                    });
+                }
+            }
+        }
+    }
+    return findings;
+}
+
 // --- activity / locks --------------------------------------------------------
 
 export interface ActivityRow {
@@ -608,26 +701,47 @@ export interface PreflightReport {
     findings: Finding[];
     remediateNow: string[];
     planItems: string[];
-    coverage: FactsCoverage;
+    coverage: FactsCoverage & FactsRangeCoverage;
     verdict: Severity;
 }
 
-function coverageFinding(coverage: FactsCoverage): Finding | null {
+function coverageFinding(
+    coverage: FactsCoverage & FactsRangeCoverage,
+): Finding | null {
     const missing = coverage.migrationsWithoutFacts.length;
     const unknown = coverage.unknownCoverageFiles;
-    if (missing === 0 && unknown === 0) return null;
-    const summary =
-        missing > 0 && unknown > 0
-            ? `${missing} of ${coverage.migrationsInRelease} migrations in files with known coverage have no facts; coverage is also unknown for ${unknown} facts file(s)`
-            : missing > 0
-              ? `${missing} of ${coverage.migrationsInRelease} migrations in this range have no facts; this run does not cover them`
-              : `coverage unknown for ${unknown} facts file(s); this run may not cover every migration in the range`;
-    const action =
-        unknown > 0 && missing > 0
-            ? `do not treat this preflight as complete: it cannot assess ${coverage.migrationsWithoutFacts.join(', ')} or tell whether the ${unknown} unknown-coverage file(s) omit more migrations; replace those files and author the known missing facts before upgrading`
-            : unknown > 0
-              ? `do not treat this preflight as complete: it cannot tell whether the ${unknown} unknown-coverage file(s) omit migrations; replace them with generated assets that include coverage before upgrading`
-              : `do not treat this preflight as complete: it cannot assess ${coverage.migrationsWithoutFacts.join(', ')}; author those facts and regenerate the release asset, or assess those migrations manually before upgrading`;
+    const missingRanges = coverage.gaps.map((gap) => `${gap.from}..${gap.to}`);
+    const rangeUnknown = missingRanges.length > 0 || coverage.unknownReleaseFiles > 0;
+    if (missing === 0 && unknown === 0 && !rangeUnknown) return null;
+    let summary: string;
+    let action: string;
+    if (rangeUnknown) {
+        const reasons = [
+            ...(missingRanges.length > 0
+                ? [`missing asset ranges: ${missingRanges.join(', ')}`]
+                : []),
+            ...(coverage.unknownReleaseFiles > 0
+                ? [
+                      `${coverage.unknownReleaseFiles} facts file(s) do not identify their release range`,
+                  ]
+                : []),
+        ];
+        summary = `coverage is unknown — ${reasons.join('; ')}${missing > 0 ? `; facts are also missing for ${coverage.migrationsWithoutFacts.join(', ')}` : ''}`;
+        action = `do not treat this preflight as complete: fetch generated facts assets spanning ${missingRanges.length > 0 ? missingRanges.join(', ') : 'the requested range'}${coverage.unknownReleaseFiles > 0 ? ' and replace files with unknown release bounds' : ''}${missing > 0 ? `; author facts for ${coverage.migrationsWithoutFacts.join(', ')}` : ''} before upgrading`;
+    } else {
+        summary =
+            missing > 0 && unknown > 0
+                ? `${missing} of ${coverage.migrationsInRelease} migrations in files with known coverage have no facts; coverage is also unknown for ${unknown} facts file(s)`
+                : missing > 0
+                  ? `${missing} of ${coverage.migrationsInRelease} migrations in this range have no facts; this run does not cover them`
+                  : `coverage unknown for ${unknown} facts file(s); this run may not cover every migration in the range`;
+        action =
+            unknown > 0 && missing > 0
+                ? `do not treat this preflight as complete: it cannot assess ${coverage.migrationsWithoutFacts.join(', ')} or tell whether the ${unknown} unknown-coverage file(s) omit more migrations; replace those files and author the known missing facts before upgrading`
+                : unknown > 0
+                  ? `do not treat this preflight as complete: it cannot tell whether the ${unknown} unknown-coverage file(s) omit migrations; replace them with generated assets that include coverage before upgrading`
+                  : `do not treat this preflight as complete: it cannot assess ${coverage.migrationsWithoutFacts.join(', ')}; author those facts and regenerate the release asset, or assess those migrations manually before upgrading`;
+    }
     return {
         check: 'coverage',
         severity: 'warn',
@@ -646,8 +760,10 @@ export function buildReport(
     facts: MigrationFact[],
     findings: Finding[],
     coverage: FactsCoverage,
+    rangeCoverage: FactsRangeCoverage,
 ): PreflightReport {
-    const coverageWarning = coverageFinding(coverage);
+    const combinedCoverage = { ...coverage, ...rangeCoverage };
+    const coverageWarning = coverageFinding(combinedCoverage);
     const sorted = [...findings, ...(coverageWarning ? [coverageWarning] : [])].sort(
         (a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity],
     );
@@ -667,7 +783,7 @@ export function buildReport(
         findings: sorted,
         remediateNow: actions('remediate'),
         planItems: actions('plan'),
-        coverage,
+        coverage: combinedCoverage,
         verdict,
     };
 }
@@ -696,7 +812,9 @@ export function renderHuman(report: PreflightReport): string {
         report.remediateNow.length === 0 &&
         report.planItems.length === 0 &&
         report.coverage.migrationsWithoutFacts.length === 0 &&
-        report.coverage.unknownCoverageFiles === 0
+        report.coverage.unknownCoverageFiles === 0 &&
+        report.coverage.gaps.length === 0 &&
+        report.coverage.unknownReleaseFiles === 0
     ) {
         lines.push(
             'All checks passed and every migration in range has facts — clear to upgrade.',
@@ -963,6 +1081,13 @@ async function runApiMode(args: CliArgs, facts: MigrationFact[]): Promise<Findin
         args.intervalSeconds,
     );
     findings.push(...analyzeWriteRates(facts, rates, args.writeRateThreshold));
+    findings.push(
+        ...analyzeLockTimeouts(
+            facts,
+            new Map(rates.map((rate) => [rate.table, rate.liveTuples])),
+            args.largeRowThreshold,
+        ),
+    );
 
     findings.push(...analyzeActivity(activityRowsFromProbe(after), args.longTxnThresholdSeconds));
 
@@ -986,16 +1111,23 @@ async function runApiMode(args: CliArgs, facts: MigrationFact[]): Promise<Findin
 
 async function main(): Promise<void> {
     const args = parseArgs(process.argv.slice(2));
-    const factsFile = mergeFactsFiles(
-        args.factsPaths.map((factsPath) =>
-            parseFactsFile(fs.readFileSync(factsPath, 'utf-8')),
-        ),
+    const factsFiles = args.factsPaths.map((factsPath) =>
+        parseFactsFile(fs.readFileSync(factsPath, 'utf-8')),
     );
+    const factsFile = mergeFactsFiles(factsFiles);
+    const rangeCoverage = findRangeGaps(factsFiles, args.from, args.to);
     const facts = selectFacts(factsFile.migrationFacts, args.from, args.to);
 
     if (args.api !== null) {
         const apiFindings = await runApiMode(args, facts);
-        const apiReport = buildReport(args.from, args.to, facts, apiFindings, factsFile);
+        const apiReport = buildReport(
+            args.from,
+            args.to,
+            facts,
+            apiFindings,
+            factsFile,
+            rangeCoverage,
+        );
         console.log(args.json ? JSON.stringify(apiReport, null, 2) : renderHuman(apiReport));
         process.exit(apiReport.verdict === 'blocker' ? 2 : apiReport.verdict === 'warn' ? 1 : 0);
     }
@@ -1040,6 +1172,9 @@ async function main(): Promise<void> {
         liveTuplesByTable = new Map(rates.map((r) => [r.table, r.liveTuples]));
         findings.push(...analyzeWriteRates(facts, rates, args.writeRateThreshold));
     }
+    findings.push(
+        ...analyzeLockTimeouts(facts, liveTuplesByTable, args.largeRowThreshold),
+    );
 
     for (const fact of facts) {
         if (!fact.backfill) continue;
@@ -1053,8 +1188,17 @@ async function main(): Promise<void> {
                     scanSeconds = null;
                 }
             }
+            const writtenTable = fact.tables.find((table) =>
+                table.access.includes('write'),
+            )?.name;
             findings.push(
-                analyzeRowEstimate(fact, estimate, args.largeRowThreshold, scanSeconds),
+                analyzeRowEstimate(
+                    fact,
+                    estimate,
+                    writtenTable ? (liveTuplesByTable.get(writtenTable) ?? 0) : 0,
+                    args.largeRowThreshold,
+                    scanSeconds,
+                ),
             );
             const planJson = fact.backfill.planSql
                 ? db.explain(fact.backfill.planSql)
@@ -1092,7 +1236,14 @@ async function main(): Promise<void> {
     ) as ActivityRow[];
     findings.push(...analyzeActivity(activity, args.longTxnThresholdSeconds));
 
-    const report = buildReport(args.from, args.to, facts, findings, factsFile);
+    const report = buildReport(
+        args.from,
+        args.to,
+        facts,
+        findings,
+        factsFile,
+        rangeCoverage,
+    );
     if (args.json) {
         console.log(JSON.stringify(report, null, 2));
     } else {


### PR DESCRIPTION
Five fixes to the upgrade-preflight tooling, all found by running it against **four real historical upgrade ranges** on a purpose-built 2 GB / 11.5M-row database and then running those upgrades for real.

Linear: SPK-885, SPK-884, SPK-886, SPK-887, SPK-888 · Relates: SPK-701

Stacked on `feature/spk-872` because it changes the facts asset that branch introduces.

## The theme

Four of the five are the same problem wearing different clothes: **the tool did not know what it had not seen, and said so with confidence.**

## SPK-885 — the preflight never checked the assets span the range

It takes `--from`/`--to` and a set of facts files, sums `migrationsInRelease` across whatever it is handed, and presents that as the size of the upgrade. Nothing checked those files cover the requested range.

Measured with the tool's own merge function, an operator upgrading `0.3137.0 → 1.51.0` who fetched 2 of ~120 release assets:

```
facts=2  migrationsInRelease=4  migrationsWithoutFacts=2  unknownCoverageFiles=0
```

The real range holds **122** migrations, and `unknownCoverageFiles: 0` means the tool believed its picture was complete. With no fetcher and ~12 releases a day, having only some assets is the only way this ever runs.

Assets now declare the range they describe (`release` / `previousRelease`). A pure `findRangeGaps` walks them against `--from`/`--to`; any gap makes coverage report as **unknown** and name the missing ranges:

```
⚠ [coverage] coverage is unknown — missing asset ranges: 0.3138.0..1.50.0
    → fetch generated facts assets spanning 0.3138.0..1.50.0 before upgrading
```

## SPK-884 — the count included migrations the operator never runs

**Enterprise.** `knexfile.ts` gates the EE migration directory on a licence key, so an unlicensed instance never runs those. The count included them anyway — on `0.3137.0..HEAD` that is 90 of 133. On `1.51.0 → 1.79.0` an unlicensed operator runs **no** migrations at all and was told 6 were unassessed. Core is now the denominator; Enterprise is carried separately.

**A test file.** The filename check ran on the basename, so `__tests__/…_unique_onboarding_organization.test.ts` matched. Confirmed empirically: an asset counted 15 core migrations for a range where exactly 14 ran. Only files directly in a migration directory are counted now.

## SPK-886 — no asset could be generated for a past release

The generator diffed `<lastTag>..HEAD` with no way to name the end of the range, and validated the corpus against the **working tree** — so checking out an older ref to work around the first problem aborted by design. Assets could only be minted for the release being cut, leaving the entire back catalogue unreachable: exactly the range a delayed self-hosted upgrade spans.

It now takes `--to`, and validates the corpus against `HEAD` independently of the range being described. The typo guard still covers the **whole** corpus, not just the selected slice.

## SPK-887 — cost that does not fall as the work drains

Some batched migrations re-scan or re-sort the whole table on every pass, so cost is unrelated to the rows left. The estimate drove severity off target rows and marked a full-table repeat loop `ok`.

Facts can now declare `perPassCost: "remaining" | "table"`; severity follows the table for those migrations. The explanatory clause is shown only when targets are meaningfully under the table size — when every row is a target the two numbers are equal and the clause read as a formatting bug.

## SPK-888 — a DDL migration with no lock timeout was never reported

`lockTimeout` was in the facts and read by nothing. An `ALTER TABLE` without one waits **without limit** behind any live reader, and every later query queues behind it. Now reported, weighted by table size.

Worth noting: this is the only check in the stack that needs no hand-authored SQL, no row estimate, and no database access — it is derivable from migration source alone.

## Testing

- `npm run test:release-safety` (the repo's gate for these files) — all 8 suites green; preflight **58** tests (was 48), generator **9** (was 6).
- Re-verified end-to-end against the campaign database: **16/16** assertions, one per ticketed behaviour plus regressions confirming the row estimate is still accurate to 0.002% on the 2M-row table and the honest-negative index case still fires.
- Type-aware lint could not run in this worktree (`tsgolint` not installed); CI covers it.

Draft: merge freeze in effect.