### PR TITLE
fix(metrics-catalog): show weekly previous-year comparisons

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.test.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.test.ts
@@ -1,0 +1,137 @@
+import {
+    FieldType,
+    MetricExplorerComparison,
+    MetricType,
+    TimeFrames,
+    type MetricWithAssociatedTimeDimension,
+} from '@lightdash/common';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useExplore } from '../../../hooks/useExplore';
+import { useQueryExecutor } from '../../../providers/Explorer/useQueryExecutor';
+import { useMetric } from './useMetricsCatalog';
+import { useMetricVisualization } from './useMetricVisualization';
+
+vi.mock('../../../hooks/useExplore');
+vi.mock('../../../providers/Explorer/useQueryExecutor');
+vi.mock('./useMetricsCatalog');
+
+const metric = {
+    table: 'orders',
+    name: 'total_sales',
+    label: 'Total sales',
+    fieldType: FieldType.METRIC,
+    type: MetricType.SUM,
+    sql: '${TABLE}.amount',
+    timeDimension: {
+        table: 'orders',
+        field: 'order_date',
+        interval: TimeFrames.WEEK,
+    },
+} as MetricWithAssociatedTimeDimension;
+
+const getMetric = (
+    interval: TimeFrames,
+): MetricWithAssociatedTimeDimension => ({
+    ...metric,
+    timeDimension: {
+        table: 'orders',
+        field: 'order_date',
+        interval,
+    },
+});
+
+describe('useMetricVisualization', () => {
+    beforeEach(() => {
+        vi.mocked(useMetric).mockReturnValue({
+            data: metric,
+            isLoading: false,
+            error: null,
+        } as ReturnType<typeof useMetric>);
+        vi.mocked(useExplore).mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            error: null,
+        } as unknown as ReturnType<typeof useExplore>);
+        vi.mocked(useQueryExecutor).mockReturnValue([
+            {
+                query: {
+                    data: undefined,
+                    isFetching: false,
+                    error: null,
+                },
+                queryResults: {
+                    rows: [],
+                    hasFetchedAllRows: true,
+                    isFetchingFirstPage: false,
+                    error: null,
+                },
+            },
+            vi.fn(),
+        ] as unknown as ReturnType<typeof useQueryExecutor>);
+    });
+
+    it('aligns weekly previous-year comparisons by 52 weeks', () => {
+        const { result } = renderHook(() =>
+            useMetricVisualization({
+                projectUuid: 'project-uuid',
+                tableName: 'orders',
+                metricName: 'total_sales',
+                comparison: MetricExplorerComparison.PREVIOUS_PERIOD,
+            }),
+        );
+
+        expect(result.current.metricQuery?.additionalMetrics).toEqual([
+            expect.objectContaining({
+                generationType: 'periodOverPeriod',
+                granularity: TimeFrames.WEEK,
+                periodOffset: 52,
+                label: 'Total sales (Previous year)',
+            }),
+        ]);
+    });
+
+    it.each([TimeFrames.DAY, TimeFrames.MONTH])(
+        'keeps %s previous-year comparisons aligned by one year',
+        (interval) => {
+            vi.mocked(useMetric).mockReturnValue({
+                data: getMetric(interval),
+                isLoading: false,
+                error: null,
+            } as ReturnType<typeof useMetric>);
+
+            const { result } = renderHook(() =>
+                useMetricVisualization({
+                    projectUuid: 'project-uuid',
+                    tableName: 'orders',
+                    metricName: 'total_sales',
+                    comparison: MetricExplorerComparison.PREVIOUS_PERIOD,
+                }),
+            );
+
+            expect(result.current.metricQuery?.additionalMetrics).toEqual([
+                expect.objectContaining({
+                    generationType: 'periodOverPeriod',
+                    granularity: TimeFrames.YEAR,
+                    periodOffset: 1,
+                }),
+            ]);
+        },
+    );
+
+    it('does not add a comparison metric when comparison is disabled', () => {
+        const { result } = renderHook(() =>
+            useMetricVisualization({
+                projectUuid: 'project-uuid',
+                tableName: 'orders',
+                metricName: 'total_sales',
+                comparison: MetricExplorerComparison.NONE,
+            }),
+        );
+
+        expect(result.current.metricQuery?.additionalMetrics).toBeUndefined();
+        expect(result.current.metricQuery?.metrics).toEqual([
+            'orders_total_sales',
+        ]);
+    });
+});

