### PR TITLE
feat(ai): label Deep Research beta surfaces

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.test.tsx
@@ -81,6 +81,16 @@ describe('AiDeepResearchSettingsPage', () => {
         mutationState.current.isLoading = false;
     });
 
+    it('labels the settings page as beta exactly once', () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <AiDeepResearchSettingsPage />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getAllByText('Beta')).toHaveLength(1);
+    });
+
     it('saves all limits with a single update button', async () => {
         const user = userEvent.setup();
         renderWithProviders(

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.tsx
@@ -17,6 +17,7 @@ import {
     SettingsGridCard,
 } from '../../../../../../components/common/Settings/SettingsCard';
 import { SettingsPage } from '../../../../../../components/common/Settings/SettingsPage';
+import { isDeepResearchBeta } from '../../../deepResearch/deepResearchBeta';
 import {
     useAiOrganizationSettings,
     useUpdateAiOrganizationSettings,
@@ -198,6 +199,7 @@ export const AiDeepResearchSettingsPage = () => {
         return (
             <SettingsPage
                 title="Deep research"
+                isBeta={isDeepResearchBeta}
                 description="Configure organization-wide data access and safety limits for deep research runs."
             >
                 <Stack gap="lg">
@@ -218,6 +220,7 @@ export const AiDeepResearchSettingsPage = () => {
     return (
         <SettingsPage
             title="Deep research"
+            isBeta={isDeepResearchBeta}
             description="Configure organization-wide data access and safety limits for deep research runs."
         >
             <SettingsCard>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -34,6 +34,12 @@ const renderReport = (onClose = vi.fn(), run = deepResearchRunFixture) =>
     );
 
 describe('DeepResearchReport', () => {
+    it('labels the report header as beta exactly once', () => {
+        renderReport();
+
+        expect(screen.getAllByText('Beta')).toHaveLength(1);
+    });
+
     it('returns to chat from the report header', async () => {
         const user = userEvent.setup();
         const onClose = vi.fn();

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -11,9 +11,8 @@ import {
 } from '@mantine/core';
 import { IconArrowLeft } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { BetaBadge } from '../../../../../components/common/BetaBadge';
 import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
-import { isDeepResearchBeta } from '../../deepResearch/deepResearchBeta';
+import { DeepResearchBetaBadge } from '../../deepResearch/DeepResearchBetaBadge';
 import {
     getDeepResearchReportHeadings,
     getDeepResearchReportSourceCount,
@@ -219,11 +218,11 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                                 data-report-heading
                                 data-heading-label="Summary"
                             >
-                                <Group gap="xs" wrap="wrap">
+                                <Group gap="xs" align="baseline" wrap="wrap">
                                     <Text className={styles.eyebrow}>
                                         Deep research
                                     </Text>
-                                    {isDeepResearchBeta ? <BetaBadge /> : null}
+                                    <DeepResearchBetaBadge />
                                 </Group>
                                 <Title order={1} className={styles.reportTitle}>
                                     {run.question}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -11,7 +11,9 @@ import {
 } from '@mantine/core';
 import { IconArrowLeft } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { BetaBadge } from '../../../../../components/common/BetaBadge';
 import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
+import { isDeepResearchBeta } from '../../deepResearch/deepResearchBeta';
 import {
     getDeepResearchReportHeadings,
     getDeepResearchReportSourceCount,
@@ -217,9 +219,12 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                                 data-report-heading
                                 data-heading-label="Summary"
                             >
-                                <Text className={styles.eyebrow}>
-                                    Deep research
-                                </Text>
+                                <Group gap="xs" wrap="wrap">
+                                    <Text className={styles.eyebrow}>
+                                        Deep research
+                                    </Text>
+                                    {isDeepResearchBeta ? <BetaBadge /> : null}
+                                </Group>
                                 <Title order={1} className={styles.reportTitle}>
                                     {run.question}
                                 </Title>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
@@ -30,7 +30,7 @@ describe('DeepResearchRunCard', () => {
         ['queued', 'Queued'],
         ['running', 'Running'],
     ] as const)(
-        'renders the %s active state without fake progress',
+        'renders the %s active state with one beta label and without fake progress',
         (status, label) => {
             renderWithProviders(
                 <DeepResearchRunCard
@@ -46,6 +46,7 @@ describe('DeepResearchRunCard', () => {
             );
 
             expect(screen.getByText(label)).toBeInTheDocument();
+            expect(screen.getAllByText('Beta')).toHaveLength(1);
             expect(screen.getByText(/leave this page/i)).toBeInTheDocument();
             expect(screen.queryByText(/%/)).not.toBeInTheDocument();
             expect(

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -26,7 +26,9 @@ import {
 } from 'react';
 import { type StreamdownProps } from 'streamdown';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
+import { BetaBadge } from '../../../../../components/common/BetaBadge';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { isDeepResearchBeta } from '../../deepResearch/deepResearchBeta';
 import {
     getDeepResearchReportPreview,
     isDeepResearchRunTerminal,
@@ -143,6 +145,7 @@ export const DeepResearchRunHeading = ({
                 >
                     Deep research
                 </Text>
+                {isDeepResearchBeta ? <BetaBadge /> : null}
                 <Box className={styles.metaSeparator} />
                 <Group className={styles.statusMeta} gap={6} wrap="nowrap">
                     <Text size="xs" className={styles.metaText}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -26,9 +26,8 @@ import {
 } from 'react';
 import { type StreamdownProps } from 'streamdown';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
-import { BetaBadge } from '../../../../../components/common/BetaBadge';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { isDeepResearchBeta } from '../../deepResearch/deepResearchBeta';
+import { DeepResearchBetaBadge } from '../../deepResearch/DeepResearchBetaBadge';
 import {
     getDeepResearchReportPreview,
     isDeepResearchRunTerminal,
@@ -136,16 +135,18 @@ export const DeepResearchRunHeading = ({
                     color="currentColor"
                     className={styles.metaText}
                 />
-                <Text
-                    size="xs"
-                    fw={700}
-                    ff="monospace"
-                    tt="uppercase"
-                    className={styles.eyebrow}
-                >
-                    Deep research
-                </Text>
-                {isDeepResearchBeta ? <BetaBadge /> : null}
+                <Group gap="xs" align="baseline" wrap="nowrap">
+                    <Text
+                        size="xs"
+                        fw={700}
+                        ff="monospace"
+                        tt="uppercase"
+                        className={styles.eyebrow}
+                    >
+                        Deep research
+                    </Text>
+                    <DeepResearchBetaBadge />
+                </Group>
                 <Box className={styles.metaSeparator} />
                 <Group className={styles.statusMeta} gap={6} wrap="nowrap">
                     <Text size="xs" className={styles.metaText}>

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/DeepResearchBetaBadge.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/DeepResearchBetaBadge.tsx
@@ -1,0 +1,5 @@
+import { BetaBadge } from '../../../../components/common/BetaBadge';
+import { isDeepResearchBeta } from './deepResearchBeta';
+
+export const DeepResearchBetaBadge = () =>
+    isDeepResearchBeta ? <BetaBadge /> : null;

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchBeta.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchBeta.ts
@@ -1,0 +1,1 @@
+export const isDeepResearchBeta = true;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9778/place-deep-research-beta-tags-on-card-settings-and-reports

## Summary

Labels Deep Research as Beta where users discover a run, configure the feature, and read its output. All three surfaces reuse the existing `BetaBadge` treatment and one feature-owned state switch.

### Placement

- **Run card** — places Beta beside the Deep Research eyebrow before the run status.
- **Settings** — uses the established title-adjacent Beta placement on both loaded and loading/error states.
- **Report** — places Beta beside the Deep Research report metadata, outside report content.

```text
Card       DEEP RESEARCH  [Beta]  ·  Status
Settings   Deep research  [Beta]
Report     DEEP RESEARCH  [Beta]
           Report title
```

The composer toggle, messages, progress steps, charts, and report sections remain unchanged.

## Screenshots

Before/after screenshots were captured in Chrome DevTools against the local app and fixture-backed card/report surfaces:

- **Before** — all three headings rendered without a maturity label.
- **After, desktop** — each heading renders exactly one indigo Beta badge without changing the existing hierarchy.
- **After, 390px mobile** — the card metadata wraps cleanly and the report badge stays beside its eyebrow while the contents rail collapses.

## Regression analysis

- **Single removal point** — `isDeepResearchBeta` controls all three placements when the feature reaches GA.
- **Shared treatment** — every placement uses the existing `BetaBadge`, including its standard explanatory tooltip.
- **Scope** — frontend presentation only; no backend, API, permissions, composer, or report-content behavior changes.

## Test plan

- [x] Run the three focused component suites — 28 tests pass.
- [x] Assert exactly one Beta label on card, settings, and report renders.
- [x] Run focused frontend lint — 0 warnings and 0 errors.
- [x] Run focused formatting check.
- [x] Verify settings in the real local app at desktop width.
- [x] Verify card and report at desktop and 390px mobile widths in Chrome DevTools.
- [x] Confirm Beta appears once in each accessibility snapshot.

`pnpm -F frontend typecheck` currently reports one unrelated existing error in `ServiceAccountProjectRoles.tsx`: `@mantine/form` does not export `FormArrayElement`. No changed file reports a type error.
