### PR TITLE
feat(backend): probe trio — DB-free livez, TTL-cached readyz, health demotion

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -60,6 +60,7 @@ import {
 import { databricksPassportStrategy } from './controllers/authentication/strategies/databricksStrategy';
 import { slackPassportStrategy } from './controllers/authentication/strategies/slackStrategy';
 import { snowflakePassportStrategy } from './controllers/authentication/strategies/snowflakeStrategy';
+import { MigrationLeaseManager } from './database/migrationLease';
 import { errorHandler, scimErrorHandler } from './errors';
 import { buildExpressSessionOptions } from './expressSessionOptions';
 import { RegisterRoutes } from './generated/routes';
@@ -81,11 +82,13 @@ import {
     oauthAuthorizationServerHandler,
     oauthProtectedResourceHandler,
 } from './routers/oauthRouter';
+import { createProbeRouter } from './routers/probeRouter';
 import { SchedulerWorker } from './scheduler/SchedulerWorker';
 import { SchedulerWorkerHealth } from './scheduler/SchedulerWorkerHealth';
 import { createOrganizationNameResolver } from './sentry/organizationNameResolver';
 import { InstanceConfigurationService } from './services/InstanceConfigurationService/InstanceConfigurationService';
 import { createCorsOptionsDelegate } from './services/OrganizationSettingsService/CorsPolicy';
+import { ReadinessService } from './services/ReadinessService/ReadinessService';
 import {
     OperationContext,
     ServiceProviderMap,
@@ -345,6 +348,19 @@ export default class App {
         // validation for `string[]` query params.
         expressApp.set('query parser', (str: string) =>
             qs.parse(str, { arrayLimit: 1000 }),
+        );
+
+        expressApp.use(
+            '/api/v1',
+            createProbeRouter(
+                new ReadinessService({
+                    migrationModel: this.models.getMigrationModel(),
+                    migrationRunLedger: new MigrationLeaseManager({
+                        database: this.database,
+                    }),
+                    ttlMs: this.lightdashConfig.database.readinessProbeTtlMs,
+                }),
+            ),
         );
 
         // Slack must be initialized before our own middleware / routes, which cause the slack app to fail

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -118,6 +118,8 @@ export const lightdashConfigMock: LightdashConfig = {
         connectionUri: undefined,
         maxConnections: undefined,
         minConnections: undefined,
+        acquireConnectionTimeout: undefined,
+        readinessProbeTtlMs: 10_000,
         allowMissingMigrations: false,
     },
     intercom: {

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -54,6 +54,25 @@ describe('Query phase metrics config', () => {
     });
 });
 
+describe('database probe config', () => {
+    it('uses the readiness TTL default and leaves the Knex timeout unset', () => {
+        expect(parseConfig().database).toMatchObject({
+            acquireConnectionTimeout: undefined,
+            readinessProbeTtlMs: 10_000,
+        });
+    });
+
+    it('parses readiness and connection acquisition overrides', () => {
+        process.env.PGACQUIRECONNECTIONTIMEOUT = '2500';
+        process.env.READINESS_PROBE_TTL_MS = '5000';
+
+        expect(parseConfig().database).toMatchObject({
+            acquireConnectionTimeout: 2500,
+            readinessProbeTtlMs: 5000,
+        });
+    });
+});
+
 describe('MotherDuck instance cache config', () => {
     afterEach(() => {
         vi.restoreAllMocks();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1434,6 +1434,8 @@ export type LightdashConfig = {
         connectionUri: string | undefined;
         maxConnections: number | undefined;
         minConnections: number | undefined;
+        acquireConnectionTimeout: number | undefined;
+        readinessProbeTtlMs: number;
         allowMissingMigrations: boolean;
     };
     allowMultiOrgs: boolean;
@@ -2744,6 +2746,12 @@ export const parseConfig = (): LightdashConfig => {
                 getIntegerFromEnvironmentVariable('PGMAXCONNECTIONS'),
             minConnections:
                 getIntegerFromEnvironmentVariable('PGMINCONNECTIONS'),
+            acquireConnectionTimeout: getIntegerFromEnvironmentVariable(
+                'PGACQUIRECONNECTIONTIMEOUT',
+            ),
+            readinessProbeTtlMs:
+                getIntegerFromEnvironmentVariable('READINESS_PROBE_TTL_MS') ??
+                10_000,
             allowMissingMigrations:
                 process.env.ALLOW_MISSING_MIGRATIONS === 'true',
         },

--- a/packages/backend/src/knexfile.test.ts
+++ b/packages/backend/src/knexfile.test.ts
@@ -6,16 +6,14 @@ describe('knex connection acquisition timeout', () => {
         vi.resetModules();
     });
 
-    it('leaves the timeout unset so Knex uses its 60000ms default', async () => {
+    it('keeps the Knex 60000ms default and the 30000ms pool default when unset', async () => {
         const knexConfig = (await import('./knexfile')).default;
 
         expect(knexConfig.development.acquireConnectionTimeout).toBeUndefined();
-        expect(
-            knexConfig.development.pool?.acquireTimeoutMillis,
-        ).toBeUndefined();
+        expect(knexConfig.development.pool?.acquireTimeoutMillis).toBe(30000);
     });
 
-    it('passes the configured timeout to Knex', async () => {
+    it('passes the configured timeout to Knex and the pool', async () => {
         lightdashConfigMock.database.acquireConnectionTimeout = 2500;
         vi.resetModules();
 
@@ -23,5 +21,7 @@ describe('knex connection acquisition timeout', () => {
 
         expect(knexConfig.development.acquireConnectionTimeout).toBe(2500);
         expect(knexConfig.production.acquireConnectionTimeout).toBe(2500);
+        expect(knexConfig.development.pool?.acquireTimeoutMillis).toBe(2500);
+        expect(knexConfig.production.pool?.acquireTimeoutMillis).toBe(2500);
     });
 });

--- a/packages/backend/src/knexfile.test.ts
+++ b/packages/backend/src/knexfile.test.ts
@@ -1,0 +1,27 @@
+import { lightdashConfigMock } from './config/lightdashConfig.mock';
+
+describe('knex connection acquisition timeout', () => {
+    afterEach(() => {
+        lightdashConfigMock.database.acquireConnectionTimeout = undefined;
+        vi.resetModules();
+    });
+
+    it('leaves the timeout unset so Knex uses its 60000ms default', async () => {
+        const knexConfig = (await import('./knexfile')).default;
+
+        expect(knexConfig.development.acquireConnectionTimeout).toBeUndefined();
+        expect(
+            knexConfig.development.pool?.acquireTimeoutMillis,
+        ).toBeUndefined();
+    });
+
+    it('passes the configured timeout to Knex', async () => {
+        lightdashConfigMock.database.acquireConnectionTimeout = 2500;
+        vi.resetModules();
+
+        const knexConfig = (await import('./knexfile')).default;
+
+        expect(knexConfig.development.acquireConnectionTimeout).toBe(2500);
+        expect(knexConfig.production.acquireConnectionTimeout).toBe(2500);
+    });
+});

--- a/packages/backend/src/knexfile.ts
+++ b/packages/backend/src/knexfile.ts
@@ -18,12 +18,17 @@ const hasEnterpriseLicense = !!lightdashConfig.license.licenseKey;
 const development: Knex.Config<Knex.PgConnectionConfig> = {
     client: 'pg',
     connection: CONNECTION,
+    ...(lightdashConfig.database.acquireConnectionTimeout === undefined
+        ? {}
+        : {
+              acquireConnectionTimeout:
+                  lightdashConfig.database.acquireConnectionTimeout,
+          }),
     pool: {
         min: lightdashConfig.database.minConnections || 0,
         max:
             lightdashConfig.database.maxConnections ||
             DEFAULT_DB_MAX_CONNECTIONS,
-        acquireTimeoutMillis: 30000, // (default) 30 seconds - max time the application will wait for a connection from the pool before failing (awaited connect will reject)
         createTimeoutMillis: 30000, // (default) 30 seconds - max time that the knex pool will wait for a connection to the postgres database to be created before failing (create operation is cancelled)
         destroyTimeoutMillis: 5000, // (default) 5 seconds - max time that the knex pool will wait for a connection to be destroyed before failing (new resources are created after timeout)
         idleTimeoutMillis: 30000, // (default) 30 seconds - max time that a connection can be idle (not used by the application) before being destroyed (disconnected from postgres) (only happens if minConnections is 0)

--- a/packages/backend/src/knexfile.ts
+++ b/packages/backend/src/knexfile.ts
@@ -29,6 +29,8 @@ const development: Knex.Config<Knex.PgConnectionConfig> = {
         max:
             lightdashConfig.database.maxConnections ||
             DEFAULT_DB_MAX_CONNECTIONS,
+        acquireTimeoutMillis:
+            lightdashConfig.database.acquireConnectionTimeout ?? 30000, // (default) 30 seconds - max time the application will wait for a connection from the pool before failing (awaited connect will reject)
         createTimeoutMillis: 30000, // (default) 30 seconds - max time that the knex pool will wait for a connection to the postgres database to be created before failing (create operation is cancelled)
         destroyTimeoutMillis: 5000, // (default) 5 seconds - max time that the knex pool will wait for a connection to be destroyed before failing (new resources are created after timeout)
         idleTimeoutMillis: 30000, // (default) 30 seconds - max time that a connection can be idle (not used by the application) before being destroyed (disconnected from postgres) (only happens if minConnections is 0)

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -383,12 +383,6 @@ const authenticateDatabricks = (
         }
     };
 
-apiV1Router.get('/livez', async (req, res, next) => {
-    res.json({
-        status: 'ok',
-    });
-});
-
 apiV1Router.get('/health', async (req, res, next) => {
     const skipMigrationCheck = req.query.skipMigrationCheck === 'true';
     req.services

--- a/packages/backend/src/routers/probeRouter.test.ts
+++ b/packages/backend/src/routers/probeRouter.test.ts
@@ -1,0 +1,109 @@
+import express from 'express';
+import { once } from 'node:events';
+import http, { type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { ReadinessResult } from '../services/ReadinessService/ReadinessService';
+import { createProbeRouter } from './probeRouter';
+
+const listen = async (app: express.Express) => {
+    const server = app.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const { port } = server.address() as AddressInfo;
+    return {
+        server,
+        baseUrl: `http://127.0.0.1:${port}`,
+    };
+};
+
+const close = async (server: Server) =>
+    new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+            if (error) {
+                reject(error);
+            } else {
+                resolve();
+            }
+        });
+    });
+
+const get = (url: string) =>
+    new Promise<{ body: string; statusCode: number | undefined }>(
+        (resolve, reject) => {
+            const request = http.get(url, (response) => {
+                let body = '';
+                response.on('data', (chunk) => {
+                    body += chunk;
+                });
+                response.on('end', () => {
+                    resolve({ body, statusCode: response.statusCode });
+                });
+            });
+            request.on('error', reject);
+        },
+    );
+
+describe('probeRouter', () => {
+    it('serves livez before downstream middleware can touch the database', async () => {
+        const app = express();
+        const getReadiness = vi.fn(
+            async (): Promise<ReadinessResult> => ({ status: 'ready' }),
+        );
+        const databaseTouch = vi.fn();
+        app.use('/api/v1', createProbeRouter({ getReadiness }));
+        app.use((_req, res) => {
+            databaseTouch();
+            res.status(500).end();
+        });
+        const { server, baseUrl } = await listen(app);
+
+        try {
+            const response = await get(`${baseUrl}/api/v1/livez`);
+            expect(JSON.parse(response.body)).toEqual({ status: 'ok' });
+            expect(response.statusCode).toBe(200);
+            expect(databaseTouch).not.toHaveBeenCalled();
+            expect(getReadiness).not.toHaveBeenCalled();
+        } finally {
+            await close(server);
+        }
+    });
+
+    it('maps not-ready verdicts to 503 responses', async () => {
+        const app = express();
+        const getReadiness = vi.fn(
+            async (): Promise<ReadinessResult> => ({
+                status: 'not_ready',
+                reason: 'db_unavailable',
+            }),
+        );
+        app.use('/api/v1', createProbeRouter({ getReadiness }));
+        const { server, baseUrl } = await listen(app);
+
+        try {
+            const response = await get(`${baseUrl}/api/v1/readyz`);
+            expect(JSON.parse(response.body)).toEqual({
+                status: 'not_ready',
+                reason: 'db_unavailable',
+            });
+            expect(response.statusCode).toBe(503);
+        } finally {
+            await close(server);
+        }
+    });
+
+    it('maps ready verdicts to 200 responses', async () => {
+        const app = express();
+        const getReadiness = vi.fn(
+            async (): Promise<ReadinessResult> => ({ status: 'ready' }),
+        );
+        app.use('/api/v1', createProbeRouter({ getReadiness }));
+        const { server, baseUrl } = await listen(app);
+
+        try {
+            const response = await get(`${baseUrl}/api/v1/readyz`);
+            expect(JSON.parse(response.body)).toEqual({ status: 'ready' });
+            expect(response.statusCode).toBe(200);
+        } finally {
+            await close(server);
+        }
+    });
+});

--- a/packages/backend/src/routers/probeRouter.ts
+++ b/packages/backend/src/routers/probeRouter.ts
@@ -1,0 +1,19 @@
+import express from 'express';
+import type { ReadinessService } from '../services/ReadinessService/ReadinessService';
+
+export const createProbeRouter = (
+    readinessService: Pick<ReadinessService, 'getReadiness'>,
+) => {
+    const router = express.Router();
+
+    router.get('/livez', (_req, res) => {
+        res.json({ status: 'ok' });
+    });
+
+    router.get('/readyz', async (_req, res) => {
+        const result = await readinessService.getReadiness();
+        res.status(result.status === 'ready' ? 200 : 503).json(result);
+    });
+
+    return router;
+};

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -7,6 +7,7 @@ import {
 
 export const BaseResponse: HealthState = {
     healthy: true,
+    requiresMigration: false,
     license: {
         hasLicenseKey: false,
         valid: false,

--- a/packages/backend/src/services/HealthService/HealthService.test.ts
+++ b/packages/backend/src/services/HealthService/HealthService.test.ts
@@ -22,7 +22,7 @@ vi.mock('../../clients/DockerHub/DockerHub', () => ({
 
 const migrationModel = {
     getMigrationStatus: vi.fn(() => ({
-        isComplete: true,
+        status: 0,
         currentVersion: 'example',
     })),
 };
@@ -197,15 +197,15 @@ describe('health', () => {
             expect(migrationModel.getMigrationStatus).toHaveBeenCalledTimes(1);
         });
 
-        it('does not check migration status when skipMigrationCheck is true', async () => {
+        it('accepts skipMigrationCheck as a no-op', async () => {
             const result = await healthService.getHealthState(undefined, {
                 skipMigrationCheck: true,
             });
             expect(result).toEqual(BaseResponse);
-            expect(migrationModel.getMigrationStatus).not.toHaveBeenCalled();
+            expect(migrationModel.getMigrationStatus).toHaveBeenCalledTimes(1);
         });
 
-        it('throws when the DB is unmigrated and the check runs', async () => {
+        it('reports when the database requires migration', async () => {
             (
                 migrationModel.getMigrationStatus as import('vitest').Mock
             ).mockImplementationOnce(() => ({
@@ -214,7 +214,10 @@ describe('health', () => {
             }));
             await expect(
                 healthService.getHealthState(undefined),
-            ).rejects.toThrow('Database has not been migrated yet');
+            ).resolves.toEqual({
+                ...BaseResponse,
+                requiresMigration: true,
+            });
         });
     });
 

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -3,7 +3,6 @@ import {
     LightdashInstallType,
     LightdashMode,
     SessionUser,
-    UnexpectedDatabaseError,
 } from '@lightdash/common';
 import { createHmac } from 'crypto';
 import { getDockerHubVersion } from '../../clients/DockerHub/DockerHub';
@@ -56,7 +55,7 @@ export class HealthService extends BaseService {
 
     async getHealthState(
         user: SessionUser | undefined,
-        options: { skipMigrationCheck: boolean } = {
+        _options: { skipMigrationCheck: boolean } = {
             skipMigrationCheck: false,
         },
     ): Promise<HealthState> {
@@ -79,23 +78,16 @@ export class HealthService extends BaseService {
                   csvCellsLimit: this.lightdashConfig.query.csvCellsLimit,
               };
 
-        let migrationExecutionTime = 0;
-        if (!options.skipMigrationCheck) {
-            const migrationStartTime = performance.now();
-            const { status: migrationStatus, currentVersion } =
-                await this.migrationModel.getMigrationStatus();
-            migrationExecutionTime = performance.now() - migrationStartTime;
+        const migrationStartTime = performance.now();
+        const { status: migrationStatus, currentVersion } =
+            await this.migrationModel.getMigrationStatus();
+        const migrationExecutionTime = performance.now() - migrationStartTime;
+        const requiresMigration = migrationStatus < 0;
 
-            if (migrationStatus < 0) {
-                throw new UnexpectedDatabaseError(
-                    'Database has not been migrated yet',
-                    { currentVersion },
-                );
-            } else if (migrationStatus > 0) {
-                console.warn(
-                    `There are more DB migrations than defined in the code (you are running old code against a newer DB). Current version: ${currentVersion}`,
-                );
-            } // else migrationStatus === 0 (all migrations are up to date)
+        if (migrationStatus > 0) {
+            console.warn(
+                `There are more DB migrations than defined in the code (you are running old code against a newer DB). Current version: ${currentVersion}`,
+            );
         }
 
         const hasOrgsStartTime = performance.now();
@@ -125,6 +117,7 @@ export class HealthService extends BaseService {
 
         return {
             healthy: true,
+            requiresMigration,
             license: this.licenseService.getLicenseStatus(),
             mode: this.lightdashConfig.mode,
             version: VERSION,

--- a/packages/backend/src/services/ReadinessService/ReadinessService.test.ts
+++ b/packages/backend/src/services/ReadinessService/ReadinessService.test.ts
@@ -1,0 +1,157 @@
+import type { MigrationLeaseManager } from '../../database/migrationLease';
+import type { MigrationModel } from '../../models/MigrationModel/MigrationModel';
+import { ReadinessService } from './ReadinessService';
+
+const createDependencies = () => {
+    const migrationModel: Pick<MigrationModel, 'getMigrationStatus'> = {
+        getMigrationStatus: vi.fn(async () => ({
+            status: 0,
+            currentVersion: '20260811122500',
+        })),
+    };
+    const migrationRunLedger: Pick<MigrationLeaseManager, 'readRunHistory'> = {
+        readRunHistory: vi.fn(async () => ({
+            initialized: true as const,
+            runs: [],
+        })),
+    };
+    return { migrationModel, migrationRunLedger };
+};
+
+describe('ReadinessService', () => {
+    it('returns ready when the schema and migration ledger are healthy', async () => {
+        const dependencies = createDependencies();
+        const service = new ReadinessService({
+            ...dependencies,
+            ttlMs: 10_000,
+        });
+
+        await expect(service.getReadiness()).resolves.toEqual({
+            status: 'ready',
+        });
+    });
+
+    it('returns schema_pending without reading the ledger', async () => {
+        const dependencies = createDependencies();
+        vi.mocked(
+            dependencies.migrationModel.getMigrationStatus,
+        ).mockResolvedValue({ status: -1, currentVersion: '20260811122500' });
+        const service = new ReadinessService({
+            ...dependencies,
+            ttlMs: 10_000,
+        });
+
+        await expect(service.getReadiness()).resolves.toEqual({
+            status: 'not_ready',
+            reason: 'schema_pending',
+        });
+        expect(
+            dependencies.migrationRunLedger.readRunHistory,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('returns migration_parked for the latest parked run', async () => {
+        const dependencies = createDependencies();
+        vi.mocked(
+            dependencies.migrationRunLedger.readRunHistory,
+        ).mockResolvedValue({
+            initialized: true,
+            runs: [
+                {
+                    runUuid: 'run-uuid',
+                    claimToken: 'claim-token',
+                    holderHostname: 'hostname',
+                    holderPodName: null,
+                    appVersion: '1.0.0',
+                    fromMigration: null,
+                    toMigration: '20260811122500',
+                    attempt: 1,
+                    startedAt: new Date('2026-08-11T10:00:00Z'),
+                    finishedAt: new Date('2026-08-11T10:01:00Z'),
+                    outcome: 'parked',
+                    failingMigration: '20260811122500',
+                    failureDetail: 'failed',
+                    lastUnlockedBy: null,
+                    lastUnlockedAt: null,
+                    lastUnlockForced: false,
+                },
+            ],
+        });
+        const service = new ReadinessService({
+            ...dependencies,
+            ttlMs: 10_000,
+        });
+
+        await expect(service.getReadiness()).resolves.toEqual({
+            status: 'not_ready',
+            reason: 'migration_parked',
+        });
+    });
+
+    it('returns db_unavailable when the readiness round cannot query the database', async () => {
+        const dependencies = createDependencies();
+        vi.mocked(
+            dependencies.migrationModel.getMigrationStatus,
+        ).mockRejectedValue(new Error('pool exhausted'));
+        const service = new ReadinessService({
+            ...dependencies,
+            ttlMs: 10_000,
+        });
+
+        await expect(service.getReadiness()).resolves.toEqual({
+            status: 'not_ready',
+            reason: 'db_unavailable',
+        });
+    });
+
+    it('shares one cold readiness round and caches the composed verdict for the TTL', async () => {
+        let now = 1_000;
+        let resolveMigrationStatus:
+            | ((value: { status: number; currentVersion: string }) => void)
+            | undefined;
+        const migrationStatus = new Promise<{
+            status: number;
+            currentVersion: string;
+        }>((resolve) => {
+            resolveMigrationStatus = resolve;
+        });
+        const dependencies = createDependencies();
+        vi.mocked(
+            dependencies.migrationModel.getMigrationStatus,
+        ).mockReturnValueOnce(migrationStatus);
+        const service = new ReadinessService({
+            ...dependencies,
+            ttlMs: 10_000,
+            now: () => now,
+        });
+
+        const probes = Array.from({ length: 20 }, () => service.getReadiness());
+        expect(
+            dependencies.migrationModel.getMigrationStatus,
+        ).toHaveBeenCalledTimes(1);
+        resolveMigrationStatus?.({
+            status: 0,
+            currentVersion: '20260811122500',
+        });
+        await expect(Promise.all(probes)).resolves.toEqual(
+            Array.from({ length: 20 }, () => ({ status: 'ready' })),
+        );
+
+        await service.getReadiness();
+        expect(
+            dependencies.migrationModel.getMigrationStatus,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+            dependencies.migrationRunLedger.readRunHistory,
+        ).toHaveBeenCalledTimes(1);
+
+        now += 10_001;
+        await service.getReadiness();
+        expect(
+            dependencies.migrationModel.getMigrationStatus,
+        ).toHaveBeenCalledTimes(2);
+        expect(
+            dependencies.migrationRunLedger.readRunHistory,
+        ).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/backend/src/services/ReadinessService/ReadinessService.ts
+++ b/packages/backend/src/services/ReadinessService/ReadinessService.ts
@@ -1,0 +1,103 @@
+import type { MigrationLeaseManager } from '../../database/migrationLease';
+import type { MigrationModel } from '../../models/MigrationModel/MigrationModel';
+
+export type ReadinessResult =
+    | { status: 'ready' }
+    | {
+          status: 'not_ready';
+          reason:
+              | 'schema_pending'
+              | 'migration_parked'
+              | 'migration_ledger_unavailable'
+              | 'db_unavailable';
+      };
+
+type ReadinessServiceArguments = {
+    migrationModel: Pick<MigrationModel, 'getMigrationStatus'>;
+    migrationRunLedger: Pick<MigrationLeaseManager, 'readRunHistory'>;
+    ttlMs: number;
+    now?: () => number;
+};
+
+export class ReadinessService {
+    private readonly migrationModel: Pick<MigrationModel, 'getMigrationStatus'>;
+
+    private readonly migrationRunLedger: Pick<
+        MigrationLeaseManager,
+        'readRunHistory'
+    >;
+
+    private readonly ttlMs: number;
+
+    private readonly now: () => number;
+
+    private cachedResult:
+        | { expiresAt: number; result: ReadinessResult }
+        | undefined;
+
+    private inFlight: Promise<ReadinessResult> | undefined;
+
+    constructor({
+        migrationModel,
+        migrationRunLedger,
+        ttlMs,
+        now = Date.now,
+    }: ReadinessServiceArguments) {
+        this.migrationModel = migrationModel;
+        this.migrationRunLedger = migrationRunLedger;
+        this.ttlMs = ttlMs;
+        this.now = now;
+    }
+
+    async getReadiness(): Promise<ReadinessResult> {
+        if (
+            this.cachedResult !== undefined &&
+            this.cachedResult.expiresAt > this.now()
+        ) {
+            return this.cachedResult.result;
+        }
+
+        if (this.inFlight !== undefined) {
+            return this.inFlight;
+        }
+
+        this.inFlight = this.checkReadiness()
+            .then((result) => {
+                this.cachedResult = {
+                    expiresAt: this.now() + this.ttlMs,
+                    result,
+                };
+                return result;
+            })
+            .finally(() => {
+                this.inFlight = undefined;
+            });
+
+        return this.inFlight;
+    }
+
+    private async checkReadiness(): Promise<ReadinessResult> {
+        try {
+            const migrationStatus =
+                await this.migrationModel.getMigrationStatus();
+            if (migrationStatus.status < 0) {
+                return { status: 'not_ready', reason: 'schema_pending' };
+            }
+
+            const runHistory = await this.migrationRunLedger.readRunHistory(1);
+            if (!runHistory.initialized) {
+                return {
+                    status: 'not_ready',
+                    reason: 'migration_ledger_unavailable',
+                };
+            }
+            if (runHistory.runs[0]?.outcome === 'parked') {
+                return { status: 'not_ready', reason: 'migration_parked' };
+            }
+
+            return { status: 'ready' };
+        } catch {
+            return { status: 'not_ready', reason: 'db_unavailable' };
+        }
+    }
+}

--- a/packages/backend/src/services/ReadinessService/ReadinessService.ts
+++ b/packages/backend/src/services/ReadinessService/ReadinessService.ts
@@ -1,4 +1,5 @@
 import type { MigrationLeaseManager } from '../../database/migrationLease';
+import Logger from '../../logging/logger';
 import type { MigrationModel } from '../../models/MigrationModel/MigrationModel';
 
 export type ReadinessResult =
@@ -96,7 +97,12 @@ export class ReadinessService {
             }
 
             return { status: 'ready' };
-        } catch {
+        } catch (error) {
+            Logger.warn(
+                `Readiness check failed: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
             return { status: 'not_ready', reason: 'db_unavailable' };
         }
     }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -513,6 +513,7 @@ export enum LightdashMode {
 
 export type HealthState = {
     healthy: boolean;
+    requiresMigration: boolean;
     license?: {
         hasLicenseKey: boolean;
         valid: boolean;

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -5,6 +5,7 @@ export default function mockHealthResponse(
 ): HealthState {
     return {
         healthy: true,
+        requiresMigration: false,
         license: {
             hasLicenseKey: false,
             valid: false,


### PR DESCRIPTION
## What

Implements the settled probe contract (SPK-908 decision) so health endpoints survive upgrades and database pressure:

- **`/api/v1/livez` is now structurally DB-free**: the probe router is mounted before every global middleware (session store, passport, auth, logging), so no code path on it can acquire a pooled connection or touch the session store. It answers promptly while PostgreSQL is down and while every pool connection is checked out. (The scheduler/NATS workers already expose static DB-free terminus livez handlers — unchanged.)
- **`/api/v1/readyz` (new): TTL-cached readiness.** Not ready (503, discriminated `reason`) when migrations are pending (`schema_pending`), when the latest migration-run-ledger entry is parked (`migration_parked`), when the ledger is unexpectedly missing (`migration_ledger_unavailable`), or when the DB check fails (`db_unavailable` — a caught 503, never a thrown 500). The composed verdict is cached (default 10s, `READINESS_PROBE_TTL_MS`) with single-flight semantics: N concurrent probes in a window share one DB round, and negative verdicts are cached too, so an outage never turns probe traffic into extra pool pressure.
- **`/api/v1/health` demoted to informational**: no longer throws while migrations are pending — reports `requiresMigration: true` with the existing rich detail. `?skipMigrationCheck` is still parsed as an accepted no-op (FE/CLI callers still send it; retiring it is separately-declared cleanup).
- **`PGACQUIRECONNECTIONTIMEOUT`**: exposes a fail-fast connection-acquisition timeout, applied to both knex's `acquireConnectionTimeout` and the tarn pool's `acquireTimeoutMillis` (so the knob is effective above and below the pool's 30s default); when unset, existing defaults are unchanged.

HPA behavior passthrough is chart-side and rides the chart major, not this PR.

## Acceptance mapping

During a live migration: liveness stays green (structurally cannot see the DB), readiness gates traffic via the schema gate, health reports state without throwing, readyz reflects the parked-failed ledger state, and probe endpoints hit the DB at most once per TTL window.

## Tests

Unit coverage for: DB unavailability, pool exhaustion (probe path acquires no pooled connection), migration-pending, parked-ledger state, TTL single-flight caching (including negative-verdict caching), middleware isolation of the probe router, `skipMigrationCheck` no-op, config parsing, and knex/pool timeout wiring. Full backend suite: 6,116 passed; typecheck and lint clean.

Linear: SPK-927
Part of #27140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ucPdRadzzrJHdW2LHRK4n