### PR TITLE
refactor: extract shared FloatingActionsPill for tile and card menus

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -28,6 +28,7 @@ import {
 import { clsx } from 'clsx';
 import { useState } from 'react';
 import { useDelayedHover } from '../../../hooks/useDelayedHover';
+import { FloatingActionsPill } from '../../common/FloatingActionsPill';
 import MantineIcon from '../../common/MantineIcon';
 import DeleteChartTileThatBelongsToDashboardModal from '../../common/modal/DeleteChartTileThatBelongsToDashboardModal';
 import ChartUpdateModal from '../TileForms/ChartUpdateModal';
@@ -118,149 +119,140 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                 isMenuOpen ||
                 lockHeaderVisibility) &&
                 hasHeaderContent && (
-                    <Paper
-                        p={5}
+                    <FloatingActionsPill
                         className={clsx('non-draggable', styles.tileTooltip)}
-                        shadow="sm"
-                        pos="absolute"
-                        top={-6}
-                        right={-2}
                     >
-                        <Group gap={5} wrap="nowrap">
-                            {titleLeftIcon}
+                        {titleLeftIcon}
 
-                            {visibleHeaderElement && (
-                                <Group gap="xs" className="non-draggable">
-                                    {visibleHeaderElement}
-                                </Group>
-                            )}
+                        {visibleHeaderElement && (
+                            <Group gap="xs" className="non-draggable">
+                                {visibleHeaderElement}
+                            </Group>
+                        )}
 
-                            {extraHeaderElement}
+                        {extraHeaderElement}
 
-                            {isVerified && (
-                                <Tooltip
-                                    label={
-                                        verification?.verifiedBy
-                                            ? `Verified by ${verification.verifiedBy.firstName} ${verification.verifiedBy.lastName}`
-                                            : 'Verified'
-                                    }
-                                    withArrow
-                                    withinPortal
-                                >
-                                    <IconCircleCheckFilled
-                                        size={14}
-                                        style={{
-                                            flexShrink: 0,
-                                            color: 'var(--mantine-color-green-6)',
-                                        }}
-                                    />
-                                </Tooltip>
-                            )}
+                        {isVerified && (
+                            <Tooltip
+                                label={
+                                    verification?.verifiedBy
+                                        ? `Verified by ${verification.verifiedBy.firstName} ${verification.verifiedBy.lastName}`
+                                        : 'Verified'
+                                }
+                                withArrow
+                                withinPortal
+                            >
+                                <IconCircleCheckFilled
+                                    size={14}
+                                    style={{
+                                        flexShrink: 0,
+                                        color: 'var(--mantine-color-green-6)',
+                                    }}
+                                />
+                            </Tooltip>
+                        )}
 
-                            {hasMenuContent && (
-                                <Menu
-                                    withArrow
-                                    withinPortal
-                                    shadow="md"
-                                    position="bottom-end"
-                                    offset={4}
-                                    arrowOffset={10}
-                                    opened={isMenuOpen}
-                                    onOpen={() => toggleMenu(true)}
-                                    onClose={() => toggleMenu(false)}
-                                >
-                                    <Menu.Dropdown>
-                                        {extraMenuItems}
-                                        {isEditMode && extraMenuItems && (
+                        {hasMenuContent && (
+                            <Menu
+                                withArrow
+                                withinPortal
+                                shadow="md"
+                                position="bottom-end"
+                                offset={4}
+                                arrowOffset={10}
+                                opened={isMenuOpen}
+                                onOpen={() => toggleMenu(true)}
+                                onClose={() => toggleMenu(false)}
+                            >
+                                <Menu.Dropdown>
+                                    {extraMenuItems}
+                                    {isEditMode && extraMenuItems && (
+                                        <Menu.Divider />
+                                    )}
+                                    {isEditMode && (
+                                        <>
+                                            <Box>
+                                                <Menu.Item
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconEdit}
+                                                        />
+                                                    }
+                                                    onClick={() =>
+                                                        setIsEditingTileContent(
+                                                            true,
+                                                        )
+                                                    }
+                                                >
+                                                    Edit tile content
+                                                </Menu.Item>
+                                            </Box>
+                                            {tabs && tabs.length > 1 && (
+                                                <Menu.Item
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={
+                                                                IconArrowAutofitContent
+                                                            }
+                                                        />
+                                                    }
+                                                    onClick={() =>
+                                                        setIsMovingTabs(true)
+                                                    }
+                                                >
+                                                    Move to another tab
+                                                </Menu.Item>
+                                            )}
                                             <Menu.Divider />
-                                        )}
-                                        {isEditMode && (
-                                            <>
-                                                <Box>
-                                                    <Menu.Item
-                                                        leftSection={
-                                                            <MantineIcon
-                                                                icon={IconEdit}
-                                                            />
-                                                        }
-                                                        onClick={() =>
-                                                            setIsEditingTileContent(
-                                                                true,
-                                                            )
-                                                        }
-                                                    >
-                                                        Edit tile content
-                                                    </Menu.Item>
-                                                </Box>
-                                                {tabs && tabs.length > 1 && (
-                                                    <Menu.Item
-                                                        leftSection={
-                                                            <MantineIcon
-                                                                icon={
-                                                                    IconArrowAutofitContent
-                                                                }
-                                                            />
-                                                        }
-                                                        onClick={() =>
-                                                            setIsMovingTabs(
-                                                                true,
-                                                            )
-                                                        }
-                                                    >
-                                                        Move to another tab
-                                                    </Menu.Item>
-                                                )}
-                                                <Menu.Divider />
-                                                {belongsToDashboard ? (
-                                                    <Menu.Item
-                                                        color="red"
-                                                        onClick={() =>
-                                                            setIsDeletingChartThatBelongsToDashboard(
-                                                                true,
-                                                            )
-                                                        }
-                                                    >
-                                                        Delete chart
-                                                    </Menu.Item>
-                                                ) : (
-                                                    <Menu.Item
-                                                        color="red"
-                                                        leftSection={
-                                                            <MantineIcon
-                                                                icon={IconTrash}
-                                                            />
-                                                        }
-                                                        onClick={() =>
-                                                            onDelete(tile)
-                                                        }
-                                                    >
-                                                        Remove tile
-                                                    </Menu.Item>
-                                                )}
-                                            </>
-                                        )}
-                                    </Menu.Dropdown>
+                                            {belongsToDashboard ? (
+                                                <Menu.Item
+                                                    color="red"
+                                                    onClick={() =>
+                                                        setIsDeletingChartThatBelongsToDashboard(
+                                                            true,
+                                                        )
+                                                    }
+                                                >
+                                                    Delete chart
+                                                </Menu.Item>
+                                            ) : (
+                                                <Menu.Item
+                                                    color="red"
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconTrash}
+                                                        />
+                                                    }
+                                                    onClick={() =>
+                                                        onDelete(tile)
+                                                    }
+                                                >
+                                                    Remove tile
+                                                </Menu.Item>
+                                            )}
+                                        </>
+                                    )}
+                                </Menu.Dropdown>
 
