### PR TITLE
feat(pre-aggregates): label required-filter misses

### DIFF
--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -1232,7 +1232,7 @@ describe('findMatch', () => {
             hit: false,
             preAggregateName: null,
             miss: {
-                reason: PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
+                reason: PreAggregateMissReason.REQUIRED_FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
                 fieldId: 'orders_status',
             },
         });
@@ -1253,7 +1253,7 @@ describe('findMatch', () => {
             hit: false,
             preAggregateName: null,
             miss: {
-                reason: PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
+                reason: PreAggregateMissReason.REQUIRED_FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
                 fieldId: 'customers_first_name',
             },
         });

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -986,11 +986,9 @@ const getMissForDef = ({
         };
     }
 
-    const filterDimensionFieldIds = [
-        ...extractDimensionFilterFieldIds(metricQuery),
-        ...unoverriddenRequiredFilterTargetFieldIds,
-    ];
-    const missingFilterDimensionFieldId = filterDimensionFieldIds.find(
+    const missingFilterDimensionFieldId = extractDimensionFilterFieldIds(
+        metricQuery,
+    ).find(
         (dimensionFieldId) =>
             !filterDimensionFieldIdMatchesDef(
                 dimensionFieldId,
@@ -1004,6 +1002,23 @@ const getMissForDef = ({
         return {
             reason: PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
             fieldId: missingFilterDimensionFieldId,
+        };
+    }
+
+    const missingRequiredFilterDimensionFieldId =
+        unoverriddenRequiredFilterTargetFieldIds.find(
+            (dimensionFieldId) =>
+                !dimensionFieldIdMatchesDef(
+                    dimensionFieldId,
+                    explore,
+                    defDimensions,
+                    dimensionsByFieldId,
+                ),
+        );
+    if (missingRequiredFilterDimensionFieldId) {
+        return {
+            reason: PreAggregateMissReason.REQUIRED_FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
+            fieldId: missingRequiredFilterDimensionFieldId,
         };
     }
 

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -62,6 +62,7 @@ export enum PreAggregateMissReason {
     NON_ADDITIVE_METRIC = 'non_additive_metric',
     CUSTOM_SQL_METRIC = 'custom_sql_metric',
     FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE = 'filter_dimension_not_in_pre_aggregate',
+    REQUIRED_FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE = 'required_filter_dimension_not_in_pre_aggregate',
     PRE_AGGREGATE_FILTER_NOT_SATISFIED = 'pre_aggregate_filter_not_satisfied',
     GRANULARITY_TOO_FINE = 'granularity_too_fine',
     CUSTOM_DIMENSION_PRESENT = 'custom_dimension_present',
@@ -94,6 +95,10 @@ export type PreAggregateMatchMiss =
       }
     | {
           reason: PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE;
+          fieldId: FieldId;
+      }
+    | {
+          reason: PreAggregateMissReason.REQUIRED_FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE;
           fieldId: FieldId;
       }
     | {
@@ -187,6 +192,8 @@ export const preAggregateMissReasonLabels: Record<
     [PreAggregateMissReason.CUSTOM_SQL_METRIC]: 'Custom SQL metric',
     [PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE]:
         'Filter dimension not in pre-aggregate',
+    [PreAggregateMissReason.REQUIRED_FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE]:
+        'Required filter dimension not in pre-aggregate',
     [PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED]:
         'Pre-aggregate filter not satisfied',
     [PreAggregateMissReason.GRANULARITY_TOO_FINE]: 'Granularity too fine',


### PR DESCRIPTION
Related: ZAP-769

Adds a dedicated miss reason for required-filter dimensions that are unavailable in a pre-aggregate. Keeps ordinary query-filter misses distinct and preserves the missing field ID for audit surfaces.
