### PR TITLE
Add exclude option to quick filters and refactor filter UI

### DIFF
--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -2305,3 +2305,219 @@ describe('getUnmetFilterRequirements', () => {
         expect(getUnmetFilterRequirements(filters)).toEqual([]);
     });
 });
+
+describe('createFilterRuleFromField — quick filter operator per field type', () => {
+    const typedDim = (type: DimensionType) => ({
+        ...dimension('field', 'orders'),
+        type,
+    });
+    const intervalDim = (timeInterval: TimeFrames) =>
+        ({
+            ...dimension(`order_date_${timeInterval.toLowerCase()}`, 'orders'),
+            type: DimensionType.DATE,
+            timeInterval,
+            timeIntervalBaseDimensionName: 'order_date',
+            timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+        }) as const;
+
+    describe('include (equals, the default)', () => {
+        test('string dimension', () => {
+            const rule = createFilterRuleFromField(
+                typedDim(DimensionType.STRING),
+                'completed',
+            );
+            expect(rule.operator).toBe(FilterOperator.EQUALS);
+            expect(rule.values).toEqual(['completed']);
+        });
+
+        test('number dimension', () => {
+            const rule = createFilterRuleFromField(
+                typedDim(DimensionType.NUMBER),
+                42,
+            );
+            expect(rule.operator).toBe(FilterOperator.EQUALS);
+            expect(rule.values).toEqual([42]);
+        });
+
+        test('boolean dimension', () => {
+            const rule = createFilterRuleFromField(
+                typedDim(DimensionType.BOOLEAN),
+                true,
+            );
+            expect(rule.operator).toBe(FilterOperator.EQUALS);
+            expect(rule.values).toEqual([true]);
+        });
+
+        test('null value becomes isNull', () => {
+            const rule = createFilterRuleFromField(
+                typedDim(DimensionType.STRING),
+                null,
+            );
+            expect(rule.operator).toBe(FilterOperator.NULL);
+            expect(rule.values).toEqual([]);
+        });
+    });
+
+    describe('exclude (notEquals)', () => {
+        test('string dimension', () => {
+            const rule = createFilterRuleFromField(
+                typedDim(DimensionType.STRING),
+                'completed',
+                undefined,
+                FilterOperator.NOT_EQUALS,
+            );
+            expect(rule.operator).toBe(FilterOperator.NOT_EQUALS);
+            expect(rule.values).toEqual(['completed']);
+        });
+
+        test('number dimension', () => {
+            const rule = createFilterRuleFromField(
+                typedDim(DimensionType.NUMBER),
+                42,
+                undefined,
+                FilterOperator.NOT_EQUALS,
+            );
+            expect(rule.operator).toBe(FilterOperator.NOT_EQUALS);
+            expect(rule.values).toEqual([42]);
+        });
+
+        test('boolean dimension', () => {
+            const rule = createFilterRuleFromField(
+                typedDim(DimensionType.BOOLEAN),
+                false,
+                undefined,
+                FilterOperator.NOT_EQUALS,
+            );
+            expect(rule.operator).toBe(FilterOperator.NOT_EQUALS);
+            expect(rule.values).toEqual([false]);
+        });
+
+        test('null value becomes notNull', () => {
+            const rule = createFilterRuleFromField(
+                typedDim(DimensionType.STRING),
+                null,
+                undefined,
+                FilterOperator.NOT_EQUALS,
+            );
+            expect(rule.operator).toBe(FilterOperator.NOT_NULL);
+            expect(rule.values).toEqual([]);
+        });
+    });
+
+    describe('falsy but real values are kept', () => {
+        test('number 0 with equals', () => {
+            const rule = createFilterRuleFromField(
+                typedDim(DimensionType.NUMBER),
+                0,
+            );
+            expect(rule.operator).toBe(FilterOperator.EQUALS);
+            expect(rule.values).toEqual([0]);
+        });
+
+        test('number 0 with notEquals', () => {
+            const rule = createFilterRuleFromField(
+                typedDim(DimensionType.NUMBER),
+                0,
+                undefined,
+                FilterOperator.NOT_EQUALS,
+            );
+            expect(rule.values).toEqual([0]);
+        });
+
+        test('boolean false with equals', () => {
+            const rule = createFilterRuleFromField(
+                typedDim(DimensionType.BOOLEAN),
+                false,
+            );
+            expect(rule.operator).toBe(FilterOperator.EQUALS);
+            expect(rule.values).toEqual([false]);
+        });
+    });
+
+    describe.each([FilterOperator.EQUALS, FilterOperator.NOT_EQUALS] as const)(
+        'date/timestamp value formatting is identical for %s',
+        (operator) => {
+            test('DAY keeps the calendar day', () => {
+                const rule = createFilterRuleFromField(
+                    intervalDim(TimeFrames.DAY),
+                    '2026-03-03',
+                    undefined,
+                    operator,
+                );
+                expect(rule.operator).toBe(operator);
+                expect(rule.values).toEqual(['2026-03-03']);
+            });
+
+            test('WEEK keeps the week-commencing day', () => {
+                const rule = createFilterRuleFromField(
+                    intervalDim(TimeFrames.WEEK),
+                    '2026-03-02',
+                    undefined,
+                    operator,
+                );
+                expect(rule.values).toEqual(['2026-03-02']);
+            });
+
+            test('MONTH formats as YYYY-MM', () => {
+                const rule = createFilterRuleFromField(
+                    intervalDim(TimeFrames.MONTH),
+                    '2026-03-01',
+                    undefined,
+                    operator,
+                );
+                expect(rule.values).toEqual(['2026-03']);
+            });
+
+            test('QUARTER stores the first day of the quarter', () => {
+                const rule = createFilterRuleFromField(
+                    intervalDim(TimeFrames.QUARTER),
+                    '2025-04-01',
+                    undefined,
+                    operator,
+                );
+                expect(rule.values).toEqual(['2025-04-01']);
+            });
+
+            test('YEAR formats as YYYY', () => {
+                const rule = createFilterRuleFromField(
+                    intervalDim(TimeFrames.YEAR),
+                    '2026-01-01',
+                    undefined,
+                    operator,
+                );
+                expect(rule.values).toEqual(['2026']);
+            });
+
+            test('timestamp (RAW) keeps the full instant as ISO', () => {
+                const rawDim = {
+                    ...dimension('created_raw', 'customers'),
+                    type: DimensionType.TIMESTAMP,
+                    timeInterval: TimeFrames.RAW,
+                } as const;
+                const rule = createFilterRuleFromField(
+                    rawDim,
+                    '2025-06-28T11:00:00+00:00',
+                    'UTC',
+                    operator,
+                );
+                expect(rule.operator).toBe(operator);
+                expect(rule.values).toEqual(['2025-06-28T11:00:00+00:00']);
+            });
+
+            test('timestamp HOUR keeps the truncated instant', () => {
+                const hourDim = {
+                    ...dimension('timestamp_tz_hour', 'events'),
+                    type: DimensionType.TIMESTAMP,
+                    timeInterval: TimeFrames.HOUR,
+                } as const;
+                const rule = createFilterRuleFromField(
+                    hourDim,
+                    '2020-08-11T23:00:00+00:00',
+                    'UTC',
+                    operator,
+                );
+                expect(rule.values).toEqual(['2020-08-11T23:00:00+00:00']);
+            });
+        },
+    );
+});

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -422,7 +422,8 @@ export const createFilterRuleFromField = (
             },
             operator: ruleOperator,
         },
