### PR TITLE
fix(ai): recover Deep Research from warehouse limits

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -555,7 +555,12 @@ const buildPrepareStep = ({
     invalidToolCallIds: ReadonlySet<string>;
 }) => {
     const forcedFirstStep = buildForcedFirstStep(args, tools);
-    let retryCapPersisted = false;
+    const retryMarkersPersisted = new Set<string>();
+    const retryMarkerScope =
+        args.execution.mode === 'deep_research'
+            ? (args.execution.parentToolCallId ??
+              `deep-research:${args.execution.runUuid}:coordinator`)
+            : args.promptUuid;
 
     return async ({
         stepNumber,
@@ -583,6 +588,7 @@ const buildPrepareStep = ({
             messages,
             Object.keys(tools),
             invalidToolCallIds,
+            args.execution.mode,
         );
         if (retryOverride) {
             activeTools = activeTools
@@ -598,14 +604,14 @@ const buildPrepareStep = ({
                 'Prepare Step',
                 `Query retry cap tripped for prompt UUID: ${args.promptUuid}`,
             );
-            // Once per prompt: leave a debugging trail that the query tools
-            // were removed this turn (the cap stays tripped on later steps).
-            if (!retryCapPersisted) {
-                retryCapPersisted = true;
+            // Persist each distinct recovery/cap state once so the original
+            // failure, chosen retry round, and terminal outcome are traceable.
+            if (!retryMarkersPersisted.has(retryOverride.markerKey)) {
+                retryMarkersPersisted.add(retryOverride.markerKey);
                 void dependencies
                     .storeToolCallError({
                         promptUuid: args.promptUuid,
-                        toolCallId: `${QUERY_RETRY_CAP_TOOL_NAME}-${args.promptUuid}`,
+                        toolCallId: `${QUERY_RETRY_CAP_TOOL_NAME}-${retryOverride.markerKey}-${retryMarkerScope}`,
                         toolName: QUERY_RETRY_CAP_TOOL_NAME,
                         errorMessage: retryOverride.nudge,
                         rawArgs: null,

--- a/packages/backend/src/ee/services/ai/agents/queryRetryCap.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/queryRetryCap.test.ts
@@ -2,6 +2,7 @@ import type { ModelMessage } from 'ai';
 import { describe, expect, it } from 'vitest';
 import {
     buildQueryRetryStepOverride,
+    DEEP_RESEARCH_RESOURCE_RECOVERY_ATTEMPTS,
     INVALID_INPUT_CAP,
     QUERY_TOOL_NAMES,
     WAREHOUSE_ERROR_CAP,
@@ -52,11 +53,18 @@ const makeTurn = () => {
             invalidToolCallIds.add(toolCallId);
             return toolCallId;
         },
-        override: () =>
+        nextRound: () => {
+            messages.push({
+                role: 'assistant',
+                content: [{ type: 'text', text: 'Trying a narrower query.' }],
+            } as unknown as ModelMessage);
+        },
+        override: (executionMode: 'standard' | 'deep_research' = 'standard') =>
             buildQueryRetryStepOverride(
                 messages,
                 ALL_TOOLS,
                 invalidToolCallIds,
+                executionMode,
             ),
     };
 };
@@ -187,6 +195,86 @@ describe('query retry cap', () => {
         expect(override?.nudge).toContain('Access Denied: no permission');
         expect(override?.nudge).not.toContain(
             'SDK wording for the dropped call',
+        );
+    });
+
+    it('keeps query tools available for a narrowed deep research recovery', () => {
+        const turn = makeTurn();
+        times(3, () =>
+            turn.failure(
+                'runQuery',
+                'BigQuery error: bytesBilledLimitExceeded. Query exceeded limit for bytes billed.',
+            ),
+        );
+
+        const override = turn.override('deep_research');
+
+        expect(override?.activeTools).toEqual(ALL_TOOLS);
+        expect(override?.markerKey).toBe('resource-recovery-1');
+        expect(override?.nudge).toContain('Recovery attempt 1 of 2');
+        expect(override?.nudge).toContain(
+            'Do not repeat the same query unchanged',
+        );
+        expect(override?.nudge).toContain('narrowing the date range');
+    });
+
+    it('counts parallel resource failures as one recovery round', () => {
+        const turn = makeTurn();
+        times(3, () =>
+            turn.failure('runQuery', 'Query exceeded limit for bytes billed.'),
+        );
+
+        expect(turn.override('deep_research')?.markerKey).toBe(
+            'resource-recovery-1',
+        );
+    });
+
+    it('allows two changed recovery rounds before using partial evidence', () => {
+        const turn = makeTurn();
+        for (
+            let round = 0;
+            round < DEEP_RESEARCH_RESOURCE_RECOVERY_ATTEMPTS;
+            round += 1
+        ) {
+            turn.failure(
+                'runSql',
+                'Warehouse resource exhausted: memory limit exceeded.',
+            );
+            expect(turn.override('deep_research')?.activeTools).toEqual(
+                ALL_TOOLS,
+            );
+            turn.nextRound();
+        }
+        turn.failure(
+            'runSql',
+            'Warehouse resource exhausted: memory limit exceeded.',
+        );
+
+        const override = turn.override('deep_research');
+
+        expect(override?.activeTools).toEqual([NON_QUERY_TOOL]);
+        expect(override?.markerKey).toBe('resource-recovery-exhausted');
+        expect(override?.nudge).toContain('verified evidence already gathered');
+        expect(override?.nudge).toContain(
+            'Do not fail the whole research run when useful evidence remains',
+        );
+    });
+
+    it('stops recovery guidance after a successful changed query', () => {
+        const turn = makeTurn();
+        turn.failure('runQuery', 'Query exceeded limit for bytes billed.');
+        turn.nextRound();
+        turn.success();
+
+        expect(turn.override('deep_research')).toBeNull();
+
+        turn.nextRound();
+        turn.failure(
+            'runQuery',
+            'Query exceeded limit for bytes billed on different evidence.',
+        );
+        expect(turn.override('deep_research')?.markerKey).toBe(
+            'resource-recovery-1',
         );
     });
 });

--- a/packages/backend/src/ee/services/ai/agents/queryRetryCap.ts
+++ b/packages/backend/src/ee/services/ai/agents/queryRetryCap.ts
@@ -1,4 +1,7 @@
-import { assertUnreachable } from '@lightdash/common';
+import {
+    assertUnreachable,
+    isWarehouseResourceLimitError,
+} from '@lightdash/common';
 import type { ModelMessage } from 'ai';
 
 /**
@@ -20,13 +23,20 @@ export const QUERY_TOOL_NAMES: ReadonlySet<string> = new Set([
 export const WAREHOUSE_SLOW_CAP = 2;
 /** Executed-query failures of any kind: the model is looping, not converging. */
 export const WAREHOUSE_ERROR_CAP = 3;
+/** Two changed query attempts after the original resource-limit failure. */
+export const DEEP_RESEARCH_RESOURCE_RECOVERY_ATTEMPTS = 2;
 /**
  * Schema-validation failures never reach the warehouse and usually converge
  * after the relayed error, so their bound is later and corrective, not final.
  */
 export const INVALID_INPUT_CAP = 6;
 
-type QueryResultClass = 'ok' | 'warehouse-slow' | 'invalid-input' | 'other';
+type QueryResultClass =
+    | 'ok'
+    | 'warehouse-resource-limit'
+    | 'warehouse-slow'
+    | 'invalid-input'
+    | 'other';
 
 // A tool result as it appears in the model messages (see toModelOutput):
 // success → { type: 'text' }, error → { type: 'error-text' }.
@@ -36,12 +46,11 @@ const WAREHOUSE_SLOW =
     /timed out|timeout|polling|connection (terminated|lost)|econnreset/i;
 
 /**
- * We deliberately do NOT bucket errors by warehouse-specific meaning
- * (permissions, scan limits, bad SQL, ...) — that would mean matching each
- * warehouse's error prose, which is brittle and only ever covers whichever
- * warehouse we hard-coded. Invalid input is likewise not detected from the
- * message text: the caller records the failed calls' ids as the AI SDK
- * reports them (`toolCall.invalid`), so classification survives SDK rewording.
+ * Resource-limit recovery needs a small stable vocabulary shared by warehouse
+ * errors (bytes, memory, quota, and resource exhaustion). Other warehouse
+ * prose remains deliberately unclassified. Invalid input is not detected from
+ * message text: the caller records the failed calls' ids as the AI SDK reports
+ * them (`toolCall.invalid`), so classification survives SDK rewording.
  */
 const classifyQueryResult = (
     output: ToolResultOutput,
@@ -49,12 +58,18 @@ const classifyQueryResult = (
 ): QueryResultClass => {
     if (output.type !== 'error-text') return 'ok';
     if (isInvalidInput) return 'invalid-input';
+    if (isWarehouseResourceLimitError(output.value)) {
+        return 'warehouse-resource-limit';
+    }
     if (WAREHOUSE_SLOW.test(output.value)) return 'warehouse-slow';
     return 'other';
 };
 
 const isWarehouseFailure = (c: QueryResultClass): boolean =>
-    c === 'warehouse-slow' || c === 'other';
+    c === 'warehouse-resource-limit' || c === 'warehouse-slow' || c === 'other';
+
+const isRecoverableResourceFailure = (c: QueryResultClass): boolean =>
+    c === 'warehouse-resource-limit' || c === 'warehouse-slow';
 
 type QueryRetryCapDecision =
     | { capped: false }
@@ -101,15 +116,21 @@ const shouldCapQueryRetries = (
     return { capped: false };
 };
 
-type QueryResult = { class: QueryResultClass; value: string };
+type QueryResult = { class: QueryResultClass; value: string; round: number };
 
 const collectQueryResults = (
     messages: ModelMessage[],
     invalidToolCallIds: ReadonlySet<string>,
 ): QueryResult[] => {
     const results: QueryResult[] = [];
+    let round = -1;
+    let previousMessageWasTool = false;
     for (const message of messages) {
         if (message.role === 'tool' && Array.isArray(message.content)) {
+            if (!previousMessageWasTool) {
+                round += 1;
+            }
+            previousMessageWasTool = true;
             for (const part of message.content) {
                 if (
                     part &&
@@ -131,9 +152,12 @@ const collectQueryResults = (
                             typeof output.value === 'string'
                                 ? output.value
                                 : '',
+                        round,
                     });
                 }
             }
+        } else {
+            previousMessageWasTool = false;
         }
     }
     return results;
@@ -153,29 +177,119 @@ const cleanWarehouseError = (value: string): string =>
 
 const MAX_ERROR_SNIPPET_CHARS = 500;
 
+const countActiveResourceFailureRounds = (results: QueryResult[]): number => {
+    const rounds = new Map<number, QueryResult[]>();
+    for (const result of results) {
+        rounds.set(result.round, [...(rounds.get(result.round) ?? []), result]);
+    }
+
+    let failures = 0;
+    for (const roundResults of rounds.values()) {
+        const hasResourceFailure = roundResults.some((result) =>
+            isRecoverableResourceFailure(result.class),
+        );
+        if (hasResourceFailure) {
+            failures += 1;
+        } else if (roundResults.some((result) => result.class === 'ok')) {
+            failures = 0;
+        }
+    }
+    return failures;
+};
+
+const buildDeepResearchResourceRecoveryOverride = (
+    results: QueryResult[],
+    allToolNames: string[],
+): { activeTools: string[]; nudge: string; markerKey: string } | null => {
+    const latestRound = results.at(-1)?.round;
+    if (latestRound === undefined) return null;
+
+    const latestResults = results.filter(
+        (result) => result.round === latestRound,
+    );
+    if (
+        !latestResults.some((result) =>
+            isRecoverableResourceFailure(result.class),
+        )
+    ) {
+        return null;
+    }
+
+    const resourceFailureRounds = countActiveResourceFailureRounds(results);
+    const lastError = [...latestResults]
+        .reverse()
+        .find((result) => isRecoverableResourceFailure(result.class))?.value;
+    const snippet = lastError
+        ? cleanWarehouseError(lastError).slice(0, MAX_ERROR_SNIPPET_CHARS)
+        : '';
+
+    if (resourceFailureRounds <= DEEP_RESEARCH_RESOURCE_RECOVERY_ATTEMPTS) {
+        return {
+            activeTools: allToolNames,
+            markerKey: `resource-recovery-${resourceFailureRounds}`,
+            nudge: [
+                `A warehouse resource limit stopped the last evidence query. Recovery attempt ${resourceFailureRounds} of ${DEEP_RESEARCH_RESOURCE_RECOVERY_ATTEMPTS}.`,
+                'Do not repeat the same query unchanged.',
+                'Reduce its cost by narrowing the date range, removing high-cardinality dimensions, aggregating earlier, or splitting the question.',
+                'Record the original limit and the strategy you chose in your findings.',
+                ...(snippet ? [`The warehouse reported: "${snippet}".`] : []),
+            ].join(' '),
+        };
+    }
+
+    return {
+        activeTools: allToolNames.filter((name) => !QUERY_TOOL_NAMES.has(name)),
+        markerKey: 'resource-recovery-exhausted',
+        nudge: [
+            `The warehouse resource limit remained after ${DEEP_RESEARCH_RESOURCE_RECOVERY_ATTEMPTS} changed recovery attempts.`,
+            'Do not run another query for this evidence.',
+            'Continue with verified evidence already gathered and submit the best supported findings available.',
+            'Mention the limitation only where it materially affects a finding. Do not fail the whole research run when useful evidence remains.',
+            ...(snippet ? [`The warehouse reported: "${snippet}".`] : []),
+        ].join(' '),
+    };
+};
+
 /**
  * Given the current model messages, the full tool set, and the ids of tool
  * calls the AI SDK dropped for invalid input, decide the `prepareStep`
  * override that bounds query-tool retries: returns `activeTools` and a nudge
- * message, or null when no cap has tripped. Warehouse failures remove the
- * query tools and relay the actual warehouse error so the agent surfaces it
- * (permissions / query-size limit) instead of failing silently; validation
- * loops keep the tools and steer the model to fix its input. Pure so the
- * `prepareStep` wiring stays trivial.
+ * message, or null when no cap has tripped. Deep Research can recover from a
+ * resource limit with a changed query before its tools are removed. Other
+ * warehouse failures relay the actual error instead of failing silently;
+ * validation loops keep the tools and steer the model to fix their input.
+ * Pure so the `prepareStep` wiring stays trivial.
  */
 export const buildQueryRetryStepOverride = (
     messages: ModelMessage[],
     allToolNames: string[],
     invalidToolCallIds: ReadonlySet<string>,
-): { activeTools: string[]; nudge: string } | null => {
+    executionMode: 'standard' | 'deep_research' = 'standard',
+): { activeTools: string[]; nudge: string; markerKey: string } | null => {
     const results = collectQueryResults(messages, invalidToolCallIds);
-    const decision = shouldCapQueryRetries(results.map((r) => r.class));
+    if (executionMode === 'deep_research') {
+        const resourceRecovery = buildDeepResearchResourceRecoveryOverride(
+            results,
+            allToolNames,
+        );
+        if (resourceRecovery) return resourceRecovery;
+    }
+
+    const classes = results
+        .map((result) => result.class)
+        .filter(
+            (resultClass) =>
+                executionMode !== 'deep_research' ||
+                !isRecoverableResourceFailure(resultClass),
+        );
+    const decision = shouldCapQueryRetries(classes);
     if (!decision.capped) return null;
 
     switch (decision.kind) {
         case 'correct-input':
             return {
                 activeTools: allToolNames,
+                markerKey: 'invalid-input-cap',
                 nudge: [
                     `Your query tool calls keep failing schema validation (${decision.reason}).`,
                     'Stop retrying the same input shape.',
@@ -213,6 +327,7 @@ export const buildQueryRetryStepOverride = (
                 activeTools: allToolNames.filter(
                     (name) => !QUERY_TOOL_NAMES.has(name),
                 ),
+                markerKey: 'warehouse-error-cap',
                 nudge,
             };
         }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -380,6 +380,7 @@ export * from './utils/timeFrames';
 export * from './utils/resolveQueryTimezone';
 export * from './utils/virtualView';
 export * from './utils/warehouse';
+export * from './utils/warehouseResourceLimits';
 export * from './visualizations/BigNumberDataModel';
 export * from './visualizations/CartesianChartDataModel';
 export * from './visualizations/helpers/getCartesianAxisFormatterConfig';

--- a/packages/common/src/utils/warehouseResourceLimits.test.ts
+++ b/packages/common/src/utils/warehouseResourceLimits.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isWarehouseResourceLimitError } from './warehouseResourceLimits';
+
+describe('isWarehouseResourceLimitError', () => {
+    it.each([
+        'BigQuery error: bytesBilledLimitExceeded',
+        'Query exceeded limit for bytes billed: 50000000000',
+        'Warehouse resource exhausted: memory limit exceeded',
+    ])('recognizes warehouse resource limits: %s', (message) => {
+        expect(isWarehouseResourceLimitError(message)).toBe(true);
+    });
+
+    it('does not classify unrelated query errors', () => {
+        expect(
+            isWarehouseResourceLimitError('Access denied for table orders'),
+        ).toBe(false);
+    });
+});

--- a/packages/common/src/utils/warehouseResourceLimits.ts
+++ b/packages/common/src/utils/warehouseResourceLimits.ts
@@ -1,0 +1,5 @@
+const WAREHOUSE_RESOURCE_LIMIT =
+    /bytesBilledLimitExceeded|maximumBytesBilled|bytes billed|resource[_ -]?exhausted|resource limit|memory limit|out of memory|exceeded (?:its |the )?(?:query |warehouse )?(?:limit|quota)/i;
+
+export const isWarehouseResourceLimitError = (message: string): boolean =>
+    WAREHOUSE_RESOURCE_LIMIT.test(message);

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.test.tsx
@@ -287,4 +287,36 @@ describe('DeepResearchChartTile', () => {
         screen.getByRole('button', { name: 'Retry' }).click();
         expect(refetchRows).toHaveBeenCalledOnce();
     });
+
+    it('explains warehouse limits without offering an unchanged retry', () => {
+        mocks.useQueryResults.mockReturnValue({
+            ...idleResults,
+            error: {
+                status: 'error',
+                error: {
+                    name: 'Error',
+                    statusCode: 500,
+                    message:
+                        'BigQuery error: bytesBilledLimitExceeded. Query exceeded limit for bytes billed.',
+                    data: {},
+                },
+            },
+        });
+
+        renderTile();
+
+        expect(
+            screen.getByText(
+                'This chart exceeds the warehouse query limit. Open it in Explore to narrow the query.',
+            ),
+        ).toBeVisible();
+        expect(
+            screen.getByRole('link', {
+                name: `Open ${chart.title} in Explore`,
+            }),
+        ).toBeVisible();
+        expect(
+            screen.queryByRole('button', { name: 'Retry' }),
+        ).not.toBeInTheDocument();
+    });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
@@ -1,5 +1,7 @@
 import {
     type AiDeepResearchChartData,
+    isApiError,
+    isWarehouseResourceLimitError,
     type ToolRunQueryArgs,
 } from '@lightdash/common';
 import { Anchor, Box, Group } from '@mantine/core';
@@ -27,6 +29,12 @@ type Props = {
     withExploreLink?: boolean;
 };
 
+const getErrorMessage = (error: unknown): string => {
+    if (isApiError(error)) return error.error.message;
+    if (error instanceof Error) return error.message;
+    return '';
+};
+
 export const DeepResearchChartTile = ({
     chartKey,
     chart,
@@ -51,6 +59,9 @@ export const DeepResearchChartTile = ({
     );
 
     const liveError = liveQuery.error ?? liveResults.error;
+    const isResourceLimitError = isWarehouseResourceLimitError(
+        getErrorMessage(liveError),
+    );
     const isLoadingLive = liveQuery.isFetching || liveResults.isFetchingRows;
     const appliedFilters = chart.metricQuery.filters;
     const displayFilterPills =
@@ -90,13 +101,21 @@ export const DeepResearchChartTile = ({
             <Box>
                 {liveError ? (
                     <InlineErrorState
-                        message="The live data for this chart could not be loaded."
-                        onRetry={() => {
-                            void liveQuery.refetch();
-                            if (liveResults.error) {
-                                void liveResults.refetchRows();
-                            }
-                        }}
+                        message={
+                            isResourceLimitError
+                                ? 'This chart exceeds the warehouse query limit. Open it in Explore to narrow the query.'
+                                : 'The live data for this chart could not be loaded.'
+                        }
+                        onRetry={
+                            isResourceLimitError
+                                ? undefined
+                                : () => {
+                                      void liveQuery.refetch();
+                                      if (liveResults.error) {
+                                          void liveResults.refetchRows();
+                                      }
+                                  }
+                        }
                     />
                 ) : isLoadingLive || !liveQuery.data ? (
                     <EmptyStateLoader title="Loading live chart data" />


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9813

## Summary

PR 3 of 3. Treats warehouse resource limits as recoverable Deep Research feedback while keeping the connection limit authoritative.

Stacks on top of PR 2 ([#27158](https://github.com/lightdash/lightdash/pull/27158)), which makes report content full width.

## Recovery flow

```
resource limit
  -> narrow or simplify query
  -> retry round 1
  -> retry round 2
  -> continue from verified partial evidence
```

Parallel failures count as one round. Each retry instruction requires a changed query, suggests lower-cost strategies, and leaves a persisted marker. Exhaustion removes query tools for that research path instead of failing a run that already has useful evidence. Standard agent retries remain unchanged.

Saved report charts now identify warehouse-limit failures, keep the Explore handoff visible, and remove the unchanged Retry action.

## Test plan

- [x] Query recovery policy: 16 tests pass
- [x] Warehouse-limit classifier: 4 tests pass
- [x] Chart error state: 8 tests pass
- [x] Common typecheck passes
- [x] Common, backend, and frontend lint pass
- [ ] Backend typecheck is blocked by the existing missing `@duckdb/node-api` dependency
- [ ] Frontend typecheck is blocked by the existing unrelated `FormArrayElement` export error