### PR TITLE
fix(deep-research): skip unavailable MCP servers

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3444,17 +3444,6 @@ export class AiAgentService extends BaseService {
         });
 
         try {
-            if (setup.unavailableMcpServers.length > 0) {
-                throw new ParameterError(
-                    `Connect or disable these MCP servers before starting Deep Research: ${setup.unavailableMcpServers
-                        .map(
-                            (server) =>
-                                `${server.serverName} (${server.message})`,
-                        )
-                        .join(', ')}`,
-                );
-            }
-
             const ability = this.createAuditedAbility(user);
             const getSubjectAttributes = () => ({
                 organizationUuid: agent.organizationUuid,
@@ -9623,18 +9612,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 debugLoggingEnabled:
                     this.lightdashConfig.ai.copilot.debugLoggingEnabled,
             });
-
-        if (
-            responseExecution.mode === 'deep_research' &&
-            mcpToolSetup.unavailableMcpServers.length > 0
-        ) {
-            await mcpToolSetup.closeMcpClients();
-            throw new ParameterError(
-                `Attached MCP servers became unavailable: ${mcpToolSetup.unavailableMcpServers
-                    .map((server) => server.serverName)
-                    .join(', ')}`,
-            );
-        }
 
         if (
             isSlackPrompt(prompt) &&

--- a/packages/backend/src/ee/services/AiAgentService/mcpBearerCredential.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/mcpBearerCredential.test.ts
@@ -214,12 +214,18 @@ describe('resolveDeepResearchExecutionContext', () => {
         expect(closeMcpClients).toHaveBeenCalledOnce();
     });
 
-    it('rejects unavailable credentials and closes connected MCP clients', async () => {
+    it('keeps healthy MCP tools when another server is unavailable', async () => {
+        const unavailableServer = {
+            ...bearerServer,
+            uuid: 'unavailable-server-uuid',
+            name: 'Unavailable MCP',
+        };
         const { service, closeMcpClients } = buildPreflightService({
+            attachedServers: [bearerServer, unavailableServer],
             unavailableMcpServers: [
                 {
-                    serverUuid: SERVER_UUID,
-                    serverName: bearerServer.name,
+                    serverUuid: unavailableServer.uuid,
+                    serverName: unavailableServer.name,
                     message: 'authentication required',
                     status: 'not_connected',
                 },
@@ -232,9 +238,21 @@ describe('resolveDeepResearchExecutionContext', () => {
                 agentUuid: 'agent-1',
                 modelConfig: null,
             }),
-        ).rejects.toThrow(
-            'Connect or disable these MCP servers before starting Deep Research',
-        );
+        ).resolves.toMatchObject({
+            tools: {
+                availableToolNames: ['mcp_github__search_issues'],
+                attachedMcpServers: expect.arrayContaining([
+                    expect.objectContaining({
+                        uuid: bearerServer.uuid,
+                        enabledToolNames: ['mcp_github__search_issues'],
+                    }),
+                    expect.objectContaining({
+                        uuid: unavailableServer.uuid,
+                        enabledToolNames: [],
+                    }),
+                ]),
+            },
+        });
         expect(closeMcpClients).toHaveBeenCalledOnce();
     });
 });


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9776/deep-research-should-skip-unavailable-mcp-servers-at-startup

## Summary

Deep Research no longer refuses to start when one attached MCP server is unavailable. It continues with healthy MCP and built-in tools while keeping unavailable sources out of the active tool set.

## Root cause

MCP discovery already isolates failures and returns healthy tools alongside unavailable-server metadata. Deep Research added two all-or-nothing guards that discarded that partial success during preflight and again during execution.

```ts
if (setup.unavailableMcpServers.length > 0) {
    throw new ParameterError(...);
}
```

The inherited Deep Research execution settings exposed the mismatch: every attached MCP reaches discovery, but an authorization requirement on any one server aborted the whole run.

## Fix

Remove the Deep Research-only guards and rely on the existing partial-success resolver. Unavailable OAuth sources remain described in model context, while healthy tools continue into the run.

- `AiAgentService.ts` — allow partial MCP discovery at preflight and execution.
- `mcpBearerCredential.test.ts` — cover a healthy server alongside an authorization-required server.

## Before

![Deep Research blocked by unavailable MCP servers](https://uploads.linear.app/63b56e5e-f571-4fec-a07d-c4fe22d5eef5/78c3cd77-a2b5-4e1f-89be-2b3842f09cb5/13ac7fac-72e9-4b5b-8749-2512edb189eb)

## After

```text
Healthy MCP ───── tools ────┐
Unavailable MCP ─ skipped ──┼─> Deep Research starts
Built-in sources ───────────┘
```

## Test plan

- [x] Failing → passing regression: `mcpBearerCredential.test.ts`
- [x] MCP resolver, agent prompt, and preflight suites — 90 tests pass
- [x] Changed backend suites — 95 tests pass
- [x] `pnpm backend-typecheck`
- [x] `pnpm -F backend lint`
- [x] Restarted `ld1-api`; health endpoint returned 200