### PR TITLE
fix(ai): use nullish instead of nullable for skill resourceName

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -3897,7 +3897,6 @@ Parameters:
       },
       "required": [
         "name",
-        "resourceName",
       ],
       "type": "object",
     },

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolLoadSkillArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolLoadSkillArgs.ts
@@ -12,7 +12,7 @@ export const toolLoadSkillArgsSchema = z.object({
     resourceName: z
         .string()
         .min(1)
-        .nullable()
+        .nullish()
         .describe(
             'Optional sub-resource file name to load from the skill. You can find names of sub-resources by first loading the skill without this parameter.',
         ),


### PR DESCRIPTION
## Description

`loadSkill` tool calls that omit `resourceName` fail Zod validation (`expected string, received undefined`) — the schema declared it `.nullable()` (key required, value may be null) while the field description tells the model it's optional and to "first load the skill without this parameter". Claude models omit optional keys routinely: 516 events / 248 users since Jun 18 in Sentry ([LIGHTDASH-BACKEND-CZX](https://lightdash.sentry.io/issues/LIGHTDASH-BACKEND-CZX)). The agent self-corrects on retry, but each occurrence wastes a step and emits Sentry noise.

Change `resourceName` to `.nullish()` — accepts omitted, `null`, and string. Not plain `.optional()`: models also send explicit `null` (verified GPT-5.4 does), which `.optional()` alone would reject.

Backwards compatible: strictly more permissive; all historical stored tool args still validate, and the emitted JSON schema only drops `resourceName` from `required` (tools are sent non-strict to all providers).

## Testing

- Local browser test: GPT-5.4 thread on the seeded project asking a question that triggers `developing-in-lightdash` — `loadSkill` called twice (`"resourceName": null`, then a real resource name), both succeeded, zero rows in `ai_agent_tool_call_error`.
- `common` + `backend` typecheck.

Closes: ZAP-828

🤖 Generated with [Claude Code](https://claude.com/claude-code)
