### PR TITLE
feat: export organization theme packages

### DIFF
--- a/packages/backend/src/controllers/organizationDesignController.ts
+++ b/packages/backend/src/controllers/organizationDesignController.ts
@@ -6,6 +6,7 @@ import {
     ApiSuccessEmpty,
     assertRegisteredAccount,
     CreateOrganizationDesignRequest,
+    ORGANIZATION_DESIGN_PACKAGE_CONTENT_TYPE,
     ParameterError,
     UpdateOrganizationDesignRequest,
     type UuidOrSlug,
@@ -27,6 +28,9 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { createContentDispositionHeader } from '../utils/FileDownloadUtils/FileDownloadUtils';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -57,6 +61,34 @@ export class OrganizationDesignController extends BaseController {
                 .getOrganizationDesignService()
                 .listDesigns(req.account),
         };
+    }
+
+    /**
+     * Download a complete organization theme as the canonical theme-as-code
+     * tar package.
+     * @summary Download theme package
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{designUuidOrSlug}/package')
+    @OperationId('DownloadOrganizationDesignPackage')
+    async downloadPackage(
+        @Request() req: express.Request,
+        @Path() designUuidOrSlug: UuidOrSlug,
+    ): Promise<void> {
+        assertRegisteredAccount(req.account);
+        const { body, filename } = await this.services
+            .getOrganizationDesignService()
+            .exportPackage(req.account, designUuidOrSlug);
+        const res = req.res!;
+        res.status(200);
+        res.setHeader('Content-Type', ORGANIZATION_DESIGN_PACKAGE_CONTENT_TYPE);
+        res.setHeader('Content-Length', String(body.length));
+        res.setHeader(
+            'Content-Disposition',
+            createContentDispositionHeader(filename),
+        );
+        await pipeline(Readable.from(body), res);
     }
 
     /**

--- a/packages/backend/src/models/OrganizationDesignModel.ts
+++ b/packages/backend/src/models/OrganizationDesignModel.ts
@@ -148,7 +148,8 @@ export class OrganizationDesignModel {
         if (!row) return undefined;
         const files = await this.database(OrganizationDesignFilesTableName)
             .where('design_uuid', designUuid)
-            .orderBy('created_at', 'asc');
+            .orderBy('created_at', 'asc')
+            .orderBy('file_uuid', 'asc');
         return mapDbDesign(row, files);
     }
 
@@ -169,7 +170,8 @@ export class OrganizationDesignModel {
         if (!row) return undefined;
         const files = await this.database(OrganizationDesignFilesTableName)
             .where('design_uuid', row.design_uuid)
-            .orderBy('created_at', 'asc');
+            .orderBy('created_at', 'asc')
+            .orderBy('file_uuid', 'asc');
         return mapDbDesign(row, files);
     }
 
@@ -183,7 +185,8 @@ export class OrganizationDesignModel {
         const designUuids = designs.map((d) => d.design_uuid);
         const files = await this.database(OrganizationDesignFilesTableName)
             .whereIn('design_uuid', designUuids)
-            .orderBy('created_at', 'asc');
+            .orderBy('created_at', 'asc')
+            .orderBy('file_uuid', 'asc');
         const filesByDesign = new Map<string, DbOrganizationDesignFile[]>();
         for (const f of files) {
             const arr = filesByDesign.get(f.design_uuid) ?? [];
@@ -205,7 +208,8 @@ export class OrganizationDesignModel {
         if (!row) return null;
         const files = await this.database(OrganizationDesignFilesTableName)
             .where('design_uuid', row.design_uuid)
-            .orderBy('created_at', 'asc');
+            .orderBy('created_at', 'asc')
+            .orderBy('file_uuid', 'asc');
         return mapDbDesign(row, files);
     }
 
@@ -237,7 +241,8 @@ export class OrganizationDesignModel {
         }
         const files = await this.database(OrganizationDesignFilesTableName)
             .where('design_uuid', designUuid)
-            .orderBy('created_at', 'asc');
+            .orderBy('created_at', 'asc')
+            .orderBy('file_uuid', 'asc');
         return mapDbDesign(row, files);
     }
 
@@ -298,7 +303,8 @@ export class OrganizationDesignModel {
                 .returning('*');
             const files = await trx(OrganizationDesignFilesTableName)
                 .where('design_uuid', designUuid)
-                .orderBy('created_at', 'asc');
+                .orderBy('created_at', 'asc')
+                .orderBy('file_uuid', 'asc');
             return mapDbDesign(row, files);
         });
     }

--- a/packages/backend/src/services/OrganizationDesignService/CLAUDE.md
+++ b/packages/backend/src/services/OrganizationDesignService/CLAUDE.md
@@ -5,7 +5,7 @@ Service for managing organization-shared design assets (CSS, fonts, images, inst
 </summary>
 
 <howToUse>
-Access via `ServiceRepository.getOrganizationDesignService()`. Service methods all take an `Account` and enforce CASL permissions internally (`view:OrganizationDesign` for reads, `manage:OrganizationDesign` for writes). Designs have an immutable, organization-scoped slug; all single-design methods accept either that slug or the UUID and resolve it to the canonical UUID before accessing Postgres or S3. The `designS3Key` helper is exported separately for the Stage 3 pipeline copy.
+Access via `ServiceRepository.getOrganizationDesignService()`. Service methods all take an `Account` and enforce CASL permissions internally (`view:OrganizationDesign` for ordinary reads, `manage:OrganizationDesign` for writes and package export). Designs have an immutable, organization-scoped slug; all single-design methods accept either that slug or the UUID and resolve it to the canonical UUID before accessing Postgres or S3. The `designS3Key` helper is exported separately for the Stage 3 pipeline copy.
 
 ```typescript
 const designService = serviceRepository.getOrganizationDesignService();
@@ -17,6 +17,12 @@ await designService.createDesign(account, { name, description });
 await designService.updateDesign(account, designUuidOrSlug, { name });
 await designService.deleteDesign(account, designUuidOrSlug); // cascades S3 prefix
 await designService.setAsDefault(account, designUuidOrSlug);
+
+// Canonical theme-as-code tar package
+const { body: archive } = await designService.exportPackage(
+    account,
+    designUuidOrSlug,
+);
 
 // Files
 await designService.uploadFile(account, designUuidOrSlug, {
@@ -109,6 +115,7 @@ This is not a full XSS defense — for a hypothetical future cross-origin consum
 
 <links>
 - @/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts - Service implementation
+- @/packages/backend/src/services/OrganizationDesignService/OrganizationDesignPackage.ts - Canonical tar parser/builder
 - @/packages/backend/src/models/OrganizationDesignModel.ts - Data access
 - @/packages/backend/src/controllers/organizationDesignController.ts - TSOA controller
 - @/packages/common/src/ee/designs/types.ts - API types

--- a/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.test.ts
+++ b/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.test.ts
@@ -1,0 +1,96 @@
+import { GetObjectCommand, type S3Client } from '@aws-sdk/client-s3';
+import type { ApiOrganizationDesign } from '@lightdash/common';
+import { buildAccount } from '../../auth/account/account.mock';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import type { OrganizationDesignModel } from '../../models/OrganizationDesignModel';
+import { parseOrganizationDesignPackage } from './OrganizationDesignPackage';
+import { OrganizationDesignService } from './OrganizationDesignService';
+
+describe('OrganizationDesignService package export', () => {
+    it('exports the effective file and theme metadata as a canonical package', async () => {
+        const effectiveBody = Buffer.from(':root { color: purple; }');
+        const design: ApiOrganizationDesign = {
+            designUuid: '00000000-0000-4000-8000-000000000010',
+            organizationUuid: 'test-org-uuid',
+            slug: 'acme-brand',
+            name: 'Acme Brand',
+            description: 'Primary brand',
+            extraInstructions: 'Prefer generous whitespace.',
+            isDefault: false,
+            createdAt: new Date('2026-01-01T00:00:00Z'),
+            updatedAt: new Date('2026-01-02T00:00:00Z'),
+            createdByUserUuid: 'test-user-uuid',
+            files: [
+                {
+                    fileUuid: '00000000-0000-4000-8000-000000000100',
+                    kind: 'css',
+                    filename: 'theme.css',
+                    contentType: 'text/css',
+                    sizeBytes: 3,
+                    createdAt: new Date('2026-01-01T00:00:00Z'),
+                },
+                {
+                    fileUuid: '00000000-0000-4000-8000-000000000101',
+                    kind: 'css',
+                    filename: 'THEME.CSS',
+                    contentType: 'text/css',
+                    sizeBytes: effectiveBody.length,
+                    createdAt: new Date('2026-01-02T00:00:00Z'),
+                },
+            ],
+        };
+        const organizationDesignModel = {
+            findByIdOrSlug: vi.fn().mockResolvedValue(design),
+        };
+        const send = vi.fn(async (command: unknown) => {
+            expect(command).toBeInstanceOf(GetObjectCommand);
+            expect((command as GetObjectCommand).input.Key).toContain(
+                design.files[1].fileUuid,
+            );
+            return {
+                Body: {
+                    transformToByteArray: async () => effectiveBody,
+                },
+            };
+        });
+        const service = new OrganizationDesignService({
+            lightdashConfig: lightdashConfigMock,
+            organizationDesignModel:
+                organizationDesignModel as unknown as OrganizationDesignModel,
+        });
+        (
+            service as unknown as {
+                createAuditedAbility: () => { cannot: () => boolean };
+                getS3Client: () => { client: S3Client; bucket: string };
+            }
+        ).createAuditedAbility = () => ({ cannot: () => false });
+        (
+            service as unknown as {
+                getS3Client: () => { client: S3Client; bucket: string };
+            }
+        ).getS3Client = () => ({
+            client: { send } as unknown as S3Client,
+            bucket: 'themes',
+        });
+
+        const result = await service.exportPackage(buildAccount(), design.slug);
+        const parsed = await parseOrganizationDesignPackage(result.body);
+
+        expect(result.filename).toBe('acme-brand.tar');
+        expect(parsed.manifest).toEqual({
+            codeVersion: 1,
+            slug: design.slug,
+            name: design.name,
+            description: design.description,
+            extraInstructions: design.extraInstructions,
+        });
+        expect(parsed.files).toEqual([
+            expect.objectContaining({
+                kind: 'css',
+                filename: 'THEME.CSS',
+                body: effectiveBody,
+            }),
+        ]);
+        expect(send).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
+++ b/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
@@ -16,13 +16,17 @@ import {
     checkThemeLimits,
     ForbiddenError,
     MAX_THEME_FILE_BYTES,
+    MAX_THEME_PACKAGE_BYTES,
+    MAX_THEME_TOTAL_BYTES,
     MissingConfigError,
     NotFoundError,
     ORGANIZATION_DESIGN_FILE_KINDS,
+    ORGANIZATION_DESIGN_PACKAGE_CODE_VERSION,
     OrganizationDesignFileKind,
     ParameterError,
     themeLimitMessage,
     type Account,
+    type OrganizationDesignPackageManifest,
     type UuidOrSlug,
 } from '@lightdash/common';
 import createDOMPurify from 'dompurify';
@@ -33,6 +37,11 @@ import { resolveS3Credentials } from '../../clients/Aws/S3BaseClient';
 import { LightdashConfig } from '../../config/parseConfig';
 import { OrganizationDesignModel } from '../../models/OrganizationDesignModel';
 import { BaseService } from '../BaseService';
+import {
+    buildOrganizationDesignPackage,
+    getOrganizationDesignPackageFilePath,
+    type OrganizationDesignPackageFile,
+} from './OrganizationDesignPackage';
 
 type OrganizationDesignServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -392,6 +401,92 @@ export class OrganizationDesignService extends BaseService {
             name,
             description: body.description?.trim() || null,
         });
+    }
+
+    async exportPackage(
+        account: Account,
+        designUuidOrSlug: UuidOrSlug,
+    ): Promise<{ body: Buffer; filename: string }> {
+        const { organizationUuid } = this.assertCanManage(account);
+        const design = await this.loadOwned(organizationUuid, designUuidOrSlug);
+        const { client, bucket } = this.getS3Client();
+
+        // Existing UI uploads historically allowed the same destination path
+        // more than once. The sandbox applies those in created order, so the
+        // last file is the effective one. Export only that effective file to
+        // produce an importable package with unique paths.
+        const effectiveFiles = new Map<string, ApiOrganizationDesignFile>();
+        for (const file of design.files) {
+            const path = getOrganizationDesignPackageFilePath(
+                file.kind,
+                file.filename,
+            );
+            effectiveFiles.set(path.toLowerCase(), file);
+        }
+
+        const packageFiles: OrganizationDesignPackageFile[] = [];
+        let totalBytes = 0;
+        /* eslint-disable no-await-in-loop */
+        for (const file of effectiveFiles.values()) {
+            const response = await client.send(
+                new GetObjectCommand({
+                    Bucket: bucket,
+                    Key: designS3Key(
+                        organizationUuid,
+                        design.designUuid,
+                        file.fileUuid,
+                        file.filename,
+                    ),
+                }),
+            );
+            if (!response.Body) {
+                throw new NotFoundError(
+                    `Design file body missing from storage: ${file.fileUuid}`,
+                );
+            }
+            const body = Buffer.from(
+                await response.Body.transformToByteArray(),
+            );
+            if (body.length !== file.sizeBytes) {
+                throw new Error(
+                    `Stored theme file size does not match metadata: ${file.fileUuid}`,
+                );
+            }
+            totalBytes += body.length;
+            if (totalBytes > MAX_THEME_TOTAL_BYTES) {
+                throw new ParameterError(
+                    themeLimitMessage(
+                        { bytes: totalBytes, limit: MAX_THEME_TOTAL_BYTES },
+                        design.name,
+                    ),
+                );
+            }
+            packageFiles.push({
+                kind: file.kind,
+                filename: file.filename,
+                contentType: file.contentType,
+                body,
+            });
+        }
+        /* eslint-enable no-await-in-loop */
+
+        const manifest: OrganizationDesignPackageManifest = {
+            codeVersion: ORGANIZATION_DESIGN_PACKAGE_CODE_VERSION,
+            slug: design.slug,
+            name: design.name,
+            description: design.description,
+            extraInstructions: design.extraInstructions,
+        };
+        const body = await buildOrganizationDesignPackage(
+            manifest,
+            packageFiles,
+        );
+        if (body.length > MAX_THEME_PACKAGE_BYTES) {
+            throw new ParameterError(
+                `Theme package exceeds ${MAX_THEME_PACKAGE_BYTES} bytes`,
+            );
+        }
+        return { body, filename: `${design.slug}.tar` };
     }
 
     async updateDesign(


### PR DESCRIPTION
Relates to: Relates to: https://linear.app/lightdash/issue/GLITCH-658/data-app-themes-theme-as-code-v1-stable-identity-and-atomic-package

## Summary

- add `GET /api/v1/org/designs/{uuidOrSlug}/package`
- read effective theme files from S3 and verify stored sizes
- export deterministic package bytes with stable filename and headers
- require manage permission for full package export

## Why

Teams need a portable, source-controlled representation of an existing organization theme.

## Validation

- 15 focused model and service tests
- backend typecheck
- focused lint and format checks
- `git diff --check`
