### PR TITLE
feat(pre-aggregates): guide required-filter misses

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.tsx
+++ b/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.tsx
@@ -26,6 +26,7 @@ import { type TilePreAggregateStatus } from '../../../providers/Dashboard/types'
 import MantineIcon from '../MantineIcon';
 import { PolymorphicGroupButton } from '../PolymorphicGroupButton';
 import classes from './PreAggregateAuditIndicator.module.css';
+import { getTileMissGuidance } from './PreAggregateAuditIndicator.utils';
 import { scrollToDashboardTile } from './scrollToDashboardTile';
 
 const NONE_KEY = 'none';
@@ -73,6 +74,7 @@ function TileDetail({ tile }: { tile: TilePreAggregateStatus }) {
         const fieldDisplay = tile.reasonFieldLabel ?? fieldId;
         const showTooltip =
             tile.reasonFieldLabel !== null && tile.reasonFieldLabel !== fieldId;
+        const guidance = getTileMissGuidance(tile.reason);
         return (
             <Text fz={10} className={classes.tileDetail}>
                 {reasonLabel}:{' '}
@@ -91,6 +93,7 @@ function TileDetail({ tile }: { tile: TilePreAggregateStatus }) {
                 ) : (
                     fieldDisplay
                 )}
+                {guidance ? ` — ${guidance}` : null}
             </Text>
         );
     }

--- a/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.utils.test.ts
+++ b/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.utils.test.ts
@@ -1,0 +1,29 @@
+import {
+    PreAggregateMissReason,
+    type PreAggregateMatchMiss,
+} from '@lightdash/common';
+import { formatTileMissReason } from './PreAggregateAuditIndicator.utils';
+
+const missingRequiredFilterDimension = {
+    reason: PreAggregateMissReason.REQUIRED_FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
+    fieldId: 'orders_status',
+} satisfies PreAggregateMatchMiss;
+
+describe('formatTileMissReason', () => {
+    it('explains how to make a required-filter dimension available', () => {
+        expect(
+            formatTileMissReason(
+                missingRequiredFilterDimension,
+                'Order status',
+            ),
+        ).toBe(
+            'Required filter dimension not in pre-aggregate: Order status — add this field to the pre-aggregate dimensions',
+        );
+    });
+
+    it('falls back to the field ID when its label is unavailable', () => {
+        expect(formatTileMissReason(missingRequiredFilterDimension)).toBe(
+            'Required filter dimension not in pre-aggregate: orders_status — add this field to the pre-aggregate dimensions',
+        );
+    });
+});

--- a/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.utils.ts
+++ b/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.utils.ts
@@ -1,16 +1,32 @@
 import {
+    PreAggregateMissReason,
     preAggregateMissReasonLabels,
     type PreAggregateMatchMiss,
 } from '@lightdash/common';
+
+export function getTileMissGuidance(
+    reason: PreAggregateMatchMiss,
+): string | null {
+    if (
+        reason.reason ===
+        PreAggregateMissReason.REQUIRED_FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE
+    ) {
+        return 'add this field to the pre-aggregate dimensions';
+    }
+
+    return null;
+}
 
 export function formatTileMissReason(
     reason: PreAggregateMatchMiss,
     fieldLabel?: string | null,
 ): string {
     const label = preAggregateMissReasonLabels[reason.reason] ?? reason.reason;
-    if ('fieldId' in reason && reason.fieldId) {
-        const fieldDisplay = fieldLabel ?? reason.fieldId;
-        return `${label}: ${fieldDisplay}`;
-    }
-    return label;
+    const guidance = getTileMissGuidance(reason);
+    const detail =
+        'fieldId' in reason && reason.fieldId
+            ? `${label}: ${fieldLabel ?? reason.fieldId}`
+            : label;
+
+    return guidance ? `${detail} — ${guidance}` : detail;
 }


### PR DESCRIPTION
Related: ZAP-769

Adds actionable required-filter miss guidance to Explorer cache tooltips and dashboard pre-aggregate audit details.
