### PR TITLE
fix(ai): query live data for deep research charts

### DIFF
--- a/packages/backend/src/ee/controllers/AiDeepResearchController.ts
+++ b/packages/backend/src/ee/controllers/AiDeepResearchController.ts
@@ -121,7 +121,7 @@ export class AiDeepResearchController extends BaseController {
 
     /**
      * Re-execute the metric query behind a warehouse-backed report chart to
-     * load its live results instead of the persisted snapshot.
+     * load its live results.
      * @summary Refresh Deep Research chart
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4,7 +4,6 @@ import {
     AgentSuggestion,
     AgentSummaryContext,
     AI_DEEP_RESEARCH_MAX_CONTEXT_ROWS,
-    AI_DEEP_RESEARCH_QUERY_RESULTS_RETENTION_DAYS,
     AiAgent,
     AiAgentEvalRunJobPayload,
     AiAgentEvaluationRun,
@@ -425,9 +424,6 @@ const ALLOWED_AGENT_AVATAR_MIME_TYPES = new Set([
 // wrong" even though the backend job completes and opens the PR. 15s sits
 // comfortably under the usual 30-60s idle timeouts.
 const STREAM_KEEPALIVE_INTERVAL_MS = 15_000;
-const DEEP_RESEARCH_QUERY_RESULTS_EXPIRATION_MS =
-    AI_DEEP_RESEARCH_QUERY_RESULTS_RETENTION_DAYS * 24 * 60 * 60 * 1_000;
-
 const MAX_MCP_BEARER_TOKEN_LENGTH = 8192;
 
 type GenerateAgentExecutionOptions =
@@ -8213,7 +8209,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
             suppressWritebackPreview?: boolean;
             onWarehouseQuery?: () => void | Promise<void>;
-            queryResultsExpirationMs?: number;
         },
     ) {
         const { projectUuid, organizationUuid } = prompt;
@@ -8235,7 +8230,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             agentUuid: runtimeAgentSettings.uuid,
             threadUuid: prompt.threadUuid,
             onWarehouseQuery: options?.onWarehouseQuery,
-            queryResultsExpirationMs: options?.queryResultsExpirationMs,
         });
 
         const getProjectContextDocument: AiAgentDependencies['getProjectContextDocument'] =
@@ -9165,10 +9159,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             onWarehouseQuery:
                 responseExecution.mode === 'deep_research'
                     ? responseExecution.onWarehouseQuery
-                    : undefined,
-            queryResultsExpirationMs:
-                responseExecution.mode === 'deep_research'
-                    ? DEEP_RESEARCH_QUERY_RESULTS_EXPIRATION_MS
                     : undefined,
         });
 

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -203,7 +203,7 @@ function makeRuntimeContext(
 }
 
 describe('AiAgentToolsService', () => {
-    it('retains Deep Research query results for the runtime retention window', async () => {
+    it('extends query result retention when the runtime opts in', async () => {
         vi.useFakeTimers();
         vi.setSystemTime(new Date('2026-07-31T12:00:00.000Z'));
         const executeMetricQueryAndGetResults = vi.fn().mockResolvedValue({

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -1848,7 +1848,6 @@ describe('AiDeepResearchService', () => {
                 title: chart.title,
                 chartConfig: chart.chartConfig,
                 metricQuery: queryHistory.metricQuery,
-                snapshot: null,
             });
         });
 
@@ -1893,8 +1892,8 @@ describe('AiDeepResearchService', () => {
             createdByUserUuid: 'user-1',
             createdByActorType: 'session',
             status: QueryHistoryStatus.READY,
-            resultsFileName: 'evidence.jsonl',
-            resultsExpiresAt: new Date('2099-07-15T12:00:00.000Z'),
+            resultsFileName: null,
+            resultsExpiresAt: new Date('2026-07-15T12:00:00.000Z'),
             metricQuery: {
                 exploreName: 'orders',
                 dimensions: ['orders_order_month'],

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -849,21 +849,7 @@ export class AiDeepResearchService extends BaseService {
             args.projectUuid,
             args.aiDeepResearchRunUuid,
         );
-        const reportExpiresAt = getReportExpiresAt(run);
-        if (
-            run.report_expired_at ||
-            (reportExpiresAt && reportExpiresAt.getTime() <= Date.now())
-        ) {
-            throw new NotFoundError(
-                `Deep Research chart ${args.chartKey} not found`,
-            );
-        }
-        const chart = await this.getChart({
-            user: args.user,
-            projectUuid: args.projectUuid,
-            aiDeepResearchRunUuid: args.aiDeepResearchRunUuid,
-            queryUuid: args.chartKey,
-        });
+        const chart = await this.getRunChart(run, args.chartKey);
 
         const query = await this.asyncQueryService.executeAsyncMetricQuery({
             account: args.account,
@@ -903,30 +889,37 @@ export class AiDeepResearchService extends BaseService {
             args.projectUuid,
             args.aiDeepResearchRunUuid,
         );
+        return this.getRunChart(run, args.queryUuid);
+    }
+
+    private async getRunChart(
+        run: DbAiDeepResearchRun,
+        queryUuid: string,
+    ): Promise<AiDeepResearchChartData> {
         const reportExpiresAt = getReportExpiresAt(run);
         const isExpired =
             run.report_expired_at !== null ||
             (reportExpiresAt && reportExpiresAt.getTime() <= Date.now());
         const isReferenced = findDeepResearchChartRefs(
             run.result_markdown ?? '',
-        ).some(({ key }) => key === args.queryUuid);
+        ).some(({ key }) => key === queryUuid);
         if (isExpired || !isReferenced) {
             throw new NotFoundError(
-                `Deep Research chart ${args.queryUuid} not found`,
+                `Deep Research chart ${queryUuid} not found`,
             );
         }
 
-        const chart = await this.findRunWarehouseChart(run, args.queryUuid);
+        const chart = await this.findRunWarehouseChart(run, queryUuid);
         const chartData = chart
             ? await this.buildWarehouseChartData(
                   run,
                   chart,
-                  new Set([args.queryUuid]),
+                  new Set([queryUuid]),
               )
             : null;
         if (!chartData) {
             throw new NotFoundError(
-                `Deep Research chart ${args.queryUuid} not found`,
+                `Deep Research chart ${queryUuid} not found`,
             );
         }
         return chartData;
@@ -1331,9 +1324,7 @@ export class AiDeepResearchService extends BaseService {
                 queryHistory.createdByUserUuid === run.created_by_user_uuid &&
                 queryHistory.createdAt >= executionStartedAt &&
                 queryHistory.status === QueryHistoryStatus.READY &&
-                queryHistory.resultsFileName !== null &&
-                (!queryHistory.resultsExpiresAt ||
-                    queryHistory.resultsExpiresAt > new Date());
+                queryHistory.resultsFileName !== null;
             if (!isVerified || queryHistory.resultsFileName === null) {
                 return null;
             }
@@ -1402,11 +1393,8 @@ export class AiDeepResearchService extends BaseService {
             (queryHistory.createdByActorType === 'session' ||
                 queryHistory.createdByActorType === 'pat') &&
             queryHistory.status === QueryHistoryStatus.READY &&
-            queryHistory.resultsFileName !== null &&
-            (!queryHistory.resultsExpiresAt ||
-                queryHistory.resultsExpiresAt > new Date()) &&
             isChartConfigCompatible(chart, queryHistory.metricQuery);
-        if (!isVerified || queryHistory.resultsFileName === null) {
+        if (!isVerified) {
             return null;
         }
 
@@ -1417,7 +1405,6 @@ export class AiDeepResearchService extends BaseService {
             queryUuid: chart.queryUuid,
             metricQuery: queryHistory.metricQuery,
             fields: queryHistory.fields,
-            snapshot: null,
         };
     }
 

--- a/packages/common/src/ee/aiDeepResearch/markdown.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.ts
@@ -48,7 +48,7 @@ const rejectGroupBy = (
     chartConfig: AiDeepResearchChartConfig,
     context: z.RefinementCtx,
 ) => {
-    // Grouped charts need a pivoted execution; snapshots are unpivoted.
+    // Grouped charts need a pivoted execution; report chart results are unpivoted.
     if (chartConfig.groupBy?.length) {
         context.addIssue({
             code: 'custom',
@@ -61,8 +61,8 @@ const rejectGroupBy = (
 
 /**
  * A chart backed by a completed run_metric_query execution. Every report chart
- * is one of these: the backend verifies the queryUuid and injects the snapshot
- * at publish time, so a chart can never assert data no query produced.
+ * is one of these: the backend verifies the queryUuid before using its metric
+ * query for live execution, so a chart can never assert a query the run did not make.
  */
 const warehouseChartObjectSchema = z.object({
     source: z.literal('warehouse'),

--- a/packages/common/src/ee/aiDeepResearch/types.test.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.test.ts
@@ -1,16 +1,12 @@
 import {
     AI_DEEP_RESEARCH_QUERY_HISTORY_RETENTION_DAYS,
-    AI_DEEP_RESEARCH_QUERY_RESULTS_RETENTION_DAYS,
     AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS,
 } from './types';
 
 describe('Deep Research retention policy', () => {
-    it('keeps query data and history longer than the report', () => {
-        expect(AI_DEEP_RESEARCH_QUERY_RESULTS_RETENTION_DAYS).toBeGreaterThan(
-            AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS,
-        );
+    it('keeps query history longer than the report', () => {
         expect(AI_DEEP_RESEARCH_QUERY_HISTORY_RETENTION_DAYS).toBeGreaterThan(
-            AI_DEEP_RESEARCH_QUERY_RESULTS_RETENTION_DAYS,
+            AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS,
         );
     });
 });

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -3,7 +3,6 @@ import { type ItemsMap } from '../../types/field';
 import { type MetricQuery } from '../../types/metricQuery';
 
 export const AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS = 30;
-export const AI_DEEP_RESEARCH_QUERY_RESULTS_RETENTION_DAYS = 31;
 export const AI_DEEP_RESEARCH_QUERY_HISTORY_RETENTION_DAYS = 32;
 
 export const AI_DEEP_RESEARCH_RUN_STATUSES = [
@@ -227,19 +226,6 @@ export type AiDeepResearchChartConfig = {
     secondaryYAxisLabel: string | null;
 };
 
-export type AiDeepResearchChartSnapshotValue = string | number | boolean | null;
-
-/** The rendered dataset of a report chart, frozen at publish time. */
-export type AiDeepResearchChartSnapshot = {
-    takenAt: string;
-    rowCount: number;
-    truncated: boolean;
-    /** Field ids ordering the values in each row. */
-    columnOrder: string[];
-    /** Raw row values ordered by `columnOrder`; formatted client-side. */
-    rows: AiDeepResearchChartSnapshotValue[][];
-};
-
 /**
  * Everything the UI needs to render one report chart. Derived on demand from
  * the execution the chart references; the markdown only carries compact
@@ -254,8 +240,6 @@ export type AiDeepResearchChartData = {
     metricQuery: MetricQuery;
     /** Selected + filter fields; drives labels and value formatting. */
     fields: ItemsMap;
-    /** Null only for reports persisted before snapshots existed. */
-    snapshot: AiDeepResearchChartSnapshot | null;
 };
 
 export const AI_DEEP_RESEARCH_EVENT_TYPES = [

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.test.tsx
@@ -1,5 +1,5 @@
 import { type AiDeepResearchChartData } from '@lightdash/common';
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { type ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
@@ -89,24 +89,15 @@ const chart: AiDeepResearchChartData = {
         additionalMetrics: [],
     } as AiDeepResearchChartData['metricQuery'],
     fields: {},
-    snapshot: {
-        takenAt: '2026-07-15T09:18:00.000Z',
-        rowCount: 2,
-        truncated: false,
-        columnOrder: ['orders_order_month', 'orders_total_revenue'],
-        rows: [
-            ['2026-05', 120],
-            ['2026-06', 90],
-        ],
-    },
 };
 
 const idleLiveQuery = {
     isLoading: false,
+    isFetching: false,
     isError: false,
     error: null,
     refetch: vi.fn(),
-    data: undefined,
+    data: { query: { queryUuid: 'live-query-uuid' } },
 };
 
 const idleResults = {
@@ -123,6 +114,7 @@ const renderTile = (chartOverrides: Partial<AiDeepResearchChartData> = {}) =>
             chart={{ ...chart, ...chartOverrides }}
             projectUuid="project-1"
             runUuid="run-1"
+            reportRunAt="2026-07-15T09:18:00.000Z"
         />,
     );
 
@@ -132,7 +124,7 @@ describe('DeepResearchChartTile', () => {
         mocks.useQueryResults.mockReturnValue(idleResults);
     });
 
-    it('renders the snapshot without executing any query', () => {
+    it('executes and renders a live query', () => {
         renderTile();
 
         expect(screen.getByTestId('visualization')).toHaveTextContent(
@@ -141,13 +133,19 @@ describe('DeepResearchChartTile', () => {
         expect(
             screen.getByRole('figure', { name: chart.title }),
         ).toBeInTheDocument();
-        expect(screen.getByText(/Snapshot from/)).toBeVisible();
+        expect(
+            screen.getByText(/Report data as of .*; chart shows live data/),
+        ).toBeVisible();
         expect(mocks.useLiveQuery).toHaveBeenCalledWith({
             projectUuid: 'project-1',
             runUuid: 'run-1',
             chartKey: QUERY_UUID,
-            enabled: false,
         });
+        expect(mocks.useQueryResults).toHaveBeenLastCalledWith(
+            'project-1',
+            'live-query-uuid',
+            chart.title,
+        );
         expect(screen.getByTestId('visualization')).toHaveAttribute(
             'data-display-fields',
             'false',
@@ -176,33 +174,18 @@ describe('DeepResearchChartTile', () => {
         expect(screen.queryByTestId('filter-pills')).not.toBeInTheDocument();
     });
 
-    it('switches to live data on demand', () => {
+    it('shows a loader while the live query is starting', () => {
+        mocks.useLiveQuery.mockReturnValue({
+            ...idleLiveQuery,
+            isLoading: true,
+            data: undefined,
+        });
         renderTile();
 
-        fireEvent.click(screen.getByRole('button', { name: 'View live data' }));
-
-        expect(mocks.useLiveQuery).toHaveBeenLastCalledWith({
-            projectUuid: 'project-1',
-            runUuid: 'run-1',
-            chartKey: QUERY_UUID,
-            enabled: true,
-        });
-    });
-
-    it('loads the retained query directly when the report has no snapshot', () => {
-        renderTile({ snapshot: null });
-
-        expect(mocks.useLiveQuery).toHaveBeenCalledWith(
-            expect.objectContaining({ enabled: false }),
+        expect(mocks.useLiveQuery).toHaveBeenLastCalledWith(
+            expect.objectContaining({ chartKey: QUERY_UUID }),
         );
-        expect(mocks.useQueryResults).toHaveBeenCalledWith(
-            'project-1',
-            QUERY_UUID,
-            chart.title,
-        );
-        expect(screen.getByText('Report data')).toBeVisible();
-        expect(screen.getByTestId('visualization')).toBeVisible();
-        expect(screen.queryByText(/Snapshot from/)).not.toBeInTheDocument();
+        expect(screen.getByText('Loading live chart data')).toBeVisible();
     });
 
     it('shows the live error state even while a page fetch is marked in-flight', () => {
@@ -219,7 +202,7 @@ describe('DeepResearchChartTile', () => {
             refetchRows,
         });
 
-        renderTile({ snapshot: null });
+        renderTile();
 
         expect(
             screen.getByText(

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
@@ -1,20 +1,12 @@
 import {
-    AiResultType,
-    formatRows,
     type AiDeepResearchChartData,
-    type ApiAiAgentThreadMessageVizQuery,
     type ToolRunQueryArgs,
 } from '@lightdash/common';
-import { Box, Button, Group, Text } from '@mantine/core';
-import { IconCamera, IconRefresh } from '@tabler/icons-react';
-import { useMemo, useState } from 'react';
+import { Box, Group, Text } from '@mantine/core';
+import { useMemo } from 'react';
 import EmptyStateLoader from '../../../../../components/common/EmptyStateLoader';
 import InlineErrorState from '../../../../../components/common/InlineErrorState';
-import MantineIcon from '../../../../../components/common/MantineIcon';
-import {
-    useInfiniteQueryResults,
-    type InfiniteQueryResults,
-} from '../../../../../hooks/useQueryResults';
+import { useInfiniteQueryResults } from '../../../../../hooks/useQueryResults';
 import { useDeepResearchChartLiveQuery } from '../../hooks/useDeepResearch';
 import AgentVisualizationFilters from '../ChatElements/AgentVisualizationFilters';
 import { AiVisualizationRenderer } from '../ChatElements/AiVisualizationRenderer';
@@ -26,92 +18,26 @@ type Props = {
     chart: AiDeepResearchChartData;
     projectUuid: string;
     runUuid: string;
+    reportRunAt: string;
 };
-
-const noop = () => {};
-const asyncNoop = async () => {};
 
 export const DeepResearchChartTile = ({
     chartKey,
     chart,
     projectUuid,
     runUuid,
+    reportRunAt,
 }: Props) => {
-    const hasSnapshot = chart.snapshot !== null;
-    const canRefresh = chart.source === 'warehouse' && hasSnapshot;
-    const [view, setView] = useState<'snapshot' | 'live'>(
-        hasSnapshot ? 'snapshot' : 'live',
-    );
-    const isLive = view === 'live' && chart.source === 'warehouse';
-
     const liveQuery = useDeepResearchChartLiveQuery({
         projectUuid,
         runUuid,
         chartKey,
-        enabled: isLive && hasSnapshot,
     });
     const liveResults = useInfiniteQueryResults(
         projectUuid,
-        isLive
-            ? hasSnapshot
-                ? liveQuery.data?.query.queryUuid
-                : (chart.queryUuid ?? undefined)
-            : undefined,
+        liveQuery.data?.query.queryUuid,
         chart.title,
     );
-
-    const snapshotVizQueryData = useMemo<ApiAiAgentThreadMessageVizQuery>(
-        () => ({
-            source: 'semantic',
-            type: AiResultType.QUERY_RESULT,
-            query: {
-                queryUuid: chart.queryUuid ?? chartKey,
-                cacheMetadata: { cacheHit: false },
-                metricQuery: chart.metricQuery,
-                fields: chart.fields,
-                warnings: [],
-                parameterReferences: [],
-                usedParametersValues: {},
-                resolvedTimezone: chart.metricQuery.timezone ?? null,
-            },
-            metadata: { title: chart.title, description: null },
-        }),
-        [chart, chartKey],
-    );
-    const snapshotResults = useMemo<InfiniteQueryResults>(() => {
-        const snapshot = chart.snapshot;
-        const rawRows =
-            snapshot?.rows.map((row) =>
-                Object.fromEntries(
-                    snapshot.columnOrder.map((columnId, index) => [
-                        columnId,
-                        row[index],
-                    ]),
-                ),
-            ) ?? [];
-        return {
-            rows: formatRows(rawRows, chart.fields),
-            totalResults: snapshot?.rowCount ?? 0,
-            isInitialLoading: false,
-            isFetchingFirstPage: false,
-            isFetchingRows: false,
-            isFetchingAllPages: false,
-            fetchMoreRows: noop,
-            refetchRows: asyncNoop,
-            setFetchAll: noop,
-            fetchAll: true,
-            hasFetchedAllRows: !snapshot?.truncated,
-            totalClientFetchTimeMs: undefined,
-            error: null,
-        };
-    }, [chart]);
-
-    const vizQueryData = isLive
-        ? hasSnapshot
-            ? liveQuery.data
-            : snapshotVizQueryData
-        : snapshotVizQueryData;
-    const results = isLive ? liveResults : snapshotResults;
 
     const visualizationConfig = useMemo<ToolRunQueryArgs>(() => {
         const metricQuery = chart.metricQuery;
@@ -135,17 +61,12 @@ export const DeepResearchChartTile = ({
         };
     }, [chart]);
 
-    const liveError =
-        (hasSnapshot ? liveQuery.error : null) ?? liveResults.error;
-    const isLoadingLive =
-        isLive &&
-        ((hasSnapshot && liveQuery.isLoading) || liveResults.isFetchingRows);
+    const liveError = liveQuery.error ?? liveResults.error;
+    const isLoadingLive = liveQuery.isFetching || liveResults.isFetchingRows;
     const appliedFilters = chart.metricQuery.filters;
     const displayFilterPills =
         shouldDisplayVisualizationFilters(appliedFilters);
-    const snapshotTakenAt = chart.snapshot
-        ? new Date(chart.snapshot.takenAt)
-        : null;
+    const reportRunDate = new Date(reportRunAt).toLocaleDateString();
 
     return (
         <Box
@@ -154,48 +75,12 @@ export const DeepResearchChartTile = ({
             aria-label={chart.title}
         >
             <Group gap="xs" justify="space-between" mb="xs" wrap="wrap">
-                <Group gap="xs">
-                    {!isLive && snapshotTakenAt ? (
-                        <Group gap={4}>
-                            <MantineIcon
-                                icon={IconCamera}
-                                size={12}
-                                color="gray.6"
-                            />
-                            <Text size="xs" c="dimmed">
-                                Snapshot from{' '}
-                                {snapshotTakenAt.toLocaleDateString()}
-                            </Text>
-                        </Group>
-                    ) : null}
-                    {isLive ? (
-                        <Text size="xs" c="dimmed">
-                            {hasSnapshot ? 'Live data' : 'Report data'}
-                        </Text>
-                    ) : null}
-                </Group>
-                {canRefresh ? (
-                    <Button
-                        size="compact-xs"
-                        variant="subtle"
-                        color="ldGray"
-                        leftSection={
-                            <MantineIcon
-                                icon={isLive ? IconCamera : IconRefresh}
-                                size={12}
-                            />
-                        }
-                        onClick={() =>
-                            setView(isLive && hasSnapshot ? 'snapshot' : 'live')
-                        }
-                        disabled={isLive && !hasSnapshot}
-                    >
-                        {isLive ? 'View snapshot' : 'View live data'}
-                    </Button>
-                ) : null}
+                <Text size="xs" c="dimmed">
+                    Report data as of {reportRunDate}; chart shows live data
+                </Text>
             </Group>
-            <Box flex="1" mih={0} miw={0} w="100%">
-                {isLive && liveError ? (
+            <Box>
+                {liveError ? (
                     <InlineErrorState
                         message="The live data for this chart could not be loaded."
                         onRetry={() => {
@@ -205,12 +90,12 @@ export const DeepResearchChartTile = ({
                             }
                         }}
                     />
-                ) : isLoadingLive || !vizQueryData ? (
+                ) : isLoadingLive || !liveQuery.data ? (
                     <EmptyStateLoader title="Loading live chart data" />
                 ) : (
                     <AiVisualizationRenderer
-                        vizQueryData={vizQueryData}
-                        results={results}
+                        vizQueryData={liveQuery.data}
+                        results={liveResults}
                         chartConfig={visualizationConfig}
                         selectedChartType={chart.chartConfig.defaultVizType}
                         displayFields={false}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.test.tsx
@@ -18,7 +18,7 @@ vi.mock('./DeepResearchChartTile', () => ({
 const queryUuid = '7c4b40ba-79f8-4fd2-9c43-223eca8fa76f';
 
 describe('DeepResearchMarkdownReport', () => {
-    it('hydrates a query-backed chart when no legacy snapshot exists', async () => {
+    it('hydrates a live query-backed chart', async () => {
         mocks.useChartQuery.mockReturnValue({
             isLoading: false,
             data: { title: 'Revenue trend' },
@@ -29,6 +29,7 @@ describe('DeepResearchMarkdownReport', () => {
                 markdown={`## Finding\n\n<chart id="${queryUuid}" title="Revenue trend" description="Revenue by month.">`}
                 projectUuid="project-1"
                 runUuid="run-1"
+                reportRunAt="2026-07-15T09:18:00.000Z"
             />,
         );
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
@@ -25,6 +25,7 @@ import styles from './DeepResearchReport.module.css';
 const DeepResearchReportContext = createContext<{
     projectUuid: string;
     runUuid: string;
+    reportRunAt: string;
 } | null>(null);
 
 const CONFIDENCE_COLORS: Record<AiDeepResearchConfidence, string> = {
@@ -68,7 +69,8 @@ const QueryBackedChart: FC<{
     projectUuid: string;
     runUuid: string;
     queryUuid: string;
-}> = ({ projectUuid, runUuid, queryUuid }) => {
+    reportRunAt: string;
+}> = ({ projectUuid, runUuid, queryUuid, reportRunAt }) => {
     const chartQuery = useDeepResearchChartQuery({
         projectUuid,
         runUuid,
@@ -90,13 +92,14 @@ const QueryBackedChart: FC<{
             chart={chartQuery.data}
             projectUuid={projectUuid}
             runUuid={runUuid}
+            reportRunAt={reportRunAt}
         />
     );
 };
 
 /**
  * Chart tags are converted to these internal links before rendering and
- * hydrate into chart tiles from the run's persisted chart data. Every other
+ * hydrate into chart tiles from the run's persisted chart metadata. Every other
  * link renders as a regular external anchor.
  */
 const ReportLink: FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
@@ -120,6 +123,7 @@ const ReportLink: FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
                 projectUuid={context.projectUuid}
                 runUuid={context.runUuid}
                 queryUuid={chartKey}
+                reportRunAt={context.reportRunAt}
             />
         );
     }
@@ -184,26 +188,28 @@ type Props = {
     markdown: string;
     projectUuid: string;
     runUuid: string;
+    reportRunAt: string;
 };
 
 /**
  * Renders a deep research report markdown document as one linear flow:
  * prose via streamdown, <chart> references hydrated into
- * chart tiles from the run's chart data, and the whitelisted
+ * chart tiles from the run's chart metadata, and the whitelisted
  * callout/confidence tags mapped to house components.
  */
 export const DeepResearchMarkdownReport: FC<Props> = ({
     markdown,
     projectUuid,
     runUuid,
+    reportRunAt,
 }) => {
     const renderMarkdown = useMemo(
         () => renderDeepResearchChartRefs(markdown),
         [markdown],
     );
     const contextValue = useMemo(
-        () => ({ projectUuid, runUuid }),
-        [projectUuid, runUuid],
+        () => ({ projectUuid, runUuid, reportRunAt }),
+        [projectUuid, runUuid, reportRunAt],
     );
     return (
         <DeepResearchReportContext.Provider value={contextValue}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -221,7 +221,7 @@
         flex: 1;
     }
 
-    /* The snapshot/live header keeps its intrinsic height. */
+    /* The report/live-data label keeps its intrinsic height. */
     > :first-child {
         flex: 0 0 auto;
     }

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -89,30 +89,6 @@ describe('DeepResearchReport', () => {
         ).toBe(true);
     });
 
-    it.each([
-        {
-            timestamps: { completedAt: null },
-            expected: deepResearchRunFixture.startedAt,
-        },
-        {
-            timestamps: { completedAt: null, startedAt: null },
-            expected: deepResearchRunFixture.updatedAt,
-        },
-    ])(
-        'falls back to $expected for the report date',
-        async ({ timestamps, expected }) => {
-            mocks.useChartQuery.mockReturnValue({
-                isLoading: false,
-                data: { title: 'Enterprise retention by incident exposure' },
-            });
-            renderReport(vi.fn(), { ...deepResearchRunFixture, ...timestamps });
-
-            expect(
-                await screen.findByTestId('deep-research-chart'),
-            ).toHaveAttribute('data-report-run-at', expected);
-        },
-    );
-
     it('renders confidence tags as badges with their caveats', async () => {
         renderReport();
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -15,8 +15,16 @@ vi.mock('../../hooks/useDeepResearch', async (importOriginal) => ({
 }));
 
 vi.mock('./DeepResearchChartTile', () => ({
-    DeepResearchChartTile: ({ chart }: { chart: { title: string } }) => (
-        <div data-testid="deep-research-chart">{chart.title}</div>
+    DeepResearchChartTile: ({
+        chart,
+        reportRunAt,
+    }: {
+        chart: { title: string };
+        reportRunAt: string;
+    }) => (
+        <div data-testid="deep-research-chart" data-report-run-at={reportRunAt}>
+            {chart.title}
+        </div>
     ),
 }));
 
@@ -58,6 +66,10 @@ describe('DeepResearchReport', () => {
         expect(chart).toHaveTextContent(
             'Enterprise retention by incident exposure',
         );
+        expect(chart).toHaveAttribute(
+            'data-report-run-at',
+            deepResearchRunFixture.completedAt,
+        );
         expect(
             screen.queryByText(
                 'Three incident-affected renewals account for most churn in the quarter.',
@@ -76,6 +88,30 @@ describe('DeepResearchReport', () => {
             ),
         ).toBe(true);
     });
+
+    it.each([
+        {
+            timestamps: { completedAt: null },
+            expected: deepResearchRunFixture.startedAt,
+        },
+        {
+            timestamps: { completedAt: null, startedAt: null },
+            expected: deepResearchRunFixture.updatedAt,
+        },
+    ])(
+        'falls back to $expected for the report date',
+        async ({ timestamps, expected }) => {
+            mocks.useChartQuery.mockReturnValue({
+                isLoading: false,
+                data: { title: 'Enterprise retention by incident exposure' },
+            });
+            renderReport(vi.fn(), { ...deepResearchRunFixture, ...timestamps });
+
+            expect(
+                await screen.findByTestId('deep-research-chart'),
+            ).toHaveAttribute('data-report-run-at', expected);
+        },
+    );
 
     it('renders confidence tags as badges with their caveats', async () => {
         renderReport();

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -95,7 +95,7 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
         return () => window.cancelAnimationFrame(frame);
     }, [opened, reportHeadings]);
 
-    if (!run.resultMarkdown) {
+    if (!run.resultMarkdown || !run.completedAt) {
         return null;
     }
 
@@ -228,11 +228,7 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                                 markdown={run.resultMarkdown}
                                 projectUuid={run.projectUuid}
                                 runUuid={run.uuid}
-                                reportRunAt={
-                                    run.completedAt ??
-                                    run.startedAt ??
-                                    run.updatedAt
-                                }
+                                reportRunAt={run.completedAt}
                             />
                         </Stack>
                     </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -228,6 +228,11 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                                 markdown={run.resultMarkdown}
                                 projectUuid={run.projectUuid}
                                 runUuid={run.uuid}
+                                reportRunAt={
+                                    run.completedAt ??
+                                    run.startedAt ??
+                                    run.updatedAt
+                                }
                             />
                         </Stack>
                     </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
@@ -9,6 +9,7 @@ import {
 import { type DeepResearchRunRegistration } from '../deepResearch/types';
 import {
     useHasActiveDeepResearchRun,
+    useDeepResearchChartLiveQuery,
     useDeepResearchRun,
     useStartDeepResearchMutation,
     useTrackDeepResearchFollowUp,
@@ -113,6 +114,52 @@ const getWrapper = () => {
         </QueryClientProvider>
     );
 };
+
+describe('useDeepResearchChartLiveQuery', () => {
+    afterEach(() => {
+        lightdashApiMock.mockReset();
+    });
+
+    it('executes the chart query again when the report chart remounts', async () => {
+        const queryClient = new QueryClient({
+            defaultOptions: {
+                queries: {
+                    retry: false,
+                    cacheTime: Infinity,
+                    staleTime: Infinity,
+                },
+            },
+        });
+        const wrapper = ({ children }: PropsWithChildren) => (
+            <QueryClientProvider client={queryClient}>
+                {children}
+            </QueryClientProvider>
+        );
+        lightdashApiMock.mockResolvedValue({
+            query: { queryUuid: 'live-query-uuid' },
+        });
+        const renderLiveQuery = () =>
+            renderHook(
+                () =>
+                    useDeepResearchChartLiveQuery({
+                        projectUuid: 'project-1',
+                        runUuid: 'run-1',
+                        chartKey: 'chart-1',
+                    }),
+                { wrapper },
+            );
+
+        const firstView = renderLiveQuery();
+        await waitFor(() =>
+            expect(firstView.result.current.isSuccess).toBe(true),
+        );
+        firstView.unmount();
+
+        const secondView = renderLiveQuery();
+        await waitFor(() => expect(lightdashApiMock).toHaveBeenCalledTimes(2));
+        secondView.unmount();
+    });
+});
 
 describe('useStartDeepResearchMutation', () => {
     afterEach(() => {

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -517,18 +517,16 @@ export const useCancelDeepResearchMutation = (
 
 /**
  * Re-executes the stored metric query behind a warehouse-backed report
- * chart. Only runs when the user asks for live data (`enabled`).
+ * chart. Report charts use this as their only render path.
  */
 export const useDeepResearchChartLiveQuery = ({
     projectUuid,
     runUuid,
     chartKey,
-    enabled,
 }: {
     projectUuid: string;
     runUuid: string;
     chartKey: string;
-    enabled: boolean;
 }) =>
     useQuery<ApiAiAgentThreadMessageVizQuery, ApiError>({
         queryKey: [
@@ -540,8 +538,7 @@ export const useDeepResearchChartLiveQuery = ({
             'live',
         ],
         queryFn: () => refreshDeepResearchChart(projectUuid, runUuid, chartKey),
-        enabled,
-        staleTime: Infinity,
+        refetchOnMount: 'always',
         refetchOnWindowFocus: false,
     });
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9767/deep-research-charts-always-query-live-data

## Summary

Deep Research report charts stop loading after the original query result disappears from the one-day object-storage cache. Report charts now execute their verified metric query whenever the chart is viewed and clearly distinguish the report completion date from live chart data.

## Root cause

Deep Research extended query-result metadata to 31 days, but the underlying result object still followed the one-day cache lifecycle. Chart hydration therefore treated an expired or missing original result as an invalid chart before the refresh path could run.

```ts
queryHistory.status === QueryHistoryStatus.READY &&
queryHistory.resultsFileName !== null &&
queryHistory.resultsExpiresAt > new Date()
```

The persisted chart-data path was already removed by #27043. The remaining metadata checks kept post-publish rendering coupled to the original result object.

## Fix

Report charts retain server-owned provenance and access checks, then execute the stored metric query through the existing async query path on every mount. Ordinary one-day query caching remains enabled to bound repeated warehouse cost.

- `packages/backend` — removes Deep Research result-retention wiring and validates chart metadata without requiring the original result file.
- `packages/common` — removes the 31-day result-retention constant and obsolete chart snapshot contract.
- `packages/frontend` — removes snapshot mode, refreshes on every chart mount, and labels the canonical report completion date versus live chart data.
- No compatibility fallback is retained for reports without `completedAt`; the feature is unreleased and report persistence writes markdown and completion time atomically.
- Evidence-pack reads during report generation and 30-day report retention remain unchanged.

## Before

```text
view report chart
        │
        ▼
original query UUID ──▶ one-day result object ──▶ 404 after expiry
```

## After

```text
view report chart
        │
        ▼
verified metric query ──▶ async execution ──▶ ordinary one-day cache ──▶ chart
```

## Test plan

- [x] `pnpm -F common typecheck && pnpm -F common lint`
- [x] `pnpm -F backend typecheck && pnpm -F backend lint`
- [x] `pnpm -F frontend typecheck && pnpm -F frontend lint`
- [x] Common Deep Research tests — 31 passed
- [x] Backend Deep Research/tool-runtime tests — 100 passed
- [x] Frontend report chart, markdown, report-flow, and remount tests — 25 passed
- [x] `pnpm generate-api` — generated contract validation passed; generated artifacts are release-managed
- [x] Restarted the local backend and verified health plus the authenticated refresh-route boundary