### PR TITLE
feat: add stable slugs to organization themes

### DIFF
--- a/packages/backend/src/controllers/organizationDesignController.ts
+++ b/packages/backend/src/controllers/organizationDesignController.ts
@@ -8,6 +8,7 @@ import {
     CreateOrganizationDesignRequest,
     ParameterError,
     UpdateOrganizationDesignRequest,
+    type UuidOrSlug,
 } from '@lightdash/common';
 import {
     Body,
@@ -64,11 +65,11 @@ export class OrganizationDesignController extends BaseController {
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Get('/{designUuid}')
+    @Get('/{designUuidOrSlug}')
     @OperationId('GetOrganizationDesign')
     async getDesign(
         @Request() req: express.Request,
-        @Path() designUuid: string,
+        @Path() designUuidOrSlug: UuidOrSlug,
     ): Promise<ApiOrganizationDesignResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -76,7 +77,7 @@ export class OrganizationDesignController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getOrganizationDesignService()
-                .getDesign(req.account, designUuid),
+                .getDesign(req.account, designUuidOrSlug),
         };
     }
 
@@ -116,11 +117,11 @@ export class OrganizationDesignController extends BaseController {
         unauthorisedInDemo,
     ])
     @SuccessResponse('200', 'Success')
-    @Patch('/{designUuid}')
+    @Patch('/{designUuidOrSlug}')
     @OperationId('UpdateOrganizationDesign')
     async updateDesign(
         @Request() req: express.Request,
-        @Path() designUuid: string,
+        @Path() designUuidOrSlug: UuidOrSlug,
         @Body() body: UpdateOrganizationDesignRequest,
     ): Promise<ApiOrganizationDesignResponse> {
         assertRegisteredAccount(req.account);
@@ -129,7 +130,7 @@ export class OrganizationDesignController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getOrganizationDesignService()
-                .updateDesign(req.account, designUuid, body),
+                .updateDesign(req.account, designUuidOrSlug, body),
         };
     }
 
@@ -138,9 +139,9 @@ export class OrganizationDesignController extends BaseController {
      * — succeeds when no default is set.
      *
      * NOTE: This literal `/default` route MUST stay registered before
-     * `Delete('/{designUuid}')` below so Express routes a request to
+     * `Delete('/{designUuidOrSlug}')` below so Express routes a request to
      * `DELETE /api/v1/org/designs/default` here rather than treating
-     * "default" as a `designUuid` path param.
+     * "default" as a `designUuidOrSlug` path param.
      * @summary Clear default organization design
      */
     @Middlewares([
@@ -172,16 +173,16 @@ export class OrganizationDesignController extends BaseController {
         unauthorisedInDemo,
     ])
     @SuccessResponse('200', 'Success')
-    @Delete('/{designUuid}')
+    @Delete('/{designUuidOrSlug}')
     @OperationId('DeleteOrganizationDesign')
     async deleteDesign(
         @Request() req: express.Request,
-        @Path() designUuid: string,
+        @Path() designUuidOrSlug: UuidOrSlug,
     ): Promise<ApiSuccessEmpty> {
         assertRegisteredAccount(req.account);
         await this.services
             .getOrganizationDesignService()
-            .deleteDesign(req.account, designUuid);
+            .deleteDesign(req.account, designUuidOrSlug);
         this.setStatus(200);
         return { status: 'ok', results: undefined };
     }
@@ -196,11 +197,11 @@ export class OrganizationDesignController extends BaseController {
         unauthorisedInDemo,
     ])
     @SuccessResponse('200', 'Success')
-    @Post('/{designUuid}/default')
+    @Post('/{designUuidOrSlug}/default')
     @OperationId('SetDefaultOrganizationDesign')
     async setAsDefault(
         @Request() req: express.Request,
-        @Path() designUuid: string,
+        @Path() designUuidOrSlug: UuidOrSlug,
     ): Promise<ApiOrganizationDesignResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -208,7 +209,7 @@ export class OrganizationDesignController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getOrganizationDesignService()
-                .setAsDefault(req.account, designUuid),
+                .setAsDefault(req.account, designUuidOrSlug),
         };
     }
 
@@ -225,11 +226,11 @@ export class OrganizationDesignController extends BaseController {
         unauthorisedInDemo,
     ])
     @SuccessResponse('201', 'Created')
