### PR TITLE
refactor(frontend): drive toast styling from data-variant CSS

### DIFF
--- a/packages/frontend/src/hooks/toaster/types.ts
+++ b/packages/frontend/src/hooks/toaster/types.ts
@@ -7,9 +7,11 @@ import { type notifications } from '@mantine/notifications';
 import { type Icon } from '@tabler/icons-react';
 import { type ReactNode } from 'react';
 
+export type ToastVariant = 'success' | 'error' | 'info' | 'primary' | 'warning';
+
 export type NotificationData = Omit<
     Parameters<typeof notifications.show>[0],
-    'message' | 'key'
+    'message' | 'key' | 'color'
 > & {
     key?: string;
     subtitle?: string | ReactNode;
@@ -18,5 +20,4 @@ export type NotificationData = Omit<
     };
     apiError?: ApiErrorDetail;
     messageKey?: string;
-    isError?: boolean;
 };

--- a/packages/frontend/src/hooks/toaster/useToaster.module.css
+++ b/packages/frontend/src/hooks/toaster/useToaster.module.css
@@ -1,4 +1,4 @@
-.colorBlue {
+.root[data-variant='primary'] {
     --toast-0: var(--mantine-color-blue-0);
     --toast-1: var(--mantine-color-blue-1);
     --toast-2: var(--mantine-color-blue-2);
@@ -8,7 +8,7 @@
     --toast-9: var(--mantine-color-blue-9);
 }
 
-.colorGreen {
+.root[data-variant='success'] {
     --toast-0: var(--mantine-color-green-0);
     --toast-1: var(--mantine-color-green-1);
     --toast-2: var(--mantine-color-green-2);
@@ -18,7 +18,7 @@
     --toast-9: var(--mantine-color-green-9);
 }
 
-.colorRed {
+.root[data-variant='error'] {
     --toast-0: var(--mantine-color-red-0);
     --toast-1: var(--mantine-color-red-1);
     --toast-2: var(--mantine-color-red-2);
@@ -28,7 +28,7 @@
     --toast-9: var(--mantine-color-red-9);
 }
 
-.colorIndigo {
+.root[data-variant='info'] {
     --toast-0: var(--mantine-color-indigo-0);
     --toast-1: var(--mantine-color-indigo-1);
     --toast-2: var(--mantine-color-indigo-2);
@@ -38,7 +38,7 @@
     --toast-9: var(--mantine-color-indigo-9);
 }
 
-.colorYellow {
+.root[data-variant='warning'] {
     --toast-0: var(--mantine-color-yellow-0);
     --toast-1: var(--mantine-color-yellow-1);
     --toast-2: var(--mantine-color-yellow-2);
@@ -49,7 +49,6 @@
 }
 
 .root {
-    /* darken/lighten from the v6 theme.fn become color-mix */
     --toast-text: light-dark(var(--toast-9), var(--toast-2));
 
     background: light-dark(
@@ -69,7 +68,7 @@
     font-weight: 700;
 }
 
-.titleNoMargin {
+.root:has(.description:empty) .title {
     margin-bottom: 0;
 }
 
@@ -106,4 +105,10 @@
     color: var(--toast-text);
     font-size: 12px;
     width: 100%;
+}
+
+.markdown {
+    background-color: transparent;
+    color: var(--toast-text);
+    font-size: 12px;
 }

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -1,5 +1,5 @@
 import type { ApiErrorDetail } from '@lightdash/common';
-import { Box, Button, Stack } from '@mantine/core';
+import { Box, Button, Stack, type MantineColor } from '@mantine/core';
 import {
     notifications,
     type NotificationData as MantineNotificationData,
@@ -9,24 +9,59 @@ import {
     IconAlertTriangleFilled,
     IconCircleCheckFilled,
     IconInfoCircleFilled,
+    type Icon,
 } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
-import { clsx } from 'clsx';
 import React, { useCallback, useRef, type ReactNode } from 'react';
 import rehypeExternalLinks from 'rehype-external-links';
 import { v4 as uuid } from 'uuid';
-import MantineIcon from '../../components/common/MantineIcon';
+import MantineIcon, {
+    type MantineIconSize,
+} from '../../components/common/MantineIcon';
 import ApiErrorDisplay from './ApiErrorDisplay';
 import MultipleToastBody from './MultipleToastBody';
-import { type NotificationData } from './types';
+import { type NotificationData, type ToastVariant } from './types';
 import styles from './useToaster.module.css';
 
-const colorClasses: Record<string, string> = {
-    blue: styles.colorBlue,
-    green: styles.colorGreen,
-    red: styles.colorRed,
-    indigo: styles.colorIndigo,
-    yellow: styles.colorYellow,
+const TOAST_VARIANTS: Record<
+    ToastVariant,
+    {
+        icon: Icon;
+        iconSize: MantineIconSize;
+        color: MantineColor;
+        autoClose: number;
+    }
+> = {
+    success: {
+        icon: IconCircleCheckFilled,
+        iconSize: 'xl',
+        color: 'green',
+        autoClose: 5000,
+    },
+    error: {
+        icon: IconAlertCircleFilled,
+        iconSize: 'xl',
+        color: 'red',
+        autoClose: 60000,
+    },
+    info: {
+        icon: IconInfoCircleFilled,
+        iconSize: 'xl',
+        color: 'indigo',
+        autoClose: 5000,
+    },
+    primary: {
+        icon: IconInfoCircleFilled,
+        iconSize: 'xl',
+        color: 'blue',
+        autoClose: 5000,
+    },
+    warning: {
+        icon: IconAlertCircleFilled,
+        iconSize: 'xl',
+        color: 'yellow',
+        autoClose: 5000,
+    },
 };
 
 const useToaster = () => {
@@ -34,26 +69,31 @@ const useToaster = () => {
     const currentErrors = useRef<Record<string, NotificationData[]>>({});
 
     const showToast = useCallback(
-        ({
-            key = uuid(),
-            subtitle,
-            action,
-            color = 'blue',
-            autoClose = 5000,
-            ...rest
-        }: NotificationData) => {
-            const commonProps = {
+        (
+            variant: ToastVariant,
+            {
+                key = uuid(),
+                subtitle,
+                action,
                 autoClose,
-                color,
+                ...rest
+            }: NotificationData,
+        ) => {
+            const variantConfig = TOAST_VARIANTS[variant];
+
+            const commonProps = {
+                'data-variant': variant,
+                color: variantConfig.color,
+                autoClose: autoClose ?? variantConfig.autoClose,
+                icon: (
+                    <MantineIcon
+                        icon={variantConfig.icon}
+                        size={variantConfig.iconSize}
+                    />
+                ),
                 classNames: {
-                    root: clsx(
-                        styles.root,
-                        colorClasses[color] ?? styles.colorBlue,
-                    ),
-                    title: clsx(
-                        styles.title,
-                        !subtitle && !action && styles.titleNoMargin,
-                    ),
+                    root: styles.root,
+                    title: styles.title,
                     description: styles.description,
                     closeButton: styles.closeButton,
                     icon: styles.icon,
@@ -64,6 +104,7 @@ const useToaster = () => {
                         <Stack gap="xs" align="flex-start">
                             {typeof subtitle == 'string' ? (
                                 <MarkdownPreview
+                                    className={styles.markdown}
                                     source={subtitle}
                                     rehypePlugins={[
                                         [
@@ -71,11 +112,6 @@ const useToaster = () => {
                                             { target: '_blank' },
                                         ],
                                     ]}
-                                    style={{
-                                        backgroundColor: 'transparent',
-                                        color: 'var(--toast-text)',
-                                        fontSize: '12px',
-                                    }}
                                 />
                             ) : (
                                 <Box className={styles.subtitle}>
@@ -89,7 +125,7 @@ const useToaster = () => {
                                     size="xs"
                                     radius="md"
                                     variant="light"
-                                    color={color}
+                                    color={variantConfig.color}
                                     leftSection={
                                         action.icon ? (
                                             <MantineIcon icon={action.icon} />
@@ -130,26 +166,12 @@ const useToaster = () => {
     );
 
     const showToastSuccess = useCallback(
-        (props: NotificationData) => {
-            showToast({
-                color: 'green',
-                icon: <MantineIcon icon={IconCircleCheckFilled} size="xl" />,
-                ...props,
-            });
-        },
+        (props: NotificationData) => showToast('success', props),
         [showToast],
     );
 
     const showToastError = useCallback(
-        (props: NotificationData) => {
-            showToast({
-                color: 'red',
-                icon: <MantineIcon icon={IconAlertCircleFilled} size="xl" />,
-                autoClose: 60000,
-                isError: true,
-                ...props,
-            });
-        },
+        (props: NotificationData) => showToast('error', props),
         [showToast],
     );
 
@@ -167,10 +189,8 @@ const useToaster = () => {
                 ''
             );
 
-            showToast({
-                color: 'red',
+            showToast('error', {
                 icon: <MantineIcon icon={IconAlertTriangleFilled} size="xl" />,
-                autoClose: 60000,
                 title,
                 subtitle,
                 ...props,
@@ -180,35 +200,17 @@ const useToaster = () => {
     );
 
     const showToastInfo = useCallback(
-        (props: NotificationData) => {
-            showToast({
-                color: 'indigo',
-                icon: <MantineIcon icon={IconInfoCircleFilled} size="xl" />,
-                ...props,
-            });
-        },
+        (props: NotificationData) => showToast('info', props),
         [showToast],
     );
 
     const showToastPrimary = useCallback(
-        (props: NotificationData) => {
-            showToast({
-                color: 'blue',
-                icon: <MantineIcon icon={IconInfoCircleFilled} size="xl" />,
-                ...props,
-            });
-        },
+        (props: NotificationData) => showToast('primary', props),
         [showToast],
     );
 
     const showToastWarning = useCallback(
-        (props: NotificationData) => {
-            showToast({
-                color: 'yellow',
-                icon: <MantineIcon icon={IconAlertCircleFilled} size="xl" />,
-                ...props,
-            });
-        },
+        (props: NotificationData) => showToast('warning', props),
         [showToast],
     );
 


### PR DESCRIPTION
The toaster hook was making styling decisions in TypeScript: a color-to-class map plus clsx branching picked the CSS for each toast, a dead `isError` flag leaked onto the DOM as an invalid attribute, and the markdown body carried inline styles that outranked any stylesheet. That plumbing made visual changes require touching both the hook and the CSS module, and it left the styling contract implicit — nothing said which combinations of color and flags were actually valid.

This is a mechanical refactor with zero visual change: the notification root now carries a single `data-variant` attribute (`success | error | info | primary | warning`) and the CSS module owns every visual decision keyed off it. A `TOAST_VARIANTS` dict holds the only things React must render — icon, icon size, Mantine color for loader/action-button plumbing, and autoClose policy — and each public `showToastX` function collapses to a one-liner. The two layout conditionals (title margin when there is no body) moved to `:has()` selectors, inline markdown styles became a `.markdown` class, and `NotificationData` dropped the unused `isError` and `color` fields. The public `useToaster` API and all call sites are unchanged.