### PR TITLE
fix: debounce admin thread search

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -28,14 +28,7 @@ import {
     IconTilde,
     IconUser,
 } from '@tabler/icons-react';
-import {
-    useCallback,
-    useDeferredValue,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import {
@@ -109,8 +102,6 @@ const AiAgentAdminThreadsTable = ({
         resetFilters,
     } = useAiAgentAdminFilters();
 
-    const deferredSearch = useDeferredValue(search);
-
     const sorting = useMemo<ContentTableSortingState>(
         () => [{ id: sortField, desc: sortDirection === 'desc' }],
         [sortField, sortDirection],
@@ -152,10 +143,7 @@ const AiAgentAdminThreadsTable = ({
         useInfiniteAiAgentAdminThreads(
             {
                 pagination: {},
-                filters: {
-                    ...apiFilters,
-                    ...(deferredSearch && { search: deferredSearch }),
-                },
+                filters: apiFilters,
                 sort: {
                     field: sortField,
                     direction: sortDirection,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
@@ -8,7 +8,7 @@ import {
     type GroupProps,
 } from '@mantine/core';
 import { IconTrash } from '@tabler/icons-react';
-import { memo, type FC } from 'react';
+import { memo, useCallback, useState, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { type useAiAgentAdminFilters } from '../../hooks/useAiAgentAdminFilters';
 import AgentsFilter from './AgentsFilter';
@@ -65,6 +65,12 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
         ...props
     }) => {
         const theme = useMantineTheme();
+        const [searchInputKey, setSearchInputKey] = useState(0);
+
+        const handleClearFilters = useCallback(() => {
+            onClearFilters?.();
+            setSearchInputKey((key) => key + 1);
+        }, [onClearFilters]);
 
         return (
             <Box>
@@ -75,9 +81,11 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                 >
                     <Group gap="xs">
                         <SearchFilter
-                            search={search}
+                            key={searchInputKey}
+                            search={searchInputKey === 0 ? search : undefined}
                             setSearch={setSearch}
                             placeholder="Search threads by title"
+                            debounceMs={300}
                         />
 
                         <Divider
@@ -163,7 +171,7 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                                             size="sm"
                                         />
                                     }
-                                    onClick={onClearFilters}
+                                    onClick={handleClearFilters}
                                 >
                                     Clear all filters
                                 </Button>


### PR DESCRIPTION
### Description
- opt the Threads admin search into the shared 300 ms local-input debounce
- reset the local search when clearing all filters
- remove the redundant `useDeferredValue` query layer

### Stack
Depends on #27096.

### Validation
- frontend typecheck passed
- focused lint, format, and git diff checks passed

Relates: ZAP-816