### PR TITLE
feat(ai): polish deep research report hierarchy

### DIFF
--- a/packages/common/src/ee/aiDeepResearch/markdown.test.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.test.ts
@@ -485,6 +485,25 @@ describe('report parsing', () => {
             title: 'Customer LTV rising but completion rate falling',
         });
     });
+
+    it('preserves inline markdown for the sanitized frontend renderer', () => {
+        const markdown = validReport
+            .replace(
+                '## Revenue grew before reversing',
+                '## **Revenue** `grew` before reversing',
+            )
+            .replace(
+                'Revenue grew steadily until spring.',
+                '[Revenue grew steadily](https://example.com) until spring.',
+            );
+        const report = parseDeepResearchReport(markdown);
+
+        expect(report?.findings[0]).toMatchObject({
+            title: '**Revenue** `grew` before reversing',
+            interpretationMarkdown:
+                '[Revenue grew steadily](https://example.com) until spring.\n\nThe dip aligns with contract renewals.',
+        });
+    });
     it('returns null for malformed model output', () => {
         const invalid = validReport.replace(
             /## Renewals drove[\s\S]*?(?=## Conclusion)/,

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
@@ -103,7 +103,11 @@ export const DeepResearchChartTile = ({
             aria-label={chart.title}
         >
             {openInExploreUrl ? (
-                <Group justify="flex-end" mb="xs">
+                <Group
+                    className={styles.chartActions}
+                    justify="flex-end"
+                    mb="xs"
+                >
                     <Anchor
                         href={openInExploreUrl}
                         target="_blank"

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchInlineMarkdown.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchInlineMarkdown.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DeepResearchInlineMarkdown } from './DeepResearchInlineMarkdown';
+
+describe('DeepResearchInlineMarkdown', () => {
+    it('renders CommonMark inline forms and preserves safe link text', () => {
+        const { container } = render(
+            <DeepResearchInlineMarkdown
+                markdown={`Escaped \\*literal\\*, \`orders_total\`, ~~superseded~~, [parenthesized](https://example.com/docs_(api)), [reference][docs], <https://example.com/autolink>, and [unsafe](javascript:alert(1)).
+
+[docs]: https://example.com/reference`}
+            />,
+        );
+
+        expect(screen.getByText(/Escaped \*literal\*/)).toBeVisible();
+        expect(screen.getByText('orders_total').tagName).toBe('CODE');
+        expect(screen.getByText('superseded').tagName).toBe('DEL');
+        expect(
+            screen.getByRole('link', { name: 'parenthesized' }),
+        ).toHaveAttribute('href', 'https://example.com/docs_(api)');
+        expect(screen.getByRole('link', { name: 'reference' })).toHaveAttribute(
+            'href',
+            'https://example.com/reference',
+        );
+        expect(
+            screen.getByRole('link', {
+                name: 'https://example.com/autolink',
+            }),
+        ).toHaveAttribute('href', 'https://example.com/autolink');
+        expect(screen.queryByRole('link', { name: 'unsafe' })).toBeNull();
+        expect(container).toHaveTextContent('unsafe');
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchInlineMarkdown.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchInlineMarkdown.tsx
@@ -1,0 +1,126 @@
+import { Fragment, useMemo, type FC, type ReactNode } from 'react';
+import remarkGfm from 'remark-gfm';
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+
+type MarkdownNode = {
+    type: string;
+    value?: string;
+    alt?: string | null;
+    url?: string;
+    identifier?: string;
+    children?: MarkdownNode[];
+};
+
+type MarkdownDefinitions = Map<string, string>;
+
+const markdownParser = unified().use(remarkParse).use(remarkGfm);
+
+const getDefinitions = (root: MarkdownNode): MarkdownDefinitions => {
+    const definitions: MarkdownDefinitions = new Map();
+
+    const visit = (node: MarkdownNode) => {
+        if (node.type === 'definition' && node.identifier && node.url) {
+            definitions.set(node.identifier.toLowerCase(), node.url);
+        }
+        node.children?.forEach(visit);
+    };
+    visit(root);
+
+    return definitions;
+};
+
+const getSafeHref = (href: string | undefined): string | undefined => {
+    if (!href) return undefined;
+
+    try {
+        const url = new URL(href);
+        return ['http:', 'https:', 'mailto:'].includes(url.protocol)
+            ? href
+            : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+const renderChildren = (
+    node: MarkdownNode,
+    definitions: MarkdownDefinitions,
+    keyPrefix: string,
+): ReactNode =>
+    node.children?.map((child, index) =>
+        renderNode(child, definitions, `${keyPrefix}-${index}`),
+    );
+
+const renderLink = (
+    node: MarkdownNode,
+    definitions: MarkdownDefinitions,
+    key: string,
+) => {
+    const referenceHref = node.identifier
+        ? definitions.get(node.identifier.toLowerCase())
+        : undefined;
+    const href = getSafeHref(node.url ?? referenceHref);
+    const children = renderChildren(node, definitions, key);
+
+    return href ? (
+        <a key={key} href={href} target="_blank" rel="noreferrer">
+            {children}
+        </a>
+    ) : (
+        <Fragment key={key}>{children}</Fragment>
+    );
+};
+
+const renderNode = (
+    node: MarkdownNode,
+    definitions: MarkdownDefinitions,
+    key: string,
+): ReactNode => {
+    switch (node.type) {
+        case 'text':
+            return node.value;
+        case 'inlineCode':
+            return <code key={key}>{node.value}</code>;
+        case 'strong':
+            return (
+                <strong key={key}>
+                    {renderChildren(node, definitions, key)}
+                </strong>
+            );
+        case 'emphasis':
+            return <em key={key}>{renderChildren(node, definitions, key)}</em>;
+        case 'delete':
+            return (
+                <del key={key}>{renderChildren(node, definitions, key)}</del>
+            );
+        case 'link':
+        case 'linkReference':
+            return renderLink(node, definitions, key);
+        case 'image':
+        case 'imageReference':
+            return node.alt ?? '';
+        case 'break':
+            return <br key={key} />;
+        case 'html':
+        case 'definition':
+            return null;
+        default:
+            return (
+                <Fragment key={key}>
+                    {renderChildren(node, definitions, key)}
+                </Fragment>
+            );
+    }
+};
+
+export const DeepResearchInlineMarkdown: FC<{ markdown: string }> = ({
+    markdown,
+}) => {
+    const content = useMemo(() => {
+        const root = markdownParser.parse(markdown) as MarkdownNode;
+        return renderNode(root, getDefinitions(root), 'inline-markdown');
+    }, [markdown]);
+
+    return content;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
@@ -27,7 +27,7 @@ const DeepResearchReportContext = createContext<{
 
 const CHART_HREF_PREFIX = '#chart-';
 
-const QueryBackedChart: FC<{
+export const QueryBackedChart: FC<{
     projectUuid: string;
     runUuid: string;
     queryUuid: string;
@@ -144,6 +144,7 @@ type Props = {
     markdown: string;
     projectUuid: string;
     runUuid: string;
+    className?: string;
 };
 
 /**
@@ -156,6 +157,7 @@ export const DeepResearchMarkdownReport: FC<Props> = ({
     markdown,
     projectUuid,
     runUuid,
+    className = styles.reportBody,
 }) => {
     const renderMarkdown = useMemo(
         () => renderDeepResearchChartRefs(markdown),
@@ -168,7 +170,7 @@ export const DeepResearchMarkdownReport: FC<Props> = ({
     return (
         <DeepResearchReportContext.Provider value={contextValue}>
             <AiMarkdown
-                className={styles.reportBody}
+                className={className}
                 rehypePlugins={REHYPE_PLUGINS}
                 components={MARKDOWN_COMPONENTS}
             >

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -88,9 +88,21 @@
 }
 
 .report {
-    width: min(100%, 60rem);
     margin-inline: auto;
     padding: var(--mantine-spacing-lg) clamp(1.25rem, 4vw, 3rem) 6rem;
+}
+
+.reportFallback {
+    width: min(100%, 60rem);
+}
+
+.structuredReportLayout {
+    grid-template-columns: 12rem minmax(0, 1fr);
+    width: min(100%, 80rem);
+}
+
+.structuredReportPage {
+    width: 100%;
 }
 
 .visuallyHidden {
@@ -202,6 +214,84 @@
     }
 }
 
+.structuredReport {
+    gap: clamp(3rem, 6vw, 5rem);
+}
+
+.reportIntroduction {
+    max-width: 52rem;
+}
+
+.reportIntroductionProse {
+    color: var(--mantine-color-text);
+    font-size: 1rem;
+    line-height: 1.75;
+}
+
+.reportFinding {
+    display: grid;
+    gap: clamp(1.5rem, 3vw, 2.5rem);
+    padding-top: var(--mantine-spacing-xl);
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.reportFindingTitle {
+    max-width: 52rem;
+    font-size: clamp(1.15rem, 2vw, 1.35rem);
+    font-weight: 650;
+    letter-spacing: -0.02em;
+    line-height: 1.3;
+    scroll-margin-top: var(--mantine-spacing-xl);
+}
+
+.reportEvidence {
+    min-width: 0;
+
+    .chartTile {
+        height: 30rem;
+        margin: 0;
+    }
+}
+
+.reportNarrative {
+    min-width: 0;
+    max-width: 52rem;
+}
+
+.reportProse,
+.reportConclusionProse {
+    overflow-wrap: anywhere;
+    color: var(--mantine-color-dimmed);
+    font-size: 0.875rem;
+    line-height: 1.75;
+
+    > :first-child {
+        margin-top: 0;
+    }
+
+    > :last-child {
+        margin-bottom: 0;
+    }
+}
+
+.reportConclusion {
+    display: grid;
+    gap: var(--mantine-spacing-md);
+    max-width: 52rem;
+    padding: var(--mantine-spacing-xl);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-lg);
+    background: var(--mantine-color-ldGray-0);
+    scroll-margin-top: var(--mantine-spacing-xl);
+}
+
+.reportConclusionTitle {
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    scroll-margin-top: var(--mantine-spacing-xl);
+}
+
 .chartTile {
     display: flex;
     flex-direction: column;
@@ -220,11 +310,10 @@
         min-width: 0;
         flex: 1;
     }
+}
 
-    /* The report/live-data label keeps its intrinsic height. */
-    > :first-child {
-        flex: 0 0 auto;
-    }
+.chartActions {
+    flex: 0 0 auto !important;
 }
 
 .findingTitle,
@@ -320,6 +409,14 @@
 
     .evidenceItem {
         grid-template-columns: 1.25rem minmax(0, 1fr);
+    }
+
+    .reportEvidence .chartTile {
+        height: 24rem;
+    }
+
+    .reportConclusion {
+        padding: var(--mantine-spacing-lg);
     }
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -25,6 +25,24 @@ const renderReport = (onClose = vi.fn(), run = deepResearchRunFixture) =>
         <DeepResearchReport run={run} opened onClose={onClose} />,
     );
 
+const canonicalMarkdown = `# Reliability Drove Retention Losses
+
+Retention fell because reliability incidents affected several large renewals. The pattern is concentrated rather than a broad commercial slowdown.
+
+## Reliability drove the decline
+
+<chart id="7c4b40ba-79f8-4fd2-9c43-223eca8fa76f">
+
+The concentration makes reliability the strongest tested explanation, while incomplete support sentiment for one account limits causal certainty. Compare incident timing with renewal decisions next.
+
+## Adoption was not the cause
+
+Adoption improved after renewal decisions and therefore does not explain the losses.
+
+## Conclusion
+
+Reliability at renewal is the clearest intervention point.`;
+
 describe('DeepResearchReport', () => {
     it('labels the report header as beta exactly once', () => {
         renderReport();
@@ -81,6 +99,149 @@ describe('DeepResearchReport', () => {
                 Node.DOCUMENT_POSITION_FOLLOWING,
             ),
         ).toBe(true);
+    });
+
+    it('renders the generated title and chart-first findings', async () => {
+        mocks.useChartQuery.mockReturnValue({
+            isLoading: false,
+            data: { title: 'Enterprise retention by incident exposure' },
+        });
+        renderReport(vi.fn(), {
+            ...deepResearchRunFixture,
+            resultMarkdown: canonicalMarkdown,
+            sourceCount: null,
+        });
+
+        const findingTitle = await screen.findByRole('heading', {
+            name: 'Reliability drove the decline',
+        });
+        const chart = screen.getByTestId('deep-research-chart');
+        const interpretation = screen.getByText(
+            /strongest tested explanation/i,
+        );
+
+        expect(
+            Boolean(
+                findingTitle.compareDocumentPosition(chart) &
+                Node.DOCUMENT_POSITION_FOLLOWING,
+            ),
+        ).toBe(true);
+        expect(
+            Boolean(
+                chart.compareDocumentPosition(interpretation) &
+                Node.DOCUMENT_POSITION_FOLLOWING,
+            ),
+        ).toBe(true);
+        expect(screen.getByText(/incomplete support sentiment/i)).toBeVisible();
+        expect(
+            screen.getByRole('heading', {
+                name: 'Reliability Drove Retention Losses',
+            }),
+        ).toBeVisible();
+        expect(
+            screen.queryByRole('heading', {
+                name: deepResearchRunFixture.question,
+            }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.getByRole('navigation', { name: 'Report contents' }),
+        ).not.toHaveTextContent('Sources');
+        expect(
+            screen.getByRole('heading', {
+                name: 'Adoption was not the cause',
+            }),
+        ).toBeVisible();
+        expect(
+            screen.getByText(/Reliability at renewal is the clearest/i),
+        ).toBeVisible();
+    });
+
+    it('renders inline markdown in the generated report title', async () => {
+        mocks.useChartQuery.mockReturnValue({
+            isLoading: false,
+            data: undefined,
+        });
+        renderReport(vi.fn(), {
+            ...deepResearchRunFixture,
+            resultMarkdown: canonicalMarkdown.replace(
+                '# Reliability Drove Retention Losses',
+                '# Reliability **Drove** Retention Losses',
+            ),
+        });
+
+        expect((await screen.findByText('Drove')).tagName).toBe('STRONG');
+    });
+
+    it('preserves interpretation when its live evidence is unavailable', async () => {
+        mocks.useChartQuery.mockReturnValue({
+            isLoading: false,
+            data: undefined,
+        });
+        renderReport(vi.fn(), {
+            ...deepResearchRunFixture,
+            resultMarkdown: canonicalMarkdown,
+        });
+
+        expect(await screen.findByText('Chart unavailable')).toBeVisible();
+        expect(screen.getByText(/strongest tested explanation/i)).toBeVisible();
+    });
+
+    it('renders inline finding markdown without corrupting text', async () => {
+        mocks.useChartQuery.mockReturnValue({
+            isLoading: false,
+            data: undefined,
+        });
+        const markdown = canonicalMarkdown
+            .replace(
+                '## Reliability drove the decline',
+                '## Escaped \\*literal\\* and `orders_total`',
+            )
+            .replace(
+                'Compare incident timing with renewal decisions next.',
+                'See [warehouse](https://example.com/docs).',
+            );
+        renderReport(vi.fn(), {
+            ...deepResearchRunFixture,
+            resultMarkdown: markdown,
+        });
+
+        expect(
+            await screen.findByRole('heading', {
+                name: 'Escaped *literal* and orders_total',
+            }),
+        ).toBeVisible();
+        expect(screen.getByText('orders_total').tagName).toBe('CODE');
+        expect(screen.getByRole('link', { name: 'warehouse' })).toHaveAttribute(
+            'href',
+            'https://example.com/docs',
+        );
+    });
+
+    it('falls back to plain Markdown for malformed structured reports', async () => {
+        const malformed = `# Incomplete Research Report
+
+This report has only one finding.
+
+## Legacy-compatible finding
+
+The narrative remains readable.
+
+## Conclusion
+
+Run the research again.`;
+        renderReport(vi.fn(), {
+            ...deepResearchRunFixture,
+            resultMarkdown: malformed,
+        });
+
+        expect(
+            await screen.findByRole('heading', {
+                name: 'Legacy-compatible finding',
+            }),
+        ).toBeVisible();
+        expect(
+            screen.getByText('The narrative remains readable.'),
+        ).toBeVisible();
     });
 
     it('renders whitelisted callouts with markdown children', async () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -1,3 +1,4 @@
+import { parseDeepResearchReport } from '@lightdash/common';
 import {
     Box,
     Button,
@@ -18,8 +19,10 @@ import {
     getDeepResearchReportSourceCount,
 } from '../../deepResearch/reportDocument';
 import { type DeepResearchRunView } from '../../deepResearch/types';
+import { DeepResearchInlineMarkdown } from './DeepResearchInlineMarkdown';
 import { DeepResearchMarkdownReport } from './DeepResearchMarkdownReport';
 import styles from './DeepResearchReport.module.css';
+import { DeepResearchReportContent } from './DeepResearchReportContent';
 
 type Props = {
     run: DeepResearchRunView;
@@ -37,6 +40,13 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
             run.resultMarkdown
                 ? getDeepResearchReportHeadings(run.resultMarkdown)
                 : [],
+        [run.resultMarkdown],
+    );
+    const parsedReport = useMemo(
+        () =>
+            run.resultMarkdown
+                ? parseDeepResearchReport(run.resultMarkdown)
+                : null,
         [run.resultMarkdown],
     );
     const contents = useMemo(
@@ -141,7 +151,11 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                 viewportRef={scrollViewportRef}
                 onScrollPositionChange={updateActiveSection}
             >
-                <Box className={styles.reportLayout}>
+                <Box
+                    className={`${styles.reportLayout} ${
+                        parsedReport ? styles.structuredReportLayout : ''
+                    }`}
+                >
                     <Box component="aside" className={styles.contentsRail}>
                         <Box
                             component="nav"
@@ -207,7 +221,11 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                     <Box
                         component="article"
                         ref={reportRef}
-                        className={styles.report}
+                        className={`${styles.report} ${
+                            parsedReport
+                                ? styles.structuredReportPage
+                                : styles.reportFallback
+                        }`}
                         data-deep-research-report
                     >
                         <Stack gap="xl">
@@ -225,14 +243,28 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                                     <DeepResearchBetaBadge />
                                 </Group>
                                 <Title order={1} className={styles.reportTitle}>
-                                    {run.question}
+                                    {parsedReport ? (
+                                        <DeepResearchInlineMarkdown
+                                            markdown={parsedReport.title}
+                                        />
+                                    ) : (
+                                        run.question
+                                    )}
                                 </Title>
                             </Box>
-                            <DeepResearchMarkdownReport
-                                markdown={run.resultMarkdown}
-                                projectUuid={run.projectUuid}
-                                runUuid={run.uuid}
-                            />
+                            {parsedReport ? (
+                                <DeepResearchReportContent
+                                    report={parsedReport}
+                                    projectUuid={run.projectUuid}
+                                    runUuid={run.uuid}
+                                />
+                            ) : (
+                                <DeepResearchMarkdownReport
+                                    markdown={run.resultMarkdown}
+                                    projectUuid={run.projectUuid}
+                                    runUuid={run.uuid}
+                                />
+                            )}
                         </Stack>
                     </Box>
                 </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReportContent.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReportContent.tsx
@@ -1,0 +1,86 @@
+import { type ParsedDeepResearchReport } from '@lightdash/common';
+import { Box, Stack, Title } from '@mantine/core';
+import { type FC, type ReactNode } from 'react';
+import { DeepResearchInlineMarkdown } from './DeepResearchInlineMarkdown';
+import {
+    DeepResearchMarkdownReport,
+    QueryBackedChart,
+} from './DeepResearchMarkdownReport';
+import styles from './DeepResearchReport.module.css';
+
+type Props = {
+    report: ParsedDeepResearchReport;
+    projectUuid: string;
+    runUuid: string;
+    renderEvidence?: (queryUuid: string) => ReactNode;
+};
+
+export const DeepResearchReportContent: FC<Props> = ({
+    report,
+    projectUuid,
+    runUuid,
+    renderEvidence,
+}) => {
+    const renderMarkdown = (markdown: string, className: string) => (
+        <DeepResearchMarkdownReport
+            markdown={markdown}
+            projectUuid={projectUuid}
+            runUuid={runUuid}
+            className={className}
+        />
+    );
+
+    return (
+        <Stack className={styles.structuredReport}>
+            <Box className={styles.reportIntroduction}>
+                {renderMarkdown(
+                    report.introductionMarkdown,
+                    styles.reportIntroductionProse,
+                )}
+            </Box>
+
+            {report.findings.map((finding, index) => (
+                <Box
+                    component="section"
+                    className={styles.reportFinding}
+                    key={`${finding.title}-${index}`}
+                >
+                    <Title order={2} className={styles.reportFindingTitle}>
+                        <DeepResearchInlineMarkdown markdown={finding.title} />
+                    </Title>
+
+                    {finding.evidenceQueryUuid ? (
+                        <Box className={styles.reportEvidence}>
+                            {renderEvidence ? (
+                                renderEvidence(finding.evidenceQueryUuid)
+                            ) : (
+                                <QueryBackedChart
+                                    projectUuid={projectUuid}
+                                    runUuid={runUuid}
+                                    queryUuid={finding.evidenceQueryUuid}
+                                />
+                            )}
+                        </Box>
+                    ) : null}
+
+                    <Box className={styles.reportNarrative}>
+                        {renderMarkdown(
+                            finding.interpretationMarkdown,
+                            styles.reportProse,
+                        )}
+                    </Box>
+                </Box>
+            ))}
+
+            <Box component="section" className={styles.reportConclusion}>
+                <Title order={2} className={styles.reportConclusionTitle}>
+                    Conclusion
+                </Title>
+                {renderMarkdown(
+                    report.conclusionMarkdown,
+                    styles.reportConclusionProse,
+                )}
+            </Box>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/stories/DeepResearchReportContent.stories.tsx
+++ b/packages/frontend/src/stories/DeepResearchReportContent.stories.tsx
@@ -1,0 +1,132 @@
+import { type ParsedDeepResearchReport } from '@lightdash/common';
+import {
+    Box,
+    Center,
+    Loader,
+    Paper,
+    Stack,
+    Text,
+    useMantineTheme,
+} from '@mantine/core';
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import Callout from '../components/common/Callout';
+import { DeepResearchReportContent } from '../ee/features/aiCopilot/components/DeepResearch/DeepResearchReportContent';
+
+const report: ParsedDeepResearchReport = {
+    title: 'Reliability Drove Retention Losses',
+    introductionMarkdown:
+        'Enterprise retention fell because unresolved reliability incidents coincided with several large renewals. One account has incomplete support sentiment, but the pattern is concentrated enough to make renewal reliability the central story.',
+    findings: [
+        {
+            title: 'Reliability drove the decline',
+            evidenceQueryUuid: 'chart-1',
+            interpretationMarkdown:
+                'Losses cluster among incident-exposed accounts, making reliability the strongest tested explanation rather than a broad commercial slowdown. The evidence is observational, so the useful next step is to compare incident timing with renewal decisions for the affected cohort.',
+        },
+        {
+            title: 'Adoption was not the cause',
+            evidenceQueryUuid: null,
+            interpretationMarkdown:
+                'Adoption improved after most renewal decisions had already been made. It remains a useful health signal for retained customers, but it does not explain the losses in this cohort.',
+        },
+    ],
+    conclusionMarkdown:
+        'Reliability at renewal is the clearest intervention point. Prioritize incident resolution for accounts entering their renewal window, then track whether the retention gap narrows.',
+};
+
+const SimulatedChart = () => {
+    const theme = useMantineTheme();
+    const bars = [42, 68, 52, 86, 73, 94];
+
+    return (
+        <Paper withBorder radius="md" p="lg" h="100%">
+            <Stack h="100%" gap="lg">
+                <Text fw={650}>Renewal rate by incident exposure</Text>
+                <Box
+                    role="img"
+                    aria-label="Simulated renewal rate chart"
+                    style={{
+                        display: 'flex',
+                        alignItems: 'end',
+                        gap: theme.spacing.md,
+                        flex: 1,
+                        minHeight: 220,
+                        padding: `${theme.spacing.lg} ${theme.spacing.md}`,
+                        borderBottom: `1px solid ${theme.colors.gray[3]}`,
+                    }}
+                >
+                    {bars.map((height, index) => (
+                        <Box
+                            key={index}
+                            style={{
+                                width: '100%',
+                                height: `${height}%`,
+                                borderRadius: `${theme.radius.sm} ${theme.radius.sm} 0 0`,
+                                background:
+                                    index > 3
+                                        ? theme.colors.indigo[6]
+                                        : theme.colors.indigo[3],
+                            }}
+                        />
+                    ))}
+                </Box>
+            </Stack>
+        </Paper>
+    );
+};
+
+const meta: Meta<typeof DeepResearchReportContent> = {
+    component: DeepResearchReportContent,
+    parameters: {
+        layout: 'fullscreen',
+        chromatic: { viewports: [390, 900, 1440] },
+    },
+    decorators: [
+        (Story) => (
+            <Box p={{ base: 'md', md: 'xl' }} maw={1280} mx="auto">
+                <Story />
+            </Box>
+        ),
+    ],
+    args: {
+        report,
+        projectUuid: 'project-1',
+        runUuid: 'run-1',
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DeepResearchReportContent>;
+
+export const ResponsiveReport: Story = {
+    args: { renderEvidence: () => <SimulatedChart /> },
+};
+
+export const LoadingEvidence: Story = {
+    args: {
+        renderEvidence: () => (
+            <Paper withBorder radius="md" h="100%">
+                <Center h="100%">
+                    <Stack align="center" gap="sm">
+                        <Loader size="sm" />
+                        <Text size="sm" c="dimmed">
+                            Loading live chart data
+                        </Text>
+                    </Stack>
+                </Center>
+            </Paper>
+        ),
+    },
+};
+
+export const UnavailableEvidence: Story = {
+    args: {
+        renderEvidence: () => (
+            <Callout variant="warning" title="Chart unavailable">
+                The live data for this chart could not be loaded. The finding’s
+                interpretation remains available.
+            </Callout>
+        ),
+    },
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9792

## Summary

PR 3 of 3 for [PROD-9792](https://linear.app/lightdash/issue/PROD-9792). Renders canonical reports as responsive, data-dominant findings with a short generated title, full-width evidence, and editorial narrative below.

Stacks on top of [#27127](https://github.com/lightdash/lightdash/pull/27127), which bounds inline interactions and adds the Explore handoff.

## Changes

- Uses the generated report title in the header and reserves the original prompt for malformed-output fallback.
- Gives every chart the full report row, then places one or two narrative paragraphs below it.
- Removes confidence UI, version markers, versioned component names, and compatibility branches.
- Preserves concise introduction, text-only findings, inline Markdown, evidence failure, and conclusion states.
- Adds responsive Storybook coverage at 390px, 900px, and 1440px.

```text
Short finding
┌──────────────────────────────────────────────┐
│                visual evidence               │
└──────────────────────────────────────────────┘
Complementary narrative and inline caveat
```

## Test plan

- [x] Focused report and inline Markdown tests: 21 passed
- [x] Frontend lint and format
- [ ] Frontend typecheck is blocked by the unrelated current-main FormArrayElement import error in ServiceAccountProjectRoles.tsx
- [x] Fresh real run generated 4 findings and 4 charts with zero tool errors

