### PR TITLE
fix(release): close the safety-index chain gap and align the marker schema with the generator

### DIFF
--- a/.github/workflows/release-safety-tests.yml
+++ b/.github/workflows/release-safety-tests.yml
@@ -43,10 +43,14 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Install root dependencies
-        run: sfw pnpm install --frozen-lockfile --filter . || pnpm install --frozen-lockfile --filter .
+        run: |
+          sfw pnpm install --frozen-lockfile --filter . || true
+          node -e "require.resolve('ajv')" 2>/dev/null || pnpm install --frozen-lockfile --filter .
 
       - name: Install tsx
-        run: sfw npm install -g tsx@4.19.4 || npm install -g tsx@4.19.4
+        run: |
+          sfw npm install -g tsx@4.19.4 || true
+          command -v tsx >/dev/null || npm install -g tsx@4.19.4
 
       - name: Run release-safety script tests
         run: npm run test:release-safety

--- a/release-safety-index.json
+++ b/release-safety-index.json
@@ -30816,6 +30816,76 @@
       "syntheticRequiredStop": false
     },
     {
+      "version": "1.116.0",
+      "previousVersion": "1.115.0",
+      "releaseDate": "2026-08-11T08:00:22Z",
+      "rollingUpdateSafe": "unknown",
+      "requiredStops": [],
+      "minPreviousVersion": "1.111.0",
+      "backfilled": true,
+      "syntheticRequiredStop": false
+    },
+    {
+      "version": "1.116.1",
+      "previousVersion": "1.116.0",
+      "releaseDate": "2026-08-11T08:30:00Z",
+      "rollingUpdateSafe": "unknown",
+      "requiredStops": [],
+      "minPreviousVersion": "1.111.0",
+      "backfilled": true,
+      "syntheticRequiredStop": false
+    },
+    {
+      "version": "1.117.0",
+      "previousVersion": "1.116.1",
+      "releaseDate": "2026-08-11T08:57:58Z",
+      "rollingUpdateSafe": "unknown",
+      "requiredStops": [],
+      "minPreviousVersion": "1.111.0",
+      "backfilled": true,
+      "syntheticRequiredStop": false
+    },
+    {
+      "version": "1.118.0",
+      "previousVersion": "1.117.0",
+      "releaseDate": "2026-08-11T09:25:08Z",
+      "rollingUpdateSafe": "unknown",
+      "requiredStops": [],
+      "minPreviousVersion": "1.111.0",
+      "backfilled": true,
+      "syntheticRequiredStop": false
+    },
+    {
+      "version": "1.119.0",
+      "previousVersion": "1.118.0",
+      "releaseDate": "2026-08-11T10:08:17Z",
+      "rollingUpdateSafe": "unknown",
+      "requiredStops": [],
+      "minPreviousVersion": "1.111.0",
+      "backfilled": true,
+      "syntheticRequiredStop": false
+    },
+    {
+      "version": "1.120.0",
+      "previousVersion": "1.119.0",
+      "releaseDate": "2026-08-11T10:24:32Z",
+      "rollingUpdateSafe": "unknown",
+      "requiredStops": [],
+      "minPreviousVersion": "1.111.0",
+      "backfilled": true,
+      "syntheticRequiredStop": false
+    },
+    {
+      "version": "1.120.1",
+      "previousVersion": "1.120.0",
+      "releaseDate": "2026-08-11T10:41:54Z",
+      "rollingUpdateSafe": "unknown",
+      "requiredStops": [],
+      "minPreviousVersion": "1.111.0",
+      "backfilled": true,
+      "syntheticRequiredStop": false
+    },
+    {
       "version": "1.121.0",
       "previousVersion": "1.120.1",
       "releaseDate": "2026-08-11T11:08:39.052Z",

--- a/release.config.js
+++ b/release.config.js
@@ -92,6 +92,14 @@ module.exports = {
             },
         ],
 
