### PR TITLE
feat(frontend): build-hash handshake with refresh-on-navigation

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -3,6 +3,7 @@ import {
     AnyType,
     ApiError,
     getErrorMessage,
+    LightdashBuildHashHeader,
     LightdashError,
     LightdashMode,
     LightdashVersionHeader,
@@ -36,6 +37,7 @@ import { createEventStreamWriter } from './analytics/eventStream/createEventStre
 import { EventStreamSink } from './analytics/eventStream/EventStreamSink';
 import { eventStreamRegistry } from './analytics/eventStream/registry';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
+import { getFrontendBuildHash } from './buildHash';
 import {
     ClientProviderMap,
     ClientRepository,
@@ -630,10 +632,15 @@ export default class App {
             next();
         });
 
+        const frontendBuildHash = getFrontendBuildHash();
+
         expressApp.use((req, res, next) => {
             // Permissions-Policy header that is not yet supported by helmet. More details here: https://github.com/helmetjs/helmet/issues/234
             res.setHeader('Permissions-Policy', 'camera=(), microphone=()');
             res.setHeader(LightdashVersionHeader, VERSION);
+            if (frontendBuildHash) {
+                res.setHeader(LightdashBuildHashHeader, frontendBuildHash);
+            }
             next();
         });
 

--- a/packages/backend/src/buildHash.ts
+++ b/packages/backend/src/buildHash.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'fs';
+import * as path from 'path';
+
+const FRONTEND_BUILD_HASH_PATH = path.join(
+    __dirname,
+    '../../frontend/build',
+    'build-hash.json',
+);
+
+const parseBuildHash = (contents: string): string | null => {
+    try {
+        const parsed: unknown = JSON.parse(contents);
+        if (typeof parsed !== 'object' || parsed === null) {
+            return null;
+        }
+
+        const { buildHash } = parsed as { buildHash?: unknown };
+        return typeof buildHash === 'string' && buildHash.length > 0
+            ? buildHash
+            : null;
+    } catch {
+        return null;
+    }
+};
+
+let cachedBuildHash: string | null | undefined;
+
+export const getFrontendBuildHash = (): string | null => {
+    if (cachedBuildHash !== undefined) {
+        return cachedBuildHash;
+    }
+
+    try {
+        cachedBuildHash = parseBuildHash(
+            readFileSync(FRONTEND_BUILD_HASH_PATH, 'utf-8'),
+        );
+    } catch {
+        cachedBuildHash = null;
+    }
+
+    return cachedBuildHash;
+};

--- a/packages/common/src/utils/api.ts
+++ b/packages/common/src/utils/api.ts
@@ -3,6 +3,7 @@ import { isRequestMethod, RequestMethod } from '../types/api';
 export const LightdashRequestMethodHeader = 'Lightdash-Request-Method';
 export const LightdashVersionHeader = 'Lightdash-Version';
 export const LightdashSdkVersionHeader = 'Lightdash-SDK-Version';
+export const LightdashBuildHashHeader = 'Lightdash-Build-Hash';
 export const LightdashCliVersionHeader = 'Lightdash-CLI-Version';
 // Attaches the originating data app to a request so warehouse queries can be
 // tagged with `app_uuid`. Self-reported provenance for tracking only — not

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -11,7 +11,7 @@ import { AgentOnboardingCompletionWatcher } from './ee/features/agentOnboarding/
 import { AiAgentsGlobalProvider } from './ee/features/aiCopilot/components/Launcher/AiAgentsGlobalProvider';
 import { parseEmbedThemeParams } from './ee/providers/Embed/parseEmbedThemeParams';
 import BuildSkewRefresher from './features/buildHashHandshake/BuildSkewRefresher';
-import { installChunkLoadErrorHandler } from './features/chunkErrorHandler';
+import { installChunkLoadErrorHandler } from './features/chunkErrorHandler/chunkErrorHandler';
 import ChunkErrorRouteBoundary from './features/errorBoundary/ChunkErrorRouteBoundary';
 import ErrorBoundary from './features/errorBoundary/ErrorBoundary';
 import { SourceCodeEditorProvider } from './features/sourceCodeEditor';

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import {
 import { AgentOnboardingCompletionWatcher } from './ee/features/agentOnboarding/AgentOnboardingCompletionWatcher';
 import { AiAgentsGlobalProvider } from './ee/features/aiCopilot/components/Launcher/AiAgentsGlobalProvider';
 import { parseEmbedThemeParams } from './ee/providers/Embed/parseEmbedThemeParams';
+import { BuildSkewRefresher } from './features/buildHashHandshake';
 import { installChunkLoadErrorHandler } from './features/chunkErrorHandler';
 import ChunkErrorRouteBoundary from './features/errorBoundary/ChunkErrorRouteBoundary';
 import ErrorBoundary from './features/errorBoundary/ErrorBoundary';
@@ -59,6 +60,7 @@ const router = sentryCreateBrowserRouter([
             <AppProvider>
                 <FullscreenProvider enabled={isMobile || !isMinimalPage}>
                     <VersionAutoUpdater />
+                    <BuildSkewRefresher />
                     <ThirdPartyProvider enabled={isMobile || !isMinimalPage}>
                         <ErrorBoundary wrapper={{ mt: '4xl' }}>
                             <TrackingProvider

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -10,7 +10,7 @@ import {
 import { AgentOnboardingCompletionWatcher } from './ee/features/agentOnboarding/AgentOnboardingCompletionWatcher';
 import { AiAgentsGlobalProvider } from './ee/features/aiCopilot/components/Launcher/AiAgentsGlobalProvider';
 import { parseEmbedThemeParams } from './ee/providers/Embed/parseEmbedThemeParams';
-import { BuildSkewRefresher } from './features/buildHashHandshake';
+import BuildSkewRefresher from './features/buildHashHandshake/BuildSkewRefresher';
 import { installChunkLoadErrorHandler } from './features/chunkErrorHandler';
 import ChunkErrorRouteBoundary from './features/errorBoundary/ChunkErrorRouteBoundary';
 import ErrorBoundary from './features/errorBoundary/ErrorBoundary';

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -14,6 +14,7 @@ import { spanToTraceHeader, startSpan } from '@sentry/react';
 // restores fetch strands us with a stale reference. The global `fetch`
 // resolves at call time instead.
 import { EMBED_KEY, type InMemoryEmbed } from './ee/providers/Embed/types';
+import { recordServerBuildHash } from './features/buildHashHandshake';
 import { getFromInMemoryStorage } from './utils/inMemoryStorage';
 
 // TODO: import from common or fix the instantiation of the request module
@@ -193,6 +194,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
         signal,
     })
         .then((r) => {
+            recordServerBuildHash(r);
             if (!r.ok) {
                 return r.json().then((d) => {
                     throw d;

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -14,7 +14,7 @@ import { spanToTraceHeader, startSpan } from '@sentry/react';
 // restores fetch strands us with a stale reference. The global `fetch`
 // resolves at call time instead.
 import { EMBED_KEY, type InMemoryEmbed } from './ee/providers/Embed/types';
-import { recordServerBuildHash } from './features/buildHashHandshake';
+import { recordServerBuildHash } from './features/buildHashHandshake/buildHashHandshake';
 import { getFromInMemoryStorage } from './utils/inMemoryStorage';
 
 // TODO: import from common or fix the instantiation of the request module

--- a/packages/frontend/src/features/buildHashHandshake/BuildSkewRefresher.test.tsx
+++ b/packages/frontend/src/features/buildHashHandshake/BuildSkewRefresher.test.tsx
@@ -1,0 +1,69 @@
+import { act, render } from '@testing-library/react';
+import { createMemoryRouter, Outlet, RouterProvider } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { refreshForBuildSkew } from './buildHashHandshake';
+import BuildSkewRefresher from './BuildSkewRefresher';
+
+vi.mock('./buildHashHandshake', () => ({
+    refreshForBuildSkew: vi.fn(),
+}));
+
+const renderWithRouter = () => {
+    const router = createMemoryRouter(
+        [
+            {
+                path: '/',
+                element: (
+                    <>
+                        <BuildSkewRefresher />
+                        <Outlet />
+                    </>
+                ),
+                children: [
+                    { index: true, element: <div>home</div> },
+                    { path: 'other', element: <div>other</div> },
+                ],
+            },
+        ],
+        { initialEntries: ['/'] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    return router;
+};
+
+describe('BuildSkewRefresher', () => {
+    beforeEach(() => {
+        vi.mocked(refreshForBuildSkew).mockClear();
+    });
+
+    it('does not refresh on first render', () => {
+        renderWithRouter();
+
+        expect(refreshForBuildSkew).not.toHaveBeenCalled();
+    });
+
+    it('refreshes on the next navigation', async () => {
+        const router = renderWithRouter();
+
+        await act(async () => {
+            await router.navigate('/other');
+        });
+
+        expect(refreshForBuildSkew).toHaveBeenCalledTimes(1);
+    });
+
+    it('checks again on each subsequent navigation', async () => {
+        const router = renderWithRouter();
+
+        await act(async () => {
+            await router.navigate('/other');
+        });
+        await act(async () => {
+            await router.navigate('/');
+        });
+
+        expect(refreshForBuildSkew).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/frontend/src/features/buildHashHandshake/BuildSkewRefresher.tsx
+++ b/packages/frontend/src/features/buildHashHandshake/BuildSkewRefresher.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useRef, type FC } from 'react';
+import { useLocation } from 'react-router';
+import { refreshForBuildSkew } from './buildHashHandshake';
+
+const BuildSkewRefresher: FC = () => {
+    const { pathname } = useLocation();
+    const previousPathname = useRef(pathname);
+
+    useEffect(() => {
+        if (previousPathname.current === pathname) {
+            return;
+        }
+
+        previousPathname.current = pathname;
+        refreshForBuildSkew();
+    }, [pathname]);
+
+    return null;
+};
+
+export default BuildSkewRefresher;

--- a/packages/frontend/src/features/buildHashHandshake/buildHashHandshake.test.ts
+++ b/packages/frontend/src/features/buildHashHandshake/buildHashHandshake.test.ts
@@ -1,7 +1,13 @@
 import { LightdashBuildHashHeader } from '@lightdash/common';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const reloadMock = vi.fn();
+const SKEW_RELOAD_KEY = 'lightdash-build-skew-reload';
+const RELOAD_COOLDOWN_MS = 60_000;
+const MAX_SKEW_RELOADS = 2;
+const START_TIME = 1_700_000_000_000;
+
+let currentTime = START_TIME;
 
 const loadHandshake = async () => {
     vi.resetModules();
@@ -23,10 +29,16 @@ describe('buildHashHandshake', () => {
     beforeEach(() => {
         reloadMock.mockClear();
         sessionStorage.clear();
+        currentTime = START_TIME;
+        vi.spyOn(Date, 'now').mockImplementation(() => currentTime);
         Object.defineProperty(window, 'location', {
             configurable: true,
             value: { href: window.location.href, reload: reloadMock },
         });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it('does not refresh when the served build matches the backend', async () => {
@@ -94,5 +106,66 @@ describe('buildHashHandshake', () => {
         expect(refreshForBuildSkew()).toBe(true);
         expect(refreshForBuildSkew()).toBe(false);
         expect(reloadMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the reload guard once a reloaded app converges with the backend', async () => {
+        const stale = await loadHandshake();
+        setServedBuildHash('abc123');
+        stale.recordServerBuildHash(serverResponse('def456'));
+
+        expect(stale.refreshForBuildSkew()).toBe(true);
+        expect(sessionStorage.getItem(SKEW_RELOAD_KEY)).not.toBeNull();
+
+        const converged = await loadHandshake();
+        setServedBuildHash('def456');
+        converged.recordServerBuildHash(serverResponse('def456'));
+
+        expect(sessionStorage.getItem(SKEW_RELOAD_KEY)).toBeNull();
+        expect(converged.refreshForBuildSkew()).toBe(false);
+
+        const skewedAgain = await loadHandshake();
+        setServedBuildHash('def456');
+        skewedAgain.recordServerBuildHash(serverResponse('ghi789'));
+
+        expect(skewedAgain.refreshForBuildSkew()).toBe(true);
+        expect(reloadMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('stops auto-reloading after the attempt cap and does not resume when the cooldown expires', async () => {
+        const reloadOnPermanentSkew = async () => {
+            const handshake = await loadHandshake();
+            setServedBuildHash('abc123');
+            handshake.recordServerBuildHash(serverResponse('def456'));
+            return handshake.refreshForBuildSkew();
+        };
+
+        expect(await reloadOnPermanentSkew()).toBe(true);
+        currentTime += RELOAD_COOLDOWN_MS + 1;
+
+        expect(await reloadOnPermanentSkew()).toBe(true);
+        currentTime += RELOAD_COOLDOWN_MS + 1;
+
+        expect(reloadMock).toHaveBeenCalledTimes(MAX_SKEW_RELOADS);
+
+        expect(await reloadOnPermanentSkew()).toBe(false);
+
+        currentTime += RELOAD_COOLDOWN_MS * 100;
+
+        expect(await reloadOnPermanentSkew()).toBe(false);
+        expect(reloadMock).toHaveBeenCalledTimes(MAX_SKEW_RELOADS);
+    });
+
+    it('does not auto-refresh when session storage cannot be read', async () => {
+        const { recordServerBuildHash, refreshForBuildSkew } =
+            await loadHandshake();
+        setServedBuildHash('abc123');
+        recordServerBuildHash(serverResponse('def456'));
+
+        vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+            throw new Error('storage disabled');
+        });
+
+        expect(refreshForBuildSkew()).toBe(false);
+        expect(reloadMock).not.toHaveBeenCalled();
     });
 });

--- a/packages/frontend/src/features/buildHashHandshake/buildHashHandshake.test.ts
+++ b/packages/frontend/src/features/buildHashHandshake/buildHashHandshake.test.ts
@@ -1,0 +1,98 @@
+import { LightdashBuildHashHeader } from '@lightdash/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const reloadMock = vi.fn();
+
+const loadHandshake = async () => {
+    vi.resetModules();
+    return import('./buildHashHandshake');
+};
+
+const serverResponse = (buildHash: string | null): Response =>
+    new Response(null, {
+        headers: buildHash ? { [LightdashBuildHashHeader]: buildHash } : {},
+    });
+
+const setServedBuildHash = (buildHash: string | null) => {
+    document.head.innerHTML = buildHash
+        ? `<meta name="lightdash-build-hash" content="${buildHash}" />`
+        : '';
+};
+
+describe('buildHashHandshake', () => {
+    beforeEach(() => {
+        reloadMock.mockClear();
+        sessionStorage.clear();
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { href: window.location.href, reload: reloadMock },
+        });
+    });
+
+    it('does not refresh when the served build matches the backend', async () => {
+        const { recordServerBuildHash, refreshForBuildSkew } =
+            await loadHandshake();
+        setServedBuildHash('abc123');
+
+        recordServerBuildHash(serverResponse('abc123'));
+
+        expect(refreshForBuildSkew()).toBe(false);
+        expect(reloadMock).not.toHaveBeenCalled();
+    });
+
+    it('does not refresh when the backend sends no build hash', async () => {
+        const { recordServerBuildHash, refreshForBuildSkew } =
+            await loadHandshake();
+        setServedBuildHash('abc123');
+
+        recordServerBuildHash(serverResponse(null));
+
+        expect(refreshForBuildSkew()).toBe(false);
+        expect(reloadMock).not.toHaveBeenCalled();
+    });
+
+    it('does not refresh when the served app has no baked build hash', async () => {
+        const { recordServerBuildHash, refreshForBuildSkew } =
+            await loadHandshake();
+        setServedBuildHash(null);
+
+        recordServerBuildHash(serverResponse('def456'));
+
+        expect(refreshForBuildSkew()).toBe(false);
+        expect(reloadMock).not.toHaveBeenCalled();
+    });
+
+    it('refreshes once the backend reports a different build', async () => {
+        const { recordServerBuildHash, refreshForBuildSkew } =
+            await loadHandshake();
+        setServedBuildHash('abc123');
+
+        recordServerBuildHash(serverResponse('def456'));
+
+        expect(refreshForBuildSkew()).toBe(true);
+        expect(reloadMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps reporting skew after a later response matches again', async () => {
+        const { recordServerBuildHash, refreshForBuildSkew } =
+            await loadHandshake();
+        setServedBuildHash('abc123');
+
+        recordServerBuildHash(serverResponse('def456'));
+        recordServerBuildHash(serverResponse('abc123'));
+
+        expect(refreshForBuildSkew()).toBe(true);
+    });
+
+    it('does not refresh twice within the cooldown', async () => {
+        const { recordServerBuildHash, refreshForBuildSkew } =
+            await loadHandshake();
+        setServedBuildHash('abc123');
+
+        recordServerBuildHash(serverResponse('def456'));
+
+        expect(refreshForBuildSkew()).toBe(true);
+        expect(refreshForBuildSkew()).toBe(false);
+        expect(reloadMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/frontend/src/features/buildHashHandshake/buildHashHandshake.ts
+++ b/packages/frontend/src/features/buildHashHandshake/buildHashHandshake.ts
@@ -3,8 +3,17 @@ import { LightdashBuildHashHeader } from '@lightdash/common';
 const BUILD_HASH_META_NAME = 'lightdash-build-hash';
 const SKEW_RELOAD_KEY = 'lightdash-build-skew-reload';
 const RELOAD_COOLDOWN_MS = 60_000;
+const MAX_SKEW_RELOADS = 2;
+
+type SkewReloadState = {
+    attempts: number;
+    lastAttemptAt: number;
+};
+
+const NO_SKEW_RELOADS: SkewReloadState = { attempts: 0, lastAttemptAt: 0 };
 
 let skewDetected = false;
+let convergenceObserved = false;
 
 const getAppBuildHash = (): string | null => {
     if (typeof document === 'undefined') {
@@ -16,6 +25,15 @@ const getAppBuildHash = (): string | null => {
         ?.getAttribute('content');
 
     return content ? content : null;
+};
+
+const clearSkewReloadState = (): boolean => {
+    try {
+        sessionStorage.removeItem(SKEW_RELOAD_KEY);
+        return true;
+    } catch {
+        return false;
+    }
 };
 
 export const recordServerBuildHash = (response: Response): void => {
@@ -33,38 +51,71 @@ export const recordServerBuildHash = (response: Response): void => {
         return;
     }
 
-    skewDetected = serverBuildHash !== appBuildHash;
+    if (serverBuildHash === appBuildHash) {
+        if (!convergenceObserved) {
+            convergenceObserved = true;
+            clearSkewReloadState();
+        }
+        return;
+    }
+
+    skewDetected = true;
 };
 
-const hasRecentSkewReload = (): boolean => {
+const parseSkewReloadState = (value: string): SkewReloadState | null => {
     try {
-        const reloadTimestamp = sessionStorage.getItem(SKEW_RELOAD_KEY);
-        if (!reloadTimestamp) {
-            return false;
+        const parsed: unknown = JSON.parse(value);
+        if (typeof parsed !== 'object' || parsed === null) {
+            return null;
         }
 
-        const reloadTime = parseInt(reloadTimestamp, 10);
+        const { attempts, lastAttemptAt } = parsed as Partial<SkewReloadState>;
         if (
-            Number.isNaN(reloadTime) ||
-            Date.now() - reloadTime > RELOAD_COOLDOWN_MS
+            typeof attempts !== 'number' ||
+            !Number.isFinite(attempts) ||
+            typeof lastAttemptAt !== 'number' ||
+            !Number.isFinite(lastAttemptAt)
         ) {
-            sessionStorage.removeItem(SKEW_RELOAD_KEY);
-            return false;
+            return null;
         }
 
-        return true;
+        return { attempts, lastAttemptAt };
     } catch {
-        return true;
+        return null;
+    }
+};
+
+const readSkewReloadState = (): SkewReloadState | null => {
+    try {
+        const stored = sessionStorage.getItem(SKEW_RELOAD_KEY);
+        return stored === null ? NO_SKEW_RELOADS : parseSkewReloadState(stored);
+    } catch {
+        return null;
     }
 };
 
 export const refreshForBuildSkew = (): boolean => {
-    if (!skewDetected || hasRecentSkewReload()) {
+    if (!skewDetected) {
+        return false;
+    }
+
+    const reloadState = readSkewReloadState();
+    if (!reloadState || reloadState.attempts >= MAX_SKEW_RELOADS) {
+        return false;
+    }
+
+    if (Date.now() - reloadState.lastAttemptAt <= RELOAD_COOLDOWN_MS) {
         return false;
     }
 
     try {
-        sessionStorage.setItem(SKEW_RELOAD_KEY, Date.now().toString());
+        sessionStorage.setItem(
+            SKEW_RELOAD_KEY,
+            JSON.stringify({
+                attempts: reloadState.attempts + 1,
+                lastAttemptAt: Date.now(),
+            }),
+        );
     } catch {
         return false;
     }

--- a/packages/frontend/src/features/buildHashHandshake/buildHashHandshake.ts
+++ b/packages/frontend/src/features/buildHashHandshake/buildHashHandshake.ts
@@ -1,0 +1,74 @@
+import { LightdashBuildHashHeader } from '@lightdash/common';
+
+const BUILD_HASH_META_NAME = 'lightdash-build-hash';
+const SKEW_RELOAD_KEY = 'lightdash-build-skew-reload';
+const RELOAD_COOLDOWN_MS = 60_000;
+
+let skewDetected = false;
+
+const getAppBuildHash = (): string | null => {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+
+    const content = document
+        .querySelector(`meta[name="${BUILD_HASH_META_NAME}"]`)
+        ?.getAttribute('content');
+
+    return content ? content : null;
+};
+
+export const recordServerBuildHash = (response: Response): void => {
+    if (skewDetected) {
+        return;
+    }
+
+    const serverBuildHash = response.headers.get(LightdashBuildHashHeader);
+    if (!serverBuildHash) {
+        return;
+    }
+
+    const appBuildHash = getAppBuildHash();
+    if (!appBuildHash) {
+        return;
+    }
+
+    skewDetected = serverBuildHash !== appBuildHash;
+};
+
+const hasRecentSkewReload = (): boolean => {
+    try {
+        const reloadTimestamp = sessionStorage.getItem(SKEW_RELOAD_KEY);
+        if (!reloadTimestamp) {
+            return false;
+        }
+
+        const reloadTime = parseInt(reloadTimestamp, 10);
+        if (
+            Number.isNaN(reloadTime) ||
+            Date.now() - reloadTime > RELOAD_COOLDOWN_MS
+        ) {
+            sessionStorage.removeItem(SKEW_RELOAD_KEY);
+            return false;
+        }
+
+        return true;
+    } catch {
+        return true;
+    }
+};
+
+export const refreshForBuildSkew = (): boolean => {
+    if (!skewDetected || hasRecentSkewReload()) {
+        return false;
+    }
+
+    try {
+        sessionStorage.setItem(SKEW_RELOAD_KEY, Date.now().toString());
+    } catch {
+        return false;
+    }
+
+    window.location.reload();
+    return true;
+};

--- a/packages/frontend/src/features/buildHashHandshake/index.ts
+++ b/packages/frontend/src/features/buildHashHandshake/index.ts
@@ -1,0 +1,2 @@
+export { default as BuildSkewRefresher } from './BuildSkewRefresher';
+export { recordServerBuildHash } from './buildHashHandshake';

--- a/packages/frontend/src/features/buildHashHandshake/index.ts
+++ b/packages/frontend/src/features/buildHashHandshake/index.ts
@@ -1,2 +1,0 @@
-export { default as BuildSkewRefresher } from './BuildSkewRefresher';
-export { recordServerBuildHash } from './buildHashHandshake';

--- a/packages/frontend/src/features/chunkErrorHandler/index.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/index.ts
@@ -1,6 +1,5 @@
 export {
     hasRecentChunkReload,
-    installChunkLoadErrorHandler,
     isChunkLoadError,
     isChunkLoadErrorObject,
     RouteChunkLoadError,

--- a/packages/frontend/vite.config.buildHash.ts
+++ b/packages/frontend/vite.config.buildHash.ts
@@ -1,0 +1,62 @@
+import { createHash } from 'crypto';
+import { writeFileSync } from 'fs';
+import * as path from 'path';
+import { type Plugin, type ResolvedConfig } from 'vite';
+
+export const BUILD_HASH_MANIFEST_FILENAME = 'build-hash.json';
+export const BUILD_HASH_META_NAME = 'lightdash-build-hash';
+
+export const buildHashPlugin = (): Plugin => {
+    let resolvedConfig: ResolvedConfig | undefined;
+    let buildHash: string | undefined;
+
+    return {
+        name: 'lightdash-build-hash',
+        apply: 'build',
+        configResolved(config) {
+            resolvedConfig = config;
+        },
+        transformIndexHtml: {
+            order: 'post',
+            handler(html, ctx) {
+                if (!ctx.bundle) {
+                    return html;
+                }
+
+                buildHash = createHash('sha256')
+                    .update(Object.keys(ctx.bundle).sort().join('\n'))
+                    .digest('hex')
+                    .slice(0, 16);
+
+                return {
+                    html,
+                    tags: [
+                        {
+                            tag: 'meta',
+                            attrs: {
+                                name: BUILD_HASH_META_NAME,
+                                content: buildHash,
+                            },
+                            injectTo: 'head',
+                        },
+                    ],
+                };
+            },
+        },
+        closeBundle() {
+            if (!buildHash || !resolvedConfig) {
+                return;
+            }
+
+            const outDir = path.resolve(
+                resolvedConfig.root,
+                resolvedConfig.build.outDir,
+            );
+
+            writeFileSync(
+                path.join(outDir, BUILD_HASH_MANIFEST_FILENAME),
+                `${JSON.stringify({ buildHash })}\n`,
+            );
+        },
+    };
+};

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -5,6 +5,7 @@ import { compression } from 'vite-plugin-compression2';
 import monacoEditorPlugin from 'vite-plugin-monaco-editor';
 import svgrPlugin from 'vite-plugin-svgr';
 import { defineConfig } from 'vitest/config';
+import { buildHashPlugin } from './vite.config.buildHash';
 
 const FE_PORT = process.env.FE_PORT ? parseInt(process.env.FE_PORT) : 3000;
 const FE_HOST = process.env.FE_HOST;
@@ -23,6 +24,7 @@ export default defineConfig({
             process.env.REACT_QUERY_DEVTOOLS_ENABLED ?? true,
     },
     plugins: [
+        buildHashPlugin(),
         compression({
             include: [/\.(js)$/, /\.(css)$/],
             algorithms: ['gzip'],


### PR DESCRIPTION
## What

The SPK-909 frontend/backend skew guard — invisible by design:

- **Build hash emitted at build time**: the production build writes a build hash consumed both as a meta tag in `index.html` and by the backend module — verified end-to-end against a real build (identical value on both sides).
- **Backend stamps the served hash** on every response; the frontend compares its own baked-in hash.
- **Refresh on the NEXT navigation** on mismatch — never mid-task, no data loss, no error card. The refresher lives on a persistent layout route deliberately (a per-route mount would reset its ref and never fire).
- Complements (doesn't replace) the existing chunk-error boundary.
- react-doctor clean on all touched files (barrel imports converted to direct module imports; one now-unused re-export dropped).

## Verification

New tests 9/9 (6 detection, 3 navigation-deferral); full frontend suite 2,369/2,369 green (verified against a clean main baseline after ruling out a resource-starvation artifact); typecheck clean across common/backend/frontend; real-build hash roundtrip proven.

Part of #27140

Closes: SPK-922