### PR TITLE
feat(explorer): merge queries in the explorer, entered from the ghost "+" tab

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -34,6 +34,10 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { MergeJoinBar } from '../../../features/mergeQuery/components/MergeJoinBar';
+import { MergeTabStrip } from '../../../features/mergeQuery/components/MergeTabStrip';
+import { QueryBTree } from '../../../features/mergeQuery/components/QueryBTree';
+import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
 import { useSourceCodeEditor } from '../../../features/sourceCodeEditor';
 import {
     DeleteVirtualViewModal,
@@ -75,6 +79,10 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
     const { data: editYamlInUiFlag } = useServerFeatureFlag(
         FeatureFlags.EditYamlInUi,
     );
+    const { data: mergeFlag } = useServerFeatureFlag(FeatureFlags.MergeQueries);
+    const merge = useMergeSafe();
+    const showQueryBTree =
+        mergeFlag?.enabled === true && merge?.isMerging && merge.focus === 'b';
 
     const activeTableName = useExplorerSelector(selectTableName);
     const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
@@ -226,7 +234,16 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                     display: isVisualizationConfigOpen ? 'none' : 'flex',
                 }}
             >
-                <Group justify="space-between">
+                <MergeTabStrip />
+                <MergeJoinBar />
+
+                {/* The breadcrumbs, warnings and menu all belong to the
+                    first query's explore; shown above the second query's
+                    picker they read as its header, which they are not. */}
+                <Group
+                    justify="space-between"
+                    display={showQueryBTree ? 'none' : undefined}
+                >
                     <Group gap="xs">
                         <PageBreadcrumbs size="md" items={breadcrumbs} />
                         {explore.warnings && explore.warnings.length > 0 && (
@@ -370,12 +387,19 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                         )}
                 </Group>
 
