### PR TITLE
fix(ai): explain deep research runs with no relevant data

### DIFF
--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -270,12 +270,17 @@ const evidencePack = (
     ...overrides,
 });
 
+const evidenceBuildResult = (
+    pack: AiDeepResearchEvidencePack = evidencePack(),
+    hasEvidenceBuildFailures = false,
+) => ({ evidencePack: pack, hasEvidenceBuildFailures });
+
 const buildExecutor = ({
     generateAgentThreadResponse = respondByRole(),
     provenance = [],
     childProvenance = provenance,
     generateDeepResearchReport = vi.fn().mockResolvedValue(report),
-    buildEvidencePack = vi.fn().mockResolvedValue(evidencePack()),
+    buildEvidencePack = vi.fn().mockResolvedValue(evidenceBuildResult()),
 }: {
     generateAgentThreadResponse?: AnyType;
     provenance?: AnyType[];
@@ -593,6 +598,38 @@ describe('AiDeepResearchExecutor', () => {
         expect(outcomes[0]).toMatchObject({
             findings: workerFindings(),
             failureReason: null,
+        });
+    });
+
+    it('keeps provider failure when worker findings were not rebuilt after a crash', async () => {
+        const generateAgentThreadResponse = respondByRole({
+            onCoordinate: async (options: AnyType) => {
+                await options.execution.research.runTask(taskInput(1));
+                return 'coordinated';
+            },
+            onWork: (options: AnyType) => {
+                options.execution.research.onFindings(workerFindings());
+                throw new Error('provider disconnected after submission');
+            },
+        });
+        const { executor } = buildExecutor({
+            generateAgentThreadResponse,
+            buildEvidencePack: vi
+                .fn()
+                .mockResolvedValue(
+                    evidenceBuildResult(
+                        evidencePack({ queries: [], workerFindings: [] }),
+                    ),
+                ),
+        });
+
+        await expect(
+            executor.execute(run(), {
+                signal: new AbortController().signal,
+            }),
+        ).resolves.toMatchObject({
+            status: 'failed',
+            terminalReason: 'provider_error',
         });
     });
 
@@ -974,13 +1011,15 @@ describe('AiDeepResearchExecutor', () => {
         });
     });
 
