### PR TITLE
feat(backend): migration-run ledger + clean-abort semantics (bounded-retry-then-park)

### DIFF
--- a/packages/backend/src/database/migrationLease.test.ts
+++ b/packages/backend/src/database/migrationLease.test.ts
@@ -6,7 +6,9 @@ import {
     type MigrationLeaseIdentity,
 } from './migrationLease';
 import { MIGRATION_LEASE_SCHEMA_SQL } from './migrationLeaseSchema';
+import { MIGRATION_RUN_LEDGER_SCHEMA_SQL } from './migrationRunLedgerSchema';
 import { MIGRATION_LEASE_SCHEMA_SQL as FROZEN_MIGRATION_LEASE_SCHEMA_SQL } from './migrations/20260810120000_create_migration_lease';
+import { MIGRATION_RUN_LEDGER_SCHEMA_SQL as FROZEN_MIGRATION_RUN_LEDGER_SCHEMA_SQL } from './migrations/20260811122500_create_migration_run_ledger';
 
 const identity: MigrationLeaseIdentity = {
     hostname: 'host-a',
@@ -30,6 +32,12 @@ const databaseRow = (
     last_heartbeat: token === null ? null : lastHeartbeat,
     last_unlocked_by: null,
     last_unlocked_at: null,
+    last_unlock_forced: false,
+    parked_at: null,
+    parked_app_version: null,
+    parked_migration: null,
+    parked_error: null,
+    parked_run_uuid: null,
 });
 
 let database: Knex;
@@ -39,11 +47,13 @@ const manager = (token: string) =>
     new MigrationLeaseManager({
         database,
         tokenFactory: () => token,
+        runIdFactory: () => '00000000-0000-4000-8000-000000000001',
         bootstrapDelay: async () => {},
     });
 
 const handleBootstrap = () => {
     tracker.on.any(MIGRATION_LEASE_SCHEMA_SQL).response([]);
+    tracker.on.any(MIGRATION_RUN_LEDGER_SCHEMA_SQL).response([]);
 };
 
 const handleInitializedSchema = () => {
@@ -68,13 +78,19 @@ describe('MigrationLeaseManager', () => {
         expect(MIGRATION_LEASE_SCHEMA_SQL).toEqual(
             FROZEN_MIGRATION_LEASE_SCHEMA_SQL,
         );
+        expect(MIGRATION_RUN_LEDGER_SCHEMA_SQL).toEqual(
+            FROZEN_MIGRATION_RUN_LEDGER_SCHEMA_SQL,
+        );
     });
 
     test('uses the runtime schema during bootstrap', async () => {
         handleBootstrap();
         await manager('claim-a').ensureSchema();
-        expect(tracker.history.any).toHaveLength(1);
+        expect(tracker.history.any).toHaveLength(2);
         expect(tracker.history.any[0]?.sql).toEqual(MIGRATION_LEASE_SCHEMA_SQL);
+        expect(tracker.history.any[1]?.sql).toEqual(
+            MIGRATION_RUN_LEDGER_SCHEMA_SQL,
+        );
     });
 
     test('claims an idle singleton lease with a new opaque token', async () => {
@@ -91,6 +107,10 @@ describe('MigrationLeaseManager', () => {
         );
         expect(tracker.history.update[0]?.bindings).toContain(
             MIGRATION_LEASE_EXPIRY_MS,
+        );
+        expect(tracker.history.update[0]?.sql).toContain('"parked_at" is null');
+        expect(tracker.history.update[0]?.bindings).toContain(
+            identity.appVersion,
         );
     });
 
@@ -114,6 +134,33 @@ describe('MigrationLeaseManager', () => {
         });
     });
 
