### PR TITLE
fix(frontend): save all deep research limits with one update button

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.test.tsx
@@ -78,7 +78,7 @@ describe('AiDeepResearchSettingsPage', () => {
         mutationState.current.isLoading = false;
     });
 
-    it('updates one organization limit while preserving the others', async () => {
+    it('saves all limits with a single update button', async () => {
         const user = userEvent.setup();
         renderWithProviders(
             <MemoryRouter>
@@ -86,43 +86,60 @@ describe('AiDeepResearchSettingsPage', () => {
             </MemoryRouter>,
         );
 
-        const updateButtons = screen.getAllByRole('button', { name: 'Update' });
-        expect(updateButtons).toHaveLength(5);
-        updateButtons.forEach((button) => expect(button).toBeDisabled());
+        const updateButton = screen.getByRole('button', { name: 'Update' });
+        expect(updateButton).toBeDisabled();
 
-        // "Maximum tokens" is the last limit field on the page.
-        const editedIndex = updateButtons.length - 1;
         fireEvent.change(
             screen.getByRole('textbox', { name: 'Maximum tokens' }),
             { target: { value: '9000000' } },
         );
-
-        updateButtons.forEach((button, index) =>
-            index === editedIndex
-                ? expect(button).toBeEnabled()
-                : expect(button).toBeDisabled(),
+        // The time limit is edited in minutes and stored in milliseconds.
+        fireEvent.change(
+            screen.getByRole('textbox', { name: 'Time limit (minutes)' }),
+            { target: { value: '12' } },
         );
+
+        expect(updateButton).toBeEnabled();
 
         updateSettings.mockImplementation(() => {
             mutationState.current.isLoading = true;
         });
-        await user.click(updateButtons[editedIndex]);
+        await user.click(updateButton);
 
-        updateButtons.forEach((button, index) =>
-            index === editedIndex
-                ? expect(button).toHaveAttribute('data-loading')
-                : expect(button).not.toHaveAttribute('data-loading'),
-        );
-
+        expect(updateButton).toHaveAttribute('data-loading');
         expect(updateSettings).toHaveBeenCalledWith({
             deepResearchLimits: {
                 maxTokens: 9_000_000,
                 maxToolCalls: 24,
                 maxWarehouseQueries: 15,
                 maxSteps: 16,
-                deadlineMs: 600_000,
+                deadlineMs: 720_000,
             },
         });
+    });
+
+    it('resets edits with the cancel button', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <MemoryRouter>
+                <AiDeepResearchSettingsPage />
+            </MemoryRouter>,
+        );
+
+        expect(
+            screen.queryByRole('button', { name: 'Cancel' }),
+        ).not.toBeInTheDocument();
+
+        const stepsInput = screen.getByRole('textbox', {
+            name: 'Maximum steps',
+        });
+        fireEvent.change(stepsInput, { target: { value: '20' } });
+
+        await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+        expect(stepsInput).toHaveValue('16');
+        expect(screen.getByRole('button', { name: 'Update' })).toBeDisabled();
+        expect(updateSettings).not.toHaveBeenCalled();
     });
 
     it('shows the query error and allows retrying', async () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.tsx
@@ -1,7 +1,6 @@
 import { type AiDeepResearchLimits } from '@lightdash/common';
 import { Button, Group, Loader, Stack, Text, Title } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { useState } from 'react';
 import ErrorState from '../../../../../../components/common/ErrorState';
 import { NumberInput } from '../../../../../../components/common/NumberInput';
 import {
@@ -14,8 +13,16 @@ import {
     useUpdateAiOrganizationSettings,
 } from '../../../hooks/useAiOrganizationSettings';
 
-const DEEP_RESEARCH_LIMIT_FIELDS: Array<{
-    key: keyof AiDeepResearchLimits;
+type LimitsFormValues = {
+    maxSteps: number;
+    maxToolCalls: number;
+    maxWarehouseQueries: number;
+    maxTokens: number;
+    deadlineMinutes: number;
+};
+
+const LIMIT_FIELDS: Array<{
+    key: keyof LimitsFormValues;
     label: string;
     description: string;
 }> = [
@@ -38,92 +45,102 @@ const DEEP_RESEARCH_LIMIT_FIELDS: Array<{
             'The maximum number of warehouse queries across a deep research run.',
     },
     {
-        key: 'deadlineMs',
-        label: 'Time limit (ms)',
-        description:
-            'The wall-clock limit for a deep research run before it stops and reports what it has.',
-    },
-    {
         key: 'maxTokens',
         label: 'Maximum tokens',
         description:
             'The maximum total model tokens consumed across a deep research run.',
     },
+    {
+        key: 'deadlineMinutes',
+        label: 'Time limit (minutes)',
+        description:
+            'The wall-clock limit for a deep research run before it stops and reports what it has.',
+    },
 ];
+
+const toFormValues = (limits: AiDeepResearchLimits): LimitsFormValues => ({
+    maxSteps: limits.maxSteps,
+    maxToolCalls: limits.maxToolCalls,
+    maxWarehouseQueries: limits.maxWarehouseQueries,
+    maxTokens: limits.maxTokens,
+    deadlineMinutes: Math.round(limits.deadlineMs / 60_000),
+});
+
+const toLimits = (values: LimitsFormValues): AiDeepResearchLimits => ({
+    maxSteps: values.maxSteps,
+    maxToolCalls: values.maxToolCalls,
+    maxWarehouseQueries: values.maxWarehouseQueries,
+    maxTokens: values.maxTokens,
+    deadlineMs: values.deadlineMinutes * 60_000,
+});
 
 const DeepResearchLimitsForm = ({
     initialLimits,
 }: {
     initialLimits: AiDeepResearchLimits;
 }) => {
-    const [updatingLimit, setUpdatingLimit] = useState<
-        keyof AiDeepResearchLimits | null
-    >(null);
-    const updateSettings = useUpdateAiOrganizationSettings({
-        onSettled: () => setUpdatingLimit(null),
-    });
-    const form = useForm({ initialValues: initialLimits });
+    const updateSettings = useUpdateAiOrganizationSettings();
 
-    const updateLimit = (key: keyof AiDeepResearchLimits) => {
-        setUpdatingLimit(key);
-        updateSettings.mutate({
-            deepResearchLimits: {
-                ...initialLimits,
-                [key]: form.values[key],
-            },
-        });
-    };
+    const initialValues = toFormValues(initialLimits);
+    const form = useForm({ initialValues });
+
+    const handleSubmit = form.onSubmit((values) => {
+        updateSettings.mutate({ deepResearchLimits: toLimits(values) });
+    });
+
+    const isUnchanged = LIMIT_FIELDS.every(
+        ({ key }) => form.values[key] === initialValues[key],
+    );
 
     return (
         <SettingsPage
             title="Deep research"
             description="Configure organization-wide safety limits for deep research runs."
         >
-            <Stack gap="lg">
-                {DEEP_RESEARCH_LIMIT_FIELDS.map((field) => (
-                    <SettingsGridCard key={field.key}>
-                        <div>
-                            <Title order={5}>{field.label}</Title>
-                            <Text c="ldGray.6" fz="xs">
-                                {field.description}
-                            </Text>
-                        </div>
+            <SettingsGridCard>
+                <div>
+                    <Title order={5}>Run limits</Title>
+                    <Text c="ldGray.6" fz="xs">
+                        Ceilings applied to every deep research run in your
+                        organization. A run that reaches any of these limits
+                        stops and reports what it has.
+                    </Text>
+                </div>
 
-                        <form
-                            onSubmit={(event) => {
-                                event.preventDefault();
-                                updateLimit(field.key);
-                            }}
-                        >
-                            <Stack gap="md">
-                                <NumberInput
-                                    label={field.label}
-                                    allowDecimal={false}
-                                    allowNegative={false}
-                                    thousandSeparator=","
-                                    {...form.getInputProps(field.key)}
-                                />
-                                <Group justify="flex-end">
-                                    <Button
-                                        type="submit"
-                                        loading={
-                                            updateSettings.isLoading &&
-                                            updatingLimit === field.key
-                                        }
-                                        disabled={
-                                            updateSettings.isLoading ||
-                                            form.values[field.key] ===
-                                                initialLimits[field.key]
-                                        }
-                                    >
-                                        Update
-                                    </Button>
-                                </Group>
-                            </Stack>
-                        </form>
-                    </SettingsGridCard>
-                ))}
-            </Stack>
+                <form onSubmit={handleSubmit}>
+                    <Stack gap="md">
+                        {LIMIT_FIELDS.map((field) => (
+                            <NumberInput
+                                key={field.key}
+                                label={field.label}
+                                description={field.description}
+                                min={1}
+                                allowDecimal={false}
+                                allowNegative={false}
+                                thousandSeparator=","
+                                {...form.getInputProps(field.key)}
+                            />
+                        ))}
+                        <Group justify="flex-end">
+                            {!isUnchanged && !updateSettings.isLoading && (
+                                <Button
+                                    variant="outline"
+                                    onClick={() => form.reset()}
+                                >
+                                    Cancel
+                                </Button>
+                            )}
+                            <Button
+                                type="submit"
+                                loading={updateSettings.isLoading}
+                                disabled={isUnchanged}
+                            >
+                                Update
+                            </Button>
+                        </Group>
+                    </Stack>
+                </form>
+            </SettingsGridCard>
         </SettingsPage>
     );
 };
@@ -140,9 +157,7 @@ export const AiDeepResearchSettingsPage = () => {
     if (!isInitialLoading && !isError && settings) {
         return (
             <DeepResearchLimitsForm
-                key={DEEP_RESEARCH_LIMIT_FIELDS.map(
-                    (field) => settings.deepResearchLimits[field.key],
-                ).join('-')}
+                key={Object.values(settings.deepResearchLimits).join('-')}
                 initialLimits={settings.deepResearchLimits}
             />
         );


### PR DESCRIPTION
## Summary

The deep research settings page rendered five cards, each with its own Update button — one button per limit. This collapses them into the house-standard single form: one `SettingsGridCard`, one dirty-gated Update button, a Cancel button that appears while editing, and the time limit edited in minutes instead of milliseconds (converted to `deadlineMs` only at the API boundary).

```
Before:  5 cards · 5 Update buttons · each saves one limit · time in ms (600000)
After:   1 card  · 1 Update button  · saves all limits at once · time in minutes (10)
```

## Regression analysis

- Same query/mutation hooks and payload shape; one PATCH now carries all five limits.
- No backend/API surface touched.

## Test plan

- [x] Unit tests: single-button save (incl. minutes→ms conversion), Cancel resets edits, error state retries.
- [x] Verified in dev UI: edit, save, success toast, values persist after reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)