### PR TITLE
refactor(themes): share organization design package validation

### DIFF
--- a/packages/backend/src/services/OrganizationDesignService/OrganizationDesignPackage.ts
+++ b/packages/backend/src/services/OrganizationDesignService/OrganizationDesignPackage.ts
@@ -1,9 +1,16 @@
 import {
+    getOrganizationDesignPackageContentType,
+    getOrganizationDesignPackageFilePath,
+    isOrganizationDesignPackageDirectory,
     MAX_THEME_FILE_BYTES,
+    MAX_THEME_MANIFEST_BYTES,
     MAX_THEME_TOTAL_BYTES,
-    ORGANIZATION_DESIGN_PACKAGE_CODE_VERSION,
+    ORGANIZATION_DESIGN_PACKAGE_DIRECTORIES,
     ORGANIZATION_DESIGN_PACKAGE_MANIFEST,
     ParameterError,
+    parseOrganizationDesignPackageFilePath,
+    parseOrganizationDesignPackageManifest,
+    validateOrganizationDesignPackageEntryPath,
     type OrganizationDesignFileKind,
     type OrganizationDesignPackageManifest,
 } from '@lightdash/common';
@@ -14,42 +21,7 @@ import {
 } from 'tar-stream';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 
-const MAX_MANIFEST_BYTES = 64 * 1024;
-const MAX_SLUG_LENGTH = 255;
-const MAX_ENTRY_PATH_LENGTH = 512;
-const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-const UUID_SHAPED_SLUG_PATTERN =
-    /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i;
 const TAR_EPOCH = new Date(0);
