### PR TITLE
feat(ai): lead deep research reports with visual findings

### DIFF
--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -263,6 +263,7 @@ const evidencePack = (
             rowsCsv: 'Month,Revenue\n2026-01,100',
             truncated: false,
             chartable: true,
+            visualizationType: 'line',
         },
     ],
     workerFindings: [],

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -1740,6 +1740,7 @@ describe('AiDeepResearchService', () => {
                 // The execution carries a chart config, so the finalizer is
                 // told it may reference this queryUuid as a chart.
                 chartable: true,
+                visualizationType: chart.chartConfig.defaultVizType,
             });
             expect(pack.queries[0].rowsCsv).toContain('2026-01');
         });

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -1387,10 +1387,15 @@ export class AiDeepResearchService extends BaseService {
                     description: '',
                     columns,
                     chartable: false,
+                    visualizationType: null,
                 };
             }
 
             const parsedArgs = toolRunQueryArgsSchema.safeParse(toolArgs);
+            const resolvedChart = resolveDeepResearchWarehouseChart(
+                toolArgs,
+                queryUuid,
+            );
             return {
                 ...baseEvidence,
                 type: 'metric_query',
@@ -1400,9 +1405,9 @@ export class AiDeepResearchService extends BaseService {
                     : '',
                 dimensions: queryHistory.metricQuery.dimensions,
                 metrics: queryHistory.metricQuery.metrics,
-                chartable:
-                    resolveDeepResearchWarehouseChart(toolArgs, queryUuid) !==
-                    null,
+                chartable: resolvedChart !== null,
+                visualizationType:
+                    resolvedChart?.chart.chartConfig.defaultVizType ?? null,
             };
         } catch (error) {
             // A single unreadable result must not cost the whole pack.

--- a/packages/backend/src/ee/services/AiDeepResearchService/resolveDeepResearchWarehouseChart.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/resolveDeepResearchWarehouseChart.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { resolveDeepResearchWarehouseChart } from './resolveDeepResearchWarehouseChart';
+
+const QUERY_UUID = '11111111-1111-4111-8111-111111111111';
+
+const groupedChartToolArgs = {
+    title: 'Revenue by month and status',
+    description: 'Monthly revenue split by order status.',
+    queryConfig: {
+        exploreName: 'orders',
+        dimensions: ['orders_order_month', 'orders_status'],
+        metrics: ['orders_total_revenue'],
+        sorts: [],
+        limit: 500,
+        customMetrics: null,
+        tableCalculations: null,
+        filters: null,
+    },
+    chartConfig: {
+        defaultVizType: 'line' as const,
+        xAxisDimension: 'orders_order_month',
+        yAxisMetrics: ['orders_total_revenue'],
+        groupBy: ['orders_status'],
+        xAxisType: 'time' as const,
+        stackBars: false,
+        lineType: 'line' as const,
+        funnelDataInput: null,
+        xAxisLabel: 'Month',
+        yAxisLabel: 'Revenue',
+        secondaryYAxisMetric: null,
+        secondaryYAxisLabel: null,
+    },
+};
+
+describe('resolveDeepResearchWarehouseChart', () => {
+    it('preserves a supported grouped visualization', () => {
+        const resolved = resolveDeepResearchWarehouseChart(
+            groupedChartToolArgs,
+            QUERY_UUID,
+        );
+
+        expect(resolved?.chart.chartConfig).toMatchObject({
+            defaultVizType: 'line',
+            groupBy: ['orders_status'],
+            stackBars: false,
+        });
+    });
+
+    it('returns null when the execution has no chart config', () => {
+        expect(
+            resolveDeepResearchWarehouseChart(
+                { ...groupedChartToolArgs, chartConfig: null },
+                QUERY_UUID,
+            ),
+        ).toBeNull();
+    });
+});

--- a/packages/backend/src/ee/services/AiDeepResearchService/resolveDeepResearchWarehouseChart.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/resolveDeepResearchWarehouseChart.ts
@@ -21,14 +21,7 @@ export const resolveDeepResearchWarehouseChart = (
         title: parsedToolArgs.data.title,
         chartConfig: {
             ...chartConfig,
-            defaultVizType: chartConfig.groupBy?.length
-                ? 'table'
-                : chartConfig.defaultVizType,
-            groupBy: null,
             funnelDataInput: null,
-            stackBars: chartConfig.groupBy?.length
-                ? null
-                : chartConfig.stackBars,
         },
     });
     if (!parsedChart.success || parsedChart.data.source !== 'warehouse') {

--- a/packages/backend/src/ee/services/ai/agents/reportFinalizer.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/reportFinalizer.test.ts
@@ -1,0 +1,95 @@
+import { type AiDeepResearchEvidencePack } from '@lightdash/common';
+import { generateObject } from 'ai';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { generateDeepResearchReport } from './reportFinalizer';
+
+vi.mock('ai', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('ai')>()),
+    generateObject: vi.fn(),
+}));
+
+const evidencePack: AiDeepResearchEvidencePack = {
+    question: 'Why did revenue change?',
+    queries: [],
+    workerFindings: [],
+};
+
+const validMarkdown = `# Revenue Decline Explained
+
+Revenue declined because renewals weakened while acquisition remained flat.
+
+## Renewals weakened
+
+Renewals are the clearest driver in the available evidence.
+
+## Acquisition could not compensate
+
+New business was insufficient to offset weaker renewals. The acquisition window is short, so the next useful check is whether the pattern persists in later cohorts.
+
+## Conclusion
+
+Renewal performance is the priority.`;
+
+const invalidMarkdown = `# Incomplete Revenue Evidence
+
+The evidence is incomplete.
+
+## Only one finding
+
+There is not enough evidence.
+
+## Conclusion
+
+Investigate further.`;
+
+const modelOptions = { model: {} } as never;
+const generateObjectMock = vi.mocked(generateObject);
+
+const mockReports = (markdownReports: string[]) => {
+    markdownReports.forEach((markdown) => {
+        generateObjectMock.mockResolvedValueOnce({
+            object: { markdown },
+        } as never);
+    });
+};
+
+describe('generateDeepResearchReport', () => {
+    beforeEach(() => {
+        generateObjectMock.mockReset();
+    });
+
+    it('returns a valid first attempt in the canonical format', async () => {
+        mockReports([validMarkdown]);
+
+        const report = await generateDeepResearchReport(modelOptions, {
+            evidencePack,
+            reason: 'complete',
+        });
+
+        expect(report.markdown).toBe(validMarkdown);
+    });
+
+    it('returns a valid correction attempt', async () => {
+        mockReports([invalidMarkdown, validMarkdown]);
+
+        const report = await generateDeepResearchReport(modelOptions, {
+            evidencePack,
+            reason: 'complete',
+        });
+
+        expect(generateObjectMock).toHaveBeenCalledTimes(2);
+        expect(report.markdown).toBe(validMarkdown);
+    });
+
+    it('keeps invalid salvage output readable for the Markdown fallback', async () => {
+        mockReports([invalidMarkdown, invalidMarkdown]);
+
+        const report = await generateDeepResearchReport(modelOptions, {
+            evidencePack,
+            reason: 'complete',
+        });
+
+        expect(generateObjectMock).toHaveBeenCalledTimes(2);
+        expect(report.markdown).toBe(invalidMarkdown);
+    });
+});

