### PR TITLE
feat(memory): add in-chat memory retirement tool

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -30,6 +30,7 @@ import {
     ValidateProjectPayload,
     WarehouseTypes,
     type AiAgentMemoryConsolidationTrigger,
+    type AiAgentMemoryEditableStatus,
     type AiAgentMemoryScope,
     type AiAgentMemoryStatus,
     type AiAgentReviewItemStatus,
@@ -3077,6 +3078,19 @@ export type AiAgentMemoryViewedEvent = BaseTrack & {
     };
 };
 
+export type AiAgentMemoryStatusChangedEvent = BaseTrack & {
+    event: 'ai_agent_memory.status_changed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        agentId: string | null;
+        memoryId: string;
+        status: AiAgentMemoryEditableStatus;
+        source: 'memory_page' | 'chat';
+    };
+};
+
 /**
  * The consolidation pass is scheduled work, so the organization is the actor.
  * Memory text, titles, terms, object names, slugs and operation reasons never
@@ -3143,6 +3157,7 @@ export type AiAgentMemoryEvent =
     | AiAgentMemoryPromotionAuthoringFailedEvent
     | AiAgentMemoryCitedEvent
     | AiAgentMemoryViewedEvent
+    | AiAgentMemoryStatusChangedEvent
     | AiAgentMemoryConsolidatedEvent
     | AiAgentMemoryConsolidationFailedEvent
     | AiAgentMemoryConsolidationSkippedEvent;

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -494,6 +494,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentModel: models.getAiAgentModel(),
                     aiAgentMemoryModel:
                         models.getAiAgentMemoryModel<AiAgentMemoryModel>(),
+                    aiAgentMemoryService:
+                        repository.getAiAgentMemoryService<AiAgentMemoryService>(),
                     aiAgentDocumentModel:
                         models.getAiAgentDocumentModel<AiAgentDocumentModel>(),
                     aiDeepResearchRunModel:

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -492,6 +492,68 @@ describe('AiAgentMemoryService', () => {
         });
     });
 
+    it('retires an owned active memory by slug from chat and audits the actor', async () => {
+        const {
+            service,
+            findByProjectAndSlug,
+            findByProjectAndUuid,
+            updateStatus,
+            track,
+        } = build();
+        const memory = memoryRow({
+            user_uuid: 'current-user',
+            title: 'Use net revenue',
+        });
+        findByProjectAndSlug.mockResolvedValue({
+            memory,
+            sources: [],
+            replacement: null,
+        });
+        findByProjectAndUuid.mockResolvedValue(memory);
+
+        await expect(
+            service.retireMemoryBySlug(
+                buildUser(true),
+                'project-enabled',
+                'net-revenue-ab12cd34',
+            ),
+        ).resolves.toEqual({
+            slug: 'net-revenue-ab12cd34',
+            title: 'Use net revenue',
+        });
+        expect(updateStatus).toHaveBeenCalledWith({
+            memoryUuid: 'memory-1',
+            status: 'retired',
+        });
+        expect(track).toHaveBeenCalledWith({
+            event: 'ai_agent_memory.status_changed',
+            userId: 'current-user',
+            properties: expect.objectContaining({
+                memoryId: 'memory-1',
+                status: 'retired',
+                source: 'chat',
+            }),
+        });
+    });
+
+    it("does not let a shared-thread prompter retire another user's memory", async () => {
+        const { service, findByProjectAndSlug, updateStatus } = build();
+        findByProjectAndSlug.mockResolvedValue({
+            memory: memoryRow({ user_uuid: 'thread-owner' }),
+            sources: [],
+            replacement: null,
+        });
+
+        await expect(
+            service.retireMemoryBySlug(
+                buildUser(true),
+                'project-enabled',
+                'net-revenue-ab12cd34',
+            ),
+        ).rejects.toThrow('Memory not found');
+        expect(updateStatus).not.toHaveBeenCalled();
+    });
+
     it('does not reactivate a memory when its source has a newer active memory', async () => {
         const {
             service,

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -43,6 +43,7 @@ import {
     type AiAgentMemoryPromotionAuthoringFailedEvent,
     type AiAgentMemoryPromotionNominatedEvent,
     type AiAgentMemoryViewedEvent,
+    type AiAgentMemoryStatusChangedEvent,
     type LightdashAnalytics,
 } from '../../../analytics/LightdashAnalytics';
 import { type LightdashConfig } from '../../../config/parseConfig';
@@ -203,6 +204,7 @@ type MemoryServiceAnalyticsEvent =
     | AiAgentMemoryPromotionNominatedEvent
     | AiAgentMemoryPromotionAuthoringFailedEvent
     | AiAgentMemoryViewedEvent
+    | AiAgentMemoryStatusChangedEvent
     | AiAgentMemoryConsolidatedEvent
     | AiAgentMemoryConsolidationFailedEvent
     | AiAgentMemoryConsolidationSkippedEvent;
@@ -921,6 +923,7 @@ export class AiAgentMemoryService extends BaseService {
         projectUuid: string,
         memoryUuid: string,
         status: AiAgentMemoryEditableStatus,
+        source: AiAgentMemoryStatusChangedEvent['properties']['source'] = 'memory_page',
     ): Promise<void> {
         const organizationUuid = await this.getMemoryAccessContext(
             user,
@@ -967,6 +970,55 @@ export class AiAgentMemoryService extends BaseService {
         if (!updated) {
             throw new ParameterError('This memory can no longer be changed');
         }
+
+        this.track({
+            event: 'ai_agent_memory.status_changed',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                agentId: memory.agent_uuid,
+                memoryId: memory.ai_agent_memory_uuid,
+                status,
+                source,
+            },
+        });
+    }
+
+    async retireMemoryBySlug(
+        user: SessionUser,
+        projectUuid: string,
+        slug: string,
+    ): Promise<{ slug: string; title: string }> {
+        const organizationUuid = await this.getMemoryAccessContext(
+            user,
+            projectUuid,
+            `Memory not found: ${slug}`,
+        );
+        const memory = await this.requireReadableMemory(
+            user,
+            organizationUuid,
+            projectUuid,
+            await this.aiAgentMemoryModel
+                .findByProjectAndSlug({
+                    projectUuid,
+                    slug,
+                })
+                .then((result) => result?.memory),
+            slug,
+        );
+
+        if (memory.status !== 'active') {
+            throw new ParameterError('Only active memories can be retired');
+        }
+        await this.updateMemoryStatus(
+            user,
+            projectUuid,
+            memory.ai_agent_memory_uuid,
+            'retired',
+            'chat',
+        );
+        return { slug: memory.slug, title: memory.title };
     }
 
     /**

--- a/packages/backend/src/ee/services/AiAgentMemoryService/transcriptToolPolicy.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/transcriptToolPolicy.ts
@@ -116,6 +116,7 @@ export const DISTILL_TOOL_POLICIES = {
     improveContext: { result: truncate(DEFAULT_TOOL_RESULT_LIMIT) },
     editProjectContext: { result: truncate(DEFAULT_TOOL_RESULT_LIMIT) },
     updateUserName: { result: keep },
+    retireMemory: { result: omitCall },
     submitResearchReport: { result: truncate(RESEARCH_REPORT_RESULT_LIMIT) },
     delegateResearchTask: {
         result: truncate(RESEARCH_REPORT_RESULT_LIMIT),

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -363,6 +363,7 @@ import {
 } from '../ai/utils/populateCustomMetricsSQL';
 import { toolErrorHandler } from '../ai/utils/toolErrorHandler';
 import { validateSelectedFieldsExistence } from '../ai/utils/validators';
+import type { AiAgentMemoryService } from '../AiAgentMemoryService/AiAgentMemoryService';
 import { AiAgentToolsService } from '../AiAgentToolsService/AiAgentToolsService';
 import { type AiDeepResearchSubmittedReport } from '../AiDeepResearchService/AiDeepResearchService';
 import { isDeepResearchRawSqlMcpTool } from '../AiDeepResearchService/toolClassification';
@@ -473,6 +474,7 @@ type EmbedAiAgentRuntimeOptions = {
 type AiAgentServiceDependencies = {
     aiAgentModel: AiAgentModel;
     aiAgentMemoryModel: AiAgentMemoryModel;
+    aiAgentMemoryService?: AiAgentMemoryService;
     aiAgentDocumentModel: AiAgentDocumentModel;
     aiDeepResearchRunModel: Pick<
         AiDeepResearchRunModel,
@@ -722,6 +724,8 @@ export class AiAgentService extends BaseService {
     private shutdownPromise: Promise<void> | undefined;
 
     private readonly aiAgentMemoryModel: AiAgentMemoryModel;
+
+    private readonly aiAgentMemoryService?: AiAgentMemoryService;
 
     private readonly aiAgentDocumentModel: AiAgentDocumentModel;
 
@@ -1063,6 +1067,7 @@ export class AiAgentService extends BaseService {
         super();
         this.aiAgentModel = dependencies.aiAgentModel;
         this.aiAgentMemoryModel = dependencies.aiAgentMemoryModel;
+        this.aiAgentMemoryService = dependencies.aiAgentMemoryService;
         this.aiAgentDocumentModel = dependencies.aiAgentDocumentModel;
         this.aiDeepResearchRunModel = dependencies.aiDeepResearchRunModel;
         this.projectContextModel = dependencies.projectContextModel;
@@ -8394,6 +8399,16 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     slugs,
                 });
             };
+        const retireMemory: AiAgentDependencies['retireMemory'] = ({ slug }) =>
+            this.aiAgentMemoryService
+                ? this.aiAgentMemoryService.retireMemoryBySlug(
+                      user,
+                      projectUuid,
+                      slug,
+                  )
+                : Promise.reject(
+                      new Error('AI agent memory service is unavailable'),
+                  );
 
         const updateProgress: UpdateProgressFn = (
             progress,
@@ -9002,6 +9017,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             getProjectContextDocument,
             getAiAgentMemoryContextEntries,
             incrementAiAgentMemoryPulls,
+            retireMemory,
             resolveThreadMemoryOwnerUuid,
             getExplore: toolsRuntime.getExplore,
             listContent: toolsRuntime.listContent,
@@ -9204,6 +9220,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             getProjectContextDocument,
             getAiAgentMemoryContextEntries,
             incrementAiAgentMemoryPulls,
+            retireMemory,
             resolveThreadMemoryOwnerUuid,
             getExplore,
             listContent,
@@ -9754,6 +9771,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             getProjectContextDocument,
             getAiAgentMemoryContextEntries,
             incrementAiAgentMemoryPulls,
+            retireMemory,
             getExplore,
             listContent,
             findContent,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -80,6 +80,7 @@ import { getProjectContextSearchEntries } from '../tools/memoryProjectContext';
 import { getReadContent } from '../tools/readContent';
 import { getReadPinnedThread } from '../tools/readPinnedThread';
 import { getResolveUrl } from '../tools/resolveUrl';
+import { getRetireMemory } from '../tools/retireMemory';
 import { getRunContentQuery } from '../tools/runContentQuery';
 import { getRunSavedChart } from '../tools/runSavedChart';
 import { getRunSql } from '../tools/runSql';
@@ -1000,6 +1001,9 @@ export const getAgentTools = (
                       : undefined,
               })
             : null;
+    const retireMemory = args.aiAgentMemoryEnabled
+        ? getRetireMemory({ retireMemory: dependencies.retireMemory })
+        : null;
 
     const enableContentTools = args.enableDataAccess && args.enableContentTools;
     const mcpTools = Object.fromEntries(
@@ -1068,6 +1072,7 @@ export const getAgentTools = (
         ...(describeWarehouseTable ? { describeWarehouseTable } : {}),
         ...(loadSkill ? { loadSkill } : {}),
         ...(loadProjectContext ? { loadProjectContext } : {}),
+        ...(retireMemory ? { retireMemory } : {}),
         ...(loadMcpTools ? { loadMcpTools } : {}),
     };
 

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -7951,6 +7951,7 @@ exports[`AI agent tool contracts > matches the shared agent tool definition name
   "createContent",
   "createScheduledDelivery",
   "updateUserName",
+  "retireMemory",
   "runContentQuery",
   "listContent",
   "loadSkill",

--- a/packages/backend/src/ee/services/ai/tools/retireMemory.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/retireMemory.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRetireMemory } from './retireMemory';
+
+describe('retireMemory tool', () => {
+    it('confirms the retired title and slug and mentions reactivation', async () => {
+        const retireMemory = vi.fn().mockResolvedValue({
+            slug: 'net-revenue-ab12cd34',
+            title: 'Use net revenue',
+        });
+        const tool = getRetireMemory({ retireMemory });
+
+        const output = await tool.execute!(
+            { slug: 'net-revenue-ab12cd34' },
+            { toolCallId: 'call-1', messages: [] },
+        );
+
+        expect(retireMemory).toHaveBeenCalledWith({
+            slug: 'net-revenue-ab12cd34',
+        });
+        expect(output).toMatchObject({
+            result: expect.stringContaining(
+                'Retired memory "Use net revenue" (net-revenue-ab12cd34)',
+            ),
+            metadata: {
+                status: 'success',
+                slug: 'net-revenue-ab12cd34',
+                title: 'Use net revenue',
+            },
+        });
+        expect(output).toMatchObject({
+            result: expect.stringContaining('reactivate'),
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/retireMemory.ts
+++ b/packages/backend/src/ee/services/ai/tools/retireMemory.ts
@@ -1,0 +1,35 @@
+import { retireMemoryToolDefinition } from '@lightdash/common';
+import { tool } from 'ai';
+import type { RetireMemoryFn } from '../types/aiAgentDependencies';
+import { toModelOutput } from '../utils/toModelOutput';
+import { toolErrorHandler } from '../utils/toolErrorHandler';
+
+const toolDefinition = retireMemoryToolDefinition.for('agent');
+
+export const getRetireMemory = ({
+    retireMemory,
+}: {
+    retireMemory: RetireMemoryFn;
+}) =>
+    tool({
+        ...toolDefinition,
+        execute: async ({ slug }) => {
+            try {
+                const memory = await retireMemory({ slug });
+                return {
+                    result: `Retired memory "${memory.title}" (${memory.slug}). It will no longer be used in future conversations. The user can reactivate it from the memories page.`,
+                    metadata: {
+                        status: 'success' as const,
+                        slug: memory.slug,
+                        title: memory.title,
+                    },
+                };
+            } catch (error) {
+                return {
+                    result: toolErrorHandler(error, 'Error retiring memory.'),
+                    metadata: { status: 'error' as const },
+                };
+            }
+        },
+        toModelOutput: ({ output }) => toModelOutput(output),
+    });

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -66,6 +66,7 @@ import {
     LoadAgentSkillFn,
     ReadContentFn,
     ReadPinnedThreadFn,
+    RetireMemoryFn,
     RecordSqlApprovalFn,
     ResolveUrlFn,
     RunAsyncQueryFn,
@@ -290,6 +291,7 @@ export type AiAgentDependencies = {
     incrementAiAgentMemoryPulls: (
         entries: ProjectContextSearchEntry[],
     ) => Promise<void>;
+    retireMemory: RetireMemoryFn;
     listContent: ListContentFn;
     findContent: FindContentFn;
     readContent: ReadContentFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -616,6 +616,11 @@ export type ListWorkstreamsFn = (args: {
  */
 export type ClosePullRequestFn = (args: { prUrl: string }) => Promise<void>;
 
