### PR TITLE
fix: backfill default user spaces when the feature is enabled

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -761,7 +761,8 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
 
     /**
      * Toggle default user spaces for a project.
-     * When enabled, creates personal spaces for all eligible users.
+     * When enabled, queues a background job that creates personal spaces
+     * for all eligible users.
      * @summary Update default user spaces setting
      */
     @Middlewares([

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -1,5 +1,6 @@
 import {
     AnyType,
+    BackfillDefaultUserSpacesPayload,
     CompileProjectPayload,
     CreateSchedulerAndTargets,
     CreateSchedulerTarget,
@@ -1483,6 +1484,34 @@ export class SchedulerClient {
 
         await this.schedulerModel.logSchedulerJob({
             task,
+            jobId,
+            scheduledTime: now,
+            status: SchedulerJobStatus.SCHEDULED,
+            details: {
+                userUuid: payload.userUuid,
+                organizationUuid: payload.organizationUuid,
+                projectUuid: payload.projectUuid,
+                createdByUserUuid: payload.userUuid,
+            },
+        });
+
+        return { jobId };
+    }
+
+    async backfillDefaultUserSpaces(payload: BackfillDefaultUserSpacesPayload) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const jobId = await SchedulerClient.addJob(
+            graphileClient,
+            SCHEDULER_TASKS.BACKFILL_DEFAULT_USER_SPACES,
+            payload,
+            now,
+            JobPriority.LOW,
+            1,
+        );
+
+        await this.schedulerModel.logSchedulerJob({
+            task: SCHEDULER_TASKS.BACKFILL_DEFAULT_USER_SPACES,
             jobId,
             scheduledTime: now,
             status: SchedulerJobStatus.SCHEDULED,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -3,6 +3,7 @@ import {
     appendUuidQueryParam,
     applyDimensionOverrides,
     assertUnreachable,
+    BackfillDefaultUserSpacesPayload,
     CompileProjectPayload,
     convertReplaceableFieldMatchMapToReplaceCustomFields,
     CreateProject,
@@ -6405,6 +6406,30 @@ export default class SchedulerTask {
             fileUrl: downloadResult.fileUrl,
             s3FileUrl: downloadResult.s3FileUrl,
         };
+    }
+
+    protected async backfillDefaultUserSpaces(
+        jobId: string,
+        scheduledTime: Date,
+        payload: BackfillDefaultUserSpacesPayload,
+    ) {
+        await this.logWrapper(
+            {
+                task: SCHEDULER_TASKS.BACKFILL_DEFAULT_USER_SPACES,
+                jobId,
+                scheduledTime,
+                details: {
+                    userUuid: payload.userUuid,
+                    projectUuid: payload.projectUuid,
+                    organizationUuid: payload.organizationUuid,
+                    createdByUserUuid: payload.userUuid,
+                },
+            },
+            async () =>
+                this.userService.ensureDefaultUserSpacesForOrganizationMembers(
+                    payload.organizationUuid,
+                ),
+        );
     }
 
     protected async replaceCustomFields(

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -131,6 +131,12 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
     }),
 
+    [SCHEDULER_TASKS.BACKFILL_DEFAULT_USER_SPACES]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+    }),
+
     [SCHEDULER_TASKS.INDEX_CATALOG]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -1054,6 +1054,43 @@ export class SchedulerWorker extends SchedulerTask {
                     },
                 );
             },
