### PR TITLE
feat(data-apps): stop offering vizs on data app surfaces

### DIFF
--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1250,6 +1250,15 @@ export class AppModel {
             })
             .where(`${AppsTableName}.created_by_user_uuid`, userUuid)
             .whereNull(`${AppsTableName}.deleted_at`)
+            // Vizs (custom chart types) are not offered on app surfaces.
+            .where((templateFilter) => {
+                void templateFilter
+                    .whereNot(
+                        `${AppsTableName}.template`,
+                        DATA_APP_VIZ_TEMPLATE,
+                    )
+                    .orWhereNull(`${AppsTableName}.template`);
+            })
             .modify((queryBuilder) => {
                 if (options.excludePreviewProjects ?? true) {
                     void queryBuilder.whereNot(

--- a/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
@@ -19,7 +19,7 @@ const setup = (
 };
 
 describe('AppTemplatePicker', () => {
-    it('renders all four starting points and no Lets go button', () => {
+    it('renders the app starting points, no viz template, no Lets go button', () => {
         setup(null);
         expect(
             screen.getByRole('button', { name: /Dashboard/i }),
@@ -30,9 +30,10 @@ describe('AppTemplatePicker', () => {
         expect(
             screen.getByRole('button', { name: /PDF Report/i }),
         ).toBeInTheDocument();
+        // Vizs (custom chart types) are created from Explorer, not here.
         expect(
-            screen.getByRole('button', { name: /Data app visualization/i }),
-        ).toBeInTheDocument();
+            screen.queryByRole('button', { name: /Data app visualization/i }),
+        ).not.toBeInTheDocument();
         expect(
             screen.queryByRole('button', { name: /Let's go/i }),
         ).not.toBeInTheDocument();

--- a/packages/frontend/src/features/apps/AppTemplatePicker.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.tsx
@@ -3,7 +3,7 @@ import { Stack, Text, ThemeIcon } from '@mantine/core';
 import { type FC } from 'react';
 import { PolymorphicPaperButton } from '../../components/common/PolymorphicPaperButton';
 import classes from './AppTemplatePicker.module.css';
-import { TEMPLATES } from './templates';
+import { PICKER_TEMPLATES } from './templates';
 
 type Props = {
     selected: DataAppTemplate | null;
@@ -12,7 +12,7 @@ type Props = {
 
 const AppTemplatePicker: FC<Props> = ({ selected, onSelectedChange }) => (
     <div className={classes.fan}>
-        {TEMPLATES.map((template, index) => {
+        {PICKER_TEMPLATES.map((template, index) => {
             const Icon = template.icon;
             const isSelected = selected === template.id;
             return (

--- a/packages/frontend/src/features/apps/templates.ts
+++ b/packages/frontend/src/features/apps/templates.ts
@@ -14,7 +14,7 @@ export type TemplateDefinition = {
     icon: TablerIcon;
 };
 
-export const TEMPLATES: TemplateDefinition[] = [
+const TEMPLATES: TemplateDefinition[] = [
     {
         id: 'dashboard',
         title: 'Dashboard',
@@ -43,6 +43,13 @@ export const TEMPLATES: TemplateDefinition[] = [
         icon: IconPuzzle,
     },
 ];
+
+// Offered when creating a data app. Vizs (custom chart types) are created from
+// Explorer's chart type picker instead, but existing viz apps still resolve
+// their definition via `getTemplate`, so the entry stays in TEMPLATES.
+export const PICKER_TEMPLATES: TemplateDefinition[] = TEMPLATES.filter(
+    (t) => t.id !== 'data_app_viz',
+);
 
 export const getTemplate = (id: DataAppTemplate): TemplateDefinition => {
     const t = TEMPLATES.find((x) => x.id === id);


### PR DESCRIPTION
## Summary

Data app vizs (custom chart types) are no longer offered anywhere on the data-app surfaces:

- **Template picker**: the `data_app_viz` entry is removed from the create-app fan (`PICKER_TEMPLATES`). The full `TEMPLATES` list stays module-internal because `getTemplate` must keep resolving existing viz apps (opened via Explorer's dock) — removing the definition outright would crash the builder for them.
- **My-apps surfaces**: `AppModel.listMyApps` excludes viz-template rows server-side, which cleans both consumers — the "Continue building" recent-apps strip on the generate page and the My apps panel in user settings.

Viz creation and editing remain in Explorer's Custom chart type picker (unchanged code path — it posts the template directly, not via the picker).

## Testing

- Frontend + backend typecheck, lint
- Browser-verified on a live backend: the create-app fan shows Dashboard / Slide Show / PDF Report only, and the recent-apps strip lists only standalone apps

Relates: GLITCH-648