### PR TITLE
feat: direct edit button on gallery cards, rename builder links to Edit

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -366,7 +366,7 @@ describe('DataAppVizConfigTabs', () => {
         ).toBeInTheDocument();
         // `findBy`: the gate reads false until the user query settles.
         expect(
-            (await screen.findByText('Open in builder ↗')).closest('a'),
+            (await screen.findByText('Edit ↗')).closest('a'),
         ).toHaveAttribute(
             'href',
             '/projects/project-1/chart-types/data-app-viz-uuid',
@@ -379,7 +379,7 @@ describe('DataAppVizConfigTabs', () => {
         renderWithProviders(<ConfigTabs />);
 
         expect(screen.getByText('Radial gauge')).toBeInTheDocument();
-        await expect(screen.findByText('Open in builder ↗')).rejects.toThrow();
+        await expect(screen.findByText('Edit ↗')).rejects.toThrow();
     });
 
     it('fires setOption when a control changes', async () => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -124,7 +124,7 @@ export const ConfigTabs: FC = memo(() => {
                             mt={4}
                             display="inline-block"
                         >
-                            Open in builder ↗
+                            Edit ↗
                         </Anchor>
                     )}
                 </Box>

--- a/packages/frontend/src/features/apps/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeDetailModal.tsx
@@ -1,6 +1,6 @@
 import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
 import { Box, Button, SimpleGrid, Stack, Text } from '@mantine/core';
-import { IconExternalLink, IconTrash } from '@tabler/icons-react';
+import { IconFilePencil, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link, useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -72,9 +72,9 @@ const ChartTypeDetailModal: FC<Props> = ({
                     component={Link}
                     to={`/projects/${projectUuid}/chart-types/${dataAppViz.dataAppVizUuid}`}
                     variant="default"
-                    rightSection={<MantineIcon icon={IconExternalLink} />}
+                    leftSection={<MantineIcon icon={IconFilePencil} />}
                 >
-                    Open in builder
+                    Edit
                 </Button>
             }
             onConfirm={() =>

--- a/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.tsx
@@ -1,5 +1,5 @@
 import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
-import { ActionIcon, Box, Menu, Stack, Text } from '@mantine/core';
+import { ActionIcon, Box, Menu, Stack, Text, Tooltip } from '@mantine/core';
 import {
     IconDots,
     IconFilePencil,
@@ -53,6 +53,21 @@ const ChartTypeGalleryCard: FC<Props> = ({ dataAppViz, onClick, onDelete }) => {
                 </Text>
             </Stack>
             <FloatingActionsPill className={classes.menuHost}>
+                {canEdit && (
+                    <Tooltip label="Edit" withArrow withinPortal>
+                        <ActionIcon
+                            size="sm"
+                            variant="subtle"
+                            color="gray"
+                            component={Link}
+                            to={`/projects/${dataAppViz.projectUuid}/chart-types/${dataAppViz.dataAppVizUuid}`}
+                            aria-label={`Edit ${displayName}`}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <MantineIcon icon={IconFilePencil} />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
                 <Menu
                     withArrow
                     withinPortal
@@ -73,18 +88,6 @@ const ChartTypeGalleryCard: FC<Props> = ({ dataAppViz, onClick, onDelete }) => {
                         </ActionIcon>
                     </Menu.Target>
                     <Menu.Dropdown>
-                        {canEdit && (
-                            <Menu.Item
-                                component={Link}
-                                leftSection={
-                                    <MantineIcon icon={IconFilePencil} />
-                                }
-                                to={`/projects/${dataAppViz.projectUuid}/chart-types/${dataAppViz.dataAppVizUuid}`}
-                                onClick={(e) => e.stopPropagation()}
-                            >
-                                Edit
-                            </Menu.Item>
-                        )}
                         <Menu.Item
                             component={Link}
                             leftSection={<MantineIcon icon={IconTelescope} />}

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -143,7 +143,7 @@ describe('ChartTypeGallery', () => {
 
         expect(screen.getByText('Preview in explorer')).toBeInTheDocument();
         expect(
-            screen.getByText('Open in builder').closest('a'),
+            screen.getByRole('link', { name: 'Edit' }).closest('a'),
         ).toHaveAttribute(
             'href',
             '/projects/project-1/chart-types/data-app-viz-1',
@@ -189,12 +189,15 @@ describe('ChartTypeGallery', () => {
         setData([makeDataAppViz({})]);
         renderPage();
 
-        fireEvent.click(screen.getByLabelText('Actions for Radial gauge'));
-
-        expect(screen.getByText('Edit').closest('a')).toHaveAttribute(
+        expect(
+            screen.getByLabelText('Edit Radial gauge').closest('a'),
+        ).toHaveAttribute(
             'href',
             '/projects/project-1/chart-types/data-app-viz-1',
         );
+
+        fireEvent.click(screen.getByLabelText('Actions for Radial gauge'));
+
         expect(
             screen.getByText('Preview in explorer').closest('a'),
         ).toHaveAttribute(
@@ -232,10 +235,13 @@ describe('ChartTypeGallery', () => {
         setData([makeDataAppViz({})]);
         renderPage();
 
+        expect(
+            screen.queryByLabelText('Edit Radial gauge'),
+        ).not.toBeInTheDocument();
+
         fireEvent.click(screen.getByLabelText('Actions for Radial gauge'));
 
         expect(screen.getByText('Preview in explorer')).toBeInTheDocument();
-        expect(screen.queryByText('Edit')).not.toBeInTheDocument();
         expect(screen.queryByText('Delete')).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByText('Radial gauge'));


### PR DESCRIPTION
Surfaces Edit as a first-class action instead of burying it in the ⋯ menu, and makes the action wording consistent:

- Gallery cards: a pencil `ActionIcon` (with tooltip) sits in the floating pill next to the ⋯ menu; the Edit menu item is gone. Gated by `useCanEditDataApp` like before.
- Detail modal: "Open in builder" → "Edit" (pencil icon instead of the external-link icon — it's an in-app navigation).
- Explorer chart type card: "Open in builder ↗" → "Edit ↗".

Relates: GLITCH-661