### PR TITLE
fix: show unable to load your memories only when status is 404

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/MyMemoriesModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/MyMemoriesModal.tsx
@@ -132,7 +132,10 @@ export const MyMemoriesModal: FC<MyMemoriesModalProps> = ({
     let content: ReactNode;
     if (memoriesQuery.isInitialLoading) {
         content = <EmptyStateLoader py="xl" />;
-    } else if (memoriesQuery.isError) {
+    } else if (
+        memoriesQuery.isError &&
+        memoriesQuery.error.error?.statusCode !== 404
+    ) {
         content = (
             <InlineErrorState
                 message="Unable to load your memories."


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->



### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Show the "Unable to load your memories" error only when memories return 404.

<!-- Even better add a screenshot / gif / loom -->

**before**

<img width="1368" height="295" alt="image" src="https://github.com/user-attachments/assets/f40f5fe2-a921-41fc-a923-262bd6799669" />

**after**

<img width="1368" height="295"  src="https://github.com/user-attachments/assets/893583b8-0f8a-4d9c-9728-6ecbb8bce144" />