-                <ItemDetailProvider>
-                    <ExploreTree
-                        explore={explore}
-                        onSelectedFieldChange={toggleActiveField}
-                    />
-                </ItemDetailProvider>
+                {/* The tab strip swaps the field tree only: the second
+                    query's picker takes the tree's place while the rest of
+                    the panel stays put. */}
+                {showQueryBTree ? (
+                    <QueryBTree />
+                ) : (
+                    <ItemDetailProvider>
+                        <ExploreTree
+                            explore={explore}
+                            onSelectedFieldChange={toggleActiveField}
+                        />
+                    </ItemDetailProvider>
+                )}
 
                 {isEditVirtualViewOpen && (
                     <EditVirtualViewModal

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -3,6 +3,7 @@ import {
     isCustomDimension,
     isDimension,
     type AdditionalMetric,
+    type CustomDimension,
     type CompiledTable,
     type Dimension,
     type Explore,
@@ -42,31 +43,74 @@ import {
 } from './TableTree/Virtualization/flattenTree';
 import VirtualizedTreeList from './TableTree/Virtualization/VirtualizedTreeList';
 
+/**
+ * Which fields read as selected, and which extra fields the query defines.
+ *
+ * Supplied when the tree edits a query other than the explorer's own — a
+ * merge's second query. Without it the tree reads the explorer's state, which
+ * is the only query most of the app has.
+ */
+export type ExploreTreeSelection = {
+    activeFields: Set<string>;
+    selectedDimensions: string[];
+};
+
 type ExploreTreeProps = {
     explore: Explore;
     onSelectedFieldChange: (fieldId: string, isDimension: boolean) => void;
+    selection?: ExploreTreeSelection;
 };
 
 type Records = Record<string, AdditionalMetric | Dimension | Metric>;
 
+// Stable empties, so a tree editing another query does not rebuild every render.
+const EMPTY_METRICS: AdditionalMetric[] = [];
+const EMPTY_DIMENSIONS: CustomDimension[] = [];
+const EMPTY_IDS: string[] = [];
+
 const ExploreTreeComponent: FC<ExploreTreeProps> = ({
     explore,
     onSelectedFieldChange,
+    selection,
 }) => {
-    const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
-    const customDimensions = useExplorerSelector(selectCustomDimensions);
+    const explorerAdditionalMetrics = useExplorerSelector(
+        selectAdditionalMetrics,
+    );
+    const explorerCustomDimensions = useExplorerSelector(
+        selectCustomDimensions,
+    );
 
-    const missingCustomMetrics = useExplorerSelector((state) =>
+    const explorerMissingCustomMetrics = useExplorerSelector((state) =>
         selectMissingCustomMetrics(state, explore),
     );
-    const missingCustomDimensions = useExplorerSelector((state) =>
+    const explorerMissingCustomDimensions = useExplorerSelector((state) =>
         selectMissingCustomDimensions(state, explore),
     );
-    const missingFieldIds = useExplorerSelector((state) =>
+    const explorerMissingFieldIds = useExplorerSelector((state) =>
         selectMissingFieldIds(state, explore),
     );
-    const activeFields = useExplorerSelector(selectActiveFields);
-    const selectedDimensions = useExplorerSelector(selectDimensions);
+    const explorerActiveFields = useExplorerSelector(selectActiveFields);
+    const explorerSelectedDimensions = useExplorerSelector(selectDimensions);
+
+    // Custom fields and "missing field" warnings describe the explorer's own
+    // query. Against another query's explore they would report that query's
+    // fields as missing, so they are empty whenever the selection is supplied.
+    const additionalMetrics = selection
+        ? EMPTY_METRICS
+        : explorerAdditionalMetrics;
+    const customDimensions = selection
+        ? EMPTY_DIMENSIONS
+        : explorerCustomDimensions;
+    const missingCustomMetrics = selection
+        ? EMPTY_METRICS
+        : explorerMissingCustomMetrics;
+    const missingCustomDimensions = selection
+        ? EMPTY_DIMENSIONS
+        : explorerMissingCustomDimensions;
+    const missingFieldIds = selection ? EMPTY_IDS : explorerMissingFieldIds;
+    const activeFields = selection?.activeFields ?? explorerActiveFields;
+    const selectedDimensions =
+        selection?.selectedDimensions ?? explorerSelectedDimensions;
 
     const [search, setSearch] = useState<string>('');
     const [isPending, startTransition] = useTransition();

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -35,6 +35,9 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { MergeFilterSwitch } from '../../../features/mergeQuery/components/MergeFilterSwitch';
+import MergeQueryBFiltersCard from '../../../features/mergeQuery/components/MergeQueryBFiltersCard';
+import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { useProject } from '../../../hooks/useProject';
@@ -46,7 +49,8 @@ import { getConditionalRuleLabelFromItem } from '../../common/Filters/FilterInpu
 import FiltersProvider from '../../common/Filters/FiltersProvider';
 import { useFieldsWithSuggestions } from './useFieldsWithSuggestions';
 
-const FiltersCard: FC = memo(() => {
+const QueryAFiltersCard: FC = memo(() => {
+    const merge = useMergeSafe();
     const projectUuid = useProjectUuid();
     const project = useProject(projectUuid);
 
@@ -271,6 +275,7 @@ const FiltersCard: FC = memo(() => {
             onToggle={() => toggleExpandedSection(ExplorerSection.FILTERS)}
             headerElement={
                 <>
+                    {merge?.isMerging ? <MergeFilterSwitch /> : null}
                     {totalActiveFilters > 0 && !filterIsOpen ? (
                         <Tooltip
                             arrowOffset={12}
@@ -338,6 +343,19 @@ const FiltersCard: FC = memo(() => {
             )}
         </CollapsableCard>
     );
+});
+
+/**
+ * The Filters card follows the merge focus the way the sidebar does: focusing
+ * Query B re-targets this card to that query's filters, with ownership shown
+ * by the query's colour.
+ */
+const FiltersCard: FC = memo(() => {
+    const merge = useMergeSafe();
+    if (merge?.isMerging && merge.focus === 'b' && merge.queryB.exploreName) {
+        return <MergeQueryBFiltersCard />;
+    }
+    return <QueryAFiltersCard />;
 });
 
 export default FiltersCard;

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -14,6 +14,7 @@ import { useClipboard } from '@mantine/hooks';
 import { IconCopy, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';
+import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { Can } from '../../../providers/Ability';
@@ -38,6 +39,7 @@ const CellContextMenu: FC<
         onExpand: (name: string, data: object) => void;
     }
 > = ({ cell, isEditMode, itemsMap, onViewJsonCell }) => {
+    const isMerged = !!useMergeSafe()?.mergeResults;
     const { openUnderlyingDataModal, metricQuery } =
         useMetricQueryDataContext();
     const { track } = useTracking();
@@ -114,7 +116,11 @@ const CellContextMenu: FC<
             {item &&
                 !isDimension(item) &&
                 !isCustomDimension(item) &&
-                !hasCustomBinDimension(metricQuery) && (
+                !hasCustomBinDimension(metricQuery) &&
+                // A merged column descends from one of two queries, and
+                // nothing here knows which. Offering the drill would run it
+                // against an explore that does not exist.
+                !isMerged && (
                     <Can
                         I="view"
                         this={subject('UnderlyingData', {

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -14,6 +14,7 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
 import { useColumnTotalsEnabledByDefault } from '../../../hooks/useAsyncCalculateTotal';
 import { useColumns } from '../../../hooks/useColumns';
 import { useExplore } from '../../../hooks/useExplore';
@@ -83,6 +84,8 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
             ? chartConfig.config.columns
             : undefined;
 
+    const mergeResults = useMergeSafe()?.mergeResults ?? null;
+
     // Get query state from new hook
     const {
         query,
@@ -111,6 +114,24 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
         useGroupedResultsAvailability();
 
     const resultsData = useMemo(() => {
+        // A configured merge is the explorer's result, so the table reads it
+        // instead of the query it was built from.
+        if (mergeResults) {
+            return {
+                rows: mergeResults.results.rows,
+                totalResults: mergeResults.results.totalResults,
+                isFetchingRows:
+                    mergeResults.results.isFetchingRows &&
+                    !mergeResults.results.error,
+                fetchMoreRows: mergeResults.results.fetchMoreRows,
+                status: mergeResults.results.error
+                    ? ('error' as const)
+                    : ('success' as const),
+                apiError: mergeResults.results.error ?? undefined,
+                queryStatus: mergeResults.results.queryStatus,
+            };
+        }
+
         const hasUnpivotedQuery = !!unpivotedQuery?.data?.queryUuid;
 
         // Check if we need unpivoted data (regardless of whether it's ready)
@@ -177,6 +198,7 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
 
         return result;
     }, [
+        mergeResults,
         unpivotedQuery,
         hasPivotConfig,
         unpivotedEnabled,
@@ -242,6 +264,7 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
     };
 
     const itemsMap = useMemo(() => {
+        if (mergeResults) return mergeResults.fields;
         return exploreData
             ? getItemMap(
                   exploreData,
@@ -250,7 +273,13 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
                   customDimensions,
               )
             : undefined;
-    }, [exploreData, additionalMetrics, tableCalculations, customDimensions]);
+    }, [
+        mergeResults,
+        exploreData,
+        additionalMetrics,
+        tableCalculations,
+        customDimensions,
+    ]);
 
     // Field helper functions for PivotTable
     const getField = useCallback(

--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -1,4 +1,4 @@
-import { getItemId, getMetrics } from '@lightdash/common';
+import { deepEqual, getItemId, getMetrics } from '@lightdash/common';
 import { Button, Group, rgba, Text, Tooltip } from '@mantine/core';
 import {
     IconCircleCheckFilled,
@@ -22,6 +22,7 @@ import {
     selectUnsavedColorPaletteUuid,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { useSavedMerge } from '../../../features/mergeQuery/hooks/useSavedMerge';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
@@ -56,6 +57,15 @@ const SaveChartButton: FC<{
     const hasUnsavedChangesInStore = useExplorerSelector(
         selectHasUnsavedChanges,
     );
+    // Merge state lives outside the explorer store, so it is attached at save
+    // time rather than arriving with the chart version — and its changes are
+    // tracked here too, or editing only the merge would leave Save inert.
+    const { merge, isValid: isMergeValid } = useSavedMerge();
+    const hasMergeChanges = useMemo(() => {
+        const saved = savedChart?.merge ?? null;
+        if (merge === null || saved === null) return merge !== saved;
+        return !deepEqual(merge, saved);
+    }, [merge, savedChart?.merge]);
 
     // Read isValidQuery from Redux
     const isValidQuery = useExplorerSelector(selectIsValidQuery);
@@ -64,11 +74,10 @@ const SaveChartButton: FC<{
     // For new charts, button is enabled when query is valid
     // For existing charts, button is enabled when there are unsaved changes
     const hasUnsavedChanges = savedChart
-        ? hasUnsavedChangesInStore
+        ? hasUnsavedChangesInStore || hasMergeChanges
         : isValidQuery;
 
     const { missingRequiredParameters } = useExplorerQuery();
-
     const [isQueryModalOpen, setIsQueryModalOpen] = useState<boolean>(false);
     const [isSaveAsModal, setIsSaveAsModal] = useState(false);
     const [isSaveVerificationModalOpen, setIsSaveVerificationModalOpen] =
@@ -106,12 +115,13 @@ const SaveChartButton: FC<{
                 ...verificationUpdate,
             });
         }
-        if (hasVersionChanges) {
+        if (hasVersionChanges || hasMergeChanges) {
             update.mutate(
                 {
                     uuid: savedChart.uuid,
                     payload: {
                         ...unsavedChartVersionForSave,
+                        merge,
                         ...verificationUpdate,
                     },
                 },
@@ -160,6 +170,7 @@ const SaveChartButton: FC<{
         !unsavedChartVersion.tableName ||
         !hasUnsavedChanges ||
         foundCustomMetricWithDuplicateId ||
+        !isMergeValid ||
         !!missingRequiredParameters?.length;
 
     const handleSaveChart = () => {
@@ -185,6 +196,7 @@ const SaveChartButton: FC<{
         // one there); the main app keeps requiring changes
         (!hasUnsavedChanges && !isEmbedded) ||
         foundCustomMetricWithDuplicateId ||
+        !isMergeValid ||
         !!missingRequiredParameters?.length;
 
     return (
@@ -192,9 +204,11 @@ const SaveChartButton: FC<{
             <Button.Group>
                 <Tooltip
                     label={
-                        'A custom metric ID matches an existing table metric. Rename it to avoid conflicts.'
+                        !isMergeValid
+                            ? 'Finish configuring the merge before saving.'
+                            : 'A custom metric ID matches an existing table metric. Rename it to avoid conflicts.'
                     }
-                    disabled={!foundCustomMetricWithDuplicateId}
+                    disabled={isMergeValid && !foundCustomMetricWithDuplicateId}
                     withinPortal
                     multiline
                     position={'bottom'}
@@ -265,7 +279,7 @@ const SaveChartButton: FC<{
             {unsavedChartVersionForSave && (
                 <ChartCreateModal
                     opened={isQueryModalOpen}
-                    savedData={unsavedChartVersionForSave}
+                    savedData={{ ...unsavedChartVersionForSave, merge }}
                     colorPaletteUuid={stagedColorPaletteUuid}
                     onClose={() => {
                         setIsQueryModalOpen(false);

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -32,6 +32,7 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { useMergeCompiledSql } from '../../../features/mergeQuery/hooks/useMergeCompiledSql';
 import { useCompiledSql } from '../../../hooks/useCompiledSql';
 import { useProject } from '../../../hooks/useProject';
 import { useCannotViewCompiledSql } from '../../../hooks/user/useCannotViewCompiledSql';
@@ -84,10 +85,16 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
     const { data, isSuccess, isInitialLoading, error } = useCompiledSql({
         enabled: !!unsavedChartVersionTableName && !cannotViewSqlAuthoredFields,
     });
+    // With a merge configured, the merged statement is what Run executes;
+    // the card's copy and open-in-SQL-runner must carry it, not Query A's.
+    const merge = useMergeCompiledSql();
 
-    const hasPivotQuery = !!data?.pivotQuery;
-    const selectedSql =
-        selectedView === 'pivotQuery' ? data?.pivotQuery : data?.query;
+    const hasPivotQuery = !merge.isMergeActive && !!data?.pivotQuery;
+    const selectedSql = merge.isMergeActive
+        ? merge.data?.sql
+        : selectedView === 'pivotQuery'
+          ? data?.pivotQuery
+          : data?.query;
 
     const formattedSql = useMemo(
         () =>

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -41,6 +41,7 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
 import { useColorPalettes } from '../../../hooks/appearance/useOrganizationAppearance';
 import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColorPalette';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
@@ -146,17 +147,52 @@ const VisualizationCard: FC<Props> = memo((props) => {
         getDownloadQueryUuid,
         validQueryArgs,
     } = useExplorerQuery();
-    const isLoadingQueryResults = isLoading || queryResults.isFetchingRows;
+    // A configured merge replaces the query it was built from: its result is
+    // the chart's result, so running both would cost two warehouse queries to
+    // show one of them.
+    const merge = useMergeSafe();
+    const mergeResults = merge?.mergeResults ?? null;
+    // A restored merge is the chart. Until it lands, Query A's rows are the
+    // wrong numbers wearing the right config — show loading, not them.
+    const awaitingRestoredMerge =
+        !!merge?.isMerging &&
+        merge.wasRestored &&
+        !mergeResults &&
+        !merge.runError &&
+        merge.runErrors.length === 0;
+    const isLoadingQueryResults = mergeResults
+        ? mergeResults.results.isFetchingRows
+        : awaitingRestoredMerge || isLoading || queryResults.isFetchingRows;
 
-    const resultsData = useMemo(
-        () => ({
+    const resultsData = useMemo(() => {
+        if (mergeResults) {
+            return {
+                ...mergeResults.results,
+                metricQuery: mergeResults.metricQuery,
+                fields: mergeResults.fields,
+                resolvedTimezone: undefined,
+            };
+        }
+        // No fields and no rows while the restored merge is pending: the
+        // chart config validates its layout against whatever fields it is
+        // given, and Query A's fields would fail the saved merged layout and
+        // rebuild it from defaults — silently discarding the saved config.
+        if (awaitingRestoredMerge) {
+            return {
+                ...queryResults,
+                rows: [],
+                metricQuery: undefined,
+                fields: undefined,
+                resolvedTimezone: undefined,
+            };
+        }
+        return {
             ...queryResults,
             metricQuery: query.data?.metricQuery,
             fields: query.data?.fields,
             resolvedTimezone: query.data?.resolvedTimezone ?? undefined,
-        }),
-        [query.data, queryResults],
-    );
+        };
+    }, [query.data, queryResults, mergeResults, awaitingRestoredMerge]);
 
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
 
@@ -348,7 +384,10 @@ const VisualizationCard: FC<Props> = memo((props) => {
                 resultsData={resultsData}
                 apiErrorDetail={apiErrorDetail}
                 isLoading={isLoadingQueryResults}
-                columnOrder={unsavedChartVersion.tableConfig.columnOrder}
+                columnOrder={
+                    mergeResults?.columnOrder ??
+                    unsavedChartVersion.tableConfig.columnOrder
+                }
                 onSeriesContextMenu={onSeriesContextMenu}
                 savedChartUuid={isEditMode ? undefined : savedChart?.uuid}
                 onChartConfigChange={handleSetChartConfig}

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -31,6 +31,8 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../features/explorer/store';
+import { MergeAutoRun } from '../../features/mergeQuery/components/MergeAutoRun';
+import { MergeReadOnlyBar } from '../../features/mergeQuery/components/MergeReadOnlyBar';
 import { useOrganization } from '../../hooks/organization/useOrganization';
 import { useParameters } from '../../hooks/parameters/useParameters';
 import { useCompiledSql } from '../../hooks/useCompiledSql';
@@ -253,6 +255,9 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                         ) : (
                             !savedChart && <RefreshDbtButton />
                         ))}
+
+                    <MergeAutoRun />
+                    {!isFullscreen && <MergeReadOnlyBar />}
 
                     {!isFullscreen &&
                         !!tableName &&

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -21,6 +21,7 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../features/explorer/store';
+import { useMergeSetup } from '../features/mergeQuery/hooks/useMergeSetup';
 import useHealth from '../hooks/health/useHealth';
 import { useExplorerQuery } from '../hooks/useExplorerQuery';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
@@ -65,16 +66,27 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
         [dispatch],
     );
 
-    const canRunQuery = isValidQuery;
+    // A configured merge is what the explorer runs, so this is the control that
+    // runs it. Two run buttons for one result is how you end up with a chart
+    // showing the answer to a question nobody asked.
+    const merge = useMergeSetup();
+    const canRunQuery = merge.isMerging ? merge.canRun : isValidQuery;
+    // A merge blocks the run for a reason it can name; a silently disabled
+    // button makes the user hunt the sidebar for it.
+    const mergeBlockedReason =
+        merge.isMerging && !merge.canRun ? merge.blockingReason : null;
 
     const { track } = useTracking();
 
     const onClick = useCallback(() => {
-        if (canRunQuery) {
+        if (!canRunQuery) return;
+        if (merge.isMerging) {
+            merge.handleRun();
+        } else {
             fetchResults();
-            track({ name: EventName.RUN_QUERY_BUTTON_CLICKED });
         }
-    }, [fetchResults, track, canRunQuery]);
+        track({ name: EventName.RUN_QUERY_BUTTON_CLICKED });
+    }, [fetchResults, track, canRunQuery, merge]);
 
     useHotkeys([['mod + enter', onClick, { preventDefault: true }]]);
 
@@ -83,31 +95,40 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
             <Button.Group>
                 <Tooltip
                     label={
-                        <Group gap="xxs">
-                            <Kbd fw={600}>
-                                {os === 'macos' || os === 'ios' ? '⌘' : 'ctrl'}
-                            </Kbd>
+                        mergeBlockedReason ?? (
+                            <Group gap="xxs">
+                                <Kbd fw={600}>
+                                    {os === 'macos' || os === 'ios'
+                                        ? '⌘'
+                                        : 'ctrl'}
+                                </Kbd>
 
-                            <Text fw={600}>+</Text>
+                                <Text fw={600}>+</Text>
 
-                            <Kbd fw={600}>Enter</Kbd>
-                        </Group>
+                                <Kbd fw={600}>Enter</Kbd>
+                            </Group>
+                        )
                     }
                     position="bottom"
                     withArrow
                     withinPortal
-                    disabled={isLoading || !isValidQuery}
+                    disabled={
+                        isLoading || (!canRunQuery && !mergeBlockedReason)
+                    }
                 >
                     <Button
                         size={size}
                         pr={limit ? 'xs' : undefined}
-                        disabled={!isValidQuery}
+                        // data-disabled keeps the button hoverable so the
+                        // tooltip can say why the merge cannot run yet.
+                        disabled={!canRunQuery && !mergeBlockedReason}
+                        data-disabled={mergeBlockedReason ? true : undefined}
                         leftSection={<MantineIcon icon={IconPlayerPlay} />}
-                        loading={isLoading}
+                        loading={isLoading || !!merge.isRunning}
                         onClick={onClick}
                         style={(theme) => ({
                             flex: 1,
-                            borderRight: isValidQuery
+                            borderRight: canRunQuery
                                 ? `1px solid ${rgba(theme.colors.ldGray[5], 0.6)}`
                                 : undefined,
                             borderTopRightRadius: 0,
@@ -115,7 +136,7 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
                         })}
                         data-testid="RefreshButton/RunQueryButton"
                     >
-                        Run query ({limit})
+                        {`Run query (${limit})`}
                     </Button>
                 </Tooltip>
 

--- a/packages/frontend/src/components/RenderedSql.tsx
+++ b/packages/frontend/src/components/RenderedSql.tsx
@@ -4,12 +4,14 @@ import {
     Box,
     Loader,
     Stack,
+    Text,
     Title,
     useMantineColorScheme,
 } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
+import { useMergeCompiledSql } from '../features/mergeQuery/hooks/useMergeCompiledSql';
 import {
     getLightdashMonacoTheme,
     getMonacoLanguage,
@@ -42,6 +44,9 @@ export const RenderedSql: FC<RenderedSqlProps> = ({
         [project],
     );
     const { data, error, isInitialLoading } = useCompiledSql();
+    // With a merge configured, the merged statement is what Run executes;
+    // Query A's SQL alone would be SQL that does not run.
+    const merge = useMergeCompiledSql();
 
     const beforeMount: BeforeMount = useCallback(
         (monaco) => {
@@ -70,18 +75,27 @@ export const RenderedSql: FC<RenderedSqlProps> = ({
     );
 
     const formattedSql = useMemo(() => {
-        const sqlToFormat =
-            effectiveView === 'pivotQuery' ? data?.pivotQuery : data?.query;
+        const sqlToFormat = merge.isMergeActive
+            ? merge.data?.sql
+            : effectiveView === 'pivotQuery'
+              ? data?.pivotQuery
+              : data?.query;
         if (!sqlToFormat) return '';
         return formatSql(sqlToFormat, project?.warehouseConnection?.type);
     }, [
         data?.query,
         data?.pivotQuery,
         effectiveView,
+        merge.isMergeActive,
+        merge.data?.sql,
         project?.warehouseConnection?.type,
     ]);
 
-    if (isInitialLoading) {
+    const mergeCompileErrors = merge.isMergeActive
+        ? (merge.data?.errors ?? [])
+        : [];
+
+    if (isInitialLoading || (merge.isMergeActive && merge.isInitialLoading)) {
         return (
             <Stack my="xs" align="center">
                 <Loader size="lg" color="gray" mt="xs" />
@@ -94,21 +108,21 @@ export const RenderedSql: FC<RenderedSqlProps> = ({
 
     if (error?.error.message) {
         return (
-            <div style={{ margin: 10 }}>
+            <Box m="sm">
                 <Alert
                     icon={<IconAlertCircle size="1rem" />}
                     title="Compilation error"
                     color="red"
                     variant="filled"
                 >
-                    <p>{error.error.message}</p>
+                    <Text>{error.error.message}</Text>
                 </Alert>
-            </div>
+            </Box>
         );
     } else if (error?.error.data) {
         // Validation error
         return (
-            <div style={{ margin: 10 }}>
+            <Box m="sm">
                 <Alert
                     icon={<IconAlertCircle size="1rem" />}
                     title="Compilation error"
@@ -118,19 +132,39 @@ export const RenderedSql: FC<RenderedSqlProps> = ({
                     {Object.entries(error.error.data).map(
                         ([key, validation]) => {
                             return (
-                                <p key={key}>{JSON.stringify(validation)}</p>
+                                <Text key={key}>
+                                    {JSON.stringify(validation)}
+                                </Text>
                             );
                         },
                     )}
                 </Alert>
-            </div>
+            </Box>
         );
     }
 
     return (
         <Stack gap={0} h="100%">
+            {mergeCompileErrors.length > 0 && (
+                <Box m="sm">
+                    <Alert
+                        icon={<IconAlertCircle size="1rem" />}
+                        title="This merge cannot compile"
+                        color="red"
+                        variant="filled"
+                    >
+                        {mergeCompileErrors.map((mergeError) => (
+                            <Text
+                                key={`${mergeError.kind}-${mergeError.sourceId ?? ''}`}
+                            >
+                                {mergeError.message}
+                            </Text>
+                        ))}
+                    </Alert>
+                </Box>
+            )}
             {data?.compilationErrors && data.compilationErrors.length > 0 && (
-                <div style={{ margin: 10 }}>
+                <Box m="sm">
                     <Alert
                         icon={<IconAlertCircle size="1rem" />}
                         title="Compilation error"
@@ -139,11 +173,11 @@ export const RenderedSql: FC<RenderedSqlProps> = ({
                     >
                         {data.compilationErrors.map(
                             (errorMsg: string, index: number) => (
-                                <p key={index}>{errorMsg}</p>
+                                <Text key={index}>{errorMsg}</Text>
                             ),
                         )}
                     </Alert>
-                </div>
+                </Box>
             )}
             <Box flex={1}>
                 <Editor

--- a/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
@@ -14,6 +14,7 @@ import {
     buildInitialExplorerState,
     createExplorerStore,
 } from '../../../../../features/explorer/store';
+import { MergeProvider } from '../../../../../features/mergeQuery/context/MergeContext';
 import { useExplore } from '../../../../../hooks/useExplore';
 import { useExplorerQueryEffects } from '../../../../../hooks/useExplorerQueryEffects';
 import { ExplorerSection } from '../../../../../providers/Explorer/types';
@@ -47,7 +48,9 @@ const EmbedExploreView: FC<{
             withFullHeight
             withPaddedContent
         >
-            <Explorer />
+            <MergeProvider>
+                <Explorer />
+            </MergeProvider>
         </Page>
     );
 };

--- a/packages/frontend/src/features/mergeQuery/components/MergeAutoRun.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeAutoRun.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useRef, type FC } from 'react';
+import { useMergeSafe } from '../context/useMerge';
+import { useMergeSetup } from '../hooks/useMergeSetup';
+
+/**
+ * Runs a restored merge once, headlessly.
+ *
+ * A merge that arrived with the chart has to run itself: without this a saved
+ * merged chart opens showing Query A's results — the wrong numbers, presented
+ * as the chart that was saved. It lives in the main column rather than the
+ * sidebar because the saved-chart view opens with the sidebar closed.
+ */
+export const MergeAutoRun: FC = () => {
+    const merge = useMergeSafe();
+    const { canRun, handleRun } = useMergeSetup();
+    const wasRestored = merge?.wasRestored ?? false;
+    const isRunning = merge?.isRunning ?? false;
+    const mergeResults = merge?.mergeResults ?? null;
+
+    const hasAutoRun = useRef(false);
+    useEffect(() => {
+        if (!wasRestored || hasAutoRun.current || isRunning) return;
+        if (!canRun || mergeResults) return;
+        hasAutoRun.current = true;
+        handleRun();
+    }, [wasRestored, canRun, isRunning, mergeResults, handleRun]);
+
+    return null;
+};

--- a/packages/frontend/src/features/mergeQuery/components/MergeFilterSwitch.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeFilterSwitch.tsx
@@ -1,0 +1,45 @@
+import { SegmentedControl } from '@mantine/core';
+import { type FC } from 'react';
+import { useExplore } from '../../../hooks/useExplore';
+import { selectTableName, useExplorerSelector } from '../../explorer/store';
+import { useMergeSafe } from '../context/useMerge';
+
+/**
+ * Which query's filters the card is showing, switchable from the card itself
+ * so a viewer is never stuck on whichever side was focused last — the merge
+ * tokens are inert on a saved chart, but reading both sides' filters is not
+ * an edit.
+ */
+export const MergeFilterSwitch: FC = () => {
+    const merge = useMergeSafe();
+    const tableName = useExplorerSelector(selectTableName);
+    const { data: exploreA } = useExplore(tableName, {
+        refetchOnMount: false,
+    });
+    const { data: exploreB } = useExplore(
+        merge?.queryB.exploreName ?? undefined,
+        { refetchOnMount: false },
+    );
+
+    if (!merge?.isMerging) return null;
+
+    const labelA = exploreA?.label ?? 'Query A';
+    const labelB = exploreB?.label ?? 'Query B';
+    const collide = labelA === labelB;
+
+    return (
+        <SegmentedControl
+            size="xs"
+            radius="md"
+            value={merge.focus}
+            onChange={(value) => {
+                if (value === 'a' || value === 'b') merge.setFocus(value);
+            }}
+            onClick={(event) => event.stopPropagation()}
+            data={[
+                { value: 'a', label: collide ? `${labelA} (A)` : labelA },
+                { value: 'b', label: collide ? `${labelB} (B)` : labelB },
+            ]}
+        />
+    );
+};

--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.module.css
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.module.css
@@ -1,0 +1,66 @@
+.bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--mantine-color-ldGray-0);
+    border: 1px solid var(--mantine-color-ldGray-3);
+    border-radius: 6px;
+    padding: 6px 10px;
+    min-height: 32px;
+}
+
+.summary {
+    flex: 1;
+    min-width: 0;
+    font-size: 12px;
+    color: var(--mantine-color-ldGray-7);
+}
+
+.summary b {
+    font-weight: 650;
+    color: var(--mantine-color-text);
+}
+
+.root {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.editor {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    border: 1px solid var(--mantine-color-ldGray-3);
+    border-top: none;
+    border-radius: 0 0 6px 6px;
+    padding: 10px;
+    background: var(--mantine-color-body);
+}
+
+.bar[data-expanded='true'] {
+    border-radius: 6px 6px 0 0;
+}
+
+.pair {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.pairHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.note {
+    display: flex;
+    gap: 6px;
+    align-items: flex-start;
+}
+
+.noteIcon {
+    flex: none;
+    margin-top: 2px;
+}

--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
@@ -1,0 +1,310 @@
+import { FeatureFlags, getItemId, MergeJoinType } from '@lightdash/common';
+import {
+    ActionIcon,
+    Anchor,
+    Box,
+    Group,
+    SegmentedControl,
+    Text,
+    Tooltip,
+} from '@mantine/core';
+import {
+    IconAlertTriangle,
+    IconInfoCircle,
+    IconPlus,
+    IconX,
+} from '@tabler/icons-react';
+import { useState, type FC, type ReactNode } from 'react';
+import FieldSelect from '../../../components/common/FieldSelect';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { selectTableName, useExplorerSelector } from '../../explorer/store';
+import { EMPTY_MERGE } from '../constants';
+import { useMergeSafe } from '../context/useMerge';
+import { useMergeSetup } from '../hooks/useMergeSetup';
+import styles from './MergeJoinBar.module.css';
+
+/** Guidance as a line of text. A coloured box for every hint is a lot to read. */
+const Note: FC<{ tone: 'muted' | 'warn'; children: ReactNode }> = ({
+    tone,
+    children,
+}) => (
+    <Box className={styles.note}>
+        <MantineIcon
+            className={styles.noteIcon}
+            icon={tone === 'warn' ? IconAlertTriangle : IconInfoCircle}
+            color={tone === 'warn' ? 'orange.7' : 'gray.6'}
+        />
+        <Text size="xs" c={tone === 'warn' ? undefined : 'dimmed'}>
+            {children}
+        </Text>
+    </Box>
+);
+
+/**
+ * The merge relationship, as a persistent bar under the sidebar tabs.
+ *
+ * Collapsed, it says what the merge is — the join key and the keep mode — so
+ * the relationship never hides behind the inactive tab. Edit expands the key
+ * pairs and keep modes inline; anything wrong (a missing key, a fan-out, a
+ * run error) shows beneath the bar whether or not it is expanded, because an
+ * error is not chrome.
+ */
+export const MergeJoinBar: FC = () => {
+    const { data: mergeFlag } = useServerFeatureFlag(FeatureFlags.MergeQueries);
+    const tableName = useExplorerSelector(selectTableName);
+    const mergeContext = useMergeSafe();
+    const {
+        isMerging,
+        readOnly,
+        joinType,
+        setJoinField,
+        addJoinPart,
+        removeJoinPart,
+        setJoinType,
+    } = mergeContext ?? EMPTY_MERGE;
+    const { runErrors, mergeResults } = mergeContext ?? {};
+
+    const {
+        effectiveParts,
+        labelFor,
+        fanOut,
+        joinKeyErrors,
+        joinFieldLabel,
+        joinItemsA,
+        joinItemsB,
+        exploreALabel,
+        exploreBLabel,
+        isIncomplete,
+        blockingReason,
+    } = useMergeSetup();
+
+    // Expanded while the merge is incomplete — there is nothing to summarise
+    // yet — and by explicit choice afterwards.
+    const [editingOverride, setEditingOverride] = useState<boolean | null>(
+        null,
+    );
+    const expanded = !readOnly && (editingOverride ?? isIncomplete);
+
+    if (!mergeContext || !tableName || mergeFlag?.enabled !== true) return null;
+    if (!isMerging) return null;
+
+    const thisQuery = exploreALabel || 'this query';
+    const otherQuery = exploreBLabel || 'the other query';
+    const keepOptions = [
+        {
+            value: MergeJoinType.FULL,
+            label: 'Everything',
+            help: `Every ${joinFieldLabel} from either query. Where one side has no match, its columns are blank.`,
+        },
+        {
+            value: MergeJoinType.LEFT,
+            label: thisQuery,
+            help: `Only the ${joinFieldLabel} values in ${thisQuery}. Anything found solely in ${otherQuery} is dropped.`,
+        },
+        {
+            value: MergeJoinType.INNER,
+            label: 'Matches',
+            help: `Only the ${joinFieldLabel} values in both ${thisQuery} and ${otherQuery}. Everything unmatched is dropped.`,
+        },
+    ];
+    const activeKeep =
+        keepOptions.find((option) => option.value === joinType) ??
+        keepOptions[0];
+    const mergeError = mergeResults?.results.error ?? null;
+
+    const summary = isIncomplete ? (
+        <>
+            match <b>{thisQuery}</b> and <b>{otherQuery}</b> on a shared field
+        </>
+    ) : (
+        <>
+            joined on{' '}
+            <b>
+                {effectiveParts
+                    .map((part) => (part.fieldA ? labelFor(part.fieldA) : '?'))
+                    .join(' + ')}
+            </b>{' '}
+            · keep <b>{activeKeep.label}</b>
+        </>
+    );
+
+    return (
+        <Box className={styles.root}>
+            {/* The bar and its expanded editor are one attached shape; only
+                the notes below get breathing room. */}
+            <Box>
+                <Box className={styles.bar} data-expanded={expanded}>
+                    <Text className={styles.summary} span truncate>
+                        {summary}
+                    </Text>
+                    {!readOnly && (
+                        <Anchor
+                            component="button"
+                            type="button"
+                            size="xs"
+                            fw={600}
+                            onClick={() => setEditingOverride(!expanded)}
+                        >
+                            {expanded ? 'Done' : 'Edit'}
+                        </Anchor>
+                    )}
+                </Box>
+
+                {expanded && (
+                    <Box className={styles.editor}>
+                        {effectiveParts.map((part, index) => (
+                            // eslint-disable-next-line react/no-array-index-key
+                            <Box className={styles.pair} key={index}>
+                                <Box className={styles.pairHeader}>
+                                    <Text span size="xs" c="dimmed">
+                                        {exploreALabel} matches{' '}
+                                        {exploreBLabel ?? 'Query B'} on
+                                    </Text>
+                                    {effectiveParts.length > 1 && (
+                                        <ActionIcon
+                                            variant="subtle"
+                                            color="gray"
+                                            size="xs"
+                                            onClick={() =>
+                                                removeJoinPart(index)
+                                            }
+                                            aria-label="Remove this key"
+                                        >
+                                            <MantineIcon
+                                                icon={IconX}
+                                                size={12}
+                                            />
+                                        </ActionIcon>
+                                    )}
+                                </Box>
+                                <FieldSelect
+                                    size="xs"
+                                    placeholder="field in this query"
+                                    hasGrouping
+                                    items={joinItemsA}
+                                    item={joinItemsA.find(
+                                        (candidate) =>
+                                            getItemId(candidate) ===
+                                            part.fieldA,
+                                    )}
+                                    onChange={(value) =>
+                                        setJoinField(
+                                            index,
+                                            'fieldA',
+                                            value ? getItemId(value) : null,
+                                        )
+                                    }
+                                />
+                                <FieldSelect
+                                    size="xs"
+                                    placeholder={
+                                        joinItemsB.length === 0
+                                            ? 'pick a field first'
+                                            : 'field in the other query'
+                                    }
+                                    hasGrouping
+                                    items={joinItemsB}
+                                    item={joinItemsB.find(
+                                        (candidate) =>
+                                            getItemId(candidate) ===
+                                            part.fieldB,
+                                    )}
+                                    onChange={(value) =>
+                                        setJoinField(
+                                            index,
+                                            'fieldB',
+                                            value ? getItemId(value) : null,
+                                        )
+                                    }
+                                    disabled={joinItemsB.length === 0}
+                                />
+                            </Box>
+                        ))}
+
+                        <Anchor
+                            component="button"
+                            type="button"
+                            size="xs"
+                            c="dimmed"
+                            onClick={addJoinPart}
+                        >
+                            <Group gap={4} wrap="nowrap">
+                                <MantineIcon icon={IconPlus} size={12} />
+                                match on another field
+                            </Group>
+                        </Anchor>
+
+                        <Group gap="xs" wrap="nowrap" mt={4}>
+                            <Text size="xs" c="dimmed">
+                                Keep
+                            </Text>
+                            <SegmentedControl
+                                size="xs"
+                                radius="md"
+                                value={joinType}
+                                onChange={(value) =>
+                                    setJoinType(value as MergeJoinType)
+                                }
+                                data={keepOptions.map((option) => ({
+                                    value: option.value,
+                                    label: (
+                                        <Tooltip
+                                            label={option.help}
+                                            withinPortal
+                                            position="bottom"
+                                            openDelay={250}
+                                            multiline
+                                            w={260}
+                                        >
+                                            <Text span>{option.label}</Text>
+                                        </Tooltip>
+                                    ),
+                                }))}
+                            />
+                        </Group>
+
+                        {/* What the current choice does, in the terms of this
+                        merge, so the trade-off reads without hovering. */}
+                        <Note tone="muted">{activeKeep.help}</Note>
+                    </Box>
+                )}
+            </Box>
+
+            {blockingReason && !expanded && (
+                <Note tone="muted">{blockingReason}</Note>
+            )}
+
+            {joinKeyErrors.map((error) => (
+                <Note key={error.kind} tone="warn">
+                    {error.message}
+                </Note>
+            ))}
+
+            {!isIncomplete &&
+                fanOut.map(({ side, fields }) => (
+                    <Note key={side} tone="warn">
+                        Query {side.toUpperCase()} is split by{' '}
+                        {fields.map(labelFor).join(' and ')}, which the other
+                        query does not have. Merging would repeat the other
+                        query's rows once per value. Remove{' '}
+                        {fields.length === 1 ? 'it' : 'them'}, or select{' '}
+                        {fields.length === 1 ? 'it' : 'them'} on both queries
+                        and join on {fields.length === 1 ? 'it' : 'them'}.
+                    </Note>
+                ))}
+
+            {(runErrors ?? []).map((error) => (
+                <Note key={`${error.kind}-${error.sourceId ?? ''}`} tone="warn">
+                    {error.message}
+                </Note>
+            ))}
+
+            {mergeError && (
+                <Note tone="warn">
+                    {mergeError.error?.message ?? 'Something went wrong'}
+                </Note>
+            )}
+        </Box>
+    );
+};

--- a/packages/frontend/src/features/mergeQuery/components/MergeQueryBFiltersCard.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeQueryBFiltersCard.tsx
@@ -1,0 +1,104 @@
+import { countTotalFilterRules, type Filters } from '@lightdash/common';
+import { Badge } from '@mantine/core';
+import { memo, useCallback, useMemo, type FC } from 'react';
+import CollapsableCard from '../../../components/common/CollapsableCard/CollapsableCard';
+import FiltersForm from '../../../components/common/Filters';
+import FiltersProvider from '../../../components/common/Filters/FiltersProvider';
+import { useFieldsWithSuggestions } from '../../../components/Explorer/FiltersCard/useFieldsWithSuggestions';
+import { useExplore } from '../../../hooks/useExplore';
+import { useProject } from '../../../hooks/useProject';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { ExplorerSection } from '../../../providers/Explorer/types';
+import {
+    explorerActions,
+    selectIsEditMode,
+    selectIsFiltersExpanded,
+    selectParameters,
+    useExplorerDispatch,
+    useExplorerSelector,
+} from '../../explorer/store';
+import { useMerge } from '../context/useMerge';
+import { MergeFilterSwitch } from './MergeFilterSwitch';
+
+/**
+ * The Filters card, editing Query B. The card follows the merge focus the
+ * same way the sidebar does: one interaction model, with ownership shown by
+ * the query's colour rather than a second panel or a tab the other side's
+ * filters would hide behind.
+ */
+const MergeQueryBFiltersCard: FC = memo(() => {
+    const projectUuid = useProjectUuid();
+    const project = useProject(projectUuid);
+    const { queryB, filtersB, setFiltersB } = useMerge();
+
+    const filterIsOpen = useExplorerSelector(selectIsFiltersExpanded);
+    const isEditMode = useExplorerSelector(selectIsEditMode);
+    const parameterValues = useExplorerSelector(selectParameters);
+    const dispatch = useExplorerDispatch();
+
+    const { data: exploreB } = useExplore(queryB.exploreName ?? undefined);
+
+    const fieldsWithSuggestions = useFieldsWithSuggestions({
+        exploreData: exploreB,
+        rows: undefined,
+        customDimensions: undefined,
+        additionalMetrics: undefined,
+        tableCalculations: undefined,
+        includeHiddenFields: false,
+    });
+
+    const setFilters = useCallback(
+        (newFilters: Filters) => setFiltersB(newFilters),
+        [setFiltersB],
+    );
+    const toggleExpandedSection = useCallback(
+        (section: ExplorerSection) => {
+            dispatch(explorerActions.toggleExpandedSection(section));
+        },
+        [dispatch],
+    );
+
+    const totalActiveFilters = useMemo(
+        () => countTotalFilterRules(filtersB),
+        [filtersB],
+    );
+
+    return (
+        <CollapsableCard
+            isOpen={filterIsOpen}
+            title="Filters"
+            disabled={!queryB.exploreName}
+            onToggle={() => toggleExpandedSection(ExplorerSection.FILTERS)}
+            headerElement={
+                <>
+                    <MergeFilterSwitch />
+                    {totalActiveFilters > 0 && !filterIsOpen ? (
+                        <Badge color="gray" variant="light" tt="none" fw={500}>
+                            {totalActiveFilters} active filter
+                            {totalActiveFilters === 1 ? '' : 's'}
+                        </Badge>
+                    ) : null}
+                </>
+            }
+        >
+            <FiltersProvider
+                projectUuid={projectUuid}
+                itemsMap={fieldsWithSuggestions}
+                startOfWeek={
+                    project.data?.warehouseConnection?.startOfWeek ?? undefined
+                }
+                popoverProps={{ withinPortal: true }}
+                baseTable={exploreB?.baseTable}
+                parameterValues={parameterValues}
+            >
+                <FiltersForm
+                    isEditMode={isEditMode}
+                    filters={filtersB}
+                    setFilters={setFilters}
+                />
+            </FiltersProvider>
+        </CollapsableCard>
+    );
+});
+
+export default MergeQueryBFiltersCard;

--- a/packages/frontend/src/features/mergeQuery/components/MergeReadOnlyBar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeReadOnlyBar.tsx
@@ -1,0 +1,48 @@
+import { Group, Paper, Text } from '@mantine/core';
+import { IconArrowMerge } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useMergeSafe } from '../context/useMerge';
+import { useMergeSetup } from '../hooks/useMergeSetup';
+
+/**
+ * One line for the saved-chart view: what this chart is merged with and on
+ * what. The view opens with the sidebar closed, so without this a viewer has
+ * merged numbers with nothing saying where half of them came from.
+ */
+export const MergeReadOnlyBar: FC = () => {
+    const merge = useMergeSafe();
+    const {
+        effectiveParts,
+        labelFor,
+        exploreALabel,
+        exploreBLabel,
+        isIncomplete,
+    } = useMergeSetup();
+
+    if (!merge?.isMerging || !merge.readOnly || isIncomplete) return null;
+
+    const keys = effectiveParts
+        .map((part) => (part.fieldA ? labelFor(part.fieldA) : '?'))
+        .join(' + ');
+    const runError = merge.mergeResults?.results.error ?? null;
+
+    return (
+        <Paper withBorder radius="md" px="sm" py={6}>
+            <Group gap="xs" wrap="nowrap">
+                <MantineIcon icon={IconArrowMerge} color="ldGray.6" />
+                <Text size="xs" c="dimmed" truncate>
+                    {exploreALabel} merged with {exploreBLabel}, joined on{' '}
+                    <Text span size="xs" fw={600} c="dark">
+                        {keys}
+                    </Text>
+                </Text>
+                {runError && (
+                    <Text size="xs" c="orange.8" truncate>
+                        {runError.error?.message ?? 'The merge failed to run'}
+                    </Text>
+                )}
+            </Group>
+        </Paper>
+    );
+};

--- a/packages/frontend/src/features/mergeQuery/components/MergeTabStrip.module.css
+++ b/packages/frontend/src/features/mergeQuery/components/MergeTabStrip.module.css
@@ -1,0 +1,71 @@
+.tabs {
+    display: flex;
+    align-items: stretch;
+    gap: 2px;
+    border-bottom: 1px solid var(--mantine-color-ldGray-3);
+}
+
+.tab {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    padding: 6px 12px 8px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--mantine-color-ldGray-6);
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    max-width: 55%;
+}
+
+.tab[data-active='true'] {
+    color: var(--mantine-color-text);
+    border-bottom-color: var(--mantine-color-blue-6);
+}
+
+.tab:hover:not([data-active='true']) {
+    color: var(--mantine-color-text);
+}
+
+.tab.add {
+    color: var(--mantine-color-ldGray-5);
+    font-weight: 500;
+}
+
+.tab.add:hover {
+    color: var(--mantine-color-blue-6);
+}
+
+.dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 2px;
+    flex: none;
+}
+
+.dot[data-side='a'] {
+    background: var(--mantine-color-blue-6);
+}
+
+.dot[data-side='b'] {
+    background: var(--mantine-color-orange-6);
+}
+
+.close {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 3px;
+    padding: 1px;
+    color: var(--mantine-color-ldGray-5);
+    opacity: 0;
+}
+
+.tab:hover .close,
+.tab[data-active='true'] .close {
+    opacity: 1;
+}
+
+.close:hover {
+    color: var(--mantine-color-text);
+    background: var(--mantine-color-ldGray-2);
+}

--- a/packages/frontend/src/features/mergeQuery/components/MergeTabStrip.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeTabStrip.tsx
@@ -1,0 +1,108 @@
+import { FeatureFlags } from '@lightdash/common';
+import { Box, Text, Tooltip, UnstyledButton } from '@mantine/core';
+import { IconPlus, IconX } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useExplore } from '../../../hooks/useExplore';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { selectTableName, useExplorerSelector } from '../../explorer/store';
+import { useMergeSafe } from '../context/useMerge';
+import styles from './MergeTabStrip.module.css';
+
+/**
+ * The merge entry point: a row of real tabs above the sidebar's field tree.
+ *
+ * Solo, the row is the current query's tab and a quiet "+ Add query" tab —
+ * the affordance is structural, not a floating button. With a second query
+ * the row becomes two tabs that swap the field tree between the queries, and
+ * the add tab disappears, because a merge joins exactly two.
+ */
+export const MergeTabStrip: FC = () => {
+    const { data: mergeFlag } = useServerFeatureFlag(FeatureFlags.MergeQueries);
+    const tableName = useExplorerSelector(selectTableName);
+    const merge = useMergeSafe();
+    const { data: exploreA } = useExplore(tableName, {
+        refetchOnMount: false,
+    });
+    const { data: exploreB } = useExplore(
+        merge?.queryB.exploreName ?? undefined,
+        { refetchOnMount: false },
+    );
+
+    if (!merge || !tableName || mergeFlag?.enabled !== true) return null;
+    if (!merge.isMerging && merge.readOnly) return null;
+
+    const labelA = exploreA?.label ?? 'Query A';
+    const labelB = exploreB?.label ?? 'Query B';
+    const collide = merge.isMerging && labelA === labelB;
+
+    return (
+        <Box className={styles.tabs}>
+            <UnstyledButton
+                className={styles.tab}
+                data-active={!merge.isMerging || merge.focus === 'a'}
+                onClick={() => {
+                    if (merge.isMerging) merge.setFocus('a');
+                }}
+            >
+                <Box component="span" className={styles.dot} data-side="a" />
+                <Text span size="sm" fw={600} truncate>
+                    {collide ? `${labelA} (A)` : labelA}
+                </Text>
+            </UnstyledButton>
+
+            {merge.isMerging ? (
+                <UnstyledButton
+                    className={styles.tab}
+                    data-active={merge.focus === 'b'}
+                    onClick={() => merge.setFocus('b')}
+                    data-testid="MergeTabStrip/QueryBTab"
+                >
+                    <Box
+                        component="span"
+                        className={styles.dot}
+                        data-side="b"
+                    />
+                    <Text span size="sm" fw={600} truncate>
+                        {collide ? `${labelB} (B)` : labelB}
+                    </Text>
+                    {!merge.readOnly && (
+                        <Tooltip label="Remove this query" withinPortal>
+                            <Box
+                                component="span"
+                                className={styles.close}
+                                role="button"
+                                tabIndex={0}
+                                aria-label="Remove this query"
+                                data-testid="MergeTabStrip/RemoveQueryB"
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    merge.removeQuery();
+                                }}
+                                onKeyDown={(event) => {
+                                    if (event.key === 'Enter') {
+                                        event.stopPropagation();
+                                        merge.removeQuery();
+                                    }
+                                }}
+                            >
+                                <MantineIcon icon={IconX} size={12} />
+                            </Box>
+                        </Tooltip>
+                    )}
+                </UnstyledButton>
+            ) : (
+                <UnstyledButton
+                    className={`${styles.tab} ${styles.add}`}
+                    onClick={merge.addQuery}
+                    data-testid="MergeTabStrip/AddQueryB"
+                >
+                    <MantineIcon icon={IconPlus} size={13} />
+                    <Text span size="sm">
+                        Add query
+                    </Text>
+                </UnstyledButton>
+            )}
+        </Box>
+    );
+};

--- a/packages/frontend/src/features/mergeQuery/components/QueryBTree.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/QueryBTree.tsx
@@ -1,0 +1,61 @@
+import { Select, Stack } from '@mantine/core';
+import { useMemo, type FC } from 'react';
+import ExploreTree from '../../../components/Explorer/ExploreTree';
+import LoadingSkeleton from '../../../components/Explorer/ExploreTree/LoadingSkeleton';
+import { ItemDetailProvider } from '../../../components/Explorer/ExploreTree/TableTree/ItemDetailProvider';
+import { useExplore } from '../../../hooks/useExplore';
+import { useExplores } from '../../../hooks/useExplores';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useMerge } from '../context/useMerge';
+
+/**
+ * The field picker for the second query, shown when its tab has the focus.
+ *
+ * The explorer's own tree, pointed at the second query's explore and its
+ * selection. Picking fields is picking fields: search, grouping, descriptions
+ * and field detail all work here because it is the same component, not a
+ * second and worse one that has to be kept in step.
+ */
+export const QueryBTree: FC = () => {
+    const projectUuid = useProjectUuid();
+    const { data: explores } = useExplores(projectUuid);
+    const { queryB, setExploreB, toggleFieldB } = useMerge();
+    const { data: explore, isInitialLoading } = useExplore(
+        queryB.exploreName ?? undefined,
+    );
+
+    const selection = useMemo(
+        () => ({
+            activeFields: new Set([...queryB.dimensions, ...queryB.metrics]),
+            selectedDimensions: queryB.dimensions,
+        }),
+        [queryB.dimensions, queryB.metrics],
+    );
+
+    return (
+        <Stack gap="xs" h="100%">
+            <Select
+                placeholder="Pick a table"
+                data={(explores ?? []).map((option) => ({
+                    value: option.name,
+                    label: option.label,
+                }))}
+                value={queryB.exploreName}
+                onChange={setExploreB}
+                searchable
+            />
+
+            {queryB.exploreName && isInitialLoading && <LoadingSkeleton />}
+
+            {explore && (
+                <ItemDetailProvider>
+                    <ExploreTree
+                        explore={explore}
+                        selection={selection}
+                        onSelectedFieldChange={toggleFieldB}
+                    />
+                </ItemDetailProvider>
+            )}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/features/mergeQuery/constants.ts
+++ b/packages/frontend/src/features/mergeQuery/constants.ts
@@ -1,0 +1,33 @@
+import { MergeJoinType } from '@lightdash/common';
+
+export const SOURCE_A = 'a';
+export const SOURCE_B = 'b';
+export const JOIN_KEY = 'join_key';
+
+/** Stand-in when no provider is mounted; the setup panel renders nothing. */
+export const EMPTY_MERGE = {
+    isMerging: false,
+    readOnly: false,
+    wasRestored: false,
+    focus: 'a' as const,
+    queryB: {
+        exploreName: null,
+        dimensions: [] as string[],
+        metrics: [] as string[],
+        additionalMetrics: undefined,
+        customDimensions: undefined,
+    },
+    joinParts: [{ fieldA: null, fieldB: null }],
+    joinType: MergeJoinType.FULL,
+    filtersB: {},
+    addQuery: () => {},
+    removeQuery: () => {},
+    setFocus: () => {},
+    setExploreB: () => {},
+    toggleFieldB: () => {},
+    setJoinField: () => {},
+    addJoinPart: () => {},
+    removeJoinPart: () => {},
+    setJoinType: () => {},
+    setFiltersB: () => {},
+};

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -1,0 +1,335 @@
+import {
+    MergeJoinType,
+    type ApiError,
+    type ApiExecuteAsyncMetricQueryResults,
+    type MergeQuery,
+    type Filters,
+    type MergeQueryError,
+    type ParametersValuesMap,
+    type SavedMergeQuery,
+} from '@lightdash/common';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+    type PropsWithChildren,
+} from 'react';
+import { useParams, useSearchParams } from 'react-router';
+import { useInfiniteQueryResults } from '../../../hooks/useQueryResults';
+import { executeMergeQuery } from '../hooks/useMergeQuery';
+import {
+    MergeContext,
+    type MergeFocus,
+    type MergeJoinPart,
+    type MergeQueryBState,
+} from './context';
+import {
+    MERGE_URL_PARAM,
+    parseMergeState,
+    serializeMergeState,
+} from './mergeUrlState';
+
+const EMPTY_QUERY_B: MergeQueryBState = {
+    exploreName: null,
+    dimensions: [],
+    metrics: [],
+};
+
+/**
+ * Turns a chart's stored merge back into editable state.
+ *
+ * Without this a saved merged chart opens looking unmerged, and saving it
+ * again would drop the merge it arrived with.
+ */
+const fromSavedMerge = (saved: SavedMergeQuery) => ({
+    focus: 'a' as MergeFocus,
+    queryB: {
+        exploreName: saved.secondQuery.metricQuery.exploreName,
+        dimensions: saved.secondQuery.metricQuery.dimensions,
+        metrics: saved.secondQuery.metricQuery.metrics,
+        additionalMetrics: saved.secondQuery.metricQuery.additionalMetrics,
+        customDimensions: saved.secondQuery.metricQuery.customDimensions,
+    },
+    joinParts: saved.joinKey.map((part) => ({
+        fieldA: part.chartFieldId,
+        fieldB: part.secondFieldId,
+    })),
+    joinType: saved.joinType,
+    filtersB: saved.secondQuery.metricQuery.filters ?? {},
+});
+
+/**
+ * Merge state lives above the explorer page because the field picker and the
+ * query strip are siblings: focusing a query row has to re-target the sidebar,
+ * and the sidebar cannot reach into the main column to find out which query is
+ * being edited.
+ */
+export const MergeProvider: FC<
+    PropsWithChildren<{
+        savedMerge?: SavedMergeQuery | null;
+        /** View mode: show the merge, allow nothing, keep the URL clean. */
+        readOnly?: boolean;
+    }>
+> = ({ children, savedMerge, readOnly = false }) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const [searchParams, setSearchParams] = useSearchParams();
+    // Restored once, on mount. A link wins over the chart's stored merge, so
+    // that sharing a modified merge shows what was shared rather than what was
+    // saved.
+    const [restored] = useState(
+        () =>
+            parseMergeState(searchParams.get(MERGE_URL_PARAM)) ??
+            (savedMerge ? fromSavedMerge(savedMerge) : null),
+    );
+
+    const [isMerging, setIsMerging] = useState(restored !== null);
+    const [focus, setFocus] = useState<MergeFocus>(restored?.focus ?? 'a');
+    const [queryB, setQueryB] = useState<MergeQueryBState>(
+        restored?.queryB ?? EMPTY_QUERY_B,
+    );
+    const [joinParts, setJoinParts] = useState<MergeJoinPart[]>(
+        restored?.joinParts ?? [{ fieldA: null, fieldB: null }],
+    );
+    const [joinType, setJoinType] = useState<MergeJoinType>(
+        restored?.joinType ?? MergeJoinType.FULL,
+    );
+    const [filtersB, setFiltersB] = useState<Filters>(restored?.filtersB ?? {});
+    const activeRun = useRef(0);
+    const [runState, setRunState] = useState<{
+        isRunning: boolean;
+        errors: MergeQueryError[];
+        started: ApiExecuteAsyncMetricQueryResults | null;
+        error: ApiError | null;
+    }>({ isRunning: false, errors: [], started: null, error: null });
+
+    const addQuery = useCallback(() => {
+        setIsMerging(true);
+        setFocus('b');
+    }, []);
+
+    const removeQuery = useCallback(() => {
+        activeRun.current += 1;
+        setIsMerging(false);
+        setFocus('a');
+        setQueryB(EMPTY_QUERY_B);
+        setJoinParts([{ fieldA: null, fieldB: null }]);
+        setFiltersB({});
+        setRunState({
+            isRunning: false,
+            errors: [],
+            started: null,
+            error: null,
+        });
+    }, []);
+
+    const setExploreB = useCallback((exploreName: string | null) => {
+        // Fields belong to an explore, so changing it clears what was picked
+        // rather than leaving ids that no longer resolve.
+        setQueryB({ exploreName, dimensions: [], metrics: [] });
+        setJoinParts((current) =>
+            current.map((part) => ({ ...part, fieldB: null })),
+        );
+        setFiltersB({});
+    }, []);
+
+    const setJoinField = useCallback(
+        (index: number, side: 'fieldA' | 'fieldB', fieldId: string | null) => {
+            setJoinParts((current) =>
+                current.map((part, partIndex) =>
+                    partIndex === index ? { ...part, [side]: fieldId } : part,
+                ),
+            );
+        },
+        [],
+    );
+
+    const addJoinPart = useCallback(() => {
+        setJoinParts((current) => [...current, { fieldA: null, fieldB: null }]);
+    }, []);
+
+    const removeJoinPart = useCallback((index: number) => {
+        setJoinParts((current) =>
+            current.length === 1
+                ? current
+                : current.filter((_, partIndex) => partIndex !== index),
+        );
+        // A post-pivot names a key part by position, so dropping a part would
+        // leave it pointing at a different one.
+    }, []);
+
+    const toggleFieldB = useCallback(
+        (fieldId: string, isDimension: boolean) => {
+            setQueryB((current) => {
+                const key = isDimension ? 'dimensions' : 'metrics';
+                const selected = current[key];
+                return {
+                    ...current,
+                    [key]: selected.includes(fieldId)
+                        ? selected.filter((id) => id !== fieldId)
+                        : [...selected, fieldId],
+                };
+            });
+        },
+        [],
+    );
+
+    // Mirror the relationship into the URL. Replace rather than push, so
+    // building a merge does not fill the back button with every keystroke.
+    useEffect(() => {
+        // The URL carries a merge so a *modified* one can be shared. A saved
+        // chart in view mode is not being modified; its merge lives in the
+        // chart, and echoing it into the URL says otherwise.
+        if (readOnly) return;
+        setSearchParams(
+            (current) => {
+                const next = new URLSearchParams(current);
+                if (isMerging) {
+                    next.set(
+                        MERGE_URL_PARAM,
+                        serializeMergeState({
+                            focus,
+                            queryB,
+                            joinParts,
+                            joinType,
+                            filtersB,
+                        }),
+                    );
+                } else {
+                    next.delete(MERGE_URL_PARAM);
+                }
+                return next;
+            },
+            { replace: true },
+        );
+    }, [
+        readOnly,
+        isMerging,
+        focus,
+        queryB,
+        joinParts,
+        joinType,
+        filtersB,
+        setSearchParams,
+    ]);
+
+    useEffect(
+        () => () => {
+            activeRun.current += 1;
+        },
+        [],
+    );
+
+    const run = useCallback(
+        (mergeQuery: MergeQuery, parameters?: ParametersValuesMap) => {
+            if (!projectUuid) return;
+            const runId = activeRun.current + 1;
+            activeRun.current = runId;
+            setRunState({
+                isRunning: true,
+                errors: [],
+                started: null,
+                error: null,
+            });
+            executeMergeQuery(projectUuid, mergeQuery, parameters)
+                .then((result) => {
+                    if (activeRun.current !== runId) return;
+                    setRunState({
+                        isRunning: false,
+                        errors: result.errors,
+                        started: result.started,
+                        error: null,
+                    });
+                })
+                .catch((error: ApiError) => {
+                    if (activeRun.current !== runId) return;
+                    setRunState({
+                        isRunning: false,
+                        errors: [],
+                        started: null,
+                        error,
+                    });
+                });
+        },
+        [projectUuid],
+    );
+
+    const { started } = runState;
+    const results = useInfiniteQueryResults(projectUuid, started?.queryUuid);
+
+    const mergeResults = useMemo(
+        () =>
+            started
+                ? {
+                      queryUuid: started.queryUuid,
+                      fields: started.fields,
+                      metricQuery: started.metricQuery,
+                      // The metric query lists dimensions before metrics; the
+                      // statement returns join keys, then values, then
+                      // calculations. Column order follows the statement.
+                      columnOrder: [
+                          ...started.metricQuery.dimensions,
+                          ...started.metricQuery.metrics,
+                      ],
+                      results,
+                  }
+                : null,
+        [started, results],
+    );
+
+    const value = useMemo(
+        () => ({
+            isMerging,
+            readOnly,
+            wasRestored: restored !== null,
+            run,
+            isRunning: runState.isRunning,
+            runErrors: runState.errors,
+            runError: runState.error,
+            mergeResults,
+            focus,
+            queryB,
+            joinParts,
+            joinType,
+            filtersB,
+            addQuery,
+            removeQuery,
+            setFocus,
+            setExploreB,
+            toggleFieldB,
+            setJoinField,
+            addJoinPart,
+            removeJoinPart,
+            setJoinType,
+            setFiltersB,
+        }),
+        [
+            isMerging,
+            readOnly,
+            restored,
+            run,
+            runState.isRunning,
+            runState.errors,
+            runState.error,
+            mergeResults,
+            focus,
+            queryB,
+            joinParts,
+            joinType,
+            filtersB,
+            addQuery,
+            removeQuery,
+            setExploreB,
+            toggleFieldB,
+            setJoinField,
+            addJoinPart,
+            removeJoinPart,
+        ],
+    );
+
+    return (
+        <MergeContext.Provider value={value}>{children}</MergeContext.Provider>
+    );
+};

--- a/packages/frontend/src/features/mergeQuery/context/context.ts
+++ b/packages/frontend/src/features/mergeQuery/context/context.ts
@@ -1,0 +1,92 @@
+import {
+    type ApiError,
+    type Filters,
+    type ItemsMap,
+    type MergeJoinType,
+    type MergeQuery,
+    type MergeQueryError,
+    type MetricQuery,
+    type ParametersValuesMap,
+} from '@lightdash/common';
+import { createContext } from 'react';
+import { type InfiniteQueryResults } from '../../../hooks/useQueryResults';
+
+/** Which query the field picker is currently editing. */
+export type MergeFocus = 'a' | 'b';
+
+export type MergeQueryBState = {
+    exploreName: string | null;
+    dimensions: string[];
+    metrics: string[];
+    /** Keep saved-query-only fields intact while the merge is edited. */
+    additionalMetrics?: MetricQuery['additionalMetrics'];
+    customDimensions?: MetricQuery['customDimensions'];
+};
+
+/** One part of the join key: the field each query contributes. */
+export type MergeJoinPart = {
+    fieldA: string | null;
+    fieldB: string | null;
+};
+
+/**
+ * A merged run, in the shape the explorer's results machinery expects.
+ *
+ * Carried on the merge context rather than held by the strip that starts it,
+ * because when a merge is active it *is* the explorer's result: the chart and
+ * the results table read it, and neither is a child of the strip.
+ */
+export type MergeResults = {
+    queryUuid: string;
+    fields: ItemsMap;
+    metricQuery: MetricQuery;
+    /** Field ids in the order the merged statement returns them. */
+    columnOrder: string[];
+    results: InfiniteQueryResults;
+};
+
+export type MergeContextValue = {
+    /** True once a second query has been added. */
+    isMerging: boolean;
+    /** A saved chart in view mode shows its merge; it does not edit it. */
+    readOnly: boolean;
+    /**
+     * The merge arrived with the chart or the link rather than being built
+     * here, so it should run without being asked.
+     */
+    wasRestored: boolean;
+    /** Runs a merge, replacing any run already on screen. */
+    run: (mergeQuery: MergeQuery, parameters?: ParametersValuesMap) => void;
+    isRunning: boolean;
+    /** Why a merge was refused. Empty when it compiled. */
+    runErrors: MergeQueryError[];
+    /** Transport or server failure of the last run, if any. */
+    runError: ApiError | null;
+    /** The merged run, or null when none has succeeded yet. */
+    mergeResults: MergeResults | null;
+    focus: MergeFocus;
+    queryB: MergeQueryBState;
+    /** Query B's own filters, pushed down into that side's compile. */
+    filtersB: Filters;
+    joinParts: MergeJoinPart[];
+    joinType: MergeJoinType;
+    /** Index of the join key part spread into columns after the join, or null. */
+    addQuery: () => void;
+    removeQuery: () => void;
+    setFocus: (focus: MergeFocus) => void;
+    setExploreB: (exploreName: string | null) => void;
+    toggleFieldB: (fieldId: string, isDimension: boolean) => void;
+    setJoinField: (
+        index: number,
+        side: 'fieldA' | 'fieldB',
+        fieldId: string | null,
+    ) => void;
+    addJoinPart: () => void;
+    removeJoinPart: (index: number) => void;
+    setJoinType: (joinType: MergeJoinType) => void;
+    setFiltersB: (filters: Filters) => void;
+};
+
+export const MergeContext = createContext<MergeContextValue | undefined>(
+    undefined,
+);

--- a/packages/frontend/src/features/mergeQuery/context/mergeUrlState.test.ts
+++ b/packages/frontend/src/features/mergeQuery/context/mergeUrlState.test.ts
@@ -1,0 +1,84 @@
+import { MergeJoinType } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    parseMergeState,
+    serializeMergeState,
+    type MergeUrlState,
+} from './mergeUrlState';
+
+const state: MergeUrlState = {
+    focus: 'b',
+    queryB: {
+        exploreName: 'subscriptions',
+        dimensions: ['subscriptions_subscription_start_month'],
+        metrics: ['subscriptions_total_subscriptions'],
+    },
+    joinParts: [
+        {
+            fieldA: 'orders_order_date_month',
+            fieldB: 'subscriptions_subscription_start_month',
+        },
+        { fieldA: 'orders_status', fieldB: 'subscriptions_status' },
+    ],
+    joinType: MergeJoinType.LEFT,
+    filtersB: {},
+};
+
+describe('merge url state', () => {
+    it('round-trips the whole relationship', () => {
+        expect(parseMergeState(serializeMergeState(state))).toEqual(state);
+    });
+
+    it('returns null when there is no merge in the url', () => {
+        expect(parseMergeState(null)).toBeNull();
+        expect(parseMergeState('')).toBeNull();
+    });
+
+    // A shared link can be stale or hand-edited. Dropping back to the ordinary
+    // explorer is the right failure; throwing away the page is not.
+    it('returns null for anything that is not JSON', () => {
+        expect(parseMergeState('not json')).toBeNull();
+        expect(parseMergeState('{oops')).toBeNull();
+    });
+
+    it('returns null for JSON that is not an object', () => {
+        expect(parseMergeState('"a string"')).toBeNull();
+        expect(parseMergeState('null')).toBeNull();
+    });
+
+    it('falls back to safe defaults for missing or wrong-typed fields', () => {
+        expect(parseMergeState('{}')).toEqual({
+            focus: 'a',
+            queryB: { exploreName: null, dimensions: [], metrics: [] },
+            // A merge always has at least one key part, even an unfilled one.
+            joinParts: [{ fieldA: null, fieldB: null }],
+            joinType: MergeJoinType.FULL,
+            filtersB: {},
+        });
+    });
+
+    it('drops non-string entries rather than carrying them into a query', () => {
+        const parsed = parseMergeState(
+            JSON.stringify({ d: ['ok', 3, null, 'fine'] }),
+        );
+
+        expect(parsed?.queryB.dimensions).toEqual(['ok', 'fine']);
+    });
+
+    it('rejects a join type it does not recognise', () => {
+        expect(
+            parseMergeState(JSON.stringify({ j: 'sideways' }))?.joinType,
+        ).toBe(MergeJoinType.FULL);
+    });
+
+    it('keeps composite key parts and drops malformed ones', () => {
+        const parsed = parseMergeState(
+            JSON.stringify({ k: [['a', 'b'], 'nope', [1, 'c']] }),
+        );
+
+        expect(parsed?.joinParts).toEqual([
+            { fieldA: 'a', fieldB: 'b' },
+            { fieldA: null, fieldB: 'c' },
+        ]);
+    });
+});

--- a/packages/frontend/src/features/mergeQuery/context/mergeUrlState.ts
+++ b/packages/frontend/src/features/mergeQuery/context/mergeUrlState.ts
@@ -1,0 +1,111 @@
+import { MergeJoinType, type Filters } from '@lightdash/common';
+import {
+    type MergeFocus,
+    type MergeJoinPart,
+    type MergeQueryBState,
+} from './context';
+
+/** Search param the merge relationship is kept in. */
+export const MERGE_URL_PARAM = 'merge';
+
+export type MergeUrlState = {
+    focus: MergeFocus;
+    queryB: MergeQueryBState;
+    joinParts: MergeJoinPart[];
+    joinType: MergeJoinType;
+    /** Query B's own filters. */
+    filtersB: Filters;
+};
+
+/**
+ * Short keys because this rides in the URL alongside the chart state, which is
+ * already long enough to strain what a browser and a Slack unfurl will carry.
+ */
+type SerializedMerge = {
+    e: string | null;
+    d: string[];
+    m: string[];
+    /** Join key parts as [queryA field, queryB field] pairs. */
+    k: Array<[string | null, string | null]>;
+    j: MergeJoinType;
+    /** Query B's filters ("where"). */
+    w: Filters;
+    a?: MergeQueryBState['additionalMetrics'];
+    c?: MergeQueryBState['customDimensions'];
+    f: MergeFocus;
+};
+
+const isJoinType = (value: unknown): value is MergeJoinType =>
+    typeof value === 'string' &&
+    (Object.values(MergeJoinType) as string[]).includes(value);
+
+const asStringArray = (value: unknown): string[] =>
+    Array.isArray(value)
+        ? value.filter((item): item is string => typeof item === 'string')
+        : [];
+
+export const serializeMergeState = (state: MergeUrlState): string =>
+    JSON.stringify({
+        e: state.queryB.exploreName,
+        d: state.queryB.dimensions,
+        m: state.queryB.metrics,
+        k: state.joinParts.map((part) => [part.fieldA, part.fieldB]),
+        j: state.joinType,
+        w: state.filtersB,
+        a: state.queryB.additionalMetrics,
+        c: state.queryB.customDimensions,
+        f: state.focus,
+    } satisfies SerializedMerge);
+
+const asJoinParts = (value: unknown): MergeJoinPart[] => {
+    if (!Array.isArray(value)) return [{ fieldA: null, fieldB: null }];
+    const parts = value.flatMap((entry) =>
+        Array.isArray(entry)
+            ? [
+                  {
+                      fieldA: typeof entry[0] === 'string' ? entry[0] : null,
+                      fieldB: typeof entry[1] === 'string' ? entry[1] : null,
+                  },
+              ]
+            : [],
+    );
+    // A merge always has at least one key part, even an unfilled one.
+    return parts.length > 0 ? parts : [{ fieldA: null, fieldB: null }];
+};
+
+/**
+ * Returns null for anything that does not parse. A merge shared with a stale or
+ * hand-edited link should drop back to the ordinary explorer rather than throw
+ * the page away.
+ */
+export const parseMergeState = (raw: string | null): MergeUrlState | null => {
+    if (!raw) return null;
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return null;
+    }
+    if (parsed === null || typeof parsed !== 'object') return null;
+
+    const value = parsed as Partial<SerializedMerge>;
+    return {
+        focus: value.f === 'b' ? 'b' : 'a',
+        queryB: {
+            exploreName: typeof value.e === 'string' ? value.e : null,
+            dimensions: asStringArray(value.d),
+            metrics: asStringArray(value.m),
+            additionalMetrics: value.a,
+            customDimensions: value.c,
+        },
+        joinParts: asJoinParts(value.k),
+        joinType: isJoinType(value.j) ? value.j : MergeJoinType.FULL,
+        filtersB:
+            typeof value.w === 'object' &&
+            value.w !== null &&
+            !Array.isArray(value.w)
+                ? value.w
+                : {},
+    };
+};

--- a/packages/frontend/src/features/mergeQuery/context/useMerge.ts
+++ b/packages/frontend/src/features/mergeQuery/context/useMerge.ts
@@ -1,0 +1,20 @@
+import { useContext } from 'react';
+import { MergeContext, type MergeContextValue } from './context';
+
+export const useMerge = (): MergeContextValue => {
+    const context = useContext(MergeContext);
+    if (!context) {
+        throw new Error('useMerge must be used within a MergeProvider');
+    }
+    return context;
+};
+
+/**
+ * Merge state when a provider is present, null when it is not.
+ *
+ * The explorer is rendered by several pages, and one forgetting the provider
+ * should cost the merge control, not the whole page. `useMerge` still throws
+ * for code that genuinely requires it.
+ */
+export const useMergeSafe = (): MergeContextValue | null =>
+    useContext(MergeContext) ?? null;

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeCompiledSql.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeCompiledSql.ts
@@ -1,0 +1,42 @@
+import { FeatureFlags, type ApiError } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import {
+    selectParameters,
+    useExplorerSelector,
+} from '../../../features/explorer/store';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { useMergeSafe } from '../context/useMerge';
+import { compileMergeQuery, type CompiledMergeQuery } from './useMergeQuery';
+import { useMergeSetup } from './useMergeSetup';
+
+/**
+ * The merged statement, compiled for the SQL card.
+ *
+ * With a merge configured, the merged statement is what Run executes — a SQL
+ * card showing Query A's SQL alone would be showing SQL that does not run.
+ * `isMergeActive` is false until the merge is complete enough to compile, so
+ * callers fall back to the single-query SQL while the join is being set up.
+ */
+export const useMergeCompiledSql = () => {
+    const projectUuid = useProjectUuid();
+    const { data: mergeFlag } = useServerFeatureFlag(FeatureFlags.MergeQueries);
+    const merge = useMergeSafe();
+    const { mergeQuery, canRun } = useMergeSetup();
+    const parameters = useExplorerSelector(selectParameters);
+
+    const isMergeActive =
+        mergeFlag?.enabled === true &&
+        !!merge?.isMerging &&
+        !!mergeQuery &&
+        canRun;
+
+    const query = useQuery<CompiledMergeQuery, ApiError>({
+        queryKey: ['mergeCompiledQuery', projectUuid, mergeQuery, parameters],
+        queryFn: () => compileMergeQuery(projectUuid!, mergeQuery!, parameters),
+        enabled: isMergeActive && !!projectUuid,
+        keepPreviousData: true,
+    });
+
+    return { isMergeActive, ...query };
+};

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
@@ -1,0 +1,74 @@
+import {
+    type ApiCompiledMergeQueryResults,
+    type ApiExecuteAsyncMetricQueryResults,
+    type CompileMergeQueryRequest,
+    type MergeQuery,
+    type ParametersValuesMap,
+    type RunMergeQueryRequest,
+} from '@lightdash/common';
+import { lightdashApi } from '../../../api';
+
+export type CompiledMergeQuery = ApiCompiledMergeQueryResults;
+
+export const compileMergeQuery = (
+    projectUuid: string,
+    mergeQuery: MergeQuery,
+    parameters: ParametersValuesMap | undefined,
+) =>
+    lightdashApi<CompiledMergeQuery>({
+        url: `/projects/${projectUuid}/mergeQuery/compile`,
+        method: 'POST',
+        body: JSON.stringify({
+            mergeQuery,
+            parameters,
+        } satisfies CompileMergeQueryRequest),
+    });
+
+export type MergeQueryRun = {
+    /** Errors that stopped the merge running. Empty when `started` is set. */
+    errors: CompiledMergeQuery['errors'];
+    /** The query to page results from, or null when the merge was refused. */
+    started: ApiExecuteAsyncMetricQueryResults | null;
+};
+
+const runMergeQuery = (
+    projectUuid: string,
+    mergeQuery: MergeQuery,
+    parameters: ParametersValuesMap | undefined,
+) =>
+    lightdashApi<ApiExecuteAsyncMetricQueryResults>({
+        url: `/projects/${projectUuid}/mergeQuery/run`,
+        method: 'POST',
+        body: JSON.stringify({
+            mergeQuery,
+            parameters,
+        } satisfies RunMergeQueryRequest),
+    });
+
+/**
+ * Compiles a merge, then runs it as an ordinary async query.
+ *
+ * Compiling first is what lets a refusal be shown against the query row that
+ * caused it: a merge that would produce wrong numbers is a result to render,
+ * not a failure to throw. A plain async function rather than a mutation —
+ * the caller owns the state, and there is no cache identity for a run that
+ * only ever belongs to the screen that started it.
+ */
+export const executeMergeQuery = async (
+    projectUuid: string,
+    mergeQuery: MergeQuery,
+    parameters?: ParametersValuesMap,
+): Promise<MergeQueryRun> => {
+    const compiled = await compileMergeQuery(
+        projectUuid,
+        mergeQuery,
+        parameters,
+    );
+    if (!compiled.sql) {
+        return { errors: compiled.errors, started: null };
+    }
+    return {
+        errors: [],
+        started: await runMergeQuery(projectUuid, mergeQuery, parameters),
+    };
+};

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeSetup.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeSetup.ts
@@ -1,0 +1,412 @@
+import {
+    FeatureFlags,
+    DimensionType,
+    convertItemTypeToDimensionType,
+    getItemLabelWithoutTableName,
+    getItemMap,
+    getUnaccountedDimensions,
+    isCustomDimension,
+    isDimension,
+    MergeQueryErrorKind,
+    validateMergeQuery,
+    type MergeFieldTypes,
+    type MergeQuery,
+    type MetricQuery,
+} from '@lightdash/common';
+import { useCallback, useMemo } from 'react';
+import { useExplore } from '../../../hooks/useExplore';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import {
+    selectMetricQuery,
+    selectParameters,
+    selectTableName,
+    useExplorerSelector,
+} from '../../explorer/store';
+import { EMPTY_MERGE, JOIN_KEY, SOURCE_A, SOURCE_B } from '../constants';
+import { useMergeSafe } from '../context/useMerge';
+
+/**
+ * Everything derived from the two queries and the relationship between them:
+ * the merge to run, whether it can run, and what is stopping it.
+ *
+ * Lives in a hook rather than the setup panel because the run control is not
+ * inside that panel. The explorer's own Run button runs a merge when one is
+ * configured, and both need the same answer to "is this runnable, and what is
+ * it".
+ */
+export const useMergeSetup = () => {
+    const { data: mergeFlag } = useServerFeatureFlag(FeatureFlags.MergeQueries);
+    const tableName = useExplorerSelector(selectTableName);
+    const metricQuery = useExplorerSelector(selectMetricQuery);
+    const parameters = useExplorerSelector(selectParameters);
+    const mergeContext = useMergeSafe();
+    const { isMerging, queryB, joinParts, joinType, filtersB } =
+        mergeContext ?? EMPTY_MERGE;
+    const { run, isRunning, runErrors, mergeResults } = mergeContext ?? {};
+
+    const { data: exploreA } = useExplore(tableName, { refetchOnMount: false });
+    const { data: exploreB } = useExplore(queryB.exploreName ?? undefined, {
+        refetchOnMount: false,
+    });
+
+    const metricQueryB = useMemo<MetricQuery>(
+        () => ({
+            exploreName: queryB.exploreName ?? '',
+            dimensions: queryB.dimensions,
+            metrics: queryB.metrics,
+            filters: filtersB,
+            sorts: [],
+            limit: metricQuery.limit,
+            tableCalculations: [],
+            additionalMetrics: queryB.additionalMetrics,
+            customDimensions: queryB.customDimensions,
+        }),
+        [filtersB, queryB, metricQuery.limit],
+    );
+    const itemMapA = useMemo(
+        () =>
+            exploreA
+                ? getItemMap(
+                      exploreA,
+                      metricQuery.additionalMetrics,
+                      metricQuery.tableCalculations,
+                      metricQuery.customDimensions,
+                  )
+                : {},
+        [exploreA, metricQuery],
+    );
+    const itemMapB = useMemo(
+        () =>
+            exploreB
+                ? getItemMap(
+                      exploreB,
+                      metricQueryB.additionalMetrics,
+                      metricQueryB.tableCalculations,
+                      metricQueryB.customDimensions,
+                  )
+                : {},
+        [exploreB, metricQueryB],
+    );
+
+    /**
+     * The best joinable pair among what each query already selects: matching
+     * type class, matching grain for dates, dates preferred over everything
+     * (they are almost always the key), same field name as the tiebreaker.
+     * Only pairs the validator would accept are ever suggested — a suggestion
+     * that gets refused is worse than none.
+     */
+    const suggestedPair = useMemo<{
+        fieldA: string;
+        fieldB: string;
+    } | null>(() => {
+        if (!exploreA || !exploreB) return null;
+        const classOf = (type: DimensionType) =>
+            type === DimensionType.DATE || type === DimensionType.TIMESTAMP
+                ? 'temporal'
+                : type;
+
+        let best: { fieldA: string; fieldB: string } | null = null;
+        let bestScore = 0;
+        metricQuery.dimensions.forEach((fieldA) => {
+            const itemA = itemMapA[fieldA];
+            if (!itemA || (!isDimension(itemA) && !isCustomDimension(itemA)))
+                return;
+            queryB.dimensions.forEach((fieldB) => {
+                const itemB = itemMapB[fieldB];
+                if (
+                    !itemB ||
+                    (!isDimension(itemB) && !isCustomDimension(itemB))
+                )
+                    return;
+                const typeA = convertItemTypeToDimensionType(itemA);
+                const typeB = convertItemTypeToDimensionType(itemB);
+                if (classOf(typeA) !== classOf(typeB)) return;
+                const isTemporal = classOf(typeA) === 'temporal';
+                if (
+                    isTemporal &&
+                    (isDimension(itemA)
+                        ? (itemA.timeInterval ?? null)
+                        : null) !==
+                        (isDimension(itemB)
+                            ? (itemB.timeInterval ?? null)
+                            : null)
+                ) {
+                    return;
+                }
+                let score = 1;
+                if (isTemporal) score += 3;
+                if (itemA.name === itemB.name) score += 4;
+                if (score > bestScore) {
+                    bestScore = score;
+                    best = { fieldA, fieldB };
+                }
+            });
+        });
+        return best;
+    }, [
+        exploreA,
+        exploreB,
+        itemMapA,
+        itemMapB,
+        metricQuery.dimensions,
+        queryB.dimensions,
+    ]);
+
+    // The first key part defaults to the suggested pair, falling back to each
+    // query's first dimension while the explores are still loading. Further
+    // parts start empty because there is no obvious default.
+    const effectiveParts = useMemo(
+        () =>
+            joinParts.map((part, index) => ({
+                fieldA:
+                    part.fieldA ??
+                    (index === 0
+                        ? (suggestedPair?.fieldA ??
+                          metricQuery.dimensions[0] ??
+                          null)
+                        : null),
+                fieldB:
+                    part.fieldB ??
+                    (index === 0
+                        ? (suggestedPair?.fieldB ??
+                          queryB.dimensions[0] ??
+                          null)
+                        : null),
+            })),
+        [joinParts, suggestedPair, metricQuery.dimensions, queryB.dimensions],
+    );
+    const completeParts = effectiveParts.filter(
+        (part) => part.fieldA && part.fieldB,
+    );
+
+    // Field ids are how the merge is addressed, but they are not what anyone
+    // calls these things. Everything the user reads says the label.
+    const labelFor = useCallback(
+        (fieldId: string) => {
+            const item = itemMapA[fieldId] ?? itemMapB[fieldId];
+            return item ? getItemLabelWithoutTableName(item) : fieldId;
+        },
+        [itemMapA, itemMapB],
+    );
+
+    // Either query can be the finer-grained one. Both are checked, because a
+    // merge is refused for whichever side carries the extra dimension and the
+    // refusal has to name where the problem is.
+    const unaccountedA = useMemo(
+        () =>
+            getUnaccountedDimensions(
+                { id: SOURCE_A, metricQuery },
+                completeParts.map((part, index) => ({
+                    name: `${JOIN_KEY}_${index}`,
+                    fieldIdBySourceId: { [SOURCE_A]: part.fieldA as string },
+                })),
+            ),
+        [metricQuery, completeParts],
+    );
+    const unaccountedB = useMemo(
+        () =>
+            getUnaccountedDimensions(
+                { id: SOURCE_B, metricQuery: metricQueryB },
+                completeParts.map((part, index) => ({
+                    name: `${JOIN_KEY}_${index}`,
+                    fieldIdBySourceId: { [SOURCE_B]: part.fieldB as string },
+                })),
+            ),
+        [metricQueryB, completeParts],
+    );
+
+    /**
+     * A dimension only one side carries would repeat the other side's rows
+     * once per value. Refused with where and what: the fix is to remove the
+     * dimension, or to select it on both queries and join on it.
+     */
+    const fanOut = useMemo(
+        () => [
+            ...(unaccountedA.length > 0
+                ? [{ side: 'a' as const, fields: unaccountedA }]
+                : []),
+            ...(unaccountedB.length > 0
+                ? [{ side: 'b' as const, fields: unaccountedB }]
+                : []),
+        ],
+        [unaccountedA, unaccountedB],
+    );
+
+    // The join selects take the fields themselves, not ids, so they can show
+    // the same icons and labels as every other field picker.
+    const joinItemsA = useMemo(
+        () =>
+            metricQuery.dimensions
+                .map((id) => itemMapA[id])
+                .filter(
+                    (item) =>
+                        !!item &&
+                        (isDimension(item) || isCustomDimension(item)),
+                ),
+        [itemMapA, metricQuery.dimensions],
+    );
+    const joinItemsB = useMemo(
+        () =>
+            queryB.dimensions
+                .map((id) => itemMapB[id])
+                .filter(
+                    (item) =>
+                        !!item &&
+                        (isDimension(item) || isCustomDimension(item)),
+                ),
+        [itemMapB, queryB.dimensions],
+    );
+
+    // What people call these tables, not what dbt does.
+    const exploreALabel = exploreA?.label ?? tableName;
+    const exploreBLabel = exploreB?.label ?? queryB.exploreName;
+
+    const joinFieldLabel = effectiveParts[0]?.fieldA
+        ? labelFor(effectiveParts[0].fieldA)
+        : 'the join key';
+
+    const unaccountedTotal = unaccountedA.length + unaccountedB.length;
+    // Built here rather than inside the run handler so the same object can be
+    // validated while it is being configured. The rules that refuse a merge do
+    // not need it to have run.
+    const mergeQuery = useMemo<MergeQuery | null>(() => {
+        // Query A hydrates from the saved chart after mount; a merge built
+        // before that carries an empty explore and compiles to a 404.
+        if (!metricQuery.exploreName) return null;
+        if (!queryB.exploreName || completeParts.length === 0) return null;
+
+        const joinKey = completeParts.map((part, index) => ({
+            name: `${JOIN_KEY}_${index}`,
+            fieldIdBySourceId: {
+                [SOURCE_A]: part.fieldA as string,
+                [SOURCE_B]: part.fieldB as string,
+            },
+        }));
+
+        return {
+            sources: [
+                { id: SOURCE_A, metricQuery },
+                { id: SOURCE_B, metricQuery: metricQueryB },
+            ],
+            joinKey,
+            joinType,
+            tableCalculations: [],
+            limit: metricQuery.limit,
+        };
+    }, [queryB, completeParts, metricQuery, metricQueryB, joinType]);
+
+    // The same rules the server refuses on, run here as the merge is built.
+    // Whether two fields can be joined depends only on the two fields, so
+    // making the user press Run to find out is a round trip for an answer we
+    // already have.
+    const joinFieldTypes = useMemo<MergeFieldTypes>(() => {
+        const collect = (itemMap: typeof itemMapA) =>
+            Object.entries(itemMap).flatMap(([id, item]) =>
+                isDimension(item) || isCustomDimension(item)
+                    ? [
+                          [
+                              id,
+                              {
+                                  type: convertItemTypeToDimensionType(item),
+                                  timeInterval: isDimension(item)
+                                      ? (item.timeInterval ?? null)
+                                      : null,
+                                  timestampDomain: isDimension(item)
+                                      ? item.timestampDomain
+                                      : undefined,
+                              },
+                          ] as const,
+                      ]
+                    : [],
+            );
+        return {
+            [SOURCE_A]: Object.fromEntries(collect(itemMapA)),
+            [SOURCE_B]: Object.fromEntries(collect(itemMapB)),
+        };
+    }, [itemMapA, itemMapB]);
+
+    const joinKeyErrors = useMemo(
+        () =>
+            mergeQuery
+                ? validateMergeQuery(mergeQuery, joinFieldTypes).filter(
+                      (error) =>
+                          error.kind ===
+                              MergeQueryErrorKind.JOIN_KEY_TYPE_MISMATCH ||
+                          error.kind ===
+                              MergeQueryErrorKind.JOIN_KEY_GRANULARITY_MISMATCH,
+                  )
+                : [],
+        [mergeQuery, joinFieldTypes],
+    );
+
+    // A merge that is not built yet and a merge that is built but unsafe are
+    // different problems. Saying both at once is what makes the panel
+    // unreadable: a grain warning means nothing until there is a merge to
+    // warn about.
+    const setupStep = !queryB.exploreName
+        ? 'Pick a table for Query B'
+        : queryB.metrics.length === 0
+          ? 'Pick at least one metric for Query B'
+          : !effectiveParts.every(
+                  (part) =>
+                      part.fieldA &&
+                      part.fieldB &&
+                      metricQuery.dimensions.includes(part.fieldA) &&
+                      queryB.dimensions.includes(part.fieldB),
+              )
+            ? 'Pick a field from each query to join on'
+            : null;
+    const isIncomplete = setupStep !== null;
+
+    const blockingReason =
+        setupStep ??
+        (joinKeyErrors.length > 0
+            ? 'These queries cannot be joined on that field'
+            : fanOut.length > 0
+              ? 'A field is only in one of the queries'
+              : null);
+
+    const canRun =
+        mergeFlag?.enabled === true &&
+        !!mergeQuery &&
+        completeParts.length > 0 &&
+        completeParts.length === effectiveParts.length &&
+        !!queryB.exploreName &&
+        queryB.metrics.length > 0 &&
+        joinKeyErrors.length === 0 &&
+        fanOut.length === 0;
+
+    const handleRun = useCallback(() => {
+        if (mergeFlag?.enabled === true && mergeQuery)
+            run?.(mergeQuery, parameters);
+    }, [mergeFlag?.enabled, mergeQuery, run, parameters]);
+    return {
+        // state passed through, so callers need only this hook
+        isMerging,
+        queryB,
+        joinType,
+        run,
+        isRunning,
+        runErrors,
+        mergeResults,
+        // derived
+        effectiveParts,
+        labelFor,
+        unaccountedA,
+        unaccountedB,
+        unaccountedTotal,
+        fanOut,
+        joinFieldLabel,
+        joinItemsA,
+        joinItemsB,
+        exploreALabel,
+        exploreBLabel,
+        joinKeyErrors,
+        setupStep,
+        isIncomplete,
+        blockingReason,
+        canRun,
+        handleRun,
+        mergeQuery,
+    };
+};

--- a/packages/frontend/src/features/mergeQuery/hooks/useSavedMerge.test.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useSavedMerge.test.ts
@@ -1,0 +1,61 @@
+import { MergeJoinType, type MergeQuery } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { toSavedMerge } from './useSavedMerge';
+
+const metricQuery = (exploreName: string) => ({
+    exploreName,
+    dimensions: [`${exploreName}_date`],
+    metrics: [`${exploreName}_total`],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+});
+
+describe('toSavedMerge', () => {
+    it('persists the exact effective join used by the runtime', () => {
+        const mergeQuery: MergeQuery = {
+            sources: [
+                { id: 'a', metricQuery: metricQuery('orders') },
+                { id: 'b', metricQuery: metricQuery('payments') },
+            ],
+            joinKey: [
+                {
+                    name: 'k0',
+                    fieldIdBySourceId: {
+                        a: 'orders_suggested_date',
+                        b: 'payments_suggested_date',
+                    },
+                },
+                {
+                    name: 'k1',
+                    fieldIdBySourceId: {
+                        a: 'orders_status',
+                        b: 'payments_status',
+                    },
+                },
+            ],
+            joinType: MergeJoinType.INNER,
+            tableCalculations: [],
+            limit: 500,
+        };
+
+        expect(toSavedMerge(mergeQuery)).toEqual({
+            secondQuery: { metricQuery: metricQuery('payments') },
+            joinKey: [
+                {
+                    name: 'k0',
+                    chartFieldId: 'orders_suggested_date',
+                    secondFieldId: 'payments_suggested_date',
+                },
+                {
+                    name: 'k1',
+                    chartFieldId: 'orders_status',
+                    secondFieldId: 'payments_status',
+                },
+            ],
+            joinType: MergeJoinType.INNER,
+            tableCalculations: [],
+        });
+    });
+});

--- a/packages/frontend/src/features/mergeQuery/hooks/useSavedMerge.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useSavedMerge.ts
@@ -1,0 +1,38 @@
+import { type MergeQuery, type SavedMergeQuery } from '@lightdash/common';
+import { useMemo } from 'react';
+import { SOURCE_A, SOURCE_B } from '../constants';
+import { useMergeSetup } from './useMergeSetup';
+
+export const toSavedMerge = (mergeQuery: MergeQuery): SavedMergeQuery => {
+    const secondQuery = mergeQuery.sources.find(
+        (source) => source.id === SOURCE_B,
+    );
+    if (!secondQuery) {
+        throw new Error('A saved merge requires Query B.');
+    }
+
+    return {
+        secondQuery: { metricQuery: secondQuery.metricQuery },
+        joinKey: mergeQuery.joinKey.map((part) => ({
+            name: part.name,
+            chartFieldId: part.fieldIdBySourceId[SOURCE_A],
+            secondFieldId: part.fieldIdBySourceId[SOURCE_B],
+        })),
+        joinType: mergeQuery.joinType,
+        tableCalculations: mergeQuery.tableCalculations,
+    };
+};
+
+/** Runtime and persistence consume the same validated merge definition. */
+export const useSavedMerge = (): {
+    merge: SavedMergeQuery | null;
+    isValid: boolean;
+} => {
+    const { isMerging, canRun, mergeQuery } = useMergeSetup();
+
+    return useMemo(() => {
+        if (!isMerging) return { merge: null, isValid: true };
+        if (!canRun || !mergeQuery) return { merge: null, isValid: false };
+        return { merge: toSavedMerge(mergeQuery), isValid: true };
+    }, [isMerging, canRun, mergeQuery]);
+};

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -24,6 +24,7 @@ import { createWorkerFactory, useWorker } from '@shopify/react-web-worker';
 import isEqual from 'lodash/isEqual';
 import uniq from 'lodash/uniq';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMergeSafe } from '../../features/mergeQuery/context/useMerge';
 import {
     useAsyncCalculateGrandTotal,
     useAsyncCalculateRowSubtotals,
@@ -246,9 +247,13 @@ const useTableConfig = (
     const numUnpivotedDimensions =
         dimensions.length - (pivotDimensions?.length || 0);
 
+    // Subtotals re-derive from the metric query behind the source query. A
+    // merge has no such query — its metric query describes the merged result
+    // rather than anything the warehouse can be asked to group again.
+    const isMerged = !!useMergeSafe()?.mergeResults;
     const canUseSubtotals = useMemo(
-        () => numUnpivotedDimensions > 1,
-        [numUnpivotedDimensions],
+        () => numUnpivotedDimensions > 1 && !isMerged,
+        [numUnpivotedDimensions, isMerged],
     );
 
     // Once dimensions are loaded, turn off subtotals if there are not enough dimensions.

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -8,6 +8,7 @@ import {
     getMetricOverridesWithPopInheritance,
     isCustomDimension,
     isDimension,
+    MERGE_TABLE_NAME,
     isField,
     isMetric,
     isNumericItem,
@@ -28,7 +29,7 @@ import {
     type TableCalculation,
 } from '@lightdash/common';
 import { Group, Skeleton, Tooltip } from '@mantine/core';
-import { IconExclamationCircle } from '@tabler/icons-react';
+import { IconExclamationCircle, IconKey } from '@tabler/icons-react';
 import { type CellContext } from '@tanstack/react-table';
 import omit from 'lodash/omit';
 import { useMemo } from 'react';
@@ -64,6 +65,7 @@ import {
     selectTableName,
     useExplorerSelector,
 } from '../features/explorer/store';
+import { useMergeSafe } from '../features/mergeQuery/context/useMerge';
 import { getFieldColors } from '../utils/fieldColors';
 import { TableCellBar } from './TableCellBar';
 import {
@@ -488,7 +490,7 @@ export const useColumns = (): TableColumn[] => {
     const metricOverrides = useExplorerSelector(selectMetricOverrides);
 
     const {
-        activeFields,
+        activeFields: exploreActiveFields,
         query,
         queryResults,
         unpivotedQueryResults,
@@ -496,8 +498,21 @@ export const useColumns = (): TableColumn[] => {
         validQueryArgs,
         projectUuid,
     } = useExplorerQuery();
-    const resultsMetricQuery = query.data?.metricQuery;
-    const resultsFields = query.data?.fields;
+
+    // A merged result has no explore behind it, so its fields cannot be
+    // recovered from one. They arrive already described, and every one of them
+    // is active — a merge returns exactly the columns it was asked for.
+    const mergeResults = useMergeSafe()?.mergeResults ?? null;
+    const activeFields = useMemo(
+        () =>
+            mergeResults
+                ? new Set(mergeResults.columnOrder)
+                : exploreActiveFields,
+        [mergeResults, exploreActiveFields],
+    );
+    const resultsMetricQuery =
+        mergeResults?.metricQuery ?? query.data?.metricQuery;
+    const resultsFields = mergeResults?.fields ?? query.data?.fields;
 
     const parameters = useExplorerSelector(selectParameters);
     // Format temporal cells in the flag-gated resolved timezone (null when
@@ -513,7 +528,9 @@ export const useColumns = (): TableColumn[] => {
     // Split itemsMap into base map (rarely changes) and override layer (frequently changes)
     // This prevents full recalculation when only metricOverrides change
     const baseItemsMap = useMemo<ItemsMap | undefined>(() => {
-        if (!exploreData || hasNoActiveFields) return;
+        if (hasNoActiveFields) return;
+        if (mergeResults) return mergeResults.fields;
+        if (!exploreData) return;
 
         const baseFields = getItemMap(
             exploreData,
@@ -528,6 +545,7 @@ export const useColumns = (): TableColumn[] => {
         };
     }, [
         hasNoActiveFields,
+        mergeResults,
         resultsFields,
         exploreData,
         additionalMetrics,
@@ -628,7 +646,10 @@ export const useColumns = (): TableColumn[] => {
             isInitialQueryReady &&
             !!sourceQueryUuid &&
             hasMetricFields &&
-            totalsEnabledByDefault,
+            totalsEnabledByDefault &&
+            // Totals are recomputed from the metric query behind the source
+            // query, which a merged result does not have.
+            !mergeResults,
         invalidateCache: validQueryArgs?.invalidateCache,
     });
 
@@ -645,6 +666,14 @@ export const useColumns = (): TableColumn[] => {
             const sortIndex = sorts.findIndex((sf) => fieldId === sf.fieldId);
             const isFieldSorted = sortIndex !== -1;
             const fieldColors = getFieldColors(item);
+            // A merged result's dimensions are the join key; mark them so the
+            // shared columns read apart from each side's own.
+            const isMergeJoinKey =
+                !!mergeResults &&
+                isField(item) &&
+                item.table === MERGE_TABLE_NAME &&
+                isDimension(item);
+            const showTablePrefix = hasJoins || !!mergeResults;
             const column: TableColumn = columnHelper.accessor(
                 (row) => row[fieldId],
                 {
@@ -655,7 +684,14 @@ export const useColumns = (): TableColumn[] => {
                         >
                             {isField(item) ? (
                                 <>
-                                    {hasJoins && (
+                                    {isMergeJoinKey && (
+                                        <MantineIcon
+                                            icon={IconKey}
+                                            size="sm"
+                                            color="gray.6"
+                                        />
+                                    )}
+                                    {showTablePrefix && !isMergeJoinKey && (
                                         <TableHeaderRegularLabel>
                                             {item.tableLabel}{' '}
                                         </TableHeaderRegularLabel>
@@ -792,5 +828,6 @@ export const useColumns = (): TableColumn[] => {
         exploreData,
         parameters,
         timezone,
+        mergeResults,
     ]);
 };

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -19,6 +19,7 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../features/explorer/store';
+import { useMergeSafe } from '../features/mergeQuery/context/useMerge';
 import { useQueryExecutor } from '../providers/Explorer/useQueryExecutor';
 import { buildQueryArgs } from './explorer/buildQueryArgs';
 import { useExploreByProjectUuid } from './useExplore';
@@ -137,11 +138,18 @@ export const useExplorerQueryManager = ({
         [dispatch],
     );
 
+    // A merge replaces the query it was built from, so once one has run there
+    // is nothing left for this query to render and re-running it is a second
+    // warehouse query for a result nobody sees. It stays enabled while the
+    // merge is being built, because until then its results are what is on
+    // screen.
+    const hasMergedResults = !!useMergeSafe()?.mergeResults;
+
     // Main query executor - creates TanStack Query subscriptions
     const [mainQueryExecutor] = useQueryExecutor(
         validQueryArgs,
         missingRequiredParameters,
-        true,
+        !hasMergedResults,
         queryUuidHistory,
         setQueryUuidHistory,
     );

--- a/packages/frontend/src/pages/ChartHistory.tsx
+++ b/packages/frontend/src/pages/ChartHistory.tsx
@@ -30,6 +30,7 @@ import {
     createExplorerStore,
     explorerActions,
 } from '../features/explorer/store';
+import { MergeProvider } from '../features/mergeQuery/context/MergeContext';
 import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
 import {
     useChartHistory,
@@ -45,7 +46,11 @@ const ChartHistoryContent = memo(() => {
     // Run the query effects hook - orchestrates all query effects
     useExplorerQueryEffects();
 
-    return <Explorer hideHeader={true} />;
+    return (
+        <MergeProvider>
+            <Explorer hideHeader={true} />
+        </MergeProvider>
+    );
 });
 
 const ChartHistoryExplorer = memo<{ selectedVersionUuid: string | undefined }>(

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -15,6 +15,7 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../features/explorer/store';
+import { MergeProvider } from '../features/mergeQuery/context/MergeContext';
 import { useExplore } from '../hooks/useExplore';
 import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
 import {
@@ -52,14 +53,16 @@ const ExplorerContent = memo(() => {
     useHotkeys([['mod + alt + k', handleClearQuery]]);
 
     return (
-        <Page
-            title={data ? data?.label : 'Tables'}
-            sidebar={<ExploreSideBar />}
-            withFullHeight
-            withPaddedContent
-        >
-            <Explorer />
-        </Page>
+        <MergeProvider>
+            <Page
+                title={data ? data?.label : 'Tables'}
+                sidebar={<ExploreSideBar />}
+                withFullHeight
+                withPaddedContent
+            >
+                <Explorer />
+            </Page>
+        </MergeProvider>
     );
 });
 

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -12,6 +12,7 @@ import {
     createExplorerStore,
     explorerActions,
 } from '../features/explorer/store';
+import { MergeProvider } from '../features/mergeQuery/context/MergeContext';
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
 import { useSavedQuery } from '../hooks/useSavedQuery';
@@ -121,7 +122,12 @@ const SavedExplorer = () => {
 
     return (
         <Provider store={store} key={`saved-${savedQueryUuid}`}>
-            <SavedExplorerContent />
+            <MergeProvider
+                savedMerge={data?.merge ?? null}
+                readOnly={mode !== 'edit'}
+            >
+                <SavedExplorerContent />
+            </MergeProvider>
         </Provider>
     );
 };


### PR DESCRIPTION
## Merge queries in the explorer, entered from the ghost "+" tab

The explorer experience for the merge engine (#27196, base of this PR). Two queries, one result, refusals that name their own repair.

### Entry point: tabs that own the merge

Prototyped in three rounds (five layout variants, then three all-in-sidebar directions); the winner is real underline tabs with a persistent join bar. Solo, the sidebar top shows the current query's tab plus a quiet "+ Add query" tab — the affordance is structural, not a floating button. Merging, the row is two explore-labelled tabs (`(A)`/`(B)` only on collision) that swap the **field tree only**, and the second query closes the way a tab closes, with an ✕ on the tab. Under the tabs sits a one-line join bar — "joined on Order date month · keep Everything · Edit" — always readable regardless of the active tab; Edit expands a flat inline editor (key pairs, add-a-pair, keep modes with plain-language help) that opens itself while the join is incomplete. The first query's breadcrumbs hide while the second query's picker has the tree. The setup panel leaves the main column entirely: what remains there is a headless auto-run for restored charts (the saved-chart view opens with the sidebar closed) and a one-line merged-with summary for view mode.

Rejected alternatives: a "+ Combine" link at the bottom of the field tree, and browser-style tabs above sidebar and content — the ghost tab was the smallest structural change and avoids introducing a new "combine" verb. There is deliberately **no** Merge toggle on the Run control and **no** "Run merge" relabel: Run Query always says Run Query, and with a merge configured it runs the merge — one control, one result.

### The rest

- **Setup panel** above the results: the join sentence (A token → key pairs → B token) with a suggested pair once both sides have fields, live client-side validation, keep modes (Everything / A / Matches) with plain-language explanations, and the fan-out refusal with guidance.
- **Query B filters** on the Filters card with an A/B segmented switch.
- **Merged results** flow through the ordinary visualization/results cards: origin-labelled columns, inherited formatting (currency stays currency), sorting, paging.
- **State**: the merge rides the URL (shareable) and persists on saved charts (rehydrates and auto-runs on open; read-only in view mode).
- **Gating**: `useServerFeatureFlag('merge-queries')` on the entry point only — no flag, no tab strip, nothing else changes.

### Regression analysis

- With the flag off (every org today), the only rendered change is nothing: the tab strip, setup panel and merge chrome all return `null`. `ExplorePanel` gains a strip mount and a tree branch guarded by the same flag+state; `RefreshButton` keeps its exact behaviour for non-merge runs (the merge branch is inert when `isMerging` is false).
- The sidebar swap components from earlier iterations (`MergeSidebar`, `MergeToggleButton`) are deleted, not orphaned — `Explorer.tsx`/`SavedExplorer.tsx` go back to mounting the plain sidebar.
- Verified in the live app: ghost "+" → pick explore B → suggested join → run (merged rows, formatted) → remove B → collapse back; fan-out refusal unchanged; URL state round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173kuaLf3CFWUYAuf27FWDx