### PR TITLE
feat(ai): data-first redesign of deep research report body

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
@@ -1,6 +1,4 @@
 import {
-    getGroupByDimensions,
-    getWebAiChartConfig,
     type AiDeepResearchChartData,
     type ToolRunQueryArgs,
 } from '@lightdash/common';
@@ -11,18 +9,22 @@ import EmptyStateLoader from '../../../../../components/common/EmptyStateLoader'
 import InlineErrorState from '../../../../../components/common/InlineErrorState';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useInfiniteQueryResults } from '../../../../../hooks/useQueryResults';
-import { getOpenInExploreUrl } from '../../../../../utils/getOpenInExploreUrl';
 import { useDeepResearchChartLiveQuery } from '../../hooks/useDeepResearch';
 import AgentVisualizationFilters from '../ChatElements/AgentVisualizationFilters';
 import { AiVisualizationRenderer } from '../ChatElements/AiVisualizationRenderer';
 import { shouldDisplayVisualizationFilters } from '../ChatElements/AiVisualizationRenderer.utils';
 import styles from './DeepResearchReport.module.css';
+import {
+    buildDeepResearchVizConfig,
+    useDeepResearchOpenInExploreUrl,
+} from './useDeepResearchExploreUrl';
 
 type Props = {
     chartKey: string;
     chart: AiDeepResearchChartData;
     projectUuid: string;
     runUuid: string;
+    withExploreLink?: boolean;
 };
 
 export const DeepResearchChartTile = ({
@@ -30,6 +32,7 @@ export const DeepResearchChartTile = ({
     chart,
     projectUuid,
     runUuid,
+    withExploreLink = true,
 }: Props) => {
     const liveQuery = useDeepResearchChartLiveQuery({
         projectUuid,
@@ -42,59 +45,20 @@ export const DeepResearchChartTile = ({
         chart.title,
     );
 
-    const visualizationConfig = useMemo<ToolRunQueryArgs>(() => {
-        const metricQuery = chart.metricQuery;
-        return {
-            title: chart.title,
-            description: '',
-            queryConfig: {
-                exploreName: metricQuery.exploreName,
-                dimensions: metricQuery.dimensions,
-                metrics: metricQuery.metrics,
-                sorts: metricQuery.sorts.map((sort) => ({
-                    ...sort,
-                    nullsFirst: sort.nullsFirst ?? null,
-                })),
-                limit: metricQuery.limit,
-                customMetrics: null,
-                tableCalculations: null,
-                filters: null,
-            },
-            chartConfig: chart.chartConfig,
-        };
-    }, [chart]);
+    const visualizationConfig = useMemo<ToolRunQueryArgs>(
+        () => buildDeepResearchVizConfig(chart),
+        [chart],
+    );
 
     const liveError = liveQuery.error ?? liveResults.error;
     const isLoadingLive = liveQuery.isFetching || liveResults.isFetchingRows;
     const appliedFilters = chart.metricQuery.filters;
     const displayFilterPills =
         shouldDisplayVisualizationFilters(appliedFilters);
-    const openInExploreUrl = useMemo(() => {
-        const webChartConfig = getWebAiChartConfig({
-            vizConfig: visualizationConfig,
-            metricQuery: chart.metricQuery,
-            fieldsMap: chart.fields,
-            overrideChartType: chart.chartConfig.defaultVizType,
-        });
-        if (!webChartConfig.echartsConfig) {
-            return null;
-        }
-
-        const { pathname, search } = getOpenInExploreUrl({
-            metricQuery: chart.metricQuery,
-            projectUuid,
-            columnOrder: [
-                ...chart.metricQuery.dimensions,
-                ...chart.metricQuery.metrics,
-                ...chart.metricQuery.tableCalculations.map(
-                    (calculation) => calculation.name,
-                ),
-            ],
-            pivotColumns: getGroupByDimensions(webChartConfig),
-            chartConfig: webChartConfig.echartsConfig,
-        });
-        return `${pathname}?${search}`;
-    }, [chart, projectUuid, visualizationConfig]);
+    const openInExploreUrl = useDeepResearchOpenInExploreUrl(
+        chart,
+        projectUuid,
+    );
 
     return (
         <Box
@@ -102,7 +66,7 @@ export const DeepResearchChartTile = ({
             className={styles.chartTile}
             aria-label={chart.title}
         >
-            {openInExploreUrl ? (
+            {withExploreLink && openInExploreUrl ? (
                 <Group
                     className={styles.chartActions}
                     justify="flex-end"

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchExploreLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchExploreLink.tsx
@@ -1,0 +1,45 @@
+import { Anchor, Group } from '@mantine/core';
+import { IconExternalLink } from '@tabler/icons-react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useDeepResearchChartQuery } from '../../hooks/useDeepResearch';
+import styles from './DeepResearchReport.module.css';
+import { useDeepResearchOpenInExploreUrl } from './useDeepResearchExploreUrl';
+
+type Props = {
+    projectUuid: string;
+    runUuid: string;
+    queryUuid: string;
+};
+
+export const DeepResearchExploreLink = ({
+    projectUuid,
+    runUuid,
+    queryUuid,
+}: Props) => {
+    const chartQuery = useDeepResearchChartQuery({
+        projectUuid,
+        runUuid,
+        queryUuid,
+    });
+    const openInExploreUrl = useDeepResearchOpenInExploreUrl(
+        chartQuery.data,
+        projectUuid,
+    );
+    if (!chartQuery.data || !openInExploreUrl) {
+        return null;
+    }
+    return (
+        <Anchor
+            href={openInExploreUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.exploreLink}
+            aria-label={`Open ${chartQuery.data.title} in Explore`}
+        >
+            <Group component="span" gap={4} wrap="nowrap">
+                Open in Explore
+                <MantineIcon icon={IconExternalLink} size={13} />
+            </Group>
+        </Anchor>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
@@ -31,7 +31,8 @@ export const QueryBackedChart: FC<{
     projectUuid: string;
     runUuid: string;
     queryUuid: string;
-}> = ({ projectUuid, runUuid, queryUuid }) => {
+    withExploreLink?: boolean;
+}> = ({ projectUuid, runUuid, queryUuid, withExploreLink = true }) => {
     const chartQuery = useDeepResearchChartQuery({
         projectUuid,
         runUuid,
@@ -53,6 +54,7 @@ export const QueryBackedChart: FC<{
             chart={chartQuery.data}
             projectUuid={projectUuid}
             runUuid={runUuid}
+            withExploreLink={withExploreLink}
         />
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -137,16 +137,16 @@
     color: var(--mantine-color-indigo-light-color);
     font-size: 0.6875rem;
     font-weight: 700;
-    letter-spacing: 0.055em;
+    letter-spacing: 0.1em;
     line-height: 1.35;
     text-transform: uppercase;
 }
 
 .reportTitle {
-    font-size: clamp(1.45rem, 3vw, 1.85rem);
-    font-weight: 650;
-    letter-spacing: -0.025em;
-    line-height: 1.2;
+    font-size: clamp(1.6rem, 3vw, 2rem);
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    line-height: 1.15;
 }
 
 .executiveAnswer {
@@ -215,37 +215,49 @@
 }
 
 .structuredReport {
-    gap: clamp(3rem, 6vw, 5rem);
+    gap: 0;
 }
 
 .reportIntroduction {
-    max-width: 52rem;
+    padding-bottom: 2.5rem;
 }
 
 .reportIntroductionProse {
     color: var(--mantine-color-text);
     font-size: 1rem;
-    line-height: 1.75;
+    line-height: 1.7;
 }
 
 .reportFinding {
     display: grid;
-    gap: clamp(1.5rem, 3vw, 2.5rem);
-    padding-top: var(--mantine-spacing-xl);
+    gap: 1.25rem;
+    padding-block: 2.5rem;
     border-top: 1px solid var(--mantine-color-ldGray-2);
 }
 
 .reportFindingTitle {
-    max-width: 52rem;
-    font-size: clamp(1.15rem, 2vw, 1.35rem);
-    font-weight: 650;
-    letter-spacing: -0.02em;
+    font-size: clamp(1.05rem, 2vw, 1.1875rem);
+    font-weight: 700;
+    letter-spacing: -0.01em;
     line-height: 1.3;
     scroll-margin-top: var(--mantine-spacing-xl);
 }
 
+.exploreLink {
+    flex-shrink: 0;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    line-height: 1.3;
+    white-space: nowrap;
+}
+
 .reportEvidence {
     min-width: 0;
+    padding: 1.5rem 1.75rem 1rem;
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 0.75rem;
+    background: var(--mantine-color-body);
+    box-shadow: var(--mantine-shadow-subtle);
 
     .chartTile {
         height: 30rem;
@@ -255,15 +267,13 @@
 
 .reportNarrative {
     min-width: 0;
-    max-width: 52rem;
 }
 
-.reportProse,
-.reportConclusionProse {
+.reportProse {
     overflow-wrap: anywhere;
     color: var(--mantine-color-dimmed);
     font-size: 0.875rem;
-    line-height: 1.75;
+    line-height: 1.7;
 
     > :first-child {
         margin-top: 0;
@@ -276,20 +286,25 @@
 
 .reportConclusion {
     display: grid;
-    gap: var(--mantine-spacing-md);
-    max-width: 52rem;
-    padding: var(--mantine-spacing-xl);
-    border: 1px solid var(--mantine-color-ldGray-2);
-    border-radius: var(--mantine-radius-lg);
-    background: var(--mantine-color-ldGray-0);
+    gap: 1.25rem;
+    padding-top: 2.5rem;
+    border-top: 1px solid var(--mantine-color-ldGray-2);
     scroll-margin-top: var(--mantine-spacing-xl);
 }
 
-.reportConclusionTitle {
+.reportConclusionProse {
+    overflow-wrap: anywhere;
+    color: var(--mantine-color-text);
     font-size: 1rem;
-    font-weight: 700;
-    letter-spacing: -0.01em;
-    scroll-margin-top: var(--mantine-spacing-xl);
+    line-height: 1.7;
+
+    > :first-child {
+        margin-top: 0;
+    }
+
+    > :last-child {
+        margin-bottom: 0;
+    }
 }
 
 .chartTile {
@@ -411,12 +426,12 @@
         grid-template-columns: 1.25rem minmax(0, 1fr);
     }
 
-    .reportEvidence .chartTile {
-        height: 24rem;
+    .reportEvidence {
+        padding: 1rem 1rem 0.5rem;
     }
 
-    .reportConclusion {
-        padding: var(--mantine-spacing-lg);
+    .reportEvidence .chartTile {
+        height: 24rem;
     }
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -1,3 +1,4 @@
+import { type AiDeepResearchChartData } from '@lightdash/common';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
@@ -19,6 +20,39 @@ vi.mock('./DeepResearchChartTile', () => ({
         <div data-testid="deep-research-chart">{chart.title}</div>
     ),
 }));
+
+// The explore link resolves its URL from the full chart payload, so the
+// mocked chart query has to return a complete AiDeepResearchChartData.
+const chartData: AiDeepResearchChartData = {
+    source: 'warehouse',
+    title: 'Enterprise retention by incident exposure',
+    chartConfig: {
+        defaultVizType: 'line',
+        xAxisDimension: 'renewals_renewal_month',
+        yAxisMetrics: ['renewals_retention_rate'],
+        groupBy: null,
+        xAxisType: 'time',
+        stackBars: null,
+        lineType: 'line',
+        funnelDataInput: null,
+        xAxisLabel: 'Month',
+        yAxisLabel: 'Retention',
+        secondaryYAxisMetric: null,
+        secondaryYAxisLabel: null,
+    },
+    queryUuid: '7c4b40ba-79f8-4fd2-9c43-223eca8fa76f',
+    metricQuery: {
+        exploreName: 'renewals',
+        dimensions: ['renewals_renewal_month'],
+        metrics: ['renewals_retention_rate'],
+        sorts: [],
+        limit: 500,
+        filters: {},
+        tableCalculations: [],
+        additionalMetrics: [],
+    } as AiDeepResearchChartData['metricQuery'],
+    fields: {},
+};
 
 const renderReport = (onClose = vi.fn(), run = deepResearchRunFixture) =>
     renderWithProviders(
@@ -62,7 +96,7 @@ describe('DeepResearchReport', () => {
     it('renders the markdown as one flow with the chart between setup and interpretation', async () => {
         mocks.useChartQuery.mockReturnValue({
             isLoading: false,
-            data: { title: 'Enterprise retention by incident exposure' },
+            data: chartData,
         });
         renderReport();
 
@@ -104,7 +138,7 @@ describe('DeepResearchReport', () => {
     it('renders the generated title and chart-first findings', async () => {
         mocks.useChartQuery.mockReturnValue({
             isLoading: false,
-            data: { title: 'Enterprise retention by incident exposure' },
+            data: chartData,
         });
         renderReport(vi.fn(), {
             ...deepResearchRunFixture,

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReportContent.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReportContent.tsx
@@ -1,6 +1,7 @@
 import { type ParsedDeepResearchReport } from '@lightdash/common';
-import { Box, Stack, Title } from '@mantine/core';
+import { Box, Group, Stack, Title } from '@mantine/core';
 import { type FC, type ReactNode } from 'react';
+import { DeepResearchExploreLink } from './DeepResearchExploreLink';
 import { DeepResearchInlineMarkdown } from './DeepResearchInlineMarkdown';
 import {
     DeepResearchMarkdownReport,
@@ -45,9 +46,25 @@ export const DeepResearchReportContent: FC<Props> = ({
                     className={styles.reportFinding}
                     key={`${finding.title}-${index}`}
                 >
-                    <Title order={2} className={styles.reportFindingTitle}>
-                        <DeepResearchInlineMarkdown markdown={finding.title} />
-                    </Title>
+                    <Group
+                        justify="space-between"
+                        align="baseline"
+                        gap="md"
+                        wrap="nowrap"
+                    >
+                        <Title order={2} className={styles.reportFindingTitle}>
+                            <DeepResearchInlineMarkdown
+                                markdown={finding.title}
+                            />
+                        </Title>
+                        {finding.evidenceQueryUuid && !renderEvidence ? (
+                            <DeepResearchExploreLink
+                                projectUuid={projectUuid}
+                                runUuid={runUuid}
+                                queryUuid={finding.evidenceQueryUuid}
+                            />
+                        ) : null}
+                    </Group>
 
                     {finding.evidenceQueryUuid ? (
                         <Box className={styles.reportEvidence}>
@@ -58,6 +75,7 @@ export const DeepResearchReportContent: FC<Props> = ({
                                     projectUuid={projectUuid}
                                     runUuid={runUuid}
                                     queryUuid={finding.evidenceQueryUuid}
+                                    withExploreLink={false}
                                 />
                             )}
                         </Box>
@@ -73,7 +91,7 @@ export const DeepResearchReportContent: FC<Props> = ({
             ))}
 
             <Box component="section" className={styles.reportConclusion}>
-                <Title order={2} className={styles.reportConclusionTitle}>
+                <Title order={2} className={styles.reportFindingTitle}>
                     Conclusion
                 </Title>
                 {renderMarkdown(

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/useDeepResearchExploreUrl.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/useDeepResearchExploreUrl.ts
@@ -1,0 +1,66 @@
+import {
+    getGroupByDimensions,
+    getWebAiChartConfig,
+    type AiDeepResearchChartData,
+    type ToolRunQueryArgs,
+} from '@lightdash/common';
+import { useMemo } from 'react';
+import { getOpenInExploreUrl } from '../../../../../utils/getOpenInExploreUrl';
+
+export const buildDeepResearchVizConfig = (
+    chart: AiDeepResearchChartData,
+): ToolRunQueryArgs => {
+    const metricQuery = chart.metricQuery;
+    return {
+        title: chart.title,
+        description: '',
+        queryConfig: {
+            exploreName: metricQuery.exploreName,
+            dimensions: metricQuery.dimensions,
+            metrics: metricQuery.metrics,
+            sorts: metricQuery.sorts.map((sort) => ({
+                ...sort,
+                nullsFirst: sort.nullsFirst ?? null,
+            })),
+            limit: metricQuery.limit,
+            customMetrics: null,
+            tableCalculations: null,
+            filters: null,
+        },
+        chartConfig: chart.chartConfig,
+    };
+};
+
+export const useDeepResearchOpenInExploreUrl = (
+    chart: AiDeepResearchChartData | undefined,
+    projectUuid: string,
+) =>
+    useMemo(() => {
+        if (!chart) {
+            return null;
+        }
+        const webChartConfig = getWebAiChartConfig({
+            vizConfig: buildDeepResearchVizConfig(chart),
+            metricQuery: chart.metricQuery,
+            fieldsMap: chart.fields,
+            overrideChartType: chart.chartConfig.defaultVizType,
+        });
+        if (!webChartConfig.echartsConfig) {
+            return null;
+        }
+
+        const { pathname, search } = getOpenInExploreUrl({
+            metricQuery: chart.metricQuery,
+            projectUuid,
+            columnOrder: [
+                ...chart.metricQuery.dimensions,
+                ...chart.metricQuery.metrics,
+                ...chart.metricQuery.tableCalculations.map(
+                    (calculation) => calculation.name,
+                ),
+            ],
+            pivotColumns: getGroupByDimensions(webChartConfig),
+            chartConfig: webChartConfig.echartsConfig,
+        });
+        return `${pathname}?${search}`;
+    }, [chart, projectUuid]);

--- a/packages/frontend/src/stories/DeepResearchReportContent.stories.tsx
+++ b/packages/frontend/src/stories/DeepResearchReportContent.stories.tsx
@@ -3,7 +3,6 @@ import {
     Box,
     Center,
     Loader,
-    Paper,
     Stack,
     Text,
     useMantineTheme,
@@ -39,39 +38,37 @@ const SimulatedChart = () => {
     const bars = [42, 68, 52, 86, 73, 94];
 
     return (
-        <Paper withBorder radius="md" p="lg" h="100%">
-            <Stack h="100%" gap="lg">
-                <Text fw={650}>Renewal rate by incident exposure</Text>
-                <Box
-                    role="img"
-                    aria-label="Simulated renewal rate chart"
-                    style={{
-                        display: 'flex',
-                        alignItems: 'end',
-                        gap: theme.spacing.md,
-                        flex: 1,
-                        minHeight: 220,
-                        padding: `${theme.spacing.lg} ${theme.spacing.md}`,
-                        borderBottom: `1px solid ${theme.colors.gray[3]}`,
-                    }}
-                >
-                    {bars.map((height, index) => (
-                        <Box
-                            key={index}
-                            style={{
-                                width: '100%',
-                                height: `${height}%`,
-                                borderRadius: `${theme.radius.sm} ${theme.radius.sm} 0 0`,
-                                background:
-                                    index > 3
-                                        ? theme.colors.indigo[6]
-                                        : theme.colors.indigo[3],
-                            }}
-                        />
-                    ))}
-                </Box>
-            </Stack>
-        </Paper>
+        <Stack h="100%" gap="lg">
+            <Text fw={650}>Renewal rate by incident exposure</Text>
+            <Box
+                role="img"
+                aria-label="Simulated renewal rate chart"
+                style={{
+                    display: 'flex',
+                    alignItems: 'end',
+                    gap: theme.spacing.md,
+                    flex: 1,
+                    minHeight: 220,
+                    padding: `${theme.spacing.lg} ${theme.spacing.md}`,
+                    borderBottom: `1px solid ${theme.colors.gray[3]}`,
+                }}
+            >
+                {bars.map((height, index) => (
+                    <Box
+                        key={index}
+                        style={{
+                            width: '100%',
+                            height: `${height}%`,
+                            borderRadius: `${theme.radius.sm} ${theme.radius.sm} 0 0`,
+                            background:
+                                index > 3
+                                    ? theme.colors.indigo[6]
+                                    : theme.colors.indigo[3],
+                        }}
+                    />
+                ))}
+            </Box>
+        </Stack>
     );
 };
 
@@ -106,16 +103,14 @@ export const ResponsiveReport: Story = {
 export const LoadingEvidence: Story = {
     args: {
         renderEvidence: () => (
-            <Paper withBorder radius="md" h="100%">
-                <Center h="100%">
-                    <Stack align="center" gap="sm">
-                        <Loader size="sm" />
-                        <Text size="sm" c="dimmed">
-                            Loading live chart data
-                        </Text>
-                    </Stack>
-                </Center>
-            </Paper>
+            <Center mih={220}>
+                <Stack align="center" gap="sm">
+                    <Loader size="sm" />
+                    <Text size="sm" c="dimmed">
+                        Loading live chart data
+                    </Text>
+                </Stack>
+            </Center>
         ),
     },
 };


### PR DESCRIPTION
Closes [PROD-9802](https://linear.app/lightdash/issue/PROD-9802/redesign-deep-research-report-body-to-a-data-first-layout)

## Summary

Repolish of the deep research report body (the view behind *Back to chat*) from a design handoff: charts lead each section, text plays a supporting role, with a three-level text hierarchy and a consistent section rhythm. Presentation-only — no data model, header, or contents-sidebar changes, and the markdown fallback path renders exactly as before.

### Report body (structured path)

- **Heading row** — each finding renders its title and a baseline-aligned "Open in Explore ↗" link on one row; the link moved out of the chart tile
- **Chart card** — the evidence chart sits in a white card (1px `ldGray-2` border, 12px radius, `subtle` shadow, 24/28px padding); the ECharts renderer and its legend are untouched
- **Section rhythm** — every section separated by a 1px rule with symmetric 40px spacing above and below
- **Text hierarchy** — 32px/700 report title and 19px/700 section headings → 16px dark lead intro and conclusion → 14px muted chart descriptions
- **Conclusion** — loses its boxed grey card; now a normal section (heading + lead paragraph) after the last rule

```
DEEP RESEARCH  [Beta]           eyebrow, brand purple
Report title                    32px / 700
Intro paragraph                 lead: 16px, dark, lh 1.7
──────────────────────────      1px rule, 40px above / below
Finding title      Open in Explore ↗
┌──────────────────────────┐
│ chart card (ECharts)     │    border, 12px radius, subtle shadow
└──────────────────────────┘
Supporting paragraph            14px, muted, lh 1.7
────────────────────────── (×N findings, same rhythm)
Conclusion
Closing paragraph               styled as lead
```

`DeepResearchExploreLink` is a new component that resolves the Explore URL from the same chart query the tile uses (shared React Query cache, no extra request); the URL/viz-config builders moved from `DeepResearchChartTile` into `useDeepResearchExploreUrl.ts`.

## Regression analysis

- **`DeepResearchChartTile` / `QueryBackedChart`** — new optional `withExploreLink` prop, defaults to `true`, so the markdown fallback path (failed parse) keeps its in-tile link and is visually unchanged.
- **Contents rail scroll-spy** — heading stamping matches rendered `h2`s to parsed markdown headings by index; the conclusion keeps a real visible `h2`, so the count still lines up and TOC click/highlight behave as before.
- **Removed** — the conclusion's grey `Paper`-style card and its mobile padding override; superseded by the shared section rhythm.
- No backend/API surface touched.

## Test plan

- [x] `pnpm -F frontend typecheck` and oxlint clean
- [x] Structured report in local dev: eyebrow/title/lead intro, per-finding heading row with working "Open in Explore" (URL verified against a live run), chart cards, muted supporting paragraphs, conclusion section
- [x] Contents rail: scroll-spy highlights each section including Conclusion; clicking every entry scrolls to it
- [x] Markdown fallback (truncated report document): unchanged rendering, in-tile Explore link still present
- [x] Storybook stories updated to the new layout (mock evidence no longer double-wraps in a card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)