### PR TITLE
test(release): pass a resolvable --last-tag in the synthetic-preview test

### DIFF
--- a/scripts/gen-release-safety-cli.test.ts
+++ b/scripts/gen-release-safety-cli.test.ts
@@ -128,6 +128,8 @@ try {
             'pr-99999',
             '--previous-version',
             '1.115.0',
+            '--last-tag',
+            'HEAD',
             '--out',
             previewMarkerPath,
             '--index',
@@ -136,6 +138,7 @@ try {
         { RELEASE_SAFETY_MARKER_ENABLED: 'true' },
     );
     assert.strictEqual(preview.status, 0, preview.stderr);
+    assert.doesNotMatch(preview.stderr, /\[release-safety\] FAILED/);
     assert.match(preview.stdout, new RegExp(`wrote ${previewMarkerPath}`));
     assert.doesNotMatch(preview.stdout, new RegExp(`wrote ${indexPath}`));
     assert.match(


### PR DESCRIPTION
## Problem

The synthetic-preview test case added to `scripts/gen-release-safety-cli.test.ts` in #27188 (SPK-941) passes deterministically **locally** but fails in the `Run scripts/*.test.ts` CI job — which the merge judged as install-weather. It is not weather.

The preview case spawns `gen-release-safety.ts --version pr-99999 --previous-version 1.115.0` **without** `--last-tag`. When `--previous-version` is present, the migrations diff runs as `git diff --name-status <ref>..HEAD` using the previous *version* as the ref. The `Run scripts/*.test.ts` job checks out shallowly with no tags, so `1.115.0` does not resolve → `fatal: bad revision '1.115.0..HEAD'`. gen-release-safety's top-level handler **swallows** the throw (exit 0, degraded `present: "unknown"` marker, no `wrote` line on stdout), so `assert.strictEqual(preview.status, 0)` passes but the `wrote`-line assertion fails. Locally the tag resolves, so it passes.

The real preview workflow never hits this — it always passes a resolvable `--last-tag <base_sha>`. The test just omitted it, exercising an invalid combination.

## Fix

Pass `--last-tag HEAD` in the preview test invocation (resolvable in any checkout, including the tagless CI one; `HEAD..HEAD` is an empty migrations diff), mirroring the real workflow. Plus a hardening assertion — `assert.doesNotMatch(preview.stderr, /\[release-safety\] FAILED/)` — so the swallowed-throw class is caught loudly rather than surfacing as a confusing `wrote`-line mismatch.

Verified: `gen-release-safety-cli` passes; full `npm run test:release-safety` green.

## Note (out of scope, filed separately)

Two latent behaviors this exposed, both pre-existing: (a) gen-release-safety's error handler swallows any generation failure and emits a degraded marker with exit 0 — a real git failure in the release/preview job would silently ship an "unknown" marker instead of failing; (b) the migrations diff degrades gracefully for an unresolvable `--last-tag` but throws for an unresolvable `--previous-version`. Filed as a follow-up finding; not changed here.

Linear: SPK-941
Part of #27140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ucPdRadzzrJHdW2LHRK4n