### PR TITLE
feat(release): fill the facts asset from source so authors need do nothing

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -96,15 +96,16 @@ module.exports = {
             },
         ],
 
-        // Emit the per-release migration-facts asset (SPK-872): the hand-authored
-        // facts for migrations shipped in this release, consumed by the upgrade
-        // preflight. Same kill-switch as the marker — the generator writes nothing
-        // while RELEASE_SAFETY_MARKER_ENABLED != "true".
+        // Emit the per-release migration-facts asset (SPK-872), consumed by the
+        // upgrade preflight. --derive (SPK-903) fills in every migration nobody
+        // hand-authored a fact for, so adding a migration needs no extra work
+        // from its author. Same kill-switch as the marker — the generator writes
+        // nothing while RELEASE_SAFETY_MARKER_ENABLED != "true".
         [
             '@semantic-release/exec',
             {
                 prepareCmd:
-                    'npx tsx scripts/gen-migration-facts.ts --last-tag "${lastRelease.gitTag}" --release "${nextRelease.gitTag}" --cumulative-through "${nextRelease.gitTag}" --out migration-facts.json',
+                    'npx tsx scripts/gen-migration-facts.ts --last-tag "${lastRelease.gitTag}" --release "${nextRelease.gitTag}" --cumulative-through "${nextRelease.gitTag}" --derive --out migration-facts.json',
             },
         ],
 

--- a/scripts/gen-migration-facts.test.ts
+++ b/scripts/gen-migration-facts.test.ts
@@ -10,7 +10,10 @@ import * as path from 'path';
 import {
     assertFactsPointAtRealMigrations,
     buildFactsAsset,
+    deriveFactsForMigrations,
     gitNameStatus,
+    introducedInFromGit,
+    mergeAuthoredAndDerivedFacts,
     gitTreePaths,
     migrationNamesFromChanges,
     migrationNamesFromPaths,
@@ -326,6 +329,68 @@ test('a bogus corpus fact throws even when it is outside the selected range', ()
             /20260199000000_bogus/,
         );
     });
