### PR TITLE
feat(release): backfill verified SQL for 30 historical migrations

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -56,6 +56,7 @@ jobs:
       base_sha: ${{ steps.base.outputs.sha }}
       base_short: ${{ steps.base.outputs.short }}
       openapi: ${{ steps.filter.outputs.release_safety_api }}
+      facts: ${{ steps.watched.outputs.facts }}
       # 'true' only on an `edited` event whose head+base the sticky comment
       # already describes — empty when the fresh step is skipped, so downstream
       # `!= 'true'` gates default to running.
@@ -96,6 +97,17 @@ jobs:
               - 'scripts/upgrade-overrides.ts'
               - 'scripts/release-safety-pr-comment.ts'
               - '.github/file-filters.yml'
+              - '.github/workflows/release-safety-pr.yml'
+            # Narrower than `watched`: rebuilding historical schemas costs a
+            # Postgres and a few minutes, so it runs on the facts corpus and the
+            # migrations themselves rather than on every backend change.
+            facts:
+              - 'scripts/migration-facts.json'
+              - 'scripts/verify-migration-facts.ts'
+              - 'scripts/derive-migration-facts.ts'
+              - 'scripts/gen-migration-facts.ts'
+              - 'packages/backend/src/database/migrations/**'
+              - 'packages/backend/src/ee/database/migrations/**'
               - '.github/workflows/release-safety-pr.yml'
 
       # SPK-858: an `edited` event that changed neither the base nor the diff
@@ -226,6 +238,78 @@ jobs:
           name: release-safety-openapi-specs
           path: /tmp/openapi-specs/
           retention-days: 1
+
+  # SPK-903: a fact's estimateSql/planSql becomes a number in front of an
+  # operator planning an upgrade, and wrong SQL does not fail loudly — it
+  # produces a confidently wrong row estimate. Migrations here are append-only,
+  # so the schema at any past release can be rebuilt by pointing knex at only the
+  # migration files that existed at that tag (~5s on an empty database). This
+  # EXPLAINs each fact's own SQL against the schema it will really run on.
+  #
+  # Deliberately at PR time rather than in the release job: the release stays
+  # pure publication, needs no database, and can never be delayed by this.
+  migration-facts:
+    name: Verify migration facts
+    needs: changes
+    if: needs.changes.outputs.facts == 'true' && needs.changes.outputs.fresh != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      # Ephemeral and disposable: the verifier creates and force-drops a database
+      # per fact, so this must never point at the shared warehouse `pr.yml` uses.
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      # fetch-depth: 0 is load-bearing — reconstructing a historical schema reads
+      # the migration set out of `git ls-tree <tag>`, so tags and real history
+      # both have to be present.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+
+      - name: Install and build common
+        run: |
+          set -euo pipefail
+          sfw pnpm install --frozen-lockfile --prefer-offline
+          pnpm common-build
+
+      # --require-verified is the anti-vacuity guard: a corpus carrying no
+      # backfill SQL would otherwise pass this job without opening a database,
+      # and success would be indistinguishable from having checked nothing.
+      # A fact whose historical schema cannot be rebuilt reports UNVERIFIABLE
+      # and does not fail the run — that is a gap in what we can check, not a
+      # defect in the fact.
+      - name: Verify each fact's SQL against its pre-upgrade schema
+        env:
+          PGCONNECTIONURI: postgresql://postgres:postgres@localhost:5432/postgres
+        run: npx tsx scripts/verify-migration-facts.ts --require-verified
 
   preview:
     name: Release-safety preview

