### PR TITLE
fix: split AI organization settings endpoints

### DIFF
--- a/packages/backend/src/ee/controllers/AiOrganizationSettingsController.ts
+++ b/packages/backend/src/ee/controllers/AiOrganizationSettingsController.ts
@@ -1,0 +1,46 @@
+import {
+    assertRegisteredAccount,
+    type ApiAiOrganizationRuntimeSettingsResponse,
+    type ApiErrorPayload,
+} from '@lightdash/common';
+import {
+    Get,
+    Middlewares,
+    OperationId,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { type AiOrganizationSettingsService } from '../services/AiOrganizationSettingsService';
+
+@Route('/api/v1/aiAgents')
+@Response<ApiErrorPayload>('default', 'Error')
+export class AiOrganizationSettingsController extends BaseController {
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Retrieved AI organization runtime settings')
+    @Get('/settings')
+    @OperationId('getAiOrganizationRuntimeSettings')
+    async getRuntimeSettings(
+        @Request() req: express.Request,
+    ): Promise<ApiAiOrganizationRuntimeSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        const results =
+            await this.getAiOrganizationSettingsService().getRuntimeSettings(
+                toSessionUser(req.account),
+            );
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    protected getAiOrganizationSettingsService() {
+        return this.services.getAiOrganizationSettingsService<AiOrganizationSettingsService>();
+    }
+}

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2877,14 +2877,16 @@ export class AiAgentService extends BaseService {
             embedSpaceUuid: runtimeOptions?.embedSpaceUuid,
         });
 
-        const aiOrganizationSettings =
+        const organizationDefaultModelConfig =
             body.modelConfig || agent.modelConfig
                 ? undefined
-                : await this.aiOrganizationSettingsService.getSettings(user);
+                : await this.aiOrganizationSettingsService.getDefaultModelConfig(
+                      organizationUuid,
+                  );
         const modelConfig =
             body.modelConfig ??
             agent.modelConfig ??
-            aiOrganizationSettings?.defaultAiAgentModelConfig ??
+            organizationDefaultModelConfig ??
             undefined;
 
         if (body.prompt) {

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.test.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.test.ts
@@ -9,7 +9,6 @@ import {
     areReviewsEnabledForSettings,
     findUnconfiguredProviderKeyWrites,
     isModelConfigAvailable,
-    maskProviderKeyExposure,
     pickReplacementDefaultModelConfig,
     validateDeepResearchLimits,
 } from './AiOrganizationSettingsService';
@@ -49,33 +48,6 @@ describe('validateDeepResearchLimits', () => {
                 [key]: value,
             }),
         ).toThrow(ParameterError);
