### PR TITLE
fix: full-page "Multiple Sentry Session Replay instances" crash when Sentry re-initializes

### DIFF
--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -1,6 +1,7 @@
 import { type HealthState, type LightdashUser } from '@lightdash/common';
 import {
     init,
+    isInitialized,
     reactRouterV7BrowserTracingIntegration,
     replayIntegration,
     setTag,
@@ -8,7 +9,7 @@ import {
     setUser,
     spotlightBrowserIntegration,
 } from '@sentry/react';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import {
     createRoutesFromChildren,
     matchRoutes,
@@ -33,12 +34,11 @@ const useSentry = (
     user: LightdashUser | undefined,
     disableDashboardTracing?: boolean,
 ) => {
-    const [isSentryLoaded, setIsSentryLoaded] = useState(false);
     useEffect(() => {
         const dsn =
             sentryConfig?.frontend.dsn ||
             (sentrySpotlightEnabled ? SPOTLIGHT_DUMMY_DSN : '');
-        if (sentryConfig && !isSentryLoaded && dsn) {
+        if (sentryConfig && dsn && !isInitialized()) {
             init({
                 dsn,
                 release: sentryConfig.release,
@@ -121,7 +121,6 @@ const useSentry = (
                     return event;
                 },
             });
-            setIsSentryLoaded(true);
         }
         if (user) {
             setUser({
@@ -134,13 +133,7 @@ const useSentry = (
                 'organization.uuid': user.organizationUuid,
             });
         }
-    }, [
-        isSentryLoaded,
-        setIsSentryLoaded,
-        sentryConfig,
-        user,
-        disableDashboardTracing,
-    ]);
+    }, [sentryConfig, user, disableDashboardTracing]);
 
     const { projectUuid, dashboardUuid } = useParams<{
         projectUuid?: string;


### PR DESCRIPTION
Re-running Sentry init after a provider remount (or a StrictMode effect re-run in local dev) constructed a second replay integration, which throws `Multiple Sentry Session Replay instances are not supported` and lands the user on the full-page error screen. In production this triggered after recovering from any route error — the init guard was component state that resets on remount, while the replay SDK's already-initialized flag is page-global, so every recovery attempt re-crashed until a hard refresh.

Fixes [LIGHTDASH-FRONTEND-5FM](https://lightdash.sentry.io/issues/LIGHTDASH-FRONTEND-5FM)
Fixes [LIGHTDASH-FRONTEND-5D0](https://lightdash.sentry.io/issues/LIGHTDASH-FRONTEND-5D0)