### PR TITLE
feat(backend): migration preflight gate — look before any schema is touched

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -107,6 +107,16 @@ Useful Development Scripts:
 - rollback last migration - `pnpm -F backend rollback-last`
 - create a new migration file - `pnpm -F backend create-migration <migration-name>`
 
+##### Migration preflight
+
+Run `pnpm -F backend migrate preflight` to inspect upgrade safety without changing the database. `migrate up` runs the same checks before claiming the migration lease. Use `--strict` to treat yellow checks as blocking, `--force` to proceed with an explicit override warning, and `--json` on the standalone command for automation.
+
+PostgreSQL does not expose filesystem free space. Set `MIGRATION_PREFLIGHT_DISK_HEADROOM_BYTES` from an external capacity signal to compare available space with the 5 GiB warning threshold; when an applicable migration is pending and the variable is unset, disk headroom is reported as unavailable yellow.
+
+The JSON payload has `schemaVersion: "1"` and fixed top-level fields: `decision`, `force`, `strict`, `summary`, and `checks`. Decisions are `proceed`, `proceed-with-warnings`, `abort`, or `force-proceed`. Checks are emitted in this order: version path, migration privileges, PostgreSQL version, held locks, long transactions, disk headroom, and pending migration inventory. Every check includes an `id`, `severity`, `outcome`, `message`, and strictly shaped `data`; red checks use `pass` or `fail`, yellow checks use `pass` or `warn`, and the inventory uses `info`.
+
+The command writes one JSON line to standard output. An `abort` decision exits through the migration CLI error path with a non-zero status and `--force` guidance. Override warnings and command errors are written to standard error.
+
 #### Seeds
 
 Seeds are responsible for populating the database with initial data.

--- a/packages/backend/src/database/migrations/CLAUDE.md
+++ b/packages/backend/src/database/migrations/CLAUDE.md
@@ -46,3 +46,7 @@ When the gate detects a breaking pattern, use this decision tree:
 1. Attempt an expand-only redesign first, such as deprecating the old shape now and dropping it in a later release.
 2. Add `export const breaking` only after an engineer confirms the product and rollout decision. Its reason must describe what breaks and for whom; it must contain more than one word, use at least 24 characters, and must not reuse placeholder text.
 3. Never add a breaking declaration merely to make CI pass. Declaring a break makes the release not rolling-safe and advises every self-hosted customer to use the Recreate strategy.
+
+## Runtime rollback granularity
+
+The lease runtime applies each migration as a separate Knex batch rather than grouping a deploy into one batch. Consequently, development tooling such as `knex migrate:rollback` unwinds one migration per invocation, not the whole deploy. During an incident, expect this per-migration unwind granularity; production recovery remains forward-only.

--- a/packages/backend/src/scripts/migrate/cli.test.ts
+++ b/packages/backend/src/scripts/migrate/cli.test.ts
@@ -13,6 +13,7 @@ import {
     type MigrationLeaseCommandClient,
 } from './cli';
 import { type KnexMigrationState } from './migrationState';
