### PR TITLE
feat: route chart type entry points to the dedicated builder

### DIFF
--- a/packages/frontend/src/features/apps/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeDetailModal.tsx
@@ -70,7 +70,7 @@ const ChartTypeDetailModal: FC<Props> = ({
             actions={
                 <Button
                     component={Link}
-                    to={`/projects/${projectUuid}/apps/${dataAppViz.dataAppVizUuid}`}
+                    to={`/projects/${projectUuid}/chart-types/${dataAppViz.dataAppVizUuid}`}
                     variant="default"
                     rightSection={<MantineIcon icon={IconExternalLink} />}
                 >

--- a/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.tsx
@@ -78,7 +78,7 @@ const ChartTypeGalleryCard: FC<Props> = ({ dataAppViz, onClick, onDelete }) => {
                                 leftSection={
                                     <MantineIcon icon={IconFilePencil} />
                                 }
-                                to={`/projects/${dataAppViz.projectUuid}/apps/${dataAppViz.dataAppVizUuid}`}
+                                to={`/projects/${dataAppViz.projectUuid}/chart-types/${dataAppViz.dataAppVizUuid}`}
                                 onClick={(e) => e.stopPropagation()}
                             >
                                 Edit

--- a/packages/frontend/src/hooks/useExplorerRoute.test.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.test.ts
@@ -1,6 +1,9 @@
 import { ChartType } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
-import { parseChartFromExplorerSearchParams } from './useExplorerRoute';
+import {
+    parseChartFromExplorerSearchParams,
+    parseDataAppVizUuidFromSearchParams,
+} from './useExplorerRoute';
 
 const searchFromPayload = (payload: unknown) =>
     `?create_saved_chart_version=${encodeURIComponent(
@@ -90,5 +93,25 @@ describe('parseChartFromExplorerSearchParams', () => {
             columnOrder: ['orders_status'],
         });
         expect(parsed!.metricQuery.limit).toBe(100);
+    });
+});
+
+describe('parseDataAppVizUuidFromSearchParams', () => {
+    it('returns the uuid a preview link carries', () => {
+        expect(
+            parseDataAppVizUuidFromSearchParams(
+                '?dataAppVizUuid=1e9a3b2c-0000-4000-8000-000000000001',
+            ),
+        ).toBe('1e9a3b2c-0000-4000-8000-000000000001');
+    });
+
+    it('returns null when the param is absent', () => {
+        expect(parseDataAppVizUuidFromSearchParams('')).toBeNull();
+    });
+
+    it('ignores values that are not uuids', () => {
+        expect(
+            parseDataAppVizUuidFromSearchParams('?dataAppVizUuid=not-a-uuid'),
+        ).toBeNull();
     });
 });

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -19,6 +19,7 @@ import {
     useParams,
     useSearchParams,
 } from 'react-router';
+import { validate as isUuidString } from 'uuid';
 import {
     explorerActions,
     selectMetricQuery,
@@ -157,6 +158,20 @@ type BackwardsCompatibleCreateSavedChartVersionUrlParam = Omit<
         sorts?: MetricQuery['sorts'];
         tableCalculations?: MetricQuery['tableCalculations'];
     };
+};
+
+/**
+ * The chart type a "Preview in explorer" link carries. The search string
+ * survives picking a table in the explore sidebar, so the link can be minted
+ * before a table is known.
+ */
+export const parseDataAppVizUuidFromSearchParams = (
+    search: string,
+): string | null => {
+    const dataAppVizUuid = new URLSearchParams(search).get('dataAppVizUuid');
+    return dataAppVizUuid && isUuidString(dataAppVizUuid)
+        ? dataAppVizUuid
+        : null;
 };
 
 export const parseChartFromExplorerSearchParams = (
@@ -300,6 +315,11 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
         if (pathParams.tableId) {
             try {
                 const parsedChart = parseChartFromExplorerSearchParams(search);
+                // A "Preview in explorer" link preselects the chart type;
+                // explicit chart state wins over the hint.
+                const dataAppVizUuid = parsedChart
+                    ? null
+                    : parseDataAppVizUuidFromSearchParams(search);
                 const unsavedChartVersion = parsedChart || {
                     tableName: pathParams.tableId,
                     metricQuery: {
@@ -316,22 +336,32 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
                     tableConfig: {
                         columnOrder: [],
                     },
-                    chartConfig: {
-                        type: ChartType.CARTESIAN,
-                        config: { layout: {}, eChartsConfig: {} },
-                    },
+                    chartConfig: dataAppVizUuid
+                        ? {
+                              type: ChartType.DATA_APP_VIZ,
+                              config: {
+                                  dataAppVizUuid,
+                                  fieldMapping: {},
+                                  optionValues: {},
+                              },
+                          }
+                        : {
+                              type: ChartType.CARTESIAN,
+                              config: { layout: {}, eChartsConfig: {} },
+                          },
                 };
 
                 return {
                     parameterReferences: [],
                     parameterDefinitions: {},
                     cachedChartConfigs: {},
-                    expandedSections: parsedChart
-                        ? [
-                              ExplorerSection.VISUALIZATION,
-                              ExplorerSection.RESULTS,
-                          ]
-                        : [ExplorerSection.RESULTS],
+                    expandedSections:
+                        parsedChart || dataAppVizUuid
+                            ? [
+                                  ExplorerSection.VISUALIZATION,
+                                  ExplorerSection.RESULTS,
+                              ]
+                            : [ExplorerSection.RESULTS],
                     unsavedChartVersion,
                     unsavedColorPaletteUuid: null,
                     modals: {

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     ChartKind,
+    DATA_APP_VIZ_TEMPLATE,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
     FeatureFlags,
     getVisibleDataAppClaudeModels,
@@ -1366,6 +1367,21 @@ const AppGenerate: FC = () => {
                     description="This data app doesn't exist or has been deleted."
                 />
             </Box>
+        );
+    }
+
+    // Chart types have their own builder; use the canonical uuid so slug
+    // deep links land on the uuid route.
+    if (
+        urlAppUuid &&
+        appPersistedTemplate === DATA_APP_VIZ_TEMPLATE &&
+        activeAppUuid
+    ) {
+        return (
+            <Navigate
+                to={`/projects/${projectUuid}/chart-types/${activeAppUuid}`}
+                replace
+            />
         );
     }
 

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -146,7 +146,10 @@ describe('ChartTypeGallery', () => {
         expect(screen.getByText('Preview in explorer')).toBeInTheDocument();
         expect(
             screen.getByText('Open in builder').closest('a'),
-        ).toHaveAttribute('href', '/projects/project-1/apps/data-app-viz-1');
+        ).toHaveAttribute(
+            'href',
+            '/projects/project-1/chart-types/data-app-viz-1',
+        );
         expect(screen.getByText('v3')).toBeInTheDocument();
         expect(screen.getByText('Value')).toBeInTheDocument();
     });
@@ -192,7 +195,7 @@ describe('ChartTypeGallery', () => {
 
         expect(screen.getByText('Edit').closest('a')).toHaveAttribute(
             'href',
-            '/projects/project-1/apps/data-app-viz-1',
+            '/projects/project-1/chart-types/data-app-viz-1',
         );
         expect(
             screen.getByText('Preview in explorer').closest('a'),

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -8,7 +8,6 @@ import {
     Stack,
     Text,
     TextInput,
-    Tooltip,
 } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconPlus, IconSearch } from '@tabler/icons-react';
@@ -115,20 +114,15 @@ const ChartTypeGallery = () => {
                                 projectUuid,
                             })}
                         >
-                            <Tooltip label="Chart types are built from a query: open a table in the explorer and pick “Custom” as the chart type">
-                                <Button
-                                    component={Link}
-                                    to={`/projects/${projectUuid}/tables`}
-                                    leftSection={
-                                        <MantineIcon
-                                            icon={IconPlus}
-                                            size={18}
-                                        />
-                                    }
-                                >
-                                    New chart type
-                                </Button>
-                            </Tooltip>
+                            <Button
+                                component={Link}
+                                to={`/projects/${projectUuid}/chart-types/new`}
+                                leftSection={
+                                    <MantineIcon icon={IconPlus} size={18} />
+                                }
+                            >
+                                New chart type
+                            </Button>
                         </Can>
                     </Group>
                 </Group>
@@ -145,7 +139,7 @@ const ChartTypeGallery = () => {
                         <Text ta="center" fz="sm" c="ldGray.6">
                             {debouncedSearch
                                 ? `No chart types match “${debouncedSearch}”`
-                                : 'No chart types yet. Build one from a query in the explorer by picking “Custom” as the chart type.'}
+                                : 'No chart types yet. Describe one in the builder to get started.'}
                         </Text>
                     </Paper>
                 ) : (


### PR DESCRIPTION
Routes the chart type entry points at the dedicated builder: gallery cards and the detail modal link to `/chart-types/:uuid`, "Preview in explorer" links carry a `dataAppVizUuid` search param that survives picking a table and preselects the chart type, and `AppGenerate` redirects chart-type apps to the builder so slug deep links land on the right page.

Relates: GLITCH-660
Relates: GLITCH-661