### PR TITLE
ci(release-safety): declare-or-fail gate for breaking migrations and API surface changes

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -45,6 +45,9 @@ release_safety_api:
   - ".github/file-filters.yml"
   - ".github/workflows/release-safety-pr.yml"
   - "scripts/gen-release-safety.ts"
+  - "scripts/mcp-tools-diff.ts"
+  - "scripts/breaking-change-declarations.ts"
+  - "scripts/release-safety-pr-gate.ts"
   - "scripts/rest-api-diff.ts"
   - *openapi_surface
 

--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -35,6 +35,27 @@ on:
     # `edited` too; the `changes` job short-circuits those via the comment's
     # describes-stamp instead of re-running the heavy jobs.
     types: [opened, synchronize, reopened, ready_for_review, edited]
+    # The OpenAPI surface is not a file list: TSOA derives the spec from the
+    # controllers and every type they reach, so any backend or common change can
+    # move it (this is also why `.github/file-filters.yml`'s api_schema filter is
+    # deliberately broad). Migrations and the MCP snapshot live under those two
+    # globs too; the generated swagger.json used to be listed here on its own,
+    # which is what left the REST check unreachable.
+    paths:
+      - 'packages/backend/**'
+      - 'packages/common/**'
+      - 'release-safety.overrides.json'
+      - 'scripts/gen-release-safety.ts'
+      - 'scripts/ai-migration-review.ts'
+      - 'scripts/sql-migration-lint.ts'
+      - 'scripts/rest-api-diff.ts'
+      - 'scripts/mcp-tools-diff.ts'
+      - 'scripts/breaking-change-declarations.ts'
+      - 'scripts/release-safety-pr-gate.ts'
+      - 'scripts/upgrade-overrides.ts'
+      - 'scripts/release-safety-pr-comment.ts'
+      - '.github/file-filters.yml'
+      - '.github/workflows/release-safety-pr.yml'
 
 # Spec generation makes a run long enough that an older run could otherwise
 # finish last and overwrite the sticky comment with a stale verdict.
@@ -167,7 +188,7 @@ jobs:
           fi
 
   openapi-specs:
-    name: Generate OpenAPI specs
+    name: Generate API snapshots
     needs: changes
     if: needs.changes.outputs.openapi == 'true' && needs.changes.outputs.fresh != 'true'
     runs-on: depot-ubuntu-24.04-4
@@ -202,29 +223,33 @@ jobs:
       # computing the marker; the root `generate-api` adds post-hooks that write
       # the chart/dashboard/MCP schemas, none of which feed the OpenAPI spec.
       # /tmp survives the second checkout's clean; the workspace does not.
-      - name: Generate base OpenAPI spec
+      - name: Generate base API snapshots
         run: |
           set -euo pipefail
           sfw pnpm install --frozen-lockfile --prefer-offline
           pnpm generate-api:backend
-          mkdir -p /tmp/openapi-specs
-          cp packages/backend/src/generated/swagger.json /tmp/openapi-specs/base-swagger.json
+          pnpm generate:mcp-tools-snapshot
+          mkdir -p /tmp/api-snapshots
+          cp packages/backend/src/generated/swagger.json /tmp/api-snapshots/base-swagger.json
+          cp packages/common/src/schemas/json/mcp-tools-1.0.json /tmp/api-snapshots/base-mcp-tools.json
 
       - name: Checkout PR
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Generate PR OpenAPI spec
+      - name: Generate PR API snapshots
         run: |
           set -euo pipefail
           sfw pnpm install --frozen-lockfile --prefer-offline
           pnpm generate-api:backend
-          cp packages/backend/src/generated/swagger.json /tmp/openapi-specs/pr-swagger.json
+          pnpm generate:mcp-tools-snapshot
+          cp packages/backend/src/generated/swagger.json /tmp/api-snapshots/pr-swagger.json
+          cp packages/common/src/schemas/json/mcp-tools-1.0.json /tmp/api-snapshots/pr-mcp-tools.json
 
-      - name: Upload the spec pair
+      - name: Upload the API snapshot pairs
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: release-safety-openapi-specs
-          path: /tmp/openapi-specs/
+          name: release-safety-api-snapshots
+          path: /tmp/api-snapshots/
           retention-days: 1
 
   preview:
@@ -274,35 +299,35 @@ jobs:
           sudo install -m 0755 /tmp/oasdiff /usr/local/bin/oasdiff
           oasdiff --version
 
-      - name: Download the generated OpenAPI spec pair
+      - name: Download the generated API snapshot pairs
         if: ${{ needs.openapi-specs.result == 'success' }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
-          name: release-safety-openapi-specs
-          path: /tmp/openapi-specs
+          name: release-safety-api-snapshots
+          path: /tmp/api-snapshots
 
       # A spec job that reported success but shipped no usable pair is broken
       # wiring, not a normal "not checked" — fail loudly instead of quietly
       # downgrading the REST result.
-      - name: Verify the spec pair
+      - name: Verify the API snapshot pairs
         if: ${{ needs.openapi-specs.result == 'success' }}
         run: |
           set -euo pipefail
-          for side in base pr; do
-            spec="/tmp/openapi-specs/${side}-swagger.json"
-            if [ ! -s "${spec}" ]; then
-              echo "::error::openapi-specs succeeded but ${spec} is missing or empty"
+          for file in base-swagger.json pr-swagger.json base-mcp-tools.json pr-mcp-tools.json; do
+            snapshot="/tmp/api-snapshots/${file}"
+            if [ ! -s "${snapshot}" ]; then
+              echo "::error::openapi-specs succeeded but ${snapshot} is missing or empty"
               exit 1
             fi
           done
 
-      - name: Select the REST spec source
-        id: rest
+      - name: Select the API snapshot sources
+        id: api
         run: |
           set -euo pipefail
           if [ "${{ needs.openapi-specs.result }}" = "success" ]; then
             echo "expected=true" >> "$GITHUB_OUTPUT"
-            echo "flags=--rest-base-spec /tmp/openapi-specs/base-swagger.json --rest-new-spec /tmp/openapi-specs/pr-swagger.json" >> "$GITHUB_OUTPUT"
+            echo "flags=--rest-base-spec /tmp/api-snapshots/base-swagger.json --rest-new-spec /tmp/api-snapshots/pr-swagger.json --mcp-base-snapshot /tmp/api-snapshots/base-mcp-tools.json --mcp-new-snapshot /tmp/api-snapshots/pr-mcp-tools.json" >> "$GITHUB_OUTPUT"
           else
             echo "expected=false" >> "$GITHUB_OUTPUT"
             echo "flags=" >> "$GITHUB_OUTPUT"
@@ -338,8 +363,24 @@ jobs:
             --last-tag "${{ needs.changes.outputs.base_sha }}" \
             --out /tmp/release-safety.json \
             --index /tmp/release-safety-index.json \
-            ${{ steps.rest.outputs.flags }} \
+            ${{ steps.api.outputs.flags }} \
             ${AI_FLAG}
+
+      - name: Enforce API breaking-change declarations
+        id: declaration-gate
+        continue-on-error: true
+        run: |
+          tsx scripts/release-safety-pr-gate.ts \
+            --base-sha "${{ needs.changes.outputs.base_sha }}" \
+            --marker /tmp/release-safety.json
+
+      - name: Enforce SQL breaking-change declarations
+        id: sql-declaration-gate
+        continue-on-error: true
+        run: |
+          tsx scripts/sql-migration-lint.ts \
+            --last-tag "${{ needs.changes.outputs.base_sha }}" \
+            --enforce
 
       # The generator soft-degrades every REST failure to `checked: false` so that
       # nothing it does can fail a release. On a PR that silence has to be visible:
@@ -352,10 +393,10 @@ jobs:
         run: |
           set -euo pipefail
           CHECKED=$(node -e 'const m=JSON.parse(require("fs").readFileSync("/tmp/release-safety.json","utf8"));process.stdout.write(String(m?.api?.rest?.checked === true))')
-          if [ "${{ steps.rest.outputs.expected }}" = "true" ] && [ "${CHECKED}" = "true" ]; then
+          if [ "${{ steps.api.outputs.expected }}" = "true" ] && [ "${CHECKED}" = "true" ]; then
             echo "status=ran" >> "$GITHUB_OUTPUT"
             echo "broken=false" >> "$GITHUB_OUTPUT"
-          elif [ "${{ steps.rest.outputs.expected }}" = "true" ]; then
+          elif [ "${{ steps.api.outputs.expected }}" = "true" ]; then
             echo "::error::the OpenAPI spec pair was generated but the REST diff did not run — see the marker step's [rest-api-diff] log"
             echo "status=failed" >> "$GITHUB_OUTPUT"
             echo "broken=true" >> "$GITHUB_OUTPUT"
@@ -365,6 +406,20 @@ jobs:
           else
             # openapi-specs is already red; it carries the failure on its own.
             echo "status=failed" >> "$GITHUB_OUTPUT"
+            echo "broken=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Confirm the MCP check ran
+        id: mcp-result
+        run: |
+          set -euo pipefail
+          CHECKED=$(node -e 'const m=JSON.parse(require("fs").readFileSync("/tmp/release-safety.json","utf8"));process.stdout.write(String(m?.api?.mcp?.checked === true))')
+          if [ "${{ steps.api.outputs.expected }}" = "true" ] && [ "${CHECKED}" = "true" ]; then
+            echo "broken=false" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.api.outputs.expected }}" = "true" ]; then
+            echo "::error::the MCP snapshot pair was generated but the MCP diff did not run — see the marker step's [mcp-tools-diff] log"
+            echo "broken=true" >> "$GITHUB_OUTPUT"
+          else
             echo "broken=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -441,8 +496,8 @@ jobs:
               });
             }
 
-      - name: Fail when a REST check was handed its specs but did not run
-        if: ${{ steps.rest-result.outputs.broken == 'true' }}
+      - name: Fail release-safety gates
+        if: ${{ steps.rest-result.outputs.broken == 'true' || steps.mcp-result.outputs.broken == 'true' || steps.declaration-gate.outcome == 'failure' || steps.sql-declaration-gate.outcome == 'failure' }}
         run: exit 1
 
   # SPK-857: when the current diff no longer touches the watched surface, an

--- a/packages/backend/src/database/migrations/CLAUDE.md
+++ b/packages/backend/src/database/migrations/CLAUDE.md
@@ -40,3 +40,9 @@ The release-safety gate applies these rules only to migration files changed by t
 - `down()` must perform a real reversal or explicitly throw an error whose message starts with `irreversible:`. Missing and silently successful no-op `down()` functions fail the gate.
 - DDL should set a finite Postgres `lock_timeout` before requesting locks. DDL without one produces a warning because a waiting `ALTER` can queue later queries behind it indefinitely.
 - `CREATE INDEX CONCURRENTLY IF NOT EXISTS` is not sufficient recovery by itself: an interrupted build can leave an invalid index that `IF NOT EXISTS` silently skips. Use a stable literal index name in the SQL so migration recovery can discover and replace an invalid index. Identifier placeholders and dynamically constructed index names defeat that recovery scan and require the migration to check `pg_index.indisvalid`, drop the invalid index, and recreate it explicitly.
