### PR TITLE
fix(ai): recognize Anthropic 400 credit-balance errors as provider billing errors

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/errorMessages.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/errorMessages.test.ts
@@ -161,6 +161,34 @@ describe('getUserFacingErrorMessage', () => {
                 }),
             ],
             ['HTTP 402', apiCallError({ statusCode: 402 })],
+            [
+                'Anthropic billing console referenced without credit balance phrasing',
+                new APICallError({
+                    message:
+                        'Please go to Plans & Billing to upgrade or purchase credits.',
+                    url: 'https://api.anthropic.com/v1/messages',
+                    requestBodyValues: {},
+                    statusCode: 400,
+                }),
+            ],
+            [
+                'Anthropic legacy credit balance shape (400 invalid_request_error)',
+                new APICallError({
+                    message:
+                        'Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.',
+                    url: 'https://api.anthropic.com/v1/messages',
+                    requestBodyValues: {},
+                    statusCode: 400,
+                    data: {
+                        type: 'error',
+                        error: {
+                            type: 'invalid_request_error',
+                            message:
+                                'Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.',
+                        },
+                    },
+                }),
+            ],
         ])(
             'shows actionable billing guidance for self-managed keys: %s',
             (_name, error) => {
@@ -185,6 +213,22 @@ describe('getUserFacingErrorMessage', () => {
                                 message: 'Provider request failed',
                             },
                         },
+                    }),
+                    'Custom fallback',
+                    'lightdash-managed',
+                ),
+            ).toBe('Custom fallback');
+        });
+
+        it('does not expose the credit balance error for Lightdash-managed keys', () => {
+            expect(
+                getUserFacingErrorMessage(
+                    new APICallError({
+                        message:
+                            'Your credit balance is too low to access the Anthropic API.',
+                        url: 'https://api.anthropic.com/v1/messages',
+                        requestBodyValues: {},
+                        statusCode: 400,
                     }),
                     'Custom fallback',
                     'lightdash-managed',

--- a/packages/backend/src/ee/services/ai/utils/errorMessages.ts
+++ b/packages/backend/src/ee/services/ai/utils/errorMessages.ts
@@ -30,6 +30,12 @@ const PROVIDER_BILLING_ERROR_CODES = new Set([
     'payment_required',
 ]);
 
+// Anthropic reports an exhausted credit balance as a 400 invalid_request_error
+// ("Your credit balance is too low... go to Plans & Billing..."), not the
+// documented 402 billing_error.
+const PROVIDER_BILLING_MESSAGE_PATTERN =
+    /credit balance is too low|plans & billing/i;
+
 const getApiCallError = (error: unknown): APICallError | undefined => {
     if (APICallError.isInstance(error)) return error;
     if (
@@ -45,6 +51,9 @@ const isProviderBillingError = (error: unknown): boolean => {
     const apiCallError = getApiCallError(error);
     if (!apiCallError) return false;
     if (apiCallError.statusCode === 402) return true;
+    if (PROVIDER_BILLING_MESSAGE_PATTERN.test(apiCallError.message)) {
+        return true;
+    }
 
     const data = isPlainObject(apiCallError.data)
         ? apiCallError.data


### PR DESCRIPTION
Anthropic reports an exhausted credit balance as a 400 `invalid_request_error` instead of the documented 402 `billing_error`, so orgs on a self-managed key were getting a generic "Something went wrong" instead of being told to top up their provider account.
