### PR TITLE
fix(ai): persist agent choice on Slack picker meta-queries

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -13458,7 +13458,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         }
     }
 
-    private async createAndScheduleSlackPromptFromAction(args: {
+    private async createSlackPromptFromAction(args: {
         channelId: string;
         threadTs: string | undefined;
         agentConfig: AiAgent;
@@ -13466,6 +13466,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         slackUserId: string;
         promptText: string;
         promptSlackTs: string;
+        // Meta-queries still create the thread and bind the agent, but schedule
+        // nothing because the agent has no question to answer.
+        forwardToAgent: boolean;
     }): Promise<void> {
         const [slackPromptUuid] = await this.createSlackPrompt({
             userUuid: args.userUuid,
@@ -13477,6 +13480,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             promptSlackTs: args.promptSlackTs,
             agentUuid: args.agentConfig.uuid,
         });
+
+        if (!args.forwardToAgent) {
+            return;
+        }
 
         await this.setThinkingStatusAndSchedule({
             agentConfig: args.agentConfig,
@@ -13670,15 +13677,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     },
                 );
 
-                // If this was a meta-query about agent selection, don't forward it to the agent
+                // A meta-query is not forwarded to the agent, but the thread is
+                // still created and bound so the choice survives the next turn.
                 if (shouldSkipForwardingQuery) {
                     Logger.info(
-                        `Skipping query forwarding for meta-query in agent selection`,
+                        `Binding thread to selected agent without forwarding meta-query`,
                     );
-                    return;
                 }
 
-                await this.createAndScheduleSlackPromptFromAction({
+                await this.createSlackPromptFromAction({
                     channelId,
                     threadTs,
                     agentConfig,
@@ -13686,8 +13693,16 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     slackUserId: body.user.id,
                     promptText: originalMessage.text,
                     promptSlackTs: originalMessage.ts || '',
+                    forwardToAgent: !shouldSkipForwardingQuery,
                 });
             } catch (e) {
+                if (e instanceof AiDuplicateSlackPromptError) {
+                    Logger.debug(
+                        'Duplicate slack prompt on agent selection',
+                        e,
+                    );
+                    return;
+                }
                 Logger.error('Error handling agent selection', e);
                 // Try to notify the user of the error
                 if (body.user?.id && 'channel' in body && body.channel?.id) {
@@ -14240,7 +14255,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         throw accessError;
                     }
 
-                    await this.createAndScheduleSlackPromptFromAction({
+                    await this.createSlackPromptFromAction({
                         channelId,
                         threadTs,
                         agentConfig,
@@ -14248,6 +14263,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         slackUserId: originalMessage.user,
                         promptText: originalMessage.text,
                         promptSlackTs: originalMessage.ts,
+                        forwardToAgent: true,
                     });
                 } catch (e) {
                     if (e instanceof AiDuplicateSlackPromptError) {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -13466,8 +13466,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         slackUserId: string;
         promptText: string;
         promptSlackTs: string;
-        // Meta-queries still create the thread and bind the agent, but schedule
-        // nothing because the agent has no question to answer.
         forwardToAgent: boolean;
     }): Promise<void> {
         const [slackPromptUuid] = await this.createSlackPrompt({
@@ -13481,6 +13479,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             agentUuid: args.agentConfig.uuid,
         });
 
+        // The thread and its agent binding are written above; a meta-query has
+        // nothing for the agent to answer, so no run is scheduled.
         if (!args.forwardToAgent) {
             return;
         }
@@ -13677,14 +13677,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     },
                 );
 
-                // A meta-query is not forwarded to the agent, but the thread is
-                // still created and bound so the choice survives the next turn.
-                if (shouldSkipForwardingQuery) {
-                    Logger.info(
-                        `Binding thread to selected agent without forwarding meta-query`,
-                    );
-                }
-
+                // A meta-query is not forwarded to the agent, but the choice
+                // still binds the thread so the next turn keeps this agent.
                 await this.createSlackPromptFromAction({
                     channelId,
                     threadTs,
@@ -13696,6 +13690,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     forwardToAgent: !shouldSkipForwardingQuery,
                 });
             } catch (e) {
+                // The picker message is already rewritten by now, so a replayed
+                // selection is a no-op rather than something to warn about.
                 if (e instanceof AiDuplicateSlackPromptError) {
                     Logger.debug(
                         'Duplicate slack prompt on agent selection',


### PR DESCRIPTION
## Problem

When a Slack mention was a meta-query about agent selection (asking about the agents themselves rather than asking for data), picking an agent from the picker rewrote the picker message into a confirmation and then returned early. It never created the thread and never bound the chosen agent to it, so the choice was not persisted. The next mention in the same thread re-ran agent selection and posted another picker.

## Fix

Agent selection now always creates the thread and binds the selected agent to it. Only the query-forwarding step is conditional: `createAndScheduleSlackPromptFromAction` becomes `createSlackPromptFromAction` with an explicit `forwardToAgent` flag, so a meta-query selection writes the thread and its agent binding but schedules no run.

Additionally, a replayed picker action (duplicate prompt) is now swallowed as a no-op — by the time the duplicate arrives the picker message has already been rewritten, so there is nothing to warn about.

## Testing

- New behavioral test file `packages/backend/src/ee/services/AiAgentService/slackAgentPickerBinding.test.ts`, written red-before-green against the fix.
- `pnpm -F backend lint` and `pnpm -F backend typecheck` clean.
- Verified end to end against a local dev Slack workspace:
    - meta-query selection now binds and persists the agent, with no scheduled run
    - a follow-up mention in the same thread goes straight to the bound agent, with no second picker
    - non-meta selection still forwards the query and answers as before
    - duplicate action replay is idempotent

Closes: ZAP-821
https://linear.app/lightdash/issue/ZAP-821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