+
+When the gate detects a breaking pattern, use this decision tree:
+
+1. Attempt an expand-only redesign first, such as deprecating the old shape now and dropping it in a later release.
+2. Add `export const breaking` only after an engineer confirms the product and rollout decision. Its reason must describe what breaks and for whom; it must contain more than one word, use at least 24 characters, and must not reuse placeholder text.
+3. Never add a breaking declaration merely to make CI pass. Declaring a break makes the release not rolling-safe and advises every self-hosted customer to use the Recreate strategy.

--- a/packages/backend/src/database/migrations/CLAUDE.md
+++ b/packages/backend/src/database/migrations/CLAUDE.md
@@ -29,3 +29,14 @@ The migration system supports both up/down functions and includes 150+ historica
     - **Building unique indexes / primary keys**: `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS`, then `ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY USING INDEX ...` — the promotion is a brief `ACCESS EXCLUSIVE` lock with no scan.
     - **Log progress** with `console.log` before each post-backfill DDL step so an operator tailing pod logs can tell exactly which statement is in flight if the migration hangs or fails.
     - End-to-end reference: `20260428153355_add_primary_keys_to_analytics_and_scheduler_log.ts` applies all of the above patterns to a multi-million row table.
+
+## Release-safety declarations
+
+The release-safety gate applies these rules only to migration files changed by the pull request. Existing untouched migrations are grandfathered.
+
+- A migration containing a detected breaking operation must declare it in that file with the exact export `export const breaking = { reason: '<operator-facing reason>', requiredStop: <true | false> }`. The reason must be a non-empty string literal and `requiredStop` must be a boolean literal. The declaration records the break; it does not hide the detector finding.
+- Raw SQL that the static lint cannot classify must add `export const classification: { kind: 'safe' | 'breaking'; reason: string } = { kind: '<safe | breaking>', reason: '<why>' }`, or the equivalent unannotated object literal. A `breaking` classification also requires the `breaking` export.
+- A `transaction: false` migration must be resumable after any completed statement. Concurrent index creation needs `IF NOT EXISTS`; backfills need bounded, state-guarded batches; inserts need conflict handling or another explicit idempotency guard.
+- `down()` must perform a real reversal or explicitly throw an error whose message starts with `irreversible:`. Missing and silently successful no-op `down()` functions fail the gate.
+- DDL should set a finite Postgres `lock_timeout` before requesting locks. DDL without one produces a warning because a waiting `ALTER` can queue later queries behind it indefinitely.
+- `CREATE INDEX CONCURRENTLY IF NOT EXISTS` is not sufficient recovery by itself: an interrupted build can leave an invalid index that `IF NOT EXISTS` silently skips. Use a stable literal index name in the SQL so migration recovery can discover and replace an invalid index. Identifier placeholders and dynamically constructed index names defeat that recovery scan and require the migration to check `pg_index.indisvalid`, drop the invalid index, and recreate it explicitly.

--- a/scripts/breaking-change-gate-policy.ts
+++ b/scripts/breaking-change-gate-policy.ts
@@ -1,0 +1,43 @@
+const MINIMUM_BREAKING_REASON_LENGTH = 24;
+
+const HOLLOW_BREAKING_REASONS = new Set([
+    '<operator-facing reason>',
+    'breaking',
+    'breaking change',
+    'fix',
+    'placeholder',
+    'reason',
+    'todo',
+]);
+
+export function isSubstantiveBreakingReason(reason: string): boolean {
+    const normalized = reason.trim().replace(/\s+/g, ' ').toLowerCase();
+    return (
+        normalized.length >= MINIMUM_BREAKING_REASON_LENGTH &&
+        normalized.includes(' ') &&
+        !HOLLOW_BREAKING_REASONS.has(normalized)
+    );
+}
+
+export function hollowBreakingReasonMessage(file: string, line: number): string {
+    return `${file}:${line} breaking declaration reason must describe what breaks and for whom. Use at least ${MINIMUM_BREAKING_REASON_LENGTH} characters and more than one word; placeholders are not accepted.`;
+}
+
+interface BreakingChangeDecisionBriefInput {
+    file: string;
+    line: number;
+    pattern: string;
+    declarationLocation: string;
+}
+
+export function breakingChangeDecisionBrief(
+    input: BreakingChangeDecisionBriefInput,
+): string {
+    return [
+        'BREAKING-CHANGE DECISION BRIEF',
+        `Detected at ${input.file}:${input.line}: ${input.pattern}`,
+        'Path 1 — redesign: redesign to expand-only — e.g. deprecate-now-drop-later. Consequence: preserves a rolling-safe release.',
+        `Path 2 — declare: declare — flips this release to not-rolling-safe, advises Recreate to every self-hosted customer. The declaration must be in ${input.declarationLocation}.`,
+        'Declaring is a product decision — confirm with a human before adding this export.',
+    ].join('\n');
+}

--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -6,6 +6,7 @@ import {
     GitChange,
     MARKER_SCHEMA_VERSION,
     ownExpandContractFloor,
+    parseArgs,
 } from './gen-release-safety';
 
 let passed = 0;
@@ -64,6 +65,32 @@ const migrationDetails = [
         },
     },
 ];
