### PR TITLE
feat: preserve YAML parameter option order in UI option lists

### DIFF
--- a/packages/frontend/src/features/parameters/components/ParameterInput.test.tsx
+++ b/packages/frontend/src/features/parameters/components/ParameterInput.test.tsx
@@ -1,0 +1,51 @@
+import { type LightdashProjectParameter } from '@lightdash/common';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { ParameterInput } from './ParameterInput';
+
+const renderParameter = (parameter: LightdashProjectParameter) =>
+    renderWithProviders(
+        <ParameterInput
+            paramKey="channel"
+            parameter={parameter}
+            value={null}
+            onParameterChange={vi.fn()}
+        />,
+    );
+
+const getOptionLabels = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('[role="option"]')).map(
+        (option) => option.textContent,
+    );
+
+describe('ParameterInput', () => {
+    it('renders plain options in the order they were authored', async () => {
+        const { container, getByRole } = renderParameter({
+            label: 'Channel',
+            options: ['Global', 'sub_channel', 'Alpha'],
+        });
+
+        await userEvent.click(getByRole('textbox'));
+
+        expect(getOptionLabels(container)).toEqual([
+            'Global',
+            'sub_channel',
+            'Alpha',
+        ]);
+    });
+
+    it('renders labelled options in the order they were authored', async () => {
+        const { container, getByRole } = renderParameter({
+            label: 'Channel',
+            options: [
+                { label: 'Zebra', value: 'z' },
+                { label: 'Apple', value: 'a' },
+            ],
+        });
+
+        await userEvent.click(getByRole('textbox'));
+
+        expect(getOptionLabels(container)).toEqual(['Zebra', 'Apple']);
+    });
+});

--- a/packages/frontend/src/features/parameters/components/ParameterInput.tsx
+++ b/packages/frontend/src/features/parameters/components/ParameterInput.tsx
@@ -283,28 +283,19 @@ export const ParameterInput: FC<ParameterInputProps> = ({
               )
             : optionsData;
 
-        const regularItems = [...baseItems] // Create a copy to avoid mutating Redux state
-            .sort((a, b) => {
-                const aLabel = isLightdashParameterOption(a)
-                    ? a.label
-                    : formatDisplayValue(String(a));
-                const bLabel = isLightdashParameterOption(b)
-                    ? b.label
-                    : formatDisplayValue(String(b));
-                return aLabel.localeCompare(bLabel);
-            })
-            .map((option) => {
-                if (isLightdashParameterOption(option)) {
-                    return {
-                        value: String(option.value),
-                        label: option.label,
-                    };
-                }
+        // Static options keep the order they were authored in YAML
+        const regularItems = baseItems.map((option) => {
+            if (isLightdashParameterOption(option)) {
                 return {
-                    value: String(option),
-                    label: formatDisplayValue(String(option)),
+                    value: String(option.value),
+                    label: option.label,
                 };
-            });
+            }
+            return {
+                value: String(option),
+                label: formatDisplayValue(String(option)),
+            };
+        });
 
         const fetchedItems =
             fetchedResults.length > 0


### PR DESCRIPTION
### Description:

Parameter option lists were sorted alphabetically when building the select items, throwing away the order authored in YAML. Modelers order `options` deliberately (defaults first, hierarchies grouped), so the UI now renders static options in the authored order.

Per the discussion on the issue, this is always-on rather than opt-in — no new config field.

- Removed the `localeCompare` sort over static `options` in `ParameterInput` (plain values and `{ label, value }` pairs alike). This is the single place order was lost, so every parameter surface (explorer, dashboards, pinned parameters, scheduler, embed) is fixed by it.
- Values fetched via `options_from_dimension` keep their existing alphabetical sort.
- Added a component test pinning authored order for both plain and labelled options; it fails against the previous sorting code.
