### PR TITLE
fix: distinguish embedded dashboard parameters from filters

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.module.css
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.module.css
@@ -1,0 +1,7 @@
+.filterParameterDivider {
+    display: none;
+}
+
+.filterBar:has([data-dashboard-filter-control]) .filterParameterDivider {
+    display: block;
+}

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
@@ -12,6 +12,7 @@ import { DashboardFiltersBarSummary } from '../../../../../features/dashboardFil
 import { DateZoom } from '../../../../../features/dateZoom';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
 import { embedContractClass } from '../../styles/embedClassContract';
+import styles from './EmbedDashboardFilterBar.module.css';
 import EmbedDashboardFilters from './EmbedDashboardFilters';
 import EmbedDashboardParameters from './EmbedDashboardParameters';
 
@@ -60,6 +61,7 @@ const EmbedDashboardFilterBar: FC<Props> = ({
                 : 0,
         [parametersEnabled, parameterDefinitions, parameterReferences],
     );
+    const hasVisibleParameters = totalParametersCount > 0;
 
     // Collapsing only hides filters and parameters — date zoom stays visible
     const isCollapsible = totalFiltersCount > 0 || totalParametersCount > 0;
@@ -87,7 +89,10 @@ const EmbedDashboardFilterBar: FC<Props> = ({
 
     return (
         <Group
-            className={embedContractClass('ld-dashboard-filters')}
+            className={embedContractClass(
+                'ld-dashboard-filters',
+                styles.filterBar,
+            )}
             justify="space-between"
             align="flex-start"
             wrap="nowrap"
@@ -98,11 +103,17 @@ const EmbedDashboardFilterBar: FC<Props> = ({
             <Group
                 align="flex-start"
                 wrap="wrap"
-                gap="sm"
+                gap="xs"
                 style={{ flex: 1, minWidth: 0 }}
             >
                 {shouldShowFilters && (
                     <EmbedDashboardFilters canAddFilters={canAddFilters} />
+                )}
+                {shouldShowFilters && hasVisibleParameters && (
+                    <Divider
+                        className={styles.filterParameterDivider}
+                        orientation="vertical"
+                    />
                 )}
                 {parametersEnabled && <EmbedDashboardParameters />}
             </Group>

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
@@ -1,5 +1,5 @@
 import { getItemId, type DashboardFilterRule } from '@lightdash/common';
-import { Button, Flex, Tooltip } from '@mantine/core';
+import { Button, Tooltip } from '@mantine/core';
 import { IconRotate2 } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
 import FiltersProvider from '../../../../../components/common/Filters/FiltersProvider';
@@ -101,7 +101,7 @@ const EmbedDashboardFilters: FC<Props> = ({ canAddFilters = false }) => {
             filterableFieldsByTileUuid={filterableFieldsByTileUuid}
             activeTabUuid={activeTab?.uuid}
         >
-            <Flex gap="xs" wrap="wrap" w="100%" justify="flex-start">
+            <>
                 {canAddFilters && (
                     <AddFilterButton
                         isEditMode={false}
@@ -124,6 +124,7 @@ const EmbedDashboardFilters: FC<Props> = ({ canAddFilters = false }) => {
                     // TODO: create a common component for this
                     <Tooltip label="Reset all filters" withinPortal>
                         <Button
+                            data-dashboard-filter-control
                             aria-label="Reset all filters"
                             size="xs"
                             variant="default"
@@ -159,7 +160,7 @@ const EmbedDashboardFilters: FC<Props> = ({ canAddFilters = false }) => {
                         'ld-dashboard-filter-dropdown',
                     )}
                 />
-            </Flex>
+            </>
         </FiltersProvider>
     );
 };

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
@@ -1,9 +1,28 @@
-import { Group } from '@mantine/core';
-import { useMemo, type FC } from 'react';
+import { Box, Group, Text } from '@mantine/core';
+import { IconAdjustmentsHorizontal } from '@tabler/icons-react';
+import { useMemo, type FC, type ReactNode } from 'react';
+import FilterGroupSeparator from '../../../../../features/dashboardFilters/FilterGroupSeparator';
 import { Parameters } from '../../../../../features/parameters';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../../../../../providers/Dashboard/useDashboardTileStatusContext';
 import { embedContractClass } from '../../styles/embedClassContract';
+
+const parametersSeparator: ReactNode = (
+    <FilterGroupSeparator
+        icon={IconAdjustmentsHorizontal}
+        tooltipLabel={
+            <Box>
+                <Text fw={500} fz="xs">
+                    Parameters
+                </Text>
+                <Text fz="xs">
+                    Adjust preset inputs that change how the dashboard's numbers
+                    are calculated.
+                </Text>
+            </Box>
+        }
+    />
+);
 
 const EmbedDashboardParameters: FC = () => {
     const parameterValues = useDashboardContext((c) => c.parameterValues);
@@ -35,7 +54,6 @@ const EmbedDashboardParameters: FC = () => {
             className={embedContractClass('ld-dashboard-parameters')}
             gap="xs"
             wrap="wrap"
-            style={{ flexShrink: 0 }}
         >
             <Parameters
                 isEditMode={false}
@@ -49,6 +67,7 @@ const EmbedDashboardParameters: FC = () => {
                 dropdownClassName={embedContractClass(
                     'ld-dashboard-parameter-dropdown',
                 )}
+                separator={parametersSeparator}
             />
         </Group>
     );

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -285,6 +285,7 @@ const Filter: FC<Props> = ({
                         maw={300}
                     >
                         <Button
+                            data-dashboard-filter-control
                             pos="relative"
                             size="xs"
                             variant={isTemporary ? 'outline' : 'default'}

--- a/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
@@ -128,6 +128,7 @@ const AddFilterButton: FC<Props> = ({
             return (
                 <Tooltip label="Reset all filters" withinPortal>
                     <Button
+                        data-dashboard-filter-control
                         aria-label="Reset all filters"
                         size="xs"
                         variant="default"
@@ -182,6 +183,7 @@ const AddFilterButton: FC<Props> = ({
                         label={tooltipLabel}
                     >
                         <Button
+                            data-dashboard-filter-control
                             className={triggerClassName}
                             size="xs"
                             variant="default"

--- a/packages/frontend/src/features/dashboardFilters/InvalidFilter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/InvalidFilter.tsx
@@ -27,6 +27,7 @@ const InvalidFilter: FC<Props> = ({ isEditMode, filterRule, onRemove }) => {
             }
         >
             <Button
+                data-dashboard-filter-control
                 size="xs"
                 data-disabled
                 style={{ borderRadius: '100px' }}


### PR DESCRIPTION
## Summary

Embedded dashboard parameters looked like ordinary filters and were forced onto a separate row even when horizontal space remained. This aligns the iframe and React SDK embed filter bar with the standalone dashboard while preserving the public embed CSS hooks.

[PROD-9795](https://linear.app/lightdash/issue/PROD-9795/embedded-dashboard-parameters-are-indistinguishable-from-filters)

## Root cause

The embed filter controls were nested inside a full-width flex container, while parameters were rendered as a separate non-shrinking sibling without the standalone divider or sliders separator.

```tsx
<Flex gap="xs" wrap="wrap" w="100%" justify="flex-start">
```

The full-width child consumed the outer wrapping row, so the parameter group always started below it. The nested filter container also prevented parameter controls from using space after the last filter pill.

## Fix

Filter controls now participate directly in the existing wrapping group. A semantic control marker shows the divider only when a filter control is actually rendered, and the shared standalone parameter separator stays attached to the first parameter pill.

- `EmbedDashboardFilterBar` — uses the shared wrapping flow and conditionally displays the filter/parameter divider.
- `EmbedDashboardFilters` — removes the full-width nested flex boundary.
- `EmbedDashboardParameters` — reuses the standalone sliders separator while preserving the public parameter-group box.
- Existing filter button branches — expose one internal marker for accurate divider visibility, including add/reset and invalid-filter states.
- Parameter values, query behavior, tabs, and embed-token permissions are intentionally unchanged.

## Before

<img width="1560" height="143" alt="prod-9795-before" src="https://github.com/user-attachments/assets/697ada18-da51-48b3-9227-3de3b7a8c190" />


## After

Verified in the local iframe preview with Chrome MCP: the filter, divider, sliders separator, and parameter share one row at 1560px, while the parameter group wraps without overflow at 520px. A final viewport screenshot was captured during the test run.

<img width="3120" height="1800" alt="image" src="https://github.com/user-attachments/assets/8e649403-325b-4ee6-99b7-c1ca4a437900" />

## Test plan

- [x] `pnpm -F @lightdash/frontend typecheck`
- [x] Oxlint on all six touched TypeScript files
- [x] Oxfmt check on all seven touched files
- [x] `pnpm -F @lightdash/frontend exec vitest run src/ee/features/embed/styles/embedClassContract.test.ts` — 16 tests pass
- [x] Full frontend Vitest suite — 294 files, 2,326 tests pass
- [x] Manual Chrome MCP: combined filter + parameter at 1560px and 520px
- [x] Manual Chrome MCP: filter-only and parameter-only previews have no orphan divider
- [x] Manual Chrome MCP: collapse/expand and stable `ld-dashboard-*` hooks
