### PR TITLE
feat(cli): add organization theme package transport

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,6 +59,7 @@
     "ora": "5.4.1",
     "p-limit": "3.1.0",
     "parse-node-version": "2.0.0",
+    "tar-stream": "3.1.8",
     "unique-names-generator": "4.7.1",
     "uuid": "11.1.1",
     "yaml": "2.8.3"
@@ -72,6 +73,7 @@
     "@types/node-fetch": "2.6.13",
     "@types/nunjucks": "3.2.1",
     "@types/parse-node-version": "1.0.0",
+    "@types/tar-stream": "3.1.4",
     "@types/uuid": "10.0.0",
     "@vercel/ncc": "0.38.4",
     "@yao-pkg/pkg": "6.7.0",

--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -12,7 +12,7 @@ import {
     type PossibleAbilities,
     type Project,
 } from '@lightdash/common';
-import fetch, { BodyInit } from 'node-fetch';
+import fetch, { BodyInit, type Response } from 'node-fetch';
 import { URL } from 'url';
 import { gzipSync } from 'zlib';
 import { getConfig } from '../../config';
@@ -27,6 +27,10 @@ type LightdashApiProps = {
     body: BodyInit | undefined;
 };
 
+type LightdashRawApiProps = LightdashApiProps & {
+    headers?: Record<string, string>;
+};
+
 const MIN_GZIP_SIZE = 1024;
 let gzipEnabled = false;
 
@@ -34,20 +38,49 @@ export const setGzipEnabled = (enabled: boolean) => {
     gzipEnabled = enabled;
 };
 
