### PR TITLE
feat(data-apps): enforce viz space-semantics guardrails

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -827,3 +827,53 @@ describe('AppGenerateService data app vizs', () => {
         expect(res.versions[1].resources?.vizSchema ?? null).toBeNull();
     });
 });
+
+describe('moving a viz into a space', () => {
+    it('rejects moveToSpace for viz-template apps before any access checks', async () => {
+        const appModel = {
+            getApp: vi.fn().mockResolvedValue(makeDataAppVizRow()),
+            moveToSpace: vi.fn(),
+        };
+        const service = buildService(appModel);
+
+        await expect(
+            service.moveToSpace(USER, {
+                projectUuid: 'project-1',
+                itemUuid: 'data-app-viz-1',
+                targetSpaceUuid: 'space-1',
+            }),
+        ).rejects.toThrow('Custom chart types cannot be moved into spaces');
+        expect(appModel.moveToSpace).not.toHaveBeenCalled();
+    });
+
+    it('still moves standalone apps', async () => {
+        const appModel = {
+            getApp: vi.fn().mockResolvedValue(
+                makeDataAppVizRow({
+                    template: null,
+                    space_uuid: 'space-0',
+                }),
+            ),
+            moveToSpace: vi.fn().mockResolvedValue(undefined),
+        };
+        const service = buildService(appModel);
+
+        await service.moveToSpace(
+            USER,
+            {
+                projectUuid: 'project-1',
+                itemUuid: 'data-app-viz-1',
+                targetSpaceUuid: 'space-1',
+            },
+            { trackEvent: false },
+        );
+        expect(appModel.moveToSpace).toHaveBeenCalledWith(
+            {
+                appId: 'data-app-viz-1',
+                projectUuid: 'project-1',
+                targetSpaceUuid: 'space-1',
+            },
+            { tx: undefined },
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -8462,6 +8462,13 @@ export class AppGenerateService extends BaseService {
 
         const app = await this.appModel.getApp(appUuid, projectUuid);
 
+        // Vizs are project-global chart content — space semantics don't apply.
+        if (app.template === DATA_APP_VIZ_TEMPLATE) {
+            throw new ParameterError(
+                'Custom chart types cannot be moved into spaces',
+            );
+        }
+
         if (checkForAccess) {
             // Manage on the source app (where it currently lives) — space
             // editors/admins of the source space can move it out.

--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -257,6 +257,7 @@ const getApps = async (
             name: `${AppsTableName}.name`,
             description: `${AppsTableName}.description`,
             created_by_user_uuid: `${AppsTableName}.created_by_user_uuid`,
+            template: `${AppsTableName}.template`,
             views: `${AppsTableName}.views_count`,
             first_viewed_at: knex.raw(`${AppsTableName}.created_at`),
             updated_at: knex.raw(
@@ -284,6 +285,7 @@ const getApps = async (
             description: row.description || undefined,
             spaceUuid: row.space_uuid,
             createdByUserUuid: row.created_by_user_uuid,
+            template: row.template ?? null,
             updatedAt: row.updated_at,
             updatedByUser: row.updated_by_user_uuid
                 ? {

--- a/packages/backend/src/models/UserFavoritesModel.ts
+++ b/packages/backend/src/models/UserFavoritesModel.ts
@@ -287,6 +287,7 @@ export class UserFavoritesModel {
                 space_uuid: `${SpaceTableName}.space_uuid`,
                 created_at: `${AppsTableName}.created_at`,
                 created_by_user_uuid: `${AppsTableName}.created_by_user_uuid`,
+                template: `${AppsTableName}.template`,
                 views: `${AppsTableName}.views_count`,
                 latest_version_number: 'latest_version.version',
                 latest_version_status: 'latest_version.status',
@@ -314,6 +315,7 @@ export class UserFavoritesModel {
                 description: row.description ?? undefined,
                 spaceUuid: row.space_uuid,
                 createdByUserUuid: row.created_by_user_uuid ?? null,
+                template: row.template ?? null,
                 updatedAt: row.latest_version_created_at ?? row.created_at,
                 updatedByUser: row.updated_by_user_uuid
                     ? {

--- a/packages/common/src/types/resourceViewItem.ts
+++ b/packages/common/src/types/resourceViewItem.ts
@@ -1,4 +1,8 @@
-import { getAppDisplayName, type AppVersionStatus } from '../ee/apps/types';
+import {
+    getAppDisplayName,
+    type AppVersionStatus,
+    type DataAppTemplate,
+} from '../ee/apps/types';
 import assertUnreachable from '../utils/assertUnreachable';
 import {
     ContentType as ResourceViewItemType,
@@ -106,6 +110,8 @@ export type ResourceViewDataAppItem = {
         latestReadyVersionNumber: number | null;
         pinnedListUuid: string | null;
         pinnedListOrder: number | null;
+        // 'data_app_viz' marks a reusable chart-type viz rather than a standalone app.
+        template: DataAppTemplate | null;
     };
     category?: ResourceItemCategory;
 };
@@ -288,6 +294,7 @@ export const contentToResourceViewItem = (content: SummaryContent) => {
                 latestReadyVersionNumber: content.latestReadyVersionNumber,
                 pinnedListUuid: content.pinnedList?.uuid || null,
                 pinnedListOrder: content.pinnedList?.order || null,
+                template: content.template,
             };
             return wrapResource(dataAppViewItem, ResourceViewItemType.DATA_APP);
         default:

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -66,7 +66,10 @@ import ResourceActionHandlers from './ResourceActionHandlers';
 import ResourceActionMenu from './ResourceActionMenu';
 import AttributeCount from './ResourceAttributeCount';
 import ResourceLastEdited from './ResourceLastEdited';
-import { getResourceUrl } from './resourceUtils';
+import {
+    getResourceUrl,
+    isNonNavigableResourceViewItem,
+} from './resourceUtils';
 import {
     ColumnVisibility,
     ResourceViewItemAction,
@@ -77,7 +80,10 @@ import {
 type ResourceView2Props = Partial<ContentTableOptions<ResourceViewItem>> & {
     filters: Pick<
         ContentArgs,
-        'spaceUuids' | 'contentTypes' | 'includePersonalDataApps'
+        | 'spaceUuids'
+        | 'contentTypes'
+        | 'includePersonalDataApps'
+        | 'dataAppVizsFilter'
     > & {
         projectUuid: string;
     };
@@ -438,6 +444,7 @@ const InfiniteResourceTable = ({
                 sortBy: sortBy?.sortBy,
                 sortDirection: sortBy?.sortDirection,
                 includePersonalDataApps: filters.includePersonalDataApps,
+                dataAppVizsFilter: filters.dataAppVizsFilter,
             },
             { keepPreviousData: true },
         );
@@ -601,7 +608,10 @@ const InfiniteResourceTable = ({
                 onClick: () => {
                     if (isTableSelectionActive) {
                         row.toggleSelected();
-                    } else if (!isInitialLoading) {
+                    } else if (
+                        !isInitialLoading &&
+                        !isNonNavigableResourceViewItem(row.original)
+                    ) {
                         void navigate(
                             getResourceUrl(filters.projectUuid, row.original),
                         );

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
@@ -32,6 +32,7 @@ import {
     getResourceTypeName,
     getResourceUrl,
     getResourceViewsSinceWhenDescription,
+    isNonNavigableResourceViewItem,
 } from './resourceUtils';
 
 type ResourceValidationErrorIndicatorProps = {
@@ -188,16 +189,10 @@ const InfiniteResourceTableColumnName = ({
         (item.data.description || isResourceViewItemChart(item)) &&
         (isChartOrDashboard || isResourceViewDataAppItem(item));
 
-    const renderContent = (hideInlineInfo = false) => (
-        <Anchor
-            component={Link}
-            c="unset"
-            underline="never"
-            to={getResourceUrl(projectUuid, item)}
-            onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
-                e.stopPropagation()
-            }
-        >
+    const isNonNavigable = isNonNavigableResourceViewItem(item);
+
+    const renderContent = (hideInlineInfo = false) => {
+        const rowContent = (
             <Group wrap="nowrap">
                 <ResourceValidationErrorIndicator
                     item={item}
@@ -298,8 +293,26 @@ const InfiniteResourceTableColumnName = ({
                     )}
                 </Stack>
             </Group>
-        </Anchor>
-    );
+        );
+
+        if (isNonNavigable) {
+            return <Box c="unset">{rowContent}</Box>;
+        }
+
+        return (
+            <Anchor
+                component={Link}
+                c="unset"
+                underline="never"
+                to={getResourceUrl(projectUuid, item)}
+                onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
+                    e.stopPropagation()
+                }
+            >
+                {rowContent}
+            </Anchor>
+        );
+    };
 
     if (isResourceViewDataAppItem(item)) {
         const appName = getResourceViewItemName(item);

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -36,6 +36,7 @@ import ShareSpaceModal from '../ShareSpaceModal';
 import SpaceActionModal from '../SpaceActionModal';
 import { ActionType } from '../SpaceActionModal/types';
 import TransferItemsModal from '../TransferItemsModal/TransferItemsModal';
+import { isDataAppVizResourceViewItem } from './resourceUtils';
 import {
     ResourceViewItemAction,
     type ResourceViewItemActionState,
@@ -243,6 +244,11 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                             initialDescription={
                                 action.item.data.description ?? ''
                             }
+                            title={
+                                isDataAppVizResourceViewItem(action.item)
+                                    ? 'Update custom chart type'
+                                    : undefined
+                            }
                             onClose={handleReset}
                             onConfirm={handleReset}
                         />
@@ -307,6 +313,11 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                             projectUuid={projectUuid}
                             uuid={action.item.data.uuid}
                             name={action.item.data.name}
+                            noun={
+                                isDataAppVizResourceViewItem(action.item)
+                                    ? 'custom chart type'
+                                    : undefined
+                            }
                             onClose={handleReset}
                             onConfirm={handleReset}
                         />

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     assertUnreachable,
     ChartSourceType,
+    DATA_APP_VIZ_TEMPLATE,
     isResourceViewItemChart,
     isResourceViewItemDashboard,
     ResourceViewItemType,
@@ -167,6 +168,11 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
     const isPersonalDataApp =
         item.type === ResourceViewItemType.DATA_APP && !item.data.spaceUuid;
 
+    // Vizs have no space semantics (Phase 0 dropped them) — hide the move action.
+    const isDataAppViz =
+        item.type === ResourceViewItemType.DATA_APP &&
+        item.data.template === DATA_APP_VIZ_TEMPLATE;
+
     // Match the app builder's wording: apps not yet in a space are "added",
     // apps already in one are "moved".
     const moveActionLabel =
@@ -177,7 +183,10 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
             : 'Move';
 
     const favoritesContext = useFavoritesContext();
-    const isFavorited = favoritesContext?.isFavorited(item.data.uuid) ?? false;
+    // Favoriting a spaceless viz would force it into a space first — no
+    // favorites for vizs until they get non-moving favorite semantics.
+    const favoritesForItem = isDataAppViz ? null : favoritesContext;
+    const isFavorited = favoritesForItem?.isFavorited(item.data.uuid) ?? false;
 
     let userCanManage = false;
     switch (item.type) {
@@ -284,7 +293,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
             }),
         ) === true;
 
-    if (!userCanManage && !canDuplicateDataApp && !favoritesContext) {
+    if (!userCanManage && !canDuplicateDataApp && !favoritesForItem) {
         return null;
     }
 
@@ -343,7 +352,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                 </Menu.Target>
 
                 <Menu.Dropdown maw={320}>
-                    {favoritesContext && (
+                    {favoritesForItem && (
                         <Menu.Item
                             component="button"
                             role="menuitem"
@@ -361,7 +370,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                     setIsFavoriteSpaceModalOpen(true);
                                     return;
                                 }
-                                favoritesContext.toggleFavorite(
+                                favoritesForItem.toggleFavorite(
                                     item.type,
                                     item.data.uuid,
                                 );
@@ -394,7 +403,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                     )}
 
                     {(userCanManage || canDuplicateDataApp) &&
-                        favoritesContext && <Menu.Divider />}
+                        favoritesForItem && <Menu.Divider />}
 
                     {/* A user who can't manage the app can still fork it. */}
                     {!userCanManage &&
@@ -403,26 +412,29 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
 
                     {userCanManage && (
                         <>
-                            {item.type === ResourceViewItemType.DATA_APP && (
-                                <Menu.Item
-                                    component="button"
-                                    role="menuitem"
-                                    leftSection={
-                                        <MantineIcon
-                                            icon={IconCode}
-                                            size={18}
-                                        />
-                                    }
-                                    onClick={() => {
-                                        if (!projectUuid) return;
-                                        void navigate(
-                                            `/projects/${projectUuid}/apps/${item.data.uuid}`,
-                                        );
-                                    }}
-                                >
-                                    Continue building
-                                </Menu.Item>
-                            )}
+                            {/* Vizs are edited from Explorer's chart type
+                                picker, never the standalone app builder. */}
+                            {item.type === ResourceViewItemType.DATA_APP &&
+                                !isDataAppViz && (
+                                    <Menu.Item
+                                        component="button"
+                                        role="menuitem"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconCode}
+                                                size={18}
+                                            />
+                                        }
+                                        onClick={() => {
+                                            if (!projectUuid) return;
+                                            void navigate(
+                                                `/projects/${projectUuid}/apps/${item.data.uuid}`,
+                                            );
+                                        }}
+                                    >
+                                        Continue building
+                                    </Menu.Item>
+                                )}
 
                             <Menu.Item
                                 component="button"
@@ -638,29 +650,33 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                     </Menu.Item>
                                 )}
 
-                            <Menu.Divider
-                                display={isSqlChart ? 'none' : 'block'}
-                            />
+                            {!isDataAppViz && (
+                                <>
+                                    <Menu.Divider
+                                        display={isSqlChart ? 'none' : 'block'}
+                                    />
 
-                            <Menu.Item
-                                component="button"
-                                role="menuitem"
-                                leftSection={
-                                    isPersonalDataApp ? (
-                                        <IconFolderPlus size={18} />
-                                    ) : (
-                                        <IconFolderSymlink size={18} />
-                                    )
-                                }
-                                onClick={() => {
-                                    onAction({
-                                        type: ResourceViewItemAction.TRANSFER_TO_SPACE,
-                                        item,
-                                    });
-                                }}
-                            >
-                                {moveActionLabel}
-                            </Menu.Item>
+                                    <Menu.Item
+                                        component="button"
+                                        role="menuitem"
+                                        leftSection={
+                                            isPersonalDataApp ? (
+                                                <IconFolderPlus size={18} />
+                                            ) : (
+                                                <IconFolderSymlink size={18} />
+                                            )
+                                        }
+                                        onClick={() => {
+                                            onAction({
+                                                type: ResourceViewItemAction.TRANSFER_TO_SPACE,
+                                                item,
+                                            });
+                                        }}
+                                    >
+                                        {moveActionLabel}
+                                    </Menu.Item>
+                                </>
+                            )}
 
                             {item.type === ResourceViewItemType.SPACE && (
                                 <Menu.Item
@@ -702,7 +718,9 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                         Delete{' '}
                                         {item.type ===
                                         ResourceViewItemType.DATA_APP
-                                            ? 'data app'
+                                            ? isDataAppViz
+                                                ? 'custom chart type'
+                                                : 'data app'
                                             : item.type}
                                     </Menu.Item>
                                 </>

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -2,11 +2,25 @@ import {
     assertUnreachable,
     ChartKind,
     ChartSourceType,
+    DATA_APP_VIZ_TEMPLATE,
+    isResourceViewDataAppItem,
     ResourceViewItemType,
     type ResourceViewChartItem,
     type ResourceViewItem,
 } from '@lightdash/common';
 import dayjs from 'dayjs';
+
+// A viz row: a reusable custom chart type on data-app rails, not a standalone
+// app. Keyed on the row's own data so every surface treats it consistently.
+export const isDataAppVizResourceViewItem = (item: ResourceViewItem): boolean =>
+    isResourceViewDataAppItem(item) &&
+    item.data.template === DATA_APP_VIZ_TEMPLATE;
+
+// Viz rows have no working destination page — `/apps/{uuid}/view` loads
+// forever for them (no host chart to feed data).
+export const isNonNavigableResourceViewItem = (
+    item: ResourceViewItem,
+): boolean => isDataAppVizResourceViewItem(item);
 
 export const getResourceTypeName = (item: ResourceViewItem) => {
     switch (item.type) {
@@ -15,7 +29,9 @@ export const getResourceTypeName = (item: ResourceViewItem) => {
         case ResourceViewItemType.SPACE:
             return 'Space';
         case ResourceViewItemType.DATA_APP:
-            return 'Data app';
+            return isDataAppVizResourceViewItem(item)
+                ? 'Custom chart type'
+                : 'Data app';
         case ResourceViewItemType.CHART:
             switch (item.data.chartKind) {
                 case undefined:

--- a/packages/frontend/src/components/common/modal/AppDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/AppDeleteModal.tsx
@@ -9,6 +9,9 @@ interface AppDeleteModalProps extends Pick<ModalProps, 'opened' | 'onClose'> {
     projectUuid: string;
     uuid: string;
     name: string;
+    /** What the copy calls the resource, e.g. "custom chart type" on surfaces
+     *  that hide the data-app ancestry. */
+    noun?: string;
     onConfirm?: () => void;
 }
 
@@ -18,6 +21,7 @@ const AppDeleteModal: FC<AppDeleteModalProps> = ({
     projectUuid,
     uuid,
     name,
+    noun = 'app',
     onConfirm,
 }) => {
     const { health } = useApp();
@@ -32,14 +36,14 @@ const AppDeleteModal: FC<AppDeleteModalProps> = ({
     };
 
     const description = softDeleteEnabled
-        ? `This app will be moved to Recently deleted and permanently removed after ${retentionDays} days.`
-        : 'This app and all of its versions will be permanently deleted, including any built artifacts in storage.';
+        ? `This ${noun} will be moved to Recently deleted and permanently removed after ${retentionDays} days.`
+        : `This ${noun} and all of its versions will be permanently deleted, including any built artifacts in storage.`;
 
     return (
         <MantineModal
             opened={opened}
             onClose={onClose}
-            title="Delete app"
+            title={`Delete ${noun}`}
             variant="delete"
             resourceType="app"
             resourceLabel={getAppDisplayName(name, uuid)}

--- a/packages/frontend/src/components/common/modal/AppUpdateModal.tsx
+++ b/packages/frontend/src/components/common/modal/AppUpdateModal.tsx
@@ -19,6 +19,8 @@ interface AppUpdateModalProps {
     uuid: string;
     initialName: string;
     initialDescription: string;
+    /** Overrides the modal title, e.g. on surfaces that hide the data-app ancestry. */
+    title?: string;
     onConfirm?: () => void;
 }
 
@@ -34,6 +36,7 @@ const AppUpdateModal: FC<AppUpdateModalProps> = ({
     uuid,
     initialName,
     initialDescription,
+    title = 'Update Data App',
     onConfirm,
     ...modalProps
 }) => {
@@ -68,7 +71,7 @@ const AppUpdateModal: FC<AppUpdateModalProps> = ({
 
     return (
         <MantineModal
-            title="Update Data App"
+            title={title}
             {...modalProps}
             icon={IconAppWindow}
             actions={

--- a/packages/frontend/src/features/apps/components/AppHeader.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeader.tsx
@@ -1,5 +1,6 @@
 import {
     ContentType,
+    DATA_APP_VIZ_TEMPLATE,
     getAppDisplayName,
     type AppVersionStatus,
 } from '@lightdash/common';
@@ -22,6 +23,7 @@ type AppHeaderApp = {
     spaceUuid: string | null;
     spaceName: string | null;
     createdByUserUuid: string | null;
+    template: string | null;
     latestVersionNumber: number | null;
     latestVersionStatus: AppVersionStatus | null;
     /** Timestamp of the latest build activity; null when never built. */
@@ -101,35 +103,39 @@ const AppHeader: FC<Props> = ({ projectUuid, app, rightSection }) => {
                     </Popover.Dropdown>
                 </Popover>
 
-                <ActionIcon
-                    variant="subtle"
-                    size="md"
-                    radius="md"
-                    color={isFavorited ? 'orange' : 'ldGray.6'}
-                    disabled={favoriteMutation.isLoading}
-                    aria-label={
-                        isFavorited
-                            ? 'Remove from favorites'
-                            : 'Add to favorites'
-                    }
-                    onClick={() => {
-                        // Personal apps must be filed in a space before they
-                        // can be favorited.
-                        if (!isFavorited && !app.spaceUuid) {
-                            setFavoriteSpaceModalOpen(true);
-                            return;
+                {/* Favoriting a spaceless viz would force it into a space —
+                    vizs have no space semantics. */}
+                {app.template !== DATA_APP_VIZ_TEMPLATE && (
+                    <ActionIcon
+                        variant="subtle"
+                        size="md"
+                        radius="md"
+                        color={isFavorited ? 'orange' : 'ldGray.6'}
+                        disabled={favoriteMutation.isLoading}
+                        aria-label={
+                            isFavorited
+                                ? 'Remove from favorites'
+                                : 'Add to favorites'
                         }
-                        favoriteMutation.mutate({
-                            contentType: ContentType.DATA_APP,
-                            contentUuid: app.uuid,
-                        });
-                    }}
-                >
-                    <MantineIcon
-                        icon={isFavorited ? IconStarFilled : IconStar}
-                        size={16}
-                    />
-                </ActionIcon>
+                        onClick={() => {
+                            // Personal apps must be filed in a space before
+                            // they can be favorited.
+                            if (!isFavorited && !app.spaceUuid) {
+                                setFavoriteSpaceModalOpen(true);
+                                return;
+                            }
+                            favoriteMutation.mutate({
+                                contentType: ContentType.DATA_APP,
+                                contentUuid: app.uuid,
+                            });
+                        }}
+                    >
+                        <MantineIcon
+                            icon={isFavorited ? IconStarFilled : IconStar}
+                            size={16}
+                        />
+                    </ActionIcon>
+                )}
             </Group>
 
             <Group gap="sm" wrap="nowrap">

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.test.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.test.tsx
@@ -88,6 +88,7 @@ const baseProps = {
     appName: 'My app',
     appDescription: null,
     appSpaceUuid: null,
+    appTemplate: null,
     appCreatedByUserUuid: null,
     latestVersionNumber: 1,
     latestVersionStatus: 'ready' as const,

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    DATA_APP_VIZ_TEMPLATE,
     getAppDisplayName,
     isApiError,
     type AppVersionStatus,
@@ -64,6 +65,7 @@ type Props = {
     appName: string;
     appDescription: string | null;
     appSpaceUuid: string | null;
+    appTemplate: string | null;
     appCreatedByUserUuid: string | null;
     /** The latest ready version's number + status — used by the favorite flow
      *  and to gate the Promote action. */
@@ -127,6 +129,7 @@ const AppHeaderActions: FC<Props> = ({
     appName,
     appDescription,
     appSpaceUuid,
+    appTemplate,
     appCreatedByUserUuid,
     latestVersionNumber,
     latestVersionStatus,
@@ -449,23 +452,26 @@ const AppHeaderActions: FC<Props> = ({
                     )}
                     {canEdit && (
                         <>
-                            <Menu.Item
-                                leftSection={
-                                    <MantineIcon
-                                        icon={
-                                            appSpaceUuid
-                                                ? IconFolderSymlink
-                                                : IconFolderPlus
-                                        }
-                                        size={14}
-                                    />
-                                }
-                                onClick={() => setIsMoveToSpaceOpen(true)}
-                            >
-                                {appSpaceUuid
-                                    ? 'Move to space'
-                                    : 'Add to space'}
-                            </Menu.Item>
+                            {/* Vizs have no space semantics — no move action. */}
+                            {appTemplate !== DATA_APP_VIZ_TEMPLATE && (
+                                <Menu.Item
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={
+                                                appSpaceUuid
+                                                    ? IconFolderSymlink
+                                                    : IconFolderPlus
+                                            }
+                                            size={14}
+                                        />
+                                    }
+                                    onClick={() => setIsMoveToSpaceOpen(true)}
+                                >
+                                    {appSpaceUuid
+                                        ? 'Move to space'
+                                        : 'Add to space'}
+                                </Menu.Item>
+                            )}
                             {isPreviewProject && hasReadyVersion && (
                                 <Menu.Item
                                     leftSection={

--- a/packages/frontend/src/features/apps/components/FavoritePersonalDataAppModal.tsx
+++ b/packages/frontend/src/features/apps/components/FavoritePersonalDataAppModal.tsx
@@ -78,6 +78,8 @@ export const FavoritePersonalDataAppModal: FC<
                                 : null,
                         pinnedListUuid: null,
                         pinnedListOrder: null,
+                        // Not surfaced by this move-to-favorite flow.
+                        template: null,
                     },
                 },
             ]}

--- a/packages/frontend/src/features/apps/components/MoveAppToSpaceModal.tsx
+++ b/packages/frontend/src/features/apps/components/MoveAppToSpaceModal.tsx
@@ -217,6 +217,8 @@ export const MoveAppToSpaceModal: FC<Props> = ({
                                     : null,
                             pinnedListUuid: null,
                             pinnedListOrder: null,
+                            // Not surfaced by this move-to-space flow.
+                            template: null,
                         },
                     },
                 ]}

--- a/packages/frontend/src/hooks/useContent.ts
+++ b/packages/frontend/src/hooks/useContent.ts
@@ -34,6 +34,7 @@ export type ContentArgs = {
     sortDirection?: 'asc' | 'desc';
     // Opt in to surfacing the caller's personal (space-less) data apps.
     includePersonalDataApps?: boolean;
+    dataAppVizsFilter?: 'exclude' | 'only';
 };
 
 const contentTypeLabel = (contentType: ContentType): string =>

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -3350,6 +3350,7 @@ const AppGenerate: FC = () => {
                                         spaceUuid: appSpaceUuid,
                                         spaceName: appSpaceName,
                                         createdByUserUuid: appCreatedByUserUuid,
+                                        template: appPersistedTemplate,
                                         latestVersionNumber:
                                             latestReadyVersion?.version ?? null,
                                         latestVersionStatus:
@@ -3376,6 +3377,7 @@ const AppGenerate: FC = () => {
                                                 appDescription || null
                                             }
                                             appSpaceUuid={appSpaceUuid}
+                                            appTemplate={appPersistedTemplate}
                                             appCreatedByUserUuid={
                                                 appCreatedByUserUuid
                                             }

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -56,6 +56,7 @@ export default function AppPreviewTest() {
     const appDescription = firstPage?.description ?? null;
     const appSpaceUuid = firstPage?.spaceUuid ?? null;
     const appSpaceName = firstPage?.spaceName ?? null;
+    const appTemplate = firstPage?.template ?? null;
     const appCreatedByUserUuid = firstPage?.createdByUserUuid ?? null;
     const appSlug = firstPage?.slug ?? null;
     const appViews = firstPage?.views ?? null;
@@ -332,6 +333,7 @@ export default function AppPreviewTest() {
                         spaceUuid: appSpaceUuid,
                         spaceName: appSpaceName,
                         createdByUserUuid: appCreatedByUserUuid,
+                        template: appTemplate,
                         latestVersionNumber: latestReadyVersion ?? null,
                         latestVersionStatus: latestReadyVersion
                             ? 'ready'
@@ -382,6 +384,7 @@ export default function AppPreviewTest() {
                             appName={appName}
                             appDescription={appDescription}
                             appSpaceUuid={appSpaceUuid}
+                            appTemplate={appTemplate}
                             appCreatedByUserUuid={appCreatedByUserUuid}
                             latestVersionNumber={latestReadyVersion ?? null}
                             latestVersionStatus={


### PR DESCRIPTION
## Summary

Viz space-semantics guardrails (stacks on #27132), extracted from the now-closed listing-page PR (#27135) — these protect an invariant that holds regardless of which listing surface ships: **custom chart type vizs are project-global chart content with no space semantics** (Phase 0 decision).

Backend (API-level, cannot be bypassed):
- `AppGenerateService.moveToSpace` rejects viz-template apps. Every move path funnels through it — the direct endpoint, the favorite-modal move flow, and the content-API bulk/single move (`appMoveService` is `appGenerateService`) — with tests (reject viz / standalone still moves).

Frontend (matching affordances hidden for vizs):
- Builder/viewer app header: favorite star and "Add/Move to space" hidden (favoriting a spaceless app first moves it into a space).
- Resource rows: `ResourceViewDataAppItem` carries `template` (both backend producers select it); viz rows don't navigate (`/apps/{uuid}/view` loads forever for a viz — no host chart), hide move/favorite/"Continue building", and use custom-chart-type vocabulary (row subtitle, delete/rename copy). Protects favorites/home surfaces where previously-favorited vizs can still appear.
- Content-API threading for `dataAppVizsFilter` in `ContentArgs`/`InfiniteResourceTable` (consumed by #27163; the upcoming gallery can reuse the `'only'` mode).

## Testing

- Backend `AppGenerateService.dataAppVizs` 30/30 (incl. the two new moveToSpace tests); typechecks + lint
- Behaviors were browser-verified on the pre-split branch against a live backend

Relates: GLITCH-649