### PR TITLE
ci(release-safety): verify each fact's SQL against its pre-upgrade schema

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -56,6 +56,7 @@ jobs:
       base_sha: ${{ steps.base.outputs.sha }}
       base_short: ${{ steps.base.outputs.short }}
       openapi: ${{ steps.filter.outputs.release_safety_api }}
+      facts: ${{ steps.watched.outputs.facts }}
       # 'true' only on an `edited` event whose head+base the sticky comment
       # already describes — empty when the fresh step is skipped, so downstream
       # `!= 'true'` gates default to running.
@@ -96,6 +97,17 @@ jobs:
               - 'scripts/upgrade-overrides.ts'
               - 'scripts/release-safety-pr-comment.ts'
               - '.github/file-filters.yml'
+              - '.github/workflows/release-safety-pr.yml'
+            # Narrower than `watched`: rebuilding historical schemas costs a
+            # Postgres and a few minutes, so it runs on the facts corpus and the
+            # migrations themselves rather than on every backend change.
+            facts:
+              - 'scripts/migration-facts.json'
+              - 'scripts/verify-migration-facts.ts'
+              - 'scripts/derive-migration-facts.ts'
+              - 'scripts/gen-migration-facts.ts'
+              - 'packages/backend/src/database/migrations/**'
+              - 'packages/backend/src/ee/database/migrations/**'
               - '.github/workflows/release-safety-pr.yml'
 
       # SPK-858: an `edited` event that changed neither the base nor the diff
@@ -226,6 +238,78 @@ jobs:
           name: release-safety-openapi-specs
           path: /tmp/openapi-specs/
           retention-days: 1
+
+  # SPK-903: a fact's estimateSql/planSql becomes a number in front of an
+  # operator planning an upgrade, and wrong SQL does not fail loudly — it
+  # produces a confidently wrong row estimate. Migrations here are append-only,
+  # so the schema at any past release can be rebuilt by pointing knex at only the
+  # migration files that existed at that tag (~5s on an empty database). This
+  # EXPLAINs each fact's own SQL against the schema it will really run on.
+  #
+  # Deliberately at PR time rather than in the release job: the release stays
+  # pure publication, needs no database, and can never be delayed by this.
+  migration-facts:
+    name: Verify migration facts
+    needs: changes
+    if: needs.changes.outputs.facts == 'true' && needs.changes.outputs.fresh != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      # Ephemeral and disposable: the verifier creates and force-drops a database
+      # per fact, so this must never point at the shared warehouse `pr.yml` uses.
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      # fetch-depth: 0 is load-bearing — reconstructing a historical schema reads
+      # the migration set out of `git ls-tree <tag>`, so tags and real history
+      # both have to be present.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+
+      - name: Install and build common
+        run: |
+          set -euo pipefail
+          sfw pnpm install --frozen-lockfile --prefer-offline
+          pnpm common-build
+
+      # --require-verified is the anti-vacuity guard: a corpus carrying no
+      # backfill SQL would otherwise pass this job without opening a database,
+      # and success would be indistinguishable from having checked nothing.
+      # A fact whose historical schema cannot be rebuilt reports UNVERIFIABLE
+      # and does not fail the run — that is a gap in what we can check, not a
+      # defect in the fact.
+      - name: Verify each fact's SQL against its pre-upgrade schema
+        env:
+          PGCONNECTIONURI: postgresql://postgres:postgres@localhost:5432/postgres
+        run: npx tsx scripts/verify-migration-facts.ts --require-verified
 
   preview:
     name: Release-safety preview

--- a/scripts/verify-migration-facts.test.ts
+++ b/scripts/verify-migration-facts.test.ts
@@ -8,6 +8,7 @@ import {
     verifyBatchedPlanShape,
     verifyEstimateCoversWriteTarget,
     verifyFact,
+    verifyPerPassCost,
     verifyPlanTables,
 } from './verify-migration-facts';
 
