### PR TITLE
feat: show Lightdash parameters in AI agent field discovery

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -448,6 +448,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     builtInSkills: BuiltInSkills,
                     lightdashConfig: context.lightdashConfig,
                     projectModel: models.getProjectModel(),
+                    projectParametersModel: models.getProjectParametersModel(),
                     projectService: repository.getProjectService(),
                     jobModel: models.getJobModel(),
                     userAttributesModel: models.getUserAttributesModel(),

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -9007,6 +9007,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         return {
             listExplores: toolsRuntime.listExplores,
+            getProjectParameterDefinitions:
+                toolsRuntime.getProjectParameterDefinitions,
             getProjectContextDocument,
             getAiAgentMemoryContextEntries,
             incrementAiAgentMemoryPulls,
@@ -9209,6 +9211,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         const {
             listExplores,
+            getProjectParameterDefinitions,
             getProjectContextDocument,
             getAiAgentMemoryContextEntries,
             incrementAiAgentMemoryPulls,
@@ -9764,6 +9767,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         const dependencies: AiAgentDependencies = {
             listExplores,
+            getProjectParameterDefinitions,
             getProjectContextDocument,
             getAiAgentMemoryContextEntries,
             incrementAiAgentMemoryPulls,

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -38,6 +38,7 @@ import {
     type ChartAsCode,
     type DashboardAsCode,
     type FieldValueSearchResult,
+    type ParameterDefinitions,
     type SchedulerAiAugmentation,
 } from '@lightdash/common';
 import * as JsonPatch from 'fast-json-patch';
@@ -47,6 +48,7 @@ import { ContentVerificationModel } from '../../../models/ContentVerificationMod
 import { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
 import { JobModel } from '../../../models/JobModel/JobModel';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { ProjectParametersModel } from '../../../models/ProjectParametersModel';
 import { SavedChartModel } from '../../../models/SavedChartModel';
 import { SearchModel } from '../../../models/SearchModel';
 import { SpaceModel } from '../../../models/SpaceModel';
@@ -187,6 +189,7 @@ type GetExploreRuntimeResult = Awaited<ReturnType<GetExploreFn>>;
 
 export type AiAgentToolsRuntime = {
     listExplores: ListExploresFn;
+    getProjectParameterDefinitions: () => Promise<ParameterDefinitions>;
     getExplore: GetExploreFn;
     findExplores: FindExploresFn;
     getVerifiedFieldUsage: GetVerifiedFieldUsageFn;
@@ -252,6 +255,7 @@ type BuiltInSkillsClient = Pick<
 type AiAgentToolsServiceDependencies = {
     builtInSkills: BuiltInSkillsClient;
     projectModel: ProjectModel;
+    projectParametersModel: ProjectParametersModel;
     projectService: ProjectService;
     jobModel: JobModel;
     userAttributesModel: UserAttributesModel;
@@ -287,6 +291,8 @@ type AiAgentToolsServiceDependencies = {
 
 export class AiAgentToolsService extends BaseService {
     private readonly projectModel: ProjectModel;
+
+    private readonly projectParametersModel: ProjectParametersModel;
 
     private readonly projectService: ProjectService;
 
@@ -374,6 +380,7 @@ export class AiAgentToolsService extends BaseService {
     constructor({
         builtInSkills,
         projectModel,
+        projectParametersModel,
         projectService,
         jobModel,
         userAttributesModel,
@@ -403,6 +410,7 @@ export class AiAgentToolsService extends BaseService {
         super();
         this.builtInSkills = builtInSkills;
         this.projectModel = projectModel;
+        this.projectParametersModel = projectParametersModel;
         this.projectService = projectService;
         this.jobModel = jobModel;
         this.userAttributesModel = userAttributesModel;
@@ -537,6 +545,8 @@ export class AiAgentToolsService extends BaseService {
     ): AiAgentToolsRuntime | McpAiAgentToolsRuntime {
         const runtime: Omit<AiAgentToolsRuntime, 'updateUserName'> = {
             listExplores: () => this.listExplores(context),
+            getProjectParameterDefinitions: () =>
+                this.getProjectParameterDefinitions(context),
             getExplore: (args) => this.getExploreForRuntime(context, args),
             findExplores: (args) => this.findExplores(context, args),
             getVerifiedFieldUsage: () => this.getVerifiedFieldUsage(context),
@@ -643,6 +653,23 @@ export class AiAgentToolsService extends BaseService {
             availableTags: context.tags,
             userAttributeOverrides: context.userAttributeOverrides,
         });
+    }
+
+    private async getProjectParameterDefinitions(
+        context: AiAgentToolsRuntimeContext,
+    ): Promise<ParameterDefinitions> {
+        const projectParameters = await this.projectParametersModel.find(
+            context.projectUuid,
+        );
+        return Object.fromEntries(
+            projectParameters.map((parameter) => [
+                parameter.name,
+                {
+                    ...parameter.config,
+                    type: parameter.config.type ?? 'string',
+                },
+            ]),
+        );
     }
 
     private getExploreForRuntime(

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -387,6 +387,7 @@ const makeMcpService = ({
 
         const runtime = {
             listExplores: vi.fn(listScopedExplores),
+            getProjectParameterDefinitions: vi.fn(async () => ({})),
             getVerifiedFieldUsage: vi.fn(async () => new Map<string, number>()),
             getExplore: vi.fn(async ({ table }: { table: string }) => {
                 const scopedExplores = await listScopedExplores();

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1833,10 +1833,14 @@ export class McpService extends BaseService {
                             ctx,
                             projectUuid,
                         );
-                        const availableExplores =
-                            await toolsRuntime.listExplores();
+                        const [availableExplores, projectParameterDefinitions] =
+                            await Promise.all([
+                                toolsRuntime.listExplores(),
+                                toolsRuntime.getProjectParameterDefinitions(),
+                            ]);
                         const result = executeGetMetadata(args, {
                             availableExplores,
+                            projectParameterDefinitions,
                         });
 
                         return await this.buildScopedResponse(

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -43,6 +43,7 @@ const buildAgentDependencies = (updatePrompt: ReturnType<typeof vi.fn>) =>
     new Proxy(
         {
             listExplores: vi.fn().mockResolvedValue([]),
+            getProjectParameterDefinitions: vi.fn().mockResolvedValue({}),
             updatePrompt,
             perf: new Proxy({}, { get: () => vi.fn() }),
         },
@@ -956,7 +957,14 @@ describe('getAgentTools workstream tool gate', () => {
         canCreateDashboards?: boolean;
     }) =>
         Object.keys(
-            getAgentTools(buildArgs(flags), depsStub(), [], mcpStub, new Map()),
+            getAgentTools(
+                buildArgs(flags),
+                depsStub(),
+                [],
+                mcpStub,
+                new Map(),
+                {},
+            ),
         );
 
     it('exposes listWorkstreams + closePullRequest when AI writeback is enabled (coding agent off)', () => {
@@ -1027,6 +1035,7 @@ describe('getAgentTools workstream tool gate', () => {
                 tools: { mcp_linear__search_issues: {} as never },
             },
             new Map(),
+            {},
         );
 
         expect(Object.keys(tools)).toEqual(
@@ -1130,6 +1139,7 @@ describe('getAgentTools workstream tool gate', () => {
                     },
                 },
                 new Map(),
+                {},
             ),
         );
 

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -5,6 +5,7 @@ import {
     Explore,
     type AiDeepResearchBudget,
     type AiDeepResearchExecutionContextSnapshot,
+    type ParameterDefinitions,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import {
@@ -679,6 +680,7 @@ export const getAgentTools = (
     availableExplores: Explore[],
     mcpToolSetup: AgentMcpToolSetup,
     verifiedFieldUsage: Map<string, number>,
+    projectParameterDefinitions: ParameterDefinitions,
 ): ToolSet => {
     const logger = createAiAgentLogger(args.debugLoggingEnabled);
     logger(
@@ -730,7 +732,7 @@ export const getAgentTools = (
     // Companion to grepFields: rich detail for the explores/fields the agent
     // selected (joined tables, required filters, filter types, hints).
     const getMetadata = args.enableGrepFields
-        ? getGetMetadata({ availableExplores })
+        ? getGetMetadata({ availableExplores, projectParameterDefinitions })
         : null;
 
     const findContent = getFindContent({
@@ -1400,10 +1402,12 @@ export const generateAgentResponse = async ({
     );
 
     try {
-        const [availableExplores, memoryBlock] = await Promise.all([
-            dependencies.listExplores(),
-            getMemoryBlock(args, dependencies),
-        ]);
+        const [availableExplores, memoryBlock, projectParameterDefinitions] =
+            await Promise.all([
+                dependencies.listExplores(),
+                getMemoryBlock(args, dependencies),
+                dependencies.getProjectParameterDefinitions(),
+            ]);
         // Verified-chart usage powers verified-first ranking in grep discovery;
         // degrade to an empty map if it can't be fetched.
         const verifiedFieldUsage = args.enableGrepFields
@@ -1418,6 +1422,7 @@ export const generateAgentResponse = async ({
                 availableExplores,
                 mcpToolSetup,
                 verifiedFieldUsage,
+                projectParameterDefinitions,
             ),
             dependencies.updateProgress,
             args.execution.mode === 'deep_research',
@@ -1758,10 +1763,12 @@ export const streamAgentResponse = async ({
     };
 
     try {
-        const [availableExplores, memoryBlock] = await Promise.all([
-            dependencies.listExplores(),
-            getMemoryBlock(args, dependencies),
-        ]);
+        const [availableExplores, memoryBlock, projectParameterDefinitions] =
+            await Promise.all([
+                dependencies.listExplores(),
+                getMemoryBlock(args, dependencies),
+                dependencies.getProjectParameterDefinitions(),
+            ]);
         const verifiedFieldUsage = args.enableGrepFields
             ? await dependencies
                   .getVerifiedFieldUsage()
@@ -1773,6 +1780,7 @@ export const streamAgentResponse = async ({
             availableExplores,
             mcpToolSetup,
             verifiedFieldUsage,
+            projectParameterDefinitions,
         );
         await persistDeepResearchExecutionContext(args, tools, mcpToolSetup);
         const messages = getAgentMessages(

--- a/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
@@ -71,7 +71,10 @@ const execute = async (
         NonNullable<ReturnType<typeof getGetMetadata>['execute']>
     >[0]['requests'],
 ): Promise<ExecuteResult> => {
-    const tool = getGetMetadata({ availableExplores: [explore] });
+    const tool = getGetMetadata({
+        availableExplores: [explore],
+        projectParameterDefinitions: {},
+    });
     const result = await tool.execute!(
         { requests },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -241,7 +244,10 @@ describe('getMetadata explore field listing', () => {
             },
         };
 
-        const tool = getGetMetadata({ availableExplores: [billing, sales] });
+        const tool = getGetMetadata({
+            availableExplores: [billing, sales],
+            projectParameterDefinitions: {},
+        });
         const result = (await tool.execute!(
             {
                 requests: [
@@ -360,12 +366,129 @@ describe('getMetadata default time dimensions', () => {
                     },
                 ],
             },
-            { availableExplores: [explore] },
+            { availableExplores: [explore], projectParameterDefinitions: {} },
         );
         expect(structured.structuredContent.fields[0]).toMatchObject({
             status: 'found',
             defaultTimeDimension: 'orders_created_at',
             defaultTimeDimensionGranularity: 'orders_created_at_month',
+        });
+    });
+});
+
+describe('getMetadata parameters', () => {
+    const makeParameterizedExplore = (): Explore => {
+        const explore = makeExplore({});
+        explore.tables.orders.parameters = {
+            metric: {
+                label: 'Metric',
+                description: 'Switches what Selected Metric returns',
+                options: ['revenue', 'active_users'],
+                default: 'revenue',
+            },
+        };
+        explore.tables.orders.dimensions.selected_metric = {
+            fieldType: FieldType.DIMENSION,
+            type: DimensionType.NUMBER,
+            name: 'selected_metric',
+            label: 'Selected Metric',
+            table: 'orders',
+            tableLabel: 'Orders',
+            sql: "${ld.parameters.orders.metric} = 'revenue'",
+            hidden: false,
+            source: undefined,
+            compiledSql: "'revenue' = 'revenue'",
+            tablesReferences: ['orders'],
+            parameterReferences: ['orders.metric'],
+        };
+        return explore;
+    };
+
+    it('renders referenced parameter definitions on the explore', async () => {
+        const result = await execute(makeParameterizedExplore(), [
+            { type: 'explore', exploreIds: ['sales'] },
+        ]);
+
+        expect(result.result).toContain('⚠ parameters');
+        expect(result.result).toContain('orders.metric');
+        expect(result.result).toContain('default: "revenue"');
+        expect(result.result).toContain('options: revenue, active_users');
+    });
+
+    it('omits the parameters block when nothing references one', async () => {
+        const result = await execute(makeExplore({}), [
+            { type: 'explore', exploreIds: ['sales'] },
+        ]);
+
+        expect(result.result).not.toContain('⚠ parameters');
+    });
+
+    it('includes referenced project-level parameter definitions', () => {
+        const explore = makeExplore({});
+        explore.tables.orders.dimensions.status.parameterReferences = [
+            'region',
+        ];
+
+        const structured = executeGetMetadata(
+            { requests: [{ type: 'explore', exploreIds: ['sales'] }] },
+            {
+                availableExplores: [explore],
+                projectParameterDefinitions: {
+                    region: {
+                        label: 'Region',
+                        type: 'string',
+                        default: 'emea',
+                    },
+                },
+            },
+        );
+
+        expect(structured.structuredContent.explores[0]).toMatchObject({
+            status: 'found',
+            parameters: [
+                {
+                    name: 'region',
+                    label: 'Region',
+                    type: 'string',
+                    default: 'emea',
+                    options: null,
+                },
+            ],
+        });
+    });
+
+    it('marks parameter-driven fields with their required parameters', async () => {
+        const explore = makeParameterizedExplore();
+        const result = await execute(explore, [
+            {
+                type: 'field',
+                fields: [
+                    { exploreId: 'sales', fieldId: 'orders_selected_metric' },
+                ],
+            },
+        ]);
+
+        expect(result.result).toContain('⚠ requires parameters: orders.metric');
+
+        const structured = executeGetMetadata(
+            {
+                requests: [
+                    {
+                        type: 'field',
+                        fields: [
+                            {
+                                exploreId: 'sales',
+                                fieldId: 'orders_selected_metric',
+                            },
+                        ],
+                    },
+                ],
+            },
+            { availableExplores: [explore], projectParameterDefinitions: {} },
+        );
+        expect(structured.structuredContent.fields[0]).toMatchObject({
+            status: 'found',
+            requiredParameters: ['orders.metric'],
         });
     });
 });

--- a/packages/backend/src/ee/services/ai/tools/getMetadata.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.ts
@@ -3,11 +3,15 @@ import {
     getEffectiveFieldAiHints,
     getFilterTypeFromItemType,
     getMetadataToolDefinition,
+    getParameterOptionValues,
+    getReferencedExploreParameterDefinitions,
     isDimension,
     isMetric,
     type CompiledField,
     type Explore,
+    type GetMetadataParameter,
     type GetMetadataResult,
+    type ParameterDefinitions,
     type ToolGetMetadataArgs,
 } from '@lightdash/common';
 import { tool } from 'ai';
@@ -24,6 +28,9 @@ const toolDefinition = getMetadataToolDefinition.for('agent');
 
 type Dependencies = {
     availableExplores: Explore[];
+    // Project-level parameter definitions (from the project_parameters table).
+    // Model-level definitions come from the explores themselves.
+    projectParameterDefinitions: ParameterDefinitions;
 };
 
 const collapse = (text: string, max = 240): string =>
@@ -64,7 +71,59 @@ const renderFieldList = (
     return `  base ${kind} (${ids.length}): ${shown.join(', ')}${overflow}`;
 };
 
-const renderExplore = (explore: Explore): string => {
+// Only parameters the explore's compiled SQL actually references can change
+// query results, so only those are surfaced.
+const getExploreParameters = (
+    explore: Explore,
+    projectParameterDefinitions: ParameterDefinitions,
+): GetMetadataParameter[] =>
+    Object.entries(
+        getReferencedExploreParameterDefinitions(
+            explore,
+            projectParameterDefinitions,
+        ),
+    ).map(([name, definition]) => ({
+        name,
+        label: definition.label,
+        description: definition.description ?? null,
+        type: definition.type ?? 'string',
+        default: definition.default ?? null,
+        multiple: definition.multiple ?? false,
+        allowCustomValues: definition.allow_custom_values ?? false,
+        options: getParameterOptionValues(definition),
+        optionsFromDimension: definition.options_from_dimension ?? null,
+    }));
+
+const renderParameter = (parameter: GetMetadataParameter): string => {
+    const parts = [
+        `    ${parameter.name}  [${parameter.type}${
+            parameter.multiple ? ', multi-value' : ''
+        }] ${parameter.label}`,
+    ];
+    if (parameter.default !== null) {
+        parts.push(`default: ${JSON.stringify(parameter.default)}`);
+    }
+    if (parameter.options) {
+        parts.push(`options: ${parameter.options.join(', ')}`);
+    }
+    if (parameter.optionsFromDimension) {
+        parts.push(
+            `options from dimension: ${parameter.optionsFromDimension.model}.${parameter.optionsFromDimension.dimension}`,
+        );
+    }
+    if (parameter.allowCustomValues) {
+        parts.push('(custom values allowed)');
+    }
+    const description = parameter.description
+        ? ` — ${collapse(parameter.description)}`
+        : '';
+    return parts.join('  ') + description;
+};
+
+const renderExplore = (
+    explore: Explore,
+    parameters: GetMetadataParameter[],
+): string => {
     const baseTable = explore.tables[explore.baseTable];
     const lines = [`Explore: ${explore.name} (${explore.label})`];
     if (baseTable?.description) {
@@ -83,6 +142,12 @@ const renderExplore = (explore: Explore): string => {
     }
     const required = summarizeRequiredFilters(explore);
     if (required) lines.push(`  ${required}`);
+    if (parameters.length > 0) {
+        lines.push(
+            '  ⚠ parameters — fields marked "requires parameters" return different results depending on these values; an unset parameter resolves to its default:',
+            ...parameters.map(renderParameter),
+        );
+    }
     lines.push(
         renderFieldList(
             'dimensions',
@@ -143,6 +208,13 @@ const renderField = (
     if (isDimension(field) && field.type === 'string') {
         lines.push(`  case-sensitive filters: ${field.caseSensitive ?? true}`);
     }
+    if (field.parameterReferences && field.parameterReferences.length > 0) {
+        lines.push(
+            `  ⚠ requires parameters: ${field.parameterReferences.join(
+                ', ',
+            )} — what this field returns depends on their values; an unset parameter resolves to its default. See the explore metadata for the definitions.`,
+        );
+    }
     const defaultTimeDimension = getResolvedDefaultTimeDimension(
         explore,
         field,
@@ -167,6 +239,7 @@ const renderField = (
 
 const buildExploreStructuredResult = (
     explore: Explore,
+    parameters: GetMetadataParameter[],
 ): GetMetadataResult['explores'][number] => {
     const baseTable = explore.tables[explore.baseTable];
     const hint = flattenAiHints(explore.aiHint);
@@ -187,6 +260,7 @@ const buildExploreStructuredResult = (
         baseTable: explore.baseTable,
         joinedTables: explore.joinedTables.map((join) => join.table),
         requiredFilters: getExploreRequiredFilters(explore),
+        parameters,
         baseDimensions: {
             count: dimensionIds.length,
             fieldIds: dimensionIds.slice(0, FIELD_LIST_MAX),
@@ -230,6 +304,7 @@ const buildFieldStructuredResult = (
             defaultTimeDimension?.defaultTimeDimension ?? null,
         defaultTimeDimensionGranularity:
             defaultTimeDimension?.defaultTimeDimensionGranularity ?? null,
+        requiredParameters: field.parameterReferences ?? [],
         description: field.description
             ? collapse(field.description, FIELD_DESCRIPTION_MAX)
             : null,
@@ -281,7 +356,7 @@ const buildFieldNotFoundError = (
 
 export const executeGetMetadata = (
     { requests }: ToolGetMetadataArgs,
-    { availableExplores }: Dependencies,
+    { availableExplores, projectParameterDefinitions }: Dependencies,
 ): ExecuteStructuredToolResult<GetMetadataResult> => {
     const byName = new Map(
         availableExplores.map((explore) => [explore.name, explore]),
@@ -303,8 +378,14 @@ export const executeGetMetadata = (
                         error,
                     });
                 } else {
-                    textBlocks.push(renderExplore(explore));
-                    explores.push(buildExploreStructuredResult(explore));
+                    const parameters = getExploreParameters(
+                        explore,
+                        projectParameterDefinitions,
+                    );
+                    textBlocks.push(renderExplore(explore, parameters));
+                    explores.push(
+                        buildExploreStructuredResult(explore, parameters),
+                    );
                 }
             }
         } else {

--- a/packages/backend/src/ee/services/ai/tools/grepFields.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFields.ts
@@ -225,6 +225,7 @@ const groupOrderedHitsByExplore = (
             defaultTimeDimension: field.defaultTimeDimension,
             defaultTimeDimensionGranularity:
                 field.defaultTimeDimensionGranularity,
+            requiredParameters: field.requiredParameters,
             usageInVerifiedCharts: field.verifiedUsage,
             matchLocality: matchLocality(field, matches),
         })),
@@ -257,7 +258,11 @@ const renderGroupedHits = (
                     const defaultTimeDimension = field.defaultTimeDimension
                         ? ` default_time_dimension: ${field.defaultTimeDimension} default_time_dimension_granularity: ${field.defaultTimeDimensionGranularity}`
                         : '';
-                    return `  ${field.path}  [${field.kind} ${field.fieldType}]${verified} ${field.label}${defaultTimeDimension}${desc}${hint}`;
+                    const params =
+                        field.requiredParameters.length > 0
+                            ? ` ⚠params: ${field.requiredParameters.join(',')}`
+                            : '';
+                    return `  ${field.path}  [${field.kind} ${field.fieldType}]${verified}${params} ${field.label}${defaultTimeDimension}${desc}${hint}`;
                 })
                 .join('\n');
             const header = `  ${exploreName} (${exploreLabel})`;

--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.grepPrecision.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.grepPrecision.test.ts
@@ -426,3 +426,26 @@ describe('selectCandidateFields', () => {
         ).toEqual(['events/events_sales_led_flag']);
     });
 });
+
+describe('buildFieldIndex parameter references', () => {
+    it('carries a field parameterReferences into the index entry', () => {
+        const explore = makeExplore({
+            name: 'orders',
+            fields: [{ name: 'selected_metric' }, { name: 'status' }],
+        });
+        explore.tables.orders.dimensions.selected_metric.parameterReferences = [
+            'orders.metric',
+        ];
+
+        const index = buildFieldIndex([explore]);
+        const parameterized = index.find(
+            (entry) => entry.path === 'orders/orders_selected_metric',
+        );
+        const plain = index.find(
+            (entry) => entry.path === 'orders/orders_status',
+        );
+
+        expect(parameterized?.requiredParameters).toEqual(['orders.metric']);
+        expect(plain?.requiredParameters).toEqual([]);
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.metricAmbiguity.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.metricAmbiguity.test.ts
@@ -12,6 +12,7 @@ const entry = (over: Partial<FieldEntry>): FieldEntry => ({
     aiHint: '',
     defaultTimeDimension: null,
     defaultTimeDimensionGranularity: null,
+    requiredParameters: [],
     nameHaystack: '',
     descHaystack: '',
     hintHaystack: '',

--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.ts
@@ -74,6 +74,9 @@ export type FieldEntry = {
     aiHint: string;
     defaultTimeDimension: string | null;
     defaultTimeDimensionGranularity: string | null;
+    // Parameters referenced in the field's compiled SQL — the field returns
+    // different results depending on the values those parameters resolve to.
+    requiredParameters: string[];
     // Locality slices of the haystack, so callers can rank a match in the
     // field's own name/label above one buried in a description or hint.
     nameHaystack: string;
@@ -166,6 +169,7 @@ export const buildFieldIndex = (
                         defaultTimeDimensionGranularity:
                             defaultTimeDimensionFieldIds?.defaultTimeDimensionGranularity ??
                             null,
+                        requiredParameters: field.parameterReferences ?? [],
                         nameHaystack,
                         descHaystack,
                         hintHaystack,
@@ -357,7 +361,11 @@ const fieldLine = (f: FieldEntry): string => {
     const defaultTimeDimension = f.defaultTimeDimension
         ? ` default_time_dimension: ${f.defaultTimeDimension} default_time_dimension_granularity: ${f.defaultTimeDimensionGranularity}`
         : '';
-    return `  ${f.path}  [${f.kind} ${f.type}]${verified} ${f.label}${defaultTimeDimension}${desc}`;
+    const params =
+        f.requiredParameters.length > 0
+            ? ` ⚠params: ${f.requiredParameters.join(',')}`
+            : '';
+    return `  ${f.path}  [${f.kind} ${f.type}]${verified}${params} ${f.label}${defaultTimeDimension}${desc}`;
 };
 
 export const renderCandidateBlock = (candidates: FieldEntry[]): string => {

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -52,6 +52,7 @@ import {
     GetExploreFn,
     GetKnowledgeDocumentContentFn,
     GetProjectInfoFn,
+    GetProjectParameterDefinitionsFn,
     GetPromptFn,
     GetPullRequestDiffFn,
     GetSavedChartFn,
@@ -286,6 +287,7 @@ export type PerformanceMetrics = {
 
 export type AiAgentDependencies = {
     listExplores: ListExploresFn;
+    getProjectParameterDefinitions: GetProjectParameterDefinitionsFn;
     // The whole cached project_context document.
     getProjectContextDocument: () => Promise<ProjectContextEntry[]>;
     getAiAgentMemoryContextEntries: () => Promise<MemorySearchEntry[]>;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -23,6 +23,7 @@ import {
     Filters,
     ItemsMap,
     KnexPaginateArgs,
+    ParameterDefinitions,
     ParametersValuesMap,
     PreviewDeploySetupResult,
     ProjectType,
@@ -61,6 +62,11 @@ export type AiAgentRequiredFilterMetadata = {
 };
 
 export type ListExploresFn = () => Promise<Explore[]>;
+
+// Project-level parameter definitions (the project_parameters table);
+// model-level definitions live on the explores themselves.
+export type GetProjectParameterDefinitionsFn =
+    () => Promise<ParameterDefinitions>;
 
 export type FindExploresFn = (args: {
     fieldSearchSize: number;

--- a/packages/common/src/compiler/parameters.test.ts
+++ b/packages/common/src/compiler/parameters.test.ts
@@ -2,6 +2,7 @@ import { ExploreType, type Explore } from '../types/explore';
 import { type LightdashProjectParameter } from '../types/lightdashProjectConfig';
 import {
     getExploreParameterDefinitions,
+    getExploreParameterReferences,
     getMissingRequiredParameters,
     getParameterReferences,
     getReferencedParameterDefinitions,
@@ -679,5 +680,67 @@ describe('getReferencedParameterDefinitions', () => {
             getReferencedParameterDefinitions({ region }, undefined),
         ).toEqual({});
         expect(getReferencedParameterDefinitions({ region }, [])).toEqual({});
+    });
+});
+
+describe('getExploreParameterReferences', () => {
+    it('collects deduplicated references from joins, tables, and fields', () => {
+        const references = getExploreParameterReferences({
+            name: 'orders',
+            label: 'Orders',
+            baseTable: 'orders',
+            joinedTables: [
+                { table: 'customers', parameterReferences: ['region'] },
+            ],
+            tables: {
+                orders: {
+                    name: 'orders',
+                    label: 'Orders',
+                    parameterReferences: ['env'],
+                    dimensions: {
+                        selected_metric: {
+                            name: 'selected_metric',
+                            parameterReferences: ['orders.metric', 'region'],
+                        },
+                    },
+                    metrics: {
+                        total: {
+                            name: 'total',
+                            parameterReferences: ['orders.metric'],
+                        },
+                    },
+                    lineageGraph: {},
+                },
+                customers: {
+                    name: 'customers',
+                    label: 'Customers',
+                    dimensions: {},
+                    metrics: {},
+                    lineageGraph: {},
+                },
+            },
+        } as unknown as Explore);
+
+        expect(references.sort()).toEqual(['env', 'orders.metric', 'region']);
+    });
+
+    it('returns empty for an explore with no references', () => {
+        const references = getExploreParameterReferences({
+            name: 'orders',
+            label: 'Orders',
+            baseTable: 'orders',
+            joinedTables: [],
+            tables: {
+                orders: {
+                    name: 'orders',
+                    label: 'Orders',
+                    dimensions: {},
+                    metrics: {},
+                    lineageGraph: {},
+                },
+            },
+        } as unknown as Explore);
+
+        expect(references).toEqual([]);
     });
 });

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -12,7 +12,10 @@ import {
 import lightdashDbtYamlSchema from '../schemas/json/lightdash-dbt-2.0.json';
 import { CompileError } from '../types/errors';
 import type { CompiledTable, Explore, Table } from '../types/explore';
-import type { LightdashProjectParameter } from '../types/lightdashProjectConfig';
+import {
+    isLightdashParameterOption,
+    type LightdashProjectParameter,
+} from '../types/lightdashProjectConfig';
 import type {
     ParameterDefinitions,
     ParametersValuesMap,
@@ -200,6 +203,28 @@ export const getExploreParameterDefinitions = (
         : {};
 
 /**
+ * Every parameter name referenced anywhere in an explore's compiled SQL —
+ * joins, table sql_where, and each field's SQL. These are the parameters whose
+ * values can change what a query against the explore returns.
+ */
+export const getExploreParameterReferences = (explore: Explore): string[] => {
+    const references = new Set<string>();
+    explore.joinedTables.forEach((join) => {
+        join.parameterReferences?.forEach((name) => references.add(name));
+    });
+    Object.values(explore.tables).forEach((table) => {
+        table.parameterReferences?.forEach((name) => references.add(name));
+        [
+            ...Object.values(table.dimensions),
+            ...Object.values(table.metrics),
+        ].forEach((field) => {
+            field.parameterReferences?.forEach((name) => references.add(name));
+        });
+    });
+    return [...references];
+};
+
+/**
  * The subset of user parameter definitions that are actually referenced. A referenced
  * name with no user definition (e.g. a reserved system variable referenced on its own)
  * is excluded, so callers only surface user-editable parameters.
@@ -213,6 +238,29 @@ export const getReferencedParameterDefinitions = (
             references?.includes(key),
         ),
     );
+
+/** Project- and model-level definitions merged (model wins), filtered to the parameters the explore actually references. */
+export const getReferencedExploreParameterDefinitions = (
+    explore: Explore,
+    projectParameterDefinitions: ParameterDefinitions = {},
+): ParameterDefinitions =>
+    getReferencedParameterDefinitions(
+        {
+            ...projectParameterDefinitions,
+            ...getExploreParameterDefinitions(explore),
+        },
+        getExploreParameterReferences(explore),
+    );
+
+/** A definition's option values as raw values, or null when options aren't statically declared. */
+export const getParameterOptionValues = (
+    definition: LightdashProjectParameter,
+): (string | number)[] | null =>
+    definition.options
+        ? definition.options.map((option) =>
+              isLightdashParameterOption(option) ? option.value : option,
+          )
+        : null;
 
 /**
  * Validate parameter names. Only bad-pattern names are invalid; names colliding with a

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolGetMetadataArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolGetMetadataArgs.ts
@@ -13,7 +13,7 @@ export const GET_METADATA_DESCRIPTION = ({
     return `Tool: ${getMetadata}
 
 Purpose:
-Get the full metadata for specific explores and/or fields that you already know the IDs of (typically from ${grepFields}). ${grepFields} is lean — it tells you WHICH fields exist; ${getMetadata} gives you the DETAIL you need to build a correct query: an explore's joined tables and table filters, and a field's filter type, case-sensitivity, resolved default time dimension, hints, and whether it comes from a joined table.
+Get the full metadata for specific explores and/or fields that you already know the IDs of (typically from ${grepFields}). ${grepFields} is lean — it tells you WHICH fields exist; ${getMetadata} gives you the DETAIL you need to build a correct query: an explore's joined tables, table filters, and parameters, and a field's filter type, case-sensitivity, resolved default time dimension, parameter dependencies, hints, and whether it comes from a joined table. A field marked with required parameters returns different results depending on the parameter values the query runs with — unset parameters resolve to their default.
 
 Call this AFTER ${grepFields}, once you have narrowed down to the explore(s) and field(s) you intend to use, and BEFORE ${visualization}. You can ask for several explores and several fields across explores in a SINGLE call — batch everything you need at once instead of one request per item.
 
@@ -67,6 +67,29 @@ export const getMetadataInputSchema = z.object({
 
 export type ToolGetMetadataArgs = z.infer<typeof getMetadataInputSchema>;
 
+const parameterValueSchema = z.union([
+    z.string(),
+    z.number(),
+    z.array(z.string()),
+    z.array(z.number()),
+]);
+
+const getMetadataParameterSchema = z.object({
+    name: z.string(),
+    label: z.string(),
+    description: z.string().nullable(),
+    type: z.enum(['string', 'number', 'date']),
+    default: parameterValueSchema.nullable(),
+    multiple: z.boolean(),
+    allowCustomValues: z.boolean(),
+    options: z.array(z.union([z.string(), z.number()])).nullable(),
+    optionsFromDimension: z
+        .object({ model: z.string(), dimension: z.string() })
+        .nullable(),
+});
+
+export type GetMetadataParameter = z.infer<typeof getMetadataParameterSchema>;
+
 const getMetadataExploreFoundSchema = z.object({
     exploreId: z.string(),
     status: z.literal('found'),
@@ -76,6 +99,7 @@ const getMetadataExploreFoundSchema = z.object({
     baseTable: z.string(),
     joinedTables: z.array(z.string()),
     requiredFilters: z.array(findExploresRequiredFilterSchema),
+    parameters: z.array(getMetadataParameterSchema),
     baseDimensions: z.object({
         count: z.number(),
         fieldIds: z.array(z.string()),
@@ -105,6 +129,7 @@ const getMetadataFieldFoundSchema = z.object({
     caseSensitiveFilters: z.boolean().nullable(),
     defaultTimeDimension: z.string().nullable(),
     defaultTimeDimensionGranularity: z.string().nullable(),
+    requiredParameters: z.array(z.string()),
     description: z.string().nullable(),
     hint: z.string().nullable(),
 });

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolGrepFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolGrepFieldsArgs.ts
@@ -23,6 +23,8 @@ Use this as the FIRST step whenever the user asks a data question (counts, total
 Each pattern is a case-insensitive keyword pattern (not a full regex): use \`|\` to OR synonyms ("revenue|sales") and a space or \`.*\` between words to require all of them ("order.*status" matches fields mentioning both "order" and "status"). Pass 1–5 patterns in a SINGLE call covering the different angles of the question — they run together so you see all results at once instead of grepping one at a time. Start broad with meaningful keywords (e.g. ["revenue|sales", "country|region", "segment|tier"]) and narrow from there — long natural-language phrases will not match. If results are empty, try synonyms or broader patterns before giving up. Read the returned fieldIds and pick the single explore that answers at the right grain before building a query.
 
 A description or hint ending in "...(truncated)" is incomplete — call ${getMetadata} to read the full text before using that field.
+
+A field annotated with \`⚠params: <names>\` depends on those Lightdash parameters — what it returns changes with the parameter values the query runs with (unset parameters resolve to their default). Call ${getMetadata} on its explore to see the parameter definitions before querying such a field.
 `;
 };
 
@@ -68,6 +70,7 @@ const grepFieldsPatternFieldSchema = z.object({
     hint: z.string().nullable(),
     defaultTimeDimension: z.string().nullable(),
     defaultTimeDimensionGranularity: z.string().nullable(),
+    requiredParameters: z.array(z.string()),
     usageInVerifiedCharts: z.number(),
     matchLocality: z.enum(['name', 'description', 'hint', 'mixed']),
 });

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -922,7 +922,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
-            "description": "Tool: get_metadata\n\nPurpose:\nGet the full metadata for specific explores and/or fields that you already know the IDs of (typically from grep_fields). grep_fields is lean — it tells you WHICH fields exist; get_metadata gives you the DETAIL you need to build a correct query: an explore's joined tables and table filters, and a field's filter type, case-sensitivity, resolved default time dimension, hints, and whether it comes from a joined table.\n\nCall this AFTER grep_fields, once you have narrowed down to the explore(s) and field(s) you intend to use, and BEFORE render_chart. You can ask for several explores and several fields across explores in a SINGLE call — batch everything you need at once instead of one request per item.\n\nEach entry in `requests` is one of:\n- `{ \"type\": \"explore\", \"exploreIds\": [\"orders\", \"customers\"] }` — full metadata for those explores (joined tables, table filters, field counts).\n- `{ \"type\": \"field\", \"fields\": [{ \"exploreId\": \"orders\", \"fieldId\": \"orders_status\" }] }` — full metadata for those specific fields.\n",
+            "description": "Tool: get_metadata\n\nPurpose:\nGet the full metadata for specific explores and/or fields that you already know the IDs of (typically from grep_fields). grep_fields is lean — it tells you WHICH fields exist; get_metadata gives you the DETAIL you need to build a correct query: an explore's joined tables, table filters, and parameters, and a field's filter type, case-sensitivity, resolved default time dimension, parameter dependencies, hints, and whether it comes from a joined table. A field marked with required parameters returns different results depending on the parameter values the query runs with — unset parameters resolve to their default.\n\nCall this AFTER grep_fields, once you have narrowed down to the explore(s) and field(s) you intend to use, and BEFORE render_chart. You can ask for several explores and several fields across explores in a SINGLE call — batch everything you need at once instead of one request per item.\n\nEach entry in `requests` is one of:\n- `{ \"type\": \"explore\", \"exploreIds\": [\"orders\", \"customers\"] }` — full metadata for those explores (joined tables, table filters, field counts).\n- `{ \"type\": \"field\", \"fields\": [{ \"exploreId\": \"orders\", \"fieldId\": \"orders_status\" }] }` — full metadata for those specific fields.\n",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -1061,6 +1061,120 @@
                                         "label": {
                                             "type": "string"
                                         },
+                                        "parameters": {
+                                            "items": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "allowCustomValues": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "default": {
+                                                        "anyOf": [
+                                                            {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    {
+                                                                        "items": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "description": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "label": {
+                                                        "type": "string"
+                                                    },
+                                                    "multiple": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "options": {
+                                                        "anyOf": [
+                                                            {
+                                                                "items": {
+                                                                    "type": [
+                                                                        "string",
+                                                                        "number"
+                                                                    ]
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "optionsFromDimension": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "dimension": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "model": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "model",
+                                                                    "dimension"
+                                                                ],
+                                                                "type": "object"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "type": {
+                                                        "enum": [
+                                                            "string",
+                                                            "number",
+                                                            "date"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "label",
+                                                    "description",
+                                                    "type",
+                                                    "default",
+                                                    "multiple",
+                                                    "allowCustomValues",
+                                                    "options",
+                                                    "optionsFromDimension"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
                                         "requiredFilters": {
                                             "items": {
                                                 "additionalProperties": false,
@@ -1111,6 +1225,7 @@
                                         "baseTable",
                                         "joinedTables",
                                         "requiredFilters",
+                                        "parameters",
                                         "baseDimensions",
                                         "baseMetrics"
                                     ],
@@ -1187,6 +1302,12 @@
                                         "label": {
                                             "type": "string"
                                         },
+                                        "requiredParameters": {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
                                         "status": {
                                             "const": "found",
                                             "type": "string"
@@ -1205,6 +1326,7 @@
                                         "caseSensitiveFilters",
                                         "defaultTimeDimension",
                                         "defaultTimeDimensionGranularity",
+                                        "requiredParameters",
                                         "description",
                                         "hint"
                                     ],
@@ -1421,7 +1543,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
-            "description": "Tool: grep_fields\n\nPurpose:\nFind which explores and fields can answer a question by grepping an in-memory, annotated view of the project's fields (names, labels, descriptions, hints and tags). Returns matching fields as `explore/fieldId  [kind type]` lines grouped by explore.\n\nUse this as the FIRST step whenever the user asks a data question (counts, totals, breakdowns, trends, \"what is\", \"show me\", \"how many\"). Do NOT call this for questions about existing dashboards/charts (use find_content).\n\nEach pattern is a case-insensitive keyword pattern (not a full regex): use `|` to OR synonyms (\"revenue|sales\") and a space or `.*` between words to require all of them (\"order.*status\" matches fields mentioning both \"order\" and \"status\"). Pass 1–5 patterns in a SINGLE call covering the different angles of the question — they run together so you see all results at once instead of grepping one at a time. Start broad with meaningful keywords (e.g. [\"revenue|sales\", \"country|region\", \"segment|tier\"]) and narrow from there — long natural-language phrases will not match. If results are empty, try synonyms or broader patterns before giving up. Read the returned fieldIds and pick the single explore that answers at the right grain before building a query.\n\nA description or hint ending in \"...(truncated)\" is incomplete — call get_metadata to read the full text before using that field.\n",
+            "description": "Tool: grep_fields\n\nPurpose:\nFind which explores and fields can answer a question by grepping an in-memory, annotated view of the project's fields (names, labels, descriptions, hints and tags). Returns matching fields as `explore/fieldId  [kind type]` lines grouped by explore.\n\nUse this as the FIRST step whenever the user asks a data question (counts, totals, breakdowns, trends, \"what is\", \"show me\", \"how many\"). Do NOT call this for questions about existing dashboards/charts (use find_content).\n\nEach pattern is a case-insensitive keyword pattern (not a full regex): use `|` to OR synonyms (\"revenue|sales\") and a space or `.*` between words to require all of them (\"order.*status\" matches fields mentioning both \"order\" and \"status\"). Pass 1–5 patterns in a SINGLE call covering the different angles of the question — they run together so you see all results at once instead of grepping one at a time. Start broad with meaningful keywords (e.g. [\"revenue|sales\", \"country|region\", \"segment|tier\"]) and narrow from there — long natural-language phrases will not match. If results are empty, try synonyms or broader patterns before giving up. Read the returned fieldIds and pick the single explore that answers at the right grain before building a query.\n\nA description or hint ending in \"...(truncated)\" is incomplete — call get_metadata to read the full text before using that field.\n\nA field annotated with `⚠params: <names>` depends on those Lightdash parameters — what it returns changes with the parameter values the query runs with (unset parameters resolve to their default). Call get_metadata on its explore to see the parameter definitions before querying such a field.\n",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -1608,6 +1730,12 @@
                                                         "path": {
                                                             "type": "string"
                                                         },
+                                                        "requiredParameters": {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        },
                                                         "usageInVerifiedCharts": {
                                                             "type": "number"
                                                         }
@@ -1624,6 +1752,7 @@
                                                         "hint",
                                                         "defaultTimeDimension",
                                                         "defaultTimeDimensionGranularity",
+                                                        "requiredParameters",
                                                         "usageInVerifiedCharts",
                                                         "matchLocality"
                                                     ],


### PR DESCRIPTION
AI agents had no way to know that a field's results depend on a Lightdash parameter — discovery and metadata never mentioned parameters, so agents picked parameter-driven fields and confidently reported numbers computed from the parameter's default. Field search now tags parameter-driven fields and explore metadata lists the referenced parameter definitions, so the agent knows what it's dealing with before it queries.

Part of #24203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)