### PR TITLE
fix(ci): install CLI deps in the release-safety preview job

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -286,6 +286,17 @@ jobs:
       - name: Install tsx
         run: sfw npm install -g tsx@4.19.4
 
+      # SPK-941: scripts/release-safety-index.ts imports
+      # packages/cli/src/releaseSafety (ajv-backed index validation), so the
+      # otherwise dependency-free preview needs the CLI package's dependencies.
+      # Verify-then-fallback because sfw can exit 0 on a half-completed install.
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Install CLI package dependencies
+        run: |
+          sfw pnpm install --frozen-lockfile --filter @lightdash/cli || true
+          node -e "require.resolve('ajv', { paths: ['packages/cli'] })" 2>/dev/null || pnpm install --frozen-lockfile --filter @lightdash/cli
+
       - name: Install oasdiff
         env:
           OASDIFF_VERSION: '1.21.0'

--- a/scripts/expand-version.ts
+++ b/scripts/expand-version.ts
@@ -22,9 +22,6 @@
  * CLI:  npx tsx scripts/expand-version.ts --object my_column --from 0.3260.2
  */
 import { execFileSync } from 'child_process';
-import { compareVersions } from '../packages/cli/src/releaseSafety/version';
-
-export { compareVersions } from '../packages/cli/src/releaseSafety/version';
 
 /** App code to scan — deliberately EXCLUDES the migration dirs (a migration that
  *  drops the object references it, which would mask the app-usage signal). */
