### PR TITLE
fix(pre-aggregates): reject capped materializations

### DIFF
--- a/packages/backend/src/ee/models/PreAggregateModel.test.ts
+++ b/packages/backend/src/ee/models/PreAggregateModel.test.ts
@@ -1,0 +1,89 @@
+import { toActiveMaterializationDetails } from './PreAggregateModel';
+
+type ActiveMaterializationRow = NonNullable<
+    Parameters<typeof toActiveMaterializationDetails>[0]
+>;
+
+const materializationMetricQuery = (
+    resolvedMaxRows: number | null,
+): ActiveMaterializationRow['materialization_metric_query'] => ({
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: [],
+        metrics: [],
+        filters: {},
+        sorts: [],
+        limit: 100,
+        tableCalculations: [],
+    },
+    metricComponents: {},
+    timeDimensionFieldId: null,
+    resolvedMaxRows,
+});
+
+const activeRow = (
+    overrides: Partial<ActiveMaterializationRow> = {},
+): ActiveMaterializationRow => ({
+    pre_aggregate_materialization_uuid: 'mat-1',
+    query_uuid: 'query-1',
+    materialization_uri: 's3://bucket/query-1.parquet',
+    columns: null,
+    materialized_at: new Date('2024-02-01T10:00:00.000Z'),
+    total_bytes: 456789,
+    row_count: null,
+    materialization_metric_query: materializationMetricQuery(100),
+    ...overrides,
+});
+
+describe('toActiveMaterializationDetails', () => {
+    test('returns details when the row count is strictly below the persisted cap', () => {
+        expect(
+            toActiveMaterializationDetails(activeRow({ row_count: 99 })),
+        ).toEqual({
+            materializationUuid: 'mat-1',
+            queryUuid: 'query-1',
+            materializationUri: 's3://bucket/query-1.parquet',
+            format: 'parquet',
+            columns: null,
+            materializedAt: new Date('2024-02-01T10:00:00.000Z'),
+            totalBytes: 456789,
+            rowCount: 99,
+            resolvedMaxRows: 100,
+        });
+    });
+
+    test('rejects details when the row count reached the persisted cap', () => {
+        expect(
+            toActiveMaterializationDetails(activeRow({ row_count: 100 })),
+        ).toBeUndefined();
+    });
+
+    test('returns details when the row has no row count', () => {
+        expect(
+            toActiveMaterializationDetails(activeRow({ row_count: null })),
+        ).toEqual(
+            expect.objectContaining({
+                materializationUuid: 'mat-1',
+                rowCount: null,
+                resolvedMaxRows: 100,
+            }),
+        );
+    });
+
+    test('returns details when the persisted payload has no cap', () => {
+        expect(
+            toActiveMaterializationDetails(
+                activeRow({
+                    row_count: 10_000_000,
+                    materialization_metric_query: null,
+                }),
+            ),
+        ).toEqual(
+            expect.objectContaining({
+                materializationUuid: 'mat-1',
+                rowCount: 10_000_000,
+                resolvedMaxRows: null,
+            }),
+        );
+    });
+});