@@ -119,6 +120,9 @@ async function main(): Promise<void> {
             explain: async () => {
                 throw new Error('database should not be called');
             },
+            explainWithoutSeqScan: async () => {
+                throw new Error('database should not be called');
+            },
             executeSupportingIndex: async () => {
                 throw new Error('database should not be called');
             },
@@ -181,6 +185,43 @@ async function main(): Promise<void> {
         );
         assert.strictEqual(
             verifyBatchedPlanShape(fact({ batchSize: null }), stripped).ok,
+            true,
+        );
+    });
+
+    await test('a batched plan that still seq-scans its write target understates per-pass cost', () => {
+        const candidate = fact();
+        const verdict = verifyPerPassCost(
+            candidate,
+            'SELECT widget_id FROM widgets LIMIT 1000',
+            explain({ 'Node Type': 'Seq Scan', 'Relation Name': 'widgets' }),
+        );
+        assert.strictEqual(verdict.ok, false);
+        if (verdict.ok) return;
+        assert.strictEqual(verdict.reason, 'per-pass-cost-understated');
+    });
+
+    await test('per-pass cost passes on an index path, when already declared table, and when unbatched', () => {
+        const indexed = explain({
+            'Node Type': 'Index Only Scan',
+            'Relation Name': 'widgets',
+        });
+        const seqScanned = explain({
+            'Node Type': 'Seq Scan',
+            'Relation Name': 'widgets',
+        });
+        assert.strictEqual(verifyPerPassCost(fact(), 'x', indexed).ok, true);
+        assert.strictEqual(
+            verifyPerPassCost(fact({ batchSize: null }), 'x', seqScanned).ok,
+            true,
+        );
+        const declaredTable = fact();
+        declaredTable.backfill = {
+            ...declaredTable.backfill!,
+            perPassCost: 'table',
+        };
+        assert.strictEqual(
+            verifyPerPassCost(declaredTable, 'x', seqScanned).ok,
             true,
         );
     });

--- a/scripts/verify-migration-facts.test.ts
+++ b/scripts/verify-migration-facts.test.ts
@@ -135,9 +135,34 @@ async function main(): Promise<void> {
             total: 397,
             verified: 0,
             skipped: 397,
+            unverifiable: 0,
             failed: 0,
         });
         assert.match(summaryLine(summary), /0 verified against a database/);
+    });
+
+    await test('a fact whose schema cannot be rebuilt is unverifiable, not verified and not failed', () => {
+        const summary = summarizeVerdicts([
+            { ok: true, verified: true },
+            { ok: true, verified: false, unverifiable: true },
+            { ok: true, verified: false },
+        ]);
+        assert.deepStrictEqual(summary, {
+            total: 3,
+            verified: 1,
+            skipped: 1,
+            unverifiable: 1,
+            failed: 0,
+        });
+        assert.strictEqual(nothingVerifiedError(summary), null);
+        assert.match(summaryLine(summary), /1 unverifiable/);
+    });
+
+    await test('a corpus that is entirely unverifiable does not satisfy --require-verified', () => {
+        const summary = summarizeVerdicts([
+            { ok: true, verified: false, unverifiable: true },
+        ]);
+        assert.notStrictEqual(nothingVerifiedError(summary), null);
     });
 
     await test('--require-verified fails a run that checked nothing against a database', () => {
@@ -159,7 +184,7 @@ async function main(): Promise<void> {
                 { ok: false, verified: true },
                 { ok: true, verified: false },
             ]),
-            { total: 3, verified: 2, skipped: 1, failed: 1 },
+            { total: 3, verified: 2, skipped: 1, unverifiable: 0, failed: 1 },
         );
     });
 

--- a/scripts/verify-migration-facts.test.ts
+++ b/scripts/verify-migration-facts.test.ts
@@ -5,6 +5,8 @@ import {
     sqlFailureVerdict,
     summarizeVerdicts,
     summaryLine,
+    verifyBatchedPlanShape,
+    verifyEstimateCoversWriteTarget,
     verifyFact,
     verifyPlanTables,
 } from './verify-migration-facts';
@@ -125,6 +127,62 @@ async function main(): Promise<void> {
             ok: true,
             migration: candidate.migration,
         });
