### PR TITLE
fix: create default user spaces for SCIM-provisioned users at provisioning time

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -692,12 +692,13 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getAiAgentService<AiAgentService>(),
                     aiService: repository.getAiService<AiService>(),
                 }),
-            scimService: ({ models, context }) =>
+            scimService: ({ models, context, repository }) =>
                 new ScimService({
                     lightdashConfig: context.lightdashConfig,
                     organizationMemberProfileModel:
                         models.getOrganizationMemberProfileModel(),
                     userModel: models.getUserModel(),
+                    userService: repository.getUserService(),
                     emailModel: models.getEmailModel(),
                     analytics: context.lightdashAnalytics,
                     groupsModel: models.getGroupsModel(),

--- a/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
@@ -16,6 +16,7 @@ import { OrganizationMemberProfileModel } from '../../../models/OrganizationMemb
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { RolesModel } from '../../../models/RolesModel';
 import { UserModel } from '../../../models/UserModel';
+import { UserService } from '../../../services/UserService';
 import { CommercialFeatureFlagModel } from '../../models/CommercialFeatureFlagModel';
 import { ServiceAccountModel } from '../../models/ServiceAccountModel';
 import { ScimService } from './ScimService';
@@ -190,6 +191,9 @@ export const ScimServiceArgumentsMock: ConstructorParameters<
     lightdashConfig: lightdashConfigMock,
     organizationMemberProfileModel: organizationMemberProfileModelMock,
     userModel: userModelMock,
+    userService: {
+        ensureDefaultUserSpacesForUser: vi.fn().mockResolvedValue(undefined),
+    } as unknown as UserService,
     emailModel: emailModelMock,
     analytics: analyticsMock,
     groupsModel: {

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -232,6 +232,78 @@ describe('ScimService', () => {
     });
 
     describe('createUser', () => {
+        test('should ensure default user spaces after assigning roles', async () => {
+            const { rolesModel, userService } = ScimServiceArgumentsMock;
+
+            await service.createUser({
+                account: mockScimAccount,
+                user: {
+                    schemas: [ScimSchemaType.USER],
+                    userName: 'new-user@example.com',
+                    active: true,
+                    roles: [
+                        {
+                            value: OrganizationMemberRole.MEMBER,
+                            type: 'Organization',
+                            primary: true,
+                        },
+                    ],
+                },
+                organizationUuid: mockUser.organizationUuid,
+            });
+
+            expect(
+                userService.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledExactlyOnceWith({
+                userUuid: mockUser.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+            });
+            expect(
+                vi.mocked(rolesModel.setUserOrgAndProjectRoles).mock
+                    .invocationCallOrder[0],
+            ).toBeLessThan(
+                vi.mocked(userService.ensureDefaultUserSpacesForUser).mock
+                    .invocationCallOrder[0],
+            );
+        });
+
+        test('should not ensure default user spaces for an inactive user', async () => {
+            const { userService } = ScimServiceArgumentsMock;
+
+            await service.createUser({
+                account: mockScimAccount,
+                user: {
+                    schemas: [ScimSchemaType.USER],
+                    userName: 'new-user@example.com',
+                    active: false,
+                },
+                organizationUuid: mockUser.organizationUuid,
+            });
+
+            expect(
+                userService.ensureDefaultUserSpacesForUser,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('should succeed when ensuring default user spaces fails', async () => {
+            const { userService } = ScimServiceArgumentsMock;
+            vi.mocked(
+                userService.ensureDefaultUserSpacesForUser,
+            ).mockRejectedValueOnce(new Error('Failed to create space'));
+
+            await expect(
+                service.createUser({
+                    account: mockScimAccount,
+                    user: {
+                        schemas: [ScimSchemaType.USER],
+                        userName: 'new-user@example.com',
+                        active: true,
+                    },
+                    organizationUuid: mockUser.organizationUuid,
+                }),
+            ).resolves.toMatchObject({ id: mockUser.userUuid });
+        });
+
         test('should create user with default role when no role is provided', async () => {
             // Create a SCIM user without a role in the extension schema
             const scimUser = {
@@ -506,6 +578,67 @@ describe('ScimService', () => {
     });
 
     describe('updateUser', () => {
+        test.each([
+            ['active', true],
+            ['active status omitted', undefined],
+        ])(
+            'should ensure default user spaces after assigning roles when %s',
+            async (_case, active) => {
+                const { rolesModel, userService } = ScimServiceArgumentsMock;
+
+                await service.updateUser({
+                    account: mockScimAccount,
+                    user: {
+                        schemas: [ScimSchemaType.USER],
+                        userName: mockUser.email,
+                        ...(active === undefined ? {} : { active }),
+                        roles: [
+                            {
+                                value: OrganizationMemberRole.MEMBER,
+                                type: 'Organization',
+                                primary: true,
+                            },
+                        ],
+                    },
+                    userUuid: mockUser.userUuid,
+                    organizationUuid: mockUser.organizationUuid,
+                });
+
+                expect(
+                    userService.ensureDefaultUserSpacesForUser,
+                ).toHaveBeenCalledExactlyOnceWith({
+                    userUuid: mockUser.userUuid,
+                    organizationUuid: mockUser.organizationUuid,
+                });
+                expect(
+                    vi.mocked(rolesModel.setUserOrgAndProjectRoles).mock
+                        .invocationCallOrder[0],
+                ).toBeLessThan(
+                    vi.mocked(userService.ensureDefaultUserSpacesForUser).mock
+                        .invocationCallOrder[0],
+                );
+            },
+        );
+
+        test('should not ensure default user spaces for a deactivated user', async () => {
+            const { userService } = ScimServiceArgumentsMock;
+
+            await service.updateUser({
+                account: mockScimAccount,
+                user: {
+                    schemas: [ScimSchemaType.USER],
+                    userName: mockUser.email,
+                    active: false,
+                },
+                userUuid: mockUser.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+            });
+
+            expect(
+                userService.ensureDefaultUserSpacesForUser,
+            ).not.toHaveBeenCalled();
+        });
+
         test('should downgrade role to MEMBER and remove project and group memberships when deactivating user', async () => {
             const { organizationMemberProfileModel, rolesModel, groupsModel } =
                 ScimServiceArgumentsMock;
@@ -1102,6 +1235,152 @@ describe('ScimService', () => {
 
             expect(userModel.updateUser).not.toHaveBeenCalled();
             expect(rolesModel.setUserOrgAndProjectRoles).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('group default user spaces', () => {
+        const existingMember = {
+            userUuid: 'existing-user-uuid',
+            email: 'existing@example.com',
+            firstName: 'Existing',
+            lastName: 'User',
+        };
+        const addedMember = {
+            userUuid: 'added-user-uuid',
+            email: 'added@example.com',
+            firstName: 'Added',
+            lastName: 'User',
+        };
+        const existingGroup: GroupWithMembers = {
+            uuid: 'group-uuid',
+            name: 'Data Platform',
+            createdAt: new Date('2024-01-01'),
+            createdByUserUuid: null,
+            updatedAt: new Date('2024-01-01'),
+            updatedByUserUuid: null,
+            organizationUuid: mockUser.organizationUuid,
+            members: [existingMember],
+            memberUuids: [existingMember.userUuid],
+        };
+        const updatedGroup: GroupWithMembers = {
+            ...existingGroup,
+            members: [existingMember, addedMember],
+            memberUuids: [existingMember.userUuid, addedMember.userUuid],
+        };
+
+        test('should ensure default user spaces for every member when creating a group', async () => {
+            const { userService } = ScimServiceArgumentsMock;
+            const createdGroup: GroupWithMembers = {
+                ...updatedGroup,
+                members: [existingMember, addedMember],
+            };
+            const groupService = new ScimService({
+                ...ScimServiceArgumentsMock,
+                groupsModel: {
+                    find: vi.fn().mockResolvedValue({ data: [] }),
+                    createGroup: vi.fn().mockResolvedValue(createdGroup),
+                } as never,
+            });
+
+            await groupService.createGroup(
+                mockScimAccount,
+                mockUser.organizationUuid,
+                {
+                    schemas: [ScimSchemaType.GROUP],
+                    displayName: createdGroup.name,
+                    members: createdGroup.memberUuids.map((userUuid) => ({
+                        value: userUuid,
+                    })),
+                },
+            );
+
+            expect(
+                userService.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledTimes(2);
+            expect(
+                userService.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledWith({
+                userUuid: existingMember.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+            });
+            expect(
+                userService.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledWith({
+                userUuid: addedMember.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+            });
+        });
+
+        test('should ensure default user spaces only for added members when replacing a group', async () => {
+            const { userService } = ScimServiceArgumentsMock;
+            const groupService = new ScimService({
+                ...ScimServiceArgumentsMock,
+                groupsModel: {
+                    getGroupWithMembers: vi
+                        .fn()
+                        .mockResolvedValue(existingGroup),
+                    find: vi.fn().mockResolvedValue({ data: [] }),
+                    updateGroup: vi.fn().mockResolvedValue(updatedGroup),
+                } as never,
+            });
+
+            await groupService.replaceGroup(
+                mockScimAccount,
+                mockUser.organizationUuid,
+                existingGroup.uuid,
+                {
+                    schemas: [ScimSchemaType.GROUP],
+                    displayName: updatedGroup.name,
+                    members: updatedGroup.memberUuids.map((userUuid) => ({
+                        value: userUuid,
+                    })),
+                },
+            );
+
+            expect(
+                userService.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledExactlyOnceWith({
+                userUuid: addedMember.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+            });
+        });
+
+        test('should ensure default user spaces only for added members when patching a group', async () => {
+            const { userService } = ScimServiceArgumentsMock;
+            const groupService = new ScimService({
+                ...ScimServiceArgumentsMock,
+                groupsModel: {
+                    getGroupWithMembers: vi
+                        .fn()
+                        .mockResolvedValue(existingGroup),
+                    updateGroup: vi.fn().mockResolvedValue(updatedGroup),
+                } as never,
+            });
+
+            await groupService.updateGroup(
+                mockScimAccount,
+                mockUser.organizationUuid,
+                existingGroup.uuid,
+                {
+                    schemas: [ScimSchemaType.PATCH],
+                    Operations: [
+                        {
+                            op: 'Replace',
+                            path: 'members',
+                            value: updatedGroup.memberUuids.map((userUuid) => ({
+                                value: userUuid,
+                            })),
+                        },
+                    ],
+                },
+            );
+
+            expect(
+                userService.ensureDefaultUserSpacesForUser,
+            ).toHaveBeenCalledExactlyOnceWith({
+                userUuid: addedMember.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+            });
         });
     });
 

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -50,6 +50,7 @@ import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { RolesModel } from '../../../models/RolesModel';
 import { UserModel } from '../../../models/UserModel';
 import { BaseService } from '../../../services/BaseService';
+import type { UserService } from '../../../services/UserService';
 import { wrapSentryTransaction } from '../../../utils';
 import { CommercialFeatureFlagModel } from '../../models/CommercialFeatureFlagModel';
 import { ServiceAccountModel } from '../../models/ServiceAccountModel';
@@ -58,6 +59,7 @@ type ScimServiceArguments = {
     lightdashConfig: LightdashConfig;
     organizationMemberProfileModel: OrganizationMemberProfileModel;
     userModel: UserModel;
+    userService: UserService;
     emailModel: EmailModel;
     analytics: LightdashAnalytics;
     groupsModel: GroupsModel;
@@ -86,6 +88,8 @@ export class ScimService extends BaseService {
 
     private readonly userModel: UserModel;
 
+    private readonly userService: UserService;
+
     private readonly emailModel: EmailModel;
 
     private readonly analytics: LightdashAnalytics;
@@ -106,6 +110,7 @@ export class ScimService extends BaseService {
         lightdashConfig,
         organizationMemberProfileModel,
         userModel,
+        userService,
         emailModel,
         analytics,
         groupsModel,
@@ -119,6 +124,7 @@ export class ScimService extends BaseService {
         this.lightdashConfig = lightdashConfig;
         this.organizationMemberProfileModel = organizationMemberProfileModel;
         this.userModel = userModel;
+        this.userService = userService;
         this.emailModel = emailModel;
         this.analytics = analytics;
         this.groupsModel = groupsModel;
@@ -475,6 +481,34 @@ export class ScimService extends BaseService {
         }
     }
 
+    private async ensureDefaultUserSpacesForUsers({
+        userUuids,
+        organizationUuid,
+    }: {
+        userUuids: string[];
+        organizationUuid: string;
+    }): Promise<void> {
+        await Promise.all(
+            userUuids.map(async (userUuid) => {
+                try {
+                    await this.userService.ensureDefaultUserSpacesForUser({
+                        userUuid,
+                        organizationUuid,
+                    });
+                } catch (error) {
+                    this.logger.error(
+                        'SCIM: Failed to ensure default user spaces',
+                        {
+                            userUuid,
+                            organizationUuid,
+                            error: getErrorMessage(error),
+                        },
+                    );
+                }
+            }),
+        );
+    }
+
     // Create a SCIM user
     async createUser({
         account,
@@ -595,6 +629,13 @@ export class ScimService extends BaseService {
                 userUuid: dbUser.userUuid,
                 roles: dedupedRoles,
             });
+
+            if (user.active !== false) {
+                await this.ensureDefaultUserSpacesForUsers({
+                    userUuids: [dbUser.userUuid],
+                    organizationUuid,
+                });
+            }
 
             const finalUser = await this.userModel.getUserDetailsByUuid(
                 dbUser.userUuid,
@@ -759,6 +800,11 @@ export class ScimService extends BaseService {
                     organizationUuid,
                     userUuid,
                     roles: dedupedRoles,
+                });
+
+                await this.ensureDefaultUserSpacesForUsers({
+                    userUuids: [userUuid],
+                    organizationUuid,
                 });
             }
 
@@ -1411,6 +1457,11 @@ export class ScimService extends BaseService {
                 },
             });
 
+            await this.ensureDefaultUserSpacesForUsers({
+                userUuids: group.memberUuids,
+                organizationUuid,
+            });
+
             this.logger.info('SCIM: Successfully created group', {
                 organizationUuid,
                 groupUuid: group.uuid,
@@ -1540,6 +1591,19 @@ export class ScimService extends BaseService {
                         : {}),
                 },
             });
+
+            const addedMemberUuids = updatedGroup.memberUuids.filter(
+                (userUuid) =>
+                    !group.members.some(
+                        (member) => member.userUuid === userUuid,
+                    ),
+            );
+            if (addedMemberUuids.length > 0) {
+                await this.ensureDefaultUserSpacesForUsers({
+                    userUuids: addedMemberUuids,
+                    organizationUuid,
+                });
+            }
 
             this.logger.info('SCIM: Successfully replaced group', {
                 organizationUuid,
@@ -1672,6 +1736,19 @@ export class ScimService extends BaseService {
                         : {}),
                 },
             });
+
+            const addedMemberUuids = updatedGroup.memberUuids.filter(
+                (userUuid) =>
+                    !existingGroup.members.some(
+                        (member) => member.userUuid === userUuid,
+                    ),
+            );
+            if (addedMemberUuids.length > 0) {
+                await this.ensureDefaultUserSpacesForUsers({
+                    userUuids: addedMemberUuids,
+                    organizationUuid,
+                });
+            }
 
             this.logger.info('SCIM: Successfully updated group', {
                 organizationUuid,

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -2713,6 +2713,18 @@ export class UserService extends BaseService {
         await this.ensureDefaultUserSpaces(sessionUser);
     }
 
+    async ensureDefaultUserSpacesForUser(user: {
+        userUuid: string;
+        organizationUuid: string;
+    }): Promise<void> {
+        this.userModel.invalidateSessionUserCache(user.userUuid);
+        const sessionUser = await this.findSessionUser({
+            id: user.userUuid,
+            organization: user.organizationUuid,
+        });
+        await this.ensureDefaultUserSpaces(sessionUser);
+    }
+
     private async ensureDefaultUserSpaces(
         sessionUser: SessionUser,
     ): Promise<void> {


### PR DESCRIPTION
## Problem

When **Default User Spaces** is enabled on a project, personal spaces are created lazily on fresh interactive login only (`passport.serializeUser` → `UserService.onLogin()` → `ensureDefaultUserSpaces()`). SCIM provisioning never triggers that path: `ScimService` creates the user, org membership, and project roles but never ensures the personal space.

Result: SCIM-provisioned users (e.g. via Okta) have no personal space until they happen to do a fresh interactive login. In orgs where restricted users can only save to their personal space, they can't save anything at all.

## Solution

* New public `UserService.ensureDefaultUserSpacesForUser({ userUuid, organizationUuid })` — invalidates the session-user cache (roles may have just changed), resolves the session user, and reuses the existing permission-gated `ensureDefaultUserSpaces()` logic. `onLogin` is unchanged.
* `ScimService` gets a `userService` dependency (`repository.getUserService()`, the established EE→OSS DI pattern) and a best-effort helper with per-user error isolation — space-creation failure is logged but never fails the SCIM operation.
* Trigger points (every SCIM flow that can grant eligibility):
  * `createUser` — after `upsertUserRoles`, when the user is active
  * `updateUser` — after the role upsert block, when the user is active (also covers `PATCH /Users`, which delegates here)
  * `createGroup` / `replaceGroup` / `updateGroup` (PATCH) — for newly added members only, since group-granted project roles feed the user ability

Removal flows (`deleteUser`, `deleteGroup`, member removal) are untouched — removing access never grants eligibility, and existing spaces are intentionally left alone.

## Runtime verification (local EE dev instance, seed data only)

Enabled Default User Spaces on the seeded project, created a SCIM org token, then:

1. **Pre-fix (main)**: `POST /api/v1/scim/v2/Users` (active, editor) → user provisioned, **0 personal spaces** in DB — bug reproduced.
2. **Post-fix, update path**: SCIM `PATCH /Users/{id}` on that user → personal space created immediately under the "Default User Spaces" parent.
3. **Post-fix, create path**: `POST /Users` for a fresh user → personal space exists right after provisioning, no login.

```
    name     |         created_at         |       parent
-------------+----------------------------+---------------------
 Scim Repro2 | 2026-08-10 16:05:46.5405   | Default User Spaces
 Scim Repro3 | 2026-08-10 16:06:02.370933 | Default User Spaces
```

## Notes

* Related but out of scope: the impersonation flow has the same lazy-creation gap (lightdash/lightdash#22550) — not touched here, not regressed (login path unchanged).
* Unit tests cover: ensure-after-roles ordering on create/update, inactive users skipped, group flows only touching newly added members, and SCIM ops succeeding when space creation fails.

Closes: lightdash/lightdash#27113<br>Closes: lightdash/lightdash#27113

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

[https://claude.ai/code/session_01FSpYL9pF6DCRfUzYsEq7iu](<https://claude.ai/code/session_01FSpYL9pF6DCRfUzYsEq7iu>)