### PR TITLE
fix(ai): clarify failed deep research restarts

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
@@ -341,7 +341,7 @@ The full report continues here.`,
         expect(onReviewPermissions).toHaveBeenCalledOnce();
     });
 
-    it('offers to run failed research again when the thread is idle', async () => {
+    it('explains that starting over does not reuse previous queries', async () => {
         const user = userEvent.setup();
         const onRunAgain = vi.fn();
         renderWithProviders(
@@ -357,9 +357,13 @@ The full report continues here.`,
             />,
         );
 
-        await user.click(
-            screen.getByRole('button', { name: 'Run research again' }),
-        );
+        expect(
+            screen.getByText(
+                "Starting over creates a new research run. Previous queries won't be reused.",
+            ),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Start over' }));
         expect(onRunAgain).toHaveBeenCalledOnce();
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -345,6 +345,10 @@ export const DeepResearchRunCard = ({
                                 Any completed queries and findings are saved
                                 below.
                             </Text>
+                            <Text size="sm">
+                                Starting over creates a new research run.
+                                Previous queries won&apos;t be reused.
+                            </Text>
                             {canRunAgain && onRunAgain && (
                                 <Button
                                     size="xs"
@@ -352,7 +356,7 @@ export const DeepResearchRunCard = ({
                                     w="fit-content"
                                     onClick={onRunAgain}
                                 >
-                                    Run research again
+                                    Start over
                                 </Button>
                             )}
                         </Stack>


### PR DESCRIPTION
Closes: N/A

## Description:

Clarifies that retrying failed Deep Research starts a new run and does not reuse previous queries. The existing restart callback is unchanged.

Before:
- Action: Run research again
- Reuse behavior: unstated

After:
- Action: Start over
- Reuse behavior: explicitly says previous queries are not reused

## Test plan

- `pnpm -F frontend test --run src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx`
- `pnpm -F frontend lint`
- `git diff --check`