--- a/scripts/backfill-migration-facts.ts
+++ b/scripts/backfill-migration-facts.ts
@@ -1,0 +1,172 @@
+import type { MigrationFact } from '@lightdash/common';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    deriveMigrationFact,
+    migrationContainsBackfill,
+} from './derive-migration-facts';
+import { introducedInFromGit } from './gen-migration-facts';
+import { parseFactsFile } from './preflight';
+import { proposeMigrationFact } from './propose-migration-facts';
+import {
+    previousReleaseTag,
+    verifyAgainstHistoricalSchema,
+} from './verify-migration-facts';
+
+const CORE_MIGRATIONS = 'packages/backend/src/database/migrations';
+const CORPUS = path.join(__dirname, 'migration-facts.json');
+
+interface Outcome {
+    migration: string;
+    introducedIn: string | null;
+    previousTag: string | null;
+    status: 'accepted' | 'rejected' | 'no-proposal' | 'error';
+    detail: string;
+}
+
+function backfillMigrations(): string[] {
+    return fs
+        .readdirSync(CORE_MIGRATIONS)
+        .filter((file) => /^\d{14}_.+\.ts$/.test(file))
+        .sort()
+        .filter((file) =>
+            migrationContainsBackfill(
+                fs.readFileSync(path.join(CORE_MIGRATIONS, file), 'utf-8'),
+            ),
+        )
+        .map((file) => file.replace(/\.ts$/, ''));
+}
+
+async function main(): Promise<void> {
+    const databaseUrl = process.argv.includes('--database-url')
+        ? process.argv[process.argv.indexOf('--database-url') + 1]
+        : null;
+    const limit = process.argv.includes('--limit')
+        ? Number(process.argv[process.argv.indexOf('--limit') + 1])
+        : Number.POSITIVE_INFINITY;
+    const outPath = process.argv.includes('--out')
+        ? process.argv[process.argv.indexOf('--out') + 1]
+        : null;
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+
+    const existing = parseFactsFile(fs.readFileSync(CORPUS, 'utf-8'));
+    const alreadyAuthored = new Set(
+        existing.migrationFacts.map((fact) => fact.migration),
+    );
+
+    const candidates = backfillMigrations()
+        .filter((name) => !alreadyAuthored.has(name))
+        .slice(0, limit);
+    console.log(
+        `[backfill] ${candidates.length} backfill migration(s) without an authored fact`,
+    );
+
+    const outcomes: Outcome[] = [];
+    const accepted: MigrationFact[] = [];
+
+    for (const migration of candidates) {
+        const migrationPath = path.join(CORE_MIGRATIONS, `${migration}.ts`);
+        const introducedIn = introducedInFromGit(migrationPath);
+        if (introducedIn === null) {
+            outcomes.push({
+                migration,
+                introducedIn: null,
+                previousTag: null,
+                status: 'error',
+                detail: 'not contained in any release tag',
+            });
+            continue;
+        }
+        let previousTag: string;
+        try {
+            previousTag = previousReleaseTag(introducedIn);
+        } catch (error) {
+            outcomes.push({
+                migration,
+                introducedIn,
+                previousTag: null,
+                status: 'error',
+                detail: error instanceof Error ? error.message : String(error),
+            });
+            continue;
+        }
+
+        const structuralFact = deriveMigrationFact(
+            fs.readFileSync(migrationPath, 'utf-8'),
+            migration,
+            introducedIn,
+        );
+
+        try {
+            const fact = await proposeMigrationFact({
+                apiKey,
+                previousTag,
+                migrationPath,
+                structuralFact,
+                verify: async (candidate) => {
+                    const verdict = await verifyAgainstHistoricalSchema(
+                        candidate,
+                        previousTag,
+                        databaseUrl,
+                        30,
+                    );
+                    return verdict.ok
+                        ? { ok: true }
+                        : { ok: false, reason: `${verdict.reason}: ${verdict.message}` };
+                },
+            });
+            if (fact === null || fact.backfill === null) {
+                outcomes.push({
+                    migration,
+                    introducedIn,
+                    previousTag,
+                    status: fact === null ? 'no-proposal' : 'rejected',
+                    detail: 'degraded to backfill: null',
+                });
+                console.log(`[backfill] ${migration}: no accepted SQL`);
+                continue;
+            }
+            accepted.push(fact);
+            outcomes.push({
+                migration,
+                introducedIn,
+                previousTag,
+                status: 'accepted',
+                detail: `perPassCost=${fact.backfill.perPassCost ?? 'remaining'}`,
+            });
+            console.log(`[backfill] ${migration}: ACCEPTED (verified)`);
+        } catch (error) {
+            outcomes.push({
+                migration,
+                introducedIn,
+                previousTag,
+                status: 'error',
+                detail: error instanceof Error ? error.message : String(error),
+            });
+            console.log(
+                `[backfill] ${migration}: ERROR ${error instanceof Error ? error.message : String(error)}`,
+            );
+        }
+    }
+
+    const tally = (status: Outcome['status']): number =>
+        outcomes.filter((outcome) => outcome.status === status).length;
+    console.log(
+        `[backfill] ${outcomes.length} attempted: ${tally('accepted')} accepted, ${tally('rejected')} rejected by verification, ${tally('no-proposal')} produced no proposal, ${tally('error')} errored`,
+    );
+
+    if (outPath !== null) {
+        fs.writeFileSync(
+            outPath,
+            `${JSON.stringify({ outcomes, accepted }, null, 4)}\n`,
+        );
+        console.log(`[backfill] wrote ${outPath}`);
+    }
+}
+
+main().catch((error) => {
+    console.error(
+        `[backfill] FAILED: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+});

--- a/scripts/migration-facts.json
+++ b/scripts/migration-facts.json
@@ -7,6 +7,641 @@
     "migrationsWithoutFacts": null,
     "migrationFacts": [
         {
+            "migration": "20210825125410_order_saved_fields",
+            "introducedIn": "0.6.5",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "saved_queries_version_fields",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Renumbers the \"order\" column of every row in saved_queries_version_fields. The migration reads the entire table sorted by (saved_queries_version_id, field_type, \"order\"), groups rows per saved query version, and issues one UPDATE ... WHERE saved_queries_version_field_id = ? per row so that each version's fields are numbered 0..n-1 across both dimensions and metrics. There is no batching: the full read and every per-row update run inside the single migration transaction, so the whole table is rewritten in one pass and row locks are held until commit.",
+                "estimateSql": "SELECT saved_queries_version_field_id FROM saved_queries_version_fields",
+                "planSql": "SELECT saved_queries_version_field_id, saved_queries_version_id, field_type, \"order\" FROM saved_queries_version_fields ORDER BY saved_queries_version_id, field_type, \"order\"",
+                "supportingIndexSql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS saved_queries_version_fields_order_idx ON saved_queries_version_fields (saved_queries_version_id, field_type, \"order\")",
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20220222155435_alter_chart_configuration",
+            "introducedIn": "0.28.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "saved_queries_versions",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "saved_queries_version_y_metrics",
+                    "access": [
+                        "read",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "AccessShareLock",
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "chart_types",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Adds the new 'cartesian' chart type, adds chart_config (jsonb) and pivot_dimensions (TEXT[]) to saved_queries_versions, then rewrites every saved chart version whose chart_type is not 'big_number' or 'table' (i.e. the legacy bar/column/line/scatter versions) in a single un-batched UPDATE: chart_type becomes 'cartesian', pivot_dimensions is built from group_dimension, and chart_config is built by aggregating that version's rows in saved_queries_version_y_metrics together with x_dimension. Afterwards saved_queries_version_y_metrics is dropped, x_dimension/group_dimension are dropped, and the legacy rows in chart_types are deleted. Touched-row count scales with the number of legacy chart versions, which is small in most installations.",
+                "estimateSql": "SELECT sqv.saved_queries_version_id FROM saved_queries_versions sqv WHERE sqv.chart_type NOT IN ('big_number', 'table')",
+                "planSql": "SELECT sqv.saved_queries_version_id, sqv.x_dimension, sqv.group_dimension, ct.chart_type, (SELECT jsonb_agg(jsonb_build_object('yField', ym.field_name, 'xField', sqv.x_dimension)) FROM saved_queries_version_y_metrics ym WHERE ym.saved_queries_version_id = sqv.saved_queries_version_id) AS chart_config FROM saved_queries_versions sqv JOIN chart_types ct ON ct.chart_type = sqv.chart_type WHERE sqv.chart_type NOT IN ('big_number', 'table')",
+                "supportingIndexSql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS saved_queries_version_y_metrics_version_id_idx ON saved_queries_version_y_metrics (saved_queries_version_id)",
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20220323111343_alter_chart_configuration",
+            "introducedIn": "0.37.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "saved_queries_versions",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Single-statement, unbatched rewrite of saved_queries_versions.chart_config: every row whose chart_type is 'cartesian' (the pre-existing migration folded bar/line/column/scatter into 'cartesian', so all non-'big_number'/'table' rows qualify) has its old {series:[...]} JSON reshaped into the new {layout, eChartsConfig} structure. The whole table is scanned once inside one transaction and every matching row is updated in place, so the row-level write volume equals the number of cartesian chart versions.",
+                "estimateSql": "SELECT sqv.saved_queries_version_id FROM saved_queries_versions sqv WHERE sqv.chart_type NOT IN ('big_number', 'table') AND sqv.chart_type = 'cartesian'",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20220907161709_multiply-dashboard-tile-size",
+            "introducedIn": "0.247.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [],
+            "backfill": {
+                "description": "Single unbatched UPDATE that multiplies x_offset, y_offset, width and height by 3 for every row in dashboard_tiles, rewriting the entire table (and its indexes) inside one transaction. There is no predicate and no batching, so every existing dashboard tile row is touched in one pass.",
+                "estimateSql": "SELECT dashboard_version_id, dashboard_tile_uuid, x_offset, y_offset, width, height FROM dashboard_tiles",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20230328152604_update_interactive_viewers",
+            "introducedIn": "0.489.1",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "organization_memberships",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Rewrites every organization_memberships row whose role is still 'viewer' to 'interactive_viewer' (the migration issues the same UPDATE twice against organization_memberships, since both table constants point at it; the second pass matches nothing). It is a single unbatched UPDATE inside one transaction, so all matching rows are locked and rewritten at once, and the pre-upgrade table has no index on role \u2014 the update requires a sequential scan of organization_memberships.",
+                "estimateSql": "SELECT organization_id, user_id, role FROM organization_memberships WHERE role = 'viewer'",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20230328160259_update_developer",
+            "introducedIn": "0.491.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "organization_memberships",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Renames the organization membership role 'editor' to 'developer': a single unbatched UPDATE of organization_memberships setting role='developer' wherever role='editor'. The migration issues the statement twice (both table constants resolve to organization_memberships), so the second pass matches no rows. Row count is bounded by the number of organization members currently holding the editor role, and every matching row is rewritten in one transaction.",
+                "estimateSql": "SELECT organization_id, user_id, role FROM organization_memberships WHERE role = 'editor'",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20240424131220_populate_slugs",
+            "introducedIn": "0.1082.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "saved_queries",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "dashboards",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "spaces",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "In a single transaction, rewrites every row of saved_queries, dashboards and spaces, setting slug to a lowercased, non-alphanumeric-collapsed form of the row's name, then rewrites all three tables again via ALTER COLUMN ... SET NOT NULL (each ALTER takes AccessExclusiveLock and, under knex's alter(), rebuilds the column type). There is no batching or WHERE clause: the update is one unqualified pass per table, so the whole of each table is touched and locked for the duration of the migration. The estimate enumerates all rows of the three tables, which is exactly the set the three UPDATE statements touch.",
+                "estimateSql": "SELECT sq.name AS name FROM saved_queries sq UNION ALL SELECT d.name AS name FROM dashboards d UNION ALL SELECT s.name AS name FROM spaces s",
+                "planSql": "SELECT REGEXP_REPLACE(LOWER(sq.name), '[^a-z0-9]+', '-', 'g') AS slug FROM saved_queries sq UNION ALL SELECT REGEXP_REPLACE(LOWER(d.name), '[^a-z0-9]+', '-', 'g') AS slug FROM dashboards d UNION ALL SELECT REGEXP_REPLACE(LOWER(s.name), '[^a-z0-9]+', '-', 'g') AS slug FROM spaces s",
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20240515102618_remove_table_calculation_filter_prefix",
+            "introducedIn": "0.1096.3",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "saved_queries_versions",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Rewrites the jsonb `filters` column of every saved_queries_versions row whose filters document contains a `tableCalculations` key, stripping the legacy `table_calculation_` prefix from field ids. The migration first selects all matching saved_queries_version_uuid values, then issues a single UPDATE over that uuid list inside one transaction, so the whole affected set is rewritten and locked in one pass.",
+                "estimateSql": "SELECT saved_queries_version_uuid FROM saved_queries_versions WHERE jsonb_path_exists(filters, '$.tableCalculations')",
+                "planSql": "SELECT saved_queries_version_uuid, replace(filters::text, '\"table_calculation_', '\"')::jsonb AS new_filters FROM saved_queries_versions WHERE jsonb_path_exists(filters, '$.tableCalculations')",
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20240604094543_add_views_columns_to_chart_and_dashboards_tables",
+            "introducedIn": "0.1121.3",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "dashboards",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "saved_queries",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "After adding views_count and first_viewed_at, the migration issues one unbatched UPDATE over every row of dashboards and one over every row of saved_queries, setting views_count from a correlated count over analytics_dashboard_views/analytics_chart_views and first_viewed_at from the earliest correlated timestamp. Every row in both tables is rewritten in a single transaction, so the whole of both tables is touched in one pass.",
+                "estimateSql": "SELECT d.dashboard_uuid AS uuid FROM dashboards d UNION ALL SELECT s.saved_query_uuid AS uuid FROM saved_queries s",
+                "planSql": "SELECT d.dashboard_uuid AS uuid, (SELECT count(adv.dashboard_uuid) FROM analytics_dashboard_views adv WHERE adv.dashboard_uuid = d.dashboard_uuid) AS views_count, (SELECT adv2.timestamp FROM analytics_dashboard_views adv2 WHERE adv2.dashboard_uuid = d.dashboard_uuid ORDER BY adv2.timestamp ASC LIMIT 1) AS first_viewed_at FROM dashboards d UNION ALL SELECT s.saved_query_uuid AS uuid, (SELECT count(acv.chart_uuid) FROM analytics_chart_views acv WHERE acv.chart_uuid = s.saved_query_uuid) AS views_count, (SELECT acv2.timestamp FROM analytics_chart_views acv2 WHERE acv2.chart_uuid = s.saved_query_uuid ORDER BY acv2.timestamp ASC LIMIT 1) AS first_viewed_at FROM saved_queries s",
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20241104104713_reset_users_active_status",
+            "introducedIn": "0.1341.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "users",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Unconditionally sets users.is_active = true for every row in the users table in a single UPDATE inside one transaction; there is no WHERE clause and no batching, so all user rows are rewritten and the whole table is held under RowExclusiveLock until the migration commits.",
+                "estimateSql": "SELECT user_id FROM users",
+                "planSql": "SELECT user_id, is_active FROM users",
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20241204093746_add-table-name-to-catalog-search-and-add-metrics-tree-edges-table",
+            "introducedIn": "0.1397.1",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "catalog_search",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "metrics_tree_edges",
+                    "access": [
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "cached_explore",
+                    "access": [
+                        "read"
+                    ],
+                    "expectedLockModes": [
+                        "AccessShareLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Adds a nullable text column catalog_search.table_name, then backfills it in a single un-batched UPDATE that joins every catalog_search row to its cached_explore parent on cached_explore_uuid and copies explore->>'baseTable'. The column is then altered to NOT NULL (a full table rewrite/validation under AccessExclusiveLock) and the metrics_tree_edges table is created. Every catalog_search row with a matching cached_explore row is rewritten in one transaction; the whole migration is one pass with no resume point.",
+                "estimateSql": "SELECT catalog_search.cached_explore_uuid, catalog_search.name, cached_explore.explore->>'baseTable' AS base_table FROM catalog_search JOIN cached_explore ON cached_explore.cached_explore_uuid = catalog_search.cached_explore_uuid",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20250115094940_fix_missing_slugs",
+            "introducedIn": "0.1455.2",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "saved_queries",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "dashboards",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "spaces",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Three unbatched UPDATE statements in one transaction repair rows whose slug is empty or NULL: saved_queries gets 'chart-<saved_query_id>', dashboards gets 'dashboard-<dashboard_id>', and spaces gets 'space-<space_id>'. The estimate enumerates exactly those defective rows in all three tables; in practice only a small residue of rows left behind by the earlier populate_slugs backfill should match, but each statement still rewrites every row it matches and holds row locks for the whole transaction.",
+                "estimateSql": "SELECT saved_query_id::text AS id FROM saved_queries WHERE slug = '' OR slug IS NULL UNION ALL SELECT dashboard_id::text AS id FROM dashboards WHERE slug = '' OR slug IS NULL UNION ALL SELECT space_id::text AS id FROM spaces WHERE slug = '' OR slug IS NULL",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20250501102249_add_status_column_to_results_cache",
+            "introducedIn": "0.1606.6",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "results_cache",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "After adding the NOT NULL 'status' column (default 'pending') to results_cache, the migration issues a single unfiltered UPDATE setting status = 'ready' for every existing row in results_cache. There is no batching and no predicate, so the cost is one full-table rewrite of results_cache inside the migration transaction.",
+                "estimateSql": "SELECT cache_key FROM results_cache",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20250529000000_make_cache_key_non_nullable",
+            "introducedIn": "0.1674.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "query_history",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Single un-batched UPDATE that sets query_history.cache_key = 'n/a' for every row where cache_key IS NULL, so the column can then be altered to NOT NULL. cache_key was added as a nullable FK to results_cache in 20250410085624 and has no index in the pre-upgrade schema, so the update requires a full scan of query_history and the subsequent ALTER ... SET NOT NULL takes AccessExclusiveLock and re-verifies every row. All of this happens inside one transaction.",
+                "estimateSql": "SELECT query_uuid FROM query_history WHERE cache_key IS NULL",
+                "planSql": null,
+                "supportingIndexSql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS query_history_cache_key_null_idx ON query_history (query_uuid) WHERE cache_key IS NULL",
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20251219171117_add_project_id_to_metrics_tree_edges",
+            "introducedIn": "0.2269.5",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "metrics_tree_edges",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "catalog_search",
+                    "access": [
+                        "read"
+                    ],
+                    "expectedLockModes": [
+                        "AccessShareLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "After adding the nullable project_uuid column, a single un-batched UPDATE sets metrics_tree_edges.project_uuid from catalog_search.project_uuid, joining on source_metric_catalog_search_uuid = catalog_search_uuid. Every edge row whose source metric still exists in catalog_search is rewritten in one pass inside the migration transaction, which holds AccessExclusiveLock on metrics_tree_edges for the surrounding ALTER TABLE steps (nullable add, SET NOT NULL validation scan, FK creation and index build).",
+                "estimateSql": "SELECT e.source_metric_catalog_search_uuid, e.target_metric_catalog_search_uuid, c.project_uuid FROM metrics_tree_edges e JOIN catalog_search c ON e.source_metric_catalog_search_uuid = c.catalog_search_uuid",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20260129134608_add_inherit_parent_permissions_to_spaces",
+            "introducedIn": "0.2400.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "spaces",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "After adding spaces.inherit_parent_permissions (NOT NULL DEFAULT true), a single un-batched UPDATE rewrites every root space (parent_space_uuid IS NULL), setting inherit_parent_permissions = NOT is_private. Child spaces keep the default of true and are untouched. The whole rewrite runs inside the migration transaction, holding AccessExclusiveLock from the ALTER TABLE and RowExclusiveLock for the UPDATE until commit.",
+                "estimateSql": "SELECT space_uuid FROM spaces WHERE parent_space_uuid IS NULL",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20260417111420_grant_custom_fields_to_custom_sql_roles",
+            "introducedIn": "0.2762.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "scoped_roles",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Copies the new 'manage:CustomFields' scope into every custom role that already grants 'manage:CustomSql': a single INSERT ... SELECT over scoped_roles filtered on scope_name = 'manage:CustomSql', re-inserting (role_uuid, 'manage:CustomFields', granted_by) with ON CONFLICT DO NOTHING so roles that already hold the new scope are skipped. One statement, no batching, run inside the migration transaction; the source rows are the scoped_roles rows carrying the old scope, so the touched row count equals the number of custom roles with manage:CustomSql.",
+                "estimateSql": "SELECT role_uuid, scope_name, granted_by FROM scoped_roles WHERE scope_name = 'manage:CustomSql'",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "remaining"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20260428120000_backfill_project_metrics_tree_from_legacy_ui_edges",
+            "introducedIn": "0.2826.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "metrics_trees",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "metrics_tree_nodes",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "metrics_tree_edges",
+                    "access": [
+                        "read"
+                    ],
+                    "expectedLockModes": [
+                        "AccessShareLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Single-statement, non-resumable backfill that migrates the legacy single-canvas metric graph into the new saved-trees model. It scans metrics_tree_edges for rows with source = 'ui' whose project has no row in metrics_trees yet, inserts one 'Project Metrics' tree per such project, then inserts one metrics_tree_nodes row per distinct source/target catalog_search_uuid appearing on those UI edges (ON CONFLICT DO NOTHING on the (metrics_tree_uuid, catalog_search_uuid) primary key). Work scales with the number of UI edges belonging to projects that do not already have a metrics tree; everything runs in one pass inside the migration transaction.",
+                "estimateSql": "SELECT e.project_uuid, e.source_metric_catalog_search_uuid, e.target_metric_catalog_search_uuid FROM metrics_tree_edges e WHERE e.source = 'ui' AND NOT EXISTS (SELECT 1 FROM metrics_trees t WHERE t.project_uuid = e.project_uuid)",
+                "planSql": "SELECT e.project_uuid, e.source_metric_catalog_search_uuid, e.target_metric_catalog_search_uuid, t.metrics_tree_uuid, n.catalog_search_uuid FROM metrics_tree_edges e LEFT JOIN metrics_trees t ON t.project_uuid = e.project_uuid LEFT JOIN metrics_tree_nodes n ON n.metrics_tree_uuid = t.metrics_tree_uuid AND n.catalog_search_uuid = e.source_metric_catalog_search_uuid WHERE e.source = 'ui'",
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20260511094034_grant_custom_sql_table_calculations_to_custom_sql_roles",
+            "introducedIn": "0.2906.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "scoped_roles",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Single-statement INSERT ... SELECT that copies one new row into scoped_roles for every existing grant of 'manage:CustomSql', with scope_name set to 'manage:CustomSqlTableCalculations' and the same role_uuid/granted_by. ON CONFLICT DO NOTHING makes it idempotent against the (role_uuid, scope_name) primary key. The row count touched equals the number of custom roles currently holding 'manage:CustomSql', which is bounded by the number of custom roles in the deployment and is normally tiny.",
+                "estimateSql": "SELECT role_uuid FROM scoped_roles WHERE scope_name = 'manage:CustomSql'",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "remaining"
+            },
+            "notes": null
+        },
+        {
             "migration": "20260610120000_default_saved_chart_timezone_to_project",
             "introducedIn": "0.3138.0",
             "runsInTransaction": false,
@@ -35,6 +670,158 @@
                 "perPassCost": "table"
             },
             "notes": "Every pass re-selects the remaining NULLs by scanning the table, so passes slow down as few NULLs remain; a concurrent writer appending rows extends the drain and its IO competes with the scan. The vetted partial index makes the remaining-NULLs lookup cheap once most rows are drained."
+        },
+        {
+            "migration": "20260624094144_user_attribute_multiple_values",
+            "introducedIn": "0.3243.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "organization_member_user_attributes",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "group_user_attributes",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "user_attributes",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Adds nullable text[] columns ('values' on organization_member_user_attributes and group_user_attributes, 'attribute_defaults' on user_attributes) and immediately backfills each with a single-element array wrapping the existing scalar column, in one transaction with no batching. Because value is NOT NULL on both attribute-assignment tables, the WHERE value IS NOT NULL predicate matches every row, so both tables are rewritten in full; user_attributes is rewritten for every row with a non-null attribute_default. All three UPDATEs are sequential seq-scan full-table rewrites holding AccessExclusiveLock from the ALTER TABLEs for the duration of the transaction.",
+                "estimateSql": "SELECT omua.value AS touched_value FROM organization_member_user_attributes omua WHERE omua.value IS NOT NULL UNION ALL SELECT gua.value FROM group_user_attributes gua WHERE gua.value IS NOT NULL UNION ALL SELECT ua.attribute_default FROM user_attributes ua WHERE ua.attribute_default IS NOT NULL",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20260624120002_add_download_audit_foreign_keys",
+            "introducedIn": "0.3234.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "download_audit",
+                    "access": [
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "organizations",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "projects",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Before adding the two foreign keys, the migration cleans up orphaned download_audit rows in one unbatched pass each: it DELETEs every row whose organization_uuid has no matching organizations row (CASCADE semantics), then sets project_uuid to NULL on every row whose non-null project_uuid has no matching projects row (SET NULL semantics). The estimate enumerates exactly those orphan rows \u2014 the union of both cleanups \u2014 by anti-joining download_audit against organizations and projects. Both statements are whole-table anti-joins run inside the migration transaction, followed by the CREATE INDEX on download_audit(project_uuid) and the two validated FK additions, which hold AccessExclusiveLock on download_audit for the duration.",
+                "estimateSql": "SELECT da.download_audit_id, da.organization_uuid, da.project_uuid, o.organization_id, p.project_id FROM download_audit da LEFT JOIN organizations o ON o.organization_uuid = da.organization_uuid LEFT JOIN projects p ON p.project_uuid = da.project_uuid WHERE o.organization_id IS NULL OR (da.project_uuid IS NOT NULL AND p.project_id IS NULL)",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20260720170411_grant_compiled_sql_view_to_custom_fields_roles",
+            "introducedIn": "0.3426.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "scoped_roles",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Single-statement backfill: for every scoped_roles row granting 'manage:CustomFields', insert a matching row granting the new 'view:CompiledSql' scope for the same role_uuid and granted_by, with ON CONFLICT DO NOTHING against the (role_uuid, scope_name) primary key. Row count is bounded by the number of custom roles that currently hold 'manage:CustomFields'; it runs in one pass inside the migration transaction and is wrapped in try/catch so a failure is logged rather than blocking later migrations.",
+                "estimateSql": "SELECT role_uuid FROM scoped_roles WHERE scope_name = 'manage:CustomFields'",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20260720223000_unique_onboarding_organization",
+            "introducedIn": "0.3453.0",
+            "runsInTransaction": false,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "onboarding",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Before adding the unique constraint on onboarding.organization_id, the migration de-duplicates the onboarding table in one unbatched pass: it aggregates every organization with more than one onboarding row, merges the earliest (MIN) ranQuery_at / shownSuccess_at / playground_project_deleted_at values onto the surviving lowest onboarding_id, then deletes every row whose onboarding_id is greater than the lowest one for the same organization_id. The estimate enumerates exactly those duplicate onboarding rows (all rows belonging to an organization that has more than one onboarding row); the surviving row of each group is updated and the rest are deleted. A unique index is then built CONCURRENTLY over the whole table and promoted to a constraint.",
+                "estimateSql": "SELECT o.onboarding_id, o.organization_id FROM onboarding o WHERE EXISTS (SELECT 1 FROM onboarding d WHERE d.organization_id = o.organization_id AND d.onboarding_id <> o.onboarding_id)",
+                "planSql": "SELECT duplicate.onboarding_id AS duplicate_id, original.onboarding_id AS survivor_id, duplicate.organization_id FROM onboarding duplicate JOIN onboarding original ON duplicate.organization_id = original.organization_id AND duplicate.onboarding_id > original.onboarding_id",
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
         },
         {
             "migration": "20260721112833_add_project_uuid_to_saved_queries",
@@ -92,6 +879,214 @@
             "notes": "Expand phase; every row starts NULL so the whole table is touched. A hard-killed run leaves the global knex lock held (see stale-lock check)."
         },
         {
+            "migration": "20260721170000_enforce_saved_query_project_slug_uniqueness",
+            "introducedIn": "1.4.0",
+            "runsInTransaction": false,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "saved_queries",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Repairs saved_queries in place before installing the project-scoped slug contract: dual-ownership rows have dashboard_uuid cleared, project_uuid is reconciled from the canonical ownership chains, and then every same-project duplicate slug is renamed to '<slug>-chart-<saved_query_id>' in committed batches of 10000 before a unique index on (project_uuid, slug) is built concurrently. The dominant data-rewriting pass is the slug deduplication: each pass recomputes ROW_NUMBER() OVER (PARTITION BY project_uuid, slug) across all of saved_queries and rewrites the non-winning rows, so the estimate enumerates the duplicate rows that will have their slug rewritten.",
+                "estimateSql": "SELECT ranked.saved_query_id FROM (SELECT saved_query_id, ROW_NUMBER() OVER (PARTITION BY project_uuid, slug ORDER BY (deleted_at IS NULL) DESC, created_at, saved_query_id) AS duplicate_number FROM saved_queries) AS ranked WHERE ranked.duplicate_number > 1",
+                "planSql": "WITH ranked AS (SELECT saved_query_id, project_uuid, slug, ROW_NUMBER() OVER (PARTITION BY project_uuid, slug ORDER BY (deleted_at IS NULL) DESC, created_at, saved_query_id) AS duplicate_number FROM saved_queries) SELECT ranked.saved_query_id, ranked.project_uuid, ranked.slug FROM ranked WHERE ranked.duplicate_number > 1 ORDER BY ranked.project_uuid, ranked.slug, ranked.saved_query_id LIMIT 10000",
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20260722072235_add_project_uuid_to_dashboards",
+            "introducedIn": "0.3447.0",
+            "runsInTransaction": false,
+            "resumable": true,
+            "batchSize": 1000,
+            "lockTimeout": "5s",
+            "tables": [
+                {
+                    "name": "dashboards",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "spaces",
+                    "access": [
+                        "read"
+                    ],
+                    "expectedLockModes": [
+                        "AccessShareLock"
+                    ]
+                },
+                {
+                    "name": "projects",
+                    "access": [
+                        "read"
+                    ],
+                    "expectedLockModes": [
+                        "AccessShareLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Adds a nullable dashboards.project_uuid column, then walks dashboards in primary-key order in batches of 1000 (dashboard_id > last_processed_id, up to a cutoff of MAX(dashboard_id) captured before the walk), resolving each dashboard's project through spaces.space_id -> spaces.project_id -> projects.project_id and setting project_uuid where it is still NULL. Pre-upgrade, every existing dashboards row has a NULL project_uuid, so the backfill touches the whole dashboards table once; rows whose resolved project_uuid is NULL are skipped by the UPDATE but still consumed by the batch cursor.",
+                "estimateSql": "SELECT dashboards.dashboard_id, spaces.space_id, projects.project_uuid FROM dashboards LEFT JOIN spaces ON spaces.space_id = dashboards.space_id LEFT JOIN projects ON projects.project_id = spaces.project_id WHERE dashboards.dashboard_id > 0 AND dashboards.dashboard_id <= (SELECT COALESCE(MAX(dashboard_id), 0) FROM dashboards)",
+                "planSql": "SELECT dashboards.dashboard_id, spaces.space_id, projects.project_uuid FROM dashboards LEFT JOIN spaces ON spaces.space_id = dashboards.space_id LEFT JOIN projects ON projects.project_id = spaces.project_id WHERE dashboards.dashboard_id > 0 AND dashboards.dashboard_id <= (SELECT COALESCE(MAX(dashboard_id), 0) FROM dashboards) ORDER BY dashboards.dashboard_id LIMIT 1000",
+                "supportingIndexSql": null,
+                "perPassCost": "remaining"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20260722103000_enforce_dashboard_project_slug_uniqueness",
+            "introducedIn": "0.3462.0",
+            "runsInTransaction": false,
+            "resumable": true,
+            "batchSize": 1000,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "dashboards",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "spaces",
+                    "access": [
+                        "read"
+                    ],
+                    "expectedLockModes": [
+                        "AccessShareLock"
+                    ]
+                },
+                {
+                    "name": "projects",
+                    "access": [
+                        "read"
+                    ],
+                    "expectedLockModes": [
+                        "AccessShareLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Repairs dashboards rows in 1000-row committed batches before the project-scoped slug contract is enforced. Phase one (run twice) re-derives dashboards.project_uuid from the canonical space_id -> spaces.project_id -> projects.project_uuid chain for every row whose stored value differs from the owning project. Phase two rewrites slugs of rows that are not the winner within their (project_uuid, slug) group, appending the dashboard_id (and a numeric attempt suffix when needed) and capping the result at 255 characters. Afterwards the unique index on (project_uuid, slug) is built concurrently and the NOT NULL and foreign-key contracts are validated; those DDL steps do no row rewriting but the concurrent index build and the two VALIDATE passes each read the whole dashboards table. The estimate enumerates the rows either phase can touch: dashboards whose project_uuid disagrees with the FK chain, plus dashboards sharing a (project_uuid, slug) pair with another row.",
+                "estimateSql": "SELECT dashboards.dashboard_id, dashboards.slug, spaces.space_id, projects.project_uuid FROM dashboards JOIN spaces ON spaces.space_id = dashboards.space_id JOIN projects ON projects.project_id = spaces.project_id WHERE dashboards.project_uuid IS DISTINCT FROM projects.project_uuid OR EXISTS (SELECT 1 FROM dashboards AS other WHERE other.dashboard_id <> dashboards.dashboard_id AND other.slug = dashboards.slug AND other.project_uuid IS NOT DISTINCT FROM dashboards.project_uuid)",
+                "planSql": "WITH batch AS (SELECT dashboards.dashboard_id, dashboards.slug, spaces.space_id, projects.project_uuid FROM dashboards JOIN spaces ON spaces.space_id = dashboards.space_id JOIN projects ON projects.project_id = spaces.project_id WHERE dashboards.project_uuid IS DISTINCT FROM projects.project_uuid ORDER BY dashboards.dashboard_id LIMIT 1000), ranked AS (SELECT dashboard_id, project_uuid, slug, ROW_NUMBER() OVER (PARTITION BY project_uuid, slug ORDER BY (deleted_at IS NULL) DESC, created_at, dashboard_id) AS duplicate_number FROM dashboards) SELECT batch.dashboard_id, batch.space_id, batch.project_uuid, ranked.dashboard_id AS duplicate_dashboard_id, ranked.slug FROM ranked LEFT JOIN batch ON batch.dashboard_id = ranked.dashboard_id WHERE ranked.duplicate_number > 1 ORDER BY ranked.project_uuid, ranked.slug, ranked.dashboard_id LIMIT 1000",
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20260722153938_grant_org_color_palette_scope_to_manage_org_roles",
+            "introducedIn": "0.3455.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "scoped_roles",
+                    "access": [
+                        "write"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Single-statement backfill: for every custom role row in scoped_roles holding scope_name = 'manage:Organization', insert a sibling row granting the newly split-out 'manage:OrganizationColorPalette' scope (same role_uuid and granted_by), with ON CONFLICT DO NOTHING so roles that already have the palette scope are untouched. The number of rows touched equals the number of existing 'manage:Organization' grants, which is bounded by the count of custom roles in the instance and is typically very small.",
+                "estimateSql": "SELECT role_uuid, scope_name, granted_by FROM scoped_roles WHERE scope_name = 'manage:Organization'",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "remaining"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20260722180000_enforce_saved_sql_project_slug_contract",
+            "introducedIn": "0.3472.0",
+            "runsInTransaction": false,
+            "resumable": true,
+            "batchSize": 1000,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "saved_sql",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "Repairs saved_sql rows before making project_uuid and slug NOT NULL. Three batched phases of 1000 rows each rewrite: (1) rows with a NULL slug, which receive a deterministic 'sql-chart-<uuid>' value; (2) rows whose slug duplicates another chart within the same canonical project (ownership resolved through spaces/projects directly, or through dashboards -> spaces -> projects), where every row but the winner of the (active first, then created_at, then uuid) ranking is suffixed with its chart UUID; (3) rows whose stored project_uuid differs from the canonical project derived from that ownership chain. Deleted rows participate. Afterwards NOT VALID CHECK constraints are added, validated and swapped for SET NOT NULL on project_uuid and slug, each briefly taking AccessExclusiveLock on saved_sql under a 5s lock_timeout.",
+                "estimateSql": "SELECT candidates.saved_sql_uuid FROM (SELECT saved_sql.saved_sql_uuid AS saved_sql_uuid, saved_sql.slug AS slug, saved_sql.project_uuid AS project_uuid, saved_sql_direct_space.space_id AS direct_space_id, saved_sql_direct_project.project_uuid AS direct_project_uuid, saved_sql_dashboard.dashboard_uuid AS dashboard_uuid, saved_sql_dashboard_space.space_id AS dashboard_space_id, saved_sql_dashboard_project.project_uuid AS dashboard_project_uuid, COALESCE(saved_sql_direct_project.project_uuid, saved_sql_dashboard_project.project_uuid) AS canonical_project_uuid, ROW_NUMBER() OVER (PARTITION BY COALESCE(saved_sql_direct_project.project_uuid, saved_sql_dashboard_project.project_uuid), saved_sql.slug ORDER BY (saved_sql.deleted_at IS NULL) DESC, saved_sql.created_at, saved_sql.saved_sql_uuid) AS duplicate_number FROM saved_sql AS saved_sql LEFT JOIN spaces AS saved_sql_direct_space ON saved_sql_direct_space.space_uuid = saved_sql.space_uuid LEFT JOIN projects AS saved_sql_direct_project ON saved_sql_direct_project.project_id = saved_sql_direct_space.project_id LEFT JOIN dashboards AS saved_sql_dashboard ON saved_sql_dashboard.dashboard_uuid = saved_sql.dashboard_uuid LEFT JOIN spaces AS saved_sql_dashboard_space ON saved_sql_dashboard_space.space_id = saved_sql_dashboard.space_id LEFT JOIN projects AS saved_sql_dashboard_project ON saved_sql_dashboard_project.project_id = saved_sql_dashboard_space.project_id) AS candidates WHERE candidates.slug IS NULL OR candidates.duplicate_number > 1 OR candidates.project_uuid IS DISTINCT FROM candidates.canonical_project_uuid",
+                "planSql": "WITH resolved AS (SELECT saved_sql.saved_sql_uuid AS saved_sql_uuid, saved_sql.slug AS slug, saved_sql.project_uuid AS project_uuid, saved_sql_direct_space.space_id AS direct_space_id, saved_sql_direct_project.project_uuid AS direct_project_uuid, saved_sql_dashboard.dashboard_uuid AS dashboard_uuid, saved_sql_dashboard_space.space_id AS dashboard_space_id, saved_sql_dashboard_project.project_uuid AS dashboard_project_uuid, COALESCE(saved_sql_direct_project.project_uuid, saved_sql_dashboard_project.project_uuid) AS canonical_project_uuid, ROW_NUMBER() OVER (PARTITION BY COALESCE(saved_sql_direct_project.project_uuid, saved_sql_dashboard_project.project_uuid), saved_sql.slug ORDER BY (saved_sql.deleted_at IS NULL) DESC, saved_sql.created_at, saved_sql.saved_sql_uuid) AS duplicate_number FROM saved_sql AS saved_sql LEFT JOIN spaces AS saved_sql_direct_space ON saved_sql_direct_space.space_uuid = saved_sql.space_uuid LEFT JOIN projects AS saved_sql_direct_project ON saved_sql_direct_project.project_id = saved_sql_direct_space.project_id LEFT JOIN dashboards AS saved_sql_dashboard ON saved_sql_dashboard.dashboard_uuid = saved_sql.dashboard_uuid LEFT JOIN spaces AS saved_sql_dashboard_space ON saved_sql_dashboard_space.space_id = saved_sql_dashboard.space_id LEFT JOIN projects AS saved_sql_dashboard_project ON saved_sql_dashboard_project.project_id = saved_sql_dashboard_space.project_id) SELECT resolved.saved_sql_uuid, resolved.slug, resolved.project_uuid, resolved.canonical_project_uuid, resolved.direct_space_id, resolved.direct_project_uuid, resolved.dashboard_uuid, resolved.dashboard_space_id, resolved.dashboard_project_uuid FROM resolved WHERE resolved.duplicate_number > 1 OR resolved.slug IS NULL OR resolved.project_uuid IS DISTINCT FROM resolved.canonical_project_uuid ORDER BY resolved.canonical_project_uuid, resolved.slug, resolved.saved_sql_uuid LIMIT 1000",
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
+            "migration": "20260727140000_enforce_app_project_slug_contract",
+            "introducedIn": "1.3.0",
+            "runsInTransaction": false,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "apps",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "apps.slug is added by this migration, so every existing row in apps (including soft-deleted rows, which still participate) starts with a NULL slug and must be backfilled from a slugified name, with an 'app-<sequence>' fallback when the name slugifies to empty. Backfill runs in 10000-row batches ordered by app_id, and is followed by a duplicate-repair loop that ranks all rows with ROW_NUMBER() OVER (PARTITION BY project_uuid, slug) and rewrites up to 1000 same-project duplicates per pass before the unique index on (project_uuid, slug) is built concurrently.",
+                "estimateSql": "SELECT app_id FROM apps",
+                "planSql": "SELECT app_id, LEFT(CASE WHEN TRIM(BOTH '-' FROM REGEXP_REPLACE(LOWER(name), '[^a-z0-9]+', '-', 'g')) = '' THEN 'app-fallback' ELSE TRIM(BOTH '-' FROM REGEXP_REPLACE(LOWER(name), '[^a-z0-9]+', '-', 'g')) END, 255) AS generated_slug FROM apps ORDER BY app_id LIMIT 10000",
+                "supportingIndexSql": null,
+                "perPassCost": "table"
+            },
+            "notes": null
+        },
+        {
             "migration": "20260731111612_grandfather_existing_incomplete_users_setup_complete",
             "introducedIn": "1.51.0",
             "runsInTransaction": true,
@@ -116,6 +1111,44 @@
                 "supportingIndexSql": null
             },
             "notes": "Not batched: on a large users table this holds row locks for the whole statement and the transaction blocks concurrent writers to the same rows."
+        },
+        {
+            "migration": "20260804120000_add_ai_agent_memory_enabled_to_organizations",
+            "introducedIn": "1.82.0",
+            "runsInTransaction": true,
+            "resumable": false,
+            "batchSize": null,
+            "lockTimeout": null,
+            "tables": [
+                {
+                    "name": "organizations",
+                    "access": [
+                        "write",
+                        "ddl"
+                    ],
+                    "expectedLockModes": [
+                        "RowExclusiveLock",
+                        "AccessExclusiveLock"
+                    ]
+                },
+                {
+                    "name": "feature_flag_overrides",
+                    "access": [
+                        "read"
+                    ],
+                    "expectedLockModes": [
+                        "AccessShareLock"
+                    ]
+                }
+            ],
+            "backfill": {
+                "description": "After adding the nullable boolean column organizations.ai_agent_memory_enabled, a single UPDATE sets it to true for every organization that has an org-level (user_uuid IS NULL) feature_flag_overrides row for flag_id 'ai-agent-memory' with enabled = true. The touched set is therefore only those opted-in organizations, not the whole organizations table; all other rows keep NULL and later inherit the new DEFAULT true. The whole statement runs in one pass inside the migration transaction, taking AccessExclusiveLock on organizations for the two ALTER TABLE statements.",
+                "estimateSql": "SELECT o.organization_uuid FROM organizations o JOIN feature_flag_overrides ffo ON ffo.organization_uuid = o.organization_uuid WHERE ffo.user_uuid IS NULL AND ffo.flag_id = 'ai-agent-memory' AND ffo.enabled = true",
+                "planSql": null,
+                "supportingIndexSql": null,
+                "perPassCost": "remaining"
+            },
+            "notes": null
         }
     ]
 }

--- a/scripts/preflight.test.ts
+++ b/scripts/preflight.test.ts
@@ -122,7 +122,12 @@ test('the shipped facts source file validates against the schema', () => {
         'utf-8',
     );
     const parsed = parseFactsFile(raw);
-    assert.strictEqual(parsed.migrationFacts.length, 3);
+    // Not an exact count: the corpus grows. Empty is the failure worth catching,
+    // because a corpus that silently became empty still validates.
+    assert.ok(
+        parsed.migrationFacts.length > 0,
+        'the shipped facts source file contains no facts',
+    );
     assert.strictEqual(parsed.release, null);
     assert.strictEqual(parsed.previousRelease, null);
     assert.strictEqual(parsed.cumulativeThrough, null);

--- a/scripts/propose-migration-facts.test.ts
+++ b/scripts/propose-migration-facts.test.ts
@@ -39,6 +39,7 @@ function response(
             planSql:
                 'SELECT widgets.widget_id, owners.owner_id FROM widgets JOIN owners ON owners.owner_id = widgets.owner_id WHERE widgets.ready = false LIMIT 1000',
             supportingIndexSql: null,
+            perPassCost: 'remaining',
             ...backfillOverrides,
         },
     });
@@ -53,9 +54,25 @@ assert.deepStrictEqual(valid, {
         planSql:
             'SELECT widgets.widget_id, owners.owner_id FROM widgets JOIN owners ON owners.owner_id = widgets.owner_id WHERE widgets.ready = false LIMIT 1000',
         supportingIndexSql: null,
+        perPassCost: 'remaining',
     },
     rejectionReason: null,
 });
+
+// The shared facts schema owns the enum, so an invalid value is rejected there
+// rather than by a duplicate check here.
+const invalidPerPassCost = validateMigrationFactProposal(
+    response({}, { perPassCost: 'whole-table' }),
+    structuralFact,
+);
+assert.strictEqual(invalidPerPassCost.backfill, null);
+assert.match(invalidPerPassCost.rejectionReason ?? '', /schema/);
+
+const tablePerPassCost = validateMigrationFactProposal(
+    response({}, { perPassCost: 'table' }),
+    structuralFact,
+);
+assert.strictEqual(tablePerPassCost.backfill?.perPassCost, 'table');
 
 for (const mutation of [
     {
@@ -117,14 +134,13 @@ assert.strictEqual(
 );
 
 const unexpectedBackfillField = validateMigrationFactProposal(
-    response({}, { perPassCost: 'remaining' }),
+    response({}, { estimatedSeconds: 12 }),
     structuralFact,
 );
+// Rejected by the shared schema; the local key-set check remains as a guard for
+// the case where the schema gains a field this validator does not yet know.
 assert.strictEqual(unexpectedBackfillField.backfill, null);
-assert.strictEqual(
-    unexpectedBackfillField.rejectionReason,
-    'model returned unexpected backfill fields',
-);
+assert.notStrictEqual(unexpectedBackfillField.rejectionReason, null);
 
 const nonConcurrentIndex = validateMigrationFactProposal(
     response(

--- a/scripts/propose-migration-facts.test.ts
+++ b/scripts/propose-migration-facts.test.ts
@@ -1,0 +1,160 @@
+import { type MigrationFact } from '@lightdash/common';
+import * as assert from 'assert';
+import { validateMigrationFactProposal } from './propose-migration-facts';
+
+const structuralFact: MigrationFact = {
+    migration: '20260807000000_backfill_widgets',
+    introducedIn: '1.100.0',
+    runsInTransaction: false,
+    resumable: true,
+    batchSize: 1000,
+    lockTimeout: '5s',
+    tables: [
+        {
+            name: 'widgets',
+            access: ['write'],
+            expectedLockModes: ['RowExclusiveLock'],
+        },
+        {
+            name: 'owners',
+            access: ['read'],
+            expectedLockModes: ['AccessShareLock'],
+        },
+    ],
+    backfill: null,
+    notes: null,
+};
+
+function response(
+    overrides: Partial<MigrationFact> = {},
+    backfillOverrides: Record<string, unknown> = {},
+): string {
+    return JSON.stringify({
+        ...structuralFact,
+        ...overrides,
+        backfill: {
+            description: 'Populate widget owners',
+            estimateSql:
+                'SELECT widgets.widget_id, owners.owner_id FROM widgets JOIN owners ON owners.owner_id = widgets.owner_id WHERE widgets.ready = false',
+            planSql:
+                'SELECT widgets.widget_id, owners.owner_id FROM widgets JOIN owners ON owners.owner_id = widgets.owner_id WHERE widgets.ready = false LIMIT 1000',
+            supportingIndexSql: null,
+            ...backfillOverrides,
+        },
+    });
+}
+
+const valid = validateMigrationFactProposal(response(), structuralFact);
+assert.deepStrictEqual(valid, {
+    backfill: {
+        description: 'Populate widget owners',
+        estimateSql:
+            'SELECT widgets.widget_id, owners.owner_id FROM widgets JOIN owners ON owners.owner_id = widgets.owner_id WHERE widgets.ready = false',
+        planSql:
+            'SELECT widgets.widget_id, owners.owner_id FROM widgets JOIN owners ON owners.owner_id = widgets.owner_id WHERE widgets.ready = false LIMIT 1000',
+        supportingIndexSql: null,
+    },
+    rejectionReason: null,
+});
+
+for (const mutation of [
+    {
+        tables: [
+            {
+                name: 'other_widgets',
+                access: ['write'],
+                expectedLockModes: ['RowExclusiveLock'],
+            },
+        ],
+    },
+    { batchSize: 500 },
+]) {
+    const result = validateMigrationFactProposal(
+        response(mutation as Partial<MigrationFact>),
+        structuralFact,
+    );
+    assert.strictEqual(result.backfill, null);
+    assert.strictEqual(
+        result.rejectionReason,
+        'model mutated structural fields',
+    );
+}
+
+for (const sql of [
+    'UPDATE widgets SET ready = true',
+    'DELETE FROM widgets',
+    'INSERT INTO widgets(widget_id) VALUES (1)',
+    'SELECT widget_id FROM widgets; SELECT owner_id FROM owners',
+    'WITH changed AS (UPDATE widgets SET ready = true RETURNING widget_id) SELECT widget_id FROM changed',
+    'SELECT widget_id FROM widgets FOR UPDATE',
+]) {
+    const result = validateMigrationFactProposal(
+        response({}, { estimateSql: sql }),
+        structuralFact,
+    );
+    assert.strictEqual(result.backfill, null);
+    assert.match(
+        result.rejectionReason ?? '',
+        /estimateSql rejected:|must be a single statement/,
+    );
+}
+
+const writingPlan = validateMigrationFactProposal(
+    response({}, { planSql: 'DELETE FROM owners' }),
+    structuralFact,
+);
+assert.strictEqual(writingPlan.backfill, null);
+assert.match(writingPlan.rejectionReason ?? '', /^planSql rejected:/);
+
+const missingBatchPlan = validateMigrationFactProposal(
+    response({}, { planSql: null }),
+    structuralFact,
+);
+assert.strictEqual(missingBatchPlan.backfill, null);
+assert.strictEqual(
+    missingBatchPlan.rejectionReason,
+    'batched migration requires a separate planSql',
+);
+
+const unexpectedBackfillField = validateMigrationFactProposal(
+    response({}, { perPassCost: 'remaining' }),
+    structuralFact,
+);
+assert.strictEqual(unexpectedBackfillField.backfill, null);
+assert.strictEqual(
+    unexpectedBackfillField.rejectionReason,
+    'model returned unexpected backfill fields',
+);
+
+const nonConcurrentIndex = validateMigrationFactProposal(
+    response(
+        {},
+        {
+            supportingIndexSql:
+                'CREATE INDEX widgets_ready_idx ON widgets (widget_id) WHERE ready = false',
+        },
+    ),
+    structuralFact,
+);
+assert.strictEqual(nonConcurrentIndex.backfill, null);
+assert.match(
+    nonConcurrentIndex.rejectionReason ?? '',
+    /CREATE \[UNIQUE\] INDEX CONCURRENTLY/,
+);
+
+for (const malformed of [
+    '{"migration":"truncated"',
+    'I cannot provide JSON for this migration.',
+]) {
+    const result = validateMigrationFactProposal(malformed, structuralFact);
+    assert.strictEqual(result.backfill, null);
+    assert.strictEqual(result.rejectionReason, 'could not parse final JSON');
+}
+
+const fenced = validateMigrationFactProposal(
+    `\`\`\`json\n${response()}\n\`\`\``,
+    structuralFact,
+);
+assert.notStrictEqual(fenced.backfill, null);
+
+console.log('propose-migration-facts: tests passed');

--- a/scripts/propose-migration-facts.ts
+++ b/scripts/propose-migration-facts.ts
@@ -1,0 +1,611 @@
+import { type BackfillFact, type MigrationFact } from '@lightdash/common';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { isDeepStrictEqual } from 'util';
+import { migrationContainsBackfill } from './derive-migration-facts';
+import { parseFactsFile } from './preflight';
+
+const MODEL = 'claude-opus-4-8';
+const MAX_TOOL_CALLS = 20;
+const MAX_TOKENS = 10000;
+const MAX_GREP_LINES = 80;
+const MAX_READ_CHARS = 16000;
+const MAX_MIGRATION_CHARS = 24000;
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+type ContentBlock = {
+    type: string;
+    text?: string;
+    id?: string;
+    name?: string;
+    input?: Record<string, unknown>;
+};
+
+interface MessagesResponse {
+    content: ContentBlock[];
+    stop_reason?: string;
+}
+
+export interface ProposalValidation {
+    backfill: BackfillFact | null;
+    rejectionReason: string | null;
+}
+
+export interface ProposalVerification {
+    ok: boolean;
+    reason: string | null;
+}
+
+export interface ProposeMigrationFactOptions {
+    apiKey: string | null | undefined;
+    previousTag: string;
+    migrationPath: string;
+    structuralFact: MigrationFact;
+    verify: (fact: MigrationFact) => Promise<ProposalVerification>;
+    log?: (message: string) => void;
+}
+
+interface ToolContext {
+    previousTag: string;
+    migrationPath: string;
+    migrationSource: string;
+}
+
+const SYSTEM = `You propose SQL metadata for one Lightdash Postgres migration.
+
+The supplied structural MigrationFact was derived deterministically from source and is authoritative. Return the complete fact with every field except backfill exactly unchanged. Fill only backfill.description, backfill.estimateSql, backfill.planSql, and backfill.supportingIndexSql. Do not add fields.
+
+estimateSql must be one read-only SELECT that enumerates the rows the migration will touch. It runs against the PRE-UPGRADE schema, before this migration: never reference a table or column created by the migration itself. planSql is either null when estimateSql already represents the batch query shape, or one read-only SELECT shaped like the migration's batch. The EXPLAIN plan must touch every table declared read or write by the structural fact. PostgreSQL can eliminate LEFT JOINs when no selected expression depends on them, so select a column from every joined table. supportingIndexSql is null unless a useful index can be created entirely against the pre-upgrade schema; otherwise it must be one CREATE [UNIQUE] INDEX CONCURRENTLY statement with no semicolon.
+
+Use the tools to inspect the pre-upgrade source and schema migrations. Prefer null supportingIndexSql to speculative DDL. If no safe pre-upgrade SELECT can describe the backfill, return JSON null. When finished, return only one JSON value: either the complete MigrationFact or null.`;
+
+function extractJson(text: string): unknown {
+    const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+    if (fenced) return JSON.parse(fenced[1]);
+    const start = Math.min(
+        ...['{', '['].map((character) => {
+            const index = text.indexOf(character);
+            return index === -1 ? Number.POSITIVE_INFINITY : index;
+        }),
+    );
+    if (!Number.isFinite(start)) return JSON.parse(text.trim());
+    const end = Math.max(text.lastIndexOf('}'), text.lastIndexOf(']'));
+    return JSON.parse(text.slice(start, end + 1));
+}
+
+function structuralPart(fact: MigrationFact): Omit<MigrationFact, 'backfill'> {
+    const { backfill: _backfill, ...structural } = fact;
+    return structural;
+}
+
+function readOnlySelectRejection(sql: string): string | null {
+    const trimmed = sql.trim();
+    if (trimmed.length === 0) return 'SQL is empty';
+    if (trimmed.includes(';')) return 'SQL contains a semicolon';
+
+    const withoutStrings = trimmed
+        .replace(/'(?:''|[^'])*'/g, "''")
+        .replace(/"(?:""|[^"])*"/g, '""')
+        .replace(/--[^\n\r]*/g, ' ')
+        .replace(/\/\*[\s\S]*?\*\//g, ' ');
+    const tokens: string[] =
+        withoutStrings.toUpperCase().match(/[A-Z_]+/g) ?? [];
+    if (tokens[0] !== 'SELECT' && tokens[0] !== 'WITH') {
+        return 'SQL must start with SELECT or WITH';
+    }
+    if (!tokens.includes('SELECT')) return 'SQL does not contain SELECT';
+    const forbidden = [
+        'ALTER',
+        'ANALYZE',
+        'CALL',
+        'COPY',
+        'CREATE',
+        'DELETE',
+        'DO',
+        'DROP',
+        'GRANT',
+        'INSERT',
+        'MERGE',
+        'REFRESH',
+        'REINDEX',
+        'REVOKE',
+        'TRUNCATE',
+        'UPDATE',
+        'VACUUM',
+    ].find((keyword) => tokens.includes(keyword));
+    if (forbidden !== undefined) return `SQL contains ${forbidden}`;
+    if (tokens.includes('INTO')) return 'SELECT INTO is not read-only';
+    for (let index = 0; index < tokens.length; index += 1) {
+        if (
+            tokens[index] === 'FOR' &&
+            ['UPDATE', 'SHARE'].includes(tokens[index + 1] ?? '')
+        ) {
+            return 'SELECT row locking is not read-only';
+        }
+        if (
+            tokens.slice(index, index + 4).join(' ') === 'FOR NO KEY UPDATE' ||
+            tokens.slice(index, index + 4).join(' ') === 'FOR KEY SHARE'
+        ) {
+            return 'SELECT row locking is not read-only';
+        }
+    }
+    return null;
+}
+
+function parseProposedFact(value: unknown): MigrationFact {
+    const facts = parseFactsFile(
+        JSON.stringify({
+            schemaVersion: '1-draft',
+            release: null,
+            previousRelease: null,
+            cumulativeThrough: null,
+            migrationsInRelease: null,
+            migrationsWithoutFacts: null,
+            migrationFacts: [value],
+        }),
+    );
+    return facts.migrationFacts[0];
+}
+
+export function validateMigrationFactProposal(
+    responseText: string,
+    structuralFact: MigrationFact,
+): ProposalValidation {
+    let raw: unknown;
+    try {
+        raw = extractJson(responseText);
+    } catch {
+        return {
+            backfill: null,
+            rejectionReason: 'could not parse final JSON',
+        };
+    }
+    if (raw === null) {
+        return {
+            backfill: null,
+            rejectionReason: 'model returned null',
+        };
+    }
+
+    let proposedFact: MigrationFact;
+    try {
+        proposedFact = parseProposedFact(raw);
+    } catch (error) {
+        return {
+            backfill: null,
+            rejectionReason: `response does not match the facts schema: ${error instanceof Error ? error.message : String(error)}`,
+        };
+    }
+    if (
+        !isDeepStrictEqual(
+            structuralPart(proposedFact),
+            structuralPart(structuralFact),
+        )
+    ) {
+        return {
+            backfill: null,
+            rejectionReason: 'model mutated structural fields',
+        };
+    }
+    if (proposedFact.backfill === null) {
+        return {
+            backfill: null,
+            rejectionReason: 'model returned no backfill',
+        };
+    }
+    const backfillKeys = Object.keys(proposedFact.backfill).sort();
+    const expectedBackfillKeys = [
+        'description',
+        'estimateSql',
+        'planSql',
+        'supportingIndexSql',
+    ].sort();
+    if (!isDeepStrictEqual(backfillKeys, expectedBackfillKeys)) {
+        return {
+            backfill: null,
+            rejectionReason: 'model returned unexpected backfill fields',
+        };
+    }
+    if (proposedFact.backfill.description.trim().length === 0) {
+        return {
+            backfill: null,
+            rejectionReason: 'backfill description is empty',
+        };
+    }
+    const estimateRejection = readOnlySelectRejection(
+        proposedFact.backfill.estimateSql,
+    );
+    if (estimateRejection !== null) {
+        return {
+            backfill: null,
+            rejectionReason: `estimateSql rejected: ${estimateRejection}`,
+        };
+    }
+    if (proposedFact.backfill.planSql !== null) {
+        const planRejection = readOnlySelectRejection(
+            proposedFact.backfill.planSql,
+        );
+        if (planRejection !== null) {
+            return {
+                backfill: null,
+                rejectionReason: `planSql rejected: ${planRejection}`,
+            };
+        }
+    }
+    if (structuralFact.batchSize !== null) {
+        if (proposedFact.backfill.planSql === null) {
+            return {
+                backfill: null,
+                rejectionReason:
+                    'batched migration requires a separate planSql',
+            };
+        }
+        const limitPattern = new RegExp(
+            `\\bLIMIT\\s+${structuralFact.batchSize}\\b`,
+            'i',
+        );
+        if (!limitPattern.test(proposedFact.backfill.planSql)) {
+            return {
+                backfill: null,
+                rejectionReason: `planSql does not contain LIMIT ${structuralFact.batchSize}`,
+            };
+        }
+    }
+    return { backfill: proposedFact.backfill, rejectionReason: null };
+}
+
+function git(args: string[]): { ok: boolean; output: string } {
+    try {
+        return {
+            ok: true,
+            output: execFileSync('git', args, {
+                cwd: REPO_ROOT,
+                encoding: 'utf8',
+                maxBuffer: 32 * 1024 * 1024,
+            }),
+        };
+    } catch (error) {
+        const result = error as {
+            status?: number;
+            stdout?: Buffer;
+            stderr?: Buffer;
+        };
+        if (result.status === 1) {
+            return { ok: true, output: result.stdout?.toString() ?? '' };
+        }
+        return {
+            ok: false,
+            output:
+                result.stderr?.toString() ??
+                (error instanceof Error ? error.message : String(error)),
+        };
+    }
+}
+
+function safeRepoPath(filePath: string): boolean {
+    return (
+        filePath.length > 0 &&
+        !path.isAbsolute(filePath) &&
+        !filePath.split('/').includes('..')
+    );
+}
+
+function tools(): unknown[] {
+    return [
+        {
+            name: 'grep_pre_upgrade_source',
+            description:
+                'Search the pre-upgrade git tree for an extended regex. Use this to trace tables and columns and find their schema history.',
+            input_schema: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['pattern'],
+                properties: {
+                    pattern: { type: 'string' },
+                    path: { type: 'string' },
+                },
+            },
+        },
+        {
+            name: 'read_pre_upgrade_file',
+            description:
+                'Read one repo-relative file from the pre-upgrade tree.',
+            input_schema: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['path'],
+                properties: { path: { type: 'string' } },
+            },
+        },
+        {
+            name: 'read_migration_source',
+            description: 'Read the migration source being described.',
+            input_schema: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {},
+            },
+        },
+    ];
+}
+
+function runTool(
+    name: string,
+    input: Record<string, unknown>,
+    context: ToolContext,
+): { text: string; isError: boolean } {
+    if (name === 'read_migration_source') {
+        return { text: context.migrationSource, isError: false };
+    }
+    if (name === 'read_pre_upgrade_file') {
+        const filePath = String(input.path ?? '');
+        if (!safeRepoPath(filePath)) {
+            return { text: 'error: unsafe or empty path', isError: true };
+        }
+        const result = git(['show', `${context.previousTag}:${filePath}`]);
+        if (!result.ok) {
+            return {
+                text: `cannot read ${filePath}: ${result.output.slice(0, 2000)}`,
+                isError: true,
+            };
+        }
+        return {
+            text:
+                result.output.length > MAX_READ_CHARS
+                    ? `${result.output.slice(0, MAX_READ_CHARS)}\n... (truncated)`
+                    : result.output,
+            isError: false,
+        };
+    }
+    if (name === 'grep_pre_upgrade_source') {
+        const pattern = String(input.pattern ?? '');
+        const filePath = String(input.path ?? '');
+        if (pattern.length === 0 || (filePath && !safeRepoPath(filePath))) {
+            return { text: 'error: invalid pattern or path', isError: true };
+        }
+        const args = [
+            'grep',
+            '-n',
+            '-I',
+            '-E',
+            '--no-color',
+            '-e',
+            pattern,
+            context.previousTag,
+        ];
+        if (filePath) args.push('--', filePath);
+        const result = git(args);
+        if (!result.ok) {
+            return {
+                text: `git grep failed: ${result.output.slice(0, 2000)}`,
+                isError: true,
+            };
+        }
+        const lines = result.output.split('\n').filter(Boolean);
+        return {
+            text:
+                lines.length === 0
+                    ? '(no matches)'
+                    : [
+                          ...lines.slice(0, MAX_GREP_LINES),
+                          ...(lines.length > MAX_GREP_LINES
+                              ? [
+                                    `... (${lines.length - MAX_GREP_LINES} more matches)`,
+                                ]
+                              : []),
+                      ].join('\n'),
+            isError: false,
+        };
+    }
+    return { text: `unknown tool ${name}`, isError: true };
+}
+
+async function callApi(
+    apiKey: string,
+    messages: unknown[],
+    availableTools: unknown[],
+): Promise<MessagesResponse> {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+            'x-api-key': apiKey,
+            'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+            model: MODEL,
+            max_tokens: MAX_TOKENS,
+            thinking: { type: 'adaptive' },
+            output_config: { effort: 'high' },
+            system: [
+                {
+                    type: 'text',
+                    text: SYSTEM,
+                    cache_control: { type: 'ephemeral' },
+                },
+            ],
+            tools: availableTools,
+            messages,
+        }),
+    });
+    if (!response.ok) {
+        throw new Error(
+            `Anthropic API ${response.status}: ${(await response.text()).slice(0, 500)}`,
+        );
+    }
+    return response.json() as Promise<MessagesResponse>;
+}
+
+function markRollingCache(messages: unknown[]): void {
+    for (let index = 1; index < messages.length; index += 1) {
+        const content = (messages[index] as { content?: unknown }).content;
+        if (!Array.isArray(content)) continue;
+        for (const block of content) {
+            if (block && typeof block === 'object') {
+                delete (block as { cache_control?: unknown }).cache_control;
+            }
+        }
+    }
+    const last = messages.at(-1) as { content?: unknown } | undefined;
+    if (
+        messages.length > 1 &&
+        Array.isArray(last?.content) &&
+        last.content.length > 0
+    ) {
+        (last.content.at(-1) as { cache_control?: unknown }).cache_control = {
+            type: 'ephemeral',
+        };
+    }
+}
+
+async function requestProposal(
+    apiKey: string,
+    context: ToolContext,
+    structuralFact: MigrationFact,
+    log: (message: string) => void,
+): Promise<BackfillFact | null> {
+    const availableTools = tools();
+    const migrationSource =
+        context.migrationSource.length > MAX_MIGRATION_CHARS
+            ? `${context.migrationSource.slice(0, MAX_MIGRATION_CHARS)}\n... (truncated)`
+            : context.migrationSource;
+    const messages: unknown[] = [
+        {
+            role: 'user',
+            content: [
+                {
+                    type: 'text',
+                    text: `Pre-upgrade git ref: ${context.previousTag}\nMigration path: ${context.migrationPath}\n\nAuthoritative structural fact:\n${JSON.stringify(structuralFact, null, 2)}\n\nMigration source:\n\`\`\`typescript\n${migrationSource}\n\`\`\``,
+                    cache_control: { type: 'ephemeral' },
+                },
+            ],
+        },
+    ];
+    let toolCalls = 0;
+    for (let turn = 0; turn <= MAX_TOOL_CALLS; turn += 1) {
+        markRollingCache(messages);
+        let response: MessagesResponse;
+        try {
+            response = await callApi(apiKey, messages, availableTools);
+        } catch (error) {
+            log(
+                `degrade: API error: ${error instanceof Error ? error.message : String(error)}`,
+            );
+            return null;
+        }
+        if (response.stop_reason === 'refusal') {
+            log('degrade: model refused');
+            return null;
+        }
+        if (response.stop_reason === 'max_tokens') {
+            log('degrade: response truncated');
+            return null;
+        }
+        messages.push({ role: 'assistant', content: response.content });
+        const toolUses = response.content.filter(
+            (block) => block.type === 'tool_use',
+        );
+        if (toolUses.length === 0) {
+            const textBlock = response.content.find(
+                (block) => block.type === 'text' && block.text,
+            );
+            if (textBlock?.text === undefined) {
+                log('degrade: no final text');
+                return null;
+            }
+            const validation = validateMigrationFactProposal(
+                textBlock.text,
+                structuralFact,
+            );
+            if (validation.backfill === null) {
+                log(`degrade: ${validation.rejectionReason}`);
+            }
+            return validation.backfill;
+        }
+        if (toolCalls + toolUses.length > MAX_TOOL_CALLS) {
+            log(`degrade: tool-call budget exhausted (${MAX_TOOL_CALLS})`);
+            return null;
+        }
+        toolCalls += toolUses.length;
+        messages.push({
+            role: 'user',
+            content: toolUses.map((toolUse) => {
+                const result = runTool(
+                    toolUse.name ?? '',
+                    toolUse.input ?? {},
+                    context,
+                );
+                return {
+                    type: 'tool_result',
+                    tool_use_id: toolUse.id,
+                    content: result.text,
+                    is_error: result.isError,
+                };
+            }),
+        });
+    }
+    log('degrade: loop did not converge');
+    return null;
+}
+
+export async function proposeMigrationFact(
+    options: ProposeMigrationFactOptions,
+): Promise<MigrationFact | null> {
+    const log = options.log ?? (() => {});
+    let migrationSource: string;
+    try {
+        migrationSource = fs.readFileSync(options.migrationPath, 'utf8');
+    } catch (error) {
+        log(
+            `degrade: could not read migration: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return null;
+    }
+    if (!migrationContainsBackfill(migrationSource)) {
+        log('degrade: deterministic detector found no backfill');
+        return null;
+    }
+    if (!options.apiKey) {
+        log('degrade: ANTHROPIC_API_KEY is not set');
+        return null;
+    }
+    const revision = git([
+        'rev-parse',
+        '--verify',
+        `${options.previousTag}^{commit}`,
+    ]);
+    if (!revision.ok) {
+        log(`degrade: invalid pre-upgrade ref ${options.previousTag}`);
+        return null;
+    }
+    const context = {
+        previousTag: options.previousTag,
+        migrationPath: options.migrationPath,
+        migrationSource,
+    };
+    const backfill = await requestProposal(
+        options.apiKey,
+        context,
+        options.structuralFact,
+        log,
+    );
+    if (backfill === null) return null;
+    const candidate = { ...options.structuralFact, backfill };
+    let verification: ProposalVerification;
+    try {
+        verification = await options.verify(candidate);
+    } catch (error) {
+        log(
+            `degrade: verification error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return null;
+    }
+    if (!verification.ok) {
+        log(
+            `degrade: verification failed: ${verification.reason ?? 'unknown'}`,
+        );
+        return null;
+    }
+    return candidate;
+}

--- a/scripts/propose-migration-facts.ts
+++ b/scripts/propose-migration-facts.ts
@@ -54,9 +54,11 @@ interface ToolContext {
 
 const SYSTEM = `You propose SQL metadata for one Lightdash Postgres migration.
 
-The supplied structural MigrationFact was derived deterministically from source and is authoritative. Return the complete fact with every field except backfill exactly unchanged. Fill only backfill.description, backfill.estimateSql, backfill.planSql, and backfill.supportingIndexSql. Do not add fields.
+The supplied structural MigrationFact was derived deterministically from source and is authoritative. Return the complete fact with every field except backfill exactly unchanged. Fill only backfill.description, backfill.estimateSql, backfill.planSql, backfill.supportingIndexSql, and backfill.perPassCost. Do not add fields.
 
 estimateSql must be one read-only SELECT that enumerates the rows the migration will touch. It runs against the PRE-UPGRADE schema, before this migration: never reference a table or column created by the migration itself. planSql is either null when estimateSql already represents the batch query shape, or one read-only SELECT shaped like the migration's batch. The EXPLAIN plan must touch every table declared read or write by the structural fact. PostgreSQL can eliminate LEFT JOINs when no selected expression depends on them, so select a column from every joined table. supportingIndexSql is null unless a useful index can be created entirely against the pre-upgrade schema; otherwise it must be one CREATE [UNIQUE] INDEX CONCURRENTLY statement with no semicolon.
+
+perPassCost is "remaining" or "table" and describes what ONE batch costs as the backfill drains. Answer it by asking whether an index on the PRE-UPGRADE schema serves the batch predicate and ordering. Batching on an indexed column — a primary key, or any column with a suitable index — lets each pass seek straight to the next rows, so cost falls with the work remaining: "remaining". Batching on an unindexed predicate makes every pass scan or sort the whole table to find the next rows, so cost stays flat however little work is left: "table". Say "table" whenever you are unsure, because understating this tells an operator a long migration is short.
 
 Use the tools to inspect the pre-upgrade source and schema migrations. Prefer null supportingIndexSql to speculative DDL. If no safe pre-upgrade SELECT can describe the backfill, return JSON null. When finished, return only one JSON value: either the complete MigrationFact or null.`;
 
@@ -200,6 +202,7 @@ export function validateMigrationFactProposal(
         'estimateSql',
         'planSql',
         'supportingIndexSql',
+        'perPassCost',
     ].sort();
     if (!isDeepStrictEqual(backfillKeys, expectedBackfillKeys)) {
         return {

--- a/scripts/propose-migration-facts.ts
+++ b/scripts/propose-migration-facts.ts
@@ -6,7 +6,7 @@ import { isDeepStrictEqual } from 'util';
 import { migrationContainsBackfill } from './derive-migration-facts';
 import { parseFactsFile } from './preflight';
 
-const MODEL = 'claude-opus-4-8';
+const MODEL = 'claude-opus-5';
 const MAX_TOOL_CALLS = 20;
 const MAX_TOKENS = 10000;
 const MAX_GREP_LINES = 80;
@@ -56,7 +56,7 @@ const SYSTEM = `You propose SQL metadata for one Lightdash Postgres migration.
 
 The supplied structural MigrationFact was derived deterministically from source and is authoritative. Return the complete fact with every field except backfill exactly unchanged. Fill only backfill.description, backfill.estimateSql, backfill.planSql, backfill.supportingIndexSql, and backfill.perPassCost. Do not add fields.
 
-estimateSql must be one read-only SELECT that enumerates the rows the migration will touch. It runs against the PRE-UPGRADE schema, before this migration: never reference a table or column created by the migration itself. planSql is either null when estimateSql already represents the batch query shape, or one read-only SELECT shaped like the migration's batch. The EXPLAIN plan must touch every table declared read or write by the structural fact. PostgreSQL can eliminate LEFT JOINs when no selected expression depends on them, so select a column from every joined table. supportingIndexSql is null unless a useful index can be created entirely against the pre-upgrade schema; otherwise it must be one CREATE [UNIQUE] INDEX CONCURRENTLY statement with no semicolon.
+estimateSql must be one read-only SELECT that ENUMERATES the rows the migration will touch — select a column from them. Never aggregate: the preflight reads its row estimate from the top plan node, so count(*) reports one row however large the backfill is. It runs against the PRE-UPGRADE schema, before this migration: never reference a table or column created by the migration itself. planSql is either null when estimateSql already represents the batch query shape, or one read-only SELECT shaped like the migration's batch. The EXPLAIN plan must touch every table declared read or write by the structural fact. PostgreSQL can eliminate LEFT JOINs when no selected expression depends on them, so select a column from every joined table. supportingIndexSql is null unless a useful index can be created entirely against the pre-upgrade schema; otherwise it must be one CREATE [UNIQUE] INDEX CONCURRENTLY statement with no semicolon.
 
 perPassCost is "remaining" or "table" and describes what ONE batch costs as the backfill drains. Answer it by asking whether an index on the PRE-UPGRADE schema serves the batch predicate and ordering. Batching on an indexed column — a primary key, or any column with a suitable index — lets each pass seek straight to the next rows, so cost falls with the work remaining: "remaining". Batching on an unindexed predicate makes every pass scan or sort the whole table to find the next rows, so cost stays flat however little work is left: "table". Say "table" whenever you are unsure, because understating this tells an operator a long migration is short.
 

--- a/scripts/verify-migration-facts.test.ts
+++ b/scripts/verify-migration-facts.test.ts
@@ -8,6 +8,7 @@ import {
     verifyBatchedPlanShape,
     verifyEstimateCoversWriteTarget,
     verifyFact,
+    verifyPerPassCost,
     verifyPlanTables,
 } from './verify-migration-facts';
 
@@ -119,6 +120,9 @@ async function main(): Promise<void> {
             explain: async () => {
                 throw new Error('database should not be called');
             },
+            explainWithoutSeqScan: async () => {
+                throw new Error('database should not be called');
+            },
             executeSupportingIndex: async () => {
                 throw new Error('database should not be called');
             },
@@ -181,6 +185,43 @@ async function main(): Promise<void> {
         );
         assert.strictEqual(
             verifyBatchedPlanShape(fact({ batchSize: null }), stripped).ok,
+            true,
+        );
+    });
+
+    await test('a batched plan that still seq-scans its write target understates per-pass cost', () => {
+        const candidate = fact();
+        const verdict = verifyPerPassCost(
+            candidate,
+            'SELECT widget_id FROM widgets LIMIT 1000',
+            explain({ 'Node Type': 'Seq Scan', 'Relation Name': 'widgets' }),
+        );
+        assert.strictEqual(verdict.ok, false);
+        if (verdict.ok) return;
+        assert.strictEqual(verdict.reason, 'per-pass-cost-understated');
+    });
+
+    await test('per-pass cost passes on an index path, when already declared table, and when unbatched', () => {
+        const indexed = explain({
+            'Node Type': 'Index Only Scan',
+            'Relation Name': 'widgets',
+        });
+        const seqScanned = explain({
+            'Node Type': 'Seq Scan',
+            'Relation Name': 'widgets',
+        });
+        assert.strictEqual(verifyPerPassCost(fact(), 'x', indexed).ok, true);
+        assert.strictEqual(
+            verifyPerPassCost(fact({ batchSize: null }), 'x', seqScanned).ok,
+            true,
+        );
+        const declaredTable = fact();
+        declaredTable.backfill = {
+            ...declaredTable.backfill!,
+            perPassCost: 'table',
+        };
+        assert.strictEqual(
+            verifyPerPassCost(declaredTable, 'x', seqScanned).ok,
             true,
         );
     });

--- a/scripts/verify-migration-facts.test.ts
+++ b/scripts/verify-migration-facts.test.ts
@@ -7,8 +7,10 @@ import {
     summaryLine,
     verifyBatchedPlanShape,
     verifyEstimateCoversWriteTarget,
+    verifyEstimateEnumeratesRows,
     verifyFact,
     verifyPerPassCost,
+    verifyPlanDescribesSameWork,
     verifyPlanTables,
 } from './verify-migration-facts';
 
@@ -222,6 +224,68 @@ async function main(): Promise<void> {
         };
         assert.strictEqual(
             verifyPerPassCost(declaredTable, 'x', seqScanned).ok,
+            true,
+        );
+    });
+
+    await test('a single-row planSql for a whole-table rewrite describes less work', () => {
+        const candidate = fact({ batchSize: null });
+        const rows = (n: number): unknown => [
+            { Plan: { 'Node Type': 'Seq Scan', 'Plan Rows': n } },
+        ];
+        const verdict = verifyPlanDescribesSameWork(
+            candidate,
+            candidate.backfill?.planSql ?? '',
+            rows(1270),
+            rows(1),
+        );
+        assert.strictEqual(verdict.ok, false);
+        if (verdict.ok) return;
+        assert.strictEqual(verdict.reason, 'plan-describes-less-work');
+    });
+
+    await test('a batched plan is compared against its batch, not the whole table', () => {
+        const rows = (n: number): unknown => [
+            { Plan: { 'Node Type': 'Seq Scan', 'Plan Rows': n } },
+        ];
+        // batchSize 1000, estimate 1270 -> planning 1000 rows is correct
+        assert.strictEqual(
+            verifyPlanDescribesSameWork(
+                fact(),
+                fact().backfill?.planSql ?? '',
+                rows(1270),
+                rows(1000),
+            ).ok,
+            true,
+        );
+        // an unbatched plan matching the estimate is fine
+        assert.strictEqual(
+            verifyPlanDescribesSameWork(
+                fact({ batchSize: null }),
+                fact().backfill?.planSql ?? '',
+                rows(1270),
+                rows(1270),
+            ).ok,
+            true,
+        );
+    });
+
+    await test('an estimate that counts rather than enumerates is rejected', () => {
+        const candidate = fact();
+        const verdict = verifyEstimateEnumeratesRows(
+            candidate,
+            'SELECT count(*) FROM widgets',
+            explain({ 'Node Type': 'Aggregate', 'Plan Rows': 1 }),
+        );
+        assert.strictEqual(verdict.ok, false);
+        if (verdict.ok) return;
+        assert.strictEqual(verdict.reason, 'estimate-aggregates-rows');
+        assert.strictEqual(
+            verifyEstimateEnumeratesRows(
+                candidate,
+                'SELECT widget_id FROM widgets',
+                explain({ 'Node Type': 'Seq Scan', 'Plan Rows': 1264 }),
+            ).ok,
             true,
         );
     });

--- a/scripts/verify-migration-facts.test.ts
+++ b/scripts/verify-migration-facts.test.ts
@@ -135,9 +135,34 @@ async function main(): Promise<void> {
             total: 397,
             verified: 0,
             skipped: 397,
+            unverifiable: 0,
             failed: 0,
         });
         assert.match(summaryLine(summary), /0 verified against a database/);
+    });
+
+    await test('a fact whose schema cannot be rebuilt is unverifiable, not verified and not failed', () => {
+        const summary = summarizeVerdicts([
+            { ok: true, verified: true },
+            { ok: true, verified: false, unverifiable: true },
+            { ok: true, verified: false },
+        ]);
+        assert.deepStrictEqual(summary, {
+            total: 3,
+            verified: 1,
+            skipped: 1,
+            unverifiable: 1,
+            failed: 0,
+        });
+        assert.strictEqual(nothingVerifiedError(summary), null);
+        assert.match(summaryLine(summary), /1 unverifiable/);
+    });
+
+    await test('a corpus that is entirely unverifiable does not satisfy --require-verified', () => {
+        const summary = summarizeVerdicts([
+            { ok: true, verified: false, unverifiable: true },
+        ]);
+        assert.notStrictEqual(nothingVerifiedError(summary), null);
     });
 
     await test('--require-verified fails a run that checked nothing against a database', () => {
@@ -159,7 +184,7 @@ async function main(): Promise<void> {
                 { ok: false, verified: true },
                 { ok: true, verified: false },
             ]),
-            { total: 3, verified: 2, skipped: 1, failed: 1 },
+            { total: 3, verified: 2, skipped: 1, unverifiable: 0, failed: 1 },
         );
     });
 

--- a/scripts/verify-migration-facts.test.ts
+++ b/scripts/verify-migration-facts.test.ts
@@ -5,6 +5,8 @@ import {
     sqlFailureVerdict,
     summarizeVerdicts,
     summaryLine,
+    verifyBatchedPlanShape,
+    verifyEstimateCoversWriteTarget,
     verifyFact,
     verifyPlanTables,
 } from './verify-migration-facts';
@@ -125,6 +127,62 @@ async function main(): Promise<void> {
             ok: true,
             migration: candidate.migration,
         });
+    });
+
+    await test('an estimate that counts a read-only table misses the write target', () => {
+        const candidate = fact();
+        const sql = 'SELECT owner_id FROM owners';
+        const verdict = verifyEstimateCoversWriteTarget(
+            candidate,
+            sql,
+            explain({ 'Node Type': 'Seq Scan', 'Relation Name': 'owners' }),
+        );
+        assert.strictEqual(verdict.ok, false);
+        if (verdict.ok) return;
+        assert.strictEqual(verdict.reason, 'estimate-misses-write-target');
+        assert.deepStrictEqual(verdict.missingTables, ['widgets']);
+    });
+
+    await test('an estimate over the write target passes, and no declared write target skips the check', () => {
+        const candidate = fact();
+        assert.strictEqual(
+            verifyEstimateCoversWriteTarget(
+                candidate,
+                'SELECT widget_id FROM widgets',
+                explain({ 'Node Type': 'Seq Scan', 'Relation Name': 'widgets' }),
+            ).ok,
+            true,
+        );
+        const noWriteTarget = fact({
+            tables: [
+                { name: 'owners', access: ['read'], expectedLockModes: [] },
+            ],
+        });
+        assert.strictEqual(
+            verifyEstimateCoversWriteTarget(
+                noWriteTarget,
+                'SELECT owner_id FROM owners',
+                explain({ 'Node Type': 'Seq Scan', 'Relation Name': 'owners' }),
+            ).ok,
+            true,
+        );
+    });
+
+    await test("a batched migration's plan must carry its batch limit", () => {
+        const candidate = fact();
+        const stripped = 'SELECT widgets.widget_id FROM widgets';
+        const verdict = verifyBatchedPlanShape(candidate, stripped);
+        assert.strictEqual(verdict.ok, false);
+        if (verdict.ok) return;
+        assert.strictEqual(verdict.reason, 'plan-missing-batch-limit');
+        assert.strictEqual(
+            verifyBatchedPlanShape(candidate, `${stripped} LIMIT 1000`).ok,
+            true,
+        );
+        assert.strictEqual(
+            verifyBatchedPlanShape(fact({ batchSize: null }), stripped).ok,
+            true,
+        );
     });
 
     await test('a corpus with no backfill SQL reports zero verified, not silent success', () => {

--- a/scripts/verify-migration-facts.ts
+++ b/scripts/verify-migration-facts.ts
@@ -34,26 +34,42 @@ export interface VerificationFailure {
 
 export type VerificationVerdict = VerificationPass | VerificationFailure;
 
+/**
+ * Migrations here are append-only with one known exception (a core→EE move
+ * across 0.2123.0–0.2126.1), so a schema that cannot be rebuilt is a gap in what
+ * we can check, not a defect in the fact. It never counts as verified.
+ */
+export class HistoricalSchemaUnavailable extends Error {}
+
 export interface VerificationSummary {
     total: number;
     verified: number;
     skipped: number;
+    unverifiable: number;
     failed: number;
 }
 
 export function summarizeVerdicts(
-    results: ReadonlyArray<{ ok: boolean; verified: boolean }>,
+    results: ReadonlyArray<{
+        ok: boolean;
+        verified: boolean;
+        unverifiable?: boolean;
+    }>,
 ): VerificationSummary {
     return {
         total: results.length,
         verified: results.filter((result) => result.verified).length,
-        skipped: results.filter((result) => !result.verified).length,
+        skipped: results.filter(
+            (result) => !result.verified && result.unverifiable !== true,
+        ).length,
+        unverifiable: results.filter((result) => result.unverifiable === true)
+            .length,
         failed: results.filter((result) => !result.ok).length,
     };
 }
 
 export function summaryLine(summary: VerificationSummary): string {
-    return `${summary.total} fact(s): ${summary.verified} verified against a database, ${summary.skipped} skipped (no backfill SQL), ${summary.failed} failed`;
+    return `${summary.total} fact(s): ${summary.verified} verified against a database, ${summary.skipped} skipped (no backfill SQL), ${summary.unverifiable} unverifiable (schema could not be rebuilt), ${summary.failed} failed`;
 }
 
 export function nothingVerifiedError(
@@ -300,7 +316,7 @@ export function createHistoricalMigrationDirectory(tag: string): string {
         for (const migrationPath of historicalMigrationPaths(tag)) {
             const source = path.join(REPO_ROOT, migrationPath);
             if (!fs.existsSync(source)) {
-                throw new Error(
+                throw new HistoricalSchemaUnavailable(
                     `${migrationPath} exists at ${tag} but not in the current tree; historical reconstruction requires append-only migrations`,
                 );
             }
@@ -561,7 +577,11 @@ async function main(): Promise<void> {
         );
     }
     const results: Array<
-        VerificationVerdict & { previousTag: string | null; verified: boolean }
+        VerificationVerdict & {
+            previousTag: string | null;
+            verified: boolean;
+            unverifiable?: boolean;
+        }
     > = [];
     for (const fact of facts.migrationFacts) {
         if (fact.backfill === null) {
@@ -576,12 +596,29 @@ async function main(): Promise<void> {
             args.previousTags.get(fact.migration) ??
             args.defaultPreviousTag ??
             previousReleaseTag(fact.introducedIn);
-        const verdict = await verifyAgainstHistoricalSchema(
-            fact,
-            previousTag,
-            args.databaseUrl,
-            args.statementTimeoutSeconds,
-        );
+        let verdict: VerificationVerdict;
+        try {
+            verdict = await verifyAgainstHistoricalSchema(
+                fact,
+                previousTag,
+                args.databaseUrl,
+                args.statementTimeoutSeconds,
+            );
+        } catch (error) {
+            if (!(error instanceof HistoricalSchemaUnavailable)) throw error;
+            results.push({
+                ...passVerdict(fact),
+                previousTag,
+                verified: false,
+                unverifiable: true,
+            });
+            if (!args.json) {
+                console.log(
+                    `[verify-migration-facts] ${fact.migration} against ${previousTag}: UNVERIFIABLE (${errorMessage(error)})`,
+                );
+            }
+            continue;
+        }
         results.push({ ...verdict, previousTag, verified: true });
         if (!args.json) {
             console.log(

--- a/scripts/verify-migration-facts.ts
+++ b/scripts/verify-migration-facts.ts
@@ -17,6 +17,8 @@ export type VerificationFailureReason =
     | 'estimate-misses-write-target'
     | 'plan-missing-batch-limit'
     | 'per-pass-cost-understated'
+    | 'plan-describes-less-work'
+    | 'estimate-aggregates-rows'
     | 'plan-sql-error'
     | 'plan-missing-tables'
     | 'supporting-index-sql-error';
@@ -296,6 +298,73 @@ export function verifyPerPassCost(
     };
 }
 
+/**
+ * The preflight reads its row estimate from the TOP plan node, so an estimate
+ * that aggregates reports one row however large the backfill is — the quiet
+ * wrong answer in its purest form. The estimate must enumerate rows.
+ */
+export function verifyEstimateEnumeratesRows(
+    fact: MigrationFact,
+    sql: string,
+    explainJson: unknown,
+): VerificationVerdict {
+    const plan = explainPlan(explainJson);
+    const nodeType = plan?.['Node Type'];
+    if (typeof nodeType !== 'string' || !nodeType.includes('Aggregate')) {
+        return passVerdict(fact);
+    }
+    return {
+        ok: false,
+        migration: fact.migration,
+        reason: 'estimate-aggregates-rows',
+        sql,
+        message: `estimateSql plans as ${nodeType}, so the preflight would read one row rather than the size of the backfill; select the rows instead of counting them`,
+        missingTables: [],
+    };
+}
+
+function topPlanRows(explainJson: unknown): number | null {
+    const plan = explainPlan(explainJson);
+    const rows = plan?.['Plan Rows'];
+    return typeof rows === 'number' ? rows : null;
+}
+
+/**
+ * planSql stands in for the work the migration does, so a plan far more
+ * selective than the estimate describes a smaller job than the one that will
+ * run — a single-row lookup for a whole-table rewrite reads as free. Batched
+ * migrations legitimately plan one batch, so they are compared against that.
+ * Only order-of-magnitude gaps fail, because an empty scratch schema has no
+ * statistics and its row counts are planner defaults.
+ */
+export function verifyPlanDescribesSameWork(
+    fact: MigrationFact,
+    planSql: string,
+    estimateExplainJson: unknown,
+    planExplainJson: unknown,
+): VerificationVerdict {
+    if (fact.backfill === null || planSql === fact.backfill.estimateSql) {
+        return passVerdict(fact);
+    }
+    const estimateRows = topPlanRows(estimateExplainJson);
+    const planRows = topPlanRows(planExplainJson);
+    if (estimateRows === null || planRows === null) return passVerdict(fact);
+
+    const expectedRows =
+        fact.batchSize === null
+            ? estimateRows
+            : Math.min(fact.batchSize, estimateRows);
+    if (planRows * 10 >= expectedRows) return passVerdict(fact);
+    return {
+        ok: false,
+        migration: fact.migration,
+        reason: 'plan-describes-less-work',
+        sql: planSql,
+        message: `planSql plans ${planRows} row(s) where the work is ~${expectedRows}, so it describes a much smaller job than the migration performs`,
+        missingTables: [],
+    };
+}
+
 function errorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
@@ -317,6 +386,13 @@ export async function verifyFact(
             errorMessage(error),
         );
     }
+
+    const enumerationVerdict = verifyEstimateEnumeratesRows(
+        fact,
+        fact.backfill.estimateSql,
+        estimatePlan,
+    );
+    if (!enumerationVerdict.ok) return enumerationVerdict;
 
     const estimateVerdict = verifyEstimateCoversWriteTarget(
         fact,
@@ -345,6 +421,14 @@ export async function verifyFact(
 
     const planVerdict = verifyPlanTables(fact, planSql, plan);
     if (!planVerdict.ok) return planVerdict;
+
+    const workVerdict = verifyPlanDescribesSameWork(
+        fact,
+        planSql,
+        estimatePlan,
+        plan,
+    );
+    if (!workVerdict.ok) return workVerdict;
 
     if (fact.batchSize !== null) {
         let indexOnlyPlan: unknown;
@@ -608,7 +692,7 @@ function postgresVerifier(
     };
 }
 
-async function verifyAgainstHistoricalSchema(
+export async function verifyAgainstHistoricalSchema(
     fact: MigrationFact,
     previousTag: string,
     databaseUrl: string | null,

--- a/scripts/verify-migration-facts.ts
+++ b/scripts/verify-migration-facts.ts
@@ -16,6 +16,7 @@ export type VerificationFailureReason =
     | 'estimate-sql-error'
     | 'estimate-misses-write-target'
     | 'plan-missing-batch-limit'
+    | 'per-pass-cost-understated'
     | 'plan-sql-error'
     | 'plan-missing-tables'
     | 'supporting-index-sql-error';
@@ -87,6 +88,7 @@ interface ExplainResult {
 
 export interface FactSqlVerifier {
     explain: (sql: string) => Promise<unknown>;
+    explainWithoutSeqScan: (sql: string) => Promise<unknown>;
     executeSupportingIndex: (sql: string) => Promise<void>;
 }
 
@@ -252,6 +254,48 @@ export function verifyBatchedPlanShape(
     };
 }
 
+/**
+ * With sequential scans penalised, a plan that still scans the write target has
+ * no index serving its batch predicate, so every pass re-scans the whole table
+ * however little work is left. Claiming 'remaining' there tells an operator a
+ * long migration is short. Cardinality-independent, so an empty scratch schema
+ * answers it correctly.
+ */
+export function verifyPerPassCost(
+    fact: MigrationFact,
+    sql: string,
+    explainWithoutSeqScanJson: unknown,
+): VerificationVerdict {
+    if (fact.batchSize === null) return passVerdict(fact);
+    if (fact.backfill?.perPassCost === 'table') return passVerdict(fact);
+
+    const writeTables = new Set(
+        fact.tables
+            .filter((table) => table.access.includes('write'))
+            .map((table) => normalizedRelationName(table.name)),
+    );
+    if (writeTables.size === 0) return passVerdict(fact);
+
+    const plan = explainPlan(explainWithoutSeqScanJson);
+    if (plan === null) return passVerdict(fact);
+    const seqScanned = flattenPlan(plan)
+        .filter((node) => node['Node Type'] === 'Seq Scan')
+        .map((node) => node['Relation Name'])
+        .filter((name): name is string => name !== undefined)
+        .map(normalizedRelationName)
+        .filter((name) => writeTables.has(name));
+
+    if (seqScanned.length === 0) return passVerdict(fact);
+    return {
+        ok: false,
+        migration: fact.migration,
+        reason: 'per-pass-cost-understated',
+        sql,
+        message: `no index serves the batch predicate on ${seqScanned.join(', ')}, so every pass scans the whole table; perPassCost should be "table" rather than "remaining"`,
+        missingTables: seqScanned,
+    };
+}
+
 function errorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
@@ -301,6 +345,22 @@ export async function verifyFact(
 
     const planVerdict = verifyPlanTables(fact, planSql, plan);
     if (!planVerdict.ok) return planVerdict;
+
+    if (fact.batchSize !== null) {
+        let indexOnlyPlan: unknown;
+        try {
+            indexOnlyPlan = await verifier.explainWithoutSeqScan(planSql);
+        } catch (error) {
+            return sqlFailureVerdict(
+                fact,
+                'plan-sql-error',
+                planSql,
+                errorMessage(error),
+            );
+        }
+        const perPassVerdict = verifyPerPassCost(fact, planSql, indexOnlyPlan);
+        if (!perPassVerdict.ok) return perPassVerdict;
+    }
 
     if (fact.backfill.supportingIndexSql !== null) {
         try {
@@ -513,8 +573,25 @@ function postgresVerifier(
             await client.query('ROLLBACK');
         }
     };
+    const explainWithoutSeqScan = async (sql: string): Promise<unknown> => {
+        await client.query('BEGIN TRANSACTION READ ONLY');
+        try {
+            await client.query(
+                "SELECT set_config('statement_timeout', $1, true)",
+                [`${statementTimeoutSeconds}s`],
+            );
+            await client.query(
+                "SELECT set_config('enable_seqscan', 'off', true)",
+            );
+            const result = await client.query(`EXPLAIN (FORMAT JSON) ${sql}`);
+            return result.rows[0]?.['QUERY PLAN'];
+        } finally {
+            await client.query('ROLLBACK');
+        }
+    };
     return {
         explain,
+        explainWithoutSeqScan,
         executeSupportingIndex: async (sql: string): Promise<void> => {
             await client.query(
                 "SELECT set_config('statement_timeout', $1, false)",

--- a/scripts/verify-migration-facts.ts
+++ b/scripts/verify-migration-facts.ts
@@ -14,6 +14,8 @@ import { parseFactsFile } from './preflight';
 
 export type VerificationFailureReason =
     | 'estimate-sql-error'
+    | 'estimate-misses-write-target'
+    | 'plan-missing-batch-limit'
     | 'plan-sql-error'
     | 'plan-missing-tables'
     | 'supporting-index-sql-error';
@@ -198,6 +200,58 @@ export function verifyPlanTables(
     };
 }
 
+/**
+ * An estimate that counts a table the migration only reads describes the wrong
+ * population. Skipped when the fact declares no write target, because
+ * derivation deliberately under-claims rather than guess at one.
+ */
+export function verifyEstimateCoversWriteTarget(
+    fact: MigrationFact,
+    sql: string,
+    explainJson: unknown,
+): VerificationVerdict {
+    const writeTables = fact.tables
+        .filter((table) => table.access.includes('write'))
+        .map((table) => normalizedRelationName(table.name));
+    if (writeTables.length === 0) return passVerdict(fact);
+
+    const referencedTables = tablesReferencedByPlan(explainJson);
+    if (writeTables.some((table) => referencedTables.has(table))) {
+        return passVerdict(fact);
+    }
+    return {
+        ok: false,
+        migration: fact.migration,
+        reason: 'estimate-misses-write-target',
+        sql,
+        message: `estimateSql plan references none of the table(s) the migration writes: ${writeTables.join(', ')}`,
+        missingTables: writeTables,
+    };
+}
+
+/**
+ * A batched migration's plan describes one pass. Without the batch limit the
+ * preflight EXPLAINs the whole table and reports a cost the migration never
+ * pays in one go.
+ */
+export function verifyBatchedPlanShape(
+    fact: MigrationFact,
+    planSql: string,
+): VerificationVerdict {
+    if (fact.batchSize === null) return passVerdict(fact);
+    if (new RegExp(`\\bLIMIT\\s+${fact.batchSize}\\b`, 'i').test(planSql)) {
+        return passVerdict(fact);
+    }
+    return {
+        ok: false,
+        migration: fact.migration,
+        reason: 'plan-missing-batch-limit',
+        sql: planSql,
+        message: `migration batches at ${fact.batchSize} but the plan SQL carries no matching LIMIT, so the plan describes the whole table rather than one pass`,
+        missingTables: [],
+    };
+}
+
 function errorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
@@ -220,7 +274,17 @@ export async function verifyFact(
         );
     }
 
+    const estimateVerdict = verifyEstimateCoversWriteTarget(
+        fact,
+        fact.backfill.estimateSql,
+        estimatePlan,
+    );
+    if (!estimateVerdict.ok) return estimateVerdict;
+
     const planSql = fact.backfill.planSql ?? fact.backfill.estimateSql;
+    const batchVerdict = verifyBatchedPlanShape(fact, planSql);
+    if (!batchVerdict.ok) return batchVerdict;
+
     let plan = estimatePlan;
     if (planSql !== fact.backfill.estimateSql) {
         try {

--- a/scripts/verify-migration-facts.ts
+++ b/scripts/verify-migration-facts.ts
@@ -505,6 +505,8 @@ function postgresVerifier(
                 "SELECT set_config('statement_timeout', $1, true)",
                 [`${statementTimeoutSeconds}s`],
             );
+            // Plain EXPLAIN plans without executing, so volatile functions in
+            // the fact's SQL never run. Adding ANALYZE would execute it.
             const result = await client.query(`EXPLAIN (FORMAT JSON) ${sql}`);
             return result.rows[0]?.['QUERY PLAN'];
         } finally {


### PR DESCRIPTION
Linear: SPK-903

Integration branch: merges #27061 (CI + guards) and #27062 (proposer), then adds the guards and corpus this run produced. Raise for review after those two; happy to split it back across them if you'd rather review it that way.

## Result

**30 of 38** eligible backfill migrations gained verified SQL. The corpus goes from **3 → 33** facts carrying an `estimateSql`, and a clean re-run over the merged corpus verifies **33/33** against real pre-upgrade schemas.

Eight produced nothing acceptable and keep `backfill: null`. That is the design working — they still ship structural facts, and an upgrade touching them says it cannot size the work rather than guessing.

## Nothing was accepted for looking right

Every fact was EXPLAINed against the pre-upgrade schema of its own release and had to pass all five guards. Two were added during this run because the pilot caught real failures:

| Guard | Catches |
|---|---|
| `estimate-aggregates-rows` | **new** — a `count(*)` estimate, whose top plan node reports `Plan Rows = 1`, so a whole-table migration is reported as touching one row |
| `plan-describes-less-work` | **new** — a `planSql` planning an order of magnitude less work than its estimate (a `WHERE pk = 1` lookup standing in for a full-table rewrite) |
| `estimate-misses-write-target` | an estimate counting a table the migration only reads |
| `plan-missing-batch-limit` | a batched migration whose plan describes the whole table |
| `per-pass-cost-understated` | `perPassCost: remaining` where no index serves the batch predicate |

Both new guards are cardinality-independent, which they must be — the scratch schema is empty and has no statistics.

## How the pilot moved

| | Model | Guards | Accepted | Actually correct |
|---|---|---|---|---|
| 1 | opus-4-8 | 3 | 2/2 | **1/2** |
| 2 | opus-5 | 4 | 3/4 | **1/4** |
| 3 | opus-5 | 5 | 4/4 | **4/4** |

Round 2 is the instructive one: the newer model produced *better-looking* SQL that was **more** dangerous, because `SELECT count(*)` is excellent SQL and exactly wrong for a field read as a row estimate. Nothing about it is detectable by reading.

## For review

- **`perPassCost` is `table` for 25 of 30.** Most are unbatched full-table rewrites where that is simply true, and the proposer is told to answer `table` when unsure since the error that matters understates cost. Worth a look in case it warns more often than is useful.
- **Provenance is not recorded in the data.** These thirty were machine-proposed and machine-verified; the original three were hand-written. The diff distinguishes them, the file does not. Say if you want a field for it.
- The facts-file test no longer pins an exact count (which would need raising forever); it asserts the corpus is not empty, which is the failure worth catching.

## Verification

`npm run test:release-safety` green. End-to-end asset generation produces 578 facts for 397 core + 181 Enterprise migrations, 33 carrying SQL. Postgres container and volume removed; no `ld-*` resources touched.