### PR TITLE
feat(themes): skip unchanged package imports

### DIFF
--- a/packages/backend/src/controllers/organizationDesignController.ts
+++ b/packages/backend/src/controllers/organizationDesignController.ts
@@ -1,6 +1,7 @@
 import {
     ApiErrorPayload,
     ApiOrganizationDesignFileResponse,
+    ApiOrganizationDesignPackageImportResponse,
     ApiOrganizationDesignResponse,
     ApiOrganizationDesignsResponse,
     ApiSuccessEmpty,
@@ -158,7 +159,7 @@ export class OrganizationDesignController extends BaseController {
     @OperationId('ImportOrganizationDesignPackage')
     async importPackage(
         @Request() req: express.Request,
-    ): Promise<ApiOrganizationDesignResponse> {
+    ): Promise<ApiOrganizationDesignPackageImportResponse> {
         assertRegisteredAccount(req.account);
         const contentType = req.headers['content-type']
             ?.split(';')[0]

--- a/packages/backend/src/models/OrganizationDesignModel.test.ts
+++ b/packages/backend/src/models/OrganizationDesignModel.test.ts
@@ -1,4 +1,8 @@
-import { AlreadyExistsError, NotFoundError } from '@lightdash/common';
+import {
+    AlreadyExistsError,
+    NotFoundError,
+    type ApiOrganizationDesign,
+} from '@lightdash/common';
 import knex, { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { OrganizationDesignFilesTableName } from '../database/entities/organizationDesignFiles';
@@ -337,6 +341,64 @@ describe('OrganizationDesignModel', () => {
                 [],
             );
             expect(tracker.history.update).toHaveLength(0);
+        });
+    });
+
+    describe('confirmPackageSnapshot', () => {
+        const snapshot: ApiOrganizationDesign = {
+            designUuid: DESIGN_UUID,
+            organizationUuid: ORG_UUID,
+            slug: 'brand-a',
+            name: 'Brand A',
+            description: 'Acme brand',
+            extraInstructions: null,
+            isDefault: false,
+            createdAt: new Date('2026-01-01T00:00:00Z'),
+            updatedAt: new Date('2026-01-02T00:00:00Z'),
+            createdByUserUuid: USER_UUID,
+            files: [
+                {
+                    fileUuid: FILE_UUID,
+                    kind: 'css',
+                    filename: 'theme.css',
+                    contentType: 'text/css',
+                    sizeBytes: 1234,
+                    createdAt: new Date('2026-01-03T00:00:00Z'),
+                },
+            ],
+        };
+
+        it('returns the locked design when package metadata and file identities still match', async () => {
+            tracker.on
+                .select(OrganizationDesignsTableName)
+                .responseOnce(makeDbDesign());
+            tracker.on
+                .select(OrganizationDesignFilesTableName)
+                .responseOnce([makeDbFile()]);
+
+            await expect(
+                model.confirmPackageSnapshot(ORG_UUID, snapshot),
+            ).resolves.toMatchObject({
+                designUuid: DESIGN_UUID,
+                slug: snapshot.slug,
+                files: [{ fileUuid: FILE_UUID }],
+            });
+            expect(tracker.history.select[0].sql).toContain('for update');
+        });
+
+        it('rejects the snapshot when a concurrent file replacement changed its identity', async () => {
+            tracker.on
+                .select(OrganizationDesignsTableName)
+                .responseOnce(makeDbDesign());
+            tracker.on.select(OrganizationDesignFilesTableName).responseOnce([
+                makeDbFile({
+                    file_uuid: '00000000-0000-0000-0000-000000000999',
+                }),
+            ]);
+
+            await expect(
+                model.confirmPackageSnapshot(ORG_UUID, snapshot),
+            ).resolves.toBeUndefined();
         });
     });
 

--- a/packages/backend/src/models/OrganizationDesignModel.ts
+++ b/packages/backend/src/models/OrganizationDesignModel.ts
@@ -488,6 +488,44 @@ export class OrganizationDesignModel {
         });
     }
 
