### PR TITLE
fix(pre-aggregates): defer required filters

### DIFF
--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
@@ -272,6 +272,43 @@ describe('buildPreAggregateExplore', () => {
         );
     });
 
+    it('keeps required filters for query-time application', () => {
+        const explore = sourceExplore();
+        const requiredFilters = [
+            {
+                id: 'required-status',
+                target: { fieldRef: 'status' },
+                operator: FilterOperator.EQUALS,
+                values: ['completed'],
+                required: true,
+            },
+        ];
+        const exploreWithRequiredFilters: Explore = {
+            ...explore,
+            tables: {
+                ...explore.tables,
+                orders: {
+                    ...explore.tables.orders,
+                    requiredFilters,
+                },
+            },
+        };
+
+        const preAggregateDef = exploreWithRequiredFilters.preAggregates?.[0];
+        if (!preAggregateDef) {
+            throw new Error('Expected pre-aggregate definition');
+        }
+
+        const result = buildPreAggregateExplore(
+            exploreWithRequiredFilters,
+            preAggregateDef,
+        );
+
+        expect(result.tables.orders.requiredFilters).toStrictEqual(
+            requiredFilters,
+        );
+    });
+
     it('rewrites supported metrics', () => {
         const result = buildPreAggregateExplore(
             sourceExplore(),

--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -16,6 +16,7 @@ import {
     type CompiledMetric,
     type Explore,
     type MetricQuery,
+    type PreAggregateDef,
 } from '@lightdash/common';
 
 const makeDimension = ({
@@ -100,6 +101,22 @@ const baseExplore = (): Explore => ({
                     timeInterval: TimeFrames.MONTH,
                     timeIntervalBaseDimensionName: 'order_date',
                 }),
+                created_at: makeDimension({
+                    name: 'created_at',
+                    type: DimensionType.TIMESTAMP,
+                }),
+                created_at_day: makeDimension({
+                    name: 'created_at_day',
+                    type: DimensionType.TIMESTAMP,
+                    timeInterval: TimeFrames.DAY,
+                    timeIntervalBaseDimensionName: 'created_at',
+                }),
+                created_at_week: makeDimension({
+                    name: 'created_at_week',
+                    type: DimensionType.TIMESTAMP,
+                    timeInterval: TimeFrames.WEEK,
+                    timeIntervalBaseDimensionName: 'created_at',
+                }),
                 amount: makeDimension({
                     name: 'amount',
                     type: DimensionType.NUMBER,
@@ -158,6 +175,84 @@ const baseExplore = (): Explore => ({
         },
     },
 });
+
+const makeExploreWithRequiredStatusFilter = ({
+    preAggregateDimensions,
+    preAggregateFilters,
+    required = true,
+}: {
+    preAggregateDimensions: string[];
+    preAggregateFilters?: PreAggregateDef['filters'];
+    required?: boolean;
+}): Explore => {
+    const explore = baseExplore();
+
+    return {
+        ...explore,
+        tables: {
+            ...explore.tables,
+            orders: {
+                ...explore.tables.orders,
+                requiredFilters: [
+                    {
+                        id: 'required-status',
+                        target: { fieldRef: 'status' },
+                        operator: FilterOperator.EQUALS,
+                        values: ['completed'],
+                        required,
+                    },
+                ],
+            },
+        },
+        preAggregates: [
+            {
+                name: 'orders_summary',
+                dimensions: preAggregateDimensions,
+                metrics: ['order_count'],
+                ...(preAggregateFilters
+                    ? { filters: preAggregateFilters }
+                    : {}),
+            },
+        ],
+    };
+};
+
+const makeExploreWithJoinedRequiredFilter = ({
+    preAggregateDimensions,
+}: {
+    preAggregateDimensions: string[];
+}): Explore => {
+    const explore = baseExplore();
+
+    return {
+        ...explore,
+        tables: {
+            ...explore.tables,
+            orders: {
+                ...explore.tables.orders,
+                requiredFilters: [
+                    {
+                        id: 'required-customer-name',
+                        target: {
+                            fieldRef: 'customers.first_name',
+                            tableName: 'customers',
+                        },
+                        operator: FilterOperator.EQUALS,
+                        values: ['Ada'],
+                        required: true,
+                    },
+                ],
+            },
+        },
+        preAggregates: [
+            {
+                name: 'orders_summary',
+                dimensions: preAggregateDimensions,
+                metrics: ['order_count'],
+            },
+        ],
+    };
+};
 
 const makeMetricQuery = (
     partial: Partial<MetricQuery> & Pick<MetricQuery, 'dimensions' | 'metrics'>,
@@ -1119,6 +1214,238 @@ describe('findMatch', () => {
         expect(result.miss).toStrictEqual({
             reason: PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
             fieldId: 'customers_first_name',
+        });
+    });
+
+    it('misses when a model required-filter target is absent from the pre-aggregate dimensions', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: [],
+                metrics: ['orders_order_count'],
+            }),
+            makeExploreWithRequiredStatusFilter({
+                preAggregateDimensions: ['amount'],
+            }),
+        );
+
+        expect(result).toStrictEqual({
+            hit: false,
+            preAggregateName: null,
+            miss: {
+                reason: PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
+                fieldId: 'orders_status',
+            },
+        });
+    });
+
+    it('misses when a joined model required-filter target is absent from the pre-aggregate dimensions', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: [],
+                metrics: ['orders_order_count'],
+            }),
+            makeExploreWithJoinedRequiredFilter({
+                preAggregateDimensions: ['status'],
+            }),
+        );
+
+        expect(result).toStrictEqual({
+            hit: false,
+            preAggregateName: null,
+            miss: {
+                reason: PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
+                fieldId: 'customers_first_name',
+            },
+        });
+    });
+
+    it('hits when a model required-filter target is present in the pre-aggregate dimensions', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: [],
+                metrics: ['orders_order_count'],
+            }),
+            makeExploreWithRequiredStatusFilter({
+                preAggregateDimensions: ['status'],
+            }),
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_summary',
+            miss: null,
+        });
+    });
+
+    it('misses when a raw timestamp required filter would be applied to a day-grain pre-aggregate', () => {
+        const explore = baseExplore();
+        explore.tables.orders.requiredFilters = [
+            {
+                id: 'required-created-at',
+                target: { fieldRef: 'created_at' },
+                operator: FilterOperator.IN_BETWEEN,
+                values: ['2024-02-15 12:00:00', '2024-02-16 12:00:00'],
+                required: true,
+            },
+        ];
+        explore.preAggregates = [
+            {
+                name: 'orders_daily',
+                dimensions: [],
+                metrics: ['order_count'],
+                timeDimension: 'created_at',
+                granularity: TimeFrames.DAY,
+            },
+        ];
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: [],
+                metrics: ['orders_order_count'],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: false,
+            preAggregateName: null,
+            miss: {
+                reason: PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
+                fieldId: 'orders_created_at',
+            },
+        });
+    });
+
+    it('hits when a joined model required-filter target is present in the pre-aggregate dimensions', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: [],
+                metrics: ['orders_order_count'],
+            }),
+            makeExploreWithJoinedRequiredFilter({
+                preAggregateDimensions: ['customers.first_name'],
+            }),
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_summary',
+            miss: null,
+        });
+    });
+
+    it('ignores model filters explicitly marked as not required', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: [],
+                metrics: ['orders_order_count'],
+            }),
+            makeExploreWithRequiredStatusFilter({
+                preAggregateDimensions: ['amount'],
+                required: false,
+            }),
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_summary',
+            miss: null,
+        });
+    });
+
+    it('rejects explicit pre-aggregate filters on a model required-filter target', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: [],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-status',
+                                target: { fieldId: 'orders_status' },
+                                operator: FilterOperator.EQUALS,
+                                values: ['completed'],
+                            },
+                        ],
+                    },
+                },
+            }),
+            makeExploreWithRequiredStatusFilter({
+                preAggregateDimensions: ['status'],
+                preAggregateFilters: [
+                    {
+                        id: 'pre-aggregate-status',
+                        target: { fieldRef: 'status' },
+                        operator: FilterOperator.EQUALS,
+                        values: ['completed'],
+                    },
+                ],
+            }),
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+            fieldId: 'orders_status',
+        });
+    });
+
+    it('rejects explicit pre-aggregate filters on a sibling required time dimension', () => {
+        const explore = baseExplore();
+        explore.tables.orders.requiredFilters = [
+            {
+                id: 'required-created-at-week',
+                target: { fieldRef: 'created_at_week' },
+                operator: FilterOperator.EQUALS,
+                values: ['2024-02-19'],
+                required: true,
+            },
+        ];
+        explore.preAggregates = [
+            {
+                name: 'orders_daily',
+                dimensions: [],
+                metrics: ['order_count'],
+                filters: [
+                    {
+                        id: 'pre-aggregate-created-at',
+                        target: { fieldRef: 'created_at' },
+                        operator: FilterOperator.IN_BETWEEN,
+                        values: ['2024-02-15 12:00:00', '2024-02-29 12:00:00'],
+                    },
+                ],
+                timeDimension: 'created_at',
+                granularity: TimeFrames.DAY,
+            },
+        ];
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: [],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-created-at-week',
+                                target: {
+                                    fieldId: 'orders_created_at_week',
+                                },
+                                operator: FilterOperator.EQUALS,
+                                values: ['2024-02-26'],
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+            fieldId: 'orders_created_at',
         });
     });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -3390,6 +3390,63 @@ describe('AsyncQueryService', () => {
             expect(executedSql).not.toContain('viewer-region');
         });
 
