### PR TITLE
feat: add GPT-5.6 model presets

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 export const DEFAULT_OPENAI_MODEL_NAME = 'gpt-5.4';
+export const DEFAULT_OPENAI_FAST_MODEL_NAME = 'gpt-5.6-luna';
 export const DEFAULT_ANTHROPIC_MODEL_NAME = 'claude-sonnet-4-6';
 export const DEFAULT_DEFAULT_AI_PROVIDER = 'openai';
 export const DEFAULT_OPENROUTER_MODEL_NAME = 'openai/gpt-5.2-2025-12-11';

--- a/packages/backend/src/ee/services/ai/filterPermutations/llmFilterPermutationRunner.ts
+++ b/packages/backend/src/ee/services/ai/filterPermutations/llmFilterPermutationRunner.ts
@@ -12,7 +12,7 @@ import { aiCopilotConfigSchema } from '../../../../config/aiConfigSchema';
 import { getAiConfig } from '../../../../config/parseConfig';
 import { getModel } from '../models';
 import { getOpenaiGptmodel } from '../models/openai-gpt';
-import { type ModelPreset } from '../models/presets';
+import { getModelPreset } from '../models/presets';
 import {
     fieldCatalog,
     filterPermutationCases,
@@ -24,20 +24,15 @@ import {
 export type FiltersInput = z.infer<typeof filtersSchemaV2>;
 type FilterRuleInput = NonNullable<FiltersInput['dimensions']>[number];
 
-// Keep Luna local to this opt-in suite; it is not a production model preset.
-const GPT_5_6_LUNA_FILTER_PERMUTATION_PRESET = {
-    name: 'gpt-5.6-luna',
-    provider: 'openai',
-    modelId: 'gpt-5.6-luna',
-    displayName: 'GPT-5.6 Luna',
-    description: 'Test-only model for AI filter permutation coverage',
-    contextWindowTokens: 272_000,
-    supportsReasoning: true,
-    callOptions: {},
-    providerOptions: {
-        parallelToolCalls: false,
-    },
-} as const satisfies ModelPreset<'openai'>;
+const GPT_5_6_LUNA_MODEL_NAME = 'gpt-5.6-luna';
+const getLunaFilterPermutationPreset = () => {
+    const preset = getModelPreset('openai', GPT_5_6_LUNA_MODEL_NAME);
+    if (!preset) {
+        throw new Error('GPT-5.6 Luna model preset is required');
+    }
+
+    return preset;
+};
 
 type FilterPermutationModelOptions = Pick<
     ReturnType<typeof getModel>,
@@ -49,7 +44,7 @@ export type FilterPermutationModelConfig =
     | {
           label: string;
           provider: 'openai';
-          modelName: typeof GPT_5_6_LUNA_FILTER_PERMUTATION_PRESET.name;
+          modelName: typeof GPT_5_6_LUNA_MODEL_NAME;
           requiredEnvVar: string;
       }
     | {
@@ -107,7 +102,7 @@ export const filterPermutationModelConfigs = {
     openai: {
         label: 'OpenAI GPT-5.6 Luna',
         provider: 'openai',
-        modelName: GPT_5_6_LUNA_FILTER_PERMUTATION_PRESET.name,
+        modelName: GPT_5_6_LUNA_MODEL_NAME,
         requiredEnvVar: 'OPENAI_API_KEY',
     },
     anthropic: {
@@ -407,7 +402,7 @@ export const getFilterPermutationModelOptions = (
 
             return getOpenaiGptmodel(
                 providerConfig,
-                GPT_5_6_LUNA_FILTER_PERMUTATION_PRESET,
+                getLunaFilterPermutationPreset(),
                 { enableReasoning: false },
             );
         }

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -8,6 +8,7 @@ import {
 } from '@lightdash/common';
 import { simulateStreamingMiddleware, wrapLanguageModel } from 'ai';
 import type { AiKeyManagement } from '../../../../analytics/aiUsage';
+import { DEFAULT_OPENAI_FAST_MODEL_NAME } from '../../../../config/aiConfigSchema';
 import { LightdashConfig } from '../../../../config/parseConfig';
 import Logger from '../../../../logging/logger';
 import { getAnthropicModel } from './anthropic-claude';
@@ -61,7 +62,7 @@ const withKeyManagement = <P extends AiProvider>(
 // Fast models for lightweight tasks (text generation, summaries, etc.)
 // These are cheaper and faster than default models
 const FAST_MODELS: Record<ModelPresetProvider, string> = {
-    openai: 'gpt-5-mini',
+    openai: DEFAULT_OPENAI_FAST_MODEL_NAME,
     anthropic: 'claude-haiku-4-5',
     bedrock: 'claude-haiku-4-5',
 };

--- a/packages/backend/src/ee/services/ai/models/presets.ts
+++ b/packages/backend/src/ee/services/ai/models/presets.ts
@@ -30,6 +30,34 @@ export const MODEL_PRESETS: {
 } = {
     openai: [
         {
+            name: 'gpt-5.6-sol',
+            provider: 'openai',
+            modelId: 'gpt-5.6-sol',
+            displayName: 'GPT-5.6 Sol',
+            description: 'Frontier model for complex professional work',
+            contextWindowTokens: 1050000,
+            supportsReasoning: true,
+            callOptions: {},
+            providerOptions: {
+                // strictJsonSchema: provider default is true
+                parallelToolCalls: false,
+            },
+        },
+        {
+            name: 'gpt-5.6-luna',
+            provider: 'openai',
+            modelId: 'gpt-5.6-luna',
+            displayName: 'GPT-5.6 Luna',
+            description: 'Fast, cost-effective model for lightweight tasks',
+            contextWindowTokens: 1050000,
+            supportsReasoning: true,
+            callOptions: {},
+            providerOptions: {
+                // strictJsonSchema: provider default is true
+                parallelToolCalls: false,
+            },
+        },
+        {
             name: 'gpt-5.5',
             provider: 'openai',
             modelId: 'gpt-5.5-2026-04-23',


### PR DESCRIPTION
## Summary

- add GPT-5.6 Sol and Luna to the OpenAI model catalog
- keep GPT-5.4 as the default and use Luna as the fast OpenAI model
- reuse the production Luna preset in filter-permutation runs
- validate the Luna preset only when the OpenAI permutation runner is used

## Verification

- 172 config tests passed
- backend typecheck, scoped lint, and formatting passed

Closes: ZAP-825