+    });
+
+    await test('an estimate that counts a read-only table misses the write target', () => {
+        const candidate = fact();
+        const sql = 'SELECT owner_id FROM owners';
+        const verdict = verifyEstimateCoversWriteTarget(
+            candidate,
+            sql,
+            explain({ 'Node Type': 'Seq Scan', 'Relation Name': 'owners' }),
+        );
+        assert.strictEqual(verdict.ok, false);
+        if (verdict.ok) return;
+        assert.strictEqual(verdict.reason, 'estimate-misses-write-target');
+        assert.deepStrictEqual(verdict.missingTables, ['widgets']);
+    });
+
+    await test('an estimate over the write target passes, and no declared write target skips the check', () => {
+        const candidate = fact();
+        assert.strictEqual(
+            verifyEstimateCoversWriteTarget(
+                candidate,
+                'SELECT widget_id FROM widgets',
+                explain({ 'Node Type': 'Seq Scan', 'Relation Name': 'widgets' }),
+            ).ok,
+            true,
+        );
+        const noWriteTarget = fact({
+            tables: [
+                { name: 'owners', access: ['read'], expectedLockModes: [] },
+            ],
+        });
+        assert.strictEqual(
+            verifyEstimateCoversWriteTarget(
+                noWriteTarget,
+                'SELECT owner_id FROM owners',
+                explain({ 'Node Type': 'Seq Scan', 'Relation Name': 'owners' }),
+            ).ok,
+            true,
+        );
+    });
+
+    await test("a batched migration's plan must carry its batch limit", () => {
+        const candidate = fact();
+        const stripped = 'SELECT widgets.widget_id FROM widgets';
+        const verdict = verifyBatchedPlanShape(candidate, stripped);
+        assert.strictEqual(verdict.ok, false);
+        if (verdict.ok) return;
+        assert.strictEqual(verdict.reason, 'plan-missing-batch-limit');
+        assert.strictEqual(
+            verifyBatchedPlanShape(candidate, `${stripped} LIMIT 1000`).ok,
+            true,
+        );
+        assert.strictEqual(
+            verifyBatchedPlanShape(fact({ batchSize: null }), stripped).ok,
+            true,
+        );
     });
 
     await test('a corpus with no backfill SQL reports zero verified, not silent success', () => {

--- a/scripts/verify-migration-facts.ts
+++ b/scripts/verify-migration-facts.ts
@@ -34,26 +34,42 @@ export interface VerificationFailure {
 
 export type VerificationVerdict = VerificationPass | VerificationFailure;
 
+/**
+ * Migrations here are append-only with one known exception (a core→EE move
+ * across 0.2123.0–0.2126.1), so a schema that cannot be rebuilt is a gap in what
+ * we can check, not a defect in the fact. It never counts as verified.
+ */
+export class HistoricalSchemaUnavailable extends Error {}
+
 export interface VerificationSummary {
     total: number;
     verified: number;
     skipped: number;
+    unverifiable: number;
     failed: number;
 }
 
 export function summarizeVerdicts(
-    results: ReadonlyArray<{ ok: boolean; verified: boolean }>,
+    results: ReadonlyArray<{
+        ok: boolean;
+        verified: boolean;
+        unverifiable?: boolean;
+    }>,
 ): VerificationSummary {
     return {
         total: results.length,
         verified: results.filter((result) => result.verified).length,
-        skipped: results.filter((result) => !result.verified).length,
+        skipped: results.filter(
+            (result) => !result.verified && result.unverifiable !== true,
+        ).length,
+        unverifiable: results.filter((result) => result.unverifiable === true)
+            .length,
         failed: results.filter((result) => !result.ok).length,
     };
 }
 
 export function summaryLine(summary: VerificationSummary): string {
-    return `${summary.total} fact(s): ${summary.verified} verified against a database, ${summary.skipped} skipped (no backfill SQL), ${summary.failed} failed`;
+    return `${summary.total} fact(s): ${summary.verified} verified against a database, ${summary.skipped} skipped (no backfill SQL), ${summary.unverifiable} unverifiable (schema could not be rebuilt), ${summary.failed} failed`;
 }
 
 export function nothingVerifiedError(
@@ -300,7 +316,7 @@ export function createHistoricalMigrationDirectory(tag: string): string {
         for (const migrationPath of historicalMigrationPaths(tag)) {
             const source = path.join(REPO_ROOT, migrationPath);
             if (!fs.existsSync(source)) {
-                throw new Error(
+                throw new HistoricalSchemaUnavailable(
                     `${migrationPath} exists at ${tag} but not in the current tree; historical reconstruction requires append-only migrations`,
                 );
             }
@@ -561,7 +577,11 @@ async function main(): Promise<void> {
         );
     }
     const results: Array<
-        VerificationVerdict & { previousTag: string | null; verified: boolean }
+        VerificationVerdict & {
+            previousTag: string | null;
+            verified: boolean;
+            unverifiable?: boolean;
+        }
     > = [];
     for (const fact of facts.migrationFacts) {
         if (fact.backfill === null) {
@@ -576,12 +596,29 @@ async function main(): Promise<void> {
             args.previousTags.get(fact.migration) ??
             args.defaultPreviousTag ??
             previousReleaseTag(fact.introducedIn);
-        const verdict = await verifyAgainstHistoricalSchema(
-            fact,
-            previousTag,
-            args.databaseUrl,
-            args.statementTimeoutSeconds,
-        );
+        let verdict: VerificationVerdict;
+        try {
+            verdict = await verifyAgainstHistoricalSchema(
+                fact,
+                previousTag,
+                args.databaseUrl,
+                args.statementTimeoutSeconds,
+            );
+        } catch (error) {
+            if (!(error instanceof HistoricalSchemaUnavailable)) throw error;
+            results.push({
+                ...passVerdict(fact),
+                previousTag,
+                verified: false,
+                unverifiable: true,
+            });
+            if (!args.json) {
+                console.log(
+                    `[verify-migration-facts] ${fact.migration} against ${previousTag}: UNVERIFIABLE (${errorMessage(error)})`,
+                );
+            }
+            continue;
+        }
         results.push({ ...verdict, previousTag, verified: true });
         if (!args.json) {
             console.log(

--- a/scripts/verify-migration-facts.ts
+++ b/scripts/verify-migration-facts.ts
@@ -16,6 +16,7 @@ export type VerificationFailureReason =
     | 'estimate-sql-error'
     | 'estimate-misses-write-target'
     | 'plan-missing-batch-limit'
+    | 'per-pass-cost-understated'
     | 'plan-sql-error'
     | 'plan-missing-tables'
     | 'supporting-index-sql-error';
@@ -87,6 +88,7 @@ interface ExplainResult {
 
 export interface FactSqlVerifier {
     explain: (sql: string) => Promise<unknown>;
+    explainWithoutSeqScan: (sql: string) => Promise<unknown>;
     executeSupportingIndex: (sql: string) => Promise<void>;
 }
 
@@ -252,6 +254,48 @@ export function verifyBatchedPlanShape(
     };
 }
 
+/**
+ * With sequential scans penalised, a plan that still scans the write target has
+ * no index serving its batch predicate, so every pass re-scans the whole table
+ * however little work is left. Claiming 'remaining' there tells an operator a
+ * long migration is short. Cardinality-independent, so an empty scratch schema
+ * answers it correctly.
+ */
+export function verifyPerPassCost(
+    fact: MigrationFact,
+    sql: string,
+    explainWithoutSeqScanJson: unknown,
+): VerificationVerdict {
+    if (fact.batchSize === null) return passVerdict(fact);
+    if (fact.backfill?.perPassCost === 'table') return passVerdict(fact);
+
+    const writeTables = new Set(
+        fact.tables
+            .filter((table) => table.access.includes('write'))
+            .map((table) => normalizedRelationName(table.name)),
+    );
+    if (writeTables.size === 0) return passVerdict(fact);
+
+    const plan = explainPlan(explainWithoutSeqScanJson);
+    if (plan === null) return passVerdict(fact);
+    const seqScanned = flattenPlan(plan)
+        .filter((node) => node['Node Type'] === 'Seq Scan')
+        .map((node) => node['Relation Name'])
+        .filter((name): name is string => name !== undefined)
+        .map(normalizedRelationName)
+        .filter((name) => writeTables.has(name));
+
+    if (seqScanned.length === 0) return passVerdict(fact);
+    return {
+        ok: false,
+        migration: fact.migration,
+        reason: 'per-pass-cost-understated',
+        sql,
+        message: `no index serves the batch predicate on ${seqScanned.join(', ')}, so every pass scans the whole table; perPassCost should be "table" rather than "remaining"`,
+        missingTables: seqScanned,
+    };
+}
+
 function errorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
@@ -301,6 +345,22 @@ export async function verifyFact(
 
     const planVerdict = verifyPlanTables(fact, planSql, plan);
     if (!planVerdict.ok) return planVerdict;
+
+    if (fact.batchSize !== null) {
+        let indexOnlyPlan: unknown;
+        try {
+            indexOnlyPlan = await verifier.explainWithoutSeqScan(planSql);
+        } catch (error) {
+            return sqlFailureVerdict(
+                fact,
+                'plan-sql-error',
+                planSql,
+                errorMessage(error),
+            );
+        }
+        const perPassVerdict = verifyPerPassCost(fact, planSql, indexOnlyPlan);
+        if (!perPassVerdict.ok) return perPassVerdict;
+    }
 
     if (fact.backfill.supportingIndexSql !== null) {
         try {
@@ -513,8 +573,25 @@ function postgresVerifier(
             await client.query('ROLLBACK');
         }
     };
+    const explainWithoutSeqScan = async (sql: string): Promise<unknown> => {
+        await client.query('BEGIN TRANSACTION READ ONLY');
+        try {
+            await client.query(
+                "SELECT set_config('statement_timeout', $1, true)",
+                [`${statementTimeoutSeconds}s`],
+            );
+            await client.query(
+                "SELECT set_config('enable_seqscan', 'off', true)",
+            );
+            const result = await client.query(`EXPLAIN (FORMAT JSON) ${sql}`);
+            return result.rows[0]?.['QUERY PLAN'];
+        } finally {
+            await client.query('ROLLBACK');
+        }
+    };
     return {
         explain,
+        explainWithoutSeqScan,
         executeSupportingIndex: async (sql: string): Promise<void> => {
             await client.query(
                 "SELECT set_config('statement_timeout', $1, false)",

--- a/scripts/verify-migration-facts.ts
+++ b/scripts/verify-migration-facts.ts
@@ -14,6 +14,8 @@ import { parseFactsFile } from './preflight';
 
 export type VerificationFailureReason =
     | 'estimate-sql-error'
+    | 'estimate-misses-write-target'
+    | 'plan-missing-batch-limit'
     | 'plan-sql-error'
     | 'plan-missing-tables'
     | 'supporting-index-sql-error';
@@ -198,6 +200,58 @@ export function verifyPlanTables(
     };
 }
 
+/**
+ * An estimate that counts a table the migration only reads describes the wrong
+ * population. Skipped when the fact declares no write target, because
+ * derivation deliberately under-claims rather than guess at one.
+ */
+export function verifyEstimateCoversWriteTarget(
+    fact: MigrationFact,
+    sql: string,
+    explainJson: unknown,
+): VerificationVerdict {
+    const writeTables = fact.tables
+        .filter((table) => table.access.includes('write'))
+        .map((table) => normalizedRelationName(table.name));
+    if (writeTables.length === 0) return passVerdict(fact);
+
+    const referencedTables = tablesReferencedByPlan(explainJson);
+    if (writeTables.some((table) => referencedTables.has(table))) {
+        return passVerdict(fact);
+    }
+    return {
+        ok: false,
+        migration: fact.migration,
+        reason: 'estimate-misses-write-target',
+        sql,
+        message: `estimateSql plan references none of the table(s) the migration writes: ${writeTables.join(', ')}`,
+        missingTables: writeTables,
+    };
+}
+
+/**
+ * A batched migration's plan describes one pass. Without the batch limit the
+ * preflight EXPLAINs the whole table and reports a cost the migration never
+ * pays in one go.
+ */
+export function verifyBatchedPlanShape(
+    fact: MigrationFact,
+    planSql: string,
+): VerificationVerdict {
+    if (fact.batchSize === null) return passVerdict(fact);
+    if (new RegExp(`\\bLIMIT\\s+${fact.batchSize}\\b`, 'i').test(planSql)) {
+        return passVerdict(fact);
+    }
+    return {
+        ok: false,
+        migration: fact.migration,
+        reason: 'plan-missing-batch-limit',
+        sql: planSql,
+        message: `migration batches at ${fact.batchSize} but the plan SQL carries no matching LIMIT, so the plan describes the whole table rather than one pass`,
+        missingTables: [],
+    };
+}
+
 function errorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
@@ -220,7 +274,17 @@ export async function verifyFact(
         );
     }
 
+    const estimateVerdict = verifyEstimateCoversWriteTarget(
+        fact,
+        fact.backfill.estimateSql,
+        estimatePlan,
+    );
+    if (!estimateVerdict.ok) return estimateVerdict;
+
     const planSql = fact.backfill.planSql ?? fact.backfill.estimateSql;
+    const batchVerdict = verifyBatchedPlanShape(fact, planSql);
+    if (!batchVerdict.ok) return batchVerdict;
+
     let plan = estimatePlan;
     if (planSql !== fact.backfill.estimateSql) {
         try {

--- a/scripts/verify-migration-facts.ts
+++ b/scripts/verify-migration-facts.ts
@@ -505,6 +505,8 @@ function postgresVerifier(
                 "SELECT set_config('statement_timeout', $1, true)",
                 [`${statementTimeoutSeconds}s`],
             );
+            // Plain EXPLAIN plans without executing, so volatile functions in
+            // the fact's SQL never run. Adding ANALYZE would execute it.
             const result = await client.query(`EXPLAIN (FORMAT JSON) ${sql}`);
             return result.rows[0]?.['QUERY PLAN'];
         } finally {


### PR DESCRIPTION
Linear: SPK-903

Stacked on #27060.

## Why

The verifier from #27059 had nowhere to run. This gives it a home: a job on the release-safety preview workflow with a disposable Postgres service that rebuilds the schema at the release *before* each fact's migration and `EXPLAIN`s the fact's own SQL against it.

Until now the only thing standing between a wrong `estimateSql` and a confidently wrong row estimate in front of an operator was a human reading the fact carefully. That worked for three facts. It does not scale.

## At PR time, not release time — deliberately

The release step stays pure publication: no database, no `ANTHROPIC_API_KEY`, no extra minutes, and no way for verification to delay or break a release. It also puts SQL in a diff a human can read before it ships, which matters more as facts stop being hand-written.

## Two details that are load-bearing

- **`fetch-depth: 0`.** Reconstructing a historical schema reads the migration set out of `git ls-tree <tag>`; the default checkout has neither tags nor history. This workflow already uses `fetch-depth: 0` elsewhere, which is part of why it's the right home — `release.yml` does not.
- **`--require-verified`.** A corpus carrying no backfill SQL would otherwise pass this job without ever opening a database, and success would be indistinguishable from having checked nothing.

The service container is ephemeral by design: the verifier creates and force-drops a database per fact, so it must never point at the shared warehouse `pr.yml` uses for dbt seeds.

## Append-only is 99.6% true, so unverifiable is now its own outcome

The technique rests on migrations being append-only. Sampling 25 release tags spanning 0.1.0 → 0.3395.2 found **one** violation: `20251022131031_add_chart_fields_to_embeddings` was deleted from core in "move embedding migration to EE" (#17801), so it exists at 0.2123.0 but not at HEAD. Affected window is roughly 0.2123.0 → 0.2126.1.

That used to throw and abort the whole run. It now reports `UNVERIFIABLE` — a gap in what we can check, not a defect in the fact. It never counts as verified (so `--require-verified` is not satisfied by it) and it does not fail the run.

## Verified by running it, not by reading it

Simulated the exact CI invocation locally against a fresh `postgres:16-alpine` — `PGCONNECTIONURI` only, no `--database-url`, exactly as the job passes it:

| Scenario | Result | Exit |
|---|---|---|
| the real committed corpus | 3 verified, 0 failed | 0 ✅ |
| facts broken in all 3 defect classes | 3 verified, **3 failed** | **1** ✅ job fails |
| corpus with no backfill SQL | vacuity guard fires | **1** ✅ job fails |
| pre-upgrade tag inside the append-only violation window | 3 **unverifiable**, 0 failed | 0 ✅ job passes, reports loudly |

`npm run test:release-safety` green (9 verify tests). Workflow YAML parses; job graph and `changes` outputs confirmed. Container and volume removed.