### PR TITLE
feat: dedicated chart type builder page

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -636,6 +636,28 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
         },
     },
     {
+        path: 'chart-types/new',
+        handle: { hideAILauncher: true },
+        lazy: async () => {
+            const ChartTypeBuilder = await loadLazyRouteDefault(
+                './pages/ChartTypeBuilder',
+                () => import('./pages/ChartTypeBuilder'),
+            );
+            return { Component: ChartTypeBuilder };
+        },
+    },
+    {
+        path: 'chart-types/:dataAppVizUuid',
+        handle: { hideAILauncher: true },
+        lazy: async () => {
+            const ChartTypeBuilder = await loadLazyRouteDefault(
+                './pages/ChartTypeBuilder',
+                () => import('./pages/ChartTypeBuilder'),
+            );
+            return { Component: ChartTypeBuilder };
+        },
+    },
+    {
         path: 'apps/generate',
         handle: { hideAILauncher: true },
         lazy: async () => {

--- a/packages/frontend/src/features/apps/builder/BuilderCanvas.module.css
+++ b/packages/frontend/src/features/apps/builder/BuilderCanvas.module.css
@@ -1,0 +1,116 @@
+@keyframes ldPulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.45;
+    }
+}
+
+@keyframes ldBar {
+    0%,
+    100% {
+        transform: scaleY(0.5);
+        opacity: 0.55;
+    }
+    50% {
+        transform: scaleY(1);
+        opacity: 1;
+    }
+}
+
+.canvas {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 18px 80px 10px;
+}
+
+.previewCard {
+    width: 100%;
+    max-width: 960px;
+    height: 100%;
+    background: var(--mantine-color-background-0);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-lg);
+    box-shadow: var(--mantine-shadow-subtle);
+    overflow: hidden;
+    transition: opacity 300ms;
+
+    &[data-dimmed='true'] {
+        opacity: 0.35;
+    }
+}
+
+.overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 5;
+    pointer-events: none;
+}
+
+.buildingPill {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    font-size: var(--mantine-font-size-sm);
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-7);
+    background: var(--mantine-color-background-0);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 20px;
+    padding: 6px 8px 6px 18px;
+    box-shadow: var(--mantine-shadow-heavy);
+    animation: ldPulse 1.2s ease-in-out infinite;
+    pointer-events: auto;
+}
+
+.skeletonBars {
+    display: flex;
+    align-items: flex-end;
+    gap: 12px;
+    height: 150px;
+}
+
+.skeletonBar {
+    width: 34px;
+    border-radius: 6px;
+    background: light-dark(#e4e1f7, var(--mantine-color-ldDark-6));
+    transform-origin: bottom;
+    animation: ldBar 1.15s ease-in-out infinite;
+}
+
+.skeletonBar:nth-child(1) {
+    height: 62px;
+}
+.skeletonBar:nth-child(2) {
+    height: 104px;
+    animation-delay: 0.12s;
+}
+.skeletonBar:nth-child(3) {
+    height: 82px;
+    animation-delay: 0.24s;
+}
+.skeletonBar:nth-child(4) {
+    height: 136px;
+    animation-delay: 0.36s;
+}
+.skeletonBar:nth-child(5) {
+    height: 96px;
+    animation-delay: 0.48s;
+}
+.skeletonBar:nth-child(6) {
+    height: 118px;
+    animation-delay: 0.6s;
+}
+
+.buildingLabel {
+    animation: ldPulse 1.2s ease-in-out infinite;
+}

--- a/packages/frontend/src/features/apps/builder/BuilderCanvas.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderCanvas.tsx
@@ -1,0 +1,151 @@
+import { type DataAppVizContext } from '@lightdash/common';
+import { Anchor, Box, Stack, Text } from '@mantine/core';
+import { type FC } from 'react';
+import AppPreview from '../components/AppPreview';
+import classes from './BuilderCanvas.module.css';
+
+type Props = {
+    projectUuid: string;
+    /** Null while no app exists yet (create flow before the first build). */
+    appUuid: string | null;
+    /** The version the preview renders; null when nothing is renderable. */
+    previewVersion: number | null;
+    isBuilding: boolean;
+    /** Echoed under the first-build state. */
+    buildingPrompt: string | null;
+    elapsed: string | null;
+    onCancelBuild: (() => void) | null;
+    /** Why the latest build failed, when there is nothing renderable. */
+    failureMessage: string | null;
+    /** Sample data plus configuration from the drawer; null renders the app bare. */
+    previewContext: DataAppVizContext | null;
+};
+
+const CancelBuildLink: FC<{ onCancel: () => void }> = ({ onCancel }) => (
+    <Anchor
+        component="button"
+        type="button"
+        size="xs"
+        c="dimmed"
+        px="xs"
+        onClick={onCancel}
+    >
+        Cancel
+    </Anchor>
+);
+
+/**
+ * The center of the builder: empty, building, failure, and rendered states.
+ * A first build gets a full skeleton; a rebuild keeps the previous version
+ * dimmed underneath a pill.
+ */
+const BuilderCanvas: FC<Props> = ({
+    projectUuid,
+    appUuid,
+    previewVersion,
+    isBuilding,
+    buildingPrompt,
+    elapsed,
+    onCancelBuild,
+    failureMessage,
+    previewContext,
+}) => {
+    const hasPreview = appUuid !== null && previewVersion !== null;
+    const isFirstBuild = isBuilding && !hasPreview;
+
+    return (
+        <Box className={classes.canvas}>
+            {hasPreview ? (
+                <Box className={classes.previewCard} data-dimmed={isBuilding}>
+                    <AppPreview
+                        projectUuid={projectUuid}
+                        appUuid={appUuid}
+                        version={previewVersion}
+                        refreshKey={0}
+                        dataAppVizContext={previewContext ?? undefined}
+                    />
+                </Box>
+            ) : isFirstBuild ? (
+                <Stack gap={28} align="center">
+                    <Box className={classes.skeletonBars} aria-hidden>
+                        <Box className={classes.skeletonBar} />
+                        <Box className={classes.skeletonBar} />
+                        <Box className={classes.skeletonBar} />
+                        <Box className={classes.skeletonBar} />
+                        <Box className={classes.skeletonBar} />
+                        <Box className={classes.skeletonBar} />
+                    </Box>
+                    <Stack gap={7} align="center">
+                        <Text
+                            className={classes.buildingLabel}
+                            fz="sm"
+                            fw={600}
+                            c="ldBrandViolet.7"
+                        >
+                            Building your chart type…
+                        </Text>
+                        {buildingPrompt && (
+                            <Text
+                                fz={13}
+                                c="ldGray.6"
+                                maw={440}
+                                ta="center"
+                                lh={1.5}
+                            >
+                                “{buildingPrompt}”
+                            </Text>
+                        )}
+                        {(elapsed || onCancelBuild) && (
+                            <Text fz="xs" c="dimmed">
+                                {elapsed ?? ''}
+                                {elapsed && onCancelBuild ? ' · ' : ''}
+                                {onCancelBuild && (
+                                    <CancelBuildLink onCancel={onCancelBuild} />
+                                )}
+                            </Text>
+                        )}
+                    </Stack>
+                </Stack>
+            ) : failureMessage !== null ? (
+                <Stack gap="xs" align="center" maw={460}>
+                    <Text fz={17} fw={600} c="ldGray.8">
+                        The build failed
+                    </Text>
+                    <Text fz="sm" c="ldGray.6" ta="center" lh={1.6}>
+                        {failureMessage}
+                    </Text>
+                    <Text fz="sm" c="ldGray.6" ta="center">
+                        Ask for a change below to try again.
+                    </Text>
+                </Stack>
+            ) : (
+                <Stack gap={8} align="center" maw={420}>
+                    <Text fz={17} fw={600} c="ldGray.8">
+                        Start with a prompt
+                    </Text>
+                    <Text fz="sm" c="ldGray.6" ta="center" lh={1.6}>
+                        Describe the chart type you need, like “a stream graph
+                        of category share over time”, and the first version will
+                        be generated. Iterate from there.
+                    </Text>
+                </Stack>
+            )}
+
+            {isBuilding && hasPreview && (
+                <Box className={classes.overlay}>
+                    <Box className={classes.buildingPill}>
+                        <Text span inherit>
+                            Building…
+                            {elapsed ? ` ${elapsed}` : ''}
+                        </Text>
+                        {onCancelBuild && (
+                            <CancelBuildLink onCancel={onCancelBuild} />
+                        )}
+                    </Box>
+                </Box>
+            )}
+        </Box>
+    );
+};
+
+export default BuilderCanvas;

--- a/packages/frontend/src/features/apps/builder/BuilderPromptBar.module.css
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptBar.module.css
@@ -1,0 +1,27 @@
+.wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    padding: 8px 0 22px;
+    flex-shrink: 0;
+    z-index: 10;
+}
+
+.failedPill {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-sm);
+    background: var(--mantine-color-background-0);
+    border: 1px solid var(--mantine-color-red-2);
+    border-radius: 18px;
+    padding: 6px 10px 6px 16px;
+    box-shadow: var(--mantine-shadow-subtle);
+    max-width: 80%;
+}
+
+/* Width lives on the host, same as every other composer call site. */
+.pillHost {
+    width: 620px;
+    max-width: 80%;
+}