--- a/packages/backend/src/ee/services/ai/agents/reportFinalizer.ts
+++ b/packages/backend/src/ee/services/ai/agents/reportFinalizer.ts
@@ -123,7 +123,11 @@ export const generateDeepResearchReport = async (
             const raw = await generateRaw(correction);
             const linted = aiDeepResearchReportSchema.safeParse(raw);
             return linted.success
-                ? { report: linted.data, raw: null, issues: null }
+                ? {
+                      report: linted.data,
+                      raw: null,
+                      issues: null,
+                  }
                 : {
                       report: null,
                       raw,

--- a/packages/backend/src/ee/services/ai/prompts/deepResearch.ts
+++ b/packages/backend/src/ee/services/ai/prompts/deepResearch.ts
@@ -6,22 +6,22 @@ Plan broadly, investigate competing explanations, validate important claims, and
 
 # Report format
 
-The report is ONE markdown document, written at the end of the run from the evidence gathered during it.
+The final report is ONE Markdown document of visual findings, written at the end of the run from the evidence gathered during it.
 
 Structure:
-- Start with a 2-4 sentence introduction before any heading that answers the user's question directly and states your overall confidence.
-- Then include 2-5 finding sections under "## " headings. Order them as a connected argument: establish the baseline, explain what changed, identify drivers, then test alternatives or implications.
-- Each finding section must contain exactly one confidence tag immediately after its heading: <confidence level="high">Optional short caveat.</confidence>. The level is low, medium, or high.
-- End with a "## Conclusion" section.
-- Cite external evidence inline with markers such as [1], and list each source in a final "## Sources" section.
+- Start with a short, specific report title as a single "# " heading. The title must be 3-8 words and no more than 60 characters. Never reuse the user's full prompt as the title.
+- Follow with a concise 2-4 sentence introduction that states the report's central story. Do not discuss confidence as a separate concept.
+- Then include 2-5 finding sections ordered as a connected argument: establish the pattern, explain what changed, identify drivers, then test alternatives or implications.
+- Each finding uses a short conclusion-led "## " heading of at most 6 words and 50 characters, such as "Growth came in spikes". Do not use long sentence headings.
+- When a finding has visual evidence, put one <chart id="<queryUuid>"> on its own line immediately after the heading. Then write 1-2 short narrative paragraphs below it. For a text-only finding, put the narrative directly below the heading.
+- Treat the chart as the primary evidence. Use at most one or two anchor numbers that the reader needs; never enumerate or restate the visible series. Instead, guide the reader through the pattern, explain why it matters, and identify the implication or next investigation. Aim for 80-140 words total per finding.
+- Fold a material caveat into the narrative sentence it qualifies. Do not emit confidence tags, confidence labels, or a dedicated caveat line.
+- End with a concise, one-paragraph "## Conclusion" that synthesizes the story and the most useful next action without recapping every value.
+- Do not add separate Caveats, Sources, or References sections. Keep caveats inline with the finding they qualify. Link external evidence directly in the relevant prose with normal Markdown links, never numbered citation markers.
 
-Charts:
-- You do not design charts. To show one, write <chart id="<queryUuid>"> on its own line where it belongs in the narrative, using the queryUuid of an execution marked chartable in the evidence. For example: <chart id="681831ec-b696-4cda-85ef-de7b6ddae850">.
-- The id must be a queryUuid copied verbatim from the evidence — not a slug, name, or any other label. The server builds the chart from that execution and fills in its title and description; a reference it cannot back is dropped and costs nothing else.
-- Show a chart wherever one makes a finding easier to see — a trend over time, a comparison across categories, a breakdown behind a total. Reference each execution at most once, and include no more than ${AI_DEEP_RESEARCH_MAX_CHARTS} charts.
-
-Callouts:
-- Use only paired <warning>, <info>, <tip>, <note>, and <confidence> tags.
-- Put report-wide caveats in a "## Caveats" section.
+Evidence:
+- Prefer visual evidence for trends, comparisons, composition, distributions, and relationships. Use an execution whose visualizationType is "table" only when exact lookup or dimensional detail is itself the finding.
+- You do not redesign charts in the report. To show evidence, copy the queryUuid verbatim from an execution marked chartable into <chart id="<queryUuid>">. The visualizationType tells you how the server will render it. The server owns the stored configuration and drops an unbackable reference without losing the finding.
+- Do not manufacture weak evidence to satisfy a quota. Reference each execution at most once, and select no more than ${AI_DEEP_RESEARCH_MAX_CHARTS} evidence queries.
 
 Distinguish observations from inferences and state uncertainty explicitly.`;

--- a/packages/common/src/ee/aiDeepResearch/evidence.ts
+++ b/packages/common/src/ee/aiDeepResearch/evidence.ts
@@ -1,4 +1,7 @@
-import { type AiDeepResearchWorkerFindings } from './types';
+import {
+    type AiDeepResearchChartConfig,
+    type AiDeepResearchWorkerFindings,
+} from './types';
 
 /**
  * Bounds on the evidence pack handed to the finalizer. The pack is rebuilt
@@ -27,12 +30,15 @@ export type AiDeepResearchEvidenceQuery =
           metrics: string[];
           /** Whether the server can derive a chart for this execution. */
           chartable: boolean;
+          /** The stored visualization the report will render when chartable. */
+          visualizationType: AiDeepResearchChartConfig['defaultVizType'] | null;
       })
     | (AiDeepResearchEvidenceQueryBase & {
           type: 'sql_query';
           columns: string[];
           /** Raw SQL evidence does not have a semantic chart definition. */
           chartable: false;
+          visualizationType: null;
       });
 
 /**

--- a/packages/common/src/ee/aiDeepResearch/markdown.test.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.test.ts
@@ -4,6 +4,7 @@ import {
     countDeepResearchFindings,
     findDeepResearchChartRefs,
     lintDeepResearchReport,
+    parseDeepResearchReport,
     renderDeepResearchChartRefs,
     spliceDeepResearchRanges,
     type AiDeepResearchChartDefinition,
@@ -46,21 +47,25 @@ const warehouseChart = (
     chartConfig,
 });
 
-const validReport = `The seasonal dip is driven by B2B churn, with high confidence overall.
+const validReport = `# Revenue Reversal Explained
 
-## Baseline revenue trend
+The seasonal dip is driven by B2B churn rather than a broad demand decline.
 
-<confidence level="high">Complete order history since 2022.</confidence>
-
-Revenue grew steadily until spring.
+## Revenue grew before reversing
 
 ${chartTag(UUID_A)}
 
+Revenue grew steadily until spring.
+
 The dip aligns with contract renewals.
+
+## Renewals drove the reversal
+
+B2B renewals coincide with the reversal and are the strongest tested explanation. The evidence is observational rather than causal, so the next useful test is to compare renewal cohorts directly.
 
 ## Conclusion
 
-- B2B churn explains the dip.
+B2B churn best explains the dip, making renewal health the clearest place to investigate next.
 `;
 
 describe('findDeepResearchChartRefs', () => {
@@ -233,7 +238,7 @@ describe('spliceDeepResearchRanges', () => {
 
 describe('countDeepResearchFindings', () => {
     it('counts non-structural level-two sections outside code fences', () => {
-        const markdown = `## A\n\n<confidence level="high">ok</confidence>\n\n\`\`\`md\n## Not a finding\n\`\`\`\n\n## B\n\n<confidence level="low">meh</confidence>\n\n## Sources\n\n- source\n\n## Caveats\n\n- caveat\n\n## Conclusion\n\n- done`;
+        const markdown = `## A\n\nOne paragraph.\n\n\`\`\`md\n## Not a finding\n\`\`\`\n\n## B\n\nOne paragraph.\n\n## Sources\n\n- source\n\n## Caveats\n\n- caveat\n\n## Conclusion\n\n- done`;
         expect(countDeepResearchFindings(markdown)).toBe(2);
     });
 });
@@ -243,25 +248,55 @@ describe('lintDeepResearchReport', () => {
         expect(lintDeepResearchReport(validReport)).toEqual([]);
     });
 
-    it('never fails a report over its charts', () => {
+    it('ignores chart validity because the server verifies references', () => {
         const markdown = validReport
             .replace(
-                'The dip aligns with contract renewals.',
-                `The dip aligns with contract renewals.\n\n${chartTag(
+                chartTag(UUID_A),
+                `${chartTag(
                     UUID_A,
                     'Duplicate',
                 )}\n\n${chartTag(UUID_B, 'Second')}\n\n<chart id="not a uuid!">`,
             )
-            .replace(chartTag(UUID_A), chartTag(UUID_A, 'T', 'x'.repeat(400)));
+            .replace(
+                chartTag(UUID_A, 'Duplicate'),
+                chartTag(UUID_A, 'T', 'x'.repeat(400)),
+            );
 
-        expect(lintDeepResearchReport(markdown)).toEqual([]);
+        const errors = lintDeepResearchReport(markdown);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('at most one chart reference');
     });
 
     it('requires intro prose before the first heading', () => {
         const errors = lintDeepResearchReport(
-            validReport.replace(/^.*\n\n## Baseline/, '## Baseline'),
+            validReport.replace(
+                'The seasonal dip is driven by B2B churn rather than a broad demand decline.\n\n',
+                '',
+            ),
         );
         expect(errors.some((e) => e.includes('introduction'))).toBe(true);
+    });
+
+    it('requires a short report title', () => {
+        const missing = validReport.replace(
+            '# Revenue Reversal Explained\n\n',
+            '',
+        );
+        const long = validReport.replace(
+            '# Revenue Reversal Explained',
+            '# Revenue Performance Across Every Available Historical Period and Customer Segment',
+        );
+
+        expect(
+            lintDeepResearchReport(missing).some((error) =>
+                error.includes('report with a short'),
+            ),
+        ).toBe(true);
+        expect(
+            lintDeepResearchReport(long).some((error) =>
+                error.includes('3-8 words'),
+            ),
+        ).toBe(true);
     });
 
     it('requires a conclusion section', () => {
@@ -271,35 +306,79 @@ describe('lintDeepResearchReport', () => {
         expect(errors.some((e) => e.includes('## Conclusion'))).toBe(true);
     });
 
-    it('requires exactly one confidence tag per finding section', () => {
+    it('requires two to five findings', () => {
+        const oneFinding = validReport.replace(
+            /## Renewals drove[\s\S]*?(?=## Conclusion)/,
+            '',
+        );
+        const sixFindings = validReport.replace(
+            '## Conclusion',
+            `${Array.from(
+                { length: 4 },
+                (_, index) =>
+                    `## Additional finding ${index + 1}\n\nInterpretation.\n\n`,
+            ).join('')}## Conclusion`,
+        );
+
+        expect(lintDeepResearchReport(oneFinding)[0]).toContain('found 1');
+        expect(lintDeepResearchReport(sixFindings)[0]).toContain('found 6');
+    });
+
+    it('requires conclusion to be the final section', () => {
+        const errors = lintDeepResearchReport(
+            `${validReport}\n## Afterword\n\nToo late.`,
+        );
+        expect(errors.some((error) => error.includes('final section'))).toBe(
+            true,
+        );
+    });
+
+    it('requires a one-paragraph conclusion', () => {
         const errors = lintDeepResearchReport(
             validReport.replace(
-                '<confidence level="high">Complete order history since 2022.</confidence>\n\n',
-                '',
+                'B2B churn best explains the dip, making renewal health the clearest place to investigate next.',
+                'B2B churn best explains the dip.\n\nInvestigate retention next.',
             ),
         );
         expect(
-            errors.some(
-                (e) => e.includes('Baseline revenue trend') && e.includes('0'),
-            ),
+            errors.some((error) => error.includes('one concise paragraph')),
         ).toBe(true);
     });
 
-    it('rejects a finding section with two confidence tags', () => {
+    it('requires short finding headings', () => {
         const errors = lintDeepResearchReport(
             validReport.replace(
-                'Revenue grew steadily until spring.',
-                '<confidence level="low">extra</confidence>\n\nRevenue grew steadily until spring.',
+                '## Revenue grew before reversing',
+                '## Revenue and order volume were negligible until three discrete spikes reshaped the entire picture',
             ),
         );
-        expect(errors.some((e) => e.includes('found 2'))).toBe(true);
+        expect(errors.some((error) => error.includes('Finding heading'))).toBe(
+            true,
+        );
     });
 
-    it('rejects invalid confidence levels', () => {
+    it('requires evidence before the narrative', () => {
         const errors = lintDeepResearchReport(
-            validReport.replace('level="high"', 'level="certain"'),
+            validReport
+                .replace(chartTag(UUID_A), '')
+                .replace(
+                    'Revenue grew steadily until spring.',
+                    `Revenue grew steadily until spring.\n\n${chartTag(UUID_A)}`,
+                ),
         );
-        expect(errors.some((e) => e.includes('invalid level'))).toBe(true);
+        expect(
+            errors.some((error) => error.includes('immediately after')),
+        ).toBe(true);
+    });
+
+    it('allows at most two narrative paragraphs per finding', () => {
+        const errors = lintDeepResearchReport(
+            validReport.replace(
+                'The dip aligns with contract renewals.',
+                'The dip aligns with contract renewals.\n\nA third paragraph.\n\nA fourth paragraph.',
+            ),
+        );
+        expect(errors.some((error) => error.includes('1-2'))).toBe(true);
     });
 
     it('rejects disallowed html tags', () => {
@@ -329,24 +408,89 @@ describe('lintDeepResearchReport', () => {
         expect(errors.some((e) => e.includes('Unbalanced <note>'))).toBe(true);
     });
 
-    it('requires a sources section when citations are used', () => {
+    it('requires external evidence to use inline links', () => {
         const errors = lintDeepResearchReport(
             validReport.replace(
                 'The dip aligns with contract renewals.',
                 'The dip aligns with contract renewals [1].',
             ),
         );
-        expect(errors.some((e) => e.includes('## Sources'))).toBe(true);
+        expect(errors.some((e) => e.includes('inline'))).toBe(true);
     });
 
-    it('accepts citations when a sources section exists', () => {
+    it('rejects separate sources sections', () => {
         const errors = lintDeepResearchReport(
             `${validReport.replace(
                 'The dip aligns with contract renewals.',
                 'The dip aligns with contract renewals [1].',
             )}\n## Sources\n\n1. [Benchmarks](https://example.com) — baseline\n`,
         );
-        expect(errors).toEqual([]);
+        expect(errors.some((e) => e.includes('## Sources'))).toBe(true);
+    });
+
+    it('rejects separate references sections', () => {
+        const errors = lintDeepResearchReport(
+            `${validReport}\n## References\n\n1. [Benchmarks](https://example.com) — baseline\n`,
+        );
+        expect(errors.some((e) => e.includes('## References'))).toBe(true);
+    });
+
+    it('rejects separate caveats sections', () => {
+        const errors = lintDeepResearchReport(
+            `${validReport}\n## Caveats\n\n- Directional only.\n`,
+        );
+        expect(errors.some((e) => e.includes('## Caveats'))).toBe(true);
+    });
+});
+
+describe('report parsing', () => {
+    it('parses canonical markdown into a transient finding model', () => {
+        const report = parseDeepResearchReport(validReport);
+
+        expect(report).toMatchObject({
+            title: 'Revenue Reversal Explained',
+            findings: [
+                {
+                    title: 'Revenue grew before reversing',
+                    evidenceQueryUuid: UUID_A,
+                },
+                {
+                    title: 'Renewals drove the reversal',
+                    evidenceQueryUuid: null,
+                },
+            ],
+            conclusionMarkdown:
+                'B2B churn best explains the dip, making renewal health the clearest place to investigate next.',
+        });
+        expect(report?.findings[0].interpretationMarkdown).toContain(
+            'Revenue grew steadily until spring.',
+        );
+        expect(report?.findings[0].interpretationMarkdown).not.toContain(
+            '<chart',
+        );
+    });
+
+    it('preserves structured rendering when only editorial lint fails', () => {
+        const markdown = validReport.replace(
+            '## Revenue grew before reversing',
+            '## Customer LTV rising but completion rate falling',
+        );
+
+        expect(lintDeepResearchReport(markdown)).toContain(
+            'Finding heading "Customer LTV rising but completion rate falling" must be at most 6 words and 50 characters.',
+        );
+        const report = parseDeepResearchReport(markdown);
+        expect(report?.title).toBe('Revenue Reversal Explained');
+        expect(report?.findings[0]).toMatchObject({
+            title: 'Customer LTV rising but completion rate falling',
+        });
+    });
+    it('returns null for malformed model output', () => {
+        const invalid = validReport.replace(
+            /## Renewals drove[\s\S]*?(?=## Conclusion)/,
+            '',
+        );
+        expect(parseDeepResearchReport(invalid)).toBeNull();
     });
 });
 
@@ -361,18 +505,11 @@ describe('chart definition validation', () => {
         expect(result.success).toBe(false);
     });
 
-    it('rejects grouped chart configs', () => {
+    it('accepts grouped chart configs', () => {
         const result = aiDeepResearchChartDefinitionSchema.safeParse({
             ...warehouseChart(UUID_A),
             chartConfig: { ...chartConfig, groupBy: ['orders_status'] },
         });
-        expect(result.success).toBe(false);
-        if (!result.success) {
-            expect(
-                result.error.issues.some((i) =>
-                    i.message.includes('groupBy is not supported'),
-                ),
-            ).toBe(true);
-        }
+        expect(result.success).toBe(true);
     });
 });

--- a/packages/common/src/ee/aiDeepResearch/markdown.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.ts
@@ -1,13 +1,9 @@
 import { z } from 'zod';
-import {
-    AI_DEEP_RESEARCH_CONFIDENCE_LEVELS,
-    type AiDeepResearchChartConfig,
-} from './types';
+import { type AiDeepResearchChartConfig } from './types';
 
 export const AI_DEEP_RESEARCH_MAX_CHARTS = 8;
 export const AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS = 300;
 export const AI_DEEP_RESEARCH_MAX_REPORT_MARKDOWN_CHARS = 60_000;
-
 /**
  * Whitelisted HTML tags allowed in report markdown, mapped to their allowed
  * attributes. Single source for the frontend sanitizer and the backend
@@ -18,7 +14,6 @@ export const AI_DEEP_RESEARCH_MARKDOWN_TAGS: Record<string, string[]> = {
     warning: ['title'],
     info: ['title'],
     tip: ['title'],
-    confidence: ['level'],
 };
 
 const chartConfigSchema: z.ZodType<AiDeepResearchChartConfig> = z.object({
@@ -44,21 +39,6 @@ const chartConfigSchema: z.ZodType<AiDeepResearchChartConfig> = z.object({
     secondaryYAxisLabel: z.string().nullable(),
 });
 
-const rejectGroupBy = (
-    chartConfig: AiDeepResearchChartConfig,
-    context: z.RefinementCtx,
-) => {
-    // Grouped charts need a pivoted execution; report chart results are unpivoted.
-    if (chartConfig.groupBy?.length) {
-        context.addIssue({
-            code: 'custom',
-            path: ['chartConfig', 'groupBy'],
-            message:
-                'groupBy is not supported in report charts; set it to null and use a separate chart per breakdown instead.',
-        });
-    }
-};
-
 /**
  * A chart backed by a completed run_metric_query execution. Every report chart
  * is one of these: the backend verifies the queryUuid before using its metric
@@ -71,10 +51,7 @@ const warehouseChartObjectSchema = z.object({
     chartConfig: chartConfigSchema,
 });
 
-export const aiDeepResearchChartDefinitionSchema =
-    warehouseChartObjectSchema.superRefine((chart, context) => {
-        rejectGroupBy(chart.chartConfig, context);
-    });
+export const aiDeepResearchChartDefinitionSchema = warehouseChartObjectSchema;
 
 export type AiDeepResearchWarehouseChart = z.infer<
     typeof warehouseChartObjectSchema
@@ -346,9 +323,17 @@ export const renderDeepResearchChartRefs = (markdown: string): string =>
         })),
     );
 
-const CONFIDENCE_TAG_RE = /<confidence\b[^>]*>/g;
-
-const STRUCTURAL_SECTIONS = new Set(['conclusion', 'sources', 'caveats']);
+const STRUCTURAL_SECTIONS = new Set([
+    'conclusion',
+    'sources',
+    'references',
+    'caveats',
+]);
+const REPORT_TITLE_MAX_CHARS = 60;
+const REPORT_TITLE_MIN_WORDS = 3;
+const REPORT_TITLE_MAX_WORDS = 8;
+const FINDING_TITLE_MAX_CHARS = 50;
+const FINDING_TITLE_MAX_WORDS = 6;
 
 type MarkdownSection = {
     title: string;
@@ -393,6 +378,69 @@ const splitSections = (
     }
     closeCurrent(masked.length);
     return { preamble: preambleLines.join('\n'), sections };
+};
+
+const getSectionContent = (
+    markdown: string,
+    section: MarkdownSection,
+): string => {
+    const sectionMarkdown = markdown.slice(section.start, section.end);
+    const firstNewline = sectionMarkdown.indexOf('\n');
+    return firstNewline === -1 ? '' : sectionMarkdown.slice(firstNewline + 1);
+};
+
+const getWordCount = (value: string): number =>
+    value.trim().split(/\s+/).filter(Boolean).length;
+
+const getReportHeader = (
+    preamble: string,
+): { title: string | null; introductionMarkdown: string } => {
+    const lines = preamble.split('\n');
+    const firstContentLine = lines.findIndex((line) => line.trim().length > 0);
+    const titleMatch =
+        firstContentLine === -1
+            ? null
+            : lines[firstContentLine].match(/^# +(.+?)\s*$/);
+
+    if (!titleMatch) {
+        return { title: null, introductionMarkdown: preamble.trim() };
+    }
+
+    return {
+        title: titleMatch[1].trim(),
+        introductionMarkdown: lines
+            .filter((_line, index) => index !== firstContentLine)
+            .join('\n')
+            .trim(),
+    };
+};
+
+const getNarrativeMarkdown = (content: string): string =>
+    spliceDeepResearchRanges(
+        content,
+        findDeepResearchChartTags(content).map((tag) => ({
+            match: tag,
+            replacement: '',
+        })),
+    ).trim();
+
+const getParagraphCount = (markdown: string): number =>
+    markdown
+        .split(/\n\s*\n/)
+        .map((paragraph) => paragraph.trim())
+        .filter(Boolean).length;
+
+export type ParsedDeepResearchFinding = {
+    title: string;
+    evidenceQueryUuid: string | null;
+    interpretationMarkdown: string;
+};
+
+export type ParsedDeepResearchReport = {
+    title: string;
+    introductionMarkdown: string;
+    findings: ParsedDeepResearchFinding[];
+    conclusionMarkdown: string;
 };
 
 export const countDeepResearchFindings = (markdown: string): number =>
@@ -458,63 +506,184 @@ export const lintDeepResearchReport = (markdown: string): string[] => {
     const errors: string[] = [];
     const masked = maskFencedBlocks(markdown);
     const { preamble, sections } = splitSections(masked);
+    const { title: reportTitle, introductionMarkdown } =
+        getReportHeader(preamble);
 
-    if (!/\S/.test(preamble.replace(/^#{1,6} .*$/gm, ''))) {
+    if (!reportTitle) {
         errors.push(
-            'Start the report with a short introduction (2-4 sentences of prose) before the first "## " heading.',
+            'Start the report with a short "# " title before the introduction.',
+        );
+    } else {
+        const titleWords = getWordCount(reportTitle);
+        if (
+            reportTitle.length > REPORT_TITLE_MAX_CHARS ||
+            titleWords < REPORT_TITLE_MIN_WORDS ||
+            titleWords > REPORT_TITLE_MAX_WORDS
+        ) {
+            errors.push(
+                `The report title must be ${REPORT_TITLE_MIN_WORDS}-${REPORT_TITLE_MAX_WORDS} words and at most ${REPORT_TITLE_MAX_CHARS} characters.`,
+            );
+        }
+    }
+
+    if (!/\S/.test(introductionMarkdown)) {
+        errors.push(
+            'Write a short introduction after the report title and before the first "## " heading.',
         );
     }
 
     const findingSections = sections.filter(
         ({ title }) => !STRUCTURAL_SECTIONS.has(title.trim().toLowerCase()),
     );
-    if (findingSections.length === 0) {
+    if (findingSections.length < 2 || findingSections.length > 5) {
         errors.push(
-            'The report must contain at least one "## " finding section between the introduction and the conclusion.',
+            `The report must contain 2-5 "## " finding sections between the introduction and the conclusion (found ${findingSections.length}).`,
         );
     }
-    if (
-        !sections.some(
-            ({ title }) => title.trim().toLowerCase() === 'conclusion',
-        )
-    ) {
+    const conclusionIndex = sections.findIndex(
+        ({ title }) => title.trim().toLowerCase() === 'conclusion',
+    );
+    if (conclusionIndex === -1) {
         errors.push('The report must end with a "## Conclusion" section.');
+    } else if (conclusionIndex !== sections.length - 1) {
+        errors.push('"## Conclusion" must be the final section.');
+    } else {
+        const conclusionMarkdown = getSectionContent(
+            markdown,
+            sections[conclusionIndex],
+        ).trim();
+        const conclusionParagraphs = getParagraphCount(conclusionMarkdown);
+        if (conclusionParagraphs !== 1) {
+            errors.push(
+                `"## Conclusion" must contain one concise paragraph (found ${conclusionParagraphs}).`,
+            );
+        }
+    }
+
+    for (const title of ['sources', 'references', 'caveats']) {
+        if (
+            sections.some(
+                (section) => section.title.trim().toLowerCase() === title,
+            )
+        ) {
+            errors.push(
+                `Do not add a separate "## ${title[0].toUpperCase()}${title.slice(
+                    1,
+                )}" section; put caveats with their findings and use inline Markdown links for external sources.`,
+            );
+        }
     }
 
     findingSections.forEach(({ title, content }) => {
-        const confidenceTags = content.match(CONFIDENCE_TAG_RE) ?? [];
-        if (confidenceTags.length !== 1) {
+        if (
+            title.length > FINDING_TITLE_MAX_CHARS ||
+            getWordCount(title) > FINDING_TITLE_MAX_WORDS
+        ) {
             errors.push(
-                `Finding section "${title}" must contain exactly one <confidence level="low|medium|high">...</confidence> tag right after its heading (found ${confidenceTags.length}).`,
+                `Finding heading "${title}" must be at most ${FINDING_TITLE_MAX_WORDS} words and ${FINDING_TITLE_MAX_CHARS} characters.`,
             );
         }
-        confidenceTags.forEach((tag) => {
-            const level = tag.match(/level="([^"]*)"/)?.[1];
-            if (
-                !AI_DEEP_RESEARCH_CONFIDENCE_LEVELS.includes(
-                    level as (typeof AI_DEEP_RESEARCH_CONFIDENCE_LEVELS)[number],
-                )
-            ) {
+
+        const chartRefs = findDeepResearchChartRefs(content);
+        if (chartRefs.length > 1) {
+            errors.push(
+                `Finding section "${title}" may contain at most one chart reference (found ${chartRefs.length}).`,
+            );
+        }
+        if (chartRefs[0]) {
+            if (content.slice(0, chartRefs[0].start).trim()) {
                 errors.push(
-                    `Finding section "${title}" has a <confidence> tag with an invalid level; use level="low", "medium" or "high".`,
+                    `Finding section "${title}" must put its chart immediately after the heading and before the narrative.`,
                 );
             }
-        });
+        }
+
+        const narrativeMarkdown = getNarrativeMarkdown(content);
+        const paragraphCount = getParagraphCount(narrativeMarkdown);
+        if (paragraphCount < 1 || paragraphCount > 2) {
+            errors.push(
+                `Finding section "${title}" must contain 1-2 narrative paragraphs after its chart (found ${paragraphCount}).`,
+            );
+        }
     });
 
     errors.push(...lintHtmlTags(masked));
 
-    const hasCitations = /\[\d+\]/.test(masked);
-    const hasSourcesSection = sections.some(
-        ({ title }) => title.trim().toLowerCase() === 'sources',
-    );
-    if (hasCitations && !hasSourcesSection) {
+    if (/\[\d+\]/.test(masked)) {
         errors.push(
-            'The report uses [n] citation markers but has no "## Sources" section; list every cited source there as a numbered list.',
+            'Do not use numbered citation markers or a separate references list; link external evidence inline with normal Markdown links.',
         );
     }
 
     return errors;
+};
+
+/**
+ * Builds a transient render model from the canonical report Markdown. Returning
+ * null lets structurally malformed model output fall back to the plain Markdown
+ * renderer. Editorial lint is intentionally stricter than parsing: a long
+ * heading or extra paragraph should not discard an otherwise usable report.
+ */
+export const parseDeepResearchReport = (
+    markdown: string,
+): ParsedDeepResearchReport | null => {
+    const { preamble, sections } = splitSections(maskFencedBlocks(markdown));
+    const { title: reportTitle, introductionMarkdown } =
+        getReportHeader(preamble);
+    const conclusionIndex = sections.findIndex(
+        ({ title }) => title.trim().toLowerCase() === 'conclusion',
+    );
+    const findingSections = sections.slice(0, conclusionIndex);
+    const hasStructuralFinding = findingSections.some(({ title }) =>
+        STRUCTURAL_SECTIONS.has(title.trim().toLowerCase()),
+    );
+    if (
+        !reportTitle ||
+        !introductionMarkdown ||
+        conclusionIndex === -1 ||
+        conclusionIndex !== sections.length - 1 ||
+        findingSections.length < 2 ||
+        findingSections.length > 5 ||
+        hasStructuralFinding
+    ) {
+        return null;
+    }
+
+    const chartRefs = findDeepResearchChartRefs(markdown);
+    const findings = findingSections.map((section) => {
+        const content = getSectionContent(markdown, section);
+
+        const contentStart =
+            section.start +
+            markdown.slice(section.start, section.end).indexOf('\n') +
+            1;
+        const chart = chartRefs.find(
+            ({ start, end }) => start >= contentStart && end <= section.end,
+        );
+
+        return {
+            title: section.title.trim(),
+            evidenceQueryUuid: chart?.key ?? null,
+            interpretationMarkdown: getNarrativeMarkdown(content),
+        };
+    });
+    const conclusionMarkdown = getSectionContent(
+        markdown,
+        sections[conclusionIndex],
+    ).trim();
+    if (
+        !conclusionMarkdown ||
+        findings.some(({ interpretationMarkdown }) => !interpretationMarkdown)
+    ) {
+        return null;
+    }
+
+    return {
+        title: reportTitle,
+        introductionMarkdown,
+        findings,
+        conclusionMarkdown,
+    };
 };
 
 export const aiDeepResearchReportInputSchema = z.object({


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9790

## Summary

PR 1 of 3 for [PROD-9790](https://linear.app/lightdash/issue/PROD-9790). Keeps Markdown as the canonical report artifact and constrains newly generated reports to a data-first narrative structure.

## Changes

- Generates a specific 3–8 word report title instead of reusing the user prompt.
- Limits finding headings to six words and places verified chart evidence immediately below each heading.
- Guides each finding into one or two complementary narrative paragraphs with caveats folded into the relevant sentence.
- Removes report confidence metadata and separate Caveats, Sources, and References sections.
- Parses valid canonical Markdown into a transient render model and falls back to plain Markdown when model output is malformed.

```text
# Short report title
Introduction

## Short finding
<chart>
Narrative and inline caveat

## Conclusion
```

## Test plan

- [x] Common Markdown/parser tests: 40 passed
- [x] Backend report finalizer tests: 3 passed
- [x] Common and backend lint
- [x] Common and backend typecheck


