### PR TITLE
feat(ai-memory): trigger memory extraction on thread events

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentMemoryController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentMemoryController.ts
@@ -167,8 +167,9 @@ export class AiAgentMemoryController extends BaseController {
     }
 
     /**
-     * Queues distillation for one thread immediately, skipping the 6h idle wait
-     * and the every-3h sweep. Re-distills a thread that is already up to date.
+     * Queues distillation for one thread immediately, skipping the event
+     * debounce and the backfill sweep. Re-distills a thread that is already up
+     * to date.
      * Requires permission to manage AI agents in the project.
      * @summary Distill thread
      */

--- a/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
@@ -1,5 +1,6 @@
 import { AnyType, EE_SCHEDULER_TASKS, JobPriority } from '@lightdash/common';
 import {
+    aiAgentMemoryDistillEventRunAt,
     aiAgentReviewRunAt,
     CommercialSchedulerClient,
 } from './SchedulerClient';
@@ -17,6 +18,16 @@ describe('aiAgentReviewRunAt', () => {
     it('runs response_saved reviews immediately', () => {
         const runAt = aiAgentReviewRunAt('response_saved', now);
         expect(runAt.getTime()).toBe(now.getTime());
+    });
+});
+
+describe('aiAgentMemoryDistillEventRunAt', () => {
+    it('defers event-driven distills so a burst of thread activity coalesces', () => {
+        const now = new Date('2026-06-04T11:33:48.000Z');
+        const runAt = aiAgentMemoryDistillEventRunAt(now);
+        // Delayed so the per-thread jobKey replaces the still-pending job when
+        // the next turn or the feedback comment lands shortly after.
+        expect(runAt.getTime() - now.getTime()).toBe(180_000);
     });
 });
 
