### PR TITLE
fix(ai): coerce numeric string args in AI tool input schemas

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -2279,7 +2279,8 @@ Example B — "Revenue by month with year-over-year comparison"
                                           "values": {
                                             "description": "Exactly one positive number of periods, e.g. [2].",
                                             "items": {
-                                              "type": "number",
+                                              "exclusiveMinimum": 0,
+                                              "type": "integer",
                                             },
                                             "maxItems": 1,
                                             "minItems": 1,
@@ -3229,7 +3230,8 @@ Example B — "Revenue by month with year-over-year comparison"
                                 "values": {
                                   "description": "Exactly one positive number of periods, e.g. [2].",
                                   "items": {
-                                    "type": "number",
+                                    "exclusiveMinimum": 0,
+                                    "type": "integer",
                                   },
                                   "maxItems": 1,
                                   "minItems": 1,
@@ -4063,7 +4065,8 @@ Example B — "Revenue by month with year-over-year comparison"
                                 "values": {
                                   "description": "Exactly one positive number of periods, e.g. [2].",
                                   "items": {
-                                    "type": "number",
+                                    "exclusiveMinimum": 0,
+                                    "type": "integer",
                                   },
                                   "maxItems": 1,
                                   "minItems": 1,
@@ -5925,7 +5928,8 @@ Usage Tips:
                             "values": {
                               "description": "Exactly one positive number of periods, e.g. [2].",
                               "items": {
-                                "type": "number",
+                                "exclusiveMinimum": 0,
+                                "type": "integer",
                               },
                               "maxItems": 1,
                               "minItems": 1,
@@ -6759,7 +6763,8 @@ Usage Tips:
                             "values": {
                               "description": "Exactly one positive number of periods, e.g. [2].",
                               "items": {
-                                "type": "number",
+                                "exclusiveMinimum": 0,
+                                "type": "integer",
                               },
                               "maxItems": 1,
                               "minItems": 1,

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -2315,7 +2315,8 @@ Recommended Dashboard Structure:
                                                       "values": {
                                                         "description": "Exactly one positive number of periods, e.g. [2].",
                                                         "items": {
-                                                          "type": "number",
+                                                          "exclusiveMinimum": 0,
+                                                          "type": "integer",
                                                         },
                                                         "maxItems": 1,
                                                         "minItems": 1,
@@ -5900,7 +5901,8 @@ Notes:
                                                 "values": {
                                                   "description": "Exactly one positive number of periods, e.g. [2].",
                                                   "items": {
-                                                    "type": "number",
+                                                    "exclusiveMinimum": 0,
+                                                    "type": "integer",
                                                   },
                                                   "maxItems": 1,
                                                   "minItems": 1,
@@ -7623,7 +7625,8 @@ Usage Tips:
                                   "values": {
                                     "description": "Exactly one positive number of periods, e.g. [2].",
                                     "items": {
-                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "type": "integer",
                                     },
                                     "maxItems": 1,
                                     "minItems": 1,

--- a/packages/backend/src/ee/services/ai/utils/validateFilterRuleErrors.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateFilterRuleErrors.test.ts
@@ -184,13 +184,26 @@ describe('validateFilterRules error messages', () => {
         expect(message).not.toContain('Received [].');
     });
 
+    it('accepts numeric strings for number filters via coercion', () => {
+        expect(() =>
+            validateFilterRules(mockOrdersExplore, [
+                rule({
+                    id: 'filter-number-string',
+                    fieldId: 'orders_amount',
+                    operator: FilterOperator.GREATER_THAN,
+                    values: ['100'],
+                }),
+            ]),
+        ).not.toThrow();
+    });
+
     it('explains invalid number filters with available combinations', () => {
         const message = getValidationMessage(
             rule({
                 id: 'filter-number',
                 fieldId: 'orders_amount',
                 operator: FilterOperator.GREATER_THAN,
-                values: ['100'],
+                values: ['not-a-number'],
             }),
         );
 
@@ -198,7 +211,7 @@ describe('validateFilterRules error messages', () => {
             'Invalid filter for field "orders_amount" (Amount).',
         );
         expect(message).toContain(
-            '"greaterThan" is a valid number operator, but values must be an array with exactly one number. Received ["100"].',
+            '"greaterThan" is a valid number operator, but values must be an array with exactly one number. Received ["not-a-number"].',
         );
         expect(message).toContain(
             'For number fields, these are all available filter combinations:',

--- a/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
+++ b/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
@@ -129,7 +129,7 @@ const periodComparisonCustomMetricSchema = z.object({
     granularity: popGranularityEnum.describe(
         "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
     ),
-    periodOffset: z
+    periodOffset: z.coerce
         .number()
         .int()
         .min(1)

--- a/packages/common/src/ee/AiAgent/schemas/filters/dateFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/dateFilters.ts
@@ -92,7 +92,7 @@ const dateFilterSchema = z.union([
                     `Use ${FilterOperator.IN_THE_PAST} for last/past N periods, ${FilterOperator.IN_THE_NEXT} for next N periods, ${FilterOperator.NOT_IN_THE_PAST} to exclude recent periods.`,
                 ),
             values: z
-                .array(z.number())
+                .array(z.coerce.number().int().positive())
                 .length(1)
                 .describe('Exactly one positive number of periods, e.g. [2].'),
             settings: z

--- a/packages/common/src/ee/AiAgent/schemas/filters/numberFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/numberFilters.ts
@@ -60,7 +60,7 @@ const numberFilterSchema = z.union([
                     `Use ${filterOperatorList(FilterOperator.EQUALS, FilterOperator.NOT_EQUALS)} for exact numeric matches.`,
                 ),
             values: z
-                .array(z.number())
+                .array(z.coerce.number())
                 .describe('One or more exact numeric values to match.'),
         })
         .strict()
@@ -90,7 +90,7 @@ const numberFilterSchema = z.union([
                     'Use for threshold comparisons such as greater than 100.',
                 ),
             values: z
-                .array(z.number())
+                .array(z.coerce.number())
                 .length(1)
                 .describe('Exactly one numeric threshold value.'),
         })
@@ -119,7 +119,7 @@ const numberFilterSchema = z.union([
                 ])
                 .describe('Use for ranges between two numeric bounds.'),
             values: z
-                .array(z.number())
+                .array(z.coerce.number())
                 .length(2)
                 .describe('Exactly two numeric bounds: [lower, upper].'),
         })

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolCreateContentArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolCreateContentArgs.ts
@@ -44,7 +44,7 @@ const baseContentSchema = z.object({
     name: z.string().min(1),
     description: z.string().nullable(),
     spaceSlug: z.string().min(1),
-    version: z.number(),
+    version: z.coerce.number(),
     contentType: z.string(),
     updatedAt: z.unknown(),
     downloadedAt: z.unknown(),

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolCreateScheduledDeliveryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolCreateScheduledDeliveryArgs.ts
@@ -64,7 +64,7 @@ export const toolCreateScheduledDeliveryArgsSchema = z.object({
                 .union([
                     z.literal('table'),
                     z.literal('all'),
-                    z.number().int().positive(),
+                    z.coerce.number().int().positive(),
                 ])
                 .describe(
                     '"table" = the chart\'s own limit, "all" = all results, or an explicit row count.',

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateUuidsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateUuidsArgs.ts
@@ -5,7 +5,11 @@ export const TOOL_GENERATE_UUIDS_DESCRIPTION =
     'Generate one or more UUIDs to use as stable identifiers when creating new objects.';
 
 export const toolGenerateUuidsArgsSchema = z.object({
-    count: z.number().min(1).max(20).describe('Number of UUIDs to generate.'),
+    count: z.coerce
+        .number()
+        .min(1)
+        .max(20)
+        .describe('Number of UUIDs to generate.'),
 });
 
 export const toolGenerateUuidsOutputSchema = z.object({

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolListWarehouseTablesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolListWarehouseTablesArgs.ts
@@ -39,7 +39,7 @@ export const toolListWarehouseTablesArgsSchema = createToolSchema()
             .describe(
                 'Optional case-insensitive substring filter on table name.',
             ),
-        limit: z
+        limit: z.coerce
             .number()
             .int()
             .positive()

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunContentQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunContentQueryArgs.ts
@@ -29,7 +29,7 @@ export const toolRunContentQueryArgsSchema = createToolSchema()
             z.object({
                 type: z.literal('chart'),
                 chartSlug: z.string().describe('Slug of the saved chart.'),
-                limit: z
+                limit: z.coerce
                     .number()
                     .nullable()
                     .describe('Optional row limit override.'),
@@ -40,7 +40,7 @@ export const toolRunContentQueryArgsSchema = createToolSchema()
                 dashboardSlug: z
                     .string()
                     .describe('Slug of the dashboard containing the chart.'),
-                limit: z
+                limit: z.coerce
                     .number()
                     .nullable()
                     .describe('Optional row limit override.'),

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -39,7 +39,7 @@ const queryConfigBaseSchema = z.object({
         .describe(
             'Sort configuration for the query, it can use a combination of metrics and dimensions.',
         ),
-    limit: z
+    limit: z.coerce
         .number()
         .nullable()
         .describe(

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunSqlArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunSqlArgs.ts
@@ -60,7 +60,7 @@ export const createToolRunSqlArgsSchema = ({
                 .describe(
                     'The SQL query to execute against the data warehouse.',
                 ),
-            limit: z
+            limit: z.coerce
                 .number()
                 .int()
                 .positive()

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
@@ -31,7 +31,7 @@ export const tableVizConfigSchema = z
                 'Sort configuration for the query, it can use a combination of metrics and dimensions.',
             ),
 
-        limit: z
+        limit: z.coerce
             .number()
             .nullable()
             .describe('The maximum number of rows in the table.'),

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
@@ -39,7 +39,7 @@ export const timeSeriesMetricVizConfigSchema = z.object({
         .describe(
             'default line. The type of line to display. If area then the area under the line will be filled in.',
         ),
-    limit: z
+    limit: z.coerce
         .number()
         .max(AI_DEFAULT_MAX_QUERY_LIMIT)
         .nullable()

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
@@ -30,7 +30,7 @@ export const verticalBarMetricVizConfigSchema = z.object({
         .describe(
             'Sort configuration for the query, it can use a combination of metrics and dimensions.',
         ),
-    limit: z
+    limit: z.coerce
         .number()
         .max(AI_DEFAULT_MAX_QUERY_LIMIT)
         .nullable()


### PR DESCRIPTION
AI agent tool calls were intermittently failing with `AI_InvalidToolInputError` whenever the model sent a numeric parameter as a JSON string (e.g. `runSql` with `{"limit": "500"}`) or omitted-vs-quoted numbers in filter values — surfacing as `AiAgentToolCallInvalid` noise in Sentry and costing users a wasted retry round-trip per occurrence. Neither the agent runtime nor the MCP compat layer coerced these (the MCP layer's number coercion silently skips `.default()`-wrapped fields), so the tolerance now lives in the input schemas themselves, covering both runtimes.