-        value ? [value] : [],
+        // isNil, not truthiness: false and 0 are real filter values
+        isNil(value) ? [] : [value],
         timezone,
     );
 };

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -395,24 +395,37 @@ export const getFilterRuleFromFieldWithDefaultValue = <T extends FilterRule>(
         timezone,
     );
 
+// Quick filters created from a cell/chart value are either inclusive or exclusive
+export type QuickFilterOperator =
+    | FilterOperator.EQUALS
+    | FilterOperator.NOT_EQUALS;
+
 export const createFilterRuleFromField = (
     field: FilterableField,
     value?: AnyType,
     timezone?: string,
-): FilterRule =>
-    getFilterRuleFromFieldWithDefaultValue(
+    operator: QuickFilterOperator = FilterOperator.EQUALS,
+): FilterRule => {
+    const isExclude = operator === FilterOperator.NOT_EQUALS;
+    let ruleOperator: FilterOperator = operator;
+    if (value === null) {
+        ruleOperator = isExclude
+            ? FilterOperator.NOT_NULL
+            : FilterOperator.NULL;
+    }
+    return getFilterRuleFromFieldWithDefaultValue(
         field,
         {
             id: uuidv4(),
             target: {
                 fieldId: getItemId(field),
             },
-            operator:
-                value === null ? FilterOperator.NULL : FilterOperator.EQUALS,
+            operator: ruleOperator,
         },
         value ? [value] : [],
         timezone,
     );
+};
 
 export const matchFieldExact = (a: Field) => (b: Field) =>
     a.type === b.type && a.name === b.name && a.table === b.table;