@@ -72,6 +83,34 @@ describe('CommercialSchedulerClient.aiAgentMemoryDistill', () => {
                 jobKey: 'ai-agent-memory-distill:thread-1',
                 queueName: 'ai-agent-memory-distill:project-1',
                 priority: JobPriority.LOW,
+            }),
+        );
+    });
+
+    it('schedules an event-driven distill at the debounced runAt', async () => {
+        const addJob = vi.fn().mockResolvedValue({ id: 'job-1' });
+        const client = Object.create(
+            CommercialSchedulerClient.prototype,
+        ) as CommercialSchedulerClient;
+        client.graphileUtils = Promise.resolve({ addJob } as AnyType);
+        const runAt = new Date('2026-06-04T11:34:48.000Z');
+
+        await client.aiAgentMemoryDistill(
+            {
+                threadUuid: 'thread-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'project-1',
+                userUuid: 'user-1',
+            },
+            runAt,
+        );
+
+        expect(addJob).toHaveBeenCalledWith(
+            EE_SCHEDULER_TASKS.AI_AGENT_MEMORY_DISTILL,
+            expect.not.objectContaining({ sweptUpdatedAt: expect.anything() }),
+            expect.objectContaining({
+                runAt,
+                jobKey: 'ai-agent-memory-distill:thread-1',
             }),
         );
     });

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -42,6 +42,19 @@ export const aiAgentReviewRunAt = (
         ? new Date(now.getTime() + FEEDBACK_REVIEW_DEBOUNCE_MS)
         : now;
 
+/**
+ * How long to defer an event-driven distill so a burst of activity on the same
+ * thread (consecutive turns, rate-then-comment feedback) coalesces into one
+ * distill via the shared per-thread jobKey. Long enough that a follow-up turn
+ * usually completes (and re-arms the job) before the window expires — a distill
+ * that fires while a turn is still in flight misses that turn's answer, since
+ * response saves don't advance the thread watermark.
+ */
+const MEMORY_DISTILL_EVENT_DEBOUNCE_MS = 180_000;
+
+export const aiAgentMemoryDistillEventRunAt = (now: Date): Date =>
+    new Date(now.getTime() + MEMORY_DISTILL_EVENT_DEBOUNCE_MS);
+
 export class CommercialSchedulerClient extends SchedulerClient {
     /**
      * One pending publish per announcement: the stable jobKey (default
@@ -77,13 +90,16 @@ export class CommercialSchedulerClient extends SchedulerClient {
         });
     }
 
-    async aiAgentMemoryDistill(payload: AiAgentMemoryDistillJobPayload) {
+    async aiAgentMemoryDistill(
+        payload: AiAgentMemoryDistillJobPayload,
+        runAt: Date = new Date(),
+    ) {
         const graphileClient = await this.graphileUtils;
         const { id: jobId } = await graphileClient.addJob(
             EE_SCHEDULER_TASKS.AI_AGENT_MEMORY_DISTILL,
             payload,
             {
-                runAt: new Date(),
+                runAt,
                 maxAttempts: 1,
                 jobKey: `ai-agent-memory-distill:${payload.threadUuid}`,
                 queueName: `ai-agent-memory-distill:${payload.projectUuid}`,

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -1008,6 +1008,145 @@ describe('AiAgentMemoryService', () => {
         expect(forced.distillCall).toHaveBeenCalledOnce();
     });
 
+    it('distills an event-triggered job only through the latest successful turn', async () => {
+        const completedActivity = new Date('2026-07-22T04:00:00.000Z');
+        const latestActivity = new Date('2026-07-22T05:00:00.000Z');
+        const completedTurn = distillableThread(completedActivity).turns[0];
+        const unfinishedTurn = {
+            ...completedTurn,
+            promptUuid: 'prompt-2',
+            createdAt: latestActivity,
+            userText: 'Unfinished follow-up',
+            assistantText: null,
+            respondedAt: null,
+        };
+        const {
+            service,
+            findThreadForDistill,
+            upsertThreadDistill,
+            distillCall,
+        } = build();
+        findThreadForDistill.mockResolvedValue(
+            distillableThread(latestActivity, {
+                distilledUpTo: null,
+                turns: [completedTurn, unfinishedTurn],
+            }),
+        );
+        distillCall.mockResolvedValue({
+            result: { type: 'no_op', reason: 'no_positive_evidence' },
+        });
+
+        await expect(
+            service.distillThread({
+                organizationUuid: 'org-enabled',
+                projectUuid: 'project-enabled',
+                userUuid: 'current-user',
+                threadUuid: 'thread-enabled',
+            }),
+        ).resolves.toBe('no_op');
+
+        expect(upsertThreadDistill).toHaveBeenCalledWith(
+            expect.objectContaining({ distilledUpTo: completedActivity }),
+        );
+        expect(distillCall).toHaveBeenCalledWith(
+            expect.objectContaining({
+                thread: expect.objectContaining({ turns: [completedTurn] }),
+            }),
+        );
+        expect(distillCall.mock.calls[0][0].transcript).not.toContain(
+            'Unfinished follow-up',
+        );
+    });
+
+    it('does not move the event watermark past an unfinished follow-up', async () => {
+        const completedActivity = new Date('2026-07-22T04:00:00.000Z');
+        const latestActivity = new Date('2026-07-22T05:00:00.000Z');
+        const completedTurn = distillableThread(completedActivity).turns[0];
+        const {
+            service,
+            findThreadForDistill,
+            upsertThreadDistill,
+            distillCall,
+        } = build();
+        findThreadForDistill.mockResolvedValue(
+            distillableThread(latestActivity, {
+                distilledUpTo: completedActivity,
+                turns: [
+                    completedTurn,
+                    {
+                        ...completedTurn,
+                        promptUuid: 'prompt-2',
+                        createdAt: latestActivity,
+                        userText: 'Unfinished follow-up',
+                        assistantText: null,
+                        respondedAt: null,
+                    },
+                ],
+            }),
+        );
+
+        await expect(
+            service.distillThread({
+                organizationUuid: 'org-enabled',
+                projectUuid: 'project-enabled',
+                userUuid: 'current-user',
+                threadUuid: 'thread-enabled',
+            }),
+        ).resolves.toBe('skipped');
+        expect(distillCall).not.toHaveBeenCalled();
+        expect(upsertThreadDistill).not.toHaveBeenCalled();
+    });
+
+    it('re-distills on a forced feedback event even though the watermark has not moved', async () => {
+        const completedActivity = new Date('2026-07-22T04:00:00.000Z');
+        const latestActivity = new Date('2026-07-22T05:00:00.000Z');
+        const completedTurn = distillableThread(completedActivity).turns[0];
+        const {
+            service,
+            findThreadForDistill,
+            upsertThreadDistill,
+            distillCall,
+        } = build();
+        findThreadForDistill.mockResolvedValue(
+            distillableThread(latestActivity, {
+                distilledUpTo: completedActivity,
+                turns: [
+                    completedTurn,
+                    {
+                        ...completedTurn,
+                        promptUuid: 'prompt-2',
+                        createdAt: latestActivity,
+                        userText: 'Unfinished follow-up',
+                        assistantText: null,
+                        respondedAt: null,
+                    },
+                ],
+            }),
+        );
+        distillCall.mockResolvedValue({
+            result: { type: 'no_op', reason: 'no_positive_evidence' },
+        });
+
+        await expect(
+            service.distillThread({
+                organizationUuid: 'org-enabled',
+                projectUuid: 'project-enabled',
+                userUuid: 'current-user',
+                threadUuid: 'thread-enabled',
+                force: true,
+            }),
+        ).resolves.toBe('no_op');
+
+        expect(distillCall).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+                thread: expect.objectContaining({ turns: [completedTurn] }),
+            }),
+        );
+        expect(upsertThreadDistill).toHaveBeenCalledWith(
+            expect.objectContaining({ distilledUpTo: completedActivity }),
+        );
+    });
+
     it('forcing does not override the inactive-memory guard', async () => {
         const activity = new Date('2026-07-22T05:00:00.000Z');
         const {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -224,6 +224,26 @@ type ConsolidationPromotionPreparation =
           rejection: AiAgentMemoryConsolidationRejection;
       };
 
+const isSuccessfulTurn = (
+    turn: AiAgentMemoryThread['turns'][number],
+): boolean =>
+    !turn.interrupted &&
+    turn.respondedAt !== null &&
+    turn.errorMessage === null &&
+    turn.assistantText !== null;
+
+const getLatestCompletedTurnActivity = (
+    thread: AiAgentMemoryThread,
+): Date | undefined =>
+    thread.turns.reduce<Date | undefined>(
+        (latest, turn) =>
+            isSuccessfulTurn(turn) &&
+            (latest === undefined || turn.createdAt > latest)
+                ? turn.createdAt
+                : latest,
+        undefined,
+    );
+
 type Dependencies = {
     analytics: LightdashAnalytics;
     aiAgentMemoryModel: AiAgentMemoryModel;
@@ -949,6 +969,11 @@ export class AiAgentMemoryService extends BaseService {
         }
     }
 
+    /**
+     * Cron backfill behind the event triggers (turn saved, feedback changed):
+     * catches threads whose event jobs were lost (maxAttempts 1, worker
+     * restarts) and threads from before an org enabled memory.
+     */
     async sweep(now = new Date()): Promise<number> {
         const candidates =
             await this.aiAgentMemoryModel.findThreadsDueForDistill({
@@ -1681,16 +1706,17 @@ export class AiAgentMemoryService extends BaseService {
         payload: AiAgentMemoryDistillJobPayload,
         abortSignal?: AbortSignal,
     ): Promise<AiAgentMemoryDistillOutcome> {
-        const sweptUpdatedAt =
-            typeof payload.sweptUpdatedAt === 'string'
-                ? new Date(payload.sweptUpdatedAt)
-                : undefined;
-        if (
-            !sweptUpdatedAt ||
-            Number.isNaN(sweptUpdatedAt.getTime()) ||
-            sweptUpdatedAt.toISOString() !== payload.sweptUpdatedAt
-        ) {
-            return 'skipped';
+        // Sweep/manual jobs carry a watermark; event jobs derive one from the
+        // latest successfully completed turn.
+        let payloadWatermark: Date | undefined;
+        if (payload.sweptUpdatedAt !== undefined) {
+            payloadWatermark = new Date(payload.sweptUpdatedAt);
+            if (
+                Number.isNaN(payloadWatermark.getTime()) ||
+                payloadWatermark.toISOString() !== payload.sweptUpdatedAt
+            ) {
+                return 'skipped';
+            }
         }
 
         if (!(await this.isEnabled(payload.organizationUuid))) {
@@ -1708,7 +1734,13 @@ export class AiAgentMemoryService extends BaseService {
             return 'skipped';
         }
 
-        if (sweptUpdatedAt.getTime() > thread.latestActivity.getTime()) {
+        const distillUpTo =
+            payloadWatermark ?? getLatestCompletedTurnActivity(thread);
+
+        if (
+            distillUpTo === undefined ||
+            distillUpTo.getTime() > thread.latestActivity.getTime()
+        ) {
             return 'skipped';
         }
 
@@ -1717,25 +1749,26 @@ export class AiAgentMemoryService extends BaseService {
         if (
             !payload.force &&
             thread.distilledUpTo !== null &&
-            thread.distilledUpTo.getTime() >= sweptUpdatedAt.getTime()
+            thread.distilledUpTo.getTime() >= distillUpTo.getTime()
         ) {
             return 'skipped';
         }
+
+        const threadThroughWatermark = {
+            ...thread,
+            turns: thread.turns.filter(
+                (turn) => turn.createdAt.getTime() <= distillUpTo.getTime(),
+            ),
+        };
 
         if (
             thread.projectType === ProjectType.PREVIEW ||
             !AI_AGENT_MEMORY_THREAD_SOURCES.some(
                 (createdFrom) => createdFrom === thread.createdFrom,
             ) ||
-            !thread.turns.some(
-                (turn) =>
-                    !turn.interrupted &&
-                    turn.respondedAt !== null &&
-                    turn.errorMessage === null &&
-                    turn.assistantText !== null,
-            )
+            !threadThroughWatermark.turns.some(isSuccessfulTurn)
         ) {
-            return this.recordSkip(thread.threadUuid, sweptUpdatedAt);
+            return this.recordSkip(thread.threadUuid, distillUpTo);
         }
 
         // A thread whose memory was consolidated away or retired stops feeding
@@ -1746,7 +1779,7 @@ export class AiAgentMemoryService extends BaseService {
                 thread.threadUuid,
             );
         if (memoryState === 'inactive') {
-            return this.recordSkip(thread.threadUuid, sweptUpdatedAt);
+            return this.recordSkip(thread.threadUuid, distillUpTo);
         }
 
         let failureStage: AiAgentMemoryGenerationFailedEvent['properties']['failureStage'] =
@@ -1755,7 +1788,7 @@ export class AiAgentMemoryService extends BaseService {
         try {
             abortSignal?.throwIfAborted();
             const transcript = serializeTranscript(
-                await sanitizeThread(thread, {
+                await sanitizeThread(threadThroughWatermark, {
                     onUnknownTool: (toolName) => {
                         this.logger.warn(
                             'Unknown AI agent tool uses fallback distill policy',
@@ -1766,7 +1799,7 @@ export class AiAgentMemoryService extends BaseService {
                 }),
             );
             const output = await this.distillCall({
-                thread,
+                thread: threadThroughWatermark,
                 transcript,
                 abortSignal,
             });
@@ -1779,7 +1812,7 @@ export class AiAgentMemoryService extends BaseService {
                     outcome: 'no_op',
                     noOpReason: output.result.reason,
                     distillPromptHash,
-                    distilledUpTo: sweptUpdatedAt,
+                    distilledUpTo: distillUpTo,
                 });
                 return 'no_op';
             }
@@ -1803,7 +1836,7 @@ export class AiAgentMemoryService extends BaseService {
                     thread.threadUuid,
                 )) === 'inactive'
             ) {
-                return await this.recordSkip(thread.threadUuid, sweptUpdatedAt);
+                return await this.recordSkip(thread.threadUuid, distillUpTo);
             }
             const memory =
                 await this.aiAgentMemoryModel.upsertSourceThreadMemory({
@@ -1842,7 +1875,7 @@ export class AiAgentMemoryService extends BaseService {
                 aiThreadUuid: thread.threadUuid,
                 outcome: 'memory',
                 distillPromptHash,
-                distilledUpTo: sweptUpdatedAt,
+                distilledUpTo: distillUpTo,
             });
             return 'memory';
         } catch (error) {
@@ -1852,7 +1885,7 @@ export class AiAgentMemoryService extends BaseService {
                 outcome: 'failed',
                 errorMessage,
                 distillPromptHash: await distillPromptHashPromise,
-                distilledUpTo: sweptUpdatedAt,
+                distilledUpTo: distillUpTo,
             });
             this.logger.warn('Dropping AI agent memory distill', {
                 threadUuid: thread.threadUuid,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -244,7 +244,10 @@ import {
 } from '../../models/AiDeepResearchRunModel';
 import { CommercialSlackAuthenticationModel } from '../../models/CommercialSlackAuthenticationModel';
 import { ProjectContextModel } from '../../models/ProjectContextModel';
-import { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
+import {
+    aiAgentMemoryDistillEventRunAt,
+    CommercialSchedulerClient,
+} from '../../scheduler/SchedulerClient';
 import { selectAgent } from '../ai/agents/agentSelector';
 import {
     DEFAULT_AGENT_MAX_STEPS,
@@ -1214,6 +1217,55 @@ export class AiAgentService extends BaseService {
             .catch((error) => {
                 Logger.error(
                     'Failed to enqueue AI agent review classifier job',
+                    error,
+                );
+            });
+    }
+
+    /**
+     * Event-driven distill: same triggers as the review classifier, debounced
+     * so a burst of thread activity coalesces via the per-thread jobKey. A
+     * feedback event forces a re-distill — feedback lands in the transcript
+     * without advancing the thread's activity watermark.
+     */
+    private enqueueMemoryDistillEvent(args: {
+        eventType: 'response_saved' | 'feedback_changed';
+        organizationUuid: string | null | undefined;
+        projectUuid: string | null | undefined;
+        threadUuid: string | null | undefined;
+        userUuid?: string | null;
+    }) {
+        const { organizationUuid, projectUuid, threadUuid } = args;
+        if (!organizationUuid || !projectUuid || !threadUuid) {
+            return;
+        }
+
+        const userUuid = args.userUuid ?? 'system';
+
+        // Same principal the distill job's own gate uses — the org setting
+        // decides; the flag fallback must not vary by requesting user.
+        void this.aiOrganizationSettingsService
+            .isAiAgentMemoryEnabled({ userUuid: 'system', organizationUuid })
+            .then(async (memoryEnabled) => {
+                if (!memoryEnabled) {
+                    return undefined;
+                }
+                return this.schedulerClient.aiAgentMemoryDistill(
+                    {
+                        organizationUuid,
+                        projectUuid,
+                        userUuid,
+                        threadUuid,
+                        ...(args.eventType === 'feedback_changed'
+                            ? { force: true }
+                            : {}),
+                    },
+                    aiAgentMemoryDistillEventRunAt(new Date()),
+                );
+            })
+            .catch((error) => {
+                Logger.error(
+                    'Failed to enqueue AI agent memory distill job',
                     error,
                 );
             });
@@ -6341,6 +6393,13 @@ export class AiAgentService extends BaseService {
             promptUuid: threadMessage.uuid,
             userUuid: user.userUuid,
         });
+        this.enqueueMemoryDistillEvent({
+            eventType: 'feedback_changed',
+            organizationUuid,
+            projectUuid: message.projectUuid,
+            threadUuid: message.threadUuid,
+            userUuid: user.userUuid,
+        });
     }
 
     async updateMessageSavedQuery(
@@ -9876,6 +9935,31 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         });
                 }
 
+                // Error-only updates add no distillable content — distill only
+                // after a successful terminal turn write.
+                if (
+                    aiAgentMemoryEnabled &&
+                    update.response !== undefined &&
+                    update.tokenUsage !== undefined
+                ) {
+                    void updatePromise
+                        .then(() => {
+                            this.enqueueMemoryDistillEvent({
+                                eventType: 'response_saved',
+                                organizationUuid: user.organizationUuid,
+                                projectUuid: prompt.projectUuid,
+                                threadUuid: prompt.threadUuid,
+                                userUuid: user.userUuid,
+                            });
+                        })
+                        .catch((error) => {
+                            Logger.error(
+                                'Failed to enqueue AI agent memory distill after response save',
+                                error,
+                            );
+                        });
+                }
+
                 return updateWithCitationTelemetryPromise;
             },
             trackEvent: (
@@ -10064,6 +10148,13 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             agentUuid: promptContext?.agentUuid,
             threadUuid: promptContext?.threadUuid,
             promptUuid,
+            userUuid: userId,
+        });
+        this.enqueueMemoryDistillEvent({
+            eventType: 'feedback_changed',
+            organizationUuid: promptContext?.organizationUuid,
+            projectUuid: promptContext?.projectUuid,
+            threadUuid: promptContext?.threadUuid,
             userUuid: userId,
         });
     }
@@ -12058,6 +12149,13 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     agentUuid: promptContext?.agentUuid,
                     threadUuid: promptContext?.threadUuid,
                     promptUuid,
+                    userUuid: body.user.id,
+                });
+                this.enqueueMemoryDistillEvent({
+                    eventType: 'feedback_changed',
+                    organizationUuid: promptContext?.organizationUuid,
+                    projectUuid: promptContext?.projectUuid,
+                    threadUuid: promptContext?.threadUuid,
                     userUuid: body.user.id,
                 });
             }

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -127,10 +127,13 @@ export type AiAgentEditDbtProjectPipelineJobPayload = TraceTaskBase & {
 
 export type AiAgentMemoryDistillJobPayload = TraceTaskBase & {
     threadUuid: UUID;
-    sweptUpdatedAt: string;
-    // Manual trigger only: bypass the watermark skip so an already-distilled
-    // thread re-distills. Optional because jobs enqueued before this field
-    // existed are still in the queue.
+    // Sweep/manual watermark. Event jobs derive it from the latest successful
+    // turn.
+    sweptUpdatedAt?: string;
+    // Bypass the watermark skip so an already-distilled thread re-distills:
+    // manual trigger, and feedback events (feedback lands in the transcript
+    // without advancing the thread's activity watermark). Optional because
+    // jobs enqueued before this field existed are still in the queue.
     force?: boolean;
 };
 


### PR DESCRIPTION
Memory distill was previously only reachable from a 3-hourly sweep cron with a 6h-idle heuristic, so a memory appeared hours after a conversation. This makes distill event-driven, triggered by the same events as the AI review classifier, from the same call sites in `AiAgentService`:

- `response_saved` — a successful terminal turn write enqueues a debounced distill (error-only updates are skipped).
- `feedback_changed` — web + Slack votes/feedback comments enqueue a distill with `force: true`, because feedback lands in the transcript without advancing the thread's activity watermark.

Details:

- Event jobs are debounced 3 min (`aiAgentMemoryDistillEventRunAt`) and coalesce via the existing per-thread jobKey, so a burst of turns or a rate-then-comment sequence collapses into one distill.
- `AiAgentMemoryDistillJobPayload.sweptUpdatedAt` is now optional: event jobs omit it and derive the watermark from the latest *successful* turn's creation time, filtering the transcript to turns at or before it. A distill firing while a follow-up turn is still in flight therefore never distills the unanswered prompt nor stamps the watermark past it — when the answer saves, its own event job advances the watermark and distills the full thread. Sweep/manual paths are unchanged (captured watermark).
- The 3h sweep cron is kept as backfill (lost jobs are maxAttempts 1; orgs that enable memory later).

Testing:

- Unit tests for the debounce helper, the event payload enqueue, and the three job-side watermark behaviors (event watermark resolution, watermark skip, forced feedback re-distill).
- Verified e2e locally: a downvote re-distilled an up-to-date thread's memory one debounce window later incorporating the feedback comment; a new agent turn produced a memory ~75s after the turn with no cron involvement.

Closes: [ZAP-726](https://linear.app/lightdash/issue/ZAP-726/as-a-user-i-want-memory-extraction-to-start-as-soon-as-i-open-a-new)