--- a/packages/frontend/src/features/apps/builder/BuilderPromptBar.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptBar.tsx
@@ -1,0 +1,182 @@
+import { ActionIcon, Anchor, Box, Group, Text, Tooltip } from '@mantine/core';
+import {
+    IconArrowUp,
+    IconPaperclip,
+    IconPlayerStop,
+} from '@tabler/icons-react';
+import {
+    useRef,
+    useState,
+    type ClipboardEventHandler,
+    type DragEventHandler,
+    type FC,
+} from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { ComposerSubmitButton } from '../../../components/common/PromptComposer/ComposerSubmitButton';
+import PromptComposer, {
+    type PromptComposerHandle,
+} from '../../../components/common/PromptComposer/PromptComposer';
+import { SelectedAttachmentSection } from '../AppResourcePicker';
+import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
+import { useVizComposerAttachments } from '../hooks/useVizComposerAttachments';
+import classes from './BuilderPromptBar.module.css';
+
+type Props = {
+    projectUuid: string;
+    /** The viz, or the pre-claimed draft uuid while nothing exists yet. */
+    composerAppUuid: string;
+    hasVersions: boolean;
+    build: DataAppVizBuildState;
+    onCancelBuild: (() => void) | null;
+};
+
+const PromptPill: FC<Props> = ({
+    projectUuid,
+    composerAppUuid,
+    hasVersions,
+    build,
+    onCancelBuild,
+}) => {
+    const attachments = useVizComposerAttachments({
+        projectUuid,
+        appUuid: composerAppUuid,
+    });
+    const composerRef = useRef<PromptComposerHandle>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [isEmpty, setIsEmpty] = useState(true);
+
+    const canSend = !build.isBuilding && !attachments.isUploading;
+
+    const handleSubmit = () => {
+        const description = composerRef.current?.getText().trim() ?? '';
+        if (!description || !canSend) return;
+        composerRef.current?.clear();
+        build.send({ description, fileIds: attachments.fileIds });
+        attachments.clear();
+    };
+
+    const handlePaste: ClipboardEventHandler = (event) => {
+        if (build.isBuilding || event.clipboardData.files.length === 0) return;
+        event.preventDefault();
+        attachments.add(Array.from(event.clipboardData.files));
+    };
+
+    const handleDragOver: DragEventHandler = (event) => {
+        event.preventDefault();
+    };
+
+    const handleDrop: DragEventHandler = (event) => {
+        event.preventDefault();
+        if (build.isBuilding) return;
+        attachments.add(Array.from(event.dataTransfer.files));
+    };
+
+    return (
+        <Box
+            className={classes.pillHost}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+        >
+            <PromptComposer
+                ref={composerRef}
+                variant="inline"
+                placeholder={
+                    hasVersions
+                        ? 'Ask for a change…'
+                        : 'Describe a new chart type…'
+                }
+                submitDisabled={!canSend}
+                onEmptyChange={setIsEmpty}
+                onSubmit={handleSubmit}
+                onPaste={handlePaste}
+                attachments={
+                    attachments.attachments.length > 0 ? (
+                        <SelectedAttachmentSection
+                            attachments={attachments.attachments.map((a) => ({
+                                id: a.key,
+                                previewUrl: a.previewUrl,
+                                filename: a.filename,
+                            }))}
+                            onRemove={attachments.remove}
+                            disabled={build.isBuilding}
+                        />
+                    ) : undefined
+                }
+                toolbarRight={
+                    <Group gap={4} align="center" wrap="nowrap">
+                        <input
+                            ref={fileInputRef}
+                            type="file"
+                            multiple
+                            hidden
+                            onChange={(e) => {
+                                attachments.add(
+                                    Array.from(e.target.files ?? []),
+                                );
+                                e.target.value = '';
+                            }}
+                        />
+                        <Tooltip withArrow label="Attach an image or file">
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                size="sm"
+                                disabled={build.isBuilding}
+                                aria-label="Attach"
+                                onClick={() => fileInputRef.current?.click()}
+                            >
+                                <MantineIcon icon={IconPaperclip} />
+                            </ActionIcon>
+                        </Tooltip>
+                        {build.isBuilding && onCancelBuild ? (
+                            <ComposerSubmitButton
+                                icon={IconPlayerStop}
+                                label="Stop generation"
+                                size="sm"
+                                destructive
+                                onClick={onCancelBuild}
+                            />
+                        ) : (
+                            <ComposerSubmitButton
+                                icon={IconArrowUp}
+                                label="Send"
+                                size="sm"
+                                disabled={isEmpty || !canSend}
+                                loading={build.isBuilding}
+                                onClick={handleSubmit}
+                            />
+                        )}
+                    </Group>
+                }
+            />
+        </Box>
+    );
+};
+
+/** The floating prompt pill; a failed send reports itself right above it. */
+const BuilderPromptBar: FC<Props> = (props) => (
+    <Box className={classes.wrap}>
+        {props.build.error !== null && (
+            <Box className={classes.failedPill}>
+                <Text fz={13} c="red.7" lineClamp={1}>
+                    {props.build.error}
+                </Text>
+                {props.build.retry && (
+                    <Anchor
+                        component="button"
+                        type="button"
+                        size="xs"
+                        onClick={props.build.retry}
+                    >
+                        Retry
+                    </Anchor>
+                )}
+            </Box>
+        )}
+        {/* Remount on app change so drafted text and attachments never leak
+            across visualizations. */}
+        <PromptPill key={props.composerAppUuid} {...props} />
+    </Box>
+);
+
+export default BuilderPromptBar;

--- a/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.module.css
+++ b/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.module.css
@@ -1,0 +1,48 @@
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--mantine-spacing-md);
+    padding: 0 20px;
+    height: 56px;
+    background: var(--mantine-color-background-0);
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+    flex-shrink: 0;
+    position: relative;
+    z-index: 30;
+}
+
+.side {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-sm);
+    min-width: 0;
+}
+
+.divider {
+    width: 1px;
+    height: 20px;
+    background: var(--mantine-color-ldGray-2);
+    flex-shrink: 0;
+}
+
+.nameInput {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--mantine-color-foreground-0);
+    background: transparent;
+    border: 1px solid transparent;
+
+    &:hover {
+        border-color: var(--mantine-color-ldGray-2);
+    }
+
+    &:focus {
+        border-color: var(--mantine-color-ldBrandViolet-4);
+        background: var(--mantine-color-background-0);
+    }
+}
+
+.provenance {
+    max-width: 260px;
+}

--- a/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.tsx
+++ b/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.tsx
@@ -1,0 +1,164 @@
+import {
+    getAppDisplayName,
+    type ApiAppVersionSummary,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Badge,
+    Box,
+    Button,
+    Popover,
+    Textarea,
+    TextInput,
+    Tooltip,
+} from '@mantine/core';
+import { IconChevronLeft, IconFileDescription } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { getVersionAuthorName } from '../utils/versionsToChatMessages';
+import classes from './ChartTypeBuilderHeader.module.css';
+import VersionProvenance from './VersionProvenance';
+
+const InlineNameInput: FC<{
+    initialName: string;
+    onSave: (name: string) => void;
+}> = ({ initialName, onSave }) => {
+    const [name, setName] = useState(initialName);
+    const submit = () => {
+        const trimmed = name.trim();
+        if (trimmed && trimmed !== initialName) onSave(trimmed);
+        else setName(initialName);
+    };
+    return (
+        <TextInput
+            classNames={{ input: classes.nameInput }}
+            variant="unstyled"
+            aria-label="Chart type name"
+            value={name}
+            w={280}
+            onChange={(e) => setName(e.currentTarget.value)}
+            onBlur={submit}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter') e.currentTarget.blur();
+            }}
+        />
+    );
+};
+
+const DescriptionPopover: FC<{
+    initialDescription: string;
+    onSave: (description: string) => void;
+}> = ({ initialDescription, onSave }) => {
+    const [description, setDescription] = useState(initialDescription);
+    return (
+        <Popover width={320} position="bottom-start" withArrow>
+            <Popover.Target>
+                <Tooltip withArrow label="Edit description">
+                    <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        size="sm"
+                        aria-label="Edit description"
+                    >
+                        <MantineIcon icon={IconFileDescription} />
+                    </ActionIcon>
+                </Tooltip>
+            </Popover.Target>
+            <Popover.Dropdown>
+                <Textarea
+                    label="Description"
+                    size="xs"
+                    rows={3}
+                    placeholder="What this chart type shows and expects"
+                    value={description}
+                    onChange={(e) => setDescription(e.currentTarget.value)}
+                    onBlur={() => {
+                        if (description.trim() !== initialDescription.trim()) {
+                            onSave(description.trim());
+                        }
+                    }}
+                />
+            </Popover.Dropdown>
+        </Popover>
+    );
+};
+
+type Props = {
+    projectUuid: string;
+    /** Null while no app exists yet (create flow before the first build). */
+    app: { appUuid: string; name: string; description: string } | null;
+    latestReadyVersion: number | null;
+    /** The version the provenance line reports; null while history is empty. */
+    provenanceVersion: ApiAppVersionSummary | null;
+    /** Whether `provenanceVersion` really is the origin (v1 is loaded). */
+    hasOrigin: boolean;
+    onSaveMeta: (patch: { name?: string; description?: string }) => void;
+    onPreviewInExplorer: () => void;
+};
+
+const ChartTypeBuilderHeader: FC<Props> = ({
+    projectUuid,
+    app,
+    latestReadyVersion,
+    provenanceVersion,
+    hasOrigin,
+    onSaveMeta,
+    onPreviewInExplorer,
+}) => (
+    <Box className={classes.header} component="header">
+        <Box className={classes.side}>
+            <Button
+                component={Link}
+                to={`/projects/${projectUuid}/gallery`}
+                variant="subtle"
+                size="compact-sm"
+                leftSection={<MantineIcon icon={IconChevronLeft} />}
+            >
+                Gallery
+            </Button>
+            <Box className={classes.divider} />
+            {app ? (
+                <>
+                    <InlineNameInput
+                        key={`${app.appUuid}:${app.name}`}
+                        initialName={getAppDisplayName(app.name, app.appUuid)}
+                        onSave={(name) => onSaveMeta({ name })}
+                    />
+                    <DescriptionPopover
+                        key={`${app.appUuid}:desc:${app.description}`}
+                        initialDescription={app.description}
+                        onSave={(description) => onSaveMeta({ description })}
+                    />
+                </>
+            ) : (
+                <TextInput
+                    classNames={{ input: classes.nameInput }}
+                    variant="unstyled"
+                    aria-label="Chart type name"
+                    value="Untitled chart type"
+                    w={280}
+                    readOnly
+                />
+            )}
+            {latestReadyVersion !== null && (
+                <Badge size="sm" variant="light" color="violet">
+                    {`v${latestReadyVersion}`}
+                </Badge>
+            )}
+            {provenanceVersion && (
+                <VersionProvenance
+                    className={classes.provenance}
+                    authorName={getVersionAuthorName(provenanceVersion)}
+                    at={new Date(provenanceVersion.createdAt)}
+                    isOrigin={hasOrigin}
+                />
+            )}
+        </Box>
+        {latestReadyVersion !== null && (
+            <Button onClick={onPreviewInExplorer}>Preview in explorer</Button>
+        )}
+    </Box>
+);
+
+export default ChartTypeBuilderHeader;

