### PR TITLE
feat(cli): sync themes with organization content

### DIFF
--- a/packages/cli/src/handlers/contentAsCode/registry.ts
+++ b/packages/cli/src/handlers/contentAsCode/registry.ts
@@ -5,6 +5,7 @@ import {
 } from '@lightdash/common';
 import { CUSTOM_ROLE_CODE_RESOURCE } from '../organizationContent/customRoles';
 import { GROUP_CODE_RESOURCE } from '../organizationContent/groups';
+import { THEME_CODE_RESOURCE } from '../organizationContent/themes';
 import { USER_CODE_RESOURCE } from '../organizationContent/users';
 import {
     AI_AGENT_CODE_RESOURCE,
@@ -21,7 +22,12 @@ export type CodeResourceRegistration = {
 };
 
 export const ORGANIZATION_CODE_RESOURCES: readonly CodeResourceRegistration[] =
-    [CUSTOM_ROLE_CODE_RESOURCE, USER_CODE_RESOURCE, GROUP_CODE_RESOURCE];
+    [
+        CUSTOM_ROLE_CODE_RESOURCE,
+        USER_CODE_RESOURCE,
+        GROUP_CODE_RESOURCE,
+        THEME_CODE_RESOURCE,
+    ];
 
 export const PROJECT_CODE_RESOURCES: readonly CodeResourceRegistration[] = [
     { kind: ContentAsCodeType.SPACE, dependencies: [] },

--- a/packages/cli/src/handlers/organizationContent/index.test.ts
+++ b/packages/cli/src/handlers/organizationContent/index.test.ts
@@ -16,6 +16,12 @@ import {
     downloadOrganizationContent,
     uploadOrganizationContent,
 } from './index';
+import {
+    downloadThemes,
+    prepareThemeUploads,
+    uploadThemes,
+    type ThemeUploadSummary,
+} from './themes';
 import { downloadUsers, uploadUsers, type UserUploadSummary } from './users';
 
 vi.mock('./customRoles', async (importOriginal) => ({
@@ -33,6 +39,12 @@ vi.mock('./groups', async (importOriginal) => ({
     downloadGroups: vi.fn(),
     uploadGroups: vi.fn(),
     countDependencySkippedGroups: vi.fn(),
+}));
+vi.mock('./themes', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('./themes')>()),
+    downloadThemes: vi.fn(),
+    prepareThemeUploads: vi.fn(),
+    uploadThemes: vi.fn(),
 }));
 
 describe('organization content download', () => {
@@ -59,6 +71,7 @@ describe('organization content download', () => {
         vi.mocked(downloadCustomRoles).mockResolvedValue(2);
         vi.mocked(downloadUsers).mockResolvedValue(3);
         vi.mocked(downloadGroups).mockResolvedValue(4);
+        vi.mocked(downloadThemes).mockResolvedValue(5);
     });
 
     it('skips groups when the group service is disabled', async () => {
@@ -85,7 +98,7 @@ describe('organization content download', () => {
     it('reports a duration for every downloaded resource', async () => {
         await downloadOrganizationContent({ config });
 
-        expect(spinner.succeed).toHaveBeenCalledTimes(3);
+        expect(spinner.succeed).toHaveBeenCalledTimes(4);
         spinner.succeed.mock.calls.forEach(([message]) =>
             expect(message).toMatch(/\(\d+ms\)$/),
         );
@@ -145,6 +158,14 @@ describe('organization content upload sequencing', () => {
         dependencySkipped: 0,
         failures: failed > 0 ? [{ message: 'group failure' }] : [],
     });
+    const themeSummary = (failed: number = 0): ThemeUploadSummary => ({
+        created: failed > 0 ? 1 : 0,
+        updated: 0,
+        unchanged: 0,
+        failed,
+        completedSlugs: failed > 0 ? ['processed-theme'] : [],
+        failures: failed > 0 ? [{ message: 'theme failure' }] : [],
+    });
 
     beforeEach(() => {
         vi.clearAllMocks();
@@ -154,11 +175,17 @@ describe('organization content upload sequencing', () => {
         vi.mocked(uploadCustomRoles).mockResolvedValue(customRoleSummary());
         vi.mocked(uploadUsers).mockResolvedValue(userSummary());
         vi.mocked(uploadGroups).mockResolvedValue(groupSummary());
+        vi.mocked(prepareThemeUploads).mockResolvedValue([]);
+        vi.mocked(uploadThemes).mockResolvedValue(themeSummary());
         vi.mocked(countDependencySkippedGroups).mockResolvedValue(2);
     });
 
-    it('awaits custom roles, then users, then groups', async () => {
+    it('preflights themes, then awaits organization resource uploads in order', async () => {
         const phaseOrder: string[] = [];
+        vi.mocked(prepareThemeUploads).mockImplementation(async () => {
+            phaseOrder.push('themes:preflight:start', 'themes:preflight:end');
+            return [];
+        });
         vi.mocked(uploadCustomRoles).mockImplementation(async () => {
             phaseOrder.push('roles:start', 'roles:end');
             return customRoleSummary();
@@ -171,23 +198,31 @@ describe('organization content upload sequencing', () => {
             phaseOrder.push('groups:start', 'groups:end');
             return groupSummary();
         });
+        vi.mocked(uploadThemes).mockImplementation(async () => {
+            phaseOrder.push('themes:start', 'themes:end');
+            return themeSummary();
+        });
 
         await uploadOrganizationContent({ config });
 
         expect(phaseOrder).toStrictEqual([
+            'themes:preflight:start',
+            'themes:preflight:end',
             'roles:start',
             'roles:end',
             'users:start',
             'users:end',
             'groups:start',
             'groups:end',
+            'themes:start',
+            'themes:end',
         ]);
     });
 
     it('reports a duration for every uploaded resource', async () => {
         await uploadOrganizationContent({ config });
 
-        expect(spinner.succeed).toHaveBeenCalledTimes(3);
+        expect(spinner.succeed).toHaveBeenCalledTimes(4);
         spinner.succeed.mock.calls.forEach(([message]) =>
             expect(message).toMatch(/\(\d+ms\)$/),
         );
@@ -202,6 +237,7 @@ describe('organization content upload sequencing', () => {
 
         expect(uploadUsers).not.toHaveBeenCalled();
         expect(uploadGroups).not.toHaveBeenCalled();
+        expect(uploadThemes).not.toHaveBeenCalled();
         expect(countDependencySkippedGroups).toHaveBeenCalledOnce();
     });
 
@@ -213,6 +249,34 @@ describe('organization content upload sequencing', () => {
         );
 
         expect(uploadGroups).not.toHaveBeenCalled();
+        expect(uploadThemes).not.toHaveBeenCalled();
         expect(countDependencySkippedGroups).toHaveBeenCalledOnce();
+    });
+
+    it('does not mutate organization resources when theme preflight fails', async () => {
+        vi.mocked(prepareThemeUploads).mockRejectedValue(
+            new Error('Invalid theme'),
+        );
+
+        await expect(uploadOrganizationContent({ config })).rejects.toThrow(
+            'Invalid theme',
+        );
+
+        expect(uploadCustomRoles).not.toHaveBeenCalled();
+        expect(uploadUsers).not.toHaveBeenCalled();
+        expect(uploadGroups).not.toHaveBeenCalled();
+        expect(uploadThemes).not.toHaveBeenCalled();
+    });
+
+    it('fails after reporting a partial theme upload', async () => {
+        vi.mocked(uploadThemes).mockResolvedValue(themeSummary(1));
+
+        await expect(uploadOrganizationContent({ config })).rejects.toThrow(
+            'Processed themes: 1 created, 0 updated, 0 unchanged, 1 failed',
+        );
+
+        expect(GlobalState.log).toHaveBeenCalledWith(
+            expect.stringContaining('processed-theme'),
+        );
     });
 });

--- a/packages/cli/src/handlers/organizationContent/index.ts
+++ b/packages/cli/src/handlers/organizationContent/index.ts
@@ -28,6 +28,12 @@ import {
     formatGroupUploadSummary,
     uploadGroups,
 } from './groups';
+import {
+    downloadThemes,
+    formatThemeUploadSummary,
+    prepareThemeUploads,
+    uploadThemes,
+} from './themes';
 import { downloadUsers, formatUserUploadSummary, uploadUsers } from './users';
 
 type OrganizationContentOptions = {
@@ -44,6 +50,9 @@ const createUserPartialUploadError = (message: string): Error =>
 
 const createGroupPartialUploadError = (message: string): Error =>
     new CodeResourcePhaseError('group', message);
+
+const createThemePartialUploadError = (message: string): Error =>
+    new CodeResourcePhaseError('theme', message);
 
 const isPartialUploadError = isCodeResourcePhaseError;
 
@@ -111,6 +120,11 @@ export const downloadOrganizationContent = async ({
                 '> Warning: groups were not downloaded because the group service is not enabled',
             );
         }
+        const themesTotal = await output.runItem({
+            label: 'Themes',
+            action: () => downloadThemes(organizationContentPath),
+            detail: (total) => `${total} downloaded`,
+        });
 
         const renderedSummary = output.complete(
             organizationContentPath,
@@ -133,6 +147,7 @@ export const downloadOrganizationContent = async ({
                 customRolesNum: customRolesTotal,
                 usersNum: usersTotal,
                 groupsNum: groupsTotal,
+                themesNum: themesTotal,
                 timeToCompleted: (Date.now() - start) / 1000,
             },
         });
@@ -180,6 +195,9 @@ export const uploadOrganizationContent = async ({
         scope: 'organization',
     });
     try {
+        const preparedThemes = await prepareThemeUploads(
+            organizationContentPath,
+        );
         output.startItem('Custom roles');
         const summary = await uploadCustomRoles(
             organizationUuid,
@@ -255,6 +273,26 @@ export const uploadOrganizationContent = async ({
             );
         }
         output.completeItem(groupSummaryMessage);
+        output.startItem('Themes');
+        const themeSummary = await uploadThemes(preparedThemes);
+        const themeSummaryMessage = formatThemeUploadSummary(themeSummary);
+        if (themeSummary.failed > 0) {
+            themeSummary.failures.forEach(({ message }) =>
+                GlobalState.log(styles.error(message)),
+            );
+            if (themeSummary.completedSlugs.length > 0) {
+                GlobalState.log(
+                    styles.warning(
+                        `Processed themes before failure: ${themeSummary.completedSlugs.join(', ')}`,
+                    ),
+                );
+            }
+            output.prepareForFailureDetails();
+            throw createThemePartialUploadError(
+                `Processed themes: ${themeSummaryMessage}`,
+            );
+        }
+        output.completeItem(themeSummaryMessage);
         const renderedSummary = output.complete(
             organizationContentPath,
             (Date.now() - start) / 1000,
@@ -283,6 +321,10 @@ export const uploadOrganizationContent = async ({
                 groupsCreated: groupSummary.created,
                 groupsUpdated: groupSummary.updated,
                 groupsUnchanged: groupSummary.unchanged,
+                themesCreated: themeSummary.created,
+                themesUpdated: themeSummary.updated,
+                themesUnchanged: themeSummary.unchanged,
+                themesUploaded: themeSummary.created + themeSummary.updated,
                 timeToCompleted: (Date.now() - start) / 1000,
             },
         });

--- a/packages/cli/src/handlers/organizationContent/themes.test.ts
+++ b/packages/cli/src/handlers/organizationContent/themes.test.ts
@@ -135,6 +135,7 @@ describe('organization theme content-as-code', () => {
             destinationRoot,
             'acme-brand',
         );
+        await createThemeDirectory(destinationRoot, 'remotely-deleted');
         await fs.writeFile(path.join(staleDirectory, 'stale.txt'), 'stale');
 
         vi.mocked(lightdashApi).mockResolvedValue([
@@ -163,9 +164,47 @@ describe('organization theme content-as-code', () => {
                 path.join(destinationRoot, 'themes', 'acme-brand', 'stale.txt'),
             ),
         ).rejects.toMatchObject({ code: 'ENOENT' });
+        await expect(
+            fs.stat(path.join(destinationRoot, 'themes', 'remotely-deleted')),
+        ).rejects.toMatchObject({ code: 'ENOENT' });
 
         const [downloaded] = await prepareThemeUploads(destinationRoot);
         expect(downloaded.archive).toEqual(prepared.archive);
+    });
+
+    it('keeps the previous local theme set when a package download fails', async () => {
+        const sourceRoot = path.join(temporaryRoot, 'source');
+        const destinationRoot = path.join(temporaryRoot, 'destination');
+        await createThemeDirectory(sourceRoot, 'first-theme');
+        const [prepared] = await prepareThemeUploads(sourceRoot);
+        const existingDirectory = await createThemeDirectory(
+            destinationRoot,
+            'existing-theme',
+        );
+        await fs.writeFile(
+            path.join(existingDirectory, 'local-marker.txt'),
+            'keep me',
+        );
+
+        vi.mocked(lightdashApi).mockResolvedValue([
+            { slug: 'first-theme' },
+            { slug: 'second-theme' },
+        ] as never);
+        vi.mocked(lightdashRawApi)
+            .mockResolvedValueOnce(new Response(prepared.archive))
+            .mockResolvedValueOnce(new Response(Buffer.from('not a tar')));
+
+        await expect(downloadThemes(destinationRoot)).rejects.toThrow();
+
+        await expect(
+            fs.readFile(
+                path.join(existingDirectory, 'local-marker.txt'),
+                'utf8',
+            ),
+        ).resolves.toBe('keep me');
+        await expect(
+            fs.stat(path.join(destinationRoot, 'themes', 'first-theme')),
+        ).rejects.toMatchObject({ code: 'ENOENT' });
     });
 
     it('reports completed and failed imports without claiming full success', async () => {

--- a/packages/cli/src/handlers/organizationContent/themes.ts
+++ b/packages/cli/src/handlers/organizationContent/themes.ts
@@ -9,7 +9,9 @@ import {
     type ApiOrganizationDesignPackageImportResponse,
     type ApiOrganizationDesignResponse,
 } from '@lightdash/common';
+import { randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
+import * as path from 'path';
 import { lightdashApi, lightdashRawApi } from '../dbt/apiClient';
 import {
     getThemesFolder,
@@ -20,6 +22,11 @@ import {
 
 export { prepareThemeUploads } from './themePackage';
 
+export const THEME_CODE_RESOURCE = {
+    kind: 'theme',
+    dependencies: [],
+} as const;
+
 export type ThemeUploadSummary = {
     created: number;
     updated: number;
@@ -27,6 +34,36 @@ export type ThemeUploadSummary = {
     failed: number;
     completedSlugs: string[];
     failures: Array<{ message: string }>;
+};
+
+const isEnoent = (error: unknown): boolean =>
+    (error as NodeJS.ErrnoException).code === 'ENOENT';
+
+const replaceThemesDirectory = async (
+    sourceDirectory: string,
+    targetDirectory: string,
+): Promise<void> => {
+    const backupDirectory = path.join(
+        path.dirname(targetDirectory),
+        `.lightdash-themes-backup-${randomUUID()}`,
+    );
+    let hasBackup = false;
+    try {
+        await fs.rename(targetDirectory, backupDirectory);
+        hasBackup = true;
+    } catch (error) {
+        if (!isEnoent(error)) throw error;
+    }
+
+    try {
+        await fs.rename(sourceDirectory, targetDirectory);
+    } catch (error) {
+        if (hasBackup) await fs.rename(backupDirectory, targetDirectory);
+        throw error;
+    }
+    if (hasBackup) {
+        await fs.rm(backupDirectory, { recursive: true, force: true });
+    }
 };
 
 export const downloadThemes = async (
@@ -37,27 +74,37 @@ export const downloadThemes = async (
         url: '/api/v1/org/designs/',
         body: undefined,
     });
-    await fs.mkdir(getThemesFolder(organizationContentPath), {
-        recursive: true,
-    });
+    await fs.mkdir(organizationContentPath, { recursive: true });
+    const stagingRoot = await fs.mkdtemp(
+        path.join(organizationContentPath, '.lightdash-themes-download-'),
+    );
 
-    for (const theme of [...themes].sort((left, right) =>
-        left.slug.localeCompare(right.slug),
-    )) {
-        const response = await lightdashRawApi({
-            method: 'GET',
-            url: `/api/v1/org/designs/${encodeURIComponent(theme.slug)}/package`,
-            body: undefined,
-        });
-        const parsed = await parseThemeArchive(
-            Buffer.from(await response.arrayBuffer()),
-        );
-        if (parsed.manifest.slug !== theme.slug) {
-            throw new ParameterError(
-                `Downloaded theme slug "${parsed.manifest.slug}" does not match requested slug "${theme.slug}"`,
+    try {
+        await fs.mkdir(getThemesFolder(stagingRoot));
+        for (const theme of [...themes].sort((left, right) =>
+            left.slug.localeCompare(right.slug),
+        )) {
+            const response = await lightdashRawApi({
+                method: 'GET',
+                url: `/api/v1/org/designs/${encodeURIComponent(theme.slug)}/package`,
+                body: undefined,
+            });
+            const parsed = await parseThemeArchive(
+                Buffer.from(await response.arrayBuffer()),
             );
+            if (parsed.manifest.slug !== theme.slug) {
+                throw new ParameterError(
+                    `Downloaded theme slug "${parsed.manifest.slug}" does not match requested slug "${theme.slug}"`,
+                );
+            }
+            await writeThemePackage(stagingRoot, parsed);
         }
-        await writeThemePackage(organizationContentPath, parsed);
+        await replaceThemesDirectory(
+            getThemesFolder(stagingRoot),
+            getThemesFolder(organizationContentPath),
+        );
+    } finally {
+        await fs.rm(stagingRoot, { recursive: true, force: true });
     }
     return themes.length;
 };

--- a/packages/common/src/types/contentAsCode/base.ts
+++ b/packages/common/src/types/contentAsCode/base.ts
@@ -33,6 +33,7 @@ export type ContentAsCodeResourceKind =
     | 'custom_role'
     | 'user'
     | 'group'
+    | 'theme'
     | 'external_connection';
 
 export type ContentAsCodeIdentity = {


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-598/data-app-themes-theme-as-code-v1-cli-package-and-synchronization

## Summary

- register themes as an organization content-as-code resource
- include themes in `ld download --organization`
- preflight every local theme before any organization upload mutation
- upload themes after custom roles, users, and groups
- report created, updated, unchanged, and failed themes with accurate partial results
- treat a missing or empty `themes/` directory as a no-op

## Why

Customers should be able to keep organization themes in the same upload/download workflow as the rest of their BI-as-code setup, without a separate themes command or selector.