### PR TITLE
feat(ai): bound deep research chart interactions

### DIFF
--- a/packages/frontend/src/components/FunnelChart/index.tsx
+++ b/packages/frontend/src/components/FunnelChart/index.tsx
@@ -41,12 +41,18 @@ type FunnelChartProps = Omit<EChartsReactProps, 'option'> & {
     className?: string;
     onScreenshotReady?: () => void;
     onScreenshotError?: () => void;
+    enableContextMenu?: boolean;
 };
 
 const EchartOptions: Opts = { renderer: 'svg' };
 
 const FunnelChart: FC<FunnelChartProps> = memo(
-    ({ onScreenshotReady, onScreenshotError, ...props }) => {
+    ({
+        onScreenshotReady,
+        onScreenshotError,
+        enableContextMenu = true,
+        ...props
+    }) => {
         const { chartRef, isLoading, resultsData, minimal } =
             useVisualizationContext();
         const { selectedLegends, onLegendChange } =
@@ -124,11 +130,15 @@ const FunnelChart: FC<FunnelChartProps> = memo(
 
         const onEvents = useMemo(
             () => ({
-                click: handleOpenContextMenu,
-                oncontextmenu: handleOpenContextMenu,
+                ...(enableContextMenu
+                    ? {
+                          click: handleOpenContextMenu,
+                          oncontextmenu: handleOpenContextMenu,
+                      }
+                    : {}),
                 legendselectchanged: onLegendChange,
             }),
-            [handleOpenContextMenu, onLegendChange],
+            [enableContextMenu, handleOpenContextMenu, onLegendChange],
         );
 
         if (isLoading) return <LoadingChart />;
@@ -159,7 +169,7 @@ const FunnelChart: FC<FunnelChartProps> = memo(
                     onEvents={onEvents}
                 />
 
-                {shouldShowMenu && (
+                {enableContextMenu && shouldShowMenu && (
                     <FunnelChartContextMenu
                         value={menuProps?.value}
                         menuPosition={menuProps?.position}

--- a/packages/frontend/src/components/LightdashVisualization/LightdashVisualization.interaction.test.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/LightdashVisualization.interaction.test.tsx
@@ -1,0 +1,82 @@
+import { ChartType } from '@lightdash/common';
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import LightdashVisualization from '.';
+import { renderWithProviders } from '../../testing/testUtils';
+
+const mocks = vi.hoisted(() => ({
+    useVisualizationContext: vi.fn(),
+}));
+
+vi.mock('./useVisualizationContext', () => ({
+    useVisualizationContext: mocks.useVisualizationContext,
+}));
+
+vi.mock('../SimpleTable', () => ({
+    default: ({ enableContextMenu }: { enableContextMenu?: boolean }) => (
+        <div
+            data-testid="table"
+            data-context-menu-enabled={String(enableContextMenu)}
+        />
+    ),
+}));
+vi.mock('../SimplePieChart', () => ({
+    default: ({ enableContextMenu }: { enableContextMenu?: boolean }) => (
+        <div
+            data-testid="pie"
+            data-context-menu-enabled={String(enableContextMenu)}
+        />
+    ),
+}));
+vi.mock('../FunnelChart', () => ({
+    default: ({ enableContextMenu }: { enableContextMenu?: boolean }) => (
+        <div
+            data-testid="funnel"
+            data-context-menu-enabled={String(enableContextMenu)}
+        />
+    ),
+}));
+
+const renderVisualization = (
+    chartType: ChartType,
+    enableContextMenu?: boolean,
+) => {
+    mocks.useVisualizationContext.mockReturnValue({
+        visualizationConfig: { chartType },
+        minimal: false,
+        apiErrorDetail: null,
+    });
+
+    return renderWithProviders(
+        <LightdashVisualization enableContextMenu={enableContextMenu} />,
+    );
+};
+
+describe('LightdashVisualization context menus', () => {
+    afterEach(() => {
+        cleanup();
+        mocks.useVisualizationContext.mockReset();
+    });
+
+    it.each([
+        [ChartType.TABLE, 'table'],
+        [ChartType.PIE, 'pie'],
+        [ChartType.FUNNEL, 'funnel'],
+    ])('disables menus for %s visualizations', (chartType, testId) => {
+        renderVisualization(chartType, false);
+
+        expect(screen.getByTestId(testId)).toHaveAttribute(
+            'data-context-menu-enabled',
+            'false',
+        );
+    });
+
+    it('keeps context menus enabled by default', () => {
+        renderVisualization(ChartType.PIE);
+
+        expect(screen.getByTestId('pie')).toHaveAttribute(
+            'data-context-menu-enabled',
+            'true',
+        );
+    });
+});

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -82,6 +82,7 @@ interface LightdashVisualizationProps {
     'data-testid'?: string;
     onScreenshotReady?: () => void;
     onScreenshotError?: () => void;
+    enableContextMenu?: boolean;
 }
 
 const LightdashVisualization = memo(
@@ -94,6 +95,7 @@ const LightdashVisualization = memo(
                 className,
                 onScreenshotReady,
                 onScreenshotError,
+                enableContextMenu = true,
                 ...props
             },
             ref,
@@ -178,6 +180,7 @@ const LightdashVisualization = memo(
                             minimal={minimal}
                             isDashboard={!!isDashboard}
                             $shouldExpand
+                            enableContextMenu={enableContextMenu}
                             onScreenshotReady={onScreenshotReady}
                             onScreenshotError={onScreenshotError}
                         />
@@ -198,6 +201,7 @@ const LightdashVisualization = memo(
                         <SimplePieChart
                             isInDashboard={!!isDashboard}
                             $shouldExpand
+                            enableContextMenu={enableContextMenu}
                             onScreenshotReady={onScreenshotReady}
                             onScreenshotError={onScreenshotError}
                         />
@@ -208,6 +212,7 @@ const LightdashVisualization = memo(
                         <FunnelChart
                             isInDashboard={!!isDashboard}
                             $shouldExpand
+                            enableContextMenu={enableContextMenu}
                             onScreenshotReady={onScreenshotReady}
                             onScreenshotError={onScreenshotError}
                         />

--- a/packages/frontend/src/components/SimplePieChart/contextMenu.test.tsx
+++ b/packages/frontend/src/components/SimplePieChart/contextMenu.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, screen } from '@testing-library/react';
+import { type ComponentType } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import SimplePieChart from '.';
+import { renderWithProviders } from '../../testing/testUtils';
+import FunnelChart from '../FunnelChart';
+
+vi.mock('../../hooks/echarts/useEchartsPieConfig', () => ({
+    default: () => ({ eChartsOption: {} }),
+}));
+
+vi.mock('../../hooks/echarts/useEchartsFunnelConfig', () => ({
+    default: () => ({}),
+}));
+
+vi.mock('../../hooks/echarts/useLegendDoubleClickSelection', () => ({
+    useLegendDoubleClickSelection: () => ({
+        selectedLegends: undefined,
+        onLegendChange: vi.fn(),
+    }),
+}));
+
+vi.mock('../../hooks/useContextMenuPermissions', () => ({
+    useContextMenuPermissions: () => ({
+        shouldShowMenu: true,
+        canViewUnderlyingData: true,
+    }),
+}));
+
+vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
+    useVisualizationContext: () => ({
+        chartRef: { current: null },
+        isLoading: false,
+        resultsData: { setFetchAll: vi.fn() },
+        minimal: false,
+    }),
+}));
+
+vi.mock('../EChartsReactWrapper', () => ({
+    default: ({ onEvents }: { onEvents?: Record<string, unknown> }) => (
+        <div
+            data-testid="echarts"
+            data-events={Object.keys(onEvents ?? {})
+                .sort()
+                .join(',')}
+        />
+    ),
+}));
+
+vi.mock('./PieChartContextMenu', () => ({
+    default: () => <div data-testid="pie-menu" />,
+}));
+
+vi.mock('../FunnelChart/FunnelChartContextMenu', () => ({
+    default: () => <div data-testid="funnel-menu" />,
+}));
+
+type ChartComponentProps = {
+    isInDashboard: boolean;
+    enableContextMenu?: boolean;
+};
+
+const charts: Array<{
+    name: string;
+    Component: ComponentType<ChartComponentProps>;
+    menuTestId: string;
+}> = [
+    { name: 'pie', Component: SimplePieChart, menuTestId: 'pie-menu' },
+    { name: 'funnel', Component: FunnelChart, menuTestId: 'funnel-menu' },
+];
+
+describe('non-cartesian chart context menus', () => {
+    afterEach(cleanup);
+
+    it.each(charts)(
+        'keeps legend interaction but removes analytical events for $name charts',
+        ({ Component, menuTestId }) => {
+            renderWithProviders(
+                <Component isInDashboard={false} enableContextMenu={false} />,
+            );
+
+            expect(screen.getByTestId('echarts')).toHaveAttribute(
+                'data-events',
+                'legendselectchanged',
+            );
+            expect(screen.queryByTestId(menuTestId)).toBeNull();
+        },
+    );
+
+    it.each(charts)(
+        'preserves analytical events by default for $name charts',
+        ({ Component, menuTestId }) => {
+            renderWithProviders(<Component isInDashboard={false} />);
+
+            expect(screen.getByTestId('echarts')).toHaveAttribute(
+                'data-events',
+                'click,legendselectchanged,oncontextmenu',
+            );
+            expect(screen.getByTestId(menuTestId)).toBeVisible();
+        },
+    );
+});

--- a/packages/frontend/src/components/SimplePieChart/index.tsx
+++ b/packages/frontend/src/components/SimplePieChart/index.tsx
@@ -40,12 +40,18 @@ type SimplePieChartProps = Omit<EChartsReactProps, 'option'> & {
     className?: string;
     onScreenshotReady?: () => void;
     onScreenshotError?: () => void;
+    enableContextMenu?: boolean;
 };
 
 const EchartOptions: Opts = { renderer: 'svg' };
 
 const SimplePieChart: FC<SimplePieChartProps> = memo(
-    ({ onScreenshotReady, onScreenshotError, ...props }) => {
+    ({
+        onScreenshotReady,
+        onScreenshotError,
+        enableContextMenu = true,
+        ...props
+    }) => {
         const { chartRef, isLoading, resultsData, minimal } =
             useVisualizationContext();
         const { selectedLegends, onLegendChange } =
@@ -117,11 +123,15 @@ const SimplePieChart: FC<SimplePieChartProps> = memo(
 
         const onEvents = useMemo(
             () => ({
-                click: handleOpenContextMenu,
-                oncontextmenu: handleOpenContextMenu,
+                ...(enableContextMenu
+                    ? {
+                          click: handleOpenContextMenu,
+                          oncontextmenu: handleOpenContextMenu,
+                      }
+                    : {}),
                 legendselectchanged: onLegendChange,
             }),
-            [handleOpenContextMenu, onLegendChange],
+            [enableContextMenu, handleOpenContextMenu, onLegendChange],
         );
 
         if (isLoading) return <LoadingChart />;
@@ -152,7 +162,7 @@ const SimplePieChart: FC<SimplePieChartProps> = memo(
                     onEvents={onEvents}
                 />
 
-                {shouldShowMenu && (
+                {enableContextMenu && shouldShowMenu && (
                     <PieChartContextMenu
                         value={menuProps?.value}
                         menuPosition={menuProps?.position}

--- a/packages/frontend/src/components/SimpleTable/ExplorerPivotTable.tsx
+++ b/packages/frontend/src/components/SimpleTable/ExplorerPivotTable.tsx
@@ -25,6 +25,7 @@ import PivotTable, { type PivotSortMenuTarget } from '../common/PivotTable';
 import ColumnHeaderSortMenuOptions from '../Explorer/ResultsCard/ColumnHeaderSortMenuOptions';
 import { isTableVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
+import { getExplorerPivotSortMenu } from './getExplorerPivotSortMenu';
 
 type ExplorerPivotTableProps = Omit<
     ComponentProps<typeof PivotTable>,
@@ -41,6 +42,7 @@ const ExplorerPivotTable: FC<ExplorerPivotTableProps> = ({
     getFieldLabel,
     getField,
     data,
+    enableContextMenu = true,
     ...rest
 }) => {
     const dispatch = useExplorerDispatch();
@@ -231,8 +233,13 @@ const ExplorerPivotTable: FC<ExplorerPivotTableProps> = ({
             data={data}
             getFieldLabel={getFieldLabel}
             getField={getField}
+            enableContextMenu={enableContextMenu}
             sortBy={sorts}
-            renderSortMenu={isEditMode ? renderSortMenu : undefined}
+            renderSortMenu={getExplorerPivotSortMenu({
+                enableContextMenu,
+                isEditMode,
+                renderSortMenu,
+            })}
         />
     );
 };

--- a/packages/frontend/src/components/SimpleTable/contextMenu.test.tsx
+++ b/packages/frontend/src/components/SimpleTable/contextMenu.test.tsx
@@ -1,0 +1,133 @@
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../testing/testUtils';
+
+const mocks = vi.hoisted(() => ({
+    context: { current: {} as Record<string, unknown> },
+}));
+
+vi.mock('../common/PivotTable', () => ({
+    default: ({ enableContextMenu }: { enableContextMenu?: boolean }) => (
+        <div
+            data-testid="pivot-table"
+            data-context-menu-enabled={String(enableContextMenu)}
+        />
+    ),
+}));
+
+vi.mock('../common/Table', () => ({
+    default: ({
+        cellContextMenu,
+        headerContextMenu,
+    }: {
+        cellContextMenu?: unknown;
+        headerContextMenu?: unknown;
+    }) => (
+        <div
+            data-testid="table"
+            data-cell-menu-enabled={String(cellContextMenu !== undefined)}
+            data-header-menu-enabled={String(headerContextMenu !== undefined)}
+        />
+    ),
+}));
+
+vi.mock('../LightdashVisualization/types', () => ({
+    isTableVisualizationConfig: () => true,
+}));
+
+vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
+    useVisualizationContext: () => mocks.context.current,
+}));
+
+// Module mocks must be registered before importing the component.
+// eslint-disable-next-line import/first
+import SimpleTable from '.';
+
+const buildContext = (isPivotTableEnabled: boolean) => ({
+    columnOrder: [],
+    itemsMap: {},
+    visualizationConfig: {
+        chartConfig: {
+            columns: [],
+            pivotTableData: {
+                data: isPivotTableEnabled ? { rowsCount: 1 } : undefined,
+                loading: false,
+                error: undefined,
+            },
+            isPivotTableEnabled,
+            isPivotResultStale: false,
+            showColumnCalculation: true,
+            showResultsTotal: false,
+            showSubtotals: false,
+            showSubtotalsExpanded: false,
+            showRowGrouping: false,
+            updateColumnProperty: vi.fn(),
+            getFieldLabel: vi.fn(),
+            getField: vi.fn(),
+        },
+    },
+    resultsData: {
+        rows: [{}],
+        totalResults: 1,
+        hasFetchedAllRows: true,
+        setFetchAll: vi.fn(),
+    },
+    isLoading: false,
+    isEditMode: false,
+    parameters: undefined,
+    hasExplorerStore: false,
+});
+
+describe('SimpleTable context menus', () => {
+    beforeEach(() => {
+        mocks.context.current = buildContext(false);
+    });
+
+    it('removes menus from an unpivoted table when disabled', () => {
+        renderWithProviders(
+            <SimpleTable isDashboard={false} enableContextMenu={false} />,
+        );
+
+        expect(screen.getByTestId('table')).toHaveAttribute(
+            'data-cell-menu-enabled',
+            'false',
+        );
+        expect(screen.getByTestId('table')).toHaveAttribute(
+            'data-header-menu-enabled',
+            'false',
+        );
+    });
+
+    it('removes menus from a pivoted table when disabled', () => {
+        mocks.context.current = buildContext(true);
+
+        renderWithProviders(
+            <SimpleTable isDashboard={false} enableContextMenu={false} />,
+        );
+
+        expect(screen.getByTestId('pivot-table')).toHaveAttribute(
+            'data-context-menu-enabled',
+            'false',
+        );
+    });
+
+    it('preserves unpivoted menus by default', () => {
+        renderWithProviders(<SimpleTable isDashboard={false} />);
+
+        expect(screen.getByTestId('table')).toHaveAttribute(
+            'data-cell-menu-enabled',
+            'true',
+        );
+    });
+
+    it('preserves pivoted menus by default', () => {
+        mocks.context.current = buildContext(true);
+
+        renderWithProviders(<SimpleTable isDashboard={false} />);
+
+        expect(screen.getByTestId('pivot-table')).toHaveAttribute(
+            'data-context-menu-enabled',
+            'true',
+        );
+    });
+});

--- a/packages/frontend/src/components/SimpleTable/getExplorerPivotSortMenu.test.ts
+++ b/packages/frontend/src/components/SimpleTable/getExplorerPivotSortMenu.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getExplorerPivotSortMenu } from './getExplorerPivotSortMenu';
+
+describe('getExplorerPivotSortMenu', () => {
+    it('removes edit-mode sort menus when context menus are disabled', () => {
+        expect(
+            getExplorerPivotSortMenu({
+                enableContextMenu: false,
+                isEditMode: true,
+                renderSortMenu: vi.fn(),
+            }),
+        ).toBeUndefined();
+    });
+
+    it('keeps edit-mode sort menus when interactions are enabled', () => {
+        const renderSortMenu = vi.fn();
+        expect(
+            getExplorerPivotSortMenu({
+                enableContextMenu: true,
+                isEditMode: true,
+                renderSortMenu,
+            }),
+        ).toBe(renderSortMenu);
+    });
+});

--- a/packages/frontend/src/components/SimpleTable/getExplorerPivotSortMenu.ts
+++ b/packages/frontend/src/components/SimpleTable/getExplorerPivotSortMenu.ts
@@ -1,0 +1,10 @@
+export const getExplorerPivotSortMenu = <TMenu>({
+    enableContextMenu,
+    isEditMode,
+    renderSortMenu,
+}: {
+    enableContextMenu: boolean;
+    isEditMode: boolean;
+    renderSortMenu: TMenu;
+}): TMenu | undefined =>
+    enableContextMenu && isEditMode ? renderSortMenu : undefined;

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -34,6 +34,7 @@ type SimpleTableProps = {
     minimal?: boolean;
     onScreenshotReady?: () => void;
     onScreenshotError?: () => void;
+    enableContextMenu?: boolean;
 };
 
 const SimpleTable: FC<SimpleTableProps> = ({
@@ -44,6 +45,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
     minimal = false,
     onScreenshotReady,
     onScreenshotError,
+    enableContextMenu = true,
     ...rest
 }) => {
     const {
@@ -337,6 +339,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 className={className}
                                 data={pivotTableData.data}
                                 isMinimal={minimal}
+                                enableContextMenu={enableContextMenu}
                                 isDashboard={isDashboard}
                                 conditionalFormattings={conditionalFormattings}
                                 minMaxMap={minMaxMap}
@@ -373,6 +376,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 className={className}
                                 data={pivotTableData.data}
                                 isMinimal={minimal}
+                                enableContextMenu={enableContextMenu}
                                 isDashboard={isDashboard}
                                 conditionalFormattings={conditionalFormattings}
                                 minMaxMap={minMaxMap}
@@ -448,8 +452,12 @@ const SimpleTable: FC<SimpleTableProps> = ({
                     visualizationConfig.chartConfig.columnProperties
                 }
                 footer={pagination}
-                headerContextMenu={headerContextMenu}
-                cellContextMenu={cellContextMenu}
+                headerContextMenu={
+                    enableContextMenu ? headerContextMenu : undefined
+                }
+                cellContextMenu={
+                    enableContextMenu ? cellContextMenu : undefined
+                }
                 pagination={{ showResultsTotal }}
                 {...rest}
             />

--- a/packages/frontend/src/components/common/PivotTable/getPivotCellInteractionProps.test.ts
+++ b/packages/frontend/src/components/common/PivotTable/getPivotCellInteractionProps.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getPivotCellInteractionProps } from './getPivotCellInteractionProps';
+
+describe('getPivotCellInteractionProps', () => {
+    it('removes ordinary and total-cell menu behavior when disabled', () => {
+        const menu = vi.fn();
+
+        expect(
+            getPivotCellInteractionProps({
+                enabled: false,
+                withInteractions: true,
+                withMenu: menu,
+            }),
+        ).toEqual({ withInteractions: undefined, withMenu: undefined });
+    });
+
+    it('preserves menu behavior when enabled', () => {
+        const menu = vi.fn();
+
+        expect(
+            getPivotCellInteractionProps({
+                enabled: true,
+                withInteractions: true,
+                withMenu: menu,
+            }),
+        ).toEqual({ withInteractions: true, withMenu: menu });
+    });
+});

--- a/packages/frontend/src/components/common/PivotTable/getPivotCellInteractionProps.ts
+++ b/packages/frontend/src/components/common/PivotTable/getPivotCellInteractionProps.ts
@@ -1,0 +1,17 @@
+type PivotCellInteractionOptions<TMenu> = {
+    enabled: boolean;
+    withInteractions: boolean | undefined;
+    withMenu: TMenu;
+};
+
+export const getPivotCellInteractionProps = <TMenu>({
+    enabled,
+    withInteractions,
+    withMenu,
+}: PivotCellInteractionOptions<TMenu>): {
+    withInteractions: boolean | undefined;
+    withMenu: TMenu | undefined;
+} => ({
+    withInteractions: enabled ? withInteractions : undefined,
+    withMenu: enabled ? withMenu : undefined,
+});

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -96,6 +96,7 @@ import {
     getMetricsAsRowsMetricIds,
     projectMetricsAsRowsSubtotalRenderRows,
 } from './getMetricsAsRowsSubtotalRenderRows';
+import { getPivotCellInteractionProps } from './getPivotCellInteractionProps';
 import { getGroupedDimColumnIds, getRowSpanMerges } from './getRowSpanMerges';
 import { collectPivotUnderlyingValues } from './getUnderlyingFieldValues';
 import pivotStyles from './PivotTable.module.css';
@@ -213,6 +214,7 @@ type PivotTableProps = BoxProps & // TODO: remove this
         sortBy?: SortField[];
         /** Renders inside a Mantine Menu opened by clicking sortable headers. */
         renderSortMenu?: (target: PivotSortMenuTarget) => React.ReactNode;
+        enableContextMenu?: boolean;
     };
 
 export type PivotSortMenuTarget =
@@ -253,6 +255,7 @@ const PivotTable: FC<PivotTableProps> = ({
     parameters,
     sortBy,
     renderSortMenu,
+    enableContextMenu = true,
     ...tableProps
 }) => {
     const colorScheme = useComputedColorScheme();
@@ -2139,45 +2142,49 @@ const PivotTable: FC<PivotTableProps> = ({
                                             labelFieldDescription ||
                                             conditionalFormatting?.tooltipContent
                                         }
-                                        withInteractions={allowInteractions}
                                         withValue={value?.formatted}
-                                        withMenu={(
-                                            {
-                                                isOpen,
-                                                onClose,
-                                                onCopy,
-                                            }: MenuCallbackProps,
-                                            render: RenderCallback,
-                                        ) => (
-                                            <ValueCellMenu
-                                                opened={isOpen}
-                                                rowIndex={
-                                                    dataRowIndex ?? undefined
-                                                }
-                                                colIndex={colIndex}
-                                                item={item}
-                                                value={value}
-                                                getUnderlyingFieldValues={
-                                                    isRowTotal ||
-                                                    dataRowIndex === null
-                                                        ? undefined
-                                                        : (
-                                                              _rowIndex,
-                                                              targetColIndex,
-                                                          ) =>
-                                                              getUnderlyingFieldValues(
-                                                                  row,
-                                                                  dataRowIndex,
+                                        {...getPivotCellInteractionProps({
+                                            enabled: enableContextMenu,
+                                            withInteractions: allowInteractions,
+                                            withMenu: (
+                                                {
+                                                    isOpen,
+                                                    onClose,
+                                                    onCopy,
+                                                }: MenuCallbackProps,
+                                                render: RenderCallback,
+                                            ) => (
+                                                <ValueCellMenu
+                                                    opened={isOpen}
+                                                    rowIndex={
+                                                        dataRowIndex ??
+                                                        undefined
+                                                    }
+                                                    colIndex={colIndex}
+                                                    item={item}
+                                                    value={value}
+                                                    getUnderlyingFieldValues={
+                                                        isRowTotal ||
+                                                        dataRowIndex === null
+                                                            ? undefined
+                                                            : (
+                                                                  _rowIndex,
                                                                   targetColIndex,
-                                                              )
-                                                }
-                                                onClose={onClose}
-                                                onCopy={onCopy}
-                                                isMinimal={isMinimal}
-                                            >
-                                                {render()}
-                                            </ValueCellMenu>
-                                        )}
+                                                              ) =>
+                                                                  getUnderlyingFieldValues(
+                                                                      row,
+                                                                      dataRowIndex,
+                                                                      targetColIndex,
+                                                                  )
+                                                    }
+                                                    onClose={onClose}
+                                                    onCopy={onCopy}
+                                                    isMinimal={isMinimal}
+                                                >
+                                                    {render()}
+                                                </ValueCellMenu>
+                                            ),
+                                        })}
                                     >
                                         {isMetricSubtotal &&
                                         meta?.type === 'label' ? (
@@ -2443,24 +2450,27 @@ const PivotTable: FC<PivotTableProps> = ({
                                             withAlignRight
                                             isMinimal={isMinimal}
                                             withBoldFont
-                                            withInteractions
                                             withValue={value.formatted}
-                                            withMenu={(
-                                                {
-                                                    isOpen,
-                                                    onClose,
-                                                    onCopy,
-                                                }: MenuCallbackProps,
-                                                render: RenderCallback,
-                                            ) => (
-                                                <TotalCellMenu
-                                                    opened={isOpen}
-                                                    onClose={onClose}
-                                                    onCopy={onCopy}
-                                                >
-                                                    {render()}
-                                                </TotalCellMenu>
-                                            )}
+                                            {...getPivotCellInteractionProps({
+                                                enabled: enableContextMenu,
+                                                withInteractions: true,
+                                                withMenu: (
+                                                    {
+                                                        isOpen,
+                                                        onClose,
+                                                        onCopy,
+                                                    }: MenuCallbackProps,
+                                                    render: RenderCallback,
+                                                ) => (
+                                                    <TotalCellMenu
+                                                        opened={isOpen}
+                                                        onClose={onClose}
+                                                        onCopy={onCopy}
+                                                    >
+                                                        {render()}
+                                                    </TotalCellMenu>
+                                                ),
+                                            })}
                                         >
                                             {value.formatted}
                                         </Table.CellHead>
@@ -2514,25 +2524,37 @@ const PivotTable: FC<PivotTableProps> = ({
                                                       withAlignRight
                                                       isMinimal={isMinimal}
                                                       withBoldFont
-                                                      withInteractions
                                                       withValue={
                                                           value.formatted
                                                       }
-                                                      withMenu={(
+                                                      {...getPivotCellInteractionProps(
                                                           {
-                                                              isOpen,
-                                                              onClose,
-                                                              onCopy,
-                                                          }: MenuCallbackProps,
-                                                          render: RenderCallback,
-                                                      ) => (
-                                                          <TotalCellMenu
-                                                              opened={isOpen}
-                                                              onClose={onClose}
-                                                              onCopy={onCopy}
-                                                          >
-                                                              {render()}
-                                                          </TotalCellMenu>
+                                                              enabled:
+                                                                  enableContextMenu,
+                                                              withInteractions: true,
+                                                              withMenu: (
+                                                                  {
+                                                                      isOpen,
+                                                                      onClose,
+                                                                      onCopy,
+                                                                  }: MenuCallbackProps,
+                                                                  render: RenderCallback,
+                                                              ) => (
+                                                                  <TotalCellMenu
+                                                                      opened={
+                                                                          isOpen
+                                                                      }
+                                                                      onClose={
+                                                                          onClose
+                                                                      }
+                                                                      onCopy={
+                                                                          onCopy
+                                                                      }
+                                                                  >
+                                                                      {render()}
+                                                                  </TotalCellMenu>
+                                                              ),
+                                                          },
                                                       )}
                                                   >
                                                       {value.formatted}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.test.tsx
@@ -1,0 +1,204 @@
+import {
+    AiResultType,
+    type ApiAiAgentThreadMessageVizQuery,
+    type ToolRunQueryArgs,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type InfiniteQueryResults } from '../../../../../hooks/useQueryResults';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { AiVisualizationRenderer } from './AiVisualizationRenderer';
+
+const mocks = vi.hoisted(() => ({
+    useExplore: vi.fn(),
+}));
+
+vi.mock('../../../../../hooks/health/useHealth', () => ({
+    default: () => ({ data: { query: { maxLimit: 5_000 } } }),
+}));
+
+vi.mock('../../../../../hooks/appearance/useProjectColorPalette', () => ({
+    useProjectColorPalette: () => ({ data: undefined }),
+}));
+
+vi.mock('../../../../../hooks/useExplore', () => ({
+    useExplore: mocks.useExplore,
+}));
+
+vi.mock('../../hooks/aiAgentRouting', () => ({
+    isEmbedAiAgentRoute: () => false,
+}));
+
+vi.mock(
+    '../../../../../components/MetricQueryData/MetricQueryDataProvider',
+    () => ({
+        default: ({ children }: { children: ReactNode }) => children,
+    }),
+);
+
+vi.mock(
+    '../../../../../components/LightdashVisualization/VisualizationProvider',
+    () => ({
+        default: ({
+            children,
+            onSeriesContextMenu,
+        }: {
+            children: ReactNode;
+            onSeriesContextMenu?: unknown;
+        }) => (
+            <div
+                data-testid="visualization-provider"
+                data-context-menu-enabled={String(
+                    onSeriesContextMenu !== undefined,
+                )}
+            >
+                {children}
+            </div>
+        ),
+    }),
+);
+
+vi.mock('../../../../../components/LightdashVisualization', () => ({
+    default: ({ enableContextMenu }: { enableContextMenu?: boolean }) => (
+        <div
+            data-testid="lightdash-visualization"
+            data-context-menu-enabled={String(enableContextMenu)}
+        />
+    ),
+}));
+
+vi.mock(
+    '../../../../../components/Explorer/VisualizationCard/SeriesContextMenu',
+    () => ({
+        SeriesContextMenu: () => <div data-testid="series-context-menu" />,
+    }),
+);
+
+vi.mock(
+    '../../../../../components/MetricQueryData/UnderlyingDataModal',
+    () => ({
+        default: () => <div data-testid="underlying-data-modal" />,
+    }),
+);
+
+vi.mock('../../../../../components/MetricQueryData/DrillDownModal', () => ({
+    DrillDownModal: () => <div data-testid="drill-down-modal" />,
+}));
+
+const metricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_order_month'],
+    metrics: ['orders_total_revenue'],
+    sorts: [],
+    limit: 500,
+    filters: {},
+    tableCalculations: [],
+    additionalMetrics: [],
+};
+
+const vizQueryData = {
+    source: 'semantic' as const,
+    type: AiResultType.QUERY_RESULT,
+    query: {
+        queryUuid: '11111111-1111-4111-8111-111111111111',
+        metricQuery,
+        fields: {},
+        cacheMetadata: { cacheHit: false },
+        parameterReferences: [],
+        resolvedTimezone: 'UTC',
+        usedParametersValues: {},
+        warnings: [],
+    },
+    metadata: { title: 'Revenue trend', description: 'Revenue by month.' },
+} as ApiAiAgentThreadMessageVizQuery;
+
+const chartConfig: ToolRunQueryArgs = {
+    title: 'Revenue trend',
+    description: 'Revenue by month.',
+    queryConfig: {
+        exploreName: 'orders',
+        dimensions: ['orders_order_month'],
+        metrics: ['orders_total_revenue'],
+        sorts: [],
+        limit: 500,
+        filters: null,
+        customMetrics: null,
+        tableCalculations: null,
+    },
+    chartConfig: {
+        defaultVizType: 'line',
+        xAxisDimension: 'orders_order_month',
+        yAxisMetrics: ['orders_total_revenue'],
+        groupBy: null,
+        xAxisType: 'time',
+        stackBars: null,
+        lineType: 'line',
+        xAxisLabel: 'Month',
+        yAxisLabel: 'Revenue',
+        secondaryYAxisMetric: null,
+        secondaryYAxisLabel: null,
+    },
+};
+
+const results = {
+    rows: [],
+    isFetchingRows: false,
+} as unknown as InfiniteQueryResults;
+
+const renderVisualization = (interactionMode?: 'full' | 'read-only') =>
+    renderWithProviders(
+        <AiVisualizationRenderer
+            vizQueryData={vizQueryData}
+            results={results}
+            chartConfig={chartConfig}
+            selectedChartType="line"
+            displayFields={false}
+            displayFilters={false}
+            loadExplore
+            interactionMode={interactionMode}
+        />,
+    );
+
+describe('AiVisualizationRenderer interaction mode', () => {
+    beforeEach(() => {
+        mocks.useExplore.mockReset();
+        mocks.useExplore.mockReturnValue({ data: undefined });
+    });
+
+    it('keeps the visualization but removes analytical controls in read-only mode', () => {
+        renderVisualization('read-only');
+
+        expect(screen.getByTestId('lightdash-visualization')).toBeVisible();
+        expect(screen.getByTestId('lightdash-visualization')).toHaveAttribute(
+            'data-context-menu-enabled',
+            'false',
+        );
+        expect(screen.getByTestId('visualization-provider')).toHaveAttribute(
+            'data-context-menu-enabled',
+            'false',
+        );
+        expect(mocks.useExplore).toHaveBeenCalledWith(undefined);
+        expect(screen.queryByTestId('series-context-menu')).toBeNull();
+        expect(screen.queryByTestId('underlying-data-modal')).toBeNull();
+        expect(screen.queryByTestId('drill-down-modal')).toBeNull();
+    });
+
+    it('preserves existing analytical controls by default', () => {
+        renderVisualization();
+
+        expect(screen.getByTestId('lightdash-visualization')).toBeVisible();
+        expect(screen.getByTestId('lightdash-visualization')).toHaveAttribute(
+            'data-context-menu-enabled',
+            'true',
+        );
+        expect(screen.getByTestId('visualization-provider')).toHaveAttribute(
+            'data-context-menu-enabled',
+            'true',
+        );
+        expect(mocks.useExplore).toHaveBeenCalledWith('orders');
+        expect(screen.getByTestId('series-context-menu')).toBeVisible();
+        expect(screen.getByTestId('underlying-data-modal')).toBeVisible();
+        expect(screen.getByTestId('drill-down-modal')).toBeVisible();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -77,6 +77,7 @@ type Props = {
     displayFields?: boolean;
     displayFilters?: boolean;
     loadExplore?: boolean;
+    interactionMode?: 'full' | 'read-only';
 };
 
 export const AiVisualizationRenderer: FC<Props> = ({
@@ -91,6 +92,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
     displayFields = true,
     displayFilters: displayFiltersProp = true,
     loadExplore = true,
+    interactionMode = 'full',
 }) => {
     const { data: health } = useHealth();
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -113,7 +115,10 @@ export const AiVisualizationRenderer: FC<Props> = ({
 
     const { metricQuery, fields, resolvedTimezone } = vizQueryData.query;
     const tableName = metricQuery?.exploreName;
-    const { data: explore } = useExplore(loadExplore ? tableName : undefined);
+    const allowsAnalyticalInteraction = interactionMode === 'full';
+    const { data: explore } = useExplore(
+        loadExplore && allowsAnalyticalInteraction ? tableName : undefined,
+    );
 
     const [echartsClickEvent, setEchartsClickEvent] =
         useState<EchartsSeriesClickEvent | null>(null);
@@ -238,13 +243,17 @@ export const AiVisualizationRenderer: FC<Props> = ({
                 initialPivotDimensions={groupByDimensions}
                 colorPalette={colorPalette}
                 isLoading={resultsData.isFetchingRows}
-                onSeriesContextMenu={(
-                    e: EchartsSeriesClickEvent,
-                    series: EChartsSeries[],
-                ) => {
-                    setEchartsClickEvent(e);
-                    setEchartsSeries(series);
-                }}
+                onSeriesContextMenu={
+                    allowsAnalyticalInteraction
+                        ? (
+                              event: EchartsSeriesClickEvent,
+                              series: EChartsSeries[],
+                          ) => {
+                              setEchartsClickEvent(event);
+                              setEchartsSeries(series);
+                          }
+                        : undefined
+                }
                 onChartConfigChange={handleChartConfigChange}
                 unsavedMetricQuery={metricQuery}
             >
@@ -290,21 +299,27 @@ export const AiVisualizationRenderer: FC<Props> = ({
                         <LightdashVisualization
                             className="sentry-block ph-no-capture"
                             data-testid="ai-visualization"
+                            enableContextMenu={allowsAnalyticalInteraction}
                         />
 
-                        {webAiChartConfig.echartsConfig.type ===
-                            ChartType.CARTESIAN && (
-                            <SeriesContextMenu
-                                echartsSeriesClickEvent={
-                                    echartsClickEvent ?? undefined
-                                }
-                                dimensions={metricQuery.dimensions}
-                                series={echartsSeries}
-                                explore={explore}
-                            />
-                        )}
-                        <UnderlyingDataModal />
-                        <DrillDownModal />
+                        {allowsAnalyticalInteraction &&
+                            webAiChartConfig.echartsConfig.type ===
+                                ChartType.CARTESIAN && (
+                                <SeriesContextMenu
+                                    echartsSeriesClickEvent={
+                                        echartsClickEvent ?? undefined
+                                    }
+                                    dimensions={metricQuery.dimensions}
+                                    series={echartsSeries}
+                                    explore={explore}
+                                />
+                            )}
+                        {allowsAnalyticalInteraction ? (
+                            <>
+                                <UnderlyingDataModal />
+                                <DrillDownModal />
+                            </>
+                        ) : null}
                     </Box>
 
                     {displayDetails ? (

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.test.tsx
@@ -2,6 +2,7 @@ import { type AiDeepResearchChartData } from '@lightdash/common';
 import { screen } from '@testing-library/react';
 import { type ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
+import { parseChartFromExplorerSearchParams } from '../../../../../hooks/useExplorerRoute';
 import { renderWithProviders } from '../../../../../testing/testUtils';
 import { DeepResearchChartTile } from './DeepResearchChartTile';
 
@@ -24,17 +25,20 @@ vi.mock('../ChatElements/AiVisualizationRenderer', () => ({
         displayFields,
         displayFilters,
         loadExplore,
+        interactionMode,
     }: {
         headerContent: ReactNode;
         displayFields?: boolean;
         displayFilters?: boolean;
         loadExplore?: boolean;
+        interactionMode?: 'full' | 'read-only';
     }) => (
         <div
             data-testid="visualization"
             data-display-fields={String(displayFields)}
             data-display-filters={String(displayFilters)}
             data-load-explore={String(loadExplore)}
+            data-interaction-mode={interactionMode}
         >
             {headerContent}
             <div>Rendered query data</div>
@@ -114,7 +118,6 @@ const renderTile = (chartOverrides: Partial<AiDeepResearchChartData> = {}) =>
             chart={{ ...chart, ...chartOverrides }}
             projectUuid="project-1"
             runUuid="run-1"
-            reportRunAt="2026-07-15T09:18:00.000Z"
         />,
     );
 
@@ -133,9 +136,6 @@ describe('DeepResearchChartTile', () => {
         expect(
             screen.getByRole('figure', { name: chart.title }),
         ).toBeInTheDocument();
-        expect(
-            screen.getByText(/Report data as of .*; chart shows live data/),
-        ).toBeVisible();
         expect(mocks.useLiveQuery).toHaveBeenCalledWith({
             projectUuid: 'project-1',
             runUuid: 'run-1',
@@ -156,8 +156,83 @@ describe('DeepResearchChartTile', () => {
         );
         expect(screen.getByTestId('visualization')).toHaveAttribute(
             'data-load-explore',
-            'true',
+            'false',
         );
+        expect(screen.getByTestId('visualization')).toHaveAttribute(
+            'data-interaction-mode',
+            'read-only',
+        );
+    });
+
+    it('offers a persistent external handoff to Explore', () => {
+        renderTile();
+
+        const link = screen.getByRole('link', {
+            name: `Open ${chart.title} in Explore`,
+        });
+        expect(link).toBeVisible();
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+        expect(link).toHaveAttribute(
+            'href',
+            expect.stringContaining('/projects/project-1/'),
+        );
+    });
+
+    it('preserves grouping in the Explore handoff', () => {
+        renderTile({
+            chartConfig: {
+                ...chart.chartConfig,
+                groupBy: ['orders_status'],
+            },
+            metricQuery: {
+                ...chart.metricQuery,
+                dimensions: ['orders_order_month', 'orders_status'],
+            },
+        });
+
+        const link = screen.getByRole('link', {
+            name: `Open ${chart.title} in Explore`,
+        });
+        const href = link.getAttribute('href');
+        expect(href).not.toBeNull();
+        const parsed = parseChartFromExplorerSearchParams(
+            new URL(href ?? '', window.location.origin).search,
+        );
+
+        expect(parsed?.pivotConfig?.columns).toEqual(['orders_status']);
+        expect(parsed?.metricQuery.dimensions).toEqual([
+            'orders_order_month',
+            'orders_status',
+        ]);
+        expect(parsed?.metricQuery.metrics).toEqual(['orders_total_revenue']);
+        expect(parsed?.metricQuery.filters).toEqual(chart.metricQuery.filters);
+        expect(parsed?.tableConfig.columnOrder).toEqual([
+            'orders_order_month',
+            'orders_status',
+            'orders_total_revenue',
+        ]);
+        expect(parsed?.chartConfig).toMatchObject({
+            type: 'cartesian',
+            config: {
+                layout: {
+                    xField: 'orders_order_month',
+                    yField: ['orders_total_revenue'],
+                },
+                eChartsConfig: {
+                    title: { text: chart.title },
+                    series: [
+                        {
+                            type: 'line',
+                            encode: {
+                                xRef: { field: 'orders_order_month' },
+                                yRef: { field: 'orders_total_revenue' },
+                            },
+                        },
+                    ],
+                },
+            },
+        });
     });
 
     it('shows the applied filters as read-only pills in the header', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
@@ -1,12 +1,17 @@
 import {
+    getGroupByDimensions,
+    getWebAiChartConfig,
     type AiDeepResearchChartData,
     type ToolRunQueryArgs,
 } from '@lightdash/common';
-import { Box, Group, Text } from '@mantine/core';
+import { Anchor, Box, Group } from '@mantine/core';
+import { IconExternalLink } from '@tabler/icons-react';
 import { useMemo } from 'react';
 import EmptyStateLoader from '../../../../../components/common/EmptyStateLoader';
 import InlineErrorState from '../../../../../components/common/InlineErrorState';
+import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useInfiniteQueryResults } from '../../../../../hooks/useQueryResults';
+import { getOpenInExploreUrl } from '../../../../../utils/getOpenInExploreUrl';
 import { useDeepResearchChartLiveQuery } from '../../hooks/useDeepResearch';
 import AgentVisualizationFilters from '../ChatElements/AgentVisualizationFilters';
 import { AiVisualizationRenderer } from '../ChatElements/AiVisualizationRenderer';
@@ -18,7 +23,6 @@ type Props = {
     chart: AiDeepResearchChartData;
     projectUuid: string;
     runUuid: string;
-    reportRunAt: string;
 };
 
 export const DeepResearchChartTile = ({
@@ -26,7 +30,6 @@ export const DeepResearchChartTile = ({
     chart,
     projectUuid,
     runUuid,
-    reportRunAt,
 }: Props) => {
     const liveQuery = useDeepResearchChartLiveQuery({
         projectUuid,
@@ -66,7 +69,32 @@ export const DeepResearchChartTile = ({
     const appliedFilters = chart.metricQuery.filters;
     const displayFilterPills =
         shouldDisplayVisualizationFilters(appliedFilters);
-    const reportRunDate = new Date(reportRunAt).toLocaleDateString();
+    const openInExploreUrl = useMemo(() => {
+        const webChartConfig = getWebAiChartConfig({
+            vizConfig: visualizationConfig,
+            metricQuery: chart.metricQuery,
+            fieldsMap: chart.fields,
+            overrideChartType: chart.chartConfig.defaultVizType,
+        });
+        if (!webChartConfig.echartsConfig) {
+            return null;
+        }
+
+        const { pathname, search } = getOpenInExploreUrl({
+            metricQuery: chart.metricQuery,
+            projectUuid,
+            columnOrder: [
+                ...chart.metricQuery.dimensions,
+                ...chart.metricQuery.metrics,
+                ...chart.metricQuery.tableCalculations.map(
+                    (calculation) => calculation.name,
+                ),
+            ],
+            pivotColumns: getGroupByDimensions(webChartConfig),
+            chartConfig: webChartConfig.echartsConfig,
+        });
+        return `${pathname}?${search}`;
+    }, [chart, projectUuid, visualizationConfig]);
 
     return (
         <Box
@@ -74,11 +102,23 @@ export const DeepResearchChartTile = ({
             className={styles.chartTile}
             aria-label={chart.title}
         >
-            <Group gap="xs" justify="space-between" mb="xs" wrap="wrap">
-                <Text size="xs" c="dimmed">
-                    Report data as of {reportRunDate}; chart shows live data
-                </Text>
-            </Group>
+            {openInExploreUrl ? (
+                <Group justify="flex-end" mb="xs">
+                    <Anchor
+                        href={openInExploreUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        size="xs"
+                        fw={500}
+                        aria-label={`Open ${chart.title} in Explore`}
+                    >
+                        <Group component="span" gap={4} wrap="nowrap">
+                            Open in Explore
+                            <MantineIcon icon={IconExternalLink} size={13} />
+                        </Group>
+                    </Anchor>
+                </Group>
+            ) : null}
             <Box>
                 {liveError ? (
                     <InlineErrorState
@@ -100,7 +140,8 @@ export const DeepResearchChartTile = ({
                         selectedChartType={chart.chartConfig.defaultVizType}
                         displayFields={false}
                         displayFilters={false}
-                        loadExplore={chart.source === 'warehouse'}
+                        loadExplore={false}
+                        interactionMode="read-only"
                         headerContent={
                             displayFilterPills ? (
                                 <AgentVisualizationFilters

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.test.tsx
@@ -29,7 +29,6 @@ describe('DeepResearchMarkdownReport', () => {
                 markdown={`## Finding\n\n<chart id="${queryUuid}" title="Revenue trend" description="Revenue by month.">`}
                 projectUuid="project-1"
                 runUuid="run-1"
-                reportRunAt="2026-07-15T09:18:00.000Z"
             />,
         );
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
@@ -1,9 +1,7 @@
 import {
     AI_DEEP_RESEARCH_MARKDOWN_TAGS,
     renderDeepResearchChartRefs,
-    type AiDeepResearchConfidence,
 } from '@lightdash/common';
-import { Badge, Group, Text } from '@mantine/core';
 import {
     createContext,
     useContext,
@@ -25,43 +23,7 @@ import styles from './DeepResearchReport.module.css';
 const DeepResearchReportContext = createContext<{
     projectUuid: string;
     runUuid: string;
-    reportRunAt: string;
 } | null>(null);
-
-const CONFIDENCE_COLORS: Record<AiDeepResearchConfidence, string> = {
-    low: 'red',
-    medium: 'yellow',
-    high: 'green',
-};
-
-const isConfidenceLevel = (value: unknown): value is AiDeepResearchConfidence =>
-    value === 'low' || value === 'medium' || value === 'high';
-
-const ConfidenceBadge: FC<{ level: unknown; children?: ReactNode }> = ({
-    level,
-    children,
-}) => {
-    if (!isConfidenceLevel(level)) {
-        return null;
-    }
-    return (
-        <Group gap="xs" align="center" my={4}>
-            <Badge
-                size="xs"
-                variant="light"
-                color={CONFIDENCE_COLORS[level]}
-                tt="none"
-            >
-                {level} confidence
-            </Badge>
-            {children && (
-                <Text size="xs" c="dimmed" component="span">
-                    {children}
-                </Text>
-            )}
-        </Group>
-    );
-};
 
 const CHART_HREF_PREFIX = '#chart-';
 
@@ -69,8 +31,7 @@ const QueryBackedChart: FC<{
     projectUuid: string;
     runUuid: string;
     queryUuid: string;
-    reportRunAt: string;
-}> = ({ projectUuid, runUuid, queryUuid, reportRunAt }) => {
+}> = ({ projectUuid, runUuid, queryUuid }) => {
     const chartQuery = useDeepResearchChartQuery({
         projectUuid,
         runUuid,
@@ -92,7 +53,6 @@ const QueryBackedChart: FC<{
             chart={chartQuery.data}
             projectUuid={projectUuid}
             runUuid={runUuid}
-            reportRunAt={reportRunAt}
         />
     );
 };
@@ -123,7 +83,6 @@ const ReportLink: FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
                 projectUuid={context.projectUuid}
                 runUuid={context.runUuid}
                 queryUuid={chartKey}
-                reportRunAt={context.reportRunAt}
             />
         );
     }
@@ -176,9 +135,6 @@ const MARKDOWN_COMPONENTS: StreamdownProps['components'] = {
     info: renderCallout('info'),
     warning: renderCallout('warning'),
     tip: renderCallout('success'),
-    confidence: ({ children, level }: Record<string, unknown>) => (
-        <ConfidenceBadge level={level}>{children as ReactNode}</ConfidenceBadge>
-    ),
     // The components map's custom-tag index signature and the `a` key demand
     // contradictory prop types; the runtime contract is plain anchor props.
     a: ReportLink as unknown as NonNullable<StreamdownProps['components']>['a'],
@@ -188,28 +144,26 @@ type Props = {
     markdown: string;
     projectUuid: string;
     runUuid: string;
-    reportRunAt: string;
 };
 
 /**
  * Renders a deep research report markdown document as one linear flow:
  * prose via streamdown, <chart> references hydrated into
  * chart tiles from the run's chart metadata, and the whitelisted
- * callout/confidence tags mapped to house components.
+ * callout tags mapped to house components.
  */
 export const DeepResearchMarkdownReport: FC<Props> = ({
     markdown,
     projectUuid,
     runUuid,
-    reportRunAt,
 }) => {
     const renderMarkdown = useMemo(
         () => renderDeepResearchChartRefs(markdown),
         [markdown],
     );
     const contextValue = useMemo(
-        () => ({ projectUuid, runUuid, reportRunAt }),
-        [projectUuid, runUuid, reportRunAt],
+        () => ({ projectUuid, runUuid }),
+        [projectUuid, runUuid],
     );
     return (
         <DeepResearchReportContext.Provider value={contextValue}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -15,16 +15,8 @@ vi.mock('../../hooks/useDeepResearch', async (importOriginal) => ({
 }));
 
 vi.mock('./DeepResearchChartTile', () => ({
-    DeepResearchChartTile: ({
-        chart,
-        reportRunAt,
-    }: {
-        chart: { title: string };
-        reportRunAt: string;
-    }) => (
-        <div data-testid="deep-research-chart" data-report-run-at={reportRunAt}>
-            {chart.title}
-        </div>
+    DeepResearchChartTile: ({ chart }: { chart: { title: string } }) => (
+        <div data-testid="deep-research-chart">{chart.title}</div>
     ),
 }));
 
@@ -72,10 +64,6 @@ describe('DeepResearchReport', () => {
         expect(chart).toHaveTextContent(
             'Enterprise retention by incident exposure',
         );
-        expect(chart).toHaveAttribute(
-            'data-report-run-at',
-            deepResearchRunFixture.completedAt,
-        );
         expect(
             screen.queryByText(
                 'Three incident-affected renewals account for most churn in the quarter.',
@@ -93,18 +81,6 @@ describe('DeepResearchReport', () => {
                 Node.DOCUMENT_POSITION_FOLLOWING,
             ),
         ).toBe(true);
-    });
-
-    it('renders confidence tags as badges with their caveats', async () => {
-        renderReport();
-
-        await waitFor(() =>
-            expect(screen.getByText('high confidence')).toBeInTheDocument(),
-        );
-        expect(screen.getByText('medium confidence')).toBeInTheDocument();
-        expect(
-            screen.getByText(/Association, not a controlled causal estimate/i),
-        ).toBeInTheDocument();
     });
 
     it('renders whitelisted callouts with markdown children', async () => {
@@ -165,7 +141,7 @@ describe('DeepResearchReport', () => {
     it('strips disallowed html from the report markdown', async () => {
         renderReport(vi.fn(), {
             ...deepResearchRunFixture,
-            resultMarkdown: `Intro prose.\n\n<script>window.pwned = true;</script>\n\n<img src="x" onerror="window.pwned = true" />\n\n## Finding\n\n<confidence level="high">ok</confidence>\n\nBody.\n\n## Conclusion\n\n- done`,
+            resultMarkdown: `Intro prose.\n\n<script>window.pwned = true;</script>\n\n<img src="x" onerror="window.pwned = true" />\n\n## Finding\n\n<custom>unsafe</custom>\n\nBody.\n\n## Conclusion\n\n- done`,
         });
 
         await waitFor(() =>
@@ -173,7 +149,7 @@ describe('DeepResearchReport', () => {
         );
         expect(document.querySelector('script')).toBeNull();
         expect(document.querySelector('img[onerror]')).toBeNull();
-        expect(screen.getByText('high confidence')).toBeInTheDocument();
+        expect(document.querySelector('custom')).toBeNull();
     });
 
     it('renders nothing when the run has no report', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -232,7 +232,6 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                                 markdown={run.resultMarkdown}
                                 projectUuid={run.projectUuid}
                                 runUuid={run.uuid}
-                                reportRunAt={run.completedAt}
                             />
                         </Stack>
                     </Box>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9791

## Summary

PR 2 of 3 for [PROD-9791](https://linear.app/lightdash/issue/PROD-9791). Adds a read-only report visualization mode and a persistent Open in Explore handoff while removing low-value chart chrome.

Stacks on top of [#27126](https://github.com/lightdash/lightdash/pull/27126), which establishes the canonical data-first report structure.

## Changes

- Retains reading interactions such as tooltips, legends, highlights, useful zoom, and accessibility.
- Removes drill, filter, sort-menu, edit, and save affordances from inline report charts and tables.
- Opens Explore in a new tab with equivalent query, filter, field, chart, grouping, and pivot state.
- Removes the report timestamp/live-data label while keeping Open in Explore visible.
- Keeps full interaction as the default for non-report visualization call sites.

```text
Inline report chart
├─ inspect: tooltip · legend · highlight · zoom
├─ mutate: drill · filter · edit · save          disabled
└─ explore: Open in Explore → equivalent state   new tab
```

## Test plan

- [x] Focused renderer, chart, table, pivot, URL, and report tests pass
- [x] Frontend lint and format
- [ ] Frontend typecheck is blocked by the unrelated current-main FormArrayElement import error in ServiceAccountProjectRoles.tsx
