### PR TITLE
fix(ai): define Deep Research report voice

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/deepResearch.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/deepResearch.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { AI_DEEP_RESEARCH_INSTRUCTIONS } from './deepResearch';
+
+describe('AI_DEEP_RESEARCH_INSTRUCTIONS', () => {
+    it('defines the report voice and bans em dashes', () => {
+        expect(AI_DEEP_RESEARCH_INSTRUCTIONS).toContain(
+            'direct, concise, neutral, and evidence-led analytical voice',
+        );
+        expect(AI_DEEP_RESEARCH_INSTRUCTIONS).toContain(
+            'Never use the Unicode em dash character',
+        );
+        expect(AI_DEEP_RESEARCH_INSTRUCTIONS).not.toContain('\u2014');
+    });
+});

--- a/packages/backend/src/ee/services/ai/prompts/deepResearch.ts
+++ b/packages/backend/src/ee/services/ai/prompts/deepResearch.ts
@@ -24,4 +24,11 @@ Evidence:
 - You do not redesign charts in the report. To show evidence, copy the queryUuid verbatim from an execution marked chartable into <chart id="<queryUuid>">. The visualizationType tells you how the server will render it. The server owns the stored configuration and drops an unbackable reference without losing the finding.
 - Do not manufacture weak evidence to satisfy a quota. Reference each execution at most once, and select no more than ${AI_DEEP_RESEARCH_MAX_CHARTS} evidence queries.
 
+Voice:
+- Write in a direct, concise, neutral, and evidence-led analytical voice.
+- Prefer plain declarative sentences and specific nouns and verbs.
+- Do not use canned transitions, rhetorical questions, dramatic framing, asides, or meta-commentary about the report or research process.
+- Do not repeat a point once it is established, restate visible chart values, or add filler.
+- Never use the Unicode em dash character. Use a full stop, comma, colon, or parentheses instead.
+
 Distinguish observations from inferences and state uncertainty explicitly.`;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9816

## Summary

PR 1 of 3. Defines a restrained analytical voice for the final agent-generated report. Research planning, evidence gathering, report structure, and validation stay unchanged.

## Report boundary

```
research evidence -> report finalizer -> concise analytical report
                                      -> no Unicode em dash
```

The prompt asks for direct, neutral, evidence-led prose and removes common generated-writing habits such as canned transitions, rhetorical framing, repetition, and meta-commentary.

## Test plan

- [x] Deep Research prompt test passes
- [x] Backend lint passes
- [x] Diff contains no Unicode em dash in the report prompt