--- a/packages/frontend/src/features/apps/builder/ConfigureDrawer.module.css
+++ b/packages/frontend/src/features/apps/builder/ConfigureDrawer.module.css
@@ -1,0 +1,123 @@
+.edgeButton {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    background: var(--mantine-color-background-0);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-right: none;
+    border-radius: 10px 0 0 10px;
+    padding: 16px 9px;
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--mantine-color-ldGray-7);
+    writing-mode: vertical-rl;
+    letter-spacing: 0.07em;
+    cursor: pointer;
+    box-shadow: var(--mantine-shadow-subtle);
+    z-index: 15;
+
+    &:hover {
+        color: var(--mantine-color-foreground-0);
+        background: var(--mantine-color-ldGray-0);
+    }
+}
+
+.sectionHeader {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 8px var(--mantine-spacing-lg) 4px;
+    user-select: none;
+}
+
+.chevron {
+    transition: transform 150ms ease-in-out;
+
+    &[data-collapsed='true'] {
+        transform: rotate(-90deg);
+    }
+}
+
+.changeDot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--mantine-color-violet-6);
+}
+
+.optionRow {
+    margin: 0 calc(var(--mantine-spacing-xs) * -1);
+    padding: 4px var(--mantine-spacing-xs);
+    border-radius: var(--mantine-radius-sm);
+    transition: background 400ms ease-in-out;
+
+    &[data-changed='true'] {
+        background: light-dark(
+            var(--mantine-color-violet-0),
+            rgba(94, 76, 255, 0.15)
+        );
+        box-shadow: inset 2px 0 0 var(--mantine-color-violet-6);
+        animation: fade-in 300ms ease-out;
+    }
+
+    &[data-new='true'] {
+        background: light-dark(
+            var(--mantine-color-green-0),
+            rgba(47, 122, 77, 0.2)
+        );
+        box-shadow: inset 2px 0 0 var(--mantine-color-green-7);
+        animation: fade-in 300ms ease-out;
+    }
+}
+
+.pulsing {
+    animation: pulse 1.2s ease-in-out infinite;
+}
+
+.fadeIn {
+    animation: fade-in 300ms ease-out;
+}
+
+@keyframes pulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.45;
+    }
+}
+
+@keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+.drawer {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 300px;
+    background: var(--mantine-color-background-0);
+    border-left: 1px solid var(--mantine-color-ldGray-2);
+    box-shadow: var(--mantine-shadow-heavy);
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    z-index: 20;
+    transition: transform 250ms ease-in-out;
+    transform: translateX(105%);
+
+    &[data-open='true'] {
+        transform: translateX(0);
+    }
+}

--- a/packages/frontend/src/features/apps/builder/ConfigureDrawer.test.tsx
+++ b/packages/frontend/src/features/apps/builder/ConfigureDrawer.test.tsx
@@ -1,0 +1,103 @@
+import { type DataAppVizSchema } from '@lightdash/common';
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { type VizContractDiff } from '../utils/vizContractDiff';
+import ConfigureDrawer from './ConfigureDrawer';
+
+vi.mock('../../../hooks/appearance/useOrganizationAppearance', () => ({
+    useColorPalettes: () => ({ data: [] }),
+}));
+
+const schema: DataAppVizSchema = {
+    fields: [],
+    configOptions: [
+        { name: 'grid', label: 'Show grid', type: 'boolean', default: true },
+        {
+            name: 'markers',
+            label: 'Show markers',
+            type: 'boolean',
+            default: false,
+        },
+    ],
+    colorPalette: null,
+};
+
+const diff: VizContractDiff = {
+    fromVersion: 3,
+    toVersion: 4,
+    added: ['markers'],
+    changed: {
+        grid: {
+            name: 'grid',
+            label: 'Show grid',
+            type: 'boolean',
+            default: false,
+        },
+    },
+    removed: [
+        {
+            name: 'legend',
+            label: 'Legend',
+            type: 'select',
+            choices: [{ value: 'right', label: 'Right' }],
+            default: 'right',
+        },
+    ],
+};
+
+const renderDrawer = (
+    props: Partial<React.ComponentProps<typeof ConfigureDrawer>> = {},
+) =>
+    renderWithProviders(
+        <ConfigureDrawer
+            opened
+            onOpenChange={vi.fn()}
+            schema={schema}
+            isBuilding={false}
+            contractDiff={null}
+            optionValues={{}}
+            onOptionChange={vi.fn()}
+            colorPaletteUuid={null}
+            onPaletteChange={vi.fn()}
+            {...props}
+        />,
+    );
+
+describe('ConfigureDrawer', () => {
+    it('pulses a syncing badge while a build runs', () => {
+        renderDrawer({ isBuilding: true });
+
+        expect(screen.getByText('syncing…')).toBeInTheDocument();
+    });
+
+    it('summarises and annotates what the last build changed', () => {
+        renderDrawer({ contractDiff: diff });
+
+        expect(screen.getByText('v3 → v4 · 3 changes')).toBeInTheDocument();
+        expect(screen.getByText('New in v4')).toBeInTheDocument();
+        expect(screen.getByText('Off')).toBeInTheDocument();
+        expect(
+            screen.getByText(/No longer declared: Legend/),
+        ).toBeInTheDocument();
+    });
+
+    it('clears an annotation once its control is touched', () => {
+        renderDrawer({ contractDiff: diff });
+
+        fireEvent.click(screen.getByLabelText('Show grid'));
+
+        expect(screen.queryByText('Off')).not.toBeInTheDocument();
+        expect(screen.getByText('New in v4')).toBeInTheDocument();
+    });
+
+    it('collapses a section that carries no changes', () => {
+        renderDrawer();
+
+        expect(screen.getByLabelText('Show grid')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('Display'));
+
+        expect(screen.queryByLabelText('Show grid')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/apps/builder/ConfigureDrawer.tsx
+++ b/packages/frontend/src/features/apps/builder/ConfigureDrawer.tsx
@@ -1,0 +1,314 @@
+import {
+    getEffectiveOptionValues,
+    type DataAppVizConfigOption,
+    type DataAppVizOptionValue,
+    type DataAppVizOptionValues,
+    type DataAppVizSchema,
+} from '@lightdash/common';
+import {
+    Badge,
+    Box,
+    CloseButton,
+    Group,
+    Stack,
+    Text,
+    UnstyledButton,
+} from '@mantine/core';
+import { IconChevronDown } from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { PalettePicker } from '../../../components/common/PalettePicker/PalettePicker';
+import DataAppVizOptionControl from '../../../components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionControl';
+import { groupDataAppVizOptions } from '../../../components/VisualizationConfigs/DataAppVizConfig/dataAppVizOptionGroups';
+import { useColorPalettes } from '../../../hooks/appearance/useOrganizationAppearance';
+import {
+    countVizContractChanges,
+    formatVizOptionValue,
+    type VizContractDiff,
+} from '../utils/vizContractDiff';
+import classes from './ConfigureDrawer.module.css';
+
+type Props = {
+    opened: boolean;
+    onOpenChange: (opened: boolean) => void;
+    schema: DataAppVizSchema;
+    /** A rebuild is running, so the declared options may be about to change. */
+    isBuilding: boolean;
+    /** What the last build changed in the contract; null when nothing changed. */
+    contractDiff: VizContractDiff | null;
+    /** Only what the author explicitly changed; defaults resolve at render. */
+    optionValues: DataAppVizOptionValues;
+    onOptionChange: (name: string, value: DataAppVizOptionValue) => void;
+    /** Preview-only; a chart using the viz owns the palette the normal way. */
+    colorPaletteUuid: string | null;
+    onPaletteChange: (colorPaletteUuid: string | null) => void;
+};
+
+/**
+ * The builder's configuration drawer: the declared options and palette,
+ * annotated with what the last rebuild changed; touching an annotated
+ * control dismisses its highlight. The option and palette state lives in
+ * the page, which derives the preview context from it.
+ */
+const ConfigureDrawer: FC<Props> = ({
+    opened,
+    onOpenChange,
+    schema,
+    isBuilding,
+    contractDiff,
+    optionValues,
+    onOptionChange,
+    colorPaletteUuid,
+    onPaletteChange,
+}) => {
+    // Remembered per section label; a section carrying changes stays open
+    // regardless, so the annotations cannot hide themselves.
+    const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+    // Change annotations the author has touched, and thereby dismissed.
+    const [acknowledged, setAcknowledged] = useState<string[]>([]);
+
+    const { data: palettes = [] } = useColorPalettes();
+
+    const effectiveValues = useMemo(
+        () => getEffectiveOptionValues(schema.configOptions, optionValues),
+        [schema.configOptions, optionValues],
+    );
+
+    const setOption = (name: string, value: DataAppVizOptionValue) => {
+        setAcknowledged((prev) =>
+            prev.includes(name) ? prev : [...prev, name],
+        );
+        onOptionChange(name, value);
+    };
+
+    const optionGroups = groupDataAppVizOptions(
+        schema.configOptions,
+        schema.colorPalette,
+    );
+
+    const isNew = (option: DataAppVizConfigOption): boolean =>
+        contractDiff !== null &&
+        contractDiff.added.includes(option.name) &&
+        !acknowledged.includes(option.name);
+    const previousDeclaration = (
+        option: DataAppVizConfigOption,
+    ): DataAppVizConfigOption | null =>
+        contractDiff !== null && !acknowledged.includes(option.name)
+            ? (contractDiff.changed[option.name] ?? null)
+            : null;
+
+    const changeCount =
+        contractDiff !== null ? countVizContractChanges(contractDiff) : 0;
+
+    return (
+        <>
+            {!opened && (
+                <button
+                    type="button"
+                    className={classes.edgeButton}
+                    onClick={() => onOpenChange(true)}
+                >
+                    CONFIGURE
+                </button>
+            )}
+            <Box className={classes.drawer} data-open={opened}>
+                <Group justify="space-between" px="lg" pt="sm" pb={4}>
+                    <Group gap="xs">
+                        <Text
+                            fz="xs"
+                            fw={600}
+                            c="ldGray.6"
+                            tt="uppercase"
+                            lts="0.05em"
+                        >
+                            Configure
+                        </Text>
+                        {isBuilding ? (
+                            <Badge
+                                size="xs"
+                                variant="light"
+                                color="violet"
+                                tt="none"
+                                className={classes.pulsing}
+                            >
+                                syncing…
+                            </Badge>
+                        ) : (
+                            contractDiff !== null && (
+                                <Badge
+                                    size="xs"
+                                    variant="light"
+                                    color="violet"
+                                    tt="none"
+                                    className={classes.fadeIn}
+                                >
+                                    {`v${contractDiff.fromVersion} → v${
+                                        contractDiff.toVersion
+                                    } · ${changeCount} change${
+                                        changeCount === 1 ? '' : 's'
+                                    }`}
+                                </Badge>
+                            )
+                        )}
+                    </Group>
+                    <CloseButton
+                        size="sm"
+                        aria-label="Close configure drawer"
+                        onClick={() => onOpenChange(false)}
+                    />
+                </Group>
+                <Box pb="sm">
+                    {optionGroups.length === 0 && (
+                        <Text fz="xs" c="dimmed" lh={1.5} px="lg" py="sm">
+                            This chart type declares no display options.
+                        </Text>
+                    )}
+                    {contractDiff !== null &&
+                        contractDiff.removed.length > 0 && (
+                            <Text fz="xs" c="dimmed" lh={1.5} px="lg" py={4}>
+                                No longer declared:{' '}
+                                {contractDiff.removed
+                                    .map((option) => option.label)
+                                    .join(', ')}
+                            </Text>
+                        )}
+                    {optionGroups.map((group) => {
+                        const hasChanges = group.options.some(
+                            (option) =>
+                                isNew(option) ||
+                                previousDeclaration(option) !== null,
+                        );
+                        const isOpen = hasChanges || !collapsed[group.label];
+                        const rowCount =
+                            group.options.length + (group.hasPalette ? 1 : 0);
+                        return (
+                            <Box key={group.id}>
+                                <UnstyledButton
+                                    className={classes.sectionHeader}
+                                    onClick={() =>
+                                        setCollapsed((prev) => ({
+                                            ...prev,
+                                            [group.label]: isOpen,
+                                        }))
+                                    }
+                                >
+                                    <Group gap={6}>
+                                        <MantineIcon
+                                            icon={IconChevronDown}
+                                            size={12}
+                                            color="ldGray.5"
+                                            className={classes.chevron}
+                                            data-collapsed={!isOpen}
+                                        />
+                                        <Text
+                                            fz={10}
+                                            fw={600}
+                                            c="ldGray.6"
+                                            tt="uppercase"
+                                            lts="0.07em"
+                                        >
+                                            {group.label}
+                                        </Text>
+                                        {hasChanges && (
+                                            <Box
+                                                className={classes.changeDot}
+                                            />
+                                        )}
+                                    </Group>
+                                    <Text fz={10} c="ldGray.4">
+                                        {rowCount}
+                                    </Text>
+                                </UnstyledButton>
+                                {isOpen && (
+                                    <Stack gap="sm" px="lg" pt={4} pb="sm">
+                                        {group.options.map((option) => {
+                                            const prevDeclaration =
+                                                previousDeclaration(option);
+                                            const added = isNew(option);
+                                            return (
+                                                <Box
+                                                    key={option.name}
+                                                    className={
+                                                        classes.optionRow
+                                                    }
+                                                    data-new={
+                                                        added || undefined
+                                                    }
+                                                    data-changed={
+                                                        (prevDeclaration !==
+                                                            null &&
+                                                            !added) ||
+                                                        undefined
+                                                    }
+                                                >
+                                                    <DataAppVizOptionControl
+                                                        option={option}
+                                                        value={
+                                                            effectiveValues[
+                                                                option.name
+                                                            ]
+                                                        }
+                                                        onChange={(value) =>
+                                                            setOption(
+                                                                option.name,
+                                                                value,
+                                                            )
+                                                        }
+                                                    />
+                                                    {added &&
+                                                        contractDiff !==
+                                                            null && (
+                                                            <Badge
+                                                                size="xs"
+                                                                variant="light"
+                                                                color="green"
+                                                                mt={4}
+                                                            >
+                                                                {`New in v${contractDiff.toVersion}`}
+                                                            </Badge>
+                                                        )}
+                                                    {prevDeclaration !== null &&
+                                                        !added && (
+                                                            <Text
+                                                                fz="xs"
+                                                                c="ldGray.5"
+                                                                mt={2}
+                                                            >
+                                                                Previously{' '}
+                                                                <Text
+                                                                    span
+                                                                    inherit
+                                                                    td="line-through"
+                                                                >
+                                                                    {formatVizOptionValue(
+                                                                        prevDeclaration,
+                                                                        prevDeclaration.default,
+                                                                    )}
+                                                                </Text>
+                                                            </Text>
+                                                        )}
+                                                </Box>
+                                            );
+                                        })}
+                                        {group.hasPalette && (
+                                            <PalettePicker
+                                                label="Color palette"
+                                                value={colorPaletteUuid}
+                                                onChange={onPaletteChange}
+                                                palettes={palettes}
+                                                parentLabel="Project default"
+                                                showPreview={false}
+                                            />
+                                        )}
+                                    </Stack>
+                                )}
+                            </Box>
+                        );
+                    })}
+                </Box>
+            </Box>
+        </>
+    );
+};
+
+export default ConfigureDrawer;

--- a/packages/frontend/src/features/apps/builder/VersionChips.module.css
+++ b/packages/frontend/src/features/apps/builder/VersionChips.module.css
@@ -1,0 +1,86 @@
+@keyframes ldPulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.45;
+    }
+}
+
+.wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    padding-top: 18px;
+    flex-shrink: 0;
+}
+
+.row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: center;
+    max-width: 70%;
+}
+
+.chip {
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 500;
+    border-radius: 15px;
+    padding: 6px 13px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 150ms;
+    color: var(--mantine-color-ldGray-6);
+    background: var(--mantine-color-background-0);
+    border: 1px solid var(--mantine-color-ldGray-2);
+
+    &[data-state='building'] {
+        color: var(--mantine-color-ldBrandViolet-7);
+        background: var(--mantine-color-ldBrandViolet-0);
+        border-color: var(--mantine-color-ldBrandViolet-2);
+        animation: ldPulse 1.2s ease-in-out infinite;
+        cursor: default;
+    }
+
+    &[data-state='current'] {
+        font-weight: 600;
+        color: var(--mantine-color-ldBrandViolet-7);
+        background: var(--mantine-color-ldBrandViolet-0);
+        border-color: var(--mantine-color-ldBrandViolet-2);
+    }
+
+    &[data-state='viewing'] {
+        font-weight: 600;
+        color: var(--mantine-color-ldBrandViolet-7);
+        background: var(--mantine-color-background-0);
+        border-color: var(--mantine-color-ldBrandViolet-4);
+    }
+
+    &[data-state='failed'] {
+        color: var(--mantine-color-red-7);
+        background: var(--mantine-color-background-0);
+        border-color: var(--mantine-color-red-2);
+        cursor: default;
+    }
+}
+
+.earlier {
+    composes: chip;
+    color: var(--mantine-color-ldGray-6);
+}
+
+.viewingPill {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-sm);
+    background: var(--mantine-color-background-0);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 20px;
+    padding: 6px 8px 6px 16px;
+    box-shadow: var(--mantine-shadow-subtle);
+}

