### PR TITLE
fix(ai): cache artifact visualization queries

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -67,6 +67,7 @@ import { USER_AGENT_PREFERENCES } from './useUserAgentPreferences';
 
 const PROJECT_AI_AGENTS_KEY = 'projectAiAgents';
 const AI_AGENTS_KEY = 'aiAgents';
+const AI_AGENT_ARTIFACT_VIZ_QUERY_STALE_TIME = 5 * 60 * 1000;
 
 const listProjectAgents = (projectUuid: string) =>
     lightdashApi<ApiAiAgentSummaryResponse['results']>({
@@ -1731,6 +1732,7 @@ export const useAiAgentArtifactVizQuery = (
             'versions',
             versionUuid,
         ],
+        staleTime: AI_AGENT_ARTIFACT_VIZ_QUERY_STALE_TIME,
         ...useQueryOptions,
         queryFn: () => {
             return getAiAgentArtifactVizQuery({


### PR DESCRIPTION
### Description

- Keep artifact visualization query executions fresh for five minutes.
- Avoid repeated query execution and loading flashes when reopening recently viewed artifacts.
- Preserve the global React Query stale time and hook-level overrides.

### Verification

- Browser before: reopening the same artifact after 31.5 seconds sent one new viz-query request.
- Browser after: identical sequence sent zero new viz-query requests and restored the chart from cache.
- Frontend typecheck.
- Focused frontend lint and formatting.
- git diff --check.

Closes: ZAP-832