### PR TITLE
fix(ai): stop shared writebacks from thinking forever

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -425,7 +425,7 @@ export type AiAgentToolResultTable = Knex.CompositeTableType<
         DbAiAgentToolResult,
         'ai_prompt_uuid' | 'tool_call_id' | 'tool_name' | 'result'
     > &
-        Partial<Pick<DbAiAgentToolResult, 'metadata'>>,
+        Partial<Pick<DbAiAgentToolResult, 'metadata' | 'created_at'>>,
     Partial<Pick<DbAiAgentToolResult, 'metadata' | 'result'>>
 >;
 

--- a/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
@@ -2,22 +2,34 @@ import {
     AiDuplicateSlackPromptError,
     SEED_ORG_1,
     SEED_ORG_1_ADMIN,
+    SEED_ORG_2,
+    SEED_ORG_2_ADMIN,
     SEED_PROJECT,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 import { getModels, getTestContext } from '../../vitest.setup.integration';
-import { AiPromptTableName, AiThreadTableName } from '../database/entities/ai';
+import {
+    AiAgentToolResultTableName,
+    AiPromptTableName,
+    AiThreadTableName,
+    AiWritebackRunTableName,
+} from '../database/entities/ai';
 import { AiAgentModel } from './AiAgentModel';
+import { AiWritebackRunModel } from './AiWritebackRunModel';
 
 describe('AiAgentModel prompt activity', () => {
     let database: Knex;
     let model: AiAgentModel;
+    let writebackRunModel: AiWritebackRunModel;
     const threadUuids = new Set<string>();
 
     beforeAll(() => {
         const context = getTestContext();
         database = context.db;
         model = getModels(context.app).aiAgentModel;
+        writebackRunModel = context.app
+            .getModels()
+            .getAiWritebackRunModel<AiWritebackRunModel>();
     });
 
     afterEach(async () => {
@@ -342,6 +354,365 @@ describe('AiAgentModel prompt activity', () => {
         expect(await getThreadUpdatedAt(cloneThreadUuid)).toEqual(
             clonedPrompt?.created_at,
         );
+    });
+
+    it('resolves a cloned pending writeback from its source run', async () => {
+        const sourceThreadUuid = await createWebAppThread();
+        const sourcePromptUuid = await model.createWebAppPrompt({
+            threadUuid: sourceThreadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            prompt: 'Add a revenue metric',
+        });
+        await model.updateModelResponse({
+            promptUuid: sourcePromptUuid,
+            response: 'I started the change.',
+        });
+
+        const toolCallId = 'writeback-call';
+        await model.createToolCall({
+            promptUuid: sourcePromptUuid,
+            toolCallId,
+            toolName: 'editDbtProject',
+            toolArgs: {
+                prompt: 'Add a revenue metric',
+                prUrl: null,
+                startNewPullRequest: null,
+            },
+            parentToolCallId: null,
+        });
+        const run = await writebackRunModel.create({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            aiThreadUuid: sourceThreadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            source: 'web',
+            promptUuid: sourcePromptUuid,
+            toolCallId,
+        });
+        await model.createToolResults([
+            {
+                promptUuid: sourcePromptUuid,
+                toolCallId,
+                toolName: 'editDbtProject',
+                result: 'The writeback is running.',
+                metadata: {
+                    status: 'pending',
+                    aiWritebackRunUuid: run.ai_writeback_run_uuid,
+                },
+            },
+        ]);
+        const pendingStartedAt = new Date(Math.floor(Date.now() / 1000) * 1000);
+        await database.raw('UPDATE ?? SET ?? = ? WHERE ?? = ?', [
+            AiAgentToolResultTableName,
+            'created_at',
+            pendingStartedAt,
+            'ai_prompt_uuid',
+            sourcePromptUuid,
+        ]);
+        const historicalNonWritebackCreatedAt = new Date(
+            '2025-01-01T00:00:00.000Z',
+        );
+        await database(AiAgentToolResultTableName).insert({
+            ai_prompt_uuid: sourcePromptUuid,
+            tool_call_id: 'unrelated-tool-call',
+            tool_name: 'unrelatedTool',
+            result: 'Unrelated result',
+            created_at: historicalNonWritebackCreatedAt,
+        });
+
+        const cloneThreadUuid = await model.cloneThread({
+            sourceThreadUuid,
+            sourcePromptUuid,
+            targetUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            includeSelectedPromptResponse: true,
+        });
+        threadUuids.add(cloneThreadUuid);
+        const clonePrompt = await database(AiPromptTableName)
+            .select('ai_prompt_uuid')
+            .where('ai_thread_uuid', cloneThreadUuid)
+            .first();
+        if (!clonePrompt) {
+            throw new Error('Expected the cloned prompt to exist');
+        }
+        const clonePromptUuid = clonePrompt.ai_prompt_uuid;
+        const clonedNonWritebackResult = await database(
+            AiAgentToolResultTableName,
+        )
+            .select('created_at')
+            .where('ai_prompt_uuid', clonePromptUuid)
+            .where('tool_call_id', 'unrelated-tool-call')
+            .first();
+        if (!clonedNonWritebackResult) {
+            throw new Error('Expected the unrelated tool result to be cloned');
+        }
+        expect(clonedNonWritebackResult.created_at).not.toEqual(
+            historicalNonWritebackCreatedAt,
+        );
+        const [clonedPendingResult] =
+            await model.getToolResultsForPrompt(clonePromptUuid);
+        expect(clonedPendingResult).toMatchObject({
+            promptUuid: clonePromptUuid,
+            metadata: { status: 'pending' },
+            createdAt: pendingStartedAt,
+        });
+
+        await writebackRunModel.markReady(run.ai_writeback_run_uuid, {
+            branchName: 'lightdash/add-revenue',
+            prUrl: 'https://github.com/lightdash/example/pull/1',
+        });
+
+        const [resultDuringCanonicalSync] =
+            await model.getToolResultsForPrompt(clonePromptUuid);
+        expect(resultDuringCanonicalSync.metadata).toMatchObject({
+            status: 'pending',
+        });
+
+        await database.raw('UPDATE ?? SET ?? = ? WHERE ?? = ?', [
+            AiAgentToolResultTableName,
+            'created_at',
+            new Date(Date.now() - 5 * 60 * 1000 - 1),
+            'ai_prompt_uuid',
+            clonePromptUuid,
+        ]);
+
+        const [fallbackResult] =
+            await model.getToolResultsForPrompt(clonePromptUuid);
+        expect(fallbackResult).toMatchObject({
+            promptUuid: clonePromptUuid,
+            result: 'The writeback finished and opened a pull request.',
+            metadata: {
+                status: 'success',
+                prUrl: 'https://github.com/lightdash/example/pull/1',
+            },
+        });
+
+        await model.updateToolResult(sourcePromptUuid, toolCallId, {
+            result: 'Opened the revenue metric pull request.',
+            metadata: {
+                status: 'success',
+                prUrl: 'https://github.com/lightdash/example/pull/1',
+            },
+        });
+
+        const [clonedResult] =
+            await model.getToolResultsForPrompt(clonePromptUuid);
+
+        expect(clonedResult).toMatchObject({
+            promptUuid: clonePromptUuid,
+            result: 'Opened the revenue metric pull request.',
+            metadata: {
+                status: 'success',
+                prUrl: 'https://github.com/lightdash/example/pull/1',
+            },
+        });
+
+        const [{ toolResult: clonedHistoryResult }] =
+            await model.getToolCallsAndResultsForPrompt(clonePromptUuid);
+        expect(clonedHistoryResult).toMatchObject({
+            promptUuid: clonePromptUuid,
+            result: 'Opened the revenue metric pull request.',
+            metadata: {
+                status: 'success',
+                prUrl: 'https://github.com/lightdash/example/pull/1',
+            },
+        });
+    });
+
+    it.each([
+        {
+            caseName: 'ready without a pull request',
+            status: 'ready',
+            prUrl: null,
+            errorMessage: null,
+            expectedResult:
+                'The writeback finished without opening a pull request.',
+            expectedMetadata: { status: 'success', prUrl: null },
+        },
+        {
+            caseName: 'cancelled',
+            status: 'cancelled',
+            prUrl: null,
+            errorMessage: null,
+            expectedResult: 'The writeback was cancelled.',
+            expectedMetadata: { status: 'error', errorCode: 'unknown' },
+        },
+        {
+            caseName: 'errored with a message',
+            status: 'error',
+            prUrl: null,
+            errorMessage: 'The coding agent stopped.',
+            expectedResult: 'The coding agent stopped.',
+            expectedMetadata: { status: 'error', errorCode: 'unknown' },
+        },
+        {
+            caseName: 'errored without a message',
+            status: 'error',
+            prUrl: null,
+            errorMessage: null,
+            expectedResult:
+                'The writeback stopped unexpectedly before it finished.',
+            expectedMetadata: { status: 'error', errorCode: 'unknown' },
+        },
+    ] as const)(
+        'returns a bounded fallback when a run is $caseName',
+        async ({
+            status,
+            prUrl,
+            errorMessage,
+            expectedResult,
+            expectedMetadata,
+        }) => {
+            const threadUuid = await createWebAppThread();
+            const promptUuid = await model.createWebAppPrompt({
+                threadUuid,
+                createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                prompt: 'Add a revenue metric',
+            });
+            const toolCallId = 'writeback-call';
+            const run = await writebackRunModel.create({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                aiThreadUuid: threadUuid,
+                createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                source: 'web',
+                promptUuid,
+                toolCallId,
+            });
+            await database(AiWritebackRunTableName)
+                .where('ai_writeback_run_uuid', run.ai_writeback_run_uuid)
+                .update({
+                    status,
+                    pr_url: prUrl,
+                    error_message: errorMessage,
+                });
+            await model.createToolResults([
+                {
+                    promptUuid,
+                    toolCallId,
+                    toolName: 'editDbtProject',
+                    result: 'The writeback is running.',
+                    metadata: {
+                        status: 'pending',
+                        aiWritebackRunUuid: run.ai_writeback_run_uuid,
+                    },
+                },
+            ]);
+            await database.raw('UPDATE ?? SET ?? = ? WHERE ?? = ?', [
+                AiAgentToolResultTableName,
+                'created_at',
+                new Date(Date.now() - 5 * 60 * 1000 - 1),
+                'ai_prompt_uuid',
+                promptUuid,
+            ]);
+
+            const [result] = await model.getToolResultsForPrompt(promptUuid);
+
+            expect(result).toMatchObject({
+                result: expectedResult,
+                metadata: expectedMetadata,
+            });
+        },
+    );
+
+    it('does not resolve a pending writeback from untrusted run links', async () => {
+        const threadUuid = await createWebAppThread();
+        const promptUuid = await model.createWebAppPrompt({
+            threadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            prompt: 'Add a revenue metric',
+        });
+        const toolCallId = 'writeback-call';
+        await model.createToolCall({
+            promptUuid,
+            toolCallId,
+            toolName: 'editDbtProject',
+            toolArgs: {
+                prompt: 'Add a revenue metric',
+                prUrl: null,
+                startNewPullRequest: null,
+            },
+            parentToolCallId: null,
+        });
+        const outOfScopeRun = await writebackRunModel.create({
+            organizationUuid: SEED_ORG_2.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            aiThreadUuid: threadUuid,
+            createdByUserUuid: SEED_ORG_2_ADMIN.user_uuid,
+            source: 'web',
+            promptUuid,
+            toolCallId,
+        });
+        await writebackRunModel.markReady(outOfScopeRun.ai_writeback_run_uuid, {
+            branchName: 'private-branch',
+            prUrl: 'https://github.com/another-org/private/pull/1',
+        });
+        await model.createToolResults([
+            {
+                promptUuid,
+                toolCallId,
+                toolName: 'editDbtProject',
+                result: 'The writeback is running.',
+                metadata: {
+                    status: 'pending',
+                    aiWritebackRunUuid: outOfScopeRun.ai_writeback_run_uuid,
+                },
+            },
+        ]);
+        await database.raw('UPDATE ?? SET ?? = ? WHERE ?? = ?', [
+            AiAgentToolResultTableName,
+            'created_at',
+            new Date(Date.now() - 5 * 60 * 1000 - 1),
+            'ai_prompt_uuid',
+            promptUuid,
+        ]);
+
+        const [result] = await model.getToolResultsForPrompt(promptUuid);
+
+        expect(result).toMatchObject({
+            result: 'The writeback is running.',
+            metadata: {
+                status: 'pending',
+                aiWritebackRunUuid: outOfScopeRun.ai_writeback_run_uuid,
+            },
+        });
+
+        const mismatchedRun = await writebackRunModel.create({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            aiThreadUuid: threadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            source: 'web',
+            promptUuid,
+            toolCallId: 'another-writeback-call',
+        });
+        await writebackRunModel.markReady(mismatchedRun.ai_writeback_run_uuid, {
+            branchName: 'unrelated-branch',
+            prUrl: 'https://github.com/lightdash/example/pull/2',
+        });
+        await model.updateToolResult(promptUuid, toolCallId, {
+            result: 'The writeback is running.',
+            metadata: {
+                status: 'pending',
+                aiWritebackRunUuid: mismatchedRun.ai_writeback_run_uuid,
+            },
+        });
+        await database.raw('UPDATE ?? SET ?? = ? WHERE ?? = ?', [
+            AiAgentToolResultTableName,
+            'created_at',
+            new Date(Date.now() - 5 * 60 * 1000 - 1),
+            'ai_prompt_uuid',
+            promptUuid,
+        ]);
+
+        const [mismatchedResult] =
+            await model.getToolResultsForPrompt(promptUuid);
+        expect(mismatchedResult).toMatchObject({
+            result: 'The writeback is running.',
+            metadata: {
+                status: 'pending',
+                aiWritebackRunUuid: mismatchedRun.ai_writeback_run_uuid,
+            },
+        });
     });
 
     it('serializes duplicate v1 Slack prompt delivery', async () => {

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1,5 +1,6 @@
 import {
     AgentToolOutput,
+    AI_WRITEBACK_PENDING_GRACE_MS,
     AiAgentAdminConversationsSummary,
     AiAgentAdminEvalFilters,
     AiAgentAdminEvalPrompt,
@@ -65,7 +66,9 @@ import {
     generateSlug,
     isAiAgentMcpToolName,
     isAiAgentToolName,
+    isAiWritebackRunInProgress,
     isThreadPrompt,
+    isToolEditDbtProjectResult,
     KnexPaginateArgs,
     KnexPaginatedData,
     NotFoundError,
@@ -87,6 +90,7 @@ import {
     type AiAgentIntegration,
     type AiChartRuntimeOverrides,
     type AiDashboardRuntimeOverrides,
+    type ToolEditDbtProjectOutput,
     type VerifiedContentListItem,
 } from '@lightdash/common';
 import { Knex } from 'knex';
@@ -128,6 +132,7 @@ import {
     AiThreadTableName,
     AiWebAppPromptTableName,
     AiWebAppThreadTableName,
+    AiWritebackRunTableName,
     DbAiAgentToolCall,
     DbAiAgentToolResult,
     DbAiPrompt,
@@ -141,6 +146,7 @@ import {
     DbAiThreadCompaction,
     DbAiThreadShare,
     DbAiWebAppPrompt,
+    DbAiWritebackRun,
     type AiSqlApprovalDecision,
 } from '../database/entities/ai';
 import {
@@ -368,6 +374,70 @@ const toAiPromptSteer = (row: AiPromptSteerRow): AiPromptSteer => ({
     consumedAt: row.consumed_at?.toISOString() ?? null,
     consumedStep: row.consumed_step,
 });
+
+const getWritebackResultKey = (promptUuid: string, toolCallId: string) =>
+    JSON.stringify([promptUuid, toolCallId]);
+
+type EditDbtProjectToolResult = AiAgentToolResult & {
+    toolType: 'built-in';
+    toolName: 'editDbtProject';
+    metadata: ToolEditDbtProjectOutput['metadata'];
+};
+
+type PendingEditDbtProjectToolResult = EditDbtProjectToolResult & {
+    metadata: Extract<
+        ToolEditDbtProjectOutput['metadata'],
+        { status: 'pending' }
+    >;
+};
+
+type TerminalEditDbtProjectResult = {
+    result: string;
+    metadata: Exclude<
+        ToolEditDbtProjectOutput['metadata'],
+        { status: 'pending' }
+    >;
+};
+
+const isEditDbtProjectToolResult = (
+    result: AiAgentToolResult,
+): result is EditDbtProjectToolResult => isToolEditDbtProjectResult(result);
+
+const isPendingEditDbtProjectToolResult = (
+    result: AiAgentToolResult,
+): result is PendingEditDbtProjectToolResult =>
+    isEditDbtProjectToolResult(result) && result.metadata.status === 'pending';
+
+const getTerminalWritebackFallback = (
+    run: DbAiWritebackRun,
+): TerminalEditDbtProjectResult | null => {
+    switch (run.status) {
+        case 'ready':
+            return {
+                result: run.pr_url
+                    ? 'The writeback finished and opened a pull request.'
+                    : 'The writeback finished without opening a pull request.',
+                metadata: {
+                    status: 'success',
+                    prUrl: run.pr_url,
+                },
+            };
+        case 'cancelled':
+            return {
+                result: 'The writeback was cancelled.',
+                metadata: { status: 'error', errorCode: 'unknown' },
+            };
+        case 'error':
+            return {
+                result:
+                    run.error_message ??
+                    'The writeback stopped unexpectedly before it finished.',
+                metadata: { status: 'error', errorCode: 'unknown' },
+            };
+        default:
+            return null;
+    }
+};
 
 export class AiAgentModel {
     // Cap stored raw args of invalid tool calls (they can be arbitrarily large)
@@ -6596,6 +6666,159 @@ export class AiAgentModel {
         }
     }
 
+    private async resolvePendingWritebackToolResults(
+        promptUuid: string,
+        results: AiAgentToolResult[],
+    ): Promise<AiAgentToolResult[]> {
+        const pendingResults = results.filter(
+            isPendingEditDbtProjectToolResult,
+        );
+        if (pendingResults.length === 0) {
+            return results;
+        }
+
+        const threadScope = await this.database(AiPromptTableName)
+            .innerJoin(
+                AiThreadTableName,
+                `${AiPromptTableName}.ai_thread_uuid`,
+                `${AiThreadTableName}.ai_thread_uuid`,
+            )
+            .select<Pick<DbAiThread, 'organization_uuid' | 'project_uuid'>>(
+                `${AiThreadTableName}.organization_uuid`,
+                `${AiThreadTableName}.project_uuid`,
+            )
+            .where(`${AiPromptTableName}.ai_prompt_uuid`, promptUuid)
+            .first();
+        if (!threadScope) {
+            return results;
+        }
+
+        const runRows = await this.database(AiWritebackRunTableName)
+            .select<DbAiWritebackRun[]>('*')
+            .where('organization_uuid', threadScope.organization_uuid)
+            .where('project_uuid', threadScope.project_uuid)
+            .whereIn(
+                'ai_writeback_run_uuid',
+                pendingResults.map(
+                    (result) => result.metadata.aiWritebackRunUuid,
+                ),
+            );
+        const terminalRuns = runRows.filter(
+            (run) => !isAiWritebackRunInProgress(run.status),
+        );
+        if (terminalRuns.length === 0) {
+            return results;
+        }
+
+        const linkedRuns = terminalRuns.filter(
+            (
+                run,
+            ): run is DbAiWritebackRun & {
+                prompt_uuid: string;
+                tool_call_id: string;
+            } => run.prompt_uuid !== null && run.tool_call_id !== null,
+        );
+        const canonicalRows =
+            linkedRuns.length === 0
+                ? []
+                : await this.database(AiAgentToolResultTableName)
+                      .innerJoin(
+                          AiPromptTableName,
+                          `${AiAgentToolResultTableName}.ai_prompt_uuid`,
+                          `${AiPromptTableName}.ai_prompt_uuid`,
+                      )
+                      .innerJoin(
+                          AiThreadTableName,
+                          `${AiPromptTableName}.ai_thread_uuid`,
+                          `${AiThreadTableName}.ai_thread_uuid`,
+                      )
+                      .select<DbAiAgentToolResult[]>(
+                          `${AiAgentToolResultTableName}.ai_agent_tool_result_uuid`,
+                          `${AiAgentToolResultTableName}.ai_prompt_uuid`,
+                          `${AiAgentToolResultTableName}.tool_call_id`,
+                          `${AiAgentToolResultTableName}.tool_name`,
+                          `${AiAgentToolResultTableName}.result`,
+                          `${AiAgentToolResultTableName}.metadata`,
+                          `${AiAgentToolResultTableName}.created_at`,
+                      )
+                      .where(
+                          `${AiThreadTableName}.organization_uuid`,
+                          threadScope.organization_uuid,
+                      )
+                      .where(
+                          `${AiThreadTableName}.project_uuid`,
+                          threadScope.project_uuid,
+                      )
+                      .where((query) => {
+                          linkedRuns.forEach((run) => {
+                              void query.orWhere((linkedResultQuery) => {
+                                  void linkedResultQuery
+                                      .where(
+                                          `${AiAgentToolResultTableName}.ai_prompt_uuid`,
+                                          run.prompt_uuid,
+                                      )
+                                      .where(
+                                          `${AiAgentToolResultTableName}.tool_call_id`,
+                                          run.tool_call_id,
+                                      );
+                              });
+                          });
+                      });
+        const terminalRunsByUuid = new Map(
+            terminalRuns.map((run) => [run.ai_writeback_run_uuid, run]),
+        );
+        const canonicalResultsByKey = new Map(
+            canonicalRows.map((row) => [
+                getWritebackResultKey(row.ai_prompt_uuid, row.tool_call_id),
+                this.parseToolResult(row),
+            ]),
+        );
+
+        return results.map((result) => {
+            if (!isPendingEditDbtProjectToolResult(result)) {
+                return result;
+            }
+
+            const run = terminalRunsByUuid.get(
+                result.metadata.aiWritebackRunUuid,
+            );
+            if (!run || run.tool_call_id !== result.toolCallId) {
+                return result;
+            }
+
+            const canonicalResult =
+                run.prompt_uuid && run.tool_call_id
+                    ? canonicalResultsByKey.get(
+                          getWritebackResultKey(
+                              run.prompt_uuid,
+                              run.tool_call_id,
+                          ),
+                      )
+                    : undefined;
+            if (
+                canonicalResult &&
+                isEditDbtProjectToolResult(canonicalResult) &&
+                canonicalResult.metadata.status !== 'pending'
+            ) {
+                return {
+                    ...result,
+                    result: canonicalResult.result,
+                    metadata: canonicalResult.metadata,
+                };
+            }
+
+            if (
+                result.createdAt.getTime() + AI_WRITEBACK_PENDING_GRACE_MS >
+                Date.now()
+            ) {
+                return result;
+            }
+
+            const fallback = getTerminalWritebackFallback(run);
+            return fallback ? { ...result, ...fallback } : result;
+        });
+    }
+
     async getToolCallsAndResultsForPrompt(
         promptUuid: string,
         options: { includeSubagentToolCalls?: boolean } = {},
@@ -6658,7 +6881,7 @@ export class AiAgentModel {
         }
         const rows = await query;
 
-        return rows
+        const toolCallsAndResults = rows
             .filter(
                 (row) =>
                     (row.result !== null || row.approval_decision !== null) &&
@@ -6687,6 +6910,23 @@ export class AiAgentModel {
                     approvalDecision: row.approval_decision,
                 };
             });
+        const resolvedResults = await this.resolvePendingWritebackToolResults(
+            promptUuid,
+            toolCallsAndResults.flatMap(({ toolResult }) =>
+                toolResult ? [toolResult] : [],
+            ),
+        );
+        const resolvedResultsByUuid = new Map(
+            resolvedResults.map((result) => [result.uuid, result]),
+        );
+
+        return toolCallsAndResults.map((entry) => ({
+            ...entry,
+            toolResult: entry.toolResult
+                ? (resolvedResultsByUuid.get(entry.toolResult.uuid) ??
+                  entry.toolResult)
+                : null,
+        }));
     }
 
     // A runSql call the agent suspended on awaiting approval: it has no result
@@ -6907,9 +7147,14 @@ export class AiAgentModel {
             .where('ai_prompt_uuid', promptUuid)
             .orderBy('created_at', 'asc');
 
-        return rows
+        const parsedResults = rows
             .filter((row) => isParseableToolName(row.tool_name))
             .map((row) => this.parseToolResult(row));
+
+        return this.resolvePendingWritebackToolResults(
+            promptUuid,
+            parsedResults,
+        );
     }
 
     async createToolResults(
@@ -8405,13 +8650,24 @@ export class AiAgentModel {
                     )
                     .where('ai_prompt_uuid', sourcePromptUuid);
 
-                const toolResultUpdates = toolResults.map((toolResult) => ({
-                    ai_prompt_uuid: newPromptUuid,
-                    tool_call_id: toolResult.tool_call_id,
-                    tool_name: toolResult.tool_name,
-                    result: toolResult.result,
-                    metadata: toolResult.metadata,
-                }));
+                const toolResultUpdates = toolResults.map((toolResult) => {
+                    const preservePendingStartedAt =
+                        toolResult.tool_name === 'editDbtProject' &&
+                        toolResult.metadata !== null &&
+                        'status' in toolResult.metadata &&
+                        toolResult.metadata.status === 'pending';
+
+                    return {
+                        ai_prompt_uuid: newPromptUuid,
+                        tool_call_id: toolResult.tool_call_id,
+                        tool_name: toolResult.tool_name,
+                        result: toolResult.result,
+                        metadata: toolResult.metadata,
+                        ...(preservePendingStartedAt
+                            ? { created_at: toolResult.created_at }
+                            : {}),
+                    };
+                });
 
                 await Promise.all([
                     toolCallUpdates.length > 0 &&

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+export const AI_WRITEBACK_PENDING_GRACE_MS = 5 * 60 * 1000;
+
 export const TOOL_EDIT_DBT_PROJECT_DESCRIPTION = [
     'Open or update a pull request that modifies the dbt project / Lightdash semantic layer for this project.',
     'Use this tool ONLY when the user asks to CHANGE something in the underlying repo — e.g. add or rename a metric, edit a dimension definition, modify a dbt model, update YAML metadata.',

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.test.tsx
@@ -1,0 +1,78 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { usePendingThreadRefetch } from './usePendingThreadRefetch';
+
+vi.mock('../streaming/useAiAgentThreadStreamQuery', () => ({
+    useAiAgentThreadStreaming: () => false,
+}));
+
+const pendingThread = (createdAt: Date | string) =>
+    ({
+        messages: [
+            {
+                role: 'assistant',
+                status: 'idle',
+                toolResults: [
+                    {
+                        toolType: 'built-in',
+                        toolName: 'editDbtProject',
+                        metadata: {
+                            status: 'pending',
+                            aiWritebackRunUuid: 'run-1',
+                        },
+                        createdAt,
+                    },
+                ],
+            },
+        ],
+    }) as Parameters<typeof usePendingThreadRefetch>[0];
+
+describe('usePendingThreadRefetch', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('does not keep a thread pending for a stale writeback result', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-11T12:10:00.000Z'));
+
+        const { result } = renderHook(() =>
+            usePendingThreadRefetch(
+                pendingThread('2026-08-11T12:04:59.999Z'),
+                'thread-1',
+                vi.fn(),
+            ),
+        );
+
+        expect(result.current.isPending).toBe(false);
+    });
+
+    it('refetches once more before expiring an active writeback', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-11T12:00:00.000Z'));
+        const refetch = vi.fn(() => new Promise<never>(() => undefined));
+
+        const { result } = renderHook(() =>
+            usePendingThreadRefetch(
+                pendingThread('2026-08-11T12:00:00.001Z'),
+                'thread-1',
+                refetch,
+            ),
+        );
+
+        expect(result.current.isPending).toBe(true);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+        });
+        expect(result.current.isPending).toBe(true);
+        refetch.mockClear();
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1);
+        });
+
+        expect(refetch).toHaveBeenCalledTimes(1);
+        expect(result.current.isPending).toBe(false);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.ts
@@ -1,24 +1,42 @@
 import {
+    AI_WRITEBACK_PENDING_GRACE_MS,
     isToolEditDbtProjectResult,
     type ApiAiAgentThreadResponse,
 } from '@lightdash/common';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useAiAgentThreadStreaming } from '../streaming/useAiAgentThreadStreamQuery';
 
 const POLL_INTERVAL_MS = 2000;
 
 type Thread = ApiAiAgentThreadResponse['results'] | undefined;
 
-const hasPendingWriteback = (thread: Thread): boolean =>
-    thread?.messages?.some(
-        (message) =>
-            message.role === 'assistant' &&
-            message.toolResults?.some(
-                (toolResult) =>
-                    isToolEditDbtProjectResult(toolResult) &&
-                    toolResult.metadata.status === 'pending',
-            ),
-    ) ?? false;
+const getPendingWritebackExpiresAt = (thread: Thread): number | null => {
+    const pendingExpirations =
+        thread?.messages.flatMap((message) =>
+            message.role === 'assistant'
+                ? message.toolResults.flatMap((toolResult) => {
+                      if (
+                          !isToolEditDbtProjectResult(toolResult) ||
+                          toolResult.metadata.status !== 'pending'
+                      ) {
+                          return [];
+                      }
+
+                      const createdAt =
+                          toolResult.createdAt instanceof Date
+                              ? toolResult.createdAt.getTime()
+                              : new Date(toolResult.createdAt).getTime();
+                      return Number.isFinite(createdAt)
+                          ? [createdAt + AI_WRITEBACK_PENDING_GRACE_MS]
+                          : [];
+                  })
+                : [],
+        ) ?? [];
+
+    return pendingExpirations.length > 0
+        ? Math.max(...pendingExpirations)
+        : null;
+};
 
 export const usePendingThreadRefetch = (
     thread: Thread,
@@ -26,11 +44,38 @@ export const usePendingThreadRefetch = (
     refetch: () => unknown,
 ) => {
     const isStreaming = useAiAgentThreadStreaming(threadUuid);
+    const [expirationClock, setExpirationClock] = useState(0);
+    const pendingWritebackExpiresAt = getPendingWritebackExpiresAt(thread);
+    const hasPendingWriteback =
+        pendingWritebackExpiresAt !== null &&
+        pendingWritebackExpiresAt > Math.max(Date.now(), expirationClock);
     const isPending =
         thread?.messages?.some(
             (message) =>
                 message.role === 'assistant' && message.status === 'pending',
-        ) || hasPendingWriteback(thread);
+        ) || hasPendingWriteback;
+
+    useEffect(() => {
+        if (pendingWritebackExpiresAt === null) {
+            return;
+        }
+
+        const remainingMs = pendingWritebackExpiresAt - Date.now();
+        if (remainingMs <= 0) {
+            return;
+        }
+
+        const timeout = setTimeout(() => {
+            try {
+                void Promise.resolve(refetch()).catch(() => undefined);
+            } catch {
+                // This final refresh is best-effort; expiry must stay bounded.
+            } finally {
+                setExpirationClock(pendingWritebackExpiresAt);
+            }
+        }, remainingMs);
+        return () => clearTimeout(timeout);
+    }, [pendingWritebackExpiresAt, refetch]);
 
     useEffect(() => {
         if (!isPending || isStreaming) return;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9674/ai-agent-chat-can-hang-in-a-permanent-thinking-state-after-an

## Summary

Shared AI-agent threads no longer remain in a permanent thinking state when an `editDbtProject` result is cloned while pending. Clones now resolve completed writebacks from persisted run state, while orphaned pending markers stop loading after five minutes.

## Root cause

Thread cloning copied the pending tool-result metadata as a snapshot, but the asynchronous writeback pipeline only finalized the source prompt's result. The pending-thread hook then treated every pending writeback marker as active without a deadline.

```ts
metadata: toolResult.metadata, // copied once into the clone
// ...
toolResult.metadata.status === 'pending'; // trusted indefinitely
```

Sharing during an active writeback exposed the gap. A deployment interruption could leave the cloned snapshot pending even after the source run recovered or reached a terminal state.

## Fix

Pending writeback reads now reconcile against a tenant-scoped run and its canonical source result. A shared five-minute deadline bounds both backend fallback behavior and frontend loading, with one final best-effort refetch at expiry.

- `AiAgentModel` resolves terminal clone results, preserves pending start time, and rejects cross-tenant or mismatched run links.
- `usePendingThreadRefetch` expires stale markers even when the final request never settles.
- Non-writeback clone timestamps and non-writeback result behavior remain unchanged.

## Before

```text
pending clone -> source run finishes -> clone snapshot stays pending
                                      -> polling + disabled composer forever
```

## After

```text
pending clone -> scoped run lookup -> canonical terminal result
              \-> five-minute bound -> safe run fallback + unlocked composer
```

## Test plan

- [x] Common, backend, and frontend TypeScript checks
- [x] Targeted Oxlint, Oxfmt, and `git diff --check`
- [x] `AiAgentModel.integration.test.ts` — 13 tests pass, including clone reconciliation, terminal fallbacks, and tenant/link isolation
- [x] `runEditDbtProjectPipeline.test.ts` — 18 tests pass
- [x] `usePendingThreadRefetch.test.tsx` — 2 tests pass, including JSON timestamps and a never-settling final refetch
- [x] Local API health reports healthy under Node 24.18.0
- [ ] Browser/provider end-to-end run: the in-app browser runtime had no available browser; persisted Postgres and React hook seams are covered directly
