### PR TITLE
fix: debounce admin search navigation

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx
@@ -13,7 +13,6 @@ import {
     Tooltip,
     useMantineTheme,
 } from '@mantine/core';
-import { useDebouncedValue } from '@mantine/hooks';
 import {
     IconBox,
     IconCircleDotted,
@@ -63,6 +62,7 @@ const AiAgentAdminMemoriesTable = () => {
     const theme = useMantineTheme();
     const [selectedMemory, setSelectedMemory] =
         useState<MemorySlugSelection | null>(null);
+    const [searchInputKey, setSearchInputKey] = useState(0);
 
     const {
         search,
@@ -83,15 +83,11 @@ const AiAgentAdminMemoriesTable = () => {
         resetFilters,
     } = useAiAgentAdminMemoryFilters();
 
-    // The search input writes to the URL per keystroke; debounce the query so a
-    // body-wide ILIKE doesn't run on every character
-    const [debouncedSearch] = useDebouncedValue(search, 300);
-
     const { data, isInitialLoading, isFetching, hasNextPage, fetchNextPage } =
         useInfiniteAiAgentAdminMemories(
             {
                 pagination: {},
-                filters: { ...apiFilters, search: debouncedSearch },
+                filters: apiFilters,
                 sort: { field: sortField, direction: sortDirection },
             },
             { keepPreviousData: true },
@@ -131,6 +127,11 @@ const AiAgentAdminMemoriesTable = () => {
         },
         [sorting, setSorting],
     );
+
+    const handleResetFilters = useCallback(() => {
+        resetFilters();
+        setSearchInputKey((key) => key + 1);
+    }, [resetFilters]);
 
     const { containerRef: tableContainerRef, onScroll } = useInfiniteScroll({
         fetchNextPage,
@@ -372,9 +373,11 @@ const AiAgentAdminMemoriesTable = () => {
                 >
                     <Group gap="xs">
                         <SearchFilter
-                            search={search}
+                            key={searchInputKey}
+                            search={searchInputKey === 0 ? search : undefined}
                             setSearch={setSearch}
                             placeholder="Search memories"
+                            debounceMs={300}
                         />
 
                         <Divider
@@ -419,7 +422,7 @@ const AiAgentAdminMemoriesTable = () => {
                                             size="sm"
                                         />
                                     }
-                                    onClick={resetFilters}
+                                    onClick={handleResetFilters}
                                 >
                                     Clear all filters
                                 </Button>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/SearchFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/SearchFilter.tsx
@@ -1,4 +1,6 @@
 import { type TextInputProps } from '@mantine/core';
+import { useDebouncedCallback } from '@mantine/hooks';
+import { useCallback, useState } from 'react';
 import { ContentTableSearchInput } from '../../../../../components/common/ContentTable';
 import { type useAiAgentAdminFilters } from '../../hooks/useAiAgentAdminFilters';
 
@@ -6,19 +8,39 @@ type SearchFilterProps = Pick<
     ReturnType<typeof useAiAgentAdminFilters>,
     'search' | 'setSearch'
 > &
-    Pick<TextInputProps, 'placeholder'>;
+    Pick<TextInputProps, 'placeholder'> & {
+        debounceMs?: number;
+    };
 
 export const SearchFilter = ({
     search,
     setSearch,
     placeholder,
+    debounceMs,
 }: SearchFilterProps) => {
+    const [inputValue, setInputValue] = useState(search ?? '');
+    const debouncedSetSearch = useDebouncedCallback(setSearch, debounceMs ?? 0);
+
+    const handleChange = useCallback(
+        (value: string) => {
+            if (!debounceMs) {
+                setSearch(value);
+                return;
+            }
+
+            setInputValue(value);
+            debouncedSetSearch(value || undefined);
+            if (value === '') debouncedSetSearch.flush();
+        },
+        [debounceMs, debouncedSetSearch, setSearch],
+    );
+
     return (
         <ContentTableSearchInput
             tooltipLabel="Search current view"
             placeholder={placeholder}
-            value={search ?? ''}
-            onChange={setSearch}
+            value={debounceMs ? inputValue : (search ?? '')}
+            onChange={handleChange}
             collapsedWidth={340}
             expandedWidth={340}
         />


### PR DESCRIPTION
### Description
- keep memory admin search typing local and responsive
- commit only the final search to the URL and query after 300 ms
- clear pending/local search state when filters reset

### Root cause
The input was controlled by URL state, so every keystroke navigated and re-rendered the table. Only the API value was debounced, leaving typing coupled to expensive route/table updates.

### Validation
- Browser: rapid `medicine` input retained all characters; URL updated after idle; results settled to 1 of 1
- frontend tests: 2320 passed
- frontend typecheck, focused lint/format, and git diff check passed
- two blocker-only review rounds; final round clean

Closes: ZAP-816