### PR TITLE
feat(frontend): redesign toasts

### DIFF
--- a/packages/frontend/.storybook/preview.tsx
+++ b/packages/frontend/.storybook/preview.tsx
@@ -5,6 +5,7 @@ import '@mantine/notifications/styles.css';
 import '@mantine/tiptap/styles.css';
 import '../src/styles/global.css';
 import { ActionIcon, Group } from '@mantine/core';
+import { ModalsProvider } from '@mantine/modals';
 import { IconMoon, IconSun } from '@tabler/icons-react';
 import React from 'react';
 import { useAppColorScheme } from '../src/providers/ColorSchemeContext';
@@ -45,8 +46,10 @@ const ThemeToggle = () => {
 const ThemeWrapper = (props: { children: React.ReactNode }) => {
     return (
         <MantineProvider>
-            <ThemeToggle />
-            {props.children}
+            <ModalsProvider>
+                <ThemeToggle />
+                {props.children}
+            </ModalsProvider>
         </MantineProvider>
     );
 };

--- a/packages/frontend/src/components/VersionAutoUpdater/VersionAutoUpdater.tsx
+++ b/packages/frontend/src/components/VersionAutoUpdater/VersionAutoUpdater.tsx
@@ -5,7 +5,7 @@ import useToaster from '../../hooks/toaster/useToaster';
 
 const VersionAutoUpdater: FC = () => {
     const [version, setVersion] = useState<string>();
-    const { showToastPrimary } = useToaster();
+    const { showToastInfo } = useToaster();
     const { data: healthData } = useHealth({
         refetchInterval: 1200000, // 20 minutes in milliseconds
     });
@@ -15,7 +15,7 @@ const VersionAutoUpdater: FC = () => {
             if (!version) {
                 setVersion(healthData.version);
             } else if (version !== healthData.version) {
-                showToastPrimary({
+                showToastInfo({
                     key: 'new-version-available',
                     autoClose: false,
                     title: 'A new version of Lightdash is ready for you!',
@@ -27,7 +27,7 @@ const VersionAutoUpdater: FC = () => {
                 });
             }
         }
-    }, [version, healthData, showToastPrimary]);
+    }, [version, healthData, showToastInfo]);
 
     return null;
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
@@ -139,6 +139,13 @@ const AiAgentAdminAgentsTable = () => {
         return new Map(projects.map((p) => [p.projectUuid, p]));
     }, [projects]);
 
+    const slackChannelNamesById = useMemo(() => {
+        if (!slackChannels) return new Map<string, string>();
+        return new Map(
+            slackChannels.map((channel) => [channel.id, channel.name]),
+        );
+    }, [slackChannels]);
+
     // Filter agents based on search and project selection
     const filteredAgents = useMemo(() => {
         if (!agents) return [];
@@ -177,7 +184,24 @@ const AiAgentAdminAgentsTable = () => {
                     agent.tags?.some((tag) =>
                         tag.toLowerCase().includes(searchLower),
                     ) || false;
-                return nameMatch || projectMatch || tagsMatch;
+                const slackChannelMatch = agent.integrations.some(
+                    (integration) => {
+                        if (integration.type !== 'slack') return false;
+                        const channelName =
+                            slackChannelNamesById.get(integration.channelId) ??
+                            '';
+                        // Unresolved channels render as #<id>, so match the id with the prefix too
+                        return (
+                            channelName.toLowerCase().includes(searchLower) ||
+                            `#${integration.channelId}`
+                                .toLowerCase()
+                                .includes(searchLower)
+                        );
+                    },
+                );
+                return (
+                    nameMatch || projectMatch || tagsMatch || slackChannelMatch
+                );
             });
         }
 
@@ -188,6 +212,7 @@ const AiAgentAdminAgentsTable = () => {
         deferredSearch,
         projectsMap,
         hidePreviewProjects,
+        slackChannelNamesById,
     ]);
 
     const hasActiveFilters =

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
@@ -139,13 +139,6 @@ const AiAgentAdminAgentsTable = () => {
         return new Map(projects.map((p) => [p.projectUuid, p]));
     }, [projects]);
 
-    const slackChannelNamesById = useMemo(() => {
-        if (!slackChannels) return new Map<string, string>();
-        return new Map(
-            slackChannels.map((channel) => [channel.id, channel.name]),
-        );
-    }, [slackChannels]);
-
     // Filter agents based on search and project selection
     const filteredAgents = useMemo(() => {
         if (!agents) return [];
@@ -184,24 +177,7 @@ const AiAgentAdminAgentsTable = () => {
                     agent.tags?.some((tag) =>
                         tag.toLowerCase().includes(searchLower),
                     ) || false;
-                const slackChannelMatch = agent.integrations.some(
-                    (integration) => {
-                        if (integration.type !== 'slack') return false;
-                        const channelName =
-                            slackChannelNamesById.get(integration.channelId) ??
-                            '';
-                        // Unresolved channels render as #<id>, so match the id with the prefix too
-                        return (
-                            channelName.toLowerCase().includes(searchLower) ||
-                            `#${integration.channelId}`
-                                .toLowerCase()
-                                .includes(searchLower)
-                        );
-                    },
-                );
-                return (
-                    nameMatch || projectMatch || tagsMatch || slackChannelMatch
-                );
+                return nameMatch || projectMatch || tagsMatch;
             });
         }
 