-export const lightdashApi = async <T extends ApiResponse['results']>({
+export const lightdashRawApi = async ({
     method,
     url,
     body,
-}: LightdashApiProps): Promise<T> => {
+    headers: requestHeaders = {},
+}: LightdashRawApiProps): Promise<Response> => {
     const config = await getConfig();
     if (!(config.context?.apiKey && config.context.serverUrl)) {
         throw new AuthorizationError(
             `Not logged in. Run 'lightdash login --help'`,
         );
     }
-    const headers = buildRequestHeaders(config.context.apiKey);
+    const headers = {
+        ...buildRequestHeaders(config.context.apiKey),
+        ...requestHeaders,
+    };
     const fullUrl = new URL(url, config.context.serverUrl).href;
     GlobalState.debug(`> Making HTTP ${method} request to: ${fullUrl}`);
+
+    const response = await fetch(fullUrl, { method, headers, body });
+    GlobalState.debug(`> HTTP request returned status: ${response.status}`);
+
+    if (!response.ok) {
+        const contentType = response.headers.get('content-type');
+        if (contentType?.includes('application/json')) {
+            const data = await response.json();
+            throw new LightdashError(data.error);
+        }
+        const responseText = await response.text();
+        throw new Error(
+            `Received non-JSON response from server (status ${response.status}): ${responseText}`,
+        );
+    }
+
+    return response;
+};
+
+export const lightdashApi = async <T extends ApiResponse['results']>({
+    method,
+    url,
+    body,
+}: LightdashApiProps): Promise<T> => {
+    const headers: Record<string, string> = {};
 
     let requestBody: BodyInit | undefined = body;
     if (
@@ -71,25 +104,12 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
         }
     }
 
-    return fetch(fullUrl, { method, headers, body: requestBody })
-        .then((r) => {
-            GlobalState.debug(`> HTTP request returned status: ${r.status}`);
-
-            if (!r.ok) {
-                const contentType = r.headers.get('content-type');
-                if (contentType && contentType.includes('application/json')) {
-                    return r.json().then((d) => {
-                        throw new LightdashError(d.error);
-                    });
-                }
-                return r.text().then((text) => {
-                    throw new Error(
-                        `Received non-JSON response from server (status ${r.status}): ${text}`,
-                    );
-                });
-            }
-            return r;
-        })
+    return lightdashRawApi({
+        method,
+        url,
+        body: requestBody,
+        headers,
+    })
         .then((r) => r.json())
         .then((d: ApiResponse | ApiError) => {
             GlobalState.debug(`> HTTP request returned status: ${d.status}`);

--- a/packages/cli/src/handlers/organizationContent/themePackage.ts
+++ b/packages/cli/src/handlers/organizationContent/themePackage.ts
@@ -1,0 +1,623 @@
+/* eslint-disable no-await-in-loop */
+import {
+    getErrorMessage,
+    getOrganizationDesignPackageContentType,
+    getOrganizationDesignPackageFilePath,
+    isOrganizationDesignPackageDirectory,
+    MAX_THEME_FILE_BYTES,
+    MAX_THEME_MANIFEST_BYTES,
+    MAX_THEME_PACKAGE_BYTES,
+    MAX_THEME_TOTAL_BYTES,
+    ORGANIZATION_DESIGN_PACKAGE_DIRECTORIES,
+    ORGANIZATION_DESIGN_PACKAGE_DIRECTORY_BY_KIND,
+    ORGANIZATION_DESIGN_PACKAGE_MANIFEST,
+    ParameterError,
+    parseOrganizationDesignPackageFilePath,
+    parseOrganizationDesignPackageManifest,
+    validateOrganizationDesignFileContent,
+    validateOrganizationDesignFileMetadata,
+    validateOrganizationDesignPackageEntryPath,
+    type OrganizationDesignFileKind,
+    type OrganizationDesignPackageManifest,
+} from '@lightdash/common';
+import { randomUUID } from 'crypto';
+import { promises as fs, type Dirent } from 'fs';
+import * as path from 'path';
+import {
+    extract as tarExtract,
+    pack as tarPack,
+    type Headers,
+} from 'tar-stream';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+
+const TAR_EPOCH = new Date(0);
+const MACOS_METADATA_FILENAME = '.DS_Store';
+const THEME_BACKUP_DIRECTORY_PATTERN =
+    /\.backup-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type ThemePackageFile = {
+    kind: OrganizationDesignFileKind;
+    filename: string;
+    contentType: string;
+    body: Buffer;
+};
+
+export type ParsedThemePackage = {
+    manifest: OrganizationDesignPackageManifest;
+    files: ThemePackageFile[];
+};
+
+export type PreparedThemeUpload = {
+    directory: string;
+    manifest: OrganizationDesignPackageManifest;
+    archive: Buffer;
+};
+
+export const getThemesFolder = (organizationContentPath: string): string =>
+    path.join(organizationContentPath, 'themes');
+
+const isEnoent = (error: unknown): boolean =>
+    (error as NodeJS.ErrnoException).code === 'ENOENT';
+
+const toError = (error: unknown): Error =>
+    error instanceof Error ? error : new Error(String(error));
+
+const withoutMacOsMetadata = (entries: Dirent[]): Dirent[] =>
+    entries.filter((entry) => entry.name !== MACOS_METADATA_FILENAME);
+
+const isInternalThemeDirectory = (name: string): boolean =>
+    name.startsWith('.lightdash-theme-') ||
+    THEME_BACKUP_DIRECTORY_PATTERN.test(name);
+
+const assertNoCaseInsensitiveDuplicates = (
+    entries: Dirent[],
+    source: string,
+): void => {
+    const seen = new Map<string, string>();
+    for (const entry of entries) {
+        const key = entry.name.toLowerCase();
+        const previous = seen.get(key);
+        if (previous !== undefined) {
+            throw new ParameterError(
+                `Theme package contains case-insensitive duplicate paths in "${source}": "${previous}" and "${entry.name}"`,
+            );
+        }
+        seen.set(key, entry.name);
+    }
+};
+
+const parseManifestBody = (body: Buffer): OrganizationDesignPackageManifest => {
+    if (body.length > MAX_THEME_MANIFEST_BYTES) {
+        throw new ParameterError(
+            `Theme manifest exceeds ${MAX_THEME_MANIFEST_BYTES} bytes`,
+        );
+    }
+
+    let source: string;
+    try {
+        source = new TextDecoder('utf-8', { fatal: true }).decode(body);
+    } catch {
+        throw new ParameterError('Theme manifest must be valid UTF-8 YAML');
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = parseYaml(source, { strict: true, uniqueKeys: true });
+    } catch {
+        throw new ParameterError('Theme manifest contains invalid YAML');
+    }
+    return parseOrganizationDesignPackageManifest(parsed);
+};
+
+const addTarEntry = (
+    packer: ReturnType<typeof tarPack>,
+    header: Headers,
+    body?: Buffer,
+): Promise<void> =>
+    new Promise((resolve, reject) => {
+        packer.entry(header, body, (error) => {
+            if (error) reject(error);
+            else resolve();
+        });
+    });
+
+const buildThemeArchive = (
+    manifest: OrganizationDesignPackageManifest,
+    files: ThemePackageFile[],
+): Promise<Buffer> =>
+    new Promise((resolve, reject) => {
+        const packer = tarPack();
+        const chunks: Buffer[] = [];
+        packer.on('data', (chunk: Buffer) => chunks.push(chunk));
+        packer.on('end', () => resolve(Buffer.concat(chunks)));
+        packer.on('error', reject);
+
+        void (async () => {
+            const manifestBody = Buffer.from(
+                stringifyYaml(
+                    {
+                        codeVersion: manifest.codeVersion,
+                        slug: manifest.slug,
+                        name: manifest.name,
+                        description: manifest.description,
+                        extraInstructions: manifest.extraInstructions,
+                    },
+                    { lineWidth: 0 },
+                ),
+                'utf8',
+            );
+            if (manifestBody.length > MAX_THEME_MANIFEST_BYTES) {
+                throw new ParameterError(
+                    `Theme manifest exceeds ${MAX_THEME_MANIFEST_BYTES} bytes`,
+                );
+            }
+            await addTarEntry(
+                packer,
+                {
+                    name: ORGANIZATION_DESIGN_PACKAGE_MANIFEST,
+                    type: 'file',
+                    mode: 0o644,
+                    mtime: TAR_EPOCH,
+                    uid: 0,
+                    gid: 0,
+                },
+                manifestBody,
+            );
+
+            for (const directory of ORGANIZATION_DESIGN_PACKAGE_DIRECTORIES) {
+                await addTarEntry(packer, {
+                    name: `${directory}/`,
+                    type: 'directory',
+                    mode: 0o755,
+                    mtime: TAR_EPOCH,
+                    uid: 0,
+                    gid: 0,
+                });
+            }
+
+            const sortedFiles = [...files].sort((left, right) =>
+                getOrganizationDesignPackageFilePath(
+                    left.kind,
+                    left.filename,
+                ).localeCompare(
+                    getOrganizationDesignPackageFilePath(
+                        right.kind,
+                        right.filename,
+                    ),
+                ),
+            );
+            for (const file of sortedFiles) {
+                await addTarEntry(
+                    packer,
+                    {
+                        name: getOrganizationDesignPackageFilePath(
+                            file.kind,
+                            file.filename,
+                        ),
+                        type: 'file',
+                        mode: 0o644,
+                        mtime: TAR_EPOCH,
+                        uid: 0,
+                        gid: 0,
+                    },
+                    file.body,
+                );
+            }
+            packer.finalize();
+        })().catch((error: unknown) => packer.destroy(toError(error)));
+    });
+
+const readLocalThemeDirectory = async (
+    directory: string,
+): Promise<PreparedThemeUpload> => {
+    const entries = withoutMacOsMetadata(
+        await fs.readdir(directory, { withFileTypes: true }),
+    );
+    assertNoCaseInsensitiveDuplicates(entries, directory);
+
+    const expectedEntries = new Set<string>([
+        ORGANIZATION_DESIGN_PACKAGE_MANIFEST,
+        ...ORGANIZATION_DESIGN_PACKAGE_DIRECTORIES,
+    ]);
+    const unknownEntry = entries.find(
+        (entry) => !expectedEntries.has(entry.name),
+    );
+    if (unknownEntry) {
+        throw new ParameterError(
+            `Unknown theme package path: ${path.join(directory, unknownEntry.name)}`,
+        );
+    }
+
+    if (
+        !entries.some(
+            (entry) => entry.name === ORGANIZATION_DESIGN_PACKAGE_MANIFEST,
+        )
+    ) {
+        throw new ParameterError(
+            `Theme package is missing ${path.join(directory, ORGANIZATION_DESIGN_PACKAGE_MANIFEST)}`,
+        );
+    }
+
+    const manifestEntry = entries.find(
+        (entry) => entry.name === ORGANIZATION_DESIGN_PACKAGE_MANIFEST,
+    );
+    if (!manifestEntry?.isFile()) {
+        throw new ParameterError(
+            `Theme manifest must be a regular file: ${path.join(directory, ORGANIZATION_DESIGN_PACKAGE_MANIFEST)}`,
+        );
+    }
+    const manifestBody = await fs.readFile(
+        path.join(directory, ORGANIZATION_DESIGN_PACKAGE_MANIFEST),
+    );
+    const manifest = parseManifestBody(manifestBody);
+    if (path.basename(directory) !== manifest.slug) {
+        throw new ParameterError(
+            `Theme directory "${path.basename(directory)}" must match manifest slug "${manifest.slug}"`,
+        );
+    }
+
+    const files: ThemePackageFile[] = [];
+    let totalBytes = 0;
+    for (const [kind, packageDirectory] of Object.entries(
+        ORGANIZATION_DESIGN_PACKAGE_DIRECTORY_BY_KIND,
+    ) as Array<[OrganizationDesignFileKind, string]>) {
+        const directoryEntry = entries.find(
+            (entry) => entry.name === packageDirectory,
+        );
+        if (directoryEntry && !directoryEntry.isDirectory()) {
+            throw new ParameterError(
+                `Theme package path must be a regular directory: ${path.join(directory, packageDirectory)}`,
+            );
+        }
+
+        const assetDirectory = path.join(directory, packageDirectory);
+        const assetEntries = directoryEntry
+            ? withoutMacOsMetadata(
+                  await fs.readdir(assetDirectory, {
+                      withFileTypes: true,
+                  }),
+              )
+            : [];
+        assertNoCaseInsensitiveDuplicates(assetEntries, assetDirectory);
+        for (const assetEntry of assetEntries.sort((left, right) =>
+            left.name.localeCompare(right.name),
+        )) {
+            if (!assetEntry.isFile()) {
+                throw new ParameterError(
+                    `Theme package files must be regular files without symlinks or nested directories: ${path.join(assetDirectory, assetEntry.name)}`,
+                );
+            }
+            const filePath = path.join(assetDirectory, assetEntry.name);
+            const body = await fs.readFile(filePath);
+            const metadata = validateOrganizationDesignFileMetadata({
+                kind,
+                filename: assetEntry.name,
+            });
+            if (metadata.filename !== assetEntry.name) {
+                throw new ParameterError(
+                    `Theme package filename may not have surrounding whitespace: ${filePath}`,
+                );
+            }
+            validateOrganizationDesignFileContent({
+                body,
+                filename: metadata.filename,
+            });
+            totalBytes += body.length;
+            if (totalBytes > MAX_THEME_TOTAL_BYTES) {
+                throw new ParameterError(
+                    `Theme package files exceed ${MAX_THEME_TOTAL_BYTES} bytes`,
+                );
+            }
+            files.push({
+                ...metadata,
+                contentType: getOrganizationDesignPackageContentType(
+                    metadata.filename,
+                ),
+                body,
+            });
+        }
+    }
+
+    const archive = await buildThemeArchive(manifest, files);
+    if (archive.length > MAX_THEME_PACKAGE_BYTES) {
+        throw new ParameterError(
+            `Theme package exceeds ${MAX_THEME_PACKAGE_BYTES} bytes`,
+        );
+    }
+    return { directory, manifest, archive };
+};
+
+export const prepareThemeUploads = async (
+    organizationContentPath: string,
+): Promise<PreparedThemeUpload[]> => {
+    const themesFolder = getThemesFolder(organizationContentPath);
+    let entries: Dirent[];
+    try {
+        entries = (
+            await fs.readdir(themesFolder, { withFileTypes: true })
+        ).filter(
+            (entry) =>
+                entry.name !== MACOS_METADATA_FILENAME &&
+                !isInternalThemeDirectory(entry.name),
+        );
+    } catch (error) {
+        if (isEnoent(error)) return [];
+        throw error;
+    }
+    if (entries.length === 0) return [];
+    assertNoCaseInsensitiveDuplicates(entries, themesFolder);
+
+    const failures: Array<{ message: string }> = [];
+    const prepared: PreparedThemeUpload[] = [];
+    for (const entry of entries.sort((left, right) =>
+        left.name.localeCompare(right.name),
+    )) {
+        const directory = path.join(themesFolder, entry.name);
+        if (!entry.isDirectory()) {
+            failures.push({
+                message: `Invalid theme path "${directory}": expected a regular directory without symlinks`,
+            });
+        } else {
+            try {
+                prepared.push(await readLocalThemeDirectory(directory));
+            } catch (error) {
+                failures.push({
+                    message: `Invalid theme directory "${directory}": ${getErrorMessage(error)}`,
+                });
+            }
+        }
+    }
+
+    const bySlug = new Map<string, PreparedThemeUpload[]>();
+    for (const item of prepared) {
+        bySlug.set(item.manifest.slug, [
+            ...(bySlug.get(item.manifest.slug) ?? []),
+            item,
+        ]);
+    }
+    for (const [slug, items] of bySlug) {
+        if (items.length > 1) {
+            failures.push({
+                message: `Duplicate theme slug "${slug}" in ${items.map(({ directory }) => `"${directory}"`).join(', ')}`,
+            });
+        }
+    }
+
+    if (failures.length > 0) {
+        throw new ParameterError(
+            failures.map(({ message }) => message).join('\n'),
+        );
+    }
+    return prepared;
+};
+
+export const parseThemeArchive = (
+    archive: Buffer,
+): Promise<ParsedThemePackage> =>
+    new Promise((resolve, reject) => {
+        if (archive.length === 0 || archive.length > MAX_THEME_PACKAGE_BYTES) {
+            reject(
+                new ParameterError(
+                    `Theme package must be between 1 and ${MAX_THEME_PACKAGE_BYTES} bytes`,
+                ),
+            );
+            return;
+        }
+
+        const extractor = tarExtract();
+        const seenPaths = new Set<string>();
+        const files: ThemePackageFile[] = [];
+        let manifestBody: Buffer | null = null;
+        let totalBytes = 0;
+        let settled = false;
+        const fail = (error: unknown): void => {
+            if (settled) return;
+            settled = true;
+            extractor.destroy();
+            reject(
+                error instanceof ParameterError
+                    ? error
+                    : new ParameterError(
+                          'Theme package is not a valid tar archive',
+                      ),
+            );
+        };
+
+        extractor.on('entry', (header, stream, next) => {
+            try {
+                const entryName = validateOrganizationDesignPackageEntryPath(
+                    header.name,
+                );
+                const pathKey = entryName.toLowerCase();
+                if (seenPaths.has(pathKey)) {
+                    throw new ParameterError(
+                        `Theme package contains a duplicate path: ${entryName}`,
+                    );
+                }
+                seenPaths.add(pathKey);
+
+                const entryType = header.type ?? 'file';
+                if (entryType === 'directory') {
+                    if (!isOrganizationDesignPackageDirectory(entryName)) {
+                        throw new ParameterError(
+                            `Unknown theme package directory: ${entryName}`,
+                        );
+                    }
+                    stream.resume();
+                    stream.on('end', next);
+                    return;
+                }
+                if (entryType !== 'file') {
+                    throw new ParameterError(
+                        `Theme package entry type is not allowed: ${entryType}`,
+                    );
+                }
+
+                const isManifest =
+                    entryName === ORGANIZATION_DESIGN_PACKAGE_MANIFEST;
+                const maxBytes = isManifest
+                    ? MAX_THEME_MANIFEST_BYTES
+                    : MAX_THEME_FILE_BYTES;
+                if ((header.size ?? 0) > maxBytes) {
+                    throw new ParameterError(
+                        `Theme package entry exceeds ${maxBytes} bytes: ${entryName}`,
+                    );
+                }
+                const parsedPath = isManifest
+                    ? null
+                    : parseOrganizationDesignPackageFilePath(entryName);
+                const chunks: Buffer[] = [];
+                let bytes = 0;
+                stream.on('data', (chunk: Buffer | string) => {
+                    const buffer = Buffer.isBuffer(chunk)
+                        ? chunk
+                        : Buffer.from(chunk);
+                    bytes += buffer.length;
+                    if (bytes > maxBytes) {
+                        stream.destroy(
+                            new ParameterError(
+                                `Theme package entry exceeds ${maxBytes} bytes: ${entryName}`,
+                            ),
+                        );
+                        return;
+                    }
+                    chunks.push(buffer);
+                });
+                stream.on('error', fail);
+                stream.on('end', () => {
+                    if (settled) return;
+                    try {
+                        const body = Buffer.concat(chunks);
+                        if (isManifest) {
+                            manifestBody = body;
+                        } else if (parsedPath) {
+                            const metadata =
+                                validateOrganizationDesignFileMetadata(
+                                    parsedPath,
+                                );
+                            validateOrganizationDesignFileContent({
+                                body,
+                                filename: metadata.filename,
+                            });
+                            totalBytes += body.length;
+                            if (totalBytes > MAX_THEME_TOTAL_BYTES) {
+                                throw new ParameterError(
+                                    `Theme package files exceed ${MAX_THEME_TOTAL_BYTES} bytes`,
+                                );
+                            }
+                            files.push({
+                                ...metadata,
+                                contentType:
+                                    getOrganizationDesignPackageContentType(
+                                        metadata.filename,
+                                    ),
+                                body,
+                            });
+                        }
+                        next();
+                    } catch (error) {
+                        fail(error);
+                    }
+                });
+            } catch (error) {
+                stream.resume();
+                fail(error);
+            }
+        });
+        extractor.on('error', fail);
+        extractor.on('finish', () => {
+            if (settled) return;
+            try {
+                if (!manifestBody) {
+                    throw new ParameterError(
+                        `Theme package is missing ${ORGANIZATION_DESIGN_PACKAGE_MANIFEST}`,
+                    );
+                }
+                const manifest = parseManifestBody(manifestBody);
+                settled = true;
+                resolve({ manifest, files });
+            } catch (error) {
+                fail(error);
+            }
+        });
+        try {
+            extractor.end(archive);
+        } catch (error) {
+            fail(error);
+        }
+    });
+
+const replaceThemeDirectory = async (
+    sourceDirectory: string,
+    targetDirectory: string,
+): Promise<void> => {
+    const backupDirectory = path.join(
+        path.dirname(path.dirname(targetDirectory)),
+        `.lightdash-theme-backup-${randomUUID()}`,
+    );
+    let hasBackup = false;
+    try {
+        await fs.rename(targetDirectory, backupDirectory);
+        hasBackup = true;
+    } catch (error) {
+        if (!isEnoent(error)) throw error;
+    }
+
+    try {
+        await fs.rename(sourceDirectory, targetDirectory);
+    } catch (error) {
+        if (hasBackup) await fs.rename(backupDirectory, targetDirectory);
+        throw error;
+    }
+    if (hasBackup) {
+        await fs.rm(backupDirectory, { recursive: true, force: true });
+    }
+};
+
+export const writeThemePackage = async (
+    organizationContentPath: string,
+    parsed: ParsedThemePackage,
+): Promise<void> => {
+    const themesFolder = getThemesFolder(organizationContentPath);
+    await fs.mkdir(themesFolder, { recursive: true });
+    const temporaryDirectory = await fs.mkdtemp(
+        path.join(organizationContentPath, '.lightdash-theme-'),
+    );
+    try {
+        for (const directory of ORGANIZATION_DESIGN_PACKAGE_DIRECTORIES) {
+            await fs.mkdir(path.join(temporaryDirectory, directory));
+        }
+        await fs.writeFile(
+            path.join(temporaryDirectory, ORGANIZATION_DESIGN_PACKAGE_MANIFEST),
+            stringifyYaml(
+                {
+                    codeVersion: parsed.manifest.codeVersion,
+                    slug: parsed.manifest.slug,
+                    name: parsed.manifest.name,
+                    description: parsed.manifest.description,
+                    extraInstructions: parsed.manifest.extraInstructions,
+                },
+                { lineWidth: 0 },
+            ),
+        );
+        for (const file of parsed.files) {
+            await fs.writeFile(
+                path.join(
+                    temporaryDirectory,
+                    getOrganizationDesignPackageFilePath(
+                        file.kind,
+                        file.filename,
+                    ),
+                ),
+                file.body,
+            );
+        }
+        await replaceThemeDirectory(
+            temporaryDirectory,
+            path.join(themesFolder, parsed.manifest.slug),
+        );
+    } catch (error) {
+        await fs.rm(temporaryDirectory, { recursive: true, force: true });
+        throw error;
+    }
+};

--- a/packages/cli/src/handlers/organizationContent/themes.test.ts
+++ b/packages/cli/src/handlers/organizationContent/themes.test.ts
@@ -1,0 +1,270 @@
+import { PromotionAction } from '@lightdash/common';
+import { promises as fs } from 'fs';
+import { Response } from 'node-fetch';
+import * as os from 'os';
+import * as path from 'path';
+import { stringify as stringifyYaml } from 'yaml';
+import { lightdashApi, lightdashRawApi } from '../dbt/apiClient';
+import { downloadThemes, prepareThemeUploads, uploadThemes } from './themes';
+
+vi.mock('../dbt/apiClient', () => ({
+    lightdashApi: vi.fn(),
+    lightdashRawApi: vi.fn(),
+}));
+
+const manifest = (slug: string) => ({
+    codeVersion: 1,
+    slug,
+    name: 'Acme Brand',
+    description: null,
+    extraInstructions: null,
+});
+
+const createThemeDirectory = async (
+    contentRoot: string,
+    slug: string,
+): Promise<string> => {
+    const directory = path.join(contentRoot, 'themes', slug);
+    await Promise.all(
+        ['css', 'fonts', 'images', 'instructions'].map((folder) =>
+            fs.mkdir(path.join(directory, folder), { recursive: true }),
+        ),
+    );
+    await fs.writeFile(
+        path.join(directory, 'lightdash-theme.yml'),
+        stringifyYaml(manifest(slug)),
+    );
+    await fs.writeFile(
+        path.join(directory, 'css', 'theme.css'),
+        ':root { --brand: #123456; }',
+    );
+    return directory;
+};
+
+describe('organization theme content-as-code', () => {
+    let temporaryRoot: string;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        vi.mocked(lightdashApi).mockResolvedValue([] as never);
+        temporaryRoot = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'themes-test-'),
+        );
+    });
+
+    afterEach(async () => {
+        await fs.rm(temporaryRoot, { recursive: true, force: true });
+    });
+
+    it('treats a missing themes directory as an empty upload', async () => {
+        await expect(prepareThemeUploads(temporaryRoot)).resolves.toEqual([]);
+    });
+
+    it('rejects nested paths during preflight', async () => {
+        const themeDirectory = await createThemeDirectory(
+            temporaryRoot,
+            'acme-brand',
+        );
+        await fs.mkdir(path.join(themeDirectory, 'css', 'nested'));
+
+        await expect(prepareThemeUploads(temporaryRoot)).rejects.toThrow(
+            'without symlinks or nested directories',
+        );
+    });
+
+    it('rejects symlinked files during preflight', async () => {
+        const themeDirectory = await createThemeDirectory(
+            temporaryRoot,
+            'acme-brand',
+        );
+        await fs.symlink(
+            path.join(themeDirectory, 'css', 'theme.css'),
+            path.join(themeDirectory, 'css', 'linked.css'),
+        );
+
+        await expect(prepareThemeUploads(temporaryRoot)).rejects.toThrow(
+            'without symlinks or nested directories',
+        );
+    });
+
+    it('accepts Git-dropped empty directories and ignores local filesystem artifacts', async () => {
+        const themeDirectory = await createThemeDirectory(
+            temporaryRoot,
+            'acme-brand',
+        );
+        await Promise.all(
+            ['fonts', 'images', 'instructions'].map((folder) =>
+                fs.rmdir(path.join(themeDirectory, folder)),
+            ),
+        );
+        await Promise.all([
+            fs.writeFile(
+                path.join(temporaryRoot, 'themes', '.DS_Store'),
+                'metadata',
+            ),
+            fs.writeFile(path.join(themeDirectory, '.DS_Store'), 'metadata'),
+            fs.writeFile(
+                path.join(themeDirectory, 'css', '.DS_Store'),
+                'metadata',
+            ),
+            fs.mkdir(
+                path.join(temporaryRoot, 'themes', '.lightdash-theme-ABC123'),
+            ),
+            fs.mkdir(
+                path.join(
+                    temporaryRoot,
+                    'themes',
+                    'acme-brand.backup-00000000-0000-4000-8000-000000000001',
+                ),
+            ),
+        ]);
+
+        const prepared = await prepareThemeUploads(temporaryRoot);
+
+        expect(prepared).toHaveLength(1);
+        expect(prepared[0].manifest.slug).toBe('acme-brand');
+    });
+
+    it('round-trips a downloaded package and replaces stale theme files', async () => {
+        const sourceRoot = path.join(temporaryRoot, 'source');
+        const destinationRoot = path.join(temporaryRoot, 'destination');
+        await createThemeDirectory(sourceRoot, 'acme-brand');
+        const [prepared] = await prepareThemeUploads(sourceRoot);
+
+        const staleDirectory = await createThemeDirectory(
+            destinationRoot,
+            'acme-brand',
+        );
+        await fs.writeFile(path.join(staleDirectory, 'stale.txt'), 'stale');
+
+        vi.mocked(lightdashApi).mockResolvedValue([
+            { slug: 'acme-brand' },
+        ] as never);
+        vi.mocked(lightdashRawApi).mockResolvedValue(
+            new Response(prepared.archive),
+        );
+
+        await expect(downloadThemes(destinationRoot)).resolves.toBe(1);
+
+        await expect(
+            fs.readFile(
+                path.join(
+                    destinationRoot,
+                    'themes',
+                    'acme-brand',
+                    'css',
+                    'theme.css',
+                ),
+                'utf8',
+            ),
+        ).resolves.toContain('--brand');
+        await expect(
+            fs.stat(
+                path.join(destinationRoot, 'themes', 'acme-brand', 'stale.txt'),
+            ),
+        ).rejects.toMatchObject({ code: 'ENOENT' });
+
+        const [downloaded] = await prepareThemeUploads(destinationRoot);
+        expect(downloaded.archive).toEqual(prepared.archive);
+    });
+
+    it('reports completed and failed imports without claiming full success', async () => {
+        await createThemeDirectory(temporaryRoot, 'first-theme');
+        await createThemeDirectory(temporaryRoot, 'second-theme');
+        const prepared = await prepareThemeUploads(temporaryRoot);
+        vi.mocked(lightdashRawApi)
+            .mockResolvedValueOnce(
+                new Response(
+                    JSON.stringify({
+                        status: 'ok',
+                        results: {
+                            slug: 'first-theme',
+                            action: PromotionAction.CREATE,
+                        },
+                    }),
+                ),
+            )
+            .mockRejectedValueOnce(new Error('remote failure'));
+
+        const summary = await uploadThemes(prepared);
+
+        expect(summary).toEqual({
+            created: 1,
+            updated: 0,
+            unchanged: 0,
+            failed: 1,
+            completedSlugs: ['first-theme'],
+            failures: [
+                {
+                    message:
+                        'Failed to upload theme "second-theme": remote failure',
+                },
+            ],
+        });
+    });
+
+    it('reports the action returned for every successful import', async () => {
+        await createThemeDirectory(temporaryRoot, 'created-theme');
+        await createThemeDirectory(temporaryRoot, 'updated-theme');
+        await createThemeDirectory(temporaryRoot, 'unchanged-theme');
+        const prepared = await prepareThemeUploads(temporaryRoot);
+        for (const theme of prepared) {
+            const actionBySlug: Record<string, PromotionAction> = {
+                'created-theme': PromotionAction.CREATE,
+                'updated-theme': PromotionAction.UPDATE,
+                'unchanged-theme': PromotionAction.NO_CHANGES,
+            };
+            vi.mocked(lightdashRawApi).mockResolvedValueOnce(
+                new Response(
+                    JSON.stringify({
+                        status: 'ok',
+                        results: {
+                            slug: theme.manifest.slug,
+                            action: actionBySlug[theme.manifest.slug],
+                        },
+                    }),
+                ),
+            );
+        }
+
+        await expect(uploadThemes(prepared)).resolves.toMatchObject({
+            created: 1,
+            updated: 1,
+            unchanged: 1,
+            failed: 0,
+        });
+    });
+
+    it('classifies successful imports returned by older servers', async () => {
+        await createThemeDirectory(temporaryRoot, 'existing-theme');
+        await createThemeDirectory(temporaryRoot, 'new-theme');
+        const prepared = await prepareThemeUploads(temporaryRoot);
+        vi.mocked(lightdashApi).mockResolvedValue([
+            { slug: 'existing-theme' },
+        ] as never);
+        vi.mocked(lightdashRawApi)
+            .mockResolvedValueOnce(
+                new Response(
+                    JSON.stringify({
+                        status: 'ok',
+                        results: { slug: 'existing-theme' },
+                    }),
+                ),
+            )
+            .mockResolvedValueOnce(
+                new Response(
+                    JSON.stringify({
+                        status: 'ok',
+                        results: { slug: 'new-theme' },
+                    }),
+                ),
+            );
+
+        await expect(uploadThemes(prepared)).resolves.toMatchObject({
+            created: 1,
+            updated: 1,
+            unchanged: 0,
+            failed: 0,
+        });
+    });
+});

