### PR TITLE
feat(backend): return applied migrations from the preflight probe

### DIFF
--- a/packages/backend/src/controllers/preflightController.ts
+++ b/packages/backend/src/controllers/preflightController.ts
@@ -15,8 +15,16 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { PreflightProbeSnapshot } from '../services/PreflightService/PreflightService';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
+
+type ApiPreflightProbeSnapshotResponse = Omit<
+    ApiPreflightProbeResponse,
+    'results'
+> & {
+    results: PreflightProbeSnapshot;
+};
 
 @Route('/api/v1/preflight')
 @Response<ApiErrorPayload>('default', 'Error')
@@ -40,7 +48,7 @@ export class PreflightController extends BaseController {
     async getPreflightProbe(
         @Request() req: express.Request,
         @Query() tables?: string,
-    ): Promise<ApiPreflightProbeResponse> {
+    ): Promise<ApiPreflightProbeSnapshotResponse> {
         assertRegisteredAccount(req.account);
         const tableNames = (tables ?? '')
             .split(',')

--- a/packages/backend/src/models/PreflightModel.ts
+++ b/packages/backend/src/models/PreflightModel.ts
@@ -7,6 +7,12 @@ import { Knex } from 'knex';
 
 const POSTGRES_UNDEFINED_TABLE = '42P01';
 
+export type PreflightAppliedMigration = {
+    name: string;
+    batch: number;
+    migrationTime: string;
+};
+
 export class PreflightModel {
     private readonly database: Knex;
 
@@ -45,6 +51,22 @@ export class PreflightModel {
                     ? null
                     : Number(lastMigration.rows[0].age_seconds),
         };
+    }
+
+    async getAppliedMigrations(): Promise<PreflightAppliedMigration[]> {
+        const migrations = await this.database<{
+            name: string;
+            batch: number;
+            migration_time: Date | string;
+        }>('knex_migrations')
+            .select('name', 'batch', 'migration_time')
+            .orderBy('id');
+
+        return migrations.map((migration) => ({
+            name: migration.name,
+            batch: Number(migration.batch),
+            migrationTime: new Date(migration.migration_time).toISOString(),
+        }));
     }
 
     async getTableStats(tables: string[]): Promise<PreflightTableStats[]> {

--- a/packages/backend/src/services/PreflightService/PreflightService.test.ts
+++ b/packages/backend/src/services/PreflightService/PreflightService.test.ts
@@ -37,6 +37,13 @@ const buildService = (allowMultiOrgs: boolean, probeEnabled = true) => {
             isLocked: false,
             lastMigrationAgeSeconds: 3600,
         })),
+        getAppliedMigrations: vi.fn(async () => [
+            {
+                name: '20250101000000_create_users.ts',
+                batch: 1,
+                migrationTime: '2025-01-01T00:00:00.000Z',
+            },
+        ]),
         getTableStats: vi.fn(async () => []),
         getActivity: vi.fn(async () => []),
     } as unknown as PreflightModel;
@@ -90,9 +97,25 @@ describe('PreflightService — probe', () => {
             isLocked: false,
             lastMigrationAgeSeconds: 3600,
         });
+        expect(probe.appliedMigrations).toEqual([
+            {
+                name: '20250101000000_create_users.ts',
+                batch: 1,
+                migrationTime: '2025-01-01T00:00:00.000Z',
+            },
+        ]);
         expect(preflightModel.getTableStats).toHaveBeenCalledWith(['users']);
         expect(preflightModel.getActivity).toHaveBeenCalledWith({
             includeQueryText: true,
         });
+    });
+
+    it('returns an empty list when no migrations have been applied', async () => {
+        const { service, preflightModel } = buildService(false);
+        vi.mocked(preflightModel.getAppliedMigrations).mockResolvedValue([]);
+
+        const probe = await service.probe(adminAccount, []);
+
+        expect(probe.appliedMigrations).toEqual([]);
     });
 });