+    // Re-check package-managed state under a row lock before callers return
+    // NO_CHANGES for a previously loaded snapshot.
+    async confirmPackageSnapshot(
+        organizationUuid: string,
+        snapshot: ApiOrganizationDesign,
+    ): Promise<ApiOrganizationDesign | undefined> {
+        return this.database.transaction(async (trx) => {
+            const current = await trx(OrganizationDesignsTableName)
+                .where({
+                    organization_uuid: organizationUuid,
+                    design_uuid: snapshot.designUuid,
+                })
+                .forUpdate()
+                .first();
+            if (!current) return undefined;
+
+            const files = await trx(OrganizationDesignFilesTableName)
+                .where('design_uuid', snapshot.designUuid)
+                .orderBy('created_at', 'asc')
+                .orderBy('file_uuid', 'asc');
+            const packageMetadataMatches =
+                current.slug === snapshot.slug &&
+                current.name === snapshot.name &&
+                current.description === snapshot.description &&
+                current.extra_instructions === snapshot.extraInstructions;
+            const fileSnapshotMatches =
+                files.length === snapshot.files.length &&
+                files.every(
+                    (file, index) =>
+                        file.file_uuid === snapshot.files[index].fileUuid,
+                );
+            if (!packageMetadataMatches || !fileSnapshotMatches) {
+                return undefined;
+            }
+            return mapDbDesign(current, files);
+        });
+    }
+
     async replaceFiles(
         organizationUuid: string,
         designUuid: string,

--- a/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.test.ts
+++ b/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.test.ts
@@ -1,12 +1,14 @@
 import {
     DeleteObjectsCommand,
     GetObjectCommand,
+    NoSuchKey,
     PutObjectCommand,
     type S3Client,
 } from '@aws-sdk/client-s3';
 import {
     ORGANIZATION_DESIGN_PACKAGE_CODE_VERSION,
     ParameterError,
+    PromotionAction,
     type ApiOrganizationDesign,
     type OrganizationDesignPackageManifest,
 } from '@lightdash/common';
@@ -144,14 +146,21 @@ describe('OrganizationDesignService package activation', () => {
     const makeService = ({
         replaceFiles,
         send,
+        design = existingDesign,
+        confirmPackageSnapshot = vi.fn(),
+        createWithFiles = vi.fn(),
     }: {
         replaceFiles: ReturnType<typeof vi.fn>;
         send: ReturnType<typeof vi.fn>;
+        design?: ApiOrganizationDesign | null;
+        confirmPackageSnapshot?: ReturnType<typeof vi.fn>;
+        createWithFiles?: ReturnType<typeof vi.fn>;
     }) => {
         const organizationDesignModel = {
-            findByIdOrSlug: vi.fn().mockResolvedValue(existingDesign),
+            findByIdOrSlug: vi.fn().mockResolvedValue(design),
+            confirmPackageSnapshot,
             replaceFiles,
-            createWithFiles: vi.fn(),
+            createWithFiles,
         };
         const service = new OrganizationDesignService({
             lightdashConfig: lightdashConfigMock,
@@ -172,18 +181,311 @@ describe('OrganizationDesignService package activation', () => {
             client: { send } as unknown as S3Client,
             bucket: 'themes',
         });
-        return { service };
+        return { service, organizationDesignModel };
     };
 
+    const packageBody = Buffer.from('body { color: red; }');
     const makeArchive = () =>
         buildOrganizationDesignPackage(MANIFEST, [
             {
                 kind: 'css',
                 filename: 'theme.css',
                 contentType: 'text/css; charset=utf-8',
-                body: Buffer.from('body { color: red; }'),
+                body: packageBody,
             },
         ]);
+
+    const matchingDesign: ApiOrganizationDesign = {
+        ...existingDesign,
+        name: MANIFEST.name,
+        description: MANIFEST.description,
+        extraInstructions: MANIFEST.extraInstructions,
+        files: [
+            {
+                ...existingDesign.files[0],
+                filename: 'theme.css',
+                contentType: 'text/css; charset=utf-8',
+                sizeBytes: packageBody.length,
+            },
+        ],
+    };
+
+    it('reports create when the package slug does not exist', async () => {
+        const send = vi.fn().mockResolvedValue({});
+        const replaceFiles = vi.fn();
+        const createWithFiles = vi.fn().mockResolvedValue(matchingDesign);
+        const { service, organizationDesignModel } = makeService({
+            replaceFiles,
+            send,
+            design: null,
+            createWithFiles,
+        });
+        const archive = await makeArchive();
+
+        await expect(
+            service.importPackage(buildAccount(), {
+                body: Readable.from(archive),
+                contentLength: archive.length,
+            }),
+        ).resolves.toEqual({
+            ...matchingDesign,
+            action: PromotionAction.CREATE,
+        });
+
+        expect(send).toHaveBeenCalledOnce();
+        expect(send.mock.calls[0][0]).toBeInstanceOf(PutObjectCommand);
+        expect(createWithFiles).toHaveBeenCalledOnce();
+        expect(
+            organizationDesignModel.confirmPackageSnapshot,
+        ).not.toHaveBeenCalled();
+        expect(replaceFiles).not.toHaveBeenCalled();
+    });
+
+    it('returns no changes without staging when package metadata and S3 bytes match', async () => {
+        const send = vi.fn(async (command: unknown) => {
+            expect(command).toBeInstanceOf(GetObjectCommand);
+            return {
+                Body: {
+                    transformToByteArray: async () => packageBody,
+                },
+            };
+        });
+        const replaceFiles = vi.fn();
+        const confirmPackageSnapshot = vi
+            .fn()
+            .mockResolvedValue(matchingDesign);
+        const { service } = makeService({
+            replaceFiles,
+            send,
+            design: matchingDesign,
+            confirmPackageSnapshot,
+        });
+        const archive = await makeArchive();
+
+        await expect(
+            service.importPackage(buildAccount(), {
+                body: Readable.from(archive),
+                contentLength: archive.length,
+            }),
+        ).resolves.toEqual({
+            ...matchingDesign,
+            action: PromotionAction.NO_CHANGES,
+        });
+
+        expect(send).toHaveBeenCalledOnce();
+        expect(confirmPackageSnapshot).toHaveBeenCalledWith(
+            'test-org-uuid',
+            matchingDesign,
+        );
+        expect(replaceFiles).not.toHaveBeenCalled();
+    });
+
+    it('ignores UI-provided content types when package metadata and bytes match', async () => {
+        const uiAuthoredDesign: ApiOrganizationDesign = {
+            ...matchingDesign,
+            files: matchingDesign.files.map((file) => ({
+                ...file,
+                contentType: 'text/css',
+            })),
+        };
+        const send = vi.fn(async (command: unknown) => {
+            expect(command).toBeInstanceOf(GetObjectCommand);
+            return {
+                Body: {
+                    transformToByteArray: async () => packageBody,
+                },
+            };
+        });
+        const replaceFiles = vi.fn();
+        const confirmPackageSnapshot = vi
+            .fn()
+            .mockResolvedValue(uiAuthoredDesign);
+        const { service } = makeService({
+            replaceFiles,
+            send,
+            design: uiAuthoredDesign,
+            confirmPackageSnapshot,
+        });
+        const archive = await makeArchive();
+
+        await expect(
+            service.importPackage(buildAccount(), {
+                body: Readable.from(archive),
+                contentLength: archive.length,
+            }),
+        ).resolves.toEqual({
+            ...uiAuthoredDesign,
+            action: PromotionAction.NO_CHANGES,
+        });
+
+        expect(send).toHaveBeenCalledOnce();
+        expect(replaceFiles).not.toHaveBeenCalled();
+    });
+
+    it('replaces a package when an existing S3 object is missing', async () => {
+        const send = vi.fn(async (command: unknown) => {
+            if (command instanceof GetObjectCommand) {
+                throw new NoSuchKey({
+                    message: 'The specified key does not exist',
+                    $metadata: { httpStatusCode: 404 },
+                });
+            }
+            return {};
+        });
+        const updatedDesign = { ...matchingDesign, files: [] };
+        const replaceFiles = vi.fn().mockResolvedValue({
+            design: updatedDesign,
+            removedFiles: matchingDesign.files,
+        });
+        const { service } = makeService({
+            replaceFiles,
+            send,
+            design: matchingDesign,
+        });
+        const archive = await makeArchive();
+
+        await expect(
+            service.importPackage(buildAccount(), {
+                body: Readable.from(archive),
+                contentLength: archive.length,
+            }),
+        ).resolves.toEqual({
+            ...updatedDesign,
+            action: PromotionAction.UPDATE,
+        });
+
+        expect(send.mock.calls[0][0]).toBeInstanceOf(GetObjectCommand);
+        expect(send.mock.calls[1][0]).toBeInstanceOf(PutObjectCommand);
+        expect(replaceFiles).toHaveBeenCalledOnce();
+    });
+
+    it('replaces a package to compact shadowed duplicate file rows', async () => {
+        const duplicateDesign: ApiOrganizationDesign = {
+            ...matchingDesign,
+            files: [
+                {
+                    ...matchingDesign.files[0],
+                    fileUuid: '00000000-0000-4000-8000-000000000099',
+                    filename: 'THEME.CSS',
+                },
+                matchingDesign.files[0],
+            ],
+        };
+        const send = vi.fn().mockResolvedValue({});
+        const updatedDesign = { ...matchingDesign, files: [] };
+        const replaceFiles = vi.fn().mockResolvedValue({
+            design: updatedDesign,
+            removedFiles: duplicateDesign.files,
+        });
+        const { service } = makeService({
+            replaceFiles,
+            send,
+            design: duplicateDesign,
+        });
+        const archive = await makeArchive();
+
+        await expect(
+            service.importPackage(buildAccount(), {
+                body: Readable.from(archive),
+                contentLength: archive.length,
+            }),
+        ).resolves.toEqual({
+            ...updatedDesign,
+            action: PromotionAction.UPDATE,
+        });
+
+        expect(send.mock.calls[0][0]).toBeInstanceOf(PutObjectCommand);
+        expect(send.mock.calls).not.toContainEqual([
+            expect.any(GetObjectCommand),
+        ]);
+        expect(replaceFiles).toHaveBeenCalledOnce();
+    });
+
+    it('updates when an existing file has the same size but different bytes', async () => {
+        const existingBody = Buffer.from('body { color: tan; }');
+        expect(existingBody).toHaveLength(packageBody.length);
+        const send = vi.fn(async (command: unknown) => {
+            if (command instanceof GetObjectCommand) {
+                return {
+                    Body: {
+                        transformToByteArray: async () => existingBody,
+                    },
+                };
+            }
+            return {};
+        });
+        const updatedDesign = {
+            ...matchingDesign,
+            files: [],
+        };
+        const replaceFiles = vi.fn().mockResolvedValue({
+            design: updatedDesign,
+            removedFiles: matchingDesign.files,
+        });
+        const { service, organizationDesignModel } = makeService({
+            replaceFiles,
+            send,
+            design: matchingDesign,
+        });
+        const archive = await makeArchive();
+
+        await expect(
+            service.importPackage(buildAccount(), {
+                body: Readable.from(archive),
+                contentLength: archive.length,
+            }),
+        ).resolves.toEqual({
+            ...updatedDesign,
+            action: PromotionAction.UPDATE,
+        });
+
+        expect(send.mock.calls[0][0]).toBeInstanceOf(GetObjectCommand);
+        expect(send.mock.calls[1][0]).toBeInstanceOf(PutObjectCommand);
+        expect(
+            organizationDesignModel.confirmPackageSnapshot,
+        ).not.toHaveBeenCalled();
+        expect(replaceFiles).toHaveBeenCalledOnce();
+    });
+
+    it('updates when the locked snapshot changed after matching S3 bytes were read', async () => {
+        const send = vi.fn(async (command: unknown) => {
+            if (command instanceof GetObjectCommand) {
+                return {
+                    Body: {
+                        transformToByteArray: async () => packageBody,
+                    },
+                };
+            }
+            return {};
+        });
+        const updatedDesign = { ...matchingDesign, files: [] };
+        const replaceFiles = vi.fn().mockResolvedValue({
+            design: updatedDesign,
+            removedFiles: matchingDesign.files,
+        });
+        const confirmPackageSnapshot = vi.fn().mockResolvedValue(undefined);
+        const { service } = makeService({
+            replaceFiles,
+            send,
+            design: matchingDesign,
+            confirmPackageSnapshot,
+        });
+        const archive = await makeArchive();
+
+        await expect(
+            service.importPackage(buildAccount(), {
+                body: Readable.from(archive),
+                contentLength: archive.length,
+            }),
+        ).resolves.toEqual({
+            ...updatedDesign,
+            action: PromotionAction.UPDATE,
+        });
+
+        expect(confirmPackageSnapshot).toHaveBeenCalledOnce();
+        expect(send.mock.calls[1][0]).toBeInstanceOf(PutObjectCommand);
+        expect(replaceFiles).toHaveBeenCalledOnce();
+    });
 
     it('stages files before the row-locked swap and removes the replaced objects afterward', async () => {
         const events: string[] = [];
@@ -214,7 +516,10 @@ describe('OrganizationDesignService package activation', () => {
             contentLength: archive.length,
         });
 
-        expect(result).toEqual(updatedDesign);
+        expect(result).toEqual({
+            ...updatedDesign,
+            action: PromotionAction.UPDATE,
+        });
         expect(events).toEqual(['stage', 'swap', 'cleanup']);
         const cleanup = send.mock.calls[1][0];
         expect(cleanup).toBeInstanceOf(DeleteObjectsCommand);

--- a/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
+++ b/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
@@ -2,8 +2,11 @@ import {
     DeleteObjectsCommand,
     GetObjectCommand,
     ListObjectsV2Command,
+    NoSuchKey,
+    NotFound,
     PutObjectCommand,
     S3Client,
+    type GetObjectCommandOutput,
     type ObjectIdentifier,
     type S3ClientConfig,
 } from '@aws-sdk/client-s3';
@@ -16,6 +19,7 @@ import {
     checkThemeLimits,
     ForbiddenError,
     getOrganizationDesignFileExtension,
+    getOrganizationDesignPackageContentType,
     getOrganizationDesignPackageFilePath,
     MAX_THEME_FILE_BYTES,
     MAX_THEME_PACKAGE_BYTES,
@@ -24,10 +28,12 @@ import {
     NotFoundError,
     ORGANIZATION_DESIGN_PACKAGE_CODE_VERSION,
     ParameterError,
+    PromotionAction,
     themeLimitMessage,
     validateOrganizationDesignFileContent,
     validateOrganizationDesignFileMetadata,
     type Account,
+    type OrganizationDesignPackageImportResult,
     type OrganizationDesignPackageManifest,
     type UuidOrSlug,
 } from '@lightdash/common';
@@ -190,6 +196,82 @@ export class OrganizationDesignService extends BaseService {
             client: new S3Client(config),
             bucket: s3Config.bucket,
         };
+    }
+
+    private async packageMatchesExistingDesign({
+        client,
+        bucket,
+        organizationUuid,
+        design,
+        manifest,
+        files,
+    }: {
+        client: S3Client;
+        bucket: string;
+        organizationUuid: string;
+        design: ApiOrganizationDesign;
+        manifest: OrganizationDesignPackageManifest;
+        files: OrganizationDesignPackageFile[];
+    }): Promise<boolean> {
+        if (
+            design.slug !== manifest.slug ||
+            design.name !== manifest.name ||
+            design.description !== manifest.description ||
+            design.extraInstructions !== manifest.extraInstructions
+        ) {
+            return false;
+        }
+
+        const existingFiles = getEffectiveOrganizationDesignFiles(design.files);
+        if (design.files.length !== existingFiles.size) return false;
+        if (existingFiles.size !== files.length) return false;
+
+        /* eslint-disable no-await-in-loop */
+        for (const file of files) {
+            const packagePath = getOrganizationDesignPackageFilePath(
+                file.kind,
+                file.filename,
+            );
+            const existingFile = existingFiles.get(packagePath.toLowerCase());
+            if (
+                !existingFile ||
+                existingFile.kind !== file.kind ||
+                existingFile.filename !== file.filename ||
+                getOrganizationDesignPackageContentType(
+                    existingFile.filename,
+                ) !== file.contentType ||
+                existingFile.sizeBytes !== file.body.length
+            ) {
+                return false;
+            }
+
+            let response: GetObjectCommandOutput;
+            try {
+                response = await client.send(
+                    new GetObjectCommand({
+                        Bucket: bucket,
+                        Key: designS3Key(
+                            organizationUuid,
+                            design.designUuid,
+                            existingFile.fileUuid,
+                            existingFile.filename,
+                        ),
+                    }),
+                );
+            } catch (error) {
+                if (error instanceof NoSuchKey || error instanceof NotFound) {
+                    return false;
+                }
+                throw error;
+            }
+            if (!response.Body) return false;
+            const existingBody = Buffer.from(
+                await response.Body.transformToByteArray(),
+            );
+            if (!existingBody.equals(file.body)) return false;
+        }
+        /* eslint-enable no-await-in-loop */
+        return true;
     }
 
     private assertCanManage(account: Account): {
@@ -362,7 +444,7 @@ export class OrganizationDesignService extends BaseService {
     async importPackage(
         account: Account,
         input: { body: Readable; contentLength: number },
-    ): Promise<ApiOrganizationDesign> {
+    ): Promise<OrganizationDesignPackageImportResult> {
         const { organizationUuid, userUuid } = this.assertCanManage(account);
         if (
             input.contentLength <= 0 ||
@@ -410,6 +492,28 @@ export class OrganizationDesignService extends BaseService {
             organizationUuid,
             parsed.manifest.slug,
         );
+        const { client, bucket } = this.getS3Client();
+        if (
+            existing &&
+            (await this.packageMatchesExistingDesign({
+                client,
+                bucket,
+                organizationUuid,
+                design: existing,
+                manifest: parsed.manifest,
+                files: validatedFiles,
+            }))
+        ) {
+            const confirmed =
+                await this.organizationDesignModel.confirmPackageSnapshot(
+                    organizationUuid,
+                    existing,
+                );
+            if (confirmed) {
+                return { ...confirmed, action: PromotionAction.NO_CHANGES };
+            }
+        }
+
         const designUuid = existing?.designUuid ?? uuidv4();
         const stagedFiles = validatedFiles.map((file) => {
             const fileUuid = uuidv4();
@@ -432,7 +536,6 @@ export class OrganizationDesignService extends BaseService {
             };
         });
 
-        const { client, bucket } = this.getS3Client();
         const uploadedKeys: string[] = [];
         try {
             /* eslint-disable no-await-in-loop */
@@ -515,7 +618,10 @@ export class OrganizationDesignService extends BaseService {
             ),
             `old package cleanup for theme ${parsed.manifest.slug}`,
         );
-        return result;
+        return {
+            ...result,
+            action: existing ? PromotionAction.UPDATE : PromotionAction.CREATE,
+        };
     }
 
     async updateDesign(

--- a/packages/common/src/ee/designs/types.ts
+++ b/packages/common/src/ee/designs/types.ts
@@ -1,4 +1,5 @@
 import { type ApiSuccess } from '../../types/api/success';
+import { type ContentAsCodeUpsertAction } from '../../types/contentAsCode/base';
 
 /**
  * The kind of file inside an organization design. The pipeline uses this
@@ -56,6 +57,13 @@ export type UpdateOrganizationDesignRequest = {
 };
 
 export type ApiOrganizationDesignResponse = ApiSuccess<ApiOrganizationDesign>;
+
+export interface OrganizationDesignPackageImportResult extends ApiOrganizationDesign {
+    action: ContentAsCodeUpsertAction;
+}
+
+export type ApiOrganizationDesignPackageImportResponse =
+    ApiSuccess<OrganizationDesignPackageImportResult>;
 
 export type ApiOrganizationDesignsResponse = ApiSuccess<
     ApiOrganizationDesign[]


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-598/data-app-themes-theme-as-code-v1-cli-package-and-synchronization

## Summary

- return `CREATE`, `UPDATE`, or `NO_CHANGES` from organization theme package imports
- compare manifest metadata, effective file metadata, and exact S3 bytes before replacing a theme
- confirm the previously read package snapshot under a database row lock before returning `NO_CHANGES`
- fall through to the existing atomic replacement path when bytes differ or the snapshot changes concurrently

## Why

Organization content-as-code uploads should not rewrite every theme on every run. Exact backend comparison lets the CLI report unchanged themes while keeping the server authoritative.