-
-const PACKAGE_DIRECTORY_BY_KIND: Record<OrganizationDesignFileKind, string> = {
-    css: 'css',
-    font: 'fonts',
-    image: 'images',
-    instruction: 'instructions',
-};
-
-const PACKAGE_KIND_BY_DIRECTORY = new Map<string, OrganizationDesignFileKind>(
-    Object.entries(PACKAGE_DIRECTORY_BY_KIND).map(([kind, directory]) => [
-        directory,
-        kind as OrganizationDesignFileKind,
-    ]),
-);
-
-const CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
-    '.css': 'text/css; charset=utf-8',
-    '.gif': 'image/gif',
-    '.jpeg': 'image/jpeg',
-    '.jpg': 'image/jpeg',
-    '.md': 'text/markdown; charset=utf-8',
-    '.otf': 'font/otf',
-    '.png': 'image/png',
-    '.svg': 'image/svg+xml',
-    '.ttf': 'font/ttf',
-    '.webp': 'image/webp',
-    '.woff': 'font/woff',
-    '.woff2': 'font/woff2',
-};
 
 export type OrganizationDesignPackageFile = {
     kind: OrganizationDesignFileKind;
@@ -61,92 +33,6 @@ export type OrganizationDesignPackageFile = {
 export type ParsedOrganizationDesignPackage = {
     manifest: OrganizationDesignPackageManifest;
     files: OrganizationDesignPackageFile[];
-};
-
-const getExtension = (filename: string): string => {
-    const dot = filename.lastIndexOf('.');
-    return dot === -1 ? '' : filename.slice(dot).toLowerCase();
-};
-
-export const getOrganizationDesignPackageContentType = (
-    filename: string,
-): string =>
-    CONTENT_TYPE_BY_EXTENSION[getExtension(filename)] ??
-    'application/octet-stream';
-
-export const getOrganizationDesignPackageFilePath = (
-    kind: OrganizationDesignFileKind,
-    filename: string,
-): string => `${PACKAGE_DIRECTORY_BY_KIND[kind]}/${filename}`;
-
-const validateArchivePath = (entryName: string): string => {
-    if (!entryName || entryName.length > MAX_ENTRY_PATH_LENGTH) {
-        throw new ParameterError('Theme package entry path is invalid');
-    }
-    if (
-        entryName.startsWith('/') ||
-        entryName.includes('\\') ||
-        entryName.includes('\0')
-    ) {
-        throw new ParameterError(
-            `Theme package entry path is unsafe: ${entryName}`,
-        );
-    }
-
-    const withoutTrailingSlash = entryName.endsWith('/')
-        ? entryName.slice(0, -1)
-        : entryName;
-    const segments = withoutTrailingSlash.split('/');
-    if (
-        !withoutTrailingSlash ||
-        segments.some(
-            (segment) => !segment || segment === '.' || segment === '..',
-        )
-    ) {
-        throw new ParameterError(
-            `Theme package entry path is unsafe: ${entryName}`,
-        );
-    }
-    return withoutTrailingSlash;
-};
-
-const parseFilePath = (
-    entryName: string,
-): { kind: OrganizationDesignFileKind; filename: string } => {
-    const segments = entryName.split('/');
-    if (segments.length !== 2) {
-        throw new ParameterError(
-            `Theme package file must be inside css/, fonts/, images/, or instructions/: ${entryName}`,
-        );
-    }
-    const kind = PACKAGE_KIND_BY_DIRECTORY.get(segments[0]);
-    if (!kind) {
-        throw new ParameterError(
-            `Unknown theme package directory: ${segments[0]}`,
-        );
-    }
-    if (segments[1] !== segments[1].trim()) {
-        throw new ParameterError(
-            `Theme package filename may not have surrounding whitespace: ${entryName}`,
-        );
-    }
-    return { kind, filename: segments[1] };
-};
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-    typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const normalizeNullableText = (
-    value: unknown,
-    field: 'description' | 'extraInstructions',
-): string | null => {
-    if (value === null) return null;
-    if (typeof value !== 'string') {
-        throw new ParameterError(
-            `Theme manifest ${field} must be a string or null`,
-        );
-    }
-    return value.trim() || null;
 };
 
 const parseManifest = (body: Buffer): OrganizationDesignPackageManifest => {
@@ -163,57 +49,7 @@ const parseManifest = (body: Buffer): OrganizationDesignPackageManifest => {
     } catch {
         throw new ParameterError('Theme manifest contains invalid YAML');
     }
-    if (!isRecord(parsed)) {
-        throw new ParameterError('Theme manifest must be a YAML object');
-    }
-
-    const expectedKeys = new Set([
-        'codeVersion',
-        'slug',
-        'name',
-        'description',
-        'extraInstructions',
-    ]);
-    const actualKeys = Object.keys(parsed);
-    const unknownKey = actualKeys.find((key) => !expectedKeys.has(key));
-    const missingKey = [...expectedKeys].find(
-        (key) => !Object.prototype.hasOwnProperty.call(parsed, key),
-    );
-    if (unknownKey) {
-        throw new ParameterError(`Unknown theme manifest field: ${unknownKey}`);
-    }
-    if (missingKey) {
-        throw new ParameterError(`Missing theme manifest field: ${missingKey}`);
-    }
-    if (parsed.codeVersion !== ORGANIZATION_DESIGN_PACKAGE_CODE_VERSION) {
-        throw new ParameterError(
-            `Unsupported theme package codeVersion: ${String(parsed.codeVersion)}`,
-        );
-    }
-    if (
-        typeof parsed.slug !== 'string' ||
-        parsed.slug.length > MAX_SLUG_LENGTH ||
-        !SLUG_PATTERN.test(parsed.slug) ||
-        UUID_SHAPED_SLUG_PATTERN.test(parsed.slug)
-    ) {
-        throw new ParameterError(
-            'Theme manifest slug must contain lowercase letters, numbers, and single hyphen separators',
-        );
-    }
-    if (typeof parsed.name !== 'string' || !parsed.name.trim()) {
-        throw new ParameterError('Theme manifest name is required');
-    }
-
-    return {
-        codeVersion: ORGANIZATION_DESIGN_PACKAGE_CODE_VERSION,
-        slug: parsed.slug,
-        name: parsed.name.trim(),
-        description: normalizeNullableText(parsed.description, 'description'),
-        extraInstructions: normalizeNullableText(
-            parsed.extraInstructions,
-            'extraInstructions',
-        ),
-    };
+    return parseOrganizationDesignPackageManifest(parsed);
 };
 
 const toError = (error: unknown): Error =>
@@ -244,7 +80,9 @@ export const parseOrganizationDesignPackage = (
 
         extractor.on('entry', (header, stream, next) => {
             try {
-                const entryName = validateArchivePath(header.name);
+                const entryName = validateOrganizationDesignPackageEntryPath(
+                    header.name,
+                );
                 const entryType = header.type ?? 'file';
                 const pathKey = entryName.toLowerCase();
                 if (seenPaths.has(pathKey)) {
@@ -255,7 +93,7 @@ export const parseOrganizationDesignPackage = (
                 seenPaths.add(pathKey);
 
                 if (entryType === 'directory') {
-                    if (!PACKAGE_KIND_BY_DIRECTORY.has(entryName)) {
+                    if (!isOrganizationDesignPackageDirectory(entryName)) {
                         throw new ParameterError(
                             `Unknown theme package directory: ${entryName}`,
                         );
@@ -273,7 +111,7 @@ export const parseOrganizationDesignPackage = (
                 const isManifest =
                     entryName === ORGANIZATION_DESIGN_PACKAGE_MANIFEST;
                 const maxBytes = isManifest
-                    ? MAX_MANIFEST_BYTES
+                    ? MAX_THEME_MANIFEST_BYTES
                     : MAX_THEME_FILE_BYTES;
                 if ((header.size ?? 0) > maxBytes) {
                     throw new ParameterError(
@@ -281,7 +119,9 @@ export const parseOrganizationDesignPackage = (
                     );
                 }
 
-                const parsedPath = isManifest ? null : parseFilePath(entryName);
+                const parsedPath = isManifest
+                    ? null
+                    : parseOrganizationDesignPackageFilePath(entryName);
                 const chunks: Buffer[] = [];
                 let bytes = 0;
                 stream.on('data', (chunk: Buffer | string) => {
@@ -410,7 +250,7 @@ export const buildOrganizationDesignPackage = (
                 manifestBody,
             );
 
-            for (const directory of PACKAGE_KIND_BY_DIRECTORY.keys()) {
+            for (const directory of ORGANIZATION_DESIGN_PACKAGE_DIRECTORIES) {
                 // eslint-disable-next-line no-await-in-loop
                 await addTarEntry(packer, {
                     name: `${directory}/`,
@@ -435,13 +275,13 @@ export const buildOrganizationDesignPackage = (
             );
             const seenPaths = new Set<string>();
             for (const file of sortedFiles) {
-                const entryName = validateArchivePath(
+                const entryName = validateOrganizationDesignPackageEntryPath(
                     getOrganizationDesignPackageFilePath(
                         file.kind,
                         file.filename,
                     ),
                 );
-                parseFilePath(entryName);
+                parseOrganizationDesignPackageFilePath(entryName);
                 const pathKey = entryName.toLowerCase();
                 if (seenPaths.has(pathKey)) {
                     throw new ParameterError(

--- a/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
+++ b/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
@@ -15,16 +15,18 @@ import {
     assertRegisteredAccount,
     checkThemeLimits,
     ForbiddenError,
+    getOrganizationDesignFileExtension,
+    getOrganizationDesignPackageFilePath,
     MAX_THEME_FILE_BYTES,
     MAX_THEME_PACKAGE_BYTES,
     MAX_THEME_TOTAL_BYTES,
     MissingConfigError,
     NotFoundError,
-    ORGANIZATION_DESIGN_FILE_KINDS,
     ORGANIZATION_DESIGN_PACKAGE_CODE_VERSION,
-    OrganizationDesignFileKind,
     ParameterError,
     themeLimitMessage,
+    validateOrganizationDesignFileContent,
+    validateOrganizationDesignFileMetadata,
     type Account,
     type OrganizationDesignPackageManifest,
     type UuidOrSlug,
@@ -42,7 +44,6 @@ import {
 import { BaseService } from '../BaseService';
 import {
     buildOrganizationDesignPackage,
-    getOrganizationDesignPackageFilePath,
     parseOrganizationDesignPackage,
     type OrganizationDesignPackageFile,
 } from './OrganizationDesignPackage';
@@ -50,120 +51,6 @@ import {
 type OrganizationDesignServiceArguments = {
     lightdashConfig: LightdashConfig;
     organizationDesignModel: OrganizationDesignModel;
-};
-
-/**
- * Allowed filename extensions for each kind. Filename extension is the
- * authoritative signal — client-supplied Content-Type is stored but not
- * relied on for routing/validation, since browsers send wildly different
- * MIME strings for the same font/image types.
- */
-const KIND_EXTENSIONS: Record<OrganizationDesignFileKind, string[]> = {
-    css: ['.css'],
-    font: ['.woff', '.woff2', '.ttf', '.otf'],
-    image: ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'],
-    instruction: ['.md'],
-};
-
-const FILENAME_BAD_CHARS = /[\0/\\]/;
-
-const ensureValidFilename = (filename: string): string => {
-    const trimmed = filename.trim();
-    if (!trimmed) {
-        throw new ParameterError('Filename is required');
-    }
-    if (trimmed.length > 255) {
-        throw new ParameterError('Filename exceeds 255 characters');
-    }
-    if (trimmed.includes('..')) {
-        throw new ParameterError('Filename may not contain ".."');
-    }
-    if (FILENAME_BAD_CHARS.test(trimmed)) {
-        throw new ParameterError(
-            'Filename may not contain slashes or null bytes',
-        );
-    }
-    return trimmed;
-};
-
-const ensureFilenameMatchesKind = (
-    filename: string,
-    kind: OrganizationDesignFileKind,
-): void => {
-    const lower = filename.toLowerCase();
-    const allowed = KIND_EXTENSIONS[kind];
-    if (!allowed.some((ext) => lower.endsWith(ext))) {
-        throw new ParameterError(
-            `Filename "${filename}" does not match kind "${kind}". Allowed extensions: ${allowed.join(', ')}`,
-        );
-    }
-};
-
-const ensureValidKind = (kind: string): OrganizationDesignFileKind => {
-    if (!(ORGANIZATION_DESIGN_FILE_KINDS as readonly string[]).includes(kind)) {
-        throw new ParameterError(
-            `Invalid kind "${kind}". Allowed: ${ORGANIZATION_DESIGN_FILE_KINDS.join(', ')}`,
-        );
-    }
-    return kind as OrganizationDesignFileKind;
-};
-
-/**
- * Magic-byte validation. A SignatureAlternative is a set of byte-runs at
- * given offsets that must ALL match. An extension's signature list is an
- * OR over alternatives (e.g. GIF87a OR GIF89a, TTF magic 00 01 00 00 OR
- * the 'true' variant). Extension is the authoritative signal (matched
- * against the declared `kind` upstream), so we only need one mapping.
- */
-type SignatureAlternative = ReadonlyArray<{
-    offset: number;
-    bytes: ReadonlyArray<number>;
-}>;
-
-const BINARY_SIGNATURES: Record<string, ReadonlyArray<SignatureAlternative>> = {
-    // Fonts
-    '.woff2': [[{ offset: 0, bytes: [0x77, 0x4f, 0x46, 0x32] }]], // wOF2
-    '.woff': [[{ offset: 0, bytes: [0x77, 0x4f, 0x46, 0x46] }]], // wOFF
-    '.ttf': [
-        [{ offset: 0, bytes: [0x00, 0x01, 0x00, 0x00] }],
-        [{ offset: 0, bytes: [0x74, 0x72, 0x75, 0x65] }], // 'true'
-    ],
-    '.otf': [[{ offset: 0, bytes: [0x4f, 0x54, 0x54, 0x4f] }]], // OTTO
-    // Images
-    '.png': [
-        [
-            {
-                offset: 0,
-                bytes: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
-            },
-        ],
-    ],
-    '.jpg': [[{ offset: 0, bytes: [0xff, 0xd8, 0xff] }]],
-    '.jpeg': [[{ offset: 0, bytes: [0xff, 0xd8, 0xff] }]],
-    '.gif': [
-        [{ offset: 0, bytes: [0x47, 0x49, 0x46, 0x38, 0x37, 0x61] }], // GIF87a
-        [{ offset: 0, bytes: [0x47, 0x49, 0x46, 0x38, 0x39, 0x61] }], // GIF89a
-    ],
-    '.webp': [
-        [
-            { offset: 0, bytes: [0x52, 0x49, 0x46, 0x46] }, // RIFF
-            { offset: 8, bytes: [0x57, 0x45, 0x42, 0x50] }, // WEBP
-        ],
-    ],
-};
-
-const TEXT_EXTENSIONS = new Set<string>(['.css', '.md', '.svg']);
-
-// SVG is XML — require a plausible XML/SVG prefix before the full DOMPurify
-// sanitation performed below.
-const SVG_HEAD_PREFIX = /^\s*<(?:\?xml|svg|!--|!DOCTYPE)/i;
-
-const TEXT_HEAD_SCAN_BYTES = 1024;
-
-const getExtension = (filename: string): string => {
-    const lower = filename.toLowerCase();
-    const dot = lower.lastIndexOf('.');
-    return dot === -1 ? '' : lower.slice(dot);
 };
 
 /**
@@ -194,69 +81,33 @@ const sanitizeSvg = (svgText: string): string =>
         USE_PROFILES: { svg: true, svgFilters: true },
     });
 
-const ensureContentMatchesExtension = (
+const sanitizeOrganizationDesignFile = (
     body: Buffer,
     filename: string,
-): { body: Buffer } => {
-    const ext = getExtension(filename);
-
-    const binaryAlternatives = BINARY_SIGNATURES[ext];
-    if (binaryAlternatives) {
-        const matchesAny = binaryAlternatives.some((alternative) =>
-            alternative.every(({ offset, bytes }) =>
-                bytes.every((byte, i) => body[offset + i] === byte),
-            ),
-        );
-        if (!matchesAny) {
-            throw new ParameterError(
-                `File content does not match ${ext} signature`,
-            );
-        }
-        return { body };
+): Buffer => {
+    if (getOrganizationDesignFileExtension(filename) !== '.svg') return body;
+    const sanitizedBody = Buffer.from(
+        sanitizeSvg(body.toString('utf8')),
+        'utf8',
+    );
+    if (sanitizedBody.length === 0) {
+        throw new ParameterError('SVG contains no safe content');
     }
+    return sanitizedBody;
+};
 
-    if (TEXT_EXTENSIONS.has(ext)) {
-        let text: string;
-        try {
-            text = new TextDecoder('utf-8', { fatal: true }).decode(body);
-        } catch {
-            throw new ParameterError(
-                `File content for ${ext} must be valid UTF-8 text`,
-            );
-        }
-        // Binary files almost always have a null byte in the first kilobyte;
-        // legitimate text doesn't. Cheap belt-and-suspenders alongside the
-        // UTF-8 check (NULs are valid UTF-8).
-        const head = body.subarray(
-            0,
-            Math.min(body.length, TEXT_HEAD_SCAN_BYTES),
+const getEffectiveOrganizationDesignFiles = (
+    files: ApiOrganizationDesignFile[],
+): Map<string, ApiOrganizationDesignFile> => {
+    const effectiveFiles = new Map<string, ApiOrganizationDesignFile>();
+    for (const file of files) {
+        const packagePath = getOrganizationDesignPackageFilePath(
+            file.kind,
+            file.filename,
         );
-        if (head.includes(0)) {
-            throw new ParameterError(
-                `File content for ${ext} contains null bytes`,
-            );
-        }
-        if (ext === '.svg') {
-            if (!SVG_HEAD_PREFIX.test(head.toString('utf8'))) {
-                throw new ParameterError(
-                    'SVG content must start with <?xml, <svg, or an XML comment/doctype',
-                );
-            }
-            // Returned bytes are the sanitized SVG — anything DOMPurify
-            // stripped (<script>, on*= handlers, foreignObject, javascript:
-            // hrefs) never lands in S3.
-            const sanitizedBody = Buffer.from(sanitizeSvg(text), 'utf8');
-            if (sanitizedBody.length === 0) {
-                throw new ParameterError('SVG contains no safe content');
-            }
-            return { body: sanitizedBody };
-        }
-        return { body };
+        effectiveFiles.set(packagePath.toLowerCase(), file);
     }
-
-    // Defensive default: ensureFilenameMatchesKind upstream guarantees
-    // the extension is one we recognize, so we should never get here.
-    return { body };
+    return effectiveFiles;
 };
 
 /**
@@ -439,14 +290,9 @@ export class OrganizationDesignService extends BaseService {
         // more than once. The sandbox applies those in created order, so the
         // last file is the effective one. Export only that effective file to
         // produce an importable package with unique paths.
-        const effectiveFiles = new Map<string, ApiOrganizationDesignFile>();
-        for (const file of design.files) {
-            const path = getOrganizationDesignPackageFilePath(
-                file.kind,
-                file.filename,
-            );
-            effectiveFiles.set(path.toLowerCase(), file);
-        }
+        const effectiveFiles = getEffectiveOrganizationDesignFiles(
+            design.files,
+        );
 
         const packageFiles: OrganizationDesignPackageFile[] = [];
         let totalBytes = 0;
@@ -536,15 +382,19 @@ export class OrganizationDesignService extends BaseService {
         }
         const parsed = await parseOrganizationDesignPackage(archive);
         const validatedFiles = parsed.files.map((file) => {
-            const kind = ensureValidKind(file.kind);
-            const filename = ensureValidFilename(file.filename);
-            ensureFilenameMatchesKind(filename, kind);
-            const { body } = ensureContentMatchesExtension(file.body, filename);
+            const { kind, filename } = validateOrganizationDesignFileMetadata({
+                kind: file.kind,
+                filename: file.filename,
+            });
+            validateOrganizationDesignFileContent({
+                body: file.body,
+                filename,
+            });
             return {
                 kind,
                 filename,
                 contentType: file.contentType,
-                body,
+                body: sanitizeOrganizationDesignFile(file.body, filename),
             };
         });
         const violation = checkThemeLimits(
@@ -778,9 +628,10 @@ export class OrganizationDesignService extends BaseService {
         const { organizationUuid, userUuid } = this.assertCanManage(account);
         const design = await this.loadOwned(organizationUuid, designUuidOrSlug);
 
-        const kind = ensureValidKind(input.kind);
-        const filename = ensureValidFilename(input.filename);
-        ensureFilenameMatchesKind(filename, kind);
+        const { kind, filename } = validateOrganizationDesignFileMetadata({
+            kind: input.kind,
+            filename: input.filename,
+        });
 
         // Reject uploads that would push the theme past its total-size
         // guardrail, so a theme can't grow large enough to time out the
@@ -827,9 +678,8 @@ export class OrganizationDesignService extends BaseService {
             throw new ParameterError('Upload body is empty');
         }
 
-        // ensureContentMatchesExtension may return a sanitized body (SVG).
-        // Always use the returned buffer for both S3 upload and size accounting.
-        const { body } = ensureContentMatchesExtension(rawBody, filename);
+        validateOrganizationDesignFileContent({ body: rawBody, filename });
+        const body = sanitizeOrganizationDesignFile(rawBody, filename);
 
         const contentType =
             input.contentType?.trim() || 'application/octet-stream';

--- a/packages/common/src/ee/designs/validation.ts
+++ b/packages/common/src/ee/designs/validation.ts
@@ -1,0 +1,350 @@
+import { ParameterError } from '../../types/errors';
+import {
+    MAX_THEME_FILE_BYTES,
+    ORGANIZATION_DESIGN_FILE_KINDS,
+    ORGANIZATION_DESIGN_PACKAGE_CODE_VERSION,
+    type OrganizationDesignFileKind,
+    type OrganizationDesignPackageManifest,
+} from './types';
+
+export const MAX_THEME_MANIFEST_BYTES = 64 * 1024;
+export const MAX_THEME_PACKAGE_ENTRY_PATH_LENGTH = 512;
+
+export const ORGANIZATION_DESIGN_PACKAGE_DIRECTORY_BY_KIND = {
+    css: 'css',
+    font: 'fonts',
+    image: 'images',
+    instruction: 'instructions',
+} as const satisfies Record<OrganizationDesignFileKind, string>;
+
+export const ORGANIZATION_DESIGN_PACKAGE_DIRECTORIES = Object.values(
+    ORGANIZATION_DESIGN_PACKAGE_DIRECTORY_BY_KIND,
+);
+
+const PACKAGE_KIND_BY_DIRECTORY = new Map<string, OrganizationDesignFileKind>(
+    Object.entries(ORGANIZATION_DESIGN_PACKAGE_DIRECTORY_BY_KIND).map(
+        ([kind, directory]) => [directory, kind as OrganizationDesignFileKind],
+    ),
+);
+
+const CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
+    '.css': 'text/css; charset=utf-8',
+    '.gif': 'image/gif',
+    '.jpeg': 'image/jpeg',
+    '.jpg': 'image/jpeg',
+    '.md': 'text/markdown; charset=utf-8',
+    '.otf': 'font/otf',
+    '.png': 'image/png',
+    '.svg': 'image/svg+xml',
+    '.ttf': 'font/ttf',
+    '.webp': 'image/webp',
+    '.woff': 'font/woff',
+    '.woff2': 'font/woff2',
+};
+
+const KIND_EXTENSIONS: Record<OrganizationDesignFileKind, string[]> = {
+    css: ['.css'],
+    font: ['.woff', '.woff2', '.ttf', '.otf'],
+    image: ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'],
+    instruction: ['.md'],
+};
+
+type SignatureAlternative = ReadonlyArray<{
+    offset: number;
+    bytes: ReadonlyArray<number>;
+}>;
+
+const BINARY_SIGNATURES: Record<string, ReadonlyArray<SignatureAlternative>> = {
+    '.woff2': [[{ offset: 0, bytes: [0x77, 0x4f, 0x46, 0x32] }]],
+    '.woff': [[{ offset: 0, bytes: [0x77, 0x4f, 0x46, 0x46] }]],
+    '.ttf': [
+        [{ offset: 0, bytes: [0x00, 0x01, 0x00, 0x00] }],
+        [{ offset: 0, bytes: [0x74, 0x72, 0x75, 0x65] }],
+    ],
+    '.otf': [[{ offset: 0, bytes: [0x4f, 0x54, 0x54, 0x4f] }]],
+    '.png': [
+        [
+            {
+                offset: 0,
+                bytes: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+            },
+        ],
+    ],
+    '.jpg': [[{ offset: 0, bytes: [0xff, 0xd8, 0xff] }]],
+    '.jpeg': [[{ offset: 0, bytes: [0xff, 0xd8, 0xff] }]],
+    '.gif': [
+        [{ offset: 0, bytes: [0x47, 0x49, 0x46, 0x38, 0x37, 0x61] }],
+        [{ offset: 0, bytes: [0x47, 0x49, 0x46, 0x38, 0x39, 0x61] }],
+    ],
+    '.webp': [
+        [
+            { offset: 0, bytes: [0x52, 0x49, 0x46, 0x46] },
+            { offset: 8, bytes: [0x57, 0x45, 0x42, 0x50] },
+        ],
+    ],
+};
+
+const TEXT_EXTENSIONS = new Set(['.css', '.md', '.svg']);
+const SVG_HEAD_PREFIX = /^\s*<(?:\?xml|svg|!--|!DOCTYPE)/i;
+const TEXT_HEAD_SCAN_BYTES = 1024;
+const FILENAME_BAD_CHARS = /[\0/\\]/;
+const MAX_SLUG_LENGTH = 255;
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const UUID_SHAPED_SLUG_PATTERN =
+    /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const getOrganizationDesignFileExtension = (
+    filename: string,
+): string => {
+    const lower = filename.toLowerCase();
+    const dot = lower.lastIndexOf('.');
+    return dot === -1 ? '' : lower.slice(dot);
+};
+
+export const getOrganizationDesignPackageContentType = (
+    filename: string,
+): string =>
+    CONTENT_TYPE_BY_EXTENSION[getOrganizationDesignFileExtension(filename)] ??
+    'application/octet-stream';
+
+export const getOrganizationDesignPackageFilePath = (
+    kind: OrganizationDesignFileKind,
+    filename: string,
+): string =>
+    `${ORGANIZATION_DESIGN_PACKAGE_DIRECTORY_BY_KIND[kind]}/${filename}`;
+
+export const isOrganizationDesignPackageDirectory = (value: string): boolean =>
+    PACKAGE_KIND_BY_DIRECTORY.has(value);
+
+export const validateOrganizationDesignPackageEntryPath = (
+    entryName: string,
+): string => {
+    if (!entryName || entryName.length > MAX_THEME_PACKAGE_ENTRY_PATH_LENGTH) {
+        throw new ParameterError('Theme package entry path is invalid');
+    }
+    if (
+        entryName.startsWith('/') ||
+        entryName.includes('\\') ||
+        entryName.includes('\0')
+    ) {
+        throw new ParameterError(
+            `Theme package entry path is unsafe: ${entryName}`,
+        );
+    }
+
+    const withoutTrailingSlash = entryName.endsWith('/')
+        ? entryName.slice(0, -1)
+        : entryName;
+    const segments = withoutTrailingSlash.split('/');
+    if (
+        !withoutTrailingSlash ||
+        segments.some(
+            (segment) => !segment || segment === '.' || segment === '..',
+        )
+    ) {
+        throw new ParameterError(
+            `Theme package entry path is unsafe: ${entryName}`,
+        );
+    }
+    return withoutTrailingSlash;
+};
+
+export const parseOrganizationDesignPackageFilePath = (
+    entryName: string,
+): { kind: OrganizationDesignFileKind; filename: string } => {
+    const segments = entryName.split('/');
+    if (segments.length !== 2) {
+        throw new ParameterError(
+            `Theme package file must be inside css/, fonts/, images/, or instructions/: ${entryName}`,
+        );
+    }
+    const kind = PACKAGE_KIND_BY_DIRECTORY.get(segments[0]);
+    if (!kind) {
+        throw new ParameterError(
+            `Unknown theme package directory: ${segments[0]}`,
+        );
+    }
+    if (segments[1] !== segments[1].trim()) {
+        throw new ParameterError(
+            `Theme package filename may not have surrounding whitespace: ${entryName}`,
+        );
+    }
+    return { kind, filename: segments[1] };
+};
+
+const normalizeNullableText = (
+    value: unknown,
+    field: 'description' | 'extraInstructions',
+): string | null => {
+    if (value === null) return null;
+    if (typeof value !== 'string') {
+        throw new ParameterError(
+            `Theme manifest ${field} must be a string or null`,
+        );
+    }
+    return value.trim() || null;
+};
+
+export const parseOrganizationDesignPackageManifest = (
+    parsed: unknown,
+): OrganizationDesignPackageManifest => {
+    if (!isRecord(parsed)) {
+        throw new ParameterError('Theme manifest must be a YAML object');
+    }
+
+    const expectedKeys = new Set([
+        'codeVersion',
+        'slug',
+        'name',
+        'description',
+        'extraInstructions',
+    ]);
+    const actualKeys = Object.keys(parsed);
+    const unknownKey = actualKeys.find((key) => !expectedKeys.has(key));
+    const missingKey = [...expectedKeys].find(
+        (key) => !Object.prototype.hasOwnProperty.call(parsed, key),
+    );
+    if (unknownKey) {
+        throw new ParameterError(`Unknown theme manifest field: ${unknownKey}`);
+    }
+    if (missingKey) {
+        throw new ParameterError(`Missing theme manifest field: ${missingKey}`);
+    }
+    if (parsed.codeVersion !== ORGANIZATION_DESIGN_PACKAGE_CODE_VERSION) {
+        throw new ParameterError(
+            `Unsupported theme package codeVersion: ${String(parsed.codeVersion)}`,
+        );
+    }
+    if (
+        typeof parsed.slug !== 'string' ||
+        parsed.slug.length > MAX_SLUG_LENGTH ||
+        !SLUG_PATTERN.test(parsed.slug) ||
+        UUID_SHAPED_SLUG_PATTERN.test(parsed.slug)
+    ) {
+        throw new ParameterError(
+            'Theme manifest slug must contain lowercase letters, numbers, and single hyphen separators',
+        );
+    }
+    if (typeof parsed.name !== 'string' || !parsed.name.trim()) {
+        throw new ParameterError('Theme manifest name is required');
+    }
+
+    return {
+        codeVersion: ORGANIZATION_DESIGN_PACKAGE_CODE_VERSION,
+        slug: parsed.slug,
+        name: parsed.name.trim(),
+        description: normalizeNullableText(parsed.description, 'description'),
+        extraInstructions: normalizeNullableText(
+            parsed.extraInstructions,
+            'extraInstructions',
+        ),
+    };
+};
+
+export const validateOrganizationDesignFileMetadata = ({
+    kind: inputKind,
+    filename: inputFilename,
+}: {
+    kind: string;
+    filename: string;
+}): { kind: OrganizationDesignFileKind; filename: string } => {
+    if (
+        !(ORGANIZATION_DESIGN_FILE_KINDS as readonly string[]).includes(
+            inputKind,
+        )
+    ) {
+        throw new ParameterError(
+            `Invalid kind "${inputKind}". Allowed: ${ORGANIZATION_DESIGN_FILE_KINDS.join(', ')}`,
+        );
+    }
+    const kind = inputKind as OrganizationDesignFileKind;
+    const filename = inputFilename.trim();
+    if (!filename) {
+        throw new ParameterError('Filename is required');
+    }
+    if (filename.length > 255) {
+        throw new ParameterError('Filename exceeds 255 characters');
+    }
+    if (filename.includes('..')) {
+        throw new ParameterError('Filename may not contain ".."');
+    }
+    if (FILENAME_BAD_CHARS.test(filename)) {
+        throw new ParameterError(
+            'Filename may not contain slashes or null bytes',
+        );
+    }
+
+    const allowed = KIND_EXTENSIONS[kind];
+    if (
+        !allowed.some((extension) => filename.toLowerCase().endsWith(extension))
+    ) {
+        throw new ParameterError(
+            `Filename "${filename}" does not match kind "${kind}". Allowed extensions: ${allowed.join(', ')}`,
+        );
+    }
+
+    return { kind, filename };
+};
+
+export const validateOrganizationDesignFileContent = ({
+    body,
+    filename,
+}: {
+    body: Uint8Array;
+    filename: string;
+}): void => {
+    if (body.length === 0) {
+        throw new ParameterError('Theme package file is empty');
+    }
+    if (body.length > MAX_THEME_FILE_BYTES) {
+        throw new ParameterError(
+            `Theme package file exceeds ${MAX_THEME_FILE_BYTES} bytes`,
+        );
+    }
+
+    const extension = getOrganizationDesignFileExtension(filename);
+    const binaryAlternatives = BINARY_SIGNATURES[extension];
+    if (binaryAlternatives) {
+        const matchesAny = binaryAlternatives.some((alternative) =>
+            alternative.every(({ offset, bytes }) =>
+                bytes.every((byte, index) => body[offset + index] === byte),
+            ),
+        );
+        if (!matchesAny) {
+            throw new ParameterError(
+                `File content does not match ${extension} signature`,
+            );
+        }
+        return;
+    }
+
+    if (TEXT_EXTENSIONS.has(extension)) {
+        try {
+            new TextDecoder('utf-8', { fatal: true }).decode(body);
+        } catch {
+            throw new ParameterError(
+                `File content for ${extension} must be valid UTF-8 text`,
+            );
+        }
+        const head = body.subarray(
+            0,
+            Math.min(body.length, TEXT_HEAD_SCAN_BYTES),
+        );
+        if (head.includes(0)) {
+            throw new ParameterError(
+                `File content for ${extension} contains null bytes`,
+            );
+        }
+        if (
+            extension === '.svg' &&
+            !SVG_HEAD_PREFIX.test(new TextDecoder('utf-8').decode(head))
+        ) {
+            throw new ParameterError(
+                'SVG content must start with <?xml, <svg, or an XML comment/doctype',
+            );
+        }
+    }
+};

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -20,6 +20,7 @@ export * from './apps/sdkBridgeRoutes';
 export * from './ambientAi';
 export * from './commercialFeatureFlags';
 export * from './designs/types';
+export * from './designs/validation';
 export * from './embed';
 export * from './homepage/onboardingHomepage';
 export * from './homepage/orgSettings';


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-598/data-app-themes-theme-as-code-v1-cli-package-and-synchronization

## Summary

- move canonical organization theme package validation into `@lightdash/common`
- reuse the shared manifest, path, metadata, and content validation in the backend package codec
- keep SVG sanitization server-side while sharing the format checks needed by CLI consumers
- extract effective package-file selection without changing export behavior

## Why

The organization content-as-code CLI needs to validate exactly the same package format as the backend. A single shared implementation prevents the local and remote contracts from drifting.