--- a/packages/frontend/src/features/apps/builder/VersionChips.test.tsx
+++ b/packages/frontend/src/features/apps/builder/VersionChips.test.tsx
@@ -1,0 +1,145 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { appVersion } from '../testing/appVersionHistory';
+import { buildStub } from '../testing/dataAppVizBuildStub';
+import VersionChips from './VersionChips';
+
+vi.mock('./RestoreVersionModal', () => ({
+    default: ({ version }: { version: number }) => (
+        <div data-testid="restore-modal">{`restore-${version}`}</div>
+    ),
+}));
+
+const defaultProps = {
+    projectUuid: 'project-1',
+    appUuid: 'app-1',
+    latestReadyVersion: 2 as number | null,
+    viewedVersion: null as number | null,
+    onView: vi.fn(),
+    build: buildStub(),
+    hasEarlier: false,
+    isFetchingEarlier: false,
+    fetchEarlier: vi.fn(),
+};
+
+const twoVersions = [
+    appVersion({ version: 2 }),
+    appVersion({ version: 1, prompt: 'first' }),
+];
+
+describe('VersionChips', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('lists versions oldest to newest and marks the current one', () => {
+        renderWithProviders(
+            <VersionChips {...defaultProps} versions={twoVersions} />,
+        );
+
+        const chips = screen.getAllByText(/^v\d/);
+        expect(chips.map((c) => c.textContent)).toEqual(['v1', 'v2 · current']);
+    });
+
+    it('pins an older version on click and unpins from the current chip', () => {
+        const onView = vi.fn();
+        renderWithProviders(
+            <VersionChips
+                {...defaultProps}
+                versions={twoVersions}
+                onView={onView}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('v1'));
+        expect(onView).toHaveBeenCalledWith(1);
+
+        fireEvent.click(screen.getByText('v2 · current'));
+        expect(onView).toHaveBeenCalledWith(null);
+    });
+
+    it('offers restore and the way back while viewing an older version', () => {
+        const onView = vi.fn();
+        renderWithProviders(
+            <VersionChips
+                {...defaultProps}
+                versions={twoVersions}
+                viewedVersion={1}
+                onView={onView}
+            />,
+        );
+
+        expect(screen.getByText(/not the current version/)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('Back to v2'));
+        expect(onView).toHaveBeenCalledWith(null);
+
+        fireEvent.click(screen.getByText('Restore v1'));
+        expect(screen.getByTestId('restore-modal')).toHaveTextContent(
+            'restore-1',
+        );
+    });
+
+    it('shows an in-progress history version as building', () => {
+        renderWithProviders(
+            <VersionChips
+                {...defaultProps}
+                versions={[
+                    appVersion({ version: 3, status: 'generating' }),
+                    ...twoVersions,
+                ]}
+            />,
+        );
+
+        expect(screen.getByText('v3 · building…')).toBeInTheDocument();
+    });
+
+    it('writes a live chip for a build not yet in history', () => {
+        renderWithProviders(
+            <VersionChips
+                {...defaultProps}
+                versions={twoVersions}
+                build={buildStub({ isBuilding: true, claimedVersion: 3 })}
+            />,
+        );
+
+        expect(screen.getByText('v3 · building…')).toBeInTheDocument();
+    });
+
+    it('marks a failed version and offers no preview of it', () => {
+        const onView = vi.fn();
+        renderWithProviders(
+            <VersionChips
+                {...defaultProps}
+                versions={[
+                    appVersion({
+                        version: 3,
+                        status: 'error',
+                        statusMessage: 'Sandbox crashed',
+                    }),
+                    ...twoVersions,
+                ]}
+                onView={onView}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('v3 · failed'));
+        expect(onView).not.toHaveBeenCalled();
+    });
+
+    it('loads earlier versions on demand', () => {
+        const fetchEarlier = vi.fn();
+        renderWithProviders(
+            <VersionChips
+                {...defaultProps}
+                versions={twoVersions}
+                hasEarlier
+                fetchEarlier={fetchEarlier}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('…'));
+        expect(fetchEarlier).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/frontend/src/features/apps/builder/VersionChips.tsx
+++ b/packages/frontend/src/features/apps/builder/VersionChips.tsx
@@ -1,0 +1,174 @@
+import {
+    isAppVersionInProgress,
+    type ApiAppVersionSummary,
+} from '@lightdash/common';
+import { Box, Button, Text, Tooltip, UnstyledButton } from '@mantine/core';
+import { useState, type FC } from 'react';
+import { getAppVersionFailureMessage } from '../getAppVersionFailureMessage';
+import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
+import RestoreVersionModal from './RestoreVersionModal';
+import classes from './VersionChips.module.css';
+
+type Props = {
+    projectUuid: string;
+    appUuid: string;
+    /** Newest first, as `useAppVersionHistory` returns them. */
+    versions: ApiAppVersionSummary[];
+    latestReadyVersion: number | null;
+    /** The pinned (viewed) version; null when following the current one. */
+    viewedVersion: number | null;
+    onView: (version: number | null) => void;
+    build: DataAppVizBuildState;
+    hasEarlier: boolean;
+    isFetchingEarlier: boolean;
+    fetchEarlier: () => void;
+};
+
+/**
+ * The version timeline as a row of chips, oldest to newest. Clicking a ready
+ * chip pins the preview to it; a pill underneath offers restore or return.
+ */
+const VersionChips: FC<Props> = ({
+    projectUuid,
+    appUuid,
+    versions,
+    latestReadyVersion,
+    viewedVersion,
+    onView,
+    build,
+    hasEarlier,
+    isFetchingEarlier,
+    fetchEarlier,
+}) => {
+    const [restoreTarget, setRestoreTarget] = useState<number | null>(null);
+
+    const ordered = [...versions].sort((a, b) => a.version - b.version);
+    // The build writes its own chip until the version it claimed reaches
+    // history, where it shows up as an in-progress version of its own.
+    const isClaimedInHistory =
+        build.claimedVersion !== null &&
+        versions.some((v) => v.version === build.claimedVersion);
+    const showLiveChip = build.isBuilding && !isClaimedInHistory;
+
+    const chipFor = (version: ApiAppVersionSummary) => {
+        const isBuilding = isAppVersionInProgress(version.status);
+        const isCurrent = version.version === latestReadyVersion;
+        const isViewing = version.version === viewedVersion;
+        const isFailed = !isBuilding && version.status !== 'ready';
+
+        if (isBuilding) {
+            return (
+                <Box
+                    key={version.version}
+                    component="span"
+                    className={classes.chip}
+                    data-state="building"
+                >
+                    {`v${version.version} · building…`}
+                </Box>
+            );
+        }
+        if (isFailed) {
+            return (
+                <Tooltip
+                    key={version.version}
+                    label={getAppVersionFailureMessage(version)}
+                >
+                    <Box
+                        component="span"
+                        className={classes.chip}
+                        data-state="failed"
+                    >
+                        {`v${version.version} · failed`}
+                    </Box>
+                </Tooltip>
+            );
+        }
+        return (
+            <UnstyledButton
+                key={version.version}
+                className={classes.chip}
+                data-state={
+                    isCurrent && !viewedVersion
+                        ? 'current'
+                        : isViewing
+                          ? 'viewing'
+                          : undefined
+                }
+                onClick={() => onView(isCurrent ? null : version.version)}
+            >
+                {isCurrent
+                    ? `v${version.version} · current`
+                    : `v${version.version}`}
+            </UnstyledButton>
+        );
+    };
+
+    return (
+        <Box className={classes.wrap}>
+            <Box className={classes.row}>
+                {hasEarlier && (
+                    <UnstyledButton
+                        className={classes.earlier}
+                        disabled={isFetchingEarlier}
+                        onClick={fetchEarlier}
+                    >
+                        {isFetchingEarlier ? 'Loading…' : '…'}
+                    </UnstyledButton>
+                )}
+                {ordered.map(chipFor)}
+                {showLiveChip && (
+                    <Box
+                        component="span"
+                        className={classes.chip}
+                        data-state="building"
+                    >
+                        {build.claimedVersion === null
+                            ? 'building…'
+                            : `v${build.claimedVersion} · building…`}
+                    </Box>
+                )}
+            </Box>
+
+            {viewedVersion !== null && viewedVersion !== latestReadyVersion && (
+                <Box className={classes.viewingPill}>
+                    <Text fz={13} c="ldGray.7" span>
+                        Viewing{' '}
+                        <Text fw={600} span inherit>
+                            {`v${viewedVersion}`}
+                        </Text>{' '}
+                        · not the current version
+                    </Text>
+                    <Button
+                        size="compact-xs"
+                        radius="xl"
+                        onClick={() => setRestoreTarget(viewedVersion)}
+                    >
+                        {`Restore v${viewedVersion}`}
+                    </Button>
+                    <Button
+                        size="compact-xs"
+                        radius="xl"
+                        variant="subtle"
+                        onClick={() => onView(null)}
+                    >
+                        {latestReadyVersion !== null
+                            ? `Back to v${latestReadyVersion}`
+                            : 'Back to current'}
+                    </Button>
+                </Box>
+            )}
+
+            {restoreTarget !== null && (
+                <RestoreVersionModal
+                    projectUuid={projectUuid}
+                    appUuid={appUuid}
+                    version={restoreTarget}
+                    onClose={() => setRestoreTarget(null)}
+                />
+            )}
+        </Box>
+    );
+};
+
+export default VersionChips;

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.test.ts
@@ -139,6 +139,29 @@ describe('useDataAppVizBuild', () => {
         });
     });
 
+    it('attributes builds to the surface that sent them', () => {
+        const { result } = renderHookWithProviders(() =>
+            useDataAppVizBuild({
+                projectUuid: 'project-1',
+                itemsMap,
+                dataAppVizUuid: null,
+                onCreated: vi.fn(),
+                creationExperience: 'chart_type_builder',
+            }),
+        );
+
+        act(() =>
+            result.current.send({
+                description: 'a donut of orders by status',
+                fileIds: [],
+            }),
+        );
+
+        expect(generate.mock.lastCall?.[0]).toMatchObject({
+            creationExperience: 'chart_type_builder',
+        });
+    });
+
     it('binds the contract off the version the poller hands back', () => {
         // Not off the query cache: the poll writes the cache and calls back in
         // the same tick, so the cache is still a render behind here.

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
@@ -2,6 +2,7 @@ import {
     DATA_APP_VIZ_TEMPLATE,
     getErrorMessage,
     type ApiAppVersionSummary,
+    type DataAppCreationExperience,
     type DataAppVizFieldMapping,
     type ItemsMap,
 } from '@lightdash/common';
@@ -25,6 +26,8 @@ type Args = {
         dataAppVizUuid: string,
         fieldMapping: DataAppVizFieldMapping,
     ) => void;
+    /** Which surface authored the build; recorded on every version. */
+    creationExperience?: DataAppCreationExperience;
 };
 
 /** What was asked for, kept so a failure can be retried as it was sent. */
@@ -89,6 +92,7 @@ export const useDataAppVizBuild = ({
     itemsMap,
     dataAppVizUuid,
     onCreated,
+    creationExperience = 'explorer_chart_config',
 }: Args): DataAppVizBuildState => {
     // The request in flight, and the app it is building — both null when idle.
     const [inFlight, setInFlight] = useState<VizBuildRequest | null>(null);
@@ -160,7 +164,7 @@ export const useDataAppVizBuild = ({
                         projectUuid,
                         prompt,
                         template: DATA_APP_VIZ_TEMPLATE,
-                        creationExperience: 'explorer_chart_config',
+                        creationExperience,
                         appUuid: draftAppUuid,
                         fileIds: files,
                     },
@@ -184,7 +188,7 @@ export const useDataAppVizBuild = ({
                     projectUuid,
                     appUuid: dataAppVizUuid,
                     prompt,
-                    creationExperience: 'explorer_chart_config',
+                    creationExperience,
                     fileIds: files,
                 },
                 {
@@ -206,6 +210,7 @@ export const useDataAppVizBuild = ({
             draftAppUuid,
             generateApp,
             iterateApp,
+            creationExperience,
         ],
     );
 

--- a/packages/frontend/src/features/apps/hooks/useUpdateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useUpdateApp.ts
@@ -28,7 +28,8 @@ const updateApp = async ({
     return data;
 };
 
-export const useUpdateApp = () => {
+export const useUpdateApp = (options?: { resourceLabel?: string }) => {
+    const resourceLabel = options?.resourceLabel ?? 'App';
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<UpdateAppResult, ApiError, UpdateAppParams>({
@@ -45,12 +46,12 @@ export const useUpdateApp = () => {
                   ? 'description'
                   : 'metadata';
             showToastSuccess({
-                title: `App ${field} updated successfully`,
+                title: `${resourceLabel} ${field} updated successfully`,
             });
         },
         onError: ({ error }) => {
             showToastApiError({
-                title: 'Failed to update app',
+                title: `Failed to update ${resourceLabel.toLowerCase()}`,
                 apiError: error,
             });
         },

--- a/packages/frontend/src/features/apps/utils/vizContractDiff.test.ts
+++ b/packages/frontend/src/features/apps/utils/vizContractDiff.test.ts
@@ -1,0 +1,104 @@
+import { type DataAppVizConfigOption } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    countVizContractChanges,
+    diffVizConfigOptions,
+    formatVizOptionValue,
+} from './vizContractDiff';
+
+const boolOption = (
+    name: string,
+    defaultValue: boolean,
+): DataAppVizConfigOption => ({
+    name,
+    label: name,
+    type: 'boolean',
+    default: defaultValue,
+});
+
+const selectOption = (
+    name: string,
+    defaultValue: string,
+): DataAppVizConfigOption => ({
+    name,
+    label: name,
+    type: 'select',
+    choices: [
+        { value: 'right', label: 'Right' },
+        { value: 'bottom', label: 'Bottom' },
+    ],
+    default: defaultValue,
+});
+
+describe('diffVizConfigOptions', () => {
+    it('reports added, changed and removed options', () => {
+        const prev = [
+            boolOption('grid', false),
+            selectOption('legend', 'right'),
+            boolOption('smooth', true),
+        ];
+        const next = [
+            boolOption('grid', true),
+            boolOption('smooth', true),
+            boolOption('markers', false),
+        ];
+
+        const diff = diffVizConfigOptions(prev, next, 3, 4);
+
+        expect(diff.added).toEqual(['markers']);
+        expect(Object.keys(diff.changed)).toEqual(['grid']);
+        expect(diff.changed.grid).toEqual(boolOption('grid', false));
+        expect(diff.removed).toEqual([selectOption('legend', 'right')]);
+        expect(countVizContractChanges(diff)).toBe(3);
+    });
+
+    it('counts a type change under a stable name as changed', () => {
+        const diff = diffVizConfigOptions(
+            [boolOption('legend', true)],
+            [selectOption('legend', 'right')],
+            1,
+            2,
+        );
+
+        expect(Object.keys(diff.changed)).toEqual(['legend']);
+        expect(diff.added).toEqual([]);
+        expect(diff.removed).toEqual([]);
+    });
+
+    it('is empty when the contract is unchanged', () => {
+        const options = [boolOption('grid', false)];
+        const diff = diffVizConfigOptions(options, options, 5, 6);
+
+        expect(countVizContractChanges(diff)).toBe(0);
+    });
+});
+
+describe('formatVizOptionValue', () => {
+    it('words booleans as the switch does', () => {
+        expect(formatVizOptionValue(boolOption('grid', false), true)).toBe(
+            'On',
+        );
+        expect(formatVizOptionValue(boolOption('grid', false), false)).toBe(
+            'Off',
+        );
+    });
+
+    it('resolves select values to their choice label', () => {
+        expect(
+            formatVizOptionValue(selectOption('legend', 'right'), 'bottom'),
+        ).toBe('Bottom');
+        expect(
+            formatVizOptionValue(selectOption('legend', 'right'), 'gone'),
+        ).toBe('gone');
+    });
+
+    it('stringifies numbers and text', () => {
+        const numberOption: DataAppVizConfigOption = {
+            name: 'opacity',
+            label: 'Opacity',
+            type: 'number',
+            default: 90,
+        };
+        expect(formatVizOptionValue(numberOption, 75)).toBe('75');
+    });
+});

--- a/packages/frontend/src/features/apps/utils/vizContractDiff.ts
+++ b/packages/frontend/src/features/apps/utils/vizContractDiff.ts
@@ -1,0 +1,67 @@
+import {
+    type DataAppVizConfigOption,
+    type DataAppVizOptionValue,
+} from '@lightdash/common';
+
+/**
+ * What a rebuild did to the declared option contract: options added, defaults
+ * changed under a stable name, and options removed.
+ */
+export type VizContractDiff = {
+    fromVersion: number;
+    toVersion: number;
+    added: string[];
+    /** Name → previous declaration, where the default or control type changed. */
+    changed: Record<string, DataAppVizConfigOption>;
+    removed: DataAppVizConfigOption[];
+};
+
+export const countVizContractChanges = (diff: VizContractDiff): number =>
+    diff.added.length + Object.keys(diff.changed).length + diff.removed.length;
+
+export const diffVizConfigOptions = (
+    prev: DataAppVizConfigOption[],
+    next: DataAppVizConfigOption[],
+    fromVersion: number,
+    toVersion: number,
+): VizContractDiff => {
+    const prevByName = new Map(prev.map((option) => [option.name, option]));
+    const nextNames = new Set(next.map((option) => option.name));
+
+    const added: string[] = [];
+    const changed: Record<string, DataAppVizConfigOption> = {};
+    next.forEach((option) => {
+        const before = prevByName.get(option.name);
+        if (before === undefined) {
+            added.push(option.name);
+            return;
+        }
+        if (
+            before.type !== option.type ||
+            JSON.stringify(before.default) !== JSON.stringify(option.default)
+        ) {
+            changed[option.name] = before;
+        }
+    });
+
+    return {
+        fromVersion,
+        toVersion,
+        added,
+        changed,
+        removed: prev.filter((option) => !nextNames.has(option.name)),
+    };
+};
+
+/** The declared default of an option, worded the way its control shows it. */
+export const formatVizOptionValue = (
+    option: DataAppVizConfigOption,
+    value: DataAppVizOptionValue,
+): string => {
+    if (option.type === 'boolean') return value ? 'On' : 'Off';
+    if (option.type === 'select') {
+        const choice = option.choices.find((c) => c.value === value);
+        return choice?.label ?? String(value);
+    }
+    return String(value);
+};

--- a/packages/frontend/src/pages/ChartTypeBuilder.module.css
+++ b/packages/frontend/src/pages/ChartTypeBuilder.module.css
@@ -1,0 +1,15 @@
+.root {
+    height: calc(100vh - 50px);
+    display: flex;
+    flex-direction: column;
+    background: var(--mantine-color-ldGray-0);
+}
+
+.main {
+    flex: 1;
+    position: relative;
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -1,0 +1,338 @@
+import {
+    FeatureFlags,
+    type ApiAppVersionSummary,
+    type ApiGetAppResponse,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    useAppVersionHistory,
+    type AppVersionHistory,
+} from '../features/apps/hooks/useAppVersionHistory';
+import { useCanCreateDataApp } from '../features/apps/hooks/useCanCreateDataApp';
+import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
+import { useDataAppVisualization } from '../features/apps/hooks/useDataAppVisualization';
+import { useDataAppVizBuild } from '../features/apps/hooks/useDataAppVizBuild';
+import { useGetApp } from '../features/apps/hooks/useGetApp';
+import { appVersion } from '../features/apps/testing/appVersionHistory';
+import { buildStub } from '../features/apps/testing/dataAppVizBuildStub';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import { renderWithProviders } from '../testing/testUtils';
+import ChartTypeBuilder from './ChartTypeBuilder';
+
+vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(),
+}));
+vi.mock('../features/apps/hooks/useCanCreateDataApp', () => ({
+    useCanCreateDataApp: vi.fn(),
+}));
+vi.mock('../features/apps/hooks/useCanEditDataApp', () => ({
+    useCanEditDataApp: vi.fn(),
+}));
+vi.mock('../features/apps/hooks/useGetApp', () => ({
+    useGetApp: vi.fn(),
+}));
+vi.mock('../features/apps/hooks/useAppVersionHistory', () => ({
+    useAppVersionHistory: vi.fn(),
+}));
+vi.mock('../features/apps/hooks/useDataAppVizBuild', () => ({
+    useDataAppVizBuild: vi.fn(),
+}));
+vi.mock('../features/apps/hooks/useDataAppVisualization', () => ({
+    useDataAppVisualization: vi.fn(),
+}));
+vi.mock('../features/apps/hooks/useAppBuildPoller', () => ({
+    useAppBuildPoller: vi.fn(),
+}));
+vi.mock('../features/apps/hooks/useUpdateApp', () => ({
+    useUpdateApp: () => ({ mutate: vi.fn() }),
+}));
+vi.mock('../hooks/appearance/useOrganizationAppearance', () => ({
+    useColorPalettes: () => ({ data: [] }),
+}));
+vi.mock('../hooks/appearance/useProjectColorPalette', () => ({
+    useProjectColorPalette: () => ({ data: undefined }),
+}));
+vi.mock('../features/apps/components/AppPreview', () => ({
+    default: ({ version }: { version: number }) => (
+        <div data-testid="app-preview">{`preview-v${version}`}</div>
+    ),
+}));
+vi.mock('../components/common/PromptComposer/PromptComposer', () => ({
+    default: ({ placeholder }: { placeholder: string }) => (
+        <input placeholder={placeholder} />
+    ),
+}));
+vi.mock('../features/apps/hooks/useVizComposerAttachments', () => ({
+    useVizComposerAttachments: () => ({
+        attachments: [],
+        fileIds: [],
+        isUploading: false,
+        add: vi.fn(),
+        remove: vi.fn(),
+        clear: vi.fn(),
+    }),
+}));
+
+type AppMeta = ApiGetAppResponse['results'];
+
+const appMeta = (overrides: Partial<AppMeta> = {}): AppMeta =>
+    ({
+        appUuid: 'viz-1',
+        name: 'Stream graph',
+        description: 'Layered flows',
+        createdByUserUuid: 'user-1',
+        spaceUuid: null,
+        spaceName: null,
+        template: 'data_app_viz',
+        pinnedListUuid: null,
+        pinnedListOrder: null,
+        slug: 'stream-graph',
+        views: 0,
+        versions: [],
+        hasMore: false,
+        latestReadyVersion: 1,
+        ...overrides,
+    }) as AppMeta;
+
+const historyStub = (
+    versions: ApiAppVersionSummary[],
+    latestReadyVersion: number | null,
+): AppVersionHistory => ({
+    versions,
+    oldest: versions.length ? versions[versions.length - 1] : null,
+    latest: versions.length ? versions[0] : null,
+    latestReadyVersion,
+    hasOrigin: versions.some((v) => v.version === 1),
+    hasEarlier: false,
+    isLoading: false,
+    isError: false,
+    isFetchingEarlier: false,
+    fetchEarlier: vi.fn(),
+});
+
+const setFlag = (enabled: boolean) =>
+    vi.mocked(useServerFeatureFlag).mockReturnValue({
+        data: { id: FeatureFlags.EnableDataApps, enabled },
+        isLoading: false,
+    } as ReturnType<typeof useServerFeatureFlag>);
+
+const setApp = (meta: AppMeta | null, error: unknown = null) =>
+    vi.mocked(useGetApp).mockReturnValue({
+        data: meta ? { pages: [meta], pageParams: [undefined] } : undefined,
+        error,
+    } as unknown as ReturnType<typeof useGetApp>);
+
+const renderBuilder = (path: string) =>
+    renderWithProviders(
+        <MemoryRouter initialEntries={[path]}>
+            <Routes>
+                <Route
+                    path="/projects/:projectUuid/chart-types/new"
+                    element={<ChartTypeBuilder />}
+                />
+                <Route
+                    path="/projects/:projectUuid/chart-types/:dataAppVizUuid"
+                    element={<ChartTypeBuilder />}
+                />
+                <Route
+                    path="/projects/:projectUuid/gallery"
+                    element={<div>gallery</div>}
+                />
+                <Route
+                    path="/projects/:projectUuid/home"
+                    element={<div>home</div>}
+                />
+                <Route
+                    path="/projects/:projectUuid/apps/:appUuid"
+                    element={<div>app-builder</div>}
+                />
+            </Routes>
+        </MemoryRouter>,
+    );
+
+describe('ChartTypeBuilder', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setFlag(true);
+        vi.mocked(useCanCreateDataApp).mockReturnValue(true);
+        vi.mocked(useCanEditDataApp).mockReturnValue(true);
+        vi.mocked(useDataAppVizBuild).mockReturnValue(buildStub());
+        vi.mocked(useDataAppVisualization).mockReturnValue({
+            data: undefined,
+        } as ReturnType<typeof useDataAppVisualization>);
+        setApp(null);
+        vi.mocked(useAppVersionHistory).mockReturnValue(historyStub([], null));
+    });
+
+    it('redirects home when data apps are disabled', () => {
+        setFlag(false);
+        renderBuilder('/projects/p1/chart-types/new');
+
+        expect(screen.getByText('home')).toBeInTheDocument();
+    });
+
+    it('sends users who cannot create back to the gallery', () => {
+        vi.mocked(useCanCreateDataApp).mockReturnValue(false);
+        renderBuilder('/projects/p1/chart-types/new');
+
+        expect(screen.getByText('gallery')).toBeInTheDocument();
+    });
+
+    it('reports a chart type that does not exist', () => {
+        setApp(null, { error: { statusCode: 404 } });
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        expect(screen.getByText('Chart type not found')).toBeInTheDocument();
+    });
+
+    it('hands non-viz apps to the app builder', () => {
+        setApp(appMeta({ template: 'dashboard' as AppMeta['template'] }));
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        expect(screen.getByText('app-builder')).toBeInTheDocument();
+    });
+
+    it('sends non-editors back to the gallery', () => {
+        setApp(appMeta());
+        vi.mocked(useCanEditDataApp).mockReturnValue(false);
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        expect(screen.getByText('gallery')).toBeInTheDocument();
+    });
+
+    it('starts the create flow with a prompt and nothing else', () => {
+        renderBuilder('/projects/p1/chart-types/new');
+
+        expect(screen.getByText('Start with a prompt')).toBeInTheDocument();
+        expect(
+            screen.getByPlaceholderText('Describe a new chart type…'),
+        ).toBeInTheDocument();
+        expect(screen.queryByText('Preview in explorer')).toBeNull();
+        // Nothing to configure before a schema exists.
+        expect(screen.queryByText('CONFIGURE')).toBeNull();
+    });
+
+    it('offers configuration once a version has declared a schema', () => {
+        setApp(appMeta());
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub([appVersion({ version: 1 })], 1),
+        );
+        vi.mocked(useDataAppVisualization).mockReturnValue({
+            data: {
+                schema: { fields: [], configOptions: [], colorPalette: null },
+            },
+        } as unknown as ReturnType<typeof useDataAppVisualization>);
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        expect(screen.getByText('CONFIGURE')).toBeInTheDocument();
+        expect(
+            screen.getByText('This chart type declares no display options.'),
+        ).toBeInTheDocument();
+    });
+
+    it('adopts the claimed app into the URL once a build is accepted', () => {
+        vi.mocked(useDataAppVizBuild).mockReturnValue(
+            buildStub({
+                isBuilding: true,
+                appUuid: '1e9a3b2c-0000-4000-8000-000000000009',
+                claimedVersion: 1,
+                pendingPrompt: 'a stream graph of category share',
+            }),
+        );
+        renderBuilder('/projects/p1/chart-types/new');
+
+        // The edit route re-renders with the uuid param; its useGetApp stub
+        // has no data, so the header stays bare.
+        expect(
+            screen.getByPlaceholderText('Describe a new chart type…'),
+        ).toBeInTheDocument();
+        // First build: the skeleton state echoes what was asked for.
+        expect(
+            screen.getByText('Building your chart type…'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText('“a stream graph of category share”'),
+        ).toBeInTheDocument();
+    });
+
+    it('keeps the previous version dimmed under the pill while rebuilding', () => {
+        setApp(appMeta());
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub([appVersion({ version: 1 })], 1),
+        );
+        vi.mocked(useDataAppVizBuild).mockReturnValue(
+            buildStub({
+                isBuilding: true,
+                appUuid: '1e9a3b2c-0000-4000-8000-000000000001',
+                claimedVersion: 2,
+                pendingPrompt: 'make the bars teal',
+            }),
+        );
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        expect(screen.getByTestId('app-preview')).toHaveTextContent(
+            'preview-v1',
+        );
+        expect(screen.getByText(/Building…/)).toBeInTheDocument();
+        expect(screen.queryByText('Building your chart type…')).toBeNull();
+    });
+
+    it('renders the current version with its timeline', () => {
+        setApp(appMeta());
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub(
+                [appVersion({ version: 2 }), appVersion({ version: 1 })],
+                2,
+            ),
+        );
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        expect(screen.getByTestId('app-preview')).toHaveTextContent(
+            'preview-v2',
+        );
+        expect(screen.getByText('v2 · current')).toBeInTheDocument();
+        expect(screen.getByText('Preview in explorer')).toBeInTheDocument();
+        expect(
+            screen.getByPlaceholderText('Ask for a change…'),
+        ).toBeInTheDocument();
+    });
+
+    it('explains a failed first build and keeps the prompt open', () => {
+        setApp(appMeta({ latestReadyVersion: null }));
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub(
+                [
+                    appVersion({
+                        version: 1,
+                        status: 'error',
+                        statusMessage: 'Sandbox crashed',
+                    }),
+                ],
+                null,
+            ),
+        );
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        expect(screen.getByText('The build failed')).toBeInTheDocument();
+        expect(screen.getByText('Sandbox crashed')).toBeInTheDocument();
+        expect(
+            screen.getByPlaceholderText('Ask for a change…'),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -1,0 +1,434 @@
+import {
+    DATA_APP_VIZ_TEMPLATE,
+    FeatureFlags,
+    isAppVersionInProgress,
+    type DataAppVizOptionValue,
+    type DataAppVizOptionValues,
+    type DataAppVizSchema,
+} from '@lightdash/common';
+import { Box, Button } from '@mantine/core';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
+import { Link, Navigate, useNavigate, useParams } from 'react-router';
+import { validate as isUuidString } from 'uuid';
+import { DocumentTitle } from '../components/common/DocumentTitle';
+import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
+import BuilderCanvas from '../features/apps/builder/BuilderCanvas';
+import BuilderPromptBar from '../features/apps/builder/BuilderPromptBar';
+import ChartTypeBuilderHeader from '../features/apps/builder/ChartTypeBuilderHeader';
+import ConfigureDrawer from '../features/apps/builder/ConfigureDrawer';
+import VersionChips from '../features/apps/builder/VersionChips';
+import { getAppVersionFailureMessage } from '../features/apps/getAppVersionFailureMessage';
+import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
+import { useAppVersionHistory } from '../features/apps/hooks/useAppVersionHistory';
+import { useCanCreateDataApp } from '../features/apps/hooks/useCanCreateDataApp';
+import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
+import { useDataAppVisualization } from '../features/apps/hooks/useDataAppVisualization';
+import { useDataAppVizBuild } from '../features/apps/hooks/useDataAppVizBuild';
+import { useElapsedClock } from '../features/apps/hooks/useElapsedClock';
+import { useGetApp } from '../features/apps/hooks/useGetApp';
+import { useUpdateApp } from '../features/apps/hooks/useUpdateApp';
+import { buildSampleVizContext } from '../features/apps/utils/sampleVizContext';
+import {
+    countVizContractChanges,
+    diffVizConfigOptions,
+    type VizContractDiff,
+} from '../features/apps/utils/vizContractDiff';
+import { useResolvedColorPalette } from '../hooks/appearance/useResolvedColorPalette';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import classes from './ChartTypeBuilder.module.css';
+
+const noop = () => undefined;
+
+/**
+ * The dedicated chart type builder. Mounted at both `chart-types/new`
+ * (create) and `chart-types/:dataAppVizUuid` (edit); the create flow
+ * adopts the new uuid into the URL once the first build is accepted.
+ */
+const ChartTypeBuilder: FC = () => {
+    const { projectUuid, dataAppVizUuid: urlVizUuid } = useParams<{
+        projectUuid: string;
+        dataAppVizUuid?: string;
+    }>();
+    const navigate = useNavigate();
+    const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const canCreate = useCanCreateDataApp(projectUuid);
+
+    // `useGetApp` accepts slugs, so the raw URL param is the right key.
+    const appQuery = useGetApp(projectUuid, urlVizUuid);
+    const appMeta = appQuery.data?.pages[0] ?? null;
+    // The uuid every uuid-keyed hook runs against; a slug URL resolves to it
+    // once the app row loads.
+    const activeVizUuid =
+        appMeta?.appUuid ??
+        (isUuidString(urlVizUuid ?? '') ? urlVizUuid : undefined);
+
+    const build = useDataAppVizBuild({
+        projectUuid,
+        // No chart query here; auto-mapping belongs to charts binding fields.
+        itemsMap: {},
+        dataAppVizUuid: activeVizUuid ?? null,
+        onCreated: noop,
+        creationExperience: 'chart_type_builder',
+    });
+
+    const historyUuid = activeVizUuid ?? build.appUuid;
+    const history = useAppVersionHistory(projectUuid ?? '', historyUuid);
+    const { data: dataAppViz } = useDataAppVisualization(
+        projectUuid,
+        activeVizUuid,
+    );
+
+    // Covers builds sent here and builds found already running in history.
+    const historyLatestInProgress =
+        history.latest !== null &&
+        isAppVersionInProgress(history.latest.status);
+    const buildStartedAt =
+        build.startedAt ??
+        (historyLatestInProgress && history.latest
+            ? new Date(history.latest.createdAt)
+            : null);
+    const elapsed = useElapsedClock(buildStartedAt);
+
+    // On `/new`, move to the edit route as soon as the build claims an app so
+    // a refresh mid-build lands on the in-progress version.
+    useEffect(() => {
+        if (!urlVizUuid && build.appUuid && projectUuid) {
+            void navigate(
+                `/projects/${projectUuid}/chart-types/${build.appUuid}`,
+                { replace: true },
+            );
+        }
+    }, [urlVizUuid, build.appUuid, projectUuid, navigate]);
+
+    // Intentional navigation between vizs resets session state; the
+    // post-submit `/new` → uuid replace must not.
+    const prevUrlVizUuid = useRef(urlVizUuid);
+    const [pin, setPin] = useState<{
+        appUuid: string;
+        version: number;
+        /** Latest ready version at the moment of pinning; the pin is treated
+         *  as cleared once a newer build finishes past this snapshot. */
+        pinnedAtLatest: number | null;
+    } | null>(null);
+    // Only what the author explicitly changed; defaults resolve at render.
+    const [optionValues, setOptionValues] = useState<DataAppVizOptionValues>(
+        {},
+    );
+    // Preview-only; a chart using the viz owns the palette the normal way.
+    const [colorPaletteUuid, setColorPaletteUuid] = useState<string | null>(
+        null,
+    );
+    const [drawerOpen, setDrawerOpen] = useState(false);
+    useEffect(() => {
+        const prev = prevUrlVizUuid.current;
+        prevUrlVizUuid.current = urlVizUuid;
+        // Post-submit redirect: undefined → new uuid. Don't clear state.
+        if (!prev && urlVizUuid) return;
+        setPin(null);
+        setOptionValues({});
+        setColorPaletteUuid(null);
+        setDrawerOpen(false);
+        setDiffBase(null);
+        setContractDiff(null);
+    }, [urlVizUuid]);
+
+    const isBuilding = build.isBuilding || historyLatestInProgress;
+
+    // Contract-diff bookkeeping: when a build starts, snapshot the declared
+    // options; once the rebuilt contract lands, hand the drawer what changed.
+    const [diffBase, setDiffBase] = useState<{
+        appUuid: string | null;
+        schema: DataAppVizSchema | null;
+        fromVersion: number | null;
+    } | null>(null);
+    const [contractDiff, setContractDiff] = useState<VizContractDiff | null>(
+        null,
+    );
+    const wasBuilding = useRef(false);
+    useEffect(() => {
+        if (isBuilding && !wasBuilding.current) {
+            setContractDiff(null);
+            setDiffBase({
+                appUuid: historyUuid ?? null,
+                schema: dataAppViz?.schema ?? null,
+                fromVersion: history.latestReadyVersion,
+            });
+        }
+        wasBuilding.current = isBuilding;
+    }, [
+        isBuilding,
+        historyUuid,
+        dataAppViz?.schema,
+        history.latestReadyVersion,
+    ]);
+
+    useEffect(() => {
+        if (diffBase === null || diffBase.schema === null) return;
+        if (diffBase.appUuid !== historyUuid) return;
+        const toVersion = history.latestReadyVersion;
+        if (
+            toVersion === null ||
+            diffBase.fromVersion === null ||
+            toVersion <= diffBase.fromVersion
+        ) {
+            return;
+        }
+        const nextSchema = dataAppViz?.schema;
+        // Same reference means react-query's structural sharing found the
+        // refetched contract deep-equal, i.e. the build changed nothing here.
+        if (!nextSchema || nextSchema === diffBase.schema) return;
+        const diff = diffVizConfigOptions(
+            diffBase.schema.configOptions,
+            nextSchema.configOptions,
+            diffBase.fromVersion,
+            toVersion,
+        );
+        setDiffBase(null);
+        if (countVizContractChanges(diff) > 0) {
+            setContractDiff(diff);
+            // Stale option edits must not survive a regeneration.
+            setOptionValues({});
+            setColorPaletteUuid(null);
+            // Don't leave the annotations behind a closed drawer.
+            setDrawerOpen(true);
+        }
+    }, [diffBase, historyUuid, history.latestReadyVersion, dataAppViz?.schema]);
+
+    // A build started elsewhere needs polling here; a build sent from this
+    // page already polls inside useDataAppVizBuild.
+    const externalBuildRunning = !build.isBuilding && historyLatestInProgress;
+    useAppBuildPoller(
+        projectUuid,
+        historyUuid ?? undefined,
+        externalBuildRunning,
+        noop,
+    );
+
+    // Derived pin: ignored when it belongs to another app, a newer version
+    // landed since, or the pinned version is no longer ready.
+    const effectiveViewedVersion = useMemo(() => {
+        if (pin === null || pin.appUuid !== activeVizUuid) return null;
+        if (
+            pin.pinnedAtLatest !== null &&
+            history.latestReadyVersion !== null &&
+            history.latestReadyVersion > pin.pinnedAtLatest
+        ) {
+            return null;
+        }
+        const stillReady = history.versions.some(
+            (v) => v.version === pin.version && v.status === 'ready',
+        );
+        return stillReady ? pin.version : null;
+    }, [pin, activeVizUuid, history.latestReadyVersion, history.versions]);
+
+    const previewVersion = effectiveViewedVersion ?? history.latestReadyVersion;
+
+    const colorPalette = useResolvedColorPalette(projectUuid, colorPaletteUuid);
+    // The sample-data preview context, rebuilt on any option or palette edit.
+    const previewContext = useMemo(
+        () =>
+            dataAppViz?.schema
+                ? buildSampleVizContext(
+                      dataAppViz.schema,
+                      colorPalette,
+                      optionValues,
+                  )
+                : null,
+        [dataAppViz?.schema, colorPalette, optionValues],
+    );
+
+    const handleOptionChange = useCallback(
+        (name: string, value: DataAppVizOptionValue) =>
+            setOptionValues((prev) => ({ ...prev, [name]: value })),
+        [],
+    );
+
+    const handleView = useCallback(
+        (version: number | null) => {
+            if (version === null) {
+                setPin(null);
+                return;
+            }
+            if (!activeVizUuid) return;
+            setPin({
+                appUuid: activeVizUuid,
+                version,
+                pinnedAtLatest: history.latestReadyVersion,
+            });
+        },
+        [activeVizUuid, history.latestReadyVersion],
+    );
+
+    const { mutate: updateApp } = useUpdateApp({ resourceLabel: 'Chart type' });
+    const handleSaveMeta = useCallback(
+        (patch: { name?: string; description?: string }) => {
+            if (!projectUuid || !appMeta) return;
+            updateApp({ projectUuid, appUuid: appMeta.appUuid, ...patch });
+        },
+        [projectUuid, appMeta, updateApp],
+    );
+
+    const canEdit = useCanEditDataApp(projectUuid, {
+        spaceUuid: appMeta?.spaceUuid ?? null,
+        createdByUserUuid: appMeta?.createdByUserUuid ?? null,
+    });
+
+    if (!projectUuid) return null;
+    if (dataAppsFlag.isLoading) return null;
+    if (!dataAppsFlag.data?.enabled) {
+        return <Navigate to={`/projects/${projectUuid}/home`} replace />;
+    }
+
+    const isCreateFlow = urlVizUuid === undefined && build.appUuid === null;
+    if (isCreateFlow && !canCreate) {
+        return <Navigate to={`/projects/${projectUuid}/gallery`} replace />;
+    }
+
+    if (appQuery.error?.error.statusCode === 404) {
+        return (
+            <Box className={classes.root}>
+                <Box className={classes.main}>
+                    <SuboptimalState
+                        title="Chart type not found"
+                        description="It may have been deleted, or the link is wrong."
+                        action={
+                            <Button
+                                component={Link}
+                                to={`/projects/${projectUuid}/gallery`}
+                                variant="default"
+                            >
+                                Back to the gallery
+                            </Button>
+                        }
+                    />
+                </Box>
+            </Box>
+        );
+    }
+
+    if (appMeta) {
+        // A data app that isn't a chart type belongs in the app builder.
+        if (appMeta.template !== DATA_APP_VIZ_TEMPLATE) {
+            return (
+                <Navigate
+                    to={`/projects/${projectUuid}/apps/${appMeta.appUuid}`}
+                    replace
+                />
+            );
+        }
+        if (!canEdit) {
+            return <Navigate to={`/projects/${projectUuid}/gallery`} replace />;
+        }
+    }
+
+    // The request in flight, or the stored prompt of a build found in history.
+    const buildingPrompt =
+        build.pendingPrompt ??
+        (historyLatestInProgress ? (history.latest?.prompt ?? null) : null);
+    // A first build on a brand-new viz is discarded whole; a revision is only
+    // cancelled. Builds found in history (started elsewhere) offer no cancel.
+    const onCancelBuild = build.isBuilding
+        ? build.draft !== null
+            ? build.discard
+            : build.cancel
+        : null;
+
+    // With nothing renderable, the newest terminal version explains itself.
+    const failureMessage =
+        history.latestReadyVersion === null &&
+        history.latest !== null &&
+        !isAppVersionInProgress(history.latest.status) &&
+        history.latest.status !== 'ready'
+            ? getAppVersionFailureMessage(history.latest)
+            : null;
+
+    const provenanceVersion = history.hasOrigin
+        ? history.oldest
+        : history.latest;
+
+    return (
+        <Box className={classes.root}>
+            <DocumentTitle title="Chart type builder" />
+            <ChartTypeBuilderHeader
+                projectUuid={projectUuid}
+                app={appMeta}
+                latestReadyVersion={history.latestReadyVersion}
+                provenanceVersion={provenanceVersion}
+                hasOrigin={history.hasOrigin}
+                onSaveMeta={handleSaveMeta}
+                onPreviewInExplorer={() =>
+                    void navigate(
+                        `/projects/${projectUuid}/tables?dataAppVizUuid=${activeVizUuid}`,
+                    )
+                }
+            />
+            <Box className={classes.main}>
+                {activeVizUuid && history.versions.length > 0 && (
+                    <VersionChips
+                        projectUuid={projectUuid}
+                        appUuid={activeVizUuid}
+                        versions={history.versions}
+                        latestReadyVersion={history.latestReadyVersion}
+                        viewedVersion={effectiveViewedVersion}
+                        onView={handleView}
+                        build={build}
+                        hasEarlier={history.hasEarlier}
+                        isFetchingEarlier={history.isFetchingEarlier}
+                        fetchEarlier={history.fetchEarlier}
+                    />
+                )}
+                <BuilderCanvas
+                    projectUuid={projectUuid}
+                    appUuid={activeVizUuid ?? null}
+                    previewVersion={previewVersion}
+                    isBuilding={isBuilding}
+                    buildingPrompt={buildingPrompt}
+                    elapsed={elapsed}
+                    onCancelBuild={onCancelBuild}
+                    failureMessage={failureMessage}
+                    previewContext={previewContext}
+                />
+                {dataAppViz?.schema && (
+                    <ConfigureDrawer
+                        // Remount when the annotation set changes so dismissed
+                        // highlights never outlive their contract diff.
+                        key={`${activeVizUuid}:${
+                            contractDiff
+                                ? `${contractDiff.fromVersion}-${contractDiff.toVersion}`
+                                : 'none'
+                        }`}
+                        opened={drawerOpen}
+                        onOpenChange={setDrawerOpen}
+                        schema={dataAppViz.schema}
+                        isBuilding={isBuilding}
+                        contractDiff={contractDiff}
+                        optionValues={optionValues}
+                        onOptionChange={handleOptionChange}
+                        colorPaletteUuid={colorPaletteUuid}
+                        onPaletteChange={setColorPaletteUuid}
+                    />
+                )}
+                {/* The composer captures its placeholder at mount, so wait for
+                    history before choosing create vs revise wording. */}
+                {!(activeVizUuid && history.isLoading) && (
+                    <BuilderPromptBar
+                        projectUuid={projectUuid}
+                        composerAppUuid={activeVizUuid ?? build.draftAppUuid}
+                        hasVersions={history.versions.length > 0}
+                        build={build}
+                        onCancelBuild={onCancelBuild}
+                    />
+                )}
+            </Box>
+        </Box>
+    );
+};
+
+export default ChartTypeBuilder;


### PR DESCRIPTION
Adds the dedicated chart type builder at `/projects/:projectUuid/chart-types/new` (create) and `/chart-types/:uuid` (edit): prompt bar at the bottom, the rendered visualization in the middle, version timeline chips on top, and a configure drawer on the right.

- The create flow adopts the new uuid into the URL as soon as a build claims an app, so a refresh mid-build lands on the in-progress version
- Version chips let you pin an older version, restore it (promoting it back to the head), or jump back to current
- The configure drawer owns a sample-data preview context and, after a rebuild, annotates what changed in the declared option contract: new options, defaults that moved, options that are gone
- Builds started elsewhere (or before a refresh) keep polling so their progress shows here too

Relates: GLITCH-661