### PR TITLE
fix: chart type gallery header copy and menu pill padding

### DIFF
--- a/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.module.css
+++ b/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.module.css
@@ -14,6 +14,7 @@
     position: absolute;
     top: -6px;
     right: -2px;
+    display: flex;
     opacity: 0;
     transition: opacity 150ms ease-in-out;
 }

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -137,9 +137,7 @@ describe('ChartTypeGallery', () => {
         renderPage();
 
         expect(screen.getByText('Bar race')).toBeInTheDocument();
-        expect(
-            screen.getByText(/built by your teams · 2 available/),
-        ).toBeInTheDocument();
+        expect(screen.getByText('2 available')).toBeInTheDocument();
 
         fireEvent.click(screen.getByText('Radial gauge'));
 

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -91,12 +91,11 @@ const ChartTypeGallery = () => {
                                 { title: 'Chart types', active: true },
                             ]}
                         />
-                        <Text fz="sm" c="ldGray.6">
-                            Custom visualizations built by your teams
-                            {totalCount !== null
-                                ? ` · ${totalCount} available`
-                                : ''}
-                        </Text>
+                        {totalCount !== null && (
+                            <Text fz="sm" c="ldGray.6">
+                                {totalCount} available
+                            </Text>
+                        )}
                     </Stack>
 
                     <Group gap="sm">


### PR DESCRIPTION
Two small polish fixes on the chart type gallery:

- Drops the "Custom visualizations built by your teams" sentence from the header. The subtitle now shows only the count (e.g. "12 available"), and is hidden while a search is active (the count refers to the unfiltered total, which was already null during searches).
- Evens out the card ⋯ menu pill padding. The `ActionIcon` sat inline inside the `Paper`, so the line box added ~3px of descender space below it (34×37 instead of 34×34). `display: flex` on the pill host removes the line box, matching the dashboard tile pill, which avoids this via its `Group` wrapper.

Relates: GLITCH-660