+    test('reads the legacy lease shape before the run ledger migration', async () => {
+        tracker.on
+            .any((query) => query.bindings.includes('migration_lease'))
+            .response(true);
+        tracker.on
+            .any((query) => query.bindings.includes('migration_run_ledger'))
+            .response(false);
+        tracker.on
+            .select('migration_lease')
+            .response([{ ...databaseRow(null), expired: false }]);
+
+        const result = await manager('claim-a').read();
+
+        expect(result).toMatchObject({
+            initialized: true,
+            lease: {
+                lastUnlockForced: false,
+                parkedAt: null,
+                parkedAppVersion: null,
+                parkedMigration: null,
+                parkedError: null,
+                parkedRunUuid: null,
+            },
+        });
+        expect(tracker.history.select[0]?.sql).not.toContain('parked_at');
+    });
+
     test('heartbeat renews only the matching token', async () => {
         const renewedAt = new Date('2026-08-10T10:00:10.000Z');
         tracker.on
@@ -124,6 +171,100 @@ describe('MigrationLeaseManager', () => {
             true,
         );
         expect(tracker.history.update[0]?.bindings).toContain('claim-a');
+    });
+
+    test('starts a run with version and unlock attribution', async () => {
+        tracker.on.insert('migration_run_ledger').response([
+            {
+                migration_run_uuid: '00000000-0000-4000-8000-000000000001',
+            },
+        ]);
+
+        const runUuid = await manager('claim-a').startRun({
+            token: 'claim-a',
+            identity,
+            fromMigration: '001_previous.ts',
+            toMigration: '002_next.ts',
+            attempt: 1,
+            lastUnlockedBy: 'operator@example.com',
+            lastUnlockedAt: new Date('2026-08-10T09:55:00.000Z'),
+            lastUnlockForced: true,
+        });
+
+        expect(runUuid).toEqual('00000000-0000-4000-8000-000000000001');
+        expect(tracker.history.insert[0]?.bindings).toEqual(
+            expect.arrayContaining([
+                'claim-a',
+                identity.hostname,
+                identity.podName,
+                identity.appVersion,
+                '001_previous.ts',
+                '002_next.ts',
+                'running',
+                'operator@example.com',
+                true,
+            ]),
+        );
+    });
+
+    test('records retry and terminal outcomes against the owned run', async () => {
+        tracker.on.update('migration_run_ledger').responseOnce([
+            {
+                migration_run_uuid: '00000000-0000-4000-8000-000000000001',
+            },
+        ]);
+        tracker.on.update('migration_run_ledger').responseOnce([
+            {
+                migration_run_uuid: '00000000-0000-4000-8000-000000000002',
+            },
+        ]);
+        tracker.on.update('migration_run_ledger').responseOnce([
+            {
+                migration_run_uuid: '00000000-0000-4000-8000-000000000003',
+            },
+        ]);
+        tracker.on
+            .update('migration_lease')
+            .responseOnce([{ lease_key: 'global' }]);
+        tracker.on
+            .update('migration_lease')
+            .responseOnce([{ lease_key: 'global' }]);
+        const leaseManager = manager('claim-a');
+
+        await expect(
+            leaseManager.recordRetry(
+                'claim-a',
+                '00000000-0000-4000-8000-000000000001',
+                '002_next.ts',
+                'transient failure',
+            ),
+        ).resolves.toBe(true);
+        await expect(
+            leaseManager.completeRun(
+                'claim-a',
+                '00000000-0000-4000-8000-000000000002',
+            ),
+        ).resolves.toBe(true);
+        await expect(
+            leaseManager.parkRun(
+                'claim-a',
+                '00000000-0000-4000-8000-000000000003',
+                identity.appVersion,
+                '002_next.ts',
+                'deterministic failure',
+            ),
+        ).resolves.toBe(true);
+
+        expect(tracker.history.update[0]?.bindings).toContain('retrying');
+        expect(tracker.history.update[1]?.bindings).toContain('succeeded');
+        expect(tracker.history.update[3]?.bindings).toContain('parked');
+        expect(tracker.history.update[4]?.bindings).toEqual(
+            expect.arrayContaining([
+                identity.appVersion,
+                '002_next.ts',
+                'deterministic failure',
+            ]),
+        );
     });
 
     test('an expired holder is taken over once and loses the re-race', async () => {

--- a/packages/backend/src/database/migrationLease.ts
+++ b/packages/backend/src/database/migrationLease.ts
@@ -2,8 +2,10 @@ import { type Knex } from 'knex';
 import { randomUUID } from 'node:crypto';
 import { DatabaseError } from 'pg';
 import { MIGRATION_LEASE_SCHEMA_SQL } from './migrationLeaseSchema';
+import { MIGRATION_RUN_LEDGER_SCHEMA_SQL } from './migrationRunLedgerSchema';
 
 export const MIGRATION_LEASE_TABLE_NAME = 'migration_lease';
+export const MIGRATION_RUN_LEDGER_TABLE_NAME = 'migration_run_ledger';
 export const MIGRATION_LEASE_KEY = 'global';
 export const MIGRATION_LEASE_EXPIRY_MS = 75_000;
 
@@ -12,7 +14,7 @@ const BOOTSTRAP_RETRY_DELAY_MS = 50;
 const UNLOCK_MAX_ATTEMPTS = 3;
 const RETRYABLE_BOOTSTRAP_ERROR_CODES = new Set(['23505', '42P07']);
 
-const LEASE_COLUMNS = [
+const LEGACY_LEASE_COLUMNS = [
     'lease_key',
     'holder_hostname',
     'holder_pod_name',
@@ -23,6 +25,35 @@ const LEASE_COLUMNS = [
     'last_heartbeat',
     'last_unlocked_by',
     'last_unlocked_at',
+] as const;
+
+const LEASE_COLUMNS = [
+    ...LEGACY_LEASE_COLUMNS,
+    'last_unlock_forced',
+    'parked_at',
+    'parked_app_version',
+    'parked_migration',
+    'parked_error',
+    'parked_run_uuid',
+] as const;
+
+const RUN_COLUMNS = [
+    'migration_run_uuid',
+    'claim_token',
+    'holder_hostname',
+    'holder_pod_name',
+    'app_version',
+    'from_migration',
+    'to_migration',
+    'attempt',
+    'started_at',
+    'finished_at',
+    'outcome',
+    'failing_migration',
+    'failure_detail',
+    'last_unlocked_by',
+    'last_unlocked_at',
+    'last_unlock_forced',
 ] as const;
 
 type MigrationLeaseDatabaseRow = {
@@ -36,6 +67,12 @@ type MigrationLeaseDatabaseRow = {
     last_heartbeat: Date | null;
     last_unlocked_by: string | null;
     last_unlocked_at: Date | null;
+    last_unlock_forced?: boolean;
+    parked_at?: Date | null;
+    parked_app_version?: string | null;
+    parked_migration?: string | null;
+    parked_error?: string | null;
+    parked_run_uuid?: string | null;
 };
 
 type MigrationLeaseStatusDatabaseRow = MigrationLeaseDatabaseRow & {
@@ -59,7 +96,78 @@ export type MigrationLease = {
     lastHeartbeat: Date | null;
     lastUnlockedBy: string | null;
     lastUnlockedAt: Date | null;
+    lastUnlockForced: boolean;
+    parkedAt: Date | null;
+    parkedAppVersion: string | null;
+    parkedMigration: string | null;
+    parkedError: string | null;
+    parkedRunUuid: string | null;
     expired: boolean;
+};
+
+export type MigrationRunOutcome =
+    | 'running'
+    | 'succeeded'
+    | 'retrying'
+    | 'parked';
+
+type MigrationRunDatabaseRow = {
+    migration_run_uuid: string;
+    claim_token: string;
+    holder_hostname: string;
+    holder_pod_name: string | null;
+    app_version: string;
+    from_migration: string | null;
+    to_migration: string | null;
+    attempt: number;
+    started_at: Date;
+    finished_at: Date | null;
+    outcome: MigrationRunOutcome;
+    failing_migration: string | null;
+    failure_detail: string | null;
+    last_unlocked_by: string | null;
+    last_unlocked_at: Date | null;
+    last_unlock_forced: boolean;
+};
+
+export type MigrationRun = {
+    runUuid: string;
+    claimToken: string;
+    holderHostname: string;
+    holderPodName: string | null;
+    appVersion: string;
+    fromMigration: string | null;
+    toMigration: string | null;
+    attempt: number;
+    startedAt: Date;
+    finishedAt: Date | null;
+    outcome: MigrationRunOutcome;
+    failingMigration: string | null;
+    failureDetail: string | null;
+    lastUnlockedBy: string | null;
+    lastUnlockedAt: Date | null;
+    lastUnlockForced: boolean;
+};
+
+export type MigrationRunHistoryReadResult =
+    | {
+          initialized: false;
+          runs: [];
+      }
+    | {
+          initialized: true;
+          runs: MigrationRun[];
+      };
+
+export type MigrationRunStart = {
+    token: string;
+    identity: MigrationLeaseIdentity;
+    fromMigration: string | null;
+    toMigration: string | null;
+    attempt: number;
+    lastUnlockedBy: string | null;
+    lastUnlockedAt: Date | null;
+    lastUnlockForced: boolean;
 };
 
 export type MigrationLeaseReadResult =
@@ -98,6 +206,7 @@ type MigrationLeaseManagerArguments = {
     database: Knex;
     expiryMs?: number;
     tokenFactory?: () => string;
+    runIdFactory?: () => string;
     bootstrapDelay?: (durationMs: number) => Promise<void>;
 };
 
@@ -126,7 +235,32 @@ const mapLease = (
     lastHeartbeat: row.last_heartbeat,
     lastUnlockedBy: row.last_unlocked_by,
     lastUnlockedAt: row.last_unlocked_at,
+    lastUnlockForced: row.last_unlock_forced ?? false,
+    parkedAt: row.parked_at ?? null,
+    parkedAppVersion: row.parked_app_version ?? null,
+    parkedMigration: row.parked_migration ?? null,
+    parkedError: row.parked_error ?? null,
+    parkedRunUuid: row.parked_run_uuid ?? null,
     expired,
+});
+
+const mapRun = (row: MigrationRunDatabaseRow): MigrationRun => ({
+    runUuid: row.migration_run_uuid,
+    claimToken: row.claim_token,
+    holderHostname: row.holder_hostname,
+    holderPodName: row.holder_pod_name,
+    appVersion: row.app_version,
+    fromMigration: row.from_migration,
+    toMigration: row.to_migration,
+    attempt: row.attempt,
+    startedAt: row.started_at,
+    finishedAt: row.finished_at,
+    outcome: row.outcome,
+    failingMigration: row.failing_migration,
+    failureDetail: row.failure_detail,
+    lastUnlockedBy: row.last_unlocked_by,
+    lastUnlockedAt: row.last_unlocked_at,
+    lastUnlockForced: row.last_unlock_forced,
 });
 
 export class MigrationLeaseManager {
@@ -136,17 +270,21 @@ export class MigrationLeaseManager {
 
     private readonly tokenFactory: () => string;
 
+    private readonly runIdFactory: () => string;
+
     private readonly bootstrapDelay: (durationMs: number) => Promise<void>;
 
     constructor({
         database,
         expiryMs = MIGRATION_LEASE_EXPIRY_MS,
         tokenFactory = randomUUID,
+        runIdFactory = randomUUID,
         bootstrapDelay = delay,
     }: MigrationLeaseManagerArguments) {
         this.database = database;
         this.expiryMs = expiryMs;
         this.tokenFactory = tokenFactory;
+        this.runIdFactory = runIdFactory;
         this.bootstrapDelay = bootstrapDelay;
     }
 
@@ -157,6 +295,7 @@ export class MigrationLeaseManager {
     private async ensureSchemaAttempt(attempt: number): Promise<void> {
         try {
             await this.database.raw(MIGRATION_LEASE_SCHEMA_SQL);
+            await this.database.raw(MIGRATION_RUN_LEDGER_SCHEMA_SQL);
         } catch (error) {
             if (
                 !isRetryableBootstrapError(error) ||
@@ -191,6 +330,11 @@ export class MigrationLeaseManager {
         const rows = (await this.database(MIGRATION_LEASE_TABLE_NAME)
             .where('lease_key', MIGRATION_LEASE_KEY)
             .andWhere((query) => this.whereLeaseIsClaimable(query))
+            .andWhere((query) =>
+                query
+                    .whereNull('parked_at')
+                    .orWhereNot('parked_app_version', identity.appVersion),
+            )
             .update({
                 holder_hostname: identity.hostname,
                 holder_pod_name: identity.podName,
@@ -268,6 +412,155 @@ export class MigrationLeaseManager {
         return rows.length === 1;
     }
 
+    async startRun(run: MigrationRunStart): Promise<string> {
+        const runUuid = this.runIdFactory();
+        const rows = (await this.database(MIGRATION_RUN_LEDGER_TABLE_NAME)
+            .insert({
+                migration_run_uuid: runUuid,
+                claim_token: run.token,
+                holder_hostname: run.identity.hostname,
+                holder_pod_name: run.identity.podName,
+                app_version: run.identity.appVersion,
+                from_migration: run.fromMigration,
+                to_migration: run.toMigration,
+                attempt: run.attempt,
+                outcome: 'running',
+                last_unlocked_by: run.lastUnlockedBy,
+                last_unlocked_at: run.lastUnlockedAt,
+                last_unlock_forced: run.lastUnlockForced,
+            })
+            .returning('migration_run_uuid')) as Array<{
+            migration_run_uuid: string;
+        }>;
+        const inserted = rows[0];
+        if (inserted === undefined) {
+            throw new Error('Migration run ledger row was not created');
+        }
+        return inserted.migration_run_uuid;
+    }
+
+    async recordRetry(
+        token: string,
+        runUuid: string,
+        failingMigration: string,
+        failureDetail: string,
+    ): Promise<boolean> {
+        const rows = (await this.database(MIGRATION_RUN_LEDGER_TABLE_NAME)
+            .where({
+                migration_run_uuid: runUuid,
+                claim_token: token,
+                outcome: 'running',
+            })
+            .update({
+                outcome: 'retrying',
+                finished_at: this.database.fn.now(),
+                failing_migration: failingMigration,
+                failure_detail: failureDetail,
+            })
+            .returning('migration_run_uuid')) as Array<{
+            migration_run_uuid: string;
+        }>;
+        return rows.length === 1;
+    }
+
+    async completeRun(token: string, runUuid: string): Promise<boolean> {
+        return this.database.transaction(async (transaction) => {
+            const runRows = (await transaction(MIGRATION_RUN_LEDGER_TABLE_NAME)
+                .where({
+                    migration_run_uuid: runUuid,
+                    claim_token: token,
+                    outcome: 'running',
+                })
+                .update({
+                    outcome: 'succeeded',
+                    finished_at: transaction.fn.now(),
+                })
+                .returning('migration_run_uuid')) as Array<{
+                migration_run_uuid: string;
+            }>;
+            if (runRows.length !== 1) {
+                return false;
+            }
+            const leaseRows = (await transaction(MIGRATION_LEASE_TABLE_NAME)
+                .where({
+                    lease_key: MIGRATION_LEASE_KEY,
+                    claim_token: token,
+                })
+                .update({
+                    holder_hostname: null,
+                    holder_pod_name: null,
+                    app_version: null,
+                    claim_token: null,
+                    started_at: null,
+                    current_migration: null,
+                    last_heartbeat: null,
+                    parked_at: null,
+                    parked_app_version: null,
+                    parked_migration: null,
+                    parked_error: null,
+                    parked_run_uuid: null,
+                })
+                .returning('lease_key')) as Array<{ lease_key: string }>;
+            if (leaseRows.length !== 1) {
+                throw new Error('Migration lease was lost before completion');
+            }
+            return true;
+        });
+    }
+
+    async parkRun(
+        token: string,
+        runUuid: string,
+        appVersion: string,
+        failingMigration: string,
+        failureDetail: string,
+    ): Promise<boolean> {
+        return this.database.transaction(async (transaction) => {
+            const runRows = (await transaction(MIGRATION_RUN_LEDGER_TABLE_NAME)
+                .where({
+                    migration_run_uuid: runUuid,
+                    claim_token: token,
+                    outcome: 'running',
+                })
+                .update({
+                    outcome: 'parked',
+                    finished_at: transaction.fn.now(),
+                    failing_migration: failingMigration,
+                    failure_detail: failureDetail,
+                })
+                .returning('migration_run_uuid')) as Array<{
+                migration_run_uuid: string;
+            }>;
+            if (runRows.length !== 1) {
+                return false;
+            }
+            const leaseRows = (await transaction(MIGRATION_LEASE_TABLE_NAME)
+                .where({
+                    lease_key: MIGRATION_LEASE_KEY,
+                    claim_token: token,
+                })
+                .update({
+                    holder_hostname: null,
+                    holder_pod_name: null,
+                    app_version: null,
+                    claim_token: null,
+                    started_at: null,
+                    current_migration: null,
+                    last_heartbeat: null,
+                    parked_at: transaction.fn.now(),
+                    parked_app_version: appVersion,
+                    parked_migration: failingMigration,
+                    parked_error: failureDetail,
+                    parked_run_uuid: runUuid,
+                })
+                .returning('lease_key')) as Array<{ lease_key: string }>;
+            if (leaseRows.length !== 1) {
+                throw new Error('Migration lease was lost before parking');
+            }
+            return true;
+        });
+    }
+
     async unlock(
         actor: string,
         force: boolean,
@@ -301,6 +594,12 @@ export class MigrationLeaseManager {
                 last_heartbeat: null,
                 last_unlocked_by: actor,
                 last_unlocked_at: this.database.fn.now(),
+                last_unlock_forced: force,
+                parked_at: null,
+                parked_app_version: null,
+                parked_migration: null,
+                parked_error: null,
+                parked_run_uuid: null,
             })
             .returning(LEASE_COLUMNS)) as MigrationLeaseDatabaseRow[];
         const lease = rows[0];
@@ -343,8 +642,14 @@ export class MigrationLeaseManager {
             return { initialized: false, lease: null };
         }
 
+        const ledgerInitialized = await this.database.schema.hasTable(
+            MIGRATION_RUN_LEDGER_TABLE_NAME,
+        );
+        const leaseColumns = ledgerInitialized
+            ? LEASE_COLUMNS
+            : LEGACY_LEASE_COLUMNS;
         const row = (await this.database(MIGRATION_LEASE_TABLE_NAME)
-            .select(LEASE_COLUMNS)
+            .select(leaseColumns)
             .select(
                 this.database.raw(
                     `(claim_token IS NOT NULL AND (last_heartbeat IS NULL OR last_heartbeat <= CURRENT_TIMESTAMP - (? * INTERVAL '1 millisecond'))) AS expired`,
@@ -357,6 +662,23 @@ export class MigrationLeaseManager {
         return {
             initialized: true,
             lease: row === undefined ? null : mapLease(row, row.expired),
+        };
+    }
+
+    async readRunHistory(limit = 10): Promise<MigrationRunHistoryReadResult> {
+        const initialized = await this.database.schema.hasTable(
+            MIGRATION_RUN_LEDGER_TABLE_NAME,
+        );
+        if (!initialized) {
+            return { initialized: false, runs: [] };
+        }
+        const rows = (await this.database(MIGRATION_RUN_LEDGER_TABLE_NAME)
+            .select(RUN_COLUMNS)
+            .orderBy('started_at', 'desc')
+            .limit(limit)) as MigrationRunDatabaseRow[];
+        return {
+            initialized: true,
+            runs: rows.map(mapRun),
         };
     }
 }

--- a/packages/backend/src/database/migrationRunLedgerSchema.ts
+++ b/packages/backend/src/database/migrationRunLedgerSchema.ts
@@ -1,0 +1,33 @@
+export const MIGRATION_RUN_LEDGER_SCHEMA_SQL = `
+ALTER TABLE migration_lease
+    ADD COLUMN IF NOT EXISTS last_unlock_forced boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS parked_at timestamptz,
+    ADD COLUMN IF NOT EXISTS parked_app_version text,
+    ADD COLUMN IF NOT EXISTS parked_migration text,
+    ADD COLUMN IF NOT EXISTS parked_error text,
+    ADD COLUMN IF NOT EXISTS parked_run_uuid uuid;
+
+CREATE TABLE IF NOT EXISTS migration_run_ledger (
+    migration_run_uuid uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    claim_token uuid NOT NULL,
+    holder_hostname text NOT NULL,
+    holder_pod_name text,
+    app_version text NOT NULL,
+    from_migration text,
+    to_migration text,
+    attempt integer NOT NULL,
+    started_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    finished_at timestamptz,
+    outcome text NOT NULL,
+    failing_migration text,
+    failure_detail text,
+    last_unlocked_by text,
+    last_unlocked_at timestamptz,
+    last_unlock_forced boolean NOT NULL DEFAULT false,
+    CONSTRAINT migration_run_ledger_attempt_positive CHECK (attempt > 0),
+    CONSTRAINT migration_run_ledger_outcome_check CHECK (outcome IN ('running', 'succeeded', 'retrying', 'parked'))
+);
+
+CREATE INDEX IF NOT EXISTS migration_run_ledger_started_at_idx
+    ON migration_run_ledger (started_at DESC);
+`;

--- a/packages/backend/src/database/migrations/20260811122500_create_migration_run_ledger.ts
+++ b/packages/backend/src/database/migrations/20260811122500_create_migration_run_ledger.ts
@@ -1,0 +1,60 @@
+import { type Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'adds nullable live migration state and an independent history table using idempotent additive DDL without rewriting existing rows',
+} as const;
+
+export const MIGRATION_RUN_LEDGER_SCHEMA_SQL = `
+ALTER TABLE migration_lease
+    ADD COLUMN IF NOT EXISTS last_unlock_forced boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS parked_at timestamptz,
+    ADD COLUMN IF NOT EXISTS parked_app_version text,
+    ADD COLUMN IF NOT EXISTS parked_migration text,
+    ADD COLUMN IF NOT EXISTS parked_error text,
+    ADD COLUMN IF NOT EXISTS parked_run_uuid uuid;
+
+CREATE TABLE IF NOT EXISTS migration_run_ledger (
+    migration_run_uuid uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    claim_token uuid NOT NULL,
+    holder_hostname text NOT NULL,
+    holder_pod_name text,
+    app_version text NOT NULL,
+    from_migration text,
+    to_migration text,
+    attempt integer NOT NULL,
+    started_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    finished_at timestamptz,
+    outcome text NOT NULL,
+    failing_migration text,
+    failure_detail text,
+    last_unlocked_by text,
+    last_unlocked_at timestamptz,
+    last_unlock_forced boolean NOT NULL DEFAULT false,
+    CONSTRAINT migration_run_ledger_attempt_positive CHECK (attempt > 0),
+    CONSTRAINT migration_run_ledger_outcome_check CHECK (outcome IN ('running', 'succeeded', 'retrying', 'parked'))
+);
+
+CREATE INDEX IF NOT EXISTS migration_run_ledger_started_at_idx
+    ON migration_run_ledger (started_at DESC);
+`;
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.raw(MIGRATION_RUN_LEDGER_SCHEMA_SQL);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.raw(`
+DROP TABLE IF EXISTS migration_run_ledger;
+
+ALTER TABLE migration_lease
+    DROP COLUMN IF EXISTS parked_run_uuid,
+    DROP COLUMN IF EXISTS parked_error,
+    DROP COLUMN IF EXISTS parked_migration,
+    DROP COLUMN IF EXISTS parked_app_version,
+    DROP COLUMN IF EXISTS parked_at,
+    DROP COLUMN IF EXISTS last_unlock_forced;
+`);
+}

--- a/packages/backend/src/scripts/migrate/cli.test.ts
+++ b/packages/backend/src/scripts/migrate/cli.test.ts
@@ -2,6 +2,7 @@ import {
     type MigrationLease,
     type MigrationLeaseClaimResult,
     type MigrationLeaseReadResult,
+    type MigrationRun,
 } from '../../database/migrationLease';
 import {
     createMigrateCliContext,
@@ -55,6 +56,12 @@ const heldLease = (
     lastHeartbeat: new Date('2026-08-10T10:00:10.000Z'),
     lastUnlockedBy: null,
     lastUnlockedAt: null,
+    lastUnlockForced: false,
+    parkedAt: null,
+    parkedAppVersion: null,
+    parkedMigration: null,
+    parkedError: null,
+    parkedRunUuid: null,
     expired: false,
     ...overrides,
 });
@@ -70,29 +77,66 @@ const acquired = (token = 'claim-a'): MigrationLeaseClaimResult => ({
     lease: heldLease({ claimToken: token }),
 });
 
-const leaseManager = (): MigrationLeaseCommandClient => ({
-    claim: vi.fn(async () => acquired()),
-    heartbeat: vi.fn(async () => true),
-    setCurrentMigration: vi.fn(async () => true),
-    release: vi.fn(async () => true),
-    unlock: vi.fn<MigrationLeaseCommandClient['unlock']>(
-        async (actor, _force) => ({
-            status: 'unlocked',
-            lease: heldLease({
-                claimToken: null,
-                holderHostname: null,
-                holderPodName: null,
-                appVersion: null,
-                startedAt: null,
-                currentMigration: null,
-                lastHeartbeat: null,
-                lastUnlockedBy: actor,
-                lastUnlockedAt: new Date('2026-08-10T10:05:00.000Z'),
-            }),
-        }),
-    ),
-    read: vi.fn(async () => readLease(null)),
+const migrationRun = (overrides: Partial<MigrationRun> = {}): MigrationRun => ({
+    runUuid: 'run-1',
+    claimToken: 'claim-a',
+    holderHostname: 'host-b',
+    holderPodName: 'pod-b',
+    appVersion: '1.2.3',
+    fromMigration: '000_previous.ts',
+    toMigration: '001_first.ts',
+    attempt: 1,
+    startedAt: new Date('2026-08-10T10:00:00.000Z'),
+    finishedAt: new Date('2026-08-10T10:00:05.000Z'),
+    outcome: 'succeeded',
+    failingMigration: null,
+    failureDetail: null,
+    lastUnlockedBy: null,
+    lastUnlockedAt: null,
+    lastUnlockForced: false,
+    ...overrides,
 });
+
+const leaseManager = (): MigrationLeaseCommandClient => {
+    let runNumber = 0;
+    return {
+        claim: vi.fn(async () => acquired()),
+        heartbeat: vi.fn(async () => true),
+        setCurrentMigration: vi.fn(async () => true),
+        release: vi.fn(async () => true),
+        startRun: vi.fn(async () => {
+            runNumber += 1;
+            return `run-${runNumber}`;
+        }),
+        recordRetry: vi.fn(async () => true),
+        completeRun: vi.fn(async () => true),
+        parkRun: vi.fn(async () => true),
+        readRunHistory: vi.fn<MigrationLeaseCommandClient['readRunHistory']>(
+            async () => ({
+                initialized: true,
+                runs: [],
+            }),
+        ),
+        unlock: vi.fn<MigrationLeaseCommandClient['unlock']>(
+            async (actor, force) => ({
+                status: 'unlocked',
+                lease: heldLease({
+                    claimToken: null,
+                    holderHostname: null,
+                    holderPodName: null,
+                    appVersion: null,
+                    startedAt: null,
+                    currentMigration: null,
+                    lastHeartbeat: null,
+                    lastUnlockedBy: actor,
+                    lastUnlockedAt: new Date('2026-08-10T10:05:00.000Z'),
+                    lastUnlockForced: force,
+                }),
+            }),
+        ),
+        read: vi.fn(async () => readLease(null)),
+    };
+};
 
 const context = (
     manager: MigrationLeaseCommandClient,
@@ -126,6 +170,7 @@ const context = (
             onLeaseLost: vi.fn(),
             sleep: vi.fn(async () => {}),
             heartbeatIntervalMs: 60_000,
+            migrationRetryDelayMs: 1,
             ...overrides,
         }),
     };
@@ -222,24 +267,26 @@ describe('runMigrateCli', () => {
 
     test('up re-checks the ledger after claiming and before clearing the Knex lock', async () => {
         const manager = leaseManager();
-        const states = [
-            migrationState(['002_second.ts']),
-            migrationState([], ['001_alien.ts'], ['001_alien.ts']),
-        ];
+        const getMigrationState = vi
+            .fn<MigrateCliContext['getMigrationState']>()
+            .mockResolvedValueOnce(migrationState(['002_second.ts']))
+            .mockResolvedValue(
+                migrationState([], ['001_alien.ts'], ['001_alien.ts']),
+            );
         const command = context(manager, {
-            getMigrationState: vi.fn(
-                async () => states.shift() ?? migrationState(),
-            ),
+            getMigrationState,
         });
 
         await expect(runMigrateCli(['up'], command.value)).rejects.toThrow(
-            'Migration ledger diverged from local files; offending database-only migrations: 001_alien.ts',
+            'Migration parked after 3 attempts at migration-state: Migration ledger diverged from local files; offending database-only migrations: 001_alien.ts',
         );
 
         expect(manager.claim).toHaveBeenCalledOnce();
         expect(command.value.clearKnexLock).not.toHaveBeenCalled();
         expect(command.value.migrateOne).not.toHaveBeenCalled();
         expect(command.value.runGraphileMigrations).not.toHaveBeenCalled();
+        expect(manager.recordRetry).toHaveBeenCalledTimes(2);
+        expect(manager.parkRun).toHaveBeenCalledOnce();
     });
 
     test('up runs pending local work when the database is legally ahead', async () => {
@@ -261,7 +308,10 @@ describe('runMigrateCli', () => {
             '002_local_pending.ts',
         );
         expect(command.value.runGraphileMigrations).toHaveBeenCalledOnce();
-        expect(manager.release).toHaveBeenCalledWith('claim-a');
+        expect(manager.completeRun).toHaveBeenCalledWith(
+            'claim-a',
+            expect.any(String),
+        );
     });
 
     test('up clears the stale Knex lock, migrates files singly, runs Graphile, and releases', async () => {
@@ -310,7 +360,10 @@ describe('runMigrateCli', () => {
             null,
         );
         expect(command.value.runGraphileMigrations).toHaveBeenCalledOnce();
-        expect(manager.release).toHaveBeenCalledWith('claim-a');
+        expect(manager.completeRun).toHaveBeenCalledWith(
+            'claim-a',
+            expect.any(String),
+        );
     });
 
     test('up cleans invalid pending indexes before running migrations', async () => {
@@ -337,6 +390,86 @@ describe('runMigrateCli', () => {
         await runMigrateCli(['up'], command.value);
 
         expect(events).toEqual(['cleanup', 'migration']);
+    });
+
+    test('a deterministic failure retries twice then parks the third attempt', async () => {
+        const manager = leaseManager();
+        const command = context(manager, {
+            getMigrationState: vi.fn(async () =>
+                migrationState(['001_failing.ts']),
+            ),
+            migrateOne: vi.fn(async () => {
+                throw new Error('deterministic failure');
+            }),
+        });
+
+        await expect(runMigrateCli(['up'], command.value)).rejects.toThrow(
+            'Migration parked after 3 attempts at 001_failing.ts: deterministic failure',
+        );
+
+        expect(manager.startRun).toHaveBeenCalledTimes(3);
+        expect(manager.recordRetry).toHaveBeenNthCalledWith(
+            1,
+            'claim-a',
+            'run-1',
+            '001_failing.ts',
+            expect.stringContaining('deterministic failure'),
+        );
+        expect(manager.recordRetry).toHaveBeenNthCalledWith(
+            2,
+            'claim-a',
+            'run-2',
+            '001_failing.ts',
+            expect.stringContaining('deterministic failure'),
+        );
+        expect(manager.parkRun).toHaveBeenCalledWith(
+            'claim-a',
+            'run-3',
+            '1.2.3',
+            '001_failing.ts',
+            expect.stringContaining('deterministic failure'),
+        );
+        expect(manager.completeRun).not.toHaveBeenCalled();
+        expect(command.value.migrateOne).toHaveBeenCalledTimes(3);
+        expect(command.value.sleep).toHaveBeenNthCalledWith(1, 1);
+        expect(command.value.sleep).toHaveBeenNthCalledWith(2, 2);
+    });
+
+    test('the same app version does not reclaim a parked migration', async () => {
+        const manager = leaseManager();
+        const parkedLease = heldLease({
+            claimToken: null,
+            holderHostname: null,
+            holderPodName: null,
+            appVersion: null,
+            startedAt: null,
+            currentMigration: null,
+            lastHeartbeat: null,
+            parkedAt: new Date('2026-08-10T10:00:05.000Z'),
+            parkedAppVersion: '1.2.3',
+            parkedMigration: '001_failing.ts',
+            parkedError: 'deterministic failure',
+            parkedRunUuid: 'run-3',
+        });
+        vi.mocked(manager.claim).mockResolvedValue({
+            status: 'held',
+            token: null,
+            lease: parkedLease,
+        });
+        vi.mocked(manager.read).mockResolvedValue(readLease(parkedLease));
+        const command = context(manager, {
+            getMigrationState: vi.fn(async () =>
+                migrationState(['001_failing.ts']),
+            ),
+        });
+
+        await expect(runMigrateCli(['up'], command.value)).rejects.toThrow(
+            'Migration is parked for app version 1.2.3 at 001_failing.ts: deterministic failure; deploy a fixed version or run migrate unlock with operator attribution before retrying this version',
+        );
+
+        expect(manager.claim).toHaveBeenCalledOnce();
+        expect(manager.startRun).not.toHaveBeenCalled();
+        expect(command.value.migrateOne).not.toHaveBeenCalled();
     });
 
     test('an up follower promotes through the same claim path after expiry', async () => {
@@ -369,7 +502,10 @@ describe('runMigrateCli', () => {
         expect(command.lines).toContain(
             'Promoted follower to migration lease holder',
         );
-        expect(manager.release).toHaveBeenCalledWith('claim-b');
+        expect(manager.completeRun).toHaveBeenCalledWith(
+            'claim-b',
+            expect.any(String),
+        );
     });
 
     test('wait promotes through the same claim path when pending work is stale', async () => {
@@ -396,7 +532,10 @@ describe('runMigrateCli', () => {
         expect(command.lines).toContain(
             'Promoted follower to migration lease holder',
         );
-        expect(manager.release).toHaveBeenCalledWith('claim-b');
+        expect(manager.completeRun).toHaveBeenCalledWith(
+            'claim-b',
+            expect.any(String),
+        );
     });
 
     test('polling logs pending names and the holder on every pass', async () => {
@@ -478,6 +617,72 @@ describe('runMigrateCli', () => {
         await runMigrateCli(['status'], command.value);
 
         expect(command.lines).toContain('Migration state: stale');
+    });
+
+    test('status renders the parked state and run history', async () => {
+        const manager = leaseManager();
+        vi.mocked(manager.read).mockResolvedValue(
+            readLease(
+                heldLease({
+                    claimToken: null,
+                    holderHostname: null,
+                    holderPodName: null,
+                    appVersion: null,
+                    startedAt: null,
+                    currentMigration: null,
+                    lastHeartbeat: null,
+                    parkedAt: new Date('2026-08-10T10:00:05.000Z'),
+                    parkedAppVersion: '1.2.3',
+                    parkedMigration: '001_first.ts',
+                    parkedError: 'deterministic failure',
+                    parkedRunUuid: 'run-2',
+                }),
+            ),
+        );
+        vi.mocked(manager.readRunHistory).mockResolvedValue({
+            initialized: true,
+            runs: [
+                migrationRun({
+                    runUuid: 'run-2',
+                    attempt: 2,
+                    outcome: 'parked',
+                    failingMigration: '001_first.ts',
+                    failureDetail: 'deterministic failure',
+                    lastUnlockedBy: 'operator@example.com',
+                    lastUnlockedAt: new Date('2026-08-10T09:55:00.000Z'),
+                    lastUnlockForced: true,
+                }),
+                migrationRun({
+                    attempt: 1,
+                    outcome: 'retrying',
+                    failingMigration: '001_first.ts',
+                    failureDetail: 'deterministic failure',
+                }),
+            ],
+        });
+        const command = context(manager);
+
+        await runMigrateCli(['status'], command.value);
+
+        expect(command.lines).toContain('Migration state: parked');
+        expect(command.lines).toContain(
+            'Parked migration: version=1.2.3 migration=001_first.ts at=2026-08-10T10:00:05.000Z run=run-2 error=deterministic failure',
+        );
+        expect(command.lines).toContainEqual(
+            expect.stringContaining(
+                'Migration run run-2: outcome=parked attempt=2',
+            ),
+        );
+        expect(command.lines).toContainEqual(
+            expect.stringContaining(
+                'preceding_unlock=operator@example.com at 2026-08-10T09:55:00.000Z forced=true',
+            ),
+        );
+        expect(command.lines).toContainEqual(
+            expect.stringContaining(
+                'Migration run run-1: outcome=retrying attempt=1',
+            ),
+        );
     });
 
     test('status compacts long pending migration lists', async () => {

--- a/packages/backend/src/scripts/migrate/cli.ts
+++ b/packages/backend/src/scripts/migrate/cli.ts
@@ -5,12 +5,16 @@ import {
     type MigrationLeaseIdentity,
     type MigrationLeaseReadResult,
     type MigrationLeaseUnlockResult,
+    type MigrationRunHistoryReadResult,
+    type MigrationRunStart,
 } from '../../database/migrationLease';
 import { MigrationHeartbeat, type MigrationHeartbeatClient } from './heartbeat';
 import { type KnexMigrationState } from './migrationState';
 
 const DEFAULT_WAIT_TIMEOUT_MS = 30 * 60_000;
 const DEFAULT_FOLLOWER_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_MIGRATION_MAX_ATTEMPTS = 3;
+const DEFAULT_MIGRATION_RETRY_DELAY_MS = 1_000;
 const GRAPHILE_MIGRATION_NAME = 'graphile-worker';
 const MIGRATION_NAME_PREVIEW_LIMIT = 5;
 const MIGRATE_CLI_HELP = `Usage:
@@ -33,7 +37,7 @@ Flags:
   -h, --help                   Show this help`;
 
 type MigrateCommand = 'up' | 'status' | 'wait' | 'unlock';
-type MigrationStatusState = 'idle' | 'migrating' | 'stale';
+type MigrationStatusState = 'idle' | 'migrating' | 'parked' | 'stale';
 
 type MigrateCliOptions = {
     command: MigrateCommand;
@@ -53,6 +57,22 @@ export type MigrationLeaseCommandClient = MigrationHeartbeatClient & {
         currentMigration: string | null,
     ) => Promise<boolean>;
     release: (token: string) => Promise<boolean>;
+    startRun: (run: MigrationRunStart) => Promise<string>;
+    recordRetry: (
+        token: string,
+        runUuid: string,
+        failingMigration: string,
+        failureDetail: string,
+    ) => Promise<boolean>;
+    completeRun: (token: string, runUuid: string) => Promise<boolean>;
+    parkRun: (
+        token: string,
+        runUuid: string,
+        appVersion: string,
+        failingMigration: string,
+        failureDetail: string,
+    ) => Promise<boolean>;
+    readRunHistory: (limit?: number) => Promise<MigrationRunHistoryReadResult>;
     unlock: (
         actor: string,
         force: boolean,
@@ -79,6 +99,8 @@ export type MigrateCliContext = {
     defaultTimeoutMs: number;
     followerPollIntervalMs: number;
     heartbeatIntervalMs: number;
+    migrationMaxAttempts: number;
+    migrationRetryDelayMs: number;
     allowMissingMigrations: boolean;
 };
 
@@ -93,6 +115,8 @@ type PartialMigrateCliContext = Omit<
     | 'defaultTimeoutMs'
     | 'followerPollIntervalMs'
     | 'heartbeatIntervalMs'
+    | 'migrationMaxAttempts'
+    | 'migrationRetryDelayMs'
     | 'allowMissingMigrations'
 > &
     Partial<
@@ -107,6 +131,8 @@ type PartialMigrateCliContext = Omit<
             | 'defaultTimeoutMs'
             | 'followerPollIntervalMs'
             | 'heartbeatIntervalMs'
+            | 'migrationMaxAttempts'
+            | 'migrationRetryDelayMs'
             | 'allowMissingMigrations'
         >
     >;
@@ -132,6 +158,10 @@ export const createMigrateCliContext = (
     followerPollIntervalMs:
         context.followerPollIntervalMs ?? DEFAULT_FOLLOWER_POLL_INTERVAL_MS,
     heartbeatIntervalMs: context.heartbeatIntervalMs ?? 10_000,
+    migrationMaxAttempts:
+        context.migrationMaxAttempts ?? DEFAULT_MIGRATION_MAX_ATTEMPTS,
+    migrationRetryDelayMs:
+        context.migrationRetryDelayMs ?? DEFAULT_MIGRATION_RETRY_DELAY_MS,
     allowMissingMigrations: context.allowMissingMigrations ?? false,
 });
 
@@ -280,12 +310,14 @@ const runPendingKnexMigrations = async (
     token: string,
     heartbeat: MigrationHeartbeat,
     state: KnexMigrationState,
+    setFailingMigration: (migration: string) => void,
 ): Promise<void> => {
     assertMigrationStateRunnable(state);
     const nextMigration = state.pending[0];
     if (nextMigration === undefined) {
         return;
     }
+    setFailingMigration(nextMigration);
     requireTokenMutation(
         await context.leaseManager.setCurrentMigration(token, nextMigration),
         heartbeat,
@@ -298,16 +330,156 @@ const runPendingKnexMigrations = async (
         token,
         heartbeat,
         await context.getMigrationState(),
+        setFailingMigration,
+    );
+};
+
+const getErrorDetail = (error: unknown): string => {
+    if (!(error instanceof Error)) {
+        return String(error);
+    }
+    return error.stack ?? error.message;
+};
+
+const getErrorMessage = (error: unknown): string =>
+    error instanceof Error ? error.message : String(error);
+
+type AcquiredMigrationLeaseClaim = Extract<
+    MigrationLeaseClaimResult,
+    { status: 'acquired' }
+>;
+
+type MigrationAttemptResult =
+    | {
+          status: 'succeeded';
+          runUuid: string;
+      }
+    | {
+          status: 'failed';
+          runUuid: string;
+          failingMigration: string;
+          failureDetail: string;
+          failureMessage: string;
+      };
+
+const runHolderAttempt = async (
+    context: MigrateCliContext,
+    claim: AcquiredMigrationLeaseClaim,
+    heartbeat: MigrationHeartbeat,
+    attempt: number,
+): Promise<MigrationAttemptResult> => {
+    const state = await context.getMigrationState();
+    const fromMigration = state.completed[state.completed.length - 1] ?? null;
+    const toMigration =
+        state.pending[state.pending.length - 1] ?? fromMigration;
+    const runUuid = await context.leaseManager.startRun({
+        token: claim.token,
+        identity: context.identity,
+        fromMigration,
+        toMigration,
+        attempt,
+        lastUnlockedBy: claim.lease.lastUnlockedBy,
+        lastUnlockedAt: claim.lease.lastUnlockedAt,
+        lastUnlockForced: claim.lease.lastUnlockForced,
+    });
+    let failingMigration = 'migration-state';
+    try {
+        assertMigrationStateRunnable(state);
+        failingMigration = 'knex-lock-recovery';
+        await context.clearKnexLock();
+        heartbeat.assertHeld();
+        failingMigration = 'invalid-index-cleanup';
+        await context.cleanupInvalidIndexes(state.pending);
+        heartbeat.assertHeld();
+        await runPendingKnexMigrations(
+            context,
+            claim.token,
+            heartbeat,
+            state,
+            (migration) => {
+                failingMigration = migration;
+            },
+        );
+        failingMigration = GRAPHILE_MIGRATION_NAME;
+        requireTokenMutation(
+            await context.leaseManager.setCurrentMigration(
+                claim.token,
+                GRAPHILE_MIGRATION_NAME,
+            ),
+            heartbeat,
+        );
+        context.log('Running Graphile Worker migrations');
+        await context.runGraphileMigrations();
+        heartbeat.assertHeld();
+        requireTokenMutation(
+            await context.leaseManager.setCurrentMigration(claim.token, null),
+            heartbeat,
+        );
+        return { status: 'succeeded', runUuid };
+    } catch (error) {
+        return {
+            status: 'failed',
+            runUuid,
+            failingMigration,
+            failureDetail: getErrorDetail(error),
+            failureMessage: getErrorMessage(error),
+        };
+    }
+};
+
+const runHolderAttempts = async (
+    context: MigrateCliContext,
+    claim: AcquiredMigrationLeaseClaim,
+    heartbeat: MigrationHeartbeat,
+    attempt: number,
+): Promise<string> => {
+    const result = await runHolderAttempt(context, claim, heartbeat, attempt);
+    if (result.status === 'succeeded') {
+        return result.runUuid;
+    }
+    if (attempt < context.migrationMaxAttempts) {
+        requireTokenMutation(
+            await context.leaseManager.recordRetry(
+                claim.token,
+                result.runUuid,
+                result.failingMigration,
+                result.failureDetail,
+            ),
+            heartbeat,
+        );
+        const retryDelay = context.migrationRetryDelayMs * 2 ** (attempt - 1);
+        context.logError(
+            `Migration attempt ${attempt}/${context.migrationMaxAttempts} failed at ${result.failingMigration}: ${result.failureMessage}; retrying in ${retryDelay}ms`,
+        );
+        await context.sleep(retryDelay);
+        heartbeat.assertHeld();
+        return runHolderAttempts(context, claim, heartbeat, attempt + 1);
+    }
+    await heartbeat.stop();
+    heartbeat.assertHeld();
+    if (
+        !(await context.leaseManager.parkRun(
+            claim.token,
+            result.runUuid,
+            context.identity.appVersion,
+            result.failingMigration,
+            result.failureDetail,
+        ))
+    ) {
+        throw new Error('Migration lease was lost before parking');
+    }
+    throw new Error(
+        `Migration parked after ${context.migrationMaxAttempts} attempts at ${result.failingMigration}: ${result.failureMessage}`,
     );
 };
 
 const runAsHolder = async (
     context: MigrateCliContext,
-    token: string,
+    claim: AcquiredMigrationLeaseClaim,
 ): Promise<void> => {
     const heartbeat = new MigrationHeartbeat({
         leaseManager: context.heartbeatLeaseManager,
-        token,
+        token: claim.token,
         intervalMs: context.heartbeatIntervalMs,
         onError: (error) => {
             const message =
@@ -318,32 +490,11 @@ const runAsHolder = async (
     });
     let succeeded = false;
     try {
-        const state = await context.getMigrationState();
-        assertMigrationStateRunnable(state);
         heartbeat.start();
-        // The Knex lock table deliberately survives because images older than the lease release still use it during rollback windows.
-        await context.clearKnexLock();
-        heartbeat.assertHeld();
-        await context.cleanupInvalidIndexes(state.pending);
-        heartbeat.assertHeld();
-        await runPendingKnexMigrations(context, token, heartbeat, state);
-        requireTokenMutation(
-            await context.leaseManager.setCurrentMigration(
-                token,
-                GRAPHILE_MIGRATION_NAME,
-            ),
-            heartbeat,
-        );
-        context.log('Running Graphile Worker migrations');
-        await context.runGraphileMigrations();
-        heartbeat.assertHeld();
-        requireTokenMutation(
-            await context.leaseManager.setCurrentMigration(token, null),
-            heartbeat,
-        );
+        const runUuid = await runHolderAttempts(context, claim, heartbeat, 1);
         await heartbeat.stop();
         heartbeat.assertHeld();
-        if (!(await context.leaseManager.release(token))) {
+        if (!(await context.leaseManager.completeRun(claim.token, runUuid))) {
             throw new Error('Migration lease was lost before release');
         }
         succeeded = true;
@@ -363,6 +514,21 @@ const pendingWorkExists = (
     state.pending.length > 0 ||
     (lease !== null && lease.currentMigration !== null);
 
+const assertNotParkedForCurrentVersion = (
+    context: MigrateCliContext,
+    lease: MigrationLease | null,
+): void => {
+    if (
+        lease?.parkedAt === null ||
+        lease?.parkedAppVersion !== context.identity.appVersion
+    ) {
+        return;
+    }
+    throw new Error(
+        `Migration is parked for app version ${context.identity.appVersion} at ${lease.parkedMigration ?? 'unknown'}: ${lease.parkedError ?? 'unknown error'}; deploy a fixed version or run migrate unlock with operator attribution before retrying this version`,
+    );
+};
+
 const followMigrations = async (
     context: MigrateCliContext,
     deadline: number,
@@ -373,6 +539,7 @@ const followMigrations = async (
     const leaseRead = await context.leaseManager.read();
     const { lease } = leaseRead;
     logFollowerState(context, state, lease);
+    assertNotParkedForCurrentVersion(context, lease);
     const hasPendingWork = pendingWorkExists(state, lease);
     const active = lease !== null && lease.claimToken !== null;
     if (!hasPendingWork && (!active || lease?.expired === true)) {
@@ -384,7 +551,7 @@ const followMigrations = async (
         const claim = await context.leaseManager.claim(context.identity);
         if (claim.status === 'acquired') {
             context.log('Promoted follower to migration lease holder');
-            await runAsHolder(context, claim.token);
+            await runAsHolder(context, claim);
             return;
         }
     }
@@ -404,7 +571,7 @@ const runUp = async (
     const claim = await context.leaseManager.claim(context.identity);
     if (claim.status === 'acquired') {
         context.log('Acquired migration lease');
-        await runAsHolder(context, claim.token);
+        await runAsHolder(context, claim);
         return;
     }
     await followMigrations(context, context.now() + timeoutMs, true);
@@ -420,22 +587,52 @@ const runWait = async (
 const getMigrationStatusState = (
     lease: MigrationLease | null,
 ): MigrationStatusState => {
-    if (lease === null || lease.claimToken === null) {
+    if (lease === null) {
         return 'idle';
     }
-    if (lease.expired) {
+    if (lease.claimToken !== null && lease.expired) {
         return 'stale';
     }
-    return 'migrating';
+    if (lease.claimToken !== null) {
+        return 'migrating';
+    }
+    if (lease.parkedAt !== null) {
+        return 'parked';
+    }
+    return 'idle';
+};
+
+const formatParkedState = (lease: MigrationLease | null): string => {
+    if (lease?.parkedAt === null || lease === null) {
+        return 'none';
+    }
+    return `version=${lease.parkedAppVersion ?? 'unknown'} migration=${lease.parkedMigration ?? 'unknown'} at=${lease.parkedAt.toISOString()} run=${lease.parkedRunUuid ?? 'unknown'} error=${lease.parkedError ?? 'unknown'}`;
+};
+
+const formatMigrationRun = (
+    run: MigrationRunHistoryReadResult['runs'][number],
+): string => {
+    const holder = `${run.holderHostname}/${run.holderPodName ?? 'none'}`;
+    const finished = run.finishedAt?.toISOString() ?? 'running';
+    const failure =
+        run.failureDetail === null
+            ? 'none'
+            : `${run.failingMigration ?? 'unknown'}: ${run.failureDetail}`;
+    const unlock =
+        run.lastUnlockedBy === null
+            ? 'none'
+            : `${run.lastUnlockedBy} at ${run.lastUnlockedAt?.toISOString() ?? 'unknown'} forced=${run.lastUnlockForced}`;
+    return `Migration run ${run.runUuid}: outcome=${run.outcome} attempt=${run.attempt} holder=${holder} app=${run.appVersion} from=${run.fromMigration ?? 'none'} to=${run.toMigration ?? 'none'} started=${run.startedAt.toISOString()} finished=${finished} failure=${failure} preceding_unlock=${unlock}`;
 };
 
 const statusPayload = async (context: MigrateCliContext) => {
-    const [knexState, lease] = await Promise.all([
+    const [knexState, lease, runHistory] = await Promise.all([
         context.getMigrationState(),
         context.leaseManager.read(),
+        context.leaseManager.readRunHistory(),
     ]);
     const state = getMigrationStatusState(lease.lease);
-    return { state, lease, knex: knexState };
+    return { state, lease, knex: knexState, runHistory };
 };
 
 const runStatus = async (
@@ -450,6 +647,7 @@ const runStatus = async (
     context.log(`Migration state: ${status.state}`);
     context.log(`Migration lease initialized: ${status.lease.initialized}`);
     context.log(`Migration lease holder: ${formatHolder(status.lease.lease)}`);
+    context.log(`Parked migration: ${formatParkedState(status.lease.lease)}`);
     context.log(`Completed Knex migrations: ${status.knex.completed.length}`);
     context.log(
         `Pending Knex migrations: ${formatMigrationNames(status.knex.pending)}`,
@@ -458,6 +656,12 @@ const runStatus = async (
     context.log(
         `Database-only migrations: ${status.knex.missing.length === 0 ? 'none' : status.knex.missing.join(', ')}`,
     );
+    context.log(
+        `Migration run history initialized: ${status.runHistory.initialized}`,
+    );
+    status.runHistory.runs.forEach((run) => {
+        context.log(formatMigrationRun(run));
+    });
 };
 
 const runUnlock = async (


### PR DESCRIPTION
## What

The failure-record and abort behavior from the SPK-912 design — the second runtime-hardening deliverable on top of the lease:

- **`migration_run_ledger` table**: every migration run recorded — run UUID, claim token, host/pod, app version, from/to migrations, attempt number, timestamps, outcome, failure detail, and preceding unlock/force attribution. The lease stays the cheap live-state projection; the ledger is the history and the escalation pull-channel.
- **Bounded-retry-then-park**: three attempts with exponential backoff, then an atomic ledger+lease park into a declared failed state — no crash-looping. The parked state is cheaply readable (the future readyz consumes it).
- **Version-aware recovery**: a newer app version may attempt fix-forward against a parked state; the same version requires an attributed `migrate unlock` — retry bounds survive restarts by construction.
- **`migrate status`** renders the parked state and recent run history (human + `--json`).
- **Forward-only recovery** holds: the CLI never invokes down().
- The ledger migration passes the declare-or-fail gate (classification export, idempotent DDL, real down) and shares its DDL via a neutral schema module with runtime bootstrap, parity-tested — the frozen-migration pattern from the lease work.

## Verification

6,476 backend tests green (425 files); typecheck, touched-path lint, formatting green; migration gate self-check: 1 migration, 0 errors, 0 warnings.

Part of #27140

Closes: SPK-926