@@ -212,7 +188,6 @@ const AiAgentAdminAgentsTable = () => {
         deferredSearch,
         projectsMap,
         hidePreviewProjects,
-        slackChannelNamesById,
     ]);
 
     const hasActiveFilters =

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.module.css
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.module.css
@@ -1,3 +1,7 @@
+.message {
+    white-space: pre-wrap;
+}
+
 .code {
     background: light-dark(
         color-mix(in srgb, var(--mantine-color-ldGray-5) 20%, transparent),

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.module.css
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.module.css
@@ -1,0 +1,6 @@
+.code {
+    background: light-dark(
+        color-mix(in srgb, var(--mantine-color-ldGray-5) 20%, transparent),
+        color-mix(in srgb, var(--mantine-color-ldGray-6) 40%, transparent)
+    );
+}

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.module.css
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.module.css
@@ -1,5 +1,18 @@
-.message {
+.clampedMessage {
+    display: -webkit-box;
+    -webkit-line-clamp: 6;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
     white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.expandedMessage {
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-y: auto;
+    max-height: calc(100vh - 320px);
+    scrollbar-width: thin;
 }
 
 .code {

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -26,7 +26,7 @@ import styles from './ApiErrorDisplay.module.css';
 
 const LIGHTDASH_SDK_VERSION_LOCAL_STORAGE_KEY = '__lightdash_sdk_version';
 
-const CopyErrorButton = ({
+export const CopyErrorButton = ({
     value,
     color,
 }: {
@@ -41,7 +41,8 @@ const CopyErrorButton = ({
                 position="right"
             >
                 <ActionIcon
-                    color="gray"
+                    aria-label="Copy error details"
+                    color="ldGray.6"
                     size="xs"
                     onClick={copy}
                     variant="transparent"
@@ -77,7 +78,11 @@ const GoogleSheetsReauthMessage = ({ message }: { message: string }) => {
 const ApiErrorDisplayStatic = ({ apiError }: { apiError: ApiErrorDetail }) => {
     switch (apiError.name) {
         case 'GoogleSheetsScopeError':
-            return <span>{apiError.message}</span>;
+            return (
+                <Text mb={0} fz="xs">
+                    {apiError.message}
+                </Text>
+            );
         default:
             break;
     }
@@ -85,7 +90,7 @@ const ApiErrorDisplayStatic = ({ apiError }: { apiError: ApiErrorDetail }) => {
     if (apiError.sentryEventId || apiError.sentryTraceId) {
         return (
             <Stack gap="xxs">
-                <Text mb={0} fz="xs" style={{ whiteSpace: 'pre-wrap' }}>
+                <Text mb={0} fz="xs" className={styles.message}>
                     {apiError.message}
                 </Text>
                 <Text mb={0} fz="xs" fw="bold">
@@ -107,7 +112,7 @@ const ApiErrorDisplayStatic = ({ apiError }: { apiError: ApiErrorDetail }) => {
                         value={`${apiError.message}\nError ID: ${
                             apiError.sentryEventId || 'n/a'
                         }\nTrace ID: ${apiError.sentryTraceId || 'n/a'}`}
-                        color="gray.7"
+                        color="ldGray.7"
                     />
                 </Group>
             </Stack>
@@ -115,7 +120,7 @@ const ApiErrorDisplayStatic = ({ apiError }: { apiError: ApiErrorDetail }) => {
     }
 
     return (
-        <Text mb={0} fz="xs" style={{ whiteSpace: 'pre-wrap' }}>
+        <Text mb={0} fz="xs" className={styles.message}>
             {apiError.message}
         </Text>
     );
@@ -182,7 +187,7 @@ const ApiErrorDisplayWithHealth = ({
         if (showSupportButton) {
             return (
                 <Stack gap="xxs" align="start">
-                    <Text mb={0} fz="xs" style={{ whiteSpace: 'pre-wrap' }}>
+                    <Text mb={0} fz="xs" className={styles.message}>
                         {apiError.message}
                     </Text>
                     <Group gap="xs">
@@ -218,7 +223,7 @@ const ApiErrorDisplayWithHealth = ({
         // Self-hosted: show IDs with copy button
         return (
             <Stack gap="xxs">
-                <Text mb={0} fz="xs" style={{ whiteSpace: 'pre-wrap' }}>
+                <Text mb={0} fz="xs" className={styles.message}>
                     {apiError.message}
                 </Text>
                 <Text mb={0} fz="xs" fw="bold">
@@ -240,7 +245,7 @@ const ApiErrorDisplayWithHealth = ({
                         value={`${apiError.message}\nError ID: ${
                             apiError.sentryEventId || 'n/a'
                         }\nTrace ID: ${apiError.sentryTraceId || 'n/a'}`}
-                        color={isDark ? 'white' : 'gray.7'}
+                        color={isDark ? 'foreground.0' : 'ldGray.7'}
                     />
                 </Group>
             </Stack>
@@ -248,7 +253,7 @@ const ApiErrorDisplayWithHealth = ({
     }
 
     return (
-        <Text mb={0} fz="xs" style={{ whiteSpace: 'pre-wrap' }}>
+        <Text mb={0} fz="xs" className={styles.message}>
             {apiError.message}
         </Text>
     );

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -1,13 +1,14 @@
 import { LightdashMode, type ApiErrorDetail } from '@lightdash/common';
 import {
-    CopyButton,
-    Group,
-    Stack,
-    Text,
-    Button,
     ActionIcon,
     Anchor,
+    Button,
+    Code,
+    CopyButton,
+    Group,
     Modal,
+    Stack,
+    Text,
     Tooltip,
     useComputedColorScheme,
 } from '@mantine/core';
@@ -21,6 +22,7 @@ import SupportDrawerContent from '../../providers/SupportDrawer/SupportDrawerCon
 import { getFromInMemoryStorage } from '../../utils/inMemoryStorage';
 import { useGoogleLoginPopup } from '../gdrive/useGdrive';
 import useHealth from '../health/useHealth';
+import styles from './ApiErrorDisplay.module.css';
 
 const LIGHTDASH_SDK_VERSION_LOCAL_STORAGE_KEY = '__lightdash_sdk_version';
 
@@ -91,9 +93,15 @@ const ApiErrorDisplayStatic = ({ apiError }: { apiError: ApiErrorDetail }) => {
                 </Text>
                 <Group gap="xxs" align="flex-start">
                     <Text mb={0} fz="xs" fw="bold">
-                        Error ID: {apiError.sentryEventId || 'n/a'}
+                        Error ID:{' '}
+                        <Code fz="xs" className={styles.code}>
+                            {apiError.sentryEventId || 'n/a'}
+                        </Code>
                         <br />
-                        Trace ID: {apiError.sentryTraceId || 'n/a'}
+                        Trace ID:{' '}
+                        <Code fz="xs" className={styles.code}>
+                            {apiError.sentryTraceId || 'n/a'}
+                        </Code>
                     </Text>
                     <CopyErrorButton
                         value={`${apiError.message}\nError ID: ${
@@ -174,24 +182,15 @@ const ApiErrorDisplayWithHealth = ({
         if (showSupportButton) {
             return (
                 <Stack gap="xxs" align="start">
-                    <Text
-                        mb={0}
-                        fz="xs"
-                        c="red.6"
-                        style={{ whiteSpace: 'pre-wrap' }}
-                    >
+                    <Text mb={0} fz="xs" style={{ whiteSpace: 'pre-wrap' }}>
                         {apiError.message}
                     </Text>
                     <Group gap="xs">
                         <Button
                             size="compact-xs"
-                            variant="outline"
-                            color="red.6"
+                            variant="default"
                             leftSection={
-                                <MantineIcon
-                                    color="red.6"
-                                    icon={IconSpeakerphone}
-                                />
+                                <MantineIcon icon={IconSpeakerphone} />
                             }
                             onClick={() => {
                                 modals.open({
@@ -203,15 +202,13 @@ const ApiErrorDisplayWithHealth = ({
                                 });
                             }}
                         >
-                            <Text fz="xs" c="red.6" fw="lighter">
-                                Notify support
-                            </Text>
+                            <Text fz="xs">Notify support</Text>
                         </Button>
                         <CopyErrorButton
                             value={`${apiError.message}\nError ID: ${
                                 apiError.sentryEventId || 'n/a'
                             }\nTrace ID: ${apiError.sentryTraceId || 'n/a'}`}
-                            color="red.6"
+                            color="ldGray.6"
                         />
                     </Group>
                 </Stack>
@@ -229,9 +226,15 @@ const ApiErrorDisplayWithHealth = ({
                 </Text>
                 <Group gap="xxs" align="flex-start">
                     <Text mb={0} fz="xs" fw="bold">
-                        Error ID: {apiError.sentryEventId || 'n/a'}
+                        Error ID:{' '}
+                        <Code fz="xs" className={styles.code}>
+                            {apiError.sentryEventId || 'n/a'}
+                        </Code>
                         <br />
-                        Trace ID: {apiError.sentryTraceId || 'n/a'}
+                        Trace ID:{' '}
+                        <Code fz="xs" className={styles.code}>
+                            {apiError.sentryTraceId || 'n/a'}
+                        </Code>
                     </Text>
                     <CopyErrorButton
                         value={`${apiError.message}\nError ID: ${

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -15,7 +15,7 @@ import {
 import { modals } from '@mantine/modals';
 import { IconCheck, IconCopy, IconSpeakerphone } from '@tabler/icons-react';
 import { defaultContext } from '@tanstack/react-query';
-import { useContext } from 'react';
+import { useContext, useLayoutEffect, useRef, useState } from 'react';
 import MantineIcon from '../../components/common/MantineIcon';
 import { SnowflakeFormInput } from '../../components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs';
 import SupportDrawerContent from '../../providers/SupportDrawer/SupportDrawerContent';
@@ -23,8 +23,81 @@ import { getFromInMemoryStorage } from '../../utils/inMemoryStorage';
 import { useGoogleLoginPopup } from '../gdrive/useGdrive';
 import useHealth from '../health/useHealth';
 import styles from './ApiErrorDisplay.module.css';
+import { errorClipboardValue } from './errorClipboardValue';
 
 const LIGHTDASH_SDK_VERSION_LOCAL_STORAGE_KEY = '__lightdash_sdk_version';
+
+/** Clamped toast message; when the message overflows the clamp it can be
+ *  expanded in place — the toast root grows in width and height via the
+ *  [data-toast-expanded] hook in useToaster.module.css. */
+const ErrorMessage = ({
+    apiError,
+    withCopy = true,
+    defaultExpanded = false,
+}: {
+    apiError: ApiErrorDetail;
+    withCopy?: boolean;
+    defaultExpanded?: boolean;
+}) => {
+    const messageRef = useRef<HTMLParagraphElement>(null);
+    const [isClamped, setIsClamped] = useState(false);
+    const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+    useLayoutEffect(() => {
+        if (isExpanded) return;
+        const el = messageRef.current;
+        if (!el) return;
+        // Modern line-clamp collapses the clipped lines out of layout, so
+        // scrollHeight can't detect truncation; measure an unclamped clone.
+        const clone = el.cloneNode(true) as HTMLElement;
+        clone.style.setProperty('-webkit-line-clamp', 'unset');
+        clone.style.setProperty('line-clamp', 'unset');
+        clone.style.setProperty('display', 'block');
+        clone.style.setProperty('overflow', 'visible');
+        clone.style.setProperty('position', 'absolute');
+        clone.style.setProperty('visibility', 'hidden');
+        clone.style.setProperty('width', `${el.clientWidth}px`);
+        el.parentElement?.appendChild(clone);
+        setIsClamped(clone.scrollHeight > el.clientHeight + 1);
+        clone.remove();
+    }, [apiError.message, isExpanded]);
+
+    return (
+        <>
+            <Text
+                ref={messageRef}
+                mb={0}
+                fz="xs"
+                data-toast-expanded={isExpanded || undefined}
+                className={
+                    isExpanded ? styles.expandedMessage : styles.clampedMessage
+                }
+            >
+                {apiError.message}
+            </Text>
+            {(isClamped || isExpanded) && (
+                <Group gap="xs">
+                    <Anchor
+                        component="button"
+                        type="button"
+                        fz="xs"
+                        c="ldGray.7"
+                        underline="always"
+                        onClick={() => setIsExpanded(!isExpanded)}
+                    >
+                        {isExpanded ? 'Show less' : 'View full error'}
+                    </Anchor>
+                    {withCopy && (
+                        <CopyErrorButton
+                            value={errorClipboardValue(apiError)}
+                            color="ldGray.7"
+                        />
+                    )}
+                </Group>
+            )}
+        </>
+    );
+};
 
 export const CopyErrorButton = ({
     value,
@@ -75,7 +148,13 @@ const GoogleSheetsReauthMessage = ({ message }: { message: string }) => {
     );
 };
 
-const ApiErrorDisplayStatic = ({ apiError }: { apiError: ApiErrorDetail }) => {
+const ApiErrorDisplayStatic = ({
+    apiError,
+    defaultExpanded,
+}: {
+    apiError: ApiErrorDetail;
+    defaultExpanded?: boolean;
+}) => {
     switch (apiError.name) {
         case 'GoogleSheetsScopeError':
             return (
@@ -90,9 +169,11 @@ const ApiErrorDisplayStatic = ({ apiError }: { apiError: ApiErrorDetail }) => {
     if (apiError.sentryEventId || apiError.sentryTraceId) {
         return (
             <Stack gap="xxs">
-                <Text mb={0} fz="xs" className={styles.message}>
-                    {apiError.message}
-                </Text>
+                <ErrorMessage
+                    apiError={apiError}
+                    withCopy={false}
+                    defaultExpanded={defaultExpanded}
+                />
                 <Text mb={0} fz="xs" fw="bold">
                     Contact support with the following information:
                 </Text>
@@ -109,9 +190,7 @@ const ApiErrorDisplayStatic = ({ apiError }: { apiError: ApiErrorDetail }) => {
                         </Code>
                     </Text>
                     <CopyErrorButton
-                        value={`${apiError.message}\nError ID: ${
-                            apiError.sentryEventId || 'n/a'
-                        }\nTrace ID: ${apiError.sentryTraceId || 'n/a'}`}
+                        value={errorClipboardValue(apiError)}
                         color="ldGray.7"
                     />
                 </Group>
@@ -120,18 +199,18 @@ const ApiErrorDisplayStatic = ({ apiError }: { apiError: ApiErrorDetail }) => {
     }
 
     return (
-        <Text mb={0} fz="xs" className={styles.message}>
-            {apiError.message}
-        </Text>
+        <ErrorMessage apiError={apiError} defaultExpanded={defaultExpanded} />
     );
 };
 
 const ApiErrorDisplayWithHealth = ({
     apiError,
     onClose,
+    defaultExpanded,
 }: {
     apiError: ApiErrorDetail;
     onClose?: () => void;
+    defaultExpanded?: boolean;
 }) => {
     const isDark = useComputedColorScheme() === 'dark';
     const health = useHealth();
@@ -187,9 +266,11 @@ const ApiErrorDisplayWithHealth = ({
         if (showSupportButton) {
             return (
                 <Stack gap="xxs" align="start">
-                    <Text mb={0} fz="xs" className={styles.message}>
-                        {apiError.message}
-                    </Text>
+                    <ErrorMessage
+                        apiError={apiError}
+                        withCopy={false}
+                        defaultExpanded={defaultExpanded}
+                    />
                     <Group gap="xs">
                         <Button
                             size="compact-xs"
@@ -210,9 +291,7 @@ const ApiErrorDisplayWithHealth = ({
                             <Text fz="xs">Notify support</Text>
                         </Button>
                         <CopyErrorButton
-                            value={`${apiError.message}\nError ID: ${
-                                apiError.sentryEventId || 'n/a'
-                            }\nTrace ID: ${apiError.sentryTraceId || 'n/a'}`}
+                            value={errorClipboardValue(apiError)}
                             color="ldGray.6"
                         />
                     </Group>
@@ -223,9 +302,11 @@ const ApiErrorDisplayWithHealth = ({
         // Self-hosted: show IDs with copy button
         return (
             <Stack gap="xxs">
-                <Text mb={0} fz="xs" className={styles.message}>
-                    {apiError.message}
-                </Text>
+                <ErrorMessage
+                    apiError={apiError}
+                    withCopy={false}
+                    defaultExpanded={defaultExpanded}
+                />
                 <Text mb={0} fz="xs" fw="bold">
                     Contact support with the following information:
                 </Text>
@@ -242,9 +323,7 @@ const ApiErrorDisplayWithHealth = ({
                         </Code>
                     </Text>
                     <CopyErrorButton
-                        value={`${apiError.message}\nError ID: ${
-                            apiError.sentryEventId || 'n/a'
-                        }\nTrace ID: ${apiError.sentryTraceId || 'n/a'}`}
+                        value={errorClipboardValue(apiError)}
                         color={isDark ? 'foreground.0' : 'ldGray.7'}
                     />
                 </Group>
@@ -253,18 +332,18 @@ const ApiErrorDisplayWithHealth = ({
     }
 
     return (
-        <Text mb={0} fz="xs" className={styles.message}>
-            {apiError.message}
-        </Text>
+        <ErrorMessage apiError={apiError} defaultExpanded={defaultExpanded} />
     );
 };
 
 const ApiErrorDisplay = ({
     apiError,
     onClose,
+    defaultExpanded,
 }: {
     apiError: ApiErrorDetail;
     onClose?: () => void;
+    defaultExpanded?: boolean;
 }) => {
     const queryClient = useContext(defaultContext);
     const isSdk =
@@ -273,10 +352,21 @@ const ApiErrorDisplay = ({
         ) !== undefined;
 
     if (isSdk || !queryClient) {
-        return <ApiErrorDisplayStatic apiError={apiError} />;
+        return (
+            <ApiErrorDisplayStatic
+                apiError={apiError}
+                defaultExpanded={defaultExpanded}
+            />
+        );
     }
 
-    return <ApiErrorDisplayWithHealth apiError={apiError} onClose={onClose} />;
+    return (
+        <ApiErrorDisplayWithHealth
+            apiError={apiError}
+            onClose={onClose}
+            defaultExpanded={defaultExpanded}
+        />
+    );
 };
 
 export default ApiErrorDisplay;

--- a/packages/frontend/src/hooks/toaster/MultipleToastBody.module.css
+++ b/packages/frontend/src/hooks/toaster/MultipleToastBody.module.css
@@ -1,80 +1,81 @@
-.errorsTitle {
-    color: var(--mantine-color-red-9);
-
-    @mixin dark {
-        color: var(--mantine-color-red-4);
-    }
+.newestMessage {
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-7)
+    );
+    font-size: 13px;
+    line-height: 18px;
 }
 
-.toggleButton {
-    background-color: var(--mantine-color-red-1);
-    border: 1px solid var(--mantine-color-red-2);
-
-    @mixin dark {
-        background-color: color-mix(
-            in srgb,
-            var(--mantine-color-red-9) 40%,
-            black
-        );
-        border-color: var(--mantine-color-red-9);
-    }
-}
-
-.toggleButtonText {
-    font-size: var(--mantine-font-size-xs);
-    color: var(--mantine-color-red-9);
-
-    @mixin dark {
-        color: var(--mantine-color-red-1);
-    }
-}
-
-.collapseContainer {
-    max-height: 155px;
-    overflow: auto;
-    display: flex;
-    flex-direction: column;
-}
-
-.errorItem {
-    width: 100%;
-    border: 1px solid var(--mantine-color-red-2);
-    border-radius: var(--mantine-radius-md);
-    padding: var(--mantine-spacing-xs);
-    background-color: var(--mantine-color-red-0);
-
-    @mixin dark {
-        border-color: var(--mantine-color-red-9);
-        background-color: color-mix(
-            in srgb,
-            var(--mantine-color-red-9) 30%,
-            black
-        );
-    }
-}
-
-.errorItemTitle {
-    color: var(--mantine-color-red-9);
-
-    @mixin dark {
-        color: var(--mantine-color-red-2);
-    }
-}
-
-.markdownPreview {
+.markdown {
     background-color: transparent;
-    color: var(--mantine-color-red-9);
-    font-size: 12px;
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-7)
+    );
+    font-size: 13px;
+    line-height: 18px;
+}
 
-    @mixin dark {
-        color: var(--mantine-color-red-2);
+.toggle {
+    align-self: flex-start;
+    margin-top: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: -0.15px;
+    color: light-dark(var(--mantine-color-red-9), var(--mantine-color-red-3));
+
+    &:hover {
+        text-decoration: underline;
     }
 }
 
-.closeButton {
-    color: var(--mantine-color-red-9);
+.olderList {
+    margin-top: 6px;
+    max-height: 180px;
+    overflow: auto;
+    scrollbar-width: thin;
+    scrollbar-color: light-dark(
+            color-mix(in srgb, var(--mantine-color-red-8) 30%, transparent),
+            color-mix(in srgb, var(--mantine-color-red-5) 35%, transparent)
+        )
+        transparent;
+    border-top: 1px solid
+        light-dark(
+            color-mix(in srgb, var(--mantine-color-red-8) 14%, transparent),
+            color-mix(in srgb, var(--mantine-color-red-5) 20%, transparent)
+        );
+}
 
-    @mixin dark {
-        color: var(--mantine-color-red-4);
-    }
+.olderItem {
+    padding: 8px 0;
+}
+
+.olderItem:not(:last-child) {
+    border-bottom: 1px solid
+        light-dark(
+            color-mix(in srgb, var(--mantine-color-red-8) 10%, transparent),
+            color-mix(in srgb, var(--mantine-color-red-5) 14%, transparent)
+        );
+}
+
+.olderMessage {
+    flex: 1;
+    min-width: 0;
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-7)
+    );
+    font-size: 13px;
+    line-height: 18px;
+}
+
+.olderTime {
+    flex: none;
+    font-size: 12px;
+    color: light-dark(
+        var(--mantine-color-ldGray-5),
+        var(--mantine-color-ldGray-6)
+    );
+    font-variant-numeric: tabular-nums;
 }

--- a/packages/frontend/src/hooks/toaster/MultipleToastBody.module.css
+++ b/packages/frontend/src/hooks/toaster/MultipleToastBody.module.css
@@ -1,20 +1,18 @@
 .newestMessage {
-    color: light-dark(
-        var(--mantine-color-ldGray-6),
-        var(--mantine-color-ldGray-7)
-    );
+    color: var(--mantine-color-ldGray-7);
     font-size: 13px;
     line-height: 18px;
 }
 
 .markdown {
     background-color: transparent;
-    color: light-dark(
-        var(--mantine-color-ldGray-6),
-        var(--mantine-color-ldGray-7)
-    );
+    color: var(--mantine-color-ldGray-7);
     font-size: 13px;
     line-height: 18px;
+
+    & :global(p) {
+        margin: 0;
+    }
 }
 
 .toggle {
@@ -62,10 +60,7 @@
 .olderMessage {
     flex: 1;
     min-width: 0;
-    color: light-dark(
-        var(--mantine-color-ldGray-6),
-        var(--mantine-color-ldGray-7)
-    );
+    color: var(--mantine-color-ldGray-7);
     font-size: 13px;
     line-height: 18px;
 }
@@ -73,9 +68,18 @@
 .olderTime {
     flex: none;
     font-size: 12px;
-    color: light-dark(
-        var(--mantine-color-ldGray-5),
-        var(--mantine-color-ldGray-6)
-    );
+    color: var(--mantine-color-ldGray-7);
     font-variant-numeric: tabular-nums;
+}
+
+.olderDismiss {
+    flex: none;
+    color: var(--mantine-color-ldGray-6);
+
+    &:hover {
+        color: light-dark(
+            var(--mantine-color-red-9),
+            var(--mantine-color-red-3)
+        );
+    }
 }

--- a/packages/frontend/src/hooks/toaster/MultipleToastBody.tsx
+++ b/packages/frontend/src/hooks/toaster/MultipleToastBody.tsx
@@ -1,15 +1,26 @@
-import { Box, Collapse, Group, Stack, UnstyledButton } from '@mantine/core';
+import {
+    ActionIcon,
+    Box,
+    Collapse,
+    Group,
+    Stack,
+    UnstyledButton,
+} from '@mantine/core';
+import { IconX } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { useState } from 'react';
 import rehypeExternalLinks from 'rehype-external-links';
-import ApiErrorDisplay from './ApiErrorDisplay';
+import MantineIcon from '../../components/common/MantineIcon';
+import ApiErrorDisplay, { CopyErrorButton } from './ApiErrorDisplay';
 import styles from './MultipleToastBody.module.css';
 import { type NotificationData } from './types';
 
 const MultipleToastBody = ({
     toastsData,
+    onDismissError,
 }: {
     toastsData: NotificationData[];
+    onDismissError?: (messageKey: string) => void;
 }) => {
     const [expanded, setExpanded] = useState(false);
     const newest = toastsData[toastsData.length - 1];
@@ -17,10 +28,6 @@ const MultipleToastBody = ({
 
     return (
         <Stack gap={0} align="stretch">
-            {!expanded && older.length > 0 && (
-                <Box data-toast-peek-marker={older.length} />
-            )}
-
             {newest.apiError ? (
                 <ApiErrorDisplay apiError={newest.apiError} />
             ) : typeof newest.subtitle === 'string' ? (
@@ -48,27 +55,82 @@ const MultipleToastBody = ({
 
                     <Collapse in={expanded}>
                         <Box className={styles.olderList}>
-                            {older.map((toastData) => (
-                                <Group
-                                    key={toastData.messageKey}
-                                    className={styles.olderItem}
-                                    gap={12}
-                                    align="baseline"
-                                    wrap="nowrap"
-                                >
-                                    <Box className={styles.olderMessage}>
-                                        {toastData.apiError
-                                            ? toastData.apiError.message
-                                            : toastData.subtitle ||
-                                              toastData.title}
-                                    </Box>
-                                    {toastData.receivedAt && (
-                                        <Box className={styles.olderTime}>
-                                            {toastData.receivedAt}
+                            {older.map((toastData) => {
+                                const { messageKey } = toastData;
+                                const olderText = toastData.apiError
+                                    ? toastData.apiError.message
+                                    : toastData.subtitle || toastData.title;
+
+                                return (
+                                    <Group
+                                        key={toastData.messageKey}
+                                        className={styles.olderItem}
+                                        gap={12}
+                                        align="flex-start"
+                                        wrap="nowrap"
+                                    >
+                                        <Box className={styles.olderMessage}>
+                                            {typeof olderText === 'string' ? (
+                                                <MarkdownPreview
+                                                    className={styles.markdown}
+                                                    source={olderText}
+                                                    rehypePlugins={[
+                                                        [
+                                                            rehypeExternalLinks,
+                                                            {
+                                                                target: '_blank',
+                                                            },
+                                                        ],
+                                                    ]}
+                                                />
+                                            ) : (
+                                                olderText
+                                            )}
                                         </Box>
-                                    )}
-                                </Group>
-                            ))}
+                                        {toastData.receivedAt && (
+                                            <Box className={styles.olderTime}>
+                                                {toastData.receivedAt}
+                                            </Box>
+                                        )}
+                                        {toastData.apiError &&
+                                            (toastData.apiError.sentryEventId ||
+                                                toastData.apiError
+                                                    .sentryTraceId) && (
+                                                <CopyErrorButton
+                                                    value={`${
+                                                        toastData.apiError
+                                                            .message
+                                                    }\nError ID: ${
+                                                        toastData.apiError
+                                                            .sentryEventId ||
+                                                        'n/a'
+                                                    }\nTrace ID: ${
+                                                        toastData.apiError
+                                                            .sentryTraceId ||
+                                                        'n/a'
+                                                    }`}
+                                                    color="ldGray.7"
+                                                />
+                                            )}
+                                        {onDismissError && messageKey && (
+                                            <ActionIcon
+                                                aria-label="Dismiss error"
+                                                className={styles.olderDismiss}
+                                                size="xs"
+                                                variant="transparent"
+                                                onClick={() =>
+                                                    onDismissError(messageKey)
+                                                }
+                                            >
+                                                <MantineIcon
+                                                    icon={IconX}
+                                                    size={14}
+                                                />
+                                            </ActionIcon>
+                                        )}
+                                    </Group>
+                                );
+                            })}
                         </Box>
                     </Collapse>
                 </>

--- a/packages/frontend/src/hooks/toaster/MultipleToastBody.tsx
+++ b/packages/frontend/src/hooks/toaster/MultipleToastBody.tsx
@@ -1,122 +1,78 @@
-import {
-    ActionIcon,
-    Box,
-    Button,
-    Collapse,
-    Group,
-    Stack,
-    Text,
-    Title,
-    useMantineColorScheme,
-} from '@mantine/core';
-import { IconChevronDown, IconChevronUp, IconX } from '@tabler/icons-react';
+import { Box, Collapse, Group, Stack, UnstyledButton } from '@mantine/core';
 import MarkdownPreview from '@uiw/react-markdown-preview';
-import { useState, type ReactNode } from 'react';
+import { useState } from 'react';
 import rehypeExternalLinks from 'rehype-external-links';
-import MantineIcon from '../../components/common/MantineIcon';
 import ApiErrorDisplay from './ApiErrorDisplay';
 import styles from './MultipleToastBody.module.css';
 import { type NotificationData } from './types';
 
 const MultipleToastBody = ({
     toastsData,
-    onCloseError,
 }: {
-    title?: ReactNode;
     toastsData: NotificationData[];
-    onCloseError?: (errorData: NotificationData) => void;
 }) => {
-    const { colorScheme } = useMantineColorScheme();
-    const isDark = colorScheme === 'dark';
-    const [listCollapsed, setListCollapsed] = useState(true);
+    const [expanded, setExpanded] = useState(false);
+    const newest = toastsData[toastsData.length - 1];
+    const older = toastsData.slice(0, -1).reverse();
 
     return (
-        <Stack gap={listCollapsed ? 'two' : 'xs'} align="stretch">
-            <Group>
-                <Title className={styles.errorsTitle} order={6}>
-                    Errors
-                </Title>
-                <Button
-                    className={styles.toggleButton}
-                    size="compact-xs"
-                    variant="outline"
-                    color={isDark ? 'red.4' : 'red.8'}
-                    rightSection={
-                        <MantineIcon
-                            color={isDark ? 'red.4' : 'red.8'}
-                            icon={
-                                listCollapsed ? IconChevronUp : IconChevronDown
-                            }
-                        />
-                    }
-                    onClick={() => setListCollapsed(!listCollapsed)}
-                >
-                    <Text className={styles.toggleButtonText}>{`${
-                        listCollapsed ? 'Show' : 'Hide'
-                    } ${toastsData.length}`}</Text>
-                </Button>
-            </Group>
+        <Stack gap={0} align="stretch">
+            {!expanded && older.length > 0 && (
+                <Box data-toast-peek-marker={older.length} />
+            )}
 
-            <Box className={styles.collapseContainer}>
-                <Collapse in={!listCollapsed}>
-                    <Stack gap="xs" pb="sm">
-                        {toastsData.map((toastData, index) => (
-                            <Group
-                                className={styles.errorItem}
-                                key={`${toastData.subtitle}-${index}`}
-                                justify="space-between"
-                                gap="xxs"
-                                wrap="nowrap"
-                            >
-                                {toastData.apiError ? (
-                                    <ApiErrorDisplay
-                                        apiError={toastData.apiError}
-                                        onClose={() =>
-                                            onCloseError?.(toastData)
-                                        }
-                                    />
-                                ) : (
-                                    <>
-                                        {toastData.title && (
-                                            <Title
-                                                className={
-                                                    styles.errorItemTitle
-                                                }
-                                                order={6}
-                                            >
-                                                {toastData.title}
-                                            </Title>
-                                        )}
-                                        {toastData.subtitle && (
-                                            <MarkdownPreview
-                                                className={
-                                                    styles.markdownPreview
-                                                }
-                                                source={toastData.subtitle.toString()}
-                                                rehypePlugins={[
-                                                    [
-                                                        rehypeExternalLinks,
-                                                        { target: '_blank' },
-                                                    ],
-                                                ]}
-                                            />
-                                        )}
-                                    </>
-                                )}
+            {newest.apiError ? (
+                <ApiErrorDisplay apiError={newest.apiError} />
+            ) : typeof newest.subtitle === 'string' ? (
+                <MarkdownPreview
+                    className={styles.markdown}
+                    source={newest.subtitle}
+                    rehypePlugins={[
+                        [rehypeExternalLinks, { target: '_blank' }],
+                    ]}
+                />
+            ) : (
+                <Box className={styles.newestMessage}>
+                    {newest.subtitle || newest.title}
+                </Box>
+            )}
 
-                                <ActionIcon
-                                    className={styles.closeButton}
-                                    variant="transparent"
-                                    size="xs"
-                                    onClick={() => onCloseError?.(toastData)}
+            {older.length > 0 && (
+                <>
+                    <UnstyledButton
+                        className={styles.toggle}
+                        onClick={() => setExpanded(!expanded)}
+                    >
+                        {`${expanded ? 'Hide' : 'Show'} ${older.length} older`}
+                    </UnstyledButton>
+
+                    <Collapse in={expanded}>
+                        <Box className={styles.olderList}>
+                            {older.map((toastData) => (
+                                <Group
+                                    key={toastData.messageKey}
+                                    className={styles.olderItem}
+                                    gap={12}
+                                    align="baseline"
+                                    wrap="nowrap"
                                 >
-                                    <MantineIcon icon={IconX} />
-                                </ActionIcon>
-                            </Group>
-                        ))}
-                    </Stack>
-                </Collapse>
-            </Box>
+                                    <Box className={styles.olderMessage}>
+                                        {toastData.apiError
+                                            ? toastData.apiError.message
+                                            : toastData.subtitle ||
+                                              toastData.title}
+                                    </Box>
+                                    {toastData.receivedAt && (
+                                        <Box className={styles.olderTime}>
+                                            {toastData.receivedAt}
+                                        </Box>
+                                    )}
+                                </Group>
+                            ))}
+                        </Box>
+                    </Collapse>
+                </>
+            )}
         </Stack>
     );
 };

--- a/packages/frontend/src/hooks/toaster/MultipleToastBody.tsx
+++ b/packages/frontend/src/hooks/toaster/MultipleToastBody.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import rehypeExternalLinks from 'rehype-external-links';
 import MantineIcon from '../../components/common/MantineIcon';
 import ApiErrorDisplay, { CopyErrorButton } from './ApiErrorDisplay';
+import { errorClipboardValue } from './errorClipboardValue';
 import styles from './MultipleToastBody.module.css';
 import { type NotificationData } from './types';
 
@@ -97,18 +98,9 @@ const MultipleToastBody = ({
                                                 toastData.apiError
                                                     .sentryTraceId) && (
                                                 <CopyErrorButton
-                                                    value={`${
-                                                        toastData.apiError
-                                                            .message
-                                                    }\nError ID: ${
-                                                        toastData.apiError
-                                                            .sentryEventId ||
-                                                        'n/a'
-                                                    }\nTrace ID: ${
-                                                        toastData.apiError
-                                                            .sentryTraceId ||
-                                                        'n/a'
-                                                    }`}
+                                                    value={errorClipboardValue(
+                                                        toastData.apiError,
+                                                    )}
                                                     color="ldGray.7"
                                                 />
                                             )}

--- a/packages/frontend/src/hooks/toaster/errorClipboardValue.ts
+++ b/packages/frontend/src/hooks/toaster/errorClipboardValue.ts
@@ -1,0 +1,8 @@
+import { type ApiErrorDetail } from '@lightdash/common';
+
+export const errorClipboardValue = (apiError: ApiErrorDetail) =>
+    apiError.sentryEventId || apiError.sentryTraceId
+        ? `${apiError.message}\nError ID: ${
+              apiError.sentryEventId || 'n/a'
+          }\nTrace ID: ${apiError.sentryTraceId || 'n/a'}`
+        : apiError.message;

--- a/packages/frontend/src/hooks/toaster/types.ts
+++ b/packages/frontend/src/hooks/toaster/types.ts
@@ -7,7 +7,7 @@ import { type notifications } from '@mantine/notifications';
 import { type Icon } from '@tabler/icons-react';
 import { type ReactNode } from 'react';
 
-export type ToastVariant = 'success' | 'error' | 'info' | 'primary' | 'warning';
+export type ToastVariant = 'success' | 'error' | 'info' | 'warning';
 
 export type NotificationData = Omit<
     Parameters<typeof notifications.show>[0],
@@ -20,4 +20,5 @@ export type NotificationData = Omit<
     };
     apiError?: ApiErrorDetail;
     messageKey?: string;
+    receivedAt?: string;
 };

--- a/packages/frontend/src/hooks/toaster/useToaster.module.css
+++ b/packages/frontend/src/hooks/toaster/useToaster.module.css
@@ -176,6 +176,22 @@
     color: light-dark(var(--mantine-color-red-9), var(--mantine-color-red-3));
 }
 
+/* Expanded error details: outgrow the inline max-height Mantine sets for its
+   enter/exit animation (inline style, hence !important) and widen leftwards
+   via negative margin so the right edge stays anchored to the stack. */
+.root:has([data-toast-expanded]) {
+    --toast-collapsed-width: min(
+        var(--notifications-container-width, 440px),
+        calc(100vw - 32px)
+    );
+    --toast-expanded-width: min(680px, calc(100vw - 32px));
+    width: var(--toast-expanded-width);
+    margin-left: calc(
+        var(--toast-collapsed-width) - var(--toast-expanded-width)
+    );
+    max-height: calc(100vh - 96px) !important;
+}
+
 .root[data-variant='error'] .closeButton {
     color: light-dark(var(--mantine-color-red-8), var(--mantine-color-red-5));
 

--- a/packages/frontend/src/hooks/toaster/useToaster.module.css
+++ b/packages/frontend/src/hooks/toaster/useToaster.module.css
@@ -1,8 +1,6 @@
 .root {
-    --toast-text: light-dark(
-        var(--mantine-color-ldGray-6),
-        var(--mantine-color-ldGray-7)
-    );
+    /* ldGray-7 resolves per scheme: #495057 light (7.5:1 on white), #9e9e9e dark */
+    --toast-text: var(--mantine-color-ldGray-7);
 
     padding: 14px 14px 14px 16px;
     background: linear-gradient(
@@ -66,10 +64,7 @@
     min-width: 24px;
     min-height: 24px;
     border-radius: 6px;
-    color: light-dark(
-        var(--mantine-color-ldGray-5),
-        var(--mantine-color-ldGray-6)
-    );
+    color: var(--mantine-color-ldGray-6);
 
     &:hover {
         background: light-dark(
@@ -91,7 +86,9 @@
     background-color: transparent;
 }
 
+/* 12px loader centered on the 20px title line, matching the 18px icon */
 .loader {
+    margin-top: 4px;
     margin-right: 12px;
 }
 
@@ -130,19 +127,20 @@
     color: var(--toast-text);
 }
 
+/* orange-7 is the lightest step that keeps >=3:1 non-text contrast on white */
 .root[data-variant='warning'] .icon {
-    color: light-dark(#c2410c, var(--mantine-color-orange-4));
-}
-
-.root[data-variant='warning'] .title {
-    color: light-dark(#c2410c, var(--mantine-color-orange-4));
+    color: light-dark(
+        var(--mantine-color-orange-7),
+        var(--mantine-color-orange-4)
+    );
 }
 
 .root[data-variant='error'] {
-    position: relative;
-    overflow: visible;
-    background: color-mix(in srgb, var(--mantine-color-red-0) 62%, transparent);
-    backdrop-filter: blur(14px) saturate(1.6);
+    background: color-mix(
+        in srgb,
+        var(--mantine-color-red-0) 62%,
+        var(--mantine-color-white)
+    );
     border-color: color-mix(
         in srgb,
         var(--mantine-color-red-8) 20%,
@@ -156,7 +154,7 @@
         background: color-mix(
             in srgb,
             var(--mantine-color-red-5) 10%,
-            transparent
+            var(--mantine-color-ldGray-2)
         );
         border-color: color-mix(
             in srgb,
@@ -191,79 +189,4 @@
             var(--mantine-color-red-3)
         );
     }
-}
-
-[data-toast-peek-marker] {
-    display: none;
-}
-
-.root[data-variant='error']:has([data-toast-peek-marker]) {
-    margin-top: 12px;
-}
-
-.root[data-variant='error']:has([data-toast-peek-marker])::before,
-.root[data-variant='error']:has([data-toast-peek-marker])::after {
-    content: '';
-    display: block;
-    position: absolute;
-    width: auto;
-    bottom: auto;
-    border-style: solid;
-    border-bottom: none;
-    border-width: 1px;
-    border-radius: 10px 10px 0 0;
-}
-
-.root[data-variant='error']:has([data-toast-peek-marker])::before {
-    top: -12px;
-    left: 16px;
-    right: 16px;
-    height: 11px;
-    background: light-dark(
-        color-mix(
-            in srgb,
-            var(--mantine-color-red-8) 4%,
-            var(--mantine-color-white)
-        ),
-        color-mix(
-            in srgb,
-            var(--mantine-color-red-5) 4%,
-            var(--mantine-color-ldGray-2)
-        )
-    );
-    border-color: light-dark(
-        color-mix(in srgb, var(--mantine-color-red-8) 22%, transparent),
-        color-mix(in srgb, var(--mantine-color-red-5) 24%, transparent)
-    );
-}
-
-.root[data-variant='error']:has([data-toast-peek-marker])::after {
-    top: -6px;
-    left: 8px;
-    right: 8px;
-    height: 5px;
-    background: light-dark(
-        color-mix(
-            in srgb,
-            var(--mantine-color-red-8) 6%,
-            var(--mantine-color-white)
-        ),
-        color-mix(
-            in srgb,
-            var(--mantine-color-red-5) 6%,
-            var(--mantine-color-ldGray-2)
-        )
-    );
-    border-color: light-dark(
-        color-mix(in srgb, var(--mantine-color-red-8) 25%, transparent),
-        color-mix(in srgb, var(--mantine-color-red-5) 28%, transparent)
-    );
-}
-
-.root[data-variant='error']:has([data-toast-peek-marker='1']) {
-    margin-top: 6px;
-}
-
-.root[data-variant='error']:has([data-toast-peek-marker='1'])::before {
-    display: none;
 }

--- a/packages/frontend/src/hooks/toaster/useToaster.module.css
+++ b/packages/frontend/src/hooks/toaster/useToaster.module.css
@@ -1,71 +1,53 @@
-.root[data-variant='primary'] {
-    --toast-0: var(--mantine-color-blue-0);
-    --toast-1: var(--mantine-color-blue-1);
-    --toast-2: var(--mantine-color-blue-2);
-    --toast-3: var(--mantine-color-blue-3);
-    --toast-4: var(--mantine-color-blue-4);
-    --toast-7: var(--mantine-color-blue-7);
-    --toast-9: var(--mantine-color-blue-9);
-}
-
-.root[data-variant='success'] {
-    --toast-0: var(--mantine-color-green-0);
-    --toast-1: var(--mantine-color-green-1);
-    --toast-2: var(--mantine-color-green-2);
-    --toast-3: var(--mantine-color-green-3);
-    --toast-4: var(--mantine-color-green-4);
-    --toast-7: var(--mantine-color-green-7);
-    --toast-9: var(--mantine-color-green-9);
-}
-
-.root[data-variant='error'] {
-    --toast-0: var(--mantine-color-red-0);
-    --toast-1: var(--mantine-color-red-1);
-    --toast-2: var(--mantine-color-red-2);
-    --toast-3: var(--mantine-color-red-3);
-    --toast-4: var(--mantine-color-red-4);
-    --toast-7: var(--mantine-color-red-7);
-    --toast-9: var(--mantine-color-red-9);
-}
-
-.root[data-variant='info'] {
-    --toast-0: var(--mantine-color-indigo-0);
-    --toast-1: var(--mantine-color-indigo-1);
-    --toast-2: var(--mantine-color-indigo-2);
-    --toast-3: var(--mantine-color-indigo-3);
-    --toast-4: var(--mantine-color-indigo-4);
-    --toast-7: var(--mantine-color-indigo-7);
-    --toast-9: var(--mantine-color-indigo-9);
-}
-
-.root[data-variant='warning'] {
-    --toast-0: var(--mantine-color-yellow-0);
-    --toast-1: var(--mantine-color-yellow-1);
-    --toast-2: var(--mantine-color-yellow-2);
-    --toast-3: var(--mantine-color-yellow-3);
-    --toast-4: var(--mantine-color-yellow-4);
-    --toast-7: var(--mantine-color-yellow-7);
-    --toast-9: var(--mantine-color-yellow-9);
-}
-
 .root {
-    --toast-text: light-dark(var(--toast-9), var(--toast-2));
-
-    background: light-dark(
-        color-mix(in srgb, var(--toast-0), white 50%),
-        color-mix(in srgb, var(--toast-9), black 60%)
+    --toast-text: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-7)
     );
-    border: 1px solid light-dark(var(--toast-2), var(--toast-9));
-    border-radius: var(--mantine-radius-md);
-    box-shadow: var(--mantine-shadow-subtle);
+
+    padding: 14px 14px 14px 16px;
+    background: linear-gradient(
+        180deg,
+        var(--mantine-color-white) 0%,
+        var(--mantine-color-ldGray-0) 100%
+    );
+    border: 1px solid var(--mantine-color-ldGray-3);
+    border-radius: 10px;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.9),
+        var(--mantine-shadow-heavy);
+
+    @mixin dark {
+        background: linear-gradient(
+            180deg,
+            var(--mantine-color-ldGray-3) 0%,
+            var(--mantine-color-ldGray-2) 100%
+        );
+        border-color: rgba(255, 255, 255, 0.1);
+        box-shadow:
+            inset 0 1px 0 rgba(255, 255, 255, 0.08),
+            0px 12px 16px -4px rgba(0, 0, 0, 0.5),
+            0px 2px 2px -1px rgba(0, 0, 0, 0.4);
+    }
+}
+
+.root:has(.description:not(:empty)) {
+    align-items: flex-start;
+}
+
+.root :global(.mantine-Notification-body) {
+    margin-right: 12px;
 }
 
 .title {
     color: light-dark(
-        color-mix(in srgb, var(--toast-9), black 10%),
-        var(--toast-1)
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-foreground-0)
     );
-    font-weight: 700;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 20px;
+    letter-spacing: -0.15px;
+    margin-bottom: 2px;
 }
 
 .root:has(.description:empty) .title {
@@ -73,42 +55,215 @@
 }
 
 .description {
-    color: light-dark(
-        color-mix(in srgb, var(--toast-9), black 40%),
-        var(--toast-3)
-    );
+    color: var(--toast-text);
+    font-size: 13px;
+    line-height: 18px;
 }
 
 .closeButton {
-    padding: 4px;
-    color: light-dark(var(--toast-9), var(--toast-2));
+    width: 24px;
+    height: 24px;
+    min-width: 24px;
+    min-height: 24px;
+    border-radius: 6px;
+    color: light-dark(
+        var(--mantine-color-ldGray-5),
+        var(--mantine-color-ldGray-6)
+    );
 
     &:hover {
         background: light-dark(
-            var(--toast-1),
-            color-mix(in srgb, var(--toast-9), black 40%)
+            var(--mantine-color-ldGray-1),
+            rgba(255, 255, 255, 0.08)
+        );
+        color: light-dark(
+            var(--mantine-color-ldGray-7),
+            var(--mantine-color-foreground-0)
         );
     }
 }
 
 .icon {
+    width: 18px;
+    height: 18px;
+    margin-top: 1px;
+    margin-right: 12px;
     background-color: transparent;
-    color: light-dark(var(--toast-7), var(--toast-4));
-    padding: 4px;
 }
 
 .loader {
-    padding: var(--mantine-spacing-xxs);
+    margin-right: 12px;
 }
 
 .subtitle {
     color: var(--toast-text);
-    font-size: 12px;
+    font-size: 13px;
+    line-height: 18px;
     width: 100%;
 }
 
 .markdown {
     background-color: transparent;
     color: var(--toast-text);
-    font-size: 12px;
+    font-size: 13px;
+    line-height: 18px;
+}
+
+.actionButton {
+    margin-top: 8px;
+    height: 28px;
+    padding: 0 10px;
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: -0.15px;
+    border-radius: 6px;
+}
+
+.root[data-variant='success'] .icon {
+    color: light-dark(
+        var(--mantine-color-green-6),
+        var(--mantine-color-green-5)
+    );
+}
+
+.root[data-variant='info'] .icon {
+    color: var(--toast-text);
+}
+
+.root[data-variant='warning'] .icon {
+    color: light-dark(#c2410c, var(--mantine-color-orange-4));
+}
+
+.root[data-variant='warning'] .title {
+    color: light-dark(#c2410c, var(--mantine-color-orange-4));
+}
+
+.root[data-variant='error'] {
+    position: relative;
+    overflow: visible;
+    background: color-mix(in srgb, var(--mantine-color-red-0) 62%, transparent);
+    backdrop-filter: blur(14px) saturate(1.6);
+    border-color: color-mix(
+        in srgb,
+        var(--mantine-color-red-8) 20%,
+        transparent
+    );
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.7),
+        var(--mantine-shadow-heavy);
+
+    @mixin dark {
+        background: color-mix(
+            in srgb,
+            var(--mantine-color-red-5) 10%,
+            transparent
+        );
+        border-color: color-mix(
+            in srgb,
+            var(--mantine-color-red-5) 28%,
+            transparent
+        );
+        box-shadow:
+            inset 0 1px 0 rgba(255, 255, 255, 0.1),
+            0px 12px 16px -4px rgba(0, 0, 0, 0.5),
+            0px 2px 2px -1px rgba(0, 0, 0, 0.4);
+    }
+}
+
+.root[data-variant='error'] .icon {
+    color: light-dark(var(--mantine-color-red-8), var(--mantine-color-red-5));
+}
+
+.root[data-variant='error'] .title {
+    color: light-dark(var(--mantine-color-red-9), var(--mantine-color-red-3));
+}
+
+.root[data-variant='error'] .closeButton {
+    color: light-dark(var(--mantine-color-red-8), var(--mantine-color-red-5));
+
+    &:hover {
+        background: light-dark(
+            color-mix(in srgb, var(--mantine-color-red-8) 10%, transparent),
+            color-mix(in srgb, var(--mantine-color-red-5) 15%, transparent)
+        );
+        color: light-dark(
+            var(--mantine-color-red-9),
+            var(--mantine-color-red-3)
+        );
+    }
+}
+
+[data-toast-peek-marker] {
+    display: none;
+}
+
+.root[data-variant='error']:has([data-toast-peek-marker]) {
+    margin-top: 12px;
+}
+
+.root[data-variant='error']:has([data-toast-peek-marker])::before,
+.root[data-variant='error']:has([data-toast-peek-marker])::after {
+    content: '';
+    display: block;
+    position: absolute;
+    width: auto;
+    bottom: auto;
+    border-style: solid;
+    border-bottom: none;
+    border-width: 1px;
+    border-radius: 10px 10px 0 0;
+}
+
+.root[data-variant='error']:has([data-toast-peek-marker])::before {
+    top: -12px;
+    left: 16px;
+    right: 16px;
+    height: 11px;
+    background: light-dark(
+        color-mix(
+            in srgb,
+            var(--mantine-color-red-8) 4%,
+            var(--mantine-color-white)
+        ),
+        color-mix(
+            in srgb,
+            var(--mantine-color-red-5) 4%,
+            var(--mantine-color-ldGray-2)
+        )
+    );
+    border-color: light-dark(
+        color-mix(in srgb, var(--mantine-color-red-8) 22%, transparent),
+        color-mix(in srgb, var(--mantine-color-red-5) 24%, transparent)
+    );
+}
+
+.root[data-variant='error']:has([data-toast-peek-marker])::after {
+    top: -6px;
+    left: 8px;
+    right: 8px;
+    height: 5px;
+    background: light-dark(
+        color-mix(
+            in srgb,
+            var(--mantine-color-red-8) 6%,
+            var(--mantine-color-white)
+        ),
+        color-mix(
+            in srgb,
+            var(--mantine-color-red-5) 6%,
+            var(--mantine-color-ldGray-2)
+        )
+    );
+    border-color: light-dark(
+        color-mix(in srgb, var(--mantine-color-red-8) 25%, transparent),
+        color-mix(in srgb, var(--mantine-color-red-5) 28%, transparent)
+    );
+}
+
+.root[data-variant='error']:has([data-toast-peek-marker='1']) {
+    margin-top: 6px;
+}
+
+.root[data-variant='error']:has([data-toast-peek-marker='1'])::before {
+    display: none;
 }

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -79,6 +79,11 @@ const useToaster = () => {
                 'data-variant': variant,
                 color: variantConfig.color,
                 autoClose: autoClose ?? variantConfig.autoClose,
+                // notifications.update merges with the existing toast, so
+                // reset props a previous show (e.g. a loading toast under
+                // the same key) may have set; callers override via rest.
+                loading: false,
+                withCloseButton: true,
                 loaderProps: { size: 12, color: 'ldGray.6' },
                 closeButtonProps: { 'aria-label': 'Dismiss notification' },
                 icon: (

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -47,7 +47,7 @@ const TOAST_VARIANTS: Record<
     info: {
         icon: IconInfoCircle,
         iconSize: 18,
-        color: 'gray',
+        color: 'ldGray',
         autoClose: 5000,
     },
     warning: {
@@ -79,7 +79,8 @@ const useToaster = () => {
                 'data-variant': variant,
                 color: variantConfig.color,
                 autoClose: autoClose ?? variantConfig.autoClose,
-                loaderProps: { size: 14, color: 'ldGray.6' },
+                loaderProps: { size: 12, color: 'ldGray.6' },
+                closeButtonProps: { 'aria-label': 'Dismiss notification' },
                 icon: (
                     <MantineIcon
                         icon={variantConfig.icon}
@@ -201,6 +202,54 @@ const useToaster = () => {
         [showToast],
     );
 
+    const renderGroupedErrors = useCallback(
+        function render(key: string) {
+            const errors = currentErrors.current[key];
+            if (!errors || errors.length === 0) {
+                notifications.hide(key);
+                return;
+            }
+
+            const hasMultipleErrors = errors.length > 1;
+            const {
+                key: _unusedKey,
+                title,
+                subtitle,
+                apiError,
+                messageKey: _unusedMessageKey,
+                receivedAt: _unusedReceivedAt,
+                ...restProps
+            } = errors[errors.length - 1];
+
+            const toastBody = hasMultipleErrors ? (
+                <MultipleToastBody
+                    toastsData={errors}
+                    onDismissError={(messageKey) => {
+                        currentErrors.current[key] = (
+                            currentErrors.current[key] ?? []
+                        ).filter((e) => e.messageKey !== messageKey);
+                        render(key);
+                    }}
+                />
+            ) : apiError ? (
+                <ApiErrorDisplay
+                    apiError={apiError}
+                    onClose={() => notifications.hide(key)}
+                />
+            ) : (
+                subtitle || title
+            );
+
+            showToastError({
+                key,
+                subtitle: toastBody,
+                title: hasMultipleErrors ? `${errors.length} errors` : title,
+                ...restProps,
+            });
+        },
+        [showToastError],
+    );
+
     const addToastError = useCallback(
         (notificationData: NotificationData) => {
             const {
@@ -210,8 +259,6 @@ const useToaster = () => {
                 title,
                 subtitle,
                 apiError,
-                messageKey,
-                ...restProps
             } = notificationData;
 
             if (!subtitle && !title && !apiError) return;
@@ -263,28 +310,9 @@ const useToaster = () => {
                 ];
             }
 
-            const errors = currentErrors.current[key];
-            const hasMultipleErrors = errors.length > 1;
-
-            const toastBody = hasMultipleErrors ? (
-                <MultipleToastBody toastsData={errors} />
-            ) : errors[0].apiError ? (
-                <ApiErrorDisplay
-                    apiError={errors[0].apiError}
-                    onClose={() => notifications.hide(key)}
-                />
-            ) : (
-                errors[0].subtitle || errors[0].title
-            );
-
-            showToastError({
-                key,
-                subtitle: toastBody,
-                title: hasMultipleErrors ? `${errors.length} errors` : title,
-                ...restProps,
-            });
+            renderGroupedErrors(key);
         },
-        [showToastError],
+        [renderGroupedErrors],
     );
 
     return {

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -5,10 +5,10 @@ import {
     type NotificationData as MantineNotificationData,
 } from '@mantine/notifications';
 import {
-    IconAlertCircleFilled,
-    IconAlertTriangleFilled,
-    IconCircleCheckFilled,
-    IconInfoCircleFilled,
+    IconAlertCircle,
+    IconAlertTriangle,
+    IconCircleCheck,
+    IconInfoCircle,
     type Icon,
 } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
@@ -33,33 +33,27 @@ const TOAST_VARIANTS: Record<
     }
 > = {
     success: {
-        icon: IconCircleCheckFilled,
-        iconSize: 'xl',
+        icon: IconCircleCheck,
+        iconSize: 18,
         color: 'green',
         autoClose: 5000,
     },
     error: {
-        icon: IconAlertCircleFilled,
-        iconSize: 'xl',
+        icon: IconAlertCircle,
+        iconSize: 18,
         color: 'red',
         autoClose: 60000,
     },
     info: {
-        icon: IconInfoCircleFilled,
-        iconSize: 'xl',
-        color: 'indigo',
-        autoClose: 5000,
-    },
-    primary: {
-        icon: IconInfoCircleFilled,
-        iconSize: 'xl',
-        color: 'blue',
+        icon: IconInfoCircle,
+        iconSize: 18,
+        color: 'gray',
         autoClose: 5000,
     },
     warning: {
-        icon: IconAlertCircleFilled,
-        iconSize: 'xl',
-        color: 'yellow',
+        icon: IconAlertTriangle,
+        iconSize: 18,
+        color: 'orange',
         autoClose: 5000,
     },
 };
@@ -85,6 +79,7 @@ const useToaster = () => {
                 'data-variant': variant,
                 color: variantConfig.color,
                 autoClose: autoClose ?? variantConfig.autoClose,
+                loaderProps: { size: 14, color: 'ldGray.6' },
                 icon: (
                     <MantineIcon
                         icon={variantConfig.icon}
@@ -101,7 +96,7 @@ const useToaster = () => {
                 },
                 message:
                     subtitle || action ? (
-                        <Stack gap="xs" align="flex-start">
+                        <Stack gap={0} align="flex-start">
                             {typeof subtitle == 'string' ? (
                                 <MarkdownPreview
                                     className={styles.markdown}
@@ -122,10 +117,8 @@ const useToaster = () => {
                             {action && (
                                 <Button
                                     {...action}
+                                    className={styles.actionButton}
                                     size="xs"
-                                    radius="md"
-                                    variant="light"
-                                    color={variantConfig.color}
                                     leftSection={
                                         action.icon ? (
                                             <MantineIcon icon={action.icon} />
@@ -190,7 +183,6 @@ const useToaster = () => {
             );
 
             showToast('error', {
-                icon: <MantineIcon icon={IconAlertTriangleFilled} size="xl" />,
                 title,
                 subtitle,
                 ...props,
@@ -204,32 +196,13 @@ const useToaster = () => {
         [showToast],
     );
 
-    const showToastPrimary = useCallback(
-        (props: NotificationData) => showToast('primary', props),
-        [showToast],
-    );
-
     const showToastWarning = useCallback(
         (props: NotificationData) => showToast('warning', props),
         [showToast],
     );
 
-    // This is used to update a multiple toast by key. It is called by
-    // addToastError and removeToastError, which pass different specific functions to
-    // update the error list
-    const updateToastError = useCallback(
-        ({
-            errorData,
-            updateErrorsFunction,
-            onCloseError,
-        }: {
-            errorData: NotificationData;
-            updateErrorsFunction: (
-                key: string,
-                errorData: NotificationData,
-            ) => void;
-            onCloseError: (data: NotificationData) => void;
-        }) => {
+    const addToastError = useCallback(
+        (notificationData: NotificationData) => {
             const {
                 // By default errors will be grouped under 'error-list'.
                 // Consumers can override this by passing a custom key.
@@ -239,105 +212,79 @@ const useToaster = () => {
                 apiError,
                 messageKey,
                 ...restProps
-            } = errorData;
+            } = notificationData;
 
             if (!subtitle && !title && !apiError) return;
 
-            // Execute the specific error update function (add or remove)
-            updateErrorsFunction(key, errorData);
+            // Dedupe by content: when several parallel queries fail
+            // with the same error (e.g. main metric-query +
+            // useCompiledSql preview both hitting a table-calc
+            // compile error), we'd otherwise stack identical entries
+            // in the toast. Primitive fields only; ReactNode
+            // subtitles fall back to reference identity.
+            const fingerprintOf = (e: NotificationData) => [
+                e.title ?? null,
+                typeof e.subtitle === 'string' ? e.subtitle : null,
+                e.apiError?.message ?? null,
+                e.apiError?.name ?? null,
+                e.apiError?.statusCode ?? null,
+            ];
+            const fpA = fingerprintOf(notificationData);
+            const existing = currentErrors.current[key];
+            if (existing) {
+                const alreadyPresent = existing.some((e) => {
+                    const fpB = fingerprintOf(e);
+                    return (
+                        fpA.every((v, i) => v === fpB[i]) &&
+                        (typeof notificationData.subtitle === 'string' ||
+                            e.subtitle === notificationData.subtitle)
+                    );
+                });
+                if (!alreadyPresent) {
+                    existing.push({
+                        ...notificationData,
+                        messageKey: uuid(),
+                        receivedAt: new Date().toLocaleTimeString([], {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                        }),
+                    });
+                }
+            } else {
+                currentErrors.current[key] = [
+                    {
+                        ...notificationData,
+                        messageKey: uuid(),
+                        receivedAt: new Date().toLocaleTimeString([], {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                        }),
+                    },
+                ];
+            }
 
-            const hasMultipleErrors = currentErrors.current[key]?.length > 1;
+            const errors = currentErrors.current[key];
+            const hasMultipleErrors = errors.length > 1;
 
             const toastBody = hasMultipleErrors ? (
-                <MultipleToastBody
-                    title={title}
-                    toastsData={currentErrors.current[key]}
-                    onCloseError={(error) => onCloseError(error)}
-                />
-            ) : currentErrors.current[key][0].apiError ? (
+                <MultipleToastBody toastsData={errors} />
+            ) : errors[0].apiError ? (
                 <ApiErrorDisplay
-                    apiError={currentErrors.current[key][0].apiError}
+                    apiError={errors[0].apiError}
                     onClose={() => notifications.hide(key)}
                 />
             ) : (
-                currentErrors.current[key][0].subtitle ||
-                currentErrors.current[key][0].title
+                errors[0].subtitle || errors[0].title
             );
 
             showToastError({
                 key,
                 subtitle: toastBody,
-                title: hasMultipleErrors ? undefined : title,
+                title: hasMultipleErrors ? `${errors.length} errors` : title,
                 ...restProps,
             });
         },
         [showToastError],
-    );
-
-    const removeToastError = useCallback(
-        (notificationData: NotificationData) => {
-            updateToastError({
-                errorData: notificationData,
-                updateErrorsFunction: (key, errorData) => {
-                    currentErrors.current[key] = currentErrors.current[
-                        key
-                    ].filter((d) => d.messageKey !== errorData.messageKey);
-
-                    if (currentErrors.current[key].length === 0) {
-                        notifications.hide(key);
-                    }
-                },
-                onCloseError: removeToastError,
-            });
-        },
-        [updateToastError],
-    );
-
-    const addToastError = useCallback(
-        (notificationData: NotificationData) => {
-            updateToastError({
-                errorData: notificationData,
-                updateErrorsFunction: (key, errorData) => {
-                    if (!errorData) return;
-                    // Dedupe by content: when several parallel queries fail
-                    // with the same error (e.g. main metric-query +
-                    // useCompiledSql preview both hitting a table-calc
-                    // compile error), we'd otherwise stack identical entries
-                    // in the toast. Primitive fields only; ReactNode
-                    // subtitles fall back to reference identity.
-                    const fingerprintOf = (e: NotificationData) => [
-                        e.title ?? null,
-                        typeof e.subtitle === 'string' ? e.subtitle : null,
-                        e.apiError?.message ?? null,
-                        e.apiError?.name ?? null,
-                        e.apiError?.statusCode ?? null,
-                    ];
-                    const fpA = fingerprintOf(errorData);
-                    const existing = currentErrors.current[key];
-                    if (existing) {
-                        const alreadyPresent = existing.some((e) => {
-                            const fpB = fingerprintOf(e);
-                            return (
-                                fpA.every((v, i) => v === fpB[i]) &&
-                                (typeof errorData.subtitle === 'string' ||
-                                    e.subtitle === errorData.subtitle)
-                            );
-                        });
-                        if (alreadyPresent) return;
-                        existing.push({
-                            ...notificationData,
-                            messageKey: uuid(),
-                        });
-                    } else {
-                        currentErrors.current[key] = [
-                            { ...notificationData, messageKey: uuid() },
-                        ];
-                    }
-                },
-                onCloseError: removeToastError,
-            });
-        },
-        [removeToastError, updateToastError],
     );
 
     return {
@@ -346,7 +293,6 @@ const useToaster = () => {
         showToastApiError,
         showToastError,
         showToastInfo,
-        showToastPrimary,
         showToastWarning,
     };
 };

--- a/packages/frontend/src/providers/MantineProvider.tsx
+++ b/packages/frontend/src/providers/MantineProvider.tsx
@@ -54,7 +54,10 @@ const MantineProvider: FC<React.PropsWithChildren<Props>> = ({
                 env={env}
             >
                 {children}
-                <Notifications limit={notificationsLimit} />
+                <Notifications
+                    limit={notificationsLimit}
+                    notificationMaxHeight={480}
+                />
             </MantineBaseProvider>
         </ColorSchemeContext.Provider>
     );

--- a/packages/frontend/src/stories/Toaster.stories.tsx
+++ b/packages/frontend/src/stories/Toaster.stories.tsx
@@ -1,4 +1,12 @@
-import { Box, Button, Group, Notification, Stack, Title } from '@mantine/core';
+import {
+    Box,
+    Button,
+    Group,
+    Notification,
+    Paper,
+    Stack,
+    Title,
+} from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import {
@@ -29,8 +37,8 @@ const ToasterDemo = () => {
     const errorCounter = useRef(0);
 
     return (
-        <Stack gap="xl" p="xl" style={{ maxWidth: 800 }}>
-            <section>
+        <Stack gap="xl" p="xl" maw={800}>
+            <Box component="section">
                 <Title order={4} mb="md">
                     Standard Toasts
                 </Title>
@@ -95,9 +103,9 @@ const ToasterDemo = () => {
                         Loading
                     </Button>
                 </Group>
-            </section>
+            </Box>
 
-            <section>
+            <Box component="section">
                 <Title order={4} mb="md">
                     Advanced Toasts
                 </Title>
@@ -156,9 +164,9 @@ const ToasterDemo = () => {
                         Add Error
                     </Button>
                 </Group>
-            </section>
+            </Box>
 
-            <section>
+            <Box component="section">
                 <Title order={4} mb="md">
                     Custom Content
                 </Title>
@@ -211,19 +219,13 @@ const ToasterDemo = () => {
                         Version Update
                     </Button>
                 </Group>
-            </section>
+            </Box>
 
-            <section>
+            <Box component="section">
                 <Title order={4} mb="md">
                     MultipleToastBody Component (Standalone)
                 </Title>
-                <div
-                    style={{
-                        border: '1px solid #eee',
-                        padding: '20px',
-                        borderRadius: '8px',
-                    }}
-                >
+                <Paper withBorder p="lg" radius="md">
                     <MultipleToastBody
                         toastsData={[
                             {
@@ -253,8 +255,8 @@ const ToasterDemo = () => {
                             },
                         ]}
                     />
-                </div>
-            </section>
+                </Paper>
+            </Box>
 
             <Button variant="default" onClick={() => notifications.clean()}>
                 Clean All Notifications
@@ -298,7 +300,8 @@ const StaticToast = ({
         data-variant={variant}
         classNames={toastClassNames}
         loading={loading}
-        loaderProps={{ size: 18, color: 'ldGray.6' }}
+        loaderProps={{ size: 12, color: 'ldGray.6' }}
+        closeButtonProps={{ 'aria-label': 'Dismiss notification' }}
         icon={
             loading ? undefined : (
                 <MantineIcon icon={TOAST_PREVIEW_ICONS[variant]} size={18} />
@@ -355,7 +358,7 @@ const STACKED_ERRORS_FIXTURE = [
 
 const InlineGalleryDemo = () => (
     <Stack gap="xl" p="xl" w={860}>
-        <section>
+        <Box component="section">
             <Title order={4} mb="md">
                 Neutral
             </Title>
@@ -403,9 +406,9 @@ const InlineGalleryDemo = () => (
                     />
                 </Box>
             </Group>
-        </section>
+        </Box>
 
-        <section>
+        <Box component="section">
             <Title order={4} mb="md">
                 Warning
             </Title>
@@ -416,9 +419,9 @@ const InlineGalleryDemo = () => (
                     subtitle="Your filters won't apply until you save the dashboard."
                 />
             </Box>
-        </section>
+        </Box>
 
-        <section>
+        <Box component="section">
             <Title order={4} mb="md">
                 Error
             </Title>
@@ -454,11 +457,12 @@ const InlineGalleryDemo = () => (
                     >
                         <MultipleToastBody
                             toastsData={STACKED_ERRORS_FIXTURE}
+                            onDismissError={() => {}}
                         />
                     </StaticToast>
                 </Box>
             </Group>
-        </section>
+        </Box>
     </Stack>
 );
 

--- a/packages/frontend/src/stories/Toaster.stories.tsx
+++ b/packages/frontend/src/stories/Toaster.stories.tsx
@@ -1,19 +1,32 @@
-import { Group, Stack, Title, Button } from '@mantine/core';
+import { Box, Button, Group, Notification, Stack, Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
+import {
+    IconAlertCircle,
+    IconAlertTriangle,
+    IconCircleCheck,
+    IconInfoCircle,
+    IconReload,
+    type Icon,
+} from '@tabler/icons-react';
+import { useRef, type ReactNode } from 'react';
+import MantineIcon from '../components/common/MantineIcon';
+import ApiErrorDisplay from '../hooks/toaster/ApiErrorDisplay';
 import MultipleToastBody from '../hooks/toaster/MultipleToastBody';
+import { type ToastVariant } from '../hooks/toaster/types';
 import useToaster from '../hooks/toaster/useToaster';
+import toastStyles from '../hooks/toaster/useToaster.module.css';
 
 const ToasterDemo = () => {
     const {
         showToastSuccess,
         showToastError,
         showToastInfo,
-        showToastPrimary,
         showToastWarning,
         showToastApiError,
         addToastError,
     } = useToaster();
+    const errorCounter = useRef(0);
 
     return (
         <Stack gap="xl" p="xl" style={{ maxWidth: 800 }}>
@@ -56,17 +69,6 @@ const ToasterDemo = () => {
                         }
                     >
                         Info
-                    </Button>
-                    <Button
-                        color="blue"
-                        onClick={() =>
-                            showToastPrimary({
-                                title: 'Primary',
-                                subtitle: 'This is a primary action message.',
-                            })
-                        }
-                    >
-                        Primary
                     </Button>
                     <Button
                         color="yellow"
@@ -139,6 +141,20 @@ const ToasterDemo = () => {
                     >
                         Multiple Errors
                     </Button>
+
+                    <Button
+                        variant="outline"
+                        color="red"
+                        onClick={() => {
+                            errorCounter.current += 1;
+                            addToastError({
+                                title: `Error ${errorCounter.current}`,
+                                subtitle: `Something went wrong (#${errorCounter.current}).`,
+                            });
+                        }}
+                    >
+                        Add Error
+                    </Button>
                 </Group>
             </section>
 
@@ -175,6 +191,25 @@ const ToasterDemo = () => {
                     >
                         Markdown
                     </Button>
+
+                    <Button
+                        variant="subtle"
+                        onClick={() =>
+                            showToastInfo({
+                                key: 'new-version-available',
+                                autoClose: false,
+                                title: 'A new version of Lightdash is ready for you!',
+                                action: {
+                                    children: 'Use new version',
+                                    icon: IconReload,
+                                    onClick: () =>
+                                        console.log('Use new version clicked'),
+                                },
+                            })
+                        }
+                    >
+                        Version Update
+                    </Button>
                 </Group>
             </section>
 
@@ -194,10 +229,14 @@ const ToasterDemo = () => {
                             {
                                 title: 'First Error',
                                 subtitle: 'Detailed error message 1',
+                                messageKey: '1',
+                                receivedAt: '12:01',
                             },
                             {
                                 title: 'Second Error',
                                 subtitle: 'Detailed error message 2',
+                                messageKey: '2',
+                                receivedAt: '12:03',
                             },
                             {
                                 title: 'API Error',
@@ -209,9 +248,10 @@ const ToasterDemo = () => {
                                     sentryTraceId: 'abcde',
                                     data: {},
                                 },
+                                messageKey: '3',
+                                receivedAt: '12:04',
                             },
                         ]}
-                        onCloseError={(data) => console.log('Closed:', data)}
                     />
                 </div>
             </section>
@@ -222,6 +262,205 @@ const ToasterDemo = () => {
         </Stack>
     );
 };
+
+const toastClassNames = {
+    root: toastStyles.root,
+    title: toastStyles.title,
+    description: toastStyles.description,
+    closeButton: toastStyles.closeButton,
+    icon: toastStyles.icon,
+    loader: toastStyles.loader,
+};
+
+const TOAST_PREVIEW_ICONS: Record<ToastVariant, Icon> = {
+    success: IconCircleCheck,
+    error: IconAlertCircle,
+    info: IconInfoCircle,
+    warning: IconAlertTriangle,
+};
+
+const StaticToast = ({
+    variant,
+    title,
+    subtitle,
+    action,
+    loading,
+    children,
+}: {
+    variant: ToastVariant;
+    title: string;
+    subtitle?: string;
+    action?: ReactNode;
+    loading?: boolean;
+    children?: ReactNode;
+}) => (
+    <Notification
+        data-variant={variant}
+        classNames={toastClassNames}
+        loading={loading}
+        loaderProps={{ size: 18, color: 'ldGray.6' }}
+        icon={
+            loading ? undefined : (
+                <MantineIcon icon={TOAST_PREVIEW_ICONS[variant]} size={18} />
+            )
+        }
+        title={title}
+        onClose={() => {}}
+    >
+        {children ??
+            (subtitle || action ? (
+                <Stack gap={0} align="flex-start">
+                    {subtitle && (
+                        <Box className={toastStyles.subtitle}>{subtitle}</Box>
+                    )}
+                    {action}
+                </Stack>
+            ) : undefined)}
+    </Notification>
+);
+
+const StaticActionButton = ({
+    label,
+    icon,
+}: {
+    label: string;
+    icon?: Icon;
+}) => (
+    <Button
+        className={toastStyles.actionButton}
+        size="xs"
+        leftSection={icon ? <MantineIcon icon={icon} /> : undefined}
+    >
+        {label}
+    </Button>
+);
+
+const STACKED_ERRORS_FIXTURE = [
+    {
+        subtitle: 'Permission denied on schema `finance`.',
+        messageKey: 'a',
+        receivedAt: '12:01',
+    },
+    {
+        subtitle: 'Timeout after 60s while running `revenue_daily`.',
+        messageKey: 'b',
+        receivedAt: '12:03',
+    },
+    {
+        subtitle: 'Column `order_total` does not exist in `analytics.orders`.',
+        messageKey: 'c',
+        receivedAt: '12:04',
+    },
+];
+
+const InlineGalleryDemo = () => (
+    <Stack gap="xl" p="xl" w={860}>
+        <section>
+            <Title order={4} mb="md">
+                Neutral
+            </Title>
+            <Group align="flex-start" gap="md">
+                <Box w={400}>
+                    <StaticToast
+                        variant="success"
+                        title="Dashboard saved"
+                        subtitle="Support Metrics · 2 seconds ago"
+                    />
+                </Box>
+                <Box w={400}>
+                    <StaticToast
+                        variant="info"
+                        title="Results limited to 500 rows"
+                        subtitle="Increase the limit in query settings."
+                    />
+                </Box>
+                <Box w={400}>
+                    <StaticToast
+                        variant="info"
+                        title="Running query"
+                        subtitle="Snowflake · 8s elapsed"
+                        loading
+                    />
+                </Box>
+                <Box w={400}>
+                    <StaticToast
+                        variant="success"
+                        title="Chart deleted"
+                        subtitle="Revenue by month"
+                        action={<StaticActionButton label="Undo" />}
+                    />
+                </Box>
+                <Box w={400}>
+                    <StaticToast
+                        variant="info"
+                        title="A new version of Lightdash is ready for you!"
+                        action={
+                            <StaticActionButton
+                                label="Use new version"
+                                icon={IconReload}
+                            />
+                        }
+                    />
+                </Box>
+            </Group>
+        </section>
+
+        <section>
+            <Title order={4} mb="md">
+                Warning
+            </Title>
+            <Box w={400}>
+                <StaticToast
+                    variant="warning"
+                    title="Unsaved changes"
+                    subtitle="Your filters won't apply until you save the dashboard."
+                />
+            </Box>
+        </section>
+
+        <section>
+            <Title order={4} mb="md">
+                Error
+            </Title>
+            <Group align="flex-start" gap="md">
+                <Box w={400}>
+                    <StaticToast
+                        variant="error"
+                        title="Query failed"
+                        subtitle="The server responded with an error (500)."
+                    />
+                </Box>
+                <Box w={400}>
+                    <StaticToast variant="error" title="Error">
+                        <Box className={toastStyles.subtitle}>
+                            <ApiErrorDisplay
+                                apiError={{
+                                    name: 'ApiError',
+                                    message:
+                                        'Query exceeded the maximum execution time.',
+                                    statusCode: 500,
+                                    sentryEventId: 'a1b2c3d4e5',
+                                    sentryTraceId: 'f6a7b8c9d0',
+                                    data: {},
+                                }}
+                            />
+                        </Box>
+                    </StaticToast>
+                </Box>
+                <Box w={400}>
+                    <StaticToast
+                        variant="error"
+                        title={`${STACKED_ERRORS_FIXTURE.length} errors`}
+                    >
+                        <MultipleToastBody
+                            toastsData={STACKED_ERRORS_FIXTURE}
+                        />
+                    </StaticToast>
+                </Box>
+            </Group>
+        </section>
+    </Stack>
+);
 
 const meta: Meta = {
     title: 'Hooks/useToaster',
@@ -236,3 +475,7 @@ export default meta;
 type Story = StoryObj<typeof ToasterDemo>;
 
 export const Default: Story = {};
+
+export const InlineGallery: Story = {
+    render: () => <InlineGalleryDemo />,
+};

--- a/packages/frontend/src/stories/Toaster.stories.tsx
+++ b/packages/frontend/src/stories/Toaster.stories.tsx
@@ -4,7 +4,9 @@ import {
     Group,
     Notification,
     Paper,
+    Progress,
     Stack,
+    Text,
     Title,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
@@ -12,6 +14,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import {
     IconAlertCircle,
     IconAlertTriangle,
+    IconArrowRight,
     IconCircleCheck,
     IconInfoCircle,
     IconReload,
@@ -24,6 +27,9 @@ import MultipleToastBody from '../hooks/toaster/MultipleToastBody';
 import { type ToastVariant } from '../hooks/toaster/types';
 import useToaster from '../hooks/toaster/useToaster';
 import toastStyles from '../hooks/toaster/useToaster.module.css';
+
+const LONG_SQL_ERROR_MESSAGE =
+    "SQL compilation error:\nsyntax error line 12 at position 8 unexpected 'AS'.\nexpression GROUP BY position 4 is not in select list.\nThe query referenced 3 columns that are not part of the select list: order_total, order_date, customer_id.\n\ncompiled SQL:\nSELECT\n  order_date,\n  customer_id,\n  SUM(order_total) AS AS total\nFROM analytics.orders\nWHERE order_date >= '2026-01-01'\nGROUP BY 1, 4\nORDER BY total DESC\nLIMIT 500";
 
 const ToasterDemo = () => {
     const {
@@ -102,6 +108,15 @@ const ToasterDemo = () => {
                     >
                         Loading
                     </Button>
+                    <Button
+                        color="green"
+                        variant="outline"
+                        onClick={() =>
+                            showToastSuccess({ title: 'Copied to clipboard' })
+                        }
+                    >
+                        Title Only
+                    </Button>
                 </Group>
             </Box>
 
@@ -129,6 +144,26 @@ const ToasterDemo = () => {
                         }
                     >
                         API Error
+                    </Button>
+
+                    <Button
+                        variant="outline"
+                        color="red"
+                        onClick={() =>
+                            showToastApiError({
+                                title: 'Query failed',
+                                apiError: {
+                                    name: 'ApiError',
+                                    message: LONG_SQL_ERROR_MESSAGE,
+                                    statusCode: 400,
+                                    sentryEventId: 'c3d4e5f6a7',
+                                    sentryTraceId: 'b8c9d0e1f2',
+                                    data: {},
+                                },
+                            })
+                        }
+                    >
+                        Long API Error
                     </Button>
 
                     <Button
@@ -162,6 +197,70 @@ const ToasterDemo = () => {
                         }}
                     >
                         Add Error
+                    </Button>
+
+                    <Button
+                        variant="outline"
+                        color="red"
+                        onClick={() => {
+                            addToastError({
+                                title: "Chart 'Revenue by month': Error",
+                                apiError: {
+                                    name: 'ApiError',
+                                    message:
+                                        'Query exceeded the maximum execution time.',
+                                    statusCode: 500,
+                                    sentryEventId: 'a1b2c3d4e5',
+                                    sentryTraceId: 'f6a7b8c9d0',
+                                    data: {},
+                                },
+                            });
+                            setTimeout(() => {
+                                addToastError({
+                                    title: "Chart 'Orders funnel': Error",
+                                    apiError: {
+                                        name: 'ApiError',
+                                        message:
+                                            'Compilation failed: unknown dimension `orders.status`.',
+                                        statusCode: 400,
+                                        sentryEventId: 'b2c3d4e5f6',
+                                        sentryTraceId: 'a7b8c9d0e1',
+                                        data: {},
+                                    },
+                                });
+                            }, 600);
+                        }}
+                    >
+                        Grouped API Errors
+                    </Button>
+
+                    <Button
+                        variant="outline"
+                        color="indigo"
+                        onClick={() => {
+                            const key = 'job-progress-demo';
+                            showToastInfo({
+                                key,
+                                title: 'Refreshing dbt project',
+                                subtitle: 'Compiling models...',
+                                loading: true,
+                                autoClose: false,
+                                withCloseButton: false,
+                                action: {
+                                    children: 'View log',
+                                    icon: IconArrowRight,
+                                    onClick: () => {},
+                                },
+                            });
+                            setTimeout(() => {
+                                showToastSuccess({
+                                    key,
+                                    title: 'Project refreshed',
+                                });
+                            }, 2500);
+                        }}
+                    >
+                        Job Progress
                     </Button>
                 </Group>
             </Box>
@@ -287,6 +386,7 @@ const StaticToast = ({
     subtitle,
     action,
     loading,
+    withCloseButton,
     children,
 }: {
     variant: ToastVariant;
@@ -294,12 +394,14 @@ const StaticToast = ({
     subtitle?: string;
     action?: ReactNode;
     loading?: boolean;
+    withCloseButton?: boolean;
     children?: ReactNode;
 }) => (
     <Notification
         data-variant={variant}
         classNames={toastClassNames}
         loading={loading}
+        withCloseButton={withCloseButton}
         loaderProps={{ size: 12, color: 'ldGray.6' }}
         closeButtonProps={{ 'aria-label': 'Dismiss notification' }}
         icon={
@@ -345,7 +447,15 @@ const STACKED_ERRORS_FIXTURE = [
         receivedAt: '12:01',
     },
     {
-        subtitle: 'Timeout after 60s while running `revenue_daily`.',
+        title: "Chart 'Revenue by month': Error",
+        apiError: {
+            name: 'ApiError',
+            message: 'Query exceeded the maximum execution time.',
+            statusCode: 500,
+            sentryEventId: 'a1b2c3d4e5',
+            sentryTraceId: 'f6a7b8c9d0',
+            data: {},
+        },
         messageKey: 'b',
         receivedAt: '12:03',
     },
@@ -355,6 +465,24 @@ const STACKED_ERRORS_FIXTURE = [
         receivedAt: '12:04',
     },
 ];
+
+const StaticJobProgressBody = () => (
+    <Box className={toastStyles.subtitle}>
+        <Text fz="xs" ff="monospace" mb={4}>
+            validate_dashboards
+        </Text>
+        <Text fz="xs" mb={4}>
+            3 of 5 completed
+        </Text>
+        <Progress.Root size="sm">
+            <Progress.Section value={60} color="green" />
+            <Progress.Section value={20} color="red" />
+        </Progress.Root>
+        <Text fz="xs" c="red" mt={4}>
+            1 failed
+        </Text>
+    </Box>
+);
 
 const InlineGalleryDemo = () => (
     <Stack gap="xl" p="xl" w={860}>
@@ -404,6 +532,28 @@ const InlineGalleryDemo = () => (
                             />
                         }
                     />
+                </Box>
+                <Box w={400}>
+                    <StaticToast
+                        variant="success"
+                        title="Copied to clipboard"
+                    />
+                </Box>
+                <Box w={400}>
+                    <StaticToast
+                        variant="info"
+                        title="Validating content"
+                        loading
+                        withCloseButton={false}
+                    >
+                        <Stack gap={0} align="flex-start">
+                            <StaticJobProgressBody />
+                            <StaticActionButton
+                                label="View log"
+                                icon={IconArrowRight}
+                            />
+                        </Stack>
+                    </StaticToast>
                 </Box>
             </Group>
         </Box>
@@ -461,7 +611,49 @@ const InlineGalleryDemo = () => (
                         />
                     </StaticToast>
                 </Box>
+                <Box w={400}>
+                    <StaticToast variant="error" title="Query failed">
+                        <Box className={toastStyles.subtitle}>
+                            <ApiErrorDisplay
+                                apiError={{
+                                    name: 'ApiError',
+                                    message: LONG_SQL_ERROR_MESSAGE,
+                                    statusCode: 400,
+                                    sentryEventId: 'c3d4e5f6a7',
+                                    sentryTraceId: 'b8c9d0e1f2',
+                                    data: {},
+                                }}
+                            />
+                        </Box>
+                    </StaticToast>
+                </Box>
             </Group>
+        </Box>
+
+        <Box component="section">
+            <Title order={4} mb="md">
+                Error (expanded)
+            </Title>
+            {/* Expanded root is 680px wide with a -240px margin-left (it
+                widens leftwards to stay right-anchored in the live stack);
+                the wrapper offsets that so the card sits flush here. */}
+            <Box w={440} ml={240}>
+                <StaticToast variant="error" title="Query failed">
+                    <Box className={toastStyles.subtitle}>
+                        <ApiErrorDisplay
+                            defaultExpanded
+                            apiError={{
+                                name: 'ApiError',
+                                message: LONG_SQL_ERROR_MESSAGE,
+                                statusCode: 400,
+                                sentryEventId: 'c3d4e5f6a7',
+                                sentryTraceId: 'b8c9d0e1f2',
+                                data: {},
+                            }}
+                        />
+                    </Box>
+                </StaticToast>
+            </Box>
         </Box>
     </Stack>
 );


### PR DESCRIPTION
New design for toasts: neutral cards with color only where it means something — green check for success, amber warning, red glass error. Stacked errors collapse into one "N errors" card with a "Show N older" toggle and peeking cards behind.

Builds on the `data-variant` refactor below, so the change is almost entirely CSS. The `primary` variant is removed (identical to `info` now). Storybook gets an inline gallery showing every toast state.

| Light | Dark |
|--------|--------|
| <img width="1482" height="4283" alt="CleanShot 2026-08-11 at 13 51 26@2x" src="https://github.com/user-attachments/assets/4c7e99fa-ec79-4477-9fba-754a300566c6" /> | <img width="1458" height="4263" alt="CleanShot 2026-08-11 at 13 51 53@2x" src="https://github.com/user-attachments/assets/4dce77f9-abfb-46ec-bf36-1042d6cfe054" /> | 