### PR TITLE
fix(ai-agents): treat interrupted prompts as stopped and unpoison retries

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
@@ -377,4 +377,33 @@ describe('AiAgentModel prompt activity', () => {
             results.filter((result) => result.status === 'rejected')[0],
         ).toMatchObject({ reason: expect.any(AiDuplicateSlackPromptError) });
     });
+
+    it('deletes a prompt interrupt so a retry starts clean', async () => {
+        const threadUuid = await createWebAppThread();
+        const promptUuid = await model.createWebAppPrompt({
+            threadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            prompt: 'Interrupt me',
+        });
+
+        // Deleting when no interrupt exists is a no-op (the common retry case)
+        await model.deleteAiPromptInterrupt(promptUuid);
+        expect(await model.hasAiPromptInterrupt(promptUuid)).toBe(false);
+
+        await model.createAiPromptInterrupt({
+            promptUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        expect(await model.hasAiPromptInterrupt(promptUuid)).toBe(true);
+
+        await model.deleteAiPromptInterrupt(promptUuid);
+        expect(await model.hasAiPromptInterrupt(promptUuid)).toBe(false);
+
+        // A fresh interrupt after the delete still applies to the new run.
+        await model.createAiPromptInterrupt({
+            promptUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        expect(await model.hasAiPromptInterrupt(promptUuid)).toBe(true);
+    });
 });

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -5018,6 +5018,14 @@ export class AiAgentModel {
         return row !== undefined;
     }
 
+    // An interrupt targets one in-flight generation; a retry must start
+    // clean or the stale row would stop it after its first step, forever.
+    async deleteAiPromptInterrupt(promptUuid: string): Promise<void> {
+        await this.database(AiPromptInterruptTableName)
+            .where('ai_prompt_uuid', promptUuid)
+            .delete();
+    }
+
     async createAiPromptSteer(data: {
         promptUuid: string;
         createdByUserUuid: string;

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5036,6 +5036,9 @@ export class AiAgentService extends BaseService {
                     'This response changed while the retry was starting. Please try again.',
                 );
             }
+            // The failed attempt's interrupt row is stale now the retry has
+            // claimed the prompt; left in place it would stop every retry.
+            await this.aiAgentModel.deleteAiPromptInterrupt(prompt.promptUuid);
             prompt.respondedAt = null;
             prompt.errorMessage = null;
         }
@@ -5240,8 +5243,9 @@ export class AiAgentService extends BaseService {
             }
 
             // Re-running an answered prompt would stamp an error onto a good
-            // response (chat history already ends with its assistant answer)
-            if (prompt.response) {
+            // response (chat history already ends with its assistant answer).
+            // An interrupted prompt persists '' — also answered, not a retry.
+            if (prompt.response !== null) {
                 throw new ConflictError(
                     'The latest message already has a response. Refresh the page to see it.',
                 );

--- a/packages/backend/src/ee/services/AiAgentService/promptRetryInterrupt.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/promptRetryInterrupt.test.ts
@@ -1,0 +1,141 @@
+import { AiAgentService } from './AiAgentService';
+
+vi.mock('../ai/AiAgentMcpRuntimeClient', async (importOriginal) => ({
+    ...(await importOriginal()),
+    AiAgentMcpRuntimeClient: vi
+        .fn()
+        // eslint-disable-next-line prefer-arrow-callback
+        .mockImplementation(function MockAiAgentMcpRuntimeClient() {
+            return {};
+        }),
+}));
+
+type PreparationOptions = {
+    agentUuid: string;
+    threadUuid: string;
+    resetErrorForStreamRetry?: boolean;
+};
+
+type PrivateService = {
+    prepareAgentThreadResponse: (
+        user: unknown,
+        options: PreparationOptions,
+    ) => Promise<unknown>;
+    checkAgentThreadAccess: (...args: unknown[]) => Promise<boolean>;
+    maybeCompactThreadBeforeResponse: (...args: unknown[]) => Promise<null>;
+    getChatHistoryFromThreadMessages: (...args: unknown[]) => Promise<unknown>;
+};
+
+const user = {
+    organizationUuid: 'organization-uuid',
+    userUuid: 'user-uuid',
+};
+
+const buildService = (promptState: {
+    respondedAt: Date | null;
+    response: string | null;
+    errorMessage: string | null;
+}) => {
+    const resetPromptResponseForRetry = vi.fn().mockResolvedValue(true);
+    const deleteAiPromptInterrupt = vi.fn().mockResolvedValue(undefined);
+    const service = new AiAgentService({
+        lightdashConfig: {
+            ai: { copilot: { embeddingEnabled: false } },
+        },
+        aiAgentModel: {
+            getThread: vi.fn().mockResolvedValue({
+                agentUuid: 'agent-uuid',
+                user: { uuid: 'user-uuid' },
+            }),
+            getAgent: vi.fn().mockResolvedValue({
+                uuid: 'agent-uuid',
+                projectUuid: 'project-uuid',
+            }),
+            getThreadMessages: vi
+                .fn()
+                .mockResolvedValue([{ ai_prompt_uuid: 'prompt-uuid' }]),
+            findWebAppPrompt: vi.fn().mockResolvedValue({
+                promptUuid: 'prompt-uuid',
+                threadUuid: 'thread-uuid',
+                organizationUuid: 'organization-uuid',
+                projectUuid: 'project-uuid',
+                ...promptState,
+            }),
+            resetPromptResponseForRetry,
+            deleteAiPromptInterrupt,
+        },
+    } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
+
+    const privateService = service as unknown as PrivateService;
+    vi.spyOn(privateService, 'checkAgentThreadAccess').mockResolvedValue(true);
+    vi.spyOn(
+        privateService,
+        'maybeCompactThreadBeforeResponse',
+    ).mockResolvedValue(null);
+    vi.spyOn(
+        privateService,
+        'getChatHistoryFromThreadMessages',
+    ).mockResolvedValue([]);
+
+    return {
+        privateService,
+        resetPromptResponseForRetry,
+        deleteAiPromptInterrupt,
+    };
+};
+
+const prepare = (
+    privateService: PrivateService,
+    resetErrorForStreamRetry: boolean,
+) =>
+    privateService.prepareAgentThreadResponse(user, {
+        agentUuid: 'agent-uuid',
+        threadUuid: 'thread-uuid',
+        resetErrorForStreamRetry,
+    });
+
+describe('prepareAgentThreadResponse interrupt clearing', () => {
+    it('deletes the stale interrupt when a retry claims an errored prompt', async () => {
+        const {
+            privateService,
+            resetPromptResponseForRetry,
+            deleteAiPromptInterrupt,
+        } = buildService({
+            respondedAt: new Date(),
+            response: null,
+            errorMessage: 'The agent finished without writing a response.',
+        });
+
+        await prepare(privateService, true);
+
+        expect(resetPromptResponseForRetry).toHaveBeenCalledWith(
+            'prompt-uuid',
+            expect.anything(),
+        );
+        expect(deleteAiPromptInterrupt).toHaveBeenCalledWith('prompt-uuid');
+    });
+
+    it('keeps the interrupt for an in-flight prompt on a stream start', async () => {
+        const { privateService, deleteAiPromptInterrupt } = buildService({
+            respondedAt: null,
+            response: null,
+            errorMessage: null,
+        });
+
+        await prepare(privateService, true);
+
+        expect(deleteAiPromptInterrupt).not.toHaveBeenCalled();
+    });
+
+    it('keeps the interrupt when preparation is not a stream retry', async () => {
+        const { privateService, deleteAiPromptInterrupt } = buildService({
+            respondedAt: new Date(),
+            response: null,
+            errorMessage: 'Some error',
+        });
+
+        await prepare(privateService, false);
+
+        expect(deleteAiPromptInterrupt).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -1,5 +1,5 @@
 import { type AnyType } from '@lightdash/common';
-import { APICallError, generateText, type ModelMessage } from 'ai';
+import { APICallError, generateText, streamText, type ModelMessage } from 'ai';
 import {
     registerAiUsageTracker,
     type AiUsageEvent,
@@ -9,7 +9,13 @@ import type {
     AiAgentDependencies,
     AiDeepResearchExecutionRole,
 } from '../types/aiAgent';
-import { PROVIDER_BILLING_MESSAGE } from '../utils/errorMessages';
+import {
+    AiAgentEmptyResponseError,
+    AiAgentStepCapReachedError,
+    EMPTY_RESPONSE_MESSAGE,
+    PROVIDER_BILLING_MESSAGE,
+    STEP_CAP_REACHED_MESSAGE,
+} from '../utils/errorMessages';
 import {
     buildAgentMessages,
     buildDeepResearchExecutionContextSnapshot,
@@ -22,6 +28,7 @@ import {
     normalizeToolOutput,
     recordAgentStepUsage,
     storeInvalidAgentToolCall,
+    streamAgentResponse,
     withEarlyToolProgress,
     type AgentMcpToolSetup,
 } from './agentV2';
@@ -29,6 +36,7 @@ import {
 vi.mock('ai', async (importOriginal) => ({
     ...(await importOriginal<typeof import('ai')>()),
     generateText: vi.fn(),
+    streamText: vi.fn(),
 }));
 
 const buildAgentDependencies = (updatePrompt: ReturnType<typeof vi.fn>) =>
@@ -135,6 +143,185 @@ describe('generateAgentResponse error persistence', () => {
             promptUuid: 'prompt-1',
             errorMessage: PROVIDER_BILLING_MESSAGE,
         });
+    });
+});
+
+describe('empty finishes and interrupts', () => {
+    const emptyGenerateResult = {
+        text: '',
+        steps: [{}],
+        usage: { totalTokens: 10 },
+        finishReason: 'tool-calls',
+    };
+
+    const buildInterruptibleDependencies = (interrupted: boolean) => {
+        const updatePrompt = vi.fn().mockResolvedValue(undefined);
+        const dependencies = buildAgentDependencies(updatePrompt);
+        const isPromptInterrupted = vi.fn().mockResolvedValue(interrupted);
+        Object.assign(dependencies, { isPromptInterrupted });
+        return { updatePrompt, dependencies };
+    };
+
+    it('generate: persists an empty response instead of an error when the prompt was interrupted', async () => {
+        const { updatePrompt, dependencies } =
+            buildInterruptibleDependencies(true);
+        vi.mocked(generateText).mockResolvedValueOnce(
+            emptyGenerateResult as AnyType,
+        );
+
+        await expect(
+            generateAgentResponse({
+                args: buildAgentArgs(),
+                dependencies,
+                mcpToolSetup: mcpToolSetup(),
+            }),
+        ).resolves.toBe('');
+
+        expect(updatePrompt).toHaveBeenCalledWith(
+            expect.objectContaining({ promptUuid: 'prompt-1', response: '' }),
+        );
+        expect(updatePrompt).not.toHaveBeenCalledWith(
+            expect.objectContaining({ errorMessage: expect.any(String) }),
+        );
+    });
+
+    it('generate: still persists the empty-response error when not interrupted', async () => {
+        const { updatePrompt, dependencies } =
+            buildInterruptibleDependencies(false);
+        vi.mocked(generateText).mockResolvedValueOnce(
+            emptyGenerateResult as AnyType,
+        );
+
+        await expect(
+            generateAgentResponse({
+                args: buildAgentArgs(),
+                dependencies,
+                mcpToolSetup: mcpToolSetup(),
+            }),
+        ).rejects.toBeInstanceOf(AiAgentEmptyResponseError);
+
+        expect(updatePrompt).toHaveBeenCalledWith({
+            promptUuid: 'prompt-1',
+            errorMessage: EMPTY_RESPONSE_MESSAGE,
+        });
+    });
+
+    const runStreamOnFinish = async (
+        interrupted: boolean,
+        execution?: Record<string, unknown>,
+    ) => {
+        const { updatePrompt, dependencies } =
+            buildInterruptibleDependencies(interrupted);
+        let capturedOptions: AnyType;
+        vi.mocked(streamText).mockImplementationOnce(((options: AnyType) => {
+            capturedOptions = options;
+            return {} as AnyType;
+        }) as AnyType);
+
+        await streamAgentResponse({
+            args: buildAgentArgs(execution) as AnyType,
+            dependencies,
+            mcpToolSetup: mcpToolSetup(),
+        });
+        await capturedOptions.onFinish({
+            usage: { totalTokens: 10 },
+            totalUsage: { totalTokens: 10 },
+            steps: [{ text: '' }],
+            reasoning: [],
+            finishReason: 'tool-calls',
+        });
+        return updatePrompt;
+    };
+
+    it('stream: persists an empty response instead of an error when the prompt was interrupted', async () => {
+        const updatePrompt = await runStreamOnFinish(true);
+
+        expect(updatePrompt).toHaveBeenCalledWith(
+            expect.objectContaining({ promptUuid: 'prompt-1', response: '' }),
+        );
+        expect(updatePrompt).not.toHaveBeenCalledWith(
+            expect.objectContaining({ errorMessage: expect.any(String) }),
+        );
+    });
+
+    it('stream: still persists the empty-response error when not interrupted', async () => {
+        const updatePrompt = await runStreamOnFinish(false);
+
+        expect(updatePrompt).toHaveBeenCalledWith(
+            expect.objectContaining({
+                promptUuid: 'prompt-1',
+                errorMessage: EMPTY_RESPONSE_MESSAGE,
+            }),
+        );
+    });
+
+    it('generate: still throws the step-cap error at the cap when not interrupted', async () => {
+        const { updatePrompt, dependencies } =
+            buildInterruptibleDependencies(false);
+        vi.mocked(generateText).mockResolvedValueOnce(
+            emptyGenerateResult as AnyType,
+        );
+
+        await expect(
+            generateAgentResponse({
+                args: buildAgentArgs({ mode: 'standard', maxSteps: 1 }),
+                dependencies,
+                mcpToolSetup: mcpToolSetup(),
+            }),
+        ).rejects.toBeInstanceOf(AiAgentStepCapReachedError);
+
+        expect(updatePrompt).toHaveBeenCalledWith({
+            promptUuid: 'prompt-1',
+            errorMessage: STEP_CAP_REACHED_MESSAGE,
+        });
+    });
+
+    it('generate: an interrupt at the step cap still persists an empty response', async () => {
+        const { updatePrompt, dependencies } =
+            buildInterruptibleDependencies(true);
+        vi.mocked(generateText).mockResolvedValueOnce(
+            emptyGenerateResult as AnyType,
+        );
+
+        await expect(
+            generateAgentResponse({
+                args: buildAgentArgs({ mode: 'standard', maxSteps: 1 }),
+                dependencies,
+                mcpToolSetup: mcpToolSetup(),
+            }),
+        ).resolves.toBe('');
+
+        expect(updatePrompt).not.toHaveBeenCalledWith(
+            expect.objectContaining({ errorMessage: expect.any(String) }),
+        );
+    });
+
+    it('stream: still persists the step-cap error at the cap when not interrupted', async () => {
+        const updatePrompt = await runStreamOnFinish(false, {
+            mode: 'standard',
+            maxSteps: 1,
+        });
+
+        expect(updatePrompt).toHaveBeenCalledWith(
+            expect.objectContaining({
+                promptUuid: 'prompt-1',
+                errorMessage: STEP_CAP_REACHED_MESSAGE,
+            }),
+        );
+    });
+
+    it('stream: an interrupt at the step cap still persists an empty response', async () => {
+        const updatePrompt = await runStreamOnFinish(true, {
+            mode: 'standard',
+            maxSteps: 1,
+        });
+
+        expect(updatePrompt).toHaveBeenCalledWith(
+            expect.objectContaining({ promptUuid: 'prompt-1', response: '' }),
+        );
+        expect(updatePrompt).not.toHaveBeenCalledWith(
+            expect.objectContaining({ errorMessage: expect.any(String) }),
+        );
     });
 });
 

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -1651,18 +1651,25 @@ export const generateAgentResponse = async ({
         // would otherwise be stored as a blank response with no explanation
         // for the user. Structured deep-research phases are exempt: their
         // deliverable is a forced submission tool call, so ending on it with
-        // no trailing text is a success, not an empty response.
+        // no trailing text is a success, not an empty response. Interrupted
+        // prompts are exempt too: the user stopped the generation, so an
+        // empty response is expected and must not surface as an error.
         const isStructuredResearchPhase =
             args.execution.mode === 'deep_research' &&
             args.execution.research !== undefined;
         if (!result.text.trim() && !isStructuredResearchPhase) {
-            if (result.steps.length >= args.execution.maxSteps) {
-                throw new AiAgentStepCapReachedError(result.steps.length);
-            }
-            throw new AiAgentEmptyResponseError(
-                result.finishReason,
-                result.steps.length,
+            const interrupted = await dependencies.isPromptInterrupted(
+                args.promptUuid,
             );
+            if (!interrupted) {
+                if (result.steps.length >= args.execution.maxSteps) {
+                    throw new AiAgentStepCapReachedError(result.steps.length);
+                }
+                throw new AiAgentEmptyResponseError(
+                    result.finishReason,
+                    result.steps.length,
+                );
+            }
         }
 
         if (args.execution.mode !== 'deep_research') {
@@ -2063,7 +2070,14 @@ export const streamAgentResponse = async ({
                 // or an error message — a blank response with no error renders
                 // as an empty chat bubble with no explanation. trim() matters:
                 // steps with empty text still join into "\n" strings.
-                if (!completeResponse.trim()) {
+                // Interrupted prompts are exempt: the user stopped the
+                // generation, so an empty response is expected and persisted
+                // as-is instead of surfacing as an error.
+                const isEmptyResponse = !completeResponse.trim();
+                const interrupted = isEmptyResponse
+                    ? await dependencies.isPromptInterrupted(args.promptUuid)
+                    : false;
+                if (isEmptyResponse && !interrupted) {
                     const emptyResponseError = stepCapReached
                         ? new AiAgentStepCapReachedError(steps.length)
                         : new AiAgentEmptyResponseError(


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9819

## Summary

Stopping an AI agent response while the in-flight step had produced no text rendered the error **"The agent finished without writing a response"** instead of a stopped state — and every **Try again** on that message then failed within seconds, forever.

## Root cause

Two interacting defects around `ai_prompt_interrupt`:

```
stop click ──▶ row inserted in ai_prompt_interrupt (never deleted)
                    ▼
stream loop: stopWhenPromptInterrupted halts after the current step → no text
                    ▼
onFinish: empty response ──▶ AiAgentEmptyResponseError persisted as user-facing
          error + Sentry capture (interrupt never considered)
                    ▼
"Try again" reuses the same promptUuid ──▶ stale interrupt row still present
                    └──▶ every retry halts after step 1 → same error, forever
```

1. `agentV2.ts` — the empty-response invariant (`onFinish` in the stream path, post-generation check in the generate path) never asked whether the prompt was interrupted, so an intentional stop persisted `EMPTY_RESPONSE_MESSAGE` and polluted the `AiAgentEmptyResponseError` Sentry signal.
2. Nothing ever deleted the `ai_prompt_interrupt` row, and retries reuse the promptUuid, so `stopWhenPromptInterrupted` killed every retry after its first step.

## Fix

- **Interrupted prompts persist a stopped outcome**: both paths check `isPromptInterrupted` before raising the empty-response/step-cap error and instead persist the (possibly empty) response with no error and no Sentry capture. The frontend already carries an `interrupted` flag on messages and suppresses the "No response" notice for them, so the stopped state renders correctly with no frontend change.
- **Retries start clean**: once a stream retry claims an errored prompt (inside the existing `resetPromptResponseForRetry` compare-and-swap, so a live run's interrupt can never be swept), the stale interrupt row is deleted via new `AiAgentModel.deleteAiPromptInterrupt`. A fresh stop during the retry re-creates the row and still applies.
- **Stopped prompts are terminal**: the stream conflict check now treats a persisted `''` response as answered (`prompt.response !== null`), so re-streaming a stopped prompt conflicts instead of silently re-running untracked.

## Test plan

- Unit (`agentV2.test.ts`, 41 tests): interrupted × non-interrupted × generate/stream, plus step-cap precedence at the cap; the non-interrupted cases pin the existing invariant byte-for-byte. Interrupted cases verified red before the fix.
- Service (`promptRetryInterrupt.test.ts`): interrupt deleted when a retry claims an errored prompt; kept for in-flight prompts and non-retry preparations.
- Integration (`AiAgentModel.integration.test.ts`): no-op delete → create → has → delete → re-create cycle against the real DB.
- Runtime, local instance with real LLM calls: stop mid-stream persists a stopped message (no error, `interrupted: true`); a prompt seeded with the exact production failure state (error + interrupt row) retries to a full response with the row cleared; a stopped-empty prompt's re-stream conflicts and preserves its interrupt row.
- `pnpm -F backend typecheck`, `lint`, unit + integration suites all pass.

## Notes

- Non-stream reruns (`generateAgentThreadResponse`) don't pass `resetErrorForStreamRetry` and keep their current behavior; only the web stream retry path clears stale interrupts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)