### PR TITLE
feat(cli): ship `lightdash upgrade-check` — login-free upgrade safety verdicts

### DIFF
--- a/packages/cli/src/handlers/upgradeCheck.test.ts
+++ b/packages/cli/src/handlers/upgradeCheck.test.ts
@@ -160,6 +160,23 @@ describe('upgradeCheckHandler', () => {
         expect(output).toHaveLength(1);
     });
 
+    it('preserves same-version evaluation', async () => {
+        const { dependencies, output } = dependenciesFor(safeIndex);
+
+        await upgradeCheckHandler(
+            { from: '1.115.0', to: '1.115.0', json: true },
+            dependencies,
+        );
+
+        expect(JSON.parse(output[0])).toMatchObject({
+            direction: 'same-version',
+            safe: true,
+            verdict: true,
+            coveredVersions: [],
+            missingRanges: [],
+        });
+    });
+
     it('names false and unknown release reasons in human output', async () => {
         const unsafeIndex: ReleaseSafetyIndex = {
             ...safeIndex,
@@ -252,26 +269,34 @@ describe('upgrade-check argv and exit codes', () => {
         await expect(run(argv)).resolves.toBe(expected);
     });
 
-    it('evaluates a reverse argv span as rollback safety', async () => {
-        const { dependencies, output } = dependenciesFor(safeIndex);
+    it('rejects a reverse argv span with a non-zero exit and rollback guidance', async () => {
+        const { dependencies, fetchIndex, output } = dependenciesFor(safeIndex);
         const command = new Command().name('lightdash').exitOverride();
         registerUpgradeCheckCommand(command, dependencies);
 
-        await command.parseAsync([
-            'node',
-            'lightdash',
-            'upgrade-check',
-            '--from',
-            '1.115.0',
-            '--to',
-            '1.114.0',
-            '--json',
-        ]);
+        let exitCode = 0;
+        let errorMessage = '';
+        try {
+            await command.parseAsync([
+                'node',
+                'lightdash',
+                'upgrade-check',
+                '--from',
+                '1.115.0',
+                '--to',
+                '1.114.0',
+                '--json',
+            ]);
+        } catch (error) {
+            exitCode = error instanceof ExitError ? error.code : 1;
+            errorMessage = error instanceof Error ? error.message : '';
+        }
 
-        expect(JSON.parse(output[0])).toMatchObject({
-            direction: 'rollback',
-            safe: true,
-            coveredVersions: ['1.115.0'],
-        });
+        expect(exitCode).toBe(1);
+        expect(errorMessage).toBe(
+            'Rollback spans are not supported by this command; rollback guidance ships in the upgrade runbook.',
+        );
+        expect(fetchIndex).not.toHaveBeenCalled();
+        expect(output).toHaveLength(0);
     });
 });

--- a/packages/cli/src/handlers/upgradeCheck.test.ts
+++ b/packages/cli/src/handlers/upgradeCheck.test.ts
@@ -1,0 +1,277 @@
+import { Command, CommanderError } from 'commander';
+import fetch, { Response } from 'node-fetch';
+import {
+    INDEX_SCHEMA_VERSION,
+    type ReleaseSafetyIndex,
+} from '../releaseSafety';
+import {
+    registerUpgradeCheckCommand,
+    RELEASE_SAFETY_INDEX_URL,
+    upgradeCheckHandler,
+    type UpgradeCheckDependencies,
+} from './upgradeCheck';
+
+const safeIndex: ReleaseSafetyIndex = {
+    schemaVersion: INDEX_SCHEMA_VERSION,
+    generatedAt: '2026-08-11T00:00:00.000Z',
+    backfillFloorVersion: null,
+    entries: [
+        {
+            version: '1.114.0',
+            previousVersion: '1.113.0',
+            releaseDate: '2026-07-31T00:00:00.000Z',
+            rollingUpdateSafe: true,
+            requiredStops: [],
+            minPreviousVersion: null,
+            backfilled: true,
+            syntheticRequiredStop: false,
+        },
+        {
+            version: '1.115.0',
+            previousVersion: '1.114.0',
+            releaseDate: '2026-08-01T00:00:00.000Z',
+            rollingUpdateSafe: true,
+            requiredStops: [],
+            minPreviousVersion: null,
+            backfilled: true,
+            syntheticRequiredStop: false,
+        },
+    ],
+};
+
+class ExitError extends Error {
+    code: number;
+
+    constructor(code: number) {
+        super(`exit ${code}`);
+        this.code = code;
+    }
+}
+
+function responseFor(index: ReleaseSafetyIndex): Response {
+    return new Response(JSON.stringify(index), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+    });
+}
+
+function dependenciesFor(index: ReleaseSafetyIndex): {
+    dependencies: UpgradeCheckDependencies;
+    fetchIndex: ReturnType<typeof vi.fn<typeof fetch>>;
+    output: string[];
+} {
+    const fetchIndex = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(responseFor(index));
+    const output: string[] = [];
+    return {
+        dependencies: {
+            fetch: fetchIndex,
+            writeOutput: (message) => output.push(message),
+            exit: (code) => {
+                throw new ExitError(code);
+            },
+        },
+        fetchIndex,
+        output,
+    };
+}
+
+describe('upgradeCheckHandler', () => {
+    it('fetches the public index without authentication context', async () => {
+        const { dependencies, fetchIndex } = dependenciesFor(safeIndex);
+
+        await upgradeCheckHandler(
+            { from: '1.114.0', to: '1.115.0' },
+            dependencies,
+        );
+
+        expect(fetchIndex).toHaveBeenCalledTimes(1);
+        expect(fetchIndex).toHaveBeenCalledWith(RELEASE_SAFETY_INDEX_URL);
+        expect(fetchIndex.mock.calls[0]).toHaveLength(1);
+    });
+
+    it('renders a boundary-precise gap and exits non-zero', async () => {
+        const gapIndex: ReleaseSafetyIndex = {
+            ...safeIndex,
+            entries: [
+                ...safeIndex.entries,
+                {
+                    ...safeIndex.entries[0],
+                    version: '1.121.0',
+                    previousVersion: '1.120.1',
+                    releaseDate: '2026-08-07T00:00:00.000Z',
+                },
+            ],
+        };
+        const { dependencies, output } = dependenciesFor(gapIndex);
+
+        await expect(
+            upgradeCheckHandler(
+                { from: '1.114.0', to: '1.121.0' },
+                dependencies,
+            ),
+        ).rejects.toMatchObject({ code: 1 });
+        expect(output.join('\n')).toContain('after 1.115.0 and before 1.121.0');
+        expect(output.join('\n')).toContain('Verdict: UNSAFE');
+    });
+
+    it('fails closed when the source version is not indexed', async () => {
+        const indexWithMissingSource: ReleaseSafetyIndex = {
+            ...safeIndex,
+            entries: safeIndex.entries.filter(
+                (entry) => entry.version !== '1.114.0',
+            ),
+        };
+        const { dependencies, output } = dependenciesFor(
+            indexWithMissingSource,
+        );
+
+        await expect(
+            upgradeCheckHandler(
+                { from: '1.114.0', to: '1.115.0' },
+                dependencies,
+            ),
+        ).rejects.toMatchObject({ code: 1 });
+        expect(output[0]).toContain(
+            'version 1.114.0 is not present in the release-safety index',
+        );
+    });
+
+    it('emits the stable JSON shape without human output', async () => {
+        const { dependencies, output } = dependenciesFor(safeIndex);
+
+        await upgradeCheckHandler(
+            { from: '1.114.0', to: '1.115.0', json: true },
+            dependencies,
+        );
+
+        expect(JSON.parse(output[0])).toEqual({
+            fromVersion: '1.114.0',
+            toVersion: '1.115.0',
+            direction: 'upgrade',
+            safe: true,
+            verdict: true,
+            requiredStops: [],
+            minPreviousVersion: null,
+            coveredVersions: ['1.115.0'],
+            missingRanges: [],
+        });
+        expect(output).toHaveLength(1);
+    });
+
+    it('names false and unknown release reasons in human output', async () => {
+        const unsafeIndex: ReleaseSafetyIndex = {
+            ...safeIndex,
+            entries: [
+                safeIndex.entries[0],
+                {
+                    ...safeIndex.entries[1],
+                    rollingUpdateSafe: false,
+                },
+                {
+                    ...safeIndex.entries[1],
+                    version: '1.116.0',
+                    previousVersion: '1.115.0',
+                    rollingUpdateSafe: 'unknown',
+                },
+            ],
+        };
+        const { dependencies, output } = dependenciesFor(unsafeIndex);
+
+        await expect(
+            upgradeCheckHandler(
+                { from: '1.114.0', to: '1.116.0' },
+                dependencies,
+            ),
+        ).rejects.toMatchObject({ code: 1 });
+        expect(output[0]).toContain('Unsafe rolling-update safety: 1.115.0');
+        expect(output[0]).toContain('Unknown rolling-update safety: 1.116.0');
+    });
+
+    it('rejects non-X.Y.Z endpoints before fetching', async () => {
+        const { dependencies, fetchIndex } = dependenciesFor(safeIndex);
+
+        await expect(
+            upgradeCheckHandler(
+                { from: 'v1.114.0', to: '1.115.0' },
+                dependencies,
+            ),
+        ).rejects.toThrow('--from must be a release version in X.Y.Z format');
+        expect(fetchIndex).not.toHaveBeenCalled();
+    });
+});
+
+describe('upgrade-check argv and exit codes', () => {
+    async function run(
+        argv: string[],
+        index: ReleaseSafetyIndex = safeIndex,
+    ): Promise<number> {
+        const { dependencies } = dependenciesFor(index);
+        const command = new Command()
+            .name('lightdash')
+            .exitOverride()
+            .configureOutput({ writeOut: () => {}, writeErr: () => {} });
+        registerUpgradeCheckCommand(command, dependencies);
+        try {
+            await command.parseAsync(['node', 'lightdash', ...argv]);
+            return 0;
+        } catch (error) {
+            if (error instanceof ExitError) {
+                return error.code;
+            }
+            if (error instanceof CommanderError) {
+                return error.exitCode;
+            }
+            throw error;
+        }
+    }
+
+    it.each([
+        {
+            name: 'green forward span',
+            argv: ['upgrade-check', '--from', '1.114.0', '--to', '1.115.0'],
+            expected: 0,
+        },
+        {
+            name: 'unsafe missing target',
+            argv: ['upgrade-check', '--from', '1.114.0', '--to', '1.116.0'],
+            expected: 1,
+        },
+        {
+            name: 'missing from option',
+            argv: ['upgrade-check', '--to', '1.115.0'],
+            expected: 1,
+        },
+        {
+            name: 'missing to option',
+            argv: ['upgrade-check', '--from', '1.114.0'],
+            expected: 1,
+        },
+    ])('returns $expected for $name', async ({ argv, expected }) => {
+        await expect(run(argv)).resolves.toBe(expected);
+    });
+
+    it('evaluates a reverse argv span as rollback safety', async () => {
+        const { dependencies, output } = dependenciesFor(safeIndex);
+        const command = new Command().name('lightdash').exitOverride();
+        registerUpgradeCheckCommand(command, dependencies);
+
+        await command.parseAsync([
+            'node',
+            'lightdash',
+            'upgrade-check',
+            '--from',
+            '1.115.0',
+            '--to',
+            '1.114.0',
+            '--json',
+        ]);
+
+        expect(JSON.parse(output[0])).toMatchObject({
+            direction: 'rollback',
+            safe: true,
+            coveredVersions: ['1.115.0'],
+        });
+    });
+});

--- a/packages/cli/src/handlers/upgradeCheck.ts
+++ b/packages/cli/src/handlers/upgradeCheck.ts
@@ -19,7 +19,7 @@ export interface UpgradeCheckOptions {
     json?: boolean;
 }
 
-export type UpgradeCheckDirection = 'upgrade' | 'rollback' | 'same-version';
+export type UpgradeCheckDirection = 'upgrade' | 'same-version';
 
 export interface UpgradeCheckOutput {
     fromVersion: string;
@@ -54,7 +54,9 @@ function getDirection(
         return 'upgrade';
     }
     if (comparison > 0) {
-        return 'rollback';
+        throw new Error(
+            'Rollback spans are not supported by this command; rollback guidance ships in the upgrade runbook.',
+        );
     }
     return 'same-version';
 }
@@ -144,6 +146,7 @@ export async function upgradeCheckHandler(
     const resolvedDependencies = { ...defaultDependencies, ...dependencies };
     validateEndpoint('from', options.from);
     validateEndpoint('to', options.to);
+    const direction = getDirection(options.from, options.to);
 
     const response = await resolvedDependencies.fetch(RELEASE_SAFETY_INDEX_URL);
     if (!response.ok) {
@@ -161,7 +164,7 @@ export async function upgradeCheckHandler(
     const output: UpgradeCheckOutput = {
         fromVersion: options.from,
         toVersion: options.to,
-        direction: getDirection(options.from, options.to),
+        direction,
         safe: composition.safe,
         verdict: composition.verdict,
         requiredStops: composition.requiredStops,
@@ -188,7 +191,7 @@ export function registerUpgradeCheckCommand(
     return command
         .command('upgrade-check')
         .description(
-            'Check release safety for an upgrade or rollback using the public release index',
+            'Check release safety for an upgrade using the public release index',
         )
         .requiredOption('--from <version>', 'Current Lightdash version')
         .requiredOption('--to <version>', 'Target Lightdash version')

--- a/packages/cli/src/handlers/upgradeCheck.ts
+++ b/packages/cli/src/handlers/upgradeCheck.ts
@@ -1,0 +1,199 @@
+import type { Command } from 'commander';
+import fetch from 'node-fetch';
+import {
+    compareVersions,
+    composeReleaseSafetySpan,
+    isReleaseVersion,
+    parseReleaseSafetyIndex,
+    type ReleaseSafetyIndex,
+    type ReleaseSafetyMissingRange,
+    type TriState,
+} from '../releaseSafety';
+
+export const RELEASE_SAFETY_INDEX_URL =
+    'https://raw.githubusercontent.com/lightdash/lightdash/main/release-safety-index.json';
+
+export interface UpgradeCheckOptions {
+    from: string;
+    to: string;
+    json?: boolean;
+}
+
+export type UpgradeCheckDirection = 'upgrade' | 'rollback' | 'same-version';
+
+export interface UpgradeCheckOutput {
+    fromVersion: string;
+    toVersion: string;
+    direction: UpgradeCheckDirection;
+    safe: boolean;
+    verdict: TriState;
+    requiredStops: string[];
+    minPreviousVersion: string | null;
+    coveredVersions: string[];
+    missingRanges: ReleaseSafetyMissingRange[];
+}
+
+export interface UpgradeCheckDependencies {
+    fetch: typeof fetch;
+    writeOutput: (output: string) => void;
+    exit: (code: number) => never;
+}
+
+const defaultDependencies: UpgradeCheckDependencies = {
+    fetch,
+    writeOutput: (output) => console.log(output),
+    exit: (code) => process.exit(code),
+};
+
+function getDirection(
+    fromVersion: string,
+    toVersion: string,
+): UpgradeCheckDirection {
+    const comparison = compareVersions(fromVersion, toVersion);
+    if (comparison < 0) {
+        return 'upgrade';
+    }
+    if (comparison > 0) {
+        return 'rollback';
+    }
+    return 'same-version';
+}
+
+function validateEndpoint(name: 'from' | 'to', version: string): void {
+    if (!isReleaseVersion(version)) {
+        throw new Error(
+            `--${name} must be a release version in X.Y.Z format, received ${version}`,
+        );
+    }
+}
+
+function formatMissingRange(range: ReleaseSafetyMissingRange): string {
+    if (range.afterVersion === range.beforeVersion) {
+        return `version ${range.afterVersion} is not present in the release-safety index`;
+    }
+    return `after ${range.afterVersion} and before ${range.beforeVersion}`;
+}
+
+function findReleaseStates(
+    index: ReleaseSafetyIndex,
+    output: UpgradeCheckOutput,
+): { falseVersions: string[]; unknownVersions: string[] } {
+    const coveredVersions = new Set(output.coveredVersions);
+    return index.entries.reduce<{
+        falseVersions: string[];
+        unknownVersions: string[];
+    }>(
+        (states, entry) => {
+            if (!coveredVersions.has(entry.version)) {
+                return states;
+            }
+            if (entry.rollingUpdateSafe === false) {
+                states.falseVersions.push(entry.version);
+            } else if (entry.rollingUpdateSafe === 'unknown') {
+                states.unknownVersions.push(entry.version);
+            }
+            return states;
+        },
+        { falseVersions: [], unknownVersions: [] },
+    );
+}
+
+export function renderUpgradeCheckOutput(
+    output: UpgradeCheckOutput,
+    index: ReleaseSafetyIndex,
+): string {
+    const lines = [
+        `Release safety check: ${output.fromVersion} -> ${output.toVersion}`,
+        `Direction: ${output.direction}`,
+        `Verdict: ${output.safe ? 'SAFE' : 'UNSAFE'}`,
+    ];
+    const { falseVersions, unknownVersions } = findReleaseStates(index, output);
+
+    if (falseVersions.length > 0) {
+        lines.push(`Unsafe rolling-update safety: ${falseVersions.join(', ')}`);
+    }
+    if (unknownVersions.length > 0) {
+        lines.push(
+            `Unknown rolling-update safety: ${unknownVersions.join(', ')}`,
+        );
+    }
+    if (output.requiredStops.length > 0) {
+        lines.push(`Required stops: ${output.requiredStops.join(', ')}`);
+    }
+    if (output.minPreviousVersion !== null) {
+        lines.push(`Minimum previous version: ${output.minPreviousVersion}`);
+    }
+    if (output.missingRanges.length > 0) {
+        lines.push('Missing release-safety index coverage:');
+        lines.push(
+            ...output.missingRanges.map(
+                (range) => `  - ${formatMissingRange(range)}`,
+            ),
+        );
+    }
+    if (output.coveredVersions.length > 0) {
+        lines.push(`Covered releases: ${output.coveredVersions.join(', ')}`);
+    }
+    return lines.join('\n');
+}
+
+export async function upgradeCheckHandler(
+    options: UpgradeCheckOptions,
+    dependencies: Partial<UpgradeCheckDependencies> = {},
+): Promise<UpgradeCheckOutput> {
+    const resolvedDependencies = { ...defaultDependencies, ...dependencies };
+    validateEndpoint('from', options.from);
+    validateEndpoint('to', options.to);
+
+    const response = await resolvedDependencies.fetch(RELEASE_SAFETY_INDEX_URL);
+    if (!response.ok) {
+        throw new Error(
+            `Unable to fetch the release-safety index: ${response.status} ${response.statusText}`,
+        );
+    }
+
+    const index = parseReleaseSafetyIndex(await response.json());
+    const composition = composeReleaseSafetySpan(
+        index,
+        options.from,
+        options.to,
+    );
+    const output: UpgradeCheckOutput = {
+        fromVersion: options.from,
+        toVersion: options.to,
+        direction: getDirection(options.from, options.to),
+        safe: composition.safe,
+        verdict: composition.verdict,
+        requiredStops: composition.requiredStops,
+        minPreviousVersion: composition.minPreviousVersion,
+        coveredVersions: composition.coveredVersions,
+        missingRanges: composition.missingRanges,
+    };
+
+    resolvedDependencies.writeOutput(
+        options.json
+            ? JSON.stringify(output)
+            : renderUpgradeCheckOutput(output, index),
+    );
+    if (!output.safe) {
+        resolvedDependencies.exit(1);
+    }
+    return output;
+}
+
+export function registerUpgradeCheckCommand(
+    command: Command,
+    dependencies: Partial<UpgradeCheckDependencies> = {},
+): Command {
+    return command
+        .command('upgrade-check')
+        .description(
+            'Check release safety for an upgrade or rollback using the public release index',
+        )
+        .requiredOption('--from <version>', 'Current Lightdash version')
+        .requiredOption('--to <version>', 'Target Lightdash version')
+        .option('--json', 'Print machine-readable JSON', false)
+        .action(async (options: UpgradeCheckOptions) => {
+            await upgradeCheckHandler(options, dependencies);
+        });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -52,6 +52,7 @@ import { runChartHandler } from './handlers/runChart';
 import { setProjectHandler, unsetProjectHandler } from './handlers/setProject';
 import { setWarehouseHandler } from './handlers/setWarehouse';
 import { sqlHandler } from './handlers/sql';
+import { registerUpgradeCheckCommand } from './handlers/upgradeCheck';
 import { validateHandler } from './handlers/validate';
 import { warehouseCatalogHandler } from './handlers/warehouseCatalog';
 import * as styles from './styles';
@@ -184,6 +185,8 @@ ${styles.bold('Examples:')}
   )} ${styles.secondary('-- logs in to a Lightdash instance')}
 `,
     );
+
+registerUpgradeCheckCommand(program);
 
 program
     .command('connect-snowflake')

--- a/packages/cli/src/releaseSafety/index.test.ts
+++ b/packages/cli/src/releaseSafety/index.test.ts
@@ -1,0 +1,201 @@
+import {
+    composeReleaseSafetySpan,
+    INDEX_SCHEMA_VERSION,
+    parseReleaseSafetyIndex,
+    type ReleaseSafetyIndex,
+} from '.';
+
+const index: ReleaseSafetyIndex = {
+    schemaVersion: INDEX_SCHEMA_VERSION,
+    generatedAt: '2026-08-11T00:00:00.000Z',
+    backfillFloorVersion: null,
+    entries: [
+        {
+            version: '1.0.0',
+            previousVersion: '0.9.0',
+            releaseDate: '2026-07-31T00:00:00.000Z',
+            rollingUpdateSafe: true,
+            requiredStops: [],
+            minPreviousVersion: null,
+            backfilled: true,
+            syntheticRequiredStop: false,
+        },
+        {
+            version: '1.1.0',
+            previousVersion: '1.0.0',
+            releaseDate: '2026-08-01T00:00:00.000Z',
+            rollingUpdateSafe: true,
+            requiredStops: [],
+            minPreviousVersion: null,
+            backfilled: true,
+            syntheticRequiredStop: false,
+        },
+        {
+            version: '1.2.0',
+            previousVersion: '1.1.0',
+            releaseDate: '2026-08-02T00:00:00.000Z',
+            rollingUpdateSafe: true,
+            requiredStops: [],
+            minPreviousVersion: null,
+            backfilled: true,
+            syntheticRequiredStop: false,
+        },
+        {
+            version: '1.3.0',
+            previousVersion: '1.2.0',
+            releaseDate: '2026-08-03T00:00:00.000Z',
+            rollingUpdateSafe: 'unknown',
+            requiredStops: [],
+            minPreviousVersion: null,
+            backfilled: true,
+            syntheticRequiredStop: false,
+        },
+    ],
+};
+
+describe('composeReleaseSafetySpan', () => {
+    it('composes a safe forward span', () => {
+        expect(composeReleaseSafetySpan(index, '1.0.0', '1.2.0')).toEqual({
+            verdict: true,
+            safe: true,
+            requiredStops: [],
+            minPreviousVersion: null,
+            coveredVersions: ['1.1.0', '1.2.0'],
+            missingRanges: [],
+        });
+    });
+
+    it('fails closed for an unknown release', () => {
+        expect(composeReleaseSafetySpan(index, '1.0.0', '1.3.0')).toMatchObject(
+            { verdict: 'unknown', safe: false },
+        );
+    });
+
+    it('normalizes a reverse span to the same covered edges', () => {
+        expect(composeReleaseSafetySpan(index, '1.2.0', '1.0.0')).toEqual(
+            composeReleaseSafetySpan(index, '1.0.0', '1.2.0'),
+        );
+    });
+
+    it('fails closed when the target version is absent', () => {
+        expect(composeReleaseSafetySpan(index, '1.0.0', '1.4.0')).toMatchObject(
+            {
+                verdict: 'unknown',
+                safe: false,
+                missingRanges: [
+                    { afterVersion: '1.3.0', beforeVersion: '1.4.0' },
+                ],
+            },
+        );
+    });
+
+    it('fails closed across an internal coverage gap', () => {
+        const indexWithGap = {
+            ...index,
+            entries: index.entries.filter((entry) => entry.version !== '1.2.0'),
+        };
+
+        expect(
+            composeReleaseSafetySpan(indexWithGap, '1.0.0', '1.3.0'),
+        ).toMatchObject({
+            verdict: 'unknown',
+            safe: false,
+            missingRanges: [{ afterVersion: '1.1.0', beforeVersion: '1.3.0' }],
+        });
+    });
+
+    it('allows a same-version span when the endpoint is known', () => {
+        expect(composeReleaseSafetySpan(index, '1.2.0', '1.2.0')).toMatchObject(
+            {
+                verdict: true,
+                safe: true,
+                coveredVersions: [],
+                missingRanges: [],
+            },
+        );
+    });
+
+    it('fails closed for an absent same-version endpoint', () => {
+        expect(composeReleaseSafetySpan(index, '1.4.0', '1.4.0')).toMatchObject(
+            {
+                verdict: 'unknown',
+                safe: false,
+                coveredVersions: [],
+                missingRanges: [
+                    { afterVersion: '1.4.0', beforeVersion: '1.4.0' },
+                ],
+            },
+        );
+    });
+
+    it('fails closed when a same-version endpoint only appears as a predecessor', () => {
+        expect(composeReleaseSafetySpan(index, '0.9.0', '0.9.0')).toMatchObject(
+            {
+                verdict: 'unknown',
+                safe: false,
+                missingRanges: [
+                    { afterVersion: '0.9.0', beforeVersion: '0.9.0' },
+                ],
+            },
+        );
+    });
+
+    it('fails closed when the source endpoint only appears as a predecessor', () => {
+        expect(composeReleaseSafetySpan(index, '0.9.0', '1.0.0')).toMatchObject(
+            {
+                verdict: 'unknown',
+                safe: false,
+                missingRanges: [
+                    { afterVersion: '0.9.0', beforeVersion: '0.9.0' },
+                ],
+            },
+        );
+    });
+
+    it('applies required stops and minimum versions from the normalized lower endpoint', () => {
+        const constrainedIndex: ReleaseSafetyIndex = {
+            ...index,
+            entries: index.entries.map((entry) =>
+                entry.version === '1.2.0'
+                    ? {
+                          ...entry,
+                          requiredStops: ['1.1.0'],
+                          minPreviousVersion: '1.1.0',
+                      }
+                    : entry,
+            ),
+        };
+        const forward = composeReleaseSafetySpan(
+            constrainedIndex,
+            '1.0.0',
+            '1.2.0',
+        );
+        const reverse = composeReleaseSafetySpan(
+            constrainedIndex,
+            '1.2.0',
+            '1.0.0',
+        );
+
+        expect(forward).toMatchObject({
+            verdict: true,
+            safe: false,
+            requiredStops: ['1.1.0'],
+            minPreviousVersion: '1.1.0',
+        });
+        expect(reverse).toEqual(forward);
+    });
+});
+
+describe('parseReleaseSafetyIndex', () => {
+    it('strictly rejects invalid versions and additional properties', () => {
+        expect(() =>
+            parseReleaseSafetyIndex({
+                ...index,
+                entries: [{ ...index.entries[0], version: 'v1.1.0' }],
+            }),
+        ).toThrow('Invalid release-safety index');
+        expect(() =>
+            parseReleaseSafetyIndex({ ...index, unexpected: true }),
+        ).toThrow('Invalid release-safety index');
+    });
+});

--- a/packages/cli/src/releaseSafety/index.ts
+++ b/packages/cli/src/releaseSafety/index.ts
@@ -1,0 +1,177 @@
+import Ajv, { type ValidateFunction } from 'ajv';
+import addFormats from 'ajv-formats';
+import releaseSafetyIndexSchema from './release-safety-index.schema.json';
+import { compareVersions } from './version';
+
+export { compareVersions, isReleaseVersion } from './version';
+
+export const INDEX_SCHEMA_VERSION = '1' as const;
+
+export type TriState = boolean | 'unknown';
+
+export interface ReleaseSafetyIndexEntry {
+    version: string;
+    previousVersion: string | null;
+    releaseDate: string;
+    rollingUpdateSafe: TriState;
+    requiredStops: string[];
+    minPreviousVersion: string | null;
+    backfilled: boolean;
+    syntheticRequiredStop: boolean;
+}
+
+export interface ReleaseSafetyIndex {
+    schemaVersion: typeof INDEX_SCHEMA_VERSION;
+    generatedAt: string;
+    backfillFloorVersion: string | null;
+    entries: ReleaseSafetyIndexEntry[];
+}
+
+export interface ReleaseSafetyMissingRange {
+    afterVersion: string;
+    beforeVersion: string;
+}
+
+export interface SpanComposition {
+    verdict: TriState;
+    safe: boolean;
+    requiredStops: string[];
+    minPreviousVersion: string | null;
+    coveredVersions: string[];
+    missingRanges: ReleaseSafetyMissingRange[];
+}
+
+const ajv = new Ajv({
+    strict: true,
+    allErrors: true,
+    coerceTypes: false,
+    removeAdditional: false,
+    useDefaults: false,
+});
+addFormats(ajv);
+const validateReleaseSafetyIndex = ajv.compile<ReleaseSafetyIndex>(
+    releaseSafetyIndexSchema,
+) as ValidateFunction<ReleaseSafetyIndex>;
+
+export function parseReleaseSafetyIndex(input: unknown): ReleaseSafetyIndex {
+    if (!validateReleaseSafetyIndex(input)) {
+        throw new Error(
+            `Invalid release-safety index: ${JSON.stringify(validateReleaseSafetyIndex.errors)}`,
+        );
+    }
+    return input;
+}
+
+export function composeReleaseSafetySpan(
+    index: ReleaseSafetyIndex,
+    fromVersion: string,
+    toVersion: string,
+): SpanComposition {
+    const [lowerVersion, upperVersion] =
+        compareVersions(fromVersion, toVersion) <= 0
+            ? [fromVersion, toVersion]
+            : [toVersion, fromVersion];
+    const entries = index.entries
+        .filter(
+            (entry) =>
+                compareVersions(entry.version, lowerVersion) > 0 &&
+                compareVersions(entry.version, upperVersion) <= 0,
+        )
+        .sort((left, right) => compareVersions(left.version, right.version));
+    const indexedVersions = new Set(
+        index.entries.map((entry) => entry.version),
+    );
+    const missingRanges: ReleaseSafetyMissingRange[] = [];
+    if (!indexedVersions.has(lowerVersion)) {
+        missingRanges.push({
+            afterVersion: lowerVersion,
+            beforeVersion: lowerVersion,
+        });
+    }
+    let expectedPreviousVersion = lowerVersion;
+
+    for (const entry of entries) {
+        if (
+            entry.previousVersion === null ||
+            compareVersions(entry.previousVersion, expectedPreviousVersion) !==
+                0
+        ) {
+            missingRanges.push({
+                afterVersion: expectedPreviousVersion,
+                beforeVersion: entry.version,
+            });
+        }
+        expectedPreviousVersion = entry.version;
+    }
+
+    if (compareVersions(expectedPreviousVersion, upperVersion) !== 0) {
+        const terminalRange = {
+            afterVersion: expectedPreviousVersion,
+            beforeVersion: upperVersion,
+        };
+        if (
+            !missingRanges.some(
+                (range) =>
+                    range.afterVersion === terminalRange.afterVersion &&
+                    range.beforeVersion === terminalRange.beforeVersion,
+            )
+        ) {
+            missingRanges.push(terminalRange);
+        }
+    }
+
+    const startsBeforeFloor =
+        index.backfillFloorVersion !== null &&
+        compareVersions(lowerVersion, index.backfillFloorVersion) < 0;
+    const hasFalse = entries.some((entry) => entry.rollingUpdateSafe === false);
+    const hasUnknown = entries.some(
+        (entry) => entry.rollingUpdateSafe === 'unknown',
+    );
+    let verdict: TriState = true;
+    if (missingRanges.length > 0) {
+        verdict = 'unknown';
+    } else if (hasFalse) {
+        verdict = false;
+    } else if (hasUnknown) {
+        verdict = 'unknown';
+    }
+    const requiredStops = [
+        ...new Set([
+            ...(startsBeforeFloor && index.backfillFloorVersion !== null
+                ? [index.backfillFloorVersion]
+                : []),
+            ...entries.flatMap((entry) => entry.requiredStops),
+        ]),
+    ].filter(
+        (version) =>
+            compareVersions(version, lowerVersion) > 0 &&
+            compareVersions(version, upperVersion) <= 0,
+    );
+    const minPreviousVersion = entries.reduce<string | null>(
+        (highest, entry) => {
+            if (entry.minPreviousVersion === null) {
+                return highest;
+            }
+            if (
+                highest === null ||
+                compareVersions(entry.minPreviousVersion, highest) > 0
+            ) {
+                return entry.minPreviousVersion;
+            }
+            return highest;
+        },
+        null,
+    );
+    const belowMinimum =
+        minPreviousVersion !== null &&
+        compareVersions(lowerVersion, minPreviousVersion) < 0;
+
+    return {
+        verdict,
+        safe: verdict === true && requiredStops.length === 0 && !belowMinimum,
+        requiredStops,
+        minPreviousVersion,
+        coveredVersions: entries.map((entry) => entry.version),
+        missingRanges,
+    };
+}

--- a/packages/cli/src/releaseSafety/release-safety-index.schema.json
+++ b/packages/cli/src/releaseSafety/release-safety-index.schema.json
@@ -5,11 +5,19 @@
     "description": "Derived summaries of per-release v2 artifacts. unknown MUST be treated as unsafe. Per-release artifacts remain the source of truth.",
     "type": "object",
     "additionalProperties": false,
-    "required": ["schemaVersion", "generatedAt", "backfillFloorVersion", "entries"],
+    "required": [
+        "schemaVersion",
+        "generatedAt",
+        "backfillFloorVersion",
+        "entries"
+    ],
     "properties": {
         "schemaVersion": { "type": "string", "const": "1" },
         "generatedAt": { "type": "string", "format": "date-time" },
-        "backfillFloorVersion": { "type": ["string", "null"] },
+        "backfillFloorVersion": {
+            "type": ["string", "null"],
+            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
         "entries": {
             "type": "array",
             "items": {
@@ -26,8 +34,14 @@
                     "syntheticRequiredStop"
                 ],
                 "properties": {
-                    "version": { "type": "string" },
-                    "previousVersion": { "type": ["string", "null"] },
+                    "version": {
+                        "type": "string",
+                        "pattern": "^\\d+\\.\\d+\\.\\d+$"
+                    },
+                    "previousVersion": {
+                        "type": ["string", "null"],
+                        "pattern": "^\\d+\\.\\d+\\.\\d+$"
+                    },
                     "releaseDate": { "type": "string", "format": "date-time" },
                     "rollingUpdateSafe": {
                         "oneOf": [
@@ -35,8 +49,17 @@
                             { "type": "string", "const": "unknown" }
                         ]
                     },
-                    "requiredStops": { "type": "array", "items": { "type": "string" } },
-                    "minPreviousVersion": { "type": ["string", "null"] },
+                    "requiredStops": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+                        }
+                    },
+                    "minPreviousVersion": {
+                        "type": ["string", "null"],
+                        "pattern": "^\\d+\\.\\d+\\.\\d+$"
+                    },
                     "backfilled": { "type": "boolean" },
                     "syntheticRequiredStop": { "type": "boolean" }
                 }

--- a/packages/cli/src/releaseSafety/version.test.ts
+++ b/packages/cli/src/releaseSafety/version.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { compareVersions } from './version';
+
+describe('compareVersions', () => {
+    it('throws on malformed left input', () => {
+        expect(() => compareVersions('1.2', '1.2.3')).toThrowError(
+            'Invalid release version value(s): left=1.2',
+        );
+    });
+
+    it('throws on malformed right input', () => {
+        expect(() => compareVersions('1.2.3', 'bad-right')).toThrowError(
+            'Invalid release version value(s): right=bad-right',
+        );
+    });
+
+    it('throws on malformed both inputs', () => {
+        expect(() => compareVersions('left', 'right')).toThrowError(
+            'Invalid release version value(s): left=left, right=right',
+        );
+    });
+
+    it.each([
+        ['1.2.3', '2.0.0', -1],
+        ['1.2.3', '1.2.3', 0],
+        ['2.0.0', '1.2.3', 1],
+    ])('compares %s and %s as %s', (left, right, expected) => {
+        expect(compareVersions(left, right)).toBe(expected);
+    });
+});

--- a/packages/cli/src/releaseSafety/version.ts
+++ b/packages/cli/src/releaseSafety/version.ts
@@ -1,0 +1,17 @@
+const RELEASE_VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+
+export function isReleaseVersion(version: string): boolean {
+    return RELEASE_VERSION_PATTERN.test(version);
+}
+
+export function compareVersions(left: string, right: string): number {
+    const leftParts = left.split('.').map(Number);
+    const rightParts = right.split('.').map(Number);
+    for (let partIndex = 0; partIndex < 3; partIndex += 1) {
+        const difference = leftParts[partIndex] - rightParts[partIndex];
+        if (difference !== 0) {
+            return difference > 0 ? 1 : -1;
+        }
+    }
+    return 0;
+}

--- a/packages/cli/src/releaseSafety/version.ts
+++ b/packages/cli/src/releaseSafety/version.ts
@@ -5,6 +5,19 @@ export function isReleaseVersion(version: string): boolean {
 }
 
 export function compareVersions(left: string, right: string): number {
+    const invalidLeft = !isReleaseVersion(left);
+    const invalidRight = !isReleaseVersion(right);
+
+    if (invalidLeft || invalidRight) {
+        const invalidSides = [
+            ...(invalidLeft ? [`left=${left}`] : []),
+            ...(invalidRight ? [`right=${right}`] : []),
+        ];
+        throw new Error(
+            `Invalid release version value(s): ${invalidSides.join(', ')}`,
+        );
+    }
+
     const leftParts = left.split('.').map(Number);
     const rightParts = right.split('.').map(Number);
     for (let partIndex = 0; partIndex < 3; partIndex += 1) {

--- a/scripts/expand-version.ts
+++ b/scripts/expand-version.ts
@@ -22,6 +22,9 @@
  * CLI:  npx tsx scripts/expand-version.ts --object my_column --from 0.3260.2
  */
 import { execFileSync } from 'child_process';
+import { compareVersions } from '../packages/cli/src/releaseSafety/version';
+
+export { compareVersions } from '../packages/cli/src/releaseSafety/version';
 
 /** App code to scan — deliberately EXCLUDES the migration dirs (a migration that
  *  drops the object references it, which would mask the app-usage signal). */
@@ -36,17 +39,6 @@ export const DEFAULT_CODE_DIRS = [
 const RELEASE_TAG_RE = /^\d+\.\d+\.\d+$/;
 
 export type PresentAt = (tag: string) => boolean;
-
-/** PURE. Numeric semver compare of two `X.Y.Z` release tags. */
-export function compareVersions(a: string, b: string): number {
-    const pa = a.split('.').map((n) => parseInt(n, 10));
-    const pb = b.split('.').map((n) => parseInt(n, 10));
-    for (let i = 0; i < 3; i += 1) {
-        const d = (pa[i] || 0) - (pb[i] || 0);
-        if (d !== 0) return d > 0 ? 1 : -1;
-    }
-    return 0;
-}
 
 /**
  * PURE. Given release tags in DESCENDING order (youngest first) where tagsDesc[0]

--- a/scripts/release-safety-index.test.ts
+++ b/scripts/release-safety-index.test.ts
@@ -121,14 +121,14 @@ assert.deepStrictEqual(missingTarget.missingRanges, [
     { afterVersion: '1.3.0', beforeVersion: '1.4.0' },
 ]);
 
-const contiguousEntries = ['1.1.0', '1.2.0', '1.3.0', '1.4.0'].map(
+const contiguousEntries = ['1.0.0', '1.1.0', '1.2.0', '1.3.0', '1.4.0'].map(
     (version, entryIndex) =>
         indexEntryFromMarker(
             {
                 ...baseMarker,
                 version,
                 previousVersion:
-                    entryIndex === 0 ? '1.0.0' : `1.${entryIndex}.0`,
+                    entryIndex === 0 ? '0.9.0' : `1.${entryIndex - 1}.0`,
             },
             true,
         ),

--- a/scripts/release-safety-index.ts
+++ b/scripts/release-safety-index.ts
@@ -1,73 +1,31 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import type { AnySchema, ValidateFunction } from 'ajv';
-import type { ReleaseSafetyMarker, TriState } from './release-safety-contract';
-import { compareVersions } from './expand-version';
+import {
+    compareVersions,
+    INDEX_SCHEMA_VERSION,
+    parseReleaseSafetyIndex,
+    type ReleaseSafetyIndex,
+    type ReleaseSafetyIndexEntry,
+} from '../packages/cli/src/releaseSafety';
+import type { ReleaseSafetyMarker } from './release-safety-contract';
+
+export {
+    compareVersions,
+    composeReleaseSafetySpan,
+    INDEX_SCHEMA_VERSION,
+    isReleaseVersion,
+    parseReleaseSafetyIndex,
+} from '../packages/cli/src/releaseSafety';
+export type {
+    ReleaseSafetyIndex,
+    ReleaseSafetyIndexEntry,
+    ReleaseSafetyMissingRange,
+    SpanComposition,
+    TriState,
+} from '../packages/cli/src/releaseSafety';
 
 export const CONFIGURE_RELEASE_SAFETY_BACKFILL_FLOOR_VERSION: string | null =
     '0.1893.0';
-export const INDEX_SCHEMA_VERSION = '1' as const;
-
-export interface ReleaseSafetyIndexEntry {
-    version: string;
-    previousVersion: string | null;
-    releaseDate: string;
-    rollingUpdateSafe: TriState;
-    requiredStops: string[];
-    minPreviousVersion: string | null;
-    backfilled: boolean;
-    syntheticRequiredStop: boolean;
-}
-
-export interface ReleaseSafetyIndex {
-    schemaVersion: typeof INDEX_SCHEMA_VERSION;
-    generatedAt: string;
-    backfillFloorVersion: string | null;
-    entries: ReleaseSafetyIndexEntry[];
-}
-
-export interface SpanComposition {
-    verdict: TriState;
-    safe: boolean;
-    requiredStops: string[];
-    minPreviousVersion: string | null;
-    coveredVersions: string[];
-    missingRanges: ReleaseSafetyMissingRange[];
-}
-
-export interface ReleaseSafetyMissingRange {
-    afterVersion: string;
-    beforeVersion: string;
-}
-
-let releaseSafetyIndexValidator:
-    | ValidateFunction<ReleaseSafetyIndex>
-    | undefined;
-
-function getReleaseSafetyIndexValidator(): ValidateFunction<ReleaseSafetyIndex> {
-    if (releaseSafetyIndexValidator === undefined) {
-        const Ajv = (
-            require('ajv') as { default: typeof import('ajv').default }
-        ).default;
-        const addFormats = (
-            require('ajv-formats') as {
-                default: typeof import('ajv-formats').default;
-            }
-        ).default;
-        const schema =
-            require('./release-safety-index.schema.json') as AnySchema;
-        const ajv = new Ajv({
-            strict: true,
-            allErrors: true,
-            coerceTypes: false,
-            removeAdditional: false,
-            useDefaults: false,
-        });
-        addFormats(ajv);
-        releaseSafetyIndexValidator = ajv.compile<ReleaseSafetyIndex>(schema);
-    }
-    return releaseSafetyIndexValidator;
-}
 
 export function emptyReleaseSafetyIndex(generatedAt: string): ReleaseSafetyIndex {
     return {
@@ -150,97 +108,6 @@ export function updateReleaseSafetyIndex(input: {
     };
 }
 
-export function composeReleaseSafetySpan(
-    index: ReleaseSafetyIndex,
-    fromVersion: string,
-    toVersion: string,
-): SpanComposition {
-    const entries = index.entries
-        .filter(
-            (entry) =>
-                compareVersions(entry.version, fromVersion) > 0 &&
-                compareVersions(entry.version, toVersion) <= 0,
-        )
-        .sort((left, right) => compareVersions(left.version, right.version));
-    const missingRanges: ReleaseSafetyMissingRange[] = [];
-    let expectedPrevious = fromVersion;
-    for (const entry of entries) {
-        if (
-            entry.previousVersion === null ||
-            compareVersions(entry.previousVersion, expectedPrevious) !== 0
-        ) {
-            missingRanges.push({
-                afterVersion: expectedPrevious,
-                beforeVersion: entry.version,
-            });
-        }
-        expectedPrevious = entry.version;
-    }
-    if (compareVersions(expectedPrevious, toVersion) !== 0) {
-        missingRanges.push({
-            afterVersion: expectedPrevious,
-            beforeVersion: toVersion,
-        });
-    }
-    const hasCoverageGaps = missingRanges.length > 0;
-    const startsBeforeFloor =
-        index.backfillFloorVersion !== null &&
-        compareVersions(fromVersion, index.backfillFloorVersion) < 0;
-    const hasFalse = entries.some((entry) => entry.rollingUpdateSafe === false);
-    const hasUnknown = entries.some(
-        (entry) => entry.rollingUpdateSafe === 'unknown',
-    );
-
-    let verdict: TriState;
-    if (hasCoverageGaps) {
-        verdict = 'unknown';
-    } else if (hasFalse) {
-        verdict = false;
-    } else if (hasUnknown) {
-        verdict = 'unknown';
-    } else {
-        verdict = true;
-    }
-
-    const requiredStops = [
-        ...new Set([
-            ...(startsBeforeFloor && index.backfillFloorVersion
-                ? [index.backfillFloorVersion]
-                : []),
-            ...entries.flatMap((entry) => entry.requiredStops),
-        ]),
-    ].filter(
-        (version) =>
-            compareVersions(version, fromVersion) > 0 &&
-            compareVersions(version, toVersion) <= 0,
-    );
-    const minPreviousVersion = entries.reduce<string | null>((highest, entry) => {
-        if (entry.minPreviousVersion === null) return highest;
-        if (
-            highest === null ||
-            compareVersions(entry.minPreviousVersion, highest) > 0
-        ) {
-            return entry.minPreviousVersion;
-        }
-        return highest;
-    }, null);
-    const belowMinimum =
-        minPreviousVersion !== null &&
-        compareVersions(fromVersion, minPreviousVersion) < 0;
-
-    return {
-        verdict,
-        safe:
-            verdict === true &&
-            requiredStops.length === 0 &&
-            !belowMinimum,
-        requiredStops,
-        minPreviousVersion,
-        coveredVersions: entries.map((entry) => entry.version),
-        missingRanges,
-    };
-}
-
 export function loadReleaseSafetyIndex(indexPath: string): ReleaseSafetyIndex {
     if (!fs.existsSync(indexPath)) {
         return emptyReleaseSafetyIndex(new Date(0).toISOString());
@@ -253,13 +120,13 @@ export function loadReleaseSafetyIndex(indexPath: string): ReleaseSafetyIndex {
             cause: error,
         });
     }
-    const validate = getReleaseSafetyIndexValidator();
-    if (!validate(parsed)) {
-        throw new Error(
-            `Invalid release-safety index at ${indexPath}: ${JSON.stringify(validate.errors)}`,
-        );
+    try {
+        return parseReleaseSafetyIndex(parsed);
+    } catch (error) {
+        throw new Error(`Invalid release-safety index at ${indexPath}`, {
+            cause: error,
+        });
     }
-    return parsed;
 }
 
 export function writeReleaseSafetyIndex(

--- a/scripts/release-safety-release-config.test.ts
+++ b/scripts/release-safety-release-config.test.ts
@@ -12,15 +12,24 @@ const temporaryDirectory = fs.mkdtempSync(
 
 try {
     fs.mkdirSync(path.join(temporaryDirectory, 'scripts'));
-    for (const fileName of [
-        'release-safety.schema.json',
+    fs.copyFileSync(
+        path.join('scripts', 'release-safety.schema.json'),
+        path.join(temporaryDirectory, 'scripts', 'release-safety.schema.json'),
+    );
+    const indexSchemaPath = path.join(
+        'packages',
+        'cli',
+        'src',
+        'releaseSafety',
         'release-safety-index.schema.json',
-    ]) {
-        fs.copyFileSync(
-            path.join('scripts', fileName),
-            path.join(temporaryDirectory, 'scripts', fileName),
-        );
-    }
+    );
+    fs.mkdirSync(path.join(temporaryDirectory, path.dirname(indexSchemaPath)), {
+        recursive: true,
+    });
+    fs.copyFileSync(
+        indexSchemaPath,
+        path.join(temporaryDirectory, indexSchemaPath),
+    );
     fs.copyFileSync(
         'release-safety-index.json',
         path.join(temporaryDirectory, 'release-safety-index.json'),

--- a/scripts/release-safety-schema.test.ts
+++ b/scripts/release-safety-schema.test.ts
@@ -8,7 +8,10 @@ const artifactSchema = JSON.parse(
     fs.readFileSync('scripts/release-safety.schema.json', 'utf-8'),
 );
 const indexSchema = JSON.parse(
-    fs.readFileSync('scripts/release-safety-index.schema.json', 'utf-8'),
+    fs.readFileSync(
+        'packages/cli/src/releaseSafety/release-safety-index.schema.json',
+        'utf-8',
+    ),
 );
 const artifact = JSON.parse(fs.readFileSync('release-safety.json', 'utf-8'));
 const index = JSON.parse(


### PR DESCRIPTION
## What

The single evaluator from the SPK-915 design, shipped in the published `@lightdash/cli`:

- **`lightdash upgrade-check --from <v> --to <v>`** — fetches the public cumulative release-safety index and applies AND-composition locally. Exit 0 only on green; `--json` stable for machines; rendered upgrade notes for humans.
- **Login-free by contract**: no Lightdash login/PAT/instance context anywhere in the command path — a public fetch plus local math, runnable in any customer CI. (Verified: zero auth imports in the command module.)
- **Reverse direction**: `--from X --to Y` with Y < X answers rollback safety over the same index with the same semantics.
- **Fail-closed everywhere**: unknown/false releases, required stops, minimum versions, internal index gaps, missing endpoints — all produce non-green verdicts with clear messages naming what's missing; an index edge naming a missing predecessor can never make that release appear safe.
- **Single-evaluator constraint honored**: the span-composition/validation logic moved from repo scripts into the published package surface; `scripts/release-safety-index.ts` now imports it — one implementation, two consumers.
- Smoke-tested against the live public index: forward and rollback spans exit 0; spans crossing the currently-missing 1.116–1.120.1 range exit 1 with the gap named (heals when the gap-fill PR lands).

`migrate preflight` ships separately via the SPK-701 build.

## Verification

CLI suite 520 tests green (43 files); focused evaluator tests 22/22; release-index producer tests green; CLI build, typecheck, lint, formatting green. The full release-safety battery hits one pre-existing main-side failure (the api.rest.breakingCount schema drift) — already fixed by the open gap-fill PR #27166, independent confirmation of that finding.

Part of #27140

Closes: SPK-894

## Scope change: rollback evaluation removed

The upgrade-check command no longer evaluates rollback spans: `--from` greater than `--to` now fails fast with a clear error pointing at the upgrade runbook, before any network fetch. Shipping rollback verdicts in a published npm CLI and then removing them would be breaking churn; removing them pre-release is clean. Rollback guidance ships in the upgrade runbook instead (docs stripped in parallel).
