### PR TITLE
fix(mcp): require explicit project scope

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -73,7 +73,7 @@
         "@lightdash/common": "workspace:*",
         "@lightdash/formula": "workspace:*",
         "@lightdash/warehouses": "workspace:*",
-        "@modelcontextprotocol/sdk": "1.29.0",
+        "@modelcontextprotocol/sdk": "1.30.0",
         "@node-oauth/oauth2-server": "5.3.0",
         "@octokit/app": "14.0.2",
         "@octokit/auth-app": "6.0.3",

--- a/packages/backend/src/ee/services/McpService/McpService.aiWritebackTasks.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.aiWritebackTasks.test.ts
@@ -145,7 +145,9 @@ const makeMcpService = ({
             findClientInfo: vi.fn(),
         },
         projectModel: {},
-        projectService: {},
+        projectService: {
+            getProject: vi.fn().mockResolvedValue({ organizationUuid }),
+        },
         searchModel: {},
         shareService: {},
         spaceService: {},
@@ -212,7 +214,7 @@ describe('McpService AI writeback MCP tasks', () => {
                 McpToolName.RUN_AI_WRITEBACK,
             )!;
             const result = await callback(
-                { prompt: 'add a metric' },
+                { prompt: 'add a metric', projectUuid },
                 makeExtra(),
             );
 
@@ -234,7 +236,7 @@ describe('McpService AI writeback MCP tasks', () => {
                 McpToolName.RUN_AI_WRITEBACK,
             )!;
             const result = await callback(
-                { prompt: 'add a metric' },
+                { prompt: 'add a metric', projectUuid },
                 makeExtra(tasksOptInMeta),
             );
 

--- a/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
@@ -11,6 +11,8 @@ vi.mock('@sentry/node', () => ({
     captureException: vi.fn(),
     getActiveSpan: () => undefined,
     isEnabled: () => false,
+    startSpan: (_options: unknown, callback: CallableFunction) =>
+        callback({ spanContext: () => ({ spanId: 'span-id' }) }),
     startSpanManual: (_options: unknown, callback: CallableFunction) =>
         callback({ spanContext: () => ({ spanId: 'span-id' }) }, vi.fn()),
     wrapMcpServerWithSentry: (server: unknown) => server,
@@ -275,7 +277,16 @@ const makeMcpService = ({
         mcpContextModel: {
             getContext: vi.fn().mockResolvedValue({ context }),
         },
-        projectModel: {},
+        projectModel: {
+            getAllByOrganizationUuid: vi.fn().mockResolvedValue([
+                {
+                    projectUuid,
+                    name: 'Project',
+                    type: 'DEFAULT',
+                    expiresAt: null,
+                },
+            ]),
+        },
         projectService,
         searchModel: {},
         shareService: {},
@@ -306,6 +317,34 @@ const getTextResult = (result: unknown) => {
 describe('MCP list_content', () => {
     beforeEach(() => {
         mockRegisteredMcpTools.clear();
+    });
+
+    it('returns bootstrap context without changing it', async () => {
+        makeMcpService();
+
+        const result = (await getToolCallback(McpToolName.GET_CONTEXT)(
+            {},
+            extra,
+        )) as {
+            structuredContent: Record<string, unknown>;
+        };
+
+        expect(result.structuredContent).toEqual({
+            activeProject: {
+                projectUuid,
+                projectName: 'Project',
+                selectedTags: null,
+            },
+            activeAgent: null,
+            projects: [
+                {
+                    projectUuid,
+                    name: 'Project',
+                    type: 'DEFAULT',
+                    expiresAt: null,
+                },
+            ],
+        });
     });
 
     it('lists root content spaces with active agent space access', async () => {
@@ -350,7 +389,12 @@ describe('MCP list_content', () => {
         });
 
         const result = await getToolCallback(McpToolName.LIST_CONTENT)(
-            { spaceSlug: null, page: 1 },
+            {
+                projectUuid,
+                agentUuid: 'agent-uuid',
+                spaceSlug: null,
+                page: 1,
+            },
             extra,
         );
         const text = getTextResult(result);
@@ -363,6 +407,33 @@ describe('MCP list_content', () => {
         );
         expect(text).toContain('chartCount="2"');
         expect(text).not.toContain('Blocked Space');
+    });
+
+    it('uses the explicit project instead of stored context', async () => {
+        const explicitProjectUuid = 'explicit-project-uuid';
+        const { aiAgentToolsService, projectService } = makeMcpService();
+
+        await getToolCallback(McpToolName.LIST_CONTENT)(
+            {
+                projectUuid: explicitProjectUuid,
+                spaceSlug: null,
+                page: 1,
+            },
+            extra,
+        );
+
+        expect(projectService.getProject).toHaveBeenCalledWith(
+            explicitProjectUuid,
+            account,
+        );
+        expect(aiAgentToolsService.createRuntime).toHaveBeenCalledWith(
+            expect.objectContaining({
+                projectUuid: explicitProjectUuid,
+                agentUuid: undefined,
+                tags: null,
+                spaceAccess: null,
+            }),
+        );
     });
 
     it('lists direct content inside a space slug', async () => {
@@ -410,7 +481,7 @@ describe('MCP list_content', () => {
         });
 
         const result = await getToolCallback(McpToolName.LIST_CONTENT)(
-            { spaceSlug: 'allowed-space', page: 1 },
+            { projectUuid, spaceSlug: 'allowed-space', page: 1 },
             extra,
         );
         const text = getTextResult(result);

--- a/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
@@ -121,6 +121,7 @@ const makeMcpService = ({
         tags: null,
     },
     agent = null,
+    availableAgents = [],
     spaces = [],
     contentResults = { data: [], pagination: undefined },
 }: {
@@ -137,6 +138,13 @@ const makeMcpService = ({
         tags: string[] | null;
         spaceAccess: string[];
     } | null;
+    availableAgents?: Array<{
+        uuid: string;
+        name: string;
+        description: string | null;
+        tags: string[] | null;
+        projectUuid: string;
+    }>;
     spaces?: TestSpace[];
     contentResults?: {
         data: TestContentItem[];
@@ -151,6 +159,8 @@ const makeMcpService = ({
     };
 } = {}) => {
     const aiAgentService = {
+        getIsCopilotEnabled: vi.fn().mockResolvedValue(true),
+        listAgents: vi.fn().mockResolvedValue(availableAgents),
         getAgent: vi.fn().mockImplementation(async () => {
             if (!agent) throw new Error('Agent not mocked');
             return {
@@ -295,6 +305,7 @@ const makeMcpService = ({
     } as unknown as ConstructorParameters<typeof McpService>[0]);
 
     return {
+        aiAgentService,
         aiAgentToolsService,
         projectService,
         service,
@@ -336,12 +347,75 @@ describe('MCP list_content', () => {
                 selectedTags: null,
             },
             activeAgent: null,
-            projects: [
+            availableProjects: [
                 {
                     projectUuid,
                     name: 'Project',
                     type: 'DEFAULT',
                     expiresAt: null,
+                    availableAgents: [],
+                },
+            ],
+        });
+    });
+
+    it('omits an active agent that is no longer accessible', async () => {
+        makeMcpService({
+            context: {
+                projectUuid,
+                projectName: 'Project',
+                agentUuid: 'blocked-agent-uuid',
+                agentName: 'Blocked agent',
+                tags: ['blocked'],
+            },
+        });
+
+        const result = (await getToolCallback(McpToolName.GET_CONTEXT)(
+            {},
+            extra,
+        )) as {
+            structuredContent: Record<string, unknown>;
+        };
+
+        expect(result.structuredContent).toMatchObject({
+            activeAgent: null,
+            availableProjects: [{ availableAgents: [] }],
+        });
+    });
+
+    it('lists only accessible agents within accessible projects', async () => {
+        const { aiAgentService } = makeMcpService({
+            availableAgents: [
+                {
+                    uuid: 'available-agent-uuid',
+                    name: 'Available agent',
+                    description: 'Accessible to the current user',
+                    tags: ['finance'],
+                    projectUuid,
+                },
+            ],
+        });
+
+        const result = (await getToolCallback(McpToolName.GET_CONTEXT)(
+            {},
+            extra,
+        )) as {
+            structuredContent: Record<string, unknown>;
+        };
+
+        expect(aiAgentService.listAgents).toHaveBeenCalledWith(user);
+        expect(result.structuredContent).toMatchObject({
+            availableProjects: [
+                {
+                    projectUuid,
+                    availableAgents: [
+                        {
+                            agentUuid: 'available-agent-uuid',
+                            name: 'Available agent',
+                            description: 'Accessible to the current user',
+                            tags: ['finance'],
+                        },
+                    ],
                 },
             ],
         });

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -601,7 +601,10 @@ const getToolCallback = (toolName: McpToolName) => {
     if (!callback) {
         throw new Error(`Tool ${toolName} was not registered`);
     }
-    return callback;
+    return (
+        args: Record<string, unknown>,
+        callbackExtra: Record<string, unknown>,
+    ) => callback({ projectUuid, ...args }, callbackExtra);
 };
 
 const getTextResult = (result: unknown) => {
@@ -703,7 +706,7 @@ describe('MCP async query polling', () => {
 
         await expect(
             getToolCallback(McpToolName.RUN_SQL)(
-                { sql: 'select 1', limit: 10 },
+                { sql: 'select 1', limit: 10, projectUuid: headerProjectUuid },
                 {
                     ...extra,
                     authInfo: {
@@ -751,7 +754,7 @@ describe('MCP async query polling', () => {
         });
     });
 
-    it('returns relevant verified answers in find_explores for the active agent', async () => {
+    it('returns relevant verified answers in find_explores for the explicit agent', async () => {
         const relevantVerifiedAnswer = {
             artifactVersionUuid: 'artifact-version-uuid',
             artifactType: 'chart',
@@ -789,7 +792,10 @@ describe('MCP async query polling', () => {
         );
 
         const result = await getToolCallback(McpToolName.FIND_EXPLORES)(
-            { searchQuery: 'Show me revenue by month' },
+            {
+                searchQuery: 'Show me revenue by month',
+                agentUuid: 'agent-uuid',
+            },
             extra,
         );
 
@@ -993,7 +999,7 @@ describe('MCP async query polling', () => {
         });
     });
 
-    it('lists only explores available to the active agent in grep_fields', async () => {
+    it('lists only explores available to the explicit agent in grep_fields', async () => {
         makeMcpService({
             grepFieldsEnabled: true,
             context: {
@@ -1016,7 +1022,11 @@ describe('MCP async query polling', () => {
         });
 
         const result = await getToolCallback(McpToolName.GREP_FIELDS)(
-            { patterns: ['orders count'], exploreName: null },
+            {
+                patterns: ['orders count'],
+                exploreName: null,
+                agentUuid: 'agent-uuid',
+            },
             extra,
         );
 
@@ -1024,7 +1034,7 @@ describe('MCP async query polling', () => {
         expect(JSON.stringify(result)).not.toContain('payments');
     });
 
-    it('filters content by active agent space access', async () => {
+    it('filters content by explicit agent space access', async () => {
         const allowedChart = makeChartSearchResult({
             name: 'Allowed Chart',
             spaceUuid: allowedSpaceUuid,
@@ -1065,7 +1075,10 @@ describe('MCP async query polling', () => {
         });
 
         const contentResult = await getToolCallback(McpToolName.FIND_CONTENT)(
-            { searchQueries: [{ label: 'chart' }] },
+            {
+                searchQueries: [{ label: 'chart' }],
+                agentUuid: 'agent-uuid',
+            },
             extra,
         );
         const contentText = getTextResult(contentResult);
@@ -1075,7 +1088,7 @@ describe('MCP async query polling', () => {
 
         const verifiedResult = await getToolCallback(
             McpToolName.LIST_VERIFIED_CONTENT,
-        )({}, extra);
+        )({ agentUuid: 'agent-uuid' }, extra);
         const verifiedContentResult = JSON.parse(getTextResult(verifiedResult));
 
         expect(verifiedContentResult).toEqual([allowedVerifiedContent]);
@@ -1126,7 +1139,7 @@ describe('MCP async query polling', () => {
         ]);
     });
 
-    it('uses active agent tags for run_metric_query', async () => {
+    it('uses explicit agent tags for run_metric_query', async () => {
         const { asyncQueryService } = makeMcpService({
             context: {
                 projectUuid,
@@ -1157,6 +1170,7 @@ describe('MCP async query polling', () => {
             {
                 title: 'Orders',
                 description: 'Orders count',
+                agentUuid: 'agent-uuid',
                 queryConfig: {
                     exploreName: 'orders',
                     dimensions: [],
@@ -1175,7 +1189,7 @@ describe('MCP async query polling', () => {
         expect(asyncQueryService.executeAsyncMetricQuery).toHaveBeenCalled();
     });
 
-    it('lists only explores available to the active agent in find_explores', async () => {
+    it('lists only explores available to the explicit agent in find_explores', async () => {
         makeMcpService({
             context: {
                 projectUuid,
@@ -1197,7 +1211,7 @@ describe('MCP async query polling', () => {
         });
 
         const result = await getToolCallback(McpToolName.FIND_EXPLORES)(
-            { searchQuery: 'orders' },
+            { searchQuery: 'orders', agentUuid: 'agent-uuid' },
             extra,
         );
 
@@ -1214,7 +1228,7 @@ describe('MCP async query polling', () => {
         expect(JSON.stringify(result)).not.toContain('payments');
     });
 
-    it('does not fall back to manual tags with an active agent', async () => {
+    it('does not fall back to manual tags with an explicit agent', async () => {
         const { asyncQueryService } = makeMcpService({
             context: {
                 projectUuid,
@@ -1236,6 +1250,7 @@ describe('MCP async query polling', () => {
             {
                 title: 'Orders',
                 description: 'Orders count',
+                agentUuid: 'agent-uuid',
                 queryConfig: {
                     exploreName: 'orders',
                     dimensions: [],
@@ -1308,6 +1323,7 @@ describe('MCP async query polling', () => {
                     filters: null,
                 },
                 chartConfig: null,
+                projectUuid: headerProjectUuid,
             },
             {
                 ...extra,
@@ -1536,7 +1552,7 @@ describe('MCP async query polling', () => {
         );
     });
 
-    it('does not return metric results outside the active agent scope', async () => {
+    it('does not return metric results outside the explicit agent scope', async () => {
         const { asyncQueryService } = makeMcpService({
             context: {
                 projectUuid,
@@ -1561,7 +1577,7 @@ describe('MCP async query polling', () => {
         );
 
         const result = await getToolCallback(McpToolName.GET_QUERY_RESULT)(
-            { queryUuid },
+            { queryUuid, agentUuid: 'agent-uuid' },
             extra,
         );
 
@@ -1579,7 +1595,7 @@ describe('MCP async query polling', () => {
         ).not.toHaveBeenCalled();
     });
 
-    it('does not render metric results outside the active agent scope', async () => {
+    it('does not render metric results outside the explicit agent scope', async () => {
         const { asyncQueryService } = makeMcpService({
             context: {
                 projectUuid,
@@ -1609,6 +1625,7 @@ describe('MCP async query polling', () => {
                 title: 'Orders',
                 description: 'Orders count',
                 chartConfig: null,
+                agentUuid: 'agent-uuid',
             },
             extra,
         );
@@ -1654,7 +1671,7 @@ describe('MCP async query polling', () => {
         );
 
         const result = await getToolCallback(McpToolName.GET_QUERY_RESULT)(
-            { queryUuid },
+            { queryUuid, agentUuid: 'agent-uuid' },
             extra,
         );
 
@@ -1714,7 +1731,7 @@ describe('MCP async query polling', () => {
         );
 
         const result = await getToolCallback(McpToolName.GET_QUERY_RESULT)(
-            { queryUuid },
+            { queryUuid, agentUuid: 'agent-uuid' },
             extra,
         );
 
@@ -1788,7 +1805,7 @@ describe('MCP async query polling', () => {
         });
 
         const result = await getToolCallback(McpToolName.GET_QUERY_RESULT)(
-            { queryUuid },
+            { queryUuid, agentUuid: 'agent-uuid' },
             extra,
         );
 
@@ -1804,7 +1821,7 @@ describe('MCP async query polling', () => {
         expect(asyncQueryService.getRawAsyncQueryResults).toHaveBeenCalled();
     });
 
-    it('does not search field values outside the active agent scope', async () => {
+    it('does not search field values outside the explicit agent scope', async () => {
         const { projectService } = makeMcpService({
             context: {
                 projectUuid,
@@ -1828,6 +1845,7 @@ describe('MCP async query polling', () => {
                 fieldId: 'orders_hidden',
                 query: null,
                 filters: null,
+                agentUuid: 'agent-uuid',
             },
             extra,
         );

--- a/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
@@ -270,7 +270,7 @@ describe('McpService route_agent', () => {
         expect(getCurrentAgentTool).toBeDefined();
 
         const routeResult = (await routeAgentTool!(
-            { prompt: 'show revenue by month' },
+            { prompt: 'show revenue by month', projectUuid },
             extra,
         )) as {
             content: Array<{ text: string }>;
@@ -305,7 +305,10 @@ describe('McpService route_agent', () => {
             }),
         );
 
-        const currentResult = (await getCurrentAgentTool!({}, extra)) as {
+        const currentResult = (await getCurrentAgentTool!(
+            { projectUuid },
+            extra,
+        )) as {
             content: Array<{ text: string }>;
         };
         expect(JSON.parse(currentResult.content[0].text)).toEqual(
@@ -317,7 +320,7 @@ describe('McpService route_agent', () => {
         );
     });
 
-    it('applies routed agent scope to later tool calls', async () => {
+    it('applies an explicitly routed agent to later tool calls', async () => {
         const { aiAgentToolsService } = makeMcpService();
 
         const routeAgentTool = mockRegisteredMcpTools.get(
@@ -327,10 +330,19 @@ describe('McpService route_agent', () => {
             McpToolName.LIST_CONTENT,
         );
 
-        await routeAgentTool!({ prompt: 'show revenue by month' }, extra);
+        await routeAgentTool!(
+            { prompt: 'show revenue by month', projectUuid },
+            extra,
+        );
 
         const listContentResult = (await listContentTool!(
-            { spaceSlug: null, page: 1, pageSize: 25 },
+            {
+                projectUuid,
+                agentUuid: 'agent-uuid',
+                spaceSlug: null,
+                page: 1,
+                pageSize: 25,
+            },
             extra,
         )) as {
             content: Array<{ text: string }>;
@@ -401,9 +413,10 @@ describe('McpService route_agent', () => {
             {},
             pinnedExtra,
         )) as { content: Array<{ text: string }> };
-        const agentResult = (await getCurrentAgentTool!({}, pinnedExtra)) as {
-            content: Array<{ text: string }>;
-        };
+        const agentResult = (await getCurrentAgentTool!(
+            { projectUuid },
+            pinnedExtra,
+        )) as { content: Array<{ text: string }> };
 
         expect(JSON.parse(projectResult.content[0].text)).toEqual(
             expect.objectContaining({ projectUuid }),

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -4283,8 +4283,9 @@ export class McpService extends BaseService {
      * Whether the run_metric_query tool should be registered for this caller.
      *
      * Query execution performs a more specific explore-level authorization
-     * check. This registration gate uses the project-level manage:Explore
-     * capability so viewers do not see a tool that will always reject them.
+     * check. A project-pinned endpoint checks that concrete project. The
+     * unpinned endpoint uses a coarse capability check because tools/list must
+     * not vary as a side effect of legacy shared context.
      */
     public async isRunMetricQueryEnabled(
         user: SessionUser,
@@ -4292,23 +4293,12 @@ export class McpService extends BaseService {
     ): Promise<boolean> {
         const ability = this.createAuditedAbility(user);
 
-        const projectUuid =
-            headerProjectUuid ??
-            (user.organizationUuid
-                ? (
-                      await this.mcpContextModel.getContext(
-                          user.userUuid,
-                          user.organizationUuid,
-                      )
-                  )?.context.projectUuid
-                : undefined);
-
-        if (projectUuid && user.organizationUuid) {
+        if (headerProjectUuid && user.organizationUuid) {
             return ability.can(
                 'manage',
                 subject('Explore', {
                     organizationUuid: user.organizationUuid,
-                    projectUuid,
+                    projectUuid: headerProjectUuid,
                 }),
             );
         }

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -29,6 +29,7 @@ import {
     ForbiddenError,
     getAiWritebackStatusToolDefinition,
     getAiWritebackTaskStatusMessage,
+    getContextToolDefinition,
     getCurrentAgentToolDefinition,
     getCurrentProjectToolDefinition,
     getErrorMessage,
@@ -133,10 +134,7 @@ import { wrapSentryTransaction } from '../../../utils';
 import { VERSION } from '../../../version';
 import { DbMcpClientInfo } from '../../database/entities/mcpToolCall';
 import { McpToolCallModel } from '../../models/McpToolCallModel';
-import {
-    getMcpAnalystPrompt,
-    getMcpAnalystPromptWithContext,
-} from '../ai/prompts/mcpAnalyst';
+import { getMcpAnalystPrompt } from '../ai/prompts/mcpAnalyst';
 import { getCreateContent } from '../ai/tools/createContent';
 import { getCreateScheduledDelivery } from '../ai/tools/createScheduledDelivery';
 import { getEditContent } from '../ai/tools/editContent';
@@ -195,6 +193,7 @@ export enum McpToolName {
     EDIT_CONTENT = 'edit_content',
     CREATE_SCHEDULED_DELIVERY = 'create_scheduled_delivery',
     LIST_PROJECTS = 'list_projects',
+    GET_CONTEXT = 'get_context',
     SET_PROJECT = 'set_project',
     GET_CURRENT_PROJECT = 'get_current_project',
     LIST_AGENTS = 'list_agents',
@@ -215,40 +214,134 @@ export enum McpToolName {
     READ_SKILL_RESOURCE = 'read_skill_resource',
 }
 
+const projectIndependentMcpToolNames = new Set<string>([
+    McpToolName.GET_LIGHTDASH_VERSION,
+    McpToolName.LIST_PROJECTS,
+    McpToolName.GET_CONTEXT,
+    McpToolName.GET_CURRENT_PROJECT,
+    McpToolName.LIST_SKILLS,
+    McpToolName.READ_SKILL,
+    McpToolName.READ_SKILL_RESOURCE,
+]);
+const knownMcpToolNames = new Set<string>(Object.values(McpToolName));
+
+export const isProjectScopedMcpTool = (toolName: string): boolean =>
+    knownMcpToolNames.has(toolName) &&
+    !projectIndependentMcpToolNames.has(toolName);
+
 // Skills-over-MCP extension identifier (SEP-2640).
 const MCP_SKILLS_EXTENSION_NAME = 'io.modelcontextprotocol/skills';
 
-const mcpRunAiWritebackTool = runAiWritebackToolDefinition.for('mcp');
-const mcpGetAiWritebackStatusTool =
-    getAiWritebackStatusToolDefinition.for('mcp');
+const projectUuidInput = z
+    .string()
+    .uuid()
+    .describe('Project UUID for this operation.');
+
+const agentUuidInput = z
+    .string()
+    .uuid()
+    .optional()
+    .describe(
+        'Optional AI agent UUID for this operation. Omit it to use the full project scope.',
+    );
+
+const withProjectUuidInput = <
+    T extends { inputSchema: z.ZodObject<z.ZodRawShape> },
+>(
+    tool: T,
+) => ({
+    ...tool,
+    inputSchema: tool.inputSchema.extend({ projectUuid: projectUuidInput }),
+});
+
+const withProjectScopeInput = <
+    T extends { inputSchema: z.ZodObject<z.ZodRawShape> },
+>(
+    tool: T,
+) => ({
+    ...tool,
+    inputSchema: tool.inputSchema.extend({
+        projectUuid: projectUuidInput,
+        agentUuid: agentUuidInput,
+    }),
+});
+
+const mcpRunAiWritebackTool = withProjectUuidInput(
+    runAiWritebackToolDefinition.for('mcp'),
+);
+const mcpGetAiWritebackStatusTool = withProjectUuidInput(
+    getAiWritebackStatusToolDefinition.for('mcp'),
+);
 const mcpGetLightdashVersionTool = getLightdashVersionToolDefinition.for('mcp');
-const mcpListExploresTool = listExploresToolDefinition.for('mcp');
-const mcpFindExploresTool = findExploresToolDefinition.for('mcp');
-const mcpFindFieldsTool = findFieldsToolDefinition.for('mcp');
-const mcpGrepFieldsTool = grepFieldsToolDefinition.for('mcp');
-const mcpGetMetadataTool = getMetadataToolDefinition.for('mcp');
-const mcpFindContentTool = findContentToolDefinition.for('mcp');
-const mcpListContentTool = listContentToolDefinition.for('mcp');
-const mcpReadContentTool = readContentToolDefinition.for('mcp');
-const mcpResolveUrlTool = resolveUrlToolDefinition.for('mcp');
-const mcpCreateContentTool = createContentToolDefinition.for('mcp');
-const mcpEditContentTool = editContentToolDefinition.for('mcp');
-const mcpCreateScheduledDeliveryTool =
-    createScheduledDeliveryToolDefinition.for('mcp');
+const mcpListExploresTool = withProjectScopeInput(
+    listExploresToolDefinition.for('mcp'),
+);
+const mcpFindExploresTool = withProjectScopeInput(
+    findExploresToolDefinition.for('mcp'),
+);
+const mcpFindFieldsTool = withProjectScopeInput(
+    findFieldsToolDefinition.for('mcp'),
+);
+const mcpGrepFieldsTool = withProjectScopeInput(
+    grepFieldsToolDefinition.for('mcp'),
+);
+const mcpGetMetadataTool = withProjectScopeInput(
+    getMetadataToolDefinition.for('mcp'),
+);
+const mcpFindContentTool = withProjectScopeInput(
+    findContentToolDefinition.for('mcp'),
+);
+const mcpListContentTool = withProjectScopeInput(
+    listContentToolDefinition.for('mcp'),
+);
+const mcpReadContentTool = withProjectScopeInput(
+    readContentToolDefinition.for('mcp'),
+);
+const mcpResolveUrlTool = withProjectScopeInput(
+    resolveUrlToolDefinition.for('mcp'),
+);
+const mcpCreateContentTool = withProjectScopeInput(
+    createContentToolDefinition.for('mcp'),
+);
+const mcpEditContentTool = withProjectScopeInput(
+    editContentToolDefinition.for('mcp'),
+);
+const mcpCreateScheduledDeliveryTool = withProjectScopeInput(
+    createScheduledDeliveryToolDefinition.for('mcp'),
+);
 const mcpListProjectsTool = mcpListProjectsToolDefinition.for('mcp');
+const mcpGetContextTool = getContextToolDefinition.for('mcp');
 const mcpSetProjectTool = setProjectToolDefinition.for('mcp');
 const mcpGetCurrentProjectTool = getCurrentProjectToolDefinition.for('mcp');
-const mcpListAgentsTool = listAgentsToolDefinition.for('mcp');
-const mcpRouteAgentTool = routeAgentToolDefinition.for('mcp');
-const mcpSetAgentTool = setAgentToolDefinition.for('mcp');
-const mcpClearAgentTool = clearAgentToolDefinition.for('mcp');
-const mcpGetCurrentAgentTool = getCurrentAgentToolDefinition.for('mcp');
-const mcpRunMetricQueryTool = runQueryToolDefinition.for('mcp');
-const mcpRenderChartTool = renderChartToolDefinition.for('mcp');
-const mcpSearchFieldValuesTool = searchFieldValuesToolDefinition.for('mcp');
-const mcpRunSqlTool = runSqlToolDefinition.for('mcp');
-const mcpGetQueryResultTool = getQueryResultToolDefinition.for('mcp');
-const mcpListVerifiedContentTool = listVerifiedContentToolDefinition.for('mcp');
+const mcpListAgentsTool = withProjectUuidInput(
+    listAgentsToolDefinition.for('mcp'),
+);
+const mcpRouteAgentTool = withProjectUuidInput(
+    routeAgentToolDefinition.for('mcp'),
+);
+const mcpSetAgentTool = withProjectUuidInput(setAgentToolDefinition.for('mcp'));
+const mcpClearAgentTool = withProjectUuidInput(
+    clearAgentToolDefinition.for('mcp'),
+);
+const mcpGetCurrentAgentTool = withProjectUuidInput(
+    getCurrentAgentToolDefinition.for('mcp'),
+);
+const mcpRunMetricQueryTool = withProjectScopeInput(
+    runQueryToolDefinition.for('mcp'),
+);
+const mcpRenderChartTool = withProjectScopeInput(
+    renderChartToolDefinition.for('mcp'),
+);
+const mcpSearchFieldValuesTool = withProjectScopeInput(
+    searchFieldValuesToolDefinition.for('mcp'),
+);
+const mcpRunSqlTool = withProjectUuidInput(runSqlToolDefinition.for('mcp'));
+const mcpGetQueryResultTool = withProjectScopeInput(
+    getQueryResultToolDefinition.for('mcp'),
+);
+const mcpListVerifiedContentTool = withProjectScopeInput(
+    listVerifiedContentToolDefinition.for('mcp'),
+);
 const mcpListSkillsTool = listSkillsToolDefinition.for('mcp');
 const mcpReadSkillTool = readSkillToolDefinition.for('mcp');
 const mcpReadSkillResourceTool = readSkillResourceToolDefinition.for('mcp');
@@ -282,6 +375,8 @@ export type ExtraContext = {
     headerUserAttributes?: UserAttributeValueMap;
     /** Project UUID passed via X-Lightdash-Project header; overrides stored context */
     headerProjectUuid?: string;
+    /** Legacy shared context was injected for a cached pre-migration tool contract. */
+    legacyContextInjected?: boolean;
     /** User-Agent of the MCP client request, used to attach client identity to tool calls */
     userAgent?: string;
     /** Negotiated protocol version from the MCP-Protocol-Version header */
@@ -308,10 +403,18 @@ const extraContextSchema = z.object({
     account: z.custom<OauthAccount | ApiKeyAccount | ServiceAcctAccount>(),
     headerUserAttributes: z.custom<UserAttributeValueMap>().optional(),
     headerProjectUuid: z.string().optional(),
+    legacyContextInjected: z.boolean().optional(),
     userAgent: z.string().optional(),
     protocolVersion: z.string().optional(),
     sessionId: z.string().optional(),
 });
+
+const mcpToolScopeArgsSchema = z
+    .object({
+        projectUuid: z.string(),
+        agentUuid: z.string().optional(),
+    })
+    .passthrough();
 
 const mcpProtocolContextSchema = z.object({
     authInfo: z
@@ -459,14 +562,44 @@ export class McpService extends BaseService {
         );
     }
 
+    private async getAccessibleProjects(context: McpProtocolContext) {
+        const { user, organizationUuid } = McpService.getAccount(context);
+        const allProjects = await wrapSentryTransaction(
+            'McpService.getAccessibleProjects.getAllByOrganizationUuid',
+            { organizationUuid },
+            async () =>
+                this.projectModel.getAllByOrganizationUuid(organizationUuid),
+        );
+        const auditedAbility = this.createAuditedAbility(user);
+
+        return allProjects
+            .filter((project) =>
+                auditedAbility.can(
+                    'view',
+                    subject('Project', {
+                        organizationUuid,
+                        projectUuid: project.projectUuid,
+                    }),
+                ),
+            )
+            .map((project) => ({
+                name: project.name,
+                projectUuid: project.projectUuid,
+                type: project.type,
+                expiresAt: project.expiresAt?.toISOString() ?? null,
+            }));
+    }
+
     private async getScopeInfo(
         context: McpProtocolContext,
-        projectUuid?: string,
+        projectUuid: string,
+        agentUuid?: string,
     ) {
         try {
-            const metadata = await this.getEffectiveScopeFromContext(
+            const metadata = await this.getEffectiveScope(
                 context,
                 projectUuid,
+                agentUuid,
             );
             return [
                 metadata.agentName
@@ -487,10 +620,15 @@ export class McpService extends BaseService {
     private async buildScopedResponse(
         context: McpProtocolContext,
         toolResult: string,
-        structuredContent?: Record<string, unknown>,
-        projectUuid?: string,
+        structuredContent: Record<string, unknown> | undefined,
+        projectUuid: string,
+        agentUuid?: string,
     ) {
-        const scopeInfo = await this.getScopeInfo(context, projectUuid);
+        const scopeInfo = await this.getScopeInfo(
+            context,
+            projectUuid,
+            agentUuid,
+        );
 
         const content = [{ type: 'text' as const, text: toolResult }];
 
@@ -546,7 +684,10 @@ export class McpService extends BaseService {
             context: {
                 projectUuid,
                 projectName,
-                tags: existingContext?.context.tags || null,
+                tags:
+                    existingContext?.context.projectUuid === projectUuid
+                        ? existingContext.context.tags || null
+                        : null,
                 agentUuid,
                 agentName,
             },
@@ -626,17 +767,23 @@ export class McpService extends BaseService {
     private async buildMcpMetricQuery({
         ctx,
         projectUuid,
+        agentUuid,
         queryTool,
     }: {
         ctx: McpProtocolContext;
         projectUuid: string;
+        agentUuid?: string;
         queryTool: ToolRunQueryArgsTransformed;
     }): Promise<{
         query: MetricQuery;
         userAttributeOverrides: UserAttributeValueMap | undefined;
         appliedParametersNote: string;
     }> {
-        const toolsRuntime = await this.getToolsRuntime(ctx, projectUuid);
+        const toolsRuntime = await this.getToolsRuntime(
+            ctx,
+            projectUuid,
+            agentUuid,
+        );
         const explore = unwrapMcpRuntimeResult(
             await toolsRuntime.getExplore({
                 table: queryTool.queryConfig.exploreName,
@@ -695,6 +842,7 @@ export class McpService extends BaseService {
     private async getToolsRuntime(
         context: McpProtocolContext,
         projectUuid: string,
+        agentUuid?: string,
     ): Promise<McpAiAgentToolsRuntime> {
         const { user, account, organizationUuid } =
             McpService.getAccount(context);
@@ -716,9 +864,10 @@ export class McpService extends BaseService {
             throw new ForbiddenError();
         }
 
-        const effectiveScope = await this.getEffectiveScopeFromContext(
+        const effectiveScope = await this.getEffectiveScope(
             context,
             projectUuid,
+            agentUuid,
         );
 
         return this.aiAgentToolsService.createRuntime({
@@ -742,14 +891,20 @@ export class McpService extends BaseService {
         ctx,
         user,
         projectUuid,
+        agentUuid,
         metricQuery,
     }: {
         ctx: McpProtocolContext;
         user: SessionUser;
         projectUuid: string;
+        agentUuid?: string;
         metricQuery: MetricQuery;
     }) {
-        const toolsRuntime = await this.getToolsRuntime(ctx, projectUuid);
+        const toolsRuntime = await this.getToolsRuntime(
+            ctx,
+            projectUuid,
+            agentUuid,
+        );
         const explore = unwrapMcpRuntimeResult(
             await toolsRuntime.getExplore({
                 table: metricQuery.exploreName,
@@ -922,6 +1077,7 @@ export class McpService extends BaseService {
         ctx,
         queryUuid,
         projectUuid,
+        agentUuid,
         queryTool,
         query,
         rows,
@@ -930,6 +1086,7 @@ export class McpService extends BaseService {
         ctx: McpProtocolContext;
         queryUuid: string;
         projectUuid: string;
+        agentUuid?: string;
         queryTool: ToolRunQueryArgsTransformed;
         query: MetricQuery;
         rows: Record<string, unknown>[];
@@ -1002,7 +1159,7 @@ export class McpService extends BaseService {
               }
             : null;
 
-        const scopeInfo = await this.getScopeInfo(ctx, projectUuid);
+        const scopeInfo = await this.getScopeInfo(ctx, projectUuid, agentUuid);
 
         const content = [
             {
@@ -1108,6 +1265,7 @@ export class McpService extends BaseService {
         ctx,
         queryUuid,
         projectUuid,
+        agentUuid,
         pageSize,
         includeStatus,
         sqlRunnerUrl,
@@ -1115,6 +1273,7 @@ export class McpService extends BaseService {
         ctx: McpProtocolContext;
         queryUuid: string;
         projectUuid: string;
+        agentUuid?: string;
         pageSize?: number;
         includeStatus: boolean;
         sqlRunnerUrl: string | null;
@@ -1160,6 +1319,7 @@ export class McpService extends BaseService {
                     },
                 },
                 projectUuid,
+                agentUuid,
             );
         }
 
@@ -1182,6 +1342,7 @@ export class McpService extends BaseService {
                 },
             },
             projectUuid,
+            agentUuid,
         );
     }
 
@@ -1204,7 +1365,10 @@ export class McpService extends BaseService {
                 const ctx = getMcpContext(extra);
 
                 const { user } = McpService.getAccount(ctx);
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
 
                 try {
                     const { aiWritebackRunUuid, createdAt, updatedAt } =
@@ -1270,7 +1434,10 @@ export class McpService extends BaseService {
                 const ctx = getMcpContext(extra);
 
                 const { user } = McpService.getAccount(ctx);
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
 
                 try {
                     const { status, prUrl, errorMessage } =
@@ -1348,14 +1515,14 @@ export class McpService extends BaseService {
 
         this.mcpServer.server.setRequestHandler(
             GetTaskRequestSchema,
-            async (request, extra) =>
-                this.handleGetAiWritebackTask(request.params.taskId, extra),
+            async (request, ctx) =>
+                this.handleGetAiWritebackTask(request.params.taskId, ctx),
         );
 
         this.mcpServer.server.setRequestHandler(
             CancelTaskRequestSchema,
-            async (request, extra) =>
-                this.handleCancelAiWritebackTask(request.params.taskId, extra),
+            async (request, ctx) =>
+                this.handleCancelAiWritebackTask(request.params.taskId, ctx),
         );
     }
 
@@ -1453,7 +1620,7 @@ export class McpService extends BaseService {
         try {
             outcome = await this.aiWritebackService.cancelRun(user, taskId);
         } catch (error) {
-            throw McpService.toTaskProtocolError(error, taskId);
+            throw McpService.toTaskMcpError(error, taskId);
         }
 
         if (!outcome.cancelled) {
@@ -1519,7 +1686,7 @@ export class McpService extends BaseService {
         try {
             return await this.aiWritebackService.getRunSnapshot(user, taskId);
         } catch (error) {
-            throw McpService.toTaskProtocolError(error, taskId);
+            throw McpService.toTaskMcpError(error, taskId);
         }
     }
 
@@ -1530,7 +1697,7 @@ export class McpService extends BaseService {
         );
     }
 
-    private static toTaskProtocolError(error: unknown, taskId: string): Error {
+    private static toTaskMcpError(error: unknown, taskId: string): Error {
         if (error instanceof NotFoundError || error instanceof ForbiddenError) {
             return McpService.taskNotFoundError(taskId);
         }
@@ -1567,12 +1734,16 @@ export class McpService extends BaseService {
             },
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
                 const argsWithProject = { ...args, projectUuid };
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
                     projectUuid,
+                    args.agentUuid,
                 );
 
                 const createContentTool = getCreateContent({
@@ -1591,6 +1762,7 @@ export class McpService extends BaseService {
                     await McpService.streamToolResult(result),
                     undefined,
                     projectUuid,
+                    args.agentUuid,
                 );
             },
         );
@@ -1605,12 +1777,16 @@ export class McpService extends BaseService {
             },
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
                 const argsWithProject = { ...args, projectUuid };
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
                     projectUuid,
+                    args.agentUuid,
                 );
 
                 const editContentTool = getEditContent({
@@ -1626,6 +1802,7 @@ export class McpService extends BaseService {
                     await McpService.streamToolResult(result),
                     undefined,
                     projectUuid,
+                    args.agentUuid,
                 );
             },
         );
@@ -1642,11 +1819,15 @@ export class McpService extends BaseService {
             },
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
                     projectUuid,
+                    args.agentUuid,
                 );
 
                 const createScheduledDeliveryTool = getCreateScheduledDelivery({
@@ -1666,6 +1847,7 @@ export class McpService extends BaseService {
                     await McpService.streamToolResult(result),
                     undefined,
                     projectUuid,
+                    args.agentUuid,
                 );
             },
         );
@@ -1720,15 +1902,19 @@ export class McpService extends BaseService {
                 inputSchema: mcpListExploresTool.inputSchema.shape,
                 annotations: mcpListExploresTool.annotations,
             },
-            async (_args, extra) => {
+            async (args, extra) => {
                 try {
                     const ctx = getMcpContext(extra);
 
-                    const projectUuid = await this.resolveProjectUuid(ctx);
+                    const projectUuid = await this.resolveToolProjectUuid(
+                        ctx,
+                        args.projectUuid,
+                    );
 
                     const toolsRuntime = await this.getToolsRuntime(
                         ctx,
                         projectUuid,
+                        args.agentUuid,
                     );
 
                     const listExploresTool = getMcpListExplores({
@@ -1748,6 +1934,7 @@ export class McpService extends BaseService {
                         await McpService.streamToolResult(result),
                         undefined,
                         projectUuid,
+                        args.agentUuid,
                     );
                 } catch (error) {
                     this.logger.error(
@@ -1772,26 +1959,31 @@ export class McpService extends BaseService {
                 async (args, extra) => {
                     const ctx = getMcpContext(extra);
                     const { user } = McpService.getAccount(ctx);
-                    const projectUuid = await this.resolveProjectUuid(ctx);
+                    const projectUuid = await this.resolveToolProjectUuid(
+                        ctx,
+                        args.projectUuid,
+                    );
 
                     try {
                         const toolsRuntime = await this.getToolsRuntime(
                             ctx,
                             projectUuid,
+                            args.agentUuid,
                         );
-                        // Independent reads — fetch the explore list, the
-                        // verified-usage map, and the active agent context
-                        // together instead of serially.
                         const [
                             availableExplores,
                             verifiedFieldUsage,
-                            metadata,
+                            effectiveScope,
                         ] = await Promise.all([
                             toolsRuntime.listExplores(),
                             toolsRuntime
                                 .getVerifiedFieldUsage()
                                 .catch(() => new Map<string, number>()),
-                            this.getActiveContextMetadata(ctx),
+                            this.getEffectiveScope(
+                                ctx,
+                                projectUuid,
+                                args.agentUuid,
+                            ),
                         ]);
                         const [result, verifiedAnswerContext] =
                             await Promise.all([
@@ -1805,12 +1997,13 @@ export class McpService extends BaseService {
                                             ),
                                         ),
                                 }),
-                                metadata.agentUuid
+                                effectiveScope.agentUuid
                                     ? this.aiAgentService.getRelevantVerifiedAnswerContextForAgent(
                                           user,
                                           {
                                               projectUuid,
-                                              agentUuid: metadata.agentUuid,
+                                              agentUuid:
+                                                  effectiveScope.agentUuid,
                                               searchQuery:
                                                   grepPatternsToSearchQuery(
                                                       args.patterns,
@@ -1836,6 +2029,7 @@ export class McpService extends BaseService {
                             formatToolJsonOutput(structuredContent),
                             structuredContent,
                             projectUuid,
+                            args.agentUuid,
                         );
                     } catch (error) {
                         return mcpGrepFieldsTool.result.error(
@@ -1856,12 +2050,16 @@ export class McpService extends BaseService {
                 },
                 async (args, extra) => {
                     const ctx = getMcpContext(extra);
-                    const projectUuid = await this.resolveProjectUuid(ctx);
+                    const projectUuid = await this.resolveToolProjectUuid(
+                        ctx,
+                        args.projectUuid,
+                    );
 
                     try {
                         const toolsRuntime = await this.getToolsRuntime(
                             ctx,
                             projectUuid,
+                            args.agentUuid,
                         );
                         const [availableExplores, projectParameterDefinitions] =
                             await Promise.all([
@@ -1878,6 +2076,7 @@ export class McpService extends BaseService {
                             formatToolJsonOutput(result.structuredContent),
                             result.structuredContent,
                             projectUuid,
+                            args.agentUuid,
                         );
                     } catch (error) {
                         return mcpGetMetadataTool.result.error(
@@ -1900,11 +2099,15 @@ export class McpService extends BaseService {
                     const ctx = getMcpContext(extra);
                     const { user } = McpService.getAccount(ctx);
 
-                    const projectUuid = await this.resolveProjectUuid(ctx);
+                    const projectUuid = await this.resolveToolProjectUuid(
+                        ctx,
+                        args.projectUuid,
+                    );
 
                     const toolsRuntime = await this.getToolsRuntime(
                         ctx,
                         projectUuid,
+                        args.agentUuid,
                     );
                     const runtimeResult = await toolsRuntime.findExplores({
                         fieldSearchSize: 200,
@@ -1928,14 +2131,18 @@ export class McpService extends BaseService {
                                     .toolDescriptionMaxChars,
                         });
                     const resultText = formatToolJsonOutput(structuredContent);
-                    const metadata = await this.getActiveContextMetadata(ctx);
+                    const effectiveScope = await this.getEffectiveScope(
+                        ctx,
+                        projectUuid,
+                        args.agentUuid,
+                    );
 
-                    const verifiedAnswerContext = metadata.agentUuid
+                    const verifiedAnswerContext = effectiveScope.agentUuid
                         ? await this.aiAgentService.getRelevantVerifiedAnswerContextForAgent(
                               user,
                               {
                                   projectUuid,
-                                  agentUuid: metadata.agentUuid,
+                                  agentUuid: effectiveScope.agentUuid,
                                   searchQuery: args.searchQuery,
                               },
                           )
@@ -1959,6 +2166,7 @@ export class McpService extends BaseService {
                                 verifiedAnswerContext.relevantVerifiedAnswers,
                         },
                         projectUuid,
+                        args.agentUuid,
                     );
                 },
             );
@@ -1975,11 +2183,15 @@ export class McpService extends BaseService {
                 async (args, extra) => {
                     const ctx = getMcpContext(extra);
 
-                    const projectUuid = await this.resolveProjectUuid(ctx);
+                    const projectUuid = await this.resolveToolProjectUuid(
+                        ctx,
+                        args.projectUuid,
+                    );
 
                     const toolsRuntime = await this.getToolsRuntime(
                         ctx,
                         projectUuid,
+                        args.agentUuid,
                     );
                     const exploreResult = await toolsRuntime.getExplore({
                         table: args.table,
@@ -2018,6 +2230,7 @@ export class McpService extends BaseService {
                         formatToolJsonOutput(structuredContent),
                         structuredContent,
                         projectUuid,
+                        args.agentUuid,
                     );
                 },
             );
@@ -2034,12 +2247,16 @@ export class McpService extends BaseService {
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
 
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
                 const argsWithProject = { ...args, projectUuid };
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
                     projectUuid,
+                    args.agentUuid,
                 );
 
                 const findContentTool = getFindContent({
@@ -2059,6 +2276,7 @@ export class McpService extends BaseService {
                     await McpService.streamToolResult(result),
                     undefined,
                     projectUuid,
+                    args.agentUuid,
                 );
             },
         );
@@ -2074,12 +2292,16 @@ export class McpService extends BaseService {
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
 
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
                 const argsWithProject = { ...args, projectUuid };
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
                     projectUuid,
+                    args.agentUuid,
                 );
 
                 const listContentTool = getListContent({
@@ -2095,6 +2317,7 @@ export class McpService extends BaseService {
                     await McpService.streamToolResult(result),
                     undefined,
                     projectUuid,
+                    args.agentUuid,
                 );
             },
         );
@@ -2109,12 +2332,16 @@ export class McpService extends BaseService {
             },
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
                 const argsWithProject = { ...args, projectUuid };
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
                     projectUuid,
+                    args.agentUuid,
                 );
 
                 const readContentTool = getReadContent({
@@ -2130,6 +2357,7 @@ export class McpService extends BaseService {
                     await McpService.streamToolResult(result),
                     undefined,
                     projectUuid,
+                    args.agentUuid,
                 );
             },
         );
@@ -2144,11 +2372,15 @@ export class McpService extends BaseService {
             },
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
                     projectUuid,
+                    args.agentUuid,
                 );
 
                 const resolveUrlTool = getResolveUrl({
@@ -2164,6 +2396,7 @@ export class McpService extends BaseService {
                     await McpService.streamToolResult(result),
                     undefined,
                     projectUuid,
+                    args.agentUuid,
                 );
             },
         );
@@ -2178,8 +2411,63 @@ export class McpService extends BaseService {
             this.registerCreateScheduledDeliveryTool();
         }
 
-        // When the project is pinned via header, hide the project-selection
-        // tools so clients can't change context for a request-scoped pin.
+        this.registerTrackedTool(
+            mcpGetContextTool.name,
+            {
+                title: mcpGetContextTool.title,
+                description: mcpGetContextTool.description,
+                inputSchema: mcpGetContextTool.inputSchema.shape,
+                outputSchema: mcpGetContextTool.outputSchema.shape,
+                annotations: mcpGetContextTool.annotations,
+            },
+            async (_args, extra) => {
+                const ctx = getMcpContext(extra);
+                const [projects, metadata, activeProjectUuid] =
+                    await Promise.all([
+                        this.getAccessibleProjects(ctx),
+                        this.getActiveContextMetadata(ctx),
+                        this.getProjectUuidFromContext(ctx),
+                    ]);
+                const activeProject = activeProjectUuid
+                    ? projects.find(
+                          (project) =>
+                              project.projectUuid === activeProjectUuid,
+                      )
+                    : undefined;
+                const structuredContent = {
+                    activeProject: activeProject
+                        ? {
+                              projectUuid: activeProject.projectUuid,
+                              projectName: activeProject.name,
+                              selectedTags:
+                                  metadata.projectUuid === activeProjectUuid
+                                      ? metadata.tags
+                                      : null,
+                          }
+                        : null,
+                    activeAgent:
+                        activeProject &&
+                        metadata.projectUuid === activeProjectUuid &&
+                        metadata.agentUuid &&
+                        metadata.agentName
+                            ? {
+                                  projectUuid: activeProject.projectUuid,
+                                  agentUuid: metadata.agentUuid,
+                                  agentName: metadata.agentName,
+                              }
+                            : null,
+                    projects,
+                };
+
+                return mcpGetContextTool.result.structured(
+                    JSON.stringify(structuredContent, null, 2),
+                    structuredContent,
+                );
+            },
+        );
+
+        // When the project is pinned via header, hide the legacy
+        // project-selection tools so clients cannot change the pin.
         if (!options.projectPinned) {
             this.registerTrackedTool(
                 mcpListProjectsTool.name,
@@ -2197,35 +2485,7 @@ export class McpService extends BaseService {
                     >,
                 ) => {
                     const ctx = getMcpContext(extra);
-                    const { user, organizationUuid } =
-                        McpService.getAccount(ctx);
-
-                    const allProjects = await wrapSentryTransaction(
-                        'McpService.listProjects.getAllByOrganizationUuid',
-                        { organizationUuid },
-                        async () =>
-                            this.projectModel.getAllByOrganizationUuid(
-                                organizationUuid,
-                            ),
-                    );
-
-                    const auditedAbility = this.createAuditedAbility(user);
-                    const projectList = allProjects
-                        .filter((project) =>
-                            auditedAbility.can(
-                                'view',
-                                subject('Project', {
-                                    organizationUuid,
-                                    projectUuid: project.projectUuid,
-                                }),
-                            ),
-                        )
-                        .map((project) => ({
-                            name: project.name,
-                            projectUuid: project.projectUuid,
-                            type: project.type,
-                            expiresAt: project.expiresAt,
-                        }));
+                    const projectList = await this.getAccessibleProjects(ctx);
 
                     return {
                         content: [
@@ -2519,7 +2779,10 @@ export class McpService extends BaseService {
                     throw new ParameterError('Agent UUID is required');
                 }
 
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
                 const project = await this.projectService.getProject(
                     projectUuid,
                     account,
@@ -2563,27 +2826,32 @@ export class McpService extends BaseService {
                 inputSchema: mcpClearAgentTool.inputSchema.shape,
                 annotations: mcpClearAgentTool.annotations,
             },
-            async (_args, extra) => {
+            async (args, extra) => {
                 const ctx = getMcpContext(extra);
 
                 const { user, organizationUuid } = McpService.getAccount(ctx);
-
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
                 const existingContext = await this.mcpContextModel.getContext(
                     user.userUuid,
                     organizationUuid,
                 );
 
-                await this.mcpContextModel.setContext({
-                    userUuid: user.userUuid,
-                    organizationUuid,
-                    context: {
-                        projectUuid: existingContext?.context.projectUuid ?? '',
-                        projectName: existingContext?.context.projectName ?? '',
-                        tags: existingContext?.context.tags || null,
-                        agentUuid: null,
-                        agentName: null,
-                    },
-                });
+                if (existingContext?.context.projectUuid === projectUuid) {
+                    await this.mcpContextModel.setContext({
+                        userUuid: user.userUuid,
+                        organizationUuid,
+                        context: {
+                            projectUuid,
+                            projectName: existingContext.context.projectName,
+                            tags: existingContext.context.tags || null,
+                            agentUuid: null,
+                            agentName: null,
+                        },
+                    });
+                }
 
                 return {
                     content: [
@@ -2611,14 +2879,17 @@ export class McpService extends BaseService {
                 inputSchema: mcpGetCurrentAgentTool.inputSchema.shape,
                 annotations: mcpGetCurrentAgentTool.annotations,
             },
-            async (_args, extra) => {
+            async (args, extra) => {
                 const ctx = getMcpContext(extra);
 
                 const { user, organizationUuid } = McpService.getAccount(ctx);
 
                 await this.checkAiAgentsVisible(user);
 
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
                 const contextRow = await this.mcpContextModel.getContext(
                     user.userUuid,
                     organizationUuid,
@@ -2711,11 +2982,14 @@ export class McpService extends BaseService {
                     outputSchema: mcpRunMetricQueryTool.outputSchema,
                     annotations: mcpRunMetricQueryTool.annotations,
                 },
-                async (_args, extra) => {
+                async (args, extra) => {
                     const ctx = getMcpContext(extra);
 
-                    const projectUuid = await this.resolveProjectUuid(ctx);
-                    const argsWithProject = { ..._args, projectUuid };
+                    const projectUuid = await this.resolveToolProjectUuid(
+                        ctx,
+                        args.projectUuid,
+                    );
+                    const argsWithProject = { ...args, projectUuid };
 
                     try {
                         const deadlineMs =
@@ -2732,6 +3006,7 @@ export class McpService extends BaseService {
                         } = await this.buildMcpMetricQuery({
                             ctx,
                             projectUuid,
+                            agentUuid: args.agentUuid,
                             queryTool,
                         });
 
@@ -2836,11 +3111,14 @@ export class McpService extends BaseService {
             },
             this.wrapToolCallback(
                 mcpRenderChartTool.name,
-                async (_args, extra) => {
+                async (args, extra) => {
                     const ctx = getMcpContext(extra);
 
-                    const projectUuid = await this.resolveProjectUuid(ctx);
-                    const argsWithProject = { ..._args, projectUuid };
+                    const projectUuid = await this.resolveToolProjectUuid(
+                        ctx,
+                        args.projectUuid,
+                    );
+                    const argsWithProject = { ...args, projectUuid };
 
                     try {
                         const { user, account } = McpService.getAccount(ctx);
@@ -2876,6 +3154,7 @@ export class McpService extends BaseService {
                             ctx,
                             user,
                             projectUuid,
+                            agentUuid: args.agentUuid,
                             metricQuery: queryHistory.metricQuery,
                         });
 
@@ -2897,6 +3176,7 @@ export class McpService extends BaseService {
                             ctx,
                             queryUuid: renderTool.queryUuid,
                             projectUuid,
+                            agentUuid: args.agentUuid,
                             queryTool,
                             query: queryHistory.metricQuery,
                             rows: results.rows,
@@ -2933,12 +3213,16 @@ export class McpService extends BaseService {
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
 
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
                 const argsWithProject = { ...args, projectUuid };
 
                 const toolsRuntime = await this.getToolsRuntime(
                     ctx,
                     projectUuid,
+                    args.agentUuid,
                 );
 
                 const searchFieldValuesTool = getSearchFieldValues({
@@ -2957,6 +3241,7 @@ export class McpService extends BaseService {
                     await McpService.streamToolResult(result),
                     undefined,
                     projectUuid,
+                    args.agentUuid,
                 );
             },
         );
@@ -2972,7 +3257,7 @@ export class McpService extends BaseService {
             // definition instead of being rebuilt here.
             const runSqlArgsSchema = createToolRunSqlArgsSchema({
                 maxLimit: this.lightdashConfig.mcp.runSqlMaxLimit,
-            });
+            }).extend({ projectUuid: projectUuidInput });
             this.registerTrackedTool(
                 mcpRunSqlTool.name,
                 {
@@ -2990,7 +3275,10 @@ export class McpService extends BaseService {
                     const ctx = getMcpContext(extra);
 
                     const { account } = McpService.getAccount(ctx);
-                    const projectUuid = await this.resolveProjectUuid(ctx);
+                    const projectUuid = await this.resolveToolProjectUuid(
+                        ctx,
+                        args.projectUuid,
+                    );
 
                     try {
                         const deadlineMs =
@@ -3079,7 +3367,10 @@ export class McpService extends BaseService {
                 const ctx = getMcpContext(extra);
 
                 const { user, account } = McpService.getAccount(ctx);
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
 
                 try {
                     let queryHistory =
@@ -3144,6 +3435,7 @@ export class McpService extends BaseService {
                                 },
                             },
                             projectUuid,
+                            args.agentUuid,
                         );
                     }
 
@@ -3163,6 +3455,7 @@ export class McpService extends BaseService {
                             ctx,
                             queryUuid: args.queryUuid,
                             projectUuid,
+                            agentUuid: args.agentUuid,
                             includeStatus: true,
                             sqlRunnerUrl,
                         });
@@ -3173,6 +3466,7 @@ export class McpService extends BaseService {
                             ctx,
                             user,
                             projectUuid,
+                            agentUuid: args.agentUuid,
                             metricQuery: queryHistory.metricQuery,
                         });
 
@@ -3232,15 +3526,19 @@ export class McpService extends BaseService {
                 inputSchema: mcpListVerifiedContentTool.inputSchema.shape,
                 annotations: mcpListVerifiedContentTool.annotations,
             },
-            async (_args, extra) => {
+            async (args, extra) => {
                 const ctx = getMcpContext(extra);
 
                 const { user } = McpService.getAccount(ctx);
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                const projectUuid = await this.resolveToolProjectUuid(
+                    ctx,
+                    args.projectUuid,
+                );
 
-                const effectiveScope = await this.getEffectiveScopeFromContext(
+                const effectiveScope = await this.getEffectiveScope(
                     ctx,
                     projectUuid,
+                    args.agentUuid,
                 );
                 const verifiedContent =
                     await this.contentVerificationService.listVerifiedContent(
@@ -3280,6 +3578,7 @@ export class McpService extends BaseService {
                     JSON.stringify(scopedVerifiedContent, null, 2),
                     undefined,
                     projectUuid,
+                    args.agentUuid,
                 );
             },
         );
@@ -3302,46 +3601,14 @@ export class McpService extends BaseService {
             {
                 title: 'Lightdash Data Analyst',
                 description:
-                    'Guidelines for querying Lightdash data using MCP tools. After setting project context, call route_agent at the start of each new user request to activate the best agent automatically. Includes explore selection, query building, visualization rules, and active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.',
+                    'Guidelines for querying Lightdash data using MCP tools. Call get_context first, pass projectUuid to every project-scoped tool, and pass route_agent results as agentUuid when scoped agent behavior is desired. Includes explore selection, query building, and visualization rules. Inject this into your system prompt for best results.',
                 argsSchema: {},
             },
-            async (_args, extra) => {
-                const ctx = getMcpContext(extra);
-
-                const metadata = await this.getActiveContextMetadata(ctx);
-                const { user } = McpService.getAccount(ctx);
-                const projectUuid = await this.getProjectUuidFromContext(ctx);
-
-                let promptText: string;
-
-                if (metadata.agentUuid) {
-                    try {
-                        const agent = await this.aiAgentService.getAgent(
-                            user,
-                            metadata.agentUuid,
-                            projectUuid,
-                            { includeSummaryContext: true },
-                        );
-                        promptText = getMcpAnalystPromptWithContext({
-                            agentName: agent.name,
-                            instruction: agent.context.instruction,
-                            explores: agent.context.explores,
-                            verifiedQuestions: agent.context.verifiedQuestions,
-                            enableGrepFields: options.grepFieldsEnabled,
-                            runSqlEnabled: options.runSqlEnabled,
-                        });
-                    } catch {
-                        promptText = getMcpAnalystPrompt({
-                            enableGrepFields: options.grepFieldsEnabled,
-                            runSqlEnabled: options.runSqlEnabled,
-                        });
-                    }
-                } else {
-                    promptText = getMcpAnalystPrompt({
-                        enableGrepFields: options.grepFieldsEnabled,
-                        runSqlEnabled: options.runSqlEnabled,
-                    });
-                }
+            async () => {
+                const promptText = getMcpAnalystPrompt({
+                    enableGrepFields: options.grepFieldsEnabled,
+                    runSqlEnabled: options.runSqlEnabled,
+                });
 
                 return {
                     messages: [
@@ -3356,6 +3623,32 @@ export class McpService extends BaseService {
                 };
             },
         );
+    }
+
+    public async getLegacyToolScope(
+        user: SessionUser,
+        pinnedProjectUuid?: string,
+    ): Promise<{ projectUuid: string; agentUuid: string | null } | null> {
+        if (!user.organizationUuid) {
+            return null;
+        }
+        const contextRow = await this.mcpContextModel.getContext(
+            user.userUuid,
+            user.organizationUuid,
+        );
+        const projectUuid =
+            pinnedProjectUuid ?? contextRow?.context.projectUuid;
+        if (!projectUuid) {
+            return null;
+        }
+
+        return {
+            projectUuid,
+            agentUuid:
+                contextRow?.context.projectUuid === projectUuid
+                    ? (contextRow.context.agentUuid ?? null)
+                    : null,
+        };
     }
 
     async getProjectUuidFromContext(context: McpProtocolContext) {
@@ -3376,6 +3669,34 @@ export class McpService extends BaseService {
         );
 
         return contextRow?.context.projectUuid;
+    }
+
+    private async getEffectiveScope(
+        context: McpProtocolContext,
+        projectUuid: string,
+        agentUuid?: string,
+    ): Promise<McpEffectiveScope> {
+        const user = context.authInfo?.extra.user;
+        if (!user || !agentUuid) {
+            return {
+                tags: null,
+                spaceAccess: null,
+                agentUuid: null,
+                agentName: null,
+            };
+        }
+
+        const agent = await this.aiAgentService.getAgent(
+            user,
+            agentUuid,
+            projectUuid,
+        );
+        return {
+            tags: agent.tags,
+            spaceAccess: agent.spaceAccess,
+            agentUuid: agent.uuid,
+            agentName: agent.name,
+        };
     }
 
     private async getEffectiveScopeFromContext(
@@ -3621,21 +3942,34 @@ export class McpService extends BaseService {
 
     private async resolveToolProjectUuid(
         context: McpProtocolContext,
-        requestedProjectUuid?: string,
+        requestedProjectUuid: string,
     ): Promise<string> {
         const pinnedProjectUuid = context.authInfo?.extra.headerProjectUuid;
-        if (pinnedProjectUuid) {
-            if (
-                requestedProjectUuid &&
-                requestedProjectUuid !== pinnedProjectUuid
-            ) {
-                throw new ForbiddenError(
-                    'The requested project does not match the pinned MCP project',
-                );
-            }
-            return this.resolveProjectUuid(context);
+        if (pinnedProjectUuid && requestedProjectUuid !== pinnedProjectUuid) {
+            throw new ForbiddenError(
+                'The requested project does not match the pinned MCP project',
+            );
         }
-        return requestedProjectUuid ?? this.resolveProjectUuid(context);
+
+        const { user, account } = McpService.getAccount(context);
+        const project = await this.projectService.getProject(
+            requestedProjectUuid,
+            account,
+        );
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', {
+                    projectUuid: requestedProjectUuid,
+                    organizationUuid: project.organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError('You do not have access to this project');
+        }
+
+        return requestedProjectUuid;
     }
 
     public getServer(): McpServer {
@@ -3920,17 +4254,11 @@ export class McpService extends BaseService {
     /**
      * Whether the run_sql tool should be registered for this caller.
      *
-     * run_sql is gated on manage:SqlRunner. When the session already targets a
-     * known project (pinned via the X-Lightdash-Project header or a prior
-     * set_project), the permission is checked against that concrete project so
-     * the tool stays out of tools/list for a caller who is only a viewer there
-     * — even if they happen to have SqlRunner in some other project. A bare
-     * capability check on a subject *type* returns true whenever any matching
-     * conditional rule exists, which is why the project-scoped check matters.
-     *
-     * Without a resolved project we fall back to the coarse capability check;
-     * executeAsyncSqlQuery still enforces the permission per-project at
-     * invocation time.
+     * run_sql is gated on manage:SqlRunner. A project-pinned endpoint checks
+     * that concrete project. The unpinned endpoint uses a coarse capability
+     * check because tools/list must not vary as a side effect of set_project;
+     * executeAsyncSqlQuery still enforces permission for the required
+     * projectUuid at invocation time.
      */
     public async isRunSqlEnabled(
         user: SessionUser,
@@ -3938,23 +4266,12 @@ export class McpService extends BaseService {
     ): Promise<boolean> {
         const ability = this.createAuditedAbility(user);
 
-        const projectUuid =
-            headerProjectUuid ??
-            (user.organizationUuid
-                ? (
-                      await this.mcpContextModel.getContext(
-                          user.userUuid,
-                          user.organizationUuid,
-                      )
-                  )?.context.projectUuid
-                : undefined);
-
-        if (projectUuid && user.organizationUuid) {
+        if (headerProjectUuid && user.organizationUuid) {
             return ability.can(
                 'manage',
                 subject('SqlRunner', {
                     organizationUuid: user.organizationUuid,
-                    projectUuid,
+                    projectUuid: headerProjectUuid,
                 }),
             );
         }
@@ -4048,18 +4365,34 @@ export class McpService extends BaseService {
             const startedAt = Date.now();
             try {
                 const result = await handler(...cbArgs);
+                const legacyContextInjected =
+                    getMcpContext(extra).authInfo?.extra
+                        .legacyContextInjected === true;
+                const response =
+                    legacyContextInjected && Array.isArray(result?.content)
+                        ? {
+                              ...result,
+                              content: [
+                                  ...result.content,
+                                  {
+                                      type: 'text' as const,
+                                      text: '[Deprecated context fallback: refresh MCP tools and pass projectUuid explicitly.]',
+                                  },
+                              ],
+                          }
+                        : result;
                 this.recordToolCall({
                     toolName,
                     toolArgs,
                     extra,
                     durationMs: Date.now() - startedAt,
-                    status: result?.isError === true ? 'error' : 'success',
+                    status: response?.isError === true ? 'error' : 'success',
                     errorMessage:
-                        result?.isError === true
-                            ? McpService.getResultErrorText(result)
+                        response?.isError === true
+                            ? McpService.getResultErrorText(response)
                             : null,
                 });
-                return result;
+                return response;
             } catch (error) {
                 this.recordToolCall({
                     toolName,
@@ -4120,25 +4453,30 @@ export class McpService extends BaseService {
         const { userAgent, protocolVersion, headerProjectUuid, sessionId } =
             context.authInfo?.extra ?? {};
 
-        // Project/agent scope and client identity come from DB lookups, but
-        // they are enrichment only — a lookup failure must not cost the
-        // analytics event or the activity row
-        let projectUuid: string | null = headerProjectUuid ?? null;
-        let agentUuid: string | null = null;
+        // Prefer the explicit tool scope. Legacy global/context tools fall
+        // back to stored context for activity enrichment only.
+        const explicitScope = mcpToolScopeArgsSchema.safeParse(toolArgs);
+        let projectUuid: string | null = explicitScope.success
+            ? explicitScope.data.projectUuid
+            : (headerProjectUuid ?? null);
+        let agentUuid: string | null = explicitScope.success
+            ? (explicitScope.data.agentUuid ?? null)
+            : null;
         let clientInfo: DbMcpClientInfo | undefined;
         try {
-            const contextRow = await this.mcpContextModel.getContext(
-                user.userUuid,
-                organizationUuid,
-            );
-            const contextProjectUuid = contextRow?.context.projectUuid;
-            projectUuid = headerProjectUuid ?? contextProjectUuid ?? null;
-            // Mirrors getEffectiveScopeFromContext: the stored agent only
-            // applies when the effective project is the one it was selected in
-            agentUuid =
-                headerProjectUuid && contextProjectUuid !== headerProjectUuid
-                    ? null
-                    : (contextRow?.context.agentUuid ?? null);
+            if (!explicitScope.success) {
+                const contextRow = await this.mcpContextModel.getContext(
+                    user.userUuid,
+                    organizationUuid,
+                );
+                const contextProjectUuid = contextRow?.context.projectUuid;
+                projectUuid = headerProjectUuid ?? contextProjectUuid ?? null;
+                agentUuid =
+                    headerProjectUuid &&
+                    contextProjectUuid !== headerProjectUuid
+                        ? null
+                        : (contextRow?.context.agentUuid ?? null);
+            }
 
             clientInfo = userAgent
                 ? await this.mcpToolCallModel.findClientInfo(

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -4376,7 +4376,7 @@ export class McpService extends BaseService {
                                   ...result.content,
                                   {
                                       type: 'text' as const,
-                                      text: '[Deprecated context fallback: refresh MCP tools and pass projectUuid explicitly.]',
+                                      text: '[Warning: your MCP tools are outdated. Refresh them to ensure correct behavior.]',
                                   },
                               ],
                           }

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -590,6 +590,38 @@ export class McpService extends BaseService {
             }));
     }
 
+    private async getAvailableProjects(context: McpProtocolContext) {
+        const { user, organizationUuid } = McpService.getAccount(context);
+        const [projects, aiAgentsVisible, aiCopilotEnabled] = await Promise.all(
+            [
+                this.getAccessibleProjects(context),
+                this.aiOrganizationSettingsService.isAiAgentsVisible(
+                    organizationUuid,
+                ),
+                this.aiAgentService.getIsCopilotEnabled(user),
+            ],
+        );
+        if (!aiAgentsVisible || !aiCopilotEnabled) {
+            return projects.map((project) => ({
+                ...project,
+                availableAgents: [],
+            }));
+        }
+
+        const availableAgents = await this.aiAgentService.listAgents(user);
+        return projects.map((project) => ({
+            ...project,
+            availableAgents: availableAgents
+                .filter((agent) => agent.projectUuid === project.projectUuid)
+                .map((agent) => ({
+                    agentUuid: agent.uuid,
+                    name: agent.name,
+                    description: agent.description,
+                    tags: agent.tags,
+                })),
+        }));
+    }
+
     private async getScopeInfo(
         context: McpProtocolContext,
         projectUuid: string,
@@ -2422,18 +2454,26 @@ export class McpService extends BaseService {
             },
             async (_args, extra) => {
                 const ctx = getMcpContext(extra);
-                const [projects, metadata, activeProjectUuid] =
+                const [availableProjects, metadata, activeProjectUuid] =
                     await Promise.all([
-                        this.getAccessibleProjects(ctx),
+                        this.getAvailableProjects(ctx),
                         this.getActiveContextMetadata(ctx),
                         this.getProjectUuidFromContext(ctx),
                     ]);
                 const activeProject = activeProjectUuid
-                    ? projects.find(
+                    ? availableProjects.find(
                           (project) =>
                               project.projectUuid === activeProjectUuid,
                       )
                     : undefined;
+                const activeAgent =
+                    activeProject &&
+                    metadata.projectUuid === activeProjectUuid &&
+                    metadata.agentUuid
+                        ? activeProject.availableAgents.find(
+                              (agent) => agent.agentUuid === metadata.agentUuid,
+                          )
+                        : undefined;
                 const structuredContent = {
                     activeProject: activeProject
                         ? {
@@ -2446,17 +2486,14 @@ export class McpService extends BaseService {
                           }
                         : null,
                     activeAgent:
-                        activeProject &&
-                        metadata.projectUuid === activeProjectUuid &&
-                        metadata.agentUuid &&
-                        metadata.agentName
+                        activeProject && activeAgent
                             ? {
                                   projectUuid: activeProject.projectUuid,
-                                  agentUuid: metadata.agentUuid,
-                                  agentName: metadata.agentName,
+                                  agentUuid: activeAgent.agentUuid,
+                                  agentName: activeAgent.name,
                               }
                             : null,
-                    projects,
+                    availableProjects,
                 };
 
                 return mcpGetContextTool.result.structured(

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -16,7 +16,7 @@ exports[`MCP tool contracts > matches the current MCP tool and prompt contract s
 
 ## Query Building Workflow
 
-0. **Get started with explicit context**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. When agent-specific scope is useful, call \`route_agent\` with that project UUID and pass its returned \`agentUuid\` explicitly to subsequent scoped tools. If routing is unavailable or full project scope is desired, omit \`agentUuid\`; use \`set_agent\` to select an agent manually
+0. **Get started with context**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. When agent-specific scope is useful, call \`route_agent\` with that project UUID and pass its returned \`agentUuid\` to subsequent scoped tools. If routing is unavailable or full project scope is desired, omit \`agentUuid\`; use \`set_agent\` to select an agent manually
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models and any matching verified answers
    - If the response includes a verified answer that clearly matches, prefer its returned config over constructing a new query from scratch
    - Use matching verified answers as the starting point, then adapt only if the user asked for a clear modification
@@ -1330,7 +1330,7 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": true,
       },
-      "description": "Call this first to discover accessible projects and Lightdash-configured context. Copy the selected projectUuid into every project-scoped tool call. This tool reports context but does not establish implicit execution state.",
+      "description": "Call this first to discover available projects, the agents you can access in each project, and Lightdash-configured context. Pass the selected projectUuid to every project-scoped tool call and an available agentUuid when agent-specific scope is desired. This tool reports context but does not establish implicit execution state.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -1406,10 +1406,50 @@ Usage tips:
               },
             ],
           },
-          "projects": {
+          "availableProjects": {
             "items": {
               "additionalProperties": false,
               "properties": {
+                "availableAgents": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "agentUuid": {
+                        "type": "string",
+                      },
+                      "description": {
+                        "type": [
+                          "string",
+                          "null",
+                        ],
+                      },
+                      "name": {
+                        "type": "string",
+                      },
+                      "tags": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                      },
+                    },
+                    "required": [
+                      "agentUuid",
+                      "name",
+                      "description",
+                      "tags",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
                 "expiresAt": {
                   "type": [
                     "string",
@@ -1431,6 +1471,7 @@ Usage tips:
                 "name",
                 "type",
                 "expiresAt",
+                "availableAgents",
               ],
               "type": "object",
             },
@@ -1440,7 +1481,7 @@ Usage tips:
         "required": [
           "activeProject",
           "activeAgent",
-          "projects",
+          "availableProjects",
         ],
         "type": "object",
       },

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -16,7 +16,7 @@ exports[`MCP tool contracts > matches the current MCP tool and prompt contract s
 
 ## Query Building Workflow
 
-0. **Get started and route to the right agent**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. Call \`route_agent\` with that project UUID at the start of each new user request; when it selects an agent, pass the returned \`agentUuid\` explicitly to subsequent scoped tools
+0. **Get started with explicit context**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. When agent-specific scope is useful, call \`route_agent\` with that project UUID and pass its returned \`agentUuid\` explicitly to subsequent scoped tools. If routing is unavailable or full project scope is desired, omit \`agentUuid\`; use \`set_agent\` to select an agent manually
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models and any matching verified answers
    - If the response includes a verified answer that clearly matches, prefer its returned config over constructing a new query from scratch
    - Use matching verified answers as the starting point, then adapt only if the user asked for a clear modification
@@ -1548,7 +1548,7 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": false,
       },
-      "description": "Select the best AI agent for a user request within the required projectUuid. Call this at the start of each new user request, then pass the returned agentUuid explicitly to subsequent scoped tools. Also updates legacy shared agent context for older clients.",
+      "description": "Select the best AI agent for a user request within the required projectUuid when agent-specific scope is useful and routing is available. Pass the returned agentUuid explicitly to subsequent scoped tools. If routing is unavailable, use list_agents and set_agent for manual selection; omit agentUuid when full project scope is desired. Also updates shared agent context for clients that use it.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -16,7 +16,7 @@ exports[`MCP tool contracts > matches the current MCP tool and prompt contract s
 
 ## Query Building Workflow
 
-0. **Resolve context explicitly**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. Call \`route_agent\` with that project UUID at the start of each new user request; when it selects an agent, pass the returned \`agentUuid\` explicitly to subsequent scoped tools
+0. **Get started and route to the right agent**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. Call \`route_agent\` with that project UUID at the start of each new user request; when it selects an agent, pass the returned \`agentUuid\` explicitly to subsequent scoped tools
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models and any matching verified answers
    - If the response includes a verified answer that clearly matches, prefer its returned config over constructing a new query from scratch
    - Use matching verified answers as the starting point, then adapt only if the user asked for a clear modification
@@ -1472,7 +1472,7 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": false,
       },
-      "description": "@deprecated Use get_context and pass projectUuid explicitly to every project-scoped tool. Sets legacy shared project context for older clients only.",
+      "description": "Set the configured project context. Most tools (list_explores, MCP schema-discovery tools, run_metric_query, etc.) also require its projectUuid explicitly. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, prefer route_agent to auto-select the best agent for each request and pass its returned agentUuid explicitly to subsequent scoped tools; use list_agents and set_agent only for manual override.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -1493,7 +1493,7 @@ Usage tips:
         "type": "object",
       },
       "name": "set_project",
-      "title": "Set project (deprecated)",
+      "title": "Set project",
     },
     {
       "agentName": null,
@@ -1689,7 +1689,7 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": false,
       },
-      "description": "@deprecated Use route_agent with an explicit projectUuid and pass its returned agentUuid to scoped tools. Sets legacy shared agent context for older clients only.",
+      "description": "Manually select an AI agent for the required projectUuid. Prefer route_agent for default automatic selection; use this when you need to override that choice explicitly. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Pass the agentUuid explicitly to subsequent scoped tools and use this context to guide them — prefer the agent's explores when calling MCP schema-discovery tools, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -1710,7 +1710,7 @@ Usage tips:
         "type": "object",
       },
       "name": "set_agent",
-      "title": "Set agent (deprecated)",
+      "title": "Set agent",
     },
     {
       "agentName": null,

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -10,13 +10,13 @@ exports[`MCP tool contracts > matches the current MCP tool and prompt contract s
         "properties": {},
         "type": "object",
       },
-      "description": "Guidelines for querying Lightdash data using MCP tools. After setting project context, call route_agent at the start of each new user request to activate the best agent automatically. Includes explore selection, query building, visualization rules, and active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.",
+      "description": "Guidelines for querying Lightdash data using MCP tools. Call get_context first, pass projectUuid to every project-scoped tool, and pass route_agent results as agentUuid when scoped agent behavior is desired. Includes explore selection, query building, and visualization rules. Inject this into your system prompt for best results.",
       "name": "lightdash-analyst",
       "prompt": "# Lightdash MCP Tools — Usage Guidelines
 
 ## Query Building Workflow
 
-0. **Route to the right agent first**: After project context is set, call \`route_agent\` at the start of each new user request so subsequent MCP tools inherit the best agent's scope and instructions
+0. **Resolve context explicitly**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. Call \`route_agent\` with that project UUID at the start of each new user request; when it selects an agent, pass the returned \`agentUuid\` explicitly to subsequent scoped tools
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models and any matching verified answers
    - If the response includes a verified answer that clearly matches, prefer its returned config over constructing a new query from scratch
    - Use matching verified answers as the starting point, then adapt only if the user asked for a clear modification
@@ -124,7 +124,21 @@ Usage Tips:
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
-        "properties": {},
+        "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
+        },
+        "required": [
+          "projectUuid",
+        ],
         "type": "object",
       },
       "name": "list_explores",
@@ -156,6 +170,16 @@ Output:
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
           "searchQuery": {
             "description": "set of high-signal keyword terms for query. Search uses PostgreSQL websearch_to_tsquery after joining whitespace-separated terms with OR. It searches explore and field name, label, and description. Prefer metric/entity/dimension nouns that capture the user's analytical intent.",
             "type": "string",
@@ -163,6 +187,7 @@ Output:
         },
         "required": [
           "searchQuery",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -446,6 +471,11 @@ Usage tips:
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
           "fieldSearchQueries": {
             "items": {
               "additionalProperties": false,
@@ -467,6 +497,11 @@ Usage tips:
             "exclusiveMinimum": 0,
             "type": "number",
           },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
           "table": {
             "description": "The table to search in.",
             "type": "string",
@@ -475,6 +510,7 @@ Usage tips:
         "required": [
           "table",
           "fieldSearchQueries",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -692,6 +728,16 @@ Usage tips:
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
           "searchQueries": {
             "items": {
               "additionalProperties": false,
@@ -715,6 +761,7 @@ Usage tips:
         },
         "required": [
           "searchQueries",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -742,16 +789,29 @@ Usage tips:
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
           "page": {
             "description": "Use this to paginate through the results. Starts at 1., ",
             "exclusiveMinimum": 0,
             "type": "number",
+          },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
           },
           "spaceSlug": {
             "description": "Optional space slug/path to list. Use null to list root-level content., ",
             "type": "string",
           },
         },
+        "required": [
+          "projectUuid",
+        ],
         "type": "object",
       },
       "name": "list_content",
@@ -770,6 +830,16 @@ Usage tips:
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
           "slug": {
             "description": "Slug of the dashboard or chart to read.",
             "minLength": 1,
@@ -787,6 +857,7 @@ Usage tips:
         "required": [
           "slug",
           "type",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -817,6 +888,16 @@ Usage tips:
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
           "url": {
             "description": "The Lightdash URL to resolve, exactly as provided.",
             "minLength": 1,
@@ -825,6 +906,7 @@ Usage tips:
         },
         "required": [
           "url",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -844,6 +926,11 @@ Usage tips:
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
           "content": {
             "anyOf": [
               {
@@ -995,6 +1082,11 @@ Usage tips:
               },
             ],
           },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
           "type": {
             "description": "Type of Lightdash content to create.",
             "enum": [
@@ -1007,6 +1099,7 @@ Usage tips:
         "required": [
           "type",
           "content",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -1026,10 +1119,20 @@ Usage tips:
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
           "patch": {
             "description": "RFC6902 Patch objects array to apply to the current dashboard or chart JSON",
             "items": {},
             "type": "array",
+          },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
           },
           "slug": {
             "description": "Slug of the dashboard or chart to edit",
@@ -1049,6 +1152,7 @@ Usage tips:
           "slug",
           "type",
           "patch",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -1068,6 +1172,11 @@ Usage tips:
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
           "aiAugmentationPrompt": {
             "description": "Instructions for the AI-written delivery message, regenerated from the delivered data on every send. null = plain delivery without AI augmentation., ",
             "type": "string",
@@ -1127,6 +1236,11 @@ Usage tips:
           "name": {
             "description": "Human-readable delivery name.",
             "minLength": 1,
+            "type": "string",
+          },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
             "type": "string",
           },
           "resourceType": {
@@ -1201,6 +1315,7 @@ Usage tips:
           "format",
           "targets",
           "enabled",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -1215,7 +1330,131 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": true,
       },
-      "description": "List all accessible projects in the organization. Projects contain explores, fields, and content. Use this to discover available projects before calling set_project to select one as the active context for subsequent operations. Each project includes a "type": prefer DEFAULT projects, which are live production environments. PREVIEW projects are ephemeral CI/PR environments that may be decommissioned — their warehouse credentials are often gone, so queries can fail with 403 errors even when the schema is still visible. Only select a PREVIEW project if the user explicitly asks for it.",
+      "description": "Call this first to discover accessible projects and Lightdash-configured context. Copy the selected projectUuid into every project-scoped tool call. This tool reports context but does not establish implicit execution state.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object",
+      },
+      "name": "get_context",
+      "outputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "activeAgent": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "agentName": {
+                    "type": "string",
+                  },
+                  "agentUuid": {
+                    "type": "string",
+                  },
+                  "projectUuid": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "agentUuid",
+                  "agentName",
+                  "projectUuid",
+                ],
+                "type": "object",
+              },
+              {
+                "type": "null",
+              },
+            ],
+          },
+          "activeProject": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "projectName": {
+                    "type": "string",
+                  },
+                  "projectUuid": {
+                    "type": "string",
+                  },
+                  "selectedTags": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                  },
+                },
+                "required": [
+                  "projectUuid",
+                  "projectName",
+                  "selectedTags",
+                ],
+                "type": "object",
+              },
+              {
+                "type": "null",
+              },
+            ],
+          },
+          "projects": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "expiresAt": {
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
+                "name": {
+                  "type": "string",
+                },
+                "projectUuid": {
+                  "type": "string",
+                },
+                "type": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "projectUuid",
+                "name",
+                "type",
+                "expiresAt",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "activeProject",
+          "activeAgent",
+          "projects",
+        ],
+        "type": "object",
+      },
+      "title": "Get context",
+    },
+    {
+      "agentName": null,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true,
+      },
+      "description": "List all accessible projects in the organization. Projects contain explores, fields, and content. Prefer get_context for bootstrap, then pass the selected projectUuid explicitly to every project-scoped operation. Each project includes a "type": prefer DEFAULT projects, which are live production environments. PREVIEW projects are ephemeral CI/PR environments that may be decommissioned — their warehouse credentials are often gone, so queries can fail with 403 errors even when the schema is still visible. Only select a PREVIEW project if the user explicitly asks for it.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -1233,7 +1472,7 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": false,
       },
-      "description": "Set the active project for all subsequent MCP operations. Most tools (list_explores, MCP schema-discovery tools, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, prefer route_agent to auto-select the best agent for each request; use list_agents and set_agent only for manual override.",
+      "description": "@deprecated Use get_context and pass projectUuid explicitly to every project-scoped tool. Sets legacy shared project context for older clients only.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -1254,7 +1493,7 @@ Usage tips:
         "type": "object",
       },
       "name": "set_project",
-      "title": "Set project",
+      "title": "Set project (deprecated)",
     },
     {
       "agentName": null,
@@ -1264,7 +1503,7 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": true,
       },
-      "description": "Get the currently active project and its configuration. Returns the project UUID, name, and any selected tags. Use this to verify context before calling data tools.",
+      "description": "@deprecated Use get_context instead. Returns legacy shared project context for older clients.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -1272,7 +1511,7 @@ Usage tips:
         "type": "object",
       },
       "name": "get_current_project",
-      "title": "Get current project",
+      "title": "Get current project (deprecated)",
     },
     {
       "agentName": null,
@@ -1282,15 +1521,20 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": true,
       },
-      "description": "List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Prefer route_agent for automatic selection; use this tool when you need to inspect candidates or choose one manually before calling set_agent.",
+      "description": "List accessible AI agents for the required projectUuid. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Prefer route_agent for automatic selection.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
           "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
             "type": "string",
           },
         },
+        "required": [
+          "projectUuid",
+        ],
         "type": "object",
       },
       "name": "list_agents",
@@ -1304,12 +1548,14 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": false,
       },
-      "description": "Automatically select and activate the best AI agent for a user request within the active project. Call this at the start of each new user request after setting project context. Returns routing metadata plus the selected agent context; use set_agent only when you want to override the automatic choice manually.",
+      "description": "Select the best AI agent for a user request within the required projectUuid. Call this at the start of each new user request, then pass the returned agentUuid explicitly to subsequent scoped tools. Also updates legacy shared agent context for older clients.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
           "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
             "type": "string",
           },
           "prompt": {
@@ -1318,6 +1564,7 @@ Usage tips:
         },
         "required": [
           "prompt",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -1442,7 +1689,7 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": false,
       },
-      "description": "Manually set the active AI agent for the active project. Prefer route_agent for default automatic selection; use this when you need to override that choice explicitly. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling MCP schema-discovery tools, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
+      "description": "@deprecated Use route_agent with an explicit projectUuid and pass its returned agentUuid to scoped tools. Sets legacy shared agent context for older clients only.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -1450,14 +1697,20 @@ Usage tips:
           "agentUuid": {
             "type": "string",
           },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
         },
         "required": [
           "agentUuid",
+          "projectUuid",
         ],
         "type": "object",
       },
       "name": "set_agent",
-      "title": "Set agent",
+      "title": "Set agent (deprecated)",
     },
     {
       "agentName": null,
@@ -1467,15 +1720,24 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": false,
       },
-      "description": "Clear the active AI agent from context. After clearing, tool calls will no longer be scoped to a specific agent's explores, tags, or instructions. The active project is preserved.",
+      "description": "@deprecated Omit agentUuid from scoped tool calls instead. Clears legacy shared agent context for older clients only.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
-        "properties": {},
+        "properties": {
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
+        },
+        "required": [
+          "projectUuid",
+        ],
         "type": "object",
       },
       "name": "clear_agent",
-      "title": "Clear agent",
+      "title": "Clear agent (deprecated)",
     },
     {
       "agentName": null,
@@ -1485,15 +1747,24 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": true,
       },
-      "description": "Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. The active agent is usually established by route_agent; use this to inspect the current automatic or manually overridden selection before making data queries.",
+      "description": "@deprecated Use get_context for legacy configured context or route_agent for an explicit agent selection.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
-        "properties": {},
+        "properties": {
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
+        },
+        "required": [
+          "projectUuid",
+        ],
         "type": "object",
       },
       "name": "get_current_agent",
-      "title": "Get current agent",
+      "title": "Get current agent (deprecated)",
     },
     {
       "agentName": "runQuery",
@@ -1539,6 +1810,11 @@ Notes:
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
           "chartConfig": {
             "additionalProperties": false,
             "description": ", ",
@@ -1622,6 +1898,11 @@ Notes:
           },
           "description": {
             "description": "A descriptive summary or explanation for the chart.",
+            "type": "string",
+          },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
             "type": "string",
           },
           "queryConfig": {
@@ -5066,6 +5347,7 @@ Empty array or null: single partition (calculations across all rows)., ",
           "title",
           "description",
           "queryConfig",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -5183,6 +5465,11 @@ Response shape (MCP CallToolResult):
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
           "chartConfig": {
             "additionalProperties": false,
             "description": ", ",
@@ -5268,6 +5555,11 @@ Response shape (MCP CallToolResult):
             "description": "Optional chart description used in the saved Explore URL.",
             "type": "string",
           },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
           "queryUuid": {
             "description": "Completed query UUID returned by run_metric_query (or get_query_result) in this conversation, copied from the \`queryUuid: <id>\` text block of that response. Do not fabricate, guess, or reuse a UUID from another query. Currently render_chart supports UUIDs from run_metric_query and does not support SQL Runner/run_sql UUIDs.",
             "format": "uuid",
@@ -5280,6 +5572,7 @@ Response shape (MCP CallToolResult):
         },
         "required": [
           "queryUuid",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -5353,6 +5646,11 @@ Usage Tips:
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
           "fieldId": {
             "description": "The ID of the field to search values for "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
             "type": "string",
@@ -7286,6 +7584,11 @@ Usage Tips:
             ],
             "type": "object",
           },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
           "query": {
             "description": "Query string to filter field values, Query string to filter field values",
             "type": "string",
@@ -7298,6 +7601,7 @@ Usage Tips:
         "required": [
           "table",
           "fieldId",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -7365,6 +7669,11 @@ Notes:
             "maximum": 500,
             "type": "integer",
           },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
           "sql": {
             "description": "The SQL query to execute against the data warehouse.",
             "type": "string",
@@ -7372,6 +7681,7 @@ Notes:
         },
         "required": [
           "sql",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -7498,6 +7808,16 @@ Notes:
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
           "queryUuid": {
             "description": "Async query UUID returned by the query tool.",
             "format": "uuid",
@@ -7506,6 +7826,7 @@ Notes:
         },
         "required": [
           "queryUuid",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -7680,11 +8001,25 @@ Notes:
         "openWorldHint": false,
         "readOnlyHint": true,
       },
-      "description": "List all verified charts and dashboards in the active project. Verified content has been reviewed and marked as trusted — use this to discover reference examples of sanctioned metrics and visualizations when building new content. Requires an active project set via set_project. Each item includes contentType (chart or dashboard), contentUuid, name, description, space, view count, last update time, and verification metadata (who verified it and when); charts also include chartKind and exploreName. To learn the full structure of a verified item (dimensions, metrics, filters), drill into it with find_content or MCP schema-discovery tools on its explore.",
+      "description": "List all verified charts and dashboards in the required projectUuid. Verified content has been reviewed and marked as trusted — use this to discover reference examples of sanctioned metrics and visualizations when building new content. Each item includes contentType (chart or dashboard), contentUuid, name, description, space, view count, last update time, and verification metadata (who verified it and when); charts also include chartKind and exploreName. To learn the full structure of a verified item (dimensions, metrics, filters), drill into it with find_content or MCP schema-discovery tools on its explore.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
-        "properties": {},
+        "properties": {
+          "agentUuid": {
+            "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+            "format": "uuid",
+            "type": "string",
+          },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
+        },
+        "required": [
+          "projectUuid",
+        ],
         "type": "object",
       },
       "name": "list_verified_content",
@@ -8091,6 +8426,11 @@ Response shape (MCP CallToolResult):
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
           "prompt": {
             "description": "A clear, self-contained description of the change to make to the dbt project that backs the active Lightdash project. If the project has more than one dbt source, name the intended one here (e.g. "In jaffle-2, add ...") — a later get_ai_writeback_status call reports whether the run could tell which source you meant.",
             "minLength": 1,
@@ -8099,6 +8439,7 @@ Response shape (MCP CallToolResult):
         },
         "required": [
           "prompt",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -8174,9 +8515,15 @@ Response shape (MCP CallToolResult):
             "format": "uuid",
             "type": "string",
           },
+          "projectUuid": {
+            "description": "Project UUID for this operation.",
+            "format": "uuid",
+            "type": "string",
+          },
         },
         "required": [
           "aiWritebackRunUuid",
+          "projectUuid",
         ],
         "type": "object",
       },
@@ -8241,6 +8588,7 @@ exports[`MCP tool contracts > matches the shared MCP tool definition names snaps
   "read_skill",
   "read_skill_resource",
   "list_projects",
+  "get_context",
   "set_project",
   "get_current_project",
   "list_agents",

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -15,7 +15,7 @@ import {
     getMcpAnalystPrompt,
     MCP_ANALYST_PROMPT,
 } from '../ai/prompts/mcpAnalyst';
-import { McpService, McpToolName } from './McpService';
+import { isProjectScopedMcpTool, McpService, McpToolName } from './McpService';
 
 type RegisteredMcpTool = {
     name: string;
@@ -150,6 +150,10 @@ const sharedMcpToolDefinitionNames = mcpToolDefinitions.map(
     (toolDefinition) => toolDefinition.for('mcp').name,
 );
 
+const inputSchemaRequirements = z.object({
+    required: z.array(z.string()).optional(),
+});
+
 describe('MCP tool contracts', () => {
     beforeEach(() => {
         mockRegisteredMcpTools.length = 0;
@@ -209,6 +213,39 @@ describe('MCP tool contracts', () => {
         ).toEqual([]);
 
         expect({ prompts, tools }).toMatchSnapshot();
+    });
+
+    it('requires projectUuid on every project-scoped tool', async () => {
+        const mcpService = makeMcpService();
+
+        await mcpService.createServer({
+            aiWritebackEnabled: true,
+            grepFieldsEnabled: false,
+            runSqlEnabled: true,
+        });
+        await mcpService.createServer({
+            aiWritebackEnabled: true,
+            grepFieldsEnabled: true,
+            runSqlEnabled: true,
+        });
+
+        const toolsByName = new Map(
+            mockRegisteredMcpTools.map((tool) => [tool.name, tool]),
+        );
+        const projectScopedTools = [...toolsByName.values()].filter(
+            ({ name }) => isProjectScopedMcpTool(name),
+        );
+
+        const toolsWithoutProjectUuid = projectScopedTools
+            .filter(({ config }) => {
+                const inputSchema = inputSchemaRequirements.parse(
+                    schemaToJson(config.inputSchema),
+                );
+                return !inputSchema.required?.includes('projectUuid');
+            })
+            .map(({ name }) => name);
+
+        expect(toolsWithoutProjectUuid).toEqual([]);
     });
 
     it('registers run_sql only when runSqlEnabled', async () => {
@@ -306,12 +343,13 @@ describe('MCP tool contracts', () => {
             expect(await service.isRunSqlEnabled(user, PROJECT_B)).toBe(true);
         });
 
-        it('resolves the project from mcp_context when no header is pinned', async () => {
+        it('does not let legacy context mutate unpinned tool availability', async () => {
             const service = makeServiceWithContextProject(PROJECT_A);
-            const viewer = buildUser(OrganizationMemberRole.VIEWER, [
-                { projectUuid: PROJECT_A, role: ProjectMemberRole.VIEWER },
+            const developer = buildUser(OrganizationMemberRole.VIEWER, [
+                { projectUuid: PROJECT_B, role: ProjectMemberRole.DEVELOPER },
             ]);
-            expect(await service.isRunSqlEnabled(viewer)).toBe(false);
+
+            expect(await service.isRunSqlEnabled(developer)).toBe(true);
         });
 
         it('falls back to the coarse capability check when no project is resolved', async () => {

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -421,6 +421,18 @@ describe('MCP tool contracts', () => {
                 ),
             ).toBe(true);
         });
+
+        it('does not let legacy context mutate unpinned tool availability', async () => {
+            const service = makeServiceWithContextProject('another-project');
+            const interactiveViewer = buildUser(
+                OrganizationMemberRole.VIEWER,
+                ProjectMemberRole.INTERACTIVE_VIEWER,
+            );
+
+            expect(
+                await service.isRunMetricQueryEnabled(interactiveViewer),
+            ).toBe(true);
+        });
     });
 
     it('registers content and scheduled-delivery tools independently', async () => {

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
@@ -14,7 +14,7 @@ const buildLegacyMcpAnalystPrompt = (
 
 ## Query Building Workflow
 
-0. **Get started with explicit context**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. When agent-specific scope is useful, call \`route_agent\` with that project UUID and pass its returned \`agentUuid\` explicitly to subsequent scoped tools. If routing is unavailable or full project scope is desired, omit \`agentUuid\`; use \`set_agent\` to select an agent manually
+0. **Get started with context**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. When agent-specific scope is useful, call \`route_agent\` with that project UUID and pass its returned \`agentUuid\` to subsequent scoped tools. If routing is unavailable or full project scope is desired, omit \`agentUuid\`; use \`set_agent\` to select an agent manually
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models and any matching verified answers
    - If the response includes a verified answer that clearly matches, prefer its returned config over constructing a new query from scratch
    - Use matching verified answers as the starting point, then adapt only if the user asked for a clear modification
@@ -79,7 +79,7 @@ const buildGrepFieldsMcpAnalystPrompt = (
 
 ## Query Building Workflow
 
-0. **Get started with explicit context**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. When agent-specific scope is useful, call \`route_agent\` with that project UUID and pass its returned \`agentUuid\` explicitly to subsequent scoped tools. If routing is unavailable or full project scope is desired, omit \`agentUuid\`; use \`set_agent\` to select an agent manually
+0. **Get started with context**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. When agent-specific scope is useful, call \`route_agent\` with that project UUID and pass its returned \`agentUuid\` to subsequent scoped tools. If routing is unavailable or full project scope is desired, omit \`agentUuid\`; use \`set_agent\` to select an agent manually
 1. **Search fields first**: Use \`grep_fields\` with 1–5 high-signal keyword patterns to discover the relevant explore and field IDs
    - Search with business terms and synonyms, not long natural-language phrases
    - Use \`|\` to OR synonyms (for example \`revenue|sales\`) and spaces or \`.*\` to require terms together (for example \`order.*status\`)

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
@@ -14,7 +14,7 @@ const buildLegacyMcpAnalystPrompt = (
 
 ## Query Building Workflow
 
-0. **Get started and route to the right agent**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. Call \`route_agent\` with that project UUID at the start of each new user request; when it selects an agent, pass the returned \`agentUuid\` explicitly to subsequent scoped tools
+0. **Get started with explicit context**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. When agent-specific scope is useful, call \`route_agent\` with that project UUID and pass its returned \`agentUuid\` explicitly to subsequent scoped tools. If routing is unavailable or full project scope is desired, omit \`agentUuid\`; use \`set_agent\` to select an agent manually
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models and any matching verified answers
    - If the response includes a verified answer that clearly matches, prefer its returned config over constructing a new query from scratch
    - Use matching verified answers as the starting point, then adapt only if the user asked for a clear modification
@@ -79,7 +79,7 @@ const buildGrepFieldsMcpAnalystPrompt = (
 
 ## Query Building Workflow
 
-0. **Get started and route to the right agent**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. Call \`route_agent\` with that project UUID at the start of each new user request; when it selects an agent, pass the returned \`agentUuid\` explicitly to subsequent scoped tools
+0. **Get started with explicit context**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. When agent-specific scope is useful, call \`route_agent\` with that project UUID and pass its returned \`agentUuid\` explicitly to subsequent scoped tools. If routing is unavailable or full project scope is desired, omit \`agentUuid\`; use \`set_agent\` to select an agent manually
 1. **Search fields first**: Use \`grep_fields\` with 1–5 high-signal keyword patterns to discover the relevant explore and field IDs
    - Search with business terms and synonyms, not long natural-language phrases
    - Use \`|\` to OR synonyms (for example \`revenue|sales\`) and spaces or \`.*\` to require terms together (for example \`order.*status\`)

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
@@ -14,7 +14,7 @@ const buildLegacyMcpAnalystPrompt = (
 
 ## Query Building Workflow
 
-0. **Resolve context explicitly**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. Call \`route_agent\` with that project UUID at the start of each new user request; when it selects an agent, pass the returned \`agentUuid\` explicitly to subsequent scoped tools
+0. **Get started and route to the right agent**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. Call \`route_agent\` with that project UUID at the start of each new user request; when it selects an agent, pass the returned \`agentUuid\` explicitly to subsequent scoped tools
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models and any matching verified answers
    - If the response includes a verified answer that clearly matches, prefer its returned config over constructing a new query from scratch
    - Use matching verified answers as the starting point, then adapt only if the user asked for a clear modification
@@ -79,7 +79,7 @@ const buildGrepFieldsMcpAnalystPrompt = (
 
 ## Query Building Workflow
 
-0. **Resolve context explicitly**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. Call \`route_agent\` with that project UUID at the start of each new user request; when it selects an agent, pass the returned \`agentUuid\` explicitly to subsequent scoped tools
+0. **Get started and route to the right agent**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. Call \`route_agent\` with that project UUID at the start of each new user request; when it selects an agent, pass the returned \`agentUuid\` explicitly to subsequent scoped tools
 1. **Search fields first**: Use \`grep_fields\` with 1–5 high-signal keyword patterns to discover the relevant explore and field IDs
    - Search with business terms and synonyms, not long natural-language phrases
    - Use \`|\` to OR synonyms (for example \`revenue|sales\`) and spaces or \`.*\` to require terms together (for example \`order.*status\`)

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
@@ -14,7 +14,7 @@ const buildLegacyMcpAnalystPrompt = (
 
 ## Query Building Workflow
 
-0. **Route to the right agent first**: After project context is set, call \`route_agent\` at the start of each new user request so subsequent MCP tools inherit the best agent's scope and instructions
+0. **Resolve context explicitly**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. Call \`route_agent\` with that project UUID at the start of each new user request; when it selects an agent, pass the returned \`agentUuid\` explicitly to subsequent scoped tools
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models and any matching verified answers
    - If the response includes a verified answer that clearly matches, prefer its returned config over constructing a new query from scratch
    - Use matching verified answers as the starting point, then adapt only if the user asked for a clear modification
@@ -79,7 +79,7 @@ const buildGrepFieldsMcpAnalystPrompt = (
 
 ## Query Building Workflow
 
-0. **Route to the right agent first**: After project context is set, call \`route_agent\` at the start of each new user request so subsequent MCP tools inherit the best agent's scope and instructions
+0. **Resolve context explicitly**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool. Call \`route_agent\` with that project UUID at the start of each new user request; when it selects an agent, pass the returned \`agentUuid\` explicitly to subsequent scoped tools
 1. **Search fields first**: Use \`grep_fields\` with 1–5 high-signal keyword patterns to discover the relevant explore and field IDs
    - Search with business terms and synonyms, not long natural-language phrases
    - Use \`|\` to OR synonyms (for example \`revenue|sales\`) and spaces or \`.*\` to require terms together (for example \`order.*status\`)

--- a/packages/backend/src/routers/mcpRouter.authorization.test.ts
+++ b/packages/backend/src/routers/mcpRouter.authorization.test.ts
@@ -56,6 +56,10 @@ const createAccount = (authentication: TestAuthentication) =>
 const createMcpService = () =>
     Object.assign(Object.create(McpService.prototype), {
         createServer: vi.fn().mockResolvedValue({ connect: vi.fn() }),
+        getLegacyToolScope: vi.fn().mockResolvedValue({
+            projectUuid: PROJECT_UUID,
+            agentUuid: 'agent-uuid',
+        }),
         isAiGrepFieldsEnabled: vi.fn().mockResolvedValue(false),
         isContentToolsEnabled: vi.fn().mockResolvedValue(false),
         isCreateScheduledDeliveryEnabled: vi.fn().mockResolvedValue(false),
@@ -232,6 +236,40 @@ describe('project-scoped MCP route', () => {
             status: 405,
         });
         expect(mcpService.isEnabled).toHaveBeenCalledOnce();
+    });
+
+    it('injects legacy scope into cached project-scoped calls', async () => {
+        transport.handleRequest.mockImplementation(
+            async (request: Request, response) => {
+                expect(request.body).toMatchObject({
+                    params: {
+                        arguments: {
+                            projectUuid: PROJECT_UUID,
+                            agentUuid: 'agent-uuid',
+                            slug: 'orders',
+                        },
+                    },
+                });
+                response.status(200).json({ status: 'ok' });
+            },
+        );
+
+        const { response, mcpService } = await requestMcp({
+            account: createAccount({ type: 'service-account' }),
+            method: 'POST',
+            requestBody: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: {
+                    name: 'read_content',
+                    arguments: { slug: 'orders' },
+                },
+            },
+        });
+
+        expect(response.status).toBe(200);
+        expect(mcpService.getLegacyToolScope).toHaveBeenCalledOnce();
     });
 
     it('pins POST requests to the route project', async () => {

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -17,8 +17,13 @@ import { randomUUID } from 'crypto';
 import express, { type RequestHandler, type Router } from 'express';
 import { IncomingMessage } from 'http';
 import { validate as isValidUuid } from 'uuid';
+import { z } from 'zod';
 import { allowApiKeyAuthentication } from '../controllers/authentication';
-import { ExtraContext, McpService } from '../ee/services/McpService/McpService';
+import {
+    ExtraContext,
+    isProjectScopedMcpTool,
+    McpService,
+} from '../ee/services/McpService/McpService';
 import Logger from '../logging/logger';
 import { userAttributeOverridesSchema } from '../services/UserAttributesService/UserAttributeUtils';
 import { aliasMcpBearerPersonalAccessToken } from './mcpAuthentication';
@@ -97,6 +102,47 @@ function extractUserAttributesFromHeader(
         return undefined;
     }
 }
+
+const legacyToolCallSchema = z
+    .object({
+        method: z.literal('tools/call'),
+        params: z
+            .object({
+                name: z.string(),
+                arguments: z.record(z.unknown()).optional(),
+            })
+            .passthrough(),
+    })
+    .passthrough();
+
+const injectLegacyToolScope = (
+    body: unknown,
+    scope: { projectUuid: string; agentUuid: string | null },
+): { body: unknown; injected: boolean } => {
+    const toolCall = legacyToolCallSchema.safeParse(body);
+    if (
+        !toolCall.success ||
+        !isProjectScopedMcpTool(toolCall.data.params.name) ||
+        toolCall.data.params.arguments?.projectUuid !== undefined
+    ) {
+        return { body, injected: false };
+    }
+
+    return {
+        body: {
+            ...toolCall.data,
+            params: {
+                ...toolCall.data.params,
+                arguments: {
+                    projectUuid: scope.projectUuid,
+                    ...(scope.agentUuid ? { agentUuid: scope.agentUuid } : {}),
+                    ...toolCall.data.params.arguments,
+                },
+            },
+        },
+        injected: true,
+    };
+};
 
 const MCP_PROTOCOL_VERSION_HEADER = 'MCP-Protocol-Version';
 
@@ -269,6 +315,27 @@ mcpRouter.all(
                 // to prevent cross-client response data leaks (CVE-2026-25536)
                 // See: https://github.com/advisories/GHSA-345p-7cg4-v4c7
                 const pinnedProjectUuid = extractMcpProjectUuid(req);
+                const parsedToolCall = legacyToolCallSchema.safeParse(req.body);
+                let legacyContextInjected = false;
+                if (
+                    parsedToolCall.success &&
+                    isProjectScopedMcpTool(parsedToolCall.data.params.name) &&
+                    parsedToolCall.data.params.arguments?.projectUuid ===
+                        undefined
+                ) {
+                    const legacyScope = await mcpService.getLegacyToolScope(
+                        req.user!,
+                        pinnedProjectUuid,
+                    );
+                    if (legacyScope) {
+                        const injectedRequest = injectLegacyToolScope(
+                            req.body,
+                            legacyScope,
+                        );
+                        req.body = injectedRequest.body;
+                        legacyContextInjected = injectedRequest.injected;
+                    }
+                }
                 const userAgent = req.account?.requestContext?.userAgent;
                 const protocolVersion = extractProtocolVersionFromHeader(req);
 
@@ -360,6 +427,7 @@ mcpRouter.all(
                         account: oauthAuth,
                         headerUserAttributes,
                         headerProjectUuid: pinnedProjectUuid,
+                        legacyContextInjected,
                         userAgent,
                         protocolVersion,
                         sessionId,
@@ -379,6 +447,7 @@ mcpRouter.all(
                         account: apiKeyAuth,
                         headerUserAttributes,
                         headerProjectUuid: pinnedProjectUuid,
+                        legacyContextInjected,
                         userAgent,
                         protocolVersion,
                         sessionId,
@@ -399,6 +468,7 @@ mcpRouter.all(
                         account: serviceAccountAuth,
                         headerUserAttributes,
                         headerProjectUuid: pinnedProjectUuid,
+                        legacyContextInjected,
                         userAgent,
                         protocolVersion,
                         sessionId,

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
@@ -187,6 +187,7 @@ describe('defineTool', () => {
         expect(structuredMcpToolNames).toEqual([
             'find_explores',
             'find_fields',
+            'get_context',
             'get_metadata',
             'get_query_result',
             'grep_fields',

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -374,12 +374,20 @@ const mcpGetContextOutputSchema = z.object({
             projectUuid: z.string(),
         })
         .nullable(),
-    projects: z.array(
+    availableProjects: z.array(
         z.object({
             projectUuid: z.string(),
             name: z.string(),
             type: z.string(),
             expiresAt: z.string().nullable(),
+            availableAgents: z.array(
+                z.object({
+                    agentUuid: z.string(),
+                    name: z.string(),
+                    description: z.string().nullable(),
+                    tags: z.array(z.string()).nullable(),
+                }),
+            ),
         }),
     ),
 });
@@ -1418,7 +1426,7 @@ export const getContextToolDefinition: ToolDefinitionWithMcpOutput<
     name: 'getContext',
     title: 'Get context',
     description:
-        'Call this first to discover accessible projects and Lightdash-configured context. Copy the selected projectUuid into every project-scoped tool call. This tool reports context but does not establish implicit execution state.',
+        'Call this first to discover available projects, the agents you can access in each project, and Lightdash-configured context. Pass the selected projectUuid to every project-scoped tool call and an available agentUuid when agent-specific scope is desired. This tool reports context but does not establish implicit execution state.',
     availability: ['mcp'],
     inputSchema: emptyInputSchema,
     mcp: {

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -359,6 +359,31 @@ const destructiveExternalWriteAnnotations: McpToolAnnotations = {
 
 const emptyInputSchema = z.object({});
 
+const mcpGetContextOutputSchema = z.object({
+    activeProject: z
+        .object({
+            projectUuid: z.string(),
+            projectName: z.string(),
+            selectedTags: z.array(z.string()).nullable(),
+        })
+        .nullable(),
+    activeAgent: z
+        .object({
+            agentUuid: z.string(),
+            agentName: z.string(),
+            projectUuid: z.string(),
+        })
+        .nullable(),
+    projects: z.array(
+        z.object({
+            projectUuid: z.string(),
+            name: z.string(),
+            type: z.string(),
+            expiresAt: z.string().nullable(),
+        }),
+    ),
+});
+
 const routeAgentArgsSchema = z.object({
     prompt: z.string(),
     projectUuid: z.string().optional(),
@@ -1377,17 +1402,36 @@ export const mcpListProjectsToolDefinition: ToolDefinitionWithoutMcpOutput<
     name: 'listProjects',
     title: 'List projects',
     description:
-        'List all accessible projects in the organization. Projects contain explores, fields, and content. Use this to discover available projects before calling set_project to select one as the active context for subsequent operations. Each project includes a "type": prefer DEFAULT projects, which are live production environments. PREVIEW projects are ephemeral CI/PR environments that may be decommissioned — their warehouse credentials are often gone, so queries can fail with 403 errors even when the schema is still visible. Only select a PREVIEW project if the user explicitly asks for it.',
+        'List all accessible projects in the organization. Projects contain explores, fields, and content. Prefer get_context for bootstrap, then pass the selected projectUuid explicitly to every project-scoped operation. Each project includes a "type": prefer DEFAULT projects, which are live production environments. PREVIEW projects are ephemeral CI/PR environments that may be decommissioned — their warehouse credentials are often gone, so queries can fail with 403 errors even when the schema is still visible. Only select a PREVIEW project if the user explicitly asks for it.',
     availability: ['mcp'],
     inputSchema: emptyInputSchema,
     mcp: { annotations: readOnlyAnnotations },
 });
 
+export const getContextToolDefinition: ToolDefinitionWithMcpOutput<
+    'getContext',
+    typeof emptyInputSchema,
+    typeof emptyInputSchema,
+    undefined,
+    typeof mcpGetContextOutputSchema
+> = defineTool({
+    name: 'getContext',
+    title: 'Get context',
+    description:
+        'Call this first to discover accessible projects and Lightdash-configured context. Copy the selected projectUuid into every project-scoped tool call. This tool reports context but does not establish implicit execution state.',
+    availability: ['mcp'],
+    inputSchema: emptyInputSchema,
+    mcp: {
+        annotations: readOnlyAnnotations,
+        structuredContentSchema: mcpGetContextOutputSchema,
+    },
+});
+
 export const setProjectToolDefinition = defineTool({
     name: 'setProject',
-    title: 'Set project',
+    title: 'Set project (deprecated)',
     description:
-        'Set the active project for all subsequent MCP operations. Most tools (list_explores, MCP schema-discovery tools, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, prefer route_agent to auto-select the best agent for each request; use list_agents and set_agent only for manual override.',
+        '@deprecated Use get_context and pass projectUuid explicitly to every project-scoped tool. Sets legacy shared project context for older clients only.',
     availability: ['mcp'],
     inputSchema: z.object({
         projectUuid: z.string(),
@@ -1403,9 +1447,9 @@ export const getCurrentProjectToolDefinition: ToolDefinitionWithoutMcpOutput<
     undefined
 > = defineTool({
     name: 'getCurrentProject',
-    title: 'Get current project',
+    title: 'Get current project (deprecated)',
     description:
-        'Get the currently active project and its configuration. Returns the project UUID, name, and any selected tags. Use this to verify context before calling data tools.',
+        '@deprecated Use get_context instead. Returns legacy shared project context for older clients.',
     availability: ['mcp'],
     inputSchema: emptyInputSchema,
     mcp: { annotations: readOnlyAnnotations },
@@ -1415,7 +1459,7 @@ export const listAgentsToolDefinition = defineTool({
     name: 'listAgents',
     title: 'List agents',
     description:
-        'List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Prefer route_agent for automatic selection; use this tool when you need to inspect candidates or choose one manually before calling set_agent.',
+        'List accessible AI agents for the required projectUuid. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Prefer route_agent for automatic selection.',
     availability: ['mcp'],
     inputSchema: z.object({
         projectUuid: z.string().optional(),
@@ -1433,7 +1477,7 @@ export const routeAgentToolDefinition: ToolDefinitionWithMcpOutput<
     name: 'routeAgent',
     title: 'Route agent',
     description:
-        'Automatically select and activate the best AI agent for a user request within the active project. Call this at the start of each new user request after setting project context. Returns routing metadata plus the selected agent context; use set_agent only when you want to override the automatic choice manually.',
+        'Select the best AI agent for a user request within the required projectUuid. Call this at the start of each new user request, then pass the returned agentUuid explicitly to subsequent scoped tools. Also updates legacy shared agent context for older clients.',
     availability: ['mcp'],
     inputSchema: routeAgentArgsSchema,
     mcp: {
@@ -1444,9 +1488,9 @@ export const routeAgentToolDefinition: ToolDefinitionWithMcpOutput<
 
 export const setAgentToolDefinition = defineTool({
     name: 'setAgent',
-    title: 'Set agent',
+    title: 'Set agent (deprecated)',
     description:
-        "Manually set the active AI agent for the active project. Prefer route_agent for default automatic selection; use this when you need to override that choice explicitly. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling MCP schema-discovery tools, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
+        '@deprecated Use route_agent with an explicit projectUuid and pass its returned agentUuid to scoped tools. Sets legacy shared agent context for older clients only.',
     availability: ['mcp'],
     inputSchema: z.object({
         agentUuid: z.string(),
@@ -1461,9 +1505,9 @@ export const clearAgentToolDefinition: ToolDefinitionWithoutMcpOutput<
     undefined
 > = defineTool({
     name: 'clearAgent',
-    title: 'Clear agent',
+    title: 'Clear agent (deprecated)',
     description:
-        "Clear the active AI agent from context. After clearing, tool calls will no longer be scoped to a specific agent's explores, tags, or instructions. The active project is preserved.",
+        '@deprecated Omit agentUuid from scoped tool calls instead. Clears legacy shared agent context for older clients only.',
     availability: ['mcp'],
     inputSchema: emptyInputSchema,
     mcp: { annotations: contextWriteAnnotations },
@@ -1476,9 +1520,9 @@ export const getCurrentAgentToolDefinition: ToolDefinitionWithoutMcpOutput<
     undefined
 > = defineTool({
     name: 'getCurrentAgent',
-    title: 'Get current agent',
+    title: 'Get current agent (deprecated)',
     description:
-        'Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. The active agent is usually established by route_agent; use this to inspect the current automatic or manually overridden selection before making data queries.',
+        '@deprecated Use get_context for legacy configured context or route_agent for an explicit agent selection.',
     availability: ['mcp'],
     inputSchema: emptyInputSchema,
     mcp: { annotations: readOnlyAnnotations },
@@ -1493,7 +1537,7 @@ export const listVerifiedContentToolDefinition: ToolDefinitionWithoutMcpOutput<
     name: 'listVerifiedContent',
     title: 'List verified content',
     description:
-        'List all verified charts and dashboards in the active project. Verified content has been reviewed and marked as trusted — use this to discover reference examples of sanctioned metrics and visualizations when building new content. Requires an active project set via set_project. Each item includes contentType (chart or dashboard), contentUuid, name, description, space, view count, last update time, and verification metadata (who verified it and when); charts also include chartKind and exploreName. To learn the full structure of a verified item (dimensions, metrics, filters), drill into it with find_content or MCP schema-discovery tools on its explore.',
+        'List all verified charts and dashboards in the required projectUuid. Verified content has been reviewed and marked as trusted — use this to discover reference examples of sanctioned metrics and visualizations when building new content. Each item includes contentType (chart or dashboard), contentUuid, name, description, space, view count, last update time, and verification metadata (who verified it and when); charts also include chartKind and exploreName. To learn the full structure of a verified item (dimensions, metrics, filters), drill into it with find_content or MCP schema-discovery tools on its explore.',
     availability: ['mcp'],
     inputSchema: emptyInputSchema,
     mcp: { annotations: readOnlyAnnotations },
@@ -1709,6 +1753,7 @@ export const builtInToolDefinitions: readonly ToolDefinitionInstance[] = [
     listProjectsToolDefinition,
     mcpListProjectsToolDefinition,
     getProjectInfoToolDefinition,
+    getContextToolDefinition,
     setProjectToolDefinition,
     getCurrentProjectToolDefinition,
     listAgentsToolDefinition,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -1479,7 +1479,7 @@ export const routeAgentToolDefinition: ToolDefinitionWithMcpOutput<
     name: 'routeAgent',
     title: 'Route agent',
     description:
-        'Select the best AI agent for a user request within the required projectUuid. Call this at the start of each new user request, then pass the returned agentUuid explicitly to subsequent scoped tools. Also updates legacy shared agent context for older clients.',
+        'Select the best AI agent for a user request within the required projectUuid when agent-specific scope is useful and routing is available. Pass the returned agentUuid explicitly to subsequent scoped tools. If routing is unavailable, use list_agents and set_agent for manual selection; omit agentUuid when full project scope is desired. Also updates shared agent context for clients that use it.',
     availability: ['mcp'],
     inputSchema: routeAgentArgsSchema,
     mcp: {

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -1430,9 +1430,9 @@ export const getContextToolDefinition: ToolDefinitionWithMcpOutput<
 /** @deprecated Use getContextToolDefinition and explicit projectUuid arguments. */
 export const setProjectToolDefinition = defineTool({
     name: 'setProject',
-    title: 'Set project (deprecated)',
+    title: 'Set project',
     description:
-        '@deprecated Use get_context and pass projectUuid explicitly to every project-scoped tool. Sets legacy shared project context for older clients only.',
+        'Set the configured project context. Most tools (list_explores, MCP schema-discovery tools, run_metric_query, etc.) also require its projectUuid explicitly. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, prefer route_agent to auto-select the best agent for each request and pass its returned agentUuid explicitly to subsequent scoped tools; use list_agents and set_agent only for manual override.',
     availability: ['mcp'],
     inputSchema: z.object({
         projectUuid: z.string(),
@@ -1491,9 +1491,9 @@ export const routeAgentToolDefinition: ToolDefinitionWithMcpOutput<
 /** @deprecated Use routeAgentToolDefinition and explicit agentUuid arguments. */
 export const setAgentToolDefinition = defineTool({
     name: 'setAgent',
-    title: 'Set agent (deprecated)',
+    title: 'Set agent',
     description:
-        '@deprecated Use route_agent with an explicit projectUuid and pass its returned agentUuid to scoped tools. Sets legacy shared agent context for older clients only.',
+        "Manually select an AI agent for the required projectUuid. Prefer route_agent for default automatic selection; use this when you need to override that choice explicitly. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Pass the agentUuid explicitly to subsequent scoped tools and use this context to guide them — prefer the agent's explores when calling MCP schema-discovery tools, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
     availability: ['mcp'],
     inputSchema: z.object({
         agentUuid: z.string(),

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -1427,6 +1427,7 @@ export const getContextToolDefinition: ToolDefinitionWithMcpOutput<
     },
 });
 
+/** @deprecated Use getContextToolDefinition and explicit projectUuid arguments. */
 export const setProjectToolDefinition = defineTool({
     name: 'setProject',
     title: 'Set project (deprecated)',
@@ -1440,6 +1441,7 @@ export const setProjectToolDefinition = defineTool({
     mcp: { annotations: contextWriteAnnotations },
 });
 
+/** @deprecated Use getContextToolDefinition. */
 export const getCurrentProjectToolDefinition: ToolDefinitionWithoutMcpOutput<
     'getCurrentProject',
     typeof emptyInputSchema,
@@ -1486,6 +1488,7 @@ export const routeAgentToolDefinition: ToolDefinitionWithMcpOutput<
     },
 });
 
+/** @deprecated Use routeAgentToolDefinition and explicit agentUuid arguments. */
 export const setAgentToolDefinition = defineTool({
     name: 'setAgent',
     title: 'Set agent (deprecated)',
@@ -1498,6 +1501,7 @@ export const setAgentToolDefinition = defineTool({
     mcp: { annotations: contextWriteAnnotations },
 });
 
+/** @deprecated Omit agentUuid from project-scoped tool calls. */
 export const clearAgentToolDefinition: ToolDefinitionWithoutMcpOutput<
     'clearAgent',
     typeof emptyInputSchema,
@@ -1513,6 +1517,7 @@ export const clearAgentToolDefinition: ToolDefinitionWithoutMcpOutput<
     mcp: { annotations: contextWriteAnnotations },
 });
 
+/** @deprecated Use getContextToolDefinition or routeAgentToolDefinition. */
 export const getCurrentAgentToolDefinition: ToolDefinitionWithoutMcpOutput<
     'getCurrentAgent',
     typeof emptyInputSchema,

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -8,7 +8,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": false
             },
-            "description": "Clear the active AI agent from context. After clearing, tool calls will no longer be scoped to a specific agent's explores, tags, or instructions. The active project is preserved.",
+            "description": "@deprecated Omit agentUuid from scoped tool calls instead. Clears legacy shared agent context for older clients only.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -17,7 +17,7 @@
             },
             "name": "clear_agent",
             "outputSchema": null,
-            "title": "Clear agent"
+            "title": "Clear agent (deprecated)"
         },
         {
             "annotations": {
@@ -868,16 +868,114 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
-            "description": "Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. The active agent is usually established by route_agent; use this to inspect the current automatic or manually overridden selection before making data queries.",
+            "description": "Call this first to discover accessible projects and Lightdash-configured context. Copy the selected projectUuid into every project-scoped tool call. This tool reports context but does not establish implicit execution state.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
                 "properties": {},
                 "type": "object"
             },
-            "name": "get_current_agent",
-            "outputSchema": null,
-            "title": "Get current agent"
+            "name": "get_context",
+            "outputSchema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                    "activeAgent": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "agentName": {
+                                        "type": "string"
+                                    },
+                                    "agentUuid": {
+                                        "type": "string"
+                                    },
+                                    "projectUuid": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "agentUuid",
+                                    "agentName",
+                                    "projectUuid"
+                                ],
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "activeProject": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "projectName": {
+                                        "type": "string"
+                                    },
+                                    "projectUuid": {
+                                        "type": "string"
+                                    },
+                                    "selectedTags": {
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "projectUuid",
+                                    "projectName",
+                                    "selectedTags"
+                                ],
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "projects": {
+                        "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "expiresAt": {
+                                    "type": ["string", "null"]
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "projectUuid": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "projectUuid",
+                                "name",
+                                "type",
+                                "expiresAt"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["activeProject", "activeAgent", "projects"],
+                "type": "object"
+            },
+            "title": "Get context"
         },
         {
             "annotations": {
@@ -886,7 +984,25 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
-            "description": "Get the currently active project and its configuration. Returns the project UUID, name, and any selected tags. Use this to verify context before calling data tools.",
+            "description": "@deprecated Use get_context for legacy configured context or route_agent for an explicit agent selection.",
+            "inputSchema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {},
+                "type": "object"
+            },
+            "name": "get_current_agent",
+            "outputSchema": null,
+            "title": "Get current agent (deprecated)"
+        },
+        {
+            "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": false,
+                "readOnlyHint": true
+            },
+            "description": "@deprecated Use get_context instead. Returns legacy shared project context for older clients.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -895,7 +1011,7 @@
             },
             "name": "get_current_project",
             "outputSchema": null,
-            "title": "Get current project"
+            "title": "Get current project (deprecated)"
         },
         {
             "annotations": {
@@ -1893,7 +2009,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
-            "description": "List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Prefer route_agent for automatic selection; use this tool when you need to inspect candidates or choose one manually before calling set_agent.",
+            "description": "List accessible AI agents for the required projectUuid. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Prefer route_agent for automatic selection.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -1961,7 +2077,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
-            "description": "List all accessible projects in the organization. Projects contain explores, fields, and content. Use this to discover available projects before calling set_project to select one as the active context for subsequent operations. Each project includes a \"type\": prefer DEFAULT projects, which are live production environments. PREVIEW projects are ephemeral CI/PR environments that may be decommissioned — their warehouse credentials are often gone, so queries can fail with 403 errors even when the schema is still visible. Only select a PREVIEW project if the user explicitly asks for it.",
+            "description": "List all accessible projects in the organization. Projects contain explores, fields, and content. Prefer get_context for bootstrap, then pass the selected projectUuid explicitly to every project-scoped operation. Each project includes a \"type\": prefer DEFAULT projects, which are live production environments. PREVIEW projects are ephemeral CI/PR environments that may be decommissioned — their warehouse credentials are often gone, so queries can fail with 403 errors even when the schema is still visible. Only select a PREVIEW project if the user explicitly asks for it.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -2087,7 +2203,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
-            "description": "List all verified charts and dashboards in the active project. Verified content has been reviewed and marked as trusted — use this to discover reference examples of sanctioned metrics and visualizations when building new content. Requires an active project set via set_project. Each item includes contentType (chart or dashboard), contentUuid, name, description, space, view count, last update time, and verification metadata (who verified it and when); charts also include chartKind and exploreName. To learn the full structure of a verified item (dimensions, metrics, filters), drill into it with find_content or MCP schema-discovery tools on its explore.",
+            "description": "List all verified charts and dashboards in the required projectUuid. Verified content has been reviewed and marked as trusted — use this to discover reference examples of sanctioned metrics and visualizations when building new content. Each item includes contentType (chart or dashboard), contentUuid, name, description, space, view count, last update time, and verification metadata (who verified it and when); charts also include chartKind and exploreName. To learn the full structure of a verified item (dimensions, metrics, filters), drill into it with find_content or MCP schema-discovery tools on its explore.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -2538,7 +2654,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": false
             },
-            "description": "Automatically select and activate the best AI agent for a user request within the active project. Call this at the start of each new user request after setting project context. Returns routing metadata plus the selected agent context; use set_agent only when you want to override the automatic choice manually.",
+            "description": "Select the best AI agent for a user request within the required projectUuid. Call this at the start of each new user request, then pass the returned agentUuid explicitly to subsequent scoped tools. Also updates legacy shared agent context for older clients.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -7786,7 +7902,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": false
             },
-            "description": "Manually set the active AI agent for the active project. Prefer route_agent for default automatic selection; use this when you need to override that choice explicitly. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling MCP schema-discovery tools, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
+            "description": "@deprecated Use route_agent with an explicit projectUuid and pass its returned agentUuid to scoped tools. Sets legacy shared agent context for older clients only.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -7800,7 +7916,7 @@
             },
             "name": "set_agent",
             "outputSchema": null,
-            "title": "Set agent"
+            "title": "Set agent (deprecated)"
         },
         {
             "annotations": {
@@ -7809,7 +7925,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": false
             },
-            "description": "Set the active project for all subsequent MCP operations. Most tools (list_explores, MCP schema-discovery tools, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, prefer route_agent to auto-select the best agent for each request; use list_agents and set_agent only for manual override.",
+            "description": "@deprecated Use get_context and pass projectUuid explicitly to every project-scoped tool. Sets legacy shared project context for older clients only.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -7829,7 +7945,7 @@
             },
             "name": "set_project",
             "outputSchema": null,
-            "title": "Set project"
+            "title": "Set project (deprecated)"
         }
     ]
 }

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -868,7 +868,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
-            "description": "Call this first to discover accessible projects and Lightdash-configured context. Copy the selected projectUuid into every project-scoped tool call. This tool reports context but does not establish implicit execution state.",
+            "description": "Call this first to discover available projects, the agents you can access in each project, and Lightdash-configured context. Pass the selected projectUuid to every project-scoped tool call and an available agentUuid when agent-specific scope is desired. This tool reports context but does not establish implicit execution state.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -944,10 +944,47 @@
                             }
                         ]
                     },
-                    "projects": {
+                    "availableProjects": {
                         "items": {
                             "additionalProperties": false,
                             "properties": {
+                                "availableAgents": {
+                                    "items": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "agentUuid": {
+                                                "type": "string"
+                                            },
+                                            "description": {
+                                                "type": ["string", "null"]
+                                            },
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "tags": {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "agentUuid",
+                                            "name",
+                                            "description",
+                                            "tags"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                },
                                 "expiresAt": {
                                     "type": ["string", "null"]
                                 },
@@ -965,14 +1002,19 @@
                                 "projectUuid",
                                 "name",
                                 "type",
-                                "expiresAt"
+                                "expiresAt",
+                                "availableAgents"
                             ],
                             "type": "object"
                         },
                         "type": "array"
                     }
                 },
-                "required": ["activeProject", "activeAgent", "projects"],
+                "required": [
+                    "activeProject",
+                    "activeAgent",
+                    "availableProjects"
+                ],
                 "type": "object"
             },
             "title": "Get context"

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -7902,7 +7902,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": false
             },
-            "description": "@deprecated Use route_agent with an explicit projectUuid and pass its returned agentUuid to scoped tools. Sets legacy shared agent context for older clients only.",
+            "description": "Manually select an AI agent for the required projectUuid. Prefer route_agent for default automatic selection; use this when you need to override that choice explicitly. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Pass the agentUuid explicitly to subsequent scoped tools and use this context to guide them — prefer the agent's explores when calling MCP schema-discovery tools, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -7916,7 +7916,7 @@
             },
             "name": "set_agent",
             "outputSchema": null,
-            "title": "Set agent (deprecated)"
+            "title": "Set agent"
         },
         {
             "annotations": {
@@ -7925,7 +7925,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": false
             },
-            "description": "@deprecated Use get_context and pass projectUuid explicitly to every project-scoped tool. Sets legacy shared project context for older clients only.",
+            "description": "Set the configured project context. Most tools (list_explores, MCP schema-discovery tools, run_metric_query, etc.) also require its projectUuid explicitly. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, prefer route_agent to auto-select the best agent for each request and pass its returned agentUuid explicitly to subsequent scoped tools; use list_agents and set_agent only for manual override.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -7945,7 +7945,7 @@
             },
             "name": "set_project",
             "outputSchema": null,
-            "title": "Set project (deprecated)"
+            "title": "Set project"
         }
     ]
 }

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -2654,7 +2654,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": false
             },
-            "description": "Select the best AI agent for a user request within the required projectUuid. Call this at the start of each new user request, then pass the returned agentUuid explicitly to subsequent scoped tools. Also updates legacy shared agent context for older clients.",
+            "description": "Select the best AI agent for a user request within the required projectUuid when agent-specific scope is useful and routing is available. Pass the returned agentUuid explicitly to subsequent scoped tools. If routing is unavailable, use list_agents and set_agent for manual selection; omit agentUuid when full project scope is desired. Also updates shared agent context for clients that use it.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: workspace:*
         version: link:../warehouses
       '@modelcontextprotocol/sdk':
-        specifier: 1.29.0
-        version: 1.29.0(supports-color@5.5.0)(zod@3.25.55)
+        specifier: 1.30.0
+        version: 1.30.0(supports-color@5.5.0)(zod@3.25.55)
       '@node-oauth/oauth2-server':
         specifier: 5.3.0
         version: 5.3.0
@@ -693,7 +693,7 @@ importers:
         version: link:../../../../../../common
       '@modelcontextprotocol/ext-apps':
         specifier: 1.7.1
-        version: 1.7.1(@modelcontextprotocol/sdk@1.29.0(supports-color@9.1.0)(zod@4.1.5))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.5)
+        version: 1.7.1(@modelcontextprotocol/sdk@1.30.0(supports-color@9.1.0)(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.5)
       echarts:
         specifier: 5.6.0
         version: 5.6.0
@@ -4161,6 +4161,16 @@ packages:
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -9488,9 +9498,6 @@ packages:
 
   dompurify@3.4.0:
     resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
-
-  dompurify@3.4.13:
-    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -16208,6 +16215,9 @@ packages:
   zod@4.1.5:
     resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zrender@5.6.1:
     resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
 
@@ -19504,16 +19514,38 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/ext-apps@1.7.1(@modelcontextprotocol/sdk@1.29.0(supports-color@9.1.0)(zod@4.1.5))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.5)':
+  '@modelcontextprotocol/ext-apps@1.7.1(@modelcontextprotocol/sdk@1.30.0(supports-color@9.1.0)(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.5)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(supports-color@9.1.0)(zod@4.1.5)
+      '@modelcontextprotocol/sdk': 1.30.0(supports-color@9.1.0)(zod@4.4.3)
       '@standard-schema/spec': 1.1.0
       zod: 4.1.5
     optionalDependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@modelcontextprotocol/sdk@1.29.0(supports-color@5.5.0)(zod@3.25.55)':
+  '@modelcontextprotocol/sdk@1.29.0(supports-color@9.1.0)(zod@4.1.5)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.27)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1(supports-color@9.1.0)
+      express-rate-limit: 8.3.0(express@5.2.1(supports-color@9.1.0))
+      hono: 4.12.27
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.1
+      zod: 4.1.5
+      zod-to-json-schema: 3.25.1(zod@4.1.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@5.5.0)(zod@3.25.55)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.27)
       ajv: 8.18.0
@@ -19535,7 +19567,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.29.0(supports-color@9.1.0)(zod@4.1.5)':
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@9.1.0)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.27)
       ajv: 8.18.0
@@ -19552,8 +19584,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.1
-      zod: 4.1.5
-      zod-to-json-schema: 3.25.1(zod@4.1.5)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -25695,10 +25727,6 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
-  dompurify@3.4.13:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
-
   domutils@2.8.0:
     dependencies:
       dom-serializer: 1.4.1
@@ -28197,7 +28225,7 @@ snapshots:
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.45.1
-      dompurify: 3.4.13
+      dompurify: 3.4.0
       html2canvas: 1.4.1
 
   jsprim@2.0.2:
@@ -28986,7 +29014,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.13
+      dompurify: 3.4.0
       katex: 0.16.45
       khroma: 2.1.0
       lodash-es: 4.18.1
@@ -34186,9 +34214,15 @@ snapshots:
     dependencies:
       zod: 4.1.5
 
+  zod-to-json-schema@3.25.1(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
   zod@3.25.55: {}
 
   zod@4.1.5: {}
+
+  zod@4.4.3: {}
 
   zrender@5.6.1:
     dependencies:


### PR DESCRIPTION
Closes: ZAP-737

Require project-scoped MCP tools to accept and authorize an explicit `projectUuid`, with optional explicit agent routing.

Add `get_context`, retain the existing shared-context tools for cached and manual workflows, and preserve cached clients through a temporary compatibility fallback that asks them to refresh their tool contracts. Upgrade the MCP SDK to 1.30.0.

## Old stateful flow

```mermaid
sequenceDiagram
    participant Client
    participant MCP
    participant Context as Shared MCP Context
    participant Agents as Agent Service
    participant Runtime as Tool Runtime

    Client->>MCP: set_project(projectUuid, optional tags)
    MCP->>Context: Save active project + legacy project tags

    Client->>MCP: route_agent(prompt)
    MCP->>Context: Read active project
    MCP->>Agents: Select agent in active project
    Agents-->>MCP: agentUuid
    MCP->>Context: Save active agentUuid/name
    MCP-->>Client: selected agent

    Client->>MCP: run_metric_query(query)
    MCP->>Context: Read active project + agentUuid
    MCP->>Agents: getAgent(agentUuid, projectUuid)
    Agents-->>MCP: current tags + spaceAccess
    MCP->>Runtime: Execute using implicit project and agent scope
    Runtime-->>Client: result
```

The tool call itself does not identify its scope. Correctness depends on mutable state established by previous calls. Agent tags are not copied into execution scope: when an agent UUID is selected, the agent is fetched and its current tags and space access are used.

## New stateless flow with agent scope

```mermaid
sequenceDiagram
    participant Client
    participant MCP
    participant Agents as Agent Service
    participant Runtime as Tool Runtime
    participant Models as Project models/explores

    Client->>MCP: get_context()
    MCP-->>Client: accessible projects + configured legacy context

    Client->>MCP: route_agent(projectUuid, prompt)
    MCP->>Agents: Select agent within projectUuid
    Agents-->>MCP: agentUuid + agent context
    MCP-->>Client: agentUuid + agent context

    Client->>MCP: run_metric_query(projectUuid, agentUuid, query)
    MCP->>MCP: Authorize explicit projectUuid
    MCP->>Agents: getAgent(agentUuid, projectUuid)
    Agents-->>MCP: current tags + spaceAccess
    MCP->>Runtime: Create runtime(projectUuid, tags, spaceAccess)
    Runtime->>Models: Load models/explores from projectUuid
    Models-->>Runtime: project models/explores
    Runtime->>Runtime: Narrow models/fields by current agent tags
    Runtime-->>Client: scoped result
```

The explicit `projectUuid` selects and authorizes the deployment/project. The optional `agentUuid` is resolved on every call; its current tags narrow available models, explores, and fields, while its space access narrows content. Persisted legacy tags are not used for explicit stateless calls.

## New stateless flow without agent scope

```mermaid
sequenceDiagram
    participant Client
    participant MCP
    participant Runtime as Tool Runtime
    participant Models as Project models/explores

    Client->>MCP: get_context()
    MCP-->>Client: accessible projects

    Client->>MCP: run_metric_query(projectUuid, query)
    Note over Client,MCP: agentUuid omitted intentionally
    MCP->>MCP: Authorize explicit projectUuid
    MCP->>Runtime: Create runtime(projectUuid, tags=null, spaceAccess=null)
    Runtime->>Models: Load models/explores from projectUuid
    Models-->>Runtime: full authorized project scope
    Runtime-->>Client: result
```

Omitting `agentUuid` intentionally uses the full authorized project scope; no persisted active agent or legacy tag snapshot narrows the call.
