### PR TITLE
fix(ai): compare context occupancy, not cumulative spend, for compaction

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -4,6 +4,7 @@ import {
     type AiDashboardRuntimeOverrides,
     type AiDeepResearchLimits,
     type AiOrgModelVisibility,
+    type AiPromptTokenUsage,
     type AiProviderApiKeyHints,
     type AiThreadCreatedFrom,
     type AiWritebackRunStatus,
@@ -217,7 +218,7 @@ export type DbAiPrompt = {
     metric_query: object | null;
     saved_query_uuid: string | null;
     model_config: { modelName: string; modelProvider: string } | null;
-    token_usage: { totalTokens: number } | null;
+    token_usage: AiPromptTokenUsage | null;
     // Hidden turn: the agent receives and responds to the prompt, but the UI
     // doesn't render the user bubble (e.g. the post-merge migration prompt).
     hidden: boolean;

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -280,6 +280,7 @@ import {
     requestingUserRoleFromCustomRole,
     requestingUserRoleFromSystemRole,
 } from '../ai/prompts/systemV2RequestingUser';
+import { getContextOccupancyTokens } from '../ai/promptTokenUsage';
 import { parseRepoTarget, runShellCommandOnFs } from '../ai/repoFs/bashShell';
 import {
     createGithubRepoSource,
@@ -4794,17 +4795,18 @@ export class AiAgentService extends BaseService {
             return latestCompaction ?? null;
         }
 
-        const previousPromptTotalTokens =
-            previousPrompt.token_usage?.totalTokens;
+        const previousPromptOccupancyTokens = getContextOccupancyTokens(
+            previousPrompt.token_usage,
+        );
         const threshold = contextWindowTokens - Compaction.RESERVE_TOKENS;
         const shouldCompact = Compaction.shouldCompactPrompt({
-            totalTokens: previousPromptTotalTokens,
+            tokenUsage: previousPrompt.token_usage,
             contextWindowTokens,
             reserveTokens: Compaction.RESERVE_TOKENS,
         });
 
         Logger.debug(
-            `${compactionLogContext} check previousPrompt=${previousPrompt.ai_prompt_uuid} totalTokens=${previousPromptTotalTokens ?? 'unknown'} contextWindow=${contextWindowTokens} reserveTokens=${Compaction.RESERVE_TOKENS} threshold=${threshold} shouldCompact=${shouldCompact}`,
+            `${compactionLogContext} check previousPrompt=${previousPrompt.ai_prompt_uuid} occupancyTokens=${previousPromptOccupancyTokens ?? 'unknown'} cumulativeTotalTokens=${previousPrompt.token_usage?.totalTokens ?? 'unknown'} contextWindow=${contextWindowTokens} reserveTokens=${Compaction.RESERVE_TOKENS} threshold=${threshold} shouldCompact=${shouldCompact}`,
         );
 
         if (!shouldCompact) {

--- a/packages/backend/src/ee/services/AiAgentService/reviewClassifierEnqueue.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/reviewClassifierEnqueue.test.ts
@@ -15,7 +15,7 @@ describe('shouldEnqueueReviewClassifierForPromptUpdate', () => {
             shouldEnqueueReviewClassifierForPromptUpdate({
                 promptUuid: 'prompt-1',
                 response: 'Final response',
-                tokenUsage: { totalTokens: 123 },
+                tokenUsage: { totalTokens: 123, finalStepTotalTokens: 123 },
             }),
         ).toBe(true);
     });

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -1,3 +1,4 @@
+import { type AnyType } from '@lightdash/common';
 import { APICallError, generateText, type ModelMessage } from 'ai';
 import {
     registerAiUsageTracker,
@@ -30,68 +31,84 @@ vi.mock('ai', async (importOriginal) => ({
     generateText: vi.fn(),
 }));
 
+const buildAgentDependencies = (updatePrompt: ReturnType<typeof vi.fn>) =>
+    new Proxy(
+        {
+            listExplores: vi.fn().mockResolvedValue([]),
+            updatePrompt,
+            perf: new Proxy({}, { get: () => vi.fn() }),
+        },
+        {
+            get: (target, property: string) =>
+                target[property as keyof typeof target] ?? vi.fn(),
+        },
+    ) as unknown as AiAgentDependencies;
+
+const buildAgentArgs = (
+    execution: Record<string, unknown> = { mode: 'standard', maxSteps: 10 },
+) =>
+    ({
+        agentSettings: {
+            uuid: 'agent-1',
+            name: 'Test agent',
+            projectUuid: 'project-1',
+        },
+        aiAgentMemoryEnabled: false,
+        availableSkills: [],
+        callOptions: {},
+        canManageAgent: false,
+        canRunSql: true,
+        compactionSummary: null,
+        debugLoggingEnabled: false,
+        deepResearchRuns: [],
+        enableAiWriteback: false,
+        enableCodingAgent: false,
+        enableContentTools: false,
+        enableDataAccess: false,
+        enableEditProjectContext: false,
+        enableGrepFields: false,
+        enablePreviewDeploySetup: false,
+        enableRepoDiscovery: false,
+        execution,
+        findExploresFieldSearchSize: 10,
+        findFieldsPageSize: 10,
+        forceToolHints: false,
+        getDashboardChartsPageSize: 10,
+        keyManagement: 'self-managed',
+        knowledgeDocuments: [],
+        mcpServers: [],
+        messageHistory: [{ role: 'user', content: 'Question' }],
+        model: {},
+        organizationId: 'organization-1',
+        projectContext: [],
+        projectContextEnabled: false,
+        promptUuid: 'prompt-1',
+        providerOptions: {},
+        repoFsRoot: null,
+        repoFsSupportsCodeSearch: false,
+        requestingUser: null,
+        runSqlMaxLimit: 5000,
+        siteUrl: 'http://localhost',
+        telemetryEnabled: false,
+        threadUuid: 'thread-1',
+        toolDescriptionMaxChars: 1000,
+        toolHints: [],
+        userId: 'user-1',
+        writebackAttribution: null,
+    }) as unknown as AiAgentArgs;
+
+const mcpToolSetup = () => ({
+    tools: {},
+    mcpToolNameToServerUuid: {},
+    unavailableMcpServers: [],
+    closeMcpClients: vi.fn().mockResolvedValue(undefined),
+});
+
 describe('generateAgentResponse error persistence', () => {
     it('persists provider billing guidance for a self-managed key', async () => {
         const updatePrompt = vi.fn().mockResolvedValue(undefined);
-        const dependencies = new Proxy(
-            {
-                listExplores: vi.fn().mockResolvedValue([]),
-                updatePrompt,
-            },
-            {
-                get: (target, property: string) =>
-                    target[property as keyof typeof target] ?? vi.fn(),
-            },
-        ) as unknown as AiAgentDependencies;
-        const args = {
-            agentSettings: {
-                uuid: 'agent-1',
-                name: 'Test agent',
-                projectUuid: 'project-1',
-            },
-            aiAgentMemoryEnabled: false,
-            availableSkills: [],
-            callOptions: {},
-            canManageAgent: false,
-            canRunSql: true,
-            compactionSummary: null,
-            debugLoggingEnabled: false,
-            deepResearchRuns: [],
-            enableAiWriteback: false,
-            enableCodingAgent: false,
-            enableContentTools: false,
-            enableDataAccess: false,
-            enableEditProjectContext: false,
-            enableGrepFields: false,
-            enablePreviewDeploySetup: false,
-            enableRepoDiscovery: false,
-            execution: { mode: 'standard', maxSteps: 10 },
-            findExploresFieldSearchSize: 10,
-            findFieldsPageSize: 10,
-            forceToolHints: false,
-            getDashboardChartsPageSize: 10,
-            keyManagement: 'self-managed',
-            knowledgeDocuments: [],
-            mcpServers: [],
-            messageHistory: [{ role: 'user', content: 'Question' }],
-            model: {},
-            organizationId: 'organization-1',
-            projectContext: [],
-            projectContextEnabled: false,
-            promptUuid: 'prompt-1',
-            providerOptions: {},
-            repoFsRoot: null,
-            repoFsSupportsCodeSearch: false,
-            requestingUser: null,
-            runSqlMaxLimit: 5000,
-            siteUrl: 'http://localhost',
-            telemetryEnabled: false,
-            threadUuid: 'thread-1',
-            toolDescriptionMaxChars: 1000,
-            toolHints: [],
-            userId: 'user-1',
-            writebackAttribution: null,
-        } as unknown as AiAgentArgs;
+        const dependencies = buildAgentDependencies(updatePrompt);
+        const args = buildAgentArgs();
         const providerError = new APICallError({
             message: 'Provider request failed',
             url: 'https://api.anthropic.com/v1/messages',
@@ -111,17 +128,97 @@ describe('generateAgentResponse error persistence', () => {
             generateAgentResponse({
                 args,
                 dependencies,
-                mcpToolSetup: {
-                    tools: {},
-                    mcpToolNameToServerUuid: {},
-                    unavailableMcpServers: [],
-                    closeMcpClients: vi.fn().mockResolvedValue(undefined),
-                },
+                mcpToolSetup: mcpToolSetup(),
             }),
         ).rejects.toBe(providerError);
         expect(updatePrompt).toHaveBeenCalledWith({
             promptUuid: 'prompt-1',
             errorMessage: PROVIDER_BILLING_MESSAGE,
+        });
+    });
+});
+
+describe('generateAgentResponse token usage persistence', () => {
+    const runWithSteps = async (
+        execution: Record<string, unknown>,
+        stepTotals: number[],
+    ) => {
+        const updatePrompt = vi.fn().mockResolvedValue(undefined);
+        vi.mocked(generateText).mockImplementationOnce((async (
+            options: AnyType,
+        ) => {
+            await stepTotals.reduce(
+                (chain, totalTokens) =>
+                    chain.then(() =>
+                        options.onStepFinish({
+                            usage: { totalTokens },
+                            toolCalls: [],
+                            toolResults: [],
+                            text: '',
+                        }),
+                    ),
+                Promise.resolve(),
+            );
+            return {
+                text: 'Answer',
+                steps: stepTotals.map(() => ({})),
+                usage: { totalTokens: stepTotals.at(-1) ?? 0 },
+                finishReason: 'stop',
+            };
+        }) as AnyType);
+
+        await generateAgentResponse({
+            args: buildAgentArgs(execution),
+            dependencies: buildAgentDependencies(updatePrompt),
+            mcpToolSetup: mcpToolSetup(),
+        });
+
+        return updatePrompt;
+    };
+
+    it('persists the cumulative total and the final step separately for deep research', async () => {
+        const updatePrompt = await runWithSteps(
+            {
+                mode: 'deep_research',
+                maxSteps: 10,
+                initialTokenUsage: 400000,
+                runUuid: 'run-1',
+                phase: 'investigate',
+                parentToolCallId: null,
+                budget: {
+                    maxSteps: 10,
+                    maxToolCalls: 20,
+                    maxWarehouseQueries: 5,
+                    maxTokens: 1000000,
+                    deadlineMs: 60000,
+                    maxResultRows: 500,
+                },
+            },
+            [12000, 18000, 25000],
+        );
+
+        expect(updatePrompt).toHaveBeenLastCalledWith({
+            promptUuid: 'prompt-1',
+            tokenUsage: {
+                totalTokens: 455000,
+                finalStepTotalTokens: 25000,
+            },
+        });
+    });
+
+    it('persists matching figures for non-deep-research modes', async () => {
+        const updatePrompt = await runWithSteps(
+            { mode: 'standard', maxSteps: 10 },
+            [12000, 31000],
+        );
+
+        expect(updatePrompt).toHaveBeenLastCalledWith({
+            promptUuid: 'prompt-1',
+            response: 'Answer',
+            tokenUsage: {
+                totalTokens: 31000,
+                finalStepTotalTokens: 31000,
+            },
         });
     });
 });

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -34,6 +34,11 @@ import {
 import { Compaction } from '../compaction';
 import { AI_DEEP_RESEARCH_INSTRUCTIONS } from '../prompts/deepResearch';
 import { getSystemPromptV2 } from '../prompts/systemV2';
+import {
+    accumulatePromptTokenUsage,
+    finalStepPromptTokenUsage,
+    initialPromptTokenUsage,
+} from '../promptTokenUsage';
 import { getAnalyzeFieldImpact } from '../tools/analyzeFieldImpact';
 import { getClosePullRequest } from '../tools/closePullRequest';
 import { getCreateContent } from '../tools/createContent';
@@ -1380,10 +1385,11 @@ export const generateAgentResponse = async ({
     );
     const startTime = Date.now();
     const modelName = getAiAgentModelName(args.model);
-    let generatedTokenUsage =
+    let generatedTokenUsage = initialPromptTokenUsage(
         args.execution.mode === 'deep_research'
             ? args.execution.initialTokenUsage
-            : 0;
+            : 0,
+    );
 
     try {
         const [availableExplores, memoryBlock] = await Promise.all([
@@ -1603,8 +1609,10 @@ export const generateAgentResponse = async ({
                     );
                 }
 
-                const stepTokens = stepUsage.totalTokens ?? 0;
-                generatedTokenUsage += stepTokens;
+                generatedTokenUsage = accumulatePromptTokenUsage(
+                    generatedTokenUsage,
+                    stepUsage.totalTokens,
+                );
                 if (args.execution.mode === 'deep_research') {
                     // Hidden phases (planner/investigators, persisted as
                     // subagent children) each track their own slice; writing
@@ -1614,7 +1622,7 @@ export const generateAgentResponse = async ({
                     if (args.execution.parentToolCallId == null) {
                         await dependencies.updatePrompt({
                             promptUuid: args.promptUuid,
-                            tokenUsage: { totalTokens: generatedTokenUsage },
+                            tokenUsage: generatedTokenUsage,
                         });
                     }
                 } else {
@@ -1655,9 +1663,7 @@ export const generateAgentResponse = async ({
             await dependencies.updatePrompt({
                 promptUuid: args.promptUuid,
                 response: result.text,
-                tokenUsage: {
-                    totalTokens: result.usage.totalTokens ?? 0,
-                },
+                tokenUsage: finalStepPromptTokenUsage(result.usage.totalTokens),
             });
         }
 
@@ -2076,17 +2082,17 @@ export const streamAgentResponse = async ({
                         promptUuid: args.promptUuid,
                         errorMessage:
                             getUserFacingErrorMessage(emptyResponseError),
-                        tokenUsage: {
-                            totalTokens: usage.totalTokens ?? 0,
-                        },
+                        tokenUsage: finalStepPromptTokenUsage(
+                            usage.totalTokens,
+                        ),
                     });
                 } else {
                     await persistPrompt({
                         response: completeResponse,
                         promptUuid: args.promptUuid,
-                        tokenUsage: {
-                            totalTokens: usage.totalTokens ?? 0,
-                        },
+                        tokenUsage: finalStepPromptTokenUsage(
+                            usage.totalTokens,
+                        ),
                     });
                 }
 

--- a/packages/backend/src/ee/services/ai/compaction.test.ts
+++ b/packages/backend/src/ee/services/ai/compaction.test.ts
@@ -2,10 +2,13 @@ import { type AiAgentToolResult } from '@lightdash/common';
 import { Compaction } from './compaction';
 
 describe('AI context compaction helpers', () => {
-    it('triggers compaction when total tokens exceed the reserved budget', () => {
+    it('triggers compaction when the final step exceeds the reserved budget', () => {
         expect(
             Compaction.shouldCompactPrompt({
-                totalTokens: 184000,
+                tokenUsage: {
+                    totalTokens: 184000,
+                    finalStepTotalTokens: 184000,
+                },
                 contextWindowTokens: 200000,
                 reserveTokens: 16384,
             }),
@@ -13,7 +16,10 @@ describe('AI context compaction helpers', () => {
 
         expect(
             Compaction.shouldCompactPrompt({
-                totalTokens: 180000,
+                tokenUsage: {
+                    totalTokens: 180000,
+                    finalStepTotalTokens: 180000,
+                },
                 contextWindowTokens: 200000,
                 reserveTokens: 30000,
             }),
@@ -21,7 +27,71 @@ describe('AI context compaction helpers', () => {
 
         expect(
             Compaction.shouldCompactPrompt({
-                totalTokens: 150000,
+                tokenUsage: {
+                    totalTokens: 150000,
+                    finalStepTotalTokens: 150000,
+                },
+                contextWindowTokens: 200000,
+                reserveTokens: 16384,
+            }),
+        ).toBe(false);
+    });
+
+    it('ignores the cumulative billing total when a final-step figure exists', () => {
+        // Deep research sums every step into totalTokens; only the final step
+        // reflects resident context.
+        expect(
+            Compaction.shouldCompactPrompt({
+                tokenUsage: {
+                    totalTokens: 1_200_000,
+                    finalStepTotalTokens: 42_000,
+                },
+                contextWindowTokens: 200000,
+                reserveTokens: 16384,
+            }),
+        ).toBe(false);
+    });
+
+    it('falls back to totalTokens on rows persisted without a final-step figure', () => {
+        expect(
+            Compaction.shouldCompactPrompt({
+                tokenUsage: { totalTokens: 184000 },
+                contextWindowTokens: 200000,
+                reserveTokens: 16384,
+            }),
+        ).toBe(true);
+
+        expect(
+            Compaction.shouldCompactPrompt({
+                tokenUsage: { totalTokens: 150000 },
+                contextWindowTokens: 200000,
+                reserveTokens: 16384,
+            }),
+        ).toBe(false);
+    });
+
+    it('never compacts when no usage was persisted', () => {
+        expect(
+            Compaction.shouldCompactPrompt({
+                tokenUsage: null,
+                contextWindowTokens: 200000,
+                reserveTokens: 16384,
+            }),
+        ).toBe(false);
+
+        expect(
+            Compaction.shouldCompactPrompt({
+                tokenUsage: undefined,
+                contextWindowTokens: 200000,
+                reserveTokens: 16384,
+            }),
+        ).toBe(false);
+    });
+
+    it('does not compact when the final step reports zero tokens', () => {
+        expect(
+            Compaction.shouldCompactPrompt({
+                tokenUsage: { totalTokens: 500, finalStepTotalTokens: 0 },
                 contextWindowTokens: 200000,
                 reserveTokens: 16384,
             }),

--- a/packages/backend/src/ee/services/ai/compaction.ts
+++ b/packages/backend/src/ee/services/ai/compaction.ts
@@ -3,8 +3,10 @@ import {
     type AiAgentMessage,
     type AiPromptContext,
     type AiPromptContextItem,
+    type AiPromptTokenUsage,
 } from '@lightdash/common';
 import { type ModelMessage } from 'ai';
+import { getContextOccupancyTokens } from './promptTokenUsage';
 
 const TOOL_RESULT_CHAR_LIMIT = 2000;
 const SUMMARY_MESSAGE_PREFIX =
@@ -13,18 +15,21 @@ const SUMMARY_MESSAGE_PREFIX =
 export class Compaction {
     static readonly RESERVE_TOKENS = 16384;
 
+    // Takes the whole usage record, not a bare number, so the cumulative
+    // billing total can't be mistaken for context occupancy.
     static shouldCompactPrompt({
-        totalTokens,
+        tokenUsage,
         contextWindowTokens,
         reserveTokens = Compaction.RESERVE_TOKENS,
     }: {
-        totalTokens: number | null | undefined;
+        tokenUsage: AiPromptTokenUsage | null | undefined;
         contextWindowTokens: number;
         reserveTokens?: number;
     }): boolean {
+        const occupancyTokens = getContextOccupancyTokens(tokenUsage);
         return (
-            typeof totalTokens === 'number' &&
-            totalTokens > contextWindowTokens - reserveTokens
+            occupancyTokens !== null &&
+            occupancyTokens > contextWindowTokens - reserveTokens
         );
     }
 

--- a/packages/backend/src/ee/services/ai/promptTokenUsage.test.ts
+++ b/packages/backend/src/ee/services/ai/promptTokenUsage.test.ts
@@ -1,0 +1,77 @@
+import {
+    accumulatePromptTokenUsage,
+    finalStepPromptTokenUsage,
+    getContextOccupancyTokens,
+    initialPromptTokenUsage,
+} from './promptTokenUsage';
+
+const runSteps = (initialTotalTokens: number, steps: (number | null)[]) =>
+    steps.reduce(
+        (usage, stepTokens) => accumulatePromptTokenUsage(usage, stepTokens),
+        initialPromptTokenUsage(initialTotalTokens),
+    );
+
+describe('prompt token usage', () => {
+    it('keeps the cumulative total while reporting only the last step as occupancy', () => {
+        // Each tool-loop step re-sends the conversation, so per-step totals
+        // grow while the cumulative sum compounds far beyond them.
+        expect(runSteps(0, [12000, 18000, 25000, 31000])).toEqual({
+            totalTokens: 86000,
+            finalStepTotalTokens: 31000,
+        });
+    });
+
+    it('seeds the cumulative total from earlier phases without inflating occupancy', () => {
+        expect(runSteps(400000, [9000, 14000])).toEqual({
+            totalTokens: 423000,
+            finalStepTotalTokens: 14000,
+        });
+    });
+
+    it('starts with a zero final step before any step has run', () => {
+        expect(initialPromptTokenUsage(1234)).toEqual({
+            totalTokens: 1234,
+            finalStepTotalTokens: 0,
+        });
+    });
+
+    it('treats missing step usage as zero tokens', () => {
+        expect(runSteps(0, [5000, null])).toEqual({
+            totalTokens: 5000,
+            finalStepTotalTokens: 0,
+        });
+    });
+
+    it('reports identical figures for final-step-only modes', () => {
+        expect(finalStepPromptTokenUsage(7500)).toEqual({
+            totalTokens: 7500,
+            finalStepTotalTokens: 7500,
+        });
+        expect(finalStepPromptTokenUsage(undefined)).toEqual({
+            totalTokens: 0,
+            finalStepTotalTokens: 0,
+        });
+    });
+
+    describe('getContextOccupancyTokens', () => {
+        it('prefers the final-step figure', () => {
+            expect(
+                getContextOccupancyTokens({
+                    totalTokens: 900000,
+                    finalStepTotalTokens: 31000,
+                }),
+            ).toBe(31000);
+        });
+
+        it('falls back to totalTokens for rows written before the field existed', () => {
+            expect(getContextOccupancyTokens({ totalTokens: 31000 })).toBe(
+                31000,
+            );
+        });
+
+        it('returns null when no usage was persisted', () => {
+            expect(getContextOccupancyTokens(null)).toBeNull();
+            expect(getContextOccupancyTokens(undefined)).toBeNull();
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ai/promptTokenUsage.test.ts
+++ b/packages/backend/src/ee/services/ai/promptTokenUsage.test.ts
@@ -35,8 +35,13 @@ describe('prompt token usage', () => {
         });
     });
 
-    it('treats missing step usage as zero tokens', () => {
+    it('treats missing or non-finite step usage as zero tokens', () => {
         expect(runSteps(0, [5000, null])).toEqual({
+            totalTokens: 5000,
+            finalStepTotalTokens: 0,
+        });
+        // Providers that report no usage surface NaN through the AI SDK.
+        expect(accumulatePromptTokenUsage(runSteps(0, [5000]), NaN)).toEqual({
             totalTokens: 5000,
             finalStepTotalTokens: 0,
         });
@@ -72,6 +77,16 @@ describe('prompt token usage', () => {
         it('returns null when no usage was persisted', () => {
             expect(getContextOccupancyTokens(null)).toBeNull();
             expect(getContextOccupancyTokens(undefined)).toBeNull();
+        });
+
+        it('ignores non-finite figures', () => {
+            expect(
+                getContextOccupancyTokens({
+                    totalTokens: 31000,
+                    finalStepTotalTokens: NaN,
+                }),
+            ).toBe(31000);
+            expect(getContextOccupancyTokens({ totalTokens: NaN })).toBeNull();
         });
     });
 });

--- a/packages/backend/src/ee/services/ai/promptTokenUsage.ts
+++ b/packages/backend/src/ee/services/ai/promptTokenUsage.ts
@@ -1,0 +1,56 @@
+import { type AiPromptTokenUsage } from '@lightdash/common';
+
+/**
+ * `ai_prompt.token_usage` carries two distinct figures: `totalTokens` is the
+ * cumulative billing spend across every step of a run, while
+ * `finalStepTotalTokens` approximates the context resident in the last request.
+ * Only the latter is comparable to a model's context window.
+ */
+export const initialPromptTokenUsage = (
+    initialTotalTokens: number,
+): AiPromptTokenUsage => ({
+    totalTokens: initialTotalTokens,
+    finalStepTotalTokens: 0,
+});
+
+export const accumulatePromptTokenUsage = (
+    previous: AiPromptTokenUsage,
+    stepTotalTokens: number | null | undefined,
+): AiPromptTokenUsage => {
+    const stepTokens = stepTotalTokens ?? 0;
+    return {
+        totalTokens: previous.totalTokens + stepTokens,
+        finalStepTotalTokens: stepTokens,
+    };
+};
+
+/**
+ * For modes that persist only the final step's usage, both figures coincide.
+ */
+export const finalStepPromptTokenUsage = (
+    totalTokens: number | null | undefined,
+): AiPromptTokenUsage => {
+    const tokens = totalTokens ?? 0;
+    return { totalTokens: tokens, finalStepTotalTokens: tokens };
+};
+
+/**
+ * Reads the context-occupancy figure out of a persisted usage record. Rows
+ * written before `finalStepTotalTokens` existed fall back to `totalTokens`:
+ * that is exact for every mode except deep research, where it over-reports and
+ * reproduces the old over-eager compaction for one turn. Preferred over
+ * skipping compaction, which would risk a hard context-window overflow.
+ */
+export const getContextOccupancyTokens = (
+    tokenUsage: AiPromptTokenUsage | null | undefined,
+): number | null => {
+    if (!tokenUsage) {
+        return null;
+    }
+    if (typeof tokenUsage.finalStepTotalTokens === 'number') {
+        return tokenUsage.finalStepTotalTokens;
+    }
+    return typeof tokenUsage.totalTokens === 'number'
+        ? tokenUsage.totalTokens
+        : null;
+};

--- a/packages/backend/src/ee/services/ai/promptTokenUsage.ts
+++ b/packages/backend/src/ee/services/ai/promptTokenUsage.ts
@@ -1,56 +1,50 @@
-import { type AiPromptTokenUsage } from '@lightdash/common';
+import {
+    type AiPromptTokenUsage,
+    type AiPromptTokenUsageUpdate,
+} from '@lightdash/common';
 
-/**
- * `ai_prompt.token_usage` carries two distinct figures: `totalTokens` is the
- * cumulative billing spend across every step of a run, while
- * `finalStepTotalTokens` approximates the context resident in the last request.
- * Only the latter is comparable to a model's context window.
- */
+// `totalTokens` is cumulative billing spend; only `finalStepTotalTokens`
+// approximates the context resident in the last request.
 export const initialPromptTokenUsage = (
     initialTotalTokens: number,
-): AiPromptTokenUsage => ({
+): AiPromptTokenUsageUpdate => ({
     totalTokens: initialTotalTokens,
     finalStepTotalTokens: 0,
 });
 
 export const accumulatePromptTokenUsage = (
-    previous: AiPromptTokenUsage,
+    previous: AiPromptTokenUsageUpdate,
     stepTotalTokens: number | null | undefined,
-): AiPromptTokenUsage => {
-    const stepTokens = stepTotalTokens ?? 0;
+): AiPromptTokenUsageUpdate => {
+    const stepTokens = Number.isFinite(stepTotalTokens)
+        ? Number(stepTotalTokens)
+        : 0;
     return {
         totalTokens: previous.totalTokens + stepTokens,
         finalStepTotalTokens: stepTokens,
     };
 };
 
-/**
- * For modes that persist only the final step's usage, both figures coincide.
- */
+/** For modes that persist only the final step's usage, both figures coincide. */
 export const finalStepPromptTokenUsage = (
     totalTokens: number | null | undefined,
-): AiPromptTokenUsage => {
-    const tokens = totalTokens ?? 0;
+): AiPromptTokenUsageUpdate => {
+    const tokens = Number.isFinite(totalTokens) ? Number(totalTokens) : 0;
     return { totalTokens: tokens, finalStepTotalTokens: tokens };
 };
 
-/**
- * Reads the context-occupancy figure out of a persisted usage record. Rows
- * written before `finalStepTotalTokens` existed fall back to `totalTokens`:
- * that is exact for every mode except deep research, where it over-reports and
- * reproduces the old over-eager compaction for one turn. Preferred over
- * skipping compaction, which would risk a hard context-window overflow.
- */
+// Legacy rows fall back to totalTokens: exact for every mode but deep research,
+// where it over-reports for one turn — safer than risking a window overflow.
 export const getContextOccupancyTokens = (
     tokenUsage: AiPromptTokenUsage | null | undefined,
 ): number | null => {
     if (!tokenUsage) {
         return null;
     }
-    if (typeof tokenUsage.finalStepTotalTokens === 'number') {
-        return tokenUsage.finalStepTotalTokens;
+    if (Number.isFinite(tokenUsage.finalStepTotalTokens)) {
+        return Number(tokenUsage.finalStepTotalTokens);
     }
-    return typeof tokenUsage.totalTokens === 'number'
+    return Number.isFinite(tokenUsage.totalTokens)
         ? tokenUsage.totalTokens
         : null;
 };

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -66,7 +66,13 @@ export type AiThread = {
 };
 
 export type AiPromptTokenUsage = {
+    /** Billing figure: tokens summed across every step of the run. */
     totalTokens: number;
+    /**
+     * Final step's total — the proxy for resident context size, used for
+     * compaction. Absent on prompts persisted before this field existed.
+     */
+    finalStepTotalTokens?: number;
 };
 
 /**

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -65,15 +65,16 @@ export type AiThread = {
     agentUuid: string | null;
 };
 
+/** Persisted shape. `finalStepTotalTokens` is absent on rows written before it existed. */
 export type AiPromptTokenUsage = {
     /** Billing figure: tokens summed across every step of the run. */
     totalTokens: number;
-    /**
-     * Final step's total — the proxy for resident context size, used for
-     * compaction. Absent on prompts persisted before this field existed.
-     */
+    /** Final step's total — the proxy for resident context size, drives compaction. */
     finalStepTotalTokens?: number;
 };
+
+/** Write shape: both figures are required so a writer can't omit the compaction input. */
+export type AiPromptTokenUsageUpdate = Required<AiPromptTokenUsage>;
 
 /**
  * Every origin an ai_thread can be created from. Canonical source for the
@@ -317,7 +318,7 @@ export type UpdateSlackResponse = {
     response?: string;
     errorMessage?: string;
     humanScore?: number | null;
-    tokenUsage?: AiPromptTokenUsage | null;
+    tokenUsage?: AiPromptTokenUsageUpdate | null;
 };
 
 export type UpdateWebAppResponse = {
@@ -325,7 +326,7 @@ export type UpdateWebAppResponse = {
     response?: string;
     errorMessage?: string;
     humanScore?: number | null;
-    tokenUsage?: AiPromptTokenUsage | null;
+    tokenUsage?: AiPromptTokenUsageUpdate | null;
 };
 
 export type UpdateSlackResponseTs = {


### PR DESCRIPTION
## Problem

Deep-research mode accumulates token usage across every tool-loop step into `ai_prompt.token_usage.totalTokens` — a billing figure that compounds per step because each step re-sends the conversation. The compaction check compared that cumulative figure against the model's context window, so deep-research threads compacted far too early, summarising away history that was nowhere near the limit.

Other modes persist final-step usage and were unaffected.

## Fix

`token_usage` now records both figures:

- `totalTokens` keeps its cumulative billing meaning — all existing consumers are unchanged (review classifier, token badge, analytics).
- A new `finalStepTotalTokens` records context occupancy.

`Compaction.shouldCompactPrompt` takes the usage record and decides on occupancy. Rows written before this change fall back to `totalTokens` (over-compacting once is a soft cost; under-compacting risks context overflow). The write shape requires the field, so no writer can silently omit it. No migration needed.

Worth noting honestly: for deep research the occupancy figure is the coordinator's final step, which includes its own tool traffic — a small constant over-estimate, the same class of proxy as other modes use.

## Testing

- New pure-module unit tests: accumulation, final-step, NaN-coercion, fallback.
- Compaction regression cases.
- Full backend suite green.
- Verified end-to-end locally:
  - A 7-tool-call deep-research run persisted cumulative 355k vs occupancy 51k.
  - The follow-up turn logged `shouldCompact=false` despite cumulative exceeding the threshold by 177k.
  - A controlled A/B stripping only the new field from the same row flipped the decision to compact, reproducing the original bug.
  - Normal streaming turns persist equal figures.
  - The UI token badge still shows the cumulative number.

Closes: ZAP-823
https://linear.app/lightdash/issue/ZAP-823

🤖 Generated with [Claude Code](https://claude.com/claude-code)
