### PR TITLE
fix(dbt): allow configured machine environment variables

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -106,6 +106,9 @@ export const lightdashConfigMock: LightdashConfig = {
     queryPhaseMetrics: {
         projectUuids: [],
     },
+    dbt: {
+        environmentVariableAllowlist: [],
+    },
     dashboard: {
         maxTilesPerTab: 50,
         maxTabsPerDashboard: 20,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1427,6 +1427,9 @@ export type LightdashConfig = {
     queryPhaseMetrics: {
         projectUuids: string[];
     };
+    dbt: {
+        environmentVariableAllowlist: string[];
+    };
     database: {
         connectionUri: string | undefined;
         maxConnections: number | undefined;
@@ -2918,6 +2921,11 @@ export const parseConfig = (): LightdashConfig => {
         queryPhaseMetrics: {
             projectUuids: getArrayFromCommaSeparatedList(
                 'QUERY_PHASE_METRICS_PROJECT_UUIDS',
+            ),
+        },
+        dbt: {
+            environmentVariableAllowlist: getArrayFromCommaSeparatedList(
+                'ALLOW_DBT_COMMANDS_ACCESS_TO_ENV_VARS',
             ),
         },
         allowMultiOrgs: process.env.ALLOW_MULTIPLE_ORGS === 'true',

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -267,6 +267,7 @@ export async function seed(knex: Knex): Promise<void> {
                 onWarehouseCatalogChange: () => {},
             },
             SupportedDbtVersions.V1_11,
+            lightdashConfig.dbt.environmentVariableAllowlist,
         );
         const explores = await adapter.compileAllExplores({
             userUuid: user.user_uuid,

--- a/packages/backend/src/dbt/CLAUDE.md
+++ b/packages/backend/src/dbt/CLAUDE.md
@@ -68,7 +68,7 @@ await fs.writeFile('/tmp/profiles/profiles.yml', profiles.profiles);
 
 <importantToKnow>
 - DbtCliClient supports multiple dbt versions (1.4 through 1.10) with version-specific commands
-- The dbt subprocess does NOT inherit the backend environment (`extendEnv: false`). It gets only what `dbtProcessEnvironment.ts` lists by exact name, plus the project and profile variables. Anything a dbt project can read with `env_var()` ends up in compiled explore metadata, which any project viewer can read
+- The dbt subprocess does NOT inherit the backend environment (`extendEnv: false`). It gets only what `dbtProcessEnvironment.ts` lists by exact name, machine variables parsed from `ALLOW_DBT_COMMANDS_ACCESS_TO_ENV_VARS` into `LightdashConfig.dbt.environmentVariableAllowlist`, plus the project and profile variables. Anything a dbt project can read with `env_var()` ends up in compiled explore metadata, which any project viewer can read
 - The only dbt commands we run are `deps`, `ls` and `parse`, and none of them connects to the warehouse (verified against a dead endpoint on dbt-postgres). The warehouse connection in a compile comes from the Node `warehouseClient` in `dbtBaseProjectAdapter`, not from the dbt subprocess, so the cloud credentials on that list are probably unnecessary. They are still shared while that is confirmed on the adapters that authenticate from the host; narrowing them is follow up work
 - Profiles are auto-generated from warehouse credentials and use environment variables for security
 - The client automatically modifies dbt_project.yml to set target-path to '/target'

--- a/packages/backend/src/dbt/dbtCliClient.mock.ts
+++ b/packages/backend/src/dbt/dbtCliClient.mock.ts
@@ -10,6 +10,7 @@ export const cliArgs = {
     dbtProjectDirectory: 'dbtProjectDirectory',
     dbtProfilesDirectory: 'dbtProfilesDirectory',
     environment: {},
+    environmentVariableAllowlist: [],
     profileName: 'profileName',
     target: 'target',
 };

--- a/packages/backend/src/dbt/dbtCliClient.test.ts
+++ b/packages/backend/src/dbt/dbtCliClient.test.ts
@@ -145,6 +145,20 @@ describe('DbtCliClient environment', () => {
         expect(env.PATH).toEqual('/usr/local/bin');
     });
 
+    it('hands allowlisted machine variables to dbt', async () => {
+        vi.stubEnv('UTILS_PII_SALT', 'machine-owned-salt');
+
+        await new DbtCliClient({
+            ...cliArgs,
+            environmentVariableAllowlist: ['UTILS_PII_SALT'],
+        }).installDeps();
+        const [, , options] = execaMock.mock.calls[0];
+
+        expect((options as { env: Record<string, string> }).env).toMatchObject({
+            UTILS_PII_SALT: 'machine-owned-salt',
+        });
+    });
+
     it('cannot be pointed at another target directory by a project', async () => {
         await new DbtCliClient({
             ...cliArgs,

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -31,6 +31,7 @@ type DbtCliArgs = {
     dbtProjectDirectory: string;
     dbtProfilesDirectory: string;
     environment: Record<string, string>;
+    environmentVariableAllowlist: string[];
     profileName?: string;
     target?: string;
     dbtVersion: SupportedDbtVersions;
@@ -56,6 +57,8 @@ export class DbtCliClient implements DbtClient {
 
     environment: Record<string, string>;
 
+    environmentVariableAllowlist: string[];
+
     profileName: string | undefined;
 
     target: string | undefined;
@@ -70,6 +73,7 @@ export class DbtCliClient implements DbtClient {
         dbtProjectDirectory,
         dbtProfilesDirectory,
         environment,
+        environmentVariableAllowlist,
         profileName,
         target,
         dbtVersion,
@@ -78,6 +82,7 @@ export class DbtCliClient implements DbtClient {
         this.dbtProjectDirectory = dbtProjectDirectory;
         this.dbtProfilesDirectory = dbtProfilesDirectory;
         this.environment = environment;
+        this.environmentVariableAllowlist = environmentVariableAllowlist;
         this.profileName = profileName;
         this.target = target;
         this.targetDirectory = undefined;
@@ -193,6 +198,8 @@ export class DbtCliClient implements DbtClient {
                 extendEnv: false,
                 env: getDbtProcessEnvironment({
                     processEnvironment: process.env,
+                    environmentVariableAllowlist:
+                        this.environmentVariableAllowlist,
                     projectEnvironment: this.environment,
                     targetPath,
                 }),

--- a/packages/backend/src/dbt/dbtProcessEnvironment.test.ts
+++ b/packages/backend/src/dbt/dbtProcessEnvironment.test.ts
@@ -19,12 +19,17 @@ const processEnvironment: NodeJS.ProcessEnv = {
     ANTHROPIC_API_KEY: 'anthropic-key',
     MY_AWS_SECRET_KEY: 'lookalike-secret',
     UNKNOWN_VARIABLE: 'unknown',
+    UTILS_PII_SALT: 'machine-owned-salt',
+    OTHER_ALLOWED_VARIABLE: 'other-machine-value',
+    ALLOW_DBT_COMMANDS_ACCESS_TO_ENV_VARS:
+        'UTILS_PII_SALT,OTHER_ALLOWED_VARIABLE',
     EMPTY_VARIABLE: undefined,
 };
 
 const buildEnvironment = (projectEnvironment: Record<string, string> = {}) =>
     getDbtProcessEnvironment({
         processEnvironment,
+        environmentVariableAllowlist: [],
         projectEnvironment,
         targetPath: '/tmp/dbt_target_test',
     });
@@ -71,6 +76,44 @@ describe('getDbtProcessEnvironment', () => {
         expect(environment).not.toHaveProperty('MY_AWS_SECRET_KEY');
         expect(environment).not.toHaveProperty('UNKNOWN_VARIABLE');
         expect(environment).not.toHaveProperty('EMPTY_VARIABLE');
+    });
+
+    it('forwards machine variables named in the dbt allowlist', () => {
+        const environment = getDbtProcessEnvironment({
+            processEnvironment: {
+                ...processEnvironment,
+            },
+            environmentVariableAllowlist: [
+                'UTILS_PII_SALT',
+                'OTHER_ALLOWED_VARIABLE',
+            ],
+            projectEnvironment: {},
+            targetPath: '/tmp/dbt_target_test',
+        });
+
+        expect(environment.UTILS_PII_SALT).toEqual('machine-owned-salt');
+        expect(environment.OTHER_ALLOWED_VARIABLE).toEqual(
+            'other-machine-value',
+        );
+        expect(environment).not.toHaveProperty(
+            'ALLOW_DBT_COMMANDS_ACCESS_TO_ENV_VARS',
+        );
+        expect(environment).not.toHaveProperty('UNKNOWN_VARIABLE');
+    });
+
+    it('lets project variables override allowlisted machine variables', () => {
+        const environment = getDbtProcessEnvironment({
+            processEnvironment: {
+                ...processEnvironment,
+            },
+            environmentVariableAllowlist: ['UTILS_PII_SALT'],
+            projectEnvironment: {
+                UTILS_PII_SALT: 'project-owned-salt',
+            },
+            targetPath: '/tmp/dbt_target_test',
+        });
+
+        expect(environment.UTILS_PII_SALT).toEqual('project-owned-salt');
     });
 
     it('keeps the Lightdash controlled dbt variables', () => {
@@ -134,6 +177,7 @@ describe('getMissingEnvironmentVariableHint', () => {
 
         expect(hint).toContain('MY_VAR');
         expect(hint).toContain('OTHER_VAR');
+        expect(hint).toContain('ALLOW_DBT_COMMANDS_ACCESS_TO_ENV_VARS');
     });
 
     it('returns nothing for unrelated dbt failures', () => {

--- a/packages/backend/src/dbt/dbtProcessEnvironment.ts
+++ b/packages/backend/src/dbt/dbtProcessEnvironment.ts
@@ -82,6 +82,7 @@ const CLOUD_CREDENTIAL_ENVIRONMENT_VARIABLE_KEYS = [
 
 type DbtProcessEnvironmentArgs = {
     processEnvironment: NodeJS.ProcessEnv;
+    environmentVariableAllowlist: string[];
     projectEnvironment: Record<string, string>;
     targetPath: string;
 };
@@ -97,6 +98,7 @@ const inheritKeys = (
 
 export const getDbtProcessEnvironment = ({
     processEnvironment,
+    environmentVariableAllowlist,
     projectEnvironment,
     targetPath,
 }: DbtProcessEnvironmentArgs): Record<string, string> => ({
@@ -107,6 +109,7 @@ export const getDbtProcessEnvironment = ({
         processEnvironment,
         CLOUD_CREDENTIAL_ENVIRONMENT_VARIABLE_KEYS,
     ),
+    ...inheritKeys(processEnvironment, environmentVariableAllowlist),
     ...projectEnvironment,
     // Runtime plumbing sits above it: PATH decides which binary runs, and the
     // proxy and CA settings decide where dbt deps fetches from, so a project
@@ -145,5 +148,5 @@ export const getMissingEnvironmentVariableHint = (
 
     return `Your dbt project reads ${keys.join(
         ', ',
-    )} from the environment, which is not available during compilation. Set the values you need in your project's dbt environment variables.`;
+    )} from the environment, which is not available during compilation. Set the values in your project's dbt environment variables or ask an administrator to allow the machine environment variables with ALLOW_DBT_COMMANDS_ACCESS_TO_ENV_VARS.`;
 };

--- a/packages/backend/src/projectAdapters/dbtAzureDevOpsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtAzureDevOpsProjectAdapter.ts
@@ -19,6 +19,7 @@ type Args = {
     warehouseCredentials: CreateWarehouseCredentials;
     targetName: string | undefined;
     environment: DbtProjectEnvironmentVariable[] | undefined;
+    environmentVariableAllowlist: string[];
     cachedWarehouse: CachedWarehouse;
     dbtVersion: SupportedDbtVersions;
     selector?: string;
@@ -38,6 +39,7 @@ export class DbtAzureDevOpsProjectAdapter extends DbtGitProjectAdapter {
         warehouseCredentials,
         targetName,
         environment,
+        environmentVariableAllowlist,
         cachedWarehouse,
         dbtVersion,
         selector,
@@ -53,6 +55,7 @@ export class DbtAzureDevOpsProjectAdapter extends DbtGitProjectAdapter {
             warehouseCredentials,
             targetName,
             environment,
+            environmentVariableAllowlist,
             cachedWarehouse,
             dbtVersion,
             selector,

--- a/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.ts
@@ -20,6 +20,7 @@ type Args = {
     hostDomain?: string;
     targetName: string | undefined;
     environment: DbtProjectEnvironmentVariable[] | undefined;
+    environmentVariableAllowlist: string[];
     cachedWarehouse: CachedWarehouse;
     dbtVersion: SupportedDbtVersions;
     selector?: string;
@@ -39,6 +40,7 @@ export class DbtBitBucketProjectAdapter extends DbtGitProjectAdapter {
         hostDomain,
         targetName,
         environment,
+        environmentVariableAllowlist,
         cachedWarehouse,
         dbtVersion,
         selector,
@@ -56,6 +58,7 @@ export class DbtBitBucketProjectAdapter extends DbtGitProjectAdapter {
             warehouseCredentials,
             targetName,
             environment,
+            environmentVariableAllowlist,
             cachedWarehouse,
             dbtVersion,
             selector,

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -31,6 +31,7 @@ export type DbtGitProjectAdapterArgs = {
     warehouseCredentials: CreateWarehouseCredentials;
     targetName: string | undefined;
     environment: DbtProjectEnvironmentVariable[] | undefined;
+    environmentVariableAllowlist: string[];
     cachedWarehouse: CachedWarehouse;
     dbtVersion: SupportedDbtVersions;
     selector?: string;
@@ -98,6 +99,7 @@ export class DbtGitProjectAdapter
         warehouseCredentials,
         targetName,
         environment,
+        environmentVariableAllowlist,
         cachedWarehouse,
         dbtVersion,
         selector,
@@ -114,6 +116,7 @@ export class DbtGitProjectAdapter
             warehouseCredentials,
             targetName,
             environment,
+            environmentVariableAllowlist,
             cachedWarehouse,
             dbtVersion,
             selector,

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
@@ -21,6 +21,7 @@ type DbtGithubProjectAdapterArgs = {
     hostDomain?: string;
     targetName: string | undefined;
     environment: DbtProjectEnvironmentVariable[] | undefined;
+    environmentVariableAllowlist: string[];
     cachedWarehouse: CachedWarehouse;
     dbtVersion: SupportedDbtVersions;
     selector?: string;
@@ -38,6 +39,7 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
         hostDomain,
         targetName,
         environment,
+        environmentVariableAllowlist,
         cachedWarehouse,
         dbtVersion,
         selector,
@@ -60,6 +62,7 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
             gitBranch: githubBranch,
             targetName,
             environment,
+            environmentVariableAllowlist,
             cachedWarehouse,
             dbtVersion,
             selector,

--- a/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
@@ -19,6 +19,7 @@ type DbtGitlabProjectAdapterArgs = {
     hostDomain?: string;
     targetName: string | undefined;
     environment: DbtProjectEnvironmentVariable[] | undefined;
+    environmentVariableAllowlist: string[];
     cachedWarehouse: CachedWarehouse;
     dbtVersion: SupportedDbtVersions;
     selector?: string;
@@ -36,6 +37,7 @@ export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
         hostDomain,
         targetName,
         environment,
+        environmentVariableAllowlist,
         cachedWarehouse,
         dbtVersion,
         selector,
@@ -53,6 +55,7 @@ export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
             warehouseCredentials,
             targetName,
             environment,
+            environmentVariableAllowlist,
             cachedWarehouse,
             dbtVersion,
             selector,

--- a/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
@@ -24,6 +24,7 @@ type DbtLocalCredentialsProjectAdapterArgs = {
     warehouseCredentials: CreateWarehouseCredentials;
     targetName: string | undefined;
     environment: DbtProjectEnvironmentVariable[] | undefined;
+    environmentVariableAllowlist: string[];
     cachedWarehouse: CachedWarehouse;
     dbtVersion: SupportedDbtVersions;
     selector?: string;
@@ -39,6 +40,7 @@ export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
         warehouseCredentials,
         targetName,
         environment,
+        environmentVariableAllowlist,
         cachedWarehouse,
         dbtVersion,
         selector,
@@ -82,6 +84,7 @@ export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
             profilesDir,
             projectDir,
             environment: updatedEnvironment,
+            environmentVariableAllowlist,
             cachedWarehouse,
             dbtVersion,
             selector,

--- a/packages/backend/src/projectAdapters/dbtLocalProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtLocalProjectAdapter.ts
@@ -12,6 +12,7 @@ type DbtLocalProjectAdapterArgs = {
     target: string | undefined;
     profileName?: string | undefined;
     environment?: Record<string, string>;
+    environmentVariableAllowlist: string[];
     cachedWarehouse: CachedWarehouse;
     dbtVersion: SupportedDbtVersions;
     selector?: string;
@@ -27,6 +28,7 @@ export class DbtLocalProjectAdapter extends DbtBaseProjectAdapter {
         target,
         profileName,
         environment,
+        environmentVariableAllowlist,
         cachedWarehouse,
         dbtVersion,
         selector,
@@ -35,6 +37,7 @@ export class DbtLocalProjectAdapter extends DbtBaseProjectAdapter {
             dbtProjectDirectory: projectDir,
             dbtProfilesDirectory: profilesDir,
             environment: environment || {},
+            environmentVariableAllowlist,
             profileName,
             target,
             dbtVersion,

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -25,6 +25,7 @@ export const projectAdapterFromConfig = async (
     warehouseCredentials: CreateWarehouseCredentials,
     cachedWarehouse: CachedWarehouse,
     dbtVersionOption: DbtVersionOption,
+    environmentVariableAllowlist: string[],
     analytics?: LightdashAnalytics,
     // MANIFEST-only: dbt project dir to read lightdash.config.yml /
     // project_context.yml from (the multiple-dbt-sources merge passes the
@@ -50,6 +51,7 @@ export const projectAdapterFromConfig = async (
                 warehouseCredentials,
                 targetName: config.target,
                 environment: config.environment,
+                environmentVariableAllowlist,
                 cachedWarehouse,
                 dbtVersion,
 
@@ -111,6 +113,7 @@ export const projectAdapterFromConfig = async (
                 warehouseCredentials,
                 targetName: config.target,
                 environment: config.environment,
+                environmentVariableAllowlist,
                 cachedWarehouse,
                 dbtVersion,
 
@@ -128,6 +131,7 @@ export const projectAdapterFromConfig = async (
                 warehouseCredentials,
                 targetName: config.target,
                 environment: config.environment,
+                environmentVariableAllowlist,
                 cachedWarehouse,
                 dbtVersion,
 
@@ -146,6 +150,7 @@ export const projectAdapterFromConfig = async (
                 warehouseCredentials,
                 targetName: config.target,
                 environment: config.environment,
+                environmentVariableAllowlist,
                 cachedWarehouse,
                 dbtVersion,
 
@@ -164,6 +169,7 @@ export const projectAdapterFromConfig = async (
                 warehouseCredentials,
                 targetName: config.target,
                 environment: config.environment,
+                environmentVariableAllowlist,
                 cachedWarehouse,
                 dbtVersion,
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3873,6 +3873,7 @@ export class ProjectService extends BaseService {
                 warehouseCredentials,
                 cachedWarehouse,
                 dbtVersionOption,
+                this.lightdashConfig.dbt.environmentVariableAllowlist,
                 this.analytics,
             );
             await adapter.test();
@@ -4309,6 +4310,7 @@ export class ProjectService extends BaseService {
             sshTunnel.overrideCredentials,
             cachedWarehouse,
             dbtVersionOption,
+            this.lightdashConfig.dbt.environmentVariableAllowlist,
             this.analytics,
         );
         return {
@@ -4344,6 +4346,7 @@ export class ProjectService extends BaseService {
             shared.warehouseCredentials,
             shared.cachedWarehouse,
             shared.dbtVersionOption,
+            this.lightdashConfig.dbt.environmentVariableAllowlist,
             this.analytics,
         );
     }
@@ -4517,6 +4520,7 @@ export class ProjectService extends BaseService {
             shared.warehouseCredentials,
             shared.cachedWarehouse,
             shared.dbtVersionOption,
+            this.lightdashConfig.dbt.environmentVariableAllowlist,
             this.analytics,
             // Keep the primary source's lightdash.config.yml / project_context.yml
             // (spotlight categories, table_groups, parameters, AI context). The


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates: PROD-9718

### Description:
Adds instance-level `ALLOW_DBT_COMMANDS_ACCESS_TO_ENV_VARS` as a parsed dbt configuration allowlist and threads it through project adapters into the explicit subprocess environment.
This preserves backend environment isolation while letting self-hosted administrators intentionally expose selected machine variables to dbt compilation, with project values retaining precedence.
Validated with focused tests, backend typecheck, lint, and formatting.