@@ -574,6 +587,7 @@ type AddFilterRuleArgs = {
     field: FilterableField;
     value?: AnyType;
     timezone?: string;
+    operator?: QuickFilterOperator;
 };
 
 export const addFilterRule = ({
@@ -581,6 +595,7 @@ export const addFilterRule = ({
     field,
     value,
     timezone,
+    operator,
 }: AddFilterRuleArgs): Filters => {
     const groupKey = ((f: AnyType) => {
         if (isDimension(f) || isCustomSqlDimension(f)) {
@@ -599,7 +614,7 @@ export const addFilterRule = ({
             ...group,
             [getFilterGroupItemsPropertyName(group)]: [
                 ...getItemsFromFilterGroup(group),
-                createFilterRuleFromField(field, value, timezone),
+                createFilterRuleFromField(field, value, timezone, operator),
             ],
         },
     };

--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -219,7 +219,7 @@ describe('Date tests', () => {
         cy.get(
             '.mantine-Card-root tbody > :nth-child(1) > :nth-child(5)',
         ).click();
-        cy.contains('Filter by 2025').click();
+        cy.contains('Show only 2025').click();
         cy.get('.mantine-YearPickerInput-input').contains('2025');
 
         cy.wait('@compileQuery')
@@ -233,7 +233,7 @@ describe('Date tests', () => {
         cy.get(
             '.mantine-Card-root tbody > :nth-child(1) > :nth-child(4)',
         ).click();
-        cy.contains('Filter by 2025-06').click();
+        cy.contains('Show only 2025-06').click();
 
         cy.get('.mantine-MonthPickerInput-input').contains('June 2025');
         cy.wait('@compileQuery')
@@ -247,7 +247,7 @@ describe('Date tests', () => {
         cy.get(
             '.mantine-Card-root tbody > :nth-child(1) > :nth-child(3)',
         ).click();
-        cy.contains('Filter by 2025-06-09').click();
+        cy.contains('Show only 2025-06-09').click();
         cy.get('.mantine-DateInput-input').should('have.value', 'June 9, 2025');
 
         cy.wait('@compileQuery')
@@ -261,7 +261,7 @@ describe('Date tests', () => {
         cy.get(
             '.mantine-Card-root tbody > :nth-child(1) > :nth-child(2)',
         ).click();
-        cy.contains('Filter by 2025-06-15').click();
+        cy.contains('Show only 2025-06-15').click();
         cy.get('.mantine-DateInput-input').should('have.value', 'June 9, 2025');
         cy.wait('@compileQuery')
             .its('response.body.results.query')
@@ -291,7 +291,7 @@ describe('Date tests', () => {
         cy.get(
             '.mantine-Card-root tbody > :nth-child(1) > :nth-child(2)',
         ).click();
-        cy.contains('Filter by 2020-08-11, 23:44:00:000 (+00:00)').click(); // Server Timezone sensitive
+        cy.contains('Show only 2020-08-11, 23:44:00:000 (+00:00)').click(); // Server Timezone sensitive
         cy.get('.mantine-DateTimePicker-input').contains(
             getLocalTime('2020-08-11 23:44:00'), // Timezone sensitive
         );
@@ -307,7 +307,7 @@ describe('Date tests', () => {
         cy.get(
             '.mantine-Card-root tbody > :nth-child(1) > :nth-child(3)',
         ).click();
-        cy.contains('Filter by 2020-08-11, 23:44:00:000 (+00:00)').click(); // Server Timezone sensitive
+        cy.contains('Show only 2020-08-11, 23:44:00:000 (+00:00)').click(); // Server Timezone sensitive
         cy.get('.mantine-DateTimePicker-input').contains(
             getLocalTime('2020-08-11 23:44:00'), // Timezone sensitive
         );
@@ -322,7 +322,7 @@ describe('Date tests', () => {
         cy.get(
             '.mantine-Card-root tbody > :nth-child(1) > :nth-child(4)',
         ).click();
-        cy.contains('Filter by 2020-08-11, 23:44:00 (+00:00)').click(); // Server Timezone sensitive
+        cy.contains('Show only 2020-08-11, 23:44:00 (+00:00)').click(); // Server Timezone sensitive
         cy.get('.mantine-DateTimePicker-input').contains(
             getLocalTime('2020-08-11 23:44:00'), // Timezone sensitive
         );
@@ -337,7 +337,7 @@ describe('Date tests', () => {
         cy.get(
             '.mantine-Card-root tbody > :nth-child(1) > :nth-child(5)',
         ).click();
-        cy.contains('Filter by 2020-08-11, 23:44 (+00:00)').click(); // Server Timezone sensitive
+        cy.contains('Show only 2020-08-11, 23:44 (+00:00)').click(); // Server Timezone sensitive
         cy.get('.mantine-DateTimePicker-input').contains(
             getLocalTime('2020-08-11 23:44:00'), // Timezone sensitive
         );
@@ -352,7 +352,7 @@ describe('Date tests', () => {
         cy.get(
             '.mantine-Card-root tbody > :nth-child(1) > :nth-child(6)',
         ).click();
-        cy.contains('Filter by 2020-08-11, 23 (+00:00)').click(); // Server Timezone sensitive
+        cy.contains('Show only 2020-08-11, 23 (+00:00)').click(); // Server Timezone sensitive
         cy.get('.mantine-DateTimePicker-input').contains(
             getLocalTime('2020-08-11 23:00:00'), // Timezone sensitive
         );

--- a/packages/frontend/src/components/Explorer/QuickFilterMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/QuickFilterMenuItems.tsx
@@ -5,16 +5,17 @@ import {
     type QuickFilterOperator,
     type ResultValue,
 } from '@lightdash/common';
-import { Menu, Text } from '@mantine/core';
+import { Group, Menu, Text } from '@mantine/core';
 import { IconFilter, IconFilterX } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import { useFilters } from '../../hooks/useFilters';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
 import MantineIcon from '../common/MantineIcon';
+import TruncatedText from '../common/TruncatedText';
 import { useMetricQueryDataContext } from '../MetricQueryData/useMetricQueryDataContext';
 
-const MAX_FILTER_VALUE_LABEL_LENGTH = 40;
+const MAX_FILTER_VALUE_WIDTH = 250;
 
 type Props = {
     item: FilterableField;
@@ -48,11 +49,6 @@ const QuickFilterMenuItems: FC<Props> = ({ item, value }) => {
         [track, addFilter, item, value, resolvedTimezone],
     );
 
-    const filterValueLabel =
-        value.formatted.length > MAX_FILTER_VALUE_LABEL_LENGTH
-            ? `${value.formatted.slice(0, MAX_FILTER_VALUE_LABEL_LENGTH)}...`
-            : value.formatted;
-
     return (
         <>
             {(
@@ -73,40 +69,21 @@ const QuickFilterMenuItems: FC<Props> = ({ item, value }) => {
                     key={operator}
                     leftSection={<MantineIcon icon={icon} />}
                     onClick={() => handleFilterByValue(operator)}
-                    style={{ maxWidth: 360 }}
                 >
-                    <Text
-                        span
-                        fz="inherit"
-                        lh="inherit"
-                        style={{
-                            display: 'block',
-                            maxWidth: '100%',
-                            minWidth: 0,
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                        }}
-                    >
+                    <Group gap={4} wrap="nowrap">
                         <Text span fz="inherit" lh="inherit">
-                            {label}&nbsp;
+                            {label}
                         </Text>
-                        <Text
-                            span
+                        <TruncatedText
+                            inline
+                            fw="bold"
                             fz="inherit"
                             lh="inherit"
-                            fw="bold"
-                            title={value.formatted}
-                            style={{
-                                minWidth: 0,
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                            }}
+                            maxWidth={MAX_FILTER_VALUE_WIDTH}
                         >
-                            {filterValueLabel}
-                        </Text>
-                    </Text>
+                            {value.formatted}
+                        </TruncatedText>
+                    </Group>
                 </Menu.Item>
             ))}
         </>

--- a/packages/frontend/src/components/Explorer/QuickFilterMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/QuickFilterMenuItems.tsx
@@ -1,0 +1,116 @@
+import {
+    FilterOperator,
+    isDimensionValueInvalidDate,
+    type FilterableField,
+    type QuickFilterOperator,
+    type ResultValue,
+} from '@lightdash/common';
+import { Menu, Text } from '@mantine/core';
+import { IconFilter, IconFilterX } from '@tabler/icons-react';
+import { useCallback, type FC } from 'react';
+import { useFilters } from '../../hooks/useFilters';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
+import MantineIcon from '../common/MantineIcon';
+import { useMetricQueryDataContext } from '../MetricQueryData/useMetricQueryDataContext';
+
+const MAX_FILTER_VALUE_LABEL_LENGTH = 40;
+
+type Props = {
+    item: FilterableField;
+    value: ResultValue;
+};
+
+/**
+ * "Show only X" / "Exclude X" quick-filter items for a cell context menu.
+ * Requires the explorer store (useFilters) — only render when the
+ * visualization is in edit mode with an explorer store available.
+ */
+const QuickFilterMenuItems: FC<Props> = ({ item, value }) => {
+    const { addFilter } = useFilters();
+    const { resolvedTimezone } = useMetricQueryDataContext();
+    const { track } = useTracking();
+
+    const handleFilterByValue = useCallback(
+        (operator: QuickFilterOperator) => {
+            track({
+                name: EventName.ADD_FILTER_CLICKED,
+            });
+
+            const filterValue =
+                value.raw === undefined ||
+                isDimensionValueInvalidDate(item, value)
+                    ? null // Set as null if value is invalid date or undefined
+                    : value.raw;
+
+            addFilter(item, filterValue, resolvedTimezone, operator);
+        },
+        [track, addFilter, item, value, resolvedTimezone],
+    );
+
+    const filterValueLabel =
+        value.formatted.length > MAX_FILTER_VALUE_LABEL_LENGTH
+            ? `${value.formatted.slice(0, MAX_FILTER_VALUE_LABEL_LENGTH)}...`
+            : value.formatted;
+
+    return (
+        <>
+            {(
+                [
+                    {
+                        label: 'Show only',
+                        icon: IconFilter,
+                        operator: FilterOperator.EQUALS,
+                    },
+                    {
+                        label: 'Exclude',
+                        icon: IconFilterX,
+                        operator: FilterOperator.NOT_EQUALS,
+                    },
+                ] as const
+            ).map(({ label, icon, operator }) => (
+                <Menu.Item
+                    key={operator}
+                    leftSection={<MantineIcon icon={icon} />}
+                    onClick={() => handleFilterByValue(operator)}
+                    style={{ maxWidth: 360 }}
+                >
+                    <Text
+                        span
+                        fz="inherit"
+                        lh="inherit"
+                        style={{
+                            display: 'block',
+                            maxWidth: '100%',
+                            minWidth: 0,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        <Text span fz="inherit" lh="inherit">
+                            {label}&nbsp;
+                        </Text>
+                        <Text
+                            span
+                            fz="inherit"
+                            lh="inherit"
+                            fw="bold"
+                            title={value.formatted}
+                            style={{
+                                minWidth: 0,
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                            }}
+                        >
+                            {filterValueLabel}
+                        </Text>
+                    </Text>
+                </Menu.Item>
+            ))}
+        </>
+    );
+};
+
+export default QuickFilterMenuItems;

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -1,29 +1,20 @@
 import { subject } from '@casl/ability';
 import {
-    FilterOperator,
     hasCustomBinDimension,
     isCustomDimension,
     isDimension,
-    isDimensionValueInvalidDate,
     isField,
     isFilterableField,
     type Field,
-    type QuickFilterOperator,
     type ResultValue,
     type TableCalculation,
 } from '@lightdash/common';
-import { Menu, Text } from '@mantine/core';
+import { Menu } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
-import {
-    IconCopy,
-    IconFilter,
-    IconFilterX,
-    IconStack,
-} from '@tabler/icons-react';
+import { IconCopy, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
-import { useFilters } from '../../../hooks/useFilters';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
@@ -38,9 +29,8 @@ import MantineIcon from '../../common/MantineIcon';
 import { type CellContextMenuProps } from '../../common/Table/types';
 import DrillDownMenuItem from '../../MetricQueryData/DrillDownMenuItem';
 import { useMetricQueryDataContext } from '../../MetricQueryData/useMetricQueryDataContext';
+import QuickFilterMenuItems from '../QuickFilterMenuItems';
 import UrlMenuItems from './UrlMenuItems';
-
-const MAX_FILTER_VALUE_LABEL_LENGTH = 40;
 
 const CellContextMenu: FC<
     Pick<CellContextMenuProps, 'cell' | 'isEditMode' | 'onViewJsonCell'> & {
@@ -48,8 +38,7 @@ const CellContextMenu: FC<
         onExpand: (name: string, data: object) => void;
     }
 > = ({ cell, isEditMode, itemsMap, onViewJsonCell }) => {
-    const { addFilter } = useFilters();
-    const { openUnderlyingDataModal, metricQuery, resolvedTimezone } =
+    const { openUnderlyingDataModal, metricQuery } =
         useMetricQueryDataContext();
     const { track } = useTracking();
     const { showToastSuccess } = useToaster();
@@ -100,31 +89,8 @@ const CellContextMenu: FC<
         projectUuid,
     ]);
 
-    const handleFilterByValue = useCallback(
-        (operator: QuickFilterOperator) => {
-            if (!item || !isFilterableField(item)) return;
-
-            track({
-                name: EventName.ADD_FILTER_CLICKED,
-            });
-
-            const filterValue =
-                value.raw === undefined ||
-                isDimensionValueInvalidDate(item, value)
-                    ? null // Set as null if value is invalid date or undefined
-                    : value.raw;
-
-            addFilter(item, filterValue, resolvedTimezone, operator);
-        },
-        [track, addFilter, item, value, resolvedTimezone],
-    );
-
     const jsonValue =
         getJsonCellValue(value.raw) ?? getJsonLikeString(value.raw);
-    const filterValueLabel =
-        value.formatted.length > MAX_FILTER_VALUE_LABEL_LENGTH
-            ? `${value.formatted.slice(0, MAX_FILTER_VALUE_LABEL_LENGTH)}...`
-            : value.formatted;
 
     return (
         <>
@@ -171,63 +137,9 @@ const CellContextMenu: FC<
                     projectUuid: projectUuid,
                 })}
             >
-                {isEditMode &&
-                    item &&
-                    isFilterableField(item) &&
-                    (
-                        [
-                            {
-                                label: 'Show only',
-                                icon: IconFilter,
-                                operator: FilterOperator.EQUALS,
-                            },
-                            {
-                                label: 'Exclude',
-                                icon: IconFilterX,
-                                operator: FilterOperator.NOT_EQUALS,
-                            },
-                        ] as const
-                    ).map(({ label, icon, operator }) => (
-                        <Menu.Item
-                            key={operator}
-                            leftSection={<MantineIcon icon={icon} />}
-                            onClick={() => handleFilterByValue(operator)}
-                            style={{ maxWidth: 360 }}
-                        >
-                            <Text
-                                span
-                                fz="inherit"
-                                lh="inherit"
-                                style={{
-                                    display: 'block',
-                                    maxWidth: '100%',
-                                    minWidth: 0,
-                                    overflow: 'hidden',
-                                    textOverflow: 'ellipsis',
-                                    whiteSpace: 'nowrap',
-                                }}
-                            >
-                                <Text span fz="inherit" lh="inherit">
-                                    {label}&nbsp;
-                                </Text>
-                                <Text
-                                    span
-                                    fz="inherit"
-                                    lh="inherit"
-                                    fw="bold"
-                                    title={value.formatted}
-                                    style={{
-                                        minWidth: 0,
-                                        overflow: 'hidden',
-                                        textOverflow: 'ellipsis',
-                                        whiteSpace: 'nowrap',
-                                    }}
-                                >
-                                    {filterValueLabel}
-                                </Text>
-                            </Text>
-                        </Menu.Item>
-                    ))}
+                {isEditMode && item && isFilterableField(item) && (
+                    <QuickFilterMenuItems item={item} value={value} />
+                )}
 
                 <DrillDownMenuItem
                     item={item}

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -182,7 +182,7 @@ const CellContextMenu: FC<
                                 operator: FilterOperator.EQUALS,
                             },
                             {
-                                label: 'Hide',
+                                label: 'Exclude',
                                 icon: IconFilterOff,
                                 operator: FilterOperator.NOT_EQUALS,
                             },

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -17,7 +17,7 @@ import { useClipboard } from '@mantine/hooks';
 import {
     IconCopy,
     IconFilter,
-    IconFilterOff,
+    IconFilterX,
     IconStack,
 } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
@@ -183,7 +183,7 @@ const CellContextMenu: FC<
                             },
                             {
                                 label: 'Exclude',
-                                icon: IconFilterOff,
+                                icon: IconFilterX,
                                 operator: FilterOperator.NOT_EQUALS,
                             },
                         ] as const

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    FilterOperator,
     hasCustomBinDimension,
     isCustomDimension,
     isDimension,
@@ -7,12 +8,18 @@ import {
     isField,
     isFilterableField,
     type Field,
+    type QuickFilterOperator,
     type ResultValue,
     type TableCalculation,
 } from '@lightdash/common';
 import { Menu, Text } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
-import { IconCopy, IconFilter, IconStack } from '@tabler/icons-react';
+import {
+    IconCopy,
+    IconFilter,
+    IconFilterOff,
+    IconStack,
+} from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -93,20 +100,24 @@ const CellContextMenu: FC<
         projectUuid,
     ]);
 
-    const handleFilterByValue = useCallback(() => {
-        if (!item || !isFilterableField(item)) return;
+    const handleFilterByValue = useCallback(
+        (operator: QuickFilterOperator) => {
+            if (!item || !isFilterableField(item)) return;
 
-        track({
-            name: EventName.ADD_FILTER_CLICKED,
-        });
+            track({
+                name: EventName.ADD_FILTER_CLICKED,
+            });
 
-        const filterValue =
-            value.raw === undefined || isDimensionValueInvalidDate(item, value)
-                ? null // Set as null if value is invalid date or undefined
-                : value.raw;
+            const filterValue =
+                value.raw === undefined ||
+                isDimensionValueInvalidDate(item, value)
+                    ? null // Set as null if value is invalid date or undefined
+                    : value.raw;
 
-        addFilter(item, filterValue, resolvedTimezone);
-    }, [track, addFilter, item, value, resolvedTimezone]);
+            addFilter(item, filterValue, resolvedTimezone, operator);
+        },
+        [track, addFilter, item, value, resolvedTimezone],
+    );
 
     const jsonValue =
         getJsonCellValue(value.raw) ?? getJsonLikeString(value.raw);
@@ -160,46 +171,63 @@ const CellContextMenu: FC<
                     projectUuid: projectUuid,
                 })}
             >
-                {isEditMode && item && isFilterableField(item) && (
-                    <Menu.Item
-                        leftSection={<MantineIcon icon={IconFilter} />}
-                        onClick={handleFilterByValue}
-                        style={{ maxWidth: 360 }}
-                    >
-                        <Text
-                            span
-                            fz="inherit"
-                            lh="inherit"
-                            style={{
-                                display: 'block',
-                                maxWidth: '100%',
-                                minWidth: 0,
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                            }}
+                {isEditMode &&
+                    item &&
+                    isFilterableField(item) &&
+                    (
+                        [
+                            {
+                                label: 'Show only',
+                                icon: IconFilter,
+                                operator: FilterOperator.EQUALS,
+                            },
+                            {
+                                label: 'Hide',
+                                icon: IconFilterOff,
+                                operator: FilterOperator.NOT_EQUALS,
+                            },
+                        ] as const
+                    ).map(({ label, icon, operator }) => (
+                        <Menu.Item
+                            key={operator}
+                            leftSection={<MantineIcon icon={icon} />}
+                            onClick={() => handleFilterByValue(operator)}
+                            style={{ maxWidth: 360 }}
                         >
-                            <Text span fz="inherit" lh="inherit">
-                                Filter by&nbsp;
-                            </Text>
                             <Text
                                 span
                                 fz="inherit"
                                 lh="inherit"
-                                fw="bold"
-                                title={value.formatted}
                                 style={{
+                                    display: 'block',
+                                    maxWidth: '100%',
                                     minWidth: 0,
                                     overflow: 'hidden',
                                     textOverflow: 'ellipsis',
                                     whiteSpace: 'nowrap',
                                 }}
                             >
-                                {filterValueLabel}
+                                <Text span fz="inherit" lh="inherit">
+                                    {label}&nbsp;
+                                </Text>
+                                <Text
+                                    span
+                                    fz="inherit"
+                                    lh="inherit"
+                                    fw="bold"
+                                    title={value.formatted}
+                                    style={{
+                                        minWidth: 0,
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                        whiteSpace: 'nowrap',
+                                    }}
+                                >
+                                    {filterValueLabel}
+                                </Text>
                             </Text>
-                        </Text>
-                    </Menu.Item>
-                )}
+                        </Menu.Item>
+                    ))}
 
                 <DrillDownMenuItem
                     item={item}

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -4,6 +4,7 @@ import {
     isCustomDimension,
     isDimension,
     isField,
+    isFilterableField,
     type ResultValue,
 } from '@lightdash/common';
 import { Menu } from '@mantine/core';
@@ -19,13 +20,16 @@ import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
 import MantineIcon from '../common/MantineIcon';
 import { type CellContextMenuProps } from '../common/Table/types';
+import QuickFilterMenuItems from '../Explorer/QuickFilterMenuItems';
 import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
+import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import DrillDownMenuItem from '../MetricQueryData/DrillDownMenuItem';
 import { useMetricQueryDataContext } from '../MetricQueryData/useMetricQueryDataContext';
 
 const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
     const { openUnderlyingDataModal, metricQuery } =
         useMetricQueryDataContext();
+    const { isEditMode, hasExplorerStore } = useVisualizationContext();
     const { showToastSuccess } = useToaster();
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
@@ -123,6 +127,13 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
                     projectUuid: projectUuid,
                 })}
             >
+                {isEditMode &&
+                    hasExplorerStore &&
+                    item &&
+                    isFilterableField(item) && (
+                        <QuickFilterMenuItems item={item} value={value} />
+                    )}
+
                 <DrillDownMenuItem
                     item={item}
                     fieldValues={fieldValues}

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -77,40 +77,6 @@ const DashboardCellContextMenu: FC<
               ]
             : [];
 
-    // When the clicked cell can't provide a filter itself (metric, table
-    // calculation, hidden dimension), offer the row's visible dimension
-    // values instead — matching what clicking a chart point does
-    const rowDimensionFilters =
-        filterField.length === 0
-            ? Object.entries(fieldValues).reduce<FilterDashboardToRule[]>(
-                  (acc, [key, rowValue]) => {
-                      const field = itemsMap?.[key];
-                      if (
-                          !field ||
-                          !isDimension(field) ||
-                          field.hidden ||
-                          rowValue === undefined
-                      )
-                          return acc;
-
-                      return [
-                          ...acc,
-                          createDashboardFilterRuleFromField({
-                              field,
-                              availableTileFilters: {},
-                              isTemporary: true,
-                              value:
-                                  rowValue.raw === undefined ||
-                                  isDimensionValueInvalidDate(field, rowValue)
-                                      ? null
-                                      : rowValue.raw,
-                          }),
-                      ];
-                  },
-                  [],
-              )
-            : [];
-
     const possiblePivotFilters = (
         meta?.pivotReference?.pivotValues || []
     ).reduce<FilterDashboardToRule[]>((acc, pivot) => {
@@ -133,11 +99,7 @@ const DashboardCellContextMenu: FC<
         ];
     }, []);
 
-    const filters = [
-        ...filterField,
-        ...rowDimensionFilters,
-        ...possiblePivotFilters,
-    ];
+    const filters = [...filterField, ...possiblePivotFilters];
     const { track } = useTracking();
     const { user } = useApp();
     const { projectUuid } = useParams<{ projectUuid: string }>();

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -77,6 +77,40 @@ const DashboardCellContextMenu: FC<
               ]
             : [];
 
+    // When the clicked cell can't provide a filter itself (metric, table
+    // calculation, hidden dimension), offer the row's visible dimension
+    // values instead — matching what clicking a chart point does
+    const rowDimensionFilters =
+        filterField.length === 0
+            ? Object.entries(fieldValues).reduce<FilterDashboardToRule[]>(
+                  (acc, [key, rowValue]) => {
+                      const field = itemsMap?.[key];
+                      if (
+                          !field ||
+                          !isDimension(field) ||
+                          field.hidden ||
+                          rowValue === undefined
+                      )
+                          return acc;
+
+                      return [
+                          ...acc,
+                          createDashboardFilterRuleFromField({
+                              field,
+                              availableTileFilters: {},
+                              isTemporary: true,
+                              value:
+                                  rowValue.raw === undefined ||
+                                  isDimensionValueInvalidDate(field, rowValue)
+                                      ? null
+                                      : rowValue.raw,
+                          }),
+                      ];
+                  },
+                  [],
+              )
+            : [];
+
     const possiblePivotFilters = (
         meta?.pivotReference?.pivotValues || []
     ).reduce<FilterDashboardToRule[]>((acc, pivot) => {
@@ -99,7 +133,11 @@ const DashboardCellContextMenu: FC<
         ];
     }, []);
 
-    const filters = [...filterField, ...possiblePivotFilters];
+    const filters = [
+        ...filterField,
+        ...rowDimensionFilters,
+        ...possiblePivotFilters,
+    ];
     const { track } = useTracking();
     const { user } = useApp();
     const { projectUuid } = useParams<{ projectUuid: string }>();

--- a/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
@@ -1,11 +1,10 @@
 import {
     FilterOperator,
     friendlyName,
-    getItemId,
     type FilterDashboardToRule,
 } from '@lightdash/common';
 import { Menu, Text } from '@mantine/core';
-import { IconFilter, IconFilterOff } from '@tabler/icons-react';
+import { IconFilter, IconFilterX } from '@tabler/icons-react';
 import isNil from 'lodash/isNil';
 import { Fragment, type FC } from 'react';
 import MantineIcon from '../../components/common/MantineIcon';
@@ -30,20 +29,12 @@ export const FilterDashboardTo: FC<Props> = ({ filters, onAddFilter }) => {
     const addDimensionDashboardFilter = useDashboardContext(
         (c) => c.addDimensionDashboardFilter,
     );
-    const allFilterableFieldsMap = useDashboardContext(
-        (c) => c.allFilterableFieldsMap,
-    );
     const addFilterCallback = onAddFilter ?? addDimensionDashboardFilter;
     return (
         <>
             <Menu.Divider />
-            <Menu.Label>Filter dashboard to...</Menu.Label>
 
             {filters.map((filter) => {
-                const fieldLabel =
-                    Object.values(allFilterableFieldsMap).find(
-                        (field) => getItemId(field) === filter.target.fieldId,
-                    )?.tableLabel || friendlyName(filter.target.tableName);
                 const fieldName = friendlyName(filter.target.fieldName);
                 const valueLabel = (
                     <>
@@ -62,14 +53,17 @@ export const FilterDashboardTo: FC<Props> = ({ filters, onAddFilter }) => {
 
                 return (
                     <Fragment key={filter.id}>
+                        <Menu.Label>
+                            Filter dashboard on {fieldName} to
+                        </Menu.Label>
                         <Menu.Item
                             leftSection={<MantineIcon icon={IconFilter} />}
                             onClick={() => addFilterCallback(filter, true)}
                         >
-                            {fieldLabel} - {fieldName} is {valueLabel}
+                            Show only {valueLabel}
                         </Menu.Item>
                         <Menu.Item
-                            leftSection={<MantineIcon icon={IconFilterOff} />}
+                            leftSection={<MantineIcon icon={IconFilterX} />}
                             onClick={() =>
                                 addFilterCallback(
                                     getExcludeFilter(filter),
@@ -77,7 +71,7 @@ export const FilterDashboardTo: FC<Props> = ({ filters, onAddFilter }) => {
                                 )
                             }
                         >
-                            {fieldLabel} - {fieldName} is not {valueLabel}
+                            Exclude {valueLabel}
                         </Menu.Item>
                     </Fragment>
                 );

--- a/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
@@ -3,14 +3,15 @@ import {
     friendlyName,
     type FilterDashboardToRule,
 } from '@lightdash/common';
-import { Menu, Text } from '@mantine/core';
+import { Group, Menu, Text } from '@mantine/core';
 import { IconFilter, IconFilterX } from '@tabler/icons-react';
 import isNil from 'lodash/isNil';
 import { Fragment, type FC } from 'react';
 import MantineIcon from '../../components/common/MantineIcon';
+import TruncatedText from '../../components/common/TruncatedText';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 
-const MAX_FILTER_VALUE_LABEL_LENGTH = 40;
+const MAX_FILTER_VALUE_WIDTH = 250;
 
 type Props = {
     filters: FilterDashboardToRule[];
@@ -44,36 +45,49 @@ export const FilterDashboardTo: FC<Props> = ({ filters, onAddFilter }) => {
                         : filter.values && !isNil(filter.values[0])
                           ? String(filter.values[0])
                           : '';
-                const valueLabel = (
-                    <Text span fw={500} title={valueText}>
-                        {valueText.length > MAX_FILTER_VALUE_LABEL_LENGTH
-                            ? `${valueText.slice(0, MAX_FILTER_VALUE_LABEL_LENGTH)}...`
-                            : valueText}
-                    </Text>
-                );
 
                 return (
                     <Fragment key={filter.id}>
                         <Menu.Label>
                             Filter dashboard on {fieldName} to
                         </Menu.Label>
-                        <Menu.Item
-                            leftSection={<MantineIcon icon={IconFilter} />}
-                            onClick={() => addFilterCallback(filter, true)}
-                        >
-                            Show only {valueLabel}
-                        </Menu.Item>
-                        <Menu.Item
-                            leftSection={<MantineIcon icon={IconFilterX} />}
-                            onClick={() =>
-                                addFilterCallback(
-                                    getExcludeFilter(filter),
-                                    true,
-                                )
-                            }
-                        >
-                            Exclude {valueLabel}
-                        </Menu.Item>
+                        {(
+                            [
+                                {
+                                    label: 'Show only',
+                                    icon: IconFilter,
+                                    getFilter: () => filter,
+                                },
+                                {
+                                    label: 'Exclude',
+                                    icon: IconFilterX,
+                                    getFilter: () => getExcludeFilter(filter),
+                                },
+                            ] as const
+                        ).map(({ label, icon, getFilter }) => (
+                            <Menu.Item
+                                key={label}
+                                leftSection={<MantineIcon icon={icon} />}
+                                onClick={() =>
+                                    addFilterCallback(getFilter(), true)
+                                }
+                            >
+                                <Group gap={4} wrap="nowrap">
+                                    <Text span fz="inherit" lh="inherit">
+                                        {label}
+                                    </Text>
+                                    <TruncatedText
+                                        inline
+                                        fw={500}
+                                        fz="inherit"
+                                        lh="inherit"
+                                        maxWidth={MAX_FILTER_VALUE_WIDTH}
+                                    >
+                                        {valueText}
+                                    </TruncatedText>
+                                </Group>
+                            </Menu.Item>
+                        ))}
                     </Fragment>
                 );
             })}

--- a/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
@@ -10,6 +10,8 @@ import { Fragment, type FC } from 'react';
 import MantineIcon from '../../components/common/MantineIcon';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 
+const MAX_FILTER_VALUE_LABEL_LENGTH = 40;
+
 type Props = {
     filters: FilterDashboardToRule[];
     onAddFilter?: (filter: FilterDashboardToRule, isTemporary: boolean) => void;
@@ -36,19 +38,18 @@ export const FilterDashboardTo: FC<Props> = ({ filters, onAddFilter }) => {
 
             {filters.map((filter) => {
                 const fieldName = friendlyName(filter.target.fieldName);
+                const valueText =
+                    filter.operator === FilterOperator.NULL
+                        ? 'null'
+                        : filter.values && !isNil(filter.values[0])
+                          ? String(filter.values[0])
+                          : '';
                 const valueLabel = (
-                    <>
-                        {filter.operator === FilterOperator.NULL && (
-                            <Text span fw={500}>
-                                null
-                            </Text>
-                        )}
-                        {filter.values && !isNil(filter.values[0]) && (
-                            <Text span fw={500}>
-                                {String(filter.values[0])}
-                            </Text>
-                        )}
-                    </>
+                    <Text span fw={500} title={valueText}>
+                        {valueText.length > MAX_FILTER_VALUE_LABEL_LENGTH
+                            ? `${valueText.slice(0, MAX_FILTER_VALUE_LABEL_LENGTH)}...`
+                            : valueText}
+                    </Text>
                 );
 
                 return (

--- a/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
@@ -5,9 +5,9 @@ import {
     type FilterDashboardToRule,
 } from '@lightdash/common';
 import { Menu, Text } from '@mantine/core';
-import { IconFilter } from '@tabler/icons-react';
+import { IconFilter, IconFilterOff } from '@tabler/icons-react';
 import isNil from 'lodash/isNil';
-import { type FC } from 'react';
+import { Fragment, type FC } from 'react';
 import MantineIcon from '../../components/common/MantineIcon';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 
@@ -15,6 +15,16 @@ type Props = {
     filters: FilterDashboardToRule[];
     onAddFilter?: (filter: FilterDashboardToRule, isTemporary: boolean) => void;
 };
+
+const getExcludeFilter = (
+    filter: FilterDashboardToRule,
+): FilterDashboardToRule => ({
+    ...filter,
+    operator:
+        filter.operator === FilterOperator.NULL
+            ? FilterOperator.NOT_NULL
+            : FilterOperator.NOT_EQUALS,
+});
 
 export const FilterDashboardTo: FC<Props> = ({ filters, onAddFilter }) => {
     const addDimensionDashboardFilter = useDashboardContext(
@@ -29,28 +39,49 @@ export const FilterDashboardTo: FC<Props> = ({ filters, onAddFilter }) => {
             <Menu.Divider />
             <Menu.Label>Filter dashboard to...</Menu.Label>
 
-            {filters.map((filter) => (
-                <Menu.Item
-                    key={filter.id}
-                    leftSection={<MantineIcon icon={IconFilter} />}
-                    onClick={() => addFilterCallback(filter, true)}
-                >
-                    {Object.values(allFilterableFieldsMap).find(
+            {filters.map((filter) => {
+                const fieldLabel =
+                    Object.values(allFilterableFieldsMap).find(
                         (field) => getItemId(field) === filter.target.fieldId,
-                    )?.tableLabel || friendlyName(filter.target.tableName)}{' '}
-                    - {friendlyName(filter.target.fieldName)} is{' '}
-                    {filter.operator === FilterOperator.NULL && (
-                        <Text span fw={500}>
-                            null
-                        </Text>
-                    )}
-                    {filter.values && !isNil(filter.values[0]) && (
-                        <Text span fw={500}>
-                            {String(filter.values[0])}
-                        </Text>
-                    )}
-                </Menu.Item>
-            ))}
+                    )?.tableLabel || friendlyName(filter.target.tableName);
+                const fieldName = friendlyName(filter.target.fieldName);
+                const valueLabel = (
+                    <>
+                        {filter.operator === FilterOperator.NULL && (
+                            <Text span fw={500}>
+                                null
+                            </Text>
+                        )}
+                        {filter.values && !isNil(filter.values[0]) && (
+                            <Text span fw={500}>
+                                {String(filter.values[0])}
+                            </Text>
+                        )}
+                    </>
+                );
+
+                return (
+                    <Fragment key={filter.id}>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconFilter} />}
+                            onClick={() => addFilterCallback(filter, true)}
+                        >
+                            {fieldLabel} - {fieldName} is {valueLabel}
+                        </Menu.Item>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconFilterOff} />}
+                            onClick={() =>
+                                addFilterCallback(
+                                    getExcludeFilter(filter),
+                                    true,
+                                )
+                            }
+                        >
+                            {fieldLabel} - {fieldName} is not {valueLabel}
+                        </Menu.Item>
+                    </Fragment>
+                );
+            })}
         </>
     );
 };

--- a/packages/frontend/src/hooks/useFilters.ts
+++ b/packages/frontend/src/hooks/useFilters.ts
@@ -4,6 +4,7 @@ import {
     getTotalFilterRules,
     type Field,
     type FilterableField,
+    type QuickFilterOperator,
 } from '@lightdash/common';
 import { useCallback, useMemo } from 'react';
 import {
@@ -26,13 +27,19 @@ export const useAddFilter = () => {
     const store = useExplorerStore();
 
     const addFilter = useCallback(
-        (field: FilterableField, value: any, timezone?: string) => {
+        (
+            field: FilterableField,
+            value: any,
+            timezone?: string,
+            operator?: QuickFilterOperator,
+        ) => {
             const currentFilters = selectFilters(store.getState());
             const newFilters = addFilterRule({
                 filters: currentFilters,
                 field,
                 value,
                 timezone,
+                operator,
             });
             dispatch(explorerActions.setFilters(newFilters));
 
@@ -75,13 +82,19 @@ export const useFilteredFields = () => {
     );
 
     const addFilter = useCallback(
-        (field: FilterableField, value: any, timezone?: string) => {
+        (
+            field: FilterableField,
+            value: any,
+            timezone?: string,
+            operator?: QuickFilterOperator,
+        ) => {
             const currentFilters = selectFilters(store.getState());
             const newFilters = addFilterRule({
                 filters: currentFilters,
                 field,
                 value,
                 timezone,
+                operator,
             });
             dispatch(explorerActions.setFilters(newFilters));
 
@@ -132,7 +145,12 @@ export const useFilters = () => {
     );
 
     const addFilter = useCallback(
-        (field: FilterableField, value: any, timezone?: string) => {
+        (
+            field: FilterableField,
+            value: any,
+            timezone?: string,
+            operator?: QuickFilterOperator,
+        ) => {
             const currentFilters = selectFilters(store.getState());
             const isFiltersExpanded = selectIsFiltersExpanded(store.getState());
 
@@ -141,6 +159,7 @@ export const useFilters = () => {
                 field,
                 value,
                 timezone,
+                operator,
             });
             dispatch(explorerActions.setFilters(newFilters));
 

--- a/scripts/okteto-dev-up.sh
+++ b/scripts/okteto-dev-up.sh
@@ -41,4 +41,20 @@ fi
 ALLOW_MISSING_MIGRATIONS=true pnpm -F backend migrate
 
 echo "--- Starting dev servers"
-exec pnpm dev
+# Start detached in its own session so the app survives when the agent
+# sandbox pauses and okteto tears down this SSH session. Reattaching re-runs
+# this script, so stop the previous instance's process group first.
+PIDFILE=/tmp/lightdash-dev-server.pid
+DEV_LOG=/tmp/lightdash-dev-server.log
+if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+    kill -TERM -- "-$(cat "$PIDFILE")" 2>/dev/null || true
+    for _ in $(seq 1 30); do
+        kill -0 "$(cat "$PIDFILE")" 2>/dev/null || break
+        sleep 1
+    done
+    kill -KILL -- "-$(cat "$PIDFILE")" 2>/dev/null || true
+fi
+: >"$DEV_LOG"
+setsid pnpm dev >>"$DEV_LOG" 2>&1 </dev/null &
+echo $! >"$PIDFILE"
+exec tail -F "$DEV_LOG"


### PR DESCRIPTION
### Description

This PR enhances quick filters (created from cell/chart values) to support both inclusive ("Show only") and exclusive ("Exclude") operations, and refactors the filter UI components for consistency.

**Key Changes:**

1. **Quick Filter Operators**: Extended `createFilterRuleFromField()` to accept an optional `operator` parameter (`EQUALS` or `NOT_EQUALS`). When filtering with `null` values, the operator is automatically converted to `NULL` or `NOT_NULL` as appropriate.

2. **New `QuickFilterMenuItems` Component**: Created a reusable component that renders "Show only" and "Exclude" menu items for cell context menus. This replaces inline filter logic in `CellContextMenu.tsx` and is now also used in `SimpleTable/CellContextMenu.tsx`.

3. **Updated `FilterDashboardTo` Component**: Refactored to display both "Show only" and "Exclude" options for dashboard filters, with improved UX including field name context and truncated value display.

4. **Filter Value Handling**: Fixed handling of falsy but valid values (e.g., `0`, `false`) by using `isNil()` instead of truthiness checks.

5. **Hook Updates**: Updated `useFilters()` and related hooks to pass the `operator` parameter through to `addFilterRule()`.

6. **Test Coverage**: Added comprehensive test suite for `createFilterRuleFromField()` covering:
   - All field types (string, number, boolean, date, timestamp)
   - Both include and exclude operators
   - Falsy value handling (0, false)
   - Date/timestamp formatting across different time intervals

7. **Okteto Dev Script**: Improved session persistence by running the dev server in a detached process group that survives sandbox pauses.

8. **E2E Tests**: Updated date filter tests to reflect new "Show only" label.

**Test Plan:**

- Existing unit tests pass, including new comprehensive tests for `createFilterRuleFromField()`
- E2E tests updated and passing for date filtering scenarios
- Quick filters now support both inclusive and exclusive operations with proper null handling

https://claude.ai/code/session_014w733oUV9bBNugyVGAjjai