+import { type PreflightReport } from './preflight';
 
 const migrationClassification = (
     pending: string[],
@@ -97,6 +98,42 @@ const migrationRun = (overrides: Partial<MigrationRun> = {}): MigrationRun => ({
     ...overrides,
 });
 
+const preflightReport = (
+    overrides: Partial<PreflightReport> = {},
+): PreflightReport => ({
+    schemaVersion: '1',
+    decision: 'proceed',
+    force: false,
+    strict: false,
+    summary: { red: 0, yellow: 0, info: 1 },
+    checks: [],
+    ...overrides,
+});
+
+const leaseManager = (): MigrationLeaseCommandClient => ({
+    claim: vi.fn(async () => acquired()),
+    heartbeat: vi.fn(async () => true),
+    setCurrentMigration: vi.fn(async () => true),
+    release: vi.fn(async () => true),
+    unlock: vi.fn<MigrationLeaseCommandClient['unlock']>(
+        async (actor, _force) => ({
+            status: 'unlocked',
+            lease: heldLease({
+                claimToken: null,
+                holderHostname: null,
+                holderPodName: null,
+                appVersion: null,
+                startedAt: null,
+                currentMigration: null,
+                lastHeartbeat: null,
+                lastUnlockedBy: actor,
+                lastUnlockedAt: new Date('2026-08-10T10:05:00.000Z'),
+            }),
+        }),
+    ),
+    read: vi.fn(async () => readLease(null)),
+});
+
 const leaseManager = (): MigrationLeaseCommandClient => {
     let runNumber = 0;
     return {
@@ -160,6 +197,7 @@ const context = (
                 appVersion: '1.2.3',
             },
             getMigrationState: vi.fn(async () => migrationState()),
+            runPreflight: vi.fn(async () => preflightReport()),
             migrateOne: vi.fn(async () => {}),
             isKnexLockHeld: vi.fn(async () => false),
             clearKnexLock: vi.fn(async () => {}),
@@ -177,6 +215,97 @@ const context = (
 };
 
 describe('runMigrateCli', () => {
+    test('preflight runs as a standalone read-only command', async () => {
+        const manager = leaseManager();
+        const command = context(manager);
+
+        await runMigrateCli(['preflight'], command.value);
+
+        expect(command.value.runPreflight).toHaveBeenCalledWith({
+            force: false,
+            strict: false,
+        });
+        expect(manager.claim).not.toHaveBeenCalled();
+        expect(command.lines).toContain(
+            'Preflight decision: proceed (0 red, 0 yellow)',
+        );
+    });
+
+    test('preflight --json emits one stable payload line', async () => {
+        const manager = leaseManager();
+        const command = context(manager);
+
+        await runMigrateCli(['preflight', '--json'], command.value);
+
+        expect(command.lines).toEqual([JSON.stringify(preflightReport())]);
+        expect(manager.claim).not.toHaveBeenCalled();
+    });
+
+    test('up aborts on red preflight before claiming the migration lease', async () => {
+        const manager = leaseManager();
+        const command = context(manager, {
+            runPreflight: vi.fn(async () =>
+                preflightReport({
+                    decision: 'abort',
+                    summary: { red: 1, yellow: 0, info: 1 },
+                }),
+            ),
+        });
+
+        await expect(runMigrateCli(['up'], command.value)).rejects.toThrow(
+            'Migration preflight aborted; resolve the blocking checks or pass --force to override',
+        );
+
+        expect(command.value.runPreflight).toHaveBeenCalledOnce();
+        expect(manager.claim).not.toHaveBeenCalled();
+        expect(command.value.getMigrationState).not.toHaveBeenCalled();
+    });
+
+    test('strict promotes yellow preflight results to an abort before lease claim', async () => {
+        const manager = leaseManager();
+        const command = context(manager, {
+            runPreflight: vi.fn(async () =>
+                preflightReport({
+                    decision: 'abort',
+                    strict: true,
+                    summary: { red: 0, yellow: 1, info: 1 },
+                }),
+            ),
+        });
+
+        await expect(
+            runMigrateCli(['up', '--strict'], command.value),
+        ).rejects.toThrow(
+            'Migration preflight aborted; resolve the blocking checks or pass --force to override',
+        );
+
+        expect(command.value.runPreflight).toHaveBeenCalledWith({
+            force: false,
+            strict: true,
+        });
+        expect(manager.claim).not.toHaveBeenCalled();
+    });
+
+    test('force overrides a red preflight with unmistakable warning logging', async () => {
+        const manager = leaseManager();
+        const command = context(manager, {
+            runPreflight: vi.fn(async () =>
+                preflightReport({
+                    decision: 'force-proceed',
+                    force: true,
+                    summary: { red: 1, yellow: 0, info: 1 },
+                }),
+            ),
+        });
+
+        await runMigrateCli(['up', '--force'], command.value);
+
+        expect(command.warnings).toContain(
+            '!!! MIGRATION PREFLIGHT OVERRIDE ACTIVE: proceeding despite blocking checks because --force was supplied !!!',
+        );
+        expect(manager.claim).toHaveBeenCalledOnce();
+    });
+
     test('status --json is read-only and accepts a database-ahead state', async () => {
         const manager = leaseManager();
         vi.mocked(manager.read).mockResolvedValue(
@@ -896,6 +1025,8 @@ describe('runMigrateCli', () => {
         ['up', '-h'],
         ['status', '--help'],
         ['status', '-h'],
+        ['preflight', '--help'],
+        ['preflight', '-h'],
         ['wait', '--help'],
         ['wait', '-h'],
         ['unlock', '--help'],
@@ -910,12 +1041,21 @@ describe('runMigrateCli', () => {
         expect(command.lines[0]).toContain('migrate [up]');
         expect(command.lines[0]).toContain('migrate status [--json]');
         expect(command.lines[0]).toContain(
+            'migrate preflight [--strict] [--force] [--json]',
+        );
+        expect(command.lines[0]).toContain(
             'migrate wait [--timeout-ms <milliseconds>]',
         );
         expect(command.lines[0]).toContain(
             'migrate unlock --actor <identity> [--force]',
         );
         expect(command.lines[0]).toContain('-h, --help');
+        expect(command.lines[0]).toContain(
+            '--json                       Emit the status or preflight payload as JSON',
+        );
+        expect(command.lines[0]).toContain(
+            '--force                      Override blocking preflight checks, an active lease, or a legacy Knex lock',
+        );
         expect(manager.read).not.toHaveBeenCalled();
         expect(manager.claim).not.toHaveBeenCalled();
         expect(manager.unlock).not.toHaveBeenCalled();
@@ -962,10 +1102,46 @@ describe('parseMigrateCliOptions', () => {
         });
     });
 
-    test.each(['up', 'status', 'wait'])('rejects force for %s', (command) => {
+    test.each(['status', 'wait'])('rejects force for %s', (command) => {
         expect(() =>
             parseMigrateCliOptions([command, '--force'], 1_800_000),
-        ).toThrow('--force is only valid with unlock');
+        ).toThrow('--force is only valid with up, preflight, or unlock');
+    });
+
+    test.each([
+        ['up', ['--force', '--strict']],
+        ['preflight', ['--force', '--strict', '--json']],
+    ])('accepts safety flags for %s', (command, flags) => {
+        expect(
+            parseMigrateCliOptions([command, ...flags], 1_800_000),
+        ).toMatchObject({
+            command,
+            force: true,
+            strict: true,
+            json: command === 'preflight',
+        });
+    });
+
+    test.each(['status', 'wait', 'unlock'])(
+        'rejects strict for %s',
+        (command) => {
+            const args =
+                command === 'unlock'
+                    ? [command, '--actor', 'operator@example.com', '--strict']
+                    : [command, '--strict'];
+            expect(() => parseMigrateCliOptions(args, 1_800_000)).toThrow(
+                '--strict is only valid with up or preflight',
+            );
+        },
+    );
+
+    test('rejects json for up even when other safety flags are valid', () => {
+        expect(() =>
+            parseMigrateCliOptions(
+                ['up', '--strict', '--force', '--json'],
+                1_800_000,
+            ),
+        ).toThrow('--json is only valid with status or preflight');
     });
 
     test('rejects an explicitly supplied default timeout for status', () => {

--- a/packages/backend/src/scripts/migrate/cli.test.ts
+++ b/packages/backend/src/scripts/migrate/cli.test.ts
@@ -110,30 +110,6 @@ const preflightReport = (
     ...overrides,
 });
 
-const leaseManager = (): MigrationLeaseCommandClient => ({
-    claim: vi.fn(async () => acquired()),
-    heartbeat: vi.fn(async () => true),
-    setCurrentMigration: vi.fn(async () => true),
-    release: vi.fn(async () => true),
-    unlock: vi.fn<MigrationLeaseCommandClient['unlock']>(
-        async (actor, _force) => ({
-            status: 'unlocked',
-            lease: heldLease({
-                claimToken: null,
-                holderHostname: null,
-                holderPodName: null,
-                appVersion: null,
-                startedAt: null,
-                currentMigration: null,
-                lastHeartbeat: null,
-                lastUnlockedBy: actor,
-                lastUnlockedAt: new Date('2026-08-10T10:05:00.000Z'),
-            }),
-        }),
-    ),
-    read: vi.fn(async () => readLease(null)),
-});
-
 const leaseManager = (): MigrationLeaseCommandClient => {
     let runNumber = 0;
     return {

--- a/packages/backend/src/scripts/migrate/cli.ts
+++ b/packages/backend/src/scripts/migrate/cli.ts
@@ -10,6 +10,11 @@ import {
 } from '../../database/migrationLease';
 import { MigrationHeartbeat, type MigrationHeartbeatClient } from './heartbeat';
 import { type KnexMigrationState } from './migrationState';
+import {
+    renderPreflightReport,
+    type PreflightReport,
+    type PreflightRunOptions,
+} from './preflight';
 
 const DEFAULT_WAIT_TIMEOUT_MS = 30 * 60_000;
 const DEFAULT_FOLLOWER_POLL_INTERVAL_MS = 5_000;
@@ -18,25 +23,28 @@ const DEFAULT_MIGRATION_RETRY_DELAY_MS = 1_000;
 const GRAPHILE_MIGRATION_NAME = 'graphile-worker';
 const MIGRATION_NAME_PREVIEW_LIMIT = 5;
 const MIGRATE_CLI_HELP = `Usage:
-  migrate [up] [--timeout-ms <milliseconds>]
+  migrate [up] [--timeout-ms <milliseconds>] [--strict] [--force]
+  migrate preflight [--strict] [--force] [--json]
   migrate status [--json]
   migrate wait [--timeout-ms <milliseconds>]
   migrate unlock --actor <identity> [--force]
 
 Commands:
   up       Run pending Knex and Graphile Worker migrations (default)
+  preflight Check migration safety without changing the database
   status   Show migration lease and Knex migration status
   wait     Wait for migrations and take over an expired lease
   unlock   Clear migration locks for recovery
 
 Flags:
   --timeout-ms <milliseconds>  Set the up or wait timeout
-  --json                       Emit the full status payload as JSON
+  --json                       Emit the status or preflight payload as JSON
+  --strict                     Promote preflight warnings to blockers
   --actor <identity>           Attribute an unlock operation
-  --force                      Override an active lease or legacy Knex lock
+  --force                      Override blocking preflight checks, an active lease, or a legacy Knex lock
   -h, --help                   Show this help`;
 
-type MigrateCommand = 'up' | 'status' | 'wait' | 'unlock';
+type MigrateCommand = 'up' | 'preflight' | 'status' | 'wait' | 'unlock';
 type MigrationStatusState = 'idle' | 'migrating' | 'parked' | 'stale';
 
 type MigrateCliOptions = {
@@ -46,6 +54,7 @@ type MigrateCliOptions = {
     timeoutMs: number;
     actor: string | null;
     force: boolean;
+    strict: boolean;
 };
 
 export type MigrationLeaseCommandClient = MigrationHeartbeatClient & {
@@ -85,6 +94,7 @@ export type MigrateCliContext = {
     heartbeatLeaseManager: MigrationHeartbeatClient;
     identity: MigrationLeaseIdentity;
     getMigrationState: () => Promise<KnexMigrationState>;
+    runPreflight: (options: PreflightRunOptions) => Promise<PreflightReport>;
     cleanupInvalidIndexes: (pendingMigrationNames: string[]) => Promise<void>;
     migrateOne: (name: string) => Promise<void>;
     isKnexLockHeld: () => Promise<boolean>;
@@ -191,6 +201,7 @@ export const parseMigrationWaitTimeoutMs = (
 
 const isMigrateCommand = (value: string): value is MigrateCommand =>
     value === 'up' ||
+    value === 'preflight' ||
     value === 'status' ||
     value === 'wait' ||
     value === 'unlock';
@@ -212,6 +223,7 @@ export const parseMigrateCliOptions = (
         timeoutMs: defaultTimeoutMs,
         actor: null,
         force: false,
+        strict: false,
     };
     let timeoutWasProvided = false;
     const argumentsAfterCommand = argv.slice(1);
@@ -236,6 +248,8 @@ export const parseMigrateCliOptions = (
             }
         } else if (argument === '--force') {
             options.force = true;
+        } else if (argument === '--strict') {
+            options.strict = true;
         } else {
             throw new Error(`Unknown migrate argument: ${argument}`);
         }
@@ -243,8 +257,12 @@ export const parseMigrateCliOptions = (
     if (options.help) {
         return options;
     }
-    if (options.json && options.command !== 'status') {
-        throw new Error('--json is only valid with status');
+    if (
+        options.json &&
+        options.command !== 'status' &&
+        options.command !== 'preflight'
+    ) {
+        throw new Error('--json is only valid with status or preflight');
     }
     if (
         timeoutWasProvided &&
@@ -256,8 +274,20 @@ export const parseMigrateCliOptions = (
     if (options.actor !== null && options.command !== 'unlock') {
         throw new Error('--actor is only valid with unlock');
     }
-    if (options.force && options.command !== 'unlock') {
-        throw new Error('--force is only valid with unlock');
+    if (
+        options.force &&
+        options.command !== 'up' &&
+        options.command !== 'preflight' &&
+        options.command !== 'unlock'
+    ) {
+        throw new Error('--force is only valid with up, preflight, or unlock');
+    }
+    if (
+        options.strict &&
+        options.command !== 'up' &&
+        options.command !== 'preflight'
+    ) {
+        throw new Error('--strict is only valid with up or preflight');
     }
     if (options.command === 'unlock' && options.actor === null) {
         throw new Error('unlock requires --actor');
@@ -562,10 +592,31 @@ const followMigrations = async (
     await followMigrations(context, deadline, promote);
 };
 
+const runPreflightGate = async (
+    context: MigrateCliContext,
+    options: PreflightRunOptions,
+    json: boolean,
+): Promise<void> => {
+    const report = await context.runPreflight(options);
+    context.log(json ? JSON.stringify(report) : renderPreflightReport(report));
+    if (report.decision === 'force-proceed') {
+        context.warn(
+            '!!! MIGRATION PREFLIGHT OVERRIDE ACTIVE: proceeding despite blocking checks because --force was supplied !!!',
+        );
+    }
+    if (report.decision === 'abort') {
+        throw new Error(
+            'Migration preflight aborted; resolve the blocking checks or pass --force to override',
+        );
+    }
+};
+
 const runUp = async (
     context: MigrateCliContext,
     timeoutMs: number,
+    preflightOptions: PreflightRunOptions,
 ): Promise<void> => {
+    await runPreflightGate(context, preflightOptions, false);
     const state = await context.getMigrationState();
     assertMigrationStateRunnable(state);
     const claim = await context.leaseManager.claim(context.identity);
@@ -722,7 +773,17 @@ export const runMigrateCli = async (
     }
     switch (options.command) {
         case 'up':
-            await runUp(context, options.timeoutMs);
+            await runUp(context, options.timeoutMs, {
+                force: options.force,
+                strict: options.strict,
+            });
+            return;
+        case 'preflight':
+            await runPreflightGate(
+                context,
+                { force: options.force, strict: options.strict },
+                options.json,
+            );
             return;
         case 'status':
             await runStatus(context, options.json);

--- a/packages/backend/src/scripts/migrate/index.ts
+++ b/packages/backend/src/scripts/migrate/index.ts
@@ -1,6 +1,7 @@
 import { runMigrations } from 'graphile-worker';
 import knex from 'knex';
 import os from 'node:os';
+import path from 'node:path';
 import { lightdashConfig } from '../../config/lightdashConfig';
 import { MigrationLeaseManager } from '../../database/migrationLease';
 import knexConfig from '../../knexfile';
@@ -13,6 +14,14 @@ import {
 import { createMigrateKnexConfig } from './config';
 import { cleanupInvalidMigrationIndexes } from './invalidMigrationIndexes';
 import { getKnexMigrationState } from './migrationState';
+import {
+    createKnexPreflightProbe,
+    getPendingMigrationInventory,
+    loadReleaseSafetyArtifact,
+    parseDiskHeadroomBytes,
+    resolveReleaseSafetyArtifactPath,
+    runPreflight,
+} from './preflight';
 
 const environment =
     process.env.NODE_ENV === 'production' ? 'production' : 'development';
@@ -41,6 +50,10 @@ type KnexMigrationLockRow = {
 };
 
 const main = async (): Promise<void> => {
+    const migrationConfig = config.migrations ?? {};
+    const artifactPath = resolveReleaseSafetyArtifactPath({
+        cwd: path.resolve(__dirname, '../../../../..'),
+    });
     const context = createMigrateCliContext({
         leaseManager,
         heartbeatLeaseManager,
@@ -50,11 +63,35 @@ const main = async (): Promise<void> => {
             appVersion: String(VERSION),
         },
         getMigrationState: () =>
-            getKnexMigrationState(database, config.migrations ?? {}),
+            getKnexMigrationState(database, migrationConfig),
+        runPreflight: async (options) => {
+            const preflightProbe = createKnexPreflightProbe({
+                database,
+                diskHeadroomBytes: parseDiskHeadroomBytes(
+                    process.env.MIGRATION_PREFLIGHT_DISK_HEADROOM_BYTES,
+                ),
+            });
+            const [artifactLoad, migrationState] = await Promise.all([
+                loadReleaseSafetyArtifact(artifactPath),
+                getKnexMigrationState(database, migrationConfig),
+            ]);
+            const inventory = await getPendingMigrationInventory({
+                migrationState,
+                migrationConfig,
+                artifact: artifactLoad.artifact,
+            });
+            return runPreflight({
+                artifactLoad,
+                migrationState,
+                inventory,
+                probe: preflightProbe,
+                options,
+            });
+        },
         cleanupInvalidIndexes: async (pendingMigrationNames) => {
             await cleanupInvalidMigrationIndexes({
                 database,
-                migrationConfig: config.migrations ?? {},
+                migrationConfig,
                 pendingMigrationNames,
                 log: console.log,
             });

--- a/packages/backend/src/scripts/migrate/preflight.test.ts
+++ b/packages/backend/src/scripts/migrate/preflight.test.ts
@@ -1,14 +1,18 @@
 import { type Knex } from 'knex';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { type KnexMigrationState } from './migrationState';
 import {
     getPendingMigrationInventory,
+    loadReleaseSafetyArtifact,
     LONG_TRANSACTION_THRESHOLD_SECONDS,
     MIN_DISK_HEADROOM_BYTES,
     MIN_SUPPORTED_POSTGRES_MAJOR,
     normalizeMigrationName,
     parseDiskHeadroomBytes,
     parseReleaseSafetyArtifact,
+    renderPreflightReport,
     resolveReleaseSafetyArtifactPath,
     runPreflight,
     type PendingMigrationInventoryItem,
@@ -16,6 +20,7 @@ import {
     type PreflightProbe,
     type PreflightReport,
     type ReleaseSafetyArtifact,
+    type ReleaseSafetyArtifactLoadResult,
 } from './preflight';
 
 const artifact = (
@@ -85,6 +90,7 @@ const probe = (overrides: Partial<PreflightProbe> = {}): PreflightProbe => ({
 
 const report = async ({
     artifactValue = artifact(),
+    artifactLoadValue,
     migrationState = state(),
     inventoryValue = inventory,
     probeValue = probe(),
@@ -92,6 +98,7 @@ const report = async ({
     strict = false,
 }: {
     artifactValue?: ReleaseSafetyArtifact;
+    artifactLoadValue?: ReleaseSafetyArtifactLoadResult;
     migrationState?: KnexMigrationState;
     inventoryValue?: PendingMigrationInventoryItem[];
     probeValue?: PreflightProbe;
@@ -99,7 +106,8 @@ const report = async ({
     strict?: boolean;
 } = {}): Promise<PreflightReport> =>
     runPreflight({
-        artifactLoad: {
+        artifactLoad: artifactLoadValue ?? {
+            status: 'present',
             artifact: artifactValue,
             error: null,
             path: '/usr/app/release-safety.json',
@@ -133,6 +141,139 @@ describe('preflight thresholds', () => {
 });
 
 describe('release-safety artifact handling', () => {
+    test('warns when the baked release-safety artifact is absent', async () => {
+        const directory = await mkdtemp(
+            path.join(tmpdir(), 'release-safety-absent-'),
+        );
+        const artifactPath = path.join(directory, 'release-safety.json');
+
+        try {
+            const artifactLoad = await loadReleaseSafetyArtifact(artifactPath);
+            const result = await report({ artifactLoadValue: artifactLoad });
+
+            expect(artifactLoad).toMatchObject({
+                status: 'absent',
+                artifact: null,
+                error: null,
+                path: artifactPath,
+            });
+            expect(check(result, 'version-path')).toMatchObject({
+                severity: 'yellow',
+                outcome: 'warn',
+                message:
+                    'No baked release-safety artifact is present; required-stop verification was skipped; upgrade-path safety cannot be verified on this image',
+                data: { artifactError: null },
+            });
+            expect(result).toMatchObject({
+                decision: 'proceed-with-warnings',
+                summary: { red: 0, yellow: 1 },
+            });
+            expect(renderPreflightReport(result)).toContain(
+                '[YELLOW WARN] version-path: No baked release-safety artifact is present; required-stop verification was skipped; upgrade-path safety cannot be verified on this image',
+            );
+        } finally {
+            await rm(directory, { recursive: true });
+        }
+    });
+
+    test('aborts for an absent release-safety artifact under strict mode', async () => {
+        const directory = await mkdtemp(
+            path.join(tmpdir(), 'release-safety-absent-strict-'),
+        );
+        const artifactPath = path.join(directory, 'release-safety.json');
+
+        try {
+            const artifactLoad = await loadReleaseSafetyArtifact(artifactPath);
+            const result = await report({
+                artifactLoadValue: artifactLoad,
+                strict: true,
+            });
+
+            expect(check(result, 'version-path')).toMatchObject({
+                severity: 'yellow',
+                outcome: 'warn',
+            });
+            expect(result.decision).toBe('abort');
+        } finally {
+            await rm(directory, { recursive: true });
+        }
+    });
+
+    test('fails when a present release-safety artifact is corrupt', async () => {
+        const directory = await mkdtemp(
+            path.join(tmpdir(), 'release-safety-corrupt-'),
+        );
+        const artifactPath = path.join(directory, 'release-safety.json');
+
+        try {
+            await writeFile(artifactPath, '{', 'utf8');
+            const artifactLoad = await loadReleaseSafetyArtifact(artifactPath);
+            const result = await report({ artifactLoadValue: artifactLoad });
+
+            expect(artifactLoad).toMatchObject({
+                status: 'present',
+                artifact: null,
+                error: expect.stringContaining(
+                    'release-safety artifact is not valid JSON',
+                ),
+                path: artifactPath,
+            });
+            expect(check(result, 'version-path')).toMatchObject({
+                severity: 'red',
+                outcome: 'fail',
+                message: expect.stringContaining(
+                    'The baked release-safety artifact could not be read',
+                ),
+            });
+            expect(result).toMatchObject({
+                decision: 'abort',
+                summary: { red: 1, yellow: 0 },
+            });
+        } finally {
+            await rm(directory, { recursive: true });
+        }
+    });
+
+    test('preserves valid loaded artifact behavior', async () => {
+        const directory = await mkdtemp(
+            path.join(tmpdir(), 'release-safety-valid-'),
+        );
+        const artifactPath = path.join(directory, 'release-safety.json');
+        const artifactValue = artifact();
+
+        try {
+            await writeFile(
+                artifactPath,
+                JSON.stringify(artifactValue),
+                'utf8',
+            );
+            const artifactLoad = await loadReleaseSafetyArtifact(artifactPath);
+            const result = await report({ artifactLoadValue: artifactLoad });
+
+            expect(artifactLoad).toMatchObject({
+                status: 'present',
+                artifact: {
+                    schemaVersion: '2',
+                    version: '1.122.0',
+                    previousVersion: '1.121.1',
+                },
+                error: null,
+                path: artifactPath,
+            });
+            expect(artifactLoad.artifact?.migrations.files[0]?.tables).toEqual([
+                'login_grants',
+                'users',
+            ]);
+            expect(check(result, 'version-path')).toMatchObject({
+                severity: 'red',
+                outcome: 'pass',
+            });
+            expect(result.decision).toBe('proceed');
+        } finally {
+            await rm(directory, { recursive: true });
+        }
+    });
+
     test('parses the required contract-v2 fields and sorts deterministic arrays', () => {
         const parsed = parseReleaseSafetyArtifact(
             JSON.stringify({

--- a/packages/backend/src/scripts/migrate/preflight.test.ts
+++ b/packages/backend/src/scripts/migrate/preflight.test.ts
@@ -1,0 +1,581 @@
+import { type Knex } from 'knex';
+import path from 'node:path';
+import { type KnexMigrationState } from './migrationState';
+import {
+    getPendingMigrationInventory,
+    LONG_TRANSACTION_THRESHOLD_SECONDS,
+    MIN_DISK_HEADROOM_BYTES,
+    MIN_SUPPORTED_POSTGRES_MAJOR,
+    normalizeMigrationName,
+    parseDiskHeadroomBytes,
+    parseReleaseSafetyArtifact,
+    resolveReleaseSafetyArtifactPath,
+    runPreflight,
+    type PendingMigrationInventoryItem,
+    type PreflightCheck,
+    type PreflightProbe,
+    type PreflightReport,
+    type ReleaseSafetyArtifact,
+} from './preflight';
+
+const artifact = (
+    overrides: Partial<ReleaseSafetyArtifact> = {},
+): ReleaseSafetyArtifact => ({
+    schemaVersion: '2',
+    version: '1.122.0',
+    previousVersion: '1.121.1',
+    migrations: {
+        files: [
+            {
+                name: '20260811110000_create_grants.ts',
+                edition: 'core',
+                tables: ['users', 'login_grants'],
+                heaviness: {
+                    locksTable: true,
+                    rewritesTable: false,
+                    scansTable: true,
+                },
+            },
+        ],
+    },
+    upgrade: {
+        minPreviousVersion: '1.111.0',
+        requiredStops: [],
+    },
+    ...overrides,
+});
+
+const state = (
+    overrides: Partial<KnexMigrationState> = {},
+): KnexMigrationState => ({
+    completed: ['20260810100000_previous.js'],
+    pending: ['20260811110000_create_grants.js'],
+    missing: [],
+    offending: [],
+    classification: 'database-behind',
+    ...overrides,
+});
+
+const inventory: PendingMigrationInventoryItem[] = [
+    {
+        name: '20260811110000_create_grants.js',
+        transaction: false,
+        tables: ['login_grants', 'users'],
+        metadataAvailable: true,
+    },
+];
+
+const probe = (overrides: Partial<PreflightProbe> = {}): PreflightProbe => ({
+    getPostgresVersion: vi.fn(async () => ({
+        serverVersion: '16.4',
+        serverVersionNum: 160004,
+    })),
+    getMigrationPrivileges: vi.fn(async () => ({
+        schemaName: 'public',
+        canCreateInSchema: true,
+        unownedTables: [],
+    })),
+    getRelationActivity: vi.fn(async () => []),
+    getDiskHeadroom: vi.fn<PreflightProbe['getDiskHeadroom']>(async () => ({
+        availableBytes: MIN_DISK_HEADROOM_BYTES,
+        source: 'configured',
+    })),
+    ...overrides,
+});
+
+const report = async ({
+    artifactValue = artifact(),
+    migrationState = state(),
+    inventoryValue = inventory,
+    probeValue = probe(),
+    force = false,
+    strict = false,
+}: {
+    artifactValue?: ReleaseSafetyArtifact;
+    migrationState?: KnexMigrationState;
+    inventoryValue?: PendingMigrationInventoryItem[];
+    probeValue?: PreflightProbe;
+    force?: boolean;
+    strict?: boolean;
+} = {}): Promise<PreflightReport> =>
+    runPreflight({
+        artifactLoad: {
+            artifact: artifactValue,
+            error: null,
+            path: '/usr/app/release-safety.json',
+        },
+        migrationState,
+        inventory: inventoryValue,
+        probe: probeValue,
+        options: { force, strict },
+    });
+
+const check = <Id extends PreflightCheck['id']>(
+    value: PreflightReport,
+    id: Id,
+): Extract<PreflightCheck, { id: Id }> => {
+    const match = value.checks.find(
+        (candidate): candidate is Extract<PreflightCheck, { id: Id }> =>
+            candidate.id === id,
+    );
+    if (match === undefined) {
+        throw new Error(`Missing preflight check ${id}`);
+    }
+    return match;
+};
+
+describe('preflight thresholds', () => {
+    test('centralizes the supported version, long transaction, and disk thresholds', () => {
+        expect(MIN_SUPPORTED_POSTGRES_MAJOR).toBe(12);
+        expect(LONG_TRANSACTION_THRESHOLD_SECONDS).toBe(300);
+        expect(MIN_DISK_HEADROOM_BYTES).toBe(5 * 1024 * 1024 * 1024);
+    });
+});
+
+describe('release-safety artifact handling', () => {
+    test('parses the required contract-v2 fields and sorts deterministic arrays', () => {
+        const parsed = parseReleaseSafetyArtifact(
+            JSON.stringify({
+                schemaVersion: '2',
+                version: '1.122.0',
+                previousVersion: '1.121.1',
+                migrations: {
+                    files: [
+                        {
+                            name: 'b.ts',
+                            edition: 'core',
+                            tables: ['z', 'a'],
+                            heaviness: {
+                                locksTable: true,
+                                rewritesTable: false,
+                                scansTable: 'unknown',
+                            },
+                        },
+                        {
+                            name: 'a.ts',
+                            edition: 'ee',
+                            tables: [],
+                            heaviness: {
+                                locksTable: false,
+                                rewritesTable: false,
+                                scansTable: false,
+                            },
+                        },
+                    ],
+                },
+                upgrade: {
+                    minPreviousVersion: null,
+                    requiredStops: ['1.120.0', '1.119.0'],
+                },
+            }),
+        );
+
+        expect(
+            parsed.migrations.files.map((migration) => migration.name),
+        ).toEqual(['a.ts', 'b.ts']);
+        expect(parsed.migrations.files[1]?.tables).toEqual(['a', 'z']);
+        expect(parsed.upgrade.requiredStops).toEqual(['1.119.0', '1.120.0']);
+    });
+
+    test('rejects malformed JSON and incomplete v2 shapes', () => {
+        expect(() => parseReleaseSafetyArtifact('{')).toThrow(
+            'release-safety artifact is not valid JSON',
+        );
+        expect(() =>
+            parseReleaseSafetyArtifact(JSON.stringify({ schemaVersion: '2' })),
+        ).toThrow('release-safety artifact does not match contract v2');
+    });
+
+    test('resolves production, development, and explicit artifact paths', () => {
+        expect(
+            resolveReleaseSafetyArtifactPath({
+                nodeEnv: 'production',
+                cwd: '/workspace',
+                override: '',
+            }),
+        ).toBe('/usr/app/release-safety.json');
+        expect(
+            resolveReleaseSafetyArtifactPath({
+                nodeEnv: 'test',
+                cwd: '/workspace',
+                override: '',
+            }),
+        ).toBe('/workspace/release-safety.json');
+        expect(
+            resolveReleaseSafetyArtifactPath({
+                nodeEnv: 'production',
+                cwd: '/workspace',
+                override: '/tmp/custom.json',
+            }),
+        ).toBe('/tmp/custom.json');
+    });
+});
+
+describe('pending migration inventory', () => {
+    test('matches artifact .ts names to production .js names and reports transaction false', async () => {
+        const getTransaction = vi.fn(
+            async (_config: Knex.MigratorConfig, _name: string) => false,
+        );
+
+        await expect(
+            getPendingMigrationInventory({
+                migrationState: state(),
+                migrationConfig: {},
+                artifact: artifact(),
+                getTransaction,
+            }),
+        ).resolves.toEqual(inventory);
+        expect(normalizeMigrationName('migration.ts')).toBe('migration');
+        expect(normalizeMigrationName('migration.js')).toBe('migration');
+        expect(normalizeMigrationName('migration.mjs')).toBe('migration.mjs');
+        expect(getTransaction).toHaveBeenCalledWith(
+            {},
+            '20260811110000_create_grants.js',
+        );
+    });
+
+    test('loads transaction configuration from a pending migration module', async () => {
+        const migrationName =
+            '20260722103000_enforce_dashboard_project_slug_uniqueness.ts';
+        const result = await getPendingMigrationInventory({
+            migrationState: state({ pending: [migrationName] }),
+            migrationConfig: {
+                directory: path.resolve(__dirname, '../../database/migrations'),
+                loadExtensions: ['.ts'],
+            },
+            artifact: null,
+        });
+
+        expect(result).toEqual([
+            {
+                name: migrationName,
+                transaction: false,
+                tables: [],
+                metadataAvailable: false,
+            },
+        ]);
+    });
+});
+
+describe('preflight checks', () => {
+    test('passes a direct-predecessor ledger across source and built extensions', async () => {
+        const result = await report();
+
+        expect(check(result, 'version-path')).toMatchObject({
+            outcome: 'pass',
+            data: { pendingMigrationsOutsideArtifact: [] },
+        });
+        expect(result.decision).toBe('proceed');
+    });
+
+    test('treats an empty completed ledger as a fresh install', async () => {
+        const result = await report({
+            artifactValue: artifact({
+                upgrade: {
+                    minPreviousVersion: '1.111.0',
+                    requiredStops: ['1.115.0'],
+                },
+            }),
+            migrationState: state({
+                completed: [],
+                pending: ['20200101000000_old.js'],
+            }),
+        });
+
+        expect(check(result, 'version-path')).toMatchObject({
+            outcome: 'pass',
+            message: expect.stringContaining('fresh install'),
+        });
+    });
+
+    test('treats a required stop equal to the target as being landed on', async () => {
+        const result = await report({
+            artifactValue: artifact({
+                upgrade: {
+                    minPreviousVersion: null,
+                    requiredStops: ['1.122.0'],
+                },
+            }),
+            migrationState: state({
+                pending: [
+                    '20260810150000_older_pending.js',
+                    '20260811110000_create_grants.js',
+                ],
+            }),
+        });
+
+        expect(check(result, 'version-path').outcome).toBe('pass');
+    });
+
+    test('fails unresolved historical boundaries when older migrations remain pending', async () => {
+        const result = await report({
+            artifactValue: artifact({
+                upgrade: {
+                    minPreviousVersion: '1.111.0',
+                    requiredStops: ['1.115.0'],
+                },
+            }),
+            migrationState: state({
+                pending: [
+                    '20260810150000_older_pending.js',
+                    '20260811110000_create_grants.js',
+                ],
+            }),
+        });
+
+        expect(check(result, 'version-path')).toMatchObject({
+            outcome: 'fail',
+            data: {
+                pendingMigrationsOutsideArtifact: [
+                    '20260810150000_older_pending.js',
+                ],
+            },
+        });
+        expect(result.decision).toBe('abort');
+    });
+
+    test('fails a diverged actual migration ledger', async () => {
+        const result = await report({
+            migrationState: state({
+                classification: 'diverged',
+                missing: ['20260810120000_unknown.js'],
+                offending: ['20260810120000_unknown.js'],
+            }),
+        });
+
+        expect(check(result, 'version-path').outcome).toBe('fail');
+    });
+
+    test('fails missing migration privileges and privilege probe errors', async () => {
+        const denied = await report({
+            probeValue: probe({
+                getMigrationPrivileges: vi.fn(async () => ({
+                    schemaName: 'public',
+                    canCreateInSchema: false,
+                    unownedTables: ['users'],
+                })),
+            }),
+        });
+        const unavailable = await report({
+            probeValue: probe({
+                getMigrationPrivileges: vi.fn(async () => {
+                    throw new Error('permission denied');
+                }),
+            }),
+        });
+
+        expect(check(denied, 'migration-privileges')).toMatchObject({
+            outcome: 'fail',
+            data: { canCreateInSchema: false, unownedTables: ['users'] },
+        });
+        expect(check(unavailable, 'migration-privileges')).toMatchObject({
+            outcome: 'fail',
+            data: { probeError: 'permission denied' },
+        });
+    });
+
+    test('fails unsupported PostgreSQL versions', async () => {
+        const result = await report({
+            probeValue: probe({
+                getPostgresVersion: vi.fn(async () => ({
+                    serverVersion: '11.22',
+                    serverVersionNum: 110022,
+                })),
+            }),
+        });
+
+        expect(check(result, 'postgres-version')).toMatchObject({
+            outcome: 'fail',
+            data: { minimumSupportedMajor: 12 },
+        });
+    });
+
+    test('warns for held locks and only classifies old transactions as long', async () => {
+        const result = await report({
+            probeValue: probe({
+                getRelationActivity: vi.fn(async () => [
+                    {
+                        pid: 20,
+                        table: 'users',
+                        lockMode: 'AccessShareLock',
+                        transactionAgeSeconds: 10,
+                    },
+                    {
+                        pid: 10,
+                        table: 'login_grants',
+                        lockMode: 'RowExclusiveLock',
+                        transactionAgeSeconds:
+                            LONG_TRANSACTION_THRESHOLD_SECONDS,
+                    },
+                ]),
+            }),
+        });
+
+        expect(check(result, 'held-locks')).toMatchObject({
+            outcome: 'warn',
+            data: { tables: ['login_grants', 'users'] },
+        });
+        expect(check(result, 'long-transactions')).toMatchObject({
+            outcome: 'warn',
+            data: { transactions: [{ pid: 10 }] },
+        });
+        expect(result.decision).toBe('proceed-with-warnings');
+    });
+
+    test('warns for low and unavailable disk headroom without inferring it from database size', async () => {
+        const low = await report({
+            probeValue: probe({
+                getDiskHeadroom: vi.fn<PreflightProbe['getDiskHeadroom']>(
+                    async () => ({
+                        availableBytes: MIN_DISK_HEADROOM_BYTES - 1,
+                        source: 'configured',
+                    }),
+                ),
+            }),
+        });
+        const unavailable = await report({
+            probeValue: probe({
+                getDiskHeadroom: vi.fn<PreflightProbe['getDiskHeadroom']>(
+                    async () => ({
+                        availableBytes: null,
+                        source: 'unavailable',
+                    }),
+                ),
+            }),
+        });
+
+        expect(check(low, 'disk-headroom')).toMatchObject({
+            outcome: 'warn',
+            data: {
+                applicable: true,
+                availableBytes: MIN_DISK_HEADROOM_BYTES - 1,
+            },
+        });
+        expect(check(unavailable, 'disk-headroom')).toMatchObject({
+            outcome: 'warn',
+            data: {
+                applicable: true,
+                availableBytes: null,
+                source: 'unavailable',
+            },
+        });
+    });
+
+    test('does not require disk headroom when no pending migration scans or rewrites a table', async () => {
+        const getDiskHeadroom = vi.fn<PreflightProbe['getDiskHeadroom']>(
+            async () => ({
+                availableBytes: null,
+                source: 'unavailable',
+            }),
+        );
+        const result = await report({
+            migrationState: state({
+                pending: [],
+                classification: 'up-to-date',
+            }),
+            inventoryValue: [],
+            probeValue: probe({ getDiskHeadroom }),
+            strict: true,
+        });
+
+        expect(check(result, 'disk-headroom')).toMatchObject({
+            outcome: 'pass',
+            data: { applicable: false, availableBytes: null },
+        });
+        expect(getDiskHeadroom).not.toHaveBeenCalled();
+        expect(result.decision).toBe('proceed');
+    });
+
+    test('reports the pending migration inventory with explicit nulls', async () => {
+        const result = await report({
+            inventoryValue: [
+                {
+                    name: 'older.js',
+                    transaction: null,
+                    tables: [],
+                    metadataAvailable: false,
+                },
+            ],
+        });
+
+        expect(check(result, 'pending-migrations')).toEqual({
+            id: 'pending-migrations',
+            severity: 'info',
+            outcome: 'info',
+            message: '1 pending migration(s)',
+            data: {
+                migrations: [
+                    {
+                        name: 'older.js',
+                        transaction: null,
+                        tables: [],
+                        metadataAvailable: false,
+                    },
+                ],
+            },
+        });
+    });
+});
+
+describe('preflight decisions', () => {
+    test('promotes yellow to abort under strict and lets force override red or strict', async () => {
+        const warningProbe = probe({
+            getDiskHeadroom: vi.fn<PreflightProbe['getDiskHeadroom']>(
+                async () => ({
+                    availableBytes: null,
+                    source: 'unavailable',
+                }),
+            ),
+        });
+        const normal = await report({ probeValue: warningProbe });
+        const strict = await report({
+            probeValue: warningProbe,
+            strict: true,
+        });
+        const strictForced = await report({
+            probeValue: warningProbe,
+            strict: true,
+            force: true,
+        });
+        const redForced = await report({
+            force: true,
+            migrationState: state({
+                classification: 'diverged',
+                offending: ['unknown.js'],
+            }),
+        });
+
+        expect(normal.decision).toBe('proceed-with-warnings');
+        expect(strict.decision).toBe('abort');
+        expect(strictForced.decision).toBe('force-proceed');
+        expect(redForced.decision).toBe('force-proceed');
+    });
+
+    test('serializes a stable deterministic JSON payload', async () => {
+        const first = JSON.stringify(await report());
+        const second = JSON.stringify(await report());
+
+        expect(first).toBe(second);
+        expect(JSON.parse(first)).toMatchObject({
+            schemaVersion: '1',
+            decision: 'proceed',
+            force: false,
+            strict: false,
+            summary: { red: 0, yellow: 0, info: 1 },
+        });
+    });
+});
+
+describe('disk headroom configuration', () => {
+    test('parses explicit bytes and rejects malformed values', () => {
+        expect(parseDiskHeadroomBytes(undefined)).toBeNull();
+        expect(parseDiskHeadroomBytes('0')).toBe(0);
+        expect(parseDiskHeadroomBytes('1024')).toBe(1024);
+        expect(() => parseDiskHeadroomBytes('-1')).toThrow(
+            'MIGRATION_PREFLIGHT_DISK_HEADROOM_BYTES must be a non-negative safe integer',
+        );
+        expect(() => parseDiskHeadroomBytes('1.5')).toThrow(
+            'MIGRATION_PREFLIGHT_DISK_HEADROOM_BYTES must be a non-negative safe integer',
+        );
+    });
+});

--- a/packages/backend/src/scripts/migrate/preflight.ts
+++ b/packages/backend/src/scripts/migrate/preflight.ts
@@ -1,0 +1,945 @@
+import { type Knex } from 'knex';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { type KnexMigrationState } from './migrationState';
+
+export const MIN_SUPPORTED_POSTGRES_MAJOR = 12;
+export const LONG_TRANSACTION_THRESHOLD_SECONDS = 5 * 60;
+export const MIN_DISK_HEADROOM_BYTES = 5 * 1024 * 1024 * 1024;
+export const RELEASE_SAFETY_ARTIFACT_PATH = '/usr/app/release-safety.json';
+
+type MigrationHeaviness = {
+    locksTable: boolean | 'unknown';
+    rewritesTable: boolean | 'unknown';
+    scansTable: boolean | 'unknown';
+};
+
+type ReleaseSafetyMigration = {
+    name: string;
+    edition: 'core' | 'ee';
+    tables: string[];
+    heaviness: MigrationHeaviness;
+};
+
+export type ReleaseSafetyArtifact = {
+    schemaVersion: '2';
+    version: string;
+    previousVersion: string | null;
+    migrations: {
+        files: ReleaseSafetyMigration[];
+    };
+    upgrade: {
+        minPreviousVersion: string | null;
+        requiredStops: string[];
+    };
+};
+
+export type ReleaseSafetyArtifactLoadResult =
+    | { artifact: ReleaseSafetyArtifact; error: null; path: string }
+    | { artifact: null; error: string; path: string };
+
+export type PendingMigrationInventoryItem = {
+    name: string;
+    transaction: boolean | null;
+    tables: string[];
+    metadataAvailable: boolean;
+};
+
+export type PostgresVersionProbeResult = {
+    serverVersion: string;
+    serverVersionNum: number;
+};
+
+export type MigrationPrivilegesProbeResult = {
+    schemaName: string | null;
+    canCreateInSchema: boolean;
+    unownedTables: string[];
+};
+
+export type RelationActivityProbeResult = {
+    pid: number;
+    table: string;
+    lockMode: string;
+    transactionAgeSeconds: number | null;
+};
+
+export type DiskHeadroomProbeResult = {
+    availableBytes: number | null;
+    source: 'configured' | 'unavailable';
+};
+
+export type PreflightProbe = {
+    getPostgresVersion: () => Promise<PostgresVersionProbeResult>;
+    getMigrationPrivileges: (
+        tables: string[],
+    ) => Promise<MigrationPrivilegesProbeResult>;
+    getRelationActivity: (
+        tables: string[],
+    ) => Promise<RelationActivityProbeResult[]>;
+    getDiskHeadroom: () => Promise<DiskHeadroomProbeResult>;
+};
+
+type RedOutcome = 'pass' | 'fail';
+type YellowOutcome = 'pass' | 'warn';
+
+export type VersionPathCheck = {
+    id: 'version-path';
+    severity: 'red';
+    outcome: RedOutcome;
+    message: string;
+    data: {
+        artifactPath: string;
+        targetVersion: string | null;
+        previousVersion: string | null;
+        minPreviousVersion: string | null;
+        requiredStops: string[];
+        completedMigrationCount: number;
+        pendingMigrationsOutsideArtifact: string[];
+        artifactError: string | null;
+    };
+};
+
+export type MigrationPrivilegesCheck = {
+    id: 'migration-privileges';
+    severity: 'red';
+    outcome: RedOutcome;
+    message: string;
+    data: {
+        schemaName: string | null;
+        canCreateInSchema: boolean | null;
+        unownedTables: string[];
+        probeError: string | null;
+    };
+};
+
+export type PostgresVersionCheck = {
+    id: 'postgres-version';
+    severity: 'red';
+    outcome: RedOutcome;
+    message: string;
+    data: {
+        serverVersion: string | null;
+        serverVersionNum: number | null;
+        minimumSupportedMajor: number;
+        probeError: string | null;
+    };
+};
+
+export type HeldLocksCheck = {
+    id: 'held-locks';
+    severity: 'yellow';
+    outcome: YellowOutcome;
+    message: string;
+    data: {
+        tables: string[];
+        locks: RelationActivityProbeResult[];
+        probeError: string | null;
+    };
+};
+
+export type LongTransactionsCheck = {
+    id: 'long-transactions';
+    severity: 'yellow';
+    outcome: YellowOutcome;
+    message: string;
+    data: {
+        thresholdSeconds: number;
+        transactions: RelationActivityProbeResult[];
+        probeError: string | null;
+    };
+};
+
+export type DiskHeadroomCheck = {
+    id: 'disk-headroom';
+    severity: 'yellow';
+    outcome: YellowOutcome;
+    message: string;
+    data: {
+        applicable: boolean;
+        availableBytes: number | null;
+        minimumBytes: number;
+        source: 'configured' | 'unavailable';
+    };
+};
+
+export type PendingMigrationsCheck = {
+    id: 'pending-migrations';
+    severity: 'info';
+    outcome: 'info';
+    message: string;
+    data: {
+        migrations: PendingMigrationInventoryItem[];
+    };
+};
+
+export type PreflightCheck =
+    | VersionPathCheck
+    | MigrationPrivilegesCheck
+    | PostgresVersionCheck
+    | HeldLocksCheck
+    | LongTransactionsCheck
+    | DiskHeadroomCheck
+    | PendingMigrationsCheck;
+
+export type PreflightRunOptions = {
+    force: boolean;
+    strict: boolean;
+};
+
+export type PreflightReport = {
+    schemaVersion: '1';
+    decision: 'proceed' | 'proceed-with-warnings' | 'abort' | 'force-proceed';
+    force: boolean;
+    strict: boolean;
+    summary: {
+        red: number;
+        yellow: number;
+        info: number;
+    };
+    checks: PreflightCheck[];
+};
+
+type PreflightInput = {
+    artifactLoad: ReleaseSafetyArtifactLoadResult;
+    migrationState: KnexMigrationState;
+    inventory: PendingMigrationInventoryItem[];
+    probe: PreflightProbe;
+    options: PreflightRunOptions;
+};
+
+type RawPostgresVersionResult = {
+    rows: Array<{
+        server_version: string;
+        server_version_num: number | string;
+    }>;
+};
+
+type RawMigrationPrivilegesResult = {
+    rows: Array<{
+        schema_name: string | null;
+        can_create_in_schema: boolean;
+    }>;
+};
+
+type RawUnownedTablesResult = {
+    rows: Array<{
+        table_name: string;
+    }>;
+};
+
+type RawRelationActivityResult = {
+    rows: Array<{
+        pid: number | string;
+        table_name: string;
+        lock_mode: string;
+        transaction_age_seconds: number | string | null;
+    }>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isStringArray = (value: unknown): value is string[] =>
+    Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+const parseMigrationHeaviness = (value: unknown): MigrationHeaviness | null => {
+    if (!isRecord(value)) {
+        return null;
+    }
+    const values = [value.locksTable, value.rewritesTable, value.scansTable];
+    if (
+        !values.every((item) => typeof item === 'boolean' || item === 'unknown')
+    ) {
+        return null;
+    }
+    return {
+        locksTable: value.locksTable as boolean | 'unknown',
+        rewritesTable: value.rewritesTable as boolean | 'unknown',
+        scansTable: value.scansTable as boolean | 'unknown',
+    };
+};
+
+const parseReleaseSafetyMigration = (
+    value: unknown,
+): ReleaseSafetyMigration | null => {
+    if (!isRecord(value)) {
+        return null;
+    }
+    const heaviness = parseMigrationHeaviness(value.heaviness);
+    if (
+        typeof value.name !== 'string' ||
+        (value.edition !== 'core' && value.edition !== 'ee') ||
+        !isStringArray(value.tables) ||
+        heaviness === null
+    ) {
+        return null;
+    }
+    return {
+        name: value.name,
+        edition: value.edition,
+        tables: [...value.tables].sort(),
+        heaviness,
+    };
+};
+
+export const parseReleaseSafetyArtifact = (
+    raw: string,
+): ReleaseSafetyArtifact => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw) as unknown;
+    } catch (error) {
+        throw new Error(
+            `release-safety artifact is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+    if (
+        !isRecord(parsed) ||
+        parsed.schemaVersion !== '2' ||
+        typeof parsed.version !== 'string' ||
+        (parsed.previousVersion !== null &&
+            typeof parsed.previousVersion !== 'string') ||
+        !isRecord(parsed.migrations) ||
+        !Array.isArray(parsed.migrations.files) ||
+        !isRecord(parsed.upgrade) ||
+        (parsed.upgrade.minPreviousVersion !== null &&
+            typeof parsed.upgrade.minPreviousVersion !== 'string') ||
+        !isStringArray(parsed.upgrade.requiredStops)
+    ) {
+        throw new Error('release-safety artifact does not match contract v2');
+    }
+    const migrations = parsed.migrations.files.map(parseReleaseSafetyMigration);
+    if (migrations.some((migration) => migration === null)) {
+        throw new Error('release-safety artifact does not match contract v2');
+    }
+    return {
+        schemaVersion: '2',
+        version: parsed.version,
+        previousVersion: parsed.previousVersion,
+        migrations: {
+            files: (migrations as ReleaseSafetyMigration[]).sort(
+                (left, right) => left.name.localeCompare(right.name),
+            ),
+        },
+        upgrade: {
+            minPreviousVersion: parsed.upgrade.minPreviousVersion,
+            requiredStops: [...parsed.upgrade.requiredStops].sort(),
+        },
+    };
+};
+
+export const resolveReleaseSafetyArtifactPath = ({
+    nodeEnv = process.env.NODE_ENV,
+    cwd = process.cwd(),
+    override = process.env.RELEASE_SAFETY_ARTIFACT_PATH,
+}: {
+    nodeEnv?: string;
+    cwd?: string;
+    override?: string;
+} = {}): string => {
+    if (override !== undefined && override.length > 0) {
+        return path.resolve(override);
+    }
+    return nodeEnv === 'production'
+        ? RELEASE_SAFETY_ARTIFACT_PATH
+        : path.resolve(cwd, 'release-safety.json');
+};
+
+export const loadReleaseSafetyArtifact = async (
+    artifactPath = resolveReleaseSafetyArtifactPath(),
+): Promise<ReleaseSafetyArtifactLoadResult> => {
+    try {
+        const raw = await fs.readFile(artifactPath, 'utf8');
+        return {
+            artifact: parseReleaseSafetyArtifact(raw),
+            error: null,
+            path: artifactPath,
+        };
+    } catch (error) {
+        return {
+            artifact: null,
+            error: error instanceof Error ? error.message : String(error),
+            path: artifactPath,
+        };
+    }
+};
+
+export const normalizeMigrationName = (migrationName: string): string =>
+    migrationName.replace(/\.(?:js|ts)$/, '');
+
+const migrationDirectories = (config: Knex.MigratorConfig): string[] => {
+    if (config.directory === undefined) {
+        return [];
+    }
+    return typeof config.directory === 'string'
+        ? [config.directory]
+        : [...config.directory];
+};
+
+const readMigrationTransaction = async (
+    config: Knex.MigratorConfig,
+    migrationName: string,
+): Promise<boolean | null> => {
+    if (path.basename(migrationName) !== migrationName) {
+        return null;
+    }
+    const reads = await Promise.all(
+        migrationDirectories(config).map(async (directory) => {
+            try {
+                return {
+                    source: await fs.readFile(
+                        path.join(directory, migrationName),
+                        'utf8',
+                    ),
+                    error: null,
+                };
+            } catch (error) {
+                return {
+                    source: null,
+                    error:
+                        isRecord(error) && error.code === 'ENOENT'
+                            ? null
+                            : error,
+                };
+            }
+        }),
+    );
+    if (reads.some((read) => read.error !== null)) {
+        return null;
+    }
+    const source = reads.find((read) => read.source !== null)?.source ?? null;
+    return source === null
+        ? null
+        : !/(?:export\s+const\s+config(?:\s*:[^=]+)?|exports\.config)\s*=\s*\{[^}]*\btransaction\s*:\s*false\b[^}]*\}/s.test(
+              source,
+          );
+};
+
+export const getPendingMigrationInventory = async ({
+    migrationState,
+    migrationConfig,
+    artifact,
+    getTransaction = readMigrationTransaction,
+}: {
+    migrationState: KnexMigrationState;
+    migrationConfig: Knex.MigratorConfig;
+    artifact: ReleaseSafetyArtifact | null;
+    getTransaction?: (
+        config: Knex.MigratorConfig,
+        migrationName: string,
+    ) => Promise<boolean | null>;
+}): Promise<PendingMigrationInventoryItem[]> => {
+    const metadata = new Map(
+        artifact?.migrations.files.map((migration) => [
+            normalizeMigrationName(migration.name),
+            migration,
+        ]) ?? [],
+    );
+    return Promise.all(
+        migrationState.pending.map(async (name) => {
+            const migration =
+                metadata.get(normalizeMigrationName(name)) ?? null;
+            return {
+                name,
+                transaction: await getTransaction(migrationConfig, name),
+                tables: migration === null ? [] : [...migration.tables].sort(),
+                metadataAvailable: migration !== null,
+            };
+        }),
+    );
+};
+
+const messageFromError = (error: unknown): string =>
+    error instanceof Error ? error.message : String(error);
+
+const versionPathCheck = (
+    artifactLoad: ReleaseSafetyArtifactLoadResult,
+    migrationState: KnexMigrationState,
+): VersionPathCheck => {
+    const { artifact } = artifactLoad;
+    const artifactMigrationNames = new Set(
+        artifact?.migrations.files.map((migration) =>
+            normalizeMigrationName(migration.name),
+        ) ?? [],
+    );
+    const pendingMigrationsOutsideArtifact = migrationState.pending.filter(
+        (migration) =>
+            !artifactMigrationNames.has(normalizeMigrationName(migration)),
+    );
+    const data: VersionPathCheck['data'] = {
+        artifactPath: artifactLoad.path,
+        targetVersion: artifact?.version ?? null,
+        previousVersion: artifact?.previousVersion ?? null,
+        minPreviousVersion: artifact?.upgrade.minPreviousVersion ?? null,
+        requiredStops: artifact?.upgrade.requiredStops ?? [],
+        completedMigrationCount: migrationState.completed.length,
+        pendingMigrationsOutsideArtifact,
+        artifactError: artifactLoad.error,
+    };
+    if (artifact === null) {
+        return {
+            id: 'version-path',
+            severity: 'red',
+            outcome: 'fail',
+            message: `The baked release-safety artifact could not be read: ${artifactLoad.error}`,
+            data,
+        };
+    }
+    if (migrationState.classification === 'diverged') {
+        return {
+            id: 'version-path',
+            severity: 'red',
+            outcome: 'fail',
+            message: `The actual knex_migrations ledger diverges from local migration files: ${migrationState.offending.join(', ')}`,
+            data,
+        };
+    }
+    const freshInstall = migrationState.completed.length === 0;
+    const directPredecessorOrUpToDate =
+        pendingMigrationsOutsideArtifact.length === 0;
+    const unresolvedHistoricalStops = artifact.upgrade.requiredStops.filter(
+        (requiredStop) => requiredStop !== artifact.version,
+    );
+    if (freshInstall) {
+        return {
+            id: 'version-path',
+            severity: 'red',
+            outcome: 'pass',
+            message:
+                'The knex_migrations ledger is empty, so this is a fresh install rather than an upgrade path',
+            data,
+        };
+    }
+    if (
+        !directPredecessorOrUpToDate &&
+        (artifact.upgrade.minPreviousVersion !== null ||
+            unresolvedHistoricalStops.length > 0)
+    ) {
+        return {
+            id: 'version-path',
+            severity: 'red',
+            outcome: 'fail',
+            message:
+                'The ledger has pending migrations outside this release artifact, and contract v2 does not map the unresolved historical path boundaries to migration-ledger entries',
+            data,
+        };
+    }
+    let message =
+        'The artifact declares no unresolved historical version-path boundary';
+    if (
+        artifact.upgrade.minPreviousVersion === null &&
+        unresolvedHistoricalStops.length === 0
+    ) {
+        message =
+            'The artifact declares no minimum previous version or required stops';
+    } else if (directPredecessorOrUpToDate) {
+        message =
+            'The migration ledger structurally matches the target artifact direct-predecessor or up-to-date path';
+    }
+    return {
+        id: 'version-path',
+        severity: 'red',
+        outcome: 'pass',
+        message,
+        data,
+    };
+};
+
+const migrationPrivilegesCheck = async (
+    probe: PreflightProbe,
+    tables: string[],
+): Promise<MigrationPrivilegesCheck> => {
+    try {
+        const result = await probe.getMigrationPrivileges(tables);
+        const allowed =
+            result.schemaName !== null &&
+            result.canCreateInSchema &&
+            result.unownedTables.length === 0;
+        return {
+            id: 'migration-privileges',
+            severity: 'red',
+            outcome: allowed ? 'pass' : 'fail',
+            message: allowed
+                ? `The migration user can create objects in schema ${result.schemaName} and owns all existing pending-migration tables`
+                : `The migration user lacks required DDL privileges in schema ${result.schemaName}`,
+            data: {
+                schemaName: result.schemaName,
+                canCreateInSchema: result.canCreateInSchema,
+                unownedTables: [...result.unownedTables].sort(),
+                probeError: null,
+            },
+        };
+    } catch (error) {
+        return {
+            id: 'migration-privileges',
+            severity: 'red',
+            outcome: 'fail',
+            message: `Migration privileges could not be verified: ${messageFromError(error)}`,
+            data: {
+                schemaName: null,
+                canCreateInSchema: null,
+                unownedTables: [],
+                probeError: messageFromError(error),
+            },
+        };
+    }
+};
+
+const postgresVersionCheck = async (
+    probe: PreflightProbe,
+): Promise<PostgresVersionCheck> => {
+    try {
+        const result = await probe.getPostgresVersion();
+        const major = Math.floor(result.serverVersionNum / 10_000);
+        const supported = major >= MIN_SUPPORTED_POSTGRES_MAJOR;
+        return {
+            id: 'postgres-version',
+            severity: 'red',
+            outcome: supported ? 'pass' : 'fail',
+            message: supported
+                ? `PostgreSQL ${result.serverVersion} is supported`
+                : `PostgreSQL ${result.serverVersion} is unsupported; version ${MIN_SUPPORTED_POSTGRES_MAJOR} or newer is required`,
+            data: {
+                serverVersion: result.serverVersion,
+                serverVersionNum: result.serverVersionNum,
+                minimumSupportedMajor: MIN_SUPPORTED_POSTGRES_MAJOR,
+                probeError: null,
+            },
+        };
+    } catch (error) {
+        return {
+            id: 'postgres-version',
+            severity: 'red',
+            outcome: 'fail',
+            message: `The PostgreSQL version could not be verified: ${messageFromError(error)}`,
+            data: {
+                serverVersion: null,
+                serverVersionNum: null,
+                minimumSupportedMajor: MIN_SUPPORTED_POSTGRES_MAJOR,
+                probeError: messageFromError(error),
+            },
+        };
+    }
+};
+
+const activityChecks = async (
+    probe: PreflightProbe,
+    tables: string[],
+): Promise<[HeldLocksCheck, LongTransactionsCheck]> => {
+    try {
+        const activity = (await probe.getRelationActivity(tables)).sort(
+            (left, right) =>
+                left.table.localeCompare(right.table) || left.pid - right.pid,
+        );
+        const longTransactions = activity.filter(
+            (row) =>
+                (row.transactionAgeSeconds ?? 0) >=
+                LONG_TRANSACTION_THRESHOLD_SECONDS,
+        );
+        return [
+            {
+                id: 'held-locks',
+                severity: 'yellow',
+                outcome: activity.length > 0 ? 'warn' : 'pass',
+                message:
+                    activity.length > 0
+                        ? `${activity.length} held relation lock(s) may delay DDL on pending-migration tables`
+                        : 'No other sessions hold relation locks on pending-migration DDL tables',
+                data: { tables, locks: activity, probeError: null },
+            },
+            {
+                id: 'long-transactions',
+                severity: 'yellow',
+                outcome: longTransactions.length > 0 ? 'warn' : 'pass',
+                message:
+                    longTransactions.length > 0
+                        ? `${longTransactions.length} long-running transaction(s) hold locks on pending-migration DDL tables`
+                        : 'No long-running transactions hold locks on pending-migration DDL tables',
+                data: {
+                    thresholdSeconds: LONG_TRANSACTION_THRESHOLD_SECONDS,
+                    transactions: longTransactions,
+                    probeError: null,
+                },
+            },
+        ];
+    } catch (error) {
+        const probeError = messageFromError(error);
+        return [
+            {
+                id: 'held-locks',
+                severity: 'yellow',
+                outcome: 'warn',
+                message: `Held locks could not be inspected: ${probeError}`,
+                data: { tables, locks: [], probeError },
+            },
+            {
+                id: 'long-transactions',
+                severity: 'yellow',
+                outcome: 'warn',
+                message: `Long-running transactions could not be inspected: ${probeError}`,
+                data: {
+                    thresholdSeconds: LONG_TRANSACTION_THRESHOLD_SECONDS,
+                    transactions: [],
+                    probeError,
+                },
+            },
+        ];
+    }
+};
+
+const diskHeadroomCheck = async (
+    probe: PreflightProbe,
+    applicable: boolean,
+): Promise<DiskHeadroomCheck> => {
+    if (!applicable) {
+        return {
+            id: 'disk-headroom',
+            severity: 'yellow',
+            outcome: 'pass',
+            message:
+                'Disk headroom is not applicable because no pending artifact migration scans or rewrites a table',
+            data: {
+                applicable: false,
+                availableBytes: null,
+                minimumBytes: MIN_DISK_HEADROOM_BYTES,
+                source: 'unavailable',
+            },
+        };
+    }
+    try {
+        const result = await probe.getDiskHeadroom();
+        const sufficient =
+            result.availableBytes !== null &&
+            result.availableBytes >= MIN_DISK_HEADROOM_BYTES;
+        let message = 'Configured disk headroom is below the preflight minimum';
+        if (result.availableBytes === null) {
+            message =
+                'Disk headroom is unavailable from PostgreSQL without an external capacity signal';
+        } else if (sufficient) {
+            message = 'Configured disk headroom is above the preflight minimum';
+        }
+        return {
+            id: 'disk-headroom',
+            severity: 'yellow',
+            outcome: sufficient ? 'pass' : 'warn',
+            message,
+            data: {
+                applicable: true,
+                availableBytes: result.availableBytes,
+                minimumBytes: MIN_DISK_HEADROOM_BYTES,
+                source: result.source,
+            },
+        };
+    } catch {
+        return {
+            id: 'disk-headroom',
+            severity: 'yellow',
+            outcome: 'warn',
+            message:
+                'Disk headroom is unavailable from PostgreSQL without an external capacity signal',
+            data: {
+                applicable: true,
+                availableBytes: null,
+                minimumBytes: MIN_DISK_HEADROOM_BYTES,
+                source: 'unavailable',
+            },
+        };
+    }
+};
+
+const pendingMigrationsCheck = (
+    inventory: PendingMigrationInventoryItem[],
+): PendingMigrationsCheck => ({
+    id: 'pending-migrations',
+    severity: 'info',
+    outcome: 'info',
+    message: `${inventory.length} pending migration(s)`,
+    data: { migrations: inventory },
+});
+
+export const runPreflight = async ({
+    artifactLoad,
+    migrationState,
+    inventory,
+    probe,
+    options,
+}: PreflightInput): Promise<PreflightReport> => {
+    const ddlTables = [
+        ...new Set(
+            (artifactLoad.artifact?.migrations.files ?? [])
+                .filter(
+                    (migration) =>
+                        migrationState.pending.some(
+                            (pendingMigration) =>
+                                normalizeMigrationName(pendingMigration) ===
+                                normalizeMigrationName(migration.name),
+                        ) && migration.heaviness.locksTable !== false,
+                )
+                .flatMap((migration) => migration.tables),
+        ),
+    ].sort();
+    const allTables = [
+        ...new Set(inventory.flatMap((migration) => migration.tables)),
+    ].sort();
+    const diskHeadroomApplicable = (
+        artifactLoad.artifact?.migrations.files ?? []
+    ).some(
+        (migration) =>
+            migrationState.pending.some(
+                (pendingMigration) =>
+                    normalizeMigrationName(pendingMigration) ===
+                    normalizeMigrationName(migration.name),
+            ) &&
+            (migration.heaviness.scansTable !== false ||
+                migration.heaviness.rewritesTable !== false),
+    );
+    const [privileges, postgresVersion, activity, diskHeadroom] =
+        await Promise.all([
+            migrationPrivilegesCheck(probe, allTables),
+            postgresVersionCheck(probe),
+            activityChecks(probe, ddlTables),
+            diskHeadroomCheck(probe, diskHeadroomApplicable),
+        ]);
+    const checks: PreflightCheck[] = [
+        versionPathCheck(artifactLoad, migrationState),
+        privileges,
+        postgresVersion,
+        activity[0],
+        activity[1],
+        diskHeadroom,
+        pendingMigrationsCheck(inventory),
+    ];
+    const red = checks.filter(
+        (check) => check.severity === 'red' && check.outcome === 'fail',
+    ).length;
+    const yellow = checks.filter(
+        (check) => check.severity === 'yellow' && check.outcome === 'warn',
+    ).length;
+    const info = checks.filter((check) => check.severity === 'info').length;
+    const shouldAbort = red > 0 || (options.strict && yellow > 0);
+    let decision: PreflightReport['decision'] = 'proceed';
+    if (shouldAbort) {
+        decision = options.force ? 'force-proceed' : 'abort';
+    } else if (yellow > 0) {
+        decision = 'proceed-with-warnings';
+    }
+    return {
+        schemaVersion: '1',
+        decision,
+        force: options.force,
+        strict: options.strict,
+        summary: { red, yellow, info },
+        checks,
+    };
+};
+
+export const renderPreflightReport = (report: PreflightReport): string => {
+    const lines = report.checks.map(
+        (check) =>
+            `[${check.severity.toUpperCase()} ${check.outcome.toUpperCase()}] ${check.id}: ${check.message}`,
+    );
+    lines.push(
+        `Preflight decision: ${report.decision} (${report.summary.red} red, ${report.summary.yellow} yellow)`,
+    );
+    return lines.join('\n');
+};
+
+export const parseDiskHeadroomBytes = (
+    value: string | undefined,
+): number | null => {
+    if (value === undefined || value.length === 0) {
+        return null;
+    }
+    const parsed = Number(value);
+    if (!Number.isSafeInteger(parsed) || parsed < 0) {
+        throw new Error(
+            'MIGRATION_PREFLIGHT_DISK_HEADROOM_BYTES must be a non-negative safe integer',
+        );
+    }
+    return parsed;
+};
+
+export const createKnexPreflightProbe = ({
+    database,
+    diskHeadroomBytes,
+}: {
+    database: Knex;
+    diskHeadroomBytes: number | null;
+}): PreflightProbe => ({
+    getPostgresVersion: async () => {
+        const result = await database.raw<RawPostgresVersionResult>(
+            `SELECT current_setting('server_version') AS server_version,
+                    current_setting('server_version_num')::integer AS server_version_num`,
+        );
+        const row = result.rows[0];
+        if (row === undefined) {
+            throw new Error('PostgreSQL returned no version row');
+        }
+        return {
+            serverVersion: row.server_version,
+            serverVersionNum: Number(row.server_version_num),
+        };
+    },
+    getMigrationPrivileges: async (tables) => {
+        const privileges = await database.raw<RawMigrationPrivilegesResult>(
+            `SELECT current_schema() AS schema_name,
+                    has_schema_privilege(current_user, current_schema(), 'USAGE')
+                    AND has_schema_privilege(current_user, current_schema(), 'CREATE') AS can_create_in_schema`,
+        );
+        const row = privileges.rows[0];
+        if (row === undefined) {
+            throw new Error('PostgreSQL returned no privilege row');
+        }
+        const ownership = await database.raw<RawUnownedTablesResult>(
+            `SELECT pg_class.relname AS table_name
+             FROM pg_class
+             JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+             WHERE pg_namespace.nspname = current_schema()
+               AND pg_class.relkind IN ('r', 'p')
+               AND pg_class.relname = ANY(?::text[])
+               AND NOT pg_has_role(current_user, pg_class.relowner, 'USAGE')
+             ORDER BY pg_class.relname`,
+            [tables],
+        );
+        return {
+            schemaName: row.schema_name,
+            canCreateInSchema: row.can_create_in_schema,
+            unownedTables: ownership.rows.map((item) => item.table_name),
+        };
+    },
+    getRelationActivity: async (tables) => {
+        if (tables.length === 0) {
+            return [];
+        }
+        const result = await database.raw<RawRelationActivityResult>(
+            `SELECT DISTINCT pg_locks.pid,
+                    pg_class.relname AS table_name,
+                    pg_locks.mode AS lock_mode,
+                    EXTRACT(EPOCH FROM clock_timestamp() - pg_stat_activity.xact_start)::integer AS transaction_age_seconds
+             FROM pg_locks
+             JOIN pg_class ON pg_class.oid = pg_locks.relation
+             JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+             LEFT JOIN pg_stat_activity ON pg_stat_activity.pid = pg_locks.pid
+             WHERE pg_locks.locktype = 'relation'
+               AND pg_locks.granted = true
+               AND pg_locks.pid <> pg_backend_pid()
+               AND pg_namespace.nspname = current_schema()
+               AND pg_class.relname = ANY(?::text[])
+             ORDER BY pg_class.relname, pg_locks.pid, pg_locks.mode`,
+            [tables],
+        );
+        return result.rows.map((row) => ({
+            pid: Number(row.pid),
+            table: row.table_name,
+            lockMode: row.lock_mode,
+            transactionAgeSeconds:
+                row.transaction_age_seconds === null
+                    ? null
+                    : Number(row.transaction_age_seconds),
+        }));
+    },
+    getDiskHeadroom: async () => ({
+        availableBytes: diskHeadroomBytes,
+        source: diskHeadroomBytes === null ? 'unavailable' : 'configured',
+    }),
+});

--- a/packages/backend/src/scripts/migrate/preflight.ts
+++ b/packages/backend/src/scripts/migrate/preflight.ts
@@ -35,8 +35,14 @@ export type ReleaseSafetyArtifact = {
 };
 
 export type ReleaseSafetyArtifactLoadResult =
-    | { artifact: ReleaseSafetyArtifact; error: null; path: string }
-    | { artifact: null; error: string; path: string };
+    | {
+          status: 'present';
+          artifact: ReleaseSafetyArtifact;
+          error: null;
+          path: string;
+      }
+    | { status: 'present'; artifact: null; error: string; path: string }
+    | { status: 'absent'; artifact: null; error: null; path: string };
 
 export type PendingMigrationInventoryItem = {
     name: string;
@@ -82,10 +88,8 @@ export type PreflightProbe = {
 type RedOutcome = 'pass' | 'fail';
 type YellowOutcome = 'pass' | 'warn';
 
-export type VersionPathCheck = {
+type VersionPathCheckBase = {
     id: 'version-path';
-    severity: 'red';
-    outcome: RedOutcome;
     message: string;
     data: {
         artifactPath: string;
@@ -98,6 +102,12 @@ export type VersionPathCheck = {
         artifactError: string | null;
     };
 };
+
+export type VersionPathCheck = VersionPathCheckBase &
+    (
+        | { severity: 'red'; outcome: RedOutcome }
+        | { severity: 'yellow'; outcome: YellowOutcome }
+    );
 
 export type MigrationPrivilegesCheck = {
     id: 'migration-privileges';
@@ -351,12 +361,22 @@ export const loadReleaseSafetyArtifact = async (
     try {
         const raw = await fs.readFile(artifactPath, 'utf8');
         return {
+            status: 'present',
             artifact: parseReleaseSafetyArtifact(raw),
             error: null,
             path: artifactPath,
         };
     } catch (error) {
+        if (isRecord(error) && error.code === 'ENOENT') {
+            return {
+                status: 'absent',
+                artifact: null,
+                error: null,
+                path: artifactPath,
+            };
+        }
         return {
+            status: 'present',
             artifact: null,
             error: error instanceof Error ? error.message : String(error),
             path: artifactPath,
@@ -476,6 +496,16 @@ const versionPathCheck = (
         pendingMigrationsOutsideArtifact,
         artifactError: artifactLoad.error,
     };
+    if (artifactLoad.status === 'absent') {
+        return {
+            id: 'version-path',
+            severity: 'yellow',
+            outcome: 'warn',
+            message:
+                'No baked release-safety artifact is present; required-stop verification was skipped; upgrade-path safety cannot be verified on this image',
+            data,
+        };
+    }
     if (artifact === null) {
         return {
             id: 'version-path',


### PR DESCRIPTION
## What

The SPK-913 preflight gate, both doors:

- **`migrate preflight`** standalone verb + **automatic first step of `migrate up`** — red aborts before the lease claim and before any DDL; `--force` overrides with unmistakable logging. One stable report engine behind both doors so automation and boot never develop different safety semantics.
- **Red (abort)**: version-path validity — requiredStops/minPreviousVersion from the artifact **baked into the image**, verified against the DB's *actual* migration ledger (not a version string — restored databases and custom histories are handled); missing migration-user privileges; unsupported Postgres (< 12).
- **Yellow (proceed loudly)**: held locks/long transactions on tables the pending migrations will DDL; low disk headroom (external signal via `MIGRATION_PREFLIGHT_DISK_HEADROOM_BYTES` since Postgres can't portably report filesystem space — unknown reads yellow, 5 GiB threshold centralized). Unknown migration heaviness treated conservatively.
- **Info**: pending-migration inventory (names, `transaction: false` read statically from migration source without importing modules, tables touched).
- `--strict` promotes yellow to red; `--json` stable output for Argo PreSync-style automation.
- Prober plumbing harvested from the preserved spike branch; the facts-execution design discarded per the map decisions. `cli.ts` changes kept additive for the sibling ledger branch.

## Verification

77 gate tests; full backend suite post-rebase 6,502 green (426 files); typecheck, touched-path lint, hooks green.

Part of #27140

Closes: SPK-701
Relates: SPK-877