+export type RetireMemoryFn = (args: { slug: string }) => Promise<{
+    slug: string;
+    title: string;
+}>;
+
 export type GetPullRequestDiffFn = (args: {
     prUrl: string;
 }) => Promise<string | null>;

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -35,6 +35,7 @@ export * from './toolReadPinnedThreadArgs';
 export * from './toolCreateContentArgs';
 export * from './toolCreateScheduledDeliveryArgs';
 export * from './toolUpdateUserNameArgs';
+export * from './toolRetireMemoryArgs';
 export * from './toolListContentArgs';
 export * from './toolFindContentArgs';
 export * from './toolFindDashboardsArgs';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -241,6 +241,11 @@ import {
     toolResolveUrlOutputSchema,
 } from './toolResolveUrlArgs';
 import {
+    TOOL_RETIRE_MEMORY_DESCRIPTION,
+    toolRetireMemoryArgsSchema,
+    toolRetireMemoryOutputSchema,
+} from './toolRetireMemoryArgs';
+import {
     TOOL_RUN_CONTENT_QUERY_DESCRIPTION,
     toolRunContentQueryArgsSchema,
     toolRunContentQueryOutputSchema,
@@ -818,6 +823,20 @@ export const updateUserNameToolDefinition: ToolDefinitionWithoutMcpOutput<
     availability: ['agent'],
     inputSchema: toolUpdateUserNameArgsSchema,
     agent: { outputSchema: toolUpdateUserNameOutputSchema },
+});
+
+export const retireMemoryToolDefinition: ToolDefinitionWithoutMcpOutput<
+    'retireMemory',
+    typeof toolRetireMemoryArgsSchema,
+    typeof toolRetireMemoryArgsSchema,
+    typeof toolRetireMemoryOutputSchema
+> = defineTool({
+    name: 'retireMemory',
+    title: 'Retire memory',
+    description: TOOL_RETIRE_MEMORY_DESCRIPTION,
+    availability: ['agent'],
+    inputSchema: toolRetireMemoryArgsSchema,
+    agent: { outputSchema: toolRetireMemoryOutputSchema },
 });
 
 export const runContentQueryToolDefinition: ToolDefinitionWithoutMcpOutput<