--- a/packages/backend/src/ee/models/PreAggregateModel.ts
+++ b/packages/backend/src/ee/models/PreAggregateModel.ts
@@ -1,5 +1,6 @@
 import {
     computePreAggregateWarnings,
+    hasPreAggregateMaterializationReachedMaxRows,
     NotFoundError,
     type ActiveMaterializationDetails,
     type ApiPreAggregateMaterializationsResults,
@@ -28,6 +29,18 @@ import {
 type DbPreAggregateDefinitionWithExploreName = DbPreAggregateDefinition & {
     pre_agg_explore_name: string;
 };
+
+type ActiveMaterializationRow = Pick<
+    DbPreAggregateMaterialization,
+    | 'pre_aggregate_materialization_uuid'
+    | 'query_uuid'
+    | 'materialization_uri'
+    | 'columns'
+    | 'materialized_at'
+    | 'total_bytes'
+    | 'row_count'
+> &
+    Pick<DbPreAggregateDefinition, 'materialization_metric_query'>;
 
 const toPreAggregateDefinition = (
     row: DbPreAggregateDefinition,
@@ -62,6 +75,48 @@ const toPreAggregateMaterialization = (
     updatedAt: row.updated_at,
 });
 
+export const toActiveMaterializationDetails = (
+    row: ActiveMaterializationRow | undefined,
+): ActiveMaterializationDetails | undefined => {
+    if (
+        !row ||
+        !row.query_uuid ||
+        !row.materialization_uri ||
+        !row.materialized_at
+    ) {
+        return undefined;
+    }
+
+    // The cap comes from the persisted payload the artifact was built from;
+    // a payload rebuild implies a compile, which cascade-deletes the artifact,
+    // so the pair can never be mismatched. Legacy at-cap artifacts predate the
+    // promote gate and may be truncated — treat them as no active materialization.
+    const resolvedMaxRows =
+        row.materialization_metric_query?.resolvedMaxRows ?? null;
+    if (
+        hasPreAggregateMaterializationReachedMaxRows({
+            rowCount: row.row_count,
+            resolvedMaxRows,
+        })
+    ) {
+        return undefined;
+    }
+
+    return {
+        materializationUuid: row.pre_aggregate_materialization_uuid,
+        queryUuid: row.query_uuid,
+        materializationUri: row.materialization_uri,
+        format: row.materialization_uri.endsWith('.parquet')
+            ? 'parquet'
+            : 'jsonl',
+        columns: row.columns,
+        materializedAt: row.materialized_at,
+        totalBytes: row.total_bytes,
+        rowCount: row.row_count,
+        resolvedMaxRows,
+    };
+};
+
 export class PreAggregateModel {
     readonly database: Knex;
 
@@ -69,6 +124,11 @@ export class PreAggregateModel {
         this.database = database;
     }
 
+    // Compile-scoped lifecycle: every dbt compile wipes the project's cached
+    // explores and the FK cascades delete these rows (and their materializations)
+    // with them, so the merge branch below never pairs an old artifact with a new
+    // definition. An incremental sync that keeps cached explores alive would have
+    // to supersede active materializations itself when the payload changes.
     async upsertPreAggregateDefinitions(
         definitions: DbPreAggregateDefinitionIn[],
     ): Promise<void> {
@@ -446,23 +506,15 @@ export class PreAggregateModel {
                 'active',
             )
             .whereNotNull(`${PreAggregateMaterializationsTableName}.query_uuid`)
-            .select<
-                Pick<
-                    DbPreAggregateMaterialization,
-                    | 'pre_aggregate_materialization_uuid'
-                    | 'query_uuid'
-                    | 'materialization_uri'
-                    | 'columns'
-                    | 'materialized_at'
-                    | 'total_bytes'
-                >[]
-            >([
+            .select<ActiveMaterializationRow[]>([
                 `${PreAggregateMaterializationsTableName}.pre_aggregate_materialization_uuid`,
                 `${PreAggregateMaterializationsTableName}.query_uuid`,
                 `${PreAggregateMaterializationsTableName}.materialization_uri`,
                 `${PreAggregateMaterializationsTableName}.columns`,
                 `${PreAggregateMaterializationsTableName}.materialized_at`,
                 `${PreAggregateMaterializationsTableName}.total_bytes`,
+                `${PreAggregateMaterializationsTableName}.row_count`,
+                `${PreAggregateDefinitionsTableName}.materialization_metric_query`,
             ])
             .orderBy(
                 `${PreAggregateMaterializationsTableName}.materialized_at`,
@@ -470,26 +522,7 @@ export class PreAggregateModel {
             )
             .first();
 
-        if (
-            !row ||
-            !row.query_uuid ||
-            !row.materialization_uri ||
-            !row.materialized_at
-        ) {
-            return undefined;
-        }
-
-        return {
-            materializationUuid: row.pre_aggregate_materialization_uuid,
-            queryUuid: row.query_uuid,
-            materializationUri: row.materialization_uri,
-            format: row.materialization_uri.endsWith('.parquet')
-                ? 'parquet'
-                : 'jsonl',
-            columns: row.columns,
-            materializedAt: row.materialized_at,
-            totalBytes: row.total_bytes,
-        };
+        return toActiveMaterializationDetails(row);
     }
 
     async getDefinitionsWithLatestMaterialization(

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
@@ -36,6 +36,8 @@ describe('PreAggregationDuckDbClient', () => {
             columns: null,
             materializedAt: new Date('2024-01-01T00:00:00.000Z'),
             totalBytes: 987654,
+            rowCount: null,
+            resolvedMaxRows: null,
         },
     }: {
         lightdashConfig?: typeof lightdashConfigMock;
@@ -315,6 +317,8 @@ describe('PreAggregationDuckDbClient', () => {
                 },
                 materializedAt: new Date('2024-01-01T00:00:00.000Z'),
                 totalBytes: 987654,
+                rowCount: null,
+                resolvedMaxRows: null,
             },
         });
 
@@ -356,6 +360,8 @@ describe('PreAggregationDuckDbClient', () => {
                 },
                 materializedAt: new Date('2024-01-01T00:00:00.000Z'),
                 totalBytes: 987654,
+                rowCount: null,
+                resolvedMaxRows: null,
             },
         });
 

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
@@ -8,6 +8,7 @@ import type { S3ResultsFileStorageClient } from '../../../clients/ResultsFileSto
 import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
 import type { QueryHistoryModel } from '../../../models/QueryHistoryModel/QueryHistoryModel';
 import type { AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
+import { sessionAccount } from '../../../services/ProjectService/ProjectService.mock';
 import type { PreAggregateModel } from '../../models/PreAggregateModel';
 import { PreAggregateMaterializationService } from './PreAggregateMaterializationService';
 
@@ -276,6 +277,129 @@ describe('PreAggregateMaterializationService', () => {
                 'Materialization query completed without a persisted results file',
         });
         expect(preAggregateModel.promoteToActive).not.toHaveBeenCalled();
+    });
+
+    describe('maxRows promote gate', () => {
+        const definitionWithMaxRows = (resolvedMaxRows: number | null) => ({
+            ...baseStoredPreAggregateDefinition,
+            preAggregateDefinitionUuid: 'def-1',
+            materializationMetricQuery: {
+                metricQuery: {
+                    exploreName: 'orders',
+                    dimensions: [],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    limit: 100,
+                    tableCalculations: [],
+                },
+                metricComponents: {},
+                timeDimensionFieldId: null,
+                resolvedMaxRows,
+            },
+            materializationQueryError: null,
+        });
+
+        const readyQueryHistory = (totalRowCount: number | null) => ({
+            status: QueryHistoryStatus.READY,
+            resultsFileName: 'query-1-results',
+            resultsUpdatedAt: new Date('2024-02-01T10:00:00.000Z'),
+            totalRowCount,
+            columns: null,
+        });
+
+        beforeEach(() => {
+            asyncQueryService.executeAsyncMetricQuery.mockResolvedValue({
+                queryUuid: 'query-1',
+            });
+            preAggregateResultsStorageClient.getFileSize.mockResolvedValue(
+                456789,
+            );
+            preAggregateModel.promoteToActive.mockResolvedValue({
+                status: 'active',
+            });
+        });
+
+        test('marks run as failed without promoting when the row count reaches the persisted cap', async () => {
+            preAggregateModel.getPreAggregateDefinitionByUuid.mockResolvedValue(
+                definitionWithMaxRows(100),
+            );
+            queryHistoryModel.pollForQueryCompletion.mockResolvedValue(
+                readyQueryHistory(100),
+            );
+
+            const result = await service.materializePreAggregate({
+                account: sessionAccount,
+                projectUuid: 'project-1',
+                preAggregateDefinitionUuid: 'def-1',
+                trigger: 'manual',
+            });
+
+            expect(result).toEqual({
+                materializationUuid: 'mat-1',
+                status: 'failed',
+                queryUuid: 'query-1',
+            });
+            expect(preAggregateModel.markFailed).toHaveBeenCalledWith({
+                materializationUuid: 'mat-1',
+                errorMessage:
+                    'Materialization reached the maxRows limit of 100 rows and would serve truncated results. Raise max_rows, add pre-aggregate filters, or coarsen the grain.',
+            });
+            // The gate runs before promotion, so the previous active materialization keeps serving.
+            expect(preAggregateModel.promoteToActive).not.toHaveBeenCalled();
+        });
+
+        test('promotes when the row count is strictly below the persisted cap', async () => {
+            preAggregateModel.getPreAggregateDefinitionByUuid.mockResolvedValue(
+                definitionWithMaxRows(100),
+            );
+            queryHistoryModel.pollForQueryCompletion.mockResolvedValue(
+                readyQueryHistory(99),
+            );
+
+            const result = await service.materializePreAggregate({
+                account: sessionAccount,
+                projectUuid: 'project-1',
+                preAggregateDefinitionUuid: 'def-1',
+                trigger: 'manual',
+            });
+
+            expect(result).toEqual({
+                materializationUuid: 'mat-1',
+                status: 'active',
+                queryUuid: 'query-1',
+            });
+            expect(preAggregateModel.markFailed).not.toHaveBeenCalled();
+            expect(preAggregateModel.promoteToActive).toHaveBeenCalledWith(
+                expect.objectContaining({ rowCount: 99 }),
+            );
+        });
+
+        test('promotes when the warehouse omits the row count', async () => {
+            preAggregateModel.getPreAggregateDefinitionByUuid.mockResolvedValue(
+                definitionWithMaxRows(100),
+            );
+            queryHistoryModel.pollForQueryCompletion.mockResolvedValue(
+                readyQueryHistory(null),
+            );
+
+            const result = await service.materializePreAggregate({
+                account: sessionAccount,
+                projectUuid: 'project-1',
+                preAggregateDefinitionUuid: 'def-1',
+                trigger: 'manual',
+            });
+
+            expect(result).toEqual({
+                materializationUuid: 'mat-1',
+                status: 'active',
+                queryUuid: 'query-1',
+            });
+            expect(preAggregateModel.markFailed).not.toHaveBeenCalled();
+            expect(preAggregateModel.promoteToActive).toHaveBeenCalledWith(
+                expect.objectContaining({ rowCount: null }),
+            );
+        });
     });
 
     test('passes materializationRole only when the pre-aggregate definition configures it', async () => {

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
@@ -1,6 +1,7 @@
 import {
     getErrorMessage,
     getIntrinsicUserAttributes,
+    hasPreAggregateMaterializationReachedMaxRows,
     NotFoundError,
     PRE_AGGREGATE_ROW_COUNT_WARNING_THRESHOLD,
     QueryExecutionContext,
@@ -417,6 +418,81 @@ export class PreAggregateMaterializationService extends BaseService {
                     status: 'failed',
                     queryUuid,
                 };
+            }
+
+            if (
+                hasPreAggregateMaterializationReachedMaxRows({
+                    rowCount: queryHistory.totalRowCount,
+                    resolvedMaxRows: materializationMetricQuery.resolvedMaxRows,
+                })
+            ) {
+                const errorMessage = `Materialization reached the maxRows limit of ${materializationMetricQuery.resolvedMaxRows} rows and would serve truncated results. Raise max_rows, add pre-aggregate filters, or coarsen the grain.`;
+
+                this.logger.warn(
+                    `Pre-aggregate materialization rejected at the maxRows cap`,
+                    {
+                        materializationUuid,
+                        queryUuid,
+                        projectUuid: args.projectUuid,
+                        preAggregateDefinitionUuid:
+                            args.preAggregateDefinitionUuid,
+                        trigger: args.trigger,
+                        rowCount: queryHistory.totalRowCount,
+                        resolvedMaxRows:
+                            materializationMetricQuery.resolvedMaxRows,
+                    },
+                );
+
+                // Failing before promotion keeps the previous active materialization serving.
+                await this.preAggregateModel.markFailed({
+                    materializationUuid,
+                    errorMessage,
+                });
+
+                const durationMs = Date.now() - startTime;
+                this.trackMaterializationFailed({
+                    account: args.account,
+                    materializationUuid,
+                    queryUuid,
+                    projectUuid: args.projectUuid,
+                    preAggregateDefinitionUuid: args.preAggregateDefinitionUuid,
+                    preAggregateName,
+                    trigger: args.trigger,
+                    queryStatus: queryHistory.status,
+                    totalDurationMs: durationMs,
+                    errorMessage,
+                });
+                this.prometheusMetrics?.preAggregateMaterializationCounter?.inc(
+                    { status: 'failed', trigger: args.trigger },
+                );
+                this.prometheusMetrics?.preAggregateMaterializationDurationHistogram?.observe(
+                    { status: 'failed', trigger: args.trigger },
+                    durationMs / 1000,
+                );
+
+                return {
+                    materializationUuid,
+                    status: 'failed',
+                    queryUuid,
+                };
+            }
+
+            if (
+                queryHistory.totalRowCount == null &&
+                materializationMetricQuery.resolvedMaxRows !== null
+            ) {
+                this.logger.warn(
+                    `Pre-aggregate materialization completed without a row count; the maxRows cap cannot be verified`,
+                    {
+                        materializationUuid,
+                        queryUuid,
+                        projectUuid: args.projectUuid,
+                        preAggregateDefinitionUuid:
+                            args.preAggregateDefinitionUuid,
+                        resolvedMaxRows:
+                            materializationMetricQuery.resolvedMaxRows,
+                    },
+                );
             }
 
             const columnCount = queryHistory.columns

--- a/packages/common/src/types/preAggregate.test.ts
+++ b/packages/common/src/types/preAggregate.test.ts
@@ -1,0 +1,43 @@
+import {
+    computePreAggregateWarnings,
+    hasPreAggregateMaterializationReachedMaxRows,
+} from './preAggregate';
+
+describe('hasPreAggregateMaterializationReachedMaxRows', () => {
+    it.each([
+        { rowCount: 100, resolvedMaxRows: 100, expected: true },
+        { rowCount: 101, resolvedMaxRows: 100, expected: true },
+        { rowCount: 99, resolvedMaxRows: 100, expected: false },
+        { rowCount: null, resolvedMaxRows: 100, expected: false },
+        { rowCount: 100, resolvedMaxRows: null, expected: false },
+        { rowCount: null, resolvedMaxRows: null, expected: false },
+    ])(
+        'returns $expected for rowCount=$rowCount and resolvedMaxRows=$resolvedMaxRows',
+        ({ rowCount, resolvedMaxRows, expected }) => {
+            expect(
+                hasPreAggregateMaterializationReachedMaxRows({
+                    rowCount,
+                    resolvedMaxRows,
+                }),
+            ).toBe(expected);
+        },
+    );
+});
+
+describe('computePreAggregateWarnings', () => {
+    it('emits max_rows_applied exactly when the materialization reached the cap', () => {
+        const atCap = computePreAggregateWarnings(
+            { rowCount: 100 },
+            { materializationMaxRows: 100 },
+        );
+        expect(atCap).toEqual([
+            expect.objectContaining({ type: 'max_rows_applied', maxRows: 100 }),
+        ]);
+
+        const underCap = computePreAggregateWarnings(
+            { rowCount: 99 },
+            { materializationMaxRows: 100 },
+        );
+        expect(underCap).toEqual([]);
+    });
+});

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -33,7 +33,27 @@ export type ActiveMaterializationDetails = {
     columns: ResultColumns | null;
     materializedAt: Date;
     totalBytes: number | null;
+    rowCount: number | null;
+    /** Cap from the persisted materialization payload the artifact was built with. */
+    resolvedMaxRows: number | null;
 };
+
+/**
+ * Strictly-under-cap contract shared by the materialization promote gate and
+ * active-materialization resolution: an artifact built with LIMIT resolvedMaxRows
+ * that reports rowCount >= resolvedMaxRows may be truncated, so it must be failed
+ * instead of promoted and never served. Unknown row counts or caps pass.
+ */
+export const hasPreAggregateMaterializationReachedMaxRows = ({
+    rowCount,
+    resolvedMaxRows,
+}: {
+    rowCount: number | null;
+    resolvedMaxRows: number | null;
+}): boolean =>
+    rowCount !== null &&
+    resolvedMaxRows !== null &&
+    rowCount >= resolvedMaxRows;
 
 export type PreAggregateMaterializationRole = {
     email: string;
@@ -232,11 +252,13 @@ export const computePreAggregateWarnings = (
     } = options;
     const warnings: PreAggregateMaterializationWarning[] = [];
 
-    const rowCount = materialization?.rowCount;
+    const rowCount = materialization?.rowCount ?? null;
     if (
-        materializationMaxRows != null &&
-        rowCount != null &&
-        rowCount >= materializationMaxRows
+        materializationMaxRows !== null &&
+        hasPreAggregateMaterializationReachedMaxRows({
+            rowCount,
+            resolvedMaxRows: materializationMaxRows,
+        })
     ) {
         warnings.push({
             type: 'max_rows_applied',
@@ -245,7 +267,7 @@ export const computePreAggregateWarnings = (
         });
     }
 
-    if (rowCount != null && rowCount > rowCountThreshold) {
+    if (rowCount !== null && rowCount > rowCountThreshold) {
         warnings.push({
             type: 'row_count_exceeded',
             message: `This pre-aggregate has ${rowCount.toLocaleString()} rows, which exceeds the recommended threshold of ${rowCountThreshold.toLocaleString()} rows. Large pre-aggregates may take longer to build and consume more storage.`,


### PR DESCRIPTION
Related: ZAP-769

Replaces #26917 on current `main` as an independent PR.

Rejects materializations whose row count reaches their persisted `maxRows` cap before promotion, preserving the previous active artifact. Legacy at-cap artifacts are also prevented from serving; unknown row counts remain compatible.
