### PR TITLE
fix(bigquery): keep decimal values numeric in Sheets sync

### DIFF
--- a/packages/warehouses/package.json
+++ b/packages/warehouses/package.json
@@ -36,7 +36,6 @@
     "@duckdb/node-api": "1.5.2-r.2",
     "@google-cloud/bigquery": "8.3.1",
     "@lightdash/common": "workspace:*",
-    "big.js": "6.1.1",
     "node-fetch": "2.7.0",
     "pg": "8.13.1",
     "pg-cursor": "2.10.0",
@@ -46,7 +45,6 @@
     "trino-client": "0.2.9"
   },
   "devDependencies": {
-    "@types/big.js": "6.2.2",
     "oxlint": "1.75.0",
     "oxlint-tsgolint": "7.0.2001",
     "@types/node-fetch": "2.6.13",

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.mock.ts
@@ -1,10 +1,13 @@
-import { BigQueryDate, BigQueryTimestamp } from '@google-cloud/bigquery';
+import {
+    BigQuery,
+    BigQueryDate,
+    BigQueryTimestamp,
+} from '@google-cloud/bigquery';
 import {
     AnyType,
     CreateBigqueryCredentials,
     WarehouseTypes,
 } from '@lightdash/common';
-import Big from 'big.js';
 import { Readable } from 'stream';
 import { BigqueryFieldType } from './BigqueryWarehouseClient';
 
@@ -30,6 +33,10 @@ const metadata = {
             {
                 name: 'myNumberColumn',
                 type: BigqueryFieldType.NUMERIC,
+            },
+            {
+                name: 'myBigNumberColumn',
+                type: BigqueryFieldType.BIGNUMERIC,
             },
             {
                 name: 'myDateColumn',
@@ -61,16 +68,37 @@ export const getTableResponse = {
     getMetadata: vi.fn(() => [metadata]),
 };
 
+// eslint-disable-next-line no-underscore-dangle
+const [bigqueryDecimalValues] = BigQuery.mergeSchemaWithRows_(
+    {
+        fields: [
+            {
+                name: 'myNumberColumn',
+                type: BigqueryFieldType.NUMERIC,
+            },
+            {
+                name: 'myBigNumberColumn',
+                type: BigqueryFieldType.BIGNUMERIC,
+            },
+        ],
+    },
+    [
+        {
+            f: [{ v: '100.25' }, { v: '200.5' }],
+        },
+    ],
+    { wrapIntegers: false },
+);
+
 export const rows: Record<string, AnyType>[] = [
     {
         myStringColumn: 'string value',
-        // The SDK returns NUMERIC/BIGNUMERIC columns as big.js instances
-        myNumberColumn: new Big('100'),
+        ...bigqueryDecimalValues,
         myDateColumn: new BigQueryDate('2021-03-10'),
         myTimestampColumn: new BigQueryTimestamp('1990-03-02T08:30:00.010Z'),
         myBooleanColumn: false,
         myArrayColumn: ['1', '2', '3'],
-        myObjectColumn: { test: '1' },
+        myObjectColumn: { test: '1', toFixed: () => '123' },
     },
 ];
 

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -4,7 +4,7 @@ import {
     type DatasetsResponse,
     type QueryRowsResponse,
 } from '@google-cloud/bigquery';
-import { type BigqueryProject } from '@lightdash/common';
+import { DimensionType, type BigqueryProject } from '@lightdash/common';
 import type { Mock, MockInstance } from 'vitest';
 import {
     BigquerySqlBuilder,
@@ -32,8 +32,15 @@ describe('BigqueryWarehouseClient', () => {
 
         const results = await warehouse.runQuery('fake sql');
 
-        expect(results.fields).toEqual(expectedFields);
-        expect(results.rows[0]).toEqual(expectedRow);
+        expect(results.fields).toEqual({
+            ...expectedFields,
+            myBigNumberColumn: { type: 'number' },
+        });
+        expect(results.rows[0]).toEqual({
+            ...expectedRow,
+            myNumberColumn: 100.25,
+            myBigNumberColumn: 200.5,
+        });
         expect(warehouse.client.createQueryJob as Mock).toHaveBeenCalledTimes(
             1,
         );
@@ -76,9 +83,12 @@ describe('BigqueryWarehouseClient', () => {
             .mockImplementationOnce(() => getTableResponse);
         Dataset.prototype.table = getTableMock;
         const warehouse = new BigqueryWarehouseClient(credentials);
-        expect(await warehouse.getCatalog(config)).toEqual(
+        const expectedCatalog = structuredClone(
             expectedWarehouseSchemaWithAwareTimestamp,
         );
+        expectedCatalog.myDatabase.mySchema.myTable.myBigNumberColumn =
+            DimensionType.NUMBER;
+        expect(await warehouse.getCatalog(config)).toEqual(expectedCatalog);
         expect(getTableMock).toHaveBeenCalledTimes(1);
         expect(getTableResponse.getMetadata).toHaveBeenCalledTimes(1);
     });

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -36,7 +36,6 @@ import {
     WarehouseTypes,
     type TimestampDomain,
 } from '@lightdash/common';
-import Big from 'big.js';
 import { pipeline, Transform } from 'stream';
 import {
     WarehouseCatalog,
@@ -77,6 +76,27 @@ export enum BigqueryFieldType {
     ARRAY = 'ARRAY',
 }
 
+type BigqueryDecimal = {
+    c: number[];
+    e: number;
+    s: number;
+    toFixed: () => string;
+};
+
+const isBigqueryDecimal = (value: unknown): value is BigqueryDecimal =>
+    typeof value === 'object' &&
+    value !== null &&
+    'e' in value &&
+    Number.isInteger(value.e) &&
+    's' in value &&
+    (value.s === 1 || value.s === -1) &&
+    'toFixed' in value &&
+    typeof value.toFixed === 'function' &&
+    'c' in value &&
+    Array.isArray(value.c) &&
+    value.c.length > 0 &&
+    value.c.every((digit) => typeof digit === 'number');
+
 const parseCell = (cell: AnyType) => {
     if (
         cell === undefined ||
@@ -96,10 +116,8 @@ const parseCell = (cell: AnyType) => {
         return new Date(cell.value);
     }
 
-    // The SDK wraps NUMERIC/BIGNUMERIC in big.js instances; convert to number
-    // (accepting float precision, like the Postgres client's NUMERIC parser)
-    if (cell instanceof Big) {
-        return Number(cell);
+    if (isBigqueryDecimal(cell)) {
+        return Number(cell.toFixed());
     }
 
     return `${cell}`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1772,9 +1772,6 @@ importers:
       '@lightdash/common':
         specifier: workspace:*
         version: link:../common
-      big.js:
-        specifier: 6.1.1
-        version: 6.1.1
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0(encoding@0.1.13)
@@ -1797,9 +1794,6 @@ importers:
         specifier: 0.2.9
         version: 0.2.9(debug@4.4.3(supports-color@9.1.0))
     devDependencies:
-      '@types/big.js':
-        specifier: 6.2.2
-        version: 6.2.2
       '@types/node-fetch':
         specifier: 2.6.13
         version: 2.6.13
@@ -6906,9 +6900,6 @@ packages:
 
   '@types/bcrypt@5.0.0':
     resolution: {integrity: sha512-agtcFKaruL8TmcvqbndlqHPSJgsolhf/qPWchFlgnW1gECTN/nKbFcoFnvKAQRFfKbh+BO6A3SWdJu9t+xF3Lw==}
-
-  '@types/big.js@6.2.2':
-    resolution: {integrity: sha512-e2cOW9YlVzFY2iScnGBBkplKsrn2CsObHQ2Hiw4V1sSyiGbgWL8IyqE3zFi1Pt5o1pdAtYkDAIsF3KKUPjdzaA==}
 
   '@types/body-parser@1.19.0':
     resolution: {integrity: sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==}
@@ -22537,8 +22528,6 @@ snapshots:
   '@types/bcrypt@5.0.0':
     dependencies:
       '@types/node': 24.13.2
-
-  '@types/big.js@6.2.2': {}
 
   '@types/body-parser@1.19.0':
     dependencies:


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9769/bigquery-numeric-regression-causes-formatting-errors-in-google-sheets

## Summary

BigQuery `NUMERIC` and `BIGNUMERIC` values remain numbers when synced to Google Sheets instead of arriving as text with a leading apostrophe.

## Root cause

The BigQuery 8.x client constructs decimal results with its transitive `big.js@7` dependency. The warehouses package checked those values against a separate `big.js@6` constructor, so the check failed and the parser stringified them.

```ts
cell instanceof Big // v7 value checked against the v6 constructor
```

The check worked before the BigQuery client dependency moved to `big.js@7`. Constructor identity made the fix sensitive to future dependency version changes.

## Fix

The parser now recognizes the documented big.js instance shape at the SDK boundary and converts the fixed-point value to a JavaScript number. The obsolete direct `big.js@6` dependency is removed.

- `BigqueryWarehouseClient` uses a narrow, version-independent decimal guard.
- The regression fixture creates both decimal types through BigQuery 8.3.1's real row decoder.
- Non-decimal objects, including objects with an unrelated `toFixed` method, keep the existing string fallback.

## Before

```text
BigQuery NUMERIC → big.js@7 value → v6 instanceof fails → "100.25" → Sheets text
```

## After

```text
BigQuery NUMERIC → big.js value → decimal shape matches → 100.25 → Sheets number
```

## Test plan

- [x] Baseline regression: SDK-decoded `NUMERIC` and `BIGNUMERIC` fail as strings
- [x] `pnpm -F warehouses format`
- [x] `pnpm -F warehouses lint`
- [x] `pnpm -F warehouses typecheck`
- [x] `pnpm -F warehouses test` — 345 passed, 2 skipped
- [x] Verify date/time, null, boolean, array, string, and generic object parsing remain covered
