### PR TITLE
refactor: extract host-agnostic data app viz builder pieces

### DIFF
--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -112,6 +112,7 @@ export type DataAppTemplate = (typeof DATA_APP_TEMPLATES)[number];
 export const DATA_APP_CREATION_EXPERIENCES = [
     'app_builder',
     'explorer_chart_config',
+    'chart_type_builder',
 ] as const;
 export type DataAppCreationExperience =
     (typeof DATA_APP_CREATION_EXPERIENCES)[number];

--- a/packages/frontend/src/features/apps/builder/RestoreVersionModal.test.tsx
+++ b/packages/frontend/src/features/apps/builder/RestoreVersionModal.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { useRestoreAppVersion } from '../hooks/useRestoreAppVersion';
+import RestoreVersionModal from './RestoreVersionModal';
+
+vi.mock('../hooks/useRestoreAppVersion', () => ({
+    useRestoreAppVersion: vi.fn(),
+}));
+
+const mockedUseRestore = vi.mocked(useRestoreAppVersion);
+const restoreMutate = vi.fn();
+
+const setRestore = (overrides: { isLoading?: boolean; error?: unknown } = {}) =>
+    mockedUseRestore.mockReturnValue({
+        mutate: restoreMutate,
+        isLoading: overrides.isLoading ?? false,
+        error: overrides.error ?? null,
+        reset: vi.fn(),
+    } as unknown as ReturnType<typeof useRestoreAppVersion>);
+
+const renderModal = (onClose = vi.fn()) => {
+    renderWithProviders(
+        <RestoreVersionModal
+            projectUuid="project-1"
+            appUuid="app-1"
+            version={3}
+            onClose={onClose}
+        />,
+    );
+    return onClose;
+};
+
+describe('RestoreVersionModal', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setRestore();
+    });
+
+    it('warns about the consequence and restores on confirm', () => {
+        renderModal();
+
+        expect(
+            screen.getByText(
+                'All charts using this visualization will use the restored version. Selected fields unavailable in that version will be cleared.',
+            ),
+        ).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('Restore version'));
+
+        expect(restoreMutate).toHaveBeenCalledWith(
+            { projectUuid: 'project-1', appUuid: 'app-1', version: 3 },
+            expect.anything(),
+        );
+    });
+
+    it('closes once the restore succeeds', () => {
+        restoreMutate.mockImplementation((_args, opts) => opts?.onSuccess?.());
+        const onClose = renderModal();
+
+        fireEvent.click(screen.getByText('Restore version'));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('will not dismiss while the restore is in flight', () => {
+        setRestore({ isLoading: true });
+        const onClose = renderModal();
+
+        fireEvent.click(screen.getByText('Cancel'));
+
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('surfaces the failure without closing', () => {
+        setRestore({ error: { error: { message: 'Version is gone' } } });
+        const onClose = renderModal();
+
+        expect(screen.getByText('Version is gone')).toBeInTheDocument();
+        expect(onClose).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/features/apps/builder/RestoreVersionModal.tsx
+++ b/packages/frontend/src/features/apps/builder/RestoreVersionModal.tsx
@@ -1,0 +1,67 @@
+import { Stack, Text } from '@mantine/core';
+import { IconRestore } from '@tabler/icons-react';
+import { type FC } from 'react';
+import Callout from '../../../components/common/Callout';
+import MantineModal from '../../../components/common/MantineModal';
+import { useRestoreAppVersion } from '../hooks/useRestoreAppVersion';
+
+type Props = {
+    projectUuid: string;
+    appUuid: string;
+    version: number;
+    onClose: () => void;
+};
+
+/**
+ * Restoring puts the version's contents back on top of the timeline as a new
+ * version, so every chart using the visualization picks it up.
+ */
+const RestoreVersionModal: FC<Props> = ({
+    projectUuid,
+    appUuid,
+    version,
+    onClose,
+}) => {
+    const {
+        mutate: restoreVersion,
+        isLoading: isRestoring,
+        error: restoreError,
+    } = useRestoreAppVersion();
+
+    return (
+        <MantineModal
+            opened
+            onClose={() => {
+                if (isRestoring) return;
+                onClose();
+            }}
+            title={`Restore version ${version}?`}
+            icon={IconRestore}
+            confirmLabel="Restore version"
+            cancelDisabled={isRestoring}
+            confirmLoading={isRestoring}
+            onConfirm={() =>
+                restoreVersion(
+                    { projectUuid, appUuid, version },
+                    { onSuccess: onClose },
+                )
+            }
+        >
+            <Stack gap="sm">
+                <Text fz="sm">
+                    All charts using this visualization will use the restored
+                    version. Selected fields unavailable in that version will be
+                    cleared.
+                </Text>
+                {restoreError && (
+                    <Callout variant="danger">
+                        {restoreError.error?.message ??
+                            'Failed to restore version.'}
+                    </Callout>
+                )}
+            </Stack>
+        </MantineModal>
+    );
+};
+
+export default RestoreVersionModal;

--- a/packages/frontend/src/features/apps/builder/VersionProvenance.tsx
+++ b/packages/frontend/src/features/apps/builder/VersionProvenance.tsx
@@ -1,0 +1,30 @@
+import { Text, type TextProps } from '@mantine/core';
+import { type FC } from 'react';
+import { useTimeAgo } from '../../../hooks/useTimeAgo';
+
+type Props = {
+    authorName: string | null;
+    at: Date;
+    /** False while older versions are unloaded — the oldest we can see may not be v1. */
+    isOrigin: boolean;
+} & Pick<TextProps, 'className'>;
+
+/** Where a visualization came from: "Built by X · 3 days ago". */
+const VersionProvenance: FC<Props> = ({
+    authorName,
+    at,
+    isOrigin,
+    className,
+}) => {
+    const timeAgo = useTimeAgo(at);
+    const verb = isOrigin ? 'Built' : 'Last updated';
+    return (
+        <Text size="xs" c="dimmed" truncate="end" className={className}>
+            {authorName
+                ? `${verb} by ${authorName} · ${timeAgo}`
+                : `${verb} ${timeAgo}`}
+        </Text>
+    );
+};
+
+export default VersionProvenance;

--- a/packages/frontend/src/features/apps/components/AppPreview.tsx
+++ b/packages/frontend/src/features/apps/components/AppPreview.tsx
@@ -1,0 +1,136 @@
+import { type DataAppVizContext } from '@lightdash/common';
+import { Group, Loader, Text } from '@mantine/core';
+import { forwardRef } from 'react';
+import AppIframePreview, {
+    type AppIframePreviewHandle,
+} from '../AppIframePreview';
+import { getVisiblePreviewTokenError } from '../hooks/previewTokenQueryOptions';
+import { useAppPreviewToken } from '../hooks/useAppPreviewToken';
+import type {
+    ExternalRequestEvent,
+    QueryEvent,
+    SdkManifest,
+} from '../hooks/useAppSdkBridge';
+import { usePreviewOrigin } from '../previewOrigin';
+
+export type AppPreviewProps = {
+    projectUuid: string;
+    appUuid: string;
+    version: number;
+    /** Bumping this changes the iframe URL to force a reload: the new query
+     *  string defeats caching and flushes in-iframe state. */
+    refreshKey: number;
+    /** Send the iframe's metric queries with `invalidateCache` so the
+     *  warehouse results cache is bypassed. */
+    invalidateCache?: boolean;
+    onQueryEvent?: (event: QueryEvent) => void;
+    onExternalRequestEvent?: (event: ExternalRequestEvent) => void;
+    inspectorEnabled?: boolean;
+    onElementSelected?: (event: { label: string }) => void;
+    onInspectorAvailabilityChange?: (available: boolean) => void;
+    onScreenshotAvailabilityChange?: (available: boolean) => void;
+    onInspectorCancelled?: () => void;
+    lineageEnabled?: boolean;
+    onLineageAvailabilityChange?: (available: boolean) => void;
+    onLineageSelected?: (event: { queryUuid: string }) => void;
+    lineageHighlightQueryUuid?: string | null;
+    onLineageCancelled?: () => void;
+    dataAppVizContext?: DataAppVizContext;
+    onSdkManifest?: (manifest: SdkManifest) => void;
+};
+
+const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
+    (
+        {
+            projectUuid,
+            appUuid,
+            version,
+            refreshKey,
+            invalidateCache,
+            onQueryEvent,
+            onExternalRequestEvent,
+            inspectorEnabled,
+            onElementSelected,
+            onInspectorAvailabilityChange,
+            onScreenshotAvailabilityChange,
+            onInspectorCancelled,
+            lineageEnabled,
+            onLineageAvailabilityChange,
+            onLineageSelected,
+            lineageHighlightQueryUuid,
+            onLineageCancelled,
+            dataAppVizContext,
+            onSdkManifest,
+        },
+        ref,
+    ) => {
+        const {
+            data: token,
+            isLoading,
+            error,
+        } = useAppPreviewToken(projectUuid, appUuid, version);
+
+        const previewOrigin = usePreviewOrigin();
+        const previewUrl = token
+            ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/t/${token}/?r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
+            : undefined;
+        const visibleError = getVisiblePreviewTokenError(error, !!token);
+
+        if (isLoading) {
+            return (
+                <Group gap="sm" p="md" justify="center">
+                    <Loader size="sm" />
+                    <Text size="sm" c="dimmed">
+                        Loading preview...
+                    </Text>
+                </Group>
+            );
+        }
+
+        if (visibleError) {
+            return (
+                <Text c="red" p="md" size="sm">
+                    Failed to load preview:{' '}
+                    {visibleError instanceof Error
+                        ? visibleError.message
+                        : 'Unknown error'}
+                </Text>
+            );
+        }
+
+        if (!previewUrl || !token) return null;
+
+        return (
+            <AppIframePreview
+                ref={ref}
+                src={previewUrl}
+                previewToken={token}
+                expectedPreviewOrigin={previewOrigin}
+                projectUuid={projectUuid}
+                appUuid={appUuid}
+                identityKey={appUuid}
+                invalidateCache={invalidateCache}
+                onQueryEvent={onQueryEvent}
+                onExternalRequestEvent={onExternalRequestEvent}
+                inspectorEnabled={inspectorEnabled}
+                onElementSelected={onElementSelected}
+                onInspectorAvailabilityChange={onInspectorAvailabilityChange}
+                onScreenshotAvailabilityChange={onScreenshotAvailabilityChange}
+                onInspectorCancelled={onInspectorCancelled}
+                lineageEnabled={lineageEnabled}
+                onLineageAvailabilityChange={onLineageAvailabilityChange}
+                onLineageSelected={onLineageSelected}
+                lineageHighlightQueryUuid={lineageHighlightQueryUuid}
+                onLineageCancelled={onLineageCancelled}
+                capabilities={{ gsheetExport: true }}
+                dataAppVizContext={dataAppVizContext}
+                urlStateSync
+                onSdkManifest={onSdkManifest}
+            />
+        );
+    },
+);
+
+AppPreview.displayName = 'AppPreview';
+
+export default AppPreview;

--- a/packages/frontend/src/features/apps/components/DataAppVizDock.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizDock.tsx
@@ -9,7 +9,7 @@ import {
 } from '@tabler/icons-react';
 import { type FC, type ReactNode } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import VersionProvenance from '../builder/VersionProvenance';
 import { useAppBuildPoller } from '../hooks/useAppBuildPoller';
 import { useAppVersionHistory } from '../hooks/useAppVersionHistory';
 import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
@@ -18,29 +18,6 @@ import classes from './DataAppVizDock.module.css';
 import DataAppVizVersionLog from './DataAppVizVersionLog';
 
 const ignoreExternalBuildDone = () => undefined;
-
-const Provenance: FC<{
-    authorName: string | null;
-    at: Date;
-    /** False when older versions are still unloaded — then this is not the
-     *  origin, it is just the oldest we can see. */
-    isOrigin: boolean;
-}> = ({ authorName, at, isOrigin }) => {
-    const timeAgo = useTimeAgo(at);
-    const verb = isOrigin ? 'Built' : 'Last updated';
-    return (
-        <Text
-            size="xs"
-            c="dimmed"
-            truncate="end"
-            className={classes.provenance}
-        >
-            {authorName
-                ? `${verb} by ${authorName} · ${timeAgo}`
-                : `${verb} ${timeAgo}`}
-        </Text>
-    );
-};
 
 type Props = {
     projectUuid: string;
@@ -239,7 +216,8 @@ const DataAppVizDock: FC<Props> = ({
                         <>
                             {versionBadge}
                             {provenanceVersion ? (
-                                <Provenance
+                                <VersionProvenance
+                                    className={classes.provenance}
                                     authorName={getVersionAuthorName(
                                         provenanceVersion,
                                     )}

--- a/packages/frontend/src/features/apps/components/DataAppVizTestInputs.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizTestInputs.tsx
@@ -1,0 +1,81 @@
+import { getItemId, type DataAppVizSchema } from '@lightdash/common';
+import { Group, Select, Stack, Text } from '@mantine/core';
+import { type FC } from 'react';
+import FieldSelect from '../../../components/common/FieldSelect';
+import { type DataAppVizTestContextState } from '../hooks/useDataAppVizTestContext';
+import DataAppVizFieldTypeBadge from './DataAppVizFieldTypeBadge';
+
+type Props = {
+    schema: DataAppVizSchema;
+    state: DataAppVizTestContextState;
+};
+
+/** Explore picker + one field select per declared slot, feeding the test
+ *  context's mapping. */
+const DataAppVizTestInputs: FC<Props> = ({ schema, state }) => {
+    const {
+        exploreName,
+        exploreOptions,
+        handleExploreChange,
+        fieldMapping,
+        setField,
+        dimensions,
+        metrics,
+    } = state;
+
+    return (
+        <Stack gap="xs">
+            <Select
+                size="xs"
+                label="Test with data"
+                placeholder="Select an explore"
+                searchable
+                data={exploreOptions}
+                value={exploreName}
+                onChange={handleExploreChange}
+            />
+
+            <Stack gap="xs">
+                {schema.fields.map((field) => {
+                    const items =
+                        field.type === 'metric' ? metrics : dimensions;
+                    const selectedId = fieldMapping[field.name];
+                    const selectedItem = selectedId
+                        ? items.find((i) => getItemId(i) === selectedId)
+                        : undefined;
+                    return (
+                        <Stack key={field.name} gap={2}>
+                            <Group gap="xs">
+                                <Text size="xs" fw={500}>
+                                    {field.label}
+                                </Text>
+                                <DataAppVizFieldTypeBadge type={field.type} />
+                            </Group>
+                            {exploreName && (
+                                <FieldSelect
+                                    size="xs"
+                                    placeholder={`Select ${field.label.toLowerCase()}`}
+                                    disabled={items.length === 0}
+                                    item={selectedItem}
+                                    items={items}
+                                    onChange={(newField) =>
+                                        setField(
+                                            field.name,
+                                            newField
+                                                ? getItemId(newField)
+                                                : null,
+                                        )
+                                    }
+                                    clearable={!field.required}
+                                    hasGrouping
+                                />
+                            )}
+                        </Stack>
+                    );
+                })}
+            </Stack>
+        </Stack>
+    );
+};
+
+export default DataAppVizTestInputs;

--- a/packages/frontend/src/features/apps/components/DataAppVizTestPanel.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizTestPanel.tsx
@@ -1,41 +1,15 @@
 import {
-    ECHARTS_DEFAULT_COLORS,
-    getEffectiveOptionValues,
     getErrorMessage,
-    getItemId,
-    getItemMap,
-    isSummaryExploreError,
-    QueryExecutionContext,
     type DataAppVizContext,
-    type DataAppVizOptionValue,
-    type DataAppVizOptionValues,
     type DataAppVizSchema,
 } from '@lightdash/common';
-import {
-    Button,
-    Card,
-    Group,
-    Select,
-    Stack,
-    Text,
-    useComputedColorScheme,
-} from '@mantine/core';
-import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import { Button, Card, Group, Stack, Text } from '@mantine/core';
+import { type FC } from 'react';
 import Callout from '../../../components/common/Callout';
-import FieldSelect from '../../../components/common/FieldSelect';
 import { PalettePicker } from '../../../components/common/PalettePicker/PalettePicker';
 import DataAppVizOptionTabs from '../../../components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs';
-import { useColorPalettes } from '../../../hooks/appearance/useOrganizationAppearance';
-import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColorPalette';
-import { useExploreByProjectUuid } from '../../../hooks/useExplore';
-import { useExplores } from '../../../hooks/useExplores';
-import { type QueryResultsProps } from '../../../hooks/useQueryResults';
-import { useQueryExecutor } from '../../../providers/Explorer/useQueryExecutor';
-import { getDataAppVizFieldItems } from '../utils/getDataAppVizFieldItems';
-import DataAppVizFieldTypeBadge from './DataAppVizFieldTypeBadge';
-import { buildTestMetricQuery, isMappingComplete } from './dataAppVizTestQuery';
-
-type Run = { args: QueryResultsProps; mapping: Record<string, string> };
+import { useDataAppVizTestContext } from '../hooks/useDataAppVizTestContext';
+import DataAppVizTestInputs from './DataAppVizTestInputs';
 
 type Props = {
     projectUuid: string;
@@ -52,202 +26,23 @@ const DataAppVizTestPanel: FC<Props> = ({
     schema,
     onContextChange,
 }) => {
-    const [exploreName, setExploreName] = useState<string | null>(null);
-    const [fieldMapping, setFieldMapping] = useState<Record<string, string>>(
-        {},
-    );
-    // Only what the user explicitly changed; defaults resolve at push time.
-    const [optionValues, setOptionValues] = useState<DataAppVizOptionValues>(
-        {},
-    );
-    // Palette chosen here only for the preview — nothing is saved until the
-    // viz is used on a chart, which then owns the palette the normal way.
-    const [colorPaletteUuid, setColorPaletteUuid] = useState<string | null>(
-        null,
-    );
-    // Snapshot of the query + mapping captured when the user clicks Run. Gates
-    // the query so nothing fires while the user is still picking fields.
-    const [run, setRun] = useState<Run | null>(null);
-
-    const explores = useExplores(projectUuid, true);
-    const explore = useExploreByProjectUuid(
-        exploreName ?? undefined,
+    const state = useDataAppVizTestContext({
         projectUuid,
-    );
-
-    const itemsMap = useMemo(
-        () => (explore.data ? getItemMap(explore.data) : {}),
-        [explore.data],
-    );
-    const { dimensions, metrics } = useMemo(
-        () => getDataAppVizFieldItems(itemsMap),
-        [itemsMap],
-    );
-
-    const [{ query, queryResults }] = useQueryExecutor(
-        run?.args ?? null,
-        [],
-        Boolean(run),
-    );
-
-    const effectiveOptions = useMemo(
-        () => getEffectiveOptionValues(schema.configOptions, optionValues),
-        [schema.configOptions, optionValues],
-    );
-
-    const colorScheme = useComputedColorScheme();
-    const { data: palettes = [] } = useColorPalettes();
-    const { data: projectPalette } = useProjectColorPalette(projectUuid);
-    const selectedPalette = useMemo(
-        () => palettes.find((p) => p.colorPaletteUuid === colorPaletteUuid),
-        [palettes, colorPaletteUuid],
-    );
-    const colorPalette = useMemo(() => {
-        const source = selectedPalette ?? projectPalette;
-        if (!source) return ECHARTS_DEFAULT_COLORS;
-        if (colorScheme === 'dark' && source.darkColors) {
-            return source.darkColors;
-        }
-        return source.colors;
-    }, [selectedPalette, projectPalette, colorScheme]);
-
-    const rows = queryResults.rows;
-    // Notify the parent once the run's rows arrive (external async → parent),
-    // and again whenever an option changes so the preview re-renders live.
-    // Only push rows belonging to this run's query — on a re-run the executor
-    // transiently re-exposes the previous query's cached page before the new
-    // queryUuid lands.
-    const runQueryUuid = query.data?.queryUuid;
-    useEffect(() => {
-        if (
-            run &&
-            rows.length > 0 &&
-            runQueryUuid &&
-            queryResults.queryUuid === runQueryUuid
-        ) {
-            onContextChange({
-                fieldMapping: run.mapping,
-                rows,
-                options: effectiveOptions,
-                colorPalette,
-            });
-        }
-    }, [
-        rows,
-        run,
-        runQueryUuid,
-        queryResults.queryUuid,
-        effectiveOptions,
-        colorPalette,
+        schema,
         onContextChange,
-    ]);
-    // Clear the preview when this panel unmounts (e.g. a newer version lands).
-    useEffect(() => () => onContextChange(null), [onContextChange]);
-
-    const clearRun = () => {
-        setRun(null);
-        onContextChange(null);
-    };
-
-    const handleExploreChange = (value: string | null) => {
-        setExploreName(value);
-        setFieldMapping({});
-        clearRun();
-    };
-
-    const setField = (name: string, id: string | null) => {
-        setFieldMapping((prev) => {
-            const next = { ...prev };
-            if (id) next[name] = id;
-            else delete next[name];
-            return next;
-        });
-        clearRun();
-    };
-
-    const setOption = useCallback(
-        (name: string, value: DataAppVizOptionValue) => {
-            setOptionValues((prev) => ({ ...prev, [name]: value }));
-        },
-        [],
-    );
-
-    const handleRun = () => {
-        if (!exploreName || !isMappingComplete(schema, fieldMapping)) return;
-        setRun({
-            args: {
-                projectUuid,
-                tableId: exploreName,
-                query: buildTestMetricQuery(exploreName, schema, fieldMapping),
-                context: QueryExecutionContext.DATA_APP_SAMPLE,
-            },
-            mapping: fieldMapping,
-        });
-    };
-
-    const exploreOptions = (explores.data ?? [])
-        .filter((e) => !isSummaryExploreError(e))
-        .map((e) => ({ value: e.name, label: e.label }));
-
-    const complete =
-        Boolean(exploreName) && isMappingComplete(schema, fieldMapping);
-    const isRunning =
-        Boolean(run) && (query.isFetching || queryResults.isFetchingFirstPage);
-    const error = query.error ?? queryResults.error;
-
-    const generalContent = (
-        <Stack gap="xs">
-            <Select
-                size="xs"
-                label="Test with data"
-                placeholder="Select an explore"
-                searchable
-                data={exploreOptions}
-                value={exploreName}
-                onChange={handleExploreChange}
-            />
-
-            <Stack gap="xs">
-                {schema.fields.map((field) => {
-                    const items =
-                        field.type === 'metric' ? metrics : dimensions;
-                    const selectedId = fieldMapping[field.name];
-                    const selectedItem = selectedId
-                        ? items.find((i) => getItemId(i) === selectedId)
-                        : undefined;
-                    return (
-                        <Stack key={field.name} gap={2}>
-                            <Group gap="xs">
-                                <Text size="xs" fw={500}>
-                                    {field.label}
-                                </Text>
-                                <DataAppVizFieldTypeBadge type={field.type} />
-                            </Group>
-                            {exploreName && (
-                                <FieldSelect
-                                    size="xs"
-                                    placeholder={`Select ${field.label.toLowerCase()}`}
-                                    disabled={items.length === 0}
-                                    item={selectedItem}
-                                    items={items}
-                                    onChange={(newField) =>
-                                        setField(
-                                            field.name,
-                                            newField
-                                                ? getItemId(newField)
-                                                : null,
-                                        )
-                                    }
-                                    clearable={!field.required}
-                                    hasGrouping
-                                />
-                            )}
-                        </Stack>
-                    );
-                })}
-            </Stack>
-        </Stack>
-    );
+    });
+    const {
+        exploreName,
+        effectiveOptions,
+        setOption,
+        colorPaletteUuid,
+        setColorPaletteUuid,
+        palettes,
+        handleRun,
+        complete,
+        isRunning,
+        error,
+    } = state;
 
     return (
         <Card withBorder radius="md" p="sm">
@@ -257,7 +52,9 @@ const DataAppVizTestPanel: FC<Props> = ({
                 </Text>
 
                 <DataAppVizOptionTabs
-                    generalContent={generalContent}
+                    generalContent={
+                        <DataAppVizTestInputs schema={schema} state={state} />
+                    }
                     configOptions={schema.configOptions}
                     values={effectiveOptions}
                     onChange={setOption}
@@ -274,7 +71,7 @@ const DataAppVizTestPanel: FC<Props> = ({
                     }
                 />
 
-                {error && (
+                {error != null && (
                     <Callout variant="danger">{getErrorMessage(error)}</Callout>
                 )}
 

--- a/packages/frontend/src/features/apps/components/DataAppVizVersionLog.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizVersionLog.tsx
@@ -3,15 +3,13 @@ import {
     type ApiAppVersionSummary,
 } from '@lightdash/common';
 import { Anchor, Badge, Group, Loader, Stack, Text } from '@mantine/core';
-import { IconAlertTriangle, IconCheck, IconRestore } from '@tabler/icons-react';
+import { IconAlertTriangle, IconCheck } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
-import Callout from '../../../components/common/Callout';
 import MantineIcon from '../../../components/common/MantineIcon';
-import MantineModal from '../../../components/common/MantineModal';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import RestoreVersionModal from '../builder/RestoreVersionModal';
 import { useAppVersionHistory } from '../hooks/useAppVersionHistory';
 import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
-import { useRestoreAppVersion } from '../hooks/useRestoreAppVersion';
 import { type ChatMessage } from '../utils/chatMessage';
 import { formatBuildDuration } from '../utils/formatBuildDuration';
 import { versionsToChatMessages } from '../utils/versionsToChatMessages';
@@ -262,12 +260,6 @@ const DataAppVizVersionLog: FC<Props> = ({
     } = useAppVersionHistory(projectUuid, dataAppVizUuid);
     // Which version the user is about to restore; null while nothing is asked.
     const [restoreTarget, setRestoreTarget] = useState<number | null>(null);
-    const {
-        mutate: restoreVersion,
-        isLoading: isRestoring,
-        error: restoreError,
-        reset: resetRestore,
-    } = useRestoreAppVersion();
 
     const entries = useMemo<LogEntry[]>(
         () =>
@@ -360,43 +352,12 @@ const DataAppVizVersionLog: FC<Props> = ({
             </Stack>
 
             {restoreTarget !== null && dataAppVizUuid && (
-                <MantineModal
-                    opened
-                    onClose={() => {
-                        if (isRestoring) return;
-                        setRestoreTarget(null);
-                        resetRestore();
-                    }}
-                    title={`Restore version ${restoreTarget}?`}
-                    icon={IconRestore}
-                    confirmLabel="Restore version"
-                    cancelDisabled={isRestoring}
-                    confirmLoading={isRestoring}
-                    onConfirm={() =>
-                        restoreVersion(
-                            {
-                                projectUuid,
-                                appUuid: dataAppVizUuid,
-                                version: restoreTarget,
-                            },
-                            { onSuccess: () => setRestoreTarget(null) },
-                        )
-                    }
-                >
-                    <Stack gap="sm">
-                        <Text fz="sm">
-                            All charts using this visualization will use the
-                            restored version. Selected fields unavailable in
-                            that version will be cleared.
-                        </Text>
-                        {restoreError && (
-                            <Callout variant="danger">
-                                {restoreError.error?.message ??
-                                    'Failed to restore version.'}
-                            </Callout>
-                        )}
-                    </Stack>
-                </MantineModal>
+                <RestoreVersionModal
+                    projectUuid={projectUuid}
+                    appUuid={dataAppVizUuid}
+                    version={restoreTarget}
+                    onClose={() => setRestoreTarget(null)}
+                />
             )}
         </>
     );

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizTestContext.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizTestContext.ts
@@ -1,0 +1,235 @@
+import {
+    ECHARTS_DEFAULT_COLORS,
+    getEffectiveOptionValues,
+    getItemMap,
+    isSummaryExploreError,
+    QueryExecutionContext,
+    type DataAppVizContext,
+    type DataAppVizOptionValue,
+    type DataAppVizOptionValues,
+    type DataAppVizSchema,
+    type ItemsMap,
+    type OrganizationColorPaletteWithIsActive,
+} from '@lightdash/common';
+import { useComputedColorScheme } from '@mantine/core';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useColorPalettes } from '../../../hooks/appearance/useOrganizationAppearance';
+import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColorPalette';
+import { useExploreByProjectUuid } from '../../../hooks/useExplore';
+import { useExplores } from '../../../hooks/useExplores';
+import { type QueryResultsProps } from '../../../hooks/useQueryResults';
+import { useQueryExecutor } from '../../../providers/Explorer/useQueryExecutor';
+import {
+    buildTestMetricQuery,
+    isMappingComplete,
+} from '../components/dataAppVizTestQuery';
+import { getDataAppVizFieldItems } from '../utils/getDataAppVizFieldItems';
+
+type Run = { args: QueryResultsProps; mapping: Record<string, string> };
+
+type Args = {
+    projectUuid: string;
+    schema: DataAppVizSchema;
+    onContextChange: (ctx: DataAppVizContext | null) => void;
+};
+
+export type DataAppVizTestContextState = {
+    exploreName: string | null;
+    exploreOptions: { value: string; label: string }[];
+    handleExploreChange: (value: string | null) => void;
+    fieldMapping: Record<string, string>;
+    setField: (name: string, id: string | null) => void;
+    itemsMap: ItemsMap;
+    dimensions: ReturnType<typeof getDataAppVizFieldItems>['dimensions'];
+    metrics: ReturnType<typeof getDataAppVizFieldItems>['metrics'];
+    effectiveOptions: DataAppVizOptionValues;
+    setOption: (name: string, value: DataAppVizOptionValue) => void;
+    colorPaletteUuid: string | null;
+    setColorPaletteUuid: (uuid: string | null) => void;
+    palettes: OrganizationColorPaletteWithIsActive[];
+    handleRun: () => void;
+    /** Every required declared field is mapped and an explore is picked. */
+    complete: boolean;
+    isRunning: boolean;
+    error: unknown;
+};
+
+/**
+ * Stateful core of testing a data app viz with real data outside a chart:
+ * pick an explore, map the declared fields, run one sample query, and push
+ * the resulting `DataAppVizContext` up via `onContextChange`.
+ */
+export const useDataAppVizTestContext = ({
+    projectUuid,
+    schema,
+    onContextChange,
+}: Args): DataAppVizTestContextState => {
+    const [exploreName, setExploreName] = useState<string | null>(null);
+    const [fieldMapping, setFieldMapping] = useState<Record<string, string>>(
+        {},
+    );
+    // Only what the user explicitly changed; defaults resolve at push time.
+    const [optionValues, setOptionValues] = useState<DataAppVizOptionValues>(
+        {},
+    );
+    // Preview-only; a chart using the viz owns the palette the normal way.
+    const [colorPaletteUuid, setColorPaletteUuid] = useState<string | null>(
+        null,
+    );
+    // Snapshot captured on Run, so nothing fires while fields are still being picked.
+    const [run, setRun] = useState<Run | null>(null);
+
+    const explores = useExplores(projectUuid, true);
+    const explore = useExploreByProjectUuid(
+        exploreName ?? undefined,
+        projectUuid,
+    );
+
+    const itemsMap = useMemo(
+        () => (explore.data ? getItemMap(explore.data) : {}),
+        [explore.data],
+    );
+    const { dimensions, metrics } = useMemo(
+        () => getDataAppVizFieldItems(itemsMap),
+        [itemsMap],
+    );
+
+    const [{ query, queryResults }] = useQueryExecutor(
+        run?.args ?? null,
+        [],
+        Boolean(run),
+    );
+
+    const effectiveOptions = useMemo(
+        () => getEffectiveOptionValues(schema.configOptions, optionValues),
+        [schema.configOptions, optionValues],
+    );
+
+    const colorScheme = useComputedColorScheme();
+    const { data: palettes = [] } = useColorPalettes();
+    const { data: projectPalette } = useProjectColorPalette(projectUuid);
+    const selectedPalette = useMemo(
+        () => palettes.find((p) => p.colorPaletteUuid === colorPaletteUuid),
+        [palettes, colorPaletteUuid],
+    );
+    const colorPalette = useMemo(() => {
+        const source = selectedPalette ?? projectPalette;
+        if (!source) return ECHARTS_DEFAULT_COLORS;
+        if (colorScheme === 'dark' && source.darkColors) {
+            return source.darkColors;
+        }
+        return source.colors;
+    }, [selectedPalette, projectPalette, colorScheme]);
+
+    const rows = queryResults.rows;
+    // Only push rows belonging to this run's query — on a re-run the executor
+    // transiently re-exposes the previous query's cached page before the new
+    // queryUuid lands.
+    const runQueryUuid = query.data?.queryUuid;
+    useEffect(() => {
+        if (
+            run &&
+            rows.length > 0 &&
+            runQueryUuid &&
+            queryResults.queryUuid === runQueryUuid
+        ) {
+            onContextChange({
+                fieldMapping: run.mapping,
+                rows,
+                options: effectiveOptions,
+                colorPalette,
+            });
+        }
+    }, [
+        rows,
+        run,
+        runQueryUuid,
+        queryResults.queryUuid,
+        effectiveOptions,
+        colorPalette,
+        onContextChange,
+    ]);
+    // Clear the preview when the consumer unmounts.
+    useEffect(() => () => onContextChange(null), [onContextChange]);
+
+    const clearRun = useCallback(() => {
+        setRun(null);
+        onContextChange(null);
+    }, [onContextChange]);
+
+    const handleExploreChange = useCallback(
+        (value: string | null) => {
+            setExploreName(value);
+            setFieldMapping({});
+            clearRun();
+        },
+        [clearRun],
+    );
+
+    const setField = useCallback(
+        (name: string, id: string | null) => {
+            setFieldMapping((prev) => {
+                const next = { ...prev };
+                if (id) next[name] = id;
+                else delete next[name];
+                return next;
+            });
+            clearRun();
+        },
+        [clearRun],
+    );
+
+    const setOption = useCallback(
+        (name: string, value: DataAppVizOptionValue) => {
+            setOptionValues((prev) => ({ ...prev, [name]: value }));
+        },
+        [],
+    );
+
+    const handleRun = useCallback(() => {
+        if (!exploreName || !isMappingComplete(schema, fieldMapping)) return;
+        setRun({
+            args: {
+                projectUuid,
+                tableId: exploreName,
+                query: buildTestMetricQuery(exploreName, schema, fieldMapping),
+                context: QueryExecutionContext.DATA_APP_SAMPLE,
+            },
+            mapping: fieldMapping,
+        });
+    }, [exploreName, schema, fieldMapping, projectUuid]);
+
+    const exploreOptions = useMemo(
+        () =>
+            (explores.data ?? [])
+                .filter((e) => !isSummaryExploreError(e))
+                .map((e) => ({ value: e.name, label: e.label })),
+        [explores.data],
+    );
+
+    const complete =
+        Boolean(exploreName) && isMappingComplete(schema, fieldMapping);
+    const isRunning =
+        Boolean(run) && (query.isFetching || queryResults.isFetchingFirstPage);
+    const error = query.error ?? queryResults.error;
+
+    return {
+        exploreName,
+        exploreOptions,
+        handleExploreChange,
+        fieldMapping,
+        setField,
+        itemsMap,
+        dimensions,
+        metrics,
+        effectiveOptions,
+        setOption,
+        colorPaletteUuid,
+        setColorPaletteUuid,
+        palettes,
+        handleRun,
+        complete,
+        isRunning,
+        error,
+    };
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -54,7 +54,6 @@ import {
 } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
-    forwardRef,
     useCallback,
     useEffect,
     useMemo,
@@ -85,9 +84,7 @@ import { getChartIcon } from '../components/common/ResourceIcon/utils';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import { ReasoningHistoryRow } from '../ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard';
 import { useAiOrganizationSettings } from '../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
-import AppIframePreview, {
-    type AppIframePreviewHandle,
-} from '../features/apps/AppIframePreview';
+import { type AppIframePreviewHandle } from '../features/apps/AppIframePreview';
 import AppInspectorPanel from '../features/apps/AppInspectorPanel';
 import {
     AttachButton,
@@ -107,20 +104,14 @@ import ChatMessageContent from '../features/apps/ChatMessageContent';
 import AppBuilderSidebarToggle from '../features/apps/components/AppBuilderSidebarToggle';
 import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
+import AppPreview from '../features/apps/components/AppPreview';
 import DataAppVizResultCard from '../features/apps/components/DataAppVizResultCard';
 import DataAppVizTestPanel from '../features/apps/components/DataAppVizTestPanel';
 import LoadingDots from '../features/apps/components/LoadingDots';
 import RecentAppSuggestions from '../features/apps/components/RecentAppSuggestions';
-import { getVisiblePreviewTokenError } from '../features/apps/hooks/previewTokenQueryOptions';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppFileUpload } from '../features/apps/hooks/useAppFileUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
-import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
-import type {
-    ExternalRequestEvent,
-    QueryEvent,
-    SdkManifest,
-} from '../features/apps/hooks/useAppSdkBridge';
 import { useAppThumbnailUpload } from '../features/apps/hooks/useAppThumbnail';
 import { useBuildNotification } from '../features/apps/hooks/useBuildNotification';
 import { useCancelAppVersion } from '../features/apps/hooks/useCancelAppVersion';
@@ -135,7 +126,6 @@ import {
     useTrackedAppQueries,
 } from '../features/apps/hooks/useTrackedAppQueries';
 import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExternalRequests';
-import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import { getTemplate } from '../features/apps/templates';
 import {
     getAppFileValidationError,
@@ -199,129 +189,6 @@ const AppResourceImage: FC<{
     if (!data?.imageUrl) return null;
     return <Image src={data.imageUrl} className={className} alt="Attached" />;
 };
-
-type AppPreviewProps = {
-    projectUuid: string;
-    appUuid: string;
-    version: number;
-    /** Bumping this re-mounts the iframe URL to force a reload (and a
-     *  re-run of the app's metric queries). Same version → identical app
-     *  bundle, but the new query string defeats any caching and flushes
-     *  whatever in-iframe state was running. */
-    refreshKey: number;
-    /** When true, the iframe's metric queries are sent with `invalidateCache`
-     *  so the warehouse results cache is bypassed. Latched on by the preview
-     *  refresh button so a manual refresh always re-runs against the warehouse. */
-    invalidateCache?: boolean;
-    onQueryEvent?: (event: QueryEvent) => void;
-    onExternalRequestEvent?: (event: ExternalRequestEvent) => void;
-    inspectorEnabled?: boolean;
-    onElementSelected?: (event: { label: string }) => void;
-    onInspectorAvailabilityChange?: (available: boolean) => void;
-    onScreenshotAvailabilityChange?: (available: boolean) => void;
-    onInspectorCancelled?: () => void;
-    lineageEnabled?: boolean;
-    onLineageAvailabilityChange?: (available: boolean) => void;
-    onLineageSelected?: (event: { queryUuid: string }) => void;
-    lineageHighlightQueryUuid?: string | null;
-    onLineageCancelled?: () => void;
-    dataAppVizContext?: DataAppVizContext;
-    onSdkManifest?: (manifest: SdkManifest) => void;
-};
-
-const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
-    (
-        {
-            projectUuid,
-            appUuid,
-            version,
-            refreshKey,
-            invalidateCache,
-            onQueryEvent,
-            onExternalRequestEvent,
-            inspectorEnabled,
-            onElementSelected,
-            onInspectorAvailabilityChange,
-            onScreenshotAvailabilityChange,
-            onInspectorCancelled,
-            lineageEnabled,
-            onLineageAvailabilityChange,
-            onLineageSelected,
-            lineageHighlightQueryUuid,
-            onLineageCancelled,
-            dataAppVizContext,
-            onSdkManifest,
-        },
-        ref,
-    ) => {
-        const {
-            data: token,
-            isLoading,
-            error,
-        } = useAppPreviewToken(projectUuid, appUuid, version);
-
-        const previewOrigin = usePreviewOrigin();
-        const previewUrl = token
-            ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/t/${token}/?r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
-            : undefined;
-        const visibleError = getVisiblePreviewTokenError(error, !!token);
-
-        if (isLoading) {
-            return (
-                <Group gap="sm" p="md" justify="center">
-                    <Loader size="sm" />
-                    <Text size="sm" c="dimmed">
-                        Loading preview...
-                    </Text>
-                </Group>
-            );
-        }
-
-        if (visibleError) {
-            return (
-                <Text c="red" p="md" size="sm">
-                    Failed to load preview:{' '}
-                    {visibleError instanceof Error
-                        ? visibleError.message
-                        : 'Unknown error'}
-                </Text>
-            );
-        }
-
-        if (!previewUrl || !token) return null;
-
-        return (
-            <AppIframePreview
-                ref={ref}
-                src={previewUrl}
-                previewToken={token}
-                expectedPreviewOrigin={previewOrigin}
-                projectUuid={projectUuid}
-                appUuid={appUuid}
-                identityKey={appUuid}
-                invalidateCache={invalidateCache}
-                onQueryEvent={onQueryEvent}
-                onExternalRequestEvent={onExternalRequestEvent}
-                inspectorEnabled={inspectorEnabled}
-                onElementSelected={onElementSelected}
-                onInspectorAvailabilityChange={onInspectorAvailabilityChange}
-                onScreenshotAvailabilityChange={onScreenshotAvailabilityChange}
-                onInspectorCancelled={onInspectorCancelled}
-                lineageEnabled={lineageEnabled}
-                onLineageAvailabilityChange={onLineageAvailabilityChange}
-                onLineageSelected={onLineageSelected}
-                lineageHighlightQueryUuid={lineageHighlightQueryUuid}
-                onLineageCancelled={onLineageCancelled}
-                capabilities={{ gsheetExport: true }}
-                dataAppVizContext={dataAppVizContext}
-                urlStateSync
-                onSdkManifest={onSdkManifest}
-            />
-        );
-    },
-);
-
-AppPreview.displayName = 'AppPreview';
 
 const TemplateChip: FC<{ template: DataAppTemplate }> = ({ template }) => {
     const t = getTemplate(template);


### PR DESCRIPTION
Extracts the host-agnostic pieces of the data app viz authoring surface so the upcoming chart type builder page can reuse them: `AppPreview` lifted out of `AppGenerate`, `RestoreVersionModal` and `VersionProvenance` split into standalone components, and the test-context state machine pulled out of `DataAppVizTestPanel` into `useDataAppVizTestContext`. Also adds the `chart_type_builder` creation experience to the common union.

No behavior change.

Relates: GLITCH-661