### PR TITLE
fix(ai): align Deep Research prose with headings

### DIFF
--- a/packages/frontend/src/components/common/AiMarkdown/AiMarkdown.module.css
+++ b/packages/frontend/src/components/common/AiMarkdown/AiMarkdown.module.css
@@ -9,9 +9,9 @@
     --border: var(--mantine-color-ldGray-2);
     --radius: 8px;
 
-    padding-left: 7px;
+    padding-left: var(--ai-markdown-padding-left, 7px);
     color: var(--mantine-color-ldGray-9);
-    font-size: 13px;
+    font-size: var(--ai-markdown-font-size, 13px);
     line-height: 1.55;
     letter-spacing: -0.005em;
 }
@@ -62,7 +62,7 @@
 
 .aiMarkdown p {
     margin: 0;
-    font-size: 13px;
+    font-size: inherit;
 }
 
 .aiMarkdown strong {
@@ -74,13 +74,13 @@
 .aiMarkdown ol {
     margin: 0;
     padding-left: 22px;
-    font-size: 13px;
+    font-size: inherit;
 }
 
 .aiMarkdown ul li,
 .aiMarkdown ol li {
     margin: 2px 0;
-    font-size: 13px;
+    font-size: inherit;
 }
 
 .aiMarkdown ul li::marker {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -223,8 +223,10 @@
 }
 
 .reportIntroductionProse {
+    --ai-markdown-font-size: 1rem;
+    --ai-markdown-padding-left: 0;
+
     color: var(--mantine-color-text);
-    font-size: 1rem;
     line-height: 1.7;
 }
 
@@ -270,9 +272,11 @@
 }
 
 .reportProse {
+    --ai-markdown-font-size: 0.875rem;
+    --ai-markdown-padding-left: 0;
+
     overflow-wrap: anywhere;
     color: var(--mantine-color-dimmed);
-    font-size: 0.875rem;
     line-height: 1.7;
 
     > :first-child {
@@ -293,9 +297,11 @@
 }
 
 .reportConclusionProse {
+    --ai-markdown-font-size: 1rem;
+    --ai-markdown-padding-left: 0;
+
     overflow-wrap: anywhere;
     color: var(--mantine-color-text);
-    font-size: 1rem;
     line-height: 1.7;
 
     > :first-child {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9817

## Summary

PR 2 of 3. Aligns Deep Research prose with its section headings by removing the Markdown renderer's 7px inset on this report only. It also sets introduction and conclusion prose to 16px and finding prose to 14px.

Stacks on top of PR 1 ([#27157](https://github.com/lightdash/lightdash/pull/27157)), which defines the generated report voice.

## Layout and type

```
Before: report gutter | heading
        report gutter | 7px inset | prose

After:  report gutter | heading
        report gutter | prose
```

The report page and chart gutters remain unchanged. Other AI surfaces keep the Markdown renderer's 7px inset and 13px default prose size.

## Test plan

- [x] `pnpm -F frontend lint`
- [x] `git diff --check`
- [x] Local Deep Research run completed with four findings and four charts
- [ ] Refresh the local report to confirm the final alignment visually