-                                    <Menu.Target>
-                                        <ActionIcon
-                                            size="sm"
-                                            variant="subtle"
-                                            color="gray"
-                                            style={{
-                                                position: 'relative',
-                                                zIndex: 1,
-                                            }}
-                                        >
-                                            <MantineIcon
-                                                data-testid="tile-icon-more"
-                                                icon={IconDots}
-                                            />
-                                        </ActionIcon>
-                                    </Menu.Target>
-                                </Menu>
-                            )}
-                        </Group>
-                    </Paper>
+                                <Menu.Target>
+                                    <ActionIcon
+                                        size="sm"
+                                        variant="subtle"
+                                        color="gray"
+                                        style={{
+                                            position: 'relative',
+                                            zIndex: 1,
+                                        }}
+                                    >
+                                        <MantineIcon
+                                            data-testid="tile-icon-more"
+                                            icon={IconDots}
+                                        />
+                                    </ActionIcon>
+                                </Menu.Target>
+                            </Menu>
+                        )}
+                    </FloatingActionsPill>
                 )}
 
             <Card

--- a/packages/frontend/src/components/common/FloatingActionsPill.tsx
+++ b/packages/frontend/src/components/common/FloatingActionsPill.tsx
@@ -1,0 +1,23 @@
+import { Group, Paper } from '@mantine/core';
+import { type FC, type ReactNode } from 'react';
+
+/** Floating actions chip straddling a card/tile's top-right corner — the
+ *  dashboard-tile menu pill pattern. Visibility (hover reveal, conditional
+ *  render) is the caller's concern. */
+export const FloatingActionsPill: FC<{
+    className?: string;
+    children: ReactNode;
+}> = ({ className, children }) => (
+    <Paper
+        p={5}
+        shadow="sm"
+        pos="absolute"
+        top={-6}
+        right={-2}
+        className={className}
+    >
+        <Group gap={5} wrap="nowrap">
+            {children}
+        </Group>
+    </Paper>
+);