-    });
-});
-
-describe('maskProviderKeyExposure', () => {
-    it('returns the settings untouched for org admins', () => {
-        expect(maskProviderKeyExposure(settingsWithKeys, true)).toEqual(
-            settingsWithKeys,
-        );
-    });
-
-    it('strips key hints and set-booleans for non-admins', () => {
-        const masked = maskProviderKeyExposure(settingsWithKeys, false);
-        expect(masked.providerApiKeyHints).toEqual({
-            anthropic: null,
-            openai: null,
-        });
-        expect(masked.providerApiKeysSet).toEqual({
-            anthropic: false,
-            openai: false,
-        });
-    });
-
-    it('leaves non-key settings intact when masking', () => {
-        const masked = maskProviderKeyExposure(settingsWithKeys, false);
-        expect(masked.aiAgentsVisible).toBe(true);
-        expect(masked.mcpContentWritesEnabled).toBe(true);
-        expect(masked.organizationUuid).toBe('org-uuid');
     });
 });
 

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -428,6 +428,10 @@ export class AiOrganizationSettingsService extends BaseService {
             organizationUuid,
         );
         if (!availability.isCopilotEnabled && !availability.isTrial) {
+            const dataAppModelVisibility =
+                await this.orgAiCopilotConfigResolver.getDataAppModelVisibility(
+                    organizationUuid,
+                );
             return {
                 ...availability,
                 aiAgentsVisible: false,
@@ -436,7 +440,9 @@ export class AiOrganizationSettingsService extends BaseService {
                 aiAgentReviewsAvailable: false,
                 defaultAiAgentModelConfig: null,
                 defaultAiAgentModelOptions: [],
-                visibleDataAppModels: [],
+                visibleDataAppModels: getVisibleDataAppClaudeModels(
+                    dataAppModelVisibility,
+                ),
             };
         }
 

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     AI_DEEP_RESEARCH_DEFAULT_LIMITS,
+    AiOrganizationRuntimeSettings,
     AiOrganizationSettings,
     BYO_AI_PROVIDERS,
     CommercialFeatureFlags,
@@ -23,10 +24,7 @@ import { LightdashConfig } from '../../config/parseConfig';
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { BaseService } from '../../services/BaseService';
 import { FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
-import {
-    AiOrganizationSettingsModel,
-    type StoredAiOrganizationSettings,
-} from '../models/AiOrganizationSettingsModel';
+import { AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
 import { CommercialFeatureFlagModel } from '../models/CommercialFeatureFlagModel';
 import {
     filterModelsForOrg,
@@ -93,23 +91,6 @@ export const pickReplacementDefaultModelConfig = (
         reasoning: preset.supportsReasoning ? previous.reasoning : undefined,
     };
 };
-
-/**
- * Redact partial key material (hints) and the "key is set" booleans for callers
- * without the manage-AI-agent ability. Non-admin org members read the settings
- * endpoint (agent chat surfaces) and must not see key hints.
- */
-export const maskProviderKeyExposure = (
-    settings: StoredAiOrganizationSettings,
-    canManage: boolean,
-): StoredAiOrganizationSettings =>
-    canManage
-        ? settings
-        : {
-              ...settings,
-              providerApiKeysSet: { anthropic: false, openai: false },
-              providerApiKeyHints: { anthropic: null, openai: null },
-          };
 
 /**
  * Providers being SET to a key that this instance does not configure. BYO can
@@ -217,6 +198,35 @@ export class AiOrganizationSettingsService extends BaseService {
         return isCopilotEnabled.enabled;
     }
 
+    private async getAiAvailability(
+        user: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>,
+        organizationUuid: string,
+    ): Promise<{ isCopilotEnabled: boolean; isTrial: boolean }> {
+        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
+        const isTrial = await this.isEligibleForTrial(
+            isCopilotEnabled,
+            organizationUuid,
+        );
+        return { isCopilotEnabled, isTrial };
+    }
+
+    private async checkAiSettingsAccess(
+        user: SessionUser,
+        organizationUuid: string,
+    ): Promise<{ isCopilotEnabled: boolean; isTrial: boolean }> {
+        this.checkManageAiAgentAccess(user);
+        const availability = await this.getAiAvailability(
+            user,
+            organizationUuid,
+        );
+        if (!availability.isCopilotEnabled && !availability.isTrial) {
+            throw new ForbiddenError(
+                'AI agent settings are not available for this organization',
+            );
+        }
+        return availability;
+    }
+
     private async getModelOptionLists(organizationUuid: string): Promise<{
         effectiveOptions: AiModelOption[];
         configurableOptions: AiModelOption[];
@@ -318,44 +328,31 @@ export class AiOrganizationSettingsService extends BaseService {
         return flag.enabled;
     }
 
-    async getSettings(
+    private async resolveSettings(
         user: SessionUser,
+        availability: { isCopilotEnabled: boolean; isTrial: boolean },
     ): Promise<AiOrganizationSettings & ComputedAiOrganizationSettings> {
-        if (!user.organizationUuid) {
-            throw new ForbiddenError('User must belong to an organization');
-        }
-
-        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
-
-        // Check if organization qualifies for trial
-        const isTrialEligible = await this.isEligibleForTrial(
-            isCopilotEnabled,
-            user.organizationUuid,
-        );
+        const organizationUuid = user.organizationUuid!;
+        const { isCopilotEnabled, isTrial } = availability;
 
         const [settings, aiAgentMemoryEnabled] = await Promise.all([
             this.aiOrganizationSettingsModel.findByOrganizationUuid(
-                user.organizationUuid,
+                organizationUuid,
             ),
             this.isAiAgentMemoryEnabled(user),
         ]);
-
-        // Partial key material (hints) and the "key is set" booleans are only
-        // exposed to org admins; other members read this endpoint too (agent
-        // chat surfaces) but must not see another org member's key hints.
-        const canManage = this.canManageAiAgent(user);
 
         const [
             { effectiveOptions, configurableOptions, effectiveModelVisibility },
             reviewJudge,
             effectiveDataAppModelVisibility,
         ] = await Promise.all([
-            this.getModelOptionLists(user.organizationUuid),
+            this.getModelOptionLists(organizationUuid),
             this.orgAiCopilotConfigResolver.getReviewJudgeAvailability(
-                user.organizationUuid,
+                organizationUuid,
             ),
             this.orgAiCopilotConfigResolver.getDataAppModelVisibility(
-                user.organizationUuid,
+                organizationUuid,
             ),
         ]);
 
@@ -367,7 +364,7 @@ export class AiOrganizationSettingsService extends BaseService {
         // Return default settings if none exist
         if (!settings) {
             return {
-                organizationUuid: user.organizationUuid,
+                organizationUuid,
                 isCopilotEnabled,
                 aiAgentsVisible: true,
                 aiAgentReviewsEnabled: false,
@@ -382,16 +379,14 @@ export class AiOrganizationSettingsService extends BaseService {
                 providerApiKeysSet: { anthropic: false, openai: false },
                 providerApiKeyHints: { anthropic: null, openai: null },
                 defaultAiAgentModelOptions: effectiveOptions,
-                configurableModelOptions: canManage
-                    ? configurableOptions
-                    : null,
+                configurableModelOptions: configurableOptions,
                 aiAgentReviewsPausedByByok,
-                isTrial: isTrialEligible,
+                isTrial,
             };
         }
 
         return {
-            ...maskProviderKeyExposure(settings, canManage),
+            ...settings,
             aiAgentMemoryEnabled,
             // Surface the effective visibility (implicit BYOK defaults merged in)
             // so the admin card reflects what users actually see.
@@ -399,12 +394,75 @@ export class AiOrganizationSettingsService extends BaseService {
             // Likewise: stored Data App settings are inert without a BYO key,
             // so the picker must not filter on them when the backend won't.
             dataAppModelVisibility: effectiveDataAppModelVisibility,
-            isTrial: isTrialEligible,
+            isTrial,
             isCopilotEnabled,
             defaultAiAgentModelOptions: effectiveOptions,
-            configurableModelOptions: canManage ? configurableOptions : null,
+            configurableModelOptions: configurableOptions,
             aiAgentReviewsPausedByByok,
         };
+    }
+
+    async getSettings(
+        user: SessionUser,
+    ): Promise<AiOrganizationSettings & ComputedAiOrganizationSettings> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User must belong to an organization');
+        }
+        const availability = await this.checkAiSettingsAccess(
+            user,
+            organizationUuid,
+        );
+        return this.resolveSettings(user, availability);
+    }
+
+    async getRuntimeSettings(
+        user: SessionUser,
+    ): Promise<AiOrganizationRuntimeSettings> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User must belong to an organization');
+        }
+        const availability = await this.getAiAvailability(
+            user,
+            organizationUuid,
+        );
+        if (!availability.isCopilotEnabled && !availability.isTrial) {
+            return {
+                ...availability,
+                aiAgentsVisible: false,
+                aiAgentMemoryEnabled: false,
+                aiAgentReviewsEnabled: false,
+                aiAgentReviewsAvailable: false,
+                defaultAiAgentModelConfig: null,
+                defaultAiAgentModelOptions: [],
+                visibleDataAppModels: [],
+            };
+        }
+
+        const settings = await this.resolveSettings(user, availability);
+        return {
+            ...availability,
+            aiAgentsVisible: settings.aiAgentsVisible,
+            aiAgentMemoryEnabled: settings.aiAgentMemoryEnabled,
+            aiAgentReviewsEnabled: settings.aiAgentReviewsEnabled,
+            aiAgentReviewsAvailable:
+                settings.aiAgentReviewsEnabled &&
+                settings.aiAgentReviewsPausedByByok !== true,
+            defaultAiAgentModelConfig: settings.defaultAiAgentModelConfig,
+            defaultAiAgentModelOptions: settings.defaultAiAgentModelOptions,
+            visibleDataAppModels: getVisibleDataAppClaudeModels(
+                settings.dataAppModelVisibility,
+            ),
+        };
+    }
+
+    async isAiAgentsVisible(organizationUuid: string): Promise<boolean> {
+        const settings =
+            await this.aiOrganizationSettingsModel.findByOrganizationUuid(
+                organizationUuid,
+            );
+        return settings?.aiAgentsVisible ?? true;
     }
 
     async isDeepResearchRawSqlEnabled({
@@ -428,7 +486,7 @@ export class AiOrganizationSettingsService extends BaseService {
             throw new ForbiddenError('User must belong to an organization');
         }
 
-        this.checkManageAiAgentAccess(user);
+        await this.checkAiSettingsAccess(user, organizationUuid);
 
         const { aiAgentMemoryEnabled, ...aiSettingsUpdate } = data;
         const isMemoryOnlyUpdate =

--- a/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
@@ -251,7 +251,7 @@ const makeMcpService = ({
         aiAgentService,
         aiAgentToolsService,
         aiOrganizationSettingsService: {
-            getSettings: vi.fn().mockResolvedValue({ aiAgentsVisible: true }),
+            isAiAgentsVisible: vi.fn().mockResolvedValue(true),
         },
         aiRouterService: {},
         aiWritebackService: {},

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -536,7 +536,7 @@ const makeMcpService = ({
         aiAgentService,
         aiAgentToolsService,
         aiOrganizationSettingsService: {
-            getSettings: vi.fn().mockResolvedValue({ aiAgentsVisible: true }),
+            isAiAgentsVisible: vi.fn().mockResolvedValue(true),
         },
         aiRouterService: {},
         aiWritebackService: {},

--- a/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
@@ -206,7 +206,7 @@ const makeMcpService = () => {
         aiAgentService,
         aiAgentToolsService,
         aiOrganizationSettingsService: {
-            getSettings: vi.fn().mockResolvedValue({ aiAgentsVisible: true }),
+            isAiAgentsVisible: vi.fn().mockResolvedValue(true),
         },
         aiRouterService,
         aiWritebackService: {},

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -3918,9 +3918,11 @@ export class McpService extends BaseService {
         if (!user.organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        const settings =
-            await this.aiOrganizationSettingsService.getSettings(user);
-        if (!settings.aiAgentsVisible) {
+        const aiAgentsVisible =
+            await this.aiOrganizationSettingsService.isAiAgentsVisible(
+                user.organizationUuid,
+            );
+        if (!aiAgentsVisible) {
             throw new ForbiddenError(
                 'AI Agent features are disabled for this organization',
             );

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -1,6 +1,6 @@
 import type { ApiSuccess, KnexPaginatedData } from '../..';
 import type { AiDeepResearchLimits } from '../aiDeepResearch/types';
-import type { DataAppModelVisibility } from '../apps/types';
+import type { DataAppClaudeModel, DataAppModelVisibility } from '../apps/types';
 import type {
     AiAgentEvaluationRunSummary,
     AiAgentMemoryScope,
@@ -365,6 +365,21 @@ export type UpdateAiOrganizationSettings = {
 export type ApiAiOrganizationSettingsResponse = ApiSuccess<
     AiOrganizationSettings & ComputedAiOrganizationSettings
 >;
+
+export type AiOrganizationRuntimeSettings = {
+    isCopilotEnabled: boolean;
+    isTrial: boolean;
+    aiAgentsVisible: boolean;
+    aiAgentMemoryEnabled: boolean;
+    aiAgentReviewsEnabled: boolean;
+    aiAgentReviewsAvailable: boolean;
+    defaultAiAgentModelConfig: AiAgentModelConfig | null;
+    defaultAiAgentModelOptions: AiModelOption[];
+    visibleDataAppModels: DataAppClaudeModel[];
+};
+
+export type ApiAiOrganizationRuntimeSettingsResponse =
+    ApiSuccess<AiOrganizationRuntimeSettings>;
 
 export type ApiUpdateAiOrganizationSettingsResponse =
     ApiSuccess<AiOrganizationSettings>;

--- a/packages/common/src/ee/apps/types.test.ts
+++ b/packages/common/src/ee/apps/types.test.ts
@@ -323,6 +323,12 @@ describe('resolveDefaultVisibleDataAppClaudeModel', () => {
         expect(resolveDefaultVisibleDataAppClaudeModel(null)).toBe('sonnet');
     });
 
+    it('accepts an already-resolved model list', () => {
+        expect(resolveDefaultVisibleDataAppClaudeModel(['opus', 'haiku'])).toBe(
+            'haiku',
+        );
+    });
+
     // Hiding Sonnet is the obvious cost-control action; falling back to Opus
     // (the display-order first entry) would make it a cost increase.
     it('falls back to the cheaper model, not the pricier one, when the default is hidden', () => {

--- a/packages/common/src/ee/apps/types.test.ts
+++ b/packages/common/src/ee/apps/types.test.ts
@@ -4,6 +4,7 @@ import {
     dataAppVizSchema,
     getEffectiveOptionValues,
     getVisibleDataAppClaudeModels,
+    resolveDefaultDataAppClaudeModel,
     resolveDefaultVisibleDataAppClaudeModel,
     type DataAppVizConfigOption,
     type DataAppVizOptionValue,
@@ -318,15 +319,21 @@ describe('getVisibleDataAppClaudeModels', () => {
     });
 });
 
+describe('resolveDefaultDataAppClaudeModel', () => {
+    it('selects from an already-resolved model list', () => {
+        expect(resolveDefaultDataAppClaudeModel(['opus', 'haiku'])).toBe(
+            'haiku',
+        );
+    });
+
+    it('returns null when the resolved model list is empty', () => {
+        expect(resolveDefaultDataAppClaudeModel([])).toBeNull();
+    });
+});
+
 describe('resolveDefaultVisibleDataAppClaudeModel', () => {
     it('prefers the system default (sonnet) when visible', () => {
         expect(resolveDefaultVisibleDataAppClaudeModel(null)).toBe('sonnet');
-    });
-
-    it('accepts an already-resolved model list', () => {
-        expect(resolveDefaultVisibleDataAppClaudeModel(['opus', 'haiku'])).toBe(
-            'haiku',
-        );
     });
 
     // Hiding Sonnet is the obvious cost-control action; falling back to Opus

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -163,9 +163,15 @@ const DATA_APP_CLAUDE_MODEL_FALLBACK_ORDER: readonly DataAppClaudeModel[] = [
  * AiOrganizationSettingsService).
  */
 export const resolveDefaultVisibleDataAppClaudeModel = (
-    visibility: DataAppModelVisibility | null | undefined,
+    visibilityOrModels:
+        | DataAppModelVisibility
+        | DataAppClaudeModel[]
+        | null
+        | undefined,
 ): DataAppClaudeModel | null => {
-    const visible = getVisibleDataAppClaudeModels(visibility);
+    const visible = Array.isArray(visibilityOrModels)
+        ? visibilityOrModels
+        : getVisibleDataAppClaudeModels(visibilityOrModels);
     if (visible.includes(DEFAULT_DATA_APP_CLAUDE_MODEL)) {
         return DEFAULT_DATA_APP_CLAUDE_MODEL;
     }

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -162,25 +162,23 @@ const DATA_APP_CLAUDE_MODEL_FALLBACK_ORDER: readonly DataAppClaudeModel[] = [
  * every model has been hidden (rejected at write time — see
  * AiOrganizationSettingsService).
  */
-export const resolveDefaultVisibleDataAppClaudeModel = (
-    visibilityOrModels:
-        | DataAppModelVisibility
-        | DataAppClaudeModel[]
-        | null
-        | undefined,
+export const resolveDefaultDataAppClaudeModel = (
+    visibleModels: readonly DataAppClaudeModel[],
 ): DataAppClaudeModel | null => {
-    const visible = Array.isArray(visibilityOrModels)
-        ? visibilityOrModels
-        : getVisibleDataAppClaudeModels(visibilityOrModels);
-    if (visible.includes(DEFAULT_DATA_APP_CLAUDE_MODEL)) {
+    if (visibleModels.includes(DEFAULT_DATA_APP_CLAUDE_MODEL)) {
         return DEFAULT_DATA_APP_CLAUDE_MODEL;
     }
     return (
         DATA_APP_CLAUDE_MODEL_FALLBACK_ORDER.find((model) =>
-            visible.includes(model),
+            visibleModels.includes(model),
         ) ?? null
     );
 };
+
+export const resolveDefaultVisibleDataAppClaudeModel = (
+    visibility: DataAppModelVisibility | null | undefined,
+): DataAppClaudeModel | null =>
+    resolveDefaultDataAppClaudeModel(getVisibleDataAppClaudeModels(visibility));
 
 /**
  * A saved-chart reference attached to a generation request.

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -44,6 +44,7 @@ import type {
     ApiAiGenerateFormulaTableCalculationResponse,
     ApiAiGenerateTableCalculationResponse,
     ApiAiGetDashboardSummaryResponse,
+    ApiAiOrganizationRuntimeSettingsResponse,
     ApiAiOrganizationSettingsResponse,
     ApiAiReviewNotificationSettingsResponse,
     ApiAiRouterDecisionCommitResponse,
@@ -1309,6 +1310,7 @@ type ApiResults =
     | ApiAgentSuggestionsResponse['results']
     | ApiAppendInstructionResponse['results']
     | ApiAiOrganizationSettingsResponse['results']
+    | ApiAiOrganizationRuntimeSettingsResponse['results']
     | ApiUpdateAiOrganizationSettingsResponse['results']
     | ApiAiReviewNotificationSettingsResponse['results']
     | ApiAiRouterResponse['results']

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -34,7 +34,7 @@ import { Link } from 'react-router';
 import { z } from 'zod';
 import { useAiAgentAdminAgents } from '../../../ee/features/aiCopilot/hooks/useAiAgentAdmin';
 import {
-    useAiOrganizationSettings,
+    useAiOrganizationAdminSettings,
     useUpdateAiOrganizationSettings,
 } from '../../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 import {
@@ -86,7 +86,7 @@ const formSchema = z.object({
 });
 
 const SlackSettingsPanel: FC = () => {
-    const aiOrganizationSettingsQuery = useAiOrganizationSettings();
+    const aiOrganizationSettingsQuery = useAiOrganizationAdminSettings();
     const { data: aiCopilotFlag } = useServerFeatureFlag(
         CommercialFeatureFlags.AiCopilot,
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.test.tsx
@@ -49,7 +49,7 @@ const { mutationState, refetchSettings, settingsQuery, updateSettings } =
     }));
 
 vi.mock('../../../hooks/useAiOrganizationSettings', () => ({
-    useAiOrganizationSettings: () => ({
+    useAiOrganizationAdminSettings: () => ({
         ...settingsQuery.current,
         refetch: refetchSettings,
     }),

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.tsx
@@ -19,7 +19,7 @@ import {
 import { SettingsPage } from '../../../../../../components/common/Settings/SettingsPage';
 import { isDeepResearchBeta } from '../../../deepResearch/deepResearchBeta';
 import {
-    useAiOrganizationSettings,
+    useAiOrganizationAdminSettings,
     useUpdateAiOrganizationSettings,
 } from '../../../hooks/useAiOrganizationSettings';
 
@@ -193,7 +193,7 @@ export const AiDeepResearchSettingsPage = () => {
         isError,
         error,
         refetch,
-    } = useAiOrganizationSettings();
+    } = useAiOrganizationAdminSettings();
 
     if (!isInitialLoading && !isError && settings) {
         return (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -27,7 +27,7 @@ import {
 } from '../../../hooks/useAiAgentModelSelection';
 import {
     resolveAiAgentMemoryEnabled,
-    useAiOrganizationSettings,
+    useAiOrganizationAdminSettings,
     useUpdateAiOrganizationSettings,
 } from '../../../hooks/useAiOrganizationSettings';
 import {
@@ -40,7 +40,7 @@ import { ReviewNotificationsSettings } from './ReviewNotificationsSettings';
 
 export const AiGeneralSettingsPage = () => {
     const { data: settings, isInitialLoading: isSettingsLoading } =
-        useAiOrganizationSettings();
+        useAiOrganizationAdminSettings();
     const { mutate: updateSettings, isLoading: isUpdatingSettings } =
         useUpdateAiOrganizationSettings();
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryPromotionAction.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryPromotionAction.test.tsx
@@ -14,7 +14,7 @@ const { mutate, permissions, settings } = vi.hoisted(() => ({
     settings: {
         current: {
             aiAgentReviewsEnabled: true,
-            aiAgentReviewsPausedByByok: false,
+            aiAgentReviewsAvailable: true,
         },
     },
 }));
@@ -53,7 +53,7 @@ describe('MemoryPromotionAction', () => {
         mutate.mockClear();
         settings.current = {
             aiAgentReviewsEnabled: true,
-            aiAgentReviewsPausedByByok: false,
+            aiAgentReviewsAvailable: true,
         };
         permissions.canManageOrganization = false;
         permissions.canManageProject = true;
@@ -198,6 +198,7 @@ describe('MemoryPromotionAction', () => {
 
     it('disables promotion with the feature gate reason', async () => {
         settings.current.aiAgentReviewsEnabled = false;
+        settings.current.aiAgentReviewsAvailable = false;
         const user = userEvent.setup();
         renderAction();
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryPromotionAction.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryPromotionAction.tsx
@@ -79,9 +79,7 @@ export const MemoryPromotionAction: FC<Props> = ({
         );
     }
 
-    const reviewsEnabled =
-        settings?.aiAgentReviewsEnabled === true &&
-        settings.aiAgentReviewsPausedByByok !== true;
+    const reviewsEnabled = settings?.aiAgentReviewsAvailable === true;
     const disabledReason =
         status !== 'active'
             ? 'Only active memories can be proposed.'

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiOrganizationSettings.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiOrganizationSettings.ts
@@ -1,5 +1,6 @@
 import {
     FeatureFlags,
+    type ApiAiOrganizationRuntimeSettingsResponse,
     type ApiAiOrganizationSettingsResponse,
     type ApiError,
     type ApiUpdateAiOrganizationSettingsResponse,
@@ -9,6 +10,7 @@ import {
     useMutation,
     useQuery,
     useQueryClient,
+    type QueryClient,
     type UseMutationOptions,
     type UseQueryOptions,
 } from '@tanstack/react-query';
@@ -19,7 +21,7 @@ import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeature
 export const resolveAiAgentMemoryEnabled = (
     settings:
         | Pick<
-              ApiAiOrganizationSettingsResponse['results'],
+              ApiAiOrganizationRuntimeSettingsResponse['results'],
               'aiAgentMemoryEnabled'
           >
         | undefined,
@@ -27,26 +29,62 @@ export const resolveAiAgentMemoryEnabled = (
 ): boolean => settings?.aiAgentMemoryEnabled ?? featureFlag?.enabled ?? false;
 
 const getAiOrganizationSettings = async () => {
-    return lightdashApi<ApiAiOrganizationSettingsResponse['results']>({
-        url: `/aiAgents/admin/settings`,
+    return lightdashApi<ApiAiOrganizationRuntimeSettingsResponse['results']>({
+        url: `/aiAgents/settings`,
         method: 'GET',
         body: undefined,
     });
 };
 
+const getAiOrganizationAdminSettings = async () =>
+    lightdashApi<ApiAiOrganizationSettingsResponse['results']>({
+        url: `/aiAgents/admin/settings`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const aiOrganizationRuntimeSettingsQueryKey = [
+    'ai-organization-runtime-settings',
+] as const;
+const aiOrganizationAdminSettingsQueryKey = [
+    'ai-organization-admin-settings',
+] as const;
+
+const invalidateAiOrganizationSettingsQueries = (queryClient: QueryClient) =>
+    Promise.all([
+        queryClient.invalidateQueries(aiOrganizationAdminSettingsQueryKey),
+        queryClient.invalidateQueries(aiOrganizationRuntimeSettingsQueryKey),
+    ]);
+
 export const useAiOrganizationSettings = (
     queryOptions?: UseQueryOptions<
-        ApiAiOrganizationSettingsResponse['results'],
+        ApiAiOrganizationRuntimeSettingsResponse['results'],
         ApiError
     >,
 ) => {
-    return useQuery<ApiAiOrganizationSettingsResponse['results'], ApiError>({
-        queryKey: ['ai-organization-settings'],
+    return useQuery<
+        ApiAiOrganizationRuntimeSettingsResponse['results'],
+        ApiError
+    >({
+        queryKey: aiOrganizationRuntimeSettingsQueryKey,
         queryFn: getAiOrganizationSettings,
         keepPreviousData: true,
         ...queryOptions,
     });
 };
+
+export const useAiOrganizationAdminSettings = (
+    queryOptions?: UseQueryOptions<
+        ApiAiOrganizationSettingsResponse['results'],
+        ApiError
+    >,
+) =>
+    useQuery<ApiAiOrganizationSettingsResponse['results'], ApiError>({
+        queryKey: aiOrganizationAdminSettingsQueryKey,
+        queryFn: getAiOrganizationAdminSettings,
+        keepPreviousData: true,
+        ...queryOptions,
+    });
 
 export const useAiAgentMemoryEnabled = (): boolean => {
     const { data: settings } = useAiOrganizationSettings();
@@ -88,10 +126,10 @@ export const useUpdateAiOrganizationSettings = (
             });
             queryClient.setQueryData<
                 ApiAiOrganizationSettingsResponse['results'] | undefined
-            >(['ai-organization-settings'], (previous) =>
+            >(aiOrganizationAdminSettingsQueryKey, (previous) =>
                 previous ? { ...previous, ...data } : undefined,
             );
-            await queryClient.invalidateQueries(['ai-organization-settings']);
+            await invalidateAiOrganizationSettingsQueries(queryClient);
             mutationOptions?.onSuccess?.(data, variables, context);
         },
         onError: ({ error }) => {

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -7,7 +7,7 @@ import {
     isApiError,
     isAppVersionInProgress,
     MAX_APP_FILES_PER_VERSION,
-    resolveDefaultVisibleDataAppClaudeModel,
+    resolveDefaultDataAppClaudeModel,
     type ApiAppVersionSummary,
     type AppChartReference,
     type AppClarification,
@@ -963,7 +963,7 @@ const AppGenerate: FC = () => {
     // the next candidate rather than resurrecting a hidden model.
     const selectedModel: DataAppClaudeModel = useMemo(() => {
         const fallback =
-            resolveDefaultVisibleDataAppClaudeModel(visibleModels) ??
+            resolveDefaultDataAppClaudeModel(visibleModels) ??
             DEFAULT_DATA_APP_CLAUDE_MODEL;
         if (modelOverride) {
             const overrideAppUuid = modelOverride.appUuid;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -4,7 +4,6 @@ import {
     DATA_APP_VIZ_TEMPLATE,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
     FeatureFlags,
-    getVisibleDataAppClaudeModels,
     isApiError,
     isAppVersionInProgress,
     MAX_APP_FILES_PER_VERSION,
@@ -206,6 +205,7 @@ const TemplateChip: FC<{ template: DataAppTemplate }> = ({ template }) => {
 };
 
 const NO_THEME_LABEL = 'No theme';
+const NO_DATA_APP_MODELS: DataAppClaudeModel[] = [];
 
 const ThemeChip: FC<{
     themeName: string;
@@ -943,12 +943,8 @@ const AppGenerate: FC = () => {
         data: aiOrganizationSettings,
         isLoading: isModelVisibilityLoading,
     } = useAiOrganizationSettings();
-    const dataAppModelVisibility =
-        aiOrganizationSettings?.dataAppModelVisibility ?? null;
-    const visibleModels = useMemo(
-        () => getVisibleDataAppClaudeModels(dataAppModelVisibility),
-        [dataAppModelVisibility],
-    );
+    const visibleModels =
+        aiOrganizationSettings?.visibleDataAppModels ?? NO_DATA_APP_MODELS;
 
     // Effective model for the picker / next submit:
     // user's explicit pick (if it's for this app) > latest version's model
@@ -967,7 +963,7 @@ const AppGenerate: FC = () => {
     // the next candidate rather than resurrecting a hidden model.
     const selectedModel: DataAppClaudeModel = useMemo(() => {
         const fallback =
-            resolveDefaultVisibleDataAppClaudeModel(dataAppModelVisibility) ??
+            resolveDefaultVisibleDataAppClaudeModel(visibleModels) ??
             DEFAULT_DATA_APP_CLAUDE_MODEL;
         if (modelOverride) {
             const overrideAppUuid = modelOverride.appUuid;
@@ -983,13 +979,7 @@ const AppGenerate: FC = () => {
             return latestVersionModel;
         }
         return fallback;
-    }, [
-        modelOverride,
-        activeAppUuid,
-        latestVersionModel,
-        visibleModels,
-        dataAppModelVisibility,
-    ]);
+    }, [modelOverride, activeAppUuid, latestVersionModel, visibleModels]);
 
     const handleModelChange = useCallback(
         (model: DataAppClaudeModel) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-9810

### Description:
Previously, member-facing AI features shared the privileged organization settings response, exposing administrative configuration to unauthorized callers. This adds a runtime-safe settings endpoint and requires organization-level AI management plus an active Copilot entitlement or eligible trial for the existing admin GET and PATCH routes. Backend and frontend consumers now use least-privilege helpers with separate runtime/admin caches while preserving the authorized admin response. Validated with targeted tests, common/backend/frontend typechecks and lint, formatting checks, and API generation without committing generated artifacts.