-    @Post('/{designUuid}/files')
+    @Post('/{designUuidOrSlug}/files')
     @OperationId('UploadOrganizationDesignFile')
     async uploadFile(
         @Request() req: express.Request,
-        @Path() designUuid: string,
+        @Path() designUuidOrSlug: UuidOrSlug,
         @Query() kind: string,
         @Query() filename: string,
     ): Promise<ApiOrganizationDesignFileResponse> {
@@ -253,7 +254,7 @@ export class OrganizationDesignController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getOrganizationDesignService()
-                .uploadFile(req.account, designUuid, {
+                .uploadFile(req.account, designUuidOrSlug, {
                     kind,
                     filename,
                     contentType,
@@ -274,16 +275,16 @@ export class OrganizationDesignController extends BaseController {
         unauthorisedInDemo,
     ])
     @SuccessResponse('200', 'Success')
-    @Delete('/{designUuid}/files')
+    @Delete('/{designUuidOrSlug}/files')
     @OperationId('DeleteAllOrganizationDesignFiles')
     async deleteAllFiles(
         @Request() req: express.Request,
-        @Path() designUuid: string,
+        @Path() designUuidOrSlug: UuidOrSlug,
     ): Promise<ApiSuccessEmpty> {
         assertRegisteredAccount(req.account);
         await this.services
             .getOrganizationDesignService()
-            .clearFiles(req.account, designUuid);
+            .clearFiles(req.account, designUuidOrSlug);
         this.setStatus(200);
         return { status: 'ok', results: undefined };
     }
@@ -298,17 +299,17 @@ export class OrganizationDesignController extends BaseController {
         unauthorisedInDemo,
     ])
     @SuccessResponse('200', 'Success')
-    @Delete('/{designUuid}/files/{fileUuid}')
+    @Delete('/{designUuidOrSlug}/files/{fileUuid}')
     @OperationId('DeleteOrganizationDesignFile')
     async deleteFile(
         @Request() req: express.Request,
-        @Path() designUuid: string,
+        @Path() designUuidOrSlug: UuidOrSlug,
         @Path() fileUuid: string,
     ): Promise<ApiSuccessEmpty> {
         assertRegisteredAccount(req.account);
         await this.services
             .getOrganizationDesignService()
-            .deleteFile(req.account, designUuid, fileUuid);
+            .deleteFile(req.account, designUuidOrSlug, fileUuid);
         this.setStatus(200);
         return { status: 'ok', results: undefined };
     }
@@ -321,17 +322,17 @@ export class OrganizationDesignController extends BaseController {
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Get('/{designUuid}/files/{fileUuid}')
+    @Get('/{designUuidOrSlug}/files/{fileUuid}')
     @OperationId('DownloadOrganizationDesignFile')
     async downloadFile(
         @Request() req: express.Request,
-        @Path() designUuid: string,
+        @Path() designUuidOrSlug: UuidOrSlug,
         @Path() fileUuid: string,
     ): Promise<void> {
         assertRegisteredAccount(req.account);
         const { body, contentType, filename, sizeBytes } = await this.services
             .getOrganizationDesignService()
-            .getFileStream(req.account, designUuid, fileUuid);
+            .getFileStream(req.account, designUuidOrSlug, fileUuid);
         const { res } = req as express.Request & { res: express.Response };
         res.status(200);
         res.setHeader('Content-Type', contentType);

--- a/packages/backend/src/database/entities/organizationDesigns.ts
+++ b/packages/backend/src/database/entities/organizationDesigns.ts
@@ -5,6 +5,7 @@ export const OrganizationDesignsTableName = 'organization_designs';
 export type DbOrganizationDesign = {
     design_uuid: string;
     organization_uuid: string;
+    slug: string;
     name: string;
     description: string | null;
     extra_instructions: string | null;
@@ -16,13 +17,20 @@ export type DbOrganizationDesign = {
 
 export type DbOrganizationDesignIn = Pick<
     DbOrganizationDesign,
-    'organization_uuid' | 'name' | 'description' | 'created_by_user_uuid'
+    | 'design_uuid'
+    | 'organization_uuid'
+    | 'slug'
+    | 'name'
+    | 'description'
+    | 'extra_instructions'
+    | 'created_by_user_uuid'
 >;
 
 export type DbOrganizationDesignUpdate = Partial<
     Pick<
         DbOrganizationDesign,
         | 'name'
+        | 'slug'
         | 'description'
         | 'extra_instructions'
         | 'is_default'

--- a/packages/backend/src/database/migrations/20260810100500_add_slug_to_organization_designs.ts
+++ b/packages/backend/src/database/migrations/20260810100500_add_slug_to_organization_designs.ts
@@ -1,0 +1,93 @@
+import { Knex } from 'knex';
+
+const OrganizationDesignsTableName = 'organization_designs';
+const SlugSequenceName = 'organization_designs_slug_sequence';
+const SlugUniqueConstraint =
+    'organization_designs_organization_uuid_slug_unique';
+const SlugFormatConstraint = 'organization_designs_slug_format_check';
+const MaxSlugLength = 255;
+const UuidPattern = /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i;
+
+const slugifyName = (name: string): string =>
+    name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`CREATE SEQUENCE IF NOT EXISTS ${SlugSequenceName}`);
+
+    await knex.schema.alterTable(OrganizationDesignsTableName, (table) => {
+        table
+            .text('slug')
+            .nullable()
+            .defaultTo(
+                knex.raw(`'design-' || nextval('${SlugSequenceName}')::text`),
+            );
+    });
+
+    const designs = await knex(OrganizationDesignsTableName)
+        .select('design_uuid', 'organization_uuid', 'name')
+        .orderBy('organization_uuid')
+        .orderBy('created_at')
+        .orderBy('design_uuid');
+
+    const slugsByOrganization = new Map<string, Set<string>>();
+    /* eslint-disable no-await-in-loop */
+    for (const design of designs) {
+        const organizationSlugs =
+            slugsByOrganization.get(design.organization_uuid) ??
+            new Set<string>();
+        slugsByOrganization.set(design.organization_uuid, organizationSlugs);
+
+        const generatedBase = slugifyName(design.name).slice(0, MaxSlugLength);
+        const baseSlug =
+            !generatedBase || UuidPattern.test(generatedBase)
+                ? `design-${design.design_uuid}`
+                : generatedBase;
+        let slug = baseSlug;
+        let suffix = 1;
+        while (organizationSlugs.has(slug)) {
+            const suffixText = `-${suffix}`;
+            slug = `${baseSlug.slice(
+                0,
+                MaxSlugLength - suffixText.length,
+            )}${suffixText}`;
+            suffix += 1;
+        }
+        organizationSlugs.add(slug);
+
+        await knex(OrganizationDesignsTableName)
+            .where('design_uuid', design.design_uuid)
+            .update({ slug });
+    }
+    /* eslint-enable no-await-in-loop */
+
+    await knex.raw(`
+        ALTER TABLE ${OrganizationDesignsTableName}
+        ALTER COLUMN slug SET NOT NULL
+    `);
+    await knex.raw(`
+        ALTER TABLE ${OrganizationDesignsTableName}
+        ADD CONSTRAINT ${SlugFormatConstraint}
+        CHECK (
+            CHAR_LENGTH(slug) <= ${MaxSlugLength}
+            AND slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'
+            AND slug !~* '^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$'
+        )
+    `);
+    await knex.schema.alterTable(OrganizationDesignsTableName, (table) => {
+        table.unique(['organization_uuid', 'slug'], {
+            indexName: SlugUniqueConstraint,
+        });
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(OrganizationDesignsTableName, (table) => {
+        table.dropUnique(['organization_uuid', 'slug'], SlugUniqueConstraint);
+        table.dropChecks(SlugFormatConstraint);
+        table.dropColumn('slug');
+    });
+    await knex.raw(`DROP SEQUENCE IF EXISTS ${SlugSequenceName}`);
+}

--- a/packages/backend/src/models/OrganizationDesignModel.test.ts
+++ b/packages/backend/src/models/OrganizationDesignModel.test.ts
@@ -14,13 +14,16 @@ import { OrganizationDesignModel } from './OrganizationDesignModel';
 const ORG_UUID = '00000000-0000-0000-0000-000000000001';
 const USER_UUID = '00000000-0000-0000-0000-000000000002';
 const DESIGN_UUID = '00000000-0000-0000-0000-000000000010';
+const VALID_DESIGN_UUID = '00000000-0000-4000-8000-000000000010';
 const FILE_UUID = '00000000-0000-0000-0000-000000000100';
 
 const makeDbDesign = (overrides: Partial<Record<string, unknown>> = {}) => ({
     design_uuid: DESIGN_UUID,
     organization_uuid: ORG_UUID,
+    slug: 'brand-a',
     name: 'Brand A',
     description: 'Acme brand',
+    extra_instructions: null,
     is_default: false,
     created_at: new Date('2026-01-01T00:00:00Z'),
     updated_at: new Date('2026-01-02T00:00:00Z'),
@@ -53,6 +56,53 @@ describe('OrganizationDesignModel', () => {
 
     afterEach(() => {
         tracker.reset();
+    });
+
+    describe('create', () => {
+        it('serializes slug allocation and suffixes an organization conflict', async () => {
+            tracker.on.select('pg_advisory_xact_lock').response({});
+            tracker.on
+                .select(OrganizationDesignsTableName)
+                .responseOnce({ slug: 'brand-a' });
+            tracker.on
+                .select(OrganizationDesignsTableName)
+                .responseOnce(undefined);
+            tracker.on
+                .insert(OrganizationDesignsTableName)
+                .responseOnce([makeDbDesign({ slug: 'brand-a-1' })]);
+
+            const result = await model.create(ORG_UUID, USER_UUID, {
+                name: 'Brand A',
+                description: null,
+            });
+
+            expect(result.slug).toBe('brand-a-1');
+            expect(
+                tracker.history.all.filter(({ sql }) =>
+                    sql.includes('pg_advisory_xact_lock'),
+                ),
+            ).toHaveLength(2);
+        });
+    });
+
+    describe('findByIdOrSlug', () => {
+        it.each([
+            { selector: VALID_DESIGN_UUID, column: 'design_uuid' },
+            { selector: 'brand-a', column: 'slug' },
+        ])('resolves a design by $column', async ({ selector, column }) => {
+            tracker.on
+                .select(OrganizationDesignsTableName)
+                .responseOnce(makeDbDesign());
+            tracker.on
+                .select(OrganizationDesignFilesTableName)
+                .responseOnce([]);
+
+            const result = await model.findByIdOrSlug(ORG_UUID, selector);
+
+            expect(result?.designUuid).toBe(DESIGN_UUID);
+            expect(tracker.history.select[0].sql).toContain(column);
+            expect(tracker.history.select[0].bindings).toContain(selector);
+        });
     });
 
     describe('update', () => {

--- a/packages/backend/src/models/OrganizationDesignModel.ts
+++ b/packages/backend/src/models/OrganizationDesignModel.ts
@@ -1,10 +1,13 @@
 import {
     ApiOrganizationDesign,
     ApiOrganizationDesignFile,
+    generateSlug,
     NotFoundError,
     OrganizationDesignFileKind,
+    type UuidOrSlug,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { validate as isValidUuid, v4 as uuidv4 } from 'uuid';
 import {
     DbOrganizationDesignFile,
     OrganizationDesignFilesTableName,
@@ -16,6 +19,61 @@ import {
 
 type OrganizationDesignModelArguments = {
     database: Knex;
+};
+
+const ORGANIZATION_DESIGN_SLUG_LOCK_NAMESPACE = 4;
+const MAX_ORGANIZATION_DESIGN_SLUG_LENGTH = 255;
+const UUID_SHAPED_SLUG_PATTERN =
+    /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i;
+
+const acquireOrganizationDesignSlugLock = async (
+    trx: Knex.Transaction,
+    organizationUuid: string,
+    slug: string,
+): Promise<void> => {
+    await trx.raw('SELECT pg_advisory_xact_lock(?, hashtext(?))', [
+        ORGANIZATION_DESIGN_SLUG_LOCK_NAMESPACE,
+        `${organizationUuid}:${slug}`,
+    ]);
+};
+
+const generateUniqueSlug = async (
+    trx: Knex.Transaction,
+    organizationUuid: string,
+    name: string,
+): Promise<string> => {
+    const generatedSlug = generateSlug(name).slice(
+        0,
+        MAX_ORGANIZATION_DESIGN_SLUG_LENGTH,
+    );
+    const baseSlug = UUID_SHAPED_SLUG_PATTERN.test(generatedSlug)
+        ? `theme-${generatedSlug}`
+        : generatedSlug;
+
+    let increment = 0;
+    for (;;) {
+        const suffix = increment === 0 ? '' : `-${increment}`;
+        const candidate = `${baseSlug.slice(
+            0,
+            MAX_ORGANIZATION_DESIGN_SLUG_LENGTH - suffix.length,
+        )}${suffix}`;
+        // An explicitly reserved slug can match any generated suffix. Lock
+        // each candidate before checking so allocations cannot race within an
+        // organization.
+        // eslint-disable-next-line no-await-in-loop
+        await acquireOrganizationDesignSlugLock(
+            trx,
+            organizationUuid,
+            candidate,
+        );
+        // eslint-disable-next-line no-await-in-loop
+        const existing = await trx(OrganizationDesignsTableName)
+            .select('slug')
+            .where({ organization_uuid: organizationUuid, slug: candidate })
+            .first();
+        if (!existing) return candidate;
+        increment += 1;
+    }
 };
 
 const mapDbFile = (
@@ -35,6 +93,7 @@ const mapDbDesign = (
 ): ApiOrganizationDesign => ({
     designUuid: row.design_uuid,
     organizationUuid: row.organization_uuid,
+    slug: row.slug,
     name: row.name,
     description: row.description,
     extraInstructions: row.extra_instructions,
@@ -57,15 +116,25 @@ export class OrganizationDesignModel {
         createdByUserUuid: string,
         data: { name: string; description: string | null },
     ): Promise<ApiOrganizationDesign> {
-        const [row] = await this.database(OrganizationDesignsTableName)
-            .insert({
-                organization_uuid: organizationUuid,
-                name: data.name,
-                description: data.description,
-                created_by_user_uuid: createdByUserUuid,
-            })
-            .returning('*');
-        return mapDbDesign(row, []);
+        return this.database.transaction(async (trx) => {
+            const slug = await generateUniqueSlug(
+                trx,
+                organizationUuid,
+                data.name,
+            );
+            const [row] = await trx(OrganizationDesignsTableName)
+                .insert({
+                    design_uuid: uuidv4(),
+                    organization_uuid: organizationUuid,
+                    slug,
+                    name: data.name,
+                    description: data.description,
+                    extra_instructions: null,
+                    created_by_user_uuid: createdByUserUuid,
+                })
+                .returning('*');
+            return mapDbDesign(row, []);
+        });
     }
 
     async findInOrganization(
@@ -79,6 +148,27 @@ export class OrganizationDesignModel {
         if (!row) return undefined;
         const files = await this.database(OrganizationDesignFilesTableName)
             .where('design_uuid', designUuid)
+            .orderBy('created_at', 'asc');
+        return mapDbDesign(row, files);
+    }
+
+    async findByIdOrSlug(
+        organizationUuid: string,
+        designUuidOrSlug: UuidOrSlug,
+    ): Promise<ApiOrganizationDesign | undefined> {
+        const query = this.database(OrganizationDesignsTableName).where(
+            'organization_uuid',
+            organizationUuid,
+        );
+        if (isValidUuid(designUuidOrSlug)) {
+            void query.andWhere('design_uuid', designUuidOrSlug);
+        } else {
+            void query.andWhere('slug', designUuidOrSlug);
+        }
+        const row = await query.first();
+        if (!row) return undefined;
+        const files = await this.database(OrganizationDesignFilesTableName)
+            .where('design_uuid', row.design_uuid)
             .orderBy('created_at', 'asc');
         return mapDbDesign(row, files);
     }

--- a/packages/backend/src/services/OrganizationDesignService/CLAUDE.md
+++ b/packages/backend/src/services/OrganizationDesignService/CLAUDE.md
@@ -5,29 +5,33 @@ Service for managing organization-shared design assets (CSS, fonts, images, inst
 </summary>
 
 <howToUse>
-Access via `ServiceRepository.getOrganizationDesignService()`. Service methods all take an `Account` and enforce CASL permissions internally (`view:OrganizationDesign` for reads, `manage:OrganizationDesign` for writes). The `designS3Key` helper is exported separately for the Stage 3 pipeline copy.
+Access via `ServiceRepository.getOrganizationDesignService()`. Service methods all take an `Account` and enforce CASL permissions internally (`view:OrganizationDesign` for reads, `manage:OrganizationDesign` for writes). Designs have an immutable, organization-scoped slug; all single-design methods accept either that slug or the UUID and resolve it to the canonical UUID before accessing Postgres or S3. The `designS3Key` helper is exported separately for the Stage 3 pipeline copy.
 
 ```typescript
 const designService = serviceRepository.getOrganizationDesignService();
 
 // CRUD
 const designs = await designService.listDesigns(account);
-const design = await designService.getDesign(account, designUuid);
+const design = await designService.getDesign(account, designUuidOrSlug);
 await designService.createDesign(account, { name, description });
-await designService.updateDesign(account, designUuid, { name });
-await designService.deleteDesign(account, designUuid); // cascades S3 prefix
-await designService.setAsDefault(account, designUuid);
+await designService.updateDesign(account, designUuidOrSlug, { name });
+await designService.deleteDesign(account, designUuidOrSlug); // cascades S3 prefix
+await designService.setAsDefault(account, designUuidOrSlug);
 
 // Files
-await designService.uploadFile(account, designUuid, {
+await designService.uploadFile(account, designUuidOrSlug, {
     kind,           // 'css' | 'font' | 'image' | 'instruction'
     filename,       // original name; backend sets Content-Disposition from this
     contentType,    // stored but not trusted; extension is authoritative
     body,           // Readable stream — streaming cap fires at 10 MB
     contentLength,  // pre-checked against the cap before reading bytes
 });
-await designService.deleteFile(account, designUuid, fileUuid);
-const stream = await designService.getFileStream(account, designUuid, fileUuid);
+await designService.deleteFile(account, designUuidOrSlug, fileUuid);
+const stream = await designService.getFileStream(
+    account,
+    designUuidOrSlug,
+    fileUuid,
+);
 ```
 
 </howToUse>

--- a/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
+++ b/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
@@ -23,6 +23,7 @@ import {
     ParameterError,
     themeLimitMessage,
     type Account,
+    type UuidOrSlug,
 } from '@lightdash/common';
 import createDOMPurify from 'dompurify';
 import { JSDOM } from 'jsdom';
@@ -351,14 +352,14 @@ export class OrganizationDesignService extends BaseService {
 
     private async loadOwned(
         organizationUuid: string,
-        designUuid: string,
+        designUuidOrSlug: UuidOrSlug,
     ): Promise<ApiOrganizationDesign> {
-        const design = await this.organizationDesignModel.findInOrganization(
+        const design = await this.organizationDesignModel.findByIdOrSlug(
             organizationUuid,
-            designUuid,
+            designUuidOrSlug,
         );
         if (!design) {
-            throw new NotFoundError(`Design not found: ${designUuid}`);
+            throw new NotFoundError(`Design not found: ${designUuidOrSlug}`);
         }
         return design;
     }
@@ -372,10 +373,10 @@ export class OrganizationDesignService extends BaseService {
 
     async getDesign(
         account: Account,
-        designUuid: string,
+        designUuidOrSlug: UuidOrSlug,
     ): Promise<ApiOrganizationDesign> {
         const { organizationUuid } = this.assertCanView(account);
-        return this.loadOwned(organizationUuid, designUuid);
+        return this.loadOwned(organizationUuid, designUuidOrSlug);
     }
 
     async createDesign(
@@ -395,7 +396,7 @@ export class OrganizationDesignService extends BaseService {
 
     async updateDesign(
         account: Account,
-        designUuid: string,
+        designUuidOrSlug: UuidOrSlug,
         body: {
             name?: string;
             description?: string | null;
@@ -403,7 +404,7 @@ export class OrganizationDesignService extends BaseService {
         },
     ): Promise<ApiOrganizationDesign> {
         const { organizationUuid } = this.assertCanManage(account);
-        await this.loadOwned(organizationUuid, designUuid);
+        const design = await this.loadOwned(organizationUuid, designUuidOrSlug);
         const update: {
             name?: string;
             description?: string | null;
@@ -433,30 +434,39 @@ export class OrganizationDesignService extends BaseService {
         }
         return this.organizationDesignModel.update(
             organizationUuid,
-            designUuid,
+            design.designUuid,
             update,
         );
     }
 
-    async deleteDesign(account: Account, designUuid: string): Promise<void> {
+    async deleteDesign(
+        account: Account,
+        designUuidOrSlug: UuidOrSlug,
+    ): Promise<void> {
         const { organizationUuid } = this.assertCanManage(account);
-        await this.loadOwned(organizationUuid, designUuid);
+        const design = await this.loadOwned(organizationUuid, designUuidOrSlug);
         // Drop the metadata first — once gone, no API path can reference
         // these S3 objects, so an orphaned-S3 failure is safe and
         // reconcilable later.
-        await this.organizationDesignModel.delete(organizationUuid, designUuid);
+        await this.organizationDesignModel.delete(
+            organizationUuid,
+            design.designUuid,
+        );
         try {
-            await this.deleteDesignS3Prefix(organizationUuid, designUuid);
+            await this.deleteDesignS3Prefix(
+                organizationUuid,
+                design.designUuid,
+            );
         } catch (err) {
             // The metadata row is already gone — the API can no longer
             // reach these S3 objects, so the user-visible deletion is
             // complete. Log loudly so the orphaned objects can be swept
             // up later (e.g. by a future cross-cutting GC job).
             this.logger.error(
-                `Failed to delete S3 objects for design ${designUuid} (org ${organizationUuid}); objects are orphaned and require manual reconciliation`,
+                `Failed to delete S3 objects for design ${design.designUuid} (org ${organizationUuid}); objects are orphaned and require manual reconciliation`,
                 {
                     organizationUuid,
-                    designUuid,
+                    designUuid: design.designUuid,
                     error: err,
                 },
             );
@@ -465,12 +475,13 @@ export class OrganizationDesignService extends BaseService {
 
     async setAsDefault(
         account: Account,
-        designUuid: string,
+        designUuidOrSlug: UuidOrSlug,
     ): Promise<ApiOrganizationDesign> {
         const { organizationUuid } = this.assertCanManage(account);
+        const design = await this.loadOwned(organizationUuid, designUuidOrSlug);
         return this.organizationDesignModel.setDefault(
             organizationUuid,
-            designUuid,
+            design.designUuid,
         );
     }
 
@@ -481,7 +492,7 @@ export class OrganizationDesignService extends BaseService {
 
     async uploadFile(
         account: Account,
-        designUuid: string,
+        designUuidOrSlug: UuidOrSlug,
         input: {
             kind: string;
             filename: string;
@@ -491,7 +502,7 @@ export class OrganizationDesignService extends BaseService {
         },
     ): Promise<ApiOrganizationDesignFile> {
         const { organizationUuid, userUuid } = this.assertCanManage(account);
-        const design = await this.loadOwned(organizationUuid, designUuid);
+        const design = await this.loadOwned(organizationUuid, designUuidOrSlug);
 
         const kind = ensureValidKind(input.kind);
         const filename = ensureValidFilename(input.filename);
@@ -551,7 +562,7 @@ export class OrganizationDesignService extends BaseService {
         const fileUuid = uuidv4();
         const key = designS3Key(
             organizationUuid,
-            designUuid,
+            design.designUuid,
             fileUuid,
             filename,
         );
@@ -567,31 +578,38 @@ export class OrganizationDesignService extends BaseService {
             }),
         );
 
-        return this.organizationDesignModel.addFile(designUuid, userUuid, {
-            fileUuid,
-            kind,
-            filename,
-            contentType,
-            sizeBytes: body.length,
-        });
+        return this.organizationDesignModel.addFile(
+            design.designUuid,
+            userUuid,
+            {
+                fileUuid,
+                kind,
+                filename,
+                contentType,
+                sizeBytes: body.length,
+            },
+        );
     }
 
     async deleteFile(
         account: Account,
-        designUuid: string,
+        designUuidOrSlug: UuidOrSlug,
         fileUuid: string,
     ): Promise<void> {
         const { organizationUuid } = this.assertCanManage(account);
-        await this.loadOwned(organizationUuid, designUuid);
+        const design = await this.loadOwned(organizationUuid, designUuidOrSlug);
 
         const file = await this.organizationDesignModel.findFile(
-            designUuid,
+            design.designUuid,
             fileUuid,
         );
         if (!file) {
             throw new NotFoundError(`Design file not found: ${fileUuid}`);
         }
-        await this.organizationDesignModel.removeFile(designUuid, fileUuid);
+        await this.organizationDesignModel.removeFile(
+            design.designUuid,
+            fileUuid,
+        );
 
         const { client, bucket } = this.getS3Client();
         await client.send(
@@ -602,7 +620,7 @@ export class OrganizationDesignService extends BaseService {
                         {
                             Key: designS3Key(
                                 organizationUuid,
-                                designUuid,
+                                design.designUuid,
                                 fileUuid,
                                 file.filename,
                             ),
@@ -620,12 +638,15 @@ export class OrganizationDesignService extends BaseService {
      * links all survive). Deleting and recreating the theme is not an
      * equivalent workaround — that unlinks every app already using it.
      */
-    async clearFiles(account: Account, designUuid: string): Promise<void> {
+    async clearFiles(
+        account: Account,
+        designUuidOrSlug: UuidOrSlug,
+    ): Promise<void> {
         const { organizationUuid } = this.assertCanManage(account);
         // Key off the stored uuid, not the raw path arg — Postgres matches uuids
         // case-insensitively, so an uppercase arg would build keys that hit
         // nothing and silently orphan every object.
-        const design = await this.loadOwned(organizationUuid, designUuid);
+        const design = await this.loadOwned(organizationUuid, designUuidOrSlug);
 
         // Fail loudly if storage isn't configured — a swallowed MissingConfigError
         // here would report a successful clear that never deleted any bytes.
@@ -663,15 +684,19 @@ export class OrganizationDesignService extends BaseService {
             /* eslint-enable no-await-in-loop */
         } catch (err) {
             this.logger.error(
-                `Failed to delete S3 objects while clearing files for design ${designUuid} (org ${organizationUuid}); objects are orphaned and require manual reconciliation`,
-                { organizationUuid, designUuid, error: err },
+                `Failed to delete S3 objects while clearing files for design ${design.designUuid} (org ${organizationUuid}); objects are orphaned and require manual reconciliation`,
+                {
+                    organizationUuid,
+                    designUuid: design.designUuid,
+                    error: err,
+                },
             );
         }
     }
 
     async getFileStream(
         account: Account,
-        designUuid: string,
+        designUuidOrSlug: UuidOrSlug,
         fileUuid: string,
     ): Promise<{
         body: Readable;
@@ -680,10 +705,10 @@ export class OrganizationDesignService extends BaseService {
         sizeBytes: number;
     }> {
         const { organizationUuid } = this.assertCanView(account);
-        await this.loadOwned(organizationUuid, designUuid);
+        const design = await this.loadOwned(organizationUuid, designUuidOrSlug);
 
         const file = await this.organizationDesignModel.findFile(
-            designUuid,
+            design.designUuid,
             fileUuid,
         );
         if (!file) {
@@ -696,7 +721,7 @@ export class OrganizationDesignService extends BaseService {
                 Bucket: bucket,
                 Key: designS3Key(
                     organizationUuid,
-                    designUuid,
+                    design.designUuid,
                     fileUuid,
                     file.filename,
                 ),

--- a/packages/common/src/ee/designs/types.ts
+++ b/packages/common/src/ee/designs/types.ts
@@ -28,6 +28,7 @@ export type ApiOrganizationDesignFile = {
 export type ApiOrganizationDesign = {
     designUuid: string;
     organizationUuid: string;
+    slug: string;
     name: string;
     description: string | null;
     /**


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-658/data-app-themes-theme-as-code-v1-stable-identity-and-atomic-package

## Summary

- add immutable, organization-scoped slugs to organization themes
- backfill existing themes and enforce slug format and uniqueness in Postgres
- keep existing UUID routes compatible while allowing UUID-or-slug selectors

## Why

Theme-as-code packages need a stable human-readable identifier that survives theme renames.

## Validation

- 14 focused model tests
- backend and common typechecks
- focused lint and format checks
- `git diff --check`