### PR TITLE
fix: mint signed download URLs for data-app SDK exports

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -14,6 +14,7 @@ import {
     isExecuteAsyncDashboardSqlChartByUuidParams,
     isExecuteAsyncSqlChartByUuidParams,
     isJwtUser,
+    LightdashSignedDownloadHeader,
     PersistentDownloadFileAccessMode,
     QueryExecutionContext,
     type ApiDownloadAsyncQueryResults,
@@ -616,10 +617,19 @@ export class QueryController extends BaseController {
     ): Promise<ApiJobScheduledResponse> {
         this.setStatus(200);
 
+        // The data-app SDK bridge (and CLI preview proxy) stamp this header
+        // because the app fetches the resulting fileUrl from a sandboxed,
+        // credential-less context — only a SIGNED URL survives that fetch.
+        const wantsSignedDownload =
+            req.header(LightdashSignedDownloadHeader) === 'true';
+
         const jobId = await this.services
             .getAsyncQueryService()
             .scheduleDownloadAsyncQueryResults({
                 account: req.account!,
+                fileAccessMode: wantsSignedDownload
+                    ? PersistentDownloadFileAccessMode.SIGNED
+                    : undefined,
                 projectUuid,
                 queryUuid,
                 type: body.type,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -6500,11 +6500,13 @@ export default class SchedulerTask {
                 const account = await this.userService.getAccountByUserUuid(
                     payload.userUuid,
                 );
+                const { fileAccessMode, ...downloadArgs } = payload;
                 return this.asyncQueryService.download({
                     account,
                     accessMode:
+                        fileAccessMode ??
                         PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
-                    ...payload,
+                    ...downloadArgs,
                 });
             },
         );

--- a/packages/cli/src/handlers/apps/previewProxy.test.ts
+++ b/packages/cli/src/handlers/apps/previewProxy.test.ts
@@ -1,3 +1,4 @@
+import { LightdashSignedDownloadHeader } from '@lightdash/common';
 import * as http from 'http';
 import {
     PREVIEW_PROXY_NONCE_HEADER,
@@ -120,6 +121,34 @@ describe('startPreviewProxy', () => {
         expect(forwarded.headers.authorization).toBe(AUTHORIZATION);
         // …and the run-scoped nonce never travels upstream.
         expect(forwarded.headers[PREVIEW_PROXY_NONCE_HEADER]).toBeUndefined();
+    });
+
+    it('stamps the signed-download header on schedule-download and nothing else', async () => {
+        await proxyFetch(
+            `/api/v2/projects/${PROJECT_UUID}/query/some-query-uuid/schedule-download`,
+            {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    authorization: `ApiKey ${NONCE}`,
+                },
+                body: JSON.stringify({ type: 'csv' }),
+            },
+        );
+        await proxyFetch(
+            `/api/v2/projects/${PROJECT_UUID}/query/some-query-uuid`,
+        );
+        expect(upstream.seen).toHaveLength(2);
+        expect(
+            upstream.seen[0].headers[
+                LightdashSignedDownloadHeader.toLowerCase()
+            ],
+        ).toBe('true');
+        expect(
+            upstream.seen[1].headers[
+                LightdashSignedDownloadHeader.toLowerCase()
+            ],
+        ).toBeUndefined();
     });
 
     it('preserves the query string on result polling', async () => {

--- a/packages/cli/src/handlers/apps/previewProxy.ts
+++ b/packages/cli/src/handlers/apps/previewProxy.ts
@@ -1,6 +1,8 @@
 import {
     extractAppSdkRouteProjectUuid,
     isAllowedAppSdkRoute,
+    isAppSdkScheduleDownloadRoute,
+    LightdashSignedDownloadHeader,
 } from '@lightdash/common';
 import { timingSafeEqual } from 'crypto';
 import * as http from 'http';
@@ -148,6 +150,12 @@ export const startPreviewProxy = (args: {
         headers.authorization = args.authorization;
         if (args.proxyAuthorization) {
             headers['proxy-authorization'] = args.proxyAuthorization;
+        }
+        // The previewed app fetches the export's fileUrl directly from the
+        // local dev page, which carries no instance credentials — ask the
+        // backend for a SIGNED URL, same as the deployed app's bridge.
+        if (isAppSdkScheduleDownloadRoute(method, pathname)) {
+            headers[LightdashSignedDownloadHeader.toLowerCase()] = 'true';
         }
 
         const upstreamReq = requestFn(

--- a/packages/common/src/ee/apps/sdkBridgeRoutes.ts
+++ b/packages/common/src/ee/apps/sdkBridgeRoutes.ts
@@ -14,6 +14,23 @@ export type AppSdkAllowedRoute = {
     pattern: RegExp;
 };
 
+const SCHEDULE_DOWNLOAD_PATTERN =
+    /^\/api\/v2\/projects\/[^/]+\/query\/[^/]+\/schedule-download$/;
+
+/**
+ * The one allowlisted route whose response triggers a follow-up fetch the app
+ * performs OUTSIDE the bridge: the SDK anchor-clicks the returned fileUrl from
+ * inside the sandboxed iframe, which cannot attach session cookies. Both
+ * mediators stamp `LightdashSignedDownloadHeader` on this route so the backend
+ * mints a SIGNED (token/presigned) URL that survives that credential-less
+ * fetch.
+ */
+export const isAppSdkScheduleDownloadRoute = (
+    method: string,
+    path: string,
+): boolean =>
+    method.toUpperCase() === 'POST' && SCHEDULE_DOWNLOAD_PATTERN.test(path);
+
 export const APP_SDK_ALLOWED_ROUTES: AppSdkAllowedRoute[] = [
     // Async metric query execution
     {
@@ -38,8 +55,7 @@ export const APP_SDK_ALLOWED_ROUTES: AppSdkAllowedRoute[] = [
     // Schedule backend CSV/XLSX export jobs for SDK query results
     {
         method: 'POST',
-        pattern:
-            /^\/api\/v2\/projects\/[^/]+\/query\/[^/]+\/schedule-download$/,
+        pattern: SCHEDULE_DOWNLOAD_PATTERN,
     },
     // Poll export job status until the backend returns a file URL
     {

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -12,6 +12,7 @@ import {
 } from './filter';
 import { type KnexPaginatedData } from './knex-paginate';
 import { type ParametersValuesMap } from './parameters';
+import { type PersistentDownloadFileAccessMode } from './persistentDownloadFile';
 import { type PivotConfig } from './pivot';
 import type { CompilationSource } from './projectCompileLogs';
 import { SchedulerResourceType } from './schedulerLog';
@@ -903,6 +904,17 @@ export type DownloadAsyncQueryResultsPayload = TraceTaskBase & {
     conditionalFormattings?: ConditionalFormattingConfig[];
     showColumnTotals?: boolean;
     encodedJwt?: string;
+    /**
+     * Access mode for the persistent URL of the exported file. Set to SIGNED
+     * for downloads scheduled through the data-app SDK bridge, whose final
+     * file fetch happens in a sandboxed, credential-less context. Absent on
+     * jobs from other callers (and all jobs queued before this field existed),
+     * which keep the AUTHENTICATED_CREATOR default.
+     */
+    fileAccessMode?: Exclude<
+        PersistentDownloadFileAccessMode,
+        PersistentDownloadFileAccessMode.LEGACY_PUBLIC
+    >;
 };
 
 export type SyncSlackChannelsPayload = Pick<

--- a/packages/common/src/utils/api.ts
+++ b/packages/common/src/utils/api.ts
@@ -9,6 +9,14 @@ export const LightdashCliVersionHeader = 'Lightdash-CLI-Version';
 // authenticated, so it must not gate access or feed anything authoritative.
 export const LightdashAppUuidHeader = 'Lightdash-App-Uuid';
 
+// Declares that the file produced by a schedule-download request will be
+// fetched from a context that cannot attach session credentials (the data-app
+// sandbox iframe, or an app previewed on a local dev page), so the backend
+// must mint a SIGNED download URL instead of a session-authenticated one.
+// Client-set and unauthenticated, which is safe: a signed URL grants nothing
+// the requesting session couldn't already download and share.
+export const LightdashSignedDownloadHeader = 'Lightdash-Signed-Download';
+
 export const getRequestMethod = (
     headerValue: string | undefined,
 ): RequestMethod =>

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -5,6 +5,7 @@ import {
     APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
     FilterOperator,
     LightdashAppUuidHeader,
+    LightdashSignedDownloadHeader,
     QueryExecutionContext,
     type AppColorScheme,
     type DashboardFilters,
@@ -505,6 +506,13 @@ describe('useAppSdkBridge', () => {
             ),
         );
 
+        // The final fileUrl fetch happens inside the sandboxed iframe with no
+        // session cookies, so the bridge must ask for a SIGNED download URL.
+        const [, scheduleInit] = (fetch as Mock).mock.calls[0];
+        expect(scheduleInit.headers).toMatchObject({
+            [LightdashSignedDownloadHeader]: 'true',
+        });
+
         mockFetchOk({
             status: 'ok',
             results: {
@@ -525,6 +533,13 @@ describe('useAppSdkBridge', () => {
                 JOB_STATUS_PATH,
                 expect.objectContaining({ method: 'GET' }),
             ),
+        );
+
+        // Job-status polling rides the bridge with real credentials — no
+        // signed-download request there.
+        const [, pollInit] = (fetch as Mock).mock.calls[1];
+        expect(pollInit.headers).not.toHaveProperty(
+            LightdashSignedDownloadHeader,
         );
     });
 });

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -5,8 +5,10 @@ import {
     APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
     extractAppSdkRouteProjectUuid,
     isAllowedAppSdkRoute,
+    isAppSdkScheduleDownloadRoute,
     JWT_HEADER_NAME,
     LightdashAppUuidHeader,
+    LightdashSignedDownloadHeader,
     type AppColorScheme,
     type DashboardFilters,
     type DataAppVizContext,
@@ -849,6 +851,13 @@ export function useAppSdkBridge({
                         // warehouse queries with it. Tracking only.
                         ...(appUuid
                             ? { [LightdashAppUuidHeader]: appUuid }
+                            : {}),
+                        // The SDK fetches the export's fileUrl from inside
+                        // the sandboxed iframe, where session cookies don't
+                        // attach — ask the backend for a SIGNED URL that
+                        // survives that credential-less fetch.
+                        ...(isAppSdkScheduleDownloadRoute(method, path)
+                            ? { [LightdashSignedDownloadHeader]: 'true' }
                             : {}),
                     },
                     ...(effectiveBody


### PR DESCRIPTION
## Problem

Since #26914 secured persistent download URLs, CSV/XLSX exports triggered from a **data app** fail with 404 `{"name":"NotFoundError","message":"Cannot find file"}` for logged-in users, even though the export job completes and returns a fileUrl.

The SDK schedules the export and polls job status through the postMessage bridge, which runs with the user's real session — so the file is created in `AUTHENTICATED_CREATOR` mode. But the final fetch of the returned fileUrl is an anchor click **inside the sandboxed iframe** (`triggerBrowserDownload` in query-sdk). The iframe has no `allow-same-origin`, so its opaque origin sends no session cookie and authorization fails.

It only reproduces on instances whose session cookies are `SameSite=Lax` (the default). With iframe embedding enabled, cookies are `SameSite=None` and happen to ride along on the sandbox's fetch, masking the bug — so exports there currently work only by grace of browser cookie policy.

## Fix

The two mediators of app traffic — the in-product postMessage bridge and the CLI preview proxy — now stamp a `Lightdash-Signed-Download` header on `schedule-download` requests. The backend responds by minting a **SIGNED** download URL (`?downloadToken=` or S3 presigned, depending on `PERSISTENT_DOWNLOAD_URLS_ENABLED`) that survives the credential-less fetch. Every other caller keeps the `AUTHENTICATED_CREATOR` default, as do jobs queued before this change (the payload field is optional).

Since both mediators are platform code, **existing deployed apps are fixed without rebuilds** — the bundled SDK just anchor-clicks whichever fileUrl the job returns. This also stops data-app exports depending on cross-site cookie behavior on embedding-enabled instances.

The header is client-set and unauthenticated, which is safe: a signed URL grants nothing the requesting session couldn't already download and share, and SIGNED is the access model #26914 introduced for exactly these credential-less fetch contexts.

## Testing

- Reproduced locally: data-app "export all" 404'd before, downloads after; native chart exports unchanged (`AUTHENTICATED_CREATOR`)
- Extended the bridge hook test to assert the header on schedule-download and its absence on job-status polling
- New preview-proxy test asserting the header is stamped on forwarded schedule-download requests only
- Typecheck clean on common/backend/frontend/cli; full backend (6258), frontend (2317), and CLI (500) suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)