### PR TITLE
fix(backend): resolve release-safety artifact only from the baked path

### DIFF
--- a/packages/backend/src/scripts/migrate/index.ts
+++ b/packages/backend/src/scripts/migrate/index.ts
@@ -1,7 +1,6 @@
 import { runMigrations } from 'graphile-worker';
 import knex from 'knex';
 import os from 'node:os';
-import path from 'node:path';
 import { lightdashConfig } from '../../config/lightdashConfig';
 import { MigrationLeaseManager } from '../../database/migrationLease';
 import knexConfig from '../../knexfile';
@@ -51,9 +50,7 @@ type KnexMigrationLockRow = {
 
 const main = async (): Promise<void> => {
     const migrationConfig = config.migrations ?? {};
-    const artifactPath = resolveReleaseSafetyArtifactPath({
-        cwd: path.resolve(__dirname, '../../../../..'),
-    });
+    const artifactPath = resolveReleaseSafetyArtifactPath();
     const context = createMigrateCliContext({
         leaseManager,
         heartbeatLeaseManager,

--- a/packages/backend/src/scripts/migrate/preflight.test.ts
+++ b/packages/backend/src/scripts/migrate/preflight.test.ts
@@ -327,28 +327,28 @@ describe('release-safety artifact handling', () => {
         ).toThrow('release-safety artifact does not match contract v2');
     });
 
-    test('resolves production, development, and explicit artifact paths', () => {
-        expect(
-            resolveReleaseSafetyArtifactPath({
-                nodeEnv: 'production',
-                cwd: '/workspace',
-                override: '',
-            }),
-        ).toBe('/usr/app/release-safety.json');
-        expect(
-            resolveReleaseSafetyArtifactPath({
-                nodeEnv: 'test',
-                cwd: '/workspace',
-                override: '',
-            }),
-        ).toBe('/workspace/release-safety.json');
-        expect(
-            resolveReleaseSafetyArtifactPath({
-                nodeEnv: 'production',
-                cwd: '/workspace',
-                override: '/tmp/custom.json',
-            }),
-        ).toBe('/tmp/custom.json');
+    test('resolves the baked artifact path unless explicitly overridden', () => {
+        const originalOverride = process.env.RELEASE_SAFETY_ARTIFACT_PATH;
+        delete process.env.RELEASE_SAFETY_ARTIFACT_PATH;
+        try {
+            expect(resolveReleaseSafetyArtifactPath({ override: '' })).toBe(
+                '/usr/app/release-safety.json',
+            );
+            expect(resolveReleaseSafetyArtifactPath()).toBe(
+                '/usr/app/release-safety.json',
+            );
+            expect(
+                resolveReleaseSafetyArtifactPath({
+                    override: '/tmp/custom.json',
+                }),
+            ).toBe('/tmp/custom.json');
+        } finally {
+            if (originalOverride === undefined) {
+                delete process.env.RELEASE_SAFETY_ARTIFACT_PATH;
+            } else {
+                process.env.RELEASE_SAFETY_ARTIFACT_PATH = originalOverride;
+            }
+        }
     });
 });
 

--- a/packages/backend/src/scripts/migrate/preflight.ts
+++ b/packages/backend/src/scripts/migrate/preflight.ts
@@ -339,20 +339,12 @@ export const parseReleaseSafetyArtifact = (
 };
 
 export const resolveReleaseSafetyArtifactPath = ({
-    nodeEnv = process.env.NODE_ENV,
-    cwd = process.cwd(),
     override = process.env.RELEASE_SAFETY_ARTIFACT_PATH,
-}: {
-    nodeEnv?: string;
-    cwd?: string;
-    override?: string;
-} = {}): string => {
+}: { override?: string } = {}): string => {
     if (override !== undefined && override.length > 0) {
         return path.resolve(override);
     }
-    return nodeEnv === 'production'
-        ? RELEASE_SAFETY_ARTIFACT_PATH
-        : path.resolve(cwd, 'release-safety.json');
+    return RELEASE_SAFETY_ARTIFACT_PATH;
 };
 
 export const loadReleaseSafetyArtifact = async (


### PR DESCRIPTION
## Problem

Fresh dev worktrees cannot bootstrap: the migration preflight gate red-fails `migrate up` with *"pending migrations outside this release artifact"* on any snapshot-restored dev database (`./scripts/dev-fast-start.sh` dies at the migrate step; verified workaround was `migrate up --force`).

Root cause: in non-production environments the artifact resolver fell back to `path.resolve(cwd, 'release-safety.json')` — which picks up the **checked-in per-release marker** at the repo root. That file is generated per release and lists only migrations *added in that release* (frequently zero), so the gate read it as a genuine baked artifact that knows none of the pending migrations, and the version-path check went red. The marker was never a baked release-safety artifact.

## Fix

`resolveReleaseSafetyArtifactPath` now resolves only the baked path (`/usr/app/release-safety.json`), with the existing `RELEASE_SAFETY_ARTIFACT_PATH` env override unchanged. Dev checkouts therefore hit the **absent-artifact path**: YELLOW-loudly, non-blocking, `--strict` still promotes to a hard abort. No dev special-casing in the gate logic; the version-path check is untouched.

Trust-model semantics preserved (all pinned by existing tests):
- absent artifact → YELLOW warn, `--strict` aborts
- artifact present but unreadable/corrupt → RED
- artifact present with pending migrations unknown to it → RED

Note on artifact-less **production source builds**: `NODE_ENV=production` always resolved the baked path (before and after this change), so a production build without the baked artifact already followed absent→YELLOW and never hit this red. Production behavior is byte-identical.

## Verification

- `pnpm -F backend exec vitest run src/scripts/migrate`: 6 files, 100 tests pass; backend typecheck clean; oxlint clean on touched files
- End-to-end fresh-worktree bootstrap on this branch: `dev-fast-start.sh` completes (previously red-failed at migrate) — preflight logs `[YELLOW WARN] version-path` and `Preflight decision: proceed-with-warnings (0 red, 1 yellow)`, all migrations apply, backend healthy
- Live `migrate preflight --strict` on the same environment: `Preflight decision: abort (0 red, 1 yellow)`

Linear: SPK-938
Part of #27140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ucPdRadzzrJHdW2LHRK4n