### PR TITLE
feat(release): publish the migration facts cumulatively

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -104,7 +104,7 @@ module.exports = {
             '@semantic-release/exec',
             {
                 prepareCmd:
-                    'npx tsx scripts/gen-migration-facts.ts --last-tag "${lastRelease.gitTag}" --release "${nextRelease.gitTag}" --out migration-facts.json',
+                    'npx tsx scripts/gen-migration-facts.ts --last-tag "${lastRelease.gitTag}" --release "${nextRelease.gitTag}" --cumulative-through "${nextRelease.gitTag}" --out migration-facts.json',
             },
         ],
 

--- a/scripts/gen-migration-facts.test.ts
+++ b/scripts/gen-migration-facts.test.ts
@@ -11,7 +11,9 @@ import {
     assertFactsPointAtRealMigrations,
     buildFactsAsset,
     gitNameStatus,
+    gitTreePaths,
     migrationNamesFromChanges,
+    migrationNamesFromPaths,
     selectFactsForMigrations,
 } from './gen-migration-facts';
 import { FactsFile, MigrationFact, parseFactsFile } from './preflight';
@@ -44,6 +46,7 @@ const source = (migrationFacts: MigrationFact[]): FactsFile => ({
     schemaVersion: '1-draft',
     release: null,
     previousRelease: null,
+    cumulativeThrough: null,
     migrationsInRelease: null,
     migrationsWithoutFacts: null,
     migrationFacts,
@@ -104,6 +107,7 @@ test('generated assets carry concrete release coverage', () => {
         false,
         '1.51.0',
         '1.50.0',
+        null,
     );
     assert.strictEqual(output.migrationsInRelease, 2);
     assert.deepStrictEqual(output.migrationsWithoutFacts, ['20260102000000_two']);
@@ -111,6 +115,7 @@ test('generated assets carry concrete release coverage', () => {
     assert.deepStrictEqual(output.enterpriseMigrationsWithoutFacts, []);
     assert.strictEqual(output.release, '1.51.0');
     assert.strictEqual(output.previousRelease, '1.50.0');
+    assert.strictEqual(output.cumulativeThrough, null);
     assert.deepStrictEqual(
         output.migrationFacts.map((migration) => migration.migration),
         ['20260101000000_one', '20260103000000_enterprise'],
@@ -129,6 +134,7 @@ test('--all selects every authored fact while coverage still describes the relea
         true,
         '1.51.0',
         '1.50.0',
+        null,
     );
     assert.deepStrictEqual(
         output.migrationFacts.map((migration) => migration.migration),
@@ -190,6 +196,69 @@ test('--to limits the generated migration range to the supplied ref', () => {
     });
 });
 
+test('cumulative mode counts every migration at the target ref and excludes test files', () => {
+    withTempGitRepo((repo) => {
+        const migrationDir = path.join(
+            repo,
+            'packages/backend/src/database/migrations',
+        );
+        fs.mkdirSync(path.join(migrationDir, '__tests__'), { recursive: true });
+        fs.writeFileSync(path.join(migrationDir, '20260101000000_before_range.ts'), 'export {};\n');
+        execFileSync('git', ['add', '.']);
+        execFileSync('git', ['commit', '--quiet', '-m', 'before range']);
+        const lastTag = execFileSync('git', ['rev-parse', 'HEAD'], {
+            encoding: 'utf-8',
+        }).trim();
+        fs.writeFileSync(path.join(migrationDir, '20260102000000_in_range.ts'), 'export {};\n');
+        fs.writeFileSync(
+            path.join(migrationDir, '__tests__/20260103000000_not_a_migration.test.ts'),
+            'export {};\n',
+        );
+        execFileSync('git', ['add', '.']);
+        execFileSync('git', ['commit', '--quiet', '-m', 'target']);
+        const target = execFileSync('git', ['rev-parse', 'HEAD'], {
+            encoding: 'utf-8',
+        }).trim();
+
+        const rangeNames = migrationNamesFromChanges(
+            gitNameStatus(`${lastTag}..${target}`, [
+                'packages/backend/src/database/migrations',
+            ]),
+        );
+        const cumulativeNames = migrationNamesFromPaths(
+            gitTreePaths(target, ['packages/backend/src/database/migrations']),
+        );
+
+        assert.deepStrictEqual([...rangeNames], ['20260102000000_in_range']);
+        assert.deepStrictEqual([...cumulativeNames].sort(), [
+            '20260101000000_before_range',
+            '20260102000000_in_range',
+        ]);
+    });
+});
+
+test('cumulative assets carry cumulative release bounds and every authored fact', () => {
+    const output = buildFactsAsset(
+        source([
+            fact('20260199000000_other_release'),
+            fact('20260101000000_one'),
+        ]),
+        new Set(['20260102000000_two', '20260101000000_one']),
+        new Set(),
+        false,
+        '1.79.0',
+        null,
+        '1.79.0',
+    );
+    assert.strictEqual(output.release, '1.79.0');
+    assert.strictEqual(output.previousRelease, null);
+    assert.strictEqual(output.cumulativeThrough, '1.79.0');
+    assert.deepStrictEqual(
+        output.migrationFacts.map((migration) => migration.migration),
+        ['20260101000000_one', '20260199000000_other_release'],
+    );
+});
+
 test('migration existence is asserted against the supplied ref', () => {
     withTempGitRepo((repo) => {
         const migrationDir = path.join(
@@ -245,6 +314,7 @@ test('a bogus corpus fact throws even when it is outside the selected range', ()
             false,
             '1.51.0',
             '1.50.0',
+            null,
         );
 
         assert.deepStrictEqual(

--- a/scripts/gen-migration-facts.ts
+++ b/scripts/gen-migration-facts.ts
@@ -30,24 +30,38 @@ const MIGRATION_FILENAME_RE = /^\d{14}_.+\.(ts|js)$/;
 
 export const DEFAULT_SOURCE = path.join(__dirname, 'migration-facts.json');
 
+export function isMigrationPath(
+    filePath: string,
+    migrationDirs: readonly string[] = MIGRATION_DIRS,
+): boolean {
+    return (
+        migrationDirs.includes(path.dirname(filePath)) &&
+        MIGRATION_FILENAME_RE.test(path.basename(filePath))
+    );
+}
+
+export function migrationNamesFromPaths(
+    paths: string[],
+    migrationDirs: readonly string[] = MIGRATION_DIRS,
+): Set<string> {
+    return new Set(
+        paths
+            .filter((filePath) => isMigrationPath(filePath, migrationDirs))
+            .map((filePath) => path.basename(filePath).replace(/\.(ts|js)$/, '')),
+    );
+}
+
 /** migration names (basename, no extension) ADDED in the range */
 export function migrationNamesFromChanges(
     changes: GitChange[],
     migrationDirs: readonly string[] = MIGRATION_DIRS,
 ): Set<string> {
-    const names = new Set<string>();
-    for (const change of changes) {
-        if (
-            change.status.startsWith('A') &&
-            migrationDirs.includes(path.dirname(change.path))
-        ) {
-            const base = path.basename(change.path);
-            if (MIGRATION_FILENAME_RE.test(base)) {
-                names.add(base.replace(/\.(ts|js)$/, ''));
-            }
-        }
-    }
-    return names;
+    return migrationNamesFromPaths(
+        changes
+            .filter((change) => change.status.startsWith('A'))
+            .map((change) => change.path),
+        migrationDirs,
+    );
 }
 
 export function selectFactsForMigrations(
@@ -71,6 +85,7 @@ export function buildFactsAsset(
     includeAll: boolean,
     release: string | null,
     previousRelease: string | null,
+    cumulativeThrough: string | null,
 ): FactsFile {
     const releaseMigrations = new Set([
         ...coreReleaseMigrations,
@@ -92,11 +107,12 @@ export function buildFactsAsset(
         schemaVersion: source.schemaVersion,
         release,
         previousRelease,
+        cumulativeThrough,
         migrationsInRelease: coreReleaseMigrations.size,
         migrationsWithoutFacts: coreWithoutFacts,
         enterpriseMigrationsInRelease: enterpriseReleaseMigrations.size,
         enterpriseMigrationsWithoutFacts: enterpriseWithoutFacts,
-        migrationFacts: includeAll
+        migrationFacts: includeAll || cumulativeThrough !== null
             ? [...source.migrationFacts].sort((a, b) =>
                   a.migration.localeCompare(b.migration),
               )
@@ -118,6 +134,16 @@ export function gitNameStatus(range: string, dirs: readonly string[]): GitChange
         }
     }
     return changes;
+}
+
+export function gitTreePaths(ref: string, dirs: readonly string[]): string[] {
+    return execFileSync(
+        'git',
+        ['ls-tree', '-r', '--name-only', ref, '--', ...dirs],
+        { encoding: 'utf-8' },
+    )
+        .split('\n')
+        .filter((line) => line.length > 0);
 }
 
 export function assertFactsPointAtRealMigrations(
@@ -164,9 +190,10 @@ function main(): void {
     const out = get('--out');
     const to = get('--to') ?? 'HEAD';
     const release = get('--release');
+    const cumulativeThrough = get('--cumulative-through');
     if (!lastTag || !out) {
         throw new Error(
-            'usage: gen-migration-facts.ts --last-tag <tag> --out <file> [--to <ref>] [--release <version>] [--source <facts file>] [--all]',
+            'usage: gen-migration-facts.ts --last-tag <tag> --out <file> [--to <ref>] [--release <version>] [--cumulative-through <version>] [--source <facts file>] [--all]',
         );
     }
     if (process.env.RELEASE_SAFETY_MARKER_ENABLED !== 'true') {
@@ -179,18 +206,25 @@ function main(): void {
     const factsFile = parseFactsFile(fs.readFileSync(source, 'utf-8'));
     assertFactsPointAtRealMigrations(factsFile.migrationFacts, 'HEAD');
 
-    const changes = gitNameStatus(`${lastTag}..${to}`, MIGRATION_DIRS);
-    const coreReleaseMigrations = migrationNamesFromChanges(changes, [CORE_MIGRATION_DIR]);
-    const enterpriseReleaseMigrations = migrationNamesFromChanges(changes, [
-        ENTERPRISE_MIGRATION_DIR,
-    ]);
+    const changes = cumulativeThrough
+        ? null
+        : gitNameStatus(`${lastTag}..${to}`, MIGRATION_DIRS);
+    const paths = cumulativeThrough ? gitTreePaths(to, MIGRATION_DIRS) : null;
+    const coreReleaseMigrations = cumulativeThrough
+        ? migrationNamesFromPaths(paths ?? [], [CORE_MIGRATION_DIR])
+        : migrationNamesFromChanges(changes ?? [], [CORE_MIGRATION_DIR]);
+    const enterpriseReleaseMigrations = cumulativeThrough
+        ? migrationNamesFromPaths(paths ?? [], [ENTERPRISE_MIGRATION_DIR])
+        : migrationNamesFromChanges(changes ?? [], [ENTERPRISE_MIGRATION_DIR]);
+    const includeAll = argv.includes('--all') || cumulativeThrough !== null;
     const output = buildFactsAsset(
         factsFile,
         coreReleaseMigrations,
         enterpriseReleaseMigrations,
-        argv.includes('--all'),
-        release,
-        lastTag,
+        includeAll,
+        cumulativeThrough ?? release,
+        cumulativeThrough ? null : lastTag,
+        cumulativeThrough,
     );
     for (const name of output.migrationsWithoutFacts ?? []) {
         console.log(`[migration-facts] no facts authored for ${name} (fine unless it backfills)`);
@@ -205,7 +239,7 @@ function main(): void {
     parseFactsFile(json);
     writeAtomic(out, `${json}\n`);
     console.log(
-        `[migration-facts] wrote ${out}: ${output.migrationFacts.length} fact(s) for ${coreReleaseMigrations.size} core and ${enterpriseReleaseMigrations.size} Enterprise migration(s) in ${lastTag}..${to}${argv.includes('--all') ? ' (--all)' : ''}`,
+        `[migration-facts] wrote ${out}: ${output.migrationFacts.length} fact(s) for ${coreReleaseMigrations.size} core and ${enterpriseReleaseMigrations.size} Enterprise migration(s) ${cumulativeThrough ? `cumulative through ${cumulativeThrough}` : `in ${lastTag}..${to}`}${includeAll ? ' (--all)' : ''}`,
     );
 }
 

--- a/scripts/migration-facts.json
+++ b/scripts/migration-facts.json
@@ -2,6 +2,7 @@
     "schemaVersion": "1-draft",
     "release": null,
     "previousRelease": null,
+    "cumulativeThrough": null,
     "migrationsInRelease": null,
     "migrationsWithoutFacts": null,
     "migrationFacts": [

--- a/scripts/preflight-facts.schema.json
+++ b/scripts/preflight-facts.schema.json
@@ -5,7 +5,7 @@
     "description": "Per-migration facts consumed by scripts/preflight.ts (SPK-701 spike). Draft of the `migrationFacts` extension to the release-safety marker: each entry describes what one migration will do to the operator's database so the preflight prober can join it with read-only probes. All backfill SQL must be runnable against the PRE-upgrade schema — columns the migration itself adds do not exist yet on the operator's database.",
     "type": "object",
     "additionalProperties": false,
-    "required": ["schemaVersion", "release", "previousRelease", "migrationsInRelease", "migrationsWithoutFacts", "migrationFacts"],
+    "required": ["schemaVersion", "release", "previousRelease", "cumulativeThrough", "migrationsInRelease", "migrationsWithoutFacts", "migrationFacts"],
     "definitions": {
         "tableFact": {
             "type": "object",
@@ -87,6 +87,7 @@
         "schemaVersion": { "type": "string", "const": "1-draft" },
         "release": { "type": ["string", "null"] },
         "previousRelease": { "type": ["string", "null"] },
+        "cumulativeThrough": { "type": ["string", "null"] },
         "migrationsInRelease": {
             "type": ["integer", "null"],
             "minimum": 0,

--- a/scripts/preflight.test.ts
+++ b/scripts/preflight.test.ts
@@ -36,6 +36,7 @@ import {
     parseArgs,
     parseFactsFile,
     parseIntegerFlag,
+    PreflightReport,
     renderHuman,
     selectFacts,
     StatRow,
@@ -83,6 +84,7 @@ const explainFixture = (planRows: number, relation = 'users') => [
 ];
 
 const completeCoverage = (migrationsInRelease: number): FactsCoverage => ({
+    cumulativeThrough: null,
     migrationsInRelease,
     migrationsWithoutFacts: [],
     unknownCoverageFiles: 0,
@@ -100,6 +102,7 @@ const factsFile = (
     schemaVersion: '1-draft',
     release: null,
     previousRelease: null,
+    cumulativeThrough: null,
     ...coverage,
     migrationFacts,
 });
@@ -122,6 +125,7 @@ test('the shipped facts source file validates against the schema', () => {
     assert.strictEqual(parsed.migrationFacts.length, 3);
     assert.strictEqual(parsed.release, null);
     assert.strictEqual(parsed.previousRelease, null);
+    assert.strictEqual(parsed.cumulativeThrough, null);
     assert.strictEqual(parsed.migrationsInRelease, null);
     assert.strictEqual(parsed.migrationsWithoutFacts, null);
 });
@@ -150,6 +154,7 @@ test('parseFactsFile rejects multi-statement backfill SQL', () => {
         schemaVersion: '1-draft',
         release: null,
         previousRelease: null,
+        cumulativeThrough: null,
         migrationsInRelease: null,
         migrationsWithoutFacts: null,
         migrationFacts: [
@@ -225,6 +230,16 @@ test('mergeFactsFiles rejects mismatched schema versions', () => {
     const a = factsFile([]);
     const b = { ...factsFile([]), schemaVersion: '2-draft' };
     assert.throws(() => mergeFactsFiles([a, b]), /different schema versions/);
+});
+
+test('mergeFactsFiles carries the highest cumulative coverage version', () => {
+    const older = { ...factsFile([]), cumulativeThrough: '1.9.0' };
+    const perRelease = factsFile([]);
+    const newer = { ...factsFile([]), cumulativeThrough: '1.10.0' };
+    assert.strictEqual(
+        mergeFactsFiles([older, perRelease, newer]).cumulativeThrough,
+        '1.10.0',
+    );
 });
 
 // --- selectFacts -------------------------------------------------------------
@@ -376,6 +391,43 @@ test('findRangeGaps clamps a trailing gap to the requested range', () => {
             '2.0.0',
         ).gaps,
         [{ from: '1.0.0', to: '2.0.0' }],
+    );
+});
+
+test('findRangeGaps treats a cumulative asset through the target as complete coverage', () => {
+    assert.deepStrictEqual(
+        findRangeGaps(
+            [
+                {
+                    previousRelease: null,
+                    release: '3.0.0',
+                    cumulativeThrough: '3.0.0',
+                },
+            ],
+            '0.1.0',
+            '3.0.0',
+        ),
+        { gaps: [], unknownReleaseFiles: 0 },
+    );
+});
+
+test('findRangeGaps does not short-circuit for cumulative coverage below the target', () => {
+    assert.deepStrictEqual(
+        findRangeGaps(
+            [
+                {
+                    previousRelease: null,
+                    release: '2.0.0',
+                    cumulativeThrough: '2.0.0',
+                },
+            ],
+            '0.1.0',
+            '3.0.0',
+        ),
+        {
+            gaps: [{ from: '0.1.0', to: '3.0.0' }],
+            unknownReleaseFiles: 1,
+        },
     );
 });
 
@@ -876,13 +928,14 @@ test('complete coverage and all-ok findings render an honest clear-to-upgrade me
     );
 });
 
-test('missing facts add a coverage warning, cap the verdict, and never render clear-to-upgrade', () => {
+test('per-release missing facts warn, cap the verdict, and keep range-scoped wording', () => {
     const report = buildReport(
         '1.50.0',
         '1.60.0',
         [fact()],
         [],
         {
+            cumulativeThrough: null,
             migrationsInRelease: 2,
             migrationsWithoutFacts: ['20260102000000_missing'],
             unknownCoverageFiles: 0,
@@ -892,8 +945,111 @@ test('missing facts add a coverage warning, cap the verdict, and never render cl
     const coverage = report.findings.find((finding) => finding.check === 'coverage');
     assert.strictEqual(report.verdict, 'warn');
     assert.match(coverage?.summary ?? '', /1 of 2 migrations in this range have no facts/);
+    assert.strictEqual(coverage?.severity, 'warn');
     assert.strictEqual(coverage?.actionKind, 'plan');
     assert.doesNotMatch(renderHuman(report), /clear to upgrade/i);
+});
+
+test('cumulative historical gaps are informational and do not cap a clean short upgrade', () => {
+    const report = buildReport(
+        '1.78.0',
+        '1.79.0',
+        [],
+        [],
+        {
+            cumulativeThrough: '1.79.0',
+            migrationsInRelease: 393,
+            migrationsWithoutFacts: Array.from(
+                { length: 390 },
+                (_, index) => `migration_${index}`,
+            ),
+            unknownCoverageFiles: 0,
+        },
+        completeRangeCoverage,
+    );
+    const coverage = report.findings.find((finding) => finding.check === 'coverage');
+    assert.strictEqual(report.verdict, 'ok');
+    assert.deepStrictEqual(report.planItems, []);
+    assert.strictEqual(coverage?.severity, 'info');
+    assert.strictEqual(coverage?.action, null);
+    assert.strictEqual(coverage?.actionKind, null);
+    assert.match(
+        coverage?.summary ?? '',
+        /390 of 393 migrations across all releases up to 1\.79\.0 have no facts/,
+    );
+    assert.doesNotMatch(coverage?.summary ?? '', /in this range/);
+});
+
+test('per-release coverage remains a range-scoped warning', () => {
+    const report = buildReport(
+        '1.78.0',
+        '1.79.0',
+        [],
+        [],
+        {
+            cumulativeThrough: null,
+            migrationsInRelease: 1,
+            migrationsWithoutFacts: ['20260102000000_missing'],
+            unknownCoverageFiles: 0,
+        },
+        completeRangeCoverage,
+    );
+    const coverage = report.findings.find((finding) => finding.check === 'coverage');
+    assert.strictEqual(report.verdict, 'warn');
+    assert.strictEqual(coverage?.severity, 'warn');
+    assert.strictEqual(coverage?.actionKind, 'plan');
+    assert.match(coverage?.summary ?? '', /1 of 1 migrations in this range have no facts/);
+});
+
+test('human coverage output truncates core and Enterprise migration names while JSON keeps all', () => {
+    const coreMissing = Array.from(
+        { length: 400 },
+        (_, index) => `core_${String(index).padStart(3, '0')}`,
+    );
+    const enterpriseMissing = Array.from(
+        { length: 400 },
+        (_, index) => `enterprise_${String(index).padStart(3, '0')}`,
+    );
+    const report = buildReport(
+        '1.0.0',
+        '2.0.0',
+        [],
+        [],
+        {
+            cumulativeThrough: null,
+            migrationsInRelease: 500,
+            migrationsWithoutFacts: coreMissing,
+            unknownCoverageFiles: 0,
+        },
+        completeRangeCoverage,
+        enterpriseMissing,
+    );
+    const rendered = renderHuman(report);
+    assert.match(rendered, /400 of 500 migrations/);
+    assert.match(rendered, /core_000, core_001, core_002, core_003, core_004, …and 395 more/);
+    assert.match(
+        rendered,
+        /400 Enterprise migration\(s\).*enterprise_000, enterprise_001, enterprise_002, enterprise_003, enterprise_004, …and 395 more/,
+    );
+    assert.doesNotMatch(rendered, /core_005|core_399|enterprise_005|enterprise_399/);
+
+    const json = JSON.parse(JSON.stringify(report)) as PreflightReport;
+    const coreFinding = json.findings.find(
+        (finding) =>
+            finding.check === 'coverage' &&
+            'migrationsWithoutFacts' in finding.data,
+    );
+    const enterpriseFinding = json.findings.find(
+        (finding) => 'enterpriseMigrationsWithoutFacts' in finding.data,
+    );
+    assert.strictEqual(
+        (coreFinding?.data.migrationsWithoutFacts as string[]).length,
+        400,
+    );
+    assert.strictEqual(
+        (enterpriseFinding?.data.enterpriseMigrationsWithoutFacts as string[]).length,
+        400,
+    );
 });
 
 test('range gaps make coverage unknown without presenting a precise denominator', () => {
@@ -903,6 +1059,7 @@ test('range gaps make coverage unknown without presenting a precise denominator'
         [fact()],
         [],
         {
+            cumulativeThrough: null,
             migrationsInRelease: 2,
             migrationsWithoutFacts: ['20260102000000_missing'],
             unknownCoverageFiles: 0,
@@ -922,6 +1079,7 @@ test('range gaps make coverage unknown without presenting a precise denominator'
 
 test('unknown facts-file coverage warns even when no known migrations are missing', () => {
     const report = buildReport('1.50.0', '1.60.0', [], [], {
+        cumulativeThrough: null,
         migrationsInRelease: 4,
         migrationsWithoutFacts: [],
         unknownCoverageFiles: 2,

--- a/scripts/preflight.ts
+++ b/scripts/preflight.ts
@@ -67,6 +67,7 @@ export interface FactsFile {
     schemaVersion: string;
     release: string | null;
     previousRelease: string | null;
+    cumulativeThrough: string | null;
     migrationsInRelease: number | null;
     migrationsWithoutFacts: string[] | null;
     enterpriseMigrationsInRelease?: number | null;
@@ -75,6 +76,7 @@ export interface FactsFile {
 }
 
 export interface FactsCoverage {
+    cumulativeThrough: string | null;
     migrationsInRelease: number;
     migrationsWithoutFacts: string[];
     unknownCoverageFiles: number;
@@ -143,6 +145,7 @@ export function mergeFactsFiles(files: FactsFile[]): MergedFactsFile {
     let migrationsInRelease = 0;
     const migrationsWithoutFacts: string[] = [];
     let unknownCoverageFiles = 0;
+    let cumulativeThrough: string | null = null;
     const enterpriseMigrationsWithoutFacts: string[] = [];
     for (const file of files) {
         if (file.schemaVersion !== schemaVersion) {
@@ -162,6 +165,13 @@ export function mergeFactsFiles(files: FactsFile[]): MergedFactsFile {
         enterpriseMigrationsWithoutFacts.push(
             ...(file.enterpriseMigrationsWithoutFacts ?? []),
         );
+        if (
+            file.cumulativeThrough !== null &&
+            (cumulativeThrough === null ||
+                compareVersions(file.cumulativeThrough, cumulativeThrough) > 0)
+        ) {
+            cumulativeThrough = file.cumulativeThrough;
+        }
         for (const fact of file.migrationFacts) {
             if (seen.has(fact.migration)) {
                 throw new Error(
@@ -174,6 +184,7 @@ export function mergeFactsFiles(files: FactsFile[]): MergedFactsFile {
     }
     return {
         schemaVersion,
+        cumulativeThrough,
         migrationsInRelease,
         migrationsWithoutFacts: migrationsWithoutFacts.sort(),
         unknownCoverageFiles,
@@ -183,10 +194,24 @@ export function mergeFactsFiles(files: FactsFile[]): MergedFactsFile {
 }
 
 export function findRangeGaps(
-    files: { release: string | null; previousRelease: string | null }[],
+    files: {
+        release: string | null;
+        previousRelease: string | null;
+        cumulativeThrough?: string | null;
+    }[],
     from: string,
     to: string,
 ): FactsRangeCoverage {
+    if (
+        files.some(
+            (file) =>
+                file.cumulativeThrough !== null &&
+                file.cumulativeThrough !== undefined &&
+                compareVersions(file.cumulativeThrough, to) >= 0,
+        )
+    ) {
+        return { gaps: [], unknownReleaseFiles: 0 };
+    }
     let unknownReleaseFiles = 0;
     const knownFiles = files
         .flatMap((file) => {
@@ -723,6 +748,12 @@ export interface PreflightReport {
     verdict: Severity;
 }
 
+function formatMigrationNames(migrations: string[]): string {
+    const shown = migrations.slice(0, 5);
+    const remaining = migrations.length - shown.length;
+    return `${shown.join(', ')}${remaining > 0 ? `, …and ${remaining} more` : ''}`;
+}
+
 function coverageFinding(
     coverage: FactsCoverage & FactsRangeCoverage,
 ): Finding | null {
@@ -731,6 +762,18 @@ function coverageFinding(
     const missingRanges = coverage.gaps.map((gap) => `${gap.from}..${gap.to}`);
     const rangeUnknown = missingRanges.length > 0 || coverage.unknownReleaseFiles > 0;
     if (missing === 0 && unknown === 0 && !rangeUnknown) return null;
+    if (coverage.cumulativeThrough !== null) {
+        return {
+            check: 'coverage',
+            severity: 'info',
+            migration: null,
+            table: null,
+            summary: `${missing} of ${coverage.migrationsInRelease} migrations across all releases up to ${coverage.cumulativeThrough} have no facts; this run cannot tell which of them fall in your upgrade range${missing > 0 ? `: ${formatMigrationNames(coverage.migrationsWithoutFacts)}` : ''}`,
+            action: null,
+            actionKind: null,
+            data: { ...coverage },
+        };
+    }
     let summary: string;
     let action: string;
     if (rangeUnknown) {
@@ -744,8 +787,8 @@ function coverageFinding(
                   ]
                 : []),
         ];
-        summary = `coverage is unknown — ${reasons.join('; ')}${missing > 0 ? `; facts are also missing for ${coverage.migrationsWithoutFacts.join(', ')}` : ''}`;
-        action = `do not treat this preflight as complete: fetch generated facts assets spanning ${missingRanges.length > 0 ? missingRanges.join(', ') : 'the requested range'}${coverage.unknownReleaseFiles > 0 ? ' and replace files with unknown release bounds' : ''}${missing > 0 ? `; author facts for ${coverage.migrationsWithoutFacts.join(', ')}` : ''} before upgrading`;
+        summary = `coverage is unknown — ${reasons.join('; ')}${missing > 0 ? `; facts are also missing for ${missing} migration(s): ${formatMigrationNames(coverage.migrationsWithoutFacts)}` : ''}`;
+        action = `do not treat this preflight as complete: fetch generated facts assets spanning ${missingRanges.length > 0 ? missingRanges.join(', ') : 'the requested range'}${coverage.unknownReleaseFiles > 0 ? ' and replace files with unknown release bounds' : ''}${missing > 0 ? `; author facts for ${missing} migration(s): ${formatMigrationNames(coverage.migrationsWithoutFacts)}` : ''} before upgrading`;
     } else {
         summary =
             missing > 0 && unknown > 0
@@ -755,10 +798,10 @@ function coverageFinding(
                   : `coverage unknown for ${unknown} facts file(s); this run may not cover every migration in the range`;
         action =
             unknown > 0 && missing > 0
-                ? `do not treat this preflight as complete: it cannot assess ${coverage.migrationsWithoutFacts.join(', ')} or tell whether the ${unknown} unknown-coverage file(s) omit more migrations; replace those files and author the known missing facts before upgrading`
+                ? `do not treat this preflight as complete: it cannot assess ${missing} migration(s): ${formatMigrationNames(coverage.migrationsWithoutFacts)}, or tell whether the ${unknown} unknown-coverage file(s) omit more migrations; replace those files and author the known missing facts before upgrading`
                 : unknown > 0
                   ? `do not treat this preflight as complete: it cannot tell whether the ${unknown} unknown-coverage file(s) omit migrations; replace them with generated assets that include coverage before upgrading`
-                  : `do not treat this preflight as complete: it cannot assess ${coverage.migrationsWithoutFacts.join(', ')}; author those facts and regenerate the release asset, or assess those migrations manually before upgrading`;
+                  : `do not treat this preflight as complete: it cannot assess ${missing} migration(s): ${formatMigrationNames(coverage.migrationsWithoutFacts)}; author those facts and regenerate the release asset, or assess those migrations manually before upgrading`;
     }
     return {
         check: 'coverage',
@@ -774,6 +817,7 @@ function coverageFinding(
 
 export function enterpriseCoverageFinding(
     enterpriseMigrationsWithoutFacts: string[],
+    cumulativeThrough: string | null = null,
 ): Finding | null {
     if (enterpriseMigrationsWithoutFacts.length === 0) return null;
     return {
@@ -781,7 +825,9 @@ export function enterpriseCoverageFinding(
         severity: 'info',
         migration: null,
         table: null,
-        summary: `${enterpriseMigrationsWithoutFacts.length} Enterprise migration(s) in this range have no facts; they only run on a licensed instance, so they are not counted in the coverage verdict above`,
+        summary: cumulativeThrough
+            ? `${enterpriseMigrationsWithoutFacts.length} Enterprise migration(s) across all releases up to ${cumulativeThrough} have no facts: ${formatMigrationNames(enterpriseMigrationsWithoutFacts)}; this run cannot tell which of them fall in your upgrade range, and they only run on a licensed instance`
+            : `${enterpriseMigrationsWithoutFacts.length} Enterprise migration(s) in this range have no facts: ${formatMigrationNames(enterpriseMigrationsWithoutFacts)}; they only run on a licensed instance, so they are not counted in the coverage verdict above`,
         action: null,
         actionKind: null,
         data: { enterpriseMigrationsWithoutFacts },
@@ -800,7 +846,10 @@ export function buildReport(
     const combinedCoverage = { ...coverage, ...rangeCoverage };
     const extra = [
         coverageFinding(combinedCoverage),
-        enterpriseCoverageFinding(enterpriseMigrationsWithoutFacts),
+        enterpriseCoverageFinding(
+            enterpriseMigrationsWithoutFacts,
+            coverage.cumulativeThrough,
+        ),
     ].flatMap((finding) => (finding ? [finding] : []));
     const sorted = [...findings, ...extra].sort(
         (a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity],


### PR DESCRIPTION
Linear: SPK-893 · Relates: SPK-701, SPK-872

## The number

An operator upgrading `0.3137.0 → 1.79.0` — the realistic self-hosted jump measured in the SPK-701 campaign — crosses **656 releases**. With one facts asset per release that is 656 downloads and 656 `--facts` flags, and we cut 16–20 releases a day.

`release-safety.json` already solved this by being cumulative. The facts asset did not copy it, and everything painful downstream followed from that one choice.

## The change

`--cumulative-through <version>` makes the asset carry every fact up to a version, and the preflight satisfies any range ending at or below it from that single file. The generator's `--all` flag already existed for exactly this and was unused.

Coverage counts are computed over every migration at the ref rather than the ones added in a range, which means the migration set comes from a tree listing rather than a diff.

## What this deliberately does *not* claim

Cumulative coverage **cannot be attributed to the operator's range**: the uncovered list carries names with no version, and filename timestamps do not track release order in this repo (`20260721170000_…` shipped in 1.4.0; the later-named `20260722103000_…` shipped in 0.3462.0, 104 releases earlier).

Left as a `warn` it told an operator upgrading `1.78.0 → 1.79.0` — a range with **no core migrations at all** — that *390 of 393 migrations in their range had no facts*. So on the cumulative path the coverage finding is an `info` note that says plainly it is historical and cannot be scoped, and it no longer caps the verdict. The per-release path keeps today's wording, severity and cap.

Scoping it properly needs a per-release coverage map: **SPK-895**.

## Also here

The uncovered list is truncated to a count plus five names, with the full list still in `--json`. At cumulative scale it was several hundred names printed twice, around findings of one line each.

## Testing

`npm run test:release-safety` — all 9 suites; preflight 62 → 68, generator 9 → 11. End-to-end generation verified against the real repo: 393 core + 174 Enterprise migrations in one asset.