### PR TITLE
feat(backend): quiesce scheduled jobs during migrations with jittered ramped resume

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -1101,9 +1101,9 @@ export default class App {
         await MotherduckInstanceCache.closeAll('shutdown');
         await this.prometheusMetrics.stop();
         await shutdownOtelTracing();
-        if (this.schedulerWorker && this.schedulerWorker.runner) {
+        if (this.schedulerWorker) {
             try {
-                await this.schedulerWorker.runner.stop();
+                await this.schedulerWorker.stop();
                 Logger.info('Stopped scheduler worker');
             } catch (e) {
                 Logger.error('Error stopping scheduler worker', e);

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -350,7 +350,14 @@ export default class SchedulerApp {
             signals: ['SIGUSR2', 'SIGTERM', 'SIGINT', 'SIGHUP', 'SIGABRT'],
             healthChecks: {
                 '/api/v1/health': () => {
-                    const status = workerHealth.isHealthy();
+                    const status = worker.isQuiesced
+                        ? workerHealth.isHealthyWhileQuiesced()
+                        : workerHealth.isHealthy();
+                    if (worker.isQuiesced && status.ok) {
+                        return Promise.resolve(
+                            'Scheduler worker is quiesced for migration',
+                        );
+                    }
                     const runnerUp = Boolean(
                         worker?.runner && worker.isRunning,
                     );
@@ -393,7 +400,7 @@ export default class SchedulerApp {
                 Logger.info('Stopping Prometheus metrics');
                 await this.prometheusMetrics.stop();
                 await shutdownOtelTracing();
-                if (worker && worker.runner) {
+                if (worker) {
                     Logger.info('Stopping scheduler worker');
                     // worker.stop() (not runner.stop()) so the settling runner
                     // promise is recognised as graceful, not a pool crash.

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -181,6 +181,12 @@ export const lightdashConfigMock: LightdashConfig = {
         pollInterval: 1000,
         jobTimeout: 0,
         tasks: ALL_TASK_NAMES,
+        quiesce: {
+            pollInterval: 2_000,
+            gracePeriod: 180_000,
+            resumeJitter: 60_000,
+            resumeRampPeriod: 180_000,
+        },
         queryHistory: {
             cleanup: {
                 enabled: true,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -1373,6 +1373,48 @@ describe('scheduler poll interval', () => {
     });
 });
 
+describe('scheduler migration quiesce', () => {
+    const environmentVariables = [
+        'SCHEDULER_QUIESCE_POLL_INTERVAL',
+        'SCHEDULER_QUIESCE_GRACE_PERIOD',
+        'SCHEDULER_RESUME_JITTER',
+        'SCHEDULER_RESUME_RAMP_PERIOD',
+    ] as const;
+
+    afterEach(() => {
+        environmentVariables.forEach((name) => {
+            delete process.env[name];
+        });
+    });
+
+    test('uses bounded grace and ramp defaults', () => {
+        const config = parseConfig();
+
+        expect(config.scheduler.quiesce).toEqual({
+            pollInterval: 2_000,
+            gracePeriod: 180_000,
+            resumeJitter: 60_000,
+            resumeRampPeriod: 180_000,
+        });
+    });
+
+    test('parses migration quiesce timings from the environment', () => {
+        process.env.SCHEDULER_QUIESCE_POLL_INTERVAL = '3000';
+        process.env.SCHEDULER_QUIESCE_GRACE_PERIOD = '240000';
+        process.env.SCHEDULER_RESUME_JITTER = '90000';
+        process.env.SCHEDULER_RESUME_RAMP_PERIOD = '300000';
+
+        const config = parseConfig();
+
+        expect(config.scheduler.quiesce).toEqual({
+            pollInterval: 3_000,
+            gracePeriod: 240_000,
+            resumeJitter: 90_000,
+            resumeRampPeriod: 300_000,
+        });
+    });
+});
+
 test('should set groups.enabled only when the environment variable is set', () => {
     const undefinedConfig = parseConfig();
     expect(undefinedConfig.groups.enabled).toBeUndefined();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1488,6 +1488,12 @@ export type LightdashConfig = {
         jobTimeout: number;
         screenshotTimeout?: number;
         tasks: Array<SchedulerTaskName>;
+        quiesce: {
+            pollInterval: number;
+            gracePeriod: number;
+            resumeJitter: number;
+            resumeRampPeriod: number;
+        };
         queryHistory: {
             cleanup: {
                 enabled: boolean;
@@ -3057,6 +3063,24 @@ export const parseConfig = (): LightdashConfig => {
                 ? parseInt(process.env.SCHEDULER_SCREENSHOT_TIMEOUT, 10)
                 : undefined,
             tasks: parseAndSanitizeSchedulerTasks(),
+            quiesce: {
+                pollInterval:
+                    getIntegerFromEnvironmentVariable(
+                        'SCHEDULER_QUIESCE_POLL_INTERVAL',
+                    ) ?? 2_000,
+                gracePeriod:
+                    getIntegerFromEnvironmentVariable(
+                        'SCHEDULER_QUIESCE_GRACE_PERIOD',
+                    ) ?? 180_000,
+                resumeJitter:
+                    getIntegerFromEnvironmentVariable(
+                        'SCHEDULER_RESUME_JITTER',
+                    ) ?? 60_000,
+                resumeRampPeriod:
+                    getIntegerFromEnvironmentVariable(
+                        'SCHEDULER_RESUME_RAMP_PERIOD',
+                    ) ?? 180_000,
+            },
             queryHistory: {
                 cleanup: {
                     enabled:

--- a/packages/backend/src/scheduler/MigrationLeaseProbe.test.ts
+++ b/packages/backend/src/scheduler/MigrationLeaseProbe.test.ts
@@ -1,0 +1,60 @@
+import type { WorkerUtils } from 'graphile-worker';
+import { DatabaseError } from 'pg';
+import { MigrationLeaseProbe } from './MigrationLeaseProbe';
+
+const makeGraphileUtils = (query: import('vitest').Mock) =>
+    Promise.resolve({
+        withPgClient: vi.fn(async (callback) => callback({ query } as never)),
+    } as Pick<WorkerUtils, 'withPgClient'>);
+
+describe('MigrationLeaseProbe', () => {
+    it('reports a fresh claimed lease as active and caches the indexed read', async () => {
+        let now = 1_000;
+        const query = vi.fn().mockResolvedValue({ rows: [{ active: true }] });
+        const probe = new MigrationLeaseProbe({
+            graphileUtils: makeGraphileUtils(query),
+            cacheMs: 2_000,
+            now: () => now,
+        });
+
+        await expect(probe.isActive()).resolves.toBe(true);
+        now = 2_000;
+        await expect(probe.isActive()).resolves.toBe(true);
+
+        expect(query).toHaveBeenCalledExactlyOnceWith(
+            expect.stringContaining('FROM migration_lease'),
+            [75_000],
+        );
+    });
+
+    it('refreshes an expired cached result', async () => {
+        let now = 1_000;
+        const query = vi
+            .fn()
+            .mockResolvedValueOnce({ rows: [{ active: true }] })
+            .mockResolvedValueOnce({ rows: [{ active: false }] });
+        const probe = new MigrationLeaseProbe({
+            graphileUtils: makeGraphileUtils(query),
+            cacheMs: 2_000,
+            now: () => now,
+        });
+
+        await expect(probe.isActive()).resolves.toBe(true);
+        now = 3_001;
+        await expect(probe.isActive()).resolves.toBe(false);
+
+        expect(query).toHaveBeenCalledTimes(2);
+    });
+
+    it('treats a pre-lease database as having no active lease', async () => {
+        const error = new DatabaseError('relation does not exist', 0, 'error');
+        error.code = '42P01';
+        const query = vi.fn().mockRejectedValue(error);
+        const probe = new MigrationLeaseProbe({
+            graphileUtils: makeGraphileUtils(query),
+            cacheMs: 2_000,
+        });
+
+        await expect(probe.isActive()).resolves.toBe(false);
+    });
+});

--- a/packages/backend/src/scheduler/MigrationLeaseProbe.ts
+++ b/packages/backend/src/scheduler/MigrationLeaseProbe.ts
@@ -1,0 +1,104 @@
+import type { WorkerUtils } from 'graphile-worker';
+import { DatabaseError } from 'pg';
+
+const MIGRATION_LEASE_EXPIRY_MS = 75_000;
+const UNDEFINED_TABLE_ERROR_CODE = '42P01';
+
+type MigrationLeaseProbeRow = {
+    active: boolean;
+};
+
+type MigrationLeaseProbeArguments = {
+    graphileUtils: Promise<Pick<WorkerUtils, 'withPgClient'>>;
+    cacheMs: number;
+    now?: () => number;
+};
+
+type MigrationLeaseProbeOptions = {
+    refresh?: boolean;
+};
+
+export interface MigrationLeaseStatusProbe {
+    isActive(options?: MigrationLeaseProbeOptions): Promise<boolean>;
+}
+
+export class MigrationLeaseProbe implements MigrationLeaseStatusProbe {
+    private readonly graphileUtils: Promise<Pick<WorkerUtils, 'withPgClient'>>;
+
+    private readonly cacheMs: number;
+
+    private readonly now: () => number;
+
+    private cachedResult: { active: boolean; expiresAt: number } | null = null;
+
+    private pendingResult: Promise<boolean> | null = null;
+
+    constructor({
+        graphileUtils,
+        cacheMs,
+        now = Date.now,
+    }: MigrationLeaseProbeArguments) {
+        this.graphileUtils = graphileUtils;
+        this.cacheMs = cacheMs;
+        this.now = now;
+    }
+
+    async isActive({
+        refresh = false,
+    }: MigrationLeaseProbeOptions = {}): Promise<boolean> {
+        if (
+            !refresh &&
+            this.cachedResult !== null &&
+            this.cachedResult.expiresAt > this.now()
+        ) {
+            return this.cachedResult.active;
+        }
+
+        if (this.pendingResult !== null) {
+            return this.pendingResult;
+        }
+
+        this.pendingResult = this.readLease().then((active) => {
+            this.cachedResult = {
+                active,
+                expiresAt: this.now() + this.cacheMs,
+            };
+            return active;
+        });
+
+        try {
+            return await this.pendingResult;
+        } finally {
+            this.pendingResult = null;
+        }
+    }
+
+    private async readLease(): Promise<boolean> {
+        try {
+            const graphileUtils = await this.graphileUtils;
+            const result = await graphileUtils.withPgClient((client) =>
+                client.query<MigrationLeaseProbeRow>(
+                    `SELECT COALESCE(
+                        (
+                            SELECT claim_token IS NOT NULL
+                                AND last_heartbeat > CURRENT_TIMESTAMP - ($1 * INTERVAL '1 millisecond')
+                            FROM migration_lease
+                            WHERE lease_key = 'global'
+                        ),
+                        false
+                    ) AS active`,
+                    [MIGRATION_LEASE_EXPIRY_MS],
+                ),
+            );
+            return result.rows[0]?.active ?? false;
+        } catch (error) {
+            if (
+                error instanceof DatabaseError &&
+                error.code === UNDEFINED_TABLE_ERROR_CODE
+            ) {
+                return false;
+            }
+            throw error;
+        }
+    }
+}

--- a/packages/backend/src/scheduler/SchedulerMigrationQuiesce.test.ts
+++ b/packages/backend/src/scheduler/SchedulerMigrationQuiesce.test.ts
@@ -1,0 +1,103 @@
+import type { MigrationLeaseStatusProbe } from './MigrationLeaseProbe';
+import { SchedulerMigrationQuiesce } from './SchedulerMigrationQuiesce';
+
+const makeHooks = () => ({
+    onQuiesceStateChange: vi.fn(),
+    onFailure: vi.fn(),
+    stopWorkersForRetry: vi.fn(async () => {}),
+    startResumeWorkers: vi.fn(async () => {}),
+    finishResumeRamp: vi.fn(async () => {}),
+});
+
+const makeProbe = (read: () => boolean): MigrationLeaseStatusProbe => ({
+    isActive: vi.fn(async () => read()),
+});
+
+describe('SchedulerMigrationQuiesce', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('does not grant a dequeue permit while the lease is active', async () => {
+        const hooks = makeHooks();
+        const controller = new SchedulerMigrationQuiesce({
+            probe: makeProbe(() => true),
+            pollIntervalMs: 10_000,
+            gracePeriodMs: 1_000,
+            resumeJitterMs: 100,
+            resumeRampPeriodMs: 200,
+            hooks,
+        });
+        await controller.start();
+
+        let settled = false;
+        const permit = controller
+            .waitForDequeuePermit()
+            .then(() => {
+                settled = true;
+            })
+            .catch(() => {
+                settled = true;
+            });
+        await vi.advanceTimersByTimeAsync(999);
+
+        expect(settled).toBe(false);
+        expect(hooks.onQuiesceStateChange).toHaveBeenCalledWith(true);
+
+        await controller.stop();
+        await permit;
+    });
+
+    it('parks in-flight jobs through Graphile after the grace period', async () => {
+        const hooks = makeHooks();
+        const controller = new SchedulerMigrationQuiesce({
+            probe: makeProbe(() => true),
+            pollIntervalMs: 10_000,
+            gracePeriodMs: 1_000,
+            resumeJitterMs: 100,
+            resumeRampPeriodMs: 200,
+            hooks,
+        });
+        await controller.start();
+
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        expect(hooks.stopWorkersForRetry).toHaveBeenCalledWith(
+            'Migration lease grace period expired',
+        );
+        await controller.stop();
+    });
+
+    it('resumes with jitter at reduced concurrency before finishing the ramp', async () => {
+        let active = true;
+        const hooks = makeHooks();
+        const controller = new SchedulerMigrationQuiesce({
+            probe: makeProbe(() => active),
+            pollIntervalMs: 10_000,
+            gracePeriodMs: 1_000,
+            resumeJitterMs: 100,
+            resumeRampPeriodMs: 200,
+            hooks,
+            random: () => 0.5,
+        });
+        await controller.start();
+
+        active = false;
+        await controller.refreshNow(true);
+        await vi.advanceTimersByTimeAsync(49);
+        expect(hooks.startResumeWorkers).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(hooks.startResumeWorkers).toHaveBeenCalledOnce();
+        expect(hooks.finishResumeRamp).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(200);
+        expect(hooks.finishResumeRamp).toHaveBeenCalledOnce();
+        expect(hooks.onQuiesceStateChange).toHaveBeenLastCalledWith(false);
+        await controller.stop();
+    });
+});

--- a/packages/backend/src/scheduler/SchedulerMigrationQuiesce.ts
+++ b/packages/backend/src/scheduler/SchedulerMigrationQuiesce.ts
@@ -1,0 +1,277 @@
+import { getErrorMessage } from '@lightdash/common';
+import Logger from '../logging/logger';
+import type { MigrationLeaseStatusProbe } from './MigrationLeaseProbe';
+
+const DEQUEUE_WAIT_CANCELLED_MESSAGE =
+    'Migration lease dequeue wait was cancelled';
+
+type SchedulerMigrationQuiesceHooks = {
+    onQuiesceStateChange: (quiesced: boolean) => void;
+    onFailure: (error: unknown) => void;
+    stopWorkersForRetry: (reason: string) => Promise<void>;
+    startResumeWorkers: () => Promise<void>;
+    finishResumeRamp: () => Promise<void>;
+};
+
+type SchedulerMigrationQuiesceArguments = {
+    probe: MigrationLeaseStatusProbe;
+    pollIntervalMs: number;
+    gracePeriodMs: number;
+    resumeJitterMs: number;
+    resumeRampPeriodMs: number;
+    hooks: SchedulerMigrationQuiesceHooks;
+    random?: () => number;
+};
+
+type DequeueWaiter = {
+    reject: (error: Error) => void;
+};
+
+const delay = async (durationMs: number): Promise<void> => {
+    await new Promise<void>((resolve) => {
+        const timeout = setTimeout(resolve, durationMs);
+        timeout.unref();
+    });
+};
+
+export class SchedulerMigrationQuiesce {
+    private readonly probe: MigrationLeaseStatusProbe;
+
+    private readonly pollIntervalMs: number;
+
+    private readonly gracePeriodMs: number;
+
+    private readonly resumeJitterMs: number;
+
+    private readonly resumeRampPeriodMs: number;
+
+    private readonly hooks: SchedulerMigrationQuiesceHooks;
+
+    private readonly random: () => number;
+
+    private readonly dequeueWaiters = new Set<DequeueWaiter>();
+
+    private pollTimeout: NodeJS.Timeout | null = null;
+
+    private graceTimeout: NodeJS.Timeout | null = null;
+
+    private refreshPromise: Promise<boolean> | null = null;
+
+    private leaseActive: boolean | null = null;
+
+    private generation = 0;
+
+    private stopped = false;
+
+    constructor({
+        probe,
+        pollIntervalMs,
+        gracePeriodMs,
+        resumeJitterMs,
+        resumeRampPeriodMs,
+        hooks,
+        random = Math.random,
+    }: SchedulerMigrationQuiesceArguments) {
+        this.probe = probe;
+        this.pollIntervalMs = pollIntervalMs;
+        this.gracePeriodMs = gracePeriodMs;
+        this.resumeJitterMs = resumeJitterMs;
+        this.resumeRampPeriodMs = resumeRampPeriodMs;
+        this.hooks = hooks;
+        this.random = random;
+    }
+
+    async start(): Promise<boolean> {
+        const active = await this.refreshNow(true);
+        this.schedulePoll();
+        return active;
+    }
+
+    async waitForDequeuePermit(): Promise<null> {
+        const active = await this.refreshNow();
+        if (!active) {
+            return null;
+        }
+
+        return new Promise<null>((_resolve, reject) => {
+            this.dequeueWaiters.add({ reject });
+        });
+    }
+
+    async refreshNow(refresh = false): Promise<boolean> {
+        if (this.stopped) {
+            return true;
+        }
+
+        if (this.refreshPromise !== null) {
+            return this.refreshPromise;
+        }
+
+        this.refreshPromise = this.probe
+            .isActive({ refresh })
+            .then((active) => {
+                this.applyLeaseState(active);
+                return active;
+            })
+            .catch((error: unknown) => {
+                Logger.warn(
+                    `Migration lease probe failed: ${getErrorMessage(error)}`,
+                );
+                this.applyLeaseState(true);
+                return true;
+            });
+
+        try {
+            return await this.refreshPromise;
+        } finally {
+            this.refreshPromise = null;
+        }
+    }
+
+    async stop(): Promise<void> {
+        if (this.stopped) {
+            return;
+        }
+
+        this.stopped = true;
+        this.generation += 1;
+        this.clearPoll();
+        this.clearGrace();
+        this.cancelDequeueWaiters();
+        await this.hooks.stopWorkersForRetry('Scheduler worker stopping');
+    }
+
+    private applyLeaseState(active: boolean): void {
+        if (this.leaseActive === null) {
+            this.leaseActive = active;
+            this.generation += 1;
+            if (active) {
+                this.hooks.onQuiesceStateChange(true);
+                this.scheduleGrace(this.generation);
+            } else {
+                this.hooks.onQuiesceStateChange(false);
+            }
+            return;
+        }
+
+        if (this.leaseActive === active) {
+            return;
+        }
+
+        this.leaseActive = active;
+        this.generation += 1;
+        const { generation } = this;
+
+        if (active) {
+            this.hooks.onQuiesceStateChange(true);
+            this.scheduleGrace(generation);
+            return;
+        }
+
+        this.clearGrace();
+        this.cancelDequeueWaiters();
+        void this.resume(generation).catch((error: unknown) =>
+            this.hooks.onFailure(error),
+        );
+    }
+
+    private scheduleGrace(generation: number): void {
+        this.clearGrace();
+        this.graceTimeout = setTimeout(() => {
+            this.graceTimeout = null;
+            if (
+                this.stopped ||
+                this.leaseActive !== true ||
+                generation !== this.generation
+            ) {
+                return;
+            }
+            this.cancelDequeueWaiters();
+            void this.hooks
+                .stopWorkersForRetry('Migration lease grace period expired')
+                .catch((error: unknown) => this.hooks.onFailure(error));
+        }, this.gracePeriodMs);
+        this.graceTimeout.unref();
+    }
+
+    private async resume(generation: number): Promise<void> {
+        await this.hooks.stopWorkersForRetry(
+            'Migration lease cleared before worker resume',
+        );
+        if (!this.canResume(generation)) {
+            return;
+        }
+
+        const jitterMs = Math.floor(this.random() * this.resumeJitterMs);
+        await delay(jitterMs);
+        if (!this.canResume(generation)) {
+            return;
+        }
+
+        const leaseActive = await this.refreshNow(true);
+        if (leaseActive || !this.canResume(generation)) {
+            return;
+        }
+
+        await this.hooks.startResumeWorkers();
+        if (!this.canResume(generation)) {
+            return;
+        }
+        this.hooks.onQuiesceStateChange(false);
+
+        await delay(this.resumeRampPeriodMs);
+        if (!this.canResume(generation)) {
+            return;
+        }
+
+        const leaseReactivated = await this.refreshNow(true);
+        if (leaseReactivated || !this.canResume(generation)) {
+            return;
+        }
+
+        await this.hooks.finishResumeRamp();
+    }
+
+    private canResume(generation: number): boolean {
+        return (
+            !this.stopped &&
+            this.leaseActive === false &&
+            generation === this.generation
+        );
+    }
+
+    private cancelDequeueWaiters(): void {
+        const error = new Error(DEQUEUE_WAIT_CANCELLED_MESSAGE);
+        for (const waiter of this.dequeueWaiters) {
+            waiter.reject(error);
+        }
+        this.dequeueWaiters.clear();
+    }
+
+    private schedulePoll(): void {
+        this.clearPoll();
+        this.pollTimeout = setTimeout(() => {
+            this.pollTimeout = null;
+            void this.refreshNow(true).finally(() => {
+                if (!this.stopped) {
+                    this.schedulePoll();
+                }
+            });
+        }, this.pollIntervalMs);
+        this.pollTimeout.unref();
+    }
+
+    private clearPoll(): void {
+        if (this.pollTimeout !== null) {
+            clearTimeout(this.pollTimeout);
+            this.pollTimeout = null;
+        }
+    }
+
+    private clearGrace(): void {
+        if (this.graceTimeout !== null) {
+            clearTimeout(this.graceTimeout);
+            this.graceTimeout = null;
+        }
+    }
+}

--- a/packages/backend/src/scheduler/SchedulerWorker.heartbeat.test.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.heartbeat.test.ts
@@ -179,16 +179,24 @@ describe('SchedulerWorker — pingPgOnce', () => {
         expect(pgClient.query).toHaveBeenCalledTimes(2);
     });
 
-    it('does not hang when withPgClient never resolves (wedged backend)', async () => {
+    it('destroys the borrowed client when its query exceeds the timeout', async () => {
         vi.useFakeTimers();
         try {
             const health = new SchedulerWorkerHealth('pod-wedged');
             const markPgReachableSpy = vi.spyOn(health, 'markPgReachable');
-            const withPgClient = vi.fn().mockImplementation(
-                () =>
-                    new Promise(() => {
-                        // intentionally pending forever
-                    }),
+            const pgClient = {
+                query: vi.fn(
+                    () =>
+                        new Promise<never>((resolve) => {
+                            void resolve;
+                        }),
+                ),
+                release: vi.fn(),
+            };
+            const withPgClient = vi.fn(
+                async (
+                    callback: (client: typeof pgClient) => Promise<unknown>,
+                ) => callback(pgClient),
             );
 
             const worker = new TestableSchedulerWorker(
@@ -197,12 +205,55 @@ describe('SchedulerWorker — pingPgOnce', () => {
 
             const ping = worker.pingPgOnceExposed(health);
 
-            // Advance past the 5s ping timeout.
             await vi.advanceTimersByTimeAsync(6_000);
 
             await expect(ping).resolves.toBeUndefined();
             expect(withPgClient).toHaveBeenCalledTimes(1);
-            // Timeout path must NOT mark reachable — that's the whole point.
+            expect(pgClient.query).toHaveBeenCalledWith(
+                `SELECT pg_notify('jobs:insert', '')`,
+            );
+            expect(pgClient.release).toHaveBeenCalledWith(true);
+            expect(markPgReachableSpy).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('destroys a client borrowed after the timeout without querying it', async () => {
+        vi.useFakeTimers();
+        try {
+            const health = new SchedulerWorkerHealth('pod-delayed-borrow');
+            const markPgReachableSpy = vi.spyOn(health, 'markPgReachable');
+            const pgClient = {
+                query: vi.fn(),
+                release: vi.fn(),
+            };
+            let completeBorrow!: () => void;
+            const borrow = new Promise<void>((resolve) => {
+                completeBorrow = resolve;
+            });
+            const withPgClient = vi.fn(
+                async (
+                    callback: (client: typeof pgClient) => Promise<unknown>,
+                ) => {
+                    await borrow;
+                    return callback(pgClient);
+                },
+            );
+            const worker = new TestableSchedulerWorker(
+                makeWorkerArgs(withPgClient, health),
+            );
+
+            const ping = worker.pingPgOnceExposed(health);
+
+            await vi.advanceTimersByTimeAsync(6_000);
+            await expect(ping).resolves.toBeUndefined();
+
+            completeBorrow();
+            await vi.runAllTimersAsync();
+
+            expect(pgClient.query).not.toHaveBeenCalled();
+            expect(pgClient.release).toHaveBeenCalledWith(true);
             expect(markPgReachableSpy).not.toHaveBeenCalled();
         } finally {
             vi.useRealTimers();

--- a/packages/backend/src/scheduler/SchedulerWorker.heartbeat.test.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.heartbeat.test.ts
@@ -37,6 +37,12 @@ const makeConfig = (): LightdashConfig =>
             concurrency: 1,
             pollInterval: 1000,
             jobTimeout: 60_000,
+            quiesce: {
+                pollInterval: 2_000,
+                gracePeriod: 180_000,
+                resumeJitter: 60_000,
+                resumeRampPeriod: 180_000,
+            },
             queryHistory: {
                 cleanup: {
                     enabled: false,

--- a/packages/backend/src/scheduler/SchedulerWorker.quiesce.test.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.quiesce.test.ts
@@ -1,0 +1,182 @@
+import { ALL_TASK_NAMES } from '@lightdash/common';
+import {
+    run as runGraphileWorker,
+    type Runner,
+    type RunnerOptions,
+    type WorkerPool,
+} from 'graphile-worker';
+import { type LightdashConfig } from '../config/parseConfig';
+import {
+    SchedulerWorker,
+    type SchedulerWorkerArguments,
+} from './SchedulerWorker';
+
+vi.mock('graphile-worker', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('graphile-worker')>();
+    return {
+        ...actual,
+        run: vi.fn(),
+    };
+});
+
+type FakeGraphileRunner = {
+    runner: Runner;
+    workerPool: WorkerPool;
+};
+
+const makeConfig = (): LightdashConfig =>
+    ({
+        scheduler: {
+            tasks: [...ALL_TASK_NAMES],
+            concurrency: 3,
+            pollInterval: 1_000,
+            jobTimeout: 60_000,
+            quiesce: {
+                pollInterval: 10,
+                gracePeriod: 100,
+                resumeJitter: 100,
+                resumeRampPeriod: 200,
+            },
+            queryHistory: {
+                cleanup: {
+                    enabled: false,
+                    schedule: '0 0 * * *',
+                    retentionDays: 30,
+                    batchSize: 100,
+                    delayMs: 0,
+                    maxBatches: 1,
+                },
+            },
+        },
+        database: {
+            connectionUri: 'postgres://noop',
+            maxConnections: 10,
+        },
+    }) as unknown as LightdashConfig;
+
+const makeWorker = (readActive: () => boolean): SchedulerWorker => {
+    const query = vi.fn(async () => ({ rows: [{ active: readActive() }] }));
+    const graphileUtils = Promise.resolve({
+        addJob: vi.fn(),
+        withPgClient: vi.fn(async (callback) => callback({ query } as never)),
+    });
+
+    return new SchedulerWorker({
+        lightdashConfig: makeConfig(),
+        schedulerClient: { graphileUtils },
+    } as unknown as SchedulerWorkerArguments);
+};
+
+const makeFakeGraphileRunner = (): FakeGraphileRunner => {
+    let settle!: () => void;
+    const promise = new Promise<void>((resolve) => {
+        settle = resolve;
+    });
+    const workerPool = {
+        release: vi.fn(async () => {
+            settle();
+        }),
+        gracefulShutdown: vi.fn(async () => {
+            settle();
+        }),
+        promise,
+    };
+    const runner = {
+        promise,
+        stop: vi.fn(async () => {
+            settle();
+        }),
+        addJob: vi.fn(),
+        events: undefined,
+    } as unknown as Runner;
+    return { runner, workerPool };
+};
+
+describe('SchedulerWorker migration quiesce', () => {
+    const fakeRunners: FakeGraphileRunner[] = [];
+    const runnerOptions: RunnerOptions[] = [];
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        fakeRunners.length = 0;
+        runnerOptions.length = 0;
+        vi.mocked(runGraphileWorker).mockReset();
+        vi.mocked(runGraphileWorker).mockImplementation(async (options) => {
+            const fakeRunner = makeFakeGraphileRunner();
+            fakeRunners.push(fakeRunner);
+            runnerOptions.push(options);
+            options.events?.emit('pool:create', {
+                workerPool: fakeRunner.workerPool,
+            });
+            return fakeRunner.runner;
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('blocks Graphile dequeue while a fresh migration lease is active', async () => {
+        let active = false;
+        const worker = makeWorker(() => active);
+        await worker.run();
+        active = true;
+        await vi.advanceTimersByTimeAsync(10);
+
+        let settled = false;
+        const forbiddenFlags = runnerOptions[0]?.forbiddenFlags;
+        expect(forbiddenFlags).toBeTypeOf('function');
+        const dequeue = Promise.resolve(
+            typeof forbiddenFlags === 'function' ? forbiddenFlags() : null,
+        )
+            .then(() => {
+                settled = true;
+            })
+            .catch(() => {
+                settled = true;
+            });
+        await vi.advanceTimersByTimeAsync(89);
+
+        expect(settled).toBe(false);
+        await worker.stop();
+        await dequeue;
+    });
+
+    it('uses Graphile native shutdown to park jobs after the grace period', async () => {
+        let active = false;
+        const worker = makeWorker(() => active);
+        await worker.run();
+        active = true;
+
+        await vi.advanceTimersByTimeAsync(110);
+
+        expect(
+            fakeRunners[0]?.workerPool.gracefulShutdown,
+        ).toHaveBeenCalledExactlyOnceWith(
+            'Migration lease grace period expired',
+        );
+        await worker.stop();
+    });
+
+    it('starts at reduced concurrency after jitter and adds capacity after the ramp', async () => {
+        vi.spyOn(Math, 'random').mockReturnValue(0.5);
+        let active = true;
+        const worker = makeWorker(() => active);
+        await worker.run();
+        expect(runGraphileWorker).not.toHaveBeenCalled();
+
+        active = false;
+        await vi.advanceTimersByTimeAsync(59);
+        expect(runGraphileWorker).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(runnerOptions[0]?.concurrency).toBe(1);
+        expect(runnerOptions[0]?.parsedCronItems).not.toEqual([]);
+
+        await vi.advanceTimersByTimeAsync(200);
+        expect(runnerOptions[1]?.concurrency).toBe(2);
+        expect(runnerOptions[1]?.parsedCronItems).toEqual([]);
+        await worker.stop();
+    });
+});

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -19,6 +19,7 @@ import {
 } from 'graphile-worker';
 import moment from 'moment';
 import { EventEmitter } from 'node:events';
+import type { PoolClient } from 'pg';
 import { UsageEventsCompactor } from '../analytics/eventStream/UsageEventsCompactor';
 import { DEFAULT_DB_MAX_CONNECTIONS } from '../knexfile';
 import Logger from '../logging/logger';
@@ -337,17 +338,25 @@ export class SchedulerWorker extends SchedulerTask {
 
     private async pingPgOnce(health: SchedulerWorkerHealth) {
         let timeoutHandle: NodeJS.Timeout | undefined;
+        let borrowedClient: PoolClient | undefined;
+        let timedOut = false;
         try {
             const graphileClient = await this.schedulerClient.graphileUtils;
-            // withPgClient borrows from graphile's existing pool and releases the
-            // client back when the callback resolves — no long-lived client to leak.
-            const ping = graphileClient.withPgClient((pgClient) =>
-                pgClient.query(PG_PING_QUERY),
-            );
+            const ping = graphileClient.withPgClient(async (pgClient) => {
+                borrowedClient = pgClient;
+                if (timedOut) {
+                    pgClient.release(true);
+                    return;
+                }
+                await pgClient.query(PG_PING_QUERY);
+            });
+            void ping.catch(() => undefined);
             await Promise.race([
                 ping,
                 new Promise<never>((_resolve, reject) => {
                     timeoutHandle = setTimeout(() => {
+                        timedOut = true;
+                        borrowedClient?.release(true);
                         reject(
                             new Error(
                                 `pg ping timeout after ${PG_PING_TIMEOUT_MS}ms`,

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -14,19 +14,24 @@ import {
     run as runGraphileWorker,
     Runner,
     type CronItem,
+    type WorkerEvents,
+    type WorkerPool,
 } from 'graphile-worker';
 import moment from 'moment';
+import { EventEmitter } from 'node:events';
 import { UsageEventsCompactor } from '../analytics/eventStream/UsageEventsCompactor';
 import { DEFAULT_DB_MAX_CONNECTIONS } from '../knexfile';
 import Logger from '../logging/logger';
 import type PrometheusMetrics from '../prometheus/PrometheusMetrics';
 import { type OrganizationNameResolver } from '../sentry/organizationNameResolver';
+import { MigrationLeaseProbe } from './MigrationLeaseProbe';
 import { SchedulerClient } from './SchedulerClient';
 import {
     resolveSchedulerDeliveryFailureAction,
     SchedulerDeliveryError,
 } from './SchedulerDeliveryError';
 import { tryJobOrTimeout } from './SchedulerJobTimeout';
+import { SchedulerMigrationQuiesce } from './SchedulerMigrationQuiesce';
 import SchedulerTask, { type SchedulerTaskArguments } from './SchedulerTask';
 import { traceTasks } from './SchedulerTaskTracer';
 import schedulerWorkerEventEmitter from './SchedulerWorkerEventEmitter';
@@ -70,10 +75,28 @@ const PG_PING_TIMEOUT_MS = 5_000;
 // runner's, so it keeps working when the runner is wedged.
 const PG_PING_QUERY = `SELECT pg_notify('jobs:insert', '')`;
 
+type ManagedRunner = {
+    runner: Runner;
+    workerPool: WorkerPool | null;
+};
+
+class ForwardingWorkerEvents extends EventEmitter {
+    constructor(private readonly target: EventEmitter) {
+        super();
+    }
+
+    emit(eventName: string | symbol, ...args: unknown[]): boolean {
+        const emitted = super.emit(eventName, ...args);
+        return this.target.emit(eventName, ...args) || emitted;
+    }
+}
+
 export class SchedulerWorker extends SchedulerTask {
     runner: Runner | undefined;
 
     isRunning: boolean = false;
+
+    isQuiesced: boolean = false;
 
     enabledTasks: Array<SchedulerTaskName>;
 
@@ -86,6 +109,16 @@ export class SchedulerWorker extends SchedulerTask {
     private readonly resolveOrganizationName?: OrganizationNameResolver;
 
     private readonly prometheusMetrics: PrometheusMetrics | null;
+
+    private readonly managedRunners = new Set<ManagedRunner>();
+
+    private readonly expectedRunnerStops = new Set<Runner>();
+
+    private migrationQuiesce: SchedulerMigrationQuiesce | null = null;
+
+    private maxPoolSize = 0;
+
+    private runnerStopPromise: Promise<void> | null = null;
 
     constructor(schedulerWorkerArgs: SchedulerWorkerArguments) {
         super(schedulerWorkerArgs);
@@ -114,35 +147,103 @@ export class SchedulerWorker extends SchedulerTask {
                 : 10;
 
         // We don't want to exceed the max number of connections to the database
-        const maxPoolSize = Math.min(desiredPoolSize, dbMaxConnections);
+        this.maxPoolSize = Math.min(desiredPoolSize, dbMaxConnections);
 
-        this.runner = await runGraphileWorker({
-            connectionString: this.lightdashConfig.database.connectionUri,
-            logger: workerLogger,
-            concurrency: this.lightdashConfig.scheduler.concurrency,
-            noHandleSignals: true,
-            pollInterval: this.lightdashConfig.scheduler.pollInterval,
-            maxPoolSize,
-            parsedCronItems: parseCronItems(this.getCronItems()),
-            taskList: traceTasks(this.getTaskList(), {
-                resolveOrganizationName: this.resolveOrganizationName,
+        const quiesceConfig = this.lightdashConfig.scheduler.quiesce;
+        this.migrationQuiesce = new SchedulerMigrationQuiesce({
+            probe: new MigrationLeaseProbe({
+                graphileUtils: this.schedulerClient.graphileUtils,
+                cacheMs: quiesceConfig.pollInterval,
             }),
-            events: schedulerWorkerEventEmitter,
+            pollIntervalMs: quiesceConfig.pollInterval,
+            gracePeriodMs: quiesceConfig.gracePeriod,
+            resumeJitterMs: quiesceConfig.resumeJitter,
+            resumeRampPeriodMs: quiesceConfig.resumeRampPeriod,
+            hooks: {
+                onQuiesceStateChange: (quiesced) => {
+                    this.isQuiesced = quiesced;
+                },
+                onFailure: (error) => {
+                    this.isQuiesced = false;
+                    this.workerHealth?.markPoolDead(
+                        `migration quiesce failed: ${getErrorMessage(error)}`,
+                    );
+                    Logger.error('Migration quiesce failed', error);
+                },
+                stopWorkersForRetry: (reason) =>
+                    this.stopManagedRunnersForRetry(reason),
+                startResumeWorkers: () => this.startResumeWorkers(),
+                finishResumeRamp: () => this.finishResumeRamp(),
+            },
         });
 
-        this.isRunning = true;
+        const leaseActive = await this.migrationQuiesce.start();
+        if (!leaseActive) {
+            await this.startManagedRunner(
+                this.lightdashConfig.scheduler.concurrency,
+                this.maxPoolSize,
+                true,
+            );
+            this.isQuiesced = false;
+        } else {
+            this.isQuiesced = true;
+        }
+
         if (this.workerHealth) {
             this.startPgPing(this.workerHealth);
         }
-        // Don't await this! This promise will never resolve, as the worker will keep running until the process is killed
-        void this.runner.promise.finally(() => {
-            this.isRunning = false;
-            this.stopPgPing();
-            // Settling outside a graceful stop() means graphile gave up — e.g.
-            // 10 consecutive failed job acquisitions after a Postgres restart.
-            // Unrecoverable in-process in 0.13: latch so the probe goes 503
-            // and the pool-dead listeners (process exit) fire.
-            if (!this.isStopping) {
+    }
+
+    async stop() {
+        this.isStopping = true;
+        await this.migrationQuiesce?.stop();
+        this.stopPgPing();
+        this.isRunning = false;
+        this.isQuiesced = false;
+    }
+
+    private async startManagedRunner(
+        concurrency: number,
+        maxPoolSize: number,
+        includeCron: boolean,
+    ): Promise<void> {
+        const events = new ForwardingWorkerEvents(
+            schedulerWorkerEventEmitter as EventEmitter,
+        ) as WorkerEvents;
+        let workerPool: WorkerPool | null = null;
+        events.once('pool:create', ({ workerPool: createdWorkerPool }) => {
+            workerPool = createdWorkerPool;
+        });
+
+        const runner = await runGraphileWorker({
+            connectionString: this.lightdashConfig.database.connectionUri,
+            logger: workerLogger,
+            concurrency,
+            noHandleSignals: true,
+            pollInterval: this.lightdashConfig.scheduler.pollInterval,
+            maxPoolSize,
+            parsedCronItems: includeCron
+                ? parseCronItems(this.getCronItems())
+                : [],
+            taskList: traceTasks(this.getTaskList(), {
+                resolveOrganizationName: this.resolveOrganizationName,
+            }),
+            forbiddenFlags: () =>
+                this.migrationQuiesce?.waitForDequeuePermit() ?? null,
+            events,
+        });
+
+        const managedRunner = { runner, workerPool };
+        this.managedRunners.add(managedRunner);
+        if (includeCron) {
+            this.runner = runner;
+        }
+        this.isRunning = true;
+
+        void runner.promise.finally(() => {
+            this.managedRunners.delete(managedRunner);
+            this.isRunning = this.managedRunners.size > 0;
+            if (!this.isStopping && !this.expectedRunnerStops.delete(runner)) {
                 this.workerHealth?.markPoolDead(
                     'graphile runner stopped unexpectedly',
                 );
@@ -150,11 +251,65 @@ export class SchedulerWorker extends SchedulerTask {
         });
     }
 
-    // Graceful stop for shutdown paths (terminus onSignal). Sets the stopping
-    // flag first so the runner promise settling is not mistaken for a crash.
-    async stop() {
-        this.isStopping = true;
-        await this.runner?.stop();
+    private async startResumeWorkers(): Promise<void> {
+        await this.startManagedRunner(
+            1,
+            Math.max(1, Math.min(2, this.maxPoolSize)),
+            true,
+        );
+    }
+
+    private async finishResumeRamp(): Promise<void> {
+        const remainingConcurrency =
+            this.lightdashConfig.scheduler.concurrency - 1;
+        if (remainingConcurrency <= 0) {
+            return;
+        }
+
+        await this.startManagedRunner(
+            remainingConcurrency,
+            Math.max(1, this.maxPoolSize - 2),
+            false,
+        );
+    }
+
+    private async stopManagedRunnersForRetry(reason: string): Promise<void> {
+        if (this.runnerStopPromise !== null) {
+            await this.runnerStopPromise;
+            return;
+        }
+
+        this.runnerStopPromise = this.performManagedRunnerStop(reason);
+        try {
+            await this.runnerStopPromise;
+        } finally {
+            this.runnerStopPromise = null;
+        }
+    }
+
+    private async performManagedRunnerStop(reason: string): Promise<void> {
+        const managedRunners = [...this.managedRunners];
+        for (const { runner } of managedRunners) {
+            this.expectedRunnerStops.add(runner);
+        }
+
+        await Promise.all(
+            managedRunners.map(async ({ runner, workerPool }) => {
+                if (workerPool !== null) {
+                    await workerPool.gracefulShutdown(reason);
+                }
+                try {
+                    await runner.stop();
+                } catch (error) {
+                    Logger.warn(
+                        `Scheduler runner stop failed: ${getErrorMessage(error)}`,
+                    );
+                }
+            }),
+        );
+        this.managedRunners.clear();
+        this.runner = undefined;
+        this.isRunning = false;
     }
 
     private startPgPing(health: SchedulerWorkerHealth) {

--- a/packages/backend/src/scheduler/SchedulerWorker.warehouseConnect.test.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.warehouseConnect.test.ts
@@ -27,6 +27,12 @@ const makeWorkerArgs = (
                 concurrency: 1,
                 pollInterval: 1000,
                 jobTimeout: 60_000,
+                quiesce: {
+                    pollInterval: 2_000,
+                    gracePeriod: 180_000,
+                    resumeJitter: 60_000,
+                    resumeRampPeriod: 180_000,
+                },
                 queryHistory: {
                     cleanup: {
                         enabled: false,

--- a/packages/backend/src/scheduler/SchedulerWorkerHealth.test.ts
+++ b/packages/backend/src/scheduler/SchedulerWorkerHealth.test.ts
@@ -397,6 +397,34 @@ describe('SchedulerWorkerHealth', () => {
     });
 });
 
+describe('SchedulerWorkerHealth quiesced state', () => {
+    it('stays healthy without a worker pool while intentionally quiesced', () => {
+        const health = new SchedulerWorkerHealth();
+
+        expect(health.isHealthyWhileQuiesced(Date.now() + 10 * 60_000)).toEqual(
+            { ok: true },
+        );
+    });
+
+    it('retains the permanent pool-dead latch while quiesced', () => {
+        const health = new SchedulerWorkerHealth();
+        health.markPoolDead('resume failed');
+
+        expect(health.isHealthyWhileQuiesced()).toEqual({
+            ok: false,
+            reason: 'worker pool terminated: resume failed',
+        });
+    });
+
+    it('reports stale database reachability while quiesced', () => {
+        const health = new SchedulerWorkerHealth();
+        const now = Date.now();
+        health.markPgReachable();
+
+        expect(health.isHealthyWhileQuiesced(now + 4 * 60_000).ok).toBe(false);
+    });
+});
+
 describe('derivePoolIdFromEnv — multi-replica uniqueness', () => {
     it('prefers K8S_POD_NAME when present', () => {
         const env: NodeJS.ProcessEnv = {

--- a/packages/backend/src/scheduler/SchedulerWorkerHealth.ts
+++ b/packages/backend/src/scheduler/SchedulerWorkerHealth.ts
@@ -158,6 +158,31 @@ export class SchedulerWorkerHealth {
         return result;
     }
 
+    isHealthyWhileQuiesced(now: number = Date.now()): HealthCheckResult {
+        if (this.poolDeadAt !== null) {
+            return {
+                ok: false,
+                reason: `worker pool terminated: ${
+                    this.poolDeadReason ?? 'unknown'
+                }`,
+            };
+        }
+
+        if (
+            this.lastPgReachableAt !== null &&
+            now - this.lastPgReachableAt > PG_REACHABLE_STALENESS_MS
+        ) {
+            return {
+                ok: false,
+                reason: `postgres unreachable for ${Math.round(
+                    (now - this.lastPgReachableAt) / 1000,
+                )}s`,
+            };
+        }
+
+        return { ok: true };
+    }
+
     private computeHealth(now: number): HealthCheckResult {
         // Terminated pool wins over every other signal: DB reachability, a
         // reconnected LISTEN client, even in-flight bookkeeping. This is the


### PR DESCRIPTION
## What

The SPK-911 design — scheduled jobs stay off a migrating database with no operator step:

- **Implicit lease-keyed quiesce**: a read-only `MigrationLeaseProbe` (own SELECT against `migration_lease` — no coupling to the migrate runtime) gates every Graphile job on every surface (separate worker, inline scheduler, compose). No allowlist.
- **Bounded grace, then park for retry**: in-flight jobs get native `WorkerPool.gracefulShutdown()` semantics — after grace they `fail_job` into Graphile's normal retry path. No job loss.
- **Jittered ramped resume** (~3 min ramp): resume starts at concurrency 1 and adds capacity through a cron-free supplemental pool — the catch-up herd can't stampede a freshly-migrated database, and cron/backfill ownership stays with the primary pool so `backfillPeriod` semantics are unchanged.
- **Fail-closed**: an unknown lease table means no lease (pre-lease deployments work); any other probe error quiesces rather than risking dequeue during a migration.
- Worker health reporting understands the quiesced state (ignores the intentionally-absent LISTEN pool while keeping real failure signals).

## Verification

Full backend suite 6,484 tests green (428 files); focused quiesce/probe/health suites; typecheck, touched-path lint, formatting green.

Part of #27140

Closes: SPK-925