### PR TITLE
feat(trino): support optional personal warehouse credentials with project fallback

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -35,6 +35,7 @@ import {
     type Project,
     type RegisteredAccount,
     type UpdateProject,
+    type UserWarehouseCredentialsWithSecrets,
 } from '@lightdash/common';
 import { Readable } from 'stream';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
@@ -1487,6 +1488,100 @@ describe('ProjectService', () => {
                     requireUserCredentials: true,
                 }),
             );
+        });
+
+        describe('optional Trino user credentials', () => {
+            const projectTrinoCredentials = {
+                type: WarehouseTypes.TRINO,
+                host: 'trino.example.com',
+                user: 'project_user',
+                password: 'project-password',
+                port: 443,
+                dbname: 'analytics',
+                schema: 'public',
+                http_scheme: 'https',
+                requireUserCredentials: false,
+            };
+
+            const getCredentials = () =>
+                (
+                    service as unknown as {
+                        getWarehouseCredentials: (args: {
+                            projectUuid: string;
+                            userId: string;
+                            isRegisteredUser: boolean;
+                        }) => Promise<CreateWarehouseCredentials>;
+                    }
+                ).getWarehouseCredentials({
+                    projectUuid,
+                    userId: sessionAccount.user.id,
+                    isRegisteredUser: true,
+                });
+
+            const mockUserCredentials = (
+                credentials: UserWarehouseCredentialsWithSecrets | undefined,
+            ) => {
+                const findForProjectWithSecretsMock = vi.fn(
+                    async () => credentials,
+                );
+                (
+                    service as unknown as {
+                        userWarehouseCredentialsModel: {
+                            findForProjectWithSecrets: import('vitest').Mock;
+                        };
+                    }
+                ).userWarehouseCredentialsModel.findForProjectWithSecrets =
+                    findForProjectWithSecretsMock;
+                return findForProjectWithSecretsMock;
+            };
+
+            beforeEach(() => {
+                service.warehouseClients = {};
+                (
+                    projectModel.getWarehouseCredentialsForProject as import('vitest').Mock
+                ).mockImplementation(async () => projectTrinoCredentials);
+            });
+
+            test('should use user credentials when available and not required', async () => {
+                const findForProjectWithSecretsMock = mockUserCredentials({
+                    uuid: 'user-trino-creds-uuid',
+                    credentials: {
+                        type: WarehouseTypes.TRINO,
+                        user: 'personal_user',
+                        password: 'personal-password',
+                    },
+                });
+
+                const credentials = await getCredentials();
+
+                expect(findForProjectWithSecretsMock).toHaveBeenCalledWith(
+                    projectUuid,
+                    sessionAccount.user.id,
+                    WarehouseTypes.TRINO,
+                );
+                expect(credentials).toEqual(
+                    expect.objectContaining({
+                        host: 'trino.example.com',
+                        user: 'personal_user',
+                        password: 'personal-password',
+                        userWarehouseCredentialsUuid: 'user-trino-creds-uuid',
+                    }),
+                );
+            });
+
+            test('should fall back to project credentials when user has none', async () => {
+                mockUserCredentials(undefined);
+
+                const credentials = await getCredentials();
+
+                expect(credentials).toEqual(
+                    expect.objectContaining({
+                        user: 'project_user',
+                        password: 'project-password',
+                        userWarehouseCredentialsUuid: undefined,
+                    }),
+                );
+            });
         });
 
         test('should use user Redshift IAM identity when requireUserCredentials is true', async () => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -172,6 +172,7 @@ import {
     SqlRunnerPayload,
     SqlRunnerPivotQueryPayload,
     SummaryExplore,
+    supportsOptionalUserCredentials,
     TablesConfiguration,
     TableSelectionType,
     UnexpectedServerError,
@@ -1800,10 +1801,11 @@ export class ProjectService extends BaseService {
         // Check if user has their own credentials for this project's warehouse type
         // Only fetch user credentials when:
         // 1. requireUserCredentials is enabled (user credentials are mandatory)
-        // 2. Databricks warehouse (supports optional user OAuth credentials)
+        // 2. The warehouse type supports optional user credentials, which are
+        //    used when present and fall back to the project connection otherwise
         const shouldFetchUserCredentials =
             credentials.requireUserCredentials ||
-            credentials.type === WarehouseTypes.DATABRICKS;
+            supportsOptionalUserCredentials(credentials.type);
 
         if (isRegisteredUser) {
             // Fetch user credentials only when needed (for performance)

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -203,6 +203,8 @@ export {
     SnowflakeAuthenticationType,
     stripDucklakeNestedSensitive,
     SupportedDbtVersions,
+    supportsOptionalUserCredentials,
+    WAREHOUSE_TYPES_WITH_OPTIONAL_USER_CREDENTIALS,
     WarehouseTypes,
 } from './types/projects';
 export type {

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -30,6 +30,20 @@ export enum WarehouseTypes {
     DUCKDB = 'duckdb',
 }
 
+/**
+ * Warehouse types where personal warehouse credentials are optional: they are
+ * used when the user has them, and queries fall back to the shared project
+ * connection when they don't, regardless of `requireUserCredentials`.
+ */
+export const WAREHOUSE_TYPES_WITH_OPTIONAL_USER_CREDENTIALS: WarehouseTypes[] =
+    [WarehouseTypes.DATABRICKS, WarehouseTypes.TRINO];
+
+export const supportsOptionalUserCredentials = (
+    warehouseType: WarehouseTypes | undefined,
+): boolean =>
+    !!warehouseType &&
+    WAREHOUSE_TYPES_WITH_OPTIONAL_USER_CREDENTIALS.includes(warehouseType);
+
 export enum DuckdbConnectionType {
     MOTHERDUCK = 'motherduck',
     DUCKLAKE = 'ducklake',

--- a/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
@@ -1,3 +1,4 @@
+import { supportsOptionalUserCredentials } from '@lightdash/common';
 import { Button, getDefaultZIndex, Menu, Text } from '@mantine/core';
 import { IconCheck, IconDatabaseCog, IconPlus } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -159,12 +160,22 @@ const UserCredentialsSwitcher = () => {
         compatibleCredentials,
     ]);
 
+    // Show the switcher when personal credentials are mandatory, or when they
+    // are optional for this warehouse type and the user already has some
+    const isSwitcherVisible =
+        activeProject?.warehouseConnection?.requireUserCredentials ||
+        (supportsOptionalUserCredentials(
+            activeProject?.warehouseConnection?.type,
+        ) &&
+            !!compatibleCredentials?.length);
+
     if (
         isLoadingCredentials ||
         isLoadingActiveProject ||
         isLoadingActiveProjectUuid ||
         !activeProjectUuid ||
-        !activeProject?.warehouseConnection?.requireUserCredentials
+        !activeProject ||
+        !isSwitcherVisible
     ) {
         return null;
     }


### PR DESCRIPTION
Closes: lightdash/lightdash#27094

### Description:

Trino personal warehouse credentials were all-or-nothing: only looked up when the project's `Require users to provide their own credentials` toggle was on, forcing every user to set them up. Databricks already had a better model — personal credentials looked up regardless of the toggle, used when present, silently falling back to the shared project connection when absent. This applies the same semantics to Trino.

* New `supportsOptionalUserCredentials()` helper in `@lightdash/common` (backed by `WAREHOUSE_TYPES_WITH_OPTIONAL_USER_CREDENTIALS = [databricks, trino]`), replacing the hardcoded Databricks check in `ProjectService.getWarehouseCredentials`. Everything downstream (merge, refresh, fallback) was already type-agnostic.
* The navbar credential switcher now also shows for optional-credential warehouse types when the user has compatible credentials, not only when credentials are required. This makes the switcher appear for Databricks users with personal credentials too, which matches what the backend already does with them.

`requireUserCredentials = true` behaviour is unchanged, and since SQL Runner resolves credentials through the same path, a user's raw SQL access is scoped by whatever roles their personal Trino credentials carry.

Added `ProjectService` tests covering both Trino paths (user credentials merged over the project connection; fallback to project credentials when the user has none).