### PR TITLE
fix(data-apps): allow viewers to run published custom SQL

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.test.ts
+++ b/packages/backend/src/controllers/v2/QueryController.test.ts
@@ -1,0 +1,41 @@
+import { LightdashAppPreviewTokenHeader } from '@lightdash/common';
+import express from 'express';
+import { QueryController } from './QueryController';
+
+describe('QueryController', () => {
+    it('forwards the signed Data App preview token to metric-query execution', async () => {
+        const executeAsyncMetricQuery = vi.fn().mockResolvedValue({
+            queryUuid: 'query-uuid',
+        });
+        const controller = new QueryController({
+            getAsyncQueryService: () => ({ executeAsyncMetricQuery }),
+        } as unknown as ConstructorParameters<typeof QueryController>[0]);
+        controller.setStatus = vi.fn();
+        const req = {
+            account: {},
+            header: vi.fn(),
+            headers: {
+                [LightdashAppPreviewTokenHeader.toLowerCase()]:
+                    'signed-preview-token',
+            },
+        } as unknown as express.Request;
+
+        await controller.executeAsyncMetricQuery(
+            {
+                query: {
+                    exploreName: 'orders',
+                    dimensions: [],
+                    metrics: [],
+                },
+            } as never,
+            'project-uuid',
+            req,
+        );
+
+        expect(executeAsyncMetricQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                dataAppPreviewToken: 'signed-preview-token',
+            }),
+        );
+    });
+});

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -14,6 +14,7 @@ import {
     isExecuteAsyncDashboardSqlChartByUuidParams,
     isExecuteAsyncSqlChartByUuidParams,
     isJwtUser,
+    LightdashAppPreviewTokenHeader,
     LightdashSignedDownloadHeader,
     PersistentDownloadFileAccessMode,
     QueryExecutionContext,
@@ -184,6 +185,12 @@ export class QueryController extends BaseController {
     ): Promise<ApiSuccess<ApiExecuteAsyncMetricQueryResults>> {
         this.setStatus(200);
         const context = body.context ?? getContextFromHeader(req);
+        const previewTokenHeader =
+            req.headers[LightdashAppPreviewTokenHeader.toLowerCase()];
+        const dataAppPreviewToken =
+            typeof previewTokenHeader === 'string'
+                ? previewTokenHeader
+                : undefined;
 
         const metricQuery: MetricQuery = {
             exploreName: body.query.exploreName,
@@ -214,6 +221,7 @@ export class QueryController extends BaseController {
                 parameters: body.parameters,
                 pivotConfiguration: body.pivotConfiguration,
                 dashboardFilters: body.dashboardFilters,
+                dataAppPreviewToken,
             });
 
         return {

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -865,6 +865,10 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     // silent no-op in EE builds.
                     getAppGenerateService: () =>
                         repository.getAppGenerateService<AppGenerateService>(),
+                    getDataAppCustomSqlProvenance: (args) =>
+                        repository
+                            .getAppGenerateService<AppGenerateService>()
+                            .getCustomSqlProvenance(args),
                     getAiAgentService: () =>
                         repository.getAiAgentService<AiAgentService>(),
                     onProjectCreated: ({
@@ -1029,6 +1033,10 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getSpacePermissionService(),
                     organizationSettingsModel:
                         models.getOrganizationSettingsModel(),
+                    getDataAppCustomSqlProvenance: (args) =>
+                        repository
+                            .getAppGenerateService<AppGenerateService>()
+                            .getCustomSqlProvenance(args),
                 }),
             cacheService: ({ models, context, clients }) =>
                 new CommercialCacheService({

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -3,6 +3,8 @@ import {
     DATA_REFERENCE_EXTRACTOR_VERSION,
     FeatureFlags,
     ForbiddenError,
+    getCustomSqlFieldKey,
+    LIGHTDASH_APP_PREVIEW_TOKEN_MAX_AGE_SECONDS,
     ParameterError,
     TooManyRequestsError,
     type DataAppCode,
@@ -1112,6 +1114,11 @@ describe('AppGenerateService.getCustomSqlProvenance', () => {
             organizationUuid,
             PROJECT_UUID,
         );
+    const emptyProvenance = {
+        tableCalculations: new Set<string>(),
+        customDimensions: new Set<string>(),
+        additionalMetrics: new Set<string>(),
+    };
 
     it('returns exact SQL from the signed, viewable app version', async () => {
         const { service, appModel } = buildService();
@@ -1156,10 +1163,115 @@ describe('AppGenerateService.getCustomSqlProvenance', () => {
             }),
         ).resolves.toEqual({
             tableCalculations: new Set(['SUM(1)']),
-            customDimensions: new Set(['orders\0UPPER(${name})']),
-            additionalMetrics: new Set(['orders\0SUM(${amount})']),
+            customDimensions: new Set([
+                getCustomSqlFieldKey({
+                    table: 'orders',
+                    sql: 'UPPER(${name})',
+                }),
+            ]),
+            additionalMetrics: new Set([
+                getCustomSqlFieldKey({
+                    table: 'orders',
+                    sql: 'SUM(${amount})',
+                }),
+            ]),
         });
         expect(appModel.getVersion).toHaveBeenCalledWith(NEW_APP_UUID, 2);
+    });
+
+    it('fails closed after the signed capability expires', async () => {
+        vi.useFakeTimers();
+        try {
+            const now = new Date('2026-08-11T08:00:00Z');
+            vi.setSystemTime(now);
+            const token = previewToken();
+            vi.setSystemTime(
+                new Date(
+                    now.getTime() +
+                        (LIGHTDASH_APP_PREVIEW_TOKEN_MAX_AGE_SECONDS + 1) *
+                            1_000,
+                ),
+            );
+            const { service, appModel } = buildService();
+
+            await expect(
+                service.getCustomSqlProvenance({
+                    account,
+                    projectUuid: PROJECT_UUID,
+                    organizationUuid,
+                    exploreName: 'orders',
+                    previewToken: token,
+                }),
+            ).resolves.toEqual(emptyProvenance);
+            expect(appModel.findApp).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('does not expose SQL from a non-ready version', async () => {
+        const { service, appModel } = buildService();
+        appModel.findApp.mockResolvedValue({
+            app_id: NEW_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            organization_uuid: organizationUuid,
+            space_uuid: 'space-uuid',
+            created_by_user_uuid: 'author-uuid',
+        });
+        appModel.getVersion.mockResolvedValue({
+            status: 'failed',
+            data_references: null,
+        });
+
+        await expect(
+            service.getCustomSqlProvenance({
+                account,
+                projectUuid: PROJECT_UUID,
+                organizationUuid,
+                exploreName: 'orders',
+                previewToken: previewToken(),
+            }),
+        ).resolves.toEqual(emptyProvenance);
+    });
+
+    it('does not expose SQL from another explore', async () => {
+        const { service, appModel } = buildService();
+        appModel.findApp.mockResolvedValue({
+            app_id: NEW_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            organization_uuid: organizationUuid,
+            space_uuid: 'space-uuid',
+            created_by_user_uuid: 'author-uuid',
+        });
+        appModel.getVersion.mockResolvedValue({
+            status: 'ready',
+            data_references: {
+                extractorVersion: DATA_REFERENCE_EXTRACTOR_VERSION,
+                references: [
+                    {
+                        kind: 'query',
+                        explore: 'orders',
+                        customSql: {
+                            tableCalculations: ['SUM(1)'],
+                            customDimensions: [],
+                            additionalMetrics: [],
+                        },
+                    },
+                ],
+                parseErrors: [],
+                stats: {},
+            },
+        });
+
+        await expect(
+            service.getCustomSqlProvenance({
+                account,
+                projectUuid: PROJECT_UUID,
+                organizationUuid,
+                exploreName: 'customers',
+                previewToken: previewToken(),
+            }),
+        ).resolves.toEqual(emptyProvenance);
     });
 
     it('rejects a token minted for another user before loading the app', async () => {
@@ -1174,9 +1286,7 @@ describe('AppGenerateService.getCustomSqlProvenance', () => {
                 previewToken: previewToken('another-user'),
             }),
         ).resolves.toEqual({
-            tableCalculations: new Set(),
-            customDimensions: new Set(),
-            additionalMetrics: new Set(),
+            ...emptyProvenance,
         });
         expect(appModel.findApp).not.toHaveBeenCalled();
     });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -1,5 +1,6 @@
 import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import {
+    DATA_REFERENCE_EXTRACTOR_VERSION,
     FeatureFlags,
     ForbiddenError,
     ParameterError,
@@ -11,6 +12,7 @@ import {
 import { createHash } from 'node:crypto';
 import { Readable } from 'node:stream';
 import { extract as tarExtract, pack as tarPack } from 'tar-stream';
+import { mintPreviewToken } from '../../../routers/appPreviewToken';
 import { AppGenerateService } from './AppGenerateService';
 import {
     TEMPLATE_DEPENDENCIES,
@@ -114,6 +116,17 @@ const makeDeps = (
 
 const s3SendSpy = vi.fn().mockResolvedValue({});
 
+const makeSingleSourceTar = async (content: string): Promise<Buffer> =>
+    new Promise((resolve, reject) => {
+        const packer = tarPack();
+        const chunks: Buffer[] = [];
+        packer.on('data', (chunk: Buffer) => chunks.push(chunk));
+        packer.on('end', () => resolve(Buffer.concat(chunks)));
+        packer.on('error', reject);
+        packer.entry({ name: 'src/App.tsx' }, content);
+        packer.finalize();
+    });
+
 function buildService(
     opts: {
         customDependenciesOrgEnabled?: boolean;
@@ -130,6 +143,7 @@ function buildService(
         }),
         createVersion: vi.fn().mockResolvedValue({ version: 1 }),
         getLatestVersion: vi.fn().mockResolvedValue(null),
+        getVersion: vi.fn().mockResolvedValue(null),
         countInProgressVersionsForProject: vi.fn().mockResolvedValue(0),
         updateVersionDataReferences: vi.fn().mockResolvedValue(undefined),
         updateApp: vi.fn().mockResolvedValue({}),
@@ -172,6 +186,11 @@ function buildService(
     };
 
     const lightdashConfig = {
+        lightdashSecrets: {
+            active: 'test-lightdash-secret',
+            fallbacks: [],
+            all: ['test-lightdash-secret'],
+        },
         appRuntime: {
             dependencyRegistryHosts: ['registry.npmjs.org'],
             dependencyMinReleaseAgeDays: 0,
@@ -326,7 +345,7 @@ describe('AppGenerateService.importAppCode', () => {
         });
     });
 
-    it('persists extracted references without the extractor version', async () => {
+    it('persists extracted references with the extractor version', async () => {
         const { service, appModel } = buildService();
         appModel.findApp.mockResolvedValue(undefined);
 
@@ -346,6 +365,7 @@ describe('AppGenerateService.importAppCode', () => {
             NEW_APP_UUID,
             1,
             {
+                extractorVersion: DATA_REFERENCE_EXTRACTOR_VERSION,
                 references: [
                     expect.objectContaining({
                         kind: 'query',
@@ -362,9 +382,6 @@ describe('AppGenerateService.importAppCode', () => {
                 },
             },
         );
-        expect(
-            appModel.updateVersionDataReferences.mock.calls[0][2],
-        ).not.toHaveProperty('extractorVersion');
     });
 
     it('append mode: appends version 5 when latest is 4 and enqueues build', async () => {
@@ -980,6 +997,269 @@ describe('AppGenerateService.importAppCode', () => {
         });
 
         expect(entryNames).toEqual(['src/App.jsx']);
+    });
+});
+
+describe('AppGenerateService.getVersionDataReferences', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('refreshes legacy ready-version provenance from its stored source', async () => {
+        const { service, appModel } = buildService();
+        appModel.getVersion.mockResolvedValue({
+            status: 'ready',
+            data_references: { references: [], parseErrors: [], stats: {} },
+        });
+        const sourceTar = await makeSingleSourceTar(`
+            import { query } from '@lightdash/query-sdk';
+            query('orders').tableCalculations([
+                { name: 'total', displayName: 'Total', sql: 'SUM(1)' },
+            ]);
+        `);
+        s3SendSpy.mockResolvedValue({ Body: Readable.from([sourceTar]) });
+
+        const result = await service.getVersionDataReferences(NEW_APP_UUID, 2);
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                extractorVersion: DATA_REFERENCE_EXTRACTOR_VERSION,
+                references: [
+                    expect.objectContaining({
+                        explore: 'orders',
+                        customSql: expect.objectContaining({
+                            tableCalculations: ['SUM(1)'],
+                        }),
+                    }),
+                ],
+            }),
+        );
+        expect(appModel.updateVersionDataReferences).toHaveBeenCalledWith(
+            NEW_APP_UUID,
+            2,
+            result,
+        );
+    });
+
+    it('does not expose provenance from a non-ready version', async () => {
+        const { service, appModel } = buildService();
+        appModel.getVersion.mockResolvedValue({
+            status: 'failed',
+            data_references: null,
+        });
+
+        await expect(
+            service.getVersionDataReferences(NEW_APP_UUID, 2),
+        ).resolves.toBeNull();
+        expect(s3SendSpy).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when legacy provenance cannot be refreshed', async () => {
+        const { service, appModel } = buildService();
+        appModel.getVersion.mockResolvedValue({
+            status: 'ready',
+            data_references: null,
+        });
+        s3SendSpy.mockRejectedValue(new Error('source unavailable'));
+
+        await expect(
+            service.getVersionDataReferences(NEW_APP_UUID, 2),
+        ).resolves.toBeNull();
+        expect(appModel.updateVersionDataReferences).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates concurrent legacy provenance refreshes', async () => {
+        const { service, appModel } = buildService();
+        appModel.getVersion.mockResolvedValue({
+            status: 'ready',
+            data_references: null,
+        });
+        const sourceTar = await makeSingleSourceTar(`
+            import { query } from '@lightdash/query-sdk';
+            query('orders').tableCalculations([
+                { name: 'total', displayName: 'Total', sql: 'SUM(1)' },
+            ]);
+        `);
+        s3SendSpy.mockResolvedValue({ Body: Readable.from([sourceTar]) });
+
+        const [first, second] = await Promise.all([
+            service.getVersionDataReferences(NEW_APP_UUID, 2),
+            service.getVersionDataReferences(NEW_APP_UUID, 2),
+        ]);
+
+        expect(first).toEqual(second);
+        expect(s3SendSpy).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('AppGenerateService.getCustomSqlProvenance', () => {
+    const organizationUuid = PROJECT_ORG_UUID;
+    const account = {
+        isRegisteredUser: () => true,
+        user: { id: USER_UUID },
+    } as never;
+
+    const previewToken = (userUuid = USER_UUID) =>
+        mintPreviewToken(
+            {
+                active: 'test-lightdash-secret',
+                fallbacks: [],
+                all: ['test-lightdash-secret'],
+            },
+            NEW_APP_UUID,
+            2,
+            userUuid,
+            organizationUuid,
+            PROJECT_UUID,
+        );
+
+    it('returns exact SQL from the signed, viewable app version', async () => {
+        const { service, appModel } = buildService();
+        appModel.findApp.mockResolvedValue({
+            app_id: NEW_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            organization_uuid: organizationUuid,
+            space_uuid: 'space-uuid',
+            created_by_user_uuid: 'author-uuid',
+        });
+        appModel.getVersion.mockResolvedValue({
+            status: 'ready',
+            data_references: {
+                extractorVersion: DATA_REFERENCE_EXTRACTOR_VERSION,
+                references: [
+                    {
+                        kind: 'query',
+                        explore: 'orders',
+                        customSql: {
+                            tableCalculations: ['SUM(1)'],
+                            customDimensions: [
+                                { table: 'orders', sql: 'UPPER(${name})' },
+                            ],
+                            additionalMetrics: [
+                                { table: 'orders', sql: 'SUM(${amount})' },
+                            ],
+                        },
+                    },
+                ],
+                parseErrors: [],
+                stats: {},
+            },
+        });
+
+        await expect(
+            service.getCustomSqlProvenance({
+                account,
+                projectUuid: PROJECT_UUID,
+                organizationUuid,
+                exploreName: 'orders',
+                previewToken: previewToken(),
+            }),
+        ).resolves.toEqual({
+            tableCalculations: new Set(['SUM(1)']),
+            customDimensions: new Set(['orders\0UPPER(${name})']),
+            additionalMetrics: new Set(['orders\0SUM(${amount})']),
+        });
+        expect(appModel.getVersion).toHaveBeenCalledWith(NEW_APP_UUID, 2);
+    });
+
+    it('rejects a token minted for another user before loading the app', async () => {
+        const { service, appModel } = buildService();
+
+        await expect(
+            service.getCustomSqlProvenance({
+                account,
+                projectUuid: PROJECT_UUID,
+                organizationUuid,
+                exploreName: 'orders',
+                previewToken: previewToken('another-user'),
+            }),
+        ).resolves.toEqual({
+            tableCalculations: new Set(),
+            customDimensions: new Set(),
+            additionalMetrics: new Set(),
+        });
+        expect(appModel.findApp).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        {
+            name: 'project',
+            organizationUuid,
+            projectUuid: 'another-project',
+        },
+        {
+            name: 'organization',
+            organizationUuid: 'another-organization',
+            projectUuid: PROJECT_UUID,
+        },
+    ])('rejects a token minted for another $name', async (tokenScope) => {
+        const { service, appModel } = buildService();
+        const token = mintPreviewToken(
+            {
+                active: 'test-lightdash-secret',
+                fallbacks: [],
+                all: ['test-lightdash-secret'],
+            },
+            NEW_APP_UUID,
+            2,
+            USER_UUID,
+            tokenScope.organizationUuid,
+            tokenScope.projectUuid,
+        );
+
+        await expect(
+            service.getCustomSqlProvenance({
+                account,
+                projectUuid: PROJECT_UUID,
+                organizationUuid,
+                exploreName: 'orders',
+                previewToken: token,
+            }),
+        ).resolves.toEqual({
+            tableCalculations: new Set(),
+            customDimensions: new Set(),
+            additionalMetrics: new Set(),
+        });
+        expect(appModel.findApp).not.toHaveBeenCalled();
+    });
+
+    it('does not expose SQL when the caller cannot view the app', async () => {
+        const { service, appModel } = buildService();
+        appModel.findApp.mockResolvedValue({
+            app_id: NEW_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            organization_uuid: organizationUuid,
+            space_uuid: 'space-uuid',
+            created_by_user_uuid: 'author-uuid',
+        });
+        vi.mocked(
+            (
+                service as unknown as {
+                    createAuditedAbility: () => {
+                        can: () => boolean;
+                        cannot: () => boolean;
+                    };
+                }
+            ).createAuditedAbility,
+        ).mockReturnValue({
+            can: () => false,
+            cannot: () => true,
+        });
+
+        await expect(
+            service.getCustomSqlProvenance({
+                account,
+                projectUuid: PROJECT_UUID,
+                organizationUuid,
+                exploreName: 'orders',
+                previewToken: previewToken(),
+            }),
+        ).resolves.toEqual({
+            tableCalculations: new Set(),
+            customDimensions: new Set(),
+            additionalMetrics: new Set(),
+        });
+        expect(appModel.getVersion).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -21,6 +21,7 @@ import {
     checkThemeLimits,
     DATA_APP_CLAUDE_MODELS,
     DATA_APP_VIZ_TEMPLATE,
+    DATA_REFERENCE_EXTRACTOR_VERSION,
     dataAppVizJsonSchema,
     dataAppVizSchema,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
@@ -48,6 +49,7 @@ import {
     TooManyRequestsError,
     validateDataAppCode,
     validateDataAppDependencies,
+    type Account,
     type AnonymousAccount,
     type ApiOrganizationDesign,
     type AppBuildFromSourceJobPayload,
@@ -144,7 +146,10 @@ import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { ProjectParametersModel } from '../../../models/ProjectParametersModel';
 import { SavedChartModel } from '../../../models/SavedChartModel';
 import { SpaceModel } from '../../../models/SpaceModel';
-import { mintPreviewToken } from '../../../routers/appPreviewToken';
+import {
+    mintPreviewToken,
+    verifyPreviewTokenClaims,
+} from '../../../routers/appPreviewToken';
 import { BaseService } from '../../../services/BaseService';
 import type { CoderService } from '../../../services/CoderService/CoderService';
 import type { DashboardService } from '../../../services/DashboardService/DashboardService';
@@ -482,6 +487,11 @@ export class AppGenerateService extends BaseService {
 
     // Lazily built from config on first use; memoized for the service lifetime.
     private sandboxManager: SandboxManager | undefined;
+
+    private readonly dataReferenceRefreshes = new Map<
+        string,
+        Promise<PersistedDataAppDataReferences | null>
+    >();
 
     constructor({
         lightdashConfig,
@@ -9379,10 +9389,157 @@ export class AppGenerateService extends BaseService {
             })),
         );
         return {
+            extractorVersion: extracted.extractorVersion,
             references: extracted.references,
             parseErrors: extracted.parseErrors,
             stats: extracted.stats,
         };
+    }
+
+    private async refreshVersionDataReferences(
+        appUuid: string,
+        version: number,
+    ): Promise<PersistedDataAppDataReferences | null> {
+        try {
+            const { client, bucket } = this.getS3Client();
+            const sourceTar = await readS3ObjectAsBuffer(
+                client,
+                bucket,
+                `${versionPrefix(appUuid, version)}source.tar`,
+            );
+            const files = await AppGenerateService.extractTarFiles(sourceTar);
+            const dataReferences =
+                AppGenerateService.extractPersistedDataReferences(files);
+            await this.persistVersionDataReferences(
+                appUuid,
+                version,
+                dataReferences,
+            );
+            return dataReferences;
+        } catch (error) {
+            this.logger.warn(
+                `App ${appUuid}: failed to refresh data references for version ${version}: ${getErrorMessage(error)}`,
+            );
+            return null;
+        }
+    }
+
+    async getVersionDataReferences(
+        appUuid: string,
+        version: number,
+    ): Promise<PersistedDataAppDataReferences | null> {
+        const versionRow = await this.appModel.getVersion(appUuid, version);
+        if (!versionRow || versionRow.status !== 'ready') return null;
+        if (
+            versionRow.data_references?.extractorVersion ===
+            DATA_REFERENCE_EXTRACTOR_VERSION
+        ) {
+            return versionRow.data_references;
+        }
+
+        const key = `${appUuid}:${version}`;
+        const existingRefresh = this.dataReferenceRefreshes.get(key);
+        if (existingRefresh) return existingRefresh;
+
+        const refresh = this.refreshVersionDataReferences(appUuid, version);
+        this.dataReferenceRefreshes.set(key, refresh);
+        try {
+            return await refresh;
+        } finally {
+            this.dataReferenceRefreshes.delete(key);
+        }
+    }
+
+    async getCustomSqlProvenance({
+        account,
+        projectUuid,
+        organizationUuid,
+        exploreName,
+        previewToken,
+    }: {
+        account: Account;
+        projectUuid: string;
+        organizationUuid: string;
+        exploreName: string;
+        previewToken: string | undefined;
+    }): Promise<{
+        tableCalculations: Set<string>;
+        customDimensions: Set<string>;
+        additionalMetrics: Set<string>;
+    }> {
+        const empty = () => ({
+            tableCalculations: new Set<string>(),
+            customDimensions: new Set<string>(),
+            additionalMetrics: new Set<string>(),
+        });
+        if (!account.isRegisteredUser() || !previewToken) return empty();
+
+        const verified = verifyPreviewTokenClaims(
+            previewToken,
+            this.lightdashConfig.lightdashSecrets,
+        );
+        if (!verified.ok) return empty();
+        const { payload } = verified;
+        if (
+            payload.userUuid !== account.user.id ||
+            payload.organizationUuid !== organizationUuid ||
+            payload.projectUuid !== projectUuid
+        ) {
+            return empty();
+        }
+
+        const app = await this.appModel.findApp(payload.appUuid, projectUuid);
+        if (!app || app.organization_uuid !== organizationUuid) return empty();
+        const spaceContext = app.space_uuid
+            ? await this.spacePermissionService.getSpaceAccessContext(
+                  account.user.id,
+                  app.space_uuid,
+              )
+            : {};
+        const auditedAbility = this.createAuditedAbility(account);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('DataApp', {
+                    organizationUuid,
+                    projectUuid,
+                    ...spaceContext,
+                    createdByUserUuid: app.created_by_user_uuid,
+                }),
+            )
+        ) {
+            return empty();
+        }
+
+        const dataReferences = await this.getVersionDataReferences(
+            payload.appUuid,
+            payload.version,
+        );
+        if (!dataReferences) return empty();
+
+        const provenance = empty();
+        for (const reference of dataReferences.references) {
+            if (
+                reference.kind === 'query' &&
+                reference.explore === exploreName &&
+                reference.customSql
+            ) {
+                for (const sql of reference.customSql.tableCalculations) {
+                    provenance.tableCalculations.add(sql);
+                }
+                for (const field of reference.customSql.customDimensions) {
+                    provenance.customDimensions.add(
+                        `${field.table}\0${field.sql}`,
+                    );
+                }
+                for (const metric of reference.customSql.additionalMetrics) {
+                    provenance.additionalMetrics.add(
+                        `${metric.table}\0${metric.sql}`,
+                    );
+                }
+            }
+        }
+        return provenance;
     }
 
     private async persistVersionDataReferences(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -32,6 +32,7 @@ import {
     ForbiddenError,
     formatPromptWithClarifications,
     getContentAsCodePathFromLtreePath,
+    getCustomSqlFieldKey,
     getEffectiveFieldAiHints,
     getErrorMessage,
     getVisibleDataAppClaudeModels,
@@ -9461,7 +9462,7 @@ export class AppGenerateService extends BaseService {
         projectUuid: string;
         organizationUuid: string;
         exploreName: string;
-        previewToken: string | undefined;
+        previewToken: string;
     }): Promise<{
         tableCalculations: Set<string>;
         customDimensions: Set<string>;
@@ -9529,12 +9530,12 @@ export class AppGenerateService extends BaseService {
                 }
                 for (const field of reference.customSql.customDimensions) {
                     provenance.customDimensions.add(
-                        `${field.table}\0${field.sql}`,
+                        getCustomSqlFieldKey(field),
                     );
                 }
                 for (const metric of reference.customSql.additionalMetrics) {
                     provenance.additionalMetrics.add(
-                        `${metric.table}\0${metric.sql}`,
+                        getCustomSqlFieldKey(metric),
                     );
                 }
             }

--- a/packages/backend/src/routers/appPreviewToken.ts
+++ b/packages/backend/src/routers/appPreviewToken.ts
@@ -94,23 +94,14 @@ type VerifySuccess = { ok: true; payload: PreviewTokenPayload };
 type VerifyFailure = { ok: false; status: 401 | 403; message: string };
 export type VerifyPreviewTokenResult = VerifySuccess | VerifyFailure;
 
-/**
- * Verifies a preview JWT and checks that the appUuid and version match
- * the expected values. Returns a discriminated union so callers can decide
- * how to handle errors without coupling to HTTP.
- */
-export const verifyPreviewToken = (
+export const verifyPreviewTokenClaims = (
     token: string | undefined,
     lightdashSecrets: LightdashSecrets,
-    appUuid: string,
-    version: number,
 ): VerifyPreviewTokenResult => {
     if (!token) {
         return { ok: false, status: 401, message: 'Missing preview token' };
     }
 
-    // Tokens are minted with the active secret only; fallback candidates keep
-    // tokens issued before a secret rotation valid until they expire.
     for (const candidateSecret of lightdashSecrets.all) {
         try {
             const decoded = jwt.verify(
@@ -122,12 +113,9 @@ export const verifyPreviewToken = (
                     audience: PREVIEW_TOKEN_AUDIENCE,
                 },
             );
-
             if (
                 typeof decoded === 'string' ||
-                decoded.type !== PREVIEW_TOKEN_TYPE ||
-                decoded.appUuid !== appUuid ||
-                decoded.version !== version
+                decoded.type !== PREVIEW_TOKEN_TYPE
             ) {
                 return {
                     ok: false,
@@ -135,7 +123,6 @@ export const verifyPreviewToken = (
                     message: 'Invalid or expired preview token',
                 };
             }
-
             const browserImageOrigins = normalizeBrowserImageOrigins(
                 decoded.browserImageOrigins,
             );
@@ -146,7 +133,6 @@ export const verifyPreviewToken = (
                     message: 'Invalid or expired preview token',
                 };
             }
-
             return {
                 ok: true,
                 payload: {
@@ -158,8 +144,34 @@ export const verifyPreviewToken = (
                 },
             };
         } catch {
-            // try the next candidate secret
+            // Try the next candidate during secret rotation.
         }
+    }
+    return {
+        ok: false,
+        status: 403,
+        message: 'Invalid or expired preview token',
+    };
+};
+
+/**
+ * Verifies a preview JWT and checks that the appUuid and version match
+ * the expected values. Returns a discriminated union so callers can decide
+ * how to handle errors without coupling to HTTP.
+ */
+export const verifyPreviewToken = (
+    token: string | undefined,
+    lightdashSecrets: LightdashSecrets,
+    appUuid: string,
+    version: number,
+): VerifyPreviewTokenResult => {
+    const result = verifyPreviewTokenClaims(token, lightdashSecrets);
+    if (
+        !result.ok ||
+        (result.payload.appUuid === appUuid &&
+            result.payload.version === version)
+    ) {
+        return result;
     }
     return {
         ok: false,

--- a/packages/backend/src/routers/appPreviewToken.ts
+++ b/packages/backend/src/routers/appPreviewToken.ts
@@ -1,9 +1,9 @@
+import { LIGHTDASH_APP_PREVIEW_TOKEN_MAX_AGE_SECONDS } from '@lightdash/common';
 import { createHmac } from 'crypto';
 import jwt from 'jsonwebtoken';
 import { LightdashSecrets } from '../config/parseConfig';
 
 const PREVIEW_TOKEN_TYPE = 'app-preview';
-const PREVIEW_TOKEN_MAX_AGE_SECONDS = 3600; // 1 hour
 const PREVIEW_TOKEN_ISSUER = 'lightdash';
 const PREVIEW_TOKEN_AUDIENCE = 'app-preview';
 
@@ -82,7 +82,7 @@ export const mintPreviewToken = (
         } satisfies PreviewTokenPayload,
         deriveSigningKey(lightdashSecrets.active),
         {
-            expiresIn: PREVIEW_TOKEN_MAX_AGE_SECONDS,
+            expiresIn: LIGHTDASH_APP_PREVIEW_TOKEN_MAX_AGE_SECONDS,
             issuer: PREVIEW_TOKEN_ISSUER,
             audience: PREVIEW_TOKEN_AUDIENCE,
             algorithm: 'HS256',

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -385,6 +385,13 @@ const getMockedAsyncQueryService = (
             })),
         } as unknown as OrganizationSettingsModel,
         ...overrides,
+        getDataAppCustomSqlProvenance:
+            overrides.getDataAppCustomSqlProvenance ??
+            (async () => ({
+                tableCalculations: new Set(),
+                customDimensions: new Set(),
+                additionalMetrics: new Set(),
+            })),
         userOAuthGrantsModel:
             overrides.userOAuthGrantsModel ?? ({} as UserOAuthGrantsModel),
     });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1568,6 +1568,30 @@ describe('AsyncQueryService', () => {
     });
 
     describe('executeAsyncMetricQuery', () => {
+        test('forwards the Data App preview token to custom SQL authorization', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const assertCustomSqlAuthorizedForQuery = vi
+                .spyOn(service as AnyType, 'assertCustomSqlAuthorizedForQuery')
+                .mockResolvedValue(undefined);
+            (service as AnyType).runAsyncMetricQueryWithoutPermissionCheck = vi
+                .fn()
+                .mockResolvedValue({ queryUuid: 'query-uuid' });
+
+            await service.executeAsyncMetricQuery({
+                account: sessionAccount,
+                projectUuid,
+                metricQuery: metricQueryMock,
+                context: QueryExecutionContext.EXPLORE,
+                dataAppPreviewToken: 'signed-preview-token',
+            });
+
+            expect(assertCustomSqlAuthorizedForQuery).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    dataAppPreviewToken: 'signed-preview-token',
+                }),
+            );
+        });
+
         test('tags warehouse queries with the originating data app from the request context', async () => {
             const service = getMockedAsyncQueryService(lightdashConfigMock);
             service.getExploreWithUserAccessControls = vi

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4444,6 +4444,7 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid,
             exploreName: inputMetricQuery.exploreName,
             metricQuery: inputMetricQuery,
+            dataAppPreviewToken: args.dataAppPreviewToken,
         });
 
         return this.runAsyncMetricQueryWithoutPermissionCheck(

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -85,6 +85,7 @@ export type ExecuteAsyncFieldValueSearchArgs = CommonAsyncQueryArgs & {
 
 export type ExecuteAsyncMetricQueryArgs = CommonAsyncQueryArgs & {
     metricQuery: MetricQuery;
+    dataAppPreviewToken?: string;
     dateZoom?: DateZoom;
     pivotConfiguration?: PivotConfiguration;
     materializationRole?: UserAccessControls;

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -97,6 +97,11 @@ describe('Csv service', () => {
             adminNotificationService: {} as AdminNotificationService,
             spacePermissionService: {} as SpacePermissionService,
             organizationSettingsModel: {} as OrganizationSettingsModel,
+            getDataAppCustomSqlProvenance: async () => ({
+                tableCalculations: new Set(),
+                customDimensions: new Set(),
+                additionalMetrics: new Set(),
+            }),
         }),
         fileStorageClient: {} as FileStorageClient,
         savedChartModel: {} as SavedChartModel,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -12,6 +12,7 @@ import {
     FeatureFlags,
     FilterOperator,
     ForbiddenError,
+    getCustomSqlFieldKey,
     JobStatusType,
     JobStepType,
     MetricType,
@@ -405,7 +406,13 @@ const getMockedProjectService = (
             overrides.spacePermissionService ?? ({} as SpacePermissionService),
         provisionPlaygroundProject: overrides.provisionPlaygroundProject,
         getAiAgentService: overrides.getAiAgentService,
-        getDataAppCustomSqlProvenance: overrides.getDataAppCustomSqlProvenance,
+        getDataAppCustomSqlProvenance:
+            overrides.getDataAppCustomSqlProvenance ??
+            (async () => ({
+                tableCalculations: new Set(),
+                customDimensions: new Set(),
+                additionalMetrics: new Set(),
+            })),
         organizationSettingsModel: {
             get: vi.fn(async () => ({
                 queryLimit: null,
@@ -4359,10 +4366,10 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
         const getCustomSqlProvenance = vi.fn(async () => ({
             tableCalculations: new Set([sqlTableCalculation.sql]),
             customDimensions: new Set([
-                `${sqlCustomDimension.table}\0${sqlCustomDimension.sql}`,
+                getCustomSqlFieldKey(sqlCustomDimension),
             ]),
             additionalMetrics: new Set([
-                `${sqlAdditionalMetric.table}\0${sqlAdditionalMetric.sql}`,
+                getCustomSqlFieldKey(sqlAdditionalMetric),
             ]),
         }));
         const dataAppService = getMockedProjectService(lightdashConfigMock, {
@@ -4413,7 +4420,12 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
     it('rejects data app custom SQL provenance bound to another table', async () => {
         const getCustomSqlProvenance = vi.fn(async () => ({
             tableCalculations: new Set<string>(),
-            customDimensions: new Set([`other\0${sqlCustomDimension.sql}`]),
+            customDimensions: new Set([
+                getCustomSqlFieldKey({
+                    table: 'other',
+                    sql: sqlCustomDimension.sql,
+                }),
+            ]),
             additionalMetrics: new Set<string>(),
         }));
         const dataAppService = getMockedProjectService(lightdashConfigMock, {
@@ -4570,6 +4582,19 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
             }),
         ).resolves.toBeUndefined();
         expect(savedChartModel.findCustomSqlProvenance).not.toHaveBeenCalled();
+    });
+
+    it('rejects modelled-field SQL rebound to another table', async () => {
+        spyExplore();
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: noScopeAccount,
+                metricQuery: {
+                    additionalMetrics: additionalMetric(fieldRefSql, 'b'),
+                },
+            }),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
     });
 
     it('allows any custom metric SQL for a user with manage:CustomFields, without loading the explore', async () => {

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -335,6 +335,7 @@ const getMockedProjectService = (
             | 'downloadFileModel'
             | 'getAiAgentService'
             | 'organizationWarehouseCredentialsModel'
+            | 'getDataAppCustomSqlProvenance'
         >
     > = {},
 ) =>
@@ -404,6 +405,7 @@ const getMockedProjectService = (
             overrides.spacePermissionService ?? ({} as SpacePermissionService),
         provisionPlaygroundProject: overrides.provisionPlaygroundProject,
         getAiAgentService: overrides.getAiAgentService,
+        getDataAppCustomSqlProvenance: overrides.getDataAppCustomSqlProvenance,
         organizationSettingsModel: {
             get: vi.fn(async () => ({
                 queryLimit: null,
@@ -4195,12 +4197,19 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
         sql: '(SELECT count(*) FROM information_schema.columns)',
         dimensionType: DimensionType.NUMBER,
     };
+    const sqlAdditionalMetric = {
+        name: 'custom_metric',
+        table: 'a',
+        type: MetricType.SUM,
+        sql: '(SELECT count(*) FROM information_schema.schemata)',
+    };
 
     type CustomSqlAuthArgs = {
         account: ReturnType<typeof buildAccount>;
         projectUuid: string;
         organizationUuid: string;
         exploreName: string;
+        dataAppPreviewToken?: string;
         metricQuery: {
             tableCalculations?: (typeof sqlTableCalculation)[];
             customDimensions?: (typeof sqlCustomDimension)[];
@@ -4248,6 +4257,11 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
         { subject: 'Project', action: 'view' },
         { subject: 'Space', action: 'view' },
     ]);
+    const dataAppViewerAccount = accountWithAbility([
+        { subject: 'Project', action: 'view' },
+        { subject: 'Space', action: 'view' },
+        { subject: 'DataApp', action: 'view' },
+    ]);
     const restrictedAccount = accountWithAbility([
         { subject: 'Project', action: 'view' },
         {
@@ -4265,6 +4279,12 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
     );
 
     const spacePermissionService = {
+        getSpaceAccessContext: vi.fn(async () => ({
+            organizationUuid,
+            projectUuid,
+            inheritsFromOrgOrProject: true,
+            access: [],
+        })),
         getSpacesAccessContext: vi.fn(
             async (_userUuid: string, spaceUuids: string[]) =>
                 Object.fromEntries(
@@ -4333,6 +4353,81 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
                 metricQuery: { tableCalculations: [sqlTableCalculation] },
             }),
         ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('allows a SQL table calculation persisted in a viewable data app', async () => {
+        const getCustomSqlProvenance = vi.fn(async () => ({
+            tableCalculations: new Set([sqlTableCalculation.sql]),
+            customDimensions: new Set([
+                `${sqlCustomDimension.table}\0${sqlCustomDimension.sql}`,
+            ]),
+            additionalMetrics: new Set([
+                `${sqlAdditionalMetric.table}\0${sqlAdditionalMetric.sql}`,
+            ]),
+        }));
+        const dataAppService = getMockedProjectService(lightdashConfigMock, {
+            getDataAppCustomSqlProvenance: getCustomSqlProvenance,
+        });
+
+        await expect(
+            assertCustomSql(dataAppService, {
+                ...baseArgs,
+                dataAppPreviewToken: 'signed-preview-token',
+                account: dataAppViewerAccount,
+                metricQuery: {
+                    tableCalculations: [sqlTableCalculation],
+                    customDimensions: [sqlCustomDimension],
+                    additionalMetrics: [sqlAdditionalMetric],
+                },
+            }),
+        ).resolves.toBeUndefined();
+        expect(getCustomSqlProvenance).toHaveBeenCalledWith({
+            account: dataAppViewerAccount,
+            projectUuid,
+            organizationUuid,
+            exploreName,
+            previewToken: 'signed-preview-token',
+        });
+    });
+
+    it('rejects substituted SQL even when its field name matches a viewable data app', async () => {
+        const getCustomSqlProvenance = vi.fn(async () => ({
+            tableCalculations: new Set(['SUM(${orders.amount})']),
+            customDimensions: new Set<string>(),
+            additionalMetrics: new Set<string>(),
+        }));
+        const dataAppService = getMockedProjectService(lightdashConfigMock, {
+            getDataAppCustomSqlProvenance: getCustomSqlProvenance,
+        });
+
+        await expect(
+            assertCustomSql(dataAppService, {
+                ...baseArgs,
+                dataAppPreviewToken: 'signed-preview-token',
+                account: dataAppViewerAccount,
+                metricQuery: { tableCalculations: [sqlTableCalculation] },
+            }),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('rejects data app custom SQL provenance bound to another table', async () => {
+        const getCustomSqlProvenance = vi.fn(async () => ({
+            tableCalculations: new Set<string>(),
+            customDimensions: new Set([`other\0${sqlCustomDimension.sql}`]),
+            additionalMetrics: new Set<string>(),
+        }));
+        const dataAppService = getMockedProjectService(lightdashConfigMock, {
+            getDataAppCustomSqlProvenance: getCustomSqlProvenance,
+        });
+
+        await expect(
+            assertCustomSql(dataAppService, {
+                ...baseArgs,
+                dataAppPreviewToken: 'signed-preview-token',
+                account: dataAppViewerAccount,
+                metricQuery: { customDimensions: [sqlCustomDimension] },
+            }),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
     });
 
     it('allows a SQL table calculation that matches a viewable saved chart', async () => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -367,6 +367,17 @@ export type ProjectServiceArguments = {
     // AppGenerateService depends on ProjectService, so eager injection would
     // create a construction cycle. Resolves undefined in core (non-EE) builds.
     getAppGenerateService?: () => AppGenerateService | undefined;
+    getDataAppCustomSqlProvenance?: (args: {
+        account: Account;
+        projectUuid: string;
+        organizationUuid: string;
+        exploreName: string;
+        previewToken: string | undefined;
+    }) => Promise<{
+        tableCalculations: Set<string>;
+        customDimensions: Set<string>;
+        additionalMetrics: Set<string>;
+    }>;
     getAiAgentService?: () => AiAgentService | undefined;
     onProjectCreated?: (args: {
         user: SessionUser;
@@ -490,6 +501,10 @@ export class ProjectService extends BaseService {
 
     getAppGenerateService: (() => AppGenerateService | undefined) | undefined;
 
+    getDataAppCustomSqlProvenance:
+        | ProjectServiceArguments['getDataAppCustomSqlProvenance']
+        | undefined;
+
     getAiAgentService: (() => AiAgentService | undefined) | undefined;
 
     onProjectCreated: ProjectServiceArguments['onProjectCreated'];
@@ -538,6 +553,7 @@ export class ProjectService extends BaseService {
         projectContextModel,
         isProjectContextEnabled,
         getAppGenerateService,
+        getDataAppCustomSqlProvenance,
         getAiAgentService,
         onProjectCreated,
         provisionPlaygroundProject,
@@ -586,6 +602,7 @@ export class ProjectService extends BaseService {
         this.projectContextModel = projectContextModel;
         this.isProjectContextEnabled = isProjectContextEnabled;
         this.getAppGenerateService = getAppGenerateService;
+        this.getDataAppCustomSqlProvenance = getDataAppCustomSqlProvenance;
         this.getAiAgentService = getAiAgentService;
         this.onProjectCreated = onProjectCreated;
         this.provisionPlaygroundProject = provisionPlaygroundProject;
@@ -4652,6 +4669,7 @@ export class ProjectService extends BaseService {
         organizationUuid,
         exploreName,
         metricQuery,
+        dataAppPreviewToken,
     }: {
         account: Account;
         projectUuid: string;
@@ -4661,6 +4679,7 @@ export class ProjectService extends BaseService {
             MetricQuery,
             'tableCalculations' | 'customDimensions' | 'additionalMetrics'
         >;
+        dataAppPreviewToken?: string;
     }): Promise<void> {
         const sqlTableCalculations = (
             metricQuery.tableCalculations ?? []
@@ -4782,6 +4801,23 @@ export class ProjectService extends BaseService {
                     .filter((r) => viewableSpaceUuids.has(r.spaceUuid))
                     .map(sqlTableKey),
             );
+
+            const appProvenance = await this.getDataAppCustomSqlProvenance?.({
+                account,
+                projectUuid,
+                organizationUuid,
+                exploreName,
+                previewToken: dataAppPreviewToken,
+            });
+            for (const sql of appProvenance?.tableCalculations ?? []) {
+                viewableTableCalculationSqls.add(sql);
+            }
+            for (const key of appProvenance?.customDimensions ?? []) {
+                viewableCustomDimensionKeys.add(key);
+            }
+            for (const key of appProvenance?.additionalMetrics ?? []) {
+                viewableAdditionalMetricKeys.add(key);
+            }
         }
 
         if (

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -79,6 +79,7 @@ import {
     getAvailableFilterFieldIds,
     getAvailableParametersFromTables,
     getColumnTimezone,
+    getCustomSqlFieldKey,
     getDashboardFieldTarget,
     getDashboardFilterRulesForTables,
     getDbtEnvironmentVariableKeyError,
@@ -367,12 +368,12 @@ export type ProjectServiceArguments = {
     // AppGenerateService depends on ProjectService, so eager injection would
     // create a construction cycle. Resolves undefined in core (non-EE) builds.
     getAppGenerateService?: () => AppGenerateService | undefined;
-    getDataAppCustomSqlProvenance?: (args: {
+    getDataAppCustomSqlProvenance: (args: {
         account: Account;
         projectUuid: string;
         organizationUuid: string;
         exploreName: string;
-        previewToken: string | undefined;
+        previewToken: string;
     }) => Promise<{
         tableCalculations: Set<string>;
         customDimensions: Set<string>;
@@ -501,9 +502,7 @@ export class ProjectService extends BaseService {
 
     getAppGenerateService: (() => AppGenerateService | undefined) | undefined;
 
-    getDataAppCustomSqlProvenance:
-        | ProjectServiceArguments['getDataAppCustomSqlProvenance']
-        | undefined;
+    getDataAppCustomSqlProvenance: ProjectServiceArguments['getDataAppCustomSqlProvenance'];
 
     getAiAgentService: (() => AiAgentService | undefined) | undefined;
 
@@ -4620,7 +4619,7 @@ export class ProjectService extends BaseService {
      * explore. A custom metric whose SQL equals one of these is the ordinary
      * (viewer-available) custom-metric feature, not injected SQL.
      */
-    private async getExploreFieldSqlSet(
+    private async getExploreFieldSqlKeys(
         account: Account,
         projectUuid: string,
         exploreName: string,
@@ -4630,16 +4629,30 @@ export class ProjectService extends BaseService {
             projectUuid,
             exploreName,
         );
-        const fieldSqls = new Set<string>();
+        const fieldSqlKeys = new Set<string>();
         for (const table of Object.values(explore.tables)) {
             for (const dimension of Object.values(table.dimensions)) {
-                if (dimension.sql) fieldSqls.add(dimension.sql);
+                if (dimension.sql) {
+                    fieldSqlKeys.add(
+                        getCustomSqlFieldKey({
+                            table: table.name,
+                            sql: dimension.sql,
+                        }),
+                    );
+                }
             }
             for (const metric of Object.values(table.metrics)) {
-                if (metric.sql) fieldSqls.add(metric.sql);
+                if (metric.sql) {
+                    fieldSqlKeys.add(
+                        getCustomSqlFieldKey({
+                            table: table.name,
+                            sql: metric.sql,
+                        }),
+                    );
+                }
             }
         }
-        return fieldSqls;
+        return fieldSqlKeys;
     }
 
     /**
@@ -4719,13 +4732,14 @@ export class ProjectService extends BaseService {
         // allowed; only hand-authored SQL needs the scope or a provenance match.
         let additionalMetricsToAuthorize: typeof additionalMetrics = [];
         if (additionalMetrics.length > 0 && !canAuthorCustomFields) {
-            const knownFieldSqls = await this.getExploreFieldSqlSet(
+            const knownFieldSqlKeys = await this.getExploreFieldSqlKeys(
                 account,
                 projectUuid,
                 exploreName,
             );
             additionalMetricsToAuthorize = additionalMetrics.filter(
-                (metric) => !knownFieldSqls.has(metric.sql),
+                (metric) =>
+                    !knownFieldSqlKeys.has(getCustomSqlFieldKey(metric)),
             );
         }
         if (
@@ -4735,9 +4749,6 @@ export class ProjectService extends BaseService {
         ) {
             return;
         }
-
-        const sqlTableKey = (item: { table: string; sql: string }) =>
-            `${item.table}\0${item.sql}`;
 
         let viewableTableCalculationSqls = new Set<string>();
         let viewableCustomDimensionKeys = new Set<string>();
@@ -4794,21 +4805,23 @@ export class ProjectService extends BaseService {
             viewableCustomDimensionKeys = new Set(
                 provenance.customSqlDimensions
                     .filter((r) => viewableSpaceUuids.has(r.spaceUuid))
-                    .map(sqlTableKey),
+                    .map(getCustomSqlFieldKey),
             );
             viewableAdditionalMetricKeys = new Set(
                 provenance.additionalMetrics
                     .filter((r) => viewableSpaceUuids.has(r.spaceUuid))
-                    .map(sqlTableKey),
+                    .map(getCustomSqlFieldKey),
             );
 
-            const appProvenance = await this.getDataAppCustomSqlProvenance?.({
-                account,
-                projectUuid,
-                organizationUuid,
-                exploreName,
-                previewToken: dataAppPreviewToken,
-            });
+            const appProvenance = dataAppPreviewToken
+                ? await this.getDataAppCustomSqlProvenance({
+                      account,
+                      projectUuid,
+                      organizationUuid,
+                      exploreName,
+                      previewToken: dataAppPreviewToken,
+                  })
+                : undefined;
             for (const sql of appProvenance?.tableCalculations ?? []) {
                 viewableTableCalculationSqls.add(sql);
             }
@@ -4831,11 +4844,14 @@ export class ProjectService extends BaseService {
         }
         if (
             customDimensionsToAuthorize.some(
-                (cd) => !viewableCustomDimensionKeys.has(sqlTableKey(cd)),
+                (cd) =>
+                    !viewableCustomDimensionKeys.has(getCustomSqlFieldKey(cd)),
             ) ||
             additionalMetricsToAuthorize.some(
                 (metric) =>
-                    !viewableAdditionalMetricKeys.has(sqlTableKey(metric)),
+                    !viewableAdditionalMetricKeys.has(
+                        getCustomSqlFieldKey(metric),
+                    ),
             )
         ) {
             throw new CustomSqlQueryForbiddenError(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -857,6 +857,13 @@ export class ServiceRepository
                         this.providers.appGenerateService
                             ? this.getAppGenerateService<AppGenerateService>()
                             : undefined,
+                    // Core has no data apps. EE replaces this provider with a
+                    // capability resolver backed by AppGenerateService.
+                    getDataAppCustomSqlProvenance: async () => ({
+                        tableCalculations: new Set(),
+                        customDimensions: new Set(),
+                        additionalMetrics: new Set(),
+                    }),
                 }),
         );
     }
@@ -934,6 +941,11 @@ export class ServiceRepository
                     spacePermissionService: this.getSpacePermissionService(),
                     organizationSettingsModel:
                         this.models.getOrganizationSettingsModel(),
+                    getDataAppCustomSqlProvenance: async () => ({
+                        tableCalculations: new Set(),
+                        customDimensions: new Set(),
+                        additionalMetrics: new Set(),
+                    }),
                 }),
         );
     }

--- a/packages/common/src/ee/apps/dataReferences.test.ts
+++ b/packages/common/src/ee/apps/dataReferences.test.ts
@@ -193,6 +193,46 @@ describe('extractDataAppDataReferences', () => {
                 'price_tier',
                 'running_total',
             ]);
+            expect(ref.customSql).toEqual({
+                tableCalculations: ['SUM(1)'],
+                additionalMetrics: [{ sql: 'x', table: 'order_items' }],
+                customDimensions: [{ sql: 'x', table: 'orders' }],
+            });
+            expect(ref.unresolved).toEqual([]);
+        });
+
+        it('does not trust dynamically constructed custom SQL', () => {
+            const [ref] = queries(
+                app(`
+                    import { query } from '@lightdash/query-sdk';
+                    function App({ sql }) {
+                        return query('orders').tableCalculations([
+                            { name: 'dynamic', displayName: 'Dynamic', sql },
+                        ]);
+                    }
+                `),
+            );
+            expect(ref.customSql).toEqual({
+                tableCalculations: [],
+                additionalMetrics: [],
+                customDimensions: [],
+            });
+            expect(ref.unresolved).toEqual([]);
+        });
+
+        it('captures custom SQL from a statically memoized definition', () => {
+            const [ref] = queries(
+                app(`
+                    import { useMemo } from 'react';
+                    import { query } from '@lightdash/query-sdk';
+                    const calculations = useMemo(
+                        () => [{ name: 'total', displayName: 'Total', sql: 'SUM(1)' }],
+                        [],
+                    );
+                    query('orders').tableCalculations(calculations);
+                `),
+            );
+            expect(ref.customSql?.tableCalculations).toEqual(['SUM(1)']);
             expect(ref.unresolved).toEqual([]);
         });
 

--- a/packages/common/src/ee/apps/dataReferences.ts
+++ b/packages/common/src/ee/apps/dataReferences.ts
@@ -58,6 +58,11 @@ export type ExtractedSqlField = {
     table: string;
 };
 
+export const getCustomSqlFieldKey = ({
+    table,
+    sql,
+}: ExtractedSqlField): string => JSON.stringify([table, sql]);
+
 export type ExtractedQueryCustomSql = {
     tableCalculations: string[];
     customDimensions: ExtractedSqlField[];
@@ -475,17 +480,17 @@ class DataReferenceExtractor {
                         ].sort(),
                         customDimensions: [
                             ...ref.customSql.customDimensions.values(),
-                        ].sort((a, b) =>
-                            `${a.table}\0${a.sql}`.localeCompare(
-                                `${b.table}\0${b.sql}`,
-                            ),
+                        ].sort(
+                            (a, b) =>
+                                a.table.localeCompare(b.table) ||
+                                a.sql.localeCompare(b.sql),
                         ),
                         additionalMetrics: [
                             ...ref.customSql.additionalMetrics.values(),
-                        ].sort((a, b) =>
-                            `${a.table}\0${a.sql}`.localeCompare(
-                                `${b.table}\0${b.sql}`,
-                            ),
+                        ].sort(
+                            (a, b) =>
+                                a.table.localeCompare(b.table) ||
+                                a.sql.localeCompare(b.sql),
                         ),
                     },
                     unresolved: [...ref.unresolved].sort(),

--- a/packages/common/src/ee/apps/dataReferences.ts
+++ b/packages/common/src/ee/apps/dataReferences.ts
@@ -10,7 +10,7 @@ import type * as t from '@babel/types';
 
 // Bump when the extractor learns new patterns so persisted results can be
 // detected as stale and re-extracted.
-export const DATA_REFERENCE_EXTRACTOR_VERSION = 3;
+export const DATA_REFERENCE_EXTRACTOR_VERSION = 4;
 
 export type DataAppSourceFile = {
     path: string; // relative to the bundle root, forward slashes
@@ -46,8 +46,22 @@ export type ExtractedQueryReference = {
     /** Fields defined inline (table calcs, additional metrics, custom
      *  dimensions) — checkers must not flag these as unknown explore fields. */
     localFields: string[];
+    /** Exact SQL persisted for execution-time authorization. Missing on
+     * versions extracted before v4. */
+    customSql?: ExtractedQueryCustomSql;
     unresolved: QueryReferenceUnresolvedPart[];
     location: DataReferenceLocation;
+};
+
+export type ExtractedSqlField = {
+    sql: string;
+    table: string;
+};
+
+export type ExtractedQueryCustomSql = {
+    tableCalculations: string[];
+    customDimensions: ExtractedSqlField[];
+    additionalMetrics: ExtractedSqlField[];
 };
 
 export type SavedChartReferenceUnresolvedPart = 'chartUuid' | 'filters';
@@ -121,7 +135,10 @@ export type DataAppDataReferences = {
 export type PersistedDataAppDataReferences = Pick<
     DataAppDataReferences,
     'references' | 'parseErrors' | 'stats'
->;
+> & {
+    /** Missing on versions persisted before extractor versioning. */
+    extractorVersion?: number;
+};
 
 export function isReferenceFullyResolved(ref: ExtractedDataReference): boolean {
     return ref.unresolved.length === 0;
@@ -230,6 +247,11 @@ type MutableQueryReference = {
     sortFields: Set<string>;
     parameterKeys: Set<string>;
     localFields: Set<string>;
+    customSql: {
+        tableCalculations: Set<string>;
+        customDimensions: Map<string, ExtractedSqlField>;
+        additionalMetrics: Map<string, ExtractedSqlField>;
+    };
     unresolved: Set<QueryReferenceUnresolvedPart>;
     location: DataReferenceLocation;
 };
@@ -447,6 +469,25 @@ class DataReferenceExtractor {
                     sortFields: [...ref.sortFields].sort(),
                     parameterKeys: [...ref.parameterKeys].sort(),
                     localFields: [...ref.localFields].sort(),
+                    customSql: {
+                        tableCalculations: [
+                            ...ref.customSql.tableCalculations,
+                        ].sort(),
+                        customDimensions: [
+                            ...ref.customSql.customDimensions.values(),
+                        ].sort((a, b) =>
+                            `${a.table}\0${a.sql}`.localeCompare(
+                                `${b.table}\0${b.sql}`,
+                            ),
+                        ),
+                        additionalMetrics: [
+                            ...ref.customSql.additionalMetrics.values(),
+                        ].sort((a, b) =>
+                            `${a.table}\0${a.sql}`.localeCompare(
+                                `${b.table}\0${b.sql}`,
+                            ),
+                        ),
+                    },
                     unresolved: [...ref.unresolved].sort(),
                     location: ref.location,
                 }),
@@ -1286,6 +1327,11 @@ class DataReferenceExtractor {
             sortFields: new Set(),
             parameterKeys: new Set(),
             localFields: new Set(),
+            customSql: {
+                tableCalculations: new Set(),
+                customDimensions: new Map(),
+                additionalMetrics: new Map(),
+            },
             unresolved: new Set(),
             location: nodeLocation(rootNode, path),
         };
@@ -1404,7 +1450,18 @@ class DataReferenceExtractor {
                       )
                     : unresolvedStrings();
                 for (const value of resolved.values) ref.localFields.add(value);
-                if (!resolved.complete) ref.unresolved.add('localFields');
+                if (argNode) {
+                    this.collectCustomSqlDefinitions(
+                        argNode,
+                        scope,
+                        0,
+                        name,
+                        ref.customSql,
+                    );
+                }
+                if (!resolved.complete) {
+                    ref.unresolved.add('localFields');
+                }
                 break;
             }
             case 'model':
@@ -2430,6 +2487,15 @@ class DataReferenceExtractor {
     ): ResolvedStrings {
         if (depth > MAX_RESOLUTION_DEPTH) return unresolvedStrings();
         const expr = unwrapExpression(node);
+        const memoized = DataReferenceExtractor.unwrapUseMemo(expr);
+        if (memoized) {
+            return this.resolveDefinitionNames(
+                memoized,
+                scope,
+                depth + 1,
+                nameKey,
+            );
+        }
         if (expr.type === 'ArrayExpression') {
             const values = new Set<string>();
             let complete = true;
@@ -2500,6 +2566,135 @@ class DataReferenceExtractor {
             }
         }
         return unresolvedStrings();
+    }
+
+    private collectCustomSqlDefinitions(
+        node: t.Node,
+        scope: Scope,
+        depth: number,
+        kind: 'tableCalculations' | 'additionalMetrics' | 'customDimensions',
+        target: MutableQueryReference['customSql'],
+    ): boolean {
+        if (depth > MAX_RESOLUTION_DEPTH) return false;
+        const expr = unwrapExpression(node);
+        const memoized = DataReferenceExtractor.unwrapUseMemo(expr);
+        if (memoized) {
+            return this.collectCustomSqlDefinitions(
+                memoized,
+                scope,
+                depth + 1,
+                kind,
+                target,
+            );
+        }
+        if (expr.type === 'Identifier') {
+            const binding = this.lookupBinding(expr.name, scope);
+            if (binding?.kind === 'init' && binding.init) {
+                return this.collectCustomSqlDefinitions(
+                    binding.init,
+                    binding.scope,
+                    depth + 1,
+                    kind,
+                    target,
+                );
+            }
+            if (binding?.kind === 'import') {
+                const imported = this.resolveImportBinding(binding, depth);
+                return imported
+                    ? this.collectCustomSqlDefinitions(
+                          imported.node,
+                          imported.scope,
+                          depth + 1,
+                          kind,
+                          target,
+                      )
+                    : false;
+            }
+            return false;
+        }
+        if (expr.type !== 'ArrayExpression') return false;
+
+        const collectCandidate = (
+            candidate: ResolvedContainers['containers'][number],
+        ): boolean => {
+            if (candidate.node.type !== 'ObjectExpression') return false;
+            const { properties } = candidate.node;
+            if (
+                properties.some(
+                    (property) =>
+                        property.type !== 'ObjectProperty' ||
+                        objectPropertyKeyName(property) === null,
+                )
+            ) {
+                return false;
+            }
+            const resolveProperty = (key: 'sql' | 'table') => {
+                const matching = properties.filter(
+                    (property): property is t.ObjectProperty =>
+                        property.type === 'ObjectProperty' &&
+                        objectPropertyKeyName(property) === key,
+                );
+                if (matching.length !== 1) return null;
+                const [property] = matching;
+                const resolved = this.resolveStrings(
+                    property.value,
+                    candidate.scope,
+                    depth + 1,
+                );
+                return resolved.complete && resolved.values.size === 1
+                    ? [...resolved.values][0]
+                    : null;
+            };
+            const sql = resolveProperty('sql');
+            if (sql === null) return false;
+            if (kind === 'tableCalculations') {
+                target.tableCalculations.add(sql);
+                return true;
+            }
+            const table = resolveProperty('table');
+            if (table === null) return false;
+            const value = { sql, table };
+            const key = JSON.stringify(value);
+            if (kind === 'customDimensions') {
+                target.customDimensions.set(key, value);
+            } else {
+                target.additionalMetrics.set(key, value);
+            }
+            return true;
+        };
+
+        let complete = true;
+        for (const element of expr.elements) {
+            if (!element) {
+                complete = false;
+            } else if (element.type === 'SpreadElement') {
+                if (
+                    !this.collectCustomSqlDefinitions(
+                        element.argument,
+                        scope,
+                        depth + 1,
+                        kind,
+                        target,
+                    )
+                ) {
+                    complete = false;
+                }
+            } else {
+                const containers = this.resolveContainers(
+                    element,
+                    scope,
+                    depth + 1,
+                );
+                if (
+                    !containers.complete ||
+                    containers.containers.length === 0 ||
+                    !containers.containers.every(collectCandidate)
+                ) {
+                    complete = false;
+                }
+            }
+        }
+        return complete;
     }
 }
 

--- a/packages/common/src/utils/api.ts
+++ b/packages/common/src/utils/api.ts
@@ -9,6 +9,7 @@ export const LightdashCliVersionHeader = 'Lightdash-CLI-Version';
 // authenticated, so it must not gate access or feed anything authoritative.
 export const LightdashAppUuidHeader = 'Lightdash-App-Uuid';
 export const LightdashAppPreviewTokenHeader = 'Lightdash-App-Preview-Token';
+export const LIGHTDASH_APP_PREVIEW_TOKEN_MAX_AGE_SECONDS = 60 * 60;
 
 // Declares that the file produced by a schedule-download request will be
 // fetched from a context that cannot attach session credentials (the data-app

--- a/packages/common/src/utils/api.ts
+++ b/packages/common/src/utils/api.ts
@@ -8,6 +8,7 @@ export const LightdashCliVersionHeader = 'Lightdash-CLI-Version';
 // tagged with `app_uuid`. Self-reported provenance for tracking only — not
 // authenticated, so it must not gate access or feed anything authoritative.
 export const LightdashAppUuidHeader = 'Lightdash-App-Uuid';
+export const LightdashAppPreviewTokenHeader = 'Lightdash-App-Preview-Token';
 
 // Declares that the file produced by a schedule-download request will be
 // fetched from a context that cannot attach session credentials (the data-app

--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -214,6 +214,7 @@ const DataAppTile: FC<Props> = (props) => {
                 ) : (
                     <AppIframePreview
                         src={previewUrl}
+                        previewToken={token!}
                         expectedPreviewOrigin={previewOrigin}
                         projectUuid={projectUuid ?? ''}
                         appUuid={appUuid}

--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -9,6 +9,7 @@ import { IconAppsOff, IconCode } from '@tabler/icons-react';
 import React, { useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import AppIframePreview from '../../features/apps/AppIframePreview';
+import { getVisiblePreviewTokenError } from '../../features/apps/hooks/previewTokenQueryOptions';
 import { useAppPreviewToken } from '../../features/apps/hooks/useAppPreviewToken';
 import { useGetApp } from '../../features/apps/hooks/useGetApp';
 import { usePreviewOrigin } from '../../features/apps/previewOrigin';
@@ -151,21 +152,22 @@ const DataAppTile: FC<Props> = (props) => {
         token && latestReadyVersion
             ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/?f=${filtersKey}&r=${refreshCounter}#transport=postMessage&projectUuid=${projectUuid}`
             : undefined;
+    const visibleTokenError = getVisiblePreviewTokenError(tokenError, !!token);
 
     const isForbidden =
         appQuery.error?.error?.statusCode === 403 ||
-        tokenError?.error?.statusCode === 403;
+        visibleTokenError?.error?.statusCode === 403;
     const isNotFound =
         appDeletedAt ||
         appQuery.error?.error?.statusCode === 404 ||
-        tokenError?.error?.statusCode === 404;
+        visibleTokenError?.error?.statusCode === 404;
     const hasNoReadyVersion =
         !appQuery.isLoading && !appQuery.error && !latestReadyVersion;
     const isLoading =
         appQuery.isLoading ||
         (latestReadyVersion !== undefined && isTokenLoading);
     const otherError =
-        !isForbidden && !isNotFound && (appQuery.error || tokenError);
+        !isForbidden && !isNotFound && (appQuery.error || visibleTokenError);
 
     return (
         <TileBase
@@ -207,14 +209,14 @@ const DataAppTile: FC<Props> = (props) => {
                             Failed to load app
                         </Text>
                     </Stack>
-                ) : isLoading || !previewUrl ? (
+                ) : isLoading || !previewUrl || !token ? (
                     <Stack align="center" justify="center" h="100%">
                         <Loader size="sm" />
                     </Stack>
                 ) : (
                     <AppIframePreview
                         src={previewUrl}
-                        previewToken={token!}
+                        previewToken={token}
                         expectedPreviewOrigin={previewOrigin}
                         projectUuid={projectUuid ?? ''}
                         appUuid={appUuid}

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -190,6 +190,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     return (
         <AppIframePreview
             src={previewUrl}
+            previewToken={token}
             expectedPreviewOrigin={previewOrigin}
             projectUuid={projectUuid}
             appUuid={dataAppVizUuid}

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -10,6 +10,7 @@ import { useParams } from 'react-router';
 import useEmbed from '../../ee/providers/Embed/useEmbed';
 import AppIframePreview from '../../features/apps/AppIframePreview';
 import { useChartVersionPreview } from '../../features/apps/ChartVersionPreview/useChartVersionPreview';
+import { getVisiblePreviewTokenError } from '../../features/apps/hooks/previewTokenQueryOptions';
 import {
     useDataAppVizPreviewToken,
     useDataAppVizRenderMetadata,
@@ -143,7 +144,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
 
     const terminalRequestErrorMessage = getTerminalRequestErrorMessage([
         renderMetadataError,
-        previewTokenError,
+        getVisiblePreviewTokenError(previewTokenError, !!token),
     ]);
     if (terminalRequestErrorMessage) {
         return <DataAppVizPlaceholder message={terminalRequestErrorMessage} />;

--- a/packages/frontend/src/ee/features/embed/EmbedApp/components/EmbedApp.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedApp/components/EmbedApp.tsx
@@ -3,6 +3,7 @@ import { IconAppsOff } from '@tabler/icons-react';
 import { type FC } from 'react';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
 import AppIframePreview from '../../../../../features/apps/AppIframePreview';
+import { getVisiblePreviewTokenError } from '../../../../../features/apps/hooks/previewTokenQueryOptions';
 import { useEmbedAppPreviewToken } from '../../../../../features/apps/hooks/useEmbedAppPreviewToken';
 import { usePreviewOrigin } from '../../../../../features/apps/previewOrigin';
 
@@ -25,7 +26,11 @@ const EmbedApp: FC<Props> = ({ appUuid, projectUuid }) => {
         ? `${previewOrigin}/api/apps/${appUuid}/versions/${tokenQuery.data.version}/t/${tokenQuery.data.token}/#transport=postMessage&projectUuid=${projectUuid}`
         : undefined;
 
-    const statusCode = tokenQuery.error?.error?.statusCode;
+    const visibleTokenError = getVisiblePreviewTokenError(
+        tokenQuery.error,
+        !!tokenQuery.data,
+    );
+    const statusCode = visibleTokenError?.error?.statusCode;
     const isNotFound = statusCode === 404;
     const isForbidden = statusCode === 403;
 
@@ -43,18 +48,18 @@ const EmbedApp: FC<Props> = ({ appUuid, projectUuid }) => {
                     title="No access"
                     description="This data app isn't authorized for this embed."
                 />
-            ) : tokenQuery.isLoading || !previewUrl ? (
+            ) : tokenQuery.isLoading || !previewUrl || !tokenQuery.data ? (
                 <Stack align="center" justify="center" h="100%">
                     <Loader size="sm" />
                 </Stack>
             ) : (
                 <AppIframePreview
                     src={previewUrl}
-                    previewToken={tokenQuery.data!.token}
+                    previewToken={tokenQuery.data.token}
                     expectedPreviewOrigin={previewOrigin}
                     projectUuid={projectUuid}
                     appUuid={appUuid}
-                    identityKey={`${appUuid}:${tokenQuery.data!.version}`}
+                    identityKey={`${appUuid}:${tokenQuery.data.version}`}
                     dashboardFilters={undefined}
                     urlStateSync
                 />

--- a/packages/frontend/src/ee/features/embed/EmbedApp/components/EmbedApp.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedApp/components/EmbedApp.tsx
@@ -50,6 +50,7 @@ const EmbedApp: FC<Props> = ({ appUuid, projectUuid }) => {
             ) : (
                 <AppIframePreview
                     src={previewUrl}
+                    previewToken={tokenQuery.data!.token}
                     expectedPreviewOrigin={previewOrigin}
                     projectUuid={projectUuid}
                     appUuid={appUuid}

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
@@ -93,6 +93,7 @@ const EmbedDataAppTile: FC<Props> = ({ tile, projectUuid }) => {
                 ) : (
                     <AppIframePreview
                         src={previewUrl}
+                        previewToken={tokenQuery.data!.token}
                         expectedPreviewOrigin={previewOrigin}
                         projectUuid={projectUuid}
                         appUuid={appUuid}

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
@@ -8,6 +8,7 @@ import { useMemo, type FC } from 'react';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
 import TileBase from '../../../../../components/DashboardTiles/TileBase';
 import AppIframePreview from '../../../../../features/apps/AppIframePreview';
+import { getVisiblePreviewTokenError } from '../../../../../features/apps/hooks/previewTokenQueryOptions';
 import { useEmbedAppPreviewToken } from '../../../../../features/apps/hooks/useEmbedAppPreviewToken';
 import { usePreviewOrigin } from '../../../../../features/apps/previewOrigin';
 import useDashboardFiltersForTile from '../../../../../hooks/dashboard/useDashboardFiltersForTile';
@@ -61,7 +62,11 @@ const EmbedDataAppTile: FC<Props> = ({ tile, projectUuid }) => {
         ? `${previewOrigin}/api/apps/${appUuid}/versions/${tokenQuery.data.version}/t/${tokenQuery.data.token}/?f=${filtersKey}#transport=postMessage&projectUuid=${projectUuid}`
         : undefined;
 
-    const statusCode = tokenQuery.error?.error?.statusCode;
+    const visibleTokenError = getVisiblePreviewTokenError(
+        tokenQuery.error,
+        !!tokenQuery.data,
+    );
+    const statusCode = visibleTokenError?.error?.statusCode;
     const isNotFound = !!appDeletedAt || statusCode === 404;
     const isForbidden = statusCode === 403;
 
@@ -86,18 +91,18 @@ const EmbedDataAppTile: FC<Props> = ({ tile, projectUuid }) => {
                         title="No access"
                         description="This data app isn't authorized for this embed."
                     />
-                ) : tokenQuery.isLoading || !previewUrl ? (
+                ) : tokenQuery.isLoading || !previewUrl || !tokenQuery.data ? (
                     <Stack align="center" justify="center" h="100%">
                         <Loader size="sm" />
                     </Stack>
                 ) : (
                     <AppIframePreview
                         src={previewUrl}
-                        previewToken={tokenQuery.data!.token}
+                        previewToken={tokenQuery.data.token}
                         expectedPreviewOrigin={previewOrigin}
                         projectUuid={projectUuid}
                         appUuid={appUuid}
-                        identityKey={`${appUuid}:${tokenQuery.data!.version}`}
+                        identityKey={`${appUuid}:${tokenQuery.data.version}`}
                         dashboardFilters={dashboardFiltersForApp}
                     />
                 )}

--- a/packages/frontend/src/features/apps/AppIframePreview.test.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { type FC } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import MantineProvider from '../../providers/MantineProvider';
@@ -29,13 +29,20 @@ const SRC =
 type HarnessProps = {
     hostColorScheme: 'light' | 'dark';
     forceColorScheme?: 'light' | 'dark';
+    previewToken?: string;
+    src?: string;
 };
 
-const Harness: FC<HarnessProps> = ({ hostColorScheme, forceColorScheme }) => (
+const Harness: FC<HarnessProps> = ({
+    hostColorScheme,
+    forceColorScheme,
+    previewToken = 'tok',
+    src = SRC,
+}) => (
     <MantineProvider forceColorScheme={hostColorScheme}>
         <AppIframePreview
-            src={SRC}
-            previewToken="tok"
+            src={src}
+            previewToken={previewToken}
             expectedPreviewOrigin="https://preview.example"
             projectUuid="p"
             appUuid="a"
@@ -72,6 +79,36 @@ describe('AppIframePreview', () => {
         // the URL here would reload the iframe and lose its state.
         rerender(<Harness hostColorScheme="light" />);
         expect(iframeSrc()).toEqual(before);
+    });
+
+    it('rotates the bridge capability without reloading the iframe', () => {
+        const { rerender } = render(<Harness hostColorScheme="light" />);
+        const before = iframeSrc();
+        rerender(
+            <Harness
+                hostColorScheme="light"
+                previewToken="tok-2"
+                src={SRC.replace('/tok/', '/tok-2/')}
+            />,
+        );
+
+        expect(iframeSrc()).toEqual(before);
+        expect(useAppSdkBridgeMock).toHaveBeenLastCalledWith(
+            expect.objectContaining({ previewToken: 'tok-2' }),
+        );
+    });
+
+    it('navigates with the latest token on an explicit refresh', async () => {
+        const { rerender } = render(<Harness hostColorScheme="light" />);
+        rerender(
+            <Harness
+                hostColorScheme="light"
+                previewToken="tok-2"
+                src={SRC.replace('/tok/#', '/tok-2/?r=1#')}
+            />,
+        );
+
+        await waitFor(() => expect(iframeSrc()).toContain('/tok-2/?r=1#'));
     });
 
     it('lets an explicit override win over the host scheme (scheduled renders)', () => {

--- a/packages/frontend/src/features/apps/AppIframePreview.test.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.test.tsx
@@ -4,15 +4,19 @@ import { describe, expect, it, vi } from 'vitest';
 import MantineProvider from '../../providers/MantineProvider';
 import AppIframePreview from './AppIframePreview';
 
-vi.mock('./hooks/useAppSdkBridge', () => ({
-    useAppSdkBridge: () => ({
+const { useAppSdkBridgeMock } = vi.hoisted(() => ({
+    useAppSdkBridgeMock: vi.fn(() => ({
         handleIframeLoad: vi.fn(),
         enableInspector: vi.fn(),
         disableInspector: vi.fn(),
         enableLineage: vi.fn(),
         disableLineage: vi.fn(),
         highlightLineage: vi.fn(),
-    }),
+    })),
+}));
+
+vi.mock('./hooks/useAppSdkBridge', () => ({
+    useAppSdkBridge: useAppSdkBridgeMock,
 }));
 
 vi.mock('./hooks/useIframeScreenshot', () => ({
@@ -31,6 +35,7 @@ const Harness: FC<HarnessProps> = ({ hostColorScheme, forceColorScheme }) => (
     <MantineProvider forceColorScheme={hostColorScheme}>
         <AppIframePreview
             src={SRC}
+            previewToken="tok"
             expectedPreviewOrigin="https://preview.example"
             projectUuid="p"
             appUuid="a"
@@ -47,6 +52,13 @@ const iframeTheme = (): string | null =>
     new URLSearchParams(iframeSrc().split('#')[1]).get('theme');
 
 describe('AppIframePreview', () => {
+    it('binds bridged queries to the signed preview token', () => {
+        render(<Harness hostColorScheme="dark" />);
+        expect(useAppSdkBridgeMock).toHaveBeenCalledWith(
+            expect.objectContaining({ previewToken: 'tok' }),
+        );
+    });
+
     it('seeds the iframe URL with the host color scheme', () => {
         render(<Harness hostColorScheme="dark" />);
         expect(iframeTheme()).toEqual('dark');

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -12,6 +12,7 @@ import {
     useImperativeHandle,
     useMemo,
     useRef,
+    useState,
 } from 'react';
 import { type DeliveryCaptureAccumulator } from './deliveryCapture/deliveryCaptureAccumulator';
 import {
@@ -201,12 +202,38 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
                 withColorSchemeParam(baseUrl, colorSchemeRef.current),
             [],
         );
-        // Memoized on `src`: the seeds are re-latched exactly when the iframe
-        // would reload anyway (refresh counter, version bump, token refetch),
-        // never on state changes alone — that would reload per filter click.
+        // A refreshed capability must reach the query bridge without reloading
+        // the running app and dropping its state. Ignore token-only URL changes;
+        // version, filter, and manual-refresh changes still navigate with the
+        // latest complete URL (and therefore the latest token).
+        const navigationKey = src.replace(previewToken, '{preview-token}');
+        const [iframeNavigation, setIframeNavigation] = useState(() => ({
+            key: navigationKey,
+            src,
+        }));
+        useEffect(() => {
+            setIframeNavigation((current) =>
+                current.key === navigationKey
+                    ? current
+                    : { key: navigationKey, src },
+            );
+        }, [navigationKey, src]);
+
+        // Seeds are re-latched exactly when the iframe navigates, never on URL
+        // state changes alone — that would reload per filter click.
         const effectiveSrc = useMemo(
-            () => applyColorSchemeSeed(urlStateSync ? applySeed(src) : src),
-            [urlStateSync, applySeed, applyColorSchemeSeed, src],
+            () =>
+                applyColorSchemeSeed(
+                    urlStateSync
+                        ? applySeed(iframeNavigation.src)
+                        : iframeNavigation.src,
+                ),
+            [
+                urlStateSync,
+                applySeed,
+                applyColorSchemeSeed,
+                iframeNavigation.src,
+            ],
         );
         // Memoized so the bridge's message listener doesn't re-attach on every
         // parent render — AppGenerate re-renders on every keystroke (editor's

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -31,6 +31,8 @@ export type AppIframePreviewHandle = {
 
 type Props = {
     src: string;
+    /** Signed capability for the exact app version served by `src`. */
+    previewToken: string;
     /** Origin the iframe will load from — used to gate the postMessage bridge.
      *  Same value for all preview iframes from the same Lightdash instance
      *  (the configured preview-host), or the parent's own origin in the
@@ -149,6 +151,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
     (
         {
             src,
+            previewToken,
             expectedPreviewOrigin,
             projectUuid,
             appUuid,
@@ -229,6 +232,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             expectedPreviewOrigin,
             projectUuid,
             appUuid,
+            previewToken,
             onQueryEvent,
             onElementSelected,
             onInspectorAvailable: handleInspectorAnnounce,

--- a/packages/frontend/src/features/apps/components/MoveAppToSpaceModal.tsx
+++ b/packages/frontend/src/features/apps/components/MoveAppToSpaceModal.tsx
@@ -266,6 +266,7 @@ export const MoveAppToSpaceModal: FC<Props> = ({
                     <AppIframePreview
                         ref={previewRef}
                         src={previewUrl}
+                        previewToken={previewToken!}
                         expectedPreviewOrigin={previewOrigin}
                         projectUuid={projectUuid}
                         appUuid={app.uuid}

--- a/packages/frontend/src/features/apps/components/MoveAppToSpaceModal.tsx
+++ b/packages/frontend/src/features/apps/components/MoveAppToSpaceModal.tsx
@@ -12,6 +12,7 @@ import { useContentAction } from '../../../hooks/useContent';
 import AppIframePreview, {
     type AppIframePreviewHandle,
 } from '../AppIframePreview';
+import { getVisiblePreviewTokenError } from '../hooks/previewTokenQueryOptions';
 import { useAppPreviewToken } from '../hooks/useAppPreviewToken';
 import {
     useAppThumbnailUpload,
@@ -102,15 +103,19 @@ export const MoveAppToSpaceModal: FC<Props> = ({
     // when the surface has no live iframe to capture from.
     const useFallbackPreview = !capturePreviewScreenshot;
     const previewOrigin = usePreviewOrigin();
-    const { data: previewToken } = useAppPreviewToken(
+    const { data: previewToken, error: previewTokenError } = useAppPreviewToken(
         opened && hasReadyVersion && useFallbackPreview
             ? projectUuid
             : undefined,
         app.uuid,
         app.latestVersionNumber ?? undefined,
     );
+    const visiblePreviewTokenError = getVisiblePreviewTokenError(
+        previewTokenError,
+        !!previewToken,
+    );
     const previewUrl =
-        hasReadyVersion && previewToken
+        hasReadyVersion && previewToken && !visiblePreviewTokenError
             ? `${previewOrigin}/api/apps/${app.uuid}/versions/${app.latestVersionNumber}/t/${previewToken}/?r=0#transport=postMessage&projectUuid=${projectUuid}`
             : undefined;
 
@@ -261,12 +266,12 @@ export const MoveAppToSpaceModal: FC<Props> = ({
                     onClose();
                 }}
             />
-            {opened && useFallbackPreview && previewUrl && (
+            {opened && useFallbackPreview && previewUrl && previewToken && (
                 <Box className={classes.offscreenPreview} aria-hidden>
                     <AppIframePreview
                         ref={previewRef}
                         src={previewUrl}
-                        previewToken={previewToken!}
+                        previewToken={previewToken}
                         expectedPreviewOrigin={previewOrigin}
                         projectUuid={projectUuid}
                         appUuid={app.uuid}

--- a/packages/frontend/src/features/apps/hooks/previewTokenQueryOptions.ts
+++ b/packages/frontend/src/features/apps/hooks/previewTokenQueryOptions.ts
@@ -1,0 +1,37 @@
+import {
+    LIGHTDASH_APP_PREVIEW_TOKEN_MAX_AGE_SECONDS,
+    type ApiError,
+} from '@lightdash/common';
+
+const PREVIEW_TOKEN_REFRESH_MARGIN_SECONDS = 5 * 60;
+
+export const APP_PREVIEW_TOKEN_REFRESH_INTERVAL_MS =
+    (LIGHTDASH_APP_PREVIEW_TOKEN_MAX_AGE_SECONDS -
+        PREVIEW_TOKEN_REFRESH_MARGIN_SECONDS) *
+    1_000;
+export const APP_PREVIEW_TOKEN_RETRY_INTERVAL_MS = 60 * 1_000;
+
+const isTerminalPreviewTokenError = (
+    error: ApiError | null | undefined,
+): boolean =>
+    error?.error?.statusCode === 403 || error?.error?.statusCode === 404;
+
+export const getVisiblePreviewTokenError = (
+    error: ApiError | null,
+    hasCachedToken: boolean,
+): ApiError | null =>
+    hasCachedToken && !isTerminalPreviewTokenError(error) ? null : error;
+
+export const getPreviewTokenRefetchInterval = (
+    error: ApiError | null,
+): number | false =>
+    isTerminalPreviewTokenError(error)
+        ? false
+        : error
+          ? APP_PREVIEW_TOKEN_RETRY_INTERVAL_MS
+          : APP_PREVIEW_TOKEN_REFRESH_INTERVAL_MS;
+
+export const previewTokenQueryOptions = {
+    refetchIntervalInBackground: true,
+    refetchOnWindowFocus: true,
+} as const;

--- a/packages/frontend/src/features/apps/hooks/useAppPreviewToken.test.tsx
+++ b/packages/frontend/src/features/apps/hooks/useAppPreviewToken.test.tsx
@@ -1,0 +1,111 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../../api';
+import {
+    APP_PREVIEW_TOKEN_REFRESH_INTERVAL_MS,
+    APP_PREVIEW_TOKEN_RETRY_INTERVAL_MS,
+    getPreviewTokenRefetchInterval,
+    getVisiblePreviewTokenError,
+} from './previewTokenQueryOptions';
+import { useAppPreviewToken } from './useAppPreviewToken';
+
+vi.mock('../../../api', () => ({ lightdashApi: vi.fn() }));
+
+const mockedLightdashApi = vi.mocked(lightdashApi);
+
+describe('useAppPreviewToken', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        mockedLightdashApi.mockReset();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('renews the signed capability before it expires', async () => {
+        mockedLightdashApi
+            .mockResolvedValueOnce({ token: 'token-1' })
+            .mockResolvedValueOnce({ token: 'token-2' });
+        const queryClient = new QueryClient({
+            defaultOptions: { queries: { retry: false } },
+        });
+        const wrapper = ({ children }: PropsWithChildren) => (
+            <QueryClientProvider client={queryClient}>
+                {children}
+            </QueryClientProvider>
+        );
+        const { result } = renderHook(
+            () => useAppPreviewToken('project-1', 'app-1', 2),
+            { wrapper },
+        );
+
+        await vi.waitFor(() => expect(result.current.data).toBe('token-1'));
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(
+                APP_PREVIEW_TOKEN_REFRESH_INTERVAL_MS,
+            );
+        });
+        await vi.waitFor(() => expect(result.current.data).toBe('token-2'));
+        expect(mockedLightdashApi).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps cached data and retries a failed renewal promptly', async () => {
+        mockedLightdashApi
+            .mockResolvedValueOnce({ token: 'token-1' })
+            .mockRejectedValueOnce(new Error('temporary mint failure'))
+            .mockResolvedValueOnce({ token: 'token-2' });
+        const queryClient = new QueryClient({
+            defaultOptions: { queries: { retry: false } },
+        });
+        const wrapper = ({ children }: PropsWithChildren) => (
+            <QueryClientProvider client={queryClient}>
+                {children}
+            </QueryClientProvider>
+        );
+        const { result } = renderHook(
+            () => useAppPreviewToken('project-1', 'app-1', 2),
+            { wrapper },
+        );
+
+        await vi.waitFor(() => expect(result.current.data).toBe('token-1'));
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(
+                APP_PREVIEW_TOKEN_REFRESH_INTERVAL_MS,
+            );
+        });
+        await vi.waitFor(() =>
+            expect(mockedLightdashApi).toHaveBeenCalledTimes(2),
+        );
+        expect(result.current.data).toBe('token-1');
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(
+                APP_PREVIEW_TOKEN_RETRY_INTERVAL_MS,
+            );
+        });
+        await vi.waitFor(() => expect(result.current.data).toBe('token-2'));
+        expect(mockedLightdashApi).toHaveBeenCalledTimes(3);
+    });
+
+    it.each([403, 404])(
+        'surfaces cached-token HTTP %s errors and stops interval retries',
+        (statusCode) => {
+            const error = {
+                status: 'error' as const,
+                error: {
+                    name: 'ApiError',
+                    statusCode,
+                    message: 'Request failed',
+                    data: {},
+                },
+            };
+
+            expect(getVisiblePreviewTokenError(error, true)).toBe(error);
+            expect(getPreviewTokenRefetchInterval(error)).toBe(false);
+        },
+    );
+});

--- a/packages/frontend/src/features/apps/hooks/useAppPreviewToken.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppPreviewToken.ts
@@ -1,6 +1,10 @@
 import { type ApiError, type ApiPreviewTokenResponse } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
+import {
+    getPreviewTokenRefetchInterval,
+    previewTokenQueryOptions,
+} from './previewTokenQueryOptions';
 
 const fetchPreviewToken = async (
     projectUuid: string,
@@ -24,4 +28,7 @@ export const useAppPreviewToken = (
         queryFn: () => fetchPreviewToken(projectUuid!, appUuid!, version!),
         enabled:
             !!projectUuid && !!appUuid && version !== undefined && version > 0,
+        refetchInterval: (_data, query) =>
+            getPreviewTokenRefetchInterval(query.state.error),
+        ...previewTokenQueryOptions,
     });

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -117,10 +117,11 @@ function pollQueryResult(id: string = GET_ID) {
 }
 
 const APP_UUID = 'app-uuid';
+const PREVIEW_TOKEN = 'signed-preview-token';
 
 function renderBridge(
     onQueryEvent: (event: QueryEvent) => void,
-    previewToken?: string,
+    previewToken = PREVIEW_TOKEN,
 ) {
     const iframeRef = {
         current: { contentWindow: window } as unknown as HTMLIFrameElement,
@@ -573,6 +574,7 @@ describe('lineage message routing', () => {
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
                 appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
                 onLineageSelected,
             }),
         );
@@ -597,6 +599,7 @@ describe('lineage message routing', () => {
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
                 appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
                 onLineageAvailable,
             }),
         );
@@ -621,6 +624,7 @@ describe('lineage message routing', () => {
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
                 appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
                 onLineageAvailable,
             }),
         );
@@ -644,6 +648,7 @@ describe('lineage message routing', () => {
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
                 appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
                 onLineageAvailable,
             }),
         );
@@ -682,6 +687,7 @@ describe('url-state-change routing', () => {
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
                 appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
                 onUrlStateChange,
             }),
         );
@@ -807,6 +813,7 @@ describe('chart-query routing', () => {
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
                 appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
                 dashboardFilters,
             }),
         );
@@ -900,6 +907,7 @@ describe('external-fetch branch', () => {
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
                 appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
                 onExternalRequestEvent,
             }),
         );
@@ -1177,6 +1185,7 @@ describe('data-app-viz-context push', () => {
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
                 appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
                 dataAppVizContext: ctx,
             }),
         );
@@ -1210,6 +1219,7 @@ describe('data-app-viz-context push', () => {
                     expectedPreviewOrigin: window.location.origin,
                     projectUuid: PROJECT_UUID,
                     appUuid: APP_UUID,
+                    previewToken: PREVIEW_TOKEN,
                     dataAppVizContext: ctx,
                 }),
             { initialProps: { ctx: dataAppVizContext } },
@@ -1245,6 +1255,7 @@ describe('data-app-viz-context push', () => {
                     expectedPreviewOrigin: window.location.origin,
                     projectUuid: PROJECT_UUID,
                     appUuid: APP_UUID,
+                    previewToken: PREVIEW_TOKEN,
                     dataAppVizContext: ctx,
                 }),
             { initialProps: { ctx: dataAppVizContext } },
@@ -1334,6 +1345,7 @@ describe('delivery capture accumulator integration', () => {
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
                 appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
                 dashboardFilters,
                 invalidateCache: true,
                 deliveryCapture,
@@ -1408,6 +1420,7 @@ describe('delivery capture accumulator integration', () => {
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
                 appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
                 deliveryCapture,
                 colorScheme: 'light',
             }),
@@ -1471,6 +1484,7 @@ describe('delivery capture accumulator integration', () => {
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
                 appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
                 invalidateCache: true,
                 queryContextOverride: QueryExecutionContext.SCHEDULED_DELIVERY,
                 colorScheme: 'light',
@@ -1524,6 +1538,7 @@ describe('color scheme push', () => {
                     expectedPreviewOrigin: window.location.origin,
                     projectUuid: PROJECT_UUID,
                     appUuid: APP_UUID,
+                    previewToken: PREVIEW_TOKEN,
                     colorScheme: scheme,
                 }),
             { initialProps: { scheme: colorScheme } },
@@ -1618,6 +1633,7 @@ describe('delivery-render flag on the ready handshake', () => {
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
                 appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
                 colorScheme: 'light',
                 captureRender,
             }),

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -4,6 +4,7 @@ import {
     APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
     APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
     FilterOperator,
+    LightdashAppPreviewTokenHeader,
     LightdashAppUuidHeader,
     LightdashSignedDownloadHeader,
     QueryExecutionContext,
@@ -117,7 +118,10 @@ function pollQueryResult(id: string = GET_ID) {
 
 const APP_UUID = 'app-uuid';
 
-function renderBridge(onQueryEvent: (event: QueryEvent) => void) {
+function renderBridge(
+    onQueryEvent: (event: QueryEvent) => void,
+    previewToken?: string,
+) {
     const iframeRef = {
         current: { contentWindow: window } as unknown as HTMLIFrameElement,
     } as RefObject<HTMLIFrameElement | null>;
@@ -128,6 +132,7 @@ function renderBridge(onQueryEvent: (event: QueryEvent) => void) {
             expectedPreviewOrigin: window.location.origin,
             projectUuid: PROJECT_UUID,
             appUuid: APP_UUID,
+            previewToken,
             onQueryEvent,
         }),
     );
@@ -278,7 +283,8 @@ describe('useAppSdkBridge', () => {
     });
 
     it('attaches the app UUID header to metric-query requests for warehouse attribution', async () => {
-        renderBridge(() => undefined);
+        const previewToken = 'signed-preview-token';
+        renderBridge(() => undefined, previewToken);
 
         mockFetchOk({
             status: 'ok',
@@ -295,6 +301,7 @@ describe('useAppSdkBridge', () => {
 
         const [, init] = (fetch as Mock).mock.calls[0];
         expect(init.headers).toMatchObject({
+            [LightdashAppPreviewTokenHeader]: previewToken,
             [LightdashAppUuidHeader]: APP_UUID,
         });
         // App attribution rides on the header, not the request body.

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -211,7 +211,7 @@ export type UseAppSdkBridgeParams = {
     /** App the proxied EE external-fetch calls are attributed to. */
     appUuid: string;
     /** Signed token binding this bridge to the rendered app version. */
-    previewToken?: string;
+    previewToken: string;
     onQueryEvent?: (event: QueryEvent) => void;
     onElementSelected?: (event: ElementSelectedEvent) => void;
     onInspectorAvailable?: () => void;
@@ -856,7 +856,7 @@ export function useAppSdkBridge({
                         ...(appUuid
                             ? { [LightdashAppUuidHeader]: appUuid }
                             : {}),
-                        ...(previewToken && isMetricQueryPost(method, path)
+                        ...(isMetricQueryPost(method, path)
                             ? {
                                   [LightdashAppPreviewTokenHeader]:
                                       previewToken,

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -7,6 +7,7 @@ import {
     isAllowedAppSdkRoute,
     isAppSdkScheduleDownloadRoute,
     JWT_HEADER_NAME,
+    LightdashAppPreviewTokenHeader,
     LightdashAppUuidHeader,
     LightdashSignedDownloadHeader,
     type AppColorScheme,
@@ -209,6 +210,8 @@ export type UseAppSdkBridgeParams = {
     projectUuid: string;
     /** App the proxied EE external-fetch calls are attributed to. */
     appUuid: string;
+    /** Signed token binding this bridge to the rendered app version. */
+    previewToken?: string;
     onQueryEvent?: (event: QueryEvent) => void;
     onElementSelected?: (event: ElementSelectedEvent) => void;
     onInspectorAvailable?: () => void;
@@ -280,6 +283,7 @@ export function useAppSdkBridge({
     expectedPreviewOrigin,
     projectUuid,
     appUuid,
+    previewToken,
     onQueryEvent,
     onElementSelected,
     onInspectorAvailable,
@@ -852,6 +856,12 @@ export function useAppSdkBridge({
                         ...(appUuid
                             ? { [LightdashAppUuidHeader]: appUuid }
                             : {}),
+                        ...(previewToken && isMetricQueryPost(method, path)
+                            ? {
+                                  [LightdashAppPreviewTokenHeader]:
+                                      previewToken,
+                              }
+                            : {}),
                         // The SDK fetches the export's fileUrl from inside
                         // the sandboxed iframe, where session cookies don't
                         // attach — ask the backend for a SIGNED URL that
@@ -1019,6 +1029,7 @@ export function useAppSdkBridge({
             expectedPreviewOrigin,
             projectUuid,
             appUuid,
+            previewToken,
             onQueryEvent,
             onElementSelected,
             onInspectorAvailable,

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizRender.test.tsx
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizRender.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { APP_PREVIEW_TOKEN_REFRESH_INTERVAL_MS } from './previewTokenQueryOptions';
 import {
     useDataAppVizPreviewToken,
     useDataAppVizRenderMetadata,
@@ -17,7 +18,14 @@ type CapturedQuery = {
     queryKey: unknown[];
     queryFn: () => Promise<unknown>;
     enabled: boolean;
-    refetchInterval?: (data: unknown) => number | false;
+    refetchInterval?:
+        | number
+        | ((
+              data: unknown,
+              query?: { state: { error: unknown } },
+          ) => number | false);
+    refetchIntervalInBackground?: boolean;
+    refetchOnWindowFocus?: boolean;
     retry?: (
         failureCount: number,
         error: ReturnType<typeof apiError>,
@@ -64,12 +72,14 @@ describe('useDataAppVizRender', () => {
             method: 'GET',
             url: '/ee/projects/project-1/apps/visualizations/viz-1/charts/chart-1/render-metadata',
         });
-        expect(query.refetchInterval?.({ latestBuildInProgress: true })).toBe(
-            3000,
-        );
-        expect(query.refetchInterval?.({ latestBuildInProgress: false })).toBe(
-            false,
-        );
+        expect(
+            typeof query.refetchInterval === 'function' &&
+                query.refetchInterval({ latestBuildInProgress: true }),
+        ).toBe(3000);
+        expect(
+            typeof query.refetchInterval === 'function' &&
+                query.refetchInterval({ latestBuildInProgress: false }),
+        ).toBe(false);
     });
 
     it('passes the previewed chart version through to the registered route', async () => {
@@ -153,6 +163,15 @@ describe('useDataAppVizRender', () => {
         const tokenQuery = tokenResult.current as unknown as CapturedQuery;
 
         await expect(tokenQuery.queryFn()).resolves.toBe('token-7');
+        expect(tokenQuery.refetchInterval).toBeTypeOf('function');
+        expect(
+            typeof tokenQuery.refetchInterval === 'function' &&
+                tokenQuery.refetchInterval(undefined, {
+                    state: { error: null },
+                }),
+        ).toBe(APP_PREVIEW_TOKEN_REFRESH_INTERVAL_MS);
+        expect(tokenQuery.refetchIntervalInBackground).toBe(true);
+        expect(tokenQuery.refetchOnWindowFocus).toBe(true);
         expect(tokenQuery.queryKey).toEqual([
             'data-app-viz-preview-token',
             'project-1',

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
@@ -6,6 +6,10 @@ import {
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
+import {
+    getPreviewTokenRefetchInterval,
+    previewTokenQueryOptions,
+} from './previewTokenQueryOptions';
 
 const DATA_APP_VIZ_RENDER_POLL_INTERVAL_MS = 3000;
 const DATA_APP_VIZ_RENDER_MAX_RETRIES = 3;
@@ -129,4 +133,7 @@ export const useDataAppVizPreviewToken = (
             version !== undefined &&
             version > 0,
         retry: shouldRetryDataAppVizRenderQuery,
+        refetchInterval: (_data, query) =>
+            getPreviewTokenRefetchInterval(query.state.error),
+        ...previewTokenQueryOptions,
     });

--- a/packages/frontend/src/features/apps/hooks/useEmbedAppPreviewToken.ts
+++ b/packages/frontend/src/features/apps/hooks/useEmbedAppPreviewToken.ts
@@ -1,6 +1,10 @@
 import { type ApiError } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
+import {
+    getPreviewTokenRefetchInterval,
+    previewTokenQueryOptions,
+} from './previewTokenQueryOptions';
 
 export type EmbedAppPreviewToken = {
     token: string;
@@ -34,4 +38,7 @@ export const useEmbedAppPreviewToken = (
         queryKey: ['embed-app-preview-token', projectUuid, appUuid],
         queryFn: () => fetchEmbedAppPreviewToken(projectUuid!, appUuid!),
         enabled: !!projectUuid && !!appUuid,
+        refetchInterval: (_data, query) =>
+            getPreviewTokenRefetchInterval(query.state.error),
+        ...previewTokenQueryOptions,
     });

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -290,6 +290,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
             <AppIframePreview
                 ref={ref}
                 src={previewUrl}
+                previewToken={token}
                 expectedPreviewOrigin={previewOrigin}
                 projectUuid={projectUuid}
                 appUuid={appUuid}

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -111,6 +111,7 @@ import DataAppVizResultCard from '../features/apps/components/DataAppVizResultCa
 import DataAppVizTestPanel from '../features/apps/components/DataAppVizTestPanel';
 import LoadingDots from '../features/apps/components/LoadingDots';
 import RecentAppSuggestions from '../features/apps/components/RecentAppSuggestions';
+import { getVisiblePreviewTokenError } from '../features/apps/hooks/previewTokenQueryOptions';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppFileUpload } from '../features/apps/hooks/useAppFileUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
@@ -263,6 +264,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
         const previewUrl = token
             ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/t/${token}/?r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
             : undefined;
+        const visibleError = getVisiblePreviewTokenError(error, !!token);
 
         if (isLoading) {
             return (
@@ -275,16 +277,18 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
             );
         }
 
-        if (error) {
+        if (visibleError) {
             return (
                 <Text c="red" p="md" size="sm">
                     Failed to load preview:{' '}
-                    {error instanceof Error ? error.message : 'Unknown error'}
+                    {visibleError instanceof Error
+                        ? visibleError.message
+                        : 'Unknown error'}
                 </Text>
             );
         }
 
-        if (!previewUrl) return null;
+        if (!previewUrl || !token) return null;
 
         return (
             <AppIframePreview

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -273,6 +273,7 @@ export default function AppPreviewTest() {
                 <AppIframePreview
                     ref={previewRef}
                     src={previewUrl}
+                    previewToken={token!}
                     expectedPreviewOrigin={previewOrigin}
                     projectUuid={projectUuid}
                     appUuid={appUuid}

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -12,6 +12,7 @@ import AppIframePreview, {
 import AppInspectorPanel from '../features/apps/AppInspectorPanel';
 import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
+import { getVisiblePreviewTokenError } from '../features/apps/hooks/previewTokenQueryOptions';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
@@ -195,17 +196,18 @@ export default function AppPreviewTest() {
         return <div>Missing route params</div>;
     }
 
-    const error = appQuery.error ?? tokenError;
+    const visibleTokenError = getVisiblePreviewTokenError(tokenError, !!token);
+    const error = appQuery.error ?? visibleTokenError;
 
     const isForbidden =
         appQuery.error?.error?.statusCode === 403 ||
-        tokenError?.error?.statusCode === 403;
+        visibleTokenError?.error?.statusCode === 403;
     if (isForbidden) {
         return <ForbiddenPanel />;
     }
     const isNotFound =
         appQuery.error?.error?.statusCode === 404 ||
-        tokenError?.error?.statusCode === 404;
+        visibleTokenError?.error?.statusCode === 404;
     if (isNotFound) {
         return (
             <Box mt="30vh">
@@ -265,7 +267,7 @@ export default function AppPreviewTest() {
                 description="There's no ready version of this app to preview yet."
             />
         );
-    } else if (isTokenLoading || !previewUrl) {
+    } else if (isTokenLoading || !previewUrl || !token) {
         body = <SuboptimalState loading title="Loading app..." />;
     } else {
         body = (
@@ -273,7 +275,7 @@ export default function AppPreviewTest() {
                 <AppIframePreview
                     ref={previewRef}
                     src={previewUrl}
-                    previewToken={token!}
+                    previewToken={token}
                     expectedPreviewOrigin={previewOrigin}
                     projectUuid={projectUuid}
                     appUuid={appUuid}

--- a/packages/frontend/src/pages/MinimalApp.tsx
+++ b/packages/frontend/src/pages/MinimalApp.tsx
@@ -14,6 +14,7 @@ import SuboptimalState from '../components/common/SuboptimalState/SuboptimalStat
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import AppIframePreview from '../features/apps/AppIframePreview';
 import { createDeliveryCaptureAccumulator } from '../features/apps/deliveryCapture/deliveryCaptureAccumulator';
+import { getVisiblePreviewTokenError } from '../features/apps/hooks/previewTokenQueryOptions';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { type QueryEvent } from '../features/apps/hooks/useAppSdkBridge';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
@@ -227,16 +228,17 @@ export default function MinimalApp() {
         return <div>Missing route params</div>;
     }
 
+    const visibleTokenError = getVisiblePreviewTokenError(tokenError, !!token);
     const isForbidden =
         appQuery.error?.error?.statusCode === 403 ||
-        tokenError?.error?.statusCode === 403;
+        visibleTokenError?.error?.statusCode === 403;
     if (isForbidden) {
         return <ForbiddenPanel />;
     }
 
     const isNotFound =
         appQuery.error?.error?.statusCode === 404 ||
-        tokenError?.error?.statusCode === 404;
+        visibleTokenError?.error?.statusCode === 404;
     if (isNotFound) {
         return (
             <Box mt="30vh">
@@ -264,7 +266,7 @@ export default function MinimalApp() {
     const isLoading =
         appQuery.isLoading ||
         (latestReadyVersion !== undefined && isTokenLoading);
-    const error = appQuery.error ?? tokenError;
+    const error = appQuery.error ?? visibleTokenError;
 
     if (isLoading) {
         return (
@@ -287,13 +289,13 @@ export default function MinimalApp() {
     const previewUrl = token
         ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/#transport=postMessage&projectUuid=${projectUuid}`
         : undefined;
-    if (!previewUrl) return null;
+    if (!previewUrl || !token) return null;
 
     return (
         <Box pos="relative" h="100vh" w="100%">
             <AppIframePreview
                 src={previewUrl}
-                previewToken={token!}
+                previewToken={token}
                 expectedPreviewOrigin={previewOrigin}
                 projectUuid={projectUuid}
                 appUuid={appUuid}

--- a/packages/frontend/src/pages/MinimalApp.tsx
+++ b/packages/frontend/src/pages/MinimalApp.tsx
@@ -293,6 +293,7 @@ export default function MinimalApp() {
         <Box pos="relative" h="100vh" w="100%">
             <AppIframePreview
                 src={previewUrl}
+                previewToken={token!}
                 expectedPreviewOrigin={previewOrigin}
                 projectUuid={projectUuid}
                 appUuid={appUuid}


### PR DESCRIPTION
Closes: N/A (customer-reported regression)

## Summary

Interactive Viewers can run custom SQL that is already published in a Data App they can view. The existing custom-SQL permission guard still rejects modified, injected, inaccessible, or unpublished SQL.

Preview capabilities now renew before expiry without reloading the running app. Transient renewal failures retain the cached token and retry quickly; revoked or deleted access still surfaces immediately.

## Root cause

The custom-SQL execution guard only recognized SQL saved in charts. Inline Data App queries use the guarded metric-query route, but their app UUID was tracking metadata rather than trusted provenance, so users without authoring scopes received a 403.

```text
Before: Data App query -> custom-SQL guard -> saved-chart provenance only -> 403
After:  Data App query -> signed app-version token -> exact published SQL match -> query
```

The regression appeared when the execution-time custom-SQL guard shipped. Developers and admins retained the authoring scope, which is why the same app continued to work for them.

## Fix

The host bridge sends the signed preview capability with metric queries. The backend binds it to the current user, organization, project, app, exact ready version, explore, table, and byte-identical SQL before granting the published-query exemption.

- `dataReferences.ts` records statically resolved SQL provenance while keeping dynamic SQL fail-closed.
- `AppGenerateService` resolves trusted app provenance and lazily refreshes legacy ready versions from immutable source artifacts.
- `ProjectService` uses a mandatory EE capability resolver and collision-safe `(table, SQL)` keys; core explicitly resolves no Data App provenance.
- Preview-token hooks renew five minutes before the one-hour expiry, retry transient failures after one minute, and stop on terminal 403/404 responses.
- Token-only rotations update the query bridge without navigating the iframe; explicit version, filter, or manual refreshes use the newest token.

## Before

- Interactive Viewer: published inline custom SQL -> `403 User cannot run queries with custom SQL table calculations`
- Developer/Admin: the same query succeeds through the authoring scope
- Long-running preview: the signed capability expires after one hour

## After

- Interactive Viewer with app access: exact published SQL succeeds
- Modified SQL, wrong table, wrong principal/project/org, inaccessible app, or non-ready version remains forbidden
- Long-running previews renew without dropping app state; revoked/deleted access still becomes a terminal error

## Test plan

- [x] Common full suite: 129 files, 3,406 tests passed (1 skipped)
- [x] Backend full suite: 420 files, 6,398 tests passed (1 skipped)
- [x] Frontend full suite: 304 files, 2,358 tests passed
- [x] Post-review affected frontend rerun: 7 files, 50 tests passed
- [x] Post-wiring backend rerun: 4 files, 274 tests passed
- [x] Common, backend, and frontend typechecks
- [x] Common, backend, and frontend lint and formatting checks
- [x] `git diff --check` and five-lens focused re-review
