### PR TITLE
feat: import organization theme packages atomically

### DIFF
--- a/packages/backend/src/controllers/organizationDesignController.ts
+++ b/packages/backend/src/controllers/organizationDesignController.ts
@@ -6,6 +6,7 @@ import {
     ApiSuccessEmpty,
     assertRegisteredAccount,
     CreateOrganizationDesignRequest,
+    MAX_THEME_PACKAGE_BYTES,
     ORGANIZATION_DESIGN_PACKAGE_CONTENT_TYPE,
     ParameterError,
     UpdateOrganizationDesignRequest,
@@ -20,6 +21,7 @@ import {
     Patch,
     Path,
     Post,
+    Put,
     Query,
     Request,
     Response,
@@ -136,6 +138,61 @@ export class OrganizationDesignController extends BaseController {
             results: await this.services
                 .getOrganizationDesignService()
                 .createDesign(req.account, body),
+        };
+    }
+
+    /**
+     * Create or atomically replace an organization theme from a canonical
+     * theme-as-code tar package. Send the uncompressed tar as the raw
+     * `application/x-tar` request body; the manifest slug selects the remote
+     * theme.
+     * @summary Import theme package
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Put('/package')
+    @OperationId('ImportOrganizationDesignPackage')
+    async importPackage(
+        @Request() req: express.Request,
+    ): Promise<ApiOrganizationDesignResponse> {
+        assertRegisteredAccount(req.account);
+        const contentType = req.headers['content-type']
+            ?.split(';')[0]
+            .trim()
+            .toLowerCase();
+        if (contentType !== ORGANIZATION_DESIGN_PACKAGE_CONTENT_TYPE) {
+            throw new ParameterError(
+                `Content-Type must be ${ORGANIZATION_DESIGN_PACKAGE_CONTENT_TYPE}`,
+            );
+        }
+        const contentLengthHeader = req.headers['content-length'];
+        if (!contentLengthHeader) {
+            throw new ParameterError('Content-Length header is required');
+        }
+        const contentLength = Number(contentLengthHeader);
+        if (
+            !Number.isSafeInteger(contentLength) ||
+            contentLength <= 0 ||
+            contentLength > MAX_THEME_PACKAGE_BYTES
+        ) {
+            throw new ParameterError(
+                `Content-Length must be between 1 and ${MAX_THEME_PACKAGE_BYTES}`,
+            );
+        }
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getOrganizationDesignService()
+                .importPackage(req.account, {
+                    body: req,
+                    contentLength,
+                }),
         };
     }
 

--- a/packages/backend/src/models/OrganizationDesignModel.test.ts
+++ b/packages/backend/src/models/OrganizationDesignModel.test.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from '@lightdash/common';
+import { AlreadyExistsError, NotFoundError } from '@lightdash/common';
 import knex, { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { OrganizationDesignFilesTableName } from '../database/entities/organizationDesignFiles';
@@ -102,6 +102,33 @@ describe('OrganizationDesignModel', () => {
             expect(result?.designUuid).toBe(DESIGN_UUID);
             expect(tracker.history.select[0].sql).toContain(column);
             expect(tracker.history.select[0].bindings).toContain(selector);
+        });
+    });
+
+    describe('createWithFiles', () => {
+        it('reserves the imported slug and rejects an existing organization theme', async () => {
+            tracker.on.select('pg_advisory_xact_lock').response({});
+            tracker.on
+                .select(OrganizationDesignsTableName)
+                .responseOnce(makeDbDesign());
+
+            await expect(
+                model.createWithFiles(ORG_UUID, USER_UUID, {
+                    designUuid: DESIGN_UUID,
+                    slug: 'brand-a',
+                    name: 'Brand A',
+                    description: null,
+                    extraInstructions: null,
+                    files: [],
+                }),
+            ).rejects.toThrow(AlreadyExistsError);
+
+            expect(tracker.history.insert).toHaveLength(0);
+            expect(
+                tracker.history.all.some(({ sql }) =>
+                    sql.includes('pg_advisory_xact_lock'),
+                ),
+            ).toBe(true);
         });
     });
 
@@ -212,6 +239,9 @@ describe('OrganizationDesignModel', () => {
             // "modified at" displays. Easy to drop in a future refactor.
             const fileRow = makeDbFile();
             tracker.on
+                .select(OrganizationDesignsTableName)
+                .responseOnce(makeDbDesign());
+            tracker.on
                 .insert(OrganizationDesignFilesTableName)
                 .responseOnce([fileRow]);
             tracker.on.update(OrganizationDesignsTableName).responseOnce(1);
@@ -236,6 +266,9 @@ describe('OrganizationDesignModel', () => {
         it('bumps the parent design updated_at on successful delete', async () => {
             const fileRow = makeDbFile();
             tracker.on
+                .select(OrganizationDesignsTableName)
+                .responseOnce(makeDbDesign());
+            tracker.on
                 .delete(OrganizationDesignFilesTableName)
                 .responseOnce([fileRow]);
             tracker.on.update(OrganizationDesignsTableName).responseOnce(1);
@@ -249,6 +282,9 @@ describe('OrganizationDesignModel', () => {
         it('throws NotFoundError and skips the parent bump when no file was deleted', async () => {
             // The parent bump must NOT fire on a missing-file path — otherwise
             // the design row's updated_at gets touched for no-op deletes.
+            tracker.on
+                .select(OrganizationDesignsTableName)
+                .responseOnce(makeDbDesign());
             tracker.on
                 .delete(OrganizationDesignFilesTableName)
                 .responseOnce([]);
@@ -273,6 +309,9 @@ describe('OrganizationDesignModel', () => {
                 }),
             ];
             tracker.on
+                .select(OrganizationDesignsTableName)
+                .responseOnce(makeDbDesign());
+            tracker.on
                 .delete(OrganizationDesignFilesTableName)
                 .responseOnce(rows);
             tracker.on.update(OrganizationDesignsTableName).responseOnce(1);
@@ -288,6 +327,9 @@ describe('OrganizationDesignModel', () => {
 
         it('skips the parent bump when the design already has no files', async () => {
             tracker.on
+                .select(OrganizationDesignsTableName)
+                .responseOnce(makeDbDesign());
+            tracker.on
                 .delete(OrganizationDesignFilesTableName)
                 .responseOnce([]);
 
@@ -295,6 +337,80 @@ describe('OrganizationDesignModel', () => {
                 [],
             );
             expect(tracker.history.update).toHaveLength(0);
+        });
+    });
+
+    describe('replaceFiles', () => {
+        it('locks the design and swaps the complete file set before updating metadata', async () => {
+            const oldFile = makeDbFile();
+            const newFile = makeDbFile({
+                file_uuid: '00000000-0000-0000-0000-000000000101',
+                filename: 'replacement.css',
+            });
+            tracker.on
+                .select(OrganizationDesignsTableName)
+                .responseOnce(makeDbDesign());
+            tracker.on
+                .delete(OrganizationDesignFilesTableName)
+                .responseOnce([oldFile]);
+            tracker.on
+                .insert(OrganizationDesignFilesTableName)
+                .responseOnce([newFile]);
+            tracker.on
+                .update(OrganizationDesignsTableName)
+                .responseOnce([makeDbDesign({ name: 'Updated brand' })]);
+
+            const result = await model.replaceFiles(
+                ORG_UUID,
+                DESIGN_UUID,
+                USER_UUID,
+                {
+                    name: 'Updated brand',
+                    description: null,
+                    extraInstructions: null,
+                    files: [
+                        {
+                            fileUuid: newFile.file_uuid,
+                            kind: 'css',
+                            filename: newFile.filename,
+                            contentType: newFile.content_type,
+                            sizeBytes: newFile.size_bytes,
+                        },
+                    ],
+                },
+            );
+
+            expect(result.design.files.map((file) => file.filename)).toEqual([
+                'replacement.css',
+            ]);
+            expect(result.removedFiles.map((file) => file.filename)).toEqual([
+                'theme.css',
+            ]);
+            expect(tracker.history.select[0].sql).toContain('for update');
+
+            const mutationSql = tracker.history.all
+                .map(({ sql }) => sql)
+                .filter(
+                    (sql) =>
+                        sql.includes(
+                            `delete from "${OrganizationDesignFilesTableName}"`,
+                        ) ||
+                        sql.includes(
+                            `insert into "${OrganizationDesignFilesTableName}"`,
+                        ) ||
+                        sql.includes(
+                            `update "${OrganizationDesignsTableName}"`,
+                        ),
+                );
+            expect(mutationSql[0]).toContain(
+                `delete from "${OrganizationDesignFilesTableName}"`,
+            );
+            expect(mutationSql[1]).toContain(
+                `insert into "${OrganizationDesignFilesTableName}"`,
+            );
+            expect(mutationSql[2]).toContain(
+                `update "${OrganizationDesignsTableName}"`,
+            );
         });
     });
 });

--- a/packages/backend/src/models/OrganizationDesignModel.ts
+++ b/packages/backend/src/models/OrganizationDesignModel.ts
@@ -1,4 +1,5 @@
 import {
+    AlreadyExistsError,
     ApiOrganizationDesign,
     ApiOrganizationDesignFile,
     generateSlug,
@@ -19,6 +20,14 @@ import {
 
 type OrganizationDesignModelArguments = {
     database: Knex;
+};
+
+export type OrganizationDesignFileWrite = {
+    fileUuid: string;
+    kind: OrganizationDesignFileKind;
+    filename: string;
+    contentType: string;
+    sizeBytes: number;
 };
 
 const ORGANIZATION_DESIGN_SLUG_LOCK_NAMESPACE = 4;
@@ -57,9 +66,9 @@ const generateUniqueSlug = async (
             0,
             MAX_ORGANIZATION_DESIGN_SLUG_LENGTH - suffix.length,
         )}${suffix}`;
-        // An explicitly reserved slug can match any generated suffix. Lock
-        // each candidate before checking so allocations cannot race within an
-        // organization.
+        // A forced package slug can match any generated suffix. Lock each
+        // candidate before checking so generated and forced creates cannot
+        // race into the same organization-scoped slug.
         // eslint-disable-next-line no-await-in-loop
         await acquireOrganizationDesignSlugLock(
             trx,
@@ -111,6 +120,20 @@ export class OrganizationDesignModel {
         this.database = database;
     }
 
+    private static async lockDesignForFileMutation(
+        trx: Knex.Transaction,
+        designUuid: string,
+    ): Promise<void> {
+        const design = await trx(OrganizationDesignsTableName)
+            .select('design_uuid')
+            .where('design_uuid', designUuid)
+            .forUpdate()
+            .first();
+        if (!design) {
+            throw new NotFoundError(`Design not found: ${designUuid}`);
+        }
+    }
+
     async create(
         organizationUuid: string,
         createdByUserUuid: string,
@@ -134,6 +157,67 @@ export class OrganizationDesignModel {
                 })
                 .returning('*');
             return mapDbDesign(row, []);
+        });
+    }
+
+    async createWithFiles(
+        organizationUuid: string,
+        createdByUserUuid: string,
+        data: {
+            designUuid: string;
+            slug: string;
+            name: string;
+            description: string | null;
+            extraInstructions: string | null;
+            files: OrganizationDesignFileWrite[];
+        },
+    ): Promise<ApiOrganizationDesign> {
+        return this.database.transaction(async (trx) => {
+            await acquireOrganizationDesignSlugLock(
+                trx,
+                organizationUuid,
+                data.slug,
+            );
+            const existing = await trx(OrganizationDesignsTableName)
+                .where({
+                    organization_uuid: organizationUuid,
+                    slug: data.slug,
+                })
+                .first();
+            if (existing) {
+                throw new AlreadyExistsError(
+                    `A theme with slug "${data.slug}" already exists in this organization`,
+                );
+            }
+
+            const [row] = await trx(OrganizationDesignsTableName)
+                .insert({
+                    design_uuid: data.designUuid,
+                    organization_uuid: organizationUuid,
+                    slug: data.slug,
+                    name: data.name,
+                    description: data.description,
+                    extra_instructions: data.extraInstructions,
+                    created_by_user_uuid: createdByUserUuid,
+                })
+                .returning('*');
+
+            const fileRows = data.files.map((file) => ({
+                file_uuid: file.fileUuid,
+                design_uuid: data.designUuid,
+                kind: file.kind,
+                filename: file.filename,
+                content_type: file.contentType,
+                size_bytes: file.sizeBytes,
+                created_by_user_uuid: createdByUserUuid,
+            }));
+            const insertedFiles =
+                fileRows.length === 0
+                    ? []
+                    : await trx(OrganizationDesignFilesTableName)
+                          .insert(fileRows)
+                          .returning('*');
+            return mapDbDesign(row, insertedFiles);
         });
     }
 
@@ -321,6 +405,10 @@ export class OrganizationDesignModel {
         },
     ): Promise<ApiOrganizationDesignFile> {
         return this.database.transaction(async (trx) => {
+            await OrganizationDesignModel.lockDesignForFileMutation(
+                trx,
+                designUuid,
+            );
             const [row] = await trx(OrganizationDesignFilesTableName)
                 .insert({
                     file_uuid: file.fileUuid,
@@ -355,6 +443,10 @@ export class OrganizationDesignModel {
         fileUuid: string,
     ): Promise<ApiOrganizationDesignFile> {
         return this.database.transaction(async (trx) => {
+            await OrganizationDesignModel.lockDesignForFileMutation(
+                trx,
+                designUuid,
+            );
             const [row] = await trx(OrganizationDesignFilesTableName)
                 .where('file_uuid', fileUuid)
                 .andWhere('design_uuid', designUuid)
@@ -379,6 +471,10 @@ export class OrganizationDesignModel {
         designUuid: string,
     ): Promise<ApiOrganizationDesignFile[]> {
         return this.database.transaction(async (trx) => {
+            await OrganizationDesignModel.lockDesignForFileMutation(
+                trx,
+                designUuid,
+            );
             const rows = await trx(OrganizationDesignFilesTableName)
                 .where('design_uuid', designUuid)
                 .delete()
@@ -389,6 +485,70 @@ export class OrganizationDesignModel {
                     .update({ updated_at: trx.fn.now() as unknown as Date });
             }
             return rows.map(mapDbFile);
+        });
+    }
+
+    async replaceFiles(
+        organizationUuid: string,
+        designUuid: string,
+        createdByUserUuid: string,
+        data: {
+            name: string;
+            description: string | null;
+            extraInstructions: string | null;
+            files: OrganizationDesignFileWrite[];
+        },
+    ): Promise<{
+        design: ApiOrganizationDesign;
+        removedFiles: ApiOrganizationDesignFile[];
+    }> {
+        return this.database.transaction(async (trx) => {
+            const current = await trx(OrganizationDesignsTableName)
+                .where({
+                    organization_uuid: organizationUuid,
+                    design_uuid: designUuid,
+                })
+                .forUpdate()
+                .first();
+            if (!current) {
+                throw new NotFoundError(`Design not found: ${designUuid}`);
+            }
+
+            const removedRows = await trx(OrganizationDesignFilesTableName)
+                .where('design_uuid', designUuid)
+                .delete()
+                .returning('*');
+
+            const fileRows = data.files.map((file) => ({
+                file_uuid: file.fileUuid,
+                design_uuid: designUuid,
+                kind: file.kind,
+                filename: file.filename,
+                content_type: file.contentType,
+                size_bytes: file.sizeBytes,
+                created_by_user_uuid: createdByUserUuid,
+            }));
+            const insertedFiles =
+                fileRows.length === 0
+                    ? []
+                    : await trx(OrganizationDesignFilesTableName)
+                          .insert(fileRows)
+                          .returning('*');
+
+            const [updated] = await trx(OrganizationDesignsTableName)
+                .where('design_uuid', designUuid)
+                .update({
+                    name: data.name,
+                    description: data.description,
+                    extra_instructions: data.extraInstructions,
+                    updated_at: trx.fn.now() as unknown as Date,
+                })
+                .returning('*');
+
+            return {
+                design: mapDbDesign(updated, insertedFiles),
+                removedFiles: removedRows.map(mapDbFile),
+            };
         });
     }
 }

--- a/packages/backend/src/services/OrganizationDesignService/CLAUDE.md
+++ b/packages/backend/src/services/OrganizationDesignService/CLAUDE.md
@@ -23,6 +23,10 @@ const { body: archive } = await designService.exportPackage(
     account,
     designUuidOrSlug,
 );
+await designService.importPackage(account, {
+    body: archiveStream,
+    contentLength,
+});
 
 // Files
 await designService.uploadFile(account, designUuidOrSlug, {
@@ -105,12 +109,18 @@ This is not a full XSS defense — for a hypothetical future cross-origin consum
 
 `getS3Client()` reads from `lightdashConfig.appRuntime.s3` (not the general S3 config) so designs share the same bucket and credentials as data-app sources. Throws `MissingConfigError` if `APPS_RUNTIME_ENABLED` is off or the bucket isn't configured.
 
+### Theme-as-code package activation
+
+The canonical uncompressed tar contains `lightdash-theme.yml` plus files under `css/`, `fonts/`, `images/`, and `instructions/`. Import validates the entire archive before mutation, stages each validated object under a fresh file UUID, and then swaps metadata and file rows in one row-locked transaction. If activation fails, staged objects are removed; after a successful swap, replaced objects are removed best-effort. Per-file mutations take the same design-row lock so they serialize with package replacement.
+
+The manifest slug selects the remote design. Import creates it when absent and replaces its metadata/files when present, while preserving the existing `designUuid` and default status. UUID-shaped slugs are forbidden so UUID-or-slug routes remain unambiguous.
+
 <importantToKnow>
 - **Bucket bootstrap is a known gap** — `APPS_S3_BUCKET` (default `lightdash-apps`) is not auto-provisioned in the dev MinIO setup. If you blow away your MinIO volume, create the bucket manually: `docker exec lightdash-app-minio-1 sh -c 'mc alias set l http://localhost:9000 minioadmin minioadmin >/dev/null 2>&1; mc mb l/lightdash-apps'`. Tracked as a follow-up.
 - **NoSuchBucket returns 500, not 400** — if the bucket is missing the AWS SDK error bubbles up as `UnexpectedServerError`. Worth translating to a clearer 4xx with a hint. Tracked as a follow-up.
 - **CSS sanitization is not implemented.** CSS files are stored as-uploaded. The vectors (`@import url(http://evil)`, `url('javascript:...')`) are mostly mitigated by browser behavior but would need a CSS-AST sanitizer if these files are ever served cross-origin. Out of scope for Stage 1.
 - **Instruction-MD goes into the LLM system prompt**, not the DOM. The threat is prompt injection ("ignore prior instructions"), not HTML XSS. DOMPurify doesn't help here; a separate prompt-hygiene pass would.
-- **Tests** — Model has 18 unit tests in `packages/backend/src/models/OrganizationDesignModel.test.ts`. Service is currently smoke-tested via the controller's E2E path (curl + UI). No service-level unit test yet; would benefit from one covering the magic-byte + sanitize-SVG paths.
+- **Tests** — Model tests cover the transactional behaviors, including slug allocation and row-locked replacement. `OrganizationDesignPackage.test.ts` covers deterministic package parsing/building, hostile archive rejection, activation order, and staged-object cleanup.
 </importantToKnow>
 
 <links>

--- a/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.test.ts
+++ b/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.test.ts
@@ -1,10 +1,32 @@
-import { GetObjectCommand, type S3Client } from '@aws-sdk/client-s3';
-import type { ApiOrganizationDesign } from '@lightdash/common';
+import {
+    DeleteObjectsCommand,
+    GetObjectCommand,
+    PutObjectCommand,
+    type S3Client,
+} from '@aws-sdk/client-s3';
+import {
+    ORGANIZATION_DESIGN_PACKAGE_CODE_VERSION,
+    ParameterError,
+    type ApiOrganizationDesign,
+    type OrganizationDesignPackageManifest,
+} from '@lightdash/common';
+import { Readable } from 'node:stream';
 import { buildAccount } from '../../auth/account/account.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import type { OrganizationDesignModel } from '../../models/OrganizationDesignModel';
-import { parseOrganizationDesignPackage } from './OrganizationDesignPackage';
+import {
+    buildOrganizationDesignPackage,
+    parseOrganizationDesignPackage,
+} from './OrganizationDesignPackage';
 import { OrganizationDesignService } from './OrganizationDesignService';
+
+const MANIFEST: OrganizationDesignPackageManifest = {
+    codeVersion: ORGANIZATION_DESIGN_PACKAGE_CODE_VERSION,
+    slug: 'acme-brand',
+    name: 'Acme Brand',
+    description: 'Primary brand',
+    extraInstructions: 'Prefer generous whitespace.',
+};
 
 describe('OrganizationDesignService package export', () => {
     it('exports the effective file and theme metadata as a canonical package', async () => {
@@ -92,5 +114,166 @@ describe('OrganizationDesignService package export', () => {
             }),
         ]);
         expect(send).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('OrganizationDesignService package activation', () => {
+    const existingDesign: ApiOrganizationDesign = {
+        designUuid: '00000000-0000-4000-8000-000000000010',
+        organizationUuid: 'test-org-uuid',
+        slug: MANIFEST.slug,
+        name: 'Previous brand',
+        description: null,
+        extraInstructions: null,
+        isDefault: true,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+        createdByUserUuid: 'test-user-uuid',
+        files: [
+            {
+                fileUuid: '00000000-0000-4000-8000-000000000100',
+                kind: 'css',
+                filename: 'old.css',
+                contentType: 'text/css; charset=utf-8',
+                sizeBytes: 6,
+                createdAt: new Date('2026-01-01T00:00:00Z'),
+            },
+        ],
+    };
+
+    const makeService = ({
+        replaceFiles,
+        send,
+    }: {
+        replaceFiles: ReturnType<typeof vi.fn>;
+        send: ReturnType<typeof vi.fn>;
+    }) => {
+        const organizationDesignModel = {
+            findByIdOrSlug: vi.fn().mockResolvedValue(existingDesign),
+            replaceFiles,
+            createWithFiles: vi.fn(),
+        };
+        const service = new OrganizationDesignService({
+            lightdashConfig: lightdashConfigMock,
+            organizationDesignModel:
+                organizationDesignModel as unknown as OrganizationDesignModel,
+        });
+        (
+            service as unknown as {
+                createAuditedAbility: () => { cannot: () => boolean };
+                getS3Client: () => { client: S3Client; bucket: string };
+            }
+        ).createAuditedAbility = () => ({ cannot: () => false });
+        (
+            service as unknown as {
+                getS3Client: () => { client: S3Client; bucket: string };
+            }
+        ).getS3Client = () => ({
+            client: { send } as unknown as S3Client,
+            bucket: 'themes',
+        });
+        return { service };
+    };
+
+    const makeArchive = () =>
+        buildOrganizationDesignPackage(MANIFEST, [
+            {
+                kind: 'css',
+                filename: 'theme.css',
+                contentType: 'text/css; charset=utf-8',
+                body: Buffer.from('body { color: red; }'),
+            },
+        ]);
+
+    it('stages files before the row-locked swap and removes the replaced objects afterward', async () => {
+        const events: string[] = [];
+        const send = vi.fn(async (command: unknown) => {
+            if (command instanceof PutObjectCommand) events.push('stage');
+            if (command instanceof DeleteObjectsCommand) events.push('cleanup');
+            return {};
+        });
+        const updatedDesign = {
+            ...existingDesign,
+            name: MANIFEST.name,
+            description: MANIFEST.description,
+            extraInstructions: MANIFEST.extraInstructions,
+            files: [],
+        };
+        const replaceFiles = vi.fn(async () => {
+            events.push('swap');
+            return {
+                design: updatedDesign,
+                removedFiles: existingDesign.files,
+            };
+        });
+        const { service } = makeService({ replaceFiles, send });
+        const archive = await makeArchive();
+
+        const result = await service.importPackage(buildAccount(), {
+            body: Readable.from(archive),
+            contentLength: archive.length,
+        });
+
+        expect(result).toEqual(updatedDesign);
+        expect(events).toEqual(['stage', 'swap', 'cleanup']);
+        const cleanup = send.mock.calls[1][0];
+        expect(cleanup).toBeInstanceOf(DeleteObjectsCommand);
+        expect((cleanup as DeleteObjectsCommand).input.Delete?.Objects).toEqual(
+            [
+                {
+                    Key: `designs/test-org-uuid/${existingDesign.designUuid}/${existingDesign.files[0].fileUuid}/old.css`,
+                },
+            ],
+        );
+    });
+
+    it('removes staged objects when database activation fails', async () => {
+        const send = vi.fn().mockResolvedValue({});
+        const replaceFiles = vi.fn().mockRejectedValue(new Error('DB failed'));
+        const { service } = makeService({ replaceFiles, send });
+        const archive = await makeArchive();
+
+        await expect(
+            service.importPackage(buildAccount(), {
+                body: Readable.from(archive),
+                contentLength: archive.length,
+            }),
+        ).rejects.toThrow('DB failed');
+
+        expect(send).toHaveBeenCalledTimes(2);
+        expect(send.mock.calls[0][0]).toBeInstanceOf(PutObjectCommand);
+        const cleanup = send.mock.calls[1][0];
+        expect(cleanup).toBeInstanceOf(DeleteObjectsCommand);
+        expect(
+            (cleanup as DeleteObjectsCommand).input.Delete?.Objects?.[0]?.Key,
+        ).toMatch(
+            new RegExp(
+                `^designs/test-org-uuid/${existingDesign.designUuid}/.+/theme\\.css$`,
+            ),
+        );
+    });
+
+    it('validates file content before staging or activating the package', async () => {
+        const send = vi.fn().mockResolvedValue({});
+        const replaceFiles = vi.fn();
+        const { service } = makeService({ replaceFiles, send });
+        const archive = await buildOrganizationDesignPackage(MANIFEST, [
+            {
+                kind: 'image',
+                filename: 'logo.png',
+                contentType: 'image/png',
+                body: Buffer.from('not a png'),
+            },
+        ]);
+
+        await expect(
+            service.importPackage(buildAccount(), {
+                body: Readable.from(archive),
+                contentLength: archive.length,
+            }),
+        ).rejects.toThrow(ParameterError);
+
+        expect(send).not.toHaveBeenCalled();
+        expect(replaceFiles).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
+++ b/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
@@ -35,11 +35,15 @@ import { Readable } from 'node:stream';
 import { v4 as uuidv4 } from 'uuid';
 import { resolveS3Credentials } from '../../clients/Aws/S3BaseClient';
 import { LightdashConfig } from '../../config/parseConfig';
-import { OrganizationDesignModel } from '../../models/OrganizationDesignModel';
+import {
+    OrganizationDesignModel,
+    type OrganizationDesignFileWrite,
+} from '../../models/OrganizationDesignModel';
 import { BaseService } from '../BaseService';
 import {
     buildOrganizationDesignPackage,
     getOrganizationDesignPackageFilePath,
+    parseOrganizationDesignPackage,
     type OrganizationDesignPackageFile,
 } from './OrganizationDesignPackage';
 
@@ -150,10 +154,8 @@ const BINARY_SIGNATURES: Record<string, ReadonlyArray<SignatureAlternative>> = {
 
 const TEXT_EXTENSIONS = new Set<string>(['.css', '.md', '.svg']);
 
-// SVG is XML — must look like one. NOTE: this is NOT a full XSS defense:
-// an SVG that passes this check can still contain <script> tags. It only
-// kills the trivial "rename .exe to .svg" path. A future hardening pass
-// should DOMPurify SVG bodies before they ship into the rendered data app.
+// SVG is XML — require a plausible XML/SVG prefix before the full DOMPurify
+// sanitation performed below.
 const SVG_HEAD_PREFIX = /^\s*<(?:\?xml|svg|!--|!DOCTYPE)/i;
 
 const TEXT_HEAD_SCAN_BYTES = 1024;
@@ -243,7 +245,11 @@ const ensureContentMatchesExtension = (
             // Returned bytes are the sanitized SVG — anything DOMPurify
             // stripped (<script>, on*= handlers, foreignObject, javascript:
             // hrefs) never lands in S3.
-            return { body: Buffer.from(sanitizeSvg(text), 'utf8') };
+            const sanitizedBody = Buffer.from(sanitizeSvg(text), 'utf8');
+            if (sanitizedBody.length === 0) {
+                throw new ParameterError('SVG contains no safe content');
+            }
+            return { body: sanitizedBody };
         }
         return { body };
     }
@@ -276,6 +282,24 @@ const designS3Prefix = (organizationUuid: string, designUuid: string): string =>
 // S3 DeleteObjects accepts at most 1000 keys per call. Themes are capped by
 // total bytes, not file count, so a theme can legitimately exceed this.
 const S3_DELETE_BATCH_SIZE = 1000;
+
+const bufferReadableWithLimit = async (
+    body: Readable,
+    limit: number,
+): Promise<Buffer> => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const chunk of body) {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        total += buffer.length;
+        if (total > limit) {
+            throw new ParameterError(`Request body exceeds ${limit} bytes`);
+        }
+        chunks.push(buffer);
+    }
+    return Buffer.concat(chunks);
+};
 
 export class OrganizationDesignService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
@@ -489,6 +513,161 @@ export class OrganizationDesignService extends BaseService {
         return { body, filename: `${design.slug}.tar` };
     }
 
+    async importPackage(
+        account: Account,
+        input: { body: Readable; contentLength: number },
+    ): Promise<ApiOrganizationDesign> {
+        const { organizationUuid, userUuid } = this.assertCanManage(account);
+        if (
+            input.contentLength <= 0 ||
+            input.contentLength > MAX_THEME_PACKAGE_BYTES
+        ) {
+            throw new ParameterError(
+                `Theme package must be between 1 and ${MAX_THEME_PACKAGE_BYTES} bytes`,
+            );
+        }
+
+        const archive = await bufferReadableWithLimit(
+            input.body,
+            MAX_THEME_PACKAGE_BYTES,
+        );
+        if (archive.length === 0) {
+            throw new ParameterError('Theme package body is empty');
+        }
+        const parsed = await parseOrganizationDesignPackage(archive);
+        const validatedFiles = parsed.files.map((file) => {
+            const kind = ensureValidKind(file.kind);
+            const filename = ensureValidFilename(file.filename);
+            ensureFilenameMatchesKind(filename, kind);
+            const { body } = ensureContentMatchesExtension(file.body, filename);
+            return {
+                kind,
+                filename,
+                contentType: file.contentType,
+                body,
+            };
+        });
+        const violation = checkThemeLimits(
+            validatedFiles.map((file) => ({ sizeBytes: file.body.length })),
+        );
+        if (violation) {
+            throw new ParameterError(
+                themeLimitMessage(violation, parsed.manifest.name),
+            );
+        }
+
+        const existing = await this.organizationDesignModel.findByIdOrSlug(
+            organizationUuid,
+            parsed.manifest.slug,
+        );
+        const designUuid = existing?.designUuid ?? uuidv4();
+        const stagedFiles = validatedFiles.map((file) => {
+            const fileUuid = uuidv4();
+            const write: OrganizationDesignFileWrite = {
+                fileUuid,
+                kind: file.kind,
+                filename: file.filename,
+                contentType: file.contentType,
+                sizeBytes: file.body.length,
+            };
+            return {
+                write,
+                body: file.body,
+                key: designS3Key(
+                    organizationUuid,
+                    designUuid,
+                    fileUuid,
+                    file.filename,
+                ),
+            };
+        });
+
+        const { client, bucket } = this.getS3Client();
+        const uploadedKeys: string[] = [];
+        try {
+            /* eslint-disable no-await-in-loop */
+            for (const file of stagedFiles) {
+                await client.send(
+                    new PutObjectCommand({
+                        Bucket: bucket,
+                        Key: file.key,
+                        Body: file.body,
+                        ContentLength: file.body.length,
+                        ContentType: file.write.contentType,
+                    }),
+                );
+                uploadedKeys.push(file.key);
+            }
+            /* eslint-enable no-await-in-loop */
+        } catch (error) {
+            await this.deleteObjectKeysBestEffort(
+                client,
+                bucket,
+                uploadedKeys,
+                `failed package staging for theme ${parsed.manifest.slug}`,
+            );
+            throw error;
+        }
+
+        let result: ApiOrganizationDesign;
+        let removedFiles: ApiOrganizationDesignFile[] = [];
+        try {
+            if (existing) {
+                const replacement =
+                    await this.organizationDesignModel.replaceFiles(
+                        organizationUuid,
+                        existing.designUuid,
+                        userUuid,
+                        {
+                            name: parsed.manifest.name,
+                            description: parsed.manifest.description,
+                            extraInstructions:
+                                parsed.manifest.extraInstructions,
+                            files: stagedFiles.map((file) => file.write),
+                        },
+                    );
+                result = replacement.design;
+                removedFiles = replacement.removedFiles;
+            } else {
+                result = await this.organizationDesignModel.createWithFiles(
+                    organizationUuid,
+                    userUuid,
+                    {
+                        designUuid,
+                        slug: parsed.manifest.slug,
+                        name: parsed.manifest.name,
+                        description: parsed.manifest.description,
+                        extraInstructions: parsed.manifest.extraInstructions,
+                        files: stagedFiles.map((file) => file.write),
+                    },
+                );
+            }
+        } catch (error) {
+            await this.deleteObjectKeysBestEffort(
+                client,
+                bucket,
+                uploadedKeys,
+                `failed package activation for theme ${parsed.manifest.slug}`,
+            );
+            throw error;
+        }
+
+        await this.deleteObjectKeysBestEffort(
+            client,
+            bucket,
+            removedFiles.map((file) =>
+                designS3Key(
+                    organizationUuid,
+                    result.designUuid,
+                    file.fileUuid,
+                    file.filename,
+                ),
+            ),
+            `old package cleanup for theme ${parsed.manifest.slug}`,
+        );
+        return result;
+    }
+
     async updateDesign(
         account: Account,
         designUuidOrSlug: UuidOrSlug,
@@ -603,8 +782,8 @@ export class OrganizationDesignService extends BaseService {
         const filename = ensureValidFilename(input.filename);
         ensureFilenameMatchesKind(filename, kind);
 
-        // Reject uploads that would push the theme past its asset-count/total-
-        // size guardrails, so a theme can't grow large enough to time out the
+        // Reject uploads that would push the theme past its total-size
+        // guardrail, so a theme can't grow large enough to time out the
         // data-app pipeline when applied. `contentLength` is an upper bound on
         // the stored size (SVG sanitization can only shrink it), so this never
         // under-counts. Checked before reading any bytes off the wire.
@@ -833,6 +1012,37 @@ export class OrganizationDesignService extends BaseService {
             filename: file.filename,
             sizeBytes: file.sizeBytes,
         };
+    }
+
+    private async deleteObjectKeysBestEffort(
+        client: S3Client,
+        bucket: string,
+        keys: string[],
+        context: string,
+    ): Promise<void> {
+        if (keys.length === 0) return;
+        try {
+            /* eslint-disable no-await-in-loop */
+            for (let i = 0; i < keys.length; i += S3_DELETE_BATCH_SIZE) {
+                await client.send(
+                    new DeleteObjectsCommand({
+                        Bucket: bucket,
+                        Delete: {
+                            Objects: keys
+                                .slice(i, i + S3_DELETE_BATCH_SIZE)
+                                .map((Key) => ({ Key })),
+                            Quiet: true,
+                        },
+                    }),
+                );
+            }
+            /* eslint-enable no-await-in-loop */
+        } catch (error) {
+            this.logger.error(
+                `Failed to delete ${keys.length} theme package object(s) during ${context}`,
+                { error, objectCount: keys.length },
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Closes: Relates to: https://linear.app/lightdash/issue/GLITCH-658/data-app-themes-theme-as-code-v1-stable-identity-and-atomic-package

## Summary

- add raw `application/x-tar` package import
- validate the complete archive before mutation
- stage S3 objects before an atomic row-locked create or replace
- clean staged and replaced objects across failure and success paths
- serialize normal file mutations with package replacement

## Why

Package import must preserve existing theme identity and default state, while avoiding partial database or S3 activation.

## Validation

- 30 focused codec, model, and service tests
- backend typecheck
- focused lint and format checks
- `git diff --check`
- Chrome smoke test: CSS, SVG, and Markdown upload plus byte-identical export/import/export roundtrip
- full backend suite: 6,287 passed, 1 skipped