+
+test('parses an explicit generated MCP snapshot pair', () => {
+    const args = parseArgs([
+        '--version',
+        'pr-1',
+        '--mcp-base-snapshot',
+        '/tmp/base-mcp.json',
+        '--mcp-new-snapshot',
+        '/tmp/pr-mcp.json',
+    ]);
+    assert.strictEqual(args.mcpBaseSnapshot, '/tmp/base-mcp.json');
+    assert.strictEqual(args.mcpNewSnapshot, '/tmp/pr-mcp.json');
+});
+
+test('rejects an incomplete generated MCP snapshot pair', () => {
+    assert.throws(
+        () =>
+            parseArgs([
+                '--version',
+                'pr-1',
+                '--mcp-base-snapshot',
+                '/tmp/base-mcp.json',
+            ]),
+        /--mcp-base-snapshot and --mcp-new-snapshot must be given together/,
+    );
+});
 
 test('detectMigrations counts only added timestamped files and splits EE', () => {
     const result = detectMigrations([

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -351,7 +351,7 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
 // IO shell
 // ---------------------------------------------------------------------------
 
-interface CliArgs {
+export interface CliArgs {
     version: string;
     previousVersion: string | null;
     lastTag: string | null;
@@ -365,9 +365,11 @@ interface CliArgs {
     restFromTag: boolean;
     restFromRefs: boolean;
     backfilled: boolean;
+    mcpBaseSnapshot: string | null;
+    mcpNewSnapshot: string | null;
 }
 
-function parseArgs(argv: string[]): CliArgs {
+export function parseArgs(argv: string[]): CliArgs {
     const get = (name: string): string | undefined => {
         const i = argv.indexOf(`--${name}`);
         return i >= 0 ? argv[i + 1] : undefined;
@@ -381,6 +383,8 @@ function parseArgs(argv: string[]): CliArgs {
     const restNewSpec = get('rest-new-spec') || null;
     const restFromTag = argv.includes('--rest-from-tag');
     const restFromRefs = argv.includes('--rest-from-refs');
+    const mcpBaseSnapshot = get('mcp-base-snapshot') || null;
+    const mcpNewSnapshot = get('mcp-new-snapshot') || null;
     if (Boolean(restBaseSpec) !== Boolean(restNewSpec)) {
         throw new Error('--rest-base-spec and --rest-new-spec must be given together');
     }
@@ -389,6 +393,9 @@ function parseArgs(argv: string[]): CliArgs {
     }
     if (restFromTag && restFromRefs) {
         throw new Error('--rest-from-tag cannot be combined with --rest-from-refs');
+    }
+    if (Boolean(mcpBaseSnapshot) !== Boolean(mcpNewSnapshot)) {
+        throw new Error('--mcp-base-snapshot and --mcp-new-snapshot must be given together');
     }
     return {
         version,
@@ -404,6 +411,8 @@ function parseArgs(argv: string[]): CliArgs {
         restFromTag,
         restFromRefs,
         backfilled: argv.includes('--backfilled'),
+        mcpBaseSnapshot,
+        mcpNewSnapshot,
     };
 }
 
@@ -591,12 +600,20 @@ export async function generateReleaseSafety(
     // Auto-runs when a previous tag exists; soft fail-safe (snapshot absent at a
     // ref → api.mcp unchecked), never fails the release.
     let mcpApi: ApiSurface | null = null;
-    if (args.lastTag) {
+    if (args.mcpBaseSnapshot && args.mcpNewSnapshot) {
+        mcpApi = diffMcpTools({
+            baseSnapshotPath: args.mcpBaseSnapshot,
+            newSnapshotPath: args.mcpNewSnapshot,
+            log: (m) => console.warn(`[mcp-tools-diff] ${m}`),
+        });
+    } else if (args.lastTag) {
         mcpApi = diffMcpTools({
             lastTag: args.lastTag,
             newRef: args.toRef,
             log: (m) => console.warn(`[mcp-tools-diff] ${m}`),
         });
+    } else {
+        console.warn('[release-safety] no MCP snapshot source given; api.mcp stays unchecked');
     }
 
     // P6: gated AI rolling-update review — the VALIDATION layer over the

--- a/scripts/mcp-tools-diff.test.ts
+++ b/scripts/mcp-tools-diff.test.ts
@@ -159,6 +159,9 @@ test('diffs an explicit generated MCP snapshot pair', () => {
             checked: true,
             breaking: true,
             changes: ['MCP tool `removed_tool` removed'],
+            advisories: [],
+            breakingCount: 1,
+            advisoryCount: 0,
         });
     } finally {
         fs.rmSync(dir, { recursive: true, force: true });
@@ -175,14 +178,28 @@ test('an explicit MCP pair must provide a readable old and new snapshot', () => 
                 baseSnapshotPath: path.join(dir, 'missing.json'),
                 newSnapshotPath: present,
             }),
-            { checked: false, breaking: false, changes: [] },
+            {
+                checked: false,
+                breaking: false,
+                changes: [],
+                advisories: [],
+                breakingCount: 0,
+                advisoryCount: 0,
+            },
         );
         assert.deepStrictEqual(
             diffMcpTools({
                 baseSnapshotPath: present,
                 newSnapshotPath: path.join(dir, 'missing.json'),
             }),
-            { checked: false, breaking: false, changes: [] },
+            {
+                checked: false,
+                breaking: false,
+                changes: [],
+                advisories: [],
+                breakingCount: 0,
+                advisoryCount: 0,
+            },
         );
     } finally {
         fs.rmSync(dir, { recursive: true, force: true });

--- a/scripts/mcp-tools-diff.test.ts
+++ b/scripts/mcp-tools-diff.test.ts
@@ -6,6 +6,9 @@
  * (git show + parse) is exercised by the CLI against committed snapshots.
  */
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
     diffMcpTools,
     diffSnapshots,
@@ -137,6 +140,65 @@ test('missing/empty inputSchema is treated as no properties (no crash)', () => {
     const r = diffSnapshots(before, after);
     // x is newly-added AND required => breaking
     assert.deepStrictEqual(r.changes, ['MCP tool `a`: input `x` became required']);
+});
+
+test('diffs an explicit generated MCP snapshot pair', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-tools-diff-test-'));
+    try {
+        const basePath = path.join(dir, 'base.json');
+        const newPath = path.join(dir, 'pr.json');
+        fs.writeFileSync(basePath, JSON.stringify(snap([tool('removed_tool')])));
+        fs.writeFileSync(newPath, JSON.stringify(snap([])));
+
+        const result = diffMcpTools({
+            baseSnapshotPath: basePath,
+            newSnapshotPath: newPath,
+        });
+
+        assert.deepStrictEqual(result, {
+            checked: true,
+            breaking: true,
+            changes: ['MCP tool `removed_tool` removed'],
+        });
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test('an explicit MCP pair must provide a readable old and new snapshot', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-tools-diff-test-'));
+    try {
+        const present = path.join(dir, 'present.json');
+        fs.writeFileSync(present, JSON.stringify(snap([])));
+        assert.deepStrictEqual(
+            diffMcpTools({
+                baseSnapshotPath: path.join(dir, 'missing.json'),
+                newSnapshotPath: present,
+            }),
+            { checked: false, breaking: false, changes: [] },
+        );
+        assert.deepStrictEqual(
+            diffMcpTools({
+                baseSnapshotPath: present,
+                newSnapshotPath: path.join(dir, 'missing.json'),
+            }),
+            { checked: false, breaking: false, changes: [] },
+        );
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test('the MCP old side must be exactly one of a git ref or generated snapshot', () => {
+    assert.throws(() => diffMcpTools({}), /exactly one of lastTag or baseSnapshotPath/);
+    assert.throws(
+        () =>
+            diffMcpTools({
+                lastTag: 'HEAD',
+                baseSnapshotPath: '/tmp/base.json',
+            }),
+        /exactly one of lastTag or baseSnapshotPath/,
+    );
 });
 
 if (failures.length > 0) {

--- a/scripts/mcp-tools-diff.ts
+++ b/scripts/mcp-tools-diff.ts
@@ -31,6 +31,7 @@
  * CLI:  npx tsx scripts/mcp-tools-diff.ts --last-tag 0.3260.2 [--new-ref HEAD]
  */
 import { execFileSync } from 'child_process';
+import * as fs from 'fs';
 
 export type TriState = boolean | 'unknown';
 
@@ -180,6 +181,14 @@ function showAtRef(ref: string, repoPath: string): string | null {
     }
 }
 
+function readSnapshotFile(snapshotPath: string): string | null {
+    try {
+        return fs.readFileSync(snapshotPath, 'utf-8');
+    } catch {
+        return null;
+    }
+}
+
 function parseSnapshot(raw: string): ToolsSnapshot | null {
     try {
         const parsed = JSON.parse(raw);
@@ -191,8 +200,10 @@ function parseSnapshot(raw: string): ToolsSnapshot | null {
 }
 
 export interface DiffMcpToolsOpts {
-    lastTag: string;
+    lastTag?: string;
+    baseSnapshotPath?: string;
     newRef?: string;
+    newSnapshotPath?: string;
     log?: (msg: string) => void;
 }
 
@@ -205,14 +216,27 @@ export function diffMcpTools(opts: DiffMcpToolsOpts): ApiSurface {
     const log = opts.log ?? (() => {});
     const newRef = opts.newRef ?? 'HEAD';
 
-    const oldRaw = showAtRef(opts.lastTag, SNAPSHOT_PATH);
+    if (opts.newRef !== undefined && opts.newSnapshotPath !== undefined) {
+        throw new Error('Provide either newRef or newSnapshotPath, not both');
+    }
+    if ((opts.lastTag === undefined) === (opts.baseSnapshotPath === undefined)) {
+        throw new Error('Provide exactly one of lastTag or baseSnapshotPath');
+    }
+
+    const oldRaw = opts.baseSnapshotPath
+        ? readSnapshotFile(opts.baseSnapshotPath)
+        : showAtRef(opts.lastTag as string, SNAPSHOT_PATH);
     if (oldRaw === null) {
-        log(`snapshot not found at ${opts.lastTag}:${SNAPSHOT_PATH}; api.mcp stays unchecked`);
+        const source = opts.baseSnapshotPath ?? `${opts.lastTag}:${SNAPSHOT_PATH}`;
+        log(`snapshot not found at ${source}; api.mcp stays unchecked`);
         return UNCHECKED;
     }
-    const newRaw = showAtRef(newRef, SNAPSHOT_PATH);
+    const newRaw = opts.newSnapshotPath
+        ? readSnapshotFile(opts.newSnapshotPath)
+        : showAtRef(newRef, SNAPSHOT_PATH);
     if (newRaw === null) {
-        log(`snapshot not found at ${newRef}:${SNAPSHOT_PATH}; api.mcp stays unchecked`);
+        const source = opts.newSnapshotPath ?? `${newRef}:${SNAPSHOT_PATH}`;
+        log(`snapshot not found at ${source}; api.mcp stays unchecked`);
         return UNCHECKED;
     }
 
@@ -243,11 +267,17 @@ function arg(name: string): string | undefined {
 }
 
 function main(): void {
-    const lastTag = arg('last-tag') ?? arg('previous-version');
-    if (!lastTag) throw new Error('--last-tag (or --previous-version) is required');
+    const baseSnapshotPath = arg('base-snapshot');
+    const lastTag = baseSnapshotPath ? undefined : arg('last-tag') ?? arg('previous-version');
+    if (!lastTag && !baseSnapshotPath) {
+        throw new Error('--last-tag (or --previous-version) or --base-snapshot is required');
+    }
+    const newSnapshotPath = arg('new-snapshot');
     const result = diffMcpTools({
         lastTag,
-        newRef: arg('new-ref'),
+        baseSnapshotPath,
+        newRef: newSnapshotPath ? undefined : arg('new-ref'),
+        newSnapshotPath,
         log: (m) => console.log(`[mcp-tools-diff] ${m}`),
     });
     console.log(JSON.stringify(result, null, 2));

--- a/scripts/release-safety-pr-gate.test.ts
+++ b/scripts/release-safety-pr-gate.test.ts
@@ -1,0 +1,173 @@
+import * as assert from 'assert';
+import {
+    evaluateReleaseSafetyGate,
+    ReleaseSafetyGateMarker,
+} from './release-safety-pr-gate';
+
+let passed = 0;
+const failures: string[] = [];
+
+function test(name: string, fn: () => void): void {
+    try {
+        fn();
+        passed += 1;
+    } catch (error) {
+        failures.push(
+            `${name}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+}
+
+function marker(rest: boolean, mcp: boolean): ReleaseSafetyGateMarker {
+    return {
+        api: {
+            rest: { checked: true, breaking: rest, changes: [] },
+            mcp: { checked: true, breaking: mcp, changes: [] },
+        },
+    };
+}
+
+const declaration =
+    "export const breaking = { reason: 'Existing clients require a staged rollout', requiredStop: false };";
+const backendSource = 'packages/backend/src/controllers/example.ts';
+const commonSource = 'packages/common/src/types/example.ts';
+const migrationSource =
+    'packages/backend/src/database/migrations/20260810120000_example.ts';
+const markerPath = '/tmp/release-safety.json';
+
+function evaluate(
+    releaseMarker: ReleaseSafetyGateMarker,
+    changedFiles: string[],
+    sources: Record<string, string> = {},
+) {
+    return evaluateReleaseSafetyGate({
+        marker: releaseMarker,
+        markerPath,
+        changedFiles,
+        readFile: (file) => sources[file] ?? '',
+    });
+}
+
+test('breaking REST without a declaration fails', () => {
+    const diagnostics = evaluate(marker(true, false), [backendSource]);
+    assert.ok(diagnostics.some((diagnostic) => diagnostic.level === 'error'));
+    assert.ok(
+        diagnostics.some((diagnostic) =>
+            diagnostic.message.includes('breaking REST'),
+        ),
+    );
+});
+
+test('breaking REST with a valid changed declaration passes', () => {
+    assert.deepStrictEqual(
+        evaluate(marker(true, false), [backendSource], {
+            [backendSource]: declaration,
+        }),
+        [],
+    );
+});
+
+test('breaking MCP without a declaration fails', () => {
+    const diagnostics = evaluate(marker(false, true), [commonSource]);
+    assert.ok(diagnostics.some((diagnostic) => diagnostic.level === 'error'));
+    assert.ok(
+        diagnostics.some((diagnostic) =>
+            diagnostic.message.includes('breaking MCP'),
+        ),
+    );
+});
+
+test('breaking MCP with a valid changed declaration passes', () => {
+    assert.deepStrictEqual(
+        evaluate(marker(false, true), [commonSource], {
+            [commonSource]: declaration,
+        }),
+        [],
+    );
+});
+
+test('one declaration covers simultaneous REST and MCP breaks', () => {
+    assert.deepStrictEqual(
+        evaluate(marker(true, true), [backendSource], {
+            [backendSource]: declaration,
+        }),
+        [],
+    );
+});
+
+test('a migration declaration is excluded from API coverage', () => {
+    const diagnostics = evaluate(marker(true, false), [migrationSource], {
+        [migrationSource]: declaration,
+    });
+    assert.ok(diagnostics.some((diagnostic) => diagnostic.level === 'warning'));
+    assert.ok(diagnostics.some((diagnostic) => diagnostic.level === 'error'));
+    assert.ok(diagnostics.every((diagnostic) => diagnostic.file.length > 0));
+});
+
+test('a malformed breaking declaration fails actionably', () => {
+    const diagnostics = evaluate(marker(false, true), [backendSource], {
+        [backendSource]:
+            "export const breaking = { reason: '', requiredStop: 'sometimes' };",
+    });
+    assert.ok(
+        diagnostics.some(
+            (diagnostic) =>
+                diagnostic.level === 'error' &&
+                diagnostic.file === backendSource,
+        ),
+    );
+    assert.ok(
+        diagnostics.some((diagnostic) => diagnostic.message.includes('reason')),
+    );
+    assert.ok(
+        diagnostics.some((diagnostic) =>
+            diagnostic.message.includes('requiredStop'),
+        ),
+    );
+});
+
+test('a clean marker requires no declaration', () => {
+    assert.deepStrictEqual(evaluate(marker(false, false), [backendSource]), []);
+});
+
+test('a clean marker ignores malformed breaking declaration text', () => {
+    assert.deepStrictEqual(
+        evaluate(marker(false, false), [backendSource], {
+            [backendSource]:
+                "export const breaking = { reason: '', requiredStop: 'sometimes' };",
+        }),
+        [],
+    );
+});
+
+test('a declaration in an untouched file does not satisfy the gate', () => {
+    const diagnostics = evaluate(marker(true, false), [commonSource], {
+        [backendSource]: declaration,
+        [commonSource]: 'export const value = 1;',
+    });
+    assert.ok(diagnostics.some((diagnostic) => diagnostic.level === 'error'));
+});
+
+test('a declaration in a changed test file does not satisfy the gate', () => {
+    const testSource = 'packages/backend/src/controllers/example.test.ts';
+    const testsDirectorySource =
+        'packages/common/src/types/__tests__/example.ts';
+    const diagnostics = evaluate(
+        marker(true, false),
+        [backendSource, testSource, testsDirectorySource],
+        {
+            [backendSource]: 'export const value = 1;',
+            [testSource]: declaration,
+            [testsDirectorySource]: declaration,
+        },
+    );
+    assert.ok(diagnostics.some((diagnostic) => diagnostic.level === 'error'));
+});
+
+if (failures.length > 0) {
+    console.error(`\n❌ ${failures.length} failed, ${passed} passed:\n`);
+    for (const failure of failures) console.error(`  - ${failure}`);
+    process.exit(1);
+}
+
+console.log(`✅ ${passed} tests passed`);

--- a/scripts/release-safety-pr-gate.test.ts
+++ b/scripts/release-safety-pr-gate.test.ts
@@ -56,6 +56,25 @@ test('breaking REST without a declaration fails', () => {
             diagnostic.message.includes('breaking REST'),
         ),
     );
+    const decisionBrief = diagnostics.find((diagnostic) =>
+        diagnostic.message.includes('BREAKING-CHANGE DECISION BRIEF'),
+    );
+    assert.ok(decisionBrief?.message.includes(`${markerPath}:1`));
+    assert.ok(
+        decisionBrief?.message.includes(
+            'redesign to expand-only — e.g. deprecate-now-drop-later',
+        ),
+    );
+    assert.ok(
+        decisionBrief?.message.includes(
+            'declare — flips this release to not-rolling-safe, advises Recreate to every self-hosted customer',
+        ),
+    );
+    assert.ok(
+        decisionBrief?.message.includes(
+            'Declaring is a product decision — confirm with a human before adding this export.',
+        ),
+    );
 });
 
 test('breaking REST with a valid changed declaration passes', () => {
@@ -123,6 +142,43 @@ test('a malformed breaking declaration fails actionably', () => {
         diagnostics.some((diagnostic) =>
             diagnostic.message.includes('requiredStop'),
         ),
+    );
+});
+
+test('hollow declaration reasons do not satisfy the API gate', () => {
+    const hollowReasons = [
+        '',
+        '   ',
+        'breaking change',
+        'fix',
+        'incompatibilityincompatibility',
+        '<operator-facing reason>',
+    ];
+    for (const reason of hollowReasons) {
+        const diagnostics = evaluate(marker(false, true), [backendSource], {
+            [backendSource]: `export const breaking = { reason: '${reason}', requiredStop: false };`,
+        });
+        assert.ok(
+            diagnostics.some((diagnostic) =>
+                diagnostic.message.includes('describe what breaks and for whom'),
+            ),
+            `expected hollow reason to fail: ${JSON.stringify(reason)}`,
+        );
+        assert.ok(
+            diagnostics.some((diagnostic) =>
+                diagnostic.message.includes('BREAKING-CHANGE DECISION BRIEF'),
+            ),
+        );
+    }
+});
+
+test('a substantive declaration reason satisfies the API gate', () => {
+    assert.deepStrictEqual(
+        evaluate(marker(true, false), [backendSource], {
+            [backendSource]:
+                "export const breaking = { reason: 'Existing API clients still send the removed request field.', requiredStop: false };",
+        }),
+        [],
     );
 });
 

--- a/scripts/release-safety-pr-gate.ts
+++ b/scripts/release-safety-pr-gate.ts
@@ -1,0 +1,173 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import {
+    collectBreakingChangeDeclarations,
+    formatChangeDeclarationDiagnostic,
+} from './breaking-change-declarations';
+
+interface ApiSurface {
+    checked: boolean;
+    breaking: boolean | 'unknown';
+    changes: string[];
+}
+
+export interface ReleaseSafetyGateMarker {
+    api: {
+        rest: ApiSurface;
+        mcp: ApiSurface;
+    };
+}
+
+export interface GateDiagnostic {
+    level: 'error' | 'warning';
+    file: string;
+    line: number;
+    message: string;
+}
+
+export interface EvaluateReleaseSafetyGateInput {
+    marker: ReleaseSafetyGateMarker;
+    markerPath: string;
+    changedFiles: readonly string[];
+    readFile?: (path: string) => string;
+}
+
+const TYPESCRIPT_SOURCE = /^packages\/(backend|common)\/src\/.+\.tsx?$/;
+const TYPESCRIPT_TEST = /(^|\/)__tests__\/|\.(test|spec)\.tsx?$/;
+const MIGRATION_SOURCE =
+    /^packages\/backend\/src\/(ee\/)?database\/migrations\//;
+
+export function evaluateReleaseSafetyGate(
+    input: EvaluateReleaseSafetyGateInput,
+): GateDiagnostic[] {
+    const breakingSurfaces = [
+        input.marker.api.rest.checked && input.marker.api.rest.breaking === true
+            ? 'REST'
+            : null,
+        input.marker.api.mcp.checked && input.marker.api.mcp.breaking === true
+            ? 'MCP'
+            : null,
+    ].filter((surface): surface is string => surface !== null);
+
+    if (breakingSurfaces.length === 0) return [];
+
+    const sourceFiles = input.changedFiles.filter(
+        (file) => TYPESCRIPT_SOURCE.test(file) && !TYPESCRIPT_TEST.test(file),
+    );
+    const declarations = collectBreakingChangeDeclarations(
+        sourceFiles,
+        input.readFile,
+    );
+    const diagnostics: GateDiagnostic[] = declarations.diagnostics
+        .filter((diagnostic) => diagnostic.declaration !== 'classification')
+        .map((diagnostic) => ({
+            level: 'error',
+            file: diagnostic.file,
+            line: diagnostic.line,
+            message: formatChangeDeclarationDiagnostic(diagnostic),
+        }));
+
+    const migrationDeclarations = declarations.breaking.filter((declaration) =>
+        MIGRATION_SOURCE.test(declaration.file),
+    );
+    for (const declaration of migrationDeclarations) {
+        diagnostics.push({
+            level: 'warning',
+            file: declaration.file,
+            line: declaration.line,
+            message: `${declaration.file}:${declaration.line} migration breaking declarations do not cover API surface changes`,
+        });
+    }
+
+    const apiDeclarations = declarations.breaking.filter(
+        (declaration) => !MIGRATION_SOURCE.test(declaration.file),
+    );
+    if (apiDeclarations.length === 0) {
+        diagnostics.push({
+            level: 'error',
+            file: input.markerPath,
+            line: 1,
+            message: `${input.markerPath}:1 breaking ${breakingSurfaces.join(' and ')} changes require export const breaking = { reason: string, requiredStop: boolean } in a changed non-migration TypeScript source file under packages/backend or packages/common`,
+        });
+    }
+
+    return diagnostics;
+}
+
+function changedFiles(baseSha: string): string[] {
+    return execFileSync(
+        'git',
+        ['diff', '--name-only', '--diff-filter=ACMR', baseSha, 'HEAD', '--'],
+        { encoding: 'utf8' },
+    )
+        .split('\n')
+        .filter(Boolean);
+}
+
+function argument(name: string): string | undefined {
+    const index = process.argv.indexOf(`--${name}`);
+    return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function escapeCommandData(value: string): string {
+    return value
+        .replaceAll('%', '%25')
+        .replaceAll('\r', '%0D')
+        .replaceAll('\n', '%0A');
+}
+
+function escapeCommandProperty(value: string): string {
+    return escapeCommandData(value)
+        .replaceAll(':', '%3A')
+        .replaceAll(',', '%2C');
+}
+
+function emit(diagnostic: GateDiagnostic): void {
+    console.log(
+        `::${diagnostic.level} file=${escapeCommandProperty(diagnostic.file)},line=${diagnostic.line}::${escapeCommandData(diagnostic.message)}`,
+    );
+}
+
+function main(): void {
+    const baseSha = argument('base-sha');
+    const markerPath = argument('marker');
+    if (!baseSha) throw new Error('--base-sha is required');
+    if (!markerPath) throw new Error('--marker is required');
+    const marker = JSON.parse(
+        fs.readFileSync(markerPath, 'utf8'),
+    ) as ReleaseSafetyGateMarker;
+    const diagnostics = evaluateReleaseSafetyGate({
+        marker,
+        markerPath,
+        changedFiles: changedFiles(baseSha),
+    });
+    diagnostics.forEach(emit);
+    const errors = diagnostics.filter(
+        (diagnostic) => diagnostic.level === 'error',
+    );
+    const warnings = diagnostics.filter(
+        (diagnostic) => diagnostic.level === 'warning',
+    );
+    console.log(
+        `[release-safety-pr-gate] ${errors.length} error(s), ${warnings.length} warning(s)`,
+    );
+    if (errors.length > 0) process.exitCode = 1;
+}
+
+const invokedDirectly =
+    require.main === module ||
+    process.argv[1]?.endsWith('release-safety-pr-gate.ts') === true;
+
+if (invokedDirectly) {
+    try {
+        main();
+    } catch (error) {
+        emit({
+            level: 'error',
+            file: argument('marker') ?? 'scripts/release-safety-pr-gate.ts',
+            line: 1,
+            message: error instanceof Error ? error.message : String(error),
+        });
+        process.exit(1);
+    }
+}

--- a/scripts/release-safety-pr-gate.ts
+++ b/scripts/release-safety-pr-gate.ts
@@ -4,6 +4,11 @@ import {
     collectBreakingChangeDeclarations,
     formatChangeDeclarationDiagnostic,
 } from './breaking-change-declarations';
+import {
+    breakingChangeDecisionBrief,
+    hollowBreakingReasonMessage,
+    isSubstantiveBreakingReason,
+} from './breaking-change-gate-policy';
 
 interface ApiSurface {
     checked: boolean;
@@ -66,6 +71,22 @@ export function evaluateReleaseSafetyGate(
             line: diagnostic.line,
             message: formatChangeDeclarationDiagnostic(diagnostic),
         }));
+    for (const diagnostic of declarations.diagnostics) {
+        if (
+            diagnostic.declaration === 'breaking' &&
+            diagnostic.message.includes('breaking.reason must not be empty')
+        ) {
+            diagnostics.push({
+                level: 'error',
+                file: diagnostic.file,
+                line: diagnostic.line,
+                message: hollowBreakingReasonMessage(
+                    diagnostic.file,
+                    diagnostic.line,
+                ),
+            });
+        }
+    }
 
     const migrationDeclarations = declarations.breaking.filter((declaration) =>
         MIGRATION_SOURCE.test(declaration.file),
@@ -82,12 +103,31 @@ export function evaluateReleaseSafetyGate(
     const apiDeclarations = declarations.breaking.filter(
         (declaration) => !MIGRATION_SOURCE.test(declaration.file),
     );
-    if (apiDeclarations.length === 0) {
+    const substantiveApiDeclarations = apiDeclarations.filter((declaration) => {
+        if (isSubstantiveBreakingReason(declaration.reason)) return true;
+        diagnostics.push({
+            level: 'error',
+            file: declaration.file,
+            line: declaration.line,
+            message: hollowBreakingReasonMessage(
+                declaration.file,
+                declaration.line,
+            ),
+        });
+        return false;
+    });
+    if (substantiveApiDeclarations.length === 0) {
         diagnostics.push({
             level: 'error',
             file: input.markerPath,
             line: 1,
-            message: `${input.markerPath}:1 breaking ${breakingSurfaces.join(' and ')} changes require export const breaking = { reason: string, requiredStop: boolean } in a changed non-migration TypeScript source file under packages/backend or packages/common`,
+            message: breakingChangeDecisionBrief({
+                file: input.markerPath,
+                line: 1,
+                pattern: `breaking ${breakingSurfaces.join(' and ')} API surface change`,
+                declarationLocation:
+                    'a changed non-migration TypeScript source file under packages/backend or packages/common as export const breaking = { reason: string, requiredStop: boolean }',
+            }),
         });
     }
 

--- a/scripts/sql-migration-lint.test.ts
+++ b/scripts/sql-migration-lint.test.ts
@@ -6,7 +6,12 @@
  * (addedMigrationPaths + readFile) is exercised by the CLI.
  */
 import * as assert from 'assert';
-import { lintSource } from './sql-migration-lint';
+import {
+    changedMigrationPathsFromNameStatus,
+    evaluateMigrationEnforcement,
+    evaluateMigrationSource,
+    lintSource,
+} from './sql-migration-lint';
 
 let passed = 0;
 const failures: string[] = [];
@@ -183,6 +188,233 @@ test('line comment does not hide nor over-trigger on the next line', () => {
   await knex.schema.alterTable('users', t => t.string('note'));
 }`;
     assert.deepStrictEqual(rules(src), []);
+});
+
+const enforcement = (source: string) => evaluateMigrationSource(source, 'migration.ts');
+const enforcementRules = (source: string, severity?: 'error' | 'warning'): string[] =>
+    enforcement(source)
+        .filter((finding) => severity === undefined || finding.severity === severity)
+        .map((finding) => finding.rule)
+        .sort();
+
+test('undeclared breaking behavior is an error with an actionable declaration shape', () => {
+    const source = `export async function up(knex) { await knex.schema.alterTable('users', table => table.dropColumn('legacy')); }
+export async function down(knex) { await knex.schema.alterTable('users', table => table.string('legacy')); }`;
+    const findings = enforcement(source);
+    assert.ok(findings.some((finding) => finding.rule === 'drop-column' && finding.severity === 'error'));
+    const undeclared = findings.find((finding) => finding.rule === 'undeclared-breaking-change');
+    assert.ok(undeclared?.message.includes('export const breaking'));
+});
+
+test('declared breaking behavior passes enforcement while preserving the legacy finding', () => {
+    const source = `export const breaking = { reason: 'old pods still read legacy', requiredStop: false };
+export async function up(knex) { await knex.schema.alterTable('users', table => table.dropColumn('legacy')); }
+export async function down(knex) { await knex.schema.alterTable('users', table => table.string('legacy')); }`;
+    const findings = enforcement(source);
+    assert.ok(findings.some((finding) => finding.rule === 'drop-column' && finding.severity === 'warning'));
+    assert.ok(!findings.some((finding) => finding.severity === 'error'));
+});
+
+test('raw breaking SQL with a valid breaking declaration needs no classification', () => {
+    const source = `export const breaking = { reason: 'old pods still read legacy', requiredStop: false };
+export async function up(knex) { await knex.raw('ALTER TABLE users DROP COLUMN legacy'); }
+export async function down(knex) { await knex.raw('ALTER TABLE users ADD COLUMN legacy text'); }`;
+    const findings = enforcement(source);
+    assert.ok(findings.some((finding) => finding.rule === 'raw-drop-column'));
+    assert.ok(!findings.some((finding) => finding.rule === 'unclassified-knex-raw'));
+    assert.ok(!findings.some((finding) => finding.severity === 'error'));
+});
+
+test('malformed declarations are enforcement errors', () => {
+    const source = `export const breaking = { reason: '', requiredStop: 'no' };
+export async function up(knex) { await knex.schema.alterTable('users', table => table.dropColumn('legacy')); }
+export async function down() { throw new Error('irreversible: test fixture'); }`;
+    const findings = enforcement(source);
+    assert.ok(findings.some((finding) => finding.rule === 'malformed-breaking-declaration'));
+    assert.ok(findings.some((finding) => finding.rule === 'undeclared-breaking-change'));
+});
+
+test('literal DML raw SQL requires explicit classification', () => {
+    const source = `export async function up(knex) { await knex.raw('UPDATE users SET active = true'); }
+export async function down() { throw new Error('irreversible: test fixture'); }`;
+    assert.ok(enforcementRules(source, 'error').includes('unclassified-knex-raw'));
+});
+
+test('dynamic raw SQL requires explicit classification', () => {
+    const source = `export async function up(knex) { await knex.raw(statement); }
+export async function down() { throw new Error('irreversible: test fixture'); }`;
+    assert.ok(enforcementRules(source, 'error').includes('unclassified-knex-raw'));
+});
+
+test('explicit safe classification permits otherwise unclassifiable raw SQL', () => {
+    const source = `export const classification: { kind: "safe" | "breaking"; reason: string } = { kind: 'safe', reason: 'idempotent repair' };
+export async function up(knex) { await knex.raw('UPDATE users SET active = true WHERE active IS NULL'); }
+export async function down() { throw new Error('irreversible: test fixture'); }`;
+    assert.ok(!enforcement(source).some((finding) => finding.severity === 'error'));
+});
+
+test('known-safe session SQL and metadata SELECT do not require classification', () => {
+    const source = `export async function up(knex) {
+  await knex.raw('SET statement_timeout = 0');
+  await knex.raw('SELECT indisvalid FROM pg_index WHERE indexrelid = ?::regclass', ['idx_users']);
+}
+export async function down() { throw new Error('irreversible: test fixture'); }`;
+    assert.ok(!enforcementRules(source, 'error').includes('unclassified-knex-raw'));
+});
+
+test('breaking classification requires a breaking declaration', () => {
+    const source = `export const classification = { kind: 'breaking', reason: 'rewrites a live contract' };
+export async function up(knex) { await knex.raw('VACUUM users'); }
+export async function down() { throw new Error('irreversible: test fixture'); }`;
+    assert.ok(enforcementRules(source, 'error').includes('undeclared-breaking-change'));
+});
+
+test('breaking classification with a declaration passes and remains visible', () => {
+    const source = `export const classification = { kind: 'breaking', reason: 'rewrites a live contract' };
+export const breaking = { reason: 'old pods require the prior shape', requiredStop: true };
+export async function up(knex) { await knex.raw('VACUUM users'); }
+export async function down() { throw new Error('irreversible: test fixture'); }`;
+    const findings = enforcement(source);
+    assert.ok(findings.some((finding) => finding.rule === 'classified-breaking-change'));
+    assert.ok(!findings.some((finding) => finding.severity === 'error'));
+});
+
+test('transaction false with bare concurrent index is an error', () => {
+    const source = `export const config = { transaction: false };
+export async function up(knex) { await knex.raw('CREATE INDEX CONCURRENTLY idx_users_email ON users (email)'); }
+export async function down(knex) { await knex.raw('DROP INDEX CONCURRENTLY IF EXISTS idx_users_email'); }`;
+    assert.ok(enforcementRules(source, 'error').includes('non-resumable-concurrent-index'));
+});
+
+test('transaction false with a non-resumable backfill is an error', () => {
+    const source = `export const config = { transaction: false };
+export const classification = { kind: 'safe', reason: 'bounded maintenance window' };
+export async function up(knex) { await knex.raw('UPDATE users SET active = true'); }
+export async function down() { throw new Error('irreversible: test fixture'); }`;
+    assert.ok(enforcementRules(source, 'error').includes('non-resumable-backfill'));
+});
+
+test('transaction false with an idempotently guarded backfill passes', () => {
+    const source = `export const config = { transaction: false };
+export const classification = { kind: 'safe', reason: 'only repairs missing values' };
+export async function up(knex) { await knex.raw('UPDATE users SET active = true WHERE active IS NULL'); }
+export async function down() { throw new Error('irreversible: test fixture'); }`;
+    assert.ok(!enforcement(source).some((finding) => finding.severity === 'error'));
+});
+
+test('missing down is an error', () => {
+    const source = `export async function up() {}`;
+    assert.ok(enforcementRules(source, 'error').includes('missing-down'));
+});
+
+test('silent no-op down forms are errors', () => {
+    const empty = `export async function up() {}
+export async function down() {}`;
+    const resolved = `export async function up() {}
+export const down = async () => Promise.resolve();`;
+    assert.ok(enforcementRules(empty, 'error').includes('silent-noop-down'));
+    assert.ok(enforcementRules(resolved, 'error').includes('silent-noop-down'));
+});
+
+test('real down and explicit irreversible throw pass rollback enforcement', () => {
+    const real = `export async function up(knex) { await knex.schema.createTable('widgets', table => table.uuid('id')); }
+export async function down(knex) { await knex.schema.dropTable('widgets'); }`;
+    const irreversible = `export async function up() {}
+export async function down() { throw new Error('irreversible: source data cannot be reconstructed'); }`;
+    assert.ok(!enforcementRules(real, 'error').includes('missing-down'));
+    assert.ok(!enforcementRules(real, 'error').includes('silent-noop-down'));
+    assert.ok(!enforcementRules(irreversible, 'error').includes('missing-down'));
+    assert.ok(!enforcementRules(irreversible, 'error').includes('silent-noop-down'));
+});
+
+test('irreversible down throw without the required prefix fails', () => {
+    const source = `export async function up() {}
+export async function down() { throw new Error('cannot roll back'); }`;
+    assert.ok(enforcementRules(source, 'error').includes('invalid-irreversible-down'));
+});
+
+test('DDL without lock timeout warns with the extracted table name', () => {
+    const source = `export async function up(knex) { await knex.schema.alterTable('users', table => table.string('nickname')); }
+export async function down(knex) { await knex.schema.alterTable('users', table => table.dropColumn('nickname')); }`;
+    const warning = enforcement(source).find((finding) => finding.rule === 'missing-lock-timeout');
+    assert.strictEqual(warning?.severity, 'warning');
+    assert.ok(warning?.message.includes('users'));
+});
+
+test('SET LOCAL lock_timeout suppresses the DDL warning', () => {
+    const source = `export async function up(knex) {
+  await knex.raw("SET LOCAL lock_timeout = '5s'");
+  await knex.schema.alterTable('users', table => table.string('nickname'));
+}
+export async function down(knex) { await knex.schema.alterTable('users', table => table.dropColumn('nickname')); }`;
+    assert.ok(!enforcementRules(source, 'warning').includes('missing-lock-timeout'));
+});
+
+test('concurrent IF NOT EXISTS warns with literal runtime-guard discoverability', () => {
+    const source = `export const config = { transaction: false };
+export async function up(knex) { await knex.raw('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_email ON users (email)'); }
+export async function down(knex) { await knex.raw('DROP INDEX CONCURRENTLY IF EXISTS idx_users_email'); }`;
+    const warning = enforcement(source).find((finding) => finding.rule === 'concurrent-index-invalid-retry');
+    assert.strictEqual(warning?.severity, 'warning');
+    assert.ok(warning?.message.includes('idx_users_email'));
+    assert.ok(warning?.message.includes('runtime retry guard'));
+});
+
+test('dynamic concurrent index warning requires explicit pg_index cleanup', () => {
+    const source = `export const config = { transaction: false };
+export async function up(knex) { await knex.raw('CREATE INDEX CONCURRENTLY IF NOT EXISTS ?? ON users (email)', [indexName]); }
+export async function down(knex) { await knex.raw('DROP INDEX CONCURRENTLY IF EXISTS ??', [indexName]); }`;
+    const findings = enforcement(source);
+    const warning = findings.find((finding) => finding.rule === 'concurrent-index-invalid-retry');
+    assert.ok(warning?.message.includes('cannot discover'), JSON.stringify(findings));
+    assert.ok(warning?.message.includes('pg_index'), JSON.stringify(findings));
+});
+
+test('dynamic concurrent index warning recognizes explicit invalid-index cleanup', () => {
+    const source = `export const config = { transaction: false };
+export async function up(knex) {
+  await knex.raw('SELECT indisvalid FROM pg_index WHERE indexrelid = ?::regclass', [indexName]);
+  await knex.raw('CREATE INDEX CONCURRENTLY IF NOT EXISTS ?? ON users (email)', [indexName]);
+}
+export async function down(knex) { await knex.raw('DROP INDEX CONCURRENTLY IF EXISTS ??', [indexName]); }`;
+    assert.ok(!enforcementRules(source, 'warning').includes('concurrent-index-invalid-retry'));
+});
+
+test('changed migration paths include existing A M R C destinations and exclude deletes', () => {
+    const root = 'packages/backend/src/database/migrations';
+    const paths = changedMigrationPathsFromNameStatus(
+        [
+            `A\t${root}/20260101000000_added.ts`,
+            `M\t${root}/20260101000001_modified.ts`,
+            `R100\t${root}/20260101000002_old.ts\t${root}/20260101000002_renamed.ts`,
+            `C100\t${root}/20260101000003_source.ts\t${root}/20260101000003_copied.ts`,
+            `D\t${root}/20260101000004_deleted.ts`,
+            'M\tscripts/not-a-migration.ts',
+        ].join('\n'),
+        (path) => !path.includes('missing'),
+    );
+    assert.deepStrictEqual(paths, [
+        `${root}/20260101000000_added.ts`,
+        `${root}/20260101000001_modified.ts`,
+        `${root}/20260101000002_renamed.ts`,
+        `${root}/20260101000003_copied.ts`,
+    ]);
+});
+
+test('enforcement evaluator reads only caller-supplied changed paths', () => {
+    const read: string[] = [];
+    const result = evaluateMigrationEnforcement({
+        paths: ['changed.ts'],
+        readFile: (path) => {
+            read.push(path);
+            return `export async function up() {}
+export async function down() { throw new Error('irreversible: test fixture'); }`;
+        },
+    });
+    assert.deepStrictEqual(read, ['changed.ts']);
+    assert.strictEqual(result.ran, true);
+    assert.strictEqual(result.passed, true);
+    assert.deepStrictEqual(result.errors, []);
 });
 
 if (failures.length > 0) {

--- a/scripts/sql-migration-lint.test.ts
+++ b/scripts/sql-migration-lint.test.ts
@@ -203,7 +203,61 @@ export async function down(knex) { await knex.schema.alterTable('users', table =
     const findings = enforcement(source);
     assert.ok(findings.some((finding) => finding.rule === 'drop-column' && finding.severity === 'error'));
     const undeclared = findings.find((finding) => finding.rule === 'undeclared-breaking-change');
-    assert.ok(undeclared?.message.includes('export const breaking'));
+    assert.ok(undeclared?.message.includes('Detected at migration.ts:1'));
+    assert.ok(
+        undeclared?.message.includes(
+            'redesign to expand-only — e.g. deprecate-now-drop-later',
+        ),
+    );
+    assert.ok(
+        undeclared?.message.includes(
+            'declare — flips this release to not-rolling-safe, advises Recreate to every self-hosted customer',
+        ),
+    );
+    assert.ok(
+        undeclared?.message.includes(
+            'Declaring is a product decision — confirm with a human before adding this export.',
+        ),
+    );
+});
+
+test('hollow breaking reasons do not satisfy migration enforcement', () => {
+    const hollowReasons = [
+        '',
+        '   ',
+        'breaking change',
+        'fix',
+        'incompatibilityincompatibility',
+        '<operator-facing reason>',
+    ];
+    for (const reason of hollowReasons) {
+        const source = `export const breaking = { reason: '${reason}', requiredStop: false };
+export async function up(knex) { await knex.schema.alterTable('users', table => table.dropColumn('legacy')); }
+export async function down(knex) { await knex.schema.alterTable('users', table => table.string('legacy')); }`;
+        const findings = enforcement(source);
+        assert.ok(
+            findings.some(
+                (finding) =>
+                    finding.rule === 'hollow-breaking-declaration' &&
+                    finding.message.includes(
+                        'describe what breaks and for whom',
+                    ),
+            ),
+            `expected hollow reason to fail: ${JSON.stringify(reason)}`,
+        );
+        assert.ok(
+            findings.some(
+                (finding) => finding.rule === 'undeclared-breaking-change',
+            ),
+        );
+    }
+});
+
+test('a substantive breaking reason satisfies migration enforcement', () => {
+    const source = `export const breaking = { reason: 'Deployments running the prior backend still read users.legacy.', requiredStop: false };
+export async function up(knex) { await knex.schema.alterTable('users', table => table.dropColumn('legacy')); }
+export async function down(knex) { await knex.schema.alterTable('users', table => table.string('legacy')); }`;
+    assert.ok(!enforcement(source).some((finding) => finding.severity === 'error'));
 });
 
 test('declared breaking behavior passes enforcement while preserving the legacy finding', () => {

--- a/scripts/sql-migration-lint.ts
+++ b/scripts/sql-migration-lint.ts
@@ -36,6 +36,7 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import { addedMigrationPaths } from './ai-migration-review';
+import { parseChangeDeclarations } from './breaking-change-declarations';
 
 export interface SqlLintFinding {
     file: string;
@@ -271,6 +272,589 @@ export function lintMigrations(opts: LintMigrationsOpts): SqlLintResult {
     return { ran: true, breaking: findings.length > 0, findings };
 }
 
+export type SqlMigrationEnforcementSeverity = 'error' | 'warning';
+
+export interface SqlMigrationEnforcementFinding extends SqlLintFinding {
+    severity: SqlMigrationEnforcementSeverity;
+}
+
+export interface SqlMigrationEnforcementResult {
+    ran: boolean;
+    passed: boolean;
+    paths: string[];
+    findings: SqlMigrationEnforcementFinding[];
+    errors: SqlMigrationEnforcementFinding[];
+    warnings: SqlMigrationEnforcementFinding[];
+}
+
+const MIGRATION_DIRS = [
+    'packages/backend/src/database/migrations',
+    'packages/backend/src/ee/database/migrations',
+];
+const MIGRATION_FILENAME_RE = /^\d{14}_.+\.(ts|js)$/;
+
+interface RawCall {
+    index: number;
+    line: number;
+    argument: string;
+    snippet: string;
+}
+
+function maskComments(source: string): string {
+    let output = '';
+    let index = 0;
+    let quote: string | null = null;
+    while (index < source.length) {
+        const char = source[index];
+        if (quote) {
+            output += char;
+            if (char === '\\') {
+                output += source[index + 1] ?? '';
+                index += 2;
+                continue;
+            }
+            if (char === quote) quote = null;
+            index += 1;
+            continue;
+        }
+        if (char === "'" || char === '"' || char === '`') {
+            quote = char;
+            output += char;
+            index += 1;
+            continue;
+        }
+        if (char === '/' && source[index + 1] === '/') {
+            while (index < source.length && source[index] !== '\n') {
+                output += ' ';
+                index += 1;
+            }
+            continue;
+        }
+        if (char === '/' && source[index + 1] === '*') {
+            output += '  ';
+            index += 2;
+            while (index < source.length && !(source[index] === '*' && source[index + 1] === '/')) {
+                output += source[index] === '\n' ? '\n' : ' ';
+                index += 1;
+            }
+            if (index < source.length) {
+                output += '  ';
+                index += 2;
+            }
+            continue;
+        }
+        output += char;
+        index += 1;
+    }
+    return output;
+}
+
+function skipSpace(source: string, start: number): number {
+    let index = start;
+    while (index < source.length && /\s/.test(source[index])) index += 1;
+    return index;
+}
+
+function matchingDelimiter(source: string, start: number, open: string, close: string): number {
+    let depth = 0;
+    let quote: string | null = null;
+    for (let index = start; index < source.length; index += 1) {
+        const char = source[index];
+        if (quote) {
+            if (char === '\\') {
+                index += 1;
+            } else if (char === quote) {
+                quote = null;
+            }
+            continue;
+        }
+        if (char === "'" || char === '"' || char === '`') {
+            quote = char;
+            continue;
+        }
+        if (char === open) depth += 1;
+        if (char === close) {
+            depth -= 1;
+            if (depth === 0) return index;
+        }
+    }
+    return -1;
+}
+
+function rawCalls(source: string): RawCall[] {
+    const masked = maskComments(source);
+    const calls: RawCall[] = [];
+    let index = 0;
+    let quote: string | null = null;
+    while (index < masked.length) {
+        const char = masked[index];
+        if (quote) {
+            if (char === '\\') index += 1;
+            else if (char === quote) quote = null;
+            index += 1;
+            continue;
+        }
+        if (char === "'" || char === '"' || char === '`') {
+            quote = char;
+            index += 1;
+            continue;
+        }
+        if (char !== '.') {
+            index += 1;
+            continue;
+        }
+        let cursor = skipSpace(masked, index + 1);
+        if (masked.slice(cursor, cursor + 3) !== 'raw' || /[A-Za-z0-9_$]/.test(masked[cursor + 3] ?? '')) {
+            index += 1;
+            continue;
+        }
+        cursor = skipSpace(masked, cursor + 3);
+        if (masked[cursor] === '<') {
+            const genericEnd = matchingDelimiter(masked, cursor, '<', '>');
+            if (genericEnd < 0) {
+                index += 1;
+                continue;
+            }
+            cursor = skipSpace(masked, genericEnd + 1);
+        }
+        if (masked[cursor] !== '(') {
+            index += 1;
+            continue;
+        }
+        const end = matchingDelimiter(masked, cursor, '(', ')');
+        if (end < 0) {
+            index += 1;
+            continue;
+        }
+        const argument = source.slice(cursor + 1, end).trim();
+        calls.push({
+            index,
+            line: lineOfIndex(source, index),
+            argument,
+            snippet: source.slice(index, end + 1).trim().replace(/\s+/g, ' ').slice(0, 200),
+        });
+        index = end + 1;
+    }
+    return calls;
+}
+
+function enforcementFinding(
+    file: string,
+    line: number,
+    rule: string,
+    message: string,
+    severity: SqlMigrationEnforcementSeverity,
+    snippet = '',
+    object?: string,
+): SqlMigrationEnforcementFinding {
+    return { file, line, rule, message, severity, snippet, object };
+}
+
+function transactionDisabled(source: string): boolean {
+    return /export\s+const\s+config\b[\s\S]*?\{[\s\S]*?transaction\s*:\s*false\b/.test(
+        maskComments(source),
+    );
+}
+
+function rawSqlText(argument: string): string | null {
+    const trimmed = argument.trim();
+    const quote = trimmed[0];
+    if (quote !== "'" && quote !== '"' && quote !== '`') return null;
+    let value = '';
+    let index = 1;
+    while (index < trimmed.length) {
+        if (trimmed[index] === '\\') {
+            value += trimmed.slice(index, index + 2);
+            index += 2;
+            continue;
+        }
+        if (trimmed[index] === quote) {
+            const rest = trimmed.slice(index + 1).trim();
+            if (rest.length > 0 && !rest.startsWith(',')) return null;
+            if (quote === '`' && value.includes('${')) return null;
+            return value;
+        }
+        value += trimmed[index];
+        index += 1;
+    }
+    return null;
+}
+
+function isKnownSafeRawSql(argument: string): boolean {
+    const sql = rawSqlText(argument);
+    if (sql === null) return false;
+    if (/^\s*(?:set(?:\s+local)?|reset)\s+[A-Za-z_][\w.]*\b/i.test(sql)) return true;
+    if (
+        /^\s*select\b[\s\S]*?\bfrom\s+(?:pg_catalog\.|information_schema\.|pg_)[A-Za-z_][\w$]*/i.test(
+            sql,
+        )
+    ) {
+        return true;
+    }
+    if (/^\s*create\s+(?:unique\s+)?index\b/i.test(sql)) return true;
+    if (/^\s*create\s+table\b/i.test(sql)) return true;
+    if (/^\s*drop\s+index\b/i.test(sql)) return true;
+    if (
+        /^\s*alter\s+table\b[\s\S]*?\badd\s+(?:column\s+)?[A-Za-z_"$][\w"$]*\b/i.test(sql) &&
+        !/\bnot\s+null\b/i.test(sql)
+    ) {
+        return true;
+    }
+    return false;
+}
+
+function concurrentIndexName(argument: string): string | null {
+    const sql = rawSqlText(argument);
+    if (sql === null) return null;
+    const create = /\bcreate\s+(?:unique\s+)?index\s+concurrently\s+/i.exec(sql);
+    if (!create) return null;
+    const remainder = sql
+        .slice(create.index + create[0].length)
+        .replace(/^if\s+not\s+exists\s+/i, '');
+    const match = /^(?:"([A-Za-z_][\w$]*)"|([A-Za-z_][\w$]*\b))/.exec(remainder);
+    return match?.[1] ?? match?.[2] ?? null;
+}
+
+function ddlTableNames(calls: readonly RawCall[], up: string): string[] {
+    const names = new Set<string>();
+    for (const call of calls) {
+        const sql = rawSqlText(call.argument);
+        if (sql === null) continue;
+        const tablePattern = /\b(?:alter|create|drop|truncate)\s+table(?:\s+if\s+(?:not\s+)?exists)?\s+(?:"([A-Za-z_][\w$]*)"|([A-Za-z_][\w$]*)(?:\.[A-Za-z_][\w$]*)?)/gi;
+        let tableMatch: RegExpExecArray | null;
+        while ((tableMatch = tablePattern.exec(sql)) !== null) {
+            names.add(tableMatch[1] ?? tableMatch[2]);
+        }
+        const indexMatch = /\bcreate\s+(?:unique\s+)?index\b[\s\S]*?\bon\s+(?:"([A-Za-z_][\w$]*)"|([A-Za-z_][\w$]*)(?:\.[A-Za-z_][\w$]*)?)/i.exec(
+            sql,
+        );
+        if (indexMatch) names.add(indexMatch[1] ?? indexMatch[2]);
+    }
+    const builderPattern = /\.\s*(?:alterTable|createTable|dropTable|dropTableIfExists|table|renameTable)\s*\(\s*['"]([^'"]+)['"]/g;
+    let builderMatch: RegExpExecArray | null;
+    while ((builderMatch = builderPattern.exec(maskComments(up))) !== null) {
+        names.add(builderMatch[1]);
+    }
+    return [...names].sort();
+}
+
+function isResumableBackfill(argument: string, source: string): boolean {
+    if (/\binsert\s+into\b/i.test(argument) && /\bon\s+conflict\b/i.test(argument)) return true;
+    if (/\bdelete\s+from\b/i.test(argument) && /\bwhere\b/i.test(argument)) return true;
+    if (/\bupdate\b/i.test(argument)) {
+        const guarded = /\bwhere\b/i.test(argument) && /\b(?:is\s+null|is\s+distinct\s+from|not\s+exists)\b/i.test(argument);
+        const batched = /\blimit\s+\d+\b/i.test(argument) && /\b(?:for\s*\(|while\s*\()/.test(source);
+        return guarded || batched;
+    }
+    return false;
+}
+
+function downState(source: string): {
+    state: 'missing' | 'noop' | 'invalid-throw' | 'real';
+    line: number;
+} {
+    const masked = maskComments(source);
+    const functionMatch = /(?:export\s+)?(?:async\s+)?function\s+down\b[^\{]*\{/.exec(masked);
+    const arrowMatch = /(?:export\s+)?const\s+down\b[^=]*=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>\s*/.exec(masked);
+    let start = -1;
+    let body = '';
+    if (functionMatch?.index !== undefined) {
+        const open = functionMatch.index + functionMatch[0].lastIndexOf('{');
+        const close = matchingDelimiter(masked, open, '{', '}');
+        start = functionMatch.index;
+        if (close >= 0) body = masked.slice(open + 1, close);
+    } else if (arrowMatch?.index !== undefined) {
+        start = arrowMatch.index;
+        const bodyStart = arrowMatch.index + arrowMatch[0].length;
+        if (masked[bodyStart] === '{') {
+            const close = matchingDelimiter(masked, bodyStart, '{', '}');
+            if (close >= 0) body = masked.slice(bodyStart + 1, close);
+        } else {
+            const end = masked.indexOf(';', bodyStart);
+            body = masked.slice(bodyStart, end < 0 ? masked.length : end);
+        }
+    }
+    if (start < 0) return { state: 'missing', line: 1 };
+    const normalized = body.replace(/\s+/g, ' ').replace(/;+\s*$/, '').trim();
+    if (
+        normalized.length === 0 ||
+        /^(?:return\s*)?(?:undefined|void\s+0|Promise\.resolve\s*\(\s*\))?$/.test(normalized)
+    ) {
+        return { state: 'noop', line: lineOfIndex(source, start) };
+    }
+    if (/^throw\b/.test(normalized) && !/^throw\s+(?:new\s+)?Error\s*\(\s*(['"`])irreversible:\s*[\s\S]*\1\s*\)$/.test(normalized)) {
+        return { state: 'invalid-throw', line: lineOfIndex(source, start) };
+    }
+    return { state: 'real', line: lineOfIndex(source, start) };
+}
+
+export function evaluateMigrationSource(
+    source: string,
+    file = '<source>',
+): SqlMigrationEnforcementFinding[] {
+    const findings: SqlMigrationEnforcementFinding[] = [];
+    const declarations = parseChangeDeclarations(source, file);
+    for (const declarationDiagnostic of declarations.diagnostics) {
+        findings.push(
+            enforcementFinding(
+                file,
+                declarationDiagnostic.line,
+                `malformed-${declarationDiagnostic.declaration}-declaration`,
+                declarationDiagnostic.message,
+                'error',
+            ),
+        );
+    }
+
+    const legacy = lintSource(source);
+    for (const finding of legacy) {
+        findings.push({
+            ...finding,
+            file,
+            severity: declarations.breaking ? 'warning' : 'error',
+            message: declarations.breaking
+                ? `${finding.message}; acknowledged by export const breaking`
+                : `${finding.message}; add export const breaking with a reason and requiredStop`,
+        });
+    }
+
+    const classifiedBreaking = declarations.classification?.kind === 'breaking';
+    if ((legacy.length > 0 || classifiedBreaking) && !declarations.breaking) {
+        findings.push(
+            enforcementFinding(
+                file,
+                declarations.classification?.line ?? legacy[0]?.line ?? 1,
+                'undeclared-breaking-change',
+                'breaking migration behavior requires export const breaking = { reason: "...", requiredStop: false }',
+                'error',
+            ),
+        );
+    }
+    if (classifiedBreaking) {
+        findings.push(
+            enforcementFinding(
+                file,
+                declarations.classification?.line ?? 1,
+                'classified-breaking-change',
+                `migration is classified as breaking: ${declarations.classification?.reason}`,
+                declarations.breaking ? 'warning' : 'error',
+            ),
+        );
+    }
+
+    const up = upPortion(source);
+    const calls = rawCalls(up);
+    if (!declarations.classification) {
+        for (const call of calls) {
+            const knownBreaking = RAW_RULES.some((ruleValue) =>
+                ruleValue.re.test(call.argument),
+            );
+            if (!knownBreaking && !isKnownSafeRawSql(call.argument)) {
+                findings.push(
+                    enforcementFinding(
+                        file,
+                        call.line,
+                        'unclassified-knex-raw',
+                        'knex.raw cannot be classified statically; add export const classification with kind and reason',
+                        'error',
+                        call.snippet,
+                    ),
+                );
+            }
+        }
+    }
+
+    const noTransaction = transactionDisabled(source);
+    const hasInvalidIndexCleanup = /\bpg_index\b/i.test(up) && /\bindisvalid\b/i.test(up);
+    for (const call of calls) {
+        const concurrentIfNotExists = /\bcreate\s+(?:unique\s+)?index\s+concurrently\s+if\s+not\s+exists\b/i.test(
+            call.argument,
+        );
+        const bareConcurrent = /\bcreate\s+(?:unique\s+)?index\s+concurrently\s+(?!if\s+not\s+exists\b)/i.test(
+            call.argument,
+        );
+        if (concurrentIfNotExists) {
+            const indexName = concurrentIndexName(call.argument);
+            if (indexName || !hasInvalidIndexCleanup) {
+                const retryMessage = indexName
+                    ? `CREATE INDEX CONCURRENTLY IF NOT EXISTS can preserve invalid index ${indexName}; its literal name is discoverable by the runtime retry guard`
+                    : 'CREATE INDEX CONCURRENTLY IF NOT EXISTS uses a placeholder or dynamic index name that the runtime retry guard cannot discover; add explicit pg_index invalid-index cleanup';
+                findings.push(
+                    enforcementFinding(
+                        file,
+                        call.line,
+                        'concurrent-index-invalid-retry',
+                        retryMessage,
+                        'warning',
+                        call.snippet,
+                    ),
+                );
+            }
+        }
+        if (noTransaction && bareConcurrent) {
+            findings.push(
+                enforcementFinding(
+                    file,
+                    call.line,
+                    'non-resumable-concurrent-index',
+                    'transaction:false with bare CREATE INDEX CONCURRENTLY is not retry-safe; use an explicit invalid-index cleanup strategy',
+                    'error',
+                    call.snippet,
+                ),
+            );
+        }
+        if (
+            noTransaction &&
+            /\b(?:update|insert\s+into|delete\s+from)\b/i.test(call.argument) &&
+            !isResumableBackfill(call.argument, up)
+        ) {
+            findings.push(
+                enforcementFinding(
+                    file,
+                    call.line,
+                    'non-resumable-backfill',
+                    'transaction:false backfill is not visibly resumable; add idempotent guards or bounded restart-safe batches',
+                    'error',
+                    call.snippet,
+                ),
+            );
+        }
+    }
+
+    if (noTransaction && /\.update\s*\(/.test(maskComments(up)) && !/\.where(?:Null|NotNull)?\s*\(/.test(maskComments(up))) {
+        const index = maskComments(up).search(/\.update\s*\(/);
+        findings.push(
+            enforcementFinding(
+                file,
+                lineOfIndex(up, index),
+                'non-resumable-backfill',
+                'transaction:false Knex update has no visible idempotent guard',
+                'error',
+                up.slice(index, index + 200).replace(/\s+/g, ' '),
+            ),
+        );
+    }
+
+    const ddl = calls.some((call) => /\b(?:alter|create|drop|truncate)\b/i.test(call.argument)) ||
+        /\.schema\s*\.\s*(?:alterTable|createTable|dropTable|dropTableIfExists|renameTable|table)\s*\(/.test(maskComments(up));
+    const lockTimeout = calls.some((call) => /\bset\s+(?:local\s+)?lock_timeout\b/i.test(call.argument));
+    if (ddl && !lockTimeout) {
+        const tables = ddlTableNames(calls, up);
+        findings.push(
+            enforcementFinding(
+                file,
+                1,
+                'missing-lock-timeout',
+                `DDL on table(s) ${tables.length > 0 ? tables.join(', ') : '<dynamic or unknown>'} has no SET LOCAL lock_timeout or SET lock_timeout protection`,
+                'warning',
+            ),
+        );
+    }
+
+    const down = downState(source);
+    if (down.state === 'missing') {
+        findings.push(
+            enforcementFinding(
+                file,
+                down.line,
+                'missing-down',
+                'migration must export a down function that rolls back or explicitly throws for an irreversible migration',
+                'error',
+            ),
+        );
+    } else if (down.state === 'noop') {
+        findings.push(
+            enforcementFinding(
+                file,
+                down.line,
+                'silent-noop-down',
+                'down must perform a rollback or explicitly throw; silently succeeding is not allowed',
+                'error',
+            ),
+        );
+    } else if (down.state === 'invalid-throw') {
+        findings.push(
+            enforcementFinding(
+                file,
+                down.line,
+                'invalid-irreversible-down',
+                'an irreversible down must explicitly throw an Error whose message starts with "irreversible:"',
+                'error',
+            ),
+        );
+    }
+
+    return findings;
+}
+
+export function changedMigrationPathsFromNameStatus(
+    output: string,
+    exists: (path: string) => boolean = fs.existsSync,
+): string[] {
+    const paths: string[] = [];
+    for (const line of output.split('\n')) {
+        if (!line.trim()) continue;
+        const fields = line.split('\t');
+        if (!/^[AMRC]/.test(fields[0])) continue;
+        const path = fields[fields.length - 1];
+        if (
+            MIGRATION_DIRS.some((directory) => path.startsWith(`${directory}/`)) &&
+            MIGRATION_FILENAME_RE.test(path.split('/').pop() ?? '') &&
+            exists(path)
+        ) {
+            paths.push(path);
+        }
+    }
+    return [...new Set(paths)].sort();
+}
+
+export function changedMigrationPaths(base: string): string[] {
+    const output = execFileSync(
+        'git',
+        ['diff', '--name-status', `${base}..HEAD`, '--', ...MIGRATION_DIRS],
+        { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+    );
+    return changedMigrationPathsFromNameStatus(output);
+}
+
+export interface EvaluateMigrationEnforcementOptions {
+    paths: readonly string[];
+    readFile?: (path: string) => string;
+}
+
+export function evaluateMigrationEnforcement(
+    options: EvaluateMigrationEnforcementOptions,
+): SqlMigrationEnforcementResult {
+    const readFile = options.readFile ?? ((path: string) => fs.readFileSync(path, 'utf8'));
+    const paths = [...options.paths];
+    const findings: SqlMigrationEnforcementFinding[] = [];
+    for (const path of paths) {
+        try {
+            findings.push(...evaluateMigrationSource(readFile(path), path));
+        } catch (error) {
+            findings.push(
+                enforcementFinding(
+                    path,
+                    1,
+                    'migration-read-error',
+                    `could not read changed migration: ${error instanceof Error ? error.message : String(error)}`,
+                    'error',
+                ),
+            );
+        }
+    }
+    const errors = findings.filter((finding) => finding.severity === 'error');
+    const warnings = findings.filter((finding) => finding.severity === 'warning');
+    return {
+        ran: paths.length > 0,
+        passed: errors.length === 0,
+        paths,
+        findings,
+        errors,
+        warnings,
+    };
+}
+
 // ---- CLI --------------------------------------------------------------------
 
 function arg(name: string): string | undefined {
@@ -281,6 +865,19 @@ function arg(name: string): string | undefined {
 function main(): void {
     const lastTag = arg('last-tag') ?? arg('previous-version');
     if (!lastTag) throw new Error('--last-tag (or --previous-version) is required');
+    if (process.argv.includes('--enforce')) {
+        const result = evaluateMigrationEnforcement({ paths: changedMigrationPaths(lastTag) });
+        for (const finding of result.findings) {
+            const output = `${finding.file}:${finding.line} ${finding.severity.toUpperCase()} ${finding.message} [${finding.rule}]`;
+            if (finding.severity === 'error') console.error(output);
+            else console.warn(output);
+        }
+        console.log(
+            `[sql-migration-lint] checked ${result.paths.length} changed migration(s): ${result.errors.length} error(s), ${result.warnings.length} warning(s)`,
+        );
+        if (!result.passed) process.exitCode = 1;
+        return;
+    }
     const result = lintMigrations({ lastTag, log: (m) => console.error(`[sql-migration-lint] ${m}`) });
     console.log(JSON.stringify({ ran: result.ran, breaking: result.breaking, findings: renderFindings(result.findings) }, null, 2));
 }

--- a/scripts/sql-migration-lint.ts
+++ b/scripts/sql-migration-lint.ts
@@ -37,6 +37,11 @@ import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import { addedMigrationPaths } from './ai-migration-review';
 import { parseChangeDeclarations } from './breaking-change-declarations';
+import {
+    breakingChangeDecisionBrief,
+    hollowBreakingReasonMessage,
+    isSubstantiveBreakingReason,
+} from './breaking-change-gate-policy';
 
 export interface SqlLintFinding {
     file: string;
@@ -604,6 +609,40 @@ export function evaluateMigrationSource(
                 'error',
             ),
         );
+        if (
+            declarationDiagnostic.declaration === 'breaking' &&
+            declarationDiagnostic.message.includes(
+                'breaking.reason must not be empty',
+            )
+        ) {
+            findings.push(
+                enforcementFinding(
+                    file,
+                    declarationDiagnostic.line,
+                    'hollow-breaking-declaration',
+                    hollowBreakingReasonMessage(
+                        file,
+                        declarationDiagnostic.line,
+                    ),
+                    'error',
+                ),
+            );
+        }
+    }
+
+    const substantiveBreakingDeclaration =
+        declarations.breaking !== null &&
+        isSubstantiveBreakingReason(declarations.breaking.reason);
+    if (declarations.breaking && !substantiveBreakingDeclaration) {
+        findings.push(
+            enforcementFinding(
+                file,
+                declarations.breaking.line,
+                'hollow-breaking-declaration',
+                hollowBreakingReasonMessage(file, declarations.breaking.line),
+                'error',
+            ),
+        );
     }
 
     const legacy = lintSource(source);
@@ -611,21 +650,35 @@ export function evaluateMigrationSource(
         findings.push({
             ...finding,
             file,
-            severity: declarations.breaking ? 'warning' : 'error',
-            message: declarations.breaking
+            severity: substantiveBreakingDeclaration ? 'warning' : 'error',
+            message: substantiveBreakingDeclaration
                 ? `${finding.message}; acknowledged by export const breaking`
-                : `${finding.message}; add export const breaking with a reason and requiredStop`,
+                : `${finding.message}; breaking behavior is not declared by a substantive product decision`,
         });
     }
 
     const classifiedBreaking = declarations.classification?.kind === 'breaking';
-    if ((legacy.length > 0 || classifiedBreaking) && !declarations.breaking) {
+    if (
+        (legacy.length > 0 || classifiedBreaking) &&
+        !substantiveBreakingDeclaration
+    ) {
+        const detectedLine =
+            declarations.classification?.line ?? legacy[0]?.line ?? 1;
+        const detectedPattern = legacy[0]
+            ? `${legacy[0].rule} — ${legacy[0].message}`
+            : `classification kind "breaking" — ${declarations.classification?.reason}`;
         findings.push(
             enforcementFinding(
                 file,
-                declarations.classification?.line ?? legacy[0]?.line ?? 1,
+                detectedLine,
                 'undeclared-breaking-change',
-                'breaking migration behavior requires export const breaking = { reason: "...", requiredStop: false }',
+                breakingChangeDecisionBrief({
+                    file,
+                    line: detectedLine,
+                    pattern: detectedPattern,
+                    declarationLocation:
+                        'this migration file as export const breaking = { reason: string, requiredStop: boolean }',
+                }),
                 'error',
             ),
         );
@@ -637,7 +690,7 @@ export function evaluateMigrationSource(
                 declarations.classification?.line ?? 1,
                 'classified-breaking-change',
                 `migration is classified as breaking: ${declarations.classification?.reason}`,
-                declarations.breaking ? 'warning' : 'error',
+                substantiveBreakingDeclaration ? 'warning' : 'error',
             ),
         );
     }


### PR DESCRIPTION
## What

The PR-time enforcement decided in SPK-917 — no breaking change lands silently, by construction:

- **Declare-or-fail on migrations**: `sql-migration-lint.ts`'s breaking-pattern detection becomes a hard CI failure on changed migration files unless the file carries `export const breaking = { reason, requiredStop }`. Unclassifiable raw SQL hard-fails asking the author to classify. Declarations are machine-readable at release time (the artifact-v2 branch consumes the same parser — byte-identical shared module).
- **Same flow for the API surface**: an undeclared oasdiff REST break or MCP tool-surface break fails CI; declared breaks land with reasoning. One declaration grammar across both detectors.
- **Two inherited hard rules** (changed files only): `transaction: false` migrations with non-idempotent patterns fail (takeover re-runs must not crash); silent no-op `down()` fails — real or an explicit throw. The lint now analyzes the `down()` half for new files instead of discarding it.
- **Warning tier**: DDL without a lock timeout; `CREATE INDEX CONCURRENTLY` relying on `IF NOT EXISTS` alone (invalid-index leftovers defeat that idempotency).
- **Grandfathering**: the gate only ever evaluates files the PR touches — verified with a real invocation against this branch (0 changed migrations → 0 errors, 0 warnings). Legacy files never trip it.
- Authoring rules documented via an appended section in the migrations CLAUDE.md.

## Notes for review

- `scripts/breaking-change-declarations.ts` is intentionally identical to the copy on `feature/spk-923` (coordinated) — git content-merges it; `scripts/sql-migration-lint.ts` is the one real overlap with that branch, whichever lands second rebases.
- Verification: 200-test release-safety suite, full repo typecheck (10/10) and tests (13/13 turbo tasks; 6,356 backend tests), workflow YAML parse, clean tree.

Closes: SPK-924

## Rollout

Two-phase (per SPK-924): at merge the gate check runs **red-but-not-required** — new status checks are non-required until branch protection changes, so the bake-in is automatic. After a 1–2 week bake-in with no false positives, an admin adds the check to required status checks on `main` (checklist item on the Linear ticket), making "no undeclared break lands" literally true.


Part of #27140
