### PR TITLE
feat(data-apps): reject moving vizs into spaces

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -827,3 +827,53 @@ describe('AppGenerateService data app vizs', () => {
         expect(res.versions[1].resources?.vizSchema ?? null).toBeNull();
     });
 });
+
+describe('moving a viz into a space', () => {
+    it('rejects moveToSpace for viz-template apps before any access checks', async () => {
+        const appModel = {
+            getApp: vi.fn().mockResolvedValue(makeDataAppVizRow()),
+            moveToSpace: vi.fn(),
+        };
+        const service = buildService(appModel);
+
+        await expect(
+            service.moveToSpace(USER, {
+                projectUuid: 'project-1',
+                itemUuid: 'data-app-viz-1',
+                targetSpaceUuid: 'space-1',
+            }),
+        ).rejects.toThrow('Custom chart types cannot be moved into spaces');
+        expect(appModel.moveToSpace).not.toHaveBeenCalled();
+    });
+
+    it('still moves standalone apps', async () => {
+        const appModel = {
+            getApp: vi.fn().mockResolvedValue(
+                makeDataAppVizRow({
+                    template: null,
+                    space_uuid: 'space-0',
+                }),
+            ),
+            moveToSpace: vi.fn().mockResolvedValue(undefined),
+        };
+        const service = buildService(appModel);
+
+        await service.moveToSpace(
+            USER,
+            {
+                projectUuid: 'project-1',
+                itemUuid: 'data-app-viz-1',
+                targetSpaceUuid: 'space-1',
+            },
+            { trackEvent: false },
+        );
+        expect(appModel.moveToSpace).toHaveBeenCalledWith(
+            {
+                appId: 'data-app-viz-1',
+                projectUuid: 'project-1',
+                targetSpaceUuid: 'space-1',
+            },
+            { tx: undefined },
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -8473,6 +8473,13 @@ export class AppGenerateService extends BaseService {
 
         const app = await this.appModel.getApp(appUuid, projectUuid);
 
+        // Vizs are project-global chart content — space semantics don't apply.
+        if (app.template === DATA_APP_VIZ_TEMPLATE) {
+            throw new ParameterError(
+                'Custom chart types cannot be moved into spaces',
+            );
+        }
+
         if (checkForAccess) {
             // Manage on the source app (where it currently lives) — space
             // editors/admins of the source space can move it out.


### PR DESCRIPTION
## Summary

Backend guard completing GLITCH-648: `AppGenerateService.moveToSpace` rejects viz-template apps (`Custom chart types cannot be moved into spaces`). Every move path funnels through this method — the direct endpoint, the favorite-modal move flow, and the content-API bulk/single move (`appMoveService` is `appGenerateService`) — so vizs stay spaceless by construction.

This also settles the ticket's open "what happens to pinned vizs" question structurally: a viz can never gain a space, so it can never be pinned and never appears in space or homepage surfaces. No existing rows to migrate (vizs are created spaceless and the feature is new).

## Testing

- `AppGenerateService.dataAppVizs` 30/30 (two new tests: viz rejected before access checks; standalone apps still move)
- Backend typecheck

Closes: GLITCH-648