### PR TITLE
feat(frontend): neutral error toast design driven by data-variant CSS

### DIFF
--- a/packages/frontend/src/hooks/toaster/types.ts
+++ b/packages/frontend/src/hooks/toaster/types.ts
@@ -7,9 +7,11 @@ import { type notifications } from '@mantine/notifications';
 import { type Icon } from '@tabler/icons-react';
 import { type ReactNode } from 'react';
 
+export type ToastVariant = 'success' | 'error' | 'info' | 'primary' | 'warning';
+
 export type NotificationData = Omit<
     Parameters<typeof notifications.show>[0],
-    'message' | 'key'
+    'message' | 'key' | 'color'
 > & {
     key?: string;
     subtitle?: string | ReactNode;
@@ -18,5 +20,4 @@ export type NotificationData = Omit<
     };
     apiError?: ApiErrorDetail;
     messageKey?: string;
-    isError?: boolean;
 };

--- a/packages/frontend/src/hooks/toaster/useToaster.module.css
+++ b/packages/frontend/src/hooks/toaster/useToaster.module.css
@@ -1,4 +1,8 @@
-.colorBlue {
+/* All toast styling is keyed off [data-variant] set by useToaster.tsx
+   (success | error | info | primary | warning). The variants only pick a
+   color ramp; the shared chrome lives on .root. */
+
+.root[data-variant='primary'] {
     --toast-0: var(--mantine-color-blue-0);
     --toast-1: var(--mantine-color-blue-1);
     --toast-2: var(--mantine-color-blue-2);
@@ -8,7 +12,7 @@
     --toast-9: var(--mantine-color-blue-9);
 }
 
-.colorGreen {
+.root[data-variant='success'] {
     --toast-0: var(--mantine-color-green-0);
     --toast-1: var(--mantine-color-green-1);
     --toast-2: var(--mantine-color-green-2);
@@ -18,7 +22,7 @@
     --toast-9: var(--mantine-color-green-9);
 }
 
-.colorRed {
+.root[data-variant='error'] {
     --toast-0: var(--mantine-color-red-0);
     --toast-1: var(--mantine-color-red-1);
     --toast-2: var(--mantine-color-red-2);
@@ -28,7 +32,7 @@
     --toast-9: var(--mantine-color-red-9);
 }
 
-.colorIndigo {
+.root[data-variant='info'] {
     --toast-0: var(--mantine-color-indigo-0);
     --toast-1: var(--mantine-color-indigo-1);
     --toast-2: var(--mantine-color-indigo-2);
@@ -38,7 +42,7 @@
     --toast-9: var(--mantine-color-indigo-9);
 }
 
-.colorYellow {
+.root[data-variant='warning'] {
     --toast-0: var(--mantine-color-yellow-0);
     --toast-1: var(--mantine-color-yellow-1);
     --toast-2: var(--mantine-color-yellow-2);
@@ -69,7 +73,9 @@
     font-weight: 700;
 }
 
-.titleNoMargin {
+/* Mantine always renders the description element; it is empty when the
+   toast has no subtitle and no action */
+.root:has(.description:empty) .title {
     margin-bottom: 0;
 }
 
@@ -106,4 +112,10 @@
     color: var(--toast-text);
     font-size: 12px;
     width: 100%;
+}
+
+.markdown {
+    background-color: transparent;
+    color: var(--toast-text);
+    font-size: 12px;
 }

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -1,5 +1,5 @@
 import type { ApiErrorDetail } from '@lightdash/common';
-import { Box, Button, Stack } from '@mantine/core';
+import { Box, Button, Stack, type MantineColor } from '@mantine/core';
 import {
     notifications,
     type NotificationData as MantineNotificationData,
@@ -9,24 +9,61 @@ import {
     IconAlertTriangleFilled,
     IconCircleCheckFilled,
     IconInfoCircleFilled,
+    type Icon,
 } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
-import { clsx } from 'clsx';
 import React, { useCallback, useRef, type ReactNode } from 'react';
 import rehypeExternalLinks from 'rehype-external-links';
 import { v4 as uuid } from 'uuid';
-import MantineIcon from '../../components/common/MantineIcon';
+import MantineIcon, {
+    type MantineIconSize,
+} from '../../components/common/MantineIcon';
 import ApiErrorDisplay from './ApiErrorDisplay';
 import MultipleToastBody from './MultipleToastBody';
-import { type NotificationData } from './types';
+import { type NotificationData, type ToastVariant } from './types';
 import styles from './useToaster.module.css';
 
-const colorClasses: Record<string, string> = {
-    blue: styles.colorBlue,
-    green: styles.colorGreen,
-    red: styles.colorRed,
-    indigo: styles.colorIndigo,
-    yellow: styles.colorYellow,
+/** All visual styling is driven by [data-variant] in useToaster.module.css;
+ *  this dict only holds what must be rendered from React. */
+const TOAST_VARIANTS: Record<
+    ToastVariant,
+    {
+        icon: Icon;
+        iconSize: MantineIconSize;
+        color: MantineColor;
+        autoClose: number;
+    }
+> = {
+    success: {
+        icon: IconCircleCheckFilled,
+        iconSize: 'xl',
+        color: 'green',
+        autoClose: 5000,
+    },
+    error: {
+        icon: IconAlertCircleFilled,
+        iconSize: 'xl',
+        color: 'red',
+        autoClose: 60000,
+    },
+    info: {
+        icon: IconInfoCircleFilled,
+        iconSize: 'xl',
+        color: 'indigo',
+        autoClose: 5000,
+    },
+    primary: {
+        icon: IconInfoCircleFilled,
+        iconSize: 'xl',
+        color: 'blue',
+        autoClose: 5000,
+    },
+    warning: {
+        icon: IconAlertCircleFilled,
+        iconSize: 'xl',
+        color: 'yellow',
+        autoClose: 5000,
+    },
 };
 
 const useToaster = () => {
@@ -34,26 +71,31 @@ const useToaster = () => {
     const currentErrors = useRef<Record<string, NotificationData[]>>({});
 
     const showToast = useCallback(
-        ({
-            key = uuid(),
-            subtitle,
-            action,
-            color = 'blue',
-            autoClose = 5000,
-            ...rest
-        }: NotificationData) => {
-            const commonProps = {
+        (
+            variant: ToastVariant,
+            {
+                key = uuid(),
+                subtitle,
+                action,
                 autoClose,
-                color,
+                ...rest
+            }: NotificationData,
+        ) => {
+            const variantConfig = TOAST_VARIANTS[variant];
+
+            const commonProps = {
+                'data-variant': variant,
+                color: variantConfig.color,
+                autoClose: autoClose ?? variantConfig.autoClose,
+                icon: (
+                    <MantineIcon
+                        icon={variantConfig.icon}
+                        size={variantConfig.iconSize}
+                    />
+                ),
                 classNames: {
-                    root: clsx(
-                        styles.root,
-                        colorClasses[color] ?? styles.colorBlue,
-                    ),
-                    title: clsx(
-                        styles.title,
-                        !subtitle && !action && styles.titleNoMargin,
-                    ),
+                    root: styles.root,
+                    title: styles.title,
                     description: styles.description,
                     closeButton: styles.closeButton,
                     icon: styles.icon,
@@ -64,6 +106,7 @@ const useToaster = () => {
                         <Stack gap="xs" align="flex-start">
                             {typeof subtitle == 'string' ? (
                                 <MarkdownPreview
+                                    className={styles.markdown}
                                     source={subtitle}
                                     rehypePlugins={[
                                         [
@@ -71,11 +114,6 @@ const useToaster = () => {
                                             { target: '_blank' },
                                         ],
                                     ]}
-                                    style={{
-                                        backgroundColor: 'transparent',
-                                        color: 'var(--toast-text)',
-                                        fontSize: '12px',
-                                    }}
                                 />
                             ) : (
                                 <Box className={styles.subtitle}>
@@ -89,7 +127,7 @@ const useToaster = () => {
                                     size="xs"
                                     radius="md"
                                     variant="light"
-                                    color={color}
+                                    color={variantConfig.color}
                                     leftSection={
                                         action.icon ? (
                                             <MantineIcon icon={action.icon} />
@@ -130,26 +168,12 @@ const useToaster = () => {
     );
 
     const showToastSuccess = useCallback(
-        (props: NotificationData) => {
-            showToast({
-                color: 'green',
-                icon: <MantineIcon icon={IconCircleCheckFilled} size="xl" />,
-                ...props,
-            });
-        },
+        (props: NotificationData) => showToast('success', props),
         [showToast],
     );
 
     const showToastError = useCallback(
-        (props: NotificationData) => {
-            showToast({
-                color: 'red',
-                icon: <MantineIcon icon={IconAlertCircleFilled} size="xl" />,
-                autoClose: 60000,
-                isError: true,
-                ...props,
-            });
-        },
+        (props: NotificationData) => showToast('error', props),
         [showToast],
     );
 
@@ -167,10 +191,8 @@ const useToaster = () => {
                 ''
             );
 
-            showToast({
-                color: 'red',
+            showToast('error', {
                 icon: <MantineIcon icon={IconAlertTriangleFilled} size="xl" />,
-                autoClose: 60000,
                 title,
                 subtitle,
                 ...props,
@@ -180,35 +202,17 @@ const useToaster = () => {
     );
 
     const showToastInfo = useCallback(
-        (props: NotificationData) => {
-            showToast({
-                color: 'indigo',
-                icon: <MantineIcon icon={IconInfoCircleFilled} size="xl" />,
-                ...props,
-            });
-        },
+        (props: NotificationData) => showToast('info', props),
         [showToast],
     );
 
     const showToastPrimary = useCallback(
-        (props: NotificationData) => {
-            showToast({
-                color: 'blue',
-                icon: <MantineIcon icon={IconInfoCircleFilled} size="xl" />,
-                ...props,
-            });
-        },
+        (props: NotificationData) => showToast('primary', props),
         [showToast],
     );
 
     const showToastWarning = useCallback(
-        (props: NotificationData) => {
-            showToast({
-                color: 'yellow',
-                icon: <MantineIcon icon={IconAlertCircleFilled} size="xl" />,
-                ...props,
-            });
-        },
+        (props: NotificationData) => showToast('warning', props),
         [showToast],
     );
 


### PR DESCRIPTION
Error toasts (single, API error, and stacked) move to the neutral design piloted in the design project: a plain card surface with ink title and gray body, where the only color is a small circular red icon badge. Stacked errors now render as a "N errors" header with a Show/Hide toggle and full-width rows (red dot, hairline separators) that span the whole card instead of being indented inside the notification body's content column. The remaining variants (success, info, primary, warning) keep their current tinted look — converging them on the neutral design is a follow-up.

Under the hood, all toast styling now hangs off a single `data-variant` attribute on the notification root, so the CSS module owns every visual decision and the hook no longer branches on styling: the `isError` flag, `clsx`'d conditional classes, and inline markdown styles are gone (`:has()` selectors cover the two layout conditionals). A small `TOAST_VARIANTS` dict keeps the only things React must render — icon, icon size, Mantine color for loader/action plumbing, and autoClose policy. The public `useToaster` API and all call sites are unchanged.