--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
@@ -42,6 +42,18 @@ import { useMetric } from './useMetricsCatalog';
 
 const METRICS_EXPLORER_PREVIOUS_PERIOD_OFFSET_DEFAULT = 1;
 const METRICS_EXPLORER_PREVIOUS_PERIOD_GRANULARITY_DEFAULT = TimeFrames.YEAR;
+const METRICS_EXPLORER_PREVIOUS_YEAR_WEEK_OFFSET = 52;
+
+const getPreviousPeriodComparison = (timeFrame: TimeFrames) =>
+    timeFrame === TimeFrames.WEEK
+        ? {
+              granularity: TimeFrames.WEEK,
+              periodOffset: METRICS_EXPLORER_PREVIOUS_YEAR_WEEK_OFFSET,
+          }
+        : {
+              granularity: METRICS_EXPLORER_PREVIOUS_PERIOD_GRANULARITY_DEFAULT,
+              periodOffset: METRICS_EXPLORER_PREVIOUS_PERIOD_OFFSET_DEFAULT,
+          };
 
 const buildMetricQueryFromField = (
     field: MetricWithAssociatedTimeDimension,
@@ -120,16 +132,34 @@ const buildMetricQueryFromField = (
                   name: compareMetric.name,
               })
             : undefined;
-    const popResult =
-        shouldCompareToPreviousYear && timeDimensionFieldId
-            ? buildPopAdditionalMetric({
-                  metric: field,
-                  timeDimensionId: timeDimensionFieldId,
-                  granularity:
-                      METRICS_EXPLORER_PREVIOUS_PERIOD_GRANULARITY_DEFAULT,
-                  periodOffset: METRICS_EXPLORER_PREVIOUS_PERIOD_OFFSET_DEFAULT,
-              })
-            : null;
+    const getPreviousYearMetric = () => {
+        if (
+            !shouldCompareToPreviousYear ||
+            !timeDimensionConfig ||
+            !timeDimensionFieldId
+        ) {
+            return null;
+        }
+
+        const result = buildPopAdditionalMetric({
+            metric: field,
+            timeDimensionId: timeDimensionFieldId,
+            ...getPreviousPeriodComparison(timeDimensionConfig.interval),
+        });
+
+        return {
+            ...result,
+            additionalMetric: {
+                ...result.additionalMetric,
+                label: `${field.label} (${getPopPeriodLabel(
+                    METRICS_EXPLORER_PREVIOUS_PERIOD_GRANULARITY_DEFAULT,
+                    METRICS_EXPLORER_PREVIOUS_PERIOD_OFFSET_DEFAULT,
+                )})`,
+            },
+        };
+    };
+
+    const popResult = getPreviousYearMetric();
 
     const popMetricId = popResult?.metricId;
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9739/previous-year-comparison-is-empty-at-weekly-granularity-in-the-metric

## Summary

Weekly Metrics Catalog charts now show previous-year comparison data instead of an empty series. Daily and monthly comparisons keep their existing behavior and all comparison labels still read “Previous year.”

## Root cause

The Metrics Catalog built every previous-year additional metric with a one-calendar-year shift:

```ts
granularity: TimeFrames.YEAR,
periodOffset: 1,
```

Adding 365 or 366 days changes the weekday. The backend then joins the shifted dates to exact weekly bucket starts, so the comparison rows never match.

## Fix

Weekly charts shift comparison data by 52 weeks, which preserves the configured week-start weekday across calendar-year boundaries. Other granularities continue to shift by one year.

- `useMetricVisualization.ts` selects WEEK/52 only for weekly time dimensions and preserves the existing display label.
- `useMetricVisualization.test.ts` covers weekly, daily, monthly, and disabled comparisons.
- General Explorer period comparisons remain out of scope because they use separate query configuration.

## Before

Weekly buckets:
- Base series: populated
- Previous year: empty

## After

Weekly buckets:
- Base series: populated
- Previous year: populated and aligned to the same week-start weekday

## Test plan

- [x] `pnpm -F frontend typecheck`
- [x] `pnpm -F frontend lint`
- [x] `pnpm -F frontend test` — 2,323 tests pass
- [x] Focused regression suite — 4 tests pass
- [x] Local async query API with Postgres — YEAR/1 reproduces empty comparison buckets; WEEK/52 restores comparison values
- [x] Final five-lens review and post-commit re-review — approve
- [x] Chrome DevTools MCP UI — Weekly + “Compare to previous year” rendered current and comparison values; the UI-triggered request used WEEK/52 and returned 200