### PR TITLE
fix(auth): re-check IdP email domain against per-org SSO whitelist at callback

### DIFF
--- a/packages/backend/src/controllers/authentication/strategies/azureStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/azureStrategy.ts
@@ -1,6 +1,10 @@
 /// <reference path="../../../@types/passport-openidconnect.d.ts" />
 /// <reference path="../../../@types/express-session.d.ts" />
-import { AzureAdSsoConfig, OpenIdIdentityIssuerType } from '@lightdash/common';
+import {
+    AzureAdSsoConfig,
+    OpenIdIdentityIssuerType,
+    OrganizationSsoProvider,
+} from '@lightdash/common';
 import {
     BaseClient,
     Issuer,
@@ -108,6 +112,7 @@ const azureAdPrivateKeyJksStrategy = async (): Promise<
  */
 export const createAzureAdOidcStrategyForConfig = (
     config: AzureAdSsoConfig,
+    organizationUuid?: string,
 ): OpenIDConnectStrategy =>
     new OpenIDConnectStrategy(
         {
@@ -123,7 +128,16 @@ export const createAzureAdOidcStrategyForConfig = (
             ).href,
             passReqToCallback: true,
         },
-        genericOidcHandler(OpenIdIdentityIssuerType.AZUREAD),
+        genericOidcHandler(
+            OpenIdIdentityIssuerType.AZUREAD,
+            undefined,
+            organizationUuid
+                ? {
+                      organizationUuid,
+                      provider: OrganizationSsoProvider.AZUREAD,
+                  }
+                : undefined,
+        ),
     );
 
 /**

--- a/packages/backend/src/controllers/authentication/strategies/oidcStrategy.test.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oidcStrategy.test.ts
@@ -1,19 +1,39 @@
-import { OpenIdIdentityIssuerType } from '@lightdash/common';
+import {
+    OpenIdIdentityIssuerType,
+    OrganizationSsoProvider,
+} from '@lightdash/common';
 import { Request } from 'express';
 import { Profile as PassportProfile } from 'passport';
 import { genericOidcHandler } from './oidcStrategy';
 
-const makeRequest = (loginWithOpenId = vi.fn()) =>
+const makeRequest = ({
+    loginWithOpenId = vi.fn(),
+    isEmailDomainAllowedForOrgSso = vi.fn().mockResolvedValue(true),
+}: {
+    loginWithOpenId?: ReturnType<typeof vi.fn>;
+    isEmailDomainAllowedForOrgSso?: ReturnType<typeof vi.fn>;
+} = {}) =>
     ({
         session: { oauth: {} },
+        user: undefined,
         services: {
             getUserService: () => ({
                 loginWithOpenId,
+            }),
+            getOrganizationSsoService: () => ({
+                isEmailDomainAllowedForOrgSso,
             }),
         },
         ip: '127.0.0.1',
         get: vi.fn(() => 'test-user-agent'),
     }) as unknown as Request;
+
+const verifiedProfile = (email: string): PassportProfile =>
+    ({
+        id: 'subject-1',
+        emails: [{ value: email }],
+        _json: { email_verified: true },
+    }) as unknown as PassportProfile;
 
 describe('genericOidcHandler', () => {
     test('rejects profiles with explicitly unverified email claims', async () => {
@@ -31,7 +51,7 @@ describe('genericOidcHandler', () => {
         } as unknown as PassportProfile;
 
         await handler(
-            makeRequest(loginWithOpenId),
+            makeRequest({ loginWithOpenId }),
             'https://issuer.example.com',
             profile,
             done,
@@ -41,6 +61,99 @@ describe('genericOidcHandler', () => {
         expect(done).toHaveBeenCalledWith(null, false, {
             message:
                 'Authentication failed: email is not verified in OpenID profile.',
+        });
+    });
+
+    describe('per-org SSO callback domain re-check', () => {
+        test('rejects an IdP identity whose email domain is outside the authorizing per-org method whitelist', async () => {
+            const loginWithOpenId = vi.fn();
+            // The authorizing org's method does not route this email's domain.
+            const isEmailDomainAllowedForOrgSso = vi
+                .fn()
+                .mockResolvedValue(false);
+            const done = vi.fn();
+            const handler = genericOidcHandler(
+                OpenIdIdentityIssuerType.GENERIC_OIDC,
+                'https://idp-a.example.com',
+                {
+                    organizationUuid: 'org-a-uuid',
+                    provider: OrganizationSsoProvider.GENERIC_OIDC,
+                },
+            );
+
+            await handler(
+                makeRequest({ loginWithOpenId, isEmailDomainAllowedForOrgSso }),
+                'https://idp-a.example.com',
+                verifiedProfile('user@domain-b.com'),
+                done,
+            );
+
+            expect(isEmailDomainAllowedForOrgSso).toHaveBeenCalledWith(
+                'user@domain-b.com',
+                'org-a-uuid',
+                OrganizationSsoProvider.GENERIC_OIDC,
+            );
+            expect(loginWithOpenId).not.toHaveBeenCalled();
+            expect(done).toHaveBeenCalledWith(
+                null,
+                false,
+                expect.objectContaining({ message: expect.any(String) }),
+            );
+        });
+
+        test('allows an IdP identity whose email domain is inside the authorizing per-org method whitelist', async () => {
+            const loginWithOpenId = vi.fn().mockResolvedValue({
+                userUuid: 'user-1',
+            });
+            const isEmailDomainAllowedForOrgSso = vi
+                .fn()
+                .mockResolvedValue(true);
+            const done = vi.fn();
+            const handler = genericOidcHandler(
+                OpenIdIdentityIssuerType.GENERIC_OIDC,
+                'https://acme-idp.example.com',
+                {
+                    organizationUuid: 'acme-org-uuid',
+                    provider: OrganizationSsoProvider.GENERIC_OIDC,
+                },
+            );
+
+            await handler(
+                makeRequest({ loginWithOpenId, isEmailDomainAllowedForOrgSso }),
+                'https://acme-idp.example.com',
+                verifiedProfile('user@acme.com'),
+                done,
+            );
+
+            expect(isEmailDomainAllowedForOrgSso).toHaveBeenCalledWith(
+                'user@acme.com',
+                'acme-org-uuid',
+                OrganizationSsoProvider.GENERIC_OIDC,
+            );
+            expect(loginWithOpenId).toHaveBeenCalledTimes(1);
+            expect(done).toHaveBeenCalledWith(null, { userUuid: 'user-1' });
+        });
+
+        test('does not re-check when no per-org context is present (env-based single-tenant strategy)', async () => {
+            const loginWithOpenId = vi.fn().mockResolvedValue({
+                userUuid: 'user-1',
+            });
+            const isEmailDomainAllowedForOrgSso = vi.fn();
+            const done = vi.fn();
+            const handler = genericOidcHandler(
+                OpenIdIdentityIssuerType.GENERIC_OIDC,
+                'https://issuer.example.com',
+            );
+
+            await handler(
+                makeRequest({ loginWithOpenId, isEmailDomainAllowedForOrgSso }),
+                'https://issuer.example.com',
+                verifiedProfile('anyone@anywhere.com'),
+                done,
+            );
+
+            expect(isEmailDomainAllowedForOrgSso).not.toHaveBeenCalled();
+            expect(loginWithOpenId).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/backend/src/controllers/authentication/strategies/oidcStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oidcStrategy.ts
@@ -6,6 +6,7 @@ import {
     LightdashError,
     OpenIdIdentityIssuerType,
     OpenIdUser,
+    OrganizationSsoProvider,
 } from '@lightdash/common';
 import {
     Issuer,
@@ -104,10 +105,22 @@ const createOpenIdUserFromProfile = (
     return openIdUser;
 };
 
+/**
+ * Identifies the per-org SSO method whose strategy authenticated a request, so
+ * the callback can confirm the IdP-asserted email domain is one that method is
+ * actually allowed to route. Absent for env-based single-tenant strategies,
+ * which are trusted instance-wide and carry no per-org whitelist.
+ */
+export type PerOrgSsoContext = {
+    organizationUuid: string;
+    provider: OrganizationSsoProvider;
+};
+
 export const genericOidcHandler =
     (
         issuerType: OpenIdUser['openId']['issuerType'],
         issuerOverride?: string,
+        perOrgSso?: PerOrgSsoContext,
     ): VerifyFunctionWithRequest =>
     async (req, issuer, profile, done) => {
         try {
@@ -122,6 +135,25 @@ export const genericOidcHandler =
             );
 
             if (openIdUser) {
+                if (perOrgSso) {
+                    const isAllowed = await req.services
+                        .getOrganizationSsoService()
+                        .isEmailDomainAllowedForOrgSso(
+                            openIdUser.openId.email,
+                            perOrgSso.organizationUuid,
+                            perOrgSso.provider,
+                        );
+                    if (!isAllowed) {
+                        Logger.error(
+                            `Authentication failed: OpenID email domain is not allowed for the authenticating SSO method (org ${perOrgSso.organizationUuid}, provider ${perOrgSso.provider}).`,
+                        );
+                        return done(null, false, {
+                            message:
+                                'Authentication failed: email domain is not allowed for this login method.',
+                        });
+                    }
+                }
+
                 const user = await req.services
                     .getUserService()
                     .loginWithOpenId(
@@ -218,6 +250,7 @@ export const createGenericOidcPassportStrategy = async () => {
  */
 export const createGenericOidcStrategyForConfig = async (
     config: GenericOidcSsoConfig,
+    organizationUuid?: string,
 ) => {
     const issuer = await Issuer.discover(config.metadataDocumentEndpoint);
 
@@ -242,6 +275,12 @@ export const createGenericOidcStrategyForConfig = async (
         genericOidcHandler(
             OpenIdIdentityIssuerType.GENERIC_OIDC,
             issuer.metadata.issuer,
+            organizationUuid
+                ? {
+                      organizationUuid,
+                      provider: OrganizationSsoProvider.GENERIC_OIDC,
+                  }
+                : undefined,
         ) as unknown as StrategyVerifyCallback<unknown>,
     );
 };

--- a/packages/backend/src/controllers/authentication/strategies/oktaStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oktaStrategy.ts
@@ -234,6 +234,32 @@ export class OpenIDClientOktaStrategy extends Strategy {
                 );
 
                 if (openIdUser) {
+                    // Per-org Okta: the strategy was selected from the login
+                    // hint's domain, so re-check the IdP-asserted email domain
+                    // is one this org's method is allowed to route before
+                    // trusting the identity.
+                    if (organizationUuid) {
+                        const isAllowed = await req.services
+                            .getOrganizationSsoService()
+                            .isEmailDomainAllowedForOrgSso(
+                                openIdUser.openId.email,
+                                organizationUuid,
+                                OrganizationSsoProvider.OKTA,
+                            );
+                        if (!isAllowed) {
+                            Logger.error(
+                                `Authentication failed: OpenID email domain is not allowed for the authenticating SSO method (org ${organizationUuid}, provider ${OrganizationSsoProvider.OKTA}).`,
+                            );
+                            return this.fail(
+                                {
+                                    message:
+                                        'Authentication failed: email domain is not allowed for this login method.',
+                                },
+                                401,
+                            );
+                        }
+                    }
+
                     const user = await req.services
                         .getUserService()
                         .loginWithOpenId(

--- a/packages/backend/src/controllers/authentication/strategies/oneLoginStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oneLoginStrategy.ts
@@ -1,6 +1,10 @@
 /// <reference path="../../../@types/passport-openidconnect.d.ts" />
 /// <reference path="../../../@types/express-session.d.ts" />
-import { OneLoginSsoConfig, OpenIdIdentityIssuerType } from '@lightdash/common';
+import {
+    OneLoginSsoConfig,
+    OpenIdIdentityIssuerType,
+    OrganizationSsoProvider,
+} from '@lightdash/common';
 import { Strategy as OpenIDConnectStrategy } from 'passport-openidconnect';
 import { URL } from 'url';
 import { lightdashConfig } from '../../../config/lightdashConfig';
@@ -13,6 +17,7 @@ import { genericOidcHandler } from './oidcStrategy';
  */
 export const createOneLoginStrategyForConfig = (
     config: OneLoginSsoConfig,
+    organizationUuid?: string,
 ): OpenIDConnectStrategy =>
     new OpenIDConnectStrategy(
         {
@@ -28,7 +33,16 @@ export const createOneLoginStrategyForConfig = (
             userInfoURL: new URL(`/oidc/2/me`, config.oauth2Issuer).href,
             passReqToCallback: true,
         },
-        genericOidcHandler(OpenIdIdentityIssuerType.ONELOGIN),
+        genericOidcHandler(
+            OpenIdIdentityIssuerType.ONELOGIN,
+            undefined,
+            organizationUuid
+                ? {
+                      organizationUuid,
+                      provider: OrganizationSsoProvider.ONELOGIN,
+                  }
+                : undefined,
+        ),
     );
 
 export const isOneLoginPassportStrategyAvailableToUse = !!(

--- a/packages/backend/src/controllers/authentication/strategies/ssoPerOrgCallback.integration.test.ts
+++ b/packages/backend/src/controllers/authentication/strategies/ssoPerOrgCallback.integration.test.ts
@@ -1,0 +1,221 @@
+import {
+    OpenIdIdentityIssuerType,
+    OrganizationSsoProvider,
+    SEED_ORG_1,
+    SEED_ORG_1_ADMIN,
+    SEED_ORG_2,
+} from '@lightdash/common';
+import { Request } from 'express';
+import { Profile as PassportProfile } from 'passport';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { OrganizationDomainVerificationsTableName } from '../../../database/entities/organizationDomainVerifications';
+import {
+    getTestContext,
+    IntegrationTestContext,
+} from '../../../vitest.setup.integration';
+import { genericOidcHandler, PerOrgSsoContext } from './oidcStrategy';
+
+// The org whose per-org SSO strategy authenticates the request ("attacker" org
+// in the finding's terms) and an unrelated org that owns a different domain.
+const ATTACKER_ORG = SEED_ORG_1.organization_uuid;
+const OTHER_ORG = SEED_ORG_2.organization_uuid;
+const ATTACKER_DOMAIN = 'attacker-corp.example';
+const OTHER_DOMAIN = 'other-corp.example';
+const ATTACKER_IDP_ISSUER = 'https://idp.attacker-corp.example';
+
+const attackerPerOrg: PerOrgSsoContext = {
+    organizationUuid: ATTACKER_ORG,
+    provider: OrganizationSsoProvider.GENERIC_OIDC,
+};
+
+const verifiedProfile = (email: string, subject: string): PassportProfile =>
+    ({
+        id: subject,
+        emails: [{ value: email }],
+        _json: { email_verified: true },
+    }) as unknown as PassportProfile;
+
+type HandlerOutcome = {
+    err: unknown;
+    user: Express.User | false | null | undefined;
+    info: { message?: string } | undefined;
+};
+
+let context: IntegrationTestContext;
+
+const runCallback = (
+    profile: PassportProfile,
+    perOrgSso: PerOrgSsoContext | undefined,
+): Promise<HandlerOutcome> =>
+    new Promise((resolve) => {
+        const req = {
+            session: { oauth: {} },
+            user: undefined,
+            services: context.app.getServiceRepository(),
+            ip: '127.0.0.1',
+            get: () => 'integration-test',
+        } as unknown as Request;
+        const handler = genericOidcHandler(
+            OpenIdIdentityIssuerType.GENERIC_OIDC,
+            ATTACKER_IDP_ISSUER,
+            perOrgSso,
+        );
+        handler(req, ATTACKER_IDP_ISSUER, profile, (err, user, info) =>
+            resolve({ err, user, info } as HandlerOutcome),
+        );
+    });
+
+// Emails provisioned by the "allowed" cases — cleaned up so re-runs stay green.
+const provisionedEmails = new Set<string>();
+
+const deleteUserByEmail = async (email: string) => {
+    const user = await context.app
+        .getModels()
+        .getUserModel()
+        .findUserByEmail(email);
+    if (user) {
+        await context.db('users').where('user_uuid', user.userUuid).delete();
+    }
+};
+
+describe('per-org SSO callback — email-domain re-check (integration)', () => {
+    beforeAll(async () => {
+        context = getTestContext();
+
+        // Self-clean any test users left by a prior run (e.g. a red-on-old run
+        // where the guard was disabled and provisioned the out-of-scope user),
+        // so the suite is idempotent regardless of prior DB state.
+        await Promise.all(
+            [
+                `newcomer@${OTHER_DOMAIN}`,
+                `employee@${ATTACKER_DOMAIN}`,
+                `env-user@${OTHER_DOMAIN}`,
+            ].map((email) => deleteUserByEmail(email)),
+        );
+
+        await context
+            .db(OrganizationDomainVerificationsTableName)
+            .insert([
+                {
+                    organization_uuid: ATTACKER_ORG,
+                    domain: ATTACKER_DOMAIN,
+                    verified_at: new Date(),
+                },
+                {
+                    organization_uuid: OTHER_ORG,
+                    domain: OTHER_DOMAIN,
+                    verified_at: new Date(),
+                },
+            ])
+            .onConflict(['organization_uuid', 'domain'])
+            .merge({ verified_at: new Date() });
+
+        // Attacker org's enabled generic-OIDC method routes ALL of its verified
+        // domains (override=false), i.e. attacker-corp.example — and nothing of
+        // other-corp.example, which is verified for a different org.
+        await context.app
+            .getModels()
+            .getOrganizationSsoModel()
+            .upsert(
+                ATTACKER_ORG,
+                OrganizationSsoProvider.GENERIC_OIDC,
+                {
+                    clientId: 'attacker-client',
+                    clientSecret: 'attacker-secret',
+                    metadataDocumentEndpoint: `${ATTACKER_IDP_ISSUER}/.well-known/openid-configuration`,
+                    scopes: null,
+                },
+                {
+                    enabled: true,
+                    overrideEmailDomains: false,
+                    emailDomains: [],
+                    allowPassword: true,
+                },
+                SEED_ORG_1_ADMIN.user_uuid,
+            );
+    });
+
+    afterAll(async () => {
+        await Promise.all([...provisionedEmails].map(deleteUserByEmail));
+        await context
+            .db('organization_sso_configurations')
+            .where('organization_uuid', ATTACKER_ORG)
+            .where('provider', OrganizationSsoProvider.GENERIC_OIDC)
+            .delete();
+        await context
+            .db(OrganizationDomainVerificationsTableName)
+            .whereIn('domain', [ATTACKER_DOMAIN, OTHER_DOMAIN])
+            .delete();
+    });
+
+    test('routing rule: the attacker org method routes its own domain but not another org domain', async () => {
+        const ssoService = context.app
+            .getServiceRepository()
+            .getOrganizationSsoService();
+
+        await expect(
+            ssoService.isEmailDomainAllowedForOrgSso(
+                `person@${ATTACKER_DOMAIN}`,
+                ATTACKER_ORG,
+                OrganizationSsoProvider.GENERIC_OIDC,
+            ),
+        ).resolves.toBe(true);
+
+        await expect(
+            ssoService.isEmailDomainAllowedForOrgSso(
+                `person@${OTHER_DOMAIN}`,
+                ATTACKER_ORG,
+                OrganizationSsoProvider.GENERIC_OIDC,
+            ),
+        ).resolves.toBe(false);
+    });
+
+    test('callback REJECTS an IdP identity whose email domain is outside the authorizing org whitelist (no user provisioned)', async () => {
+        const outOfScopeEmail = `newcomer@${OTHER_DOMAIN}`;
+
+        const { err, user, info } = await runCallback(
+            verifiedProfile(outOfScopeEmail, 'attacker-supplied-subject-1'),
+            attackerPerOrg,
+        );
+
+        expect(err).toBeNull();
+        // Rejected: passport receives `false`, not a session user.
+        expect(user).toBeFalsy();
+        expect(info?.message).toBeTruthy();
+
+        // The real login path never ran, so no cross-domain user was created.
+        const provisioned = await context.app
+            .getModels()
+            .getUserModel()
+            .findUserByEmail(outOfScopeEmail);
+        expect(provisioned).toBeUndefined();
+    });
+
+    test('callback ALLOWS an IdP identity whose email domain is inside the authorizing org whitelist', async () => {
+        const inScopeEmail = `employee@${ATTACKER_DOMAIN}`;
+        provisionedEmails.add(inScopeEmail);
+
+        const { err, user } = await runCallback(
+            verifiedProfile(inScopeEmail, 'attacker-own-subject-1'),
+            attackerPerOrg,
+        );
+
+        expect(err).toBeNull();
+        // Allowed: the real login path ran and returned a session user.
+        expect(user).toBeTruthy();
+        expect((user as { email?: string }).email).toBe(inScopeEmail);
+    });
+
+    test('env-based single-tenant callback (no per-org context) still logs in regardless of domain', async () => {
+        const envEmail = `env-user@${OTHER_DOMAIN}`;
+        provisionedEmails.add(envEmail);
+
+        const { err, user } = await runCallback(
+            verifiedProfile(envEmail, 'env-subject-1'),
+            undefined,
+        );
+
+        expect(err).toBeNull();
+        expect(user).toBeTruthy();
+    });
+});

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -178,7 +178,10 @@ const registerAzureAdStrategyForOrg = (
     const strategyName = `azuread:${organizationUuid}`;
     const existing = azureAdStrategyCache.get(strategyName);
     // Always re-register so config changes (e.g. rotated secret) take effect.
-    passport.use(strategyName, createAzureAdOidcStrategyForConfig(config));
+    passport.use(
+        strategyName,
+        createAzureAdOidcStrategyForConfig(config, organizationUuid),
+    );
     if (existing) {
         clearTimeout(existing.timer);
     }
@@ -239,7 +242,7 @@ const registerGenericOidcStrategyForOrg = async (
     // Always re-register so config changes (e.g. rotated secret) take effect.
     passport.use(
         strategyName,
-        await createGenericOidcStrategyForConfig(config),
+        await createGenericOidcStrategyForConfig(config, organizationUuid),
     );
     if (existing) {
         clearTimeout(existing.timer);
@@ -296,7 +299,10 @@ const registerOneLoginStrategyForOrg = (
 ): string => {
     const strategyName = `oneLogin:${organizationUuid}`;
     const existing = oneLoginStrategyCache.get(strategyName);
-    passport.use(strategyName, createOneLoginStrategyForConfig(config));
+    passport.use(
+        strategyName,
+        createOneLoginStrategyForConfig(config, organizationUuid),
+    );
     if (existing) {
         clearTimeout(existing.timer);
     }

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.test.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.test.ts
@@ -457,6 +457,96 @@ describe('OrganizationSsoService', () => {
                 ),
             ).resolves.toBe(false);
         });
+
+        it('rejects an existing user who does not belong to the authorizing org', async () => {
+            const { service, organizationSsoModel, userModel } = buildService();
+            organizationSsoModel.findEnabledMethodsForEmailDomain.mockResolvedValue(
+                [
+                    enabledMethodForOrg(
+                        ORG_UUID,
+                        OrganizationSsoProvider.GENERIC_OIDC,
+                    ),
+                ],
+            );
+            userModel.findUserByEmail.mockResolvedValue({
+                userUuid: USER_UUID,
+            });
+            userModel.getOrganizationsForUser.mockResolvedValue([
+                { organizationUuid: OTHER_ORG_UUID },
+            ]);
+
+            await expect(
+                service.isEmailDomainAllowedForOrgSso(
+                    'user@acme.com',
+                    ORG_UUID,
+                    OrganizationSsoProvider.GENERIC_OIDC,
+                ),
+            ).resolves.toBe(false);
+        });
+
+        it('allows an existing user who belongs to the authorizing org', async () => {
+            const { service, organizationSsoModel, userModel } = buildService();
+            organizationSsoModel.findEnabledMethodsForEmailDomain.mockResolvedValue(
+                [
+                    enabledMethodForOrg(
+                        ORG_UUID,
+                        OrganizationSsoProvider.GENERIC_OIDC,
+                    ),
+                ],
+            );
+            userModel.findUserByEmail.mockResolvedValue({
+                userUuid: USER_UUID,
+            });
+            userModel.getOrganizationsForUser.mockResolvedValue([
+                { organizationUuid: ORG_UUID },
+            ]);
+
+            await expect(
+                service.isEmailDomainAllowedForOrgSso(
+                    'user@acme.com',
+                    ORG_UUID,
+                    OrganizationSsoProvider.GENERIC_OIDC,
+                ),
+            ).resolves.toBe(true);
+        });
+
+        it('allows each org when an existing user belongs to two orgs routing the same domain and provider', async () => {
+            const { service, organizationSsoModel, userModel } = buildService();
+            organizationSsoModel.findEnabledMethodsForEmailDomain.mockResolvedValue(
+                [
+                    enabledMethodForOrg(
+                        OTHER_ORG_UUID,
+                        OrganizationSsoProvider.GENERIC_OIDC,
+                    ),
+                    enabledMethodForOrg(
+                        ORG_UUID,
+                        OrganizationSsoProvider.GENERIC_OIDC,
+                    ),
+                ],
+            );
+            userModel.findUserByEmail.mockResolvedValue({
+                userUuid: USER_UUID,
+            });
+            userModel.getOrganizationsForUser.mockResolvedValue([
+                { organizationUuid: ORG_UUID },
+                { organizationUuid: OTHER_ORG_UUID },
+            ]);
+
+            await expect(
+                service.isEmailDomainAllowedForOrgSso(
+                    'user@acme.com',
+                    ORG_UUID,
+                    OrganizationSsoProvider.GENERIC_OIDC,
+                ),
+            ).resolves.toBe(true);
+            await expect(
+                service.isEmailDomainAllowedForOrgSso(
+                    'user@acme.com',
+                    OTHER_ORG_UUID,
+                    OrganizationSsoProvider.GENERIC_OIDC,
+                ),
+            ).resolves.toBe(true);
+        });
     });
 
     describe('findEnabledOktaMethodForIssuer', () => {

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.test.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.test.ts
@@ -348,6 +348,117 @@ describe('OrganizationSsoService', () => {
         });
     });
 
+    describe('isEmailDomainAllowedForOrgSso', () => {
+        it('returns false for an email without a domain', async () => {
+            const { service, organizationSsoModel } = buildService();
+
+            await expect(
+                service.isEmailDomainAllowedForOrgSso(
+                    'no-domain',
+                    ORG_UUID,
+                    OrganizationSsoProvider.GENERIC_OIDC,
+                ),
+            ).resolves.toBe(false);
+            expect(
+                organizationSsoModel.findEnabledMethodsForEmailDomain,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('lowercases the asserted domain before querying', async () => {
+            const { service, organizationSsoModel } = buildService();
+            organizationSsoModel.findEnabledMethodsForEmailDomain.mockResolvedValue(
+                [],
+            );
+
+            await service.isEmailDomainAllowedForOrgSso(
+                'User@ACME.com',
+                ORG_UUID,
+                OrganizationSsoProvider.GENERIC_OIDC,
+            );
+
+            expect(
+                organizationSsoModel.findEnabledMethodsForEmailDomain,
+            ).toHaveBeenCalledWith('acme.com');
+        });
+
+        it('allows an identity whose domain the authorizing org+provider routes', async () => {
+            const { service, organizationSsoModel } = buildService();
+            organizationSsoModel.findEnabledMethodsForEmailDomain.mockResolvedValue(
+                [
+                    enabledMethodForOrg(
+                        ORG_UUID,
+                        OrganizationSsoProvider.GENERIC_OIDC,
+                    ),
+                ],
+            );
+
+            await expect(
+                service.isEmailDomainAllowedForOrgSso(
+                    'user@acme.com',
+                    ORG_UUID,
+                    OrganizationSsoProvider.GENERIC_OIDC,
+                ),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects when the asserted domain routes only to a different org', async () => {
+            const { service, organizationSsoModel } = buildService();
+            // The asserted domain routes to a different org's method, not the
+            // org whose strategy authenticated the request.
+            organizationSsoModel.findEnabledMethodsForEmailDomain.mockResolvedValue(
+                [
+                    enabledMethodForOrg(
+                        OTHER_ORG_UUID,
+                        OrganizationSsoProvider.GENERIC_OIDC,
+                    ),
+                ],
+            );
+
+            await expect(
+                service.isEmailDomainAllowedForOrgSso(
+                    'user@domain-b.com',
+                    ORG_UUID,
+                    OrganizationSsoProvider.GENERIC_OIDC,
+                ),
+            ).resolves.toBe(false);
+        });
+
+        it('rejects when the org routes the domain but under a different provider', async () => {
+            const { service, organizationSsoModel } = buildService();
+            organizationSsoModel.findEnabledMethodsForEmailDomain.mockResolvedValue(
+                [
+                    enabledMethodForOrg(
+                        ORG_UUID,
+                        OrganizationSsoProvider.AZUREAD,
+                    ),
+                ],
+            );
+
+            await expect(
+                service.isEmailDomainAllowedForOrgSso(
+                    'user@acme.com',
+                    ORG_UUID,
+                    OrganizationSsoProvider.GENERIC_OIDC,
+                ),
+            ).resolves.toBe(false);
+        });
+
+        it('rejects when no enabled method routes the asserted domain', async () => {
+            const { service, organizationSsoModel } = buildService();
+            organizationSsoModel.findEnabledMethodsForEmailDomain.mockResolvedValue(
+                [],
+            );
+
+            await expect(
+                service.isEmailDomainAllowedForOrgSso(
+                    'user@acme.com',
+                    ORG_UUID,
+                    OrganizationSsoProvider.GENERIC_OIDC,
+                ),
+            ).resolves.toBe(false);
+        });
+    });
+
     describe('findEnabledOktaMethodForIssuer', () => {
         it('normalizes issuer lookup before querying the SSO model', async () => {
             const { service, organizationSsoModel } = buildService();

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
@@ -822,23 +822,19 @@ export class OrganizationSsoService extends BaseService {
     /**
      * Callback-time counterpart to {@link findEnabledMethodForEmail}. Given the
      * org + provider whose strategy authenticated the request, confirms the
-     * IdP-asserted email's domain is actually routed by that org's enabled
-     * method — i.e. the domain is verified for the org and (for override
-     * methods) in the method's subset. Strategy selection is gated on the
-     * user-supplied login hint, so this re-applies the same routing rule to the
-     * asserted identity to keep the two ends consistent.
+     * IdP-asserted email is actually routed to that org's enabled method.
+     * Strategy selection is gated on the user-supplied login hint, so this
+     * re-applies the routing rule to the asserted identity to keep the two ends
+     * consistent — including the existing-user org-membership filter in
+     * {@link findEnabledMethodsForEmail}, without which another org's IdP could
+     * assert an existing user's address and have it accepted.
      */
     async isEmailDomainAllowedForOrgSso(
         email: string,
         organizationUuid: string,
         provider: OrganizationSsoProvider,
     ): Promise<boolean> {
-        const domain = email.split('@')[1]?.toLowerCase();
-        if (!domain) return false;
-        const matches =
-            await this.organizationSsoModel.findEnabledMethodsForEmailDomain(
-                domain,
-            );
+        const matches = await this.findEnabledMethodsForEmail(email);
         return matches.some(
             (m) =>
                 m.organizationUuid === organizationUuid &&

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
@@ -819,6 +819,33 @@ export class OrganizationSsoService extends BaseService {
         );
     }
 
+    /**
+     * Callback-time counterpart to {@link findEnabledMethodForEmail}. Given the
+     * org + provider whose strategy authenticated the request, confirms the
+     * IdP-asserted email's domain is actually routed by that org's enabled
+     * method — i.e. the domain is verified for the org and (for override
+     * methods) in the method's subset. Strategy selection is gated on the
+     * user-supplied login hint, so this re-applies the same routing rule to the
+     * asserted identity to keep the two ends consistent.
+     */
+    async isEmailDomainAllowedForOrgSso(
+        email: string,
+        organizationUuid: string,
+        provider: OrganizationSsoProvider,
+    ): Promise<boolean> {
+        const domain = email.split('@')[1]?.toLowerCase();
+        if (!domain) return false;
+        const matches =
+            await this.organizationSsoModel.findEnabledMethodsForEmailDomain(
+                domain,
+            );
+        return matches.some(
+            (m) =>
+                m.organizationUuid === organizationUuid &&
+                m.provider === provider,
+        );
+    }
+
     async findEnabledOktaMethodForIssuer(
         issuer: string,
     ): Promise<

--- a/packages/backend/vitest.config.integration.ts
+++ b/packages/backend/vitest.config.integration.ts
@@ -5,7 +5,10 @@ import EvalHtmlReporter from './src/ee/services/ai/agents/tests/eval-reporter';
 export default defineConfig({
     test: {
         name: 'integration-tests',
-        include: ['src/ee/**/*integration.test.ts'],
+        include: [
+            'src/ee/**/*integration.test.ts',
+            'src/controllers/authentication/**/*integration.test.ts',
+        ],
         exclude: [
             'node_modules',
             'dist',


### PR DESCRIPTION
## What & why

Per-org SSO selects a passport strategy by matching the login hint's email domain against each organization's SSO method whitelist. The OAuth/OIDC callback, however, consumed the IdP-asserted identity without re-applying that domain check — the two ends of the flow were inconsistent.

This change re-validates at callback time that the asserted email's domain is one the authenticating organization's SSO method is actually allowed to route, reusing the exact same routing rule as strategy selection, and rejects identities that fall outside it.

## Scope

- New `OrganizationSsoService.isEmailDomainAllowedForOrgSso(email, organizationUuid, provider)` — the callback-time counterpart to `findEnabledMethodForEmail`.
- Threaded a per-org context through the generic OIDC, Azure AD, OneLogin, and Okta per-org strategy builders so the callback knows which org/provider authorized the request.
- Env-based single-tenant strategies are unaffected (no per-org whitelist applies).

## Tests

- Handler-level: rejects an out-of-whitelist identity, allows an in-whitelist identity, and skips the check for env-based strategies.
- Service-level: `isEmailDomainAllowedForOrgSso` covers domain normalization, org+provider matching, wrong-org and wrong-provider rejection, and no-match rejection.
- Backend typecheck, lint (touched paths), and modified-file test suites all pass.

Linear: SPK-942