+        it('does not apply model required filters to materialization queries', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const materializationExplore: Explore = {
+                ...validExplore,
+                tables: {
+                    ...validExplore.tables,
+                    a: {
+                        ...validExplore.tables.a,
+                        requiredFilters: [
+                            {
+                                id: 'required-dimension',
+                                target: { fieldRef: 'dim1' },
+                                operator: FilterOperator.EQUALS,
+                                values: ['restricted'],
+                                required: true,
+                            },
+                        ],
+                        dimensions: {
+                            ...validExplore.tables.a.dimensions,
+                            dim1: {
+                                ...validExplore.tables.a.dimensions.dim1,
+                                sql: '${TABLE}.dim1',
+                                compiledSql: '"a".dim1',
+                            },
+                        },
+                    },
+                },
+            };
+
+            vi.spyOn(projectModel, 'getExploreFromCache').mockResolvedValue(
+                materializationExplore,
+            );
+            const executeAsyncQuery = vi.fn().mockResolvedValue({
+                queryUuid: 'queryUuid',
+                cacheMetadata: {
+                    cacheHit: false,
+                },
+            });
+            service['executeAsyncQuery'] = executeAsyncQuery;
+
+            await service.executeAsyncMetricQuery({
+                account: sessionAccount,
+                projectUuid,
+                metricQuery: {
+                    ...metricQueryMock,
+                    tableCalculations: [],
+                },
+                context: QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION,
+            });
+
+            const [executeArgs] = executeAsyncQuery.mock.calls[0];
+            const executedSql = executeArgs.queryComposer.getSql({
+                columnLimit: lightdashConfigMock.pivotTable.maxColumnLimit,
+            });
+            expect(executedSql).not.toContain('restricted');
+        });
+
         it('fails closed when materializationRole is supplied outside materialization context', async () => {
             const service = getMockedAsyncQueryService(lightdashConfigMock);
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3599,6 +3599,7 @@ export class AsyncQueryService extends ProjectService {
         pivotDimensions,
         userAttributeOverrides,
         materializationRole,
+        skipModelRequiredFilters,
         columnTimezone,
         dataTimezone,
         sessionTimezone,
@@ -3636,6 +3637,7 @@ export class AsyncQueryService extends ProjectService {
          * underlying-data path sets this (PROD-880).
          */
         applyDateZoomToFilters?: boolean;
+        skipModelRequiredFilters?: boolean;
         preloadedUserAccessControls?: UserAccessControls;
         preloadedProjectParameters?: DbProjectParameter[];
         preloadedProjectTimezone?: string;
@@ -3708,6 +3710,7 @@ export class AsyncQueryService extends ProjectService {
                 parameters,
                 dateZoom,
                 pivotDimensions: pivotDimensions ?? metricQuery.pivotDimensions,
+                skipModelRequiredFilters,
                 useTimezoneAwareDateTrunc,
                 columnTimezone,
                 dataTimezone,
@@ -4573,6 +4576,9 @@ export class AsyncQueryService extends ProjectService {
             totalConfiguration,
             userAttributeOverrides,
             materializationRole,
+            ...(context === QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION
+                ? { skipModelRequiredFilters: true }
+                : {}),
             columnTimezone: getColumnTimezone(warehouseCredentials),
             dataTimezone: warehouseCredentials.dataTimezone,
             preloadedUserAccessControls,

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -147,6 +147,8 @@ export type BuildQueryProps = {
      * invalid filters. Useful for debugging/viewing SQL even with errors.
      */
     continueOnError?: boolean;
+    /** Model required filters are skipped only for pre-aggregate materialization. */
+    skipModelRequiredFilters?: boolean;
     /**
      * The original explore before date zoom modifications.
      * When date zoom changes granularity, the explore's dimension compiledSql
@@ -431,6 +433,10 @@ export class MetricQueryBuilder {
 
     private get columnTimezone(): string {
         return this.args.columnTimezone ?? 'UTC';
+    }
+
+    private get shouldApplyModelRequiredFilters() {
+        return !this.args.skipModelRequiredFilters;
     }
 
     /** Falls back to `columnTimezone`, which is equal on every warehouse
@@ -2012,6 +2018,8 @@ export class MetricQueryBuilder {
         table: CompiledTable,
         dimensionsFilterGroup: FilterGroup | undefined,
     ): string | undefined {
+        if (!this.shouldApplyModelRequiredFilters) return undefined;
+
         const { explore } = this.args;
         // We only force required filters that are not explicitly set to false
         // requiredFilters with required:false will be added on the UI, but not enforced on the backend
@@ -2506,15 +2514,16 @@ export class MetricQueryBuilder {
             ? tableSqlWhereTableReferences.map((ref) => ref.refTable)
             : [];
 
-        const requiredFilterJoinedTables =
-            explore.tables[explore.baseTable].requiredFilters
-                ?.map((filter) => {
-                    if (isJoinModelRequiredFilter(filter)) {
-                        return filter.target.tableName;
-                    }
-                    return undefined;
-                })
-                .filter((s): s is string => Boolean(s)) || [];
+        const requiredFilterJoinedTables = this.shouldApplyModelRequiredFilters
+            ? explore.tables[explore.baseTable].requiredFilters
+                  ?.map((filter) => {
+                      if (isJoinModelRequiredFilter(filter)) {
+                          return filter.target.tableName;
+                      }
+                      return undefined;
+                  })
+                  .filter((s): s is string => Boolean(s)) || []
+            : [];
 
         const joinedTables = new Set([
             ...selectedTables,

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
@@ -60,6 +60,7 @@ export type QueryComposerContext = {
      */
     pivotItemsMap?: ItemsMap;
     continueOnError?: boolean;
+    skipModelRequiredFilters?: boolean;
     useTimezoneAwareDateTrunc?: boolean;
     columnTimezone?: string;
     dataTimezone?: string;
@@ -121,6 +122,7 @@ export class QueryComposer {
             dateZoom,
             pivotDimensions,
             continueOnError,
+            skipModelRequiredFilters,
             useTimezoneAwareDateTrunc,
             columnTimezone,
             dataTimezone,
@@ -178,6 +180,7 @@ export class QueryComposer {
             pivotConfiguration,
             pivotDimensions,
             continueOnError,
+            skipModelRequiredFilters,
             originalExplore: dateZoom ? explore : undefined,
             dateZoomFilterTargetFieldId:
                 applyDateZoomToFilters && dateZoomApplied

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/filterQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/filterQueries.test.ts
@@ -206,4 +206,15 @@ describe('MetricQueryBuilder snapshot: filter queries', () => {
             }),
         ).toMatchSnapshot();
     });
+
+    test('omits model required filters and their joins when disabled', () => {
+        const query = buildQuery({
+            explore: EXPLORE_WITH_REQUIRED_FILTERS,
+            compiledMetricQuery: METRIC_QUERY,
+            skipModelRequiredFilters: true,
+        });
+
+        expect(query).not.toContain('table2');
+        expect(query).not.toContain('IN (10)');
+    });
 });

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -25,8 +25,12 @@ import {
     type PreAggregateDef,
     type PreAggregateMatchMiss,
 } from '../../types/preAggregate';
-import type { TimeFrames } from '../../types/timeFrames';
+import { TimeFrames } from '../../types/timeFrames';
 import { getMetricsMapFromTables } from '../../utils/fields';
+import {
+    createFilterRuleFromModelRequiredFilterRule,
+    reduceRequiredDimensionFiltersToFilterRules,
+} from '../../utils/filters';
 import { getItemId } from '../../utils/item';
 import { timeFrameOrder } from '../../utils/timeFrames';
 import { isCompatible } from './additivity';
@@ -85,6 +89,50 @@ const dimensionFieldIdMatchesDef = (
     }).some((reference) => defDimensions.has(reference));
 };
 
+const filterDimensionFieldIdMatchesDef = (
+    fieldId: FieldId,
+    explore: Explore,
+    preAggregateDef: PreAggregateDef,
+    defDimensions: Set<string>,
+    dimensionsByFieldId: Map<
+        FieldId,
+        Explore['tables'][string]['dimensions'][string]
+    >,
+): boolean => {
+    if (
+        !dimensionFieldIdMatchesDef(
+            fieldId,
+            explore,
+            defDimensions,
+            dimensionsByFieldId,
+        )
+    ) {
+        return false;
+    }
+
+    if (!preAggregateDef.timeDimension || !preAggregateDef.granularity) {
+        return true;
+    }
+
+    const dimension = dimensionsByFieldId.get(fieldId);
+    if (!dimension) {
+        return false;
+    }
+
+    const targetsRollupTimeDimension = getDimensionReferences({
+        dimension,
+        baseTable: explore.baseTable,
+    }).includes(preAggregateDef.timeDimension);
+
+    return (
+        !targetsRollupTimeDimension ||
+        isGranularityCoarserOrEqual(
+            dimension.timeInterval ?? TimeFrames.RAW,
+            preAggregateDef.granularity,
+        )
+    );
+};
+
 const extractDimensionFilterFieldIds = (
     metricQuery: MetricQuery,
 ): FieldId[] => {
@@ -118,6 +166,26 @@ const getPreAggregateFilterTargetReferences = (
               ],
     );
 
+const dimensionMatchesPreAggregateFilterTarget = ({
+    dimension,
+    preAggregateFilter,
+    explore,
+}: {
+    dimension: Explore['tables'][string]['dimensions'][string];
+    preAggregateFilter: MetricFilterRule;
+    explore: Explore;
+}): boolean => {
+    const preAggregateReferences = getPreAggregateFilterTargetReferences(
+        preAggregateFilter,
+        explore.baseTable,
+    );
+
+    return getDimensionReferences({
+        dimension,
+        baseTable: explore.baseTable,
+    }).some((reference) => preAggregateReferences.has(reference));
+};
+
 const matchesPreAggregateFilterTarget = ({
     queryFilterRule,
     preAggregateFilter,
@@ -138,15 +206,11 @@ const matchesPreAggregateFilterTarget = ({
         return false;
     }
 
-    const preAggregateReferences = getPreAggregateFilterTargetReferences(
-        preAggregateFilter,
-        explore.baseTable,
-    );
-
-    return getDimensionReferences({
+    return dimensionMatchesPreAggregateFilterTarget({
         dimension: queryDimension,
-        baseTable: explore.baseTable,
-    }).some((reference) => preAggregateReferences.has(reference));
+        preAggregateFilter,
+        explore,
+    });
 };
 
 const isValueSubset = (
@@ -816,6 +880,8 @@ const getMissForDef = ({
     preAggregateDef,
     dimensionsByFieldId,
     metricsByFieldId,
+    unoverriddenRequiredFilterTargetFieldIds,
+    requiredFilterTargetFieldIds,
 }: {
     metricQuery: MetricQuery;
     explore: Explore;
@@ -825,6 +891,8 @@ const getMissForDef = ({
         Explore['tables'][string]['dimensions'][string]
     >;
     metricsByFieldId: ReturnType<typeof getMetricsMapFromTables>;
+    unoverriddenRequiredFilterTargetFieldIds: readonly FieldId[];
+    requiredFilterTargetFieldIds: ReadonlySet<FieldId>;
 }): PreAggregateMatchMiss | null => {
     const defMetrics = new Set(preAggregateDef.metrics);
     for (const metricFieldId of metricQuery.metrics) {
@@ -918,12 +986,16 @@ const getMissForDef = ({
         };
     }
 
-    const filterDimensionFieldIds = extractDimensionFilterFieldIds(metricQuery);
+    const filterDimensionFieldIds = [
+        ...extractDimensionFilterFieldIds(metricQuery),
+        ...unoverriddenRequiredFilterTargetFieldIds,
+    ];
     const missingFilterDimensionFieldId = filterDimensionFieldIds.find(
         (dimensionFieldId) =>
-            !dimensionFieldIdMatchesDef(
+            !filterDimensionFieldIdMatchesDef(
                 dimensionFieldId,
                 explore,
+                preAggregateDef,
                 defDimensions,
                 dimensionsByFieldId,
             ),
@@ -932,6 +1004,29 @@ const getMissForDef = ({
         return {
             reason: PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
             fieldId: missingFilterDimensionFieldId,
+        };
+    }
+
+    const overlappingRequiredFilter = preAggregateDef.filters?.find((filter) =>
+        [...requiredFilterTargetFieldIds].some((fieldId) => {
+            const dimension = dimensionsByFieldId.get(fieldId);
+            return (
+                !!dimension &&
+                dimensionMatchesPreAggregateFilterTarget({
+                    dimension,
+                    preAggregateFilter: filter,
+                    explore,
+                })
+            );
+        }),
+    );
+    if (overlappingRequiredFilter) {
+        return {
+            reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+            fieldId: convertFieldRefToFieldId(
+                overlappingRequiredFilter.target.fieldRef,
+                explore.baseTable,
+            ),
         };
     }
 
@@ -1001,6 +1096,26 @@ export const findMatch = (
 
     const dimensionsByFieldId = getDimensionsByFieldId(explore);
     const metricsByFieldId = getMetricsMapFromTables(explore.tables);
+    const baseTable = explore.tables[explore.baseTable];
+    const requiredModelFilters =
+        baseTable.requiredFilters?.filter(
+            (filter) => filter.required !== false,
+        ) ?? [];
+    const unoverriddenRequiredFilterTargetFieldIds =
+        reduceRequiredDimensionFiltersToFilterRules(
+            requiredModelFilters,
+            metricQuery.filters.dimensions,
+            explore,
+        ).map((filter) => filter.target.fieldId);
+    const requiredFilterTargetFieldIds = new Set(
+        requiredModelFilters.map(
+            (filter) =>
+                createFilterRuleFromModelRequiredFilterRule(
+                    filter,
+                    baseTable.name,
+                ).target.fieldId,
+        ),
+    );
 
     const matchedDefs: PreAggregateDef[] = [];
     let firstMiss: PreAggregateMatchMiss | null = null;
@@ -1012,6 +1127,8 @@ export const findMatch = (
             preAggregateDef,
             dimensionsByFieldId,
             metricsByFieldId,
+            unoverriddenRequiredFilterTargetFieldIds,
+            requiredFilterTargetFieldIds,
         });
 
         if (!miss) {


### PR DESCRIPTION
Closes: ZAP-769

Builds pre-aggregates without model required-filter predicates. Routing requires each effective required-filter target in the rollup dimensions and rejects overlapping explicit rollup filters, so DuckDB can safely reapply fallbacks and overrides.

Tests cover base and joined targets, optional filters, query-time retention, and materialization SQL.
