### PR TITLE
fix(data-apps): align connection form field order

### DIFF
--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
@@ -196,18 +196,6 @@ export const ExternalConnectionForm: FC<Props> = ({
                 disabled={disabled}
             />
 
-            <Switch
-                label="Allow public images in linked apps"
-                description="App code can send data to this origin through image URLs. Enable only for trusted public image or tile hosts."
-                disabled={
-                    disabled ||
-                    (type !== 'none' && !form.values.allowBrowserImages)
-                }
-                {...form.getInputProps('allowBrowserImages', {
-                    type: 'checkbox',
-                })}
-            />
-
             <PathRulesField
                 label="Which paths can apps call?"
                 mode={form.values.pathMode}
@@ -226,6 +214,18 @@ export const ExternalConnectionForm: FC<Props> = ({
                     form.setFieldValue('allowDataAppBuilderLinking', value)
                 }
                 disabled={disabled}
+            />
+
+            <Switch
+                label="Allow public images in linked apps"
+                description="App code can send data to this origin through image URLs. Enable only for trusted public image or tile hosts."
+                disabled={
+                    disabled ||
+                    (type !== 'none' && !form.values.allowBrowserImages)
+                }
+                {...form.getInputProps('allowBrowserImages', {
+                    type: 'checkbox',
+                })}
             />
 
             <FormSection name="advanced" isOpen={isAdvancedOpen}>


### PR DESCRIPTION
## Summary

- move the existing “Allow public images in linked apps” switch to the bottom of the request-policy fields in the edit modal
- align the edit ordering with the create flow: methods → paths → link access → public images
- leave form state, validation, and submission behavior unchanged

## Why

The create and edit connection flows presented the same settings in different orders. This follow-up makes the edit modal consistent with the create wizard introduced around the builder-linking controls.

Follow-up to #27124.

## Validation

- frontend typecheck
- targeted frontend lint and formatting
- diff check
- repository pre-commit checks