-    it('fails when the run gathered no evidence to report from', async () => {
+    it('classifies a run that found no relevant data', async () => {
         const { executor, generateDeepResearchReport } = buildExecutor({
-            buildEvidencePack: vi.fn().mockResolvedValue({
-                question: 'Investigate revenue',
-                queries: [],
-                workerFindings: [],
-            }),
+            buildEvidencePack: vi
+                .fn()
+                .mockResolvedValue(
+                    evidenceBuildResult(
+                        evidencePack({ queries: [], workerFindings: [] }),
+                    ),
+                ),
         });
 
         await expect(
@@ -989,10 +1028,173 @@ describe('AiDeepResearchExecutor', () => {
             }),
         ).resolves.toEqual({
             status: 'failed',
-            errorMessage: 'Deep Research finished without producing a report',
-            terminalReason: 'provider_error',
+            errorMessage:
+                'Deep Research could not find relevant data for this question.',
+            terminalReason: 'no_relevant_data',
         });
         // No point paying a model to write a report with nothing behind it.
         expect(generateDeepResearchReport).not.toHaveBeenCalled();
+    });
+
+    it('keeps provider failure when a worker failed before the pack stayed empty', async () => {
+        const generateAgentThreadResponse = respondByRole({
+            onCoordinate: async (options: AnyType) => {
+                await options.execution.research.runTask(taskInput(1));
+                return 'coordinated';
+            },
+            onWork: () => {
+                throw new Error('provider disconnected');
+            },
+        });
+        const { executor } = buildExecutor({
+            generateAgentThreadResponse,
+            buildEvidencePack: vi
+                .fn()
+                .mockResolvedValue(
+                    evidenceBuildResult(
+                        evidencePack({ queries: [], workerFindings: [] }),
+                    ),
+                ),
+        });
+
+        await expect(
+            executor.execute(run(), {
+                signal: new AbortController().signal,
+            }),
+        ).resolves.toMatchObject({
+            status: 'failed',
+            terminalReason: 'provider_error',
+        });
+    });
+
+    it('keeps provider failure when evidence could not be rebuilt', async () => {
+        const { executor } = buildExecutor({
+            buildEvidencePack: vi
+                .fn()
+                .mockResolvedValue(
+                    evidenceBuildResult(
+                        evidencePack({ queries: [], workerFindings: [] }),
+                        true,
+                    ),
+                ),
+        });
+
+        await expect(
+            executor.execute(run(), {
+                signal: new AbortController().signal,
+            }),
+        ).resolves.toMatchObject({
+            status: 'failed',
+            terminalReason: 'provider_error',
+        });
+    });
+
+    it('keeps provider failure when the coordinator failed with an empty pack', async () => {
+        const { executor } = buildExecutor({
+            generateAgentThreadResponse: vi
+                .fn()
+                .mockRejectedValue(new Error('provider disconnected')),
+            buildEvidencePack: vi
+                .fn()
+                .mockResolvedValue(
+                    evidenceBuildResult(
+                        evidencePack({ queries: [], workerFindings: [] }),
+                    ),
+                ),
+        });
+
+        await expect(
+            executor.execute(run(), {
+                signal: new AbortController().signal,
+            }),
+        ).resolves.toEqual({
+            status: 'failed',
+            errorMessage: 'provider disconnected',
+            terminalReason: 'provider_error',
+        });
+    });
+
+    it('keeps a partial result when the budget ended with an empty pack', async () => {
+        const generateAgentThreadResponse = respondByRole({
+            onCoordinate: async (options: AnyType) => {
+                options.execution.onWarehouseQuery();
+                options.execution.onWarehouseQuery();
+                return 'coordinated';
+            },
+        });
+        const { executor } = buildExecutor({
+            generateAgentThreadResponse,
+            buildEvidencePack: vi
+                .fn()
+                .mockResolvedValue(
+                    evidenceBuildResult(
+                        evidencePack({ queries: [], workerFindings: [] }),
+                    ),
+                ),
+        });
+
+        await expect(
+            executor.execute(
+                run({
+                    budget_snapshot: { ...budget, maxWarehouseQueries: 1 },
+                }),
+                { signal: new AbortController().signal },
+            ),
+        ).resolves.toMatchObject({
+            status: 'partially_completed',
+            terminalReason: 'query_limit',
+        });
+    });
+
+    it('keeps provider failure when clean-run finalization fails', async () => {
+        const { executor } = buildExecutor({
+            generateDeepResearchReport: vi
+                .fn()
+                .mockRejectedValue(new Error('provider unavailable')),
+        });
+
+        await expect(
+            executor.execute(run(), {
+                signal: new AbortController().signal,
+            }),
+        ).resolves.toMatchObject({
+            status: 'failed',
+            terminalReason: 'provider_error',
+        });
+    });
+
+    it.each([
+        [
+            'a verified zero-row query',
+            evidencePack({
+                queries: [
+                    {
+                        ...evidencePack().queries[0],
+                        rowCount: 0,
+                        rowsCsv: '',
+                    },
+                ],
+            }),
+        ],
+        [
+            'worker findings without a query',
+            evidencePack({
+                queries: [],
+                workerFindings: [workerFindings()],
+            }),
+        ],
+    ])('finalizes %s as evidence', async (_name, pack) => {
+        const { executor, generateDeepResearchReport } = buildExecutor({
+            buildEvidencePack: vi
+                .fn()
+                .mockResolvedValue(evidenceBuildResult(pack)),
+        });
+
+        await expect(
+            executor.execute(run(), {
+                signal: new AbortController().signal,
+            }),
+        ).resolves.toMatchObject({ status: 'completed' });
+        expect(generateDeepResearchReport).toHaveBeenCalledOnce();
     });
 });

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
@@ -7,7 +7,6 @@ import {
     type AiAgentToolCall,
     type AiAgentToolResult,
     type AiDeepResearchActivity,
-    type AiDeepResearchEvidencePack,
     type AiDeepResearchPhase,
     type AiDeepResearchProgress,
     type AiDeepResearchSubmittedReport,
@@ -30,7 +29,9 @@ import {
     getAiDeepResearchWorkerBudget,
 } from './AiDeepResearchAgent';
 import {
+    AI_DEEP_RESEARCH_NO_RELEVANT_DATA_ERROR_MESSAGE,
     getAiDeepResearchRunBudget,
+    type AiDeepResearchEvidenceBuildResult,
     type AiDeepResearchExecutor as AiDeepResearchExecutorFn,
     type AiDeepResearchExecutorResult,
 } from './AiDeepResearchService';
@@ -65,7 +66,7 @@ type Dependencies = {
      */
     buildEvidencePack: (
         run: DbAiDeepResearchRun,
-    ) => Promise<AiDeepResearchEvidencePack>;
+    ) => Promise<AiDeepResearchEvidenceBuildResult>;
     aiAgentModel: Pick<AiAgentModel, 'getToolCallsAndResultsForPrompt'>;
     aiDeepResearchRunModel: Pick<
         AiDeepResearchRunModel,
@@ -456,6 +457,7 @@ export class AiDeepResearchExecutor {
         // Delegation is the coordinator's choice, but the ceiling is not: the
         // cap is counted here rather than asked for in the prompt.
         let delegations = 0;
+        let hadWorkerExecutionFailure = false;
 
         const runWorker = async (
             input: AiDeepResearchWorkerTaskInput,
@@ -525,18 +527,22 @@ export class AiDeepResearchExecutor {
             } catch (error) {
                 // A crash after the packet was submitted (budget abort,
                 // provider error) still yields usable findings — keep them.
+                hadWorkerExecutionFailure = true;
                 failureReason = getErrorMessage(error);
             }
 
-            return findings
-                ? { task, findings, failureReason: null }
-                : {
-                      task,
-                      findings: null,
-                      failureReason:
-                          failureReason ??
-                          'The task ended without submitting findings',
-                  };
+            if (findings) {
+                return { task, findings, failureReason: null };
+            }
+
+            hadWorkerExecutionFailure = true;
+            return {
+                task,
+                findings: null,
+                failureReason:
+                    failureReason ??
+                    'The task ended without submitting findings',
+            };
         };
 
         const runCoordinator = () =>
@@ -574,29 +580,32 @@ export class AiDeepResearchExecutor {
          * mid-investigation reports exactly like one that finished, and
          * finalization costs the same either way.
          */
-        const finalize = async (
-            reason: string,
-        ): Promise<AiDeepResearchSubmittedReport | null> => {
+        const finalize = async (reason: string) => {
             try {
-                const evidencePack =
+                const { evidencePack, hasEvidenceBuildFailures } =
                     await this.dependencies.buildEvidencePack(run);
                 if (isAiDeepResearchEvidencePackEmpty(evidencePack)) {
-                    return null;
+                    if (hadWorkerExecutionFailure || hasEvidenceBuildFailures) {
+                        return { outcome: 'failed' } as const;
+                    }
+                    return { outcome: 'no_relevant_data' } as const;
                 }
-                return await this.dependencies.aiAgentService.generateDeepResearchReport(
-                    user,
-                    {
-                        agentUuid: run.agent_uuid,
-                        threadUuid: run.ai_thread_uuid,
-                        evidencePack,
-                        reason,
-                    },
-                );
+                const report =
+                    await this.dependencies.aiAgentService.generateDeepResearchReport(
+                        user,
+                        {
+                            agentUuid: run.agent_uuid,
+                            threadUuid: run.ai_thread_uuid,
+                            evidencePack,
+                            reason,
+                        },
+                    );
+                return { outcome: 'reported', report } as const;
             } catch (error) {
                 Logger.warn(
                     `[AiDeepResearch] Could not finalize run ${run.ai_deep_research_run_uuid}: ${getErrorMessage(error)}`,
                 );
-                return null;
+                return { outcome: 'failed' } as const;
             }
         };
 
@@ -611,7 +620,7 @@ export class AiDeepResearchExecutor {
 
         // Cancellation is the user's decision to stop; everything else still
         // owes a report.
-        const finalizedReport =
+        const finalization =
             cancelledByUser || signal.aborted || authorizationRevokedReason
                 ? null
                 : await finalize(
@@ -619,6 +628,8 @@ export class AiDeepResearchExecutor {
                           ? `the ${budgetExceeded} budget was exhausted`
                           : 'the investigation ran to completion',
                   );
+        const finalizedReport =
+            finalization?.outcome === 'reported' ? finalization.report : null;
         await stopRunMonitor();
 
         if (cancelledByUser || signal.aborted) {
@@ -678,6 +689,13 @@ export class AiDeepResearchExecutor {
                 status: 'failed',
                 errorMessage: getErrorMessage(executionError),
                 terminalReason: 'provider_error',
+            };
+        }
+        if (finalization?.outcome === 'no_relevant_data') {
+            return {
+                status: 'failed',
+                errorMessage: AI_DEEP_RESEARCH_NO_RELEVANT_DATA_ERROR_MESSAGE,
+                terminalReason: 'no_relevant_data',
             };
         }
         if (!finalizedReport) {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -1040,6 +1040,27 @@ describe('AiDeepResearchService', () => {
             expect(run.isReportExpired).toBe(true);
         });
 
+        it('returns the persisted terminal reason', async () => {
+            const { service } = buildService({
+                model: {
+                    findByUuidScoped: vi.fn().mockResolvedValue(
+                        runRow({
+                            status: 'failed',
+                            terminal_reason: 'no_relevant_data',
+                        }),
+                    ),
+                },
+            });
+
+            const run = await service.getRun(
+                userWithProjectAccess(),
+                'project-1',
+                'run-1',
+            );
+
+            expect(run.terminalReason).toBe('no_relevant_data');
+        });
+
         it("does not expose another creator's run to a project viewer", async () => {
             const { service, projectModel } = buildService({
                 model: {
@@ -1661,6 +1682,25 @@ describe('AiDeepResearchService', () => {
             );
         });
 
+        it('persists the no relevant data outcome with actionable copy', async () => {
+            const { service, model } = buildService({
+                executor: vi.fn().mockResolvedValue({
+                    status: 'failed',
+                    errorMessage:
+                        'Deep Research could not find relevant data for this question.',
+                    terminalReason: 'no_relevant_data',
+                }),
+            });
+
+            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
+
+            expect(model.markFailed).toHaveBeenCalledWith(
+                'run-1',
+                'Deep Research could not find relevant data for this question.',
+                'no_relevant_data',
+            );
+        });
+
         it('passes an abort signal to the executor', async () => {
             const abortController = new AbortController();
             const { service, executor } = buildService();
@@ -1725,8 +1765,10 @@ describe('AiDeepResearchService', () => {
         it('rebuilds evidence from the run own verified executions', async () => {
             const { service } = buildEvidenceService();
 
-            const pack = await service.buildEvidencePack(runRow() as AnyType);
+            const { evidencePack: pack, hasEvidenceBuildFailures } =
+                await service.buildEvidencePack(runRow() as AnyType);
 
+            expect(hasEvidenceBuildFailures).toBe(false);
             expect(pack.question).toBe('Investigate revenue');
             expect(pack.queries).toHaveLength(1);
             expect(pack.queries[0]).toMatchObject({
@@ -1780,8 +1822,10 @@ describe('AiDeepResearchService', () => {
                 },
             });
 
-            const pack = await service.buildEvidencePack(runRow() as AnyType);
+            const { evidencePack: pack, hasEvidenceBuildFailures } =
+                await service.buildEvidencePack(runRow() as AnyType);
 
+            expect(hasEvidenceBuildFailures).toBe(false);
             expect(pack.queries).toEqual([
                 expect.objectContaining({
                     type: 'sql_query',
@@ -1830,8 +1874,10 @@ describe('AiDeepResearchService', () => {
                 },
             });
 
-            const pack = await service.buildEvidencePack(runRow() as AnyType);
+            const { evidencePack: pack, hasEvidenceBuildFailures } =
+                await service.buildEvidencePack(runRow() as AnyType);
 
+            expect(hasEvidenceBuildFailures).toBe(false);
             expect(pack.queries).toEqual([
                 expect.objectContaining({
                     type: 'sql_query',
@@ -1860,8 +1906,10 @@ describe('AiDeepResearchService', () => {
                 },
             });
 
-            const pack = await service.buildEvidencePack(runRow() as AnyType);
+            const { evidencePack: pack, hasEvidenceBuildFailures } =
+                await service.buildEvidencePack(runRow() as AnyType);
 
+            expect(hasEvidenceBuildFailures).toBe(false);
             expect(pack.queries).toHaveLength(1);
             expect(pack.queries[0].chartable).toBe(false);
         });
@@ -1875,8 +1923,10 @@ describe('AiDeepResearchService', () => {
                 },
             });
 
-            const pack = await service.buildEvidencePack(runRow() as AnyType);
+            const { evidencePack: pack, hasEvidenceBuildFailures } =
+                await service.buildEvidencePack(runRow() as AnyType);
 
+            expect(hasEvidenceBuildFailures).toBe(false);
             expect(pack.queries).toEqual([]);
         });
 
@@ -1889,8 +1939,10 @@ describe('AiDeepResearchService', () => {
                 },
             });
 
-            const pack = await service.buildEvidencePack(runRow() as AnyType);
+            const { evidencePack: pack, hasEvidenceBuildFailures } =
+                await service.buildEvidencePack(runRow() as AnyType);
 
+            expect(hasEvidenceBuildFailures).toBe(true);
             expect(pack.queries).toEqual([]);
             expect(pack.question).toBe('Investigate revenue');
         });
@@ -1905,10 +1957,70 @@ describe('AiDeepResearchService', () => {
                 },
             });
 
-            const pack = await service.buildEvidencePack(runRow() as AnyType);
+            const { evidencePack: pack, hasEvidenceBuildFailures } =
+                await service.buildEvidencePack(runRow() as AnyType);
 
+            expect(hasEvidenceBuildFailures).toBe(true);
             expect(pack.queries).toEqual([]);
         });
+
+        it.each([
+            {
+                name: 'successful field-value search',
+                toolName: 'searchFieldValues',
+                toolResult: { metadata: { status: 'success' } },
+                expectedFailure: false,
+            },
+            {
+                name: 'failed field-value search',
+                toolName: 'searchFieldValues',
+                toolResult: { metadata: { status: 'error' } },
+                expectedFailure: true,
+            },
+            {
+                name: 'failed metadata discovery',
+                toolName: 'getMetadata',
+                toolResult: { metadata: { status: 'error' } },
+                expectedFailure: true,
+            },
+            {
+                name: 'failed MCP discovery',
+                toolName: 'catalog__search',
+                toolResult: {
+                    toolType: 'mcp',
+                    metadata: null,
+                    result: JSON.stringify({ isError: true }),
+                },
+                expectedFailure: true,
+            },
+        ])(
+            'classifies $name without treating value search as query evidence',
+            async ({ toolName, toolResult, expectedFailure }) => {
+                const { service } = buildEvidenceService({
+                    aiAgentModel: {
+                        getToolCallsAndResultsForPrompt: vi
+                            .fn()
+                            .mockResolvedValue([
+                                {
+                                    toolCall: {
+                                        toolName,
+                                        toolArgs: {},
+                                        parentToolCallId: null,
+                                    },
+                                    toolResult,
+                                },
+                            ]),
+                    },
+                });
+
+                const { evidencePack, hasEvidenceBuildFailures } =
+                    await service.buildEvidencePack(runRow() as AnyType);
+
+                expect(hasEvidenceBuildFailures).toBe(expectedFailure);
+                expect(evidencePack.queries).toEqual([]);
+                expect(evidencePack.workerFindings).toEqual([]);
+            },
+        );
     });
 
     describe('getChart', () => {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -23,6 +23,7 @@ import {
     toolRunQueryArgsSchema,
     UnexpectedServerError,
     type Account,
+    type AiAgentToolResult,
     type AiDeepResearchBudget,
     type AiDeepResearchChartData,
     type AiDeepResearchEntryPoint,
@@ -65,8 +66,8 @@ import { convertQueryResultsToCsv } from '../ai/utils/convertQueryResultsToCsv';
 import { type AiAgentService } from '../AiAgentService/AiAgentService';
 import { resolveDeepResearchWarehouseChart } from './resolveDeepResearchWarehouseChart';
 import {
+    isDeepResearchEvidenceQueryTool,
     isDeepResearchRawSqlTool,
-    isDeepResearchWarehouseTool,
 } from './toolClassification';
 
 const MAX_EVENT_PAGE_SIZE = 100;
@@ -76,6 +77,36 @@ const STALE_RUN_ERROR_MESSAGE =
     'Deep Research stopped unexpectedly before it could finish.';
 const FAILED_RUN_ERROR_MESSAGE =
     'Deep Research could not finish. Please try again.';
+export const AI_DEEP_RESEARCH_NO_RELEVANT_DATA_ERROR_MESSAGE =
+    'Deep Research could not find relevant data for this question.';
+const isToolResultFailure = (toolResult: AiAgentToolResult | null): boolean => {
+    if (toolResult === null) {
+        return true;
+    }
+    const { metadata } = toolResult;
+    if (
+        metadata !== null &&
+        typeof metadata === 'object' &&
+        'status' in metadata &&
+        metadata.status === 'error'
+    ) {
+        return true;
+    }
+    if (toolResult.toolType !== 'mcp') {
+        return false;
+    }
+    try {
+        const result: unknown = JSON.parse(toolResult.result);
+        return (
+            result !== null &&
+            typeof result === 'object' &&
+            'isError' in result &&
+            result.isError === true
+        );
+    } catch {
+        return false;
+    }
+};
 const getQueryUuidFromMetadata = (metadata: unknown): string | null =>
     metadata !== null &&
     typeof metadata === 'object' &&
@@ -122,6 +153,11 @@ const isChartConfigCompatible = (
 
 export type AiDeepResearchSubmittedReport = {
     markdown: string;
+};
+
+export type AiDeepResearchEvidenceBuildResult = {
+    evidencePack: AiDeepResearchEvidencePack;
+    hasEvidenceBuildFailures: boolean;
 };
 
 export type AiDeepResearchExecutorResult =
@@ -251,6 +287,7 @@ const toRun = (row: DbAiDeepResearchRun): AiDeepResearchRun => {
         entryPoint: row.entry_point,
         prompt: row.prompt,
         status: row.status,
+        terminalReason: row.terminal_reason,
         resultMarkdown: isReportExpired ? null : row.result_markdown,
         reportExpiresAt: reportExpiresAt?.toISOString() ?? null,
         reportExpiredAt: row.report_expired_at?.toISOString() ?? null,
@@ -1088,7 +1125,9 @@ export class AiDeepResearchService extends BaseService {
                 );
                 await this.aiDeepResearchRunModel.markFailed(
                     payload.aiDeepResearchRunUuid,
-                    FAILED_RUN_ERROR_MESSAGE,
+                    result.terminalReason === 'no_relevant_data'
+                        ? AI_DEEP_RESEARCH_NO_RELEVANT_DATA_ERROR_MESSAGE
+                        : FAILED_RUN_ERROR_MESSAGE,
                     result.terminalReason,
                 );
                 await this.dispatchPendingLifecycleAnalytics(
@@ -1256,14 +1295,25 @@ export class AiDeepResearchService extends BaseService {
      */
     async buildEvidencePack(
         run: DbAiDeepResearchRun,
-    ): Promise<AiDeepResearchEvidencePack> {
+    ): Promise<AiDeepResearchEvidenceBuildResult> {
         const provenance =
             await this.aiAgentModel.getToolCallsAndResultsForPrompt(
                 run.prompt_uuid,
                 { includeSubagentToolCalls: true },
             );
 
-        const workerFindings = provenance.flatMap(({ toolCall }) =>
+        const belongsToRun = (parentToolCallId: string | null) =>
+            parentToolCallId === null ||
+            parentToolCallId.startsWith(
+                `deep-research:${run.ai_deep_research_run_uuid}:`,
+            );
+        const runProvenance = provenance.filter(({ toolCall }) =>
+            belongsToRun(toolCall.parentToolCallId),
+        );
+        const hasToolFailures = runProvenance.some(({ toolResult }) =>
+            isToolResultFailure(toolResult),
+        );
+        const workerFindingResults = runProvenance.flatMap(({ toolCall }) =>
             toolCall.toolName === AI_DEEP_RESEARCH_WORKER_FINDINGS_TOOL_NAME &&
             toolCall.parentToolCallId?.startsWith(
                 `deep-research:${run.ai_deep_research_run_uuid}:`,
@@ -1272,32 +1322,32 @@ export class AiDeepResearchService extends BaseService {
                       aiDeepResearchWorkerFindingsInputSchema.safeParse(
                           toolCall.toolArgs,
                       ),
-                  ].flatMap((parsed) => (parsed.success ? [parsed.data] : []))
+                  ]
                 : [],
         );
+        const workerFindings = workerFindingResults.flatMap((parsed) =>
+            parsed.success ? [parsed.data] : [],
+        );
 
-        const belongsToRun = (parentToolCallId: string | null) =>
-            parentToolCallId === null ||
-            parentToolCallId.startsWith(
-                `deep-research:${run.ai_deep_research_run_uuid}:`,
-            );
-        const executions = provenance.flatMap(({ toolCall, toolResult }) => {
-            const queryUuid = toolResult
-                ? getQueryUuidFromMetadata(toolResult.metadata)
-                : null;
-            return queryUuid &&
-                isDeepResearchWarehouseTool(toolCall.toolName) &&
-                isValidUuid(queryUuid) &&
-                belongsToRun(toolCall.parentToolCallId)
-                ? [
-                      {
-                          queryUuid,
-                          toolName: toolCall.toolName,
-                          toolArgs: toolCall.toolArgs,
-                      },
-                  ]
-                : [];
-        });
+        const evidenceQueryCalls = runProvenance.filter(({ toolCall }) =>
+            isDeepResearchEvidenceQueryTool(toolCall.toolName),
+        );
+        const executions = evidenceQueryCalls.flatMap(
+            ({ toolCall, toolResult }) => {
+                const queryUuid = toolResult
+                    ? getQueryUuidFromMetadata(toolResult.metadata)
+                    : null;
+                return queryUuid && isValidUuid(queryUuid)
+                    ? [
+                          {
+                              queryUuid,
+                              toolName: toolCall.toolName,
+                              toolArgs: toolCall.toolArgs,
+                          },
+                      ]
+                    : [];
+            },
+        );
         // Latest execution of a queryUuid wins; a retried query would
         // otherwise appear twice.
         const uniqueExecutions = [
@@ -1306,16 +1356,25 @@ export class AiDeepResearchService extends BaseService {
             ).values(),
         ].slice(-AI_DEEP_RESEARCH_EVIDENCE_MAX_QUERIES);
 
-        const queries = await Promise.all(
+        const queryResults = await Promise.all(
             uniqueExecutions.map((execution) =>
                 this.buildEvidenceQuery(run, execution),
             ),
         );
 
         return {
-            question: run.prompt,
-            queries: queries.flatMap((query) => (query ? [query] : [])),
-            workerFindings,
+            evidencePack: {
+                question: run.prompt,
+                queries: queryResults.flatMap((query) =>
+                    query ? [query] : [],
+                ),
+                workerFindings,
+            },
+            hasEvidenceBuildFailures:
+                hasToolFailures ||
+                workerFindingResults.some((parsed) => !parsed.success) ||
+                executions.length < evidenceQueryCalls.length ||
+                queryResults.some((query) => query === null),
         };
     }
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/toolClassification.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/toolClassification.ts
@@ -5,9 +5,16 @@ const WAREHOUSE_TOOL_NAMES = new Set([
     'runSql',
     'searchFieldValues',
 ]);
+const EVIDENCE_QUERY_TOOL_NAMES = new Set([
+    'generateVisualization',
+    'runContentQuery',
+    'runSavedChart',
+    'runSql',
+]);
 
 const WAREHOUSE_MCP_TOOL_RE =
     /__(?:run_metric_query|run_sql|search_field_values)(?:_\d+)?$/;
+const EVIDENCE_QUERY_MCP_TOOL_RE = /__(?:run_metric_query|run_sql)(?:_\d+)?$/;
 const RAW_SQL_MCP_TOOL_RE = /__run_sql(?:_\d+)?$/;
 
 export const isDeepResearchWarehouseTool = (toolName: string): boolean =>
@@ -15,6 +22,10 @@ export const isDeepResearchWarehouseTool = (toolName: string): boolean =>
 
 export const isDeepResearchWarehouseMcpTool = (toolName: string): boolean =>
     WAREHOUSE_MCP_TOOL_RE.test(toolName);
+
+export const isDeepResearchEvidenceQueryTool = (toolName: string): boolean =>
+    EVIDENCE_QUERY_TOOL_NAMES.has(toolName) ||
+    EVIDENCE_QUERY_MCP_TOOL_RE.test(toolName);
 
 export const isDeepResearchRawSqlTool = (toolName: string): boolean =>
     toolName === 'runSql' || RAW_SQL_MCP_TOOL_RE.test(toolName);

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -39,6 +39,7 @@ export const AI_DEEP_RESEARCH_TERMINAL_REASONS = [
     'query_limit',
     'token_limit',
     'time_limit',
+    'no_relevant_data',
     'provider_error',
     'internal_error',
 ] as const;
@@ -338,6 +339,7 @@ export type AiDeepResearchRun = {
     entryPoint: AiDeepResearchEntryPoint;
     prompt: string;
     status: AiDeepResearchRunStatus;
+    terminalReason: AiDeepResearchTerminalReason | null;
     /** The report narrative with compact <chart> references. */
     resultMarkdown: string | null;
     reportExpiresAt: string | null;

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
@@ -151,6 +151,37 @@ describe('DeepResearchRunCard', () => {
         },
     );
 
+    it('shows how to refine a question when no relevant data was found', () => {
+        renderWithProviders(
+            <DeepResearchRunCard
+                run={{
+                    ...deepResearchRunFixture,
+                    status: 'failed',
+                    terminalReason: 'no_relevant_data',
+                    resultMarkdown: null,
+                    errorMessage:
+                        'Deep Research could not find relevant data for this question.',
+                }}
+                projectUuid="project-1"
+            />,
+        );
+
+        expect(screen.getByText('No relevant data')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Deep Research could not find relevant data for this question.',
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Try refining your question or choosing data that covers the topic.',
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText(/completed queries and findings are saved/i),
+        ).not.toBeInTheDocument();
+    });
+
     it('preserves partial findings and offers the report', () => {
         renderWithProviders(
             <DeepResearchRunCard

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -193,6 +193,9 @@ export const DeepResearchRunCard = ({
     const activityId = useId();
     const trackReportEngagement = useTrackDeepResearchReportEngagement();
     const [announcedStatus, setAnnouncedStatus] = useState(run.status);
+    const hasNoRelevantData =
+        run.status === 'failed' && run.terminalReason === 'no_relevant_data';
+    const statusLabel = hasNoRelevantData ? 'No relevant data' : status.label;
 
     useEffect(() => {
         if (announcedStatus !== run.status) {
@@ -223,7 +226,7 @@ export const DeepResearchRunCard = ({
             <Stack gap="md">
                 <DeepResearchRunHeading
                     statusLabel={
-                        isCompleted ? completedStatusLabel : status.label
+                        isCompleted ? completedStatusLabel : statusLabel
                     }
                     elapsedLabel={
                         run.status === 'queued' || isCompleted
@@ -248,7 +251,7 @@ export const DeepResearchRunCard = ({
                 />
 
                 <Text className={styles.liveRegion} aria-live="polite">
-                    Research status changed to {status.label}
+                    Research status changed to {statusLabel}
                 </Text>
 
                 {run.phase && !isTerminal && (
@@ -341,14 +344,24 @@ export const DeepResearchRunCard = ({
                                 {run.errorMessage ??
                                     'Research stopped before the report was ready.'}
                             </Text>
-                            <Text size="sm">
-                                Any completed queries and findings are saved
-                                below.
-                            </Text>
-                            <Text size="sm">
-                                Starting over creates a new research run.
-                                Previous queries won&apos;t be reused.
-                            </Text>
+                            {hasNoRelevantData ? (
+                                <Text size="sm">
+                                    Try refining your question or choosing data
+                                    that covers the topic.
+                                </Text>
+                            ) : (
+                                <>
+                                    <Text size="sm">
+                                        Any completed queries and findings are
+                                        saved below.
+                                    </Text>
+                                    <Text size="sm">
+                                        Starting over creates a new research
+                                        run. Previous queries won&apos;t be
+                                        reused.
+                                    </Text>
+                                </>
+                            )}
                             {canRunAgain && onRunAgain && (
                                 <Button
                                     size="xs"

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
@@ -66,6 +66,7 @@ export const deepResearchRunFixture: DeepResearchRunView = {
     question:
         'Why did enterprise retention fall in Q2 despite higher product adoption?',
     status: 'completed',
+    terminalReason: null,
     phase: 'Writing the report',
     startedAt: '2026-07-15T09:00:00.000Z',
     completedAt: '2026-07-15T09:18:00.000Z',

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
@@ -155,6 +155,7 @@ export const adaptDeepResearchRun = ({
         threadUuid: registration.threadUuid,
         question: registration.question,
         status: run.status,
+        terminalReason: run.terminalReason,
         phase: getPhaseLabel(
             latestProgress?.phase ?? null,
             latestProgress?.activity ?? null,

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
@@ -1,3 +1,5 @@
+import { type AiDeepResearchTerminalReason } from '@lightdash/common';
+
 export type DeepResearchRunStatus =
     | 'queued'
     | 'running'
@@ -21,6 +23,7 @@ export type DeepResearchRunView = {
     threadUuid: string;
     question: string;
     status: DeepResearchRunStatus;
+    terminalReason: AiDeepResearchTerminalReason | null;
     phase: string | null;
     startedAt: string | null;
     completedAt: string | null;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9799/deep-research-shows-a-generic-failure-when-no-relevant-data-exists

## Summary

Deep Research now distinguishes a completed search that finds no relevant data from a provider failure. Affected runs show “No relevant data” with guidance to refine the question or choose data that covers the topic.

## Root cause

The executor treated every missing report as a provider failure. An empty evidence pack intentionally skipped report generation, so it flowed through the same generic failure path as a real provider error.

```text
empty evidence → no report → provider_error → “Couldn’t complete”
```

The empty-pack behavior originated here:

```ts
if (isDeepResearchEvidencePackEmpty(evidencePack)) {
    return null;
}
```

## Fix

The executor returns `no_relevant_data` only when the rebuilt evidence pack is empty and no worker or evidence-building failure occurred. The API exposes the persisted terminal reason, and the failed-run card renders dedicated no-data copy and refinement guidance.

- Backend evidence diagnostics preserve provider failures for worker throws, missing or explicit tool errors, malformed findings, invalid query IDs, and unreadable query evidence.
- Successful field-value searches do not count as failed query evidence, while verified zero-row queries still count as evidence.
- Provider, budget, and finalizer failure behavior remains unchanged.

## Before

```text
No queries/findings
        ↓
provider_error
        ↓
Couldn’t complete · Please try again
```

## After

```text
No queries/findings + clean execution
        ↓
no_relevant_data
        ↓
No relevant data · Refine the question or choose relevant data
```

## Test plan

- [x] Backend executor/service suites: 104 tests pass
- [x] Frontend Deep Research run-card suite: 15 tests pass
- [x] Common, backend, and frontend typechecks pass
- [x] Common, backend, and frontend lint pass
- [x] `pnpm generate-api` succeeds; generated artifacts excluded per repository policy
- [x] Running API returns `failed / no_relevant_data` with the safe no-data message; temporary seeded database state restored