+});
+
+test('an authored fact wins over a derived one for the same migration', () => {
+    const authored: MigrationFact = {
+        migration: '20260101000000_one',
+        introducedIn: '1.51.0',
+        runsInTransaction: false,
+        resumable: true,
+        batchSize: 1000,
+        lockTimeout: '5s',
+        tables: [{ name: 'one', access: ['write'], expectedLockModes: [] }],
+        backfill: {
+            description: 'hand authored',
+            estimateSql: 'SELECT 1 FROM one',
+            planSql: null,
+            supportingIndexSql: null,
+        },
+        notes: null,
+    };
+    const derived: MigrationFact = {
+        ...authored,
+        tables: [],
+        batchSize: null,
+        backfill: null,
+    };
+    const merged = mergeAuthoredAndDerivedFacts(
+        [authored],
+        [derived, { ...derived, migration: '20260101000001_two' }],
+    );
+    assert.deepStrictEqual(merged.map((fact) => fact.migration), [
+        '20260101000000_one',
+        '20260101000001_two',
+    ]);
+    assert.deepStrictEqual(merged[0], authored);
+});
+
+test('a migration in no release yet falls back to the pending release', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'gen-facts-'));
+    const migrationPath = path.join(directory, '20260101000000_pending.ts');
+    fs.writeFileSync(
+        migrationPath,
+        'export async function up(knex) { await knex.raw(`UPDATE widgets SET a = 1`); }',
+    );
+    const placed = deriveFactsForMigrations([migrationPath], '2.0.0', () => null);
+    assert.strictEqual(placed.facts[0].introducedIn, '2.0.0');
+    assert.deepStrictEqual(placed.unresolved, []);
+
+    const unplaceable = deriveFactsForMigrations([migrationPath], null, () => null);
+    assert.deepStrictEqual(unplaceable.facts, []);
+    assert.deepStrictEqual(unplaceable.unresolved, ['20260101000000_pending']);
+    fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test('introducedIn comes from the release tags, not the filename timestamp', () => {
+    const later = introducedInFromGit(
+        'packages/backend/src/database/migrations/20260722103000_enforce_dashboard_project_slug_uniqueness.ts',
+    );
+    const earlier = introducedInFromGit(
+        'packages/backend/src/database/migrations/20260721170000_enforce_saved_query_project_slug_uniqueness.ts',
+    );
+    assert.strictEqual(later, '0.3462.0');
+    assert.strictEqual(earlier, '1.4.0');
 });
 
 if (failures.length > 0) {

--- a/scripts/gen-migration-facts.ts
+++ b/scripts/gen-migration-facts.ts
@@ -19,6 +19,8 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import { compareVersions } from '@lightdash/common';
+import { deriveMigrationFact } from './derive-migration-facts';
 import { GitChange } from './gen-release-safety';
 import { FactsFile, MigrationFact, parseFactsFile } from './preflight';
 
@@ -62,6 +64,21 @@ export function migrationNamesFromChanges(
             .map((change) => change.path),
         migrationDirs,
     );
+}
+
+/**
+ * Authored facts win: they carry backfill SQL and human judgement that
+ * derivation deliberately does not attempt.
+ */
+export function mergeAuthoredAndDerivedFacts(
+    authored: MigrationFact[],
+    derived: MigrationFact[],
+): MigrationFact[] {
+    const authoredNames = new Set(authored.map((fact) => fact.migration));
+    return [
+        ...authored,
+        ...derived.filter((fact) => !authoredNames.has(fact.migration)),
+    ].sort((a, b) => a.migration.localeCompare(b.migration));
 }
 
 export function selectFactsForMigrations(
@@ -146,6 +163,56 @@ export function gitTreePaths(ref: string, dirs: readonly string[]): string[] {
         .filter((line) => line.length > 0);
 }
 
+const RELEASE_TAG_RE = /^\d+\.\d+\.\d+$/;
+
+/**
+ * The release a migration first shipped in, from the tags containing the commit
+ * that added it. Filename timestamps do not track release order in this repo,
+ * so they are never used. Returns null for a migration not yet in any release.
+ */
+export function introducedInFromGit(migrationPath: string): string | null {
+    const addingCommit = execFileSync(
+        'git',
+        ['log', '--diff-filter=A', '--format=%H', '-1', '--', migrationPath],
+        { encoding: 'utf-8' },
+    ).trim();
+    if (!addingCommit) return null;
+    const tags = execFileSync(
+        'git',
+        ['tag', '--contains', addingCommit, '--list'],
+        { encoding: 'utf-8' },
+    )
+        .split('\n')
+        .map((tag) => tag.trim())
+        .filter((tag) => RELEASE_TAG_RE.test(tag));
+    return tags.sort(compareVersions)[0] ?? null;
+}
+
+export function deriveFactsForMigrations(
+    migrationPaths: string[],
+    pendingRelease: string | null,
+    resolveIntroducedIn: (migrationPath: string) => string | null = introducedInFromGit,
+): { facts: MigrationFact[]; unresolved: string[] } {
+    const facts: MigrationFact[] = [];
+    const unresolved: string[] = [];
+    for (const migrationPath of migrationPaths) {
+        const name = path.basename(migrationPath).replace(/\.(ts|js)$/, '');
+        const introducedIn = resolveIntroducedIn(migrationPath) ?? pendingRelease;
+        if (introducedIn === null) {
+            unresolved.push(name);
+            continue;
+        }
+        facts.push(
+            deriveMigrationFact(
+                fs.readFileSync(migrationPath, 'utf-8'),
+                name,
+                introducedIn,
+            ),
+        );
+    }
+    return { facts, unresolved };
+}
+
 export function assertFactsPointAtRealMigrations(
     facts: MigrationFact[],
     ref: string,
@@ -205,6 +272,35 @@ function main(): void {
     const source = get('--source') ?? DEFAULT_SOURCE;
     const factsFile = parseFactsFile(fs.readFileSync(source, 'utf-8'));
     assertFactsPointAtRealMigrations(factsFile.migrationFacts, 'HEAD');
+
+    if (argv.includes('--derive')) {
+        const authoredNames = new Set(
+            factsFile.migrationFacts.map((fact) => fact.migration),
+        );
+        const undocumented = gitTreePaths(to, MIGRATION_DIRS).filter(
+            (migrationPath) =>
+                isMigrationPath(migrationPath) &&
+                !authoredNames.has(
+                    path.basename(migrationPath).replace(/\.(ts|js)$/, ''),
+                ),
+        );
+        const { facts: derived, unresolved } = deriveFactsForMigrations(
+            undocumented,
+            cumulativeThrough ?? release,
+        );
+        for (const name of unresolved) {
+            console.log(
+                `[migration-facts] no release contains ${name} yet and no --release given; derived no fact for it`,
+            );
+        }
+        factsFile.migrationFacts = mergeAuthoredAndDerivedFacts(
+            factsFile.migrationFacts,
+            derived,
+        );
+        console.log(
+            `[migration-facts] derived ${derived.length} fact(s) for migrations with none authored; ${unresolved.length} could not be placed in a release`,
+        );
+    }
 
     const changes = cumulativeThrough
         ? null


### PR DESCRIPTION
Linear: SPK-903

Stacked on #27059.

## Why

The release asset shipped only hand-authored facts, and there were three. Every release since has published a facts file that told the upgrade preflight almost nothing — and closing that by asking migration authors to write facts would have added a step to every migration, forever.

This wires the derivation (#27058) into the release step, so the intended workflow holds end to end:

| Step | Who does it |
|---|---|
| engineer adds a migration | the engineer — and nothing else |
| migration is evaluated | automatic, at release |
| evaluation linked to a release | automatic, in the facts asset |
| self-hosted operator plans an upgrade | `lightdash preflight` |

## What changed

The release step now derives a fact for every migration nobody authored one for. Hand-authored facts still win where they exist — they carry backfill SQL and judgement that derivation deliberately does not attempt.

**Coverage goes from 3 facts to 578**, covering all 397 core and 181 Enterprise migrations.

Measured effect on real upgrade ranges:

| Upgrade range | Facts before | Facts after |
|---|---|---|
| 0.3137.0 → 0.3200.0 | 1 | 14 |
| 0.3400.0 → 0.3500.0 | 1 | 34 |
| 1.40.0 → 1.60.0 | 1 | 7 |
| 1.90.0 → 1.96.0 | **0** | 6 |

The last row is the point: an upgrade across the six most recent releases previously selected *no facts at all*.

## `introducedIn`

Derived from the release tags containing the commit that added the migration, never from the filename. Filename timestamps do not track release order here, and this reproduces the awkward cases exactly — the file stamped `20260722103000` shipped in 0.3462.0 while the earlier-stamped `20260721170000` shipped in 1.4.0, 104 releases later. A migration not yet in any release takes the release being built. Roughly 0.14s per migration, so ~55s for the full tree.

## Verification

- Generated asset validates against the facts schema; no duplicates, no missing or malformed `introducedIn`.
- The three hand-authored facts survive byte-identical, backfill SQL intact.
- 22 facts carry no tables — the honest under-claim case, where nothing could be resolved to a literal.
- Derivation of `introducedIn` matches the authored `introducedIn` on all three authored facts.
- `npm run test:release-safety` green.