### PR TITLE
fix: enforce invite expiry bounds

### DIFF
--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -3132,20 +3132,78 @@ describe('UserService', () => {
             ).toHaveBeenCalledTimes(1);
         });
         test('should default the purpose to member', async () => {
-            await userService.createPendingUserAndInviteLink(
-                sessionUser,
-                inviteUser,
-            );
+            const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+            await userService.createPendingUserAndInviteLink(sessionUser, {
+                ...inviteUser,
+                expiresAt,
+            });
 
             expect(vi.mocked(inviteLinkModel.upsert)).toHaveBeenCalledWith(
                 expect.any(String),
-                inviteUser.expiresAt,
+                expiresAt,
+                sessionUser.organizationUuid,
+                newUser.userUuid,
+                InviteLinkPurpose.Member,
+            );
+        });
+        test('should cap invite expiry at three days', async () => {
+            const now = new Date('2026-08-11T12:00:00.000Z');
+            const dateNowSpy = vi
+                .spyOn(Date, 'now')
+                .mockReturnValue(now.getTime());
+
+            await userService.createPendingUserAndInviteLink(sessionUser, {
+                ...inviteUser,
+                expiresAt: new Date('2099-01-01T00:00:00.000Z'),
+            });
+
+            expect(vi.mocked(inviteLinkModel.upsert)).toHaveBeenCalledWith(
+                expect.any(String),
+                new Date('2026-08-14T12:00:00.000Z'),
+                sessionUser.organizationUuid,
+                newUser.userUuid,
+                InviteLinkPurpose.Member,
+            );
+            dateNowSpy.mockRestore();
+        });
+        test('should replace a past invite expiry with three days', async () => {
+            const now = new Date('2026-08-11T12:00:00.000Z');
+            const dateNowSpy = vi
+                .spyOn(Date, 'now')
+                .mockReturnValue(now.getTime());
+
+            await userService.createPendingUserAndInviteLink(sessionUser, {
+                ...inviteUser,
+                expiresAt: new Date('2026-08-10T12:00:00.000Z'),
+            });
+
+            expect(vi.mocked(inviteLinkModel.upsert)).toHaveBeenCalledWith(
+                expect.any(String),
+                new Date('2026-08-14T12:00:00.000Z'),
+                sessionUser.organizationUuid,
+                newUser.userUuid,
+                InviteLinkPurpose.Member,
+            );
+            dateNowSpy.mockRestore();
+        });
+        test('should preserve an invite expiry shorter than three days', async () => {
+            const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+            await userService.createPendingUserAndInviteLink(sessionUser, {
+                ...inviteUser,
+                expiresAt,
+            });
+
+            expect(vi.mocked(inviteLinkModel.upsert)).toHaveBeenCalledWith(
+                expect.any(String),
+                expiresAt,
                 sessionUser.organizationUuid,
                 newUser.userUuid,
                 InviteLinkPurpose.Member,
             );
         });
         test('should force setup invites to use the admin role', async () => {
+            const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
             const adminUser = {
                 ...sessionUser,
                 ability: defineUserAbility(
@@ -3168,6 +3226,7 @@ describe('UserService', () => {
 
             await userService.createPendingUserAndInviteLink(adminUser, {
                 ...inviteUser,
+                expiresAt,
                 role: OrganizationMemberRole.MEMBER,
                 purpose: InviteLinkPurpose.Setup,
             });
@@ -3185,7 +3244,7 @@ describe('UserService', () => {
             );
             expect(vi.mocked(inviteLinkModel.upsert)).toHaveBeenCalledWith(
                 expect.any(String),
-                inviteUser.expiresAt,
+                expiresAt,
                 sessionUser.organizationUuid,
                 newUser.userUuid,
                 InviteLinkPurpose.Setup,

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -135,6 +135,7 @@ import { getOrganizationSettingsInstanceDefaults } from './OrganizationSettingsS
 
 const AWS_SSO_DEVICE_GRANT_TYPE =
     'urn:ietf:params:oauth:grant-type:device_code';
+const MAX_INVITE_LINK_TTL_MS = 3 * 24 * 60 * 60 * 1000;
 
 type RedshiftAwsSsoSession = {
     clientId: string;
@@ -714,10 +715,15 @@ export class UserService extends BaseService {
         }
         const { email, role } = createInviteLink;
         const purpose = createInviteLink.purpose ?? InviteLinkPurpose.Member;
-        // Same default expiry as the invite modal in the frontend
+        // Same expiry as the invite modal in the frontend
+        const now = Date.now();
+        const maximumExpiresAt = new Date(now + MAX_INVITE_LINK_TTL_MS);
         const expiresAt =
-            createInviteLink.expiresAt ??
-            new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
+            createInviteLink.expiresAt &&
+            createInviteLink.expiresAt.getTime() > now &&
+            createInviteLink.expiresAt < maximumExpiresAt
+                ? createInviteLink.expiresAt
+                : maximumExpiresAt;
         const inviteCode = nanoid(30);
         if (organizationUuid === undefined) {
             throw new NotFoundError('Organization not found');


### PR DESCRIPTION
## What changed

Invite creation now accepts only future expiries within three days. Past, omitted, and far-future values fall back to the three-day server-enforced lifetime.

## Visual evidence

![Creating an invite visibly confirms a usable server-returned link with the enforced three-day expiry.](https://ld-linear-agent.exe.xyz/artifacts/92abdbb7b5f4c3f6/3/1-bounded-invite-expiry.jpg)

_Creating an invite visibly confirms a usable server-returned link with the enforced three-day expiry._

## Preview

[Open the Lightdash preview](https://ldlin-92abdbb7b5f4.exe.xyz)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-9820

> Generated by the Lightdash Linear agent. Review and test all changes before merging.