### PR TITLE
feat(release): derive migration facts from the migration's own source

### DIFF
--- a/scripts/derive-migration-facts.test.ts
+++ b/scripts/derive-migration-facts.test.ts
@@ -1,0 +1,301 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    deriveMigrationFact,
+    deriveMigrationFactWithDiagnostics,
+    isSystemCatalogRelation,
+    migrationContainsBackfill,
+} from './derive-migration-facts';
+import type { MigrationFact, TableAccess } from './preflight';
+
+const savedChartTimezoneSource = [
+    "import { Knex } from 'knex';",
+    "const TABLE = 'saved_queries_versions';",
+    "const COLUMN = 'timezone';",
+    "const PROJECT_TIMEZONE_SETTING = 'project_timezone';",
+    'const BATCH_SIZE = 10000;',
+    'export const config = { transaction: false };',
+    'export async function up(knex: Knex): Promise<void> {',
+    '    await knex.schema.alterTable(TABLE, (table) => {',
+    '        table.text(COLUMN).defaultTo(PROJECT_TIMEZONE_SETTING);',
+    '    });',
+    '    let updatedInPass: number;',
+    '    do {',
+    '        updatedInPass = await knex(TABLE)',
+    '            .update({ [COLUMN]: PROJECT_TIMEZONE_SETTING })',
+    "            .whereIn('ctid', knex(TABLE).select('ctid').whereNull(COLUMN).limit(BATCH_SIZE));",
+    '    } while (updatedInPass > 0);',
+    '    await knex.raw(`ALTER TABLE ?? VALIDATE CONSTRAINT ??`, [',
+    '        TABLE,',
+    "        'saved_queries_versions_timezone_not_null',",
+    '    ]);',
+    '}',
+    'export async function down(knex: Knex): Promise<void> {',
+    '    await knex(TABLE).update({ timezone: null });',
+    '}',
+].join('\n');
+
+const savedQueriesProjectSource = [
+    "import { Knex } from 'knex';",
+    'export const config = { transaction: false };',
+    "const SavedQueriesTableName = 'saved_queries';",
+    'const BatchSize = 1000;',
+    "const LockTimeout = '5s';",
+    'async function addProjectUuidColumn(knex: Knex): Promise<void> {',
+    '    await knex.transaction(async (trx) => {',
+    "        await trx.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);",
+    '        await trx.raw(`ALTER TABLE ${SavedQueriesTableName} ADD COLUMN project_uuid uuid`);',
+    '    });',
+    '}',
+    'async function backfillBatch(knex: Knex): Promise<void> {',
+    '    await knex.transaction(async (trx) => {',
+    "        await trx.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);",
+    '        await trx.raw<{ rows: unknown[] }>(`',
+    '            WITH batch AS (',
+    '                SELECT saved_queries.saved_query_id',
+    '                FROM ${SavedQueriesTableName} AS saved_queries',
+    '                LEFT JOIN spaces AS direct_spaces',
+    '                    ON direct_spaces.space_id = saved_queries.space_id',
+    '                LEFT JOIN projects AS direct_projects',
+    '                    ON direct_projects.project_id = direct_spaces.project_id',
+    '                LEFT JOIN dashboards',
+    '                    ON dashboards.dashboard_uuid = saved_queries.dashboard_uuid',
+    '                LEFT JOIN spaces AS dashboard_spaces',
+    '                    ON dashboard_spaces.space_id = dashboards.space_id',
+    '                LEFT JOIN projects AS dashboard_projects',
+    '                    ON dashboard_projects.project_id = dashboard_spaces.project_id',
+    '                LIMIT ${BatchSize}',
+    '            ), updated AS (',
+    '                UPDATE ${SavedQueriesTableName} AS saved_queries',
+    '                SET project_uuid = NULL',
+    '                FROM batch',
+    '                WHERE saved_queries.project_uuid IS DISTINCT FROM batch.project_uuid',
+    '                RETURNING saved_queries.saved_query_id',
+    '            )',
+    '            SELECT COUNT(*) FROM updated',
+    '        `);',
+    '    });',
+    '}',
+    'export async function up(knex: Knex): Promise<void> {',
+    '    await addProjectUuidColumn(knex);',
+    '    await backfillBatch(knex);',
+    '}',
+    'export async function down(knex: Knex): Promise<void> {',
+    '    await knex.schema.alterTable(SavedQueriesTableName, () => undefined);',
+    '}',
+].join('\n');
+
+const incompleteUsersSource = [
+    "import { type Knex } from 'knex';",
+    'export async function up(knex: Knex): Promise<void> {',
+    "    await knex('users')",
+    "        .where('is_setup_complete', false)",
+    '        .update({ is_setup_complete: true });',
+    '}',
+    'export async function down(_knex: Knex): Promise<void> {}',
+].join('\n');
+
+const pivotRowsSource = [
+    "import { Knex } from 'knex';",
+    "const SavedChartVersionsTableName = 'saved_queries_versions';",
+    "const PivotRowsColumnName = 'pivot_rows';",
+    'export async function up(knex: Knex): Promise<void> {',
+    '    await knex.schema.alterTable(SavedChartVersionsTableName, (table) => {',
+    "        table.specificType(PivotRowsColumnName, 'TEXT[]').nullable();",
+    '    });',
+    '}',
+    'export async function down(knex: Knex): Promise<void> {',
+    '    await knex.schema.alterTable(SavedChartVersionsTableName, (table) => {',
+    '        table.dropColumn(PivotRowsColumnName);',
+    '    });',
+    '}',
+].join('\n');
+
+const dynamicTableSource = [
+    "import { Knex } from 'knex';",
+    'const newTableSingularIndexes = {',
+    "    dashboard_versions: ['dashboard_id', 'updated_by_user_uuid'],",
+    "    spaces: ['project_id'],",
+    '};',
+    'export async function up(knex: Knex): Promise<void> {',
+    '    async function createIndex(table: string, columns: string[]) {',
+    '        if (await knex.schema.hasTable(table)) {',
+    '            await knex.schema.alterTable(table, (tableBuilder) => {',
+    '                columns.forEach((column) => tableBuilder.index([column]));',
+    '            });',
+    '        }',
+    '    }',
+    '    await Promise.all(',
+    '        Object.entries(newTableSingularIndexes).map(([table, columns]) =>',
+    '            createIndex(table, columns),',
+    '        ),',
+    '    );',
+    '}',
+].join('\n');
+
+const insertSelectSource = [
+    "import { Knex } from 'knex';",
+    "const METRICS_TREES_TABLE = 'metrics_trees';",
+    "const METRICS_TREE_EDGES_TABLE = 'metrics_tree_edges';",
+    'export async function up(knex: Knex): Promise<void> {',
+    '    await knex.raw(`',
+    '        INSERT INTO ${METRICS_TREES_TABLE} (project_uuid)',
+    '        SELECT project_uuid FROM ${METRICS_TREE_EDGES_TABLE}',
+    '    `);',
+    '}',
+].join('\n');
+
+const ACCESS_ORDER: TableAccess[] = ['read', 'write', 'ddl'];
+
+function structuralFact(fact: MigrationFact): unknown {
+    return {
+        migration: fact.migration,
+        introducedIn: fact.introducedIn,
+        runsInTransaction: fact.runsInTransaction,
+        resumable: fact.resumable,
+        batchSize: fact.batchSize,
+        lockTimeout: fact.lockTimeout,
+        tables: fact.tables.map((table) => ({
+            name: table.name,
+            access: ACCESS_ORDER.filter((access) =>
+                table.access.includes(access),
+            ),
+        })),
+    };
+}
+
+const oracle = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'migration-facts.json'), 'utf8'),
+) as { migrationFacts: MigrationFact[] };
+
+const fixtures = [
+    {
+        migration: '20260610120000_default_saved_chart_timezone_to_project',
+        source: savedChartTimezoneSource,
+    },
+    {
+        migration: '20260721112833_add_project_uuid_to_saved_queries',
+        source: savedQueriesProjectSource,
+    },
+    {
+        migration:
+            '20260731111612_grandfather_existing_incomplete_users_setup_complete',
+        source: incompleteUsersSource,
+    },
+];
+
+for (const fixture of fixtures) {
+    const expected = oracle.migrationFacts.find(
+        (fact) => fact.migration === fixture.migration,
+    );
+    assert.ok(expected, `missing oracle fact for ${fixture.migration}`);
+    const derived = deriveMigrationFact(
+        fixture.source,
+        fixture.migration,
+        expected.introducedIn,
+    );
+    assert.deepStrictEqual(structuralFact(derived), structuralFact(expected));
+    assert.strictEqual(derived.backfill, null);
+    assert.strictEqual(derived.notes, null);
+}
+
+const savedChartFact = deriveMigrationFact(
+    savedChartTimezoneSource,
+    '20260610120000_default_saved_chart_timezone_to_project',
+    '0.3138.0',
+);
+assert.deepStrictEqual(savedChartFact.tables[0].expectedLockModes, [
+    'RowExclusiveLock',
+    'AccessExclusiveLock',
+]);
+
+const projectFact = deriveMigrationFact(
+    savedQueriesProjectSource,
+    '20260721112833_add_project_uuid_to_saved_queries',
+    '0.3477.0',
+);
+assert.deepStrictEqual(projectFact.tables, [
+    {
+        name: 'saved_queries',
+        access: ['write', 'ddl'],
+        expectedLockModes: ['RowExclusiveLock', 'AccessExclusiveLock'],
+    },
+    {
+        name: 'spaces',
+        access: ['read'],
+        expectedLockModes: ['AccessShareLock'],
+    },
+    {
+        name: 'projects',
+        access: ['read'],
+        expectedLockModes: ['AccessShareLock'],
+    },
+    {
+        name: 'dashboards',
+        access: ['read'],
+        expectedLockModes: ['AccessShareLock'],
+    },
+]);
+
+const pivotFact = deriveMigrationFact(
+    pivotRowsSource,
+    '20260723123000_add_pivot_rows_to_saved_chart_versions',
+    'provided-by-caller',
+);
+assert.strictEqual(pivotFact.introducedIn, 'provided-by-caller');
+assert.deepStrictEqual(pivotFact.tables, [
+    {
+        name: 'saved_queries_versions',
+        access: ['ddl'],
+        expectedLockModes: ['AccessExclusiveLock'],
+    },
+]);
+assert.strictEqual(migrationContainsBackfill(pivotRowsSource), false);
+
+assert.strictEqual(migrationContainsBackfill(savedChartTimezoneSource), true);
+assert.strictEqual(migrationContainsBackfill(savedQueriesProjectSource), true);
+assert.strictEqual(migrationContainsBackfill(incompleteUsersSource), true);
+assert.strictEqual(migrationContainsBackfill(insertSelectSource), true);
+
+const dynamicResult = deriveMigrationFactWithDiagnostics(
+    dynamicTableSource,
+    '20240604140542_add_missing_indexes_for_dashboards_query',
+    'provided-by-caller',
+);
+assert.deepStrictEqual(dynamicResult.fact.tables, []);
+assert.strictEqual(dynamicResult.unclassifiedConstructs.length, 1);
+assert.match(dynamicResult.unclassifiedConstructs[0], /alterTable\(table/);
+
+const catalogProbeSource = `
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(\`SELECT 1 FROM pg_constraint WHERE conname = 'x'\`);
+    await knex.raw(\`SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid\`);
+    await knex.raw(\`SELECT 1 FROM information_schema.table_constraints\`);
+    await knex.raw(\`UPDATE scheduler_log SET job_id = 1\`);
+}
+`;
+
+const catalogResult = deriveMigrationFactWithDiagnostics(
+    catalogProbeSource,
+    '20260428153355_add_primary_keys_to_analytics_and_scheduler_log',
+    'provided-by-caller',
+);
+assert.deepStrictEqual(catalogResult.fact.tables, [
+    {
+        name: 'scheduler_log',
+        access: ['write'],
+        expectedLockModes: ['RowExclusiveLock'],
+    },
+]);
+
+assert.strictEqual(isSystemCatalogRelation('pg_class'), true);
+assert.strictEqual(isSystemCatalogRelation('pg_catalog.pg_class'), true);
+assert.strictEqual(
+    isSystemCatalogRelation('information_schema.table_constraints'),
+    true,
+);
+assert.strictEqual(isSystemCatalogRelation('projects'), false);
+assert.strictEqual(isSystemCatalogRelation('graphile_worker.jobs'), false);
+
+console.log('derive-migration-facts: tests passed');

--- a/scripts/derive-migration-facts.ts
+++ b/scripts/derive-migration-facts.ts
@@ -1,0 +1,920 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { MigrationFact, TableAccess } from './preflight';
+
+export interface MigrationFactDerivation {
+    fact: MigrationFact;
+    unclassifiedConstructs: string[];
+    containsBackfill: boolean;
+}
+
+type LiteralValue = string | number | boolean;
+
+interface SourceRange {
+    start: number;
+    end: number;
+}
+
+const ACCESS_ORDER: TableAccess[] = ['read', 'write', 'ddl'];
+const LOCK_MODE_BY_ACCESS: Record<TableAccess, string> = {
+    read: 'AccessShareLock',
+    write: 'RowExclusiveLock',
+    ddl: 'AccessExclusiveLock',
+};
+const SCHEMA_METHODS = [
+    'alterTable',
+    'createTable',
+    'createTableIfNotExists',
+    'dropTable',
+    'dropTableIfExists',
+    'renameTable',
+    'table',
+];
+const WRITE_METHODS = ['update', 'insert', 'delete', 'del'];
+const READ_METHODS = [
+    'select',
+    'first',
+    'count',
+    'countDistinct',
+    'max',
+    'min',
+    'sum',
+    'avg',
+];
+const JOIN_METHODS = [
+    'join',
+    'leftJoin',
+    'leftOuterJoin',
+    'rightJoin',
+    'rightOuterJoin',
+    'fullOuterJoin',
+    'innerJoin',
+];
+const SQL_IDENTIFIER =
+    '(?:"[^"]+"|[A-Za-z_][A-Za-z0-9_$]*)(?:\\.(?:"[^"]+"|[A-Za-z_][A-Za-z0-9_$]*))*';
+
+function scanSource(source: string, maskStrings: boolean): string {
+    const characters = source.split('');
+    let index = 0;
+    while (index < source.length) {
+        if (source.startsWith('//', index)) {
+            const end = source.indexOf('\n', index + 2);
+            const stop = end === -1 ? source.length : end;
+            characters.fill(' ', index, stop);
+            index = stop;
+        } else if (source.startsWith('/*', index)) {
+            const end = source.indexOf('*/', index + 2);
+            const stop = end === -1 ? source.length : end + 2;
+            characters.fill(' ', index, stop);
+            index = stop;
+        } else {
+            const quote = source[index];
+            if (quote === "'" || quote === '"' || quote === '`') {
+                const start = index;
+                index += 1;
+                let closed = false;
+                while (index < source.length && !closed) {
+                    if (source[index] === '\\') {
+                        index += 2;
+                    } else if (source[index] === quote) {
+                        index += 1;
+                        closed = true;
+                    } else {
+                        index += 1;
+                    }
+                }
+                if (maskStrings) characters.fill(' ', start, index);
+            } else {
+                index += 1;
+            }
+        }
+    }
+    return characters.join('');
+}
+
+function findMatching(
+    source: string,
+    start: number,
+    open: string,
+    close: string,
+): number | undefined {
+    let depth = 0;
+    let index = start;
+    while (index < source.length) {
+        if (source.startsWith('//', index)) {
+            const end = source.indexOf('\n', index + 2);
+            index = end === -1 ? source.length : end;
+        } else if (source.startsWith('/*', index)) {
+            const end = source.indexOf('*/', index + 2);
+            index = end === -1 ? source.length : end + 2;
+        } else {
+            const quote = source[index];
+            if (quote === "'" || quote === '"' || quote === '`') {
+                index += 1;
+                let closed = false;
+                while (index < source.length && !closed) {
+                    if (source[index] === '\\') {
+                        index += 2;
+                    } else if (source[index] === quote) {
+                        index += 1;
+                        closed = true;
+                    } else {
+                        index += 1;
+                    }
+                }
+            } else {
+                if (source[index] === open) depth += 1;
+                if (source[index] === close) {
+                    depth -= 1;
+                    if (depth === 0) return index;
+                }
+                index += 1;
+            }
+        }
+    }
+    return undefined;
+}
+
+function splitArguments(argumentsSource: string): string[] {
+    const argumentsList: string[] = [];
+    let start = 0;
+    let index = 0;
+    const pairs: Record<string, string> = { '(': ')', '[': ']', '{': '}' };
+    while (index < argumentsSource.length) {
+        const character = argumentsSource[index];
+        if (character === "'" || character === '"' || character === '`') {
+            index += 1;
+            let closed = false;
+            while (index < argumentsSource.length && !closed) {
+                if (argumentsSource[index] === '\\') {
+                    index += 2;
+                } else if (argumentsSource[index] === character) {
+                    index += 1;
+                    closed = true;
+                } else {
+                    index += 1;
+                }
+            }
+        } else if (pairs[character]) {
+            const end = findMatching(
+                argumentsSource,
+                index,
+                character,
+                pairs[character],
+            );
+            index = end === undefined ? argumentsSource.length : end + 1;
+        } else {
+            if (character === ',') {
+                argumentsList.push(argumentsSource.slice(start, index).trim());
+                start = index + 1;
+            }
+            index += 1;
+        }
+    }
+    const last = argumentsSource.slice(start).trim();
+    if (last) argumentsList.push(last);
+    return argumentsList;
+}
+
+function callArguments(
+    source: string,
+    openParenthesis: number,
+): { argumentsList: string[]; end: number } | undefined {
+    const end = findMatching(source, openParenthesis, '(', ')');
+    if (end === undefined) return undefined;
+    return {
+        argumentsList: splitArguments(source.slice(openParenthesis + 1, end)),
+        end,
+    };
+}
+
+function buildFunctionMap(source: string): Map<string, SourceRange> {
+    const masked = scanSource(source, true);
+    const functions = new Map<string, SourceRange>();
+    const patterns = [
+        /\b(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*(?::[^{=]+)?\{/g,
+        /\b(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*(?::[^=]+)?=\s*(?:async\s*)?\([^)]*\)\s*(?::[^=]+)?=>\s*\{/g,
+    ];
+    for (const pattern of patterns) {
+        for (const match of masked.matchAll(pattern)) {
+            const openBrace = (match.index ?? 0) + match[0].lastIndexOf('{');
+            const closeBrace = findMatching(source, openBrace, '{', '}');
+            if (closeBrace !== undefined) {
+                functions.set(match[1], {
+                    start: openBrace + 1,
+                    end: closeBrace,
+                });
+            }
+        }
+    }
+    return functions;
+}
+
+function reachableFunctionBodies(source: string): SourceRange[] {
+    const functions = buildFunctionMap(source);
+    const ranges: SourceRange[] = [];
+    const visited = new Set<string>();
+
+    function include(name: string): void {
+        if (visited.has(name)) return;
+        visited.add(name);
+        const range = functions.get(name);
+        if (!range) return;
+        ranges.push(range);
+        const body = scanSource(source.slice(range.start, range.end), true);
+        for (const candidate of functions.keys()) {
+            if (
+                candidate !== name &&
+                new RegExp(`\\b${candidate}\\s*\\(`).test(body)
+            ) {
+                include(candidate);
+            }
+        }
+    }
+
+    include('up');
+    return ranges;
+}
+
+function buildConstantMap(source: string): Map<string, string> {
+    const withoutComments = scanSource(source, false);
+    const constants = new Map<string, string>();
+    const duplicates = new Set<string>();
+    const pattern =
+        /\bconst\s+([A-Za-z_$][\w$]*)(?:\s*:[^=;]+)?\s*=\s*([^;]+);/g;
+    for (const match of withoutComments.matchAll(pattern)) {
+        if (constants.has(match[1])) duplicates.add(match[1]);
+        constants.set(match[1], match[2].trim());
+    }
+    for (const duplicate of duplicates) constants.delete(duplicate);
+    return constants;
+}
+
+function decodeQuoted(value: string): string | undefined {
+    const quote = value[0];
+    if ((quote !== "'" && quote !== '"') || value.at(-1) !== quote) {
+        return undefined;
+    }
+    return value
+        .slice(1, -1)
+        .replace(/\\(['"\\`])/g, '$1')
+        .replace(/\\n/g, '\n')
+        .replace(/\\r/g, '\r')
+        .replace(/\\t/g, '\t');
+}
+
+function unwrapExpression(expression: string): string {
+    let value = expression.trim();
+    while (/^\([\s\S]*\)$/.test(value)) {
+        const end = findMatching(value, 0, '(', ')');
+        if (end !== value.length - 1) break;
+        value = value.slice(1, -1).trim();
+    }
+    return value.replace(/\s+as\s+const$/, '').trim();
+}
+
+function resolveLiteral(
+    expression: string,
+    constants: Map<string, string>,
+    resolving = new Set<string>(),
+): LiteralValue | undefined {
+    const value = unwrapExpression(expression);
+    const quoted = decodeQuoted(value);
+    if (quoted !== undefined) return quoted;
+    if (/^\d+$/.test(value)) return Number(value);
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    if (/^[A-Za-z_$][\w$]*$/.test(value)) {
+        if (resolving.has(value)) return undefined;
+        const initializer = constants.get(value);
+        if (!initializer) return undefined;
+        const nextResolving = new Set(resolving);
+        nextResolving.add(value);
+        return resolveLiteral(initializer, constants, nextResolving);
+    }
+    if (value.startsWith('`') && value.endsWith('`') && !value.includes('${')) {
+        return value.slice(1, -1);
+    }
+    return undefined;
+}
+
+function renderSql(
+    expression: string,
+    constants: Map<string, string>,
+): string | undefined {
+    const value = unwrapExpression(expression);
+    const literal = resolveLiteral(value, constants);
+    if (literal !== undefined) return String(literal);
+    if (!value.startsWith('`') || !value.endsWith('`')) return undefined;
+    return value.slice(1, -1).replace(/\$\{([^{}]+)\}/g, (_, inner: string) => {
+        const resolved = resolveLiteral(inner, constants);
+        return resolved === undefined
+            ? '__UNRESOLVED_EXPRESSION__'
+            : String(resolved);
+    });
+}
+
+function formatConstruct(source: string, start: number, end: number): string {
+    const prefix = source.slice(0, start);
+    const line = prefix.split('\n').length;
+    const lineStart = prefix.lastIndexOf('\n') + 1;
+    const column = start - lineStart + 1;
+    const snippet = source
+        .slice(start, end + 1)
+        .replace(/\s+/g, ' ')
+        .slice(0, 180);
+    return `${line}:${column} ${snippet}`;
+}
+
+function normalizeSqlIdentifier(identifier: string): string | undefined {
+    if (identifier.includes('__UNRESOLVED')) return undefined;
+    const normalized = identifier
+        .split('.')
+        .map((part) => part.replace(/^"|"$/g, ''))
+        .join('.');
+    return /^[A-Za-z_][A-Za-z0-9_$]*(?:\.[A-Za-z_][A-Za-z0-9_$]*)*$/.test(
+        normalized,
+    )
+        ? normalized
+        : undefined;
+}
+
+export function isSystemCatalogRelation(identifier: string): boolean {
+    const parts = identifier.toLowerCase().split('.');
+    const schema = parts.length > 1 ? parts[0] : null;
+    const relation = parts.at(-1) ?? '';
+    if (schema === 'pg_catalog' || schema === 'information_schema') return true;
+    return schema === null && relation.startsWith('pg_');
+}
+
+function substituteIdentifiers(
+    sql: string,
+    bindingsExpression: string | undefined,
+    constants: Map<string, string>,
+): string {
+    if (!bindingsExpression || !sql.includes('??')) return sql;
+    const bindingsSource = bindingsExpression.trim();
+    const bindings =
+        bindingsSource.startsWith('[') && bindingsSource.endsWith(']')
+            ? splitArguments(bindingsSource.slice(1, -1))
+            : [];
+    let bindingIndex = 0;
+    return sql.replace(/\?\?|\?/g, (placeholder) => {
+        const binding = bindings[bindingIndex];
+        bindingIndex += 1;
+        if (placeholder === '?') return '?';
+        const value = binding ? resolveLiteral(binding, constants) : undefined;
+        return typeof value === 'string' ? value : '__UNRESOLVED_IDENTIFIER__';
+    });
+}
+
+function stripSqlComments(sql: string): string {
+    return sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ');
+}
+
+function sqlMatches(sql: string, pattern: RegExp): string[] {
+    return [...sql.matchAll(pattern)].map((match) => match[1]);
+}
+
+function extractCteNames(sql: string): Set<string> {
+    const ctes = new Set<string>();
+    const pattern = new RegExp(
+        `(?:\\bWITH(?:\\s+RECURSIVE)?|,)\\s*(${SQL_IDENTIFIER})(?:\\s*\\([^)]*\\))?\\s+AS\\s*\\(`,
+        'gi',
+    );
+    for (const identifier of sqlMatches(sql, pattern)) {
+        const normalized = normalizeSqlIdentifier(identifier);
+        if (normalized) ctes.add(normalized);
+    }
+    return ctes;
+}
+
+function batchSizesFromSqlExpression(
+    expression: string,
+    constants: Map<string, string>,
+): number[] {
+    const value = unwrapExpression(expression);
+    if (!value.startsWith('`') || !value.endsWith('`')) return [];
+    const batchSizes: number[] = [];
+    for (const match of value.matchAll(
+        /\bLIMIT\s+\$\{\s*([A-Za-z_$][\w$]*)\s*\}/gi,
+    )) {
+        if (/batch/i.test(match[1])) {
+            const resolved = resolveLiteral(match[1], constants);
+            if (typeof resolved === 'number' && Number.isInteger(resolved)) {
+                batchSizes.push(resolved);
+            }
+        }
+    }
+    return batchSizes;
+}
+
+function findCalls(
+    source: string,
+    range: SourceRange,
+    pattern: RegExp,
+): Array<{ match: RegExpExecArray; start: number; openParenthesis: number }> {
+    const body = source.slice(range.start, range.end);
+    const masked = scanSource(body, true);
+    const calls: Array<{
+        match: RegExpExecArray;
+        start: number;
+        openParenthesis: number;
+    }> = [];
+    const matcher = new RegExp(pattern.source, pattern.flags);
+    let match: RegExpExecArray | null;
+    while ((match = matcher.exec(masked)) !== null) {
+        const start = range.start + match.index;
+        calls.push({
+            match,
+            start,
+            openParenthesis: range.start + matcher.lastIndex - 1,
+        });
+    }
+    return calls;
+}
+
+function nearestBuilderCall(
+    source: string,
+    range: SourceRange,
+    methodStart: number,
+): { start: number; openParenthesis: number } | undefined {
+    const chainStart = Math.max(
+        range.start,
+        source.lastIndexOf(';', methodStart - 1) + 1,
+        source.lastIndexOf('{', methodStart - 1) + 1,
+        source.lastIndexOf('}', methodStart - 1) + 1,
+    );
+    const chain = scanSource(source.slice(chainStart, methodStart), true);
+    const patterns = [/\b(?:knex|trx)\s*\(/g, /\.\s*table\s*\(/g];
+    let nearest: { start: number; openParenthesis: number } | undefined;
+    for (const pattern of patterns) {
+        for (const match of chain.matchAll(pattern)) {
+            const start = chainStart + (match.index ?? 0);
+            if (!nearest || start > nearest.start) {
+                nearest = {
+                    start,
+                    openParenthesis: start + match[0].lastIndexOf('('),
+                };
+            }
+        }
+    }
+    return nearest;
+}
+
+function configDisablesTransactions(source: string): boolean {
+    const withoutComments = scanSource(source, false);
+    const match = withoutComments.match(
+        /\bexport\s+const\s+config\b[^=]*=\s*\{([\s\S]*?)\}/,
+    );
+    return match ? /\btransaction\s*:\s*false\b/.test(match[1]) : false;
+}
+
+export function deriveMigrationFactWithDiagnostics(
+    source: string,
+    migration: string,
+    introducedIn: string,
+): MigrationFactDerivation {
+    const constants = buildConstantMap(source);
+    const accesses = new Map<string, Set<TableAccess>>();
+    const unclassifiedConstructs = new Set<string>();
+    const batchSizes = new Set<number>();
+    const lockTimeouts = new Set<string>();
+    let containsBackfill = false;
+
+    function unclassified(start: number, end: number): void {
+        unclassifiedConstructs.add(formatConstruct(source, start, end));
+    }
+
+    function addAccess(table: string, access: TableAccess): void {
+        const normalized = normalizeSqlIdentifier(table);
+        if (!normalized || isSystemCatalogRelation(normalized)) return;
+        const tableAccesses =
+            accesses.get(normalized) ?? new Set<TableAccess>();
+        tableAccesses.add(access);
+        accesses.set(normalized, tableAccesses);
+    }
+
+    function addResolvedTable(
+        expression: string | undefined,
+        access: TableAccess,
+        start: number,
+        end: number,
+    ): void {
+        const value = expression
+            ? resolveLiteral(expression, constants)
+            : undefined;
+        if (typeof value !== 'string') {
+            unclassified(start, end);
+            return;
+        }
+        addAccess(value, access);
+    }
+
+    function classifySql(
+        sqlValue: string,
+        constructStart: number,
+        constructEnd: number,
+    ): void {
+        const sql = stripSqlComments(sqlValue);
+        const ctes = extractCteNames(sql);
+        const patterns: Array<{ access: TableAccess; pattern: RegExp }> = [
+            {
+                access: 'ddl',
+                pattern: new RegExp(
+                    `\\bALTER\\s+TABLE\\s+(?:IF\\s+EXISTS\\s+)?(${SQL_IDENTIFIER}|__UNRESOLVED_(?:EXPRESSION|IDENTIFIER)__)`,
+                    'gi',
+                ),
+            },
+            {
+                access: 'ddl',
+                pattern: new RegExp(
+                    `\\bCREATE\\s+(?:UNIQUE\\s+)?INDEX(?:\\s+CONCURRENTLY)?(?:\\s+IF\\s+NOT\\s+EXISTS)?\\s+${SQL_IDENTIFIER}\\s+ON\\s+(?:ONLY\\s+)?(${SQL_IDENTIFIER}|__UNRESOLVED_(?:EXPRESSION|IDENTIFIER)__)`,
+                    'gi',
+                ),
+            },
+            {
+                access: 'ddl',
+                pattern: new RegExp(
+                    `\\bCREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?(${SQL_IDENTIFIER}|__UNRESOLVED_(?:EXPRESSION|IDENTIFIER)__)`,
+                    'gi',
+                ),
+            },
+            {
+                access: 'ddl',
+                pattern: new RegExp(
+                    `\\bDROP\\s+TABLE\\s+(?:IF\\s+EXISTS\\s+)?(${SQL_IDENTIFIER}|__UNRESOLVED_(?:EXPRESSION|IDENTIFIER)__)`,
+                    'gi',
+                ),
+            },
+            {
+                access: 'write',
+                pattern: new RegExp(
+                    `\\bUPDATE\\s+(${SQL_IDENTIFIER}|__UNRESOLVED_(?:EXPRESSION|IDENTIFIER)__)`,
+                    'gi',
+                ),
+            },
+            {
+                access: 'write',
+                pattern: new RegExp(
+                    `\\bINSERT\\s+INTO\\s+(${SQL_IDENTIFIER}|__UNRESOLVED_(?:EXPRESSION|IDENTIFIER)__)`,
+                    'gi',
+                ),
+            },
+            {
+                access: 'write',
+                pattern: new RegExp(
+                    `\\bDELETE\\s+FROM\\s+(${SQL_IDENTIFIER}|__UNRESOLVED_(?:EXPRESSION|IDENTIFIER)__)`,
+                    'gi',
+                ),
+            },
+        ];
+
+        for (const { access, pattern } of patterns) {
+            for (const identifier of sqlMatches(sql, pattern)) {
+                const table = normalizeSqlIdentifier(identifier);
+                if (!table) {
+                    unclassified(constructStart, constructEnd);
+                } else if (!ctes.has(table)) {
+                    addAccess(table, access);
+                }
+            }
+        }
+
+        const readPattern = new RegExp(
+            `\\b(FROM|JOIN)\\s+(${SQL_IDENTIFIER}|__UNRESOLVED_(?:EXPRESSION|IDENTIFIER)__)`,
+            'gi',
+        );
+        for (const match of sql.matchAll(readPattern)) {
+            const keyword = match[1].toUpperCase();
+            const identifier = match[2];
+            const start = match.index ?? 0;
+            const prefix = sql.slice(Math.max(0, start - 24), start);
+            const suffix = sql.slice(start + match[0].length);
+            const isExpressionContext =
+                (keyword === 'FROM' &&
+                    /\b(?:DISTINCT|BOTH)\s*$/i.test(prefix)) ||
+                /^(?:LATERAL|SELECT|VALUES|UNNEST)$/i.test(identifier) ||
+                /^\s*\(/.test(suffix);
+            if (!isExpressionContext) {
+                const table = normalizeSqlIdentifier(identifier);
+                if (!table) {
+                    unclassified(constructStart, constructEnd);
+                } else if (!ctes.has(table)) {
+                    addAccess(table, 'read');
+                }
+            }
+        }
+
+        if (/\bUPDATE\s+/i.test(sql)) containsBackfill = true;
+        if (/\bINSERT\s+INTO\b[\s\S]*\bSELECT\b/i.test(sql)) {
+            containsBackfill = true;
+        }
+        for (const match of sql.matchAll(
+            /\bSET\s+LOCAL\s+lock_timeout\s*=\s*['"]([^'"]+)['"]/gi,
+        )) {
+            lockTimeouts.add(match[1]);
+        }
+        if (/\bDROP\s+(?:INDEX|CONSTRAINT)\b/i.test(sql)) {
+            unclassified(constructStart, constructEnd);
+        }
+    }
+
+    for (const range of reachableFunctionBodies(source)) {
+        const schemaPattern = new RegExp(
+            `\\.\\s*schema\\s*\\.\\s*(${SCHEMA_METHODS.join('|')})\\s*\\(`,
+            'g',
+        );
+        for (const call of findCalls(source, range, schemaPattern)) {
+            const parsed = callArguments(source, call.openParenthesis);
+            if (!parsed) {
+                unclassified(call.start, call.openParenthesis);
+            } else {
+                addResolvedTable(
+                    parsed.argumentsList[0],
+                    'ddl',
+                    call.start,
+                    parsed.end,
+                );
+                if (call.match[1] === 'renameTable') {
+                    addResolvedTable(
+                        parsed.argumentsList[1],
+                        'ddl',
+                        call.start,
+                        parsed.end,
+                    );
+                }
+            }
+        }
+
+        const directMethods: Array<{ methods: string[]; access: TableAccess }> =
+            [
+                { methods: ['from'], access: 'read' },
+                { methods: ['into'], access: 'write' },
+                { methods: JOIN_METHODS, access: 'read' },
+            ];
+        for (const { methods, access } of directMethods) {
+            const pattern = new RegExp(
+                `\\.\\s*(?:${methods.join('|')})\\s*\\(`,
+                'g',
+            );
+            for (const call of findCalls(source, range, pattern)) {
+                const parsed = callArguments(source, call.openParenthesis);
+                if (!parsed) {
+                    unclassified(call.start, call.openParenthesis);
+                } else {
+                    addResolvedTable(
+                        parsed.argumentsList[0],
+                        access,
+                        call.start,
+                        parsed.end,
+                    );
+                }
+            }
+        }
+
+        const terminalMethods = WRITE_METHODS;
+        const terminalPattern = new RegExp(
+            `\\.\\s*(${terminalMethods.join('|')})\\s*\\(`,
+            'g',
+        );
+        for (const call of findCalls(source, range, terminalPattern)) {
+            const method = call.match[1];
+            const builder = nearestBuilderCall(source, range, call.start);
+            if (builder) {
+                const builderArguments = callArguments(
+                    source,
+                    builder.openParenthesis,
+                );
+                const terminalArguments = callArguments(
+                    source,
+                    call.openParenthesis,
+                );
+                if (!builderArguments || !terminalArguments) {
+                    unclassified(call.start, call.openParenthesis);
+                } else {
+                    addResolvedTable(
+                        builderArguments.argumentsList[0],
+                        'write',
+                        builder.start,
+                        terminalArguments.end,
+                    );
+                    if (method === 'update') containsBackfill = true;
+                    if (
+                        method === 'insert' &&
+                        new RegExp(
+                            `\\.\\s*(?:${READ_METHODS.join('|')})\\s*\\(`,
+                        ).test(
+                            scanSource(
+                                terminalArguments.argumentsList.join(','),
+                                true,
+                            ),
+                        )
+                    ) {
+                        containsBackfill = true;
+                    }
+                }
+            }
+        }
+
+        for (const call of findCalls(source, range, /\.\s*limit\s*\(/g)) {
+            const parsed = callArguments(source, call.openParenthesis);
+            const expression = parsed?.argumentsList[0];
+            const value = expression
+                ? resolveLiteral(expression, constants)
+                : undefined;
+            if (
+                expression &&
+                /batch/i.test(unwrapExpression(expression)) &&
+                typeof value === 'number' &&
+                Number.isInteger(value)
+            ) {
+                batchSizes.add(value);
+            } else if (typeof value !== 'number') {
+                unclassified(call.start, parsed?.end ?? call.openParenthesis);
+            }
+        }
+
+        for (const call of findCalls(
+            source,
+            range,
+            /\.\s*raw(?:\s*<[^;()]*>)?\s*\(/g,
+        )) {
+            const parsed = callArguments(source, call.openParenthesis);
+            if (!parsed || !parsed.argumentsList[0]) {
+                unclassified(call.start, parsed?.end ?? call.openParenthesis);
+            } else {
+                const rendered = renderSql(parsed.argumentsList[0], constants);
+                if (rendered === undefined) {
+                    unclassified(call.start, parsed.end);
+                } else {
+                    for (const batchSize of batchSizesFromSqlExpression(
+                        parsed.argumentsList[0],
+                        constants,
+                    )) {
+                        batchSizes.add(batchSize);
+                    }
+                    classifySql(
+                        substituteIdentifiers(
+                            rendered,
+                            parsed.argumentsList[1],
+                            constants,
+                        ),
+                        call.start,
+                        parsed.end,
+                    );
+                }
+            }
+        }
+    }
+
+    if (batchSizes.size > 1) {
+        unclassifiedConstructs.add(
+            `multiple LIMIT batch sizes: ${[...batchSizes].sort((a, b) => a - b).join(', ')}`,
+        );
+    }
+    if (lockTimeouts.size > 1) {
+        unclassifiedConstructs.add(
+            `multiple lock timeouts: ${[...lockTimeouts].sort().join(', ')}`,
+        );
+    }
+
+    const runsInTransaction = !configDisablesTransactions(source);
+    const batchSize = batchSizes.size === 1 ? [...batchSizes][0] : null;
+    const tables = [...accesses.entries()].map(([name, accessSet]) => {
+        if (accessSet.has('write')) accessSet.delete('read');
+        const access = ACCESS_ORDER.filter((candidate) =>
+            accessSet.has(candidate),
+        );
+        return {
+            name,
+            access,
+            expectedLockModes: access.map(
+                (candidate) => LOCK_MODE_BY_ACCESS[candidate],
+            ),
+        };
+    });
+
+    return {
+        fact: {
+            migration,
+            introducedIn,
+            runsInTransaction,
+            resumable: !runsInTransaction && batchSize !== null,
+            batchSize,
+            lockTimeout: lockTimeouts.size === 1 ? [...lockTimeouts][0] : null,
+            tables,
+            backfill: null,
+            notes: null,
+        },
+        unclassifiedConstructs: [...unclassifiedConstructs],
+        containsBackfill,
+    };
+}
+
+/** Resumable is a heuristic: non-transactional migrations with a bounded LIMIT are treated as resumable. */
+export function deriveMigrationFact(
+    source: string,
+    migration: string,
+    introducedIn: string,
+): MigrationFact {
+    return deriveMigrationFactWithDiagnostics(source, migration, introducedIn)
+        .fact;
+}
+
+export function migrationContainsBackfill(source: string): boolean {
+    return deriveMigrationFactWithDiagnostics(source, 'migration', 'unknown')
+        .containsBackfill;
+}
+
+function cliArguments(args: string[]): {
+    directory: string;
+    introducedIn: string;
+    summaryOnly: boolean;
+} {
+    let directory = 'packages/backend/src/database/migrations';
+    let introducedIn: string | undefined;
+    let summaryOnly = false;
+    for (let index = 0; index < args.length; index += 1) {
+        if (args[index] === '--directory') {
+            directory = args[index + 1] ?? '';
+            index += 1;
+        } else if (args[index] === '--introduced-in') {
+            introducedIn = args[index + 1];
+            index += 1;
+        } else if (args[index] === '--summary') {
+            summaryOnly = true;
+        } else {
+            throw new Error(`unknown argument: ${args[index]}`);
+        }
+    }
+    if (!introducedIn) {
+        throw new Error('--introduced-in is required and is never inferred');
+    }
+    return { directory, introducedIn, summaryOnly };
+}
+
+function runCli(): void {
+    const { directory, introducedIn, summaryOnly } = cliArguments(
+        process.argv.slice(2),
+    );
+    const files = fs
+        .readdirSync(directory, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && entry.name.endsWith('.ts'))
+        .map((entry) => entry.name)
+        .sort();
+    const derivations = files.map((file) => {
+        const migration = path.basename(file, path.extname(file));
+        const source = fs.readFileSync(path.join(directory, file), 'utf8');
+        return deriveMigrationFactWithDiagnostics(
+            source,
+            migration,
+            introducedIn,
+        );
+    });
+    const summary = {
+        factsProduced: derivations.length,
+        tablesClassified: derivations.reduce(
+            (total, derivation) => total + derivation.fact.tables.length,
+            0,
+        ),
+        constructsUnclassified: derivations.reduce(
+            (total, derivation) =>
+                total + derivation.unclassifiedConstructs.length,
+            0,
+        ),
+        backfillsDetected: derivations.filter(
+            (derivation) => derivation.containsBackfill,
+        ).length,
+    };
+    console.log(
+        JSON.stringify(
+            summaryOnly
+                ? summary
+                : {
+                      facts: derivations.map((derivation) => derivation.fact),
+                      unclassifiedConstructs: derivations.flatMap(
+                          (derivation) =>
+                              derivation.unclassifiedConstructs.map(
+                                  (construct) => ({
+                                      migration: derivation.fact.migration,
+                                      construct,
+                                  }),
+                              ),
+                      ),
+                      summary,
+                  },
+            null,
+            2,
+        ),
+    );
+}
+
+if (process.argv[1]?.endsWith('derive-migration-facts.ts')) {
+    try {
+        runCli();
+    } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+    }
+}


### PR DESCRIPTION
Linear: SPK-903

## Why

Migration facts were hand-authored, so **3 of 397** core migrations had them. Every fact-dependent check in the upgrade preflight was therefore dark for essentially every real upgrade, and hand-authoring was never going to close that gap at this repo's release rate.

The fields the shipped checks actually consume — `runsInTransaction`, `batchSize`, `lockTimeout`, and the tables touched with their access modes — are mechanically derivable from migration source. This derives them for all 397.

## What it does not do

The SQL fields need judgement and stay out of this layer: `backfill` is always `null` here. A separate exported predicate reports whether a migration backfills (41 do), so a later pass knows which ones need SQL authored.

## The rule throughout: under-claim, never over-claim

A missing table is a gap the existing coverage warning reports honestly. A *wrong* table is something an operator acts on — pausing the wrong writer, or reading a busy table as quiet. So any identifier that cannot be resolved to a literal is omitted and reported as an unclassified construct instead: 89 of them, visible rather than guessed at.

Postgres catalog relations are excluded for the same reason. Migrations routinely probe `pg_class`, `pg_constraint` and `information_schema` to test whether an index already exists, and reading those as application tables put 33 catalog claims in the corpus. In the worst case a migration adding primary keys declared `pg_class`, `pg_index` and `pg_constraint` *and nothing else* — describing catalog reads while saying nothing about the tables actually taking an `AccessExclusiveLock`.

## `introducedIn` is an argument, never inferred

Filename timestamps do not track release order here. `20260721170000_...` shipped in **1.4.0** while the later-named `20260722103000_...` shipped in **0.3462.0**, 104 releases earlier. A wrong `introducedIn` silently drops a migration from the preflight's range while everything upstream stays green.

## Verification

- Derived facts agree **exactly** with the three hand-authored facts on every structural field, including table/access sets — that corpus was written and checked against source by hand, so it is a real oracle.
- Full corpus run: 397 facts, 528 table classifications, 89 unclassified constructs, 41 backfills detected.
- Every claimed table name was cross-checked against a schema built by running all migrations on an empty database. Zero over-claims remain: the only names absent from the current schema are seven tables genuinely dropped by later migrations, plus `graphile_worker.jobs`, which lives in its own schema.
- `npm run test:release-safety` green.