### PR TITLE
feat: add chart type gallery page listing data app visualizations

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -626,6 +626,16 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
         },
     },
     {
+        path: 'gallery',
+        lazy: async () => {
+            const ChartTypeGallery = await loadLazyRouteDefault(
+                './pages/ChartTypeGallery',
+                () => import('./pages/ChartTypeGallery'),
+            );
+            return { Component: ChartTypeGallery };
+        },
+    },
+    {
         path: 'apps/generate',
         handle: { hideAILauncher: true },
         lazy: async () => {

--- a/packages/frontend/src/features/apps/components/ChartTypeDeleteModal.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeDeleteModal.tsx
@@ -1,0 +1,56 @@
+import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
+import { type FC } from 'react';
+import MantineModal from '../../../components/common/MantineModal';
+import useApp from '../../../providers/App/useApp';
+import { useDeleteApp } from '../hooks/useDeleteApp';
+
+type Props = {
+    projectUuid: string;
+    dataAppViz: DataAppViz;
+    onClose: () => void;
+    onDeleted: () => void;
+};
+
+const ChartTypeDeleteModal: FC<Props> = ({
+    projectUuid,
+    dataAppViz,
+    onClose,
+    onDeleted,
+}) => {
+    const { health } = useApp();
+    const softDeleteEnabled = health.data?.softDelete.enabled;
+    const retentionDays = health.data?.softDelete.retentionDays;
+
+    const { mutateAsync: deleteApp, isLoading: isDeleting } = useDeleteApp();
+
+    const description = softDeleteEnabled
+        ? `This chart type will be moved to Recently deleted and permanently removed after ${retentionDays} days.`
+        : 'This chart type and all of its versions will be permanently deleted, including any built artifacts in storage.';
+
+    return (
+        <MantineModal
+            opened
+            onClose={onClose}
+            title="Delete chart type"
+            variant="delete"
+            resourceType="chart type"
+            resourceLabel={getAppDisplayName(
+                dataAppViz.name,
+                dataAppViz.dataAppVizUuid,
+            )}
+            description={description}
+            onConfirm={async () => {
+                await deleteApp({
+                    projectUuid,
+                    appUuid: dataAppViz.dataAppVizUuid,
+                    successTitle: 'Chart type deleted',
+                });
+                onDeleted();
+            }}
+            confirmLoading={isDeleting}
+            cancelDisabled={isDeleting}
+        />
+    );
+};
+
+export default ChartTypeDeleteModal;

--- a/packages/frontend/src/features/apps/components/ChartTypeDetailModal.module.css
+++ b/packages/frontend/src/features/apps/components/ChartTypeDetailModal.module.css
@@ -1,0 +1,14 @@
+.metaPanel {
+    padding: var(--mantine-spacing-md) var(--mantine-spacing-lg);
+    background: var(--mantine-color-ldGray-0);
+    border: 1px solid var(--mantine-color-ldGray-1);
+    border-radius: var(--mantine-radius-md);
+}
+
+.preview {
+    height: 280px;
+    background: light-dark(#fdfdfe, var(--mantine-color-ldDark-8));
+    border: 1px solid var(--mantine-color-ldGray-1);
+    border-radius: var(--mantine-radius-md);
+    overflow: hidden;
+}

--- a/packages/frontend/src/features/apps/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeDetailModal.tsx
@@ -1,0 +1,175 @@
+import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
+import { Box, Button, SimpleGrid, Stack, Text } from '@mantine/core';
+import { IconExternalLink, IconTrash } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link, useNavigate } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import { useAppVersionHistory } from '../hooks/useAppVersionHistory';
+import { useCanEditDataApp } from '../hooks/useCanEditDataApp';
+import classes from './ChartTypeDetailModal.module.css';
+import ChartTypeSamplePreview from './ChartTypeSamplePreview';
+
+type Props = {
+    projectUuid: string;
+    dataAppViz: DataAppViz;
+    onClose: () => void;
+    onDelete: () => void;
+};
+
+const ChartTypeDetailModal: FC<Props> = ({
+    projectUuid,
+    dataAppViz,
+    onClose,
+    onDelete,
+}) => {
+    const navigate = useNavigate();
+    const canEdit = useCanEditDataApp(projectUuid, dataAppViz);
+    const { latestReadyVersion, oldest, latest, hasOrigin } =
+        useAppVersionHistory(projectUuid, dataAppViz.dataAppVizUuid);
+
+    // Only attribute once v1 is loaded — the oldest loaded version is not the
+    // origin author while older pages are unfetched.
+    const builtBy =
+        hasOrigin && oldest?.createdByUser
+            ? `${oldest.createdByUser.firstName} ${oldest.createdByUser.lastName}`.trim()
+            : null;
+    const lastUpdatedAgo = useTimeAgo(
+        latest
+            ? (latest.statusUpdatedAt ?? latest.createdAt)
+            : dataAppViz.createdAt,
+    );
+
+    return (
+        <MantineModal
+            opened
+            onClose={onClose}
+            title={getAppDisplayName(
+                dataAppViz.name,
+                dataAppViz.dataAppVizUuid,
+            )}
+            // The default 80vh cap clips the meta panel.
+            bodyScrollAreaMaxHeight="calc(100vh - 200px)"
+            cancelLabel={false}
+            leftActions={
+                canEdit && (
+                    // The theme's subtle variant hardcodes gray text; c overrides it.
+                    <Button
+                        variant="subtle"
+                        size="xs"
+                        color="red"
+                        c="red.7"
+                        leftSection={<MantineIcon icon={IconTrash} />}
+                        onClick={onDelete}
+                    >
+                        Delete
+                    </Button>
+                )
+            }
+            actions={
+                <Button
+                    component={Link}
+                    to={`/projects/${projectUuid}/apps/${dataAppViz.dataAppVizUuid}`}
+                    variant="default"
+                    rightSection={<MantineIcon icon={IconExternalLink} />}
+                >
+                    Open in builder
+                </Button>
+            }
+            onConfirm={() =>
+                navigate(
+                    `/projects/${projectUuid}/tables?dataAppVizUuid=${dataAppViz.dataAppVizUuid}`,
+                )
+            }
+            confirmLabel="Preview in explorer"
+        >
+            <Stack gap="md">
+                <Box className={classes.preview}>
+                    <ChartTypeSamplePreview
+                        projectUuid={projectUuid}
+                        dataAppVizUuid={dataAppViz.dataAppVizUuid}
+                    />
+                </Box>
+                <Text fz="sm" c="ldGray.7" lh={1.55}>
+                    {dataAppViz.description ||
+                        'Custom chart type built with the app builder'}
+                </Text>
+                <SimpleGrid cols={2} className={classes.metaPanel}>
+                    {builtBy !== null && (
+                        <Box>
+                            <Text
+                                fz={11}
+                                fw={500}
+                                c="ldGray.6"
+                                tt="uppercase"
+                                lts="0.04em"
+                            >
+                                Built by
+                            </Text>
+                            <Text fz="sm" fw={500} c="ldGray.8">
+                                {builtBy}
+                            </Text>
+                        </Box>
+                    )}
+                    <Box>
+                        <Text
+                            fz={11}
+                            fw={500}
+                            c="ldGray.6"
+                            tt="uppercase"
+                            lts="0.04em"
+                        >
+                            Last updated
+                        </Text>
+                        <Text fz="sm" fw={500} c="ldGray.8">
+                            {lastUpdatedAgo}
+                        </Text>
+                    </Box>
+                    <Box>
+                        <Text
+                            fz={11}
+                            fw={500}
+                            c="ldGray.6"
+                            tt="uppercase"
+                            lts="0.04em"
+                        >
+                            Inputs
+                        </Text>
+                        <Text fz="sm" fw={500} c="ldGray.8">
+                            {dataAppViz.schema !== null
+                                ? dataAppViz.schema.fields
+                                      .map((field) => field.label)
+                                      .join(', ')
+                                : '—'}
+                        </Text>
+                    </Box>
+                    <Box>
+                        <Text
+                            fz={11}
+                            fw={500}
+                            c="ldGray.6"
+                            tt="uppercase"
+                            lts="0.04em"
+                        >
+                            Version
+                        </Text>
+                        <Text fz="sm" fw={500} c="ldGray.8">
+                            {latestReadyVersion !== null
+                                ? `v${latestReadyVersion}`
+                                : '—'}
+                        </Text>
+                    </Box>
+                </SimpleGrid>
+                {dataAppViz.schema === null && (
+                    <Text fz="sm" c="dimmed">
+                        No finished version yet. Open the builder to generate
+                        one.
+                    </Text>
+                )}
+            </Stack>
+        </MantineModal>
+    );
+};
+
+export default ChartTypeDetailModal;

--- a/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.module.css
+++ b/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.module.css
@@ -1,0 +1,38 @@
+/* No overflow clipping: the menu pill straddles the top edge like a
+   dashboard tile's; the preview clips its own corners instead. */
+.card {
+    position: relative;
+    padding: 0;
+    transition:
+        box-shadow 150ms ease-in-out,
+        transform 150ms ease-in-out;
+}
+
+/* Same placement as the dashboard tile menu pill (TileBase). Revealed on
+   hover, but also for keyboard focus or an open menu. */
+.menuHost {
+    position: absolute;
+    top: -6px;
+    right: -2px;
+    opacity: 0;
+    transition: opacity 150ms ease-in-out;
+}
+
+.card:hover .menuHost,
+.menuHost:focus-within,
+.menuHost:has([aria-expanded='true']) {
+    opacity: 1;
+}
+
+.card:hover {
+    box-shadow: var(--mantine-shadow-heavy);
+    transform: translateY(-2px);
+}
+
+.preview {
+    height: 160px;
+    background: light-dark(#fdfdfe, var(--mantine-color-ldDark-8));
+    border-bottom: 1px solid var(--mantine-color-ldGray-1);
+    border-radius: var(--mantine-radius-md) var(--mantine-radius-md) 0 0;
+    overflow: hidden;
+}

--- a/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.tsx
@@ -1,0 +1,119 @@
+import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
+import { ActionIcon, Box, Menu, Paper, Stack, Text } from '@mantine/core';
+import {
+    IconDots,
+    IconFilePencil,
+    IconTelescope,
+    IconTrash,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { PolymorphicPaperButton } from '../../../components/common/PolymorphicPaperButton';
+import { useCanEditDataApp } from '../hooks/useCanEditDataApp';
+import classes from './ChartTypeGalleryCard.module.css';
+import ChartTypeSamplePreview from './ChartTypeSamplePreview';
+
+type Props = {
+    dataAppViz: DataAppViz;
+    onClick: () => void;
+    onDelete: () => void;
+};
+
+const ChartTypeGalleryCard: FC<Props> = ({ dataAppViz, onClick, onDelete }) => {
+    const canEdit = useCanEditDataApp(dataAppViz.projectUuid, dataAppViz);
+    const displayName = getAppDisplayName(
+        dataAppViz.name,
+        dataAppViz.dataAppVizUuid,
+    );
+
+    return (
+        <PolymorphicPaperButton
+            component="div"
+            withBorder
+            radius="md"
+            shadow="subtle"
+            className={classes.card}
+            onClick={onClick}
+        >
+            <Box className={classes.preview}>
+                <ChartTypeSamplePreview
+                    projectUuid={dataAppViz.projectUuid}
+                    dataAppVizUuid={dataAppViz.dataAppVizUuid}
+                />
+            </Box>
+            <Stack gap="xs" p="md">
+                <Text fz="sm" fw={600} truncate="end">
+                    {displayName}
+                </Text>
+                <Text fz={13} c="ldGray.6" lh={1.45} lineClamp={2}>
+                    {dataAppViz.description ||
+                        'Custom chart type built with the app builder'}
+                </Text>
+            </Stack>
+            <Paper p={5} shadow="sm" className={classes.menuHost}>
+                <Menu
+                    withArrow
+                    withinPortal
+                    shadow="md"
+                    position="bottom-end"
+                    offset={4}
+                    arrowOffset={10}
+                >
+                    <Menu.Target>
+                        <ActionIcon
+                            size="sm"
+                            variant="subtle"
+                            color="gray"
+                            aria-label={`Actions for ${displayName}`}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <MantineIcon icon={IconDots} />
+                        </ActionIcon>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        {canEdit && (
+                            <Menu.Item
+                                component={Link}
+                                leftSection={
+                                    <MantineIcon icon={IconFilePencil} />
+                                }
+                                to={`/projects/${dataAppViz.projectUuid}/apps/${dataAppViz.dataAppVizUuid}`}
+                                onClick={(e) => e.stopPropagation()}
+                            >
+                                Edit
+                            </Menu.Item>
+                        )}
+                        <Menu.Item
+                            component={Link}
+                            leftSection={<MantineIcon icon={IconTelescope} />}
+                            to={`/projects/${dataAppViz.projectUuid}/tables?dataAppVizUuid=${dataAppViz.dataAppVizUuid}`}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            Preview in explorer
+                        </Menu.Item>
+                        {canEdit && (
+                            <>
+                                <Menu.Divider />
+                                <Menu.Item
+                                    color="red"
+                                    leftSection={
+                                        <MantineIcon icon={IconTrash} />
+                                    }
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onDelete();
+                                    }}
+                                >
+                                    Delete
+                                </Menu.Item>
+                            </>
+                        )}
+                    </Menu.Dropdown>
+                </Menu>
+            </Paper>
+        </PolymorphicPaperButton>
+    );
+};
+
+export default ChartTypeGalleryCard;

--- a/packages/frontend/src/features/apps/components/ChartTypeSamplePreview.module.css
+++ b/packages/frontend/src/features/apps/components/ChartTypeSamplePreview.module.css
@@ -1,0 +1,20 @@
+/* Clicks and hovers belong to whatever hosts the preview. */
+.root {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: hidden;
+}
+
+/* Absolutely positioned so the unscaled layout width doesn't feed back into
+   the host's own flex sizing and balloon it to the natural width. */
+.scaled {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: var(--preview-natural-width);
+    height: var(--preview-natural-height);
+    transform: scale(var(--preview-scale));
+    transform-origin: top left;
+}

--- a/packages/frontend/src/features/apps/components/ChartTypeSamplePreview.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeSamplePreview.tsx
@@ -1,0 +1,128 @@
+import { Box, Stack, Text } from '@mantine/core';
+import { IconPuzzle } from '@tabler/icons-react';
+import { useMemo, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useResolvedColorPalette } from '../../../hooks/appearance/useResolvedColorPalette';
+import { useResizeObserver } from '../../../hooks/useResizeObserver';
+import AppIframePreview from '../AppIframePreview';
+import {
+    useDataAppVizBundlePreflight,
+    useDataAppVizPreviewToken,
+    useDataAppVizRenderMetadata,
+} from '../hooks/useDataAppVizRender';
+import { usePreviewOrigin } from '../previewOrigin';
+import { buildSampleVizContext } from '../utils/sampleVizContext';
+import classes from './ChartTypeSamplePreview.module.css';
+
+const RENDER_TARGET = { isEmbedded: false, savedChartUuid: undefined };
+
+// Width the app is laid out at before being scaled down to fit the host box,
+// so the miniature keeps realistic proportions.
+const PREVIEW_NATURAL_WIDTH_PX = 800;
+
+const PreviewPlaceholder: FC<{ message: string }> = ({ message }) => (
+    <Stack align="center" justify="center" gap="xs" h="100%" w="100%">
+        <MantineIcon icon={IconPuzzle} size="xl" color="ldGray.5" />
+        <Text c="dimmed" size="xs" ta="center">
+            {message}
+        </Text>
+    </Stack>
+);
+
+type Props = {
+    projectUuid: string;
+    dataAppVizUuid: string;
+};
+
+/**
+ * Non-interactive render of a chart type's current version, fed sample data
+ * synthesized from its declared schema.
+ */
+const ChartTypeSamplePreview: FC<Props> = ({ projectUuid, dataAppVizUuid }) => {
+    const previewOrigin = usePreviewOrigin();
+    const { data: metadata, error: metadataError } =
+        useDataAppVizRenderMetadata(projectUuid, dataAppVizUuid, RENDER_TARGET);
+    const readyMetadata = metadata?.state === 'ready' ? metadata : undefined;
+    const { data: token } = useDataAppVizPreviewToken(
+        projectUuid,
+        dataAppVizUuid,
+        readyMetadata?.version,
+        RENDER_TARGET,
+    );
+
+    const previewBaseUrl =
+        readyMetadata && token
+            ? `${previewOrigin}/api/apps/${dataAppVizUuid}/versions/${readyMetadata.version}/t/${token}/`
+            : undefined;
+    const { data: bundleServable } =
+        useDataAppVizBundlePreflight(previewBaseUrl);
+
+    const colorPalette = useResolvedColorPalette(projectUuid);
+    const sampleContext = useMemo(
+        () =>
+            readyMetadata
+                ? buildSampleVizContext(readyMetadata.schema, colorPalette)
+                : undefined,
+        [readyMetadata, colorPalette],
+    );
+
+    // @mantine/hooks' useElementSize never observes an element mounted after
+    // the loading placeholders; the in-repo hook tracks ref attachment.
+    const [measureRef, { width, height }] = useResizeObserver<HTMLDivElement>();
+    const scale = width > 0 ? Math.min(1, width / PREVIEW_NATURAL_WIDTH_PX) : 0;
+
+    // Keep rendering cached metadata through transient refetch errors;
+    // only fall back when there is nothing to show.
+    if (!metadata) {
+        return metadataError ? (
+            <PreviewPlaceholder message="Preview unavailable" />
+        ) : (
+            <PreviewPlaceholder message="Loading preview…" />
+        );
+    }
+    if (metadata.state === 'building') {
+        return <PreviewPlaceholder message="Still generating…" />;
+    }
+    if (metadata.state === 'failed') {
+        return <PreviewPlaceholder message="No finished version yet" />;
+    }
+    if (!token || !previewBaseUrl || bundleServable === undefined) {
+        return <PreviewPlaceholder message="Loading preview…" />;
+    }
+    if (!bundleServable) {
+        return <PreviewPlaceholder message="Preview unavailable" />;
+    }
+
+    const previewUrl = `${previewBaseUrl}?r=0#transport=postMessage&projectUuid=${projectUuid}`;
+
+    return (
+        <Box ref={measureRef} className={classes.root}>
+            {scale > 0 && (
+                <Box
+                    className={classes.scaled}
+                    __vars={{
+                        '--preview-scale': String(scale),
+                        '--preview-natural-width': `${Math.round(
+                            width / scale,
+                        )}px`,
+                        '--preview-natural-height': `${Math.round(
+                            height / scale,
+                        )}px`,
+                    }}
+                >
+                    <AppIframePreview
+                        src={previewUrl}
+                        previewToken={token}
+                        expectedPreviewOrigin={previewOrigin}
+                        projectUuid={projectUuid}
+                        appUuid={dataAppVizUuid}
+                        identityKey={dataAppVizUuid}
+                        dataAppVizContext={sampleContext}
+                    />
+                </Box>
+            )}
+        </Box>
+    );
+};
+
+export default ChartTypeSamplePreview;

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
@@ -97,6 +97,32 @@ export const useDataAppVizRenderMetadata = (
                 : false,
     });
 
+/**
+ * Verifies the served bundle exists before an iframe is pointed at it — a
+ * ready version whose files are gone from storage would render the serving
+ * route's raw JSON error. On a cross-origin preview host the HEAD is rejected
+ * and we assume servable.
+ */
+export const useDataAppVizBundlePreflight = (
+    previewBaseUrl: string | undefined,
+) =>
+    useQuery<boolean>({
+        queryKey: ['data-app-viz-bundle-preflight', previewBaseUrl],
+        queryFn: async () => {
+            try {
+                const response = await fetch(previewBaseUrl!, {
+                    method: 'HEAD',
+                });
+                return response.ok;
+            } catch {
+                return true;
+            }
+        },
+        enabled: previewBaseUrl !== undefined,
+        // Existence can't flip for a given version+token URL.
+        staleTime: Infinity,
+    });
+
 export const useDataAppVizPreviewToken = (
     projectUuid: string | undefined,
     dataAppVizUuid: string | undefined,

--- a/packages/frontend/src/features/apps/hooks/useDeleteApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useDeleteApp.ts
@@ -6,6 +6,8 @@ import useToaster from '../../../hooks/toaster/useToaster';
 type DeleteAppParams = {
     projectUuid: string;
     appUuid: string;
+    // For surfaces that say "chart type" instead of "data app".
+    successTitle?: string;
 };
 
 const deleteApp = async ({
@@ -26,10 +28,20 @@ export const useDeleteApp = () => {
         onSuccess: (_data, variables) => {
             void queryClient.invalidateQueries({ queryKey: ['myApps'] });
             void queryClient.invalidateQueries({ queryKey: ['content'] });
+            void queryClient.invalidateQueries({ queryKey: ['data-app-vizs'] });
             void queryClient.invalidateQueries({
                 queryKey: ['app', variables.projectUuid, variables.appUuid],
             });
-            showToastSuccess({ title: 'Data app deleted' });
+            void queryClient.invalidateQueries({
+                queryKey: [
+                    'data-app-viz',
+                    variables.projectUuid,
+                    variables.appUuid,
+                ],
+            });
+            showToastSuccess({
+                title: variables.successTitle ?? 'Data app deleted',
+            });
         },
         onError: ({ error }) => {
             showToastApiError({

--- a/packages/frontend/src/features/apps/utils/sampleVizContext.test.ts
+++ b/packages/frontend/src/features/apps/utils/sampleVizContext.test.ts
@@ -1,0 +1,82 @@
+import { type DataAppVizSchema } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { buildSampleVizContext } from './sampleVizContext';
+
+const schema: DataAppVizSchema = {
+    fields: [
+        {
+            name: 'category',
+            label: 'Category',
+            type: 'dimension',
+            required: true,
+        },
+        { name: 'split', label: 'Split', type: 'series', required: false },
+        { name: 'value', label: 'Value', type: 'metric', required: true },
+    ],
+    configOptions: [
+        {
+            type: 'boolean',
+            name: 'showLegend',
+            label: 'Show legend',
+            default: true,
+        },
+    ],
+    colorPalette: null,
+};
+
+describe('buildSampleVizContext', () => {
+    it('maps every declared field, required or not', () => {
+        const context = buildSampleVizContext(schema);
+
+        expect(Object.keys(context.fieldMapping)).toEqual([
+            'category',
+            'split',
+            'value',
+        ]);
+    });
+
+    it('writes a cell for every mapped column in every row', () => {
+        const context = buildSampleVizContext(schema);
+
+        expect(context.rows.length).toBeGreaterThan(0);
+        for (const row of context.rows) {
+            for (const columnId of Object.values(context.fieldMapping)) {
+                expect(row[columnId].value.raw).toBeDefined();
+                expect(row[columnId].value.formatted).not.toBe('');
+            }
+        }
+    });
+
+    it('gives dimensions date raw values with display-formatted labels', () => {
+        const context = buildSampleVizContext(schema);
+        const columnId = context.fieldMapping.category;
+
+        for (const row of context.rows) {
+            const { raw, formatted } = row[columnId].value;
+            expect(Number.isNaN(Date.parse(String(raw)))).toBe(false);
+            expect(formatted).not.toBe(String(raw));
+        }
+    });
+
+    it('crosses categories with the series split', () => {
+        const withSeries = buildSampleVizContext(schema);
+        const withoutSeries = buildSampleVizContext({
+            ...schema,
+            fields: schema.fields.filter((f) => f.type !== 'series'),
+        });
+
+        expect(withSeries.rows.length).toBe(withoutSeries.rows.length * 3);
+    });
+
+    it('is deterministic', () => {
+        expect(buildSampleVizContext(schema)).toEqual(
+            buildSampleVizContext(schema),
+        );
+    });
+
+    it('resolves options to their declared defaults', () => {
+        const context = buildSampleVizContext(schema);
+
+        expect(context.options).toEqual({ showLegend: true });
+    });
+});

--- a/packages/frontend/src/features/apps/utils/sampleVizContext.ts
+++ b/packages/frontend/src/features/apps/utils/sampleVizContext.ts
@@ -1,0 +1,83 @@
+import {
+    ECHARTS_DEFAULT_COLORS,
+    getEffectiveOptionValues,
+    type DataAppVizContext,
+    type DataAppVizField,
+    type DataAppVizOptionValues,
+    type DataAppVizSchema,
+    type ResultRow,
+} from '@lightdash/common';
+
+// ISO raw values so vizzes that build a time axis can parse them.
+const SAMPLE_CATEGORIES = [
+    { raw: '2026-01-01', formatted: 'Jan 2026' },
+    { raw: '2026-02-01', formatted: 'Feb 2026' },
+    { raw: '2026-03-01', formatted: 'Mar 2026' },
+    { raw: '2026-04-01', formatted: 'Apr 2026' },
+    { raw: '2026-05-01', formatted: 'May 2026' },
+    { raw: '2026-06-01', formatted: 'Jun 2026' },
+];
+const SAMPLE_SERIES = ['Series A', 'Series B', 'Series C'];
+
+const sampleColumnId = (field: DataAppVizField): string =>
+    `sample_${field.name}`;
+
+/** Deterministic pseudo-random metric value. */
+const sampleMetricValue = (rowIndex: number, metricIndex: number): number =>
+    Math.round(
+        20 + 80 * Math.abs(Math.sin((rowIndex + 1) * 3.7 * (metricIndex + 1))),
+    );
+
+const cell = (
+    raw: string | number,
+    formatted: string = String(raw),
+): { value: { raw: unknown; formatted: string } } => ({
+    value: { raw, formatted },
+});
+
+/**
+ * Deterministic `DataAppVizContext` fabricated from a declared schema alone,
+ * so previews can render without real data.
+ */
+export const buildSampleVizContext = (
+    schema: DataAppVizSchema,
+    colorPalette: string[] = ECHARTS_DEFAULT_COLORS,
+    optionValues: DataAppVizOptionValues = {},
+): DataAppVizContext => {
+    const dimensions = schema.fields.filter((f) => f.type === 'dimension');
+    const series = schema.fields.filter((f) => f.type === 'series');
+    const metrics = schema.fields.filter((f) => f.type === 'metric');
+
+    const fieldMapping = Object.fromEntries(
+        schema.fields.map((field) => [field.name, sampleColumnId(field)]),
+    );
+
+    const seriesCount = series.length > 0 ? SAMPLE_SERIES.length : 1;
+    const rows: ResultRow[] = [];
+    for (let s = 0; s < seriesCount; s++) {
+        for (let c = 0; c < SAMPLE_CATEGORIES.length; c++) {
+            const row: ResultRow = {};
+            dimensions.forEach((field, d) => {
+                const month =
+                    SAMPLE_CATEGORIES[(c + d) % SAMPLE_CATEGORIES.length];
+                row[sampleColumnId(field)] = cell(month.raw, month.formatted);
+            });
+            series.forEach((field) => {
+                row[sampleColumnId(field)] = cell(SAMPLE_SERIES[s]);
+            });
+            metrics.forEach((field, m) => {
+                row[sampleColumnId(field)] = cell(
+                    sampleMetricValue(s * SAMPLE_CATEGORIES.length + c, m),
+                );
+            });
+            rows.push(row);
+        }
+    }
+
+    return {
+        fieldMapping,
+        rows,
+        options: getEffectiveOptionValues(schema.configOptions, optionValues),
+        colorPalette,
+    };
+};

--- a/packages/frontend/src/hooks/appearance/useResolvedColorPalette.ts
+++ b/packages/frontend/src/hooks/appearance/useResolvedColorPalette.ts
@@ -1,0 +1,29 @@
+import { ECHARTS_DEFAULT_COLORS } from '@lightdash/common';
+import { useComputedColorScheme } from '@mantine/core';
+import { useMemo } from 'react';
+import { useColorPalettes } from './useOrganizationAppearance';
+import { useProjectColorPalette } from './useProjectColorPalette';
+
+/**
+ * The explicitly chosen palette when one is given, otherwise the project's
+ * (dark-mode corrected), falling back to the ECharts defaults.
+ */
+export const useResolvedColorPalette = (
+    projectUuid: string | undefined,
+    colorPaletteUuid: string | null = null,
+): string[] => {
+    const colorScheme = useComputedColorScheme();
+    const { data: palettes = [] } = useColorPalettes();
+    const { data: projectPalette } = useProjectColorPalette(projectUuid);
+
+    return useMemo(() => {
+        const source =
+            palettes.find((p) => p.colorPaletteUuid === colorPaletteUuid) ??
+            projectPalette;
+        if (!source) return ECHARTS_DEFAULT_COLORS;
+        if (colorScheme === 'dark' && source.darkColors) {
+            return source.darkColors;
+        }
+        return source.colors;
+    }, [palettes, colorPaletteUuid, projectPalette, colorScheme]);
+};

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -1,0 +1,261 @@
+import { FeatureFlags, type DataAppViz } from '@lightdash/common';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAppVersionHistory } from '../features/apps/hooks/useAppVersionHistory';
+import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
+import { useDataAppVisualizations } from '../features/apps/hooks/useDataAppVisualizations';
+import { useDeleteApp } from '../features/apps/hooks/useDeleteApp';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import { renderWithProviders } from '../testing/testUtils';
+import ChartTypeGallery from './ChartTypeGallery';
+
+vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(),
+}));
+
+vi.mock('../features/apps/hooks/useDataAppVisualizations', () => ({
+    useDataAppVisualizations: vi.fn(),
+}));
+
+vi.mock('../features/apps/hooks/useAppVersionHistory', () => ({
+    useAppVersionHistory: vi.fn(),
+}));
+
+vi.mock('../features/apps/hooks/useCanEditDataApp', () => ({
+    useCanEditDataApp: vi.fn(),
+}));
+
+vi.mock('../features/apps/hooks/useDeleteApp', () => ({
+    useDeleteApp: vi.fn(),
+}));
+
+vi.mock('../features/apps/components/ChartTypeSamplePreview', () => ({
+    default: () => <div data-testid="sample-preview" />,
+}));
+
+const mockedUseDataAppVisualizations = vi.mocked(useDataAppVisualizations);
+
+const makeDataAppViz = (overrides: Partial<DataAppViz>): DataAppViz => ({
+    dataAppVizUuid: 'data-app-viz-1',
+    name: 'Radial gauge',
+    description: 'A gauge for KPI progress',
+    projectUuid: 'project-1',
+    spaceUuid: null,
+    schema: {
+        fields: [
+            { name: 'value', label: 'Value', type: 'metric', required: true },
+        ],
+        configOptions: [],
+        colorPalette: null,
+    },
+    createdAt: new Date('2026-06-30'),
+    createdByUserUuid: 'user-1',
+    ...overrides,
+});
+
+const setData = (data: DataAppViz[]) => {
+    mockedUseDataAppVisualizations.mockReturnValue({
+        data: {
+            pages: [
+                {
+                    data,
+                    pagination: {
+                        page: 1,
+                        pageSize: 25,
+                        totalPageCount: 1,
+                        totalResults: data.length,
+                    },
+                },
+            ],
+            pageParams: [1],
+        },
+        isInitialLoading: false,
+        isFetching: false,
+        error: null,
+        refetch: vi.fn(),
+        hasNextPage: false,
+        fetchNextPage: vi.fn(),
+        isFetchingNextPage: false,
+    } as unknown as ReturnType<typeof useDataAppVisualizations>);
+};
+
+const setFlag = (enabled: boolean) => {
+    vi.mocked(useServerFeatureFlag).mockReturnValue({
+        data: { id: FeatureFlags.EnableDataApps, enabled },
+        isLoading: false,
+    } as ReturnType<typeof useServerFeatureFlag>);
+};
+
+const renderPage = () =>
+    renderWithProviders(
+        <MemoryRouter initialEntries={['/projects/project-1/gallery']}>
+            <Routes>
+                <Route
+                    path="/projects/:projectUuid/gallery"
+                    element={<ChartTypeGallery />}
+                />
+                <Route
+                    path="/projects/:projectUuid/home"
+                    element={<div>home</div>}
+                />
+            </Routes>
+        </MemoryRouter>,
+    );
+
+const mockedDeleteApp = vi.fn();
+
+describe('ChartTypeGallery', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setFlag(true);
+        vi.mocked(useCanEditDataApp).mockReturnValue(true);
+        mockedDeleteApp.mockResolvedValue(undefined);
+        vi.mocked(useDeleteApp).mockReturnValue({
+            mutateAsync: mockedDeleteApp,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useDeleteApp>);
+        vi.mocked(useAppVersionHistory).mockReturnValue({
+            versions: [],
+            oldest: null,
+            latest: null,
+            latestReadyVersion: 3,
+            hasOrigin: false,
+            hasEarlier: false,
+            isLoading: false,
+            isError: false,
+            isFetchingEarlier: false,
+            fetchEarlier: vi.fn(),
+        });
+    });
+
+    it('lists the project chart types and opens the detail modal', () => {
+        setData([
+            makeDataAppViz({}),
+            makeDataAppViz({ dataAppVizUuid: 'viz-2', name: 'Bar race' }),
+        ]);
+        renderPage();
+
+        expect(screen.getByText('Bar race')).toBeInTheDocument();
+        expect(
+            screen.getByText(/built by your teams · 2 available/),
+        ).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+
+        expect(screen.getByText('Preview in explorer')).toBeInTheDocument();
+        expect(
+            screen.getByText('Open in builder').closest('a'),
+        ).toHaveAttribute('href', '/projects/project-1/apps/data-app-viz-1');
+        expect(screen.getByText('v3')).toBeInTheDocument();
+        expect(screen.getByText('Value')).toBeInTheDocument();
+    });
+
+    it('shows origin author and last update in the detail modal', () => {
+        const originVersion = {
+            version: 1,
+            createdAt: new Date('2026-07-01'),
+            statusUpdatedAt: new Date('2026-07-01'),
+            createdByUser: {
+                userUuid: 'user-1',
+                firstName: 'Ada',
+                lastName: 'Lovelace',
+            },
+        };
+        vi.mocked(useAppVersionHistory).mockReturnValue({
+            versions: [],
+            oldest: originVersion,
+            latest: originVersion,
+            latestReadyVersion: 1,
+            hasOrigin: true,
+            hasEarlier: false,
+            isLoading: false,
+            isError: false,
+            isFetchingEarlier: false,
+            fetchEarlier: vi.fn(),
+        } as unknown as ReturnType<typeof useAppVersionHistory>);
+        setData([makeDataAppViz({})]);
+        renderPage();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+
+        expect(screen.getByText('Built by')).toBeInTheDocument();
+        expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+        expect(screen.getByText('Last updated')).toBeInTheDocument();
+    });
+
+    it('links the card menu actions and deletes after confirmation', async () => {
+        setData([makeDataAppViz({})]);
+        renderPage();
+
+        fireEvent.click(screen.getByLabelText('Actions for Radial gauge'));
+
+        expect(screen.getByText('Edit').closest('a')).toHaveAttribute(
+            'href',
+            '/projects/project-1/apps/data-app-viz-1',
+        );
+        expect(
+            screen.getByText('Preview in explorer').closest('a'),
+        ).toHaveAttribute(
+            'href',
+            '/projects/project-1/tables?dataAppVizUuid=data-app-viz-1',
+        );
+
+        fireEvent.click(screen.getByText('Delete'));
+
+        expect(screen.getByText('Delete chart type')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+        await waitFor(() =>
+            expect(mockedDeleteApp).toHaveBeenCalledWith({
+                projectUuid: 'project-1',
+                appUuid: 'data-app-viz-1',
+                successTitle: 'Chart type deleted',
+            }),
+        );
+    });
+
+    it('opens the delete confirmation from the detail modal', () => {
+        setData([makeDataAppViz({})]);
+        renderPage();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+        fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+        expect(screen.getByText('Delete chart type')).toBeInTheDocument();
+    });
+
+    it('hides edit and delete actions from non-editors', () => {
+        vi.mocked(useCanEditDataApp).mockReturnValue(false);
+        setData([makeDataAppViz({})]);
+        renderPage();
+
+        fireEvent.click(screen.getByLabelText('Actions for Radial gauge'));
+
+        expect(screen.getByText('Preview in explorer')).toBeInTheDocument();
+        expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+        expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+
+        expect(
+            screen.queryByRole('button', { name: 'Delete' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows the empty state when the project has no chart types', () => {
+        setData([]);
+        renderPage();
+
+        expect(screen.getByText(/No chart types yet/)).toBeInTheDocument();
+    });
+
+    it('redirects home when data apps are disabled', () => {
+        setData([]);
+        setFlag(false);
+        renderPage();
+
+        expect(screen.getByText('home')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -1,0 +1,207 @@
+import { subject } from '@casl/ability';
+import { FeatureFlags, type DataAppViz } from '@lightdash/common';
+import {
+    Button,
+    Group,
+    Paper,
+    SimpleGrid,
+    Stack,
+    Text,
+    TextInput,
+    Tooltip,
+} from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { IconPlus, IconSearch } from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+import { Link, Navigate, useParams } from 'react-router';
+import EmptyStateLoader from '../components/common/EmptyStateLoader';
+import InlineErrorState from '../components/common/InlineErrorState';
+import MantineIcon from '../components/common/MantineIcon';
+import Page from '../components/common/Page/Page';
+import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
+import ChartTypeDeleteModal from '../features/apps/components/ChartTypeDeleteModal';
+import ChartTypeDetailModal from '../features/apps/components/ChartTypeDetailModal';
+import ChartTypeGalleryCard from '../features/apps/components/ChartTypeGalleryCard';
+import { useDataAppVisualizations } from '../features/apps/hooks/useDataAppVisualizations';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import { Can } from '../providers/Ability';
+import useApp from '../providers/App/useApp';
+
+const ChartTypeGallery = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { user } = useApp();
+    const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+
+    const [search, setSearch] = useState('');
+    const [debouncedSearch] = useDebouncedValue(search, 300);
+    const [selectedUuid, setSelectedUuid] = useState<string | null>(null);
+    const [deleteUuid, setDeleteUuid] = useState<string | null>(null);
+
+    const {
+        data,
+        isInitialLoading,
+        error,
+        refetch,
+        hasNextPage,
+        fetchNextPage,
+        isFetchingNextPage,
+    } = useDataAppVisualizations(projectUuid, debouncedSearch);
+
+    const dataAppVizs: DataAppViz[] = useMemo(
+        () => data?.pages.flatMap((page) => page.data) ?? [],
+        [data?.pages],
+    );
+    const selected = dataAppVizs.find(
+        (viz) => viz.dataAppVizUuid === selectedUuid,
+    );
+    const toDelete = dataAppVizs.find(
+        (viz) => viz.dataAppVizUuid === deleteUuid,
+    );
+    // Unfiltered total, so the count holds steady while a search narrows the grid.
+    const totalCount =
+        !debouncedSearch && data?.pages[0]?.pagination
+            ? data.pages[0].pagination.totalResults
+            : null;
+
+    if (!projectUuid) {
+        return null;
+    }
+
+    if (dataAppsFlag.isLoading) {
+        return null;
+    }
+
+    if (!dataAppsFlag.data?.enabled) {
+        return <Navigate to={`/projects/${projectUuid}/home`} replace />;
+    }
+
+    return (
+        <Page
+            title="Chart types"
+            withCenteredRoot
+            withCenteredContent
+            withXLargePaddedContent
+            withLargeContent
+        >
+            <Stack gap="xxl" w="100%">
+                <Group justify="space-between" align="flex-end">
+                    <Stack gap={4}>
+                        <PageBreadcrumbs
+                            items={[
+                                { title: 'Home', to: '/home' },
+                                { title: 'Chart types', active: true },
+                            ]}
+                        />
+                        <Text fz="sm" c="ldGray.6">
+                            Custom visualizations built by your teams
+                            {totalCount !== null
+                                ? ` · ${totalCount} available`
+                                : ''}
+                        </Text>
+                    </Stack>
+
+                    <Group gap="sm">
+                        <TextInput
+                            w={260}
+                            placeholder="Search chart types…"
+                            leftSection={<MantineIcon icon={IconSearch} />}
+                            value={search}
+                            onChange={(e) => setSearch(e.currentTarget.value)}
+                        />
+                        <Can
+                            I="create"
+                            this={subject('DataApp', {
+                                organizationUuid: user.data?.organizationUuid,
+                                projectUuid,
+                            })}
+                        >
+                            <Tooltip label="Chart types are built from a query: open a table in the explorer and pick “Custom” as the chart type">
+                                <Button
+                                    component={Link}
+                                    to={`/projects/${projectUuid}/tables`}
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconPlus}
+                                            size={18}
+                                        />
+                                    }
+                                >
+                                    New chart type
+                                </Button>
+                            </Tooltip>
+                        </Can>
+                    </Group>
+                </Group>
+
+                {isInitialLoading ? (
+                    <EmptyStateLoader title="Loading chart types…" />
+                ) : error ? (
+                    <InlineErrorState
+                        message="Failed to load chart types"
+                        onRetry={() => refetch()}
+                    />
+                ) : dataAppVizs.length === 0 ? (
+                    <Paper variant="dotted" p="xl">
+                        <Text ta="center" fz="sm" c="ldGray.6">
+                            {debouncedSearch
+                                ? `No chart types match “${debouncedSearch}”`
+                                : 'No chart types yet. Build one from a query in the explorer by picking “Custom” as the chart type.'}
+                        </Text>
+                    </Paper>
+                ) : (
+                    <>
+                        <SimpleGrid
+                            cols={{ base: 1, sm: 2, lg: 3 }}
+                            spacing="lg"
+                        >
+                            {dataAppVizs.map((viz) => (
+                                <ChartTypeGalleryCard
+                                    key={viz.dataAppVizUuid}
+                                    dataAppViz={viz}
+                                    onClick={() =>
+                                        setSelectedUuid(viz.dataAppVizUuid)
+                                    }
+                                    onDelete={() =>
+                                        setDeleteUuid(viz.dataAppVizUuid)
+                                    }
+                                />
+                            ))}
+                        </SimpleGrid>
+                        {hasNextPage && (
+                            <Button
+                                variant="default"
+                                loading={isFetchingNextPage}
+                                onClick={() => fetchNextPage()}
+                                mx="auto"
+                            >
+                                Load more
+                            </Button>
+                        )}
+                    </>
+                )}
+            </Stack>
+
+            {selected && (
+                <ChartTypeDetailModal
+                    projectUuid={projectUuid}
+                    dataAppViz={selected}
+                    onClose={() => setSelectedUuid(null)}
+                    onDelete={() => setDeleteUuid(selected.dataAppVizUuid)}
+                />
+            )}
+            {toDelete && (
+                <ChartTypeDeleteModal
+                    projectUuid={projectUuid}
+                    dataAppViz={toDelete}
+                    onClose={() => setDeleteUuid(null)}
+                    onDeleted={() => {
+                        setDeleteUuid(null);
+                        setSelectedUuid(null);
+                    }}
+                />
+            )}
+        </Page>
+    );
+};
+
+export default ChartTypeGallery;


### PR DESCRIPTION
Adds a gallery page at `/projects/:projectUuid/gallery` where you can browse every custom chart type in the project, without needing to know data apps exist.

- Grid of cards with a live miniature preview of each type, rendered from sample data synthesized from its declared schema, so no query is needed
- Detail modal with a larger preview, description, Built by / Last updated / Inputs / Version panel, and links into the builder and the explorer
- Hover menu on each card (Edit / Preview in explorer / Delete) following the dashboard tile pattern
- Delete flow with soft-delete aware copy
- Gated behind the data apps feature flag

<img width="2880" height="1432" alt="pr27197-card-menu" src="https://github.com/user-attachments/assets/9a7cbd18-ba93-4e82-b1b0-acacf2223e38" />
<img width="2880" height="1432" alt="pr27197-detail-modal" src="https://github.com/user-attachments/assets/3369bc5a-e36c-46b5-b29b-26df0d68d0be" />
<img width="2880" height="1432" alt="pr27197-gallery" src="https://github.com/user-attachments/assets/2a322b86-d37b-4f46-b13e-07bc4042c701" />


Closes: GLITCH-660