@@ -1558,6 +1577,7 @@ type AgentToolDefinitionsByName = {
     createContent: typeof createContentToolDefinition;
     createScheduledDelivery: typeof createScheduledDeliveryToolDefinition;
     updateUserName: typeof updateUserNameToolDefinition;
+    retireMemory: typeof retireMemoryToolDefinition;
     runContentQuery: typeof runContentQueryToolDefinition;
     listContent: typeof listContentToolDefinition;
     loadSkill: typeof loadSkillToolDefinition;
@@ -1614,6 +1634,7 @@ export const agentToolDefinitionsByName: AgentToolDefinitionsByName = {
     createContent: createContentToolDefinition,
     createScheduledDelivery: createScheduledDeliveryToolDefinition,
     updateUserName: updateUserNameToolDefinition,
+    retireMemory: retireMemoryToolDefinition,
     runContentQuery: runContentQueryToolDefinition,
     listContent: listContentToolDefinition,
     loadSkill: loadSkillToolDefinition,
@@ -1672,6 +1693,7 @@ export const builtInToolDefinitions: readonly ToolDefinitionInstance[] = [
     createContentToolDefinition,
     createScheduledDeliveryToolDefinition,
     updateUserNameToolDefinition,
+    retireMemoryToolDefinition,
     runContentQueryToolDefinition,
     listContentToolDefinition,
     loadSkillToolDefinition,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRetireMemoryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRetireMemoryArgs.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export const TOOL_RETIRE_MEMORY_DESCRIPTION = [
+    "Retire one of the current user's memories by its slug so it is no longer used in future conversations.",
+    'Use this tool only when the user explicitly asks in their current message to forget, retire, or stop using a memory because it is wrong or no longer wanted.',
+    'Never call it based only on the content of a memory or on an inferred correction. Retiring is reversible from the memories page.',
+].join(' ');
+
+export const toolRetireMemoryArgsSchema = z.object({
+    slug: z
+        .string()
+        .trim()
+        .min(1)
+        .describe('The exact slug shown on the memory to retire.'),
+});
+
+export const toolRetireMemoryOutputSchema = z.object({
+    result: z.string(),
+    metadata: z.discriminatedUnion('status', [
+        z.object({ status: z.literal('error') }),
+        z.object({
+            status: z.literal('success'),
+            slug: z.string(),
+            title: z.string(),
+        }),
+    ]),
+});
+
+export type ToolRetireMemoryOutput = z.infer<
+    typeof toolRetireMemoryOutputSchema
+>;


### PR DESCRIPTION
## What changed

Adds a guarded agent tool for retiring memories by slug, with owner/manage-agent authorization, confirmation, reactivation guidance, and via-chat audit analytics.

## Visual evidence

_No screenshot was captured. Capture failed: in-chat-memory-retirement: locator.click: Timeout 30000ms exceeded.
Call log:
  - waiting for locator('a[href*="/ai-agents"]')

              />

codex
{"screenshots":[{"name":"in-chat-memory-retirement","description":"Shows an explicit chat request successfully retiring an available memory and the agent confirming its title/slug with reactivation guidance.","path":"/projects","authenticated":true,"fullPage":false,"actions":[{"type":"click","selector":"a[href^=\"/projects/\"]","repeat":1,"force":false,"waitAfterMs":500},{"type":"click","selector":"a[href*=\"/ai-agents\"]","repeat":1,"force":false,"waitAfterMs":500},{"type":"waitFor","selector":"textarea[placeholder^=\"Ask \"]","state":"visible"},{"type":"fill","selector":"textarea[placeholder^=\"Ask \"]","value":"Explicitly retire the first active memory available in your memory context. Use its exact slug, confirm the memory title and slug, and tell me how I can reactivate it."},{"type":"press","selector":"textarea[placeholder^=\"Ask _

## Preview

[Open the Lightdash preview](https://ldlin-d807ecc80ca8.exe.xyz)

Login: `demo@lightdash.com` / `demo_password!`

## Linear

ZAP-731: Memory: in-chat retire tool

> Generated by the Lightdash Linear agent. Review and test all changes before merging.