### PR TITLE
feat(content): add a data-app-viz filter mode to the content API

### DIFF
--- a/packages/backend/src/controllers/v2/ContentController.ts
+++ b/packages/backend/src/controllers/v2/ContentController.ts
@@ -59,6 +59,7 @@ export class ContentController extends BaseController {
         @Query() sortBy?: ContentArgs['sortBy'],
         @Query() sortDirection?: ContentArgs['sortDirection'],
         @Query() includePersonalDataApps?: boolean,
+        @Query() dataAppVizsFilter?: 'exclude' | 'only',
     ): Promise<ApiContentResponse> {
         const { user } = getAccountApiAccessContext(req.account!);
         this.setStatus(200);
@@ -73,6 +74,7 @@ export class ContentController extends BaseController {
                     contentTypes,
                     search,
                     includePersonalDataApps,
+                    dataAppVizsFilter,
                 },
                 {
                     sortBy,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.test.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.test.ts
@@ -1,0 +1,58 @@
+import knex from 'knex';
+import { MockClient } from 'knex-mock-client';
+import { ContentFilters } from '../ContentModelTypes';
+import { dataAppContentConfiguration } from './DataAppContentConfiguration';
+
+const db = knex({ client: MockClient, dialect: 'pg' });
+
+const buildQuery = (filters: ContentFilters) =>
+    dataAppContentConfiguration.getSummaryQuery(db, filters).toSQL();
+
+describe('dataAppContentConfiguration.getSummaryQuery dataAppVizsFilter', () => {
+    it('does not filter on template by default', () => {
+        const { sql } = buildQuery({});
+        expect(sql).not.toContain('"apps"."template" =');
+        expect(sql).not.toContain('"apps"."template" is null');
+    });
+
+    it('excludes viz template rows when dataAppVizsFilter is "exclude"', () => {
+        const { sql, bindings } = buildQuery({
+            dataAppVizsFilter: 'exclude',
+        });
+        // knex renders whereNot(col, val) as `not col = ?` rather than `!= ?`
+        expect(sql).toContain('not "apps"."template" = ?');
+        expect(sql).toContain('"apps"."template" is null');
+        expect(bindings).toContain('data_app_viz');
+    });
+
+    it('keeps deleted vizs visible in the recently-deleted view (no exclusion when the filter is not passed)', () => {
+        const { sql } = buildQuery({ deleted: true });
+        expect(sql).not.toContain('"apps"."template" =');
+        expect(sql).not.toContain('"apps"."template" is null');
+    });
+
+    it('returns only viz template rows when dataAppVizsFilter is "only"', () => {
+        const { sql, bindings } = buildQuery({ dataAppVizsFilter: 'only' });
+        expect(sql).toContain('"apps"."template" = ?');
+        expect(bindings).toContain('data_app_viz');
+    });
+
+    it('does not scope "only" mode by space, even with spaceUuids set and no personal opt-in — vizs are spaceless and project-global', () => {
+        const { sql, bindings } = buildQuery({
+            dataAppVizsFilter: 'only',
+            spaceUuids: ['space-1'],
+        });
+        expect(sql).not.toContain('"spaces"."space_uuid" in');
+        expect(sql).not.toContain('"apps"."space_uuid" is not null');
+        expect(bindings).not.toContain('space-1');
+    });
+
+    it('still scopes "exclude" mode by space (guards against over-broad skipping of the space-visibility block)', () => {
+        const { sql, bindings } = buildQuery({
+            dataAppVizsFilter: 'exclude',
+            spaceUuids: ['space-1'],
+        });
+        expect(sql).toContain('"spaces"."space_uuid" in');
+        expect(bindings).toContain('space-1');
+    });
+});

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
@@ -1,4 +1,8 @@
-import { ContentType, DataAppContent } from '@lightdash/common';
+import {
+    ContentType,
+    DATA_APP_VIZ_TEMPLATE,
+    DataAppContent,
+} from '@lightdash/common';
 import { Knex } from 'knex';
 import {
     AppsTableName,
@@ -49,11 +53,32 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                 // from space-based content listings unless the caller opts
                 // into personal apps (the "All data apps" browse, where
                 // `filters.dataApps` is set), and they surface in the
-                // recently-deleted view so admins can restore them.
+                // recently-deleted view so admins can restore them. Vizs are
+                // spaceless by design (project-global chart content), so the
+                // "only" listing must never hide them behind the personal opt-in.
                 .where((personalFilter) => {
-                    if (!filters.deleted && !filters.dataApps) {
+                    if (
+                        !filters.deleted &&
+                        !filters.dataApps &&
+                        filters.dataAppVizsFilter !== 'only'
+                    ) {
                         void personalFilter.whereNotNull(
                             `${AppsTableName}.space_uuid`,
+                        );
+                    }
+                })
+                .where((templateFilter) => {
+                    if (filters.dataAppVizsFilter === 'exclude') {
+                        void templateFilter
+                            .whereNot(
+                                `${AppsTableName}.template`,
+                                DATA_APP_VIZ_TEMPLATE,
+                            )
+                            .orWhereNull(`${AppsTableName}.template`);
+                    } else if (filters.dataAppVizsFilter === 'only') {
+                        void templateFilter.where(
+                            `${AppsTableName}.template`,
+                            DATA_APP_VIZ_TEMPLATE,
                         );
                     }
                 })
@@ -154,7 +179,8 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                                 order by ready_version.version desc
                                 limit 1
                             ),
-                            'pinnedListOrder', ${PinnedAppTableName}.order
+                            'pinnedListOrder', ${PinnedAppTableName}.order,
+                            'template', ${AppsTableName}.template
                         ) as metadata`,
                     ),
                 ])
@@ -173,44 +199,51 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                         );
                     }
 
-                    const personal = filters.dataApps;
-                    if (personal) {
-                        // Surface space apps the caller can access OR personal
-                        // apps they may see (their own, plus everyone's in
-                        // projects where they're an admin).
-                        void builder.where((visibility) => {
-                            if (filters.spaceUuids) {
-                                void visibility.whereIn(
-                                    `${SpaceTableName}.space_uuid`,
-                                    filters.spaceUuids,
-                                );
-                            }
-                            void visibility.orWhere((personalApps) => {
-                                void personalApps.whereNull(
-                                    `${AppsTableName}.space_uuid`,
-                                );
-                                void personalApps.where((owner) => {
-                                    void owner.where(
-                                        `${AppsTableName}.created_by_user_uuid`,
-                                        personal.personalForUserUuid,
+                    // Vizs are project-global chart content, not scoped to a
+                    // space — `space_uuid` is null for every row, so this
+                    // whole visibility block (space-uuid whereIn / personal
+                    // opt-in) would wrongly exclude them. Skip it entirely;
+                    // `filters.projectUuids` above already scopes the query.
+                    if (filters.dataAppVizsFilter !== 'only') {
+                        const personal = filters.dataApps;
+                        if (personal) {
+                            // Surface space apps the caller can access OR personal
+                            // apps they may see (their own, plus everyone's in
+                            // projects where they're an admin).
+                            void builder.where((visibility) => {
+                                if (filters.spaceUuids) {
+                                    void visibility.whereIn(
+                                        `${SpaceTableName}.space_uuid`,
+                                        filters.spaceUuids,
                                     );
-                                    if (
-                                        personal.personalAdminProjectUuids
-                                            .length > 0
-                                    ) {
-                                        void owner.orWhereIn(
-                                            `${ProjectTableName}.project_uuid`,
-                                            personal.personalAdminProjectUuids,
+                                }
+                                void visibility.orWhere((personalApps) => {
+                                    void personalApps.whereNull(
+                                        `${AppsTableName}.space_uuid`,
+                                    );
+                                    void personalApps.where((owner) => {
+                                        void owner.where(
+                                            `${AppsTableName}.created_by_user_uuid`,
+                                            personal.personalForUserUuid,
                                         );
-                                    }
+                                        if (
+                                            personal.personalAdminProjectUuids
+                                                .length > 0
+                                        ) {
+                                            void owner.orWhereIn(
+                                                `${ProjectTableName}.project_uuid`,
+                                                personal.personalAdminProjectUuids,
+                                            );
+                                        }
+                                    });
                                 });
                             });
-                        });
-                    } else if (filters.spaceUuids) {
-                        void builder.whereIn(
-                            `${SpaceTableName}.space_uuid`,
-                            filters.spaceUuids,
-                        );
+                        } else if (filters.spaceUuids) {
+                            void builder.whereIn(
+                                `${SpaceTableName}.space_uuid`,
+                                filters.spaceUuids,
+                            );
+                        }
                     }
 
                     // Pick the latest version per app — every app has at
@@ -302,6 +335,10 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                 latestReadyVersionNumber:
                     (value.metadata.latestReadyVersionNumber as
                         | number
+                        | null) ?? null,
+                template:
+                    (value.metadata.template as
+                        | DataAppContent['template']
                         | null) ?? null,
             };
         },

--- a/packages/backend/src/models/ContentModel/ContentModelTypes.ts
+++ b/packages/backend/src/models/ContentModel/ContentModelTypes.ts
@@ -41,6 +41,11 @@ export type ContentFilters = {
     // Client opt-in (set by the "All data apps" browse) to surface personal
     // (space-less) apps. The service resolves it into `dataApps` below.
     includePersonalDataApps?: boolean;
+    // Split the app listing surfaces: 'exclude' hides data app vizs (the
+    // "All data apps" browse), 'only' returns just them (the "Custom chart
+    // types" listing; vizs are spaceless and project-global, so space and
+    // personal-draft scoping don't apply).
+    dataAppVizsFilter?: 'exclude' | 'only';
     // Resolved by the service: which personal apps the caller may see.
     // `personalForUserUuid` is always the caller (their own apps);
     // `personalAdminProjectUuids` are projects where they can see everyone's.

--- a/packages/backend/src/services/ContentService/ContentService.test.ts
+++ b/packages/backend/src/services/ContentService/ContentService.test.ts
@@ -320,6 +320,93 @@ describe('ContentService.find', () => {
             expect.objectContaining({ page: 1, pageSize: 50 }),
         );
     });
+
+    // The vizs-only listing skips space scoping, so it must be gated on
+    // manage:Explore like the viz library endpoint.
+    describe('dataAppVizsFilter=only authorization', () => {
+        const emptyPage = (): Promise<KnexPaginatedData<SummaryContent[]>> =>
+            Promise.resolve({
+                pagination: {
+                    page: 1,
+                    pageSize: 50,
+                    totalPageCount: 1,
+                    totalResults: 0,
+                },
+                data: [],
+            });
+
+        const findWithUser = async (user: SessionUser) => {
+            const findSummaryContents = vi.fn(emptyPage);
+            const deps = createService({
+                contentModel: {
+                    findSummaryContents,
+                } as unknown as ContentModel,
+                spaceModel: {
+                    find: vi.fn().mockResolvedValue([]),
+                } as unknown as SpaceModel,
+                spacePermissionService: {
+                    getAccessibleSpaceUuids: vi.fn().mockResolvedValue([]),
+                    getDirectAccessUserUuids: vi.fn(),
+                } as unknown as SpacePermissionService,
+            });
+            await deps.service.find(
+                user,
+                {
+                    projectUuids: [projectUuid],
+                    contentTypes: [ContentType.DATA_APP],
+                    dataAppVizsFilter: 'only',
+                },
+                {},
+                { page: 1, pageSize: 50 },
+            );
+            return findSummaryContents;
+        };
+
+        it('drops projects where the user cannot manage explores', async () => {
+            const viewer: SessionUser = {
+                ...createUser(),
+                ability: defineUserAbility(
+                    {
+                        userUuid,
+                        role: OrganizationMemberRole.MEMBER,
+                        organizationUuid,
+                    },
+                    [
+                        {
+                            projectUuid,
+                            role: ProjectMemberRole.VIEWER,
+                            userUuid,
+                            roleUuid: undefined,
+                        },
+                    ],
+                ),
+            };
+
+            const findSummaryContents = await findWithUser(viewer);
+
+            expect(findSummaryContents).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    projectUuids: [],
+                    dataAppVizsFilter: 'only',
+                }),
+                expect.any(Object),
+                expect.any(Object),
+            );
+        });
+
+        it('keeps projects where the user can manage explores', async () => {
+            const findSummaryContents = await findWithUser(createUser());
+
+            expect(findSummaryContents).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    projectUuids: [projectUuid],
+                    dataAppVizsFilter: 'only',
+                }),
+                expect.any(Object),
+                expect.any(Object),
+            );
+        });
+    });
 });
 
 describe('ContentService.findDeleted', () => {

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -141,9 +141,20 @@ export class ContentService extends BaseService {
                 ),
             )
             .map((p) => p.projectUuid);
-        const allowedProjectUuids = filters.projectUuids
+        let allowedProjectUuids = filters.projectUuids
             ? intersection(filters.projectUuids, projectUuids)
             : projectUuids; // todo: move this filter to project model query
+
+        // The vizs-only listing skips space scoping entirely, so gate it on
+        // the same permission as the viz library: chart builders only.
+        if (filters.dataAppVizsFilter === 'only') {
+            allowedProjectUuids = allowedProjectUuids.filter((projectUuid) =>
+                auditedAbility.can(
+                    'manage',
+                    subject('Explore', { organizationUuid, projectUuid }),
+                ),
+            );
+        }
 
         const spaces = await this.spaceModel.find({
             projectUuids: allowedProjectUuids,

--- a/packages/common/src/types/content.ts
+++ b/packages/common/src/types/content.ts
@@ -1,4 +1,4 @@
-import { type AppVersionStatus } from '../ee/apps/types';
+import { type AppVersionStatus, type DataAppTemplate } from '../ee/apps/types';
 import { type ContentVerificationInfo } from './contentVerification';
 import type { KnexPaginatedData } from './knex-paginate';
 import { type ChartKind } from './savedCharts';
@@ -95,6 +95,8 @@ export interface DataAppContent extends Omit<Content, 'space' | 'pinnedList'> {
         uuid: string;
         order: number;
     } | null;
+    // 'data_app_viz' marks a reusable chart-type viz rather than a standalone app.
+    template: DataAppTemplate | null;
 }
 
 export interface SpaceContentBase extends Content {


### PR DESCRIPTION
## Summary

First slice of the Custom chart types listing work — backend only, no user-visible change on its own.

- `GET /api/v2/content` gains `dataAppVizsFilter: 'exclude' | 'only'`: `'exclude'` hides data app vizs (used by the All data apps browse in #27163), `'only'` returns just them (reserved for the upcoming viz gallery experience (server-side gated on manage:Explore)). Vizs are spaceless and project-global per the Phase 0 permission decision, so `'only'` skips space and personal-draft scoping while keeping project scoping. Because `'only'` skips space scoping, `ContentService.find` additionally gates it on `manage:Explore` per project (same permission as the viz library endpoint) — with authorization tests.
- `DataAppContent` rows now expose `template` (via the row metadata, keeping the content UNION column set unchanged) so the frontend can tell viz rows from standalone apps.
- `listDeletedContent` untouched — deleted vizs stay restorable from Recently deleted.
- SQL-shape tests cover: default (no clause), exclude (+ still space-scoped), only (+ not space-scoped, spaceless rows survive), and the deleted view.

## Testing

- `DataAppContentConfiguration.test.ts` 6/6
- Backend/common/frontend typechecks; `pnpm generate-api` clean

Relates: GLITCH-649

