### PR TITLE
fix: add Databricks personal access token option to personal warehouse credentials

### DIFF
--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
@@ -8,12 +8,12 @@ import { Button, Select, Stack, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconPlus } from '@tabler/icons-react';
 import React, { type FC } from 'react';
-import useHealth from '../../../hooks/health/useHealth';
 import { useUserWarehouseCredentialsCreateMutation } from '../../../hooks/userWarehouseCredentials/useUserWarehouseCredentials';
 import MantineModal, {
     type MantineModalProps,
 } from '../../common/MantineModal';
 import { getWarehouseLabel } from '../../ProjectConnection/ProjectConnectFlow/utils';
+import { isDatabricksPersonalAccessToken } from './utils';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
 
 type Props = Pick<MantineModalProps, 'opened' | 'onClose'> & {
@@ -88,8 +88,6 @@ export const CreateCredentialsModal: FC<Props> = ({
     projectName,
     onSuccess,
 }) => {
-    const health = useHealth();
-    const isDatabricksEnabled = health.data?.auth.databricks.enabled ?? false;
     const { mutateAsync, isLoading: isSaving } =
         useUserWarehouseCredentialsCreateMutation({
             onSuccess,
@@ -109,11 +107,12 @@ export const CreateCredentialsModal: FC<Props> = ({
             RedshiftAuthenticationType.IAM_BROWSER;
     const showSaveButton =
         !isRedshiftBrowserSso &&
-        ![
-            WarehouseTypes.BIGQUERY,
-            WarehouseTypes.SNOWFLAKE,
-            WarehouseTypes.DATABRICKS,
-        ].includes(warehouseType ?? form.values.credentials.type);
+        (isDatabricksPersonalAccessToken(form.values.credentials) ||
+            ![
+                WarehouseTypes.BIGQUERY,
+                WarehouseTypes.SNOWFLAKE,
+                WarehouseTypes.DATABRICKS,
+            ].includes(warehouseType ?? form.values.credentials.type));
 
     return (
         <MantineModal
@@ -164,16 +163,10 @@ export const CreateCredentialsModal: FC<Props> = ({
                             label="Warehouse"
                             size="xs"
                             disabled={isSaving}
-                            data={Object.values(WarehouseTypes).map((type) => {
-                                const isDisabled =
-                                    type === WarehouseTypes.DATABRICKS &&
-                                    !isDatabricksEnabled;
-                                return {
-                                    value: type,
-                                    label: getWarehouseLabel(type) || type,
-                                    disabled: isDisabled,
-                                };
-                            })}
+                            data={Object.values(WarehouseTypes).map((type) => ({
+                                value: type,
+                                label: getWarehouseLabel(type) || type,
+                            }))}
                             {...form.getInputProps('credentials.type')}
                         />
                     )}

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
@@ -12,6 +12,7 @@ import { useUserWarehouseCredentialsUpdateMutation } from '../../../hooks/userWa
 import MantineModal, {
     type MantineModalProps,
 } from '../../common/MantineModal';
+import { isDatabricksPersonalAccessToken } from './utils';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
 
 const getCredentialsWithPlaceholders = (
@@ -88,11 +89,13 @@ export const EditCredentialsModal: FC<
     // SSO-based credentials are only ever set through their OAuth popup. They
     // have no editable secret field, so a generic "Save" would persist the
     // masked placeholder and wipe the working credential.
-    const showSaveButton = ![
-        WarehouseTypes.BIGQUERY,
-        WarehouseTypes.SNOWFLAKE,
-        WarehouseTypes.DATABRICKS,
-    ].includes(userCredentials.credentials.type);
+    const showSaveButton =
+        isDatabricksPersonalAccessToken(form.values.credentials) ||
+        ![
+            WarehouseTypes.BIGQUERY,
+            WarehouseTypes.SNOWFLAKE,
+            WarehouseTypes.DATABRICKS,
+        ].includes(userCredentials.credentials.type);
 
     return (
         <MantineModal

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.test.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.test.tsx
@@ -1,0 +1,74 @@
+import {
+    WarehouseTypes,
+    type UpsertUserWarehouseCredentials,
+} from '@lightdash/common';
+import { useForm } from '@mantine/form';
+import userEvent from '@testing-library/user-event';
+import { type FC } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { WarehouseFormInputs } from './WarehouseFormInputs';
+
+let isDatabricksSsoEnabled = false;
+
+vi.mock('../../../hooks/health/useHealth', () => ({
+    default: () => ({
+        data: {
+            siteUrl: 'http://localhost:3000',
+            auth: { databricks: { enabled: isDatabricksSsoEnabled } },
+        },
+    }),
+}));
+
+const DatabricksForm: FC = () => {
+    const form = useForm<UpsertUserWarehouseCredentials>({
+        initialValues: {
+            name: 'my databricks',
+            credentials: {
+                type: WarehouseTypes.DATABRICKS,
+                personalAccessToken: '',
+            },
+        },
+    });
+
+    return (
+        <WarehouseFormInputs form={form} disabled={false} onClose={vi.fn()} />
+    );
+};
+
+describe('WarehouseFormInputs - Databricks', () => {
+    beforeEach(() => {
+        isDatabricksSsoEnabled = false;
+    });
+
+    it('offers a personal access token input when SSO is not enabled', async () => {
+        const { findByLabelText, queryByLabelText, queryByRole } =
+            renderWithProviders(<DatabricksForm />);
+
+        expect(await findByLabelText(/personal access token/i)).toBeDefined();
+        expect(queryByLabelText(/authentication type/i)).toBeNull();
+        expect(
+            queryByRole('button', { name: /sign in with databricks/i }),
+        ).toBeNull();
+    });
+
+    it('defaults to SSO when enabled and lets the user switch to a personal access token', async () => {
+        isDatabricksSsoEnabled = true;
+        const { findByRole, findByLabelText, queryByLabelText } =
+            renderWithProviders(<DatabricksForm />);
+
+        expect(
+            await findByRole('button', { name: /sign in with databricks/i }),
+        ).toBeDefined();
+        expect(queryByLabelText(/personal access token/i)).toBeNull();
+
+        await userEvent.click(
+            await findByRole('textbox', { name: /authentication type/i }),
+        );
+        await userEvent.click(
+            await findByRole('option', { name: /personal access token/i }),
+        );
+
+        expect(await findByLabelText(/personal access token/i)).toBeDefined();
+    });
+});

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
@@ -1,4 +1,5 @@
 import {
+    DatabricksAuthenticationType,
     RedshiftAuthenticationType,
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
@@ -29,7 +30,10 @@ import { useRedshiftAwsSsoLoginPopup } from '../../../hooks/useRedshiftAwsSso';
 import { getUserWarehouseCredentials } from '../../../hooks/userWarehouseCredentials/useUserWarehouseCredentials';
 import { useSnowflakeLoginPopup } from '../../../hooks/useSnowflake';
 import MantineIcon from '../../common/MantineIcon';
-import { getSsoLabel } from '../../ProjectConnection/WarehouseForms/util';
+import {
+    getSsoLabel,
+    PERSONAL_ACCESS_TOKEN_LABEL,
+} from '../../ProjectConnection/WarehouseForms/util';
 import { WarehouseSsoButton } from './WarehouseSsoButton';
 
 const BigQueryFormInput: FC<{
@@ -96,13 +100,22 @@ export const SnowflakeFormInput: FC<{ onClose: () => void }> = ({
     );
 };
 
-const DatabricksFormInput: FC<{
+const DatabricksFormInputs: FC<{
+    disabled: boolean;
+    form: UseFormReturnType<UpsertUserWarehouseCredentials>;
     onClose: () => void;
     projectUuid?: string;
     projectName?: string;
     credentialsName?: string;
-}> = ({ onClose, projectUuid, projectName, credentialsName }) => {
-    const { mutate: openLoginPopup } = useDatabricksLoginPopup({
+}> = ({
+    disabled,
+    form,
+    onClose,
+    projectUuid,
+    projectName,
+    credentialsName,
+}) => {
+    const { mutate: openLoginPopup, isSsoEnabled } = useDatabricksLoginPopup({
         onLogin: async () => {
             onClose();
         },
@@ -111,15 +124,68 @@ const DatabricksFormInput: FC<{
         credentialsName,
     });
 
-    // If this popup happens, it means we don't have warehouse credentials,
-    // (aka isAuthenticated is false), so we need to authenticate
+    const authenticationType =
+        form.values.credentials.type === WarehouseTypes.DATABRICKS
+            ? form.values.credentials.authenticationType
+            : undefined;
+
+    useEffect(() => {
+        if (isSsoEnabled === undefined || authenticationType !== undefined) {
+            return;
+        }
+        form.setFieldValue(
+            'credentials.authenticationType',
+            isSsoEnabled
+                ? DatabricksAuthenticationType.OAUTH_U2M
+                : DatabricksAuthenticationType.PERSONAL_ACCESS_TOKEN,
+        );
+    }, [form, isSsoEnabled, authenticationType]);
+
+    if (authenticationType === undefined) return null;
+
     return (
-        <WarehouseSsoButton
-            warehouseType={WarehouseTypes.DATABRICKS}
-            providerName="Databricks"
-            disabled={false}
-            openLoginPopup={openLoginPopup}
-        />
+        <Stack gap="xs">
+            {isSsoEnabled && (
+                <Select
+                    required
+                    allowDeselect={false}
+                    size="xs"
+                    label="Authentication type"
+                    data={[
+                        {
+                            value: DatabricksAuthenticationType.OAUTH_U2M,
+                            label: getSsoLabel(WarehouseTypes.DATABRICKS),
+                        },
+                        {
+                            value: DatabricksAuthenticationType.PERSONAL_ACCESS_TOKEN,
+                            label: PERSONAL_ACCESS_TOKEN_LABEL,
+                        },
+                    ]}
+                    disabled={disabled}
+                    {...form.getInputProps('credentials.authenticationType')}
+                />
+            )}
+
+            {authenticationType === DatabricksAuthenticationType.OAUTH_U2M ? (
+                // If this popup happens, it means we don't have warehouse credentials,
+                // (aka isAuthenticated is false), so we need to authenticate
+                <WarehouseSsoButton
+                    warehouseType={WarehouseTypes.DATABRICKS}
+                    providerName="Databricks"
+                    disabled={false}
+                    openLoginPopup={openLoginPopup}
+                />
+            ) : (
+                <PasswordInput
+                    required
+                    size="xs"
+                    label="Personal access token"
+                    description="Create a personal access token in your Databricks user settings."
+                    disabled={disabled}
+                    {...form.getInputProps('credentials.personalAccessToken')}
+                />
+            )}
+        </Stack>
     );
 };
 
@@ -466,7 +532,9 @@ export const WarehouseFormInputs: FC<{
             );
         case WarehouseTypes.DATABRICKS:
             return (
-                <DatabricksFormInput
+                <DatabricksFormInputs
+                    disabled={disabled}
+                    form={form}
                     onClose={onClose}
                     projectUuid={projectUuid}
                     projectName={projectName}

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/utils.ts
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/utils.ts
@@ -1,0 +1,17 @@
+import {
+    DatabricksAuthenticationType,
+    WarehouseTypes,
+    type UpsertUserWarehouseCredentials,
+} from '@lightdash/common';
+
+/**
+ * Databricks personal credentials support both "Sign in with Databricks"
+ * (OAuth U2M, enterprise-only) and a personal access token. Unlike the SSO
+ * flow, the PAT branch has an editable secret and so needs a save button.
+ */
+export const isDatabricksPersonalAccessToken = (
+    credentials: UpsertUserWarehouseCredentials['credentials'],
+) =>
+    credentials.type === WarehouseTypes.DATABRICKS &&
+    credentials.authenticationType ===
+        DatabricksAuthenticationType.PERSONAL_ACCESS_TOKEN;

--- a/packages/frontend/src/testing/__mocks__/implementations/scrollIntoView.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/implementations/scrollIntoView.mock.ts
@@ -1,0 +1,7 @@
+// jsdom doesn't implement scrollIntoView, which Mantine's Combobox calls when
+// highlighting an option.
+function mockScrollIntoView() {
+    window.Element.prototype.scrollIntoView = () => {};
+}
+
+export default mockScrollIntoView;

--- a/packages/frontend/src/testing/vitest.setup.ts
+++ b/packages/frontend/src/testing/vitest.setup.ts
@@ -4,6 +4,7 @@ import nodeFetch from 'node-fetch';
 import { afterEach, beforeAll, beforeEach, vi } from 'vitest';
 import mockMatchMedia from './__mocks__/implementations/matchMedia.mock';
 import mockResizeObserver from './__mocks__/implementations/resizeObserver.mock';
+import mockScrollIntoView from './__mocks__/implementations/scrollIntoView.mock';
 import ReactMarkdownPreview from './__mocks__/modules/ReactMarkdwnPreview.mock';
 
 // Node's built-in fetch (undici) bypasses nock and disableNetConnect below.
@@ -20,6 +21,7 @@ beforeAll(() => {
 
     mockMatchMedia();
     mockResizeObserver();
+    mockScrollIntoView();
 });
 
 // Disable all network requests by default


### PR DESCRIPTION
The Databricks case in the personal warehouse credentials panel (User Settings → My Warehouse Connections) only rendered the "Sign in with Databricks" SSO button. That OAuth U2M flow is enterprise-gated, so on instances without a license there was no way to add personal Databricks credentials at all — even though the backend and the docs both support a personal access token.

The Databricks branch now mirrors the admin `DatabricksForm`: when SSO is available it shows an authentication type select (Sign in with Databricks / Personal Access Token) defaulting to SSO; when SSO isn't enabled it just shows the PAT password input. The Save button in the create/edit modals appears for the PAT branch (SSO credentials are still popup-only, so no save button there), and Databricks is no longer disabled in the warehouse type dropdown.

Verified with a new component test covering both the SSO-disabled and SSO-enabled (switch to PAT) cases; frontend typecheck and lint pass. The new test opens a Mantine `Select`, which calls `scrollIntoView` — unimplemented in jsdom — so the shared vitest setup now stubs it alongside the existing `matchMedia`/`ResizeObserver` stubs.