--- a/packages/cli/src/handlers/organizationContent/themes.ts
+++ b/packages/cli/src/handlers/organizationContent/themes.ts
@@ -1,0 +1,147 @@
+/* eslint-disable no-await-in-loop */
+import {
+    assertUnreachable,
+    getErrorMessage,
+    ORGANIZATION_DESIGN_PACKAGE_CONTENT_TYPE,
+    ParameterError,
+    PromotionAction,
+    type ApiOrganizationDesign,
+    type ApiOrganizationDesignPackageImportResponse,
+    type ApiOrganizationDesignResponse,
+} from '@lightdash/common';
+import { promises as fs } from 'fs';
+import { lightdashApi, lightdashRawApi } from '../dbt/apiClient';
+import {
+    getThemesFolder,
+    parseThemeArchive,
+    writeThemePackage,
+    type PreparedThemeUpload,
+} from './themePackage';
+
+export { prepareThemeUploads } from './themePackage';
+
+export type ThemeUploadSummary = {
+    created: number;
+    updated: number;
+    unchanged: number;
+    failed: number;
+    completedSlugs: string[];
+    failures: Array<{ message: string }>;
+};
+
+export const downloadThemes = async (
+    organizationContentPath: string,
+): Promise<number> => {
+    const themes = await lightdashApi<ApiOrganizationDesign[]>({
+        method: 'GET',
+        url: '/api/v1/org/designs/',
+        body: undefined,
+    });
+    await fs.mkdir(getThemesFolder(organizationContentPath), {
+        recursive: true,
+    });
+
+    for (const theme of [...themes].sort((left, right) =>
+        left.slug.localeCompare(right.slug),
+    )) {
+        const response = await lightdashRawApi({
+            method: 'GET',
+            url: `/api/v1/org/designs/${encodeURIComponent(theme.slug)}/package`,
+            body: undefined,
+        });
+        const parsed = await parseThemeArchive(
+            Buffer.from(await response.arrayBuffer()),
+        );
+        if (parsed.manifest.slug !== theme.slug) {
+            throw new ParameterError(
+                `Downloaded theme slug "${parsed.manifest.slug}" does not match requested slug "${theme.slug}"`,
+            );
+        }
+        await writeThemePackage(organizationContentPath, parsed);
+    }
+    return themes.length;
+};
+
+export const uploadThemes = async (
+    prepared: PreparedThemeUpload[],
+): Promise<ThemeUploadSummary> => {
+    const summary: ThemeUploadSummary = {
+        created: 0,
+        updated: 0,
+        unchanged: 0,
+        failed: 0,
+        completedSlugs: [],
+        failures: [],
+    };
+    if (prepared.length === 0) return summary;
+
+    const existingThemes = await lightdashApi<ApiOrganizationDesign[]>({
+        method: 'GET',
+        url: '/api/v1/org/designs/',
+        body: undefined,
+    });
+    const existingSlugs = new Set(existingThemes.map(({ slug }) => slug));
+    for (const theme of prepared) {
+        try {
+            const response = await lightdashRawApi({
+                method: 'PUT',
+                url: '/api/v1/org/designs/package',
+                body: theme.archive,
+                headers: {
+                    'Content-Type': ORGANIZATION_DESIGN_PACKAGE_CONTENT_TYPE,
+                    'Content-Length': String(theme.archive.length),
+                },
+            });
+            const result = (await response.json()) as
+                | ApiOrganizationDesignPackageImportResponse
+                | ApiOrganizationDesignResponse;
+            if (result.status !== 'ok') {
+                throw new Error('Theme import returned an invalid response');
+            }
+            if (result.results.slug !== theme.manifest.slug) {
+                throw new Error(
+                    `Theme import returned slug "${result.results.slug}" instead of "${theme.manifest.slug}"`,
+                );
+            }
+            let action: PromotionAction;
+            if ('action' in result.results) {
+                action = result.results.action;
+            } else if (existingSlugs.has(result.results.slug)) {
+                action = PromotionAction.UPDATE;
+            } else {
+                action = PromotionAction.CREATE;
+            }
+            switch (action) {
+                case PromotionAction.CREATE:
+                    summary.created += 1;
+                    break;
+                case PromotionAction.UPDATE:
+                    summary.updated += 1;
+                    break;
+                case PromotionAction.NO_CHANGES:
+                    summary.unchanged += 1;
+                    break;
+                default:
+                    assertUnreachable(
+                        action,
+                        'Unsupported theme import action',
+                    );
+            }
+            summary.completedSlugs.push(result.results.slug);
+        } catch (error) {
+            summary.failures.push({
+                message: `Failed to upload theme "${theme.manifest.slug}": ${getErrorMessage(error)}`,
+            });
+        }
+    }
+    summary.failed = summary.failures.length;
+    return summary;
+};
+
+export const formatThemeUploadSummary = (summary: ThemeUploadSummary): string =>
+    [
+        `${summary.created} created`,
+        `${summary.updated} updated`,
+        `${summary.unchanged} unchanged`,
+        ...(summary.failed > 0 ? [`${summary.failed} failed`] : []),
+    ].join(', ');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -782,6 +782,9 @@ importers:
       parse-node-version:
         specifier: 2.0.0
         version: 2.0.0
+      tar-stream:
+        specifier: 3.1.8
+        version: 3.1.8
       unique-names-generator:
         specifier: 4.7.1
         version: 4.7.1
@@ -810,6 +813,9 @@ importers:
       '@types/parse-node-version':
         specifier: 1.0.0
         version: 1.0.0
+      '@types/tar-stream':
+        specifier: 3.1.4
+        version: 3.1.4
       '@types/uuid':
         specifier: 10.0.0
         version: 10.0.0


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-598/data-app-themes-theme-as-code-v1-cli-package-and-synchronization

## Summary

- add authenticated raw-response support to the CLI API client for tar downloads and uploads
- discover and strictly validate local theme directories
- build deterministic canonical tar packages
- validate downloaded archives and replace local theme directories atomically
- import remote themes while preserving per-theme create, update, unchanged, and failure results

## Why

Themes are multi-file resources, so they need a package-aware transport rather than the single-document YAML path used by other organization resources.