@@ -39,6 +36,16 @@ export const DEFAULT_CODE_DIRS = [
 const RELEASE_TAG_RE = /^\d+\.\d+\.\d+$/;
 
 export type PresentAt = (tag: string) => boolean;
+
+export function compareVersions(a: string, b: string): number {
+    const pa = a.split('.').map((n) => parseInt(n, 10));
+    const pb = b.split('.').map((n) => parseInt(n, 10));
+    for (let i = 0; i < 3; i += 1) {
+        const d = (pa[i] || 0) - (pb[i] || 0);
+        if (d !== 0) return d > 0 ? 1 : -1;
+    }
+    return 0;
+}
 
 /**
  * PURE. Given release tags in DESCENDING order (youngest first) where tagsDesc[0]

--- a/scripts/gen-release-safety-cli.test.ts
+++ b/scripts/gen-release-safety-cli.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -10,7 +10,10 @@ interface CliResult {
     stderr: string;
 }
 
-function runGenerator(args: string[]): CliResult {
+function runGenerator(
+    args: string[],
+    environment?: NodeJS.ProcessEnv,
+): CliResult {
     const result = spawnSync(
         'pnpm',
         [
@@ -22,6 +25,7 @@ function runGenerator(args: string[]): CliResult {
         {
             cwd: process.cwd(),
             encoding: 'utf8',
+            env: { ...process.env, ...environment },
         },
     );
     return {
@@ -93,6 +97,56 @@ try {
         eeCount: 0,
         files: [],
     });
+
+    const releaseMarkerPath = join(directory, 'release-marker.json');
+    const indexPath = join(directory, 'release-index.json');
+    const release = runGenerator(
+        [
+            '--version',
+            '1.115.0',
+            '--out',
+            releaseMarkerPath,
+            '--index',
+            indexPath,
+        ],
+        { RELEASE_SAFETY_MARKER_ENABLED: 'true' },
+    );
+    assert.strictEqual(release.status, 0, release.stderr);
+    assert.match(release.stdout, new RegExp(`wrote ${indexPath}`));
+    assert.deepStrictEqual(
+        JSON.parse(readFileSync(indexPath, 'utf8')).entries.map(
+            (entry: { version: string }) => entry.version,
+        ),
+        ['1.115.0'],
+    );
+
+    const indexBeforePreview = readFileSync(indexPath, 'utf8');
+    const previewMarkerPath = join(directory, 'preview-marker.json');
+    const preview = runGenerator(
+        [
+            '--version',
+            'pr-99999',
+            '--previous-version',
+            '1.115.0',
+            '--out',
+            previewMarkerPath,
+            '--index',
+            indexPath,
+        ],
+        { RELEASE_SAFETY_MARKER_ENABLED: 'true' },
+    );
+    assert.strictEqual(preview.status, 0, preview.stderr);
+    assert.match(preview.stdout, new RegExp(`wrote ${previewMarkerPath}`));
+    assert.doesNotMatch(preview.stdout, new RegExp(`wrote ${indexPath}`));
+    assert.match(
+        preview.stdout,
+        /synthetic version pr-99999; not updating the cumulative index/,
+    );
+    assert.strictEqual(readFileSync(indexPath, 'utf8'), indexBeforePreview);
+    assert.strictEqual(
+        JSON.parse(readFileSync(previewMarkerPath, 'utf8')).version,
+        'pr-99999',
+    );
 } finally {
     rmSync(directory, { recursive: true, force: true });
 }

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -14,6 +14,7 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import { isReleaseVersion } from '../packages/cli/src/releaseSafety';
 import { aiRollingUpdateReview } from './ai-migration-review';
 import {
     collectChangeDeclarations,
@@ -768,16 +769,22 @@ export async function generateReleaseSafety(
     if (markerEnabled) {
         writeAtomic(args.out, json);
         console.log(`[release-safety] wrote ${args.out}`);
-        const currentIndex = loadReleaseSafetyIndex(args.index);
-        const nextIndex = appendReleaseSafetyMarker({
-            index: currentIndex,
-            marker,
-            backfilled: args.backfilled,
-            backfillFloorVersion:
-                CONFIGURE_RELEASE_SAFETY_BACKFILL_FLOOR_VERSION,
-        });
-        writeReleaseSafetyIndex(args.index, nextIndex);
-        console.log(`[release-safety] wrote ${args.index}`);
+        if (isReleaseVersion(args.version)) {
+            const currentIndex = loadReleaseSafetyIndex(args.index);
+            const nextIndex = appendReleaseSafetyMarker({
+                index: currentIndex,
+                marker,
+                backfilled: args.backfilled,
+                backfillFloorVersion:
+                    CONFIGURE_RELEASE_SAFETY_BACKFILL_FLOOR_VERSION,
+            });
+            writeReleaseSafetyIndex(args.index, nextIndex);
+            console.log(`[release-safety] wrote ${args.index}`);
+        } else {
+            console.log(
+                `[release-safety] synthetic version ${args.version}; not updating the cumulative index`,
+            );
+        }
     } else {
         console.log(
             `[release-safety] marker disabled (RELEASE_SAFETY_MARKER_ENABLED != "true"); not writing ${args.out}`,

--- a/scripts/release-safety-index.test.ts
+++ b/scripts/release-safety-index.test.ts
@@ -70,6 +70,24 @@ assert.strictEqual(
     '2026-04-09T16:07:20.000Z',
 );
 
+const previewIndex = appendReleaseSafetyMarker({
+    index: {
+        ...emptyReleaseSafetyIndex('1970-01-01T00:00:00.000Z'),
+        entries: [indexEntryFromMarker(baseMarker, false)],
+    },
+    marker: {
+        ...baseMarker,
+        version: 'pr-99999',
+        previousVersion: '1.126.0',
+    },
+    backfilled: false,
+    backfillFloorVersion: null,
+});
+assert.deepStrictEqual(
+    previewIndex.entries.map((entry) => entry.version),
+    ['pr-99999', '1.2.0'],
+);
+
 const index = updateReleaseSafetyIndex({
     index: emptyReleaseSafetyIndex('2026-08-10T00:00:00.000Z'),
     entries: markers.map((marker) => indexEntryFromMarker(marker, true)),

--- a/scripts/release-safety-index.ts
+++ b/scripts/release-safety-index.ts
@@ -1,21 +1,21 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import {
-    compareVersions,
     INDEX_SCHEMA_VERSION,
     parseReleaseSafetyIndex,
     type ReleaseSafetyIndex,
     type ReleaseSafetyIndexEntry,
 } from '../packages/cli/src/releaseSafety';
+import { compareVersions } from './expand-version';
 import type { ReleaseSafetyMarker } from './release-safety-contract';
 
 export {
-    compareVersions,
     composeReleaseSafetySpan,
     INDEX_SCHEMA_VERSION,
     isReleaseVersion,
     parseReleaseSafetyIndex,
 } from '../packages/cli/src/releaseSafety';
+export { compareVersions } from './expand-version';
 export type {
     ReleaseSafetyIndex,
     ReleaseSafetyIndexEntry,


### PR DESCRIPTION
## Problem

Since ~16:15Z today the **Release-safety preview** job fails on **every PR** whose merge ref includes current main. #27169 restructured the release-safety index code and, as a side effect, broke the preview path (which runs `gen-release-safety.ts --version pr-<PR#>` on a synthetic version) in three ways:

1. **`Cannot find module 'ajv'`** — the `preview` job was deliberately dependency-free, but #27169 moved index validation into `packages/cli/src/releaseSafety/` (ajv-backed), which `scripts/gen-release-safety.ts` now imports at load.
2. **`Invalid release version value(s): right=pr-<N>`** — #27169 replaced `scripts/expand-version.ts`'s lenient `parseInt`-based `compareVersions` (which mapped `pr-27188` → `0.0.0`) with a re-export of the new **strict** comparator that throws on any non-`X.Y.Z`. Marker/index generation for a synthetic version throws.
3. **`Invalid release-safety index`** — #27169 also added `"pattern": "^\d+\.\d+\.\d+$"` to every version field of the index JSON schema (pre-#27169 it was `"version": {"type": "string"}`, no pattern), so writing a cumulative index containing a synthetic `pr-<N>` entry fails schema validation.

## Fix

1. **CI**: add `pnpm/action-setup` + a filtered `sfw pnpm install --frozen-lockfile --filter @lightdash/cli` to the preview job, verify-then-fallback per #27166 (resolves `ajv` from `packages/cli`).
2. **Comparator**: restore `scripts/expand-version.ts`'s own lenient comparator (the pre-#27169 status quo for the scripts path) and route `scripts/release-safety-index.ts` sorting through it. The CLI's strict `compareVersions`/`isReleaseVersion` (the actual SPK-894 user feature) is untouched.
3. **Synthetic versions**: guard the cumulative-index load/append/write in `gen-release-safety.ts` behind the **strict** `isReleaseVersion(args.version)` — a synthetic preview version has no place in the release index (a release-time artifact keyed by real versions). Real `X.Y.Z` releases still write and schema-validate the index, byte-identical to today; a `pr-<N>` preview writes only its marker.

## Verification

- Exact preview repro (`RELEASE_SAFETY_MARKER_ENABLED=true … --version pr-99999`): writes the marker, logs `synthetic version pr-99999; not updating the cumulative index`, no `FAILED`/`Invalid`.
- `npm run test:release-safety` green; `pnpm -F cli exec vitest run src/releaseSafety` 17/17 (strict validation still rejects garbage); `pnpm -F cli typecheck` clean. Regression tests added for both the synthetic-preview and real-release index behavior.
- **This PR's own Release-safety preview run is the live proof** — it executes this branch's workflow + scripts against a synthetic `pr-27188` version and should go green while other PRs stay red until this merges.

Linear: SPK-941
Part of #27140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ucPdRadzzrJHdW2LHRK4n