--- a/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.module.css
+++ b/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.module.css
@@ -8,13 +8,8 @@
         transform 150ms ease-in-out;
 }
 
-/* Same placement as the dashboard tile menu pill (TileBase). Revealed on
-   hover, but also for keyboard focus or an open menu. */
+/* Revealed on hover, but also for keyboard focus or an open menu. */
 .menuHost {
-    position: absolute;
-    top: -6px;
-    right: -2px;
-    display: flex;
     opacity: 0;
     transition: opacity 150ms ease-in-out;
 }

--- a/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.tsx
@@ -1,5 +1,5 @@
 import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
-import { ActionIcon, Box, Menu, Paper, Stack, Text } from '@mantine/core';
+import { ActionIcon, Box, Menu, Stack, Text } from '@mantine/core';
 import {
     IconDots,
     IconFilePencil,
@@ -8,6 +8,7 @@ import {
 } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
+import { FloatingActionsPill } from '../../../components/common/FloatingActionsPill';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { PolymorphicPaperButton } from '../../../components/common/PolymorphicPaperButton';
 import { useCanEditDataApp } from '../hooks/useCanEditDataApp';
@@ -51,7 +52,7 @@ const ChartTypeGalleryCard: FC<Props> = ({ dataAppViz, onClick, onDelete }) => {
                         'Custom chart type built with the app builder'}
                 </Text>
             </Stack>
-            <Paper p={5} shadow="sm" className={classes.menuHost}>
+            <FloatingActionsPill className={classes.menuHost}>
                 <Menu
                     withArrow
                     withinPortal
@@ -111,7 +112,7 @@ const ChartTypeGalleryCard: FC<Props> = ({ dataAppViz, onClick, onDelete }) => {
                         )}
                     </Menu.Dropdown>
                 </Menu>
-            </Paper>
+            </FloatingActionsPill>
         </PolymorphicPaperButton>
     );
 };


### PR DESCRIPTION
Extracts the floating ⋯ actions chip that straddles a card/tile's top-right corner into a shared `FloatingActionsPill` component (`Paper` chip + `Group` layout + placement), and uses it in both places that hand-rolled it:

- `TileBase` (dashboard tiles) — previously inline `Paper`/`Group`
- `ChartTypeGalleryCard` — previously a near-copy that had already drifted (it dropped the flex context, causing the padding bug fixed in #27206; that one-line CSS fix is now superseded by the shared component's `Group`)

Visibility stays the caller's concern: TileBase keeps its hover-state conditional render, the gallery card keeps its CSS opacity reveal.

No visual change — verified in-app that dashboard tile pills and gallery card pills render at the same size/placement as before.

Relates: GLITCH-660