### PR TITLE
fix: create default user spaces when provisioning users via SCIM

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -692,7 +692,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getAiAgentService<AiAgentService>(),
                     aiService: repository.getAiService<AiService>(),
                 }),
-            scimService: ({ models, context }) =>
+            scimService: ({ models, context, repository }) =>
                 new ScimService({
                     lightdashConfig: context.lightdashConfig,
                     organizationMemberProfileModel:
@@ -707,6 +707,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     rolesModel: models.getRolesModel(),
                     projectModel: models.getProjectModel(),
                     openIdIdentityModel: models.getOpenIdIdentityModel(),
+                    userService: repository.getUserService(),
                 }),
             serviceAccountService: ({ models, context }) =>
                 new ServiceAccountService({

--- a/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
@@ -16,6 +16,7 @@ import { OrganizationMemberProfileModel } from '../../../models/OrganizationMemb
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { RolesModel } from '../../../models/RolesModel';
 import { UserModel } from '../../../models/UserModel';
+import { UserService } from '../../../services/UserService';
 import { CommercialFeatureFlagModel } from '../../models/CommercialFeatureFlagModel';
 import { ServiceAccountModel } from '../../models/ServiceAccountModel';
 import { ScimService } from './ScimService';
@@ -184,6 +185,10 @@ const emailModelMock = {
     verifyUserEmailIfExists: vi.fn().mockResolvedValue(undefined),
 } as unknown as EmailModel;
 
+export const userServiceMock = {
+    ensureDefaultUserSpacesForUser: vi.fn().mockResolvedValue(undefined),
+} as unknown as UserService;
+
 export const ScimServiceArgumentsMock: ConstructorParameters<
     typeof ScimService
 >[0] = {
@@ -217,4 +222,5 @@ export const ScimServiceArgumentsMock: ConstructorParameters<
         deleteIdentitiesByEmail: vi.fn().mockResolvedValue(0),
         deleteIdentitiesByUserUuid: vi.fn().mockResolvedValue(0),
     } as unknown as OpenIdIdentityModel,
+    userService: userServiceMock,
 };

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -15,6 +15,7 @@ import {
     mockScimAccount,
     mockUser,
     ScimServiceArgumentsMock,
+    userServiceMock,
 } from './ScimService.mock';
 
 describe('ScimService', () => {
@@ -965,6 +966,98 @@ describe('ScimService', () => {
                 [],
                 true, // excludeProjectPreviews
             );
+        });
+    });
+
+    describe('default user spaces provisioning', () => {
+        const activeScimUser = {
+            schemas: [ScimSchemaType.USER],
+            userName: 'new-user@example.com',
+            name: {
+                givenName: 'New',
+                familyName: 'User',
+            },
+            active: true,
+            emails: [
+                {
+                    value: 'new-user@example.com',
+                    primary: true,
+                },
+            ],
+        };
+
+        test('should ensure default user spaces after creating an active user', async () => {
+            await service.createUser({
+                account: mockScimAccount,
+                user: activeScimUser,
+                organizationUuid: 'org-uuid',
+            });
+
+            expect(
+                userServiceMock.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledWith({
+                userUuid: mockUser.userUuid,
+                organizationUuid: 'org-uuid',
+            });
+        });
+
+        test('should not ensure default user spaces when creating an inactive user', async () => {
+            await service.createUser({
+                account: mockScimAccount,
+                user: { ...activeScimUser, active: false },
+                organizationUuid: 'org-uuid',
+            });
+
+            expect(
+                userServiceMock.ensureDefaultUserSpacesForUser,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('should not fail user creation when space creation throws', async () => {
+            vi.mocked(
+                userServiceMock.ensureDefaultUserSpacesForUser,
+            ).mockRejectedValueOnce(new Error('boom'));
+
+            await expect(
+                service.createUser({
+                    account: mockScimAccount,
+                    user: activeScimUser,
+                    organizationUuid: 'org-uuid',
+                }),
+            ).resolves.toBeDefined();
+        });
+
+        test('should ensure default user spaces after updating an active user', async () => {
+            await service.updateUser({
+                account: mockScimAccount,
+                user: { ...activeScimUser, userName: mockUser.email },
+                userUuid: mockUser.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+            });
+
+            expect(
+                userServiceMock.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledWith({
+                userUuid: mockUser.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+            });
+        });
+
+        test('should not ensure default user spaces when deactivating a user', async () => {
+            await service.updateUser({
+                account: mockScimAccount,
+                user: {
+                    ...activeScimUser,
+                    userName: mockUser.email,
+                    active: false,
+                },
+                userUuid: mockUser.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+            });
+
+            expect(
+                userServiceMock.ensureDefaultUserSpacesForUser,
+            ).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -1293,6 +1293,131 @@ describe('ScimService', () => {
         });
     });
 
+    describe('default user spaces provisioning for groups', () => {
+        const baseGroup: GroupWithMembers = {
+            uuid: 'group-uuid',
+            name: 'Data Platform',
+            createdAt: new Date('2024-01-01'),
+            createdByUserUuid: null,
+            updatedAt: new Date('2024-01-01'),
+            updatedByUserUuid: null,
+            organizationUuid: mockUser.organizationUuid,
+            members: [
+                {
+                    userUuid: 'user-1',
+                    email: 'user-1@example.com',
+                    firstName: 'User',
+                    lastName: 'One',
+                },
+            ],
+            memberUuids: ['user-1'],
+        };
+
+        test('should ensure default user spaces for members when creating a group', async () => {
+            const groupService = new ScimService({
+                ...ScimServiceArgumentsMock,
+                groupsModel: {
+                    find: vi.fn().mockResolvedValue({ data: [] }),
+                    createGroup: vi.fn().mockResolvedValue(baseGroup),
+                } as never,
+            });
+
+            await groupService.createGroup(
+                mockScimAccount,
+                mockUser.organizationUuid,
+                {
+                    schemas: [ScimSchemaType.GROUP],
+                    displayName: 'Data Platform',
+                    members: [{ value: 'user-1' }],
+                },
+            );
+
+            expect(
+                userServiceMock.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                userServiceMock.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledWith({
+                userUuid: 'user-1',
+                organizationUuid: mockUser.organizationUuid,
+            });
+        });
+
+        test('should ensure default user spaces only for newly added members when replacing a group', async () => {
+            const groupService = new ScimService({
+                ...ScimServiceArgumentsMock,
+                groupsModel: {
+                    find: vi.fn().mockResolvedValue({ data: [] }),
+                    getGroupWithMembers: vi.fn().mockResolvedValue(baseGroup),
+                    updateGroup: vi.fn().mockResolvedValue({
+                        ...baseGroup,
+                        memberUuids: ['user-1', 'user-2'],
+                    }),
+                } as never,
+            });
+
+            await groupService.replaceGroup(
+                mockScimAccount,
+                mockUser.organizationUuid,
+                baseGroup.uuid,
+                {
+                    schemas: [ScimSchemaType.GROUP],
+                    displayName: 'Data Platform',
+                    members: [{ value: 'user-1' }, { value: 'user-2' }],
+                },
+            );
+
+            expect(
+                userServiceMock.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                userServiceMock.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledWith({
+                userUuid: 'user-2',
+                organizationUuid: mockUser.organizationUuid,
+            });
+        });
+
+        test('should ensure default user spaces only for newly added members when patching a group', async () => {
+            const groupService = new ScimService({
+                ...ScimServiceArgumentsMock,
+                groupsModel: {
+                    getGroupWithMembers: vi.fn().mockResolvedValue(baseGroup),
+                    updateGroup: vi.fn().mockResolvedValue({
+                        ...baseGroup,
+                        memberUuids: ['user-1', 'user-2'],
+                    }),
+                } as never,
+            });
+
+            await groupService.updateGroup(
+                mockScimAccount,
+                mockUser.organizationUuid,
+                baseGroup.uuid,
+                {
+                    schemas: [ScimSchemaType.PATCH],
+                    Operations: [
+                        {
+                            op: 'Add',
+                            path: 'members',
+                            value: [{ value: 'user-2' }],
+                        },
+                    ],
+                },
+            );
+
+            expect(
+                userServiceMock.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                userServiceMock.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledWith({
+                userUuid: 'user-2',
+                organizationUuid: mockUser.organizationUuid,
+            });
+        });
+    });
+
     describe('parseRoleId', () => {
         test('should parse role ID without colon as organization role', () => {
             const roleId = 'admin';

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -50,6 +50,7 @@ import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { RolesModel } from '../../../models/RolesModel';
 import { UserModel } from '../../../models/UserModel';
 import { BaseService } from '../../../services/BaseService';
+import { UserService } from '../../../services/UserService';
 import { wrapSentryTransaction } from '../../../utils';
 import { CommercialFeatureFlagModel } from '../../models/CommercialFeatureFlagModel';
 import { ServiceAccountModel } from '../../models/ServiceAccountModel';
@@ -66,6 +67,7 @@ type ScimServiceArguments = {
     rolesModel: RolesModel;
     projectModel: ProjectModel;
     openIdIdentityModel: OpenIdIdentityModel;
+    userService: UserService;
 };
 
 const NO_ROLE_KEYWORD = 'no-role';
@@ -102,6 +104,8 @@ export class ScimService extends BaseService {
 
     private readonly openIdIdentityModel: OpenIdIdentityModel;
 
+    private readonly userService: UserService;
+
     constructor({
         lightdashConfig,
         organizationMemberProfileModel,
@@ -114,6 +118,7 @@ export class ScimService extends BaseService {
         rolesModel,
         projectModel,
         openIdIdentityModel,
+        userService,
     }: ScimServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -127,6 +132,7 @@ export class ScimService extends BaseService {
         this.rolesModel = rolesModel;
         this.projectModel = projectModel;
         this.openIdIdentityModel = openIdIdentityModel;
+        this.userService = userService;
     }
 
     private throwForbiddenErrorOnNoPermission(account: Account) {
@@ -880,6 +886,31 @@ export class ScimService extends BaseService {
                 status: ScimService.getErrorStatus(error) ?? 500,
             });
         }
+    }
+
+    private async ensureDefaultUserSpacesForUsers(
+        userUuids: string[],
+        organizationUuid: string,
+    ): Promise<void> {
+        await Promise.all(
+            userUuids.map(async (userUuid) => {
+                try {
+                    await this.userService.ensureDefaultUserSpacesForUser({
+                        userUuid,
+                        organizationUuid,
+                    });
+                } catch (error) {
+                    this.logger.warn(
+                        'SCIM: Failed to ensure default user spaces',
+                        {
+                            userUuid,
+                            organizationUuid,
+                            error: getErrorMessage(error),
+                        },
+                    );
+                }
+            }),
+        );
     }
 
     /*

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -602,6 +602,13 @@ export class ScimService extends BaseService {
                 roles: dedupedRoles,
             });
 
+            if (user.active !== false) {
+                await this.ensureDefaultUserSpacesForUsers(
+                    [dbUser.userUuid],
+                    organizationUuid,
+                );
+            }
+
             const finalUser = await this.userModel.getUserDetailsByUuid(
                 dbUser.userUuid,
             );
@@ -817,6 +824,13 @@ export class ScimService extends BaseService {
                         )}`,
                     );
                 }
+            }
+
+            if (user.active !== false) {
+                await this.ensureDefaultUserSpacesForUsers(
+                    [updatedUser.userUuid],
+                    organizationUuid,
+                );
             }
 
             // Get the updated user with potentially new role

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -1463,6 +1463,11 @@ export class ScimService extends BaseService {
                 memberCount: group.memberUuids.length,
             });
 
+            await this.ensureDefaultUserSpacesForUsers(
+                group.memberUuids,
+                organizationUuid,
+            );
+
             this.analytics.track({
                 event: 'group.created',
                 anonymousId: LightdashAnalytics.anonymousId,
@@ -1585,6 +1590,13 @@ export class ScimService extends BaseService {
                         : {}),
                 },
             });
+
+            await this.ensureDefaultUserSpacesForUsers(
+                updatedGroup.memberUuids.filter(
+                    (memberUuid) => !group.memberUuids.includes(memberUuid),
+                ),
+                organizationUuid,
+            );
 
             this.logger.info('SCIM: Successfully replaced group', {
                 organizationUuid,
@@ -1717,6 +1729,14 @@ export class ScimService extends BaseService {
                         : {}),
                 },
             });
+
+            await this.ensureDefaultUserSpacesForUsers(
+                updatedGroup.memberUuids.filter(
+                    (memberUuid) =>
+                        !existingGroup.memberUuids.includes(memberUuid),
+                ),
+                organizationUuid,
+            );
 
             this.logger.info('SCIM: Successfully updated group', {
                 organizationUuid,

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -3582,6 +3582,33 @@ describe('UserService', () => {
             );
         });
 
+        test('should create space via ensureDefaultUserSpacesForUser (provisioning entry point)', async () => {
+            const service = createUserService(lightdashConfigMock);
+
+            (
+                projectModel.getProjectsWithDefaultUserSpaces as import('vitest').Mock
+            ).mockResolvedValueOnce([projectWithDefaultSpaces]);
+
+            const editor = makeSessionUser({
+                orgRole: OrganizationMemberRole.EDITOR,
+            });
+            (
+                userModel.getSessionUserFromCacheOrDB as import('vitest').Mock
+            ).mockResolvedValueOnce({
+                sessionUser: editor,
+                cacheHit: false,
+            });
+
+            await service.ensureDefaultUserSpacesForUser({
+                userUuid: editor.userUuid,
+                organizationUuid: editor.organizationUuid,
+            });
+
+            expect(projectModel.ensureDefaultUserSpace).toHaveBeenCalledTimes(
+                1,
+            );
+        });
+
         test('should skip space creation for viewer (no manage:SavedChart ability)', async () => {
             const service = createUserService(lightdashConfigMock);
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -2704,6 +2704,13 @@ export class UserService extends BaseService {
         userUuid: string;
         organizationUuid?: string;
     }): Promise<void> {
+        await this.ensureDefaultUserSpacesForUser(user);
+    }
+
+    async ensureDefaultUserSpacesForUser(user: {
+        userUuid: string;
+        organizationUuid?: string;
+    }): Promise<void> {
         if (!user.organizationUuid) return;
 
         const sessionUser = await this.findSessionUser({


### PR DESCRIPTION
Closes #27113

## Problem

Default User Spaces are created lazily — only inside the login callback (`passport.serializeUser` → `UserService.onLogin()` → `ensureDefaultUserSpaces()`). SCIM provisioning never triggers that path, so users provisioned via SCIM (e.g. Okta) have no personal space until they happen to do a fresh interactive login. In orgs where restricted users can only save to their personal space, those users can't save anything.

## Fix

- Extract the lazy-creation entry point into a public `UserService.ensureDefaultUserSpacesForUser()` (`onLogin` now delegates to it — login behavior unchanged).
- Inject `UserService` into `ScimService` and trigger space creation from every SCIM mutation that can create a user or change their eligibility:
  - `createUser` (skipped when provisioning inactive users)
  - `updateUser` / `patchUser` (PATCH delegates to update; skipped on deactivation — reactivation goes through update, so it's covered)
  - `createGroup` (all members), `replaceGroup` / `updateGroup` (newly added members only)

Space creation stays permission-gated (`manage SavedChart`/`Explore` in the project) and idempotent via the existing `ProjectModel.ensureDefaultUserSpace`, and a failure never fails the SCIM request — it logs a warning and continues.

## Out of scope (same lazy-creation gap, different flows)

- Enable-time backfill: `PATCH /projects/{uuid}/hasDefaultUserSpaces` still only flips the flag, so users with long-lived sessions from before enablement still need a fresh login (its controller docstring overpromises a backfill).
- Impersonation (PROD-7364).

## Testing

- New vitest coverage: provisioning triggers for user create/update (active, inactive, non-fatal failure) and group create/replace/patch (added-members-only diff), plus the extracted `ensureDefaultUserSpacesForUser` entry point.
- `pnpm -F backend typecheck` clean; ScimService (73) + UserService (126) suites green.
- Manual repro of the bug on a local EE instance confirmed the mechanism (SCIM-provisioned editor had no personal space; first login created it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXwVp1qMR9vKbzhjBNNw6L
