### PR TITLE
fix: reject HTML in user names

### DIFF
--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -424,6 +424,20 @@ describe('UserService', () => {
             });
             expect(userModel.updateUser).toHaveBeenCalled();
         });
+
+        test.each([
+            { firstName: '<script>alert(1)</script>' },
+            { lastName: '<img src=x onerror=alert(1)>' },
+        ])('rejects HTML in a user name before persisting', async (data) => {
+            await expect(
+                userService.updateUser(sessionUser, data),
+            ).rejects.toThrow(
+                new ParameterError(
+                    'First name and last name must not contain HTML',
+                ),
+            );
+            expect(userModel.updateUser).not.toHaveBeenCalled();
+        });
     });
 
     describe('completeUserSetup', () => {
@@ -580,6 +594,22 @@ describe('UserService', () => {
                 id: featureFlagId,
                 enabled,
             })),
+        });
+
+        test('rejects HTML in a user name before registration', async () => {
+            await expect(
+                userService.registerOrActivateUser({
+                    firstName: '<svg onload=alert(1)>',
+                    lastName: 'User',
+                    email: 'xss@example.com',
+                    password: 'password1!',
+                }),
+            ).rejects.toThrow(
+                new ParameterError(
+                    'First name and last name must not contain HTML',
+                ),
+            );
+            expect(userModel.createUser).not.toHaveBeenCalled();
         });
 
         test('registers an email-only user when the feature is enabled', async () => {

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -31,6 +31,7 @@ import {
     hasProperty,
     InviteLink,
     InviteLinkPurpose,
+    isEmailOnlyUser,
     isOpenIdIdentityIssuerType,
     isOpenIdUser,
     isUserAvatarColorValue,
@@ -71,6 +72,7 @@ import {
     validateEmail,
     validateOrganizationEmailDomains,
     validateOrganizationNameOrThrow,
+    validateUserName,
     WarehouseTypes,
     type RegisteredAccount,
 } from '@lightdash/common';
@@ -1706,6 +1708,16 @@ export class UserService extends BaseService {
     ): Promise<LightdashUser> {
         const emailChanged = data.email && user.email !== data.email;
 
+        if (
+            (data.firstName !== undefined &&
+                !validateUserName(data.firstName)) ||
+            (data.lastName !== undefined && !validateUserName(data.lastName))
+        ) {
+            throw new ParameterError(
+                'First name and last name must not contain HTML',
+            );
+        }
+
         if (data.email !== undefined && !validateEmail(data.email)) {
             throw new ParameterError(`Invalid email: ${data.email}`);
         }
@@ -1828,6 +1840,16 @@ export class UserService extends BaseService {
         user: RegisterOrActivateUser,
     ): Promise<SessionUser> {
         let lightdashUser;
+        if (
+            !isEmailOnlyUser(user) &&
+            (!validateUserName(user.firstName) ||
+                !validateUserName(user.lastName))
+        ) {
+            throw new ParameterError(
+                'First name and last name must not contain HTML',
+            );
+        }
+
         if (hasInviteCode(user)) {
             lightdashUser = await this.activateUserFromInvite(user.inviteCode, {
                 firstName: user.firstName,

--- a/packages/common/src/index.test.ts
+++ b/packages/common/src/index.test.ts
@@ -6,8 +6,10 @@ import {
     getDateGroupLabelWithGranularity,
     getFilterRuleFromFieldWithDefaultValue,
     getPasswordSchema,
+    getUserNameSchema,
     isValidEmailAddress,
     TimeFrames,
+    validateUserName,
     type Dimension,
 } from '.';
 import {
@@ -150,6 +152,35 @@ describe('Password Validation', () => {
                 );
             }
         });
+    });
+});
+
+describe('User name validation', () => {
+    test.each(['José da Silva', "O'Connor", '李 小龍', 'Anne-Marie'])(
+        'accepts plain-text name %s',
+        (name) => {
+            expect(validateUserName(name)).toBe(true);
+        },
+    );
+
+    test.each([
+        '<script>alert(1)</script>',
+        '<img src=x onerror=alert(1)>',
+        'Jane <b>Doe</b>',
+    ])('rejects name containing HTML delimiters %s', (name) => {
+        expect(validateUserName(name)).toBe(false);
+    });
+
+    test('provides a trimmed frontend validation schema', () => {
+        expect(getUserNameSchema().parse('  José  ')).toBe('José');
+
+        const result = getUserNameSchema().safeParse('<b>José</b>');
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.errors[0].message).toBe(
+                'Name cannot contain < or >',
+            );
+        }
     });
 });
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -410,6 +410,13 @@ export const validateEmail = (email: string): boolean => {
     return re.test(String(email).toLowerCase());
 };
 
+export const validateUserName = (name: string): boolean => !/[<>]/u.test(name);
+
+export const getUserNameSchema = () =>
+    z.string().trim().min(1, { message: 'Required' }).refine(validateUserName, {
+        message: 'Name cannot contain < or >',
+    });
+
 export const getEmailSchema = () =>
     z
         .string()

--- a/packages/frontend/src/components/RegisterForms/CreateUserForm.tsx
+++ b/packages/frontend/src/components/RegisterForms/CreateUserForm.tsx
@@ -1,6 +1,7 @@
 import {
     getEmailSchema,
     getPasswordSchema,
+    getUserNameSchema,
     type CreateUserArgs,
 } from '@lightdash/common';
 import {
@@ -25,6 +26,8 @@ type Props = {
 };
 
 const validationSchema = z.object({
+    firstName: getUserNameSchema(),
+    lastName: getUserNameSchema(),
     email: getEmailSchema(),
     password: getPasswordSchema(),
 });

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
@@ -1,6 +1,7 @@
 import {
     FeatureFlags,
     getEmailSchema,
+    getUserNameSchema,
     isValidTimezone,
     type ApiError,
 } from '@lightdash/common';
@@ -31,8 +32,8 @@ import TimeZonePicker from '../../common/TimeZonePicker';
 import AvatarSettings from './AvatarSettings';
 
 const validationSchema = z.object({
-    firstName: z.string().nonempty(),
-    lastName: z.string().nonempty(),
+    firstName: getUserNameSchema(),
+    lastName: getUserNameSchema(),
     email: getEmailSchema().or(z.undefined()),
     timezone: z
         .string()

--- a/packages/frontend/src/pages/OnboardingInviteExpert.test.tsx
+++ b/packages/frontend/src/pages/OnboardingInviteExpert.test.tsx
@@ -220,6 +220,30 @@ describe('OnboardingInviteExpert', () => {
         expect(mocks.createInvite).toHaveBeenCalled();
     });
 
+    it('rejects HTML in a missing user name before submitting', async () => {
+        mocks.userName = { firstName: '', lastName: '' };
+        renderPage();
+
+        await userEvent.type(
+            screen.getByLabelText(/Your first name/),
+            '<script>alert(1)</script>',
+        );
+        await userEvent.type(screen.getByLabelText(/Your last name/), 'User');
+        await userEvent.type(
+            screen.getByLabelText(/Their email address/),
+            'expert@example.com',
+        );
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Send invite' }),
+        );
+
+        expect(
+            await screen.findByText('Name cannot contain < or >'),
+        ).toBeInTheDocument();
+        expect(mocks.updateUser).not.toHaveBeenCalled();
+        expect(mocks.createInvite).not.toHaveBeenCalled();
+    });
+
     it('fails closed with the permission state when the user query has no data', () => {
         mocks.hasUser = false;
         renderPage();

--- a/packages/frontend/src/pages/OnboardingInviteExpert.tsx
+++ b/packages/frontend/src/pages/OnboardingInviteExpert.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     FeatureFlags,
     getEmailSchema,
+    getUserNameSchema,
     InviteLinkPurpose,
     OrganizationMemberRole,
 } from '@lightdash/common';
@@ -177,12 +178,8 @@ const OnboardingInviteExpert: FC = () => {
         },
         validate: zodResolver(
             z.object({
-                firstName: needsName
-                    ? z.string().trim().min(1, 'Required')
-                    : z.string(),
-                lastName: needsName
-                    ? z.string().trim().min(1, 'Required')
-                    : z.string(),
+                firstName: needsName ? getUserNameSchema() : z.string(),
+                lastName: needsName ? getUserNameSchema() : z.string(),
                 email: getEmailSchema(),
             }),
         ),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-9808

### Description:
Rejects angle brackets in first and last names at the user service boundary, preventing stored markup from reaching organization-member and AI-thread responses.
Adds shared inline validation to registration, profile settings, and onboarding invite forms.
Validated with focused common, backend, and frontend tests plus package lint, typechecks, and formatting.