### PR TITLE
feat: soft-deprecate legacy AI models

### DIFF
--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -171,6 +171,7 @@ export const presetToModelOption = (
     defaultModel: { name: string; provider: string } | null,
 ): AiModelOption => ({
     name: preset.name,
+    modelId: preset.modelId,
     displayName: preset.displayName,
     description: preset.description,
     provider: preset.provider,
@@ -179,6 +180,7 @@ export const presetToModelOption = (
         preset.provider === defaultModel.provider &&
         matchesPreset(preset, defaultModel.name),
     supportsReasoning: preset.supportsReasoning,
+    deprecated: preset.deprecated ?? false,
 });
 
 export type OrgModelOverrides = {

--- a/packages/backend/src/ee/services/ai/models/presets.ts
+++ b/packages/backend/src/ee/services/ai/models/presets.ts
@@ -19,6 +19,8 @@ export type ModelPreset<P extends ModelPresetProvider> = {
     reasoningStyle?: ReasoningStyle;
     // Excluded from model pickers unless the org's own provider key can access it
     hiddenUnlessKeyAccess?: boolean;
+    // Kept resolvable for existing configurations, but hidden from new selections
+    deprecated?: boolean;
     callOptions: CallSettings;
     providerOptions: ProviderOptionsMap[P] | undefined;
 };
@@ -97,6 +99,7 @@ export const MODEL_PRESETS: {
             description: 'Flagship reasoning model for agentic tasks',
             contextWindowTokens: 400000,
             supportsReasoning: true,
+            deprecated: true,
             callOptions: {},
             providerOptions: {
                 // strictJsonSchema: provider default is true
@@ -111,6 +114,7 @@ export const MODEL_PRESETS: {
             description: 'Intelligent reasoning model',
             contextWindowTokens: 400000,
             supportsReasoning: true,
+            deprecated: true,
             callOptions: {},
             providerOptions: {
                 // strictJsonSchema: provider default is true
@@ -125,6 +129,7 @@ export const MODEL_PRESETS: {
             description: 'Fast and cost-effective model for simple tasks',
             contextWindowTokens: 400000,
             supportsReasoning: true,
+            deprecated: true,
             callOptions: {},
             providerOptions: {
                 // strictJsonSchema: provider default is true
@@ -192,6 +197,7 @@ export const MODEL_PRESETS: {
             description: 'Previous generation Opus for complex tasks',
             contextWindowTokens: 200000,
             supportsReasoning: true,
+            deprecated: true,
             callOptions: { temperature: 0.2 },
             providerOptions: undefined,
         },
@@ -225,6 +231,7 @@ export const MODEL_PRESETS: {
             description: 'Previous generation Sonnet for daily tasks',
             contextWindowTokens: 200000,
             supportsReasoning: true,
+            deprecated: true,
             callOptions: { temperature: 0.2 },
             providerOptions: undefined,
         },
@@ -247,6 +254,7 @@ export const MODEL_PRESETS: {
             description: 'Previous generation model with reasoning',
             contextWindowTokens: 200000,
             supportsReasoning: true,
+            deprecated: true,
             callOptions: { temperature: 0.2 },
             providerOptions: undefined,
         },
@@ -271,6 +279,7 @@ export const MODEL_PRESETS: {
             description: 'Balanced model for daily tasks',
             contextWindowTokens: 200000,
             supportsReasoning: true,
+            deprecated: true,
             callOptions: { temperature: 0.2 },
             providerOptions: undefined,
         },
@@ -293,6 +302,7 @@ export const MODEL_PRESETS: {
             description: 'Previous generation model with reasoning',
             contextWindowTokens: 200000,
             supportsReasoning: true,
+            deprecated: true,
             callOptions: { temperature: 0.2 },
             providerOptions: undefined,
         },

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -1229,11 +1229,13 @@ export type AiAgentWithContext = AiAgentSummary & {
 
 export type AiModelOption = {
     name: string;
+    modelId: string;
     displayName: string;
     description: string;
     provider: string;
     default: boolean;
     supportsReasoning: boolean;
+    deprecated: boolean;
 };
 
 export type ApiAiAgentModelOptionsResponse = ApiSuccess<AiModelOption[]>;

--- a/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
+++ b/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
@@ -11,7 +11,7 @@ import {
 import { IconCheck, IconChevronDown } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import MantineIcon from '../MantineIcon';
-import { getModelKey } from './utils';
+import { filterDeprecatedModelsForPicker, getModelKey } from './utils';
 
 interface Props extends Omit<ButtonProps, 'value' | 'onChange'> {
     models: AiModelOption[];
@@ -34,14 +34,19 @@ export const ModelSelector: FC<Props> = ({
         [models, value],
     );
 
+    const visibleModels = useMemo(
+        () => filterDeprecatedModelsForPicker(models, value),
+        [models, value],
+    );
+
     const groupedModels = useMemo(() => {
         const groups = new Map<string, AiModelOption[]>();
-        models.forEach((model) => {
+        visibleModels.forEach((model) => {
             const existing = groups.get(model.provider) ?? [];
             groups.set(model.provider, [...existing, model]);
         });
         return groups;
-    }, [models]);
+    }, [visibleModels]);
 
     const providerGroups = useMemo(
         () => Array.from(groupedModels.keys()),
@@ -53,7 +58,7 @@ export const ModelSelector: FC<Props> = ({
         onReasoningChange !== undefined;
     const reasoningLabel = reasoningEnabled ? 'High' : null;
 
-    if (models.length === 1 && !showReasoning) {
+    if (visibleModels.length === 1 && !showReasoning) {
         return null;
     }
 
@@ -122,7 +127,7 @@ export const ModelSelector: FC<Props> = ({
                         >
                             High
                         </Menu.Item>
-                        {models.length > 1 && <Menu.Divider />}
+                        {visibleModels.length > 1 && <Menu.Divider />}
                     </>
                 )}
                 <ScrollArea.Autosize mah={200}>

--- a/packages/frontend/src/components/common/ModelSelector/utils.test.ts
+++ b/packages/frontend/src/components/common/ModelSelector/utils.test.ts
@@ -1,0 +1,44 @@
+import type { AiModelOption } from '@lightdash/common';
+import { filterDeprecatedModelsForPicker, matchesModelConfig } from './utils';
+
+const model = (name: string, deprecated = false): AiModelOption => ({
+    name,
+    modelId: `${name}-model-id`,
+    displayName: name,
+    description: '',
+    provider: 'openai',
+    default: false,
+    supportsReasoning: true,
+    deprecated,
+});
+
+const current = model('current');
+const deprecated = model('deprecated', true);
+
+describe('filterDeprecatedModelsForPicker', () => {
+    it('hides deprecated models from new selections', () => {
+        expect(
+            filterDeprecatedModelsForPicker([current, deprecated], null),
+        ).toEqual([current]);
+    });
+
+    it('keeps the selected deprecated model visible', () => {
+        expect(
+            filterDeprecatedModelsForPicker(
+                [current, deprecated],
+                'openai:deprecated',
+            ),
+        ).toEqual([current, deprecated]);
+    });
+});
+
+describe('matchesModelConfig', () => {
+    it('matches stored provider model IDs to their preset option', () => {
+        expect(
+            matchesModelConfig(deprecated, {
+                modelName: 'deprecated-model-id',
+                modelProvider: 'openai',
+            }),
+        ).toBe(true);
+    });
+});

--- a/packages/frontend/src/components/common/ModelSelector/utils.ts
+++ b/packages/frontend/src/components/common/ModelSelector/utils.ts
@@ -1,5 +1,21 @@
-import type { AiModelOption } from '@lightdash/common';
+import type { AiAgentModelConfig, AiModelOption } from '@lightdash/common';
 
 // Composite key format: "provider:name"
 export const getModelKey = (model: AiModelOption): string =>
     `${model.provider}:${model.name}`;
+
+export const matchesModelConfig = (
+    model: AiModelOption,
+    modelConfig: AiAgentModelConfig,
+): boolean =>
+    model.provider === modelConfig.modelProvider &&
+    (model.name === modelConfig.modelName ||
+        model.modelId === modelConfig.modelName);
+
+export const filterDeprecatedModelsForPicker = (
+    models: AiModelOption[],
+    selectedModelKey: string | null,
+): AiModelOption[] =>
+    models.filter(
+        (model) => !model.deprecated || getModelKey(model) === selectedModelKey,
+    );

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -71,12 +71,12 @@ export const AiGeneralSettingsPage = () => {
         selectedModel: selectedDefaultModel,
         selectedModelKey: selectedDefaultModelKey,
         showReasoningDefault,
+        visibleModelOptions: visibleDefaultModelOptions,
     } = useDefaultAiAgentModel({
         modelOptions: defaultModelOptions,
         modelConfig: defaultModelConfig,
         fallbackLabel: 'System default',
     });
-
     return (
         <SettingsPage
             title="Ask AI"
@@ -168,7 +168,7 @@ export const AiGeneralSettingsPage = () => {
                                     }
                                     placeholder={systemDefaultModelLabel}
                                     clearable
-                                    data={(defaultModelOptions ?? []).map(
+                                    data={visibleDefaultModelOptions.map(
                                         (model) => ({
                                             value: getModelKey(model),
                                             label: model.displayName,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiProvidersCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiProvidersCard.tsx
@@ -25,6 +25,7 @@ import { IconKey } from '@tabler/icons-react';
 import { useState, type ComponentType, type FC, type SVGProps } from 'react';
 import Callout from '../../../../../../components/common/Callout';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
+import { filterDeprecatedModelsForPicker } from '../../../../../../components/common/ModelSelector/utils';
 import { SettingsCard } from '../../../../../../components/common/Settings/SettingsCard';
 import AnthropicIcon from '../../../../../../svgs/anthropic.svg?react';
 import OpenAiIcon from '../../../../../../svgs/openai.svg?react';
@@ -249,15 +250,17 @@ export const AiProvidersCard: FC<AiProvidersCardProps> = ({
 
     const hasAnyByoKey =
         providerApiKeysSet.anthropic || providerApiKeysSet.openai;
+    const selectableModelOptions = filterDeprecatedModelsForPicker(
+        configurableModelOptions ?? [],
+        null,
+    );
 
     // modelVisibility is the EFFECTIVE visibility (implicit BYOK hiding merged
     // on the backend) and configurableModelOptions spans every provider the
     // instance runs, so full coverage here means no user-selectable model —
     // and no background AI task — can fall back to an instance key.
     const visibleProviders = [
-        ...new Set(
-            (configurableModelOptions ?? []).map((model) => model.provider),
-        ),
+        ...new Set(selectableModelOptions.map((model) => model.provider)),
     ].filter(
         (provider) =>
             !isByoAiProvider(provider) ||
@@ -317,9 +320,9 @@ export const AiProvidersCard: FC<AiProvidersCardProps> = ({
                                 visibleProviders.includes(provider) &&
                                 usesInstanceKey(provider)
                             }
-                            providerModels={(
-                                configurableModelOptions ?? []
-                            ).filter((model) => model.provider === provider)}
+                            providerModels={selectableModelOptions.filter(
+                                (model) => model.provider === provider,
+                            )}
                             visibility={modelVisibility?.[provider]}
                             locked={isLockedByByok(provider)}
                             disabled={disabled}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -189,13 +189,13 @@ export const AiAgentFormSetup = ({
         selectedModel,
         selectedModelKey,
         showReasoningDefault,
+        visibleModelOptions,
     } = useDefaultAiAgentModel({
         modelOptions,
         modelConfig: form.values.modelConfig,
         fallbackModelConfig: aiOrganizationSettings?.defaultAiAgentModelConfig,
         fallbackLabel: 'Organization default',
     });
-
     const slackChannelsConfigured = useMemo(
         () =>
             form.values.integrations.some(
@@ -511,7 +511,7 @@ export const AiAgentFormSetup = ({
                             disabled={isSavingAgent || !modelOptions?.length}
                             placeholder={organizationDefaultModelLabel}
                             clearable
-                            data={(modelOptions ?? []).map((model) => ({
+                            data={visibleModelOptions.map((model) => ({
                                 value: getModelKey(model),
                                 label: model.displayName,
                             }))}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageModelIndicator.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageModelIndicator.tsx
@@ -1,5 +1,6 @@
 import { Badge, Tooltip } from '@mantine/core';
 import { useMemo, type FC } from 'react';
+import { matchesModelConfig } from '../../../../../components/common/ModelSelector/utils';
 import { useModelOptions } from '../../hooks/useModelOptions';
 
 interface Props {
@@ -23,8 +24,8 @@ export const MessageModelIndicator: FC<Props> = ({
     const modelDisplayName = useMemo(() => {
         if (!modelConfig || !modelOptions) return null;
 
-        const model = modelOptions.find(
-            (m) => m.name === modelConfig.modelName,
+        const model = modelOptions.find((option) =>
+            matchesModelConfig(option, modelConfig),
         );
         return model?.displayName ?? null;
     }, [modelConfig, modelOptions]);

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentModelSelection.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentModelSelection.ts
@@ -1,7 +1,11 @@
 import type { AiAgentModelConfig, AiModelOption } from '@lightdash/common';
 import { useLocalStorage } from '@mantine/hooks';
 import { useCallback, useMemo, useReducer } from 'react';
-import { getModelKey } from '../../../../components/common/ModelSelector/utils';
+import {
+    filterDeprecatedModelsForPicker,
+    getModelKey,
+    matchesModelConfig,
+} from '../../../../components/common/ModelSelector/utils';
 import { useAiOrganizationSettings } from './useAiOrganizationSettings';
 import { useModelOptions } from './useModelOptions';
 
@@ -37,11 +41,9 @@ const getConfiguredModelOption = (
     modelOptions: AiModelOption[] | undefined,
     modelConfig: AiAgentModelConfig | null | undefined,
 ) =>
-    modelOptions?.find(
-        (model) =>
-            model.name === modelConfig?.modelName &&
-            model.provider === modelConfig?.modelProvider,
-    );
+    modelConfig
+        ? modelOptions?.find((model) => matchesModelConfig(model, modelConfig))
+        : undefined;
 
 const getSystemDefaultModelOption = (
     modelOptions: AiModelOption[] | undefined,
@@ -94,6 +96,14 @@ export const useDefaultAiAgentModel = ({
         [modelConfig, modelOptions],
     );
     const selectedModelKey = selectedModel ? getModelKey(selectedModel) : null;
+    const visibleModelOptions = useMemo(
+        () =>
+            filterDeprecatedModelsForPicker(
+                modelOptions ?? [],
+                selectedModelKey,
+            ),
+        [modelOptions, selectedModelKey],
+    );
     const fallbackModel = useMemo(
         () =>
             getConfiguredModelOption(modelOptions, fallbackModelConfig) ??
@@ -111,6 +121,7 @@ export const useDefaultAiAgentModel = ({
         selectedModel,
         selectedModelKey,
         showReasoningDefault,
+        visibleModelOptions,
     };
 };
 

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -3,6 +3,7 @@ import { FeatureFlags } from '@lightdash/common';
 import { Box, Center, Flex, Loader } from '@mantine/core';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
+import { matchesModelConfig } from '../../../components/common/ModelSelector/utils';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import { ReviewVerificationPanel } from '../../features/aiCopilot/components/Admin/ReviewVerificationPanel';
@@ -206,10 +207,8 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const isThreadModelUnavailable =
         !!threadModelConfig &&
         !!availableModels &&
-        !availableModels.some(
-            (m) =>
-                m.provider === threadModelConfig.modelProvider &&
-                m.name === threadModelConfig.modelName,
+        !availableModels.some((model) =>
+            matchesModelConfig(model, threadModelConfig),
         );
 
     const disabledReasons: { when: boolean; message: string }[] = [

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -235,11 +235,13 @@ const toModelKey = (value: DataAppClaudeModel): string =>
 
 const toModelOption = (opt: ModelOption): AiModelOption => ({
     name: opt.value,
+    modelId: opt.value,
     displayName: opt.label,
     description: opt.tagline,
     provider: DATA_APP_MODEL_PROVIDER,
     default: opt.isDefault === true,
     supportsReasoning: false,
+    deprecated: false,
 });
 
 /**


### PR DESCRIPTION
## Summary

- mark legacy OpenAI, Anthropic, and Bedrock presets as soft-deprecated
- hide deprecated models from new selections while preserving configured org, agent, and thread models
- preserve dated provider model IDs for backwards-compatible display and resolution
- centralize default-picker filtering in `useDefaultAiAgentModel`

## Verification

- 34 focused tests passed
- common, backend, and frontend typechecks passed
- scoped lint and generated API validation passed
- Browser: unconfigured deprecated models hidden; configured canonical and dated models shown in org/agent defaults and chat picker

Closes: ZAP-827
