### PR TITLE
refactor: derive Databricks auth type at form initialization

### DIFF
--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
@@ -8,12 +8,16 @@ import { Button, Select, Stack, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconPlus } from '@tabler/icons-react';
 import React, { type FC } from 'react';
+import { useIsDatabricksSsoEnabled } from '../../../hooks/useDatabricks';
 import { useUserWarehouseCredentialsCreateMutation } from '../../../hooks/userWarehouseCredentials/useUserWarehouseCredentials';
 import MantineModal, {
     type MantineModalProps,
 } from '../../common/MantineModal';
 import { getWarehouseLabel } from '../../ProjectConnection/ProjectConnectFlow/utils';
-import { isDatabricksPersonalAccessToken } from './utils';
+import {
+    getDefaultDatabricksAuthenticationType,
+    isDatabricksPersonalAccessToken,
+} from './utils';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
 
 type Props = Pick<MantineModalProps, 'opened' | 'onClose'> & {
@@ -26,54 +30,66 @@ type Props = Pick<MantineModalProps, 'opened' | 'onClose'> & {
     onSuccess?: (data: UserWarehouseCredentials) => void;
 };
 
-const defaultCredentials: Record<
-    WarehouseTypes,
-    UpsertUserWarehouseCredentials['credentials']
-> = {
-    [WarehouseTypes.POSTGRES]: {
-        type: WarehouseTypes.POSTGRES,
-        user: '',
-        password: '',
-    },
-    [WarehouseTypes.REDSHIFT]: {
-        type: WarehouseTypes.REDSHIFT,
-        user: '',
-        password: '',
-        authenticationType: RedshiftAuthenticationType.PASSWORD,
-    },
-    [WarehouseTypes.SNOWFLAKE]: {
-        type: WarehouseTypes.SNOWFLAKE,
-        user: '',
-        password: '',
-    },
-    [WarehouseTypes.TRINO]: {
-        type: WarehouseTypes.TRINO,
-        user: '',
-        password: '',
-    },
-    [WarehouseTypes.BIGQUERY]: {
-        type: WarehouseTypes.BIGQUERY,
-        keyfileContents: {},
-    },
-    [WarehouseTypes.DATABRICKS]: {
-        type: WarehouseTypes.DATABRICKS,
-        personalAccessToken: '',
-    },
-    [WarehouseTypes.CLICKHOUSE]: {
-        type: WarehouseTypes.CLICKHOUSE,
-        user: '',
-        password: '',
-    },
-    [WarehouseTypes.ATHENA]: {
-        type: WarehouseTypes.ATHENA,
-        accessKeyId: '',
-        secretAccessKey: '',
-    },
-    [WarehouseTypes.DUCKDB]: {
-        type: WarehouseTypes.DUCKDB,
-        token: '',
-    },
+const getDefaultCredentials = (
+    warehouseType: WarehouseTypes,
+    isDatabricksSsoEnabled: boolean,
+): UpsertUserWarehouseCredentials['credentials'] => {
+    const defaultCredentials: Record<
+        WarehouseTypes,
+        UpsertUserWarehouseCredentials['credentials']
+    > = {
+        [WarehouseTypes.POSTGRES]: {
+            type: WarehouseTypes.POSTGRES,
+            user: '',
+            password: '',
+        },
+        [WarehouseTypes.REDSHIFT]: {
+            type: WarehouseTypes.REDSHIFT,
+            user: '',
+            password: '',
+            authenticationType: RedshiftAuthenticationType.PASSWORD,
+        },
+        [WarehouseTypes.SNOWFLAKE]: {
+            type: WarehouseTypes.SNOWFLAKE,
+            user: '',
+            password: '',
+        },
+        [WarehouseTypes.TRINO]: {
+            type: WarehouseTypes.TRINO,
+            user: '',
+            password: '',
+        },
+        [WarehouseTypes.BIGQUERY]: {
+            type: WarehouseTypes.BIGQUERY,
+            keyfileContents: {},
+        },
+        [WarehouseTypes.DATABRICKS]: {
+            type: WarehouseTypes.DATABRICKS,
+            personalAccessToken: '',
+            authenticationType: getDefaultDatabricksAuthenticationType(
+                isDatabricksSsoEnabled,
+            ),
+        },
+        [WarehouseTypes.CLICKHOUSE]: {
+            type: WarehouseTypes.CLICKHOUSE,
+            user: '',
+            password: '',
+        },
+        [WarehouseTypes.ATHENA]: {
+            type: WarehouseTypes.ATHENA,
+            accessKeyId: '',
+            secretAccessKey: '',
+        },
+        [WarehouseTypes.DUCKDB]: {
+            type: WarehouseTypes.DUCKDB,
+            token: '',
+        },
+    };
+
+    return defaultCredentials[warehouseType];
 };
+
+const warehouseTypes = Object.values(WarehouseTypes);
 
 const FORM_ID = 'create-credentials-form';
 
@@ -92,11 +108,14 @@ export const CreateCredentialsModal: FC<Props> = ({
         useUserWarehouseCredentialsCreateMutation({
             onSuccess,
         });
+    const isDatabricksSsoEnabled = useIsDatabricksSsoEnabled();
     const form = useForm<UpsertUserWarehouseCredentials>({
         initialValues: {
             name: '',
-            credentials:
-                defaultCredentials[warehouseType || WarehouseTypes.POSTGRES],
+            credentials: getDefaultCredentials(
+                warehouseType || WarehouseTypes.POSTGRES,
+                isDatabricksSsoEnabled,
+            ),
         },
     });
 
@@ -163,11 +182,24 @@ export const CreateCredentialsModal: FC<Props> = ({
                             label="Warehouse"
                             size="xs"
                             disabled={isSaving}
-                            data={Object.values(WarehouseTypes).map((type) => ({
+                            data={warehouseTypes.map((type) => ({
                                 value: type,
                                 label: getWarehouseLabel(type) || type,
                             }))}
-                            {...form.getInputProps('credentials.type')}
+                            value={form.values.credentials.type}
+                            onChange={(value) => {
+                                const type = warehouseTypes.find(
+                                    (warehouse) => warehouse === value,
+                                );
+                                if (!type) return;
+                                form.setFieldValue(
+                                    'credentials',
+                                    getDefaultCredentials(
+                                        type,
+                                        isDatabricksSsoEnabled,
+                                    ),
+                                );
+                            }}
                         />
                     )}
 

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
@@ -8,15 +8,20 @@ import { Button, Stack, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconPencil } from '@tabler/icons-react';
 import { type FC } from 'react';
+import { useIsDatabricksSsoEnabled } from '../../../hooks/useDatabricks';
 import { useUserWarehouseCredentialsUpdateMutation } from '../../../hooks/userWarehouseCredentials/useUserWarehouseCredentials';
 import MantineModal, {
     type MantineModalProps,
 } from '../../common/MantineModal';
-import { isDatabricksPersonalAccessToken } from './utils';
+import {
+    getDefaultDatabricksAuthenticationType,
+    isDatabricksPersonalAccessToken,
+} from './utils';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
 
 const getCredentialsWithPlaceholders = (
     credentials: UserWarehouseCredentials['credentials'],
+    isDatabricksSsoEnabled: boolean,
 ): UpsertUserWarehouseCredentials['credentials'] => {
     switch (credentials.type) {
         case WarehouseTypes.REDSHIFT:
@@ -40,9 +45,14 @@ const getCredentialsWithPlaceholders = (
                 keyfileContents: {},
             };
         case WarehouseTypes.DATABRICKS:
+            // Stored Databricks credentials don't expose their authentication
+            // type, so fall back to whatever the instance supports.
             return {
                 ...credentials,
                 personalAccessToken: '',
+                authenticationType: getDefaultDatabricksAuthenticationType(
+                    isDatabricksSsoEnabled,
+                ),
             };
         case WarehouseTypes.CLICKHOUSE:
             return {
@@ -77,11 +87,13 @@ export const EditCredentialsModal: FC<
 > = ({ opened, onClose, userCredentials }) => {
     const { mutateAsync, isLoading: isSaving } =
         useUserWarehouseCredentialsUpdateMutation(userCredentials.uuid);
+    const isDatabricksSsoEnabled = useIsDatabricksSsoEnabled();
     const form = useForm<UpsertUserWarehouseCredentials>({
         initialValues: {
             name: userCredentials.name,
             credentials: getCredentialsWithPlaceholders(
                 userCredentials.credentials,
+                isDatabricksSsoEnabled,
             ),
         },
     });

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.test.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { type FC } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
+import { getDefaultDatabricksAuthenticationType } from './utils';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
 
 let isDatabricksSsoEnabled = false;
@@ -27,6 +28,9 @@ const DatabricksForm: FC = () => {
             credentials: {
                 type: WarehouseTypes.DATABRICKS,
                 personalAccessToken: '',
+                authenticationType: getDefaultDatabricksAuthenticationType(
+                    isDatabricksSsoEnabled,
+                ),
             },
         },
     });

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
@@ -129,20 +129,6 @@ const DatabricksFormInputs: FC<{
             ? form.values.credentials.authenticationType
             : undefined;
 
-    useEffect(() => {
-        if (isSsoEnabled === undefined || authenticationType !== undefined) {
-            return;
-        }
-        form.setFieldValue(
-            'credentials.authenticationType',
-            isSsoEnabled
-                ? DatabricksAuthenticationType.OAUTH_U2M
-                : DatabricksAuthenticationType.PERSONAL_ACCESS_TOKEN,
-        );
-    }, [form, isSsoEnabled, authenticationType]);
-
-    if (authenticationType === undefined) return null;
-
     return (
         <Stack gap="xs">
             {isSsoEnabled && (

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/utils.ts
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/utils.ts
@@ -5,6 +5,17 @@ import {
 } from '@lightdash/common';
 
 /**
+ * "Sign in with Databricks" (OAuth U2M) is enterprise-only, so instances
+ * without it can only use a personal access token.
+ */
+export const getDefaultDatabricksAuthenticationType = (
+    isSsoEnabled: boolean,
+): DatabricksAuthenticationType =>
+    isSsoEnabled
+        ? DatabricksAuthenticationType.OAUTH_U2M
+        : DatabricksAuthenticationType.PERSONAL_ACCESS_TOKEN;
+
+/**
  * Databricks personal credentials support both "Sign in with Databricks"
  * (OAuth U2M, enterprise-only) and a personal access token. Unlike the SSO
  * flow, the PAT branch has an editable secret and so needs a save button.

--- a/packages/frontend/src/hooks/useDatabricks.ts
+++ b/packages/frontend/src/hooks/useDatabricks.ts
@@ -60,6 +60,11 @@ const triggerDatabricksLogin = async (
     });
 };
 
+export const useIsDatabricksSsoEnabled = () => {
+    const health = useHealth();
+    return !!health.data?.auth.databricks.enabled;
+};
+
 export function useDatabricksLoginPopup({
     onLogin: _onLogin,
     projectUuid,


### PR DESCRIPTION
Follow-up to #27108, addressing [this review comment](https://github.com/lightdash/lightdash/pull/27108#discussion_r3751305333): the Databricks branch defaulted `credentials.authenticationType` from a `useEffect` that called `form.setFieldValue` in response to `isSsoEnabled`, with the unstable `form` object in its dependency array.

The default is now computed in the modals' `initialValues` via `getDefaultDatabricksAuthenticationType(isSsoEnabled)`, so it's set once at initialization and the effect (plus the `return null` guard that hid the form until it resolved) is gone. Health is always loaded by the time these modals render — `PrivateRoute` gates on it — so there's nothing to wait for. Two supporting changes: the edit modal seeds the default in `getCredentialsWithPlaceholders` (stored Databricks credentials don't expose their auth type), and the create modal's warehouse-type select now resets `credentials` to the defaults for the newly picked type instead of only overwriting `type`, which previously left a mismatched credentials object behind.

Verified with the existing component tests (2 passed), frontend typecheck and lint. No dev server available in this environment, so this wasn't exercised in the browser.