--- a/packages/backend/src/services/PreflightService/PreflightService.ts
+++ b/packages/backend/src/services/PreflightService/PreflightService.ts
@@ -6,7 +6,10 @@ import {
     type RegisteredAccount,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
-import { PreflightModel } from '../../models/PreflightModel';
+import {
+    PreflightAppliedMigration,
+    PreflightModel,
+} from '../../models/PreflightModel';
 import { BaseService } from '../BaseService';
 
 type PreflightServiceArguments = {
@@ -16,6 +19,10 @@ type PreflightServiceArguments = {
 
 const TABLE_NAME_PATTERN = /^[a-z_][a-z0-9_]{0,62}$/;
 const MAX_TABLES = 50;
+
+export type PreflightProbeSnapshot = PreflightProbe & {
+    appliedMigrations: PreflightAppliedMigration[];
+};
 
 /**
  * SPK-701 spike: read-only probe of the instance database's upgrade-relevant
@@ -57,7 +64,7 @@ export class PreflightService extends BaseService {
     async probe(
         account: RegisteredAccount,
         tables: string[],
-    ): Promise<PreflightProbe> {
+    ): Promise<PreflightProbeSnapshot> {
         if (!this.lightdashConfig.preflight.probeEnabled) {
             throw new ForbiddenError(
                 'Preflight probe is not enabled on this instance (set PREFLIGHT_PROBE_ENABLED=true)',
@@ -78,16 +85,19 @@ export class PreflightService extends BaseService {
                 throw new ParameterError(`Invalid table name: ${table}`);
             }
         }
-        const [lock, tableStats, activity] = await Promise.all([
-            this.preflightModel.getLockState(),
-            this.preflightModel.getTableStats(uniqueTables),
-            this.preflightModel.getActivity({
-                includeQueryText: !this.lightdashConfig.allowMultiOrgs,
-            }),
-        ]);
+        const [lock, appliedMigrations, tableStats, activity] =
+            await Promise.all([
+                this.preflightModel.getLockState(),
+                this.preflightModel.getAppliedMigrations(),
+                this.preflightModel.getTableStats(uniqueTables),
+                this.preflightModel.getActivity({
+                    includeQueryText: !this.lightdashConfig.allowMultiOrgs,
+                }),
+            ]);
         return {
             serverTime: new Date().toISOString(),
             lock,
+            appliedMigrations,
             tableStats,
             activity,
         };


### PR DESCRIPTION
Linear: SPK-894 · Relates: SPK-701, SPK-878

## Why

The preflight asks the operator which version they are currently on. That is the wrong question, and it is asked in exactly the situation where they can least answer it: a killed or partially-applied migration run — the state the tool exists to help with.

`knex_migrations` already records what has actually run, and the probe reads that table for its stale-lock age signal without returning the list.

The CLI cannot read it directly. That is deliberate: operators frequently cannot reach their own Postgres — in the incident that motivated this work, running diagnostic SQL required platform-team involvement — which is the entire reason this endpoint exists. So the list comes back from the probe alongside the rest of the snapshot.

## The change

`PreflightModel.getAppliedMigrations()` returns migration `name`, `batch` and time from `knex_migrations`, ordered by `id`. The service includes it in the probe snapshot; the controller types it.

Migration filenames and timestamps only — our own schema history, not customer data. The payload was not widened beyond that.

## Security posture unchanged

This endpoint was built carefully and survived a dedicated review, so the existing behaviour is treated as load-bearing: org-admin gate via the audited ability helper, multi-org refused before any query runs, the enabled-check in the service rather than only the route, identifiers regex-validated *and* parameter-bound. None of those are touched, and the existing authorization tests are unmodified.

## Testing

`PreflightService` suite green, including a new case for an empty `knex_migrations` returning an empty list rather than erroring. Backend typecheck and scoped lint pass. `pnpm generate-api` runs clean; generated artefacts deliberately not committed.