### PR TITLE
fix(ai): answer the message that opened the Slack agent picker

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -372,6 +372,12 @@ import type { AiWritebackSource } from '../AiWritebackService/types';
 import { type WritebackPreviewService } from '../AiWritebackService/WritebackPreviewService';
 import { PreviewDeploySetupService } from '../PreviewDeploySetupService/PreviewDeploySetupService';
 import { ProjectContextService } from '../ProjectContextService/ProjectContextService';
+import {
+    AgentSelectionPrompt,
+    findAgentSelectionMessageByTs,
+    findLegacyAgentSelectionMessage,
+    parseAgentSelectionValue,
+} from './agentSelectionPrompt';
 import { canAccessAiAgent, canAccessAiAgentThread } from './aiAgentAccess';
 import {
     canGeneratePostResponseSuggestions,
@@ -12485,23 +12491,27 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     /**
      * Show agent selection UI when multiple agents are available
      */
-    private async showAgentSelectionUI(
-        availableAgents: AiAgent[],
-        channelId: string,
-        threadTs: string | undefined,
-        say: SayFn,
-        shouldSkipForwardingQuery = false,
-    ): Promise<void> {
-        const projectMap = await this.getAgentSelectProjectMap(availableAgents);
+    private async showAgentSelectionUI(args: {
+        availableAgents: AiAgent[];
+        channelId: string;
+        threadTs: string | undefined;
+        promptSlackTs: string;
+        say: SayFn;
+        shouldSkipForwardingQuery: boolean;
+    }): Promise<void> {
+        const projectMap = await this.getAgentSelectProjectMap(
+            args.availableAgents,
+        );
 
-        await say({
-            blocks: getAgentSelectionBlocks(
-                availableAgents,
-                channelId,
+        await args.say({
+            blocks: getAgentSelectionBlocks({
+                agents: args.availableAgents,
+                channelId: args.channelId,
+                promptSlackTs: args.promptSlackTs,
                 projectMap,
-                shouldSkipForwardingQuery,
-            ),
-            thread_ts: threadTs,
+                shouldSkipForwardingQuery: args.shouldSkipForwardingQuery,
+            }),
+            thread_ts: args.threadTs,
         });
     }
 
@@ -12994,13 +13004,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         decision.shouldSkipForwardingQuery,
                 })},`,
             );
-            await this.showAgentSelectionUI(
+            await this.showAgentSelectionUI({
                 availableAgents,
                 channelId,
                 threadTs,
+                promptSlackTs,
                 say,
-                decision.shouldSkipForwardingQuery,
-            );
+                shouldSkipForwardingQuery: decision.shouldSkipForwardingQuery,
+            });
             return undefined;
         }
 
@@ -13494,6 +13505,60 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         });
     }
 
+    /**
+     * Resolve the message the agent picker was posted for.
+     *
+     * Pickers carry the triggering message's ts, so the message is fetched
+     * directly. Pickers posted before that field existed fall back to scanning
+     * thread history for the user's first (mentioning) message.
+     */
+    private static async findAgentSelectionPrompt(
+        client: WebClient,
+        args: {
+            channelId: string;
+            threadTs: string | undefined;
+            promptSlackTs: string | null;
+            slackUserId: string;
+            botUserId: string | undefined;
+            isMultiAgentChannel: boolean;
+        },
+    ): Promise<AgentSelectionPrompt | null> {
+        const { promptSlackTs } = args;
+
+        if (promptSlackTs) {
+            const targeted = await client.conversations.replies({
+                channel: args.channelId,
+                ts: args.threadTs || promptSlackTs,
+                oldest: promptSlackTs,
+                latest: promptSlackTs,
+                inclusive: true,
+                limit: 1,
+            });
+            // Never fall back to another message here: answering a message
+            // other than the one that opened the picker is the bug this lookup
+            // exists to prevent.
+            return findAgentSelectionMessageByTs(
+                targeted.messages ?? [],
+                promptSlackTs,
+            );
+        }
+
+        const conversationHistory = await client.conversations.replies({
+            channel: args.channelId,
+            ts: args.threadTs || '',
+            limit: 100,
+        });
+
+        return findLegacyAgentSelectionMessage(
+            conversationHistory.messages ?? [],
+            {
+                slackUserId: args.slackUserId,
+                botUserId: args.botUserId,
+                isMultiAgentChannel: args.isMultiAgentChannel,
+            },
+        );
+    }
+
     public handleAgentSelection(app: App) {
         app.action('select_agent', async ({ ack, body, client, context }) => {
             await ack();
@@ -13513,20 +13578,23 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             }
 
             try {
-                // Parse the selected agent UUID, channel ID, and shouldSkipForwardingQuery flag from the action value
-                const selectedValue = JSON.parse(action.selected_option.value);
-                const {
-                    agentUuid,
-                    channelId,
-                    shouldSkipForwardingQuery = false,
-                } = selectedValue;
+                const selectedValue = parseAgentSelectionValue(
+                    action.selected_option.value,
+                );
 
-                if (!agentUuid || !channelId) {
+                if (!selectedValue) {
                     Logger.error('Invalid agent selection value', {
                         value: action.selected_option.value,
                     });
                     return;
                 }
+
+                const {
+                    agentUuid,
+                    channelId,
+                    shouldSkipForwardingQuery,
+                    promptSlackTs,
+                } = selectedValue;
 
                 const organizationUuid =
                     await this.slackAuthenticationModel.getOrganizationUuidFromTeamId(
@@ -13599,37 +13667,24 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     }
                 }
 
-                // Fetch the thread messages to find the original user message
-                const conversationHistory = await client.conversations.replies({
-                    channel: channelId,
-                    ts: threadTs || '',
-                    limit: 100,
-                });
-
                 // Check if we're in the multi-agent channel
                 const isMultiAgentChannel =
                     slackSettings.aiMultiAgentChannelId === channelId;
 
-                // Find the original user message
-                // In multi-agent channel: first user message (no @mention needed)
-                // In regular channel: first message with @mention
-                const originalMessage = conversationHistory.messages?.find(
-                    (msg) => {
-                        if (msg.user !== body.user.id) return false;
-                        if (!msg.text) return false;
+                const selectedPrompt =
+                    await AiAgentService.findAgentSelectionPrompt(client, {
+                        channelId,
+                        threadTs,
+                        promptSlackTs,
+                        slackUserId: body.user.id,
+                        botUserId: context.botUserId,
+                        isMultiAgentChannel,
+                    });
 
-                        if (isMultiAgentChannel) {
-                            // Multi-agent channel: any user message
-                            return true;
-                        }
-                        // Regular channel: must have @mention
-                        return msg.text.includes(`<@${context.botUserId}>`);
-                    },
-                );
-
-                if (!originalMessage || !originalMessage.text) {
+                if (!selectedPrompt) {
                     Logger.error('Could not find original message in thread', {
                         threadTs,
+                        promptSlackTs,
                         channelId,
                         isMultiAgentChannel,
                     });
@@ -13685,8 +13740,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     agentConfig,
                     userUuid,
                     slackUserId: body.user.id,
-                    promptText: originalMessage.text,
-                    promptSlackTs: originalMessage.ts || '',
+                    promptText: selectedPrompt.text,
+                    promptSlackTs: selectedPrompt.ts,
                     forwardToAgent: !shouldSkipForwardingQuery,
                 });
             } catch (e) {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -12491,7 +12491,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
      */
     private async showAgentSelectionUI(args: {
         availableAgents: AiAgent[];
-        channelId: string;
         threadTs: string | undefined;
         promptSlackTs: string;
         say: SayFn;
@@ -12504,7 +12503,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         await args.say({
             blocks: getAgentSelectionBlocks({
                 agents: args.availableAgents,
-                channelId: args.channelId,
                 promptSlackTs: args.promptSlackTs,
                 projectMap,
                 shouldSkipForwardingQuery: args.shouldSkipForwardingQuery,
@@ -13004,7 +13002,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             );
             await this.showAgentSelectionUI({
                 availableAgents,
-                channelId,
                 threadTs,
                 promptSlackTs,
                 say,
@@ -13533,12 +13530,21 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     return;
                 }
 
-                const {
-                    agentUuid,
-                    channelId,
-                    shouldSkipForwardingQuery,
-                    promptSlackTs,
-                } = selectedValue;
+                const { agentUuid, shouldSkipForwardingQuery, promptSlackTs } =
+                    selectedValue;
+
+                // Newer pickers leave the channel id out of the option value to
+                // fit Slack's 150-char cap; the click reports the same channel.
+                const channelId =
+                    selectedValue.channelId ??
+                    ('channel' in body ? body.channel?.id : undefined);
+
+                if (!channelId) {
+                    Logger.error('Missing channel for agent selection', {
+                        value: action.selected_option.value,
+                    });
+                    return;
+                }
 
                 const organizationUuid =
                     await this.slackAuthenticationModel.getOrganizationUuidFromTeamId(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -373,10 +373,8 @@ import { type WritebackPreviewService } from '../AiWritebackService/WritebackPre
 import { PreviewDeploySetupService } from '../PreviewDeploySetupService/PreviewDeploySetupService';
 import { ProjectContextService } from '../ProjectContextService/ProjectContextService';
 import {
-    AgentSelectionPrompt,
-    findAgentSelectionMessageByTs,
-    findLegacyAgentSelectionMessage,
     parseAgentSelectionValue,
+    resolveAgentSelectionPrompt,
 } from './agentSelectionPrompt';
 import { canAccessAiAgent, canAccessAiAgentThread } from './aiAgentAccess';
 import {
@@ -13505,60 +13503,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         });
     }
 
-    /**
-     * Resolve the message the agent picker was posted for.
-     *
-     * Pickers carry the triggering message's ts, so the message is fetched
-     * directly. Pickers posted before that field existed fall back to scanning
-     * thread history for the user's first (mentioning) message.
-     */
-    private static async findAgentSelectionPrompt(
-        client: WebClient,
-        args: {
-            channelId: string;
-            threadTs: string | undefined;
-            promptSlackTs: string | null;
-            slackUserId: string;
-            botUserId: string | undefined;
-            isMultiAgentChannel: boolean;
-        },
-    ): Promise<AgentSelectionPrompt | null> {
-        const { promptSlackTs } = args;
-
-        if (promptSlackTs) {
-            const targeted = await client.conversations.replies({
-                channel: args.channelId,
-                ts: args.threadTs || promptSlackTs,
-                oldest: promptSlackTs,
-                latest: promptSlackTs,
-                inclusive: true,
-                limit: 1,
-            });
-            // Never fall back to another message here: answering a message
-            // other than the one that opened the picker is the bug this lookup
-            // exists to prevent.
-            return findAgentSelectionMessageByTs(
-                targeted.messages ?? [],
-                promptSlackTs,
-            );
-        }
-
-        const conversationHistory = await client.conversations.replies({
-            channel: args.channelId,
-            ts: args.threadTs || '',
-            limit: 100,
-        });
-
-        return findLegacyAgentSelectionMessage(
-            conversationHistory.messages ?? [],
-            {
-                slackUserId: args.slackUserId,
-                botUserId: args.botUserId,
-                isMultiAgentChannel: args.isMultiAgentChannel,
-            },
-        );
-    }
-
     public handleAgentSelection(app: App) {
         app.action('select_agent', async ({ ack, body, client, context }) => {
             await ack();
@@ -13671,15 +13615,17 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 const isMultiAgentChannel =
                     slackSettings.aiMultiAgentChannelId === channelId;
 
-                const selectedPrompt =
-                    await AiAgentService.findAgentSelectionPrompt(client, {
+                const selectedPrompt = await resolveAgentSelectionPrompt(
+                    client,
+                    {
                         channelId,
                         threadTs,
                         promptSlackTs,
                         slackUserId: body.user.id,
                         botUserId: context.botUserId,
                         isMultiAgentChannel,
-                    });
+                    },
+                );
 
                 if (!selectedPrompt) {
                     Logger.error('Could not find original message in thread', {

--- a/packages/backend/src/ee/services/AiAgentService/agentSelectionPrompt.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/agentSelectionPrompt.test.ts
@@ -1,0 +1,204 @@
+import {
+    findAgentSelectionMessageByTs,
+    findLegacyAgentSelectionMessage,
+    parseAgentSelectionValue,
+} from './agentSelectionPrompt';
+
+const SLACK_USER_ID = 'U123';
+const OTHER_USER_ID = 'U999';
+const BOT_USER_ID = 'U0BOT01';
+const ROOT_TS = '1700000000.000100';
+const FOLLOW_UP_TS = '1700000000.000300';
+
+const threadMessages = [
+    {
+        user: SLACK_USER_ID,
+        text: `<@${BOT_USER_ID}> which agents are available here?`,
+        ts: ROOT_TS,
+    },
+    {
+        user: OTHER_USER_ID,
+        text: 'no idea',
+        ts: '1700000000.000200',
+    },
+    {
+        user: SLACK_USER_ID,
+        text: `<@${BOT_USER_ID}> what were revenues last month?`,
+        ts: FOLLOW_UP_TS,
+    },
+];
+
+describe('parseAgentSelectionValue', () => {
+    it('reads the triggering message ts from the picker payload', () => {
+        expect(
+            parseAgentSelectionValue(
+                JSON.stringify({
+                    agentUuid: 'agent-1',
+                    channelId: 'C123',
+                    shouldSkipForwardingQuery: true,
+                    promptSlackTs: FOLLOW_UP_TS,
+                }),
+            ),
+        ).toEqual({
+            agentUuid: 'agent-1',
+            channelId: 'C123',
+            shouldSkipForwardingQuery: true,
+            promptSlackTs: FOLLOW_UP_TS,
+        });
+    });
+
+    it('reports no ts for pickers posted before the ts was carried', () => {
+        expect(
+            parseAgentSelectionValue(
+                JSON.stringify({
+                    agentUuid: 'agent-1',
+                    channelId: 'C123',
+                    shouldSkipForwardingQuery: false,
+                }),
+            ),
+        ).toEqual({
+            agentUuid: 'agent-1',
+            channelId: 'C123',
+            shouldSkipForwardingQuery: false,
+            promptSlackTs: null,
+        });
+    });
+
+    it('defaults the forwarding flag to forwarding the query', () => {
+        expect(
+            parseAgentSelectionValue(
+                JSON.stringify({ agentUuid: 'agent-1', channelId: 'C123' }),
+            )?.shouldSkipForwardingQuery,
+        ).toBe(false);
+    });
+
+    it.each([
+        ['not json', 'not json'],
+        ['a json literal', '"agent-1"'],
+        ['a missing agent', JSON.stringify({ channelId: 'C123' })],
+        ['a missing channel', JSON.stringify({ agentUuid: 'agent-1' })],
+        [
+            'a non-string agent',
+            JSON.stringify({ agentUuid: 1, channelId: 'C123' }),
+        ],
+    ])('rejects %s', (_label, value) => {
+        expect(parseAgentSelectionValue(value)).toBeNull();
+    });
+
+    it('ignores a non-string ts rather than rejecting the whole payload', () => {
+        expect(
+            parseAgentSelectionValue(
+                JSON.stringify({
+                    agentUuid: 'agent-1',
+                    channelId: 'C123',
+                    promptSlackTs: 1700000000,
+                }),
+            )?.promptSlackTs,
+        ).toBeNull();
+    });
+});
+
+describe('findAgentSelectionMessageByTs', () => {
+    it('picks the message that opened the picker, not the thread root', () => {
+        expect(
+            findAgentSelectionMessageByTs(threadMessages, FOLLOW_UP_TS),
+        ).toEqual({
+            text: `<@${BOT_USER_ID}> what were revenues last month?`,
+            ts: FOLLOW_UP_TS,
+        });
+    });
+
+    it('picks the thread root when the root opened the picker', () => {
+        expect(findAgentSelectionMessageByTs(threadMessages, ROOT_TS)).toEqual({
+            text: `<@${BOT_USER_ID}> which agents are available here?`,
+            ts: ROOT_TS,
+        });
+    });
+
+    it('resolves nothing when the message is gone', () => {
+        expect(findAgentSelectionMessageByTs([], FOLLOW_UP_TS)).toBeNull();
+    });
+
+    it('resolves nothing rather than substituting another message', () => {
+        expect(
+            findAgentSelectionMessageByTs(threadMessages, '1700000000.000999'),
+        ).toBeNull();
+    });
+
+    it('resolves nothing for a message with no text', () => {
+        expect(
+            findAgentSelectionMessageByTs(
+                [{ user: SLACK_USER_ID, ts: FOLLOW_UP_TS }],
+                FOLLOW_UP_TS,
+            ),
+        ).toBeNull();
+    });
+});
+
+describe('findLegacyAgentSelectionMessage', () => {
+    it('falls back to the first message by the selecting user in a multi-agent channel', () => {
+        expect(
+            findLegacyAgentSelectionMessage(threadMessages, {
+                slackUserId: SLACK_USER_ID,
+                botUserId: BOT_USER_ID,
+                isMultiAgentChannel: true,
+            }),
+        ).toEqual({
+            text: `<@${BOT_USER_ID}> which agents are available here?`,
+            ts: ROOT_TS,
+        });
+    });
+
+    it('skips messages from other users', () => {
+        expect(
+            findLegacyAgentSelectionMessage(
+                [
+                    { user: OTHER_USER_ID, text: 'first', ts: ROOT_TS },
+                    {
+                        user: SLACK_USER_ID,
+                        text: 'second',
+                        ts: FOLLOW_UP_TS,
+                    },
+                ],
+                {
+                    slackUserId: SLACK_USER_ID,
+                    botUserId: BOT_USER_ID,
+                    isMultiAgentChannel: true,
+                },
+            ),
+        ).toEqual({ text: 'second', ts: FOLLOW_UP_TS });
+    });
+
+    it('requires a bot mention outside the multi-agent channel', () => {
+        expect(
+            findLegacyAgentSelectionMessage(
+                [
+                    { user: SLACK_USER_ID, text: 'no mention', ts: ROOT_TS },
+                    {
+                        user: SLACK_USER_ID,
+                        text: `<@${BOT_USER_ID}> revenues?`,
+                        ts: FOLLOW_UP_TS,
+                    },
+                ],
+                {
+                    slackUserId: SLACK_USER_ID,
+                    botUserId: BOT_USER_ID,
+                    isMultiAgentChannel: false,
+                },
+            ),
+        ).toEqual({
+            text: `<@${BOT_USER_ID}> revenues?`,
+            ts: FOLLOW_UP_TS,
+        });
+    });
+
+    it('resolves nothing when no message matches', () => {
+        expect(
+            findLegacyAgentSelectionMessage(threadMessages, {
+                slackUserId: 'U-nobody',
+                botUserId: BOT_USER_ID,
+                isMultiAgentChannel: true,
+            }),
+        ).toBeNull();
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/agentSelectionPrompt.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/agentSelectionPrompt.test.ts
@@ -1,7 +1,10 @@
+import type { WebClient } from '@slack/web-api';
 import {
     findAgentSelectionMessageByTs,
     findLegacyAgentSelectionMessage,
     parseAgentSelectionValue,
+    resolveAgentSelectionPrompt,
+    type SlackThreadMessage,
 } from './agentSelectionPrompt';
 
 const SLACK_USER_ID = 'U123';
@@ -200,5 +203,114 @@ describe('findLegacyAgentSelectionMessage', () => {
                 isMultiAgentChannel: true,
             }),
         ).toBeNull();
+    });
+
+    it('resolves nothing for a matching message with no ts', () => {
+        expect(
+            findLegacyAgentSelectionMessage(
+                [{ user: SLACK_USER_ID, text: 'hi' }],
+                {
+                    slackUserId: SLACK_USER_ID,
+                    botUserId: BOT_USER_ID,
+                    isMultiAgentChannel: true,
+                },
+            ),
+        ).toBeNull();
+    });
+});
+
+/**
+ * Stands in for conversations.replies: the thread parent is always returned
+ * first and counts against `limit`, and oldest/latest bound the replies.
+ */
+const buildSlackClient = (messages: SlackThreadMessage[]) => {
+    const replies = async (args: {
+        oldest?: string;
+        latest?: string;
+        inclusive?: boolean;
+        limit?: number;
+    }) => {
+        const [parent, ...rest] = messages;
+        const withinWindow = rest.filter((msg) => {
+            const ts = msg.ts ?? '';
+            if (
+                args.oldest &&
+                (args.inclusive ? ts < args.oldest : ts <= args.oldest)
+            )
+                return false;
+            if (
+                args.latest &&
+                (args.inclusive ? ts > args.latest : ts >= args.latest)
+            )
+                return false;
+            return true;
+        });
+        const window = parent ? [parent, ...withinWindow] : withinWindow;
+        return { messages: window.slice(0, args.limit ?? window.length) };
+    };
+
+    return {
+        conversations: { replies },
+    } as unknown as Pick<WebClient, 'conversations'>;
+};
+
+describe('resolveAgentSelectionPrompt', () => {
+    const args = {
+        channelId: 'C123',
+        threadTs: ROOT_TS,
+        slackUserId: SLACK_USER_ID,
+        botUserId: BOT_USER_ID,
+        isMultiAgentChannel: true,
+    };
+
+    it('resolves the reply the picker was posted for, not the thread root', async () => {
+        expect(
+            await resolveAgentSelectionPrompt(
+                buildSlackClient(threadMessages),
+                { ...args, promptSlackTs: FOLLOW_UP_TS },
+            ),
+        ).toEqual({
+            text: `<@${BOT_USER_ID}> what were revenues last month?`,
+            ts: FOLLOW_UP_TS,
+        });
+    });
+
+    it('resolves the thread root when the picker was posted for it', async () => {
+        expect(
+            await resolveAgentSelectionPrompt(
+                buildSlackClient(threadMessages),
+                { ...args, promptSlackTs: ROOT_TS },
+            ),
+        ).toEqual({
+            text: `<@${BOT_USER_ID}> which agents are available here?`,
+            ts: ROOT_TS,
+        });
+    });
+
+    it('resolves nothing when the message the picker was posted for is gone', async () => {
+        expect(
+            await resolveAgentSelectionPrompt(
+                buildSlackClient(threadMessages),
+                {
+                    ...args,
+                    promptSlackTs: '1700000000.000999',
+                },
+            ),
+        ).toBeNull();
+    });
+
+    it('falls back to the thread scan for pickers posted without a ts', async () => {
+        expect(
+            await resolveAgentSelectionPrompt(
+                buildSlackClient(threadMessages),
+                {
+                    ...args,
+                    promptSlackTs: null,
+                },
+            ),
+        ).toEqual({
+            text: `<@${BOT_USER_ID}> which agents are available here?`,
+            ts: ROOT_TS,
+        });
     });
 });

--- a/packages/backend/src/ee/services/AiAgentService/agentSelectionPrompt.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/agentSelectionPrompt.test.ts
@@ -32,7 +32,20 @@ const threadMessages = [
 ];
 
 describe('parseAgentSelectionValue', () => {
-    it('reads the triggering message ts from the picker payload', () => {
+    it('reads the terse picker payload', () => {
+        expect(
+            parseAgentSelectionValue(
+                JSON.stringify({ a: 'agent-1', s: true, t: FOLLOW_UP_TS }),
+            ),
+        ).toEqual({
+            agentUuid: 'agent-1',
+            channelId: null,
+            shouldSkipForwardingQuery: true,
+            promptSlackTs: FOLLOW_UP_TS,
+        });
+    });
+
+    it('still reads pickers posted with the long-key payload', () => {
         expect(
             parseAgentSelectionValue(
                 JSON.stringify({
@@ -67,23 +80,30 @@ describe('parseAgentSelectionValue', () => {
         });
     });
 
-    it('defaults the forwarding flag to forwarding the query', () => {
+    it('reports no channel for pickers that leave it to the click event', () => {
         expect(
             parseAgentSelectionValue(
-                JSON.stringify({ agentUuid: 'agent-1', channelId: 'C123' }),
-            )?.shouldSkipForwardingQuery,
+                JSON.stringify({ a: 'agent-1', s: false, t: FOLLOW_UP_TS }),
+            )?.channelId,
+        ).toBeNull();
+    });
+
+    it('defaults the forwarding flag to forwarding the query', () => {
+        expect(
+            parseAgentSelectionValue(JSON.stringify({ a: 'agent-1' }))
+                ?.shouldSkipForwardingQuery,
         ).toBe(false);
     });
 
     it.each([
         ['not json', 'not json'],
         ['a json literal', '"agent-1"'],
-        ['a missing agent', JSON.stringify({ channelId: 'C123' })],
-        ['a missing channel', JSON.stringify({ agentUuid: 'agent-1' })],
+        ['a missing agent', JSON.stringify({ s: false, t: FOLLOW_UP_TS })],
         [
-            'a non-string agent',
-            JSON.stringify({ agentUuid: 1, channelId: 'C123' }),
+            'a legacy payload with no agent',
+            JSON.stringify({ channelId: 'C123' }),
         ],
+        ['a non-string agent', JSON.stringify({ a: 1 })],
     ])('rejects %s', (_label, value) => {
         expect(parseAgentSelectionValue(value)).toBeNull();
     });
@@ -91,11 +111,7 @@ describe('parseAgentSelectionValue', () => {
     it('ignores a non-string ts rather than rejecting the whole payload', () => {
         expect(
             parseAgentSelectionValue(
-                JSON.stringify({
-                    agentUuid: 'agent-1',
-                    channelId: 'C123',
-                    promptSlackTs: 1700000000,
-                }),
+                JSON.stringify({ a: 'agent-1', t: 1700000000 }),
             )?.promptSlackTs,
         ).toBeNull();
     });

--- a/packages/backend/src/ee/services/AiAgentService/agentSelectionPrompt.ts
+++ b/packages/backend/src/ee/services/AiAgentService/agentSelectionPrompt.ts
@@ -1,0 +1,87 @@
+/**
+ * Resolving which message an agent picker was posted for.
+ *
+ * The picker carries the triggering message's ts in its action value, so the
+ * handler answers that message rather than re-deriving one from thread history.
+ */
+
+export type AgentSelectionValue = {
+    agentUuid: string;
+    channelId: string;
+    shouldSkipForwardingQuery: boolean;
+    // Absent on pickers posted before the ts was added to the payload.
+    promptSlackTs: string | null;
+};
+
+export const parseAgentSelectionValue = (
+    value: string,
+): AgentSelectionValue | null => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(value);
+    } catch {
+        return null;
+    }
+
+    if (typeof parsed !== 'object' || parsed === null) {
+        return null;
+    }
+
+    const { agentUuid, channelId, shouldSkipForwardingQuery, promptSlackTs } =
+        parsed as Record<string, unknown>;
+
+    if (typeof agentUuid !== 'string' || agentUuid === '') return null;
+    if (typeof channelId !== 'string' || channelId === '') return null;
+
+    return {
+        agentUuid,
+        channelId,
+        shouldSkipForwardingQuery: shouldSkipForwardingQuery === true,
+        promptSlackTs:
+            typeof promptSlackTs === 'string' && promptSlackTs !== ''
+                ? promptSlackTs
+                : null,
+    };
+};
+
+export type SlackThreadMessage = {
+    user?: string;
+    text?: string;
+    ts?: string;
+};
+
+export type AgentSelectionPrompt = {
+    text: string;
+    ts: string;
+};
+
+export const findAgentSelectionMessageByTs = (
+    messages: SlackThreadMessage[],
+    promptSlackTs: string,
+): AgentSelectionPrompt | null => {
+    const message = messages.find((msg) => msg.ts === promptSlackTs);
+    return message?.text ? { text: message.text, ts: promptSlackTs } : null;
+};
+
+/**
+ * Fallback for pickers posted without a ts: the user's first message in the
+ * thread, narrowed to bot mentions outside the multi-agent channel. Answers the
+ * thread root rather than the message that opened the picker.
+ */
+export const findLegacyAgentSelectionMessage = (
+    messages: SlackThreadMessage[],
+    args: {
+        slackUserId: string;
+        botUserId: string | undefined;
+        isMultiAgentChannel: boolean;
+    },
+): AgentSelectionPrompt | null => {
+    const message = messages.find((msg) => {
+        if (msg.user !== args.slackUserId) return false;
+        if (!msg.text) return false;
+        if (args.isMultiAgentChannel) return true;
+        return msg.text.includes(`<@${args.botUserId}>`);
+    });
+
+    return message?.text ? { text: message.text, ts: message.ts ?? '' } : null;
+};

--- a/packages/backend/src/ee/services/AiAgentService/agentSelectionPrompt.ts
+++ b/packages/backend/src/ee/services/AiAgentService/agentSelectionPrompt.ts
@@ -1,9 +1,4 @@
-/**
- * Resolving which message an agent picker was posted for.
- *
- * The picker carries the triggering message's ts in its action value, so the
- * handler answers that message rather than re-deriving one from thread history.
- */
+import type { WebClient } from '@slack/web-api';
 
 export type AgentSelectionValue = {
     agentUuid: string;
@@ -36,7 +31,7 @@ export const parseAgentSelectionValue = (
     return {
         agentUuid,
         channelId,
-        shouldSkipForwardingQuery: shouldSkipForwardingQuery === true,
+        shouldSkipForwardingQuery: Boolean(shouldSkipForwardingQuery),
         promptSlackTs:
             typeof promptSlackTs === 'string' && promptSlackTs !== ''
                 ? promptSlackTs
@@ -63,11 +58,7 @@ export const findAgentSelectionMessageByTs = (
     return message?.text ? { text: message.text, ts: promptSlackTs } : null;
 };
 
-/**
- * Fallback for pickers posted without a ts: the user's first message in the
- * thread, narrowed to bot mentions outside the multi-agent channel. Answers the
- * thread root rather than the message that opened the picker.
- */
+// Legacy pickers carry no ts: answers the user's first message in the thread.
 export const findLegacyAgentSelectionMessage = (
     messages: SlackThreadMessage[],
     args: {
@@ -83,5 +74,55 @@ export const findLegacyAgentSelectionMessage = (
         return msg.text.includes(`<@${args.botUserId}>`);
     });
 
-    return message?.text ? { text: message.text, ts: message.ts ?? '' } : null;
+    return message?.text && message.ts
+        ? { text: message.text, ts: message.ts }
+        : null;
+};
+
+/**
+ * Resolve the message an agent picker was posted for, so the selection answers
+ * that message rather than one re-derived from thread history.
+ */
+export const resolveAgentSelectionPrompt = async (
+    client: Pick<WebClient, 'conversations'>,
+    args: {
+        channelId: string;
+        threadTs: string | undefined;
+        promptSlackTs: string | null;
+        slackUserId: string;
+        botUserId: string | undefined;
+        isMultiAgentChannel: boolean;
+    },
+): Promise<AgentSelectionPrompt | null> => {
+    const { promptSlackTs } = args;
+
+    if (promptSlackTs) {
+        // No limit: conversations.replies always returns the thread parent, so
+        // a limit would squeeze out the message the window asked for.
+        const targeted = await client.conversations.replies({
+            channel: args.channelId,
+            ts: args.threadTs || promptSlackTs,
+            oldest: promptSlackTs,
+            latest: promptSlackTs,
+            inclusive: true,
+        });
+
+        // Never fall back to another message: answering one is the bug.
+        return findAgentSelectionMessageByTs(
+            targeted.messages ?? [],
+            promptSlackTs,
+        );
+    }
+
+    const conversationHistory = await client.conversations.replies({
+        channel: args.channelId,
+        ts: args.threadTs || '',
+        limit: 100,
+    });
+
+    return findLegacyAgentSelectionMessage(conversationHistory.messages ?? [], {
+        slackUserId: args.slackUserId,
+        botUserId: args.botUserId,
+        isMultiAgentChannel: args.isMultiAgentChannel,
+    });
 };

--- a/packages/backend/src/ee/services/AiAgentService/agentSelectionPrompt.ts
+++ b/packages/backend/src/ee/services/AiAgentService/agentSelectionPrompt.ts
@@ -2,12 +2,18 @@ import type { WebClient } from '@slack/web-api';
 
 export type AgentSelectionValue = {
     agentUuid: string;
-    channelId: string;
+    // Only carried by pickers posted before the value was shortened to fit
+    // Slack's 150-char cap; newer ones leave it to the click event.
+    channelId: string | null;
     shouldSkipForwardingQuery: boolean;
     // Absent on pickers posted before the ts was added to the payload.
     promptSlackTs: string | null;
 };
 
+const readString = (value: unknown): string | null =>
+    typeof value === 'string' && value !== '' ? value : null;
+
+// Keys are terse to fit the option-value cap; the long names are the legacy shape.
 export const parseAgentSelectionValue = (
     value: string,
 ): AgentSelectionValue | null => {
@@ -22,20 +28,24 @@ export const parseAgentSelectionValue = (
         return null;
     }
 
-    const { agentUuid, channelId, shouldSkipForwardingQuery, promptSlackTs } =
-        parsed as Record<string, unknown>;
-
-    if (typeof agentUuid !== 'string' || agentUuid === '') return null;
-    if (typeof channelId !== 'string' || channelId === '') return null;
-
-    return {
+    const {
+        a,
+        s,
+        t,
         agentUuid,
         channelId,
-        shouldSkipForwardingQuery: Boolean(shouldSkipForwardingQuery),
-        promptSlackTs:
-            typeof promptSlackTs === 'string' && promptSlackTs !== ''
-                ? promptSlackTs
-                : null,
+        shouldSkipForwardingQuery,
+        promptSlackTs,
+    } = parsed as Record<string, unknown>;
+
+    const resolvedAgentUuid = readString(a) ?? readString(agentUuid);
+    if (!resolvedAgentUuid) return null;
+
+    return {
+        agentUuid: resolvedAgentUuid,
+        channelId: readString(channelId),
+        shouldSkipForwardingQuery: Boolean(s ?? shouldSkipForwardingQuery),
+        promptSlackTs: readString(t) ?? readString(promptSlackTs),
     };
 };
 

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -4,6 +4,7 @@ import {
     FilterOperator,
     FilterType,
 } from '@lightdash/common';
+import type { AgentSelectOption } from './getSlackBlocks';
 import {
     buildFeedbackContextActions,
     buildSlackTaskUpdate,
@@ -1372,10 +1373,10 @@ describe('Slack AI agent blocks', () => {
     });
 
     describe('getAgentSelectionBlocks', () => {
-        const agents = [
+        const agents: AgentSelectOption[] = [
             { uuid: 'agent-1', name: 'Agent one', projectUuid: 'project-1' },
             { uuid: 'agent-2', name: 'Agent two', projectUuid: 'project-2' },
-        ] as never[];
+        ];
 
         const getOptions = (blocks: unknown[]) => {
             const actions = blocks[1] as {

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -1403,32 +1403,20 @@ describe('Slack AI agent blocks', () => {
         it('carries the triggering message ts on every option', () => {
             const blocks = getAgentSelectionBlocks({
                 agents,
-                channelId: 'C123',
                 promptSlackTs: '1700000000.000300',
                 projectMap: undefined,
                 shouldSkipForwardingQuery: false,
             });
 
             expect(getOptionValues(blocks)).toEqual([
-                {
-                    agentUuid: 'agent-1',
-                    channelId: 'C123',
-                    shouldSkipForwardingQuery: false,
-                    promptSlackTs: '1700000000.000300',
-                },
-                {
-                    agentUuid: 'agent-2',
-                    channelId: 'C123',
-                    shouldSkipForwardingQuery: false,
-                    promptSlackTs: '1700000000.000300',
-                },
+                { a: 'agent-1', s: false, t: '1700000000.000300' },
+                { a: 'agent-2', s: false, t: '1700000000.000300' },
             ]);
         });
 
         it('carries the triggering message ts when options are grouped by project', () => {
             const blocks = getAgentSelectionBlocks({
                 agents,
-                channelId: 'C123',
                 promptSlackTs: '1700000000.000300',
                 projectMap: new Map([
                     ['project-1', 'Project one'],
@@ -1440,25 +1428,44 @@ describe('Slack AI agent blocks', () => {
             expect(getOptionValues(blocks)).toEqual(
                 expect.arrayContaining([
                     expect.objectContaining({
-                        promptSlackTs: '1700000000.000300',
-                        shouldSkipForwardingQuery: true,
+                        t: '1700000000.000300',
+                        s: true,
                     }),
                 ]),
             );
             expect(getOptionValues(blocks)).toHaveLength(2);
         });
 
-        it('keeps the action value well under the 2000 character Slack limit', () => {
+        it('keeps the option value under the 150 character Slack cap at worst case', () => {
             const blocks = getAgentSelectionBlocks({
-                agents,
-                channelId: 'C0123456789',
+                agents: [
+                    {
+                        uuid: '3675b69e-8324-4110-bdca-059031aa8da3',
+                        name: 'An agent with a very long display name indeed',
+                        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
+                    },
+                ],
                 promptSlackTs: '1700000000.000300',
                 projectMap: undefined,
                 shouldSkipForwardingQuery: false,
             });
 
             for (const option of getOptions(blocks)) {
-                expect(option.value.length).toBeLessThan(2000);
+                expect(option.value.length).toBeLessThan(150);
+            }
+        });
+
+        it('leaves the channel id out so long channel ids cannot overflow the cap', () => {
+            const blocks = getAgentSelectionBlocks({
+                agents,
+                promptSlackTs: '1700000000.000300',
+                projectMap: undefined,
+                shouldSkipForwardingQuery: false,
+            });
+
+            for (const option of getOptions(blocks)) {
+                expect(option.value).not.toContain('channelId');
+                expect(JSON.parse(option.value)).not.toHaveProperty('c');
             }
         });
     });

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -7,6 +7,7 @@ import {
 import {
     buildFeedbackContextActions,
     buildSlackTaskUpdate,
+    getAgentSelectionBlocks,
     getFollowUpToolBlocks,
     getMarkdownBlocks,
     getMemoryCitationBlocks,
@@ -1367,6 +1368,97 @@ describe('Slack AI agent blocks', () => {
                 createSqlRunnerShareUrl,
             );
             expect(blocks).toEqual([]);
+        });
+    });
+
+    describe('getAgentSelectionBlocks', () => {
+        const agents = [
+            { uuid: 'agent-1', name: 'Agent one', projectUuid: 'project-1' },
+            { uuid: 'agent-2', name: 'Agent two', projectUuid: 'project-2' },
+        ] as never[];
+
+        const getOptions = (blocks: unknown[]) => {
+            const actions = blocks[1] as {
+                elements: [
+                    {
+                        options?: { value: string }[];
+                        option_groups?: { options: { value: string }[] }[];
+                    },
+                ];
+            };
+            const element = actions.elements[0];
+            return (
+                element.options ??
+                element.option_groups?.flatMap((group) => group.options) ??
+                []
+            );
+        };
+
+        const getOptionValues = (blocks: unknown[]) =>
+            getOptions(blocks).map(
+                (option) => JSON.parse(option.value) as Record<string, unknown>,
+            );
+
+        it('carries the triggering message ts on every option', () => {
+            const blocks = getAgentSelectionBlocks({
+                agents,
+                channelId: 'C123',
+                promptSlackTs: '1700000000.000300',
+                projectMap: undefined,
+                shouldSkipForwardingQuery: false,
+            });
+
+            expect(getOptionValues(blocks)).toEqual([
+                {
+                    agentUuid: 'agent-1',
+                    channelId: 'C123',
+                    shouldSkipForwardingQuery: false,
+                    promptSlackTs: '1700000000.000300',
+                },
+                {
+                    agentUuid: 'agent-2',
+                    channelId: 'C123',
+                    shouldSkipForwardingQuery: false,
+                    promptSlackTs: '1700000000.000300',
+                },
+            ]);
+        });
+
+        it('carries the triggering message ts when options are grouped by project', () => {
+            const blocks = getAgentSelectionBlocks({
+                agents,
+                channelId: 'C123',
+                promptSlackTs: '1700000000.000300',
+                projectMap: new Map([
+                    ['project-1', 'Project one'],
+                    ['project-2', 'Project two'],
+                ]),
+                shouldSkipForwardingQuery: true,
+            });
+
+            expect(getOptionValues(blocks)).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        promptSlackTs: '1700000000.000300',
+                        shouldSkipForwardingQuery: true,
+                    }),
+                ]),
+            );
+            expect(getOptionValues(blocks)).toHaveLength(2);
+        });
+
+        it('keeps the action value well under the 2000 character Slack limit', () => {
+            const blocks = getAgentSelectionBlocks({
+                agents,
+                channelId: 'C0123456789',
+                promptSlackTs: '1700000000.000300',
+                projectMap: undefined,
+                shouldSkipForwardingQuery: false,
+            });
+
+            for (const option of getOptions(blocks)) {
+                expect(option.value.length).toBeLessThan(2000);
+            }
         });
     });
 });

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -1313,20 +1313,14 @@ const buildAgentSelectBlocks = (args: {
 
 export function getAgentSelectionBlocks(args: {
     agents: AgentSelectOption[];
-    channelId: string;
     // ts of the message this picker was posted for, so the selection handler
     // answers that message instead of re-deriving one from thread history.
     promptSlackTs: string;
     projectMap: Map<string, string> | undefined;
     shouldSkipForwardingQuery: boolean;
 }): (Block | KnownBlock)[] {
-    const {
-        agents,
-        channelId,
-        promptSlackTs,
-        projectMap,
-        shouldSkipForwardingQuery,
-    } = args;
+    const { agents, promptSlackTs, projectMap, shouldSkipForwardingQuery } =
+        args;
 
     if (agents.length === 0) {
         return [
@@ -1340,12 +1334,13 @@ export function getAgentSelectionBlocks(args: {
         ];
     }
 
+    // Slack caps static_select option values at 150 chars, so keys are terse
+    // and the channel id is left out — the handler reads it off the click.
     const buildValue = (agent: AgentSelectOption) =>
         JSON.stringify({
-            agentUuid: agent.uuid,
-            channelId,
-            shouldSkipForwardingQuery,
-            promptSlackTs,
+            a: agent.uuid,
+            s: shouldSkipForwardingQuery,
+            t: promptSlackTs,
         });
 
     return buildAgentSelectBlocks({

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -1229,7 +1229,7 @@ const truncateSlackText = (text: string | null, maxLength: number): string => {
     return `${text.substring(0, maxLength - 3)}...`;
 };
 
-type AgentSelectOption = Pick<AiAgent, 'uuid' | 'name' | 'projectUuid'>;
+export type AgentSelectOption = Pick<AiAgent, 'uuid' | 'name' | 'projectUuid'>;
 
 const buildAgentOptions = (
     agents: AgentSelectOption[],
@@ -1312,10 +1312,10 @@ const buildAgentSelectBlocks = (args: {
 ];
 
 export function getAgentSelectionBlocks(args: {
-    agents: AiAgent[];
+    agents: AgentSelectOption[];
     channelId: string;
-    // ts of the message that triggered this picker, so the handler answers that
-    // message instead of re-deriving one from thread history.
+    // ts of the message this picker was posted for, so the selection handler
+    // answers that message instead of re-deriving one from thread history.
     promptSlackTs: string;
     projectMap: Map<string, string> | undefined;
     shouldSkipForwardingQuery: boolean;

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -1311,12 +1311,23 @@ const buildAgentSelectBlocks = (args: {
     },
 ];
 
-export function getAgentSelectionBlocks(
-    agents: AiAgent[],
-    channelId: string,
-    projectMap?: Map<string, string>,
-    shouldSkipForwardingQuery = false,
-): (Block | KnownBlock)[] {
+export function getAgentSelectionBlocks(args: {
+    agents: AiAgent[];
+    channelId: string;
+    // ts of the message that triggered this picker, so the handler answers that
+    // message instead of re-deriving one from thread history.
+    promptSlackTs: string;
+    projectMap: Map<string, string> | undefined;
+    shouldSkipForwardingQuery: boolean;
+}): (Block | KnownBlock)[] {
+    const {
+        agents,
+        channelId,
+        promptSlackTs,
+        projectMap,
+        shouldSkipForwardingQuery,
+    } = args;
+
     if (agents.length === 0) {
         return [
             {
@@ -1334,6 +1345,7 @@ export function getAgentSelectionBlocks(
             agentUuid: agent.uuid,
             channelId,
             shouldSkipForwardingQuery,
+            promptSlackTs,
         });
 
     return buildAgentSelectBlocks({


### PR DESCRIPTION
## Problem

Clicking the agent picker re-derived the prompt by scanning thread history with `.find()`. In multi-agent channels that scan matched *any* message by the user, so it always resolved to the thread root. The user's actual question was answered with the wrong text and never recorded — and since the message was also the dedup key, the real question was silently dropped. In regular channels the same scan took the first `@mention` rather than the latest one.

## Fix

The picker's `select_agent` option value now carries the triggering message's timestamp. On click, the handler fetches exactly that message via a thread-scoped `conversations.replies` lookup using an exact-ts window — it never falls back to another message. The channel id comes from the click event body.

Option values use terse keys so the payload stays well under Slack's 150-char option-value cap (78 chars, fixed width). Legacy option values (long keys, with or without the timestamp) still parse and degrade to the previous behavior.

## Testing

- New `agentSelectionPrompt` module unit tests, plus payload-shape and length pin tests (worst case stays under 150 chars).
- Full backend suite green.
- Verified end to end against a local dev Slack across 13 scenarios, including:
  - two-picker repro answers the second message and records its ts
  - root-opened picker behaves as before
  - legacy payload falls back correctly
  - clicking on a deleted message is a safe no-op
  - a cross-thread timestamp cannot post into another thread
  - threads with more than 100 messages resolve correctly
  - single-agent channels unaffected

## Notes

Stacks on #27101 (ZAP-821), which touches the same handler.

https://linear.app/lightdash/issue/ZAP-822

Closes: ZAP-822

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