+        [
+            '@semantic-release/exec',
+            {
+                prepareCmd:
+                    'pnpm exec tsx scripts/release-safety-schema.test.ts',
+            },
+        ],
+
         './scripts/semantic-release-safety-plugin.js',
 
         [

--- a/scripts/gen-release-safety-cli.test.ts
+++ b/scripts/gen-release-safety-cli.test.ts
@@ -1,0 +1,100 @@
+import * as assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+interface CliResult {
+    status: number | null;
+    stdout: string;
+    stderr: string;
+}
+
+function runGenerator(args: string[]): CliResult {
+    const result = spawnSync(
+        'pnpm',
+        [
+            'exec',
+            'tsx',
+            resolve('scripts/gen-release-safety.ts'),
+            ...args,
+        ],
+        {
+            cwd: process.cwd(),
+            encoding: 'utf8',
+        },
+    );
+    return {
+        status: result.status,
+        stdout: result.stdout,
+        stderr: result.stderr,
+    };
+}
+
+function markerFrom(stdout: string): Record<string, unknown> {
+    const markerStart = stdout.lastIndexOf('{\n  "schemaVersion"');
+    assert.notStrictEqual(markerStart, -1, `marker not found in stdout: ${stdout}`);
+    return JSON.parse(stdout.slice(markerStart)) as Record<string, unknown>;
+}
+
+const directory = mkdtempSync(join(tmpdir(), 'release-safety-cli-'));
+
+try {
+    const malformedOverrides = join(directory, 'malformed-overrides.json');
+    writeFileSync(malformedOverrides, '{');
+    const malformed = runGenerator([
+        '--version',
+        '1.115.0',
+        '--overrides',
+        malformedOverrides,
+    ]);
+    assert.notStrictEqual(malformed.status, 0);
+    assert.match(malformed.stderr, /not valid JSON/);
+    assert.doesNotMatch(malformed.stdout, /"schemaVersion"/);
+
+    const validOverrides = join(directory, 'valid-overrides.json');
+    writeFileSync(
+        validOverrides,
+        JSON.stringify({
+            versions: {
+                '1.115.0': {
+                    minPreviousVersion: '1.114.0',
+                    requiredStop: true,
+                    note: 'Stop before this release.',
+                },
+            },
+        }),
+    );
+    const valid = runGenerator([
+        '--version',
+        '1.115.0',
+        '--overrides',
+        validOverrides,
+    ]);
+    assert.strictEqual(valid.status, 0, valid.stderr);
+    const validMarker = markerFrom(valid.stdout);
+    assert.deepStrictEqual(validMarker.upgrade, {
+        minPreviousVersion: '1.114.0',
+        requiredStops: ['1.115.0'],
+    });
+
+    const degraded = runGenerator([
+        '--version',
+        '1.115.0',
+        '--last-tag',
+        'not-a-release-safety-test-ref',
+    ]);
+    assert.strictEqual(degraded.status, 0, degraded.stderr);
+    const degradedMarker = markerFrom(degraded.stdout);
+    assert.deepStrictEqual(degradedMarker.migrations, {
+        present: 'unknown',
+        count: 0,
+        coreCount: 0,
+        eeCount: 0,
+        files: [],
+    });
+} finally {
+    rmSync(directory, { recursive: true, force: true });
+}
+
+console.log('gen-release-safety-cli: all tests passed');

--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -35,8 +35,22 @@ const base = {
     releaseDate: '2026-08-10T00:00:00.000Z',
 };
 const checkedSurfaces = {
-    restApi: { checked: true, breaking: false as const, changes: [] },
-    mcpApi: { checked: true, breaking: false as const, changes: [] },
+    restApi: {
+        checked: true,
+        breaking: false as const,
+        changes: [],
+        breakingCount: 0,
+        advisories: [],
+        advisoryCount: 0,
+    },
+    mcpApi: {
+        checked: true,
+        breaking: false as const,
+        changes: [],
+        breakingCount: 0,
+        advisories: [],
+        advisoryCount: 0,
+    },
     config: { checked: true, breaking: false as const, changes: [] },
 };
 const noMigrations = {

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -47,6 +47,7 @@ import {
     recordDerivedFloor,
     requiredStopsUpTo,
     resolveUpgrade,
+    UpgradeOverridesFile,
     UpgradeResolution,
 } from './upgrade-overrides';
 
@@ -468,8 +469,13 @@ function writeAtomic(outPath: string, contents: string): void {
 
 export async function generateReleaseSafety(
     argv: string[],
+    suppliedOverrides?: UpgradeOverridesFile | null,
 ): Promise<ReleaseSafetyMarker> {
     const args = parseArgs(argv);
+    const overrides =
+        suppliedOverrides === undefined
+            ? loadUpgradeOverrides(args.overrides)
+            : suppliedOverrides;
     // Kill-switch: the marker is dark-launched. Unless RELEASE_SAFETY_MARKER_ENABLED
     // is "true", the generator still computes + prints the marker to stdout but
     // does NOT write the output file (so no GitHub release asset is published) and
@@ -694,9 +700,7 @@ export async function generateReleaseSafety(
     }
 
     // P4: human-authored upgrade-path overrides. A missing file is fine (mechanism
-    // unused); a present-but-malformed file degrades through the top-level
-    // unknown fallback so it never silently drops a maintainer declaration.
-    const overrides = loadUpgradeOverrides(args.overrides);
+    // unused); a present-but-malformed file fails before this detector path runs.
     const upgrade = resolveUpgrade(overrides, args.version);
     // Forward-carried floor: the high-water mark of every floor / required stop
     // declared in any release at or before this one, so the marker is self-
@@ -789,11 +793,12 @@ const invokedDirectly =
     process.argv[1]?.endsWith('gen-release-safety.ts') === true;
 
 if (invokedDirectly) {
-    generateReleaseSafety(process.argv.slice(2)).catch((err) => {
+    const argv = process.argv.slice(2);
+    const overrides = loadUpgradeOverrides(parseArgs(argv).overrides);
+    generateReleaseSafety(argv, overrides).catch((err) => {
         console.error(
             `[release-safety] FAILED: ${err instanceof Error ? err.message : String(err)}`,
         );
-        const argv = process.argv.slice(2);
         const value = (name: string): string | undefined => {
             const index = argv.indexOf(`--${name}`);
             return index >= 0 ? argv[index + 1] : undefined;

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -241,6 +241,9 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
         checked: false,
         breaking: 'unknown',
         changes: [],
+        breakingCount: 0,
+        advisories: [],
+        advisoryCount: 0,
     };
     const rest = input.restApi?.checked ? input.restApi : uncheckedApi;
     const mcp = input.mcpApi?.checked ? input.mcpApi : uncheckedApi;

--- a/scripts/release-safety-contract.ts
+++ b/scripts/release-safety-contract.ts
@@ -8,6 +8,9 @@ export interface ApiSurface {
     checked: boolean;
     breaking: TriState;
     changes: string[];
+    breakingCount: number;
+    advisories: string[];
+    advisoryCount: number;
 }
 
 export interface ReleaseSafetyMarker {

--- a/scripts/release-safety-release-config.test.ts
+++ b/scripts/release-safety-release-config.test.ts
@@ -1,0 +1,76 @@
+import * as assert from 'assert';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const releaseConfig = require('../release.config');
+
+const temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'release-safety-release-config-'),
+);
+
+try {
+    fs.mkdirSync(path.join(temporaryDirectory, 'scripts'));
+    for (const fileName of [
+        'release-safety.schema.json',
+        'release-safety-index.schema.json',
+    ]) {
+        fs.copyFileSync(
+            path.join('scripts', fileName),
+            path.join(temporaryDirectory, 'scripts', fileName),
+        );
+    }
+    fs.copyFileSync(
+        'release-safety-index.json',
+        path.join(temporaryDirectory, 'release-safety-index.json'),
+    );
+
+    const marker = JSON.parse(
+        fs.readFileSync('release-safety.json', 'utf-8'),
+    );
+    marker.unexpectedGeneratedField = true;
+    fs.writeFileSync(
+        path.join(temporaryDirectory, 'release-safety.json'),
+        `${JSON.stringify(marker, null, 2)}\n`,
+    );
+
+    assert.throws(
+        () =>
+            execFileSync(
+                path.resolve('node_modules/.bin/tsx'),
+                [path.resolve('scripts/release-safety-schema.test.ts')],
+                {
+                    cwd: temporaryDirectory,
+                    encoding: 'utf-8',
+                    stdio: 'pipe',
+                },
+            ),
+        (error: unknown) => {
+            const result = error as { status?: number; stderr?: string };
+            return (
+                result.status === 1 &&
+                result.stderr?.includes('unexpectedGeneratedField') === true
+            );
+        },
+    );
+} finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+}
+
+const generationIndex = releaseConfig.plugins.findIndex((plugin: unknown) =>
+    Array.isArray(plugin) &&
+    plugin[0] === '@semantic-release/exec' &&
+    plugin[1]?.prepareCmd?.includes('scripts/gen-release-safety.ts'),
+);
+const validationIndex = releaseConfig.plugins.findIndex((plugin: unknown) =>
+    Array.isArray(plugin) &&
+    plugin[0] === '@semantic-release/exec' &&
+    plugin[1]?.prepareCmd ===
+        'pnpm exec tsx scripts/release-safety-schema.test.ts',
+);
+
+assert.notStrictEqual(generationIndex, -1);
+assert.strictEqual(validationIndex, generationIndex + 1);
+
+console.log('release-safety-release-config: all tests passed');

--- a/scripts/release-safety-release-config.test.ts
+++ b/scripts/release-safety-release-config.test.ts
@@ -38,7 +38,7 @@ try {
     assert.throws(
         () =>
             execFileSync(
-                path.resolve('node_modules/.bin/tsx'),
+                'tsx',
                 [path.resolve('scripts/release-safety-schema.test.ts')],
                 {
                     cwd: temporaryDirectory,

--- a/scripts/release-safety-schema.test.ts
+++ b/scripts/release-safety-schema.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import Ajv from 'ajv';
+import { buildMarker } from './gen-release-safety';
 
 const ajv = new Ajv({ strict: true, validateFormats: false });
 const artifactSchema = JSON.parse(
@@ -16,8 +17,43 @@ const index = JSON.parse(
 
 const validateArtifact = ajv.compile(artifactSchema);
 const validateIndex = ajv.compile(indexSchema);
+const generatedArtifact = buildMarker({
+    version: '1.121.0',
+    previousVersion: '1.120.1',
+    releaseDate: '2026-08-11T00:00:00.000Z',
+    migrations: {
+        present: false,
+        count: 0,
+        files: [],
+        ee: false,
+        deletedHistorical: [],
+    },
+    migrationDetails: [],
+    restApi: {
+        checked: true,
+        breaking: true,
+        changes: ['DELETE /api/v1/example — endpoint removed'],
+        breakingCount: 1,
+        advisories: ['GET /api/v1/example — response enum value added'],
+        advisoryCount: 1,
+    },
+    mcpApi: {
+        checked: true,
+        breaking: false,
+        changes: [],
+        breakingCount: 0,
+        advisories: [],
+        advisoryCount: 0,
+    },
+    config: { checked: true, breaking: false, changes: [] },
+});
 assert.strictEqual(
     validateArtifact(artifact),
+    true,
+    JSON.stringify(validateArtifact.errors),
+);
+assert.strictEqual(
+    validateArtifact(generatedArtifact),
     true,
     JSON.stringify(validateArtifact.errors),
 );
@@ -26,6 +62,34 @@ assert.strictEqual(
     true,
     JSON.stringify(validateIndex.errors),
 );
+const floorIndex = index.entries.findIndex(
+    (entry: { version: string }) => entry.version === '0.1893.0',
+);
+const releaseIndex = index.entries.findIndex(
+    (entry: { version: string }) => entry.version === '1.121.0',
+);
+assert.notStrictEqual(floorIndex, -1);
+assert.ok(releaseIndex > floorIndex);
+for (let entryIndex = floorIndex + 1; entryIndex <= releaseIndex; entryIndex += 1) {
+    assert.strictEqual(
+        index.entries[entryIndex].previousVersion,
+        index.entries[entryIndex - 1].version,
+    );
+}
+for (const version of [
+    '1.116.0',
+    '1.116.1',
+    '1.117.0',
+    '1.118.0',
+    '1.119.0',
+    '1.120.0',
+    '1.120.1',
+]) {
+    const entry = index.entries.find(
+        (candidate: { version: string }) => candidate.version === version,
+    );
+    assert.strictEqual(entry?.backfilled, true);
+}
 assert.match(artifactSchema.description, /unknown.*unsafe/i);
 assert.match(artifactSchema.description, /artifact shrinks/i);
 assert.match(

--- a/scripts/release-safety.schema.json
+++ b/scripts/release-safety.schema.json
@@ -28,7 +28,14 @@
         "apiSurface": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["checked", "breaking", "changes"],
+            "required": [
+                "checked",
+                "breaking",
+                "changes",
+                "breakingCount",
+                "advisories",
+                "advisoryCount"
+            ],
             "properties": {
                 "checked": { "type": "boolean" },
                 "breaking": { "$ref": "#/definitions/triState" },
@@ -36,7 +43,13 @@
                     "type": "array",
                     "items": { "type": "string" },
                     "description": "Endpoint-specific REST or tool-specific MCP breaking-change details."
-                }
+                },
+                "breakingCount": { "type": "integer", "minimum": 0 },
+                "advisories": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                },
+                "advisoryCount": { "type": "integer", "minimum": 0 }
             }
         },
         "configChange": {


### PR DESCRIPTION
## What

Three defects found live on main right after the artifact-v2 landing (all verified before filing):

- **Index chain gap closed**: releases 1.116.0–1.120.1 shipped while the v2 PR was in draft — after the backfill snapshot, before the pipeline's append step activated — leaving a hole the span evaluator failed closed on. The seven missing entries are backfilled (`backfilled: true`); the committed index now walks contiguously 0.1893.0 → 1.122.0 with zero gaps.
- **Generator/schema drift fixed**: the generator emits `breakingCount`/`advisories`/`advisoryCount` on `api.rest`/`api.mcp` which the schema (`additionalProperties: false`) did not declare; the schema now declares them with the shapes the generator actually produces, and an end-to-end test validates a generator-produced marker against the schema (the missing drift guard).
- **Enforcement ordering hole closed**: the marker schema-validation ran too late to stop a release — it now runs in the semantic-release `prepare` step immediately after generation, so an invalid marker aborts before release notes, the release commit, or asset publication.

## Verification

Release-safety suite green; full index walk (3,089+ entries) zero gaps; typecheck 10/10 turbo tasks; rebase over the merged four-PR batch preserved main's newest index entries (1.121.1, 1.122.0) alongside the backfilled range.

Closes: SPK-934