### PR TITLE
feat(preflight): report how many rows a backfill touches

### DIFF
--- a/packages/backend/src/controllers/preflightController.ts
+++ b/packages/backend/src/controllers/preflightController.ts
@@ -1,13 +1,16 @@
 import {
     ApiErrorPayload,
+    ApiPreflightExplainResponse,
     ApiPreflightProbeResponse,
     assertRegisteredAccount,
 } from '@lightdash/common';
 import {
+    Body,
     Get,
     Hidden,
     Middlewares,
     OperationId,
+    Post,
     Query,
     Request,
     Response,
@@ -49,6 +52,28 @@ export class PreflightController extends BaseController {
         const results = await this.services
             .getPreflightService()
             .probe(req.account, tableNames);
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Plans one fact's backfill SQL against this instance so the preflight can
+     * report how many rows a migration touches. Plain EXPLAIN plans without
+     * executing; the statement must be a single read-only SELECT and runs in a
+     * read-only transaction under a statement timeout. Same gates as the probe.
+     * @summary Preflight EXPLAIN
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Post('/explain')
+    @OperationId('PostPreflightExplain')
+    async postPreflightExplain(
+        @Request() req: express.Request,
+        @Body() body: { sql: string },
+    ): Promise<ApiPreflightExplainResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getPreflightService()
+            .explain(req.account, body.sql);
         this.setStatus(200);
         return { status: 'ok', results };
     }

--- a/packages/backend/src/models/PreflightModel.ts
+++ b/packages/backend/src/models/PreflightModel.ts
@@ -107,4 +107,37 @@ export class PreflightModel {
             blockedBy: row.blocked_by ?? [],
         }));
     }
+
+    /**
+     * Plans the statement without running it — plain EXPLAIN never executes, so
+     * volatile functions in the statement do not fire, and a read-only
+     * transaction plus a statement timeout bound it further.
+     *
+     * The shape check is repeated here rather than left to the caller: a READ
+     * ONLY transaction does NOT refuse to PLAN a write, so it is not the thing
+     * keeping writes out.
+     */
+    async explain(
+        sql: string,
+        statementTimeoutSeconds: number,
+    ): Promise<unknown> {
+        if (sql.includes(';') || !/^\s*(SELECT|WITH)\s/i.test(sql)) {
+            throw new Error(
+                'preflight EXPLAIN accepts a single read-only SELECT statement',
+            );
+        }
+        return this.database.transaction(async (trx) => {
+            await trx.raw('SET TRANSACTION READ ONLY');
+            await trx.raw("SELECT set_config('statement_timeout', ?, true)", [
+                `${statementTimeoutSeconds}s`,
+            ]);
+            const result = await trx.raw<{
+                rows: Array<{ 'QUERY PLAN': unknown }>;
+            }>(`EXPLAIN (FORMAT JSON) ${sql}`);
+            // No explicit rollback: the transaction is READ ONLY, so committing
+            // it writes nothing, and knex rejects a callback transaction that
+            // rolls itself back.
+            return result.rows[0]?.['QUERY PLAN'];
+        });
+    }
 }

--- a/packages/backend/src/services/PreflightService/PreflightService.ts
+++ b/packages/backend/src/services/PreflightService/PreflightService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     ParameterError,
+    PreflightExplain,
     PreflightProbe,
     type RegisteredAccount,
 } from '@lightdash/common';
@@ -16,6 +17,9 @@ type PreflightServiceArguments = {
 
 const TABLE_NAME_PATTERN = /^[a-z_][a-z0-9_]{0,62}$/;
 const MAX_TABLES = 50;
+const MAX_SQL_LENGTH = 8000;
+const EXPLAIN_TIMEOUT_SECONDS = 15;
+const READ_ONLY_SELECT_PATTERN = /^(SELECT|WITH)\s/i;
 
 /**
  * SPK-701 spike: read-only probe of the instance database's upgrade-relevant
@@ -54,21 +58,71 @@ export class PreflightService extends BaseService {
         }
     }
 
-    async probe(
-        account: RegisteredAccount,
-        tables: string[],
-    ): Promise<PreflightProbe> {
+    private assertProbeAllowed(account: RegisteredAccount): void {
         if (!this.lightdashConfig.preflight.probeEnabled) {
             throw new ForbiddenError(
                 'Preflight probe is not enabled on this instance (set PREFLIGHT_PROBE_ENABLED=true)',
             );
         }
+        // Re-checked here rather than inherited: EXPLAIN exposes plan shapes for
+        // the whole database, and this must not become reachable if the probe's
+        // own multi-org guard is ever relaxed.
         if (this.lightdashConfig.allowMultiOrgs) {
             throw new ForbiddenError(
                 'Preflight probe is only available on single-organization instances',
             );
         }
         this.assertCanManageOrganization(account);
+    }
+
+    /**
+     * Plans a fact's backfill SQL against this instance so the preflight can
+     * report how many rows the migration touches. Plain EXPLAIN plans without
+     * executing, and the statement is rejected unless it is a single read-only
+     * SELECT.
+     */
+    async explain(
+        account: RegisteredAccount,
+        sql: string,
+    ): Promise<PreflightExplain> {
+        this.assertProbeAllowed(account);
+        const statement = sql.trim();
+        if (statement.length === 0 || statement.length > MAX_SQL_LENGTH) {
+            throw new ParameterError(
+                `SQL must be between 1 and ${MAX_SQL_LENGTH} characters`,
+            );
+        }
+        if (statement.includes(';')) {
+            throw new ParameterError(
+                'SQL must be a single statement and must not contain ";"',
+            );
+        }
+        if (!READ_ONLY_SELECT_PATTERN.test(statement)) {
+            throw new ParameterError(
+                'SQL must be a read-only statement that starts with SELECT or WITH',
+            );
+        }
+        try {
+            const plan = await this.preflightModel.explain(
+                statement,
+                EXPLAIN_TIMEOUT_SECONDS,
+            );
+            return { plan, error: null };
+        } catch (error) {
+            // A fact whose SQL does not fit this schema is a coverage gap, not a
+            // server fault: report it so the caller can say what it could not check.
+            return {
+                plan: null,
+                error: error instanceof Error ? error.message : String(error),
+            };
+        }
+    }
+
+    async probe(
+        account: RegisteredAccount,
+        tables: string[],
+    ): Promise<PreflightProbe> {
+        this.assertProbeAllowed(account);
         const uniqueTables = [...new Set(tables)];
         if (uniqueTables.length > MAX_TABLES) {
             throw new ParameterError(`Pass at most ${MAX_TABLES} tables`);

--- a/packages/cli/src/preflight/command.test.ts
+++ b/packages/cli/src/preflight/command.test.ts
@@ -273,6 +273,7 @@ describe('probe table selection', () => {
                     ]),
                 fetchFacts: async () => '',
                 sampleProbe,
+                explain: async () => null,
                 stdout: () => undefined,
                 stderr: () => undefined,
             },
@@ -282,5 +283,134 @@ describe('probe table selection', () => {
         expect(tables).toEqual(
             expect.arrayContaining(['early_table', 'late_table']),
         );
+    });
+});
+
+describe('row-estimate reporting through the EXPLAIN endpoint', () => {
+    const backfillFacts = JSON.stringify({
+        schemaVersion: '1-draft',
+        release: null,
+        previousRelease: null,
+        cumulativeThrough: '1.79.0',
+        migrationsInRelease: null,
+        migrationsWithoutFacts: null,
+        migrationFacts: [
+            {
+                migration: '001_backfill',
+                introducedIn: '1.79.0',
+                runsInTransaction: false,
+                resumable: true,
+                batchSize: 1000,
+                lockTimeout: '5s',
+                tables: [
+                    {
+                        name: 'widgets',
+                        access: ['write'],
+                        expectedLockModes: [],
+                    },
+                ],
+                backfill: {
+                    description: 'backfills widgets',
+                    estimateSql: 'SELECT widget_id FROM widgets',
+                    planSql: null,
+                    supportingIndexSql: null,
+                },
+                notes: null,
+            },
+        ],
+    });
+
+    const probeSample = {
+        before: {
+            serverTime: '2026-08-07T00:00:00.000Z',
+            lockRows: [],
+            statRows: [
+                {
+                    table: 'widgets',
+                    inserts: 0,
+                    updates: 0,
+                    deletes: 0,
+                    liveTuples: 4000000,
+                },
+            ],
+            activityRows: [],
+            lastMigrationAgeSeconds: 10,
+            appliedMigrations: null,
+        },
+        after: {
+            serverTime: '2026-08-07T00:00:01.000Z',
+            lockRows: [],
+            statRows: [
+                {
+                    table: 'widgets',
+                    inserts: 0,
+                    updates: 0,
+                    deletes: 0,
+                    liveTuples: 4000000,
+                },
+            ],
+            activityRows: [],
+            lastMigrationAgeSeconds: 11,
+            appliedMigrations: null,
+        },
+    };
+
+    const run = async (
+        explain: PreflightCommandDependencies['explain'],
+    ): Promise<string> => {
+        let out = '';
+        await runPreflight(
+            {
+                to: '1.79.0',
+                from: '1.78.0',
+                facts: ['facts.json'],
+                intervalSeconds: 0,
+                json: true,
+            },
+            {
+                core: getPreflightCore,
+                readFile: async () => backfillFacts,
+                fetchFacts: async () => backfillFacts,
+                sampleProbe: async () => probeSample as never,
+                explain,
+                stdout: (output) => {
+                    out += output;
+                },
+                stderr: () => undefined,
+            },
+        ).catch(() => undefined);
+        return out;
+    };
+
+    it('reports a row estimate when the instance can plan the backfill', async () => {
+        const out = await run(async () => ({
+            plan: [
+                {
+                    Plan: {
+                        'Node Type': 'Seq Scan',
+                        'Relation Name': 'widgets',
+                        'Plan Rows': 3900000,
+                    },
+                },
+            ],
+            error: null,
+        }));
+        expect(out).toContain('row-estimate');
+        expect(out).not.toContain('no preflight EXPLAIN endpoint');
+    });
+
+    it('says the check was skipped when the instance has no EXPLAIN endpoint', async () => {
+        const out = await run(async () => null);
+        expect(out).toContain('no preflight EXPLAIN endpoint');
+        expect(out).toContain('001_backfill');
+    });
+
+    it('says so when the instance cannot plan the SQL, rather than staying quiet', async () => {
+        const out = await run(async () => ({
+            plan: null,
+            error: 'column "widget_id" does not exist',
+        }));
+        expect(out).toContain('could not plan this backfill');
+        expect(out).toContain('widget_id');
     });
 });