+            [SCHEDULER_TASKS.BACKFILL_DEFAULT_USER_SPACES]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        SCHEDULER_TASKS.BACKFILL_DEFAULT_USER_SPACES,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.backfillDefaultUserSpaces(
+                                helpers.job.id,
+                                helpers.job.run_at,
+                                payload,
+                            );
+                        },
+                    ),
+                    helpers.job,
+                    this.lightdashConfig.scheduler.jobTimeout,
+                    async (job, e) => {
+                        await this.schedulerService.logSchedulerJob({
+                            task: SCHEDULER_TASKS.BACKFILL_DEFAULT_USER_SPACES,
+                            jobId: job.id,
+                            scheduledTime: job.run_at,
+                            status: SchedulerJobStatus.ERROR,
+                            details: {
+                                userUuid: payload.userUuid,
+                                projectUuid: payload.projectUuid,
+                                organizationUuid: payload.organizationUuid,
+                                createdByUserUuid: payload.userUuid,
+                                error: e.message,
+                            },
+                        });
+                    },
+                );
+            },
             [SCHEDULER_TASKS.REPLACE_CUSTOM_FIELDS]: async (
                 payload,
                 helpers,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -290,6 +290,9 @@ const emailModel = {
 };
 
 const schedulerClient = {
+    backfillDefaultUserSpaces: vi.fn(async () => ({
+        jobId: 'backfill-job-1',
+    })),
     createProjectWithCompile: vi.fn(async () => undefined),
     deleteScheduledPreAggregateCronJobsForProject: vi.fn(async () => undefined),
     indexCatalog: vi.fn(async () => ({ jobId: 'catalog-job-1' })),
@@ -3210,6 +3213,56 @@ describe('ProjectService', () => {
                 projectUuid,
                 false,
             );
+        });
+
+        test('should queue backfill job when enabling the feature', async () => {
+            const adminUser: SessionUser = {
+                ...user,
+                role: OrganizationMemberRole.ADMIN,
+                ability: defineUserAbility(
+                    {
+                        userUuid: user.userUuid,
+                        role: OrganizationMemberRole.ADMIN,
+                        organizationUuid: 'organizationUuid',
+                    },
+                    [],
+                ),
+            };
+
+            await service.updateDefaultUserSpaces(adminUser, projectUuid, {
+                hasDefaultUserSpaces: true,
+            });
+
+            expect(
+                schedulerClient.backfillDefaultUserSpaces,
+            ).toHaveBeenCalledWith({
+                organizationUuid: projectSummary.organizationUuid,
+                projectUuid,
+                userUuid: adminUser.userUuid,
+            });
+        });
+
+        test('should not queue backfill job when disabling the feature', async () => {
+            const adminUser: SessionUser = {
+                ...user,
+                role: OrganizationMemberRole.ADMIN,
+                ability: defineUserAbility(
+                    {
+                        userUuid: user.userUuid,
+                        role: OrganizationMemberRole.ADMIN,
+                        organizationUuid: 'organizationUuid',
+                    },
+                    [],
+                ),
+            };
+
+            await service.updateDefaultUserSpaces(adminUser, projectUuid, {
+                hasDefaultUserSpaces: false,
+            });
+
+            expect(
+                schedulerClient.backfillDefaultUserSpaces,
+            ).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -8652,6 +8652,14 @@ export class ProjectService extends BaseService {
             projectUuid,
             data.hasDefaultUserSpaces,
         );
+
+        if (data.hasDefaultUserSpaces) {
+            await this.schedulerClient.backfillDefaultUserSpaces({
+                organizationUuid,
+                projectUuid,
+                userUuid: user.userUuid,
+            });
+        }
     }
 
     async updateColorPalette(

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -13,6 +13,7 @@ import {
     LightdashUser,
     NotFoundError,
     OpenIdIdentityIssuerType,
+    OrganizationMemberProfile,
     OrganizationMemberRole,
     ParameterError,
     PasswordResetLink,
@@ -79,6 +80,7 @@ const userModel = {
         sessionUser,
         cacheHit: false,
     })),
+    invalidateSessionUserCache: vi.fn(),
     createUser: vi.fn<UserModel['createUser']>(async () => sessionUser),
     activateUser: vi.fn(async () => sessionUser),
     activateUserWithoutPassword: vi.fn(async () => sessionUser),
@@ -195,6 +197,9 @@ const sessionModel = {
 const organizationMemberProfileModel = {
     getOrganizationAdmins: vi.fn<
         OrganizationMemberProfileModel['getOrganizationAdmins']
+    >(async () => []),
+    getAllOrganizationMembers: vi.fn<
+        OrganizationMemberProfileModel['getAllOrganizationMembers']
     >(async () => []),
 };
 
@@ -3580,6 +3585,87 @@ describe('UserService', () => {
                     lastName: interactiveViewer.lastName,
                 },
             );
+        });
+
+        test('should create space via ensureDefaultUserSpacesForUser (provisioning entry point)', async () => {
+            const service = createUserService(lightdashConfigMock);
+
+            (
+                projectModel.getProjectsWithDefaultUserSpaces as import('vitest').Mock
+            ).mockResolvedValueOnce([projectWithDefaultSpaces]);
+
+            const editor = makeSessionUser({
+                orgRole: OrganizationMemberRole.EDITOR,
+            });
+            (
+                userModel.getSessionUserFromCacheOrDB as import('vitest').Mock
+            ).mockResolvedValueOnce({
+                sessionUser: editor,
+                cacheHit: false,
+            });
+
+            await service.ensureDefaultUserSpacesForUser({
+                userUuid: editor.userUuid,
+                organizationUuid,
+            });
+
+            expect(projectModel.ensureDefaultUserSpace).toHaveBeenCalledTimes(
+                1,
+            );
+        });
+
+        test('should backfill spaces for active members only', async () => {
+            const service = createUserService(lightdashConfigMock);
+
+            organizationMemberProfileModel.getAllOrganizationMembers.mockResolvedValueOnce(
+                [
+                    { userUuid: 'active-1', isActive: true },
+                    { userUuid: 'inactive-1', isActive: false },
+                    { userUuid: 'active-2', isActive: true },
+                ] as OrganizationMemberProfile[],
+            );
+            const ensureSpy = vi
+                .spyOn(service, 'ensureDefaultUserSpacesForUser')
+                .mockResolvedValue(undefined);
+
+            const result =
+                await service.ensureDefaultUserSpacesForOrganizationMembers(
+                    organizationUuid,
+                );
+
+            expect(ensureSpy).toHaveBeenCalledTimes(2);
+            expect(ensureSpy).toHaveBeenCalledWith({
+                userUuid: 'active-1',
+                organizationUuid,
+            });
+            expect(ensureSpy).toHaveBeenCalledWith({
+                userUuid: 'active-2',
+                organizationUuid,
+            });
+            expect(result).toEqual({ processedMembers: 2, failedMembers: 0 });
+        });
+
+        test('should continue backfill when one member fails', async () => {
+            const service = createUserService(lightdashConfigMock);
+
+            organizationMemberProfileModel.getAllOrganizationMembers.mockResolvedValueOnce(
+                [
+                    { userUuid: 'active-1', isActive: true },
+                    { userUuid: 'active-2', isActive: true },
+                ] as OrganizationMemberProfile[],
+            );
+            const ensureSpy = vi
+                .spyOn(service, 'ensureDefaultUserSpacesForUser')
+                .mockRejectedValueOnce(new Error('boom'))
+                .mockResolvedValue(undefined);
+
+            const result =
+                await service.ensureDefaultUserSpacesForOrganizationMembers(
+                    organizationUuid,
+                );
+
+            expect(ensureSpy).toHaveBeenCalledTimes(2);
+            expect(result).toEqual({ processedMembers: 2, failedMembers: 1 });
         });
 
         test('should skip space creation for viewer (no manage:SavedChart ability)', async () => {

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -25,6 +25,7 @@ import {
     FeatureFlags,
     ForbiddenError,
     getEmailDomain,
+    getErrorMessage,
     getUserAvatarUrl,
     hasInviteCode,
     hasProperty,
@@ -2723,6 +2724,59 @@ export class UserService extends BaseService {
             organization: user.organizationUuid,
         });
         await this.ensureDefaultUserSpaces(sessionUser);
+    }
+
+    /**
+     * System/worker-context backfill, invoked only by the
+     * backfillDefaultUserSpaces scheduler task. Authorization is enforced by the
+     * caller that enqueues the job (ProjectService.updateDefaultUserSpaces
+     * requires `manage Project`); per-member space creation stays
+     * permission-gated inside ensureDefaultUserSpaces.
+     */
+    async ensureDefaultUserSpacesForOrganizationMembers(
+        organizationUuid: string,
+    ): Promise<{ processedMembers: number; failedMembers: number }> {
+        const members =
+            await this.organizationMemberProfileModel.getAllOrganizationMembers(
+                organizationUuid,
+            );
+        const activeMembers = members.filter((member) => member.isActive);
+        const ensureMemberSpaces = async (member: {
+            userUuid: string;
+        }): Promise<boolean> => {
+            try {
+                await this.ensureDefaultUserSpacesForUser({
+                    userUuid: member.userUuid,
+                    organizationUuid,
+                });
+                return true;
+            } catch (error) {
+                this.logger.warn(
+                    'Failed to ensure default user spaces during backfill',
+                    {
+                        userUuid: member.userUuid,
+                        organizationUuid,
+                        error: getErrorMessage(error),
+                    },
+                );
+                return false;
+            }
+        };
+        // batches to bound concurrent session-user lookups against the db
+        const batchSize = 10;
+        const results: boolean[] = [];
+        for (let i = 0; i < activeMembers.length; i += batchSize) {
+            const batch = activeMembers.slice(i, i + batchSize);
+            // eslint-disable-next-line no-await-in-loop
+            const batchResults = await Promise.all(
+                batch.map(ensureMemberSpaces),
+            );
+            results.push(...batchResults);
+        }
+        return {
+            processedMembers: activeMembers.length,
+            failedMembers: results.filter((succeeded) => !succeeded).length,
+        };
     }
 
     private async ensureDefaultUserSpaces(

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -829,6 +829,8 @@ export type MaterializePreAggregatePayload = TraceTaskBase & {
 
 export type ReplaceCustomFieldsPayload = TraceTaskBase;
 
+export type BackfillDefaultUserSpacesPayload = TraceTaskBase;
+
 export type ValidateProjectPayload = TraceTaskBase & {
     context: 'lightdash_app' | 'dbt_refresh' | 'test_and_compile' | 'cli';
     explores?: (Explore | ExploreError)[];

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -23,6 +23,7 @@ import { type SchedulerIndexCatalogJobPayload } from './catalog';
 import { type UploadGsheetPayload } from './gdrive';
 import { type RenameResourcesPayload } from './rename';
 import {
+    type BackfillDefaultUserSpacesPayload,
     type CompileProjectPayload,
     type DownloadAsyncQueryResultsPayload,
     type EmailBatchNotificationPayload,
@@ -206,6 +207,7 @@ export const SCHEDULER_TASKS = {
     COMPACT_USAGE_EVENTS: 'compactUsageEvents',
     POLL_EMAIL_WHITELABEL: 'pollEmailWhitelabelVerification',
     CLEAN_WAREHOUSE_CONNECT_CODES: 'cleanWarehouseConnectCodes',
+    BACKFILL_DEFAULT_USER_SPACES: 'backfillDefaultUserSpaces',
     ...EE_SCHEDULER_TASKS,
 } as const;
 
@@ -253,6 +255,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.COMPACT_USAGE_EVENTS]: TraceTaskBase;
     [SCHEDULER_TASKS.POLL_EMAIL_WHITELABEL]: TraceTaskBase;
     [SCHEDULER_TASKS.CLEAN_WAREHOUSE_CONNECT_CODES]: TraceTaskBase;
+    [SCHEDULER_TASKS.BACKFILL_DEFAULT_USER_SPACES]: BackfillDefaultUserSpacesPayload;
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;


### PR DESCRIPTION
Closes #27116
Closes: PROD-9796

> **Now targets `main`.** The SCIM half of this work (originally the stacked base #27114) landed independently on `main` via #27130 — which added `UserService.ensureDefaultUserSpacesForUser` (organizationUuid required, invalidates the session-user cache). This branch was rebased off that superseded base onto `main` and reuses main's method. It's being carried forward by Charlie's team on Josh's behalf; original commit authorship is preserved.

## Problem

Enabling Default User Spaces (`PATCH /projects/{uuid}/hasDefaultUserSpaces`) only flips the flag — no personal spaces are created for existing users, despite the endpoint docstring claiming otherwise. Users with long-lived sessions from before enablement have no personal space until they log out and back in.

## Fix

- New Graphile Worker task `backfillDefaultUserSpaces` (payload = `TraceTaskBase`), queued by `ProjectService.updateDefaultUserSpaces` when the flag turns **on** (not on disable). Runs in the background because orgs can have thousands of members.
- The task calls a new `UserService.ensureDefaultUserSpacesForOrganizationMembers(organizationUuid)`: iterates **active** org members in batches of 10, reusing the per-user `ensureDefaultUserSpacesForUser` — so eligibility stays permission-gated (`manage SavedChart`/`Explore`) and creation stays idempotent. Per-user failures are logged and counted, never thrown; the job result records `{ processedMembers, failedMembers }`.
- Controller docstring updated to describe the queued backfill.

## Out of scope

- Impersonation flow (PROD-7364).
- Re-running backfill on eligibility changes made in the app UI (role grants, group edits) — SCIM-driven changes are covered by the SCIM trigger already on `main` (#27130).

## Testing

- Unit: backfill processes active members only, continues past per-user failures with a failure count; enqueue on enable, no enqueue on disable; scheduler client/worker/tracer suites green.
- `pnpm -F backend typecheck` + `pnpm -F common typecheck` clean; touched backend suites (`UserService`, `ProjectService`) green (258 tests).

## Runtime verification

Verified end-to-end on a local EE instance (dev seed data only).

1. Enabled Default User Spaces on the seeded project, then created a clean before-state: **no** active member had a personal space under the "Default User Spaces" parent (deleted the pre-existing ones directly in the DB).
2. Flipped the setting **off then on** via the PATCH endpoint as an admin.
3. The `backfillDefaultUserSpaces` Graphile job was enqueued and ran to completion (job 129, `scheduled → started → completed`, 156ms), result `{ processedMembers: 6, failedMembers: 0 }`.

Before → after:

| Member | Active | Org role | Space before | Space after |
|---|---|---|---|---|
| Admin | ✅ | admin | ❌ | ✅ created |
| Editor | ✅ | editor | ❌ | ✅ created |
| Editor ×3 (SCIM-provisioned) | ✅ | editor | ❌ | ✅ created |
| Viewer | ✅ | viewer | ❌ | ❌ (no `manage` ability — correctly skipped) |
| Member ×3 | ❌ inactive | member | ❌ | ❌ (inactive — correctly skipped) |

Confirms: spaces created for active **eligible** members only; ineligible (viewer) and inactive members skipped; per-user failure tolerance is covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXwVp1qMR9vKbzhjBNNw6L