--- a/packages/cli/src/preflight/command.ts
+++ b/packages/cli/src/preflight/command.ts
@@ -1,10 +1,11 @@
-import { assertUnreachable } from '@lightdash/common';
+import { assertUnreachable, type PreflightExplain } from '@lightdash/common';
 import { Command, InvalidArgumentError, type OptionValues } from 'commander';
 import { promises as fs } from 'fs';
 import {
     getPreflightCore,
     type PreflightCore,
     type PreflightFinding,
+    type PreflightMigrationFact,
     type PreflightVerdict,
 } from './core';
 import { deriveCurrentVersion, type MigrationVersion } from './currentVersion';
@@ -27,6 +28,7 @@ export interface PreflightCommandDependencies {
         tables: string[],
         intervalSeconds: number,
     ) => Promise<ProbeSample>;
+    explain: (sql: string) => Promise<PreflightExplain | null>;
     stdout: (output: string) => void;
     stderr: (output: string) => void;
 }
@@ -36,9 +38,13 @@ const defaultDependencies: PreflightCommandDependencies = {
     readFile: (path) => fs.readFile(path, 'utf8'),
     fetchFacts: fetchMigrationFacts,
     sampleProbe: createProbeClient().sample,
+    explain: createProbeClient().explain,
     stdout: (output) => process.stdout.write(output),
     stderr: (output) => process.stderr.write(output),
 };
+
+/** the row count above which a backfill is worth a maintenance window */
+const LARGE_ROW_THRESHOLD = 100000;
 
 const parsePositiveNumber = (value: string): number => {
     const parsed = Number(value);
@@ -186,29 +192,96 @@ export const runPreflight = async (
         ...core.analyzeLockTimeouts(
             selectedFacts,
             new Map(rates.map((rate) => [rate.table, rate.liveTuples])),
-            100000,
+            LARGE_ROW_THRESHOLD,
         ),
     );
     findings.push(...core.analyzeActivity(sample.after.activityRows, 300));
     findings.push(...core.analyzeUpgradeStrategy(selectedFacts));
 
-    const skippedBackfills = selectedFacts.filter(
-        (fact) => fact.backfill !== null,
+    const liveTuplesByTable = new Map(
+        rates.map((rate) => [rate.table, rate.liveTuples]),
     );
-    if (skippedBackfills.length > 0) {
+
+    const explainFact = async (
+        fact: PreflightMigrationFact,
+    ): Promise<{
+        findings: PreflightFinding[];
+        unexplained: string | null;
+    }> => {
+        const { backfill } = fact;
+        if (backfill === null) return { findings: [], unexplained: null };
+
+        const estimate = await dependencies.explain(backfill.estimateSql);
+        if (estimate === null) {
+            return { findings: [], unexplained: fact.migration };
+        }
+        if (estimate.error !== null) {
+            return {
+                findings: [
+                    {
+                        check: 'row-estimate',
+                        severity: 'warn',
+                        migration: fact.migration,
+                        table: null,
+                        summary: `could not plan this backfill against your database: ${estimate.error}`,
+                        action: 'Assess this backfill manually; the fact may not describe your schema',
+                        actionKind: 'plan',
+                        data: {},
+                    },
+                ],
+                unexplained: null,
+            };
+        }
+
+        const writtenTable = fact.tables.find((table) =>
+            table.access.includes('write'),
+        );
+        const planSql = backfill.planSql ?? backfill.estimateSql;
+        const shape =
+            planSql === backfill.estimateSql
+                ? estimate
+                : await dependencies.explain(planSql);
+        return {
+            findings: [
+                core.analyzeRowEstimate(
+                    fact,
+                    estimate.plan,
+                    liveTuplesByTable.get(writtenTable?.name ?? '') ?? 0,
+                    LARGE_ROW_THRESHOLD,
+                    null,
+                ),
+                ...(shape !== null && shape.error === null
+                    ? core.analyzeSeqScans(
+                          fact,
+                          shape.plan,
+                          liveTuplesByTable,
+                          LARGE_ROW_THRESHOLD,
+                          null,
+                      )
+                    : []),
+            ],
+            unexplained: null,
+        };
+    };
+
+    const explained = await Promise.all(
+        selectedFacts.filter((fact) => fact.backfill !== null).map(explainFact),
+    );
+    findings.push(...explained.flatMap((result) => result.findings));
+
+    const unexplained = explained
+        .map((result) => result.unexplained)
+        .filter((migration): migration is string => migration !== null);
+    if (unexplained.length > 0) {
         findings.push({
             check: 'row-estimate',
             severity: 'warn',
             migration: null,
             table: null,
-            summary: `EXPLAIN-based row-estimate and plan-shape checks are unavailable through the probe endpoint for ${skippedBackfills.length} backfill(s)`,
-            action: 'Assess these backfills manually until the server can verify a signed facts artifact and run the required EXPLAIN checks',
+            summary: `this instance has no preflight EXPLAIN endpoint, so row-estimate and plan-shape checks were skipped for ${unexplained.length} backfill(s)`,
+            action: 'Upgrade the instance to a version that serves /api/v1/preflight/explain, or assess these backfills manually',
             actionKind: 'plan',
-            data: {
-                skippedMigrations: skippedBackfills.map(
-                    (fact) => fact.migration,
-                ),
-            },
+            data: { skippedMigrations: unexplained },
         });
     }
 

--- a/packages/cli/src/preflight/core.ts
+++ b/packages/cli/src/preflight/core.ts
@@ -2,6 +2,8 @@ import {
     analyzeActivity,
     analyzeLock,
     analyzeLockTimeouts,
+    analyzeRowEstimate,
+    analyzeSeqScans,
     analyzeUpgradeStrategy,
     analyzeWriteRates,
     buildReport,
@@ -49,6 +51,8 @@ export interface PreflightCore {
     analyzeWriteRates: typeof analyzeWriteRates;
     analyzeActivity: typeof analyzeActivity;
     analyzeLockTimeouts: typeof analyzeLockTimeouts;
+    analyzeRowEstimate: typeof analyzeRowEstimate;
+    analyzeSeqScans: typeof analyzeSeqScans;
     analyzeUpgradeStrategy: typeof analyzeUpgradeStrategy;
     buildReport: typeof buildReport;
     renderHuman: typeof renderHuman;
@@ -64,6 +68,8 @@ export const getPreflightCore = (): PreflightCore => ({
     analyzeWriteRates,
     analyzeActivity,
     analyzeLockTimeouts,
+    analyzeRowEstimate,
+    analyzeSeqScans,
     analyzeUpgradeStrategy,
     buildReport,
     renderHuman,

--- a/packages/cli/src/preflight/probeClient.ts
+++ b/packages/cli/src/preflight/probeClient.ts
@@ -1,4 +1,4 @@
-import { type PreflightProbe } from '@lightdash/common';
+import { type PreflightExplain, type PreflightProbe } from '@lightdash/common';
 import fetch, { type Response } from 'node-fetch';
 import { URL } from 'url';
 import { getConfig, type Config } from '../config';
@@ -15,6 +15,11 @@ type ProbePayload = PreflightProbe & {
         batch: number;
         migrationTime: string;
     }>;
+};
+
+type ApiPreflightExplainResponse = {
+    status: 'ok';
+    results: PreflightExplain;
 };
 
 type ApiPreflightProbeResponse = {
@@ -183,9 +188,46 @@ const requestProbe = async (
     return mapProbeSnapshot(body.results);
 };
 
+/**
+ * Returns null when this server has no EXPLAIN endpoint — the CLI and the server
+ * version independently, so an older instance is a normal condition rather than
+ * an error. The caller reports what it could not check.
+ */
+const requestExplain = async (
+    config: Config,
+    sql: string,
+    request: typeof fetch,
+): Promise<PreflightExplain | null> => {
+    if (!(config.context?.apiKey && config.context.serverUrl)) {
+        throw new PreflightProbeError(
+            'unauthorized',
+            "The Lightdash session is not authenticated. Run 'lightdash login' and retry preflight.",
+        );
+    }
+    const url = new URL('/api/v1/preflight/explain', config.context.serverUrl);
+    const headers = buildRequestHeaders(config.context.apiKey);
+    headers['Content-Type'] = 'application/json';
+    if (config.context.proxyAuthorization) {
+        headers['Proxy-Authorization'] = config.context.proxyAuthorization;
+    }
+    const response = await request(url.href, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ sql }),
+    });
+    if (response.status === 404) return null;
+    if (!response.ok) throw await probeError(response);
+    const body = (await response.json()) as ApiPreflightExplainResponse;
+    return body.results;
+};
+
 export const createProbeClient = (
     dependencies: ProbeClientDependencies = defaultDependencies,
 ) => ({
+    explain: async (sql: string): Promise<PreflightExplain | null> => {
+        const config = await dependencies.getConfig();
+        return requestExplain(config, sql, dependencies.fetch);
+    },
     sample: async (
         tables: string[],
         intervalSeconds: number,

--- a/packages/common/src/types/preflight.ts
+++ b/packages/common/src/types/preflight.ts
@@ -39,3 +39,18 @@ export type ApiPreflightProbeResponse = {
     status: 'ok';
     results: PreflightProbe;
 };
+
+/**
+ * The plan for one fact's backfill SQL. `plan` is null when this instance's
+ * schema cannot run the statement — a gap the caller reports rather than a
+ * failure that stops the preflight.
+ */
+export type PreflightExplain = {
+    plan: unknown;
+    error: string | null;
+};
+
+export type ApiPreflightExplainResponse = {
+    status: 'ok';
+    results: PreflightExplain;
+};


### PR DESCRIPTION
Linear: SPK-701, SPK-903

Stacked on #27063. This connects the reader — the last mile of the workflow.

## Why

The preflight could describe a migration's **shape** but never its **size**. It knew a backfill ran outside a transaction, in batches, against a named table — and could not say whether that meant a second or an afternoon. Size is what an operator schedules around.

The analyses were already written and tested. `analyzeRowEstimate` and `analyzeSeqScans` carry 18 test references between them. Nothing produced the query plan they take, because the probe reads only its own statistics — so both sat unreachable behind a warning saying the check was unavailable.

## What changed

`POST /api/v1/preflight/explain` plans a fact's backfill SQL against the instance. It **plans without running**: plain EXPLAIN never executes the statement, so a volatile function inside a fact never fires.

Gates are the probe's own — disabled unless `PREFLIGHT_PROBE_ENABLED`, refused on multi-organization instances, organization admin only.

Two deliberate choices:

- **The multi-org check is repeated, not inherited.** EXPLAIN exposes plan shapes for the whole database, and this must not become reachable if the probe's own guard is later relaxed.
- **The statement shape is checked in the model, not only at the service boundary.** A `READ ONLY` transaction refuses to *run* a write but happily *plans* one — it is not the thing keeping writes out. I found this by trying it.

## Behaviour on older instances

The CLI and the server version independently, so an instance with no such endpoint is a normal condition. The CLI degrades and **names the migrations it could not size**, rather than failing or going quiet. A fact whose SQL does not fit the operator's schema reports the database's own message against that migration.

## Verified against a real database, not mocks

50,000 rows seeded into `users`; the shipped fact for the setup-complete backfill produced:

```
row-estimate | warn
  backfill touches ~100,000 rows here, in a single transaction
  → schedule a maintenance window sized for ~100,000 rows — row locks are held until commit

seq-scan | warn
  the backfill's predicate matches ~100% of "users" (100,000 of 100,000 rows)
  — no index can help; the scan is the work
```

Also checked live:

| Check | Result |
|---|---|
| Row counts after every EXPLAIN | unchanged |
| `EXPLAIN` of an `INSERT` | refused |
| `EXPLAIN` of a `DROP` | refused |
| Wire format (real client → real server) | correct path and body, plan parsed |
| Older server returning 404 | CLI degrades, does not fail |

Running it also caught a bug unit tests would have missed: knex rejects a callback transaction that rolls itself back, so the plan came back `undefined`. The transaction is `READ ONLY`, so committing it writes nothing.

Three new CLI tests cover the success, no-endpoint, and cannot-plan paths.

`pnpm generate-api` confirms the route registers; per repo policy the generated artifacts are **not** committed here.