### PR TITLE
feat: send scheduled deliveries as plain text

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1500,6 +1500,7 @@ export type SchedulerUpsertEvent = BaseTrack & {
         }>;
         timeZone: string | undefined;
         includeLinks: boolean;
+        plainTextEmail: boolean;
     };
 };
 export type SchedulerTimezoneUpdateEvent = BaseTrack & {

--- a/packages/backend/src/clients/EmailClient/EmailClient.test.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.test.ts
@@ -16,6 +16,7 @@ import {
     lightdashConfigWithSecurePortSMTP,
     passwordResetLinkMock,
 } from './EmailClient.mock';
+import { buildPlainTextEmailBody } from './plainTextEmailBody';
 
 vi.mock('nodemailer', () => ({
     createTransport: vi.fn(() => ({
@@ -499,6 +500,249 @@ describe('EmailClient', () => {
             // Should have recreated transporter on the second attempt (maxRetries - 1)
             expect(mockClose).toHaveBeenCalledTimes(1);
             expect(mockCreateTransport).toHaveBeenCalledTimes(2); // Initial + recreation
+        });
+    });
+
+    describe('Plain text delivery emails', () => {
+        // The retry tests above swap in a failing transport, and clearAllMocks
+        // leaves that implementation in place.
+        beforeEach(() => {
+            (
+                nodemailer.createTransport as import('vitest').Mock
+            ).mockReturnValue({
+                verify: vi.fn(),
+                sendMail: vi.fn(() => ({ messageId: 'messageId' })),
+                use: vi.fn(),
+            });
+        });
+
+        const csvAttachment = {
+            path: 'https://example.com/file.csv',
+            filename: 'file.csv',
+            localPath: '/tmp/file.csv',
+            truncated: false,
+        };
+
+        const sentMailOptions = (client: EmailClient) =>
+            vi.mocked(client.transporter!.sendMail).mock
+                .calls[0][0] as unknown as {
+                text?: string;
+                html?: string;
+                template?: string;
+                context?: Record<string, unknown>;
+                attachments?: Array<{ filename: string }>;
+            };
+
+        describe('buildPlainTextEmailBody', () => {
+            test('should generate a sentence naming the cadence', () => {
+                expect(
+                    buildPlainTextEmailBody({
+                        title: 'Partner Performance',
+                        message: undefined,
+                        cadence: 'weekly',
+                        downloads: [],
+                        noResults: false,
+                    }),
+                ).toEqual(
+                    'Hello, here is your weekly report for Partner Performance.\n',
+                );
+            });
+
+            test('should drop the cadence when the cron has no word for it', () => {
+                expect(
+                    buildPlainTextEmailBody({
+                        title: 'Partner Performance',
+                        message: undefined,
+                        cadence: undefined,
+                        downloads: [],
+                        noResults: false,
+                    }),
+                ).toEqual(
+                    'Hello, here is your report for Partner Performance.\n',
+                );
+            });
+
+            test("should use the delivery's own message instead of the generated sentence", () => {
+                expect(
+                    buildPlainTextEmailBody({
+                        title: 'Partner Performance',
+                        message: 'Please find your monthly report attached.',
+                        cadence: 'weekly',
+                        downloads: [],
+                        noResults: false,
+                    }),
+                ).toEqual('Please find your monthly report attached.\n');
+            });
+
+            test('should fall back to the generated sentence for a blank message', () => {
+                expect(
+                    buildPlainTextEmailBody({
+                        title: 'Partner Performance',
+                        message: '   ',
+                        cadence: 'daily',
+                        downloads: [],
+                        noResults: false,
+                    }),
+                ).toEqual(
+                    'Hello, here is your daily report for Partner Performance.\n',
+                );
+            });
+
+            test('should list files that could not be attached', () => {
+                expect(
+                    buildPlainTextEmailBody({
+                        title: 'Partner Performance',
+                        message: undefined,
+                        cadence: 'weekly',
+                        downloads: [
+                            {
+                                filename: 'orders',
+                                url: 'https://example.com/orders.csv',
+                            },
+                        ],
+                        noResults: false,
+                    }),
+                ).toEqual(
+                    'Hello, here is your weekly report for Partner Performance.\n\norders: https://example.com/orders.csv\n',
+                );
+            });
+
+            test('should say so when there are no results', () => {
+                expect(
+                    buildPlainTextEmailBody({
+                        title: 'Partner Performance',
+                        message: undefined,
+                        cadence: 'weekly',
+                        downloads: [],
+                        noResults: true,
+                    }),
+                ).toEqual(
+                    'Hello, here is your weekly report for Partner Performance.\n\nThis report returned no results.\n',
+                );
+            });
+        });
+
+        test('should send a chart csv delivery with no html and no template', async () => {
+            const client = new EmailClient({
+                lightdashConfig: lightdashConfigWithBasicSMTP,
+            });
+            await client.sendChartCsvNotificationEmail(
+                'recipient@example.com',
+                'subject',
+                'Partner Performance',
+                'description',
+                'Please find your report attached.',
+                'date',
+                'frequency',
+                csvAttachment,
+                'https://example.com/chart',
+                'https://example.com/scheduler',
+                true,
+                3,
+                true,
+                SchedulerFormat.CSV,
+                null,
+                { cadence: 'weekly' },
+            );
+
+            const sent = sentMailOptions(client);
+            expect(sent.template).toBeUndefined();
+            expect(sent.context).toBeUndefined();
+            expect(sent.html).toBeUndefined();
+            expect(sent.text).toEqual('Please find your report attached.\n');
+            expect(sent.attachments).toHaveLength(1);
+        });
+
+        test('should link a csv it could not attach rather than delivering nothing', async () => {
+            const client = new EmailClient({
+                lightdashConfig: lightdashConfigWithBasicSMTP,
+            });
+            await client.sendChartCsvNotificationEmail(
+                'recipient@example.com',
+                'subject',
+                'Partner Performance',
+                'description',
+                undefined,
+                'date',
+                'frequency',
+                csvAttachment,
+                'https://example.com/chart',
+                'https://example.com/scheduler',
+                true,
+                3,
+                false, // not attached
+                SchedulerFormat.CSV,
+                null,
+                { cadence: 'weekly' },
+            );
+
+            const sent = sentMailOptions(client);
+            expect(sent.attachments).toBeUndefined();
+            expect(sent.text).toEqual(
+                'Hello, here is your weekly report for Partner Performance.\n\nfile.csv: https://example.com/file.csv\n',
+            );
+        });
+
+        test('should keep the pdf attachment on an image/pdf delivery', async () => {
+            const client = new EmailClient({
+                lightdashConfig: lightdashConfigWithBasicSMTP,
+            });
+            await client.sendImageNotificationEmail(
+                'recipient@example.com',
+                'subject',
+                'Partner Performance',
+                'description',
+                undefined,
+                'date',
+                'frequency',
+                undefined,
+                'https://example.com/dashboard',
+                'https://example.com/scheduler',
+                true,
+                '/tmp/report.pdf',
+                3,
+                undefined,
+                undefined,
+                null,
+                { cadence: 'monthly' },
+            );
+
+            const sent = sentMailOptions(client);
+            expect(sent.template).toBeUndefined();
+            expect(sent.text).toEqual(
+                'Hello, here is your monthly report for Partner Performance.\n',
+            );
+            expect(sent.attachments).toEqual([
+                {
+                    filename: 'Partner Performance.pdf',
+                    path: '/tmp/report.pdf',
+                    contentType: 'application/pdf',
+                },
+            ]);
+        });
+
+        test('should still render the branded template when plain text is off', async () => {
+            const client = new EmailClient({
+                lightdashConfig: lightdashConfigWithBasicSMTP,
+            });
+            await client.sendChartCsvNotificationEmail(
+                'recipient@example.com',
+                'subject',
+                'Partner Performance',
+                'description',
+                'Please find your report attached.',
+                'date',
+                'frequency',
+                csvAttachment,
+                'https://example.com/chart',
+                'https://example.com/scheduler',
+                true,
+            );
+
+            const sent = sentMailOptions(client);
+            expect(sent.template).toEqual('chartCsvNotification');
+            expect(sent.context).toBeDefined();
+            expect(sent.text).toEqual('Partner Performance');
         });
     });
 });

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -33,6 +33,10 @@ import {
     buildFailureCountPhrase,
     toEmailFailureFields,
 } from '../../utils/partialFailureUtils';
+import {
+    buildPlainTextEmailBody,
+    type PlainTextEmailMode,
+} from './plainTextEmailBody';
 
 const RETRYABLE_ERROR_CODES = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND'];
 
@@ -268,44 +272,11 @@ export default class EmailClient {
         };
     }
 
-    private async sendEmail(
-        options: Mail.Options & EmailTemplate,
-    ): Promise<void> {
+    private async deliverMail(emailOptions: Mail.Options): Promise<void> {
         if (this.initPromise) {
             await this.initPromise;
         }
         if (this.transporter) {
-            const useCid = this.lightdashConfig.smtp?.inlineImageCid === true;
-            const host = this.lightdashConfig.siteUrl;
-
-            const imageSources: Record<string, string> = {};
-            for (const img of EmailClient.STATIC_CID_IMAGES) {
-                imageSources[img.contextKey] = useCid
-                    ? `cid:${img.cid}`
-                    : `${host}${img.hostPath}`;
-            }
-
-            const emailOptions: Mail.Options & EmailTemplate = {
-                ...options,
-                context: { ...options.context, ...imageSources },
-                attachments: [
-                    ...(Array.isArray(options.attachments)
-                        ? options.attachments
-                        : []),
-                    ...(useCid
-                        ? EmailClient.STATIC_CID_IMAGES.map((img) => ({
-                              filename: img.filename,
-                              path: path.join(
-                                  __dirname,
-                                  `./templates/${img.filename}`,
-                              ),
-                              cid: img.cid,
-                              contentDisposition: 'inline' as const,
-                          }))
-                        : []),
-                ],
-            };
-
             const maxRetries = 3;
             const baseDelay = 1000; // 1 second
 
@@ -365,6 +336,55 @@ export default class EmailClient {
                 }
             }
         }
+    }
+
+    private async sendEmail(
+        options: Mail.Options & EmailTemplate,
+    ): Promise<void> {
+        const useCid = this.lightdashConfig.smtp?.inlineImageCid === true;
+        const host = this.lightdashConfig.siteUrl;
+
+        const imageSources: Record<string, string> = {};
+        for (const img of EmailClient.STATIC_CID_IMAGES) {
+            imageSources[img.contextKey] = useCid
+                ? `cid:${img.cid}`
+                : `${host}${img.hostPath}`;
+        }
+
+        const emailOptions: Mail.Options & EmailTemplate = {
+            ...options,
+            context: { ...options.context, ...imageSources },
+            attachments: [
+                ...(Array.isArray(options.attachments)
+                    ? options.attachments
+                    : []),
+                ...(useCid
+                    ? EmailClient.STATIC_CID_IMAGES.map((img) => ({
+                          filename: img.filename,
+                          path: path.join(
+                              __dirname,
+                              `./templates/${img.filename}`,
+                          ),
+                          cid: img.cid,
+                          contentDisposition: 'inline' as const,
+                      }))
+                    : []),
+            ],
+        };
+
+        return this.deliverMail(emailOptions);
+    }
+
+    /**
+     * Sends a text-only email. No template is attached, so the compile plugin
+     * leaves `html` unset and nodemailer emits a single text/plain part
+     * (multipart/mixed once files are attached) — recipients never fall back to
+     * an HTML alternative. The branding images are skipped for the same reason.
+     */
+    private async sendPlainTextEmail(
+        options: Mail.Options & { text: string },
+    ): Promise<void> {
+        return this.deliverMail(options);
     }
 
     public canSendEmail() {
@@ -733,7 +753,37 @@ export default class EmailClient {
         deliveryType: string = 'Scheduled delivery',
         imageBuffer?: Buffer,
         sender?: EmailSenderIdentity | null,
+        plainText?: PlainTextEmailMode,
     ) {
+        if (plainText) {
+            return this.sendPlainTextEmail({
+                ...EmailClient.senderMailFields(sender),
+                to: recipient,
+                subject,
+                text: buildPlainTextEmailBody({
+                    title,
+                    message,
+                    cadence: plainText.cadence,
+                    // The chart image only exists inside the HTML body, so it
+                    // is offered as a link unless a PDF carries it.
+                    downloads:
+                        !pdfFile && imageUrl
+                            ? [{ filename: `${title}.png`, url: imageUrl }]
+                            : [],
+                    noResults: false,
+                }),
+                attachments: pdfFile
+                    ? [
+                          {
+                              filename: `${title}.pdf`,
+                              path: pdfFile,
+                              contentType: 'application/pdf',
+                          },
+                      ]
+                    : undefined,
+            });
+        }
+
         const useCidImage =
             this.lightdashConfig.smtp?.inlineImageCid === true &&
             imageBuffer !== undefined;
@@ -809,14 +859,40 @@ export default class EmailClient {
         asAttachment?: boolean,
         format?: SchedulerFormat,
         sender?: EmailSenderIdentity | null,
+        plainText?: PlainTextEmailMode,
     ) {
         const csvUrl = attachment.path;
+        const noResults = attachment.path === '#no-results';
         const attachments =
             asAttachment &&
             (attachment.localPath || attachment.path) &&
-            attachment.path !== '#no-results'
+            !noResults
                 ? [EmailClient.createFileAttachment(attachment, format)]
                 : undefined;
+
+        if (plainText) {
+            return this.sendPlainTextEmail({
+                ...EmailClient.senderMailFields(sender),
+                to: recipient,
+                subject,
+                text: buildPlainTextEmailBody({
+                    title,
+                    message,
+                    cadence: plainText.cadence,
+                    downloads:
+                        attachments || noResults
+                            ? []
+                            : [
+                                  {
+                                      filename: attachment.filename,
+                                      url: csvUrl,
+                                  },
+                              ],
+                    noResults,
+                }),
+                attachments,
+            });
+        }
 
         return this.sendEmail({
             ...EmailClient.senderMailFields(sender),
@@ -870,6 +946,7 @@ export default class EmailClient {
         notices?: DeliveryNotice[],
         sender?: EmailSenderIdentity | null,
         isApp: boolean = false,
+        plainText?: PlainTextEmailMode,
     ) {
         // App deliveries carry the query label; dashboards fall back to the
         // (timestamped) download filename.
@@ -886,20 +963,46 @@ export default class EmailClient {
             .filter((attachment) => attachment.truncated)
             .map(withDisplayName);
 
+        const attachableCsvUrls = csvUrls.filter(
+            (attachment) =>
+                (attachment.localPath || attachment.path) &&
+                attachment.path !== '#no-results',
+        );
+
         const emailAttachments = asAttachment
-            ? csvUrls
-                  .filter(
-                      (attachment) =>
-                          (attachment.localPath || attachment.path) &&
-                          attachment.path !== '#no-results',
-                  )
-                  .map((attachment) =>
-                      EmailClient.createFileAttachment(attachment, format),
-                  )
+            ? attachableCsvUrls.map((attachment) =>
+                  EmailClient.createFileAttachment(attachment, format),
+              )
             : undefined;
 
         const allChartsFailed =
             csvUrls.length === 0 && failures && failures.length > 0;
+
+        if (plainText) {
+            const attached = new Set(asAttachment ? attachableCsvUrls : []);
+            return this.sendPlainTextEmail({
+                ...EmailClient.senderMailFields(sender),
+                to: recipient,
+                subject,
+                text: buildPlainTextEmailBody({
+                    title,
+                    message,
+                    cadence: plainText.cadence,
+                    downloads: [...csvUrls, ...truncatedCsvUrls]
+                        .filter(
+                            (csvAttachment) =>
+                                csvAttachment.path !== '#no-results' &&
+                                !attached.has(csvAttachment),
+                        )
+                        .map((csvAttachment) => ({
+                            filename: csvAttachment.displayName,
+                            url: csvAttachment.path,
+                        })),
+                    noResults: csvUrls.length === 0,
+                }),
+                attachments: emailAttachments,
+            });
+        }
 
         return this.sendEmail({
             ...EmailClient.senderMailFields(sender),

--- a/packages/backend/src/clients/EmailClient/plainTextEmailBody.ts
+++ b/packages/backend/src/clients/EmailClient/plainTextEmailBody.ts
@@ -1,0 +1,66 @@
+import { type CronCadence } from '@lightdash/common';
+
+export type PlainTextEmailDownload = {
+    filename: string;
+    url: string;
+};
+
+/**
+ * Passed to the notification senders when the delivery is set to plain text.
+ * Its presence selects the text-only path; it carries the cadence the branded
+ * templates never needed.
+ */
+export type PlainTextEmailMode = {
+    cadence: CronCadence | undefined;
+};
+
+export type PlainTextEmailBody = {
+    /** Name of the delivered resource, used by the generated sentence. */
+    title: string;
+    /** The delivery's own message. Replaces the generated sentence entirely. */
+    message: string | undefined;
+    /** Cadence word for the generated sentence; omitted when the cron has none. */
+    cadence: CronCadence | undefined;
+    /** Files that could not be attached, listed so the delivery still lands. */
+    downloads: PlainTextEmailDownload[];
+    noResults: boolean;
+};
+
+const buildGeneratedSentence = (
+    title: string,
+    cadence: CronCadence | undefined,
+): string =>
+    `Hello, here is your ${cadence ? `${cadence} ` : ''}report for ${title}.`;
+
+/**
+ * Body of a plain-text scheduled delivery: the sender's own words, or a
+ * generated one-liner when they wrote none. Carries no Lightdash branding,
+ * links or footer — the file is the payload.
+ */
+export const buildPlainTextEmailBody = ({
+    title,
+    message,
+    cadence,
+    downloads,
+    noResults,
+}: PlainTextEmailBody): string => {
+    const intro = message?.trim()
+        ? message.trim()
+        : buildGeneratedSentence(title, cadence);
+
+    const sections = [intro];
+
+    if (noResults) {
+        sections.push('This report returned no results.');
+    }
+
+    if (downloads.length > 0) {
+        sections.push(
+            downloads
+                .map((download) => `${download.filename}: ${download.url}`)
+                .join('\n'),
+        );
+    }
+
+    return `${sections.join('\n\n')}\n`;
+};

--- a/packages/backend/src/database/entities/scheduler.ts
+++ b/packages/backend/src/database/entities/scheduler.ts
@@ -54,6 +54,7 @@ export type SchedulerDb = {
     notification_frequency: NotificationFrequency | null;
     selected_tabs: string[] | null;
     include_links: boolean;
+    plain_text_email: boolean;
     deleted_at: Date | null;
     deleted_by_user_uuid: string | null;
 };
@@ -179,6 +180,7 @@ export type SchedulerTable = Knex.CompositeTableType<
           | 'notification_frequency'
           | 'selected_tabs'
           | 'include_links'
+          | 'plain_text_email'
       > &
           SchedulerJsonWrite)
     | Pick<SchedulerDb, 'updated_at' | 'enabled'>

--- a/packages/backend/src/database/migrations/20260811214500_add_scheduler_plain_text_email.ts
+++ b/packages/backend/src/database/migrations/20260811214500_add_scheduler_plain_text_email.ts
@@ -3,12 +3,14 @@ import { Knex } from 'knex';
 const SchedulerTableName = 'scheduler';
 
 export async function up(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
     await knex.schema.alterTable(SchedulerTableName, (table) => {
         table.boolean('plain_text_email').defaultTo(false).notNullable();
     });
 }
 
 export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
     await knex.schema.alterTable(SchedulerTableName, (table) => {
         table.dropColumn('plain_text_email');
     });

--- a/packages/backend/src/database/migrations/20260811214500_add_scheduler_plain_text_email.ts
+++ b/packages/backend/src/database/migrations/20260811214500_add_scheduler_plain_text_email.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const SchedulerTableName = 'scheduler';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SchedulerTableName, (table) => {
+        table.boolean('plain_text_email').defaultTo(false).notNullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SchedulerTableName, (table) => {
+        table.dropColumn('plain_text_email');
+    });
+}

--- a/packages/backend/src/ee/services/ai/tools/createScheduledDelivery.ts
+++ b/packages/backend/src/ee/services/ai/tools/createScheduledDelivery.ts
@@ -32,6 +32,7 @@ const toSchedulerPayload = (
     ...(args.message ? { message: args.message } : {}),
     enabled: args.enabled,
     includeLinks: true,
+    plainTextEmail: false,
     appUuid: null,
     appName: null,
     targets: args.targets.map((target) =>

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -149,6 +149,7 @@ export class SchedulerModel {
             notificationFrequency:
                 scheduler.notification_frequency ?? undefined,
             includeLinks: scheduler.include_links,
+            plainTextEmail: scheduler.plain_text_email,
             projectUuid: scheduler.project_uuid ?? undefined,
             projectName: scheduler.project_name ?? undefined,
         };
@@ -233,6 +234,7 @@ export class SchedulerModel {
             enabled: true,
             notification_frequency: newScheduler.notificationFrequency || null,
             include_links: newScheduler.includeLinks !== false,
+            plain_text_email: newScheduler.plainTextEmail === true,
         };
 
         if (isDashboardCreateScheduler(newScheduler)) {
@@ -1265,6 +1267,7 @@ export class SchedulerModel {
                             ? (scheduler.selectedTabs as string[])
                             : null,
                     include_links: scheduler.includeLinks !== false,
+                    plain_text_email: scheduler.plainTextEmail === true,
                 })
                 .where('scheduler_uuid', scheduler.schedulerUuid);
 

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -1171,6 +1171,7 @@ describe('handleScheduledDelivery execution identity', () => {
         options: { formatted: true, limit: 'table' },
         enabled: true,
         includeLinks: true,
+        plainTextEmail: false,
         targets: [],
     } as SchedulerAndTargets;
 
@@ -1356,6 +1357,7 @@ const appScheduler = (
         options: { formatted: true, limit: 'table' },
         enabled: true,
         includeLinks: true,
+        plainTextEmail: false,
         targets: [],
         ...overrides,
     }) as CreateSchedulerAndTargets;

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -30,6 +30,7 @@ import {
     friendlyName,
     getColumnOrderFromVizTableConfig,
     getConditionalFormattingsFromChartConfig,
+    getCronCadence,
     getCustomLabelsFromTableConfig,
     getCustomLabelsFromVizTableConfig,
     getDownloadPivotConfig,
@@ -3564,7 +3565,13 @@ export default class SchedulerTask {
                 name,
                 thresholds,
                 includeLinks,
+                plainTextEmail,
             } = scheduler;
+
+            // Email-only: strips the branded template in favour of a text body.
+            const plainText = plainTextEmail
+                ? { cadence: getCronCadence(scheduler.cron) }
+                : undefined;
 
             await this.schedulerService.logSchedulerJob({
                 task: SCHEDULER_TASKS.SEND_EMAIL_NOTIFICATION,
@@ -3677,6 +3684,7 @@ export default class SchedulerTask {
                     'This is a data alert sent by Lightdash',
                     imageBuffer,
                     senderIdentity,
+                    plainText,
                 );
             } else if (
                 format === SchedulerFormat.IMAGE ||
@@ -3711,6 +3719,7 @@ export default class SchedulerTask {
                     undefined, // deliveryType
                     format === SchedulerFormat.IMAGE ? imageBuffer : undefined,
                     senderIdentity,
+                    plainText,
                 );
             } else if (savedChartUuid) {
                 if (csvUrl === undefined) {
@@ -3736,6 +3745,7 @@ export default class SchedulerTask {
                     csvOptions?.asAttachment,
                     format,
                     senderIdentity,
+                    plainText,
                 );
             } else if (dashboardUuid || appUuid) {
                 if (csvUrls === undefined) {
@@ -3765,6 +3775,7 @@ export default class SchedulerTask {
                     notices,
                     senderIdentity,
                     !!appUuid,
+                    plainText,
                 );
             } else {
                 throw new Error('Not implemented');
@@ -5983,6 +5994,7 @@ export default class SchedulerTask {
                     appName: null,
                     enabled: true,
                     includeLinks: false,
+                    plainTextEmail: false,
                     projectUuid: payload.projectUuid,
                     targets: [],
                     customViewportWidth: payload.customViewportWidth,

--- a/packages/backend/src/services/CoderService/CoderService.scheduledDeliveries.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.scheduledDeliveries.test.ts
@@ -89,6 +89,7 @@ const scheduler: SchedulerAndTargets = {
     parameters: undefined,
     enabled: true,
     includeLinks: true,
+    plainTextEmail: false,
     targets: [
         {
             schedulerEmailTargetUuid: 'email-target-uuid',
@@ -110,6 +111,7 @@ const delivery: ScheduledDeliveryAsCode = {
     timezone: 'Europe/Madrid',
     enabled: true,
     includeLinks: true,
+    plainTextEmail: false,
     targets: [{ type: 'email', recipient: 'data@example.com' }],
     resource: { type: 'chart', slug: 'orders' },
     format: SchedulerFormat.CSV,
@@ -148,6 +150,7 @@ const alert: AlertAsCode = {
     timezone: 'Europe/Madrid',
     enabled: true,
     includeLinks: true,
+    plainTextEmail: false,
     targets: [{ type: 'email', recipient: 'data@example.com' }],
     resource: { type: 'chart', slug: 'orders' },
     thresholds: [
@@ -177,6 +180,7 @@ const googleSheetsScheduler: SchedulerAndTargets = {
         tabName: 'Orders data',
     },
     includeLinks: false,
+    plainTextEmail: false,
     targets: [],
 };
 
@@ -190,6 +194,7 @@ const googleSheetsSync: GoogleSheetsSyncAsCode = {
     timezone: 'Europe/Madrid',
     enabled: true,
     includeLinks: false,
+    plainTextEmail: false,
     destination: {
         spreadsheetId: 'spreadsheet-id',
         spreadsheetName: 'Orders',

--- a/packages/backend/src/services/CoderService/handlers/ScheduledContentCoder.ts
+++ b/packages/backend/src/services/CoderService/handlers/ScheduledContentCoder.ts
@@ -143,6 +143,7 @@ export class ScheduledContentCoder extends BaseService {
             timezone: scheduler.timezone ?? null,
             enabled: scheduler.enabled,
             includeLinks: scheduler.includeLinks,
+            plainTextEmail: scheduler.plainTextEmail,
             targets,
             downloadedAt: new Date(),
         };
@@ -212,6 +213,7 @@ export class ScheduledContentCoder extends BaseService {
             timezone: scheduler.timezone ?? null,
             enabled: scheduler.enabled,
             includeLinks: scheduler.includeLinks,
+            plainTextEmail: scheduler.plainTextEmail,
             destination: {
                 spreadsheetId: scheduler.options.gdriveId,
                 spreadsheetName: scheduler.options.gdriveName,
@@ -465,6 +467,7 @@ export class ScheduledContentCoder extends BaseService {
             timezone: scheduler.timezone ?? null,
             enabled: scheduler.enabled,
             includeLinks: scheduler.includeLinks,
+            plainTextEmail: scheduler.plainTextEmail,
             targets,
             resource: { type: 'chart', slug: chart.slug },
             thresholds: scheduler.thresholds,
@@ -798,6 +801,7 @@ export class ScheduledContentCoder extends BaseService {
                 : undefined,
             enabled: delivery.enabled,
             includeLinks: delivery.includeLinks,
+            plainTextEmail: delivery.plainTextEmail ?? false,
             targets,
             appUuid: null,
             appName: null,

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -2301,6 +2301,7 @@ export class DashboardService
                         : 0,
                 timeZone: scheduler.timezone,
                 includeLinks: scheduler.includeLinks,
+                plainTextEmail: scheduler.plainTextEmail,
             },
         };
         this.analytics.track(createSchedulerData);

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -2079,6 +2079,7 @@ export class SavedChartService
                         : scheduler.targets.map(getSchedulerTargetType),
                 timeZone: getTimezoneLabel(scheduler.timezone),
                 includeLinks: scheduler.includeLinks,
+                plainTextEmail: scheduler.plainTextEmail,
             },
         };
         this.analytics.track(createSchedulerEventData);

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
@@ -100,6 +100,7 @@ const createdScheduler = {
     createdBy: 'editor-uuid',
     targets: [],
     includeLinks: false,
+    plainTextEmail: false,
     enabled: true,
     options: {},
 };
@@ -123,6 +124,7 @@ const newSchedulerPayload = {
     options: {},
     targets: [],
     includeLinks: false,
+    plainTextEmail: false,
     enabled: true,
     appUuid: null,
     appName: null,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -92,6 +92,7 @@ const chartSchedulerInPrivateSpace: ChartScheduler = {
     options: { formatted: true, limit: 'table' },
     enabled: true,
     includeLinks: true,
+    plainTextEmail: false,
 };
 
 const dashboardScheduler = {
@@ -234,6 +235,7 @@ describe('SchedulerService', () => {
             createdBy: 'userUuid',
             enabled: true,
             includeLinks: true,
+            plainTextEmail: false,
             targets: [{ recipient: 'recipient@example.com' }],
         } as unknown as CreateSchedulerAndTargets;
 
@@ -368,6 +370,7 @@ describe('SchedulerService', () => {
                     createdBy: 'userUuid',
                     enabled: true,
                     includeLinks: true,
+                    plainTextEmail: false,
                     targets: [{ recipient: 'recipient@example.com' }],
                 }) as unknown as CreateSchedulerAndTargets;
 
@@ -864,6 +867,7 @@ describe('SchedulerService', () => {
                 options,
                 enabled: true,
                 includeLinks: true,
+                plainTextEmail: false,
                 targets: [],
             }) as unknown as Parameters<
                 SchedulerService['createAppScheduler']

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1014,6 +1014,7 @@ export class SchedulerService extends BaseService {
                 }),
                 timeZone: getTimezoneLabel(scheduler.timezone),
                 includeLinks: scheduler.includeLinks !== false,
+                plainTextEmail: scheduler.plainTextEmail === true,
             },
         };
         this.analytics.track(updateSchedulerEventData);

--- a/packages/common/src/types/contentAsCode/scheduledContent.ts
+++ b/packages/common/src/types/contentAsCode/scheduledContent.ts
@@ -45,6 +45,8 @@ type ScheduledDeliveryAsCodeBase = {
     timezone: string | null;
     enabled: boolean;
     includeLinks: boolean;
+    /** Optional so files written before plain-text mode still upload. */
+    plainTextEmail?: boolean;
     targets: ScheduledDeliveryTargetAsCode[];
     downloadedAt?: Date;
 };
@@ -111,6 +113,8 @@ export type AlertAsCode = {
     timezone: string | null;
     enabled: boolean;
     includeLinks: boolean;
+    /** Optional so files written before plain-text mode still upload. */
+    plainTextEmail?: boolean;
     targets: ScheduledDeliveryTargetAsCode[];
     resource: {
         type: 'chart';
@@ -151,6 +155,8 @@ type GoogleSheetsSyncAsCodeBase = {
     timezone: string | null;
     enabled: boolean;
     includeLinks: boolean;
+    /** Optional so files written before plain-text mode still upload. */
+    plainTextEmail?: boolean;
     destination: {
         spreadsheetId: string;
         spreadsheetName: string;

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -138,6 +138,12 @@ export type SchedulerBase = {
     enabled: boolean;
     notificationFrequency?: NotificationFrequency;
     includeLinks: boolean;
+    /**
+     * Email targets only: send a bare text/plain email (no HTML template, no
+     * Lightdash branding) with the file attached. Slack and webhook targets are
+     * unaffected.
+     */
+    plainTextEmail: boolean;
     projectUuid?: string | null;
     projectName?: string | null;
 };
@@ -368,6 +374,7 @@ export type UpdateSchedulerAndTargets = Pick<
     | 'thresholds'
     | 'notificationFrequency'
     | 'includeLinks'
+    | 'plainTextEmail'
 > & {
     filters?: SchedulerFilters;
     parameters?: ParametersValuesMap;

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -343,7 +343,11 @@ export type CreateSchedulerAndTargets = Omit<
     | 'savedChartName'
     | 'dashboardName'
     | 'savedSqlName'
+    | 'plainTextEmail'
 > & {
+    // Optional on the wire so existing API clients keep working; absent means
+    // the branded HTML email, which is what they already get.
+    plainTextEmail?: boolean;
     slug?: string;
     targets: CreateSchedulerTarget[];
     // Transient: carries the AI augmentation for an unsaved "send now" so the
@@ -374,8 +378,8 @@ export type UpdateSchedulerAndTargets = Pick<
     | 'thresholds'
     | 'notificationFrequency'
     | 'includeLinks'
-    | 'plainTextEmail'
 > & {
+    plainTextEmail?: boolean;
     filters?: SchedulerFilters;
     parameters?: ParametersValuesMap;
     customViewportWidth?: number;

--- a/packages/common/src/utils/scheduler.test.ts
+++ b/packages/common/src/utils/scheduler.test.ts
@@ -1,6 +1,32 @@
-import { getHumanReadableCronExpression, isValidFrequency } from './scheduler';
+import {
+    getCronCadence,
+    getHumanReadableCronExpression,
+    isValidFrequency,
+} from './scheduler';
 
 describe('Scheduler utils', () => {
+    describe('getCronCadence', () => {
+        test('Should name the cadence of the expressions the delivery form builds', () => {
+            expect(getCronCadence('0 * * * *')).toEqual('hourly');
+            expect(getCronCadence('30 * * * *')).toEqual('hourly');
+            expect(getCronCadence('0 9 * * *')).toEqual('daily');
+            expect(getCronCadence('0 9 * * 1')).toEqual('weekly');
+            expect(getCronCadence('0 9 1 * *')).toEqual('monthly');
+            expect(getCronCadence('0 9 22 6 *')).toEqual('yearly');
+        });
+
+        test('Should return undefined when no single word describes the expression', () => {
+            expect(getCronCadence('0 9 * * 1,4')).toBeUndefined();
+            expect(getCronCadence('0 9 * * 1-5')).toBeUndefined();
+            expect(getCronCadence('*/15 * * * *')).toBeUndefined();
+            expect(getCronCadence('* * * * *')).toBeUndefined();
+            expect(getCronCadence('0 9 1 * 1')).toBeUndefined();
+            expect(getCronCadence('0 9 * 6 1')).toBeUndefined();
+            expect(getCronCadence('not a cron')).toBeUndefined();
+            expect(getCronCadence('0 9 * *')).toBeUndefined();
+        });
+    });
+
     describe('getHumanReadableCronExpression', () => {
         test('Should convert human readable cron expression with UTC', async () => {
             expect(getHumanReadableCronExpression('* * * * *', 'UTC')).toEqual(

--- a/packages/common/src/utils/scheduler.ts
+++ b/packages/common/src/utils/scheduler.ts
@@ -62,6 +62,73 @@ export function getHumanReadableCronExpression(
     );
 }
 
+export type CronCadence = 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly';
+
+const isFixedCronField = (field: string): boolean => /^\d+$/.test(field.trim());
+
+const isWildcardCronField = (field: string): boolean => field.trim() === '*';
+
+/**
+ * Names the repeat interval of a cron expression in a single word, for copy
+ * like "here is your weekly report". Only expressions built from fixed values
+ * and wildcards map to a word; lists, ranges and steps ("0 9 * * 1,4") have no
+ * one-word description and return undefined so callers can omit the cadence.
+ */
+export function getCronCadence(
+    cronExpression: string,
+): CronCadence | undefined {
+    const fields = cronExpression.trim().split(/\s+/);
+    if (fields.length !== 5) return undefined;
+
+    const [minute, hour, dayOfMonth, month, dayOfWeek] = fields.map((field) =>
+        field.trim(),
+    );
+    if (
+        minute === undefined ||
+        hour === undefined ||
+        dayOfMonth === undefined ||
+        month === undefined ||
+        dayOfWeek === undefined
+    ) {
+        return undefined;
+    }
+
+    // Sub-hourly and irregular minute fields have no cadence word.
+    if (!isFixedCronField(minute)) return undefined;
+
+    if (
+        isWildcardCronField(hour) &&
+        isWildcardCronField(dayOfMonth) &&
+        isWildcardCronField(month) &&
+        isWildcardCronField(dayOfWeek)
+    ) {
+        return 'hourly';
+    }
+
+    if (!isFixedCronField(hour)) return undefined;
+
+    const hasDayOfWeek = isFixedCronField(dayOfWeek);
+    const hasDayOfMonth = isFixedCronField(dayOfMonth);
+    const hasMonth = isFixedCronField(month);
+
+    if (
+        isWildcardCronField(dayOfMonth) &&
+        isWildcardCronField(month) &&
+        isWildcardCronField(dayOfWeek)
+    ) {
+        return 'daily';
+    }
+    if (hasDayOfWeek && isWildcardCronField(dayOfMonth) && !hasMonth) {
+        return isWildcardCronField(month) ? 'weekly' : undefined;
+    }
+    if (hasDayOfMonth && isWildcardCronField(dayOfWeek)) {
+        if (isWildcardCronField(month)) return 'monthly';
+        if (hasMonth) return 'yearly';
+    }
+
+    return undefined;
+}
+
 export function isValidFrequency(cronExpression: string): boolean {
     /** This function will return False if:
      * - the cronExpression is not valid (not 5 parts separated by spaces)

--- a/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.test.ts
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.test.ts
@@ -32,6 +32,7 @@ const base = {
     options: { formatted: true, limit: 'table' as const },
     enabled: true,
     includeLinks: true,
+    plainTextEmail: false,
     projectUuid: PROJECT_UUID,
     targets: [],
 };

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerMessageSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerMessageSection.tsx
@@ -1,4 +1,4 @@
-import { Group, Stack, Switch, Text } from '@mantine/core';
+import { Box, Group, Stack, Switch, Text, Tooltip } from '@mantine/core';
 import MDEditor, { commands } from '@uiw/react-md-editor';
 import { type FC } from 'react';
 import { useSchedulerFormContext } from '../schedulerFormContext';
@@ -7,6 +7,7 @@ import classes from './SchedulerDeliveryModal.module.css';
 export const SchedulerMessageSection: FC = () => {
     const form = useSchedulerFormContext();
     const isAiMessage = form.values.aiAugmentation !== null;
+    const hasEmailTargets = (form.values.emailTargets?.length ?? 0) > 0;
 
     return (
         <Stack gap="lg">
@@ -28,6 +29,39 @@ export const SchedulerMessageSection: FC = () => {
                         )
                     }
                 />
+            </Group>
+
+            <Group justify="space-between" wrap="nowrap" align="flex-start">
+                <Stack gap={2}>
+                    <Text fw={500} fz="sm">
+                        Send as plain text
+                    </Text>
+                    <Text fz="xs" c="dimmed">
+                        Emails arrive as plain text with the file attached — no
+                        Lightdash branding, buttons or footer. Your message
+                        below is the whole body. Slack and webhook deliveries
+                        are unaffected.
+                    </Text>
+                </Stack>
+                <Tooltip
+                    label="You must have at least one email recipient to send as plain text"
+                    position="top-end"
+                    withinPortal
+                    disabled={hasEmailTargets}
+                >
+                    <Box>
+                        <Switch
+                            checked={form.values.plainTextEmail}
+                            disabled={!hasEmailTargets}
+                            onChange={() =>
+                                form.setFieldValue(
+                                    'plainTextEmail',
+                                    !form.values?.plainTextEmail,
+                                )
+                            }
+                        />
+                    </Box>
+                </Tooltip>
             </Group>
 
             <Stack gap="xs">

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.test.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.test.ts
@@ -1,6 +1,7 @@
 import { ThresholdOperator } from '@lightdash/common';
 import { describe, expect, test } from 'vitest';
 import {
+    DEFAULT_VALUES,
     DEFAULT_VALUES_ALERT,
     transformFormValues,
 } from './schedulerFormContext';
@@ -22,5 +23,32 @@ describe('transformFormValues', () => {
         );
 
         expect(result.thresholds).toEqual([]);
+    });
+
+    test('keeps plain text on when the delivery has an email recipient', () => {
+        const result = transformFormValues(
+            {
+                ...DEFAULT_VALUES,
+                plainTextEmail: true,
+                emailTargets: ['recipient@example.com'],
+            },
+            'dashboard',
+        );
+
+        expect(result.plainTextEmail).toBe(true);
+    });
+
+    test('forces plain text off when there is no email recipient to receive it', () => {
+        const result = transformFormValues(
+            {
+                ...DEFAULT_VALUES,
+                plainTextEmail: true,
+                emailTargets: [],
+                slackTargets: ['#analytics'],
+            },
+            'dashboard',
+        );
+
+        expect(result.plainTextEmail).toBe(false);
     });
 });

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -60,6 +60,7 @@ export interface SchedulerFormValues {
         value: number | '';
     }>;
     includeLinks: boolean;
+    plainTextEmail: boolean;
     notificationFrequency?: NotificationFrequency;
     // Saved to the EE ai-augmentation sub-resource, not the scheduler body.
     aiAugmentation: SchedulerAiAugmentation | null;
@@ -98,6 +99,7 @@ export const DEFAULT_VALUES: SchedulerFormValues = {
     appState: null,
     thresholds: [],
     includeLinks: true,
+    plainTextEmail: false,
     aiAugmentation: null,
 };
 
@@ -213,6 +215,7 @@ export const getFormValuesFromScheduler = (
         thresholds: schedulerData.thresholds,
         notificationFrequency: schedulerData.notificationFrequency,
         includeLinks: schedulerData.includeLinks !== false,
+        plainTextEmail: schedulerData.plainTextEmail === true,
         // Populated separately from the ai-augmentation sub-resource.
         aiAugmentation: null,
     };
@@ -318,5 +321,10 @@ export const transformFormValues = (
                 ? (values.notificationFrequency as NotificationFrequency)
                 : undefined,
         includeLinks: values.includeLinks !== false,
+        // Plain text only affects email bodies, so it cannot be left on for a
+        // delivery with no email recipients.
+        plainTextEmail:
+            (values.emailTargets?.length || 0) > 0 &&
+            values.plainTextEmail === true,
     };
 };

--- a/packages/frontend/src/features/sync/hooks/useSyncModalForm.ts
+++ b/packages/frontend/src/features/sync/hooks/useSyncModalForm.ts
@@ -131,6 +131,7 @@ export const useSyncModalForm = (resource: SyncResource) => {
                 targets: [],
                 // TODO: Related to scheduled deliveries, not syncs. Irrelevant.
                 includeLinks: false,
+                plainTextEmail: false,
                 appUuid: null,
                 appName: null,
             };


### PR DESCRIPTION
Linear: PROD-9845

## What

Adds a per-delivery **"Send as plain text"** toggle to the scheduled delivery modal (email targets only). When it is on, the email is a bare `text/plain` body with the file attached — no branded HTML template, no header bar, logo, "View in Lightdash" CTA, expiry copy or social footer, and no inline branding images.

Customers who forward scheduled reports to their own clients can already whitelabel the *sender*; the body still announced Lightdash. The attachment was never the problem — only the wrapper around it.

Slack, MS Teams and Google Chat deliveries are unaffected.

## Two design decisions

**1. What fills the date variable.** The ask was for copy like "here is your *weekly* report", but nothing in the codebase produced a cadence word — templates get a locale date string and a cron-speak string ("at 07:37 AM (UTC -07:00), on day 22 of the month"). Added `getCronCadence()` in `packages/common/src/utils/scheduler.ts`, which maps a cron built from fixed values and wildcards to one word (hourly/daily/weekly/monthly/yearly). Lists, ranges and steps (`0 9 * * 1,4`) have no one-word description, so it returns `undefined` and the sentence simply omits the cadence — "Hello, here is your report for X." rather than something wrong.

**2. The custom message wins.** Deliveries already have a user-authored `message`. Plain-text mode renders that message as the whole body, and the generated sentence is only the fallback when no message is set. A generated one-liner can't express the account-manager sign-offs customers actually want, and this needs no new copy generator.

Kept as a **separate flag from `includeLinks`** rather than an extension of it: `includeLinks: false` still sends the branded HTML template minus its CTAs, which is a different axis from removing the chrome entirely. In plain-text mode there are no links regardless of `includeLinks`.

## How

- New scheduler column `plain_text_email` (default `false`, so every existing delivery is untouched) + migration.
- `EmailClient.sendEmail()`'s transport is split out into `deliverMail()`, so the plain-text path can bypass templating altogether. Leaving `html` unset is the point: `sendEmail()` currently sets `text: title`, so the plain-text alternative today is literally the delivery name — dropping the HTML part alone would have shipped a one-word email.
- Body building lives in a pure `buildPlainTextEmailBody()` (unit-tested).
- Files that could not be attached (CSV without "Attach the file to emails", XLSX, an image with no PDF) are listed as bare `filename: url` lines, so a plain-text delivery never arrives empty.
- Round-tripped through content-as-code (optional in the as-code types, so files written before this still upload) and added to the scheduler upsert analytics event.

## Verification

Sent end-to-end through a local instance and inspected the MIME parts in Mailpit:

| Case | HTML part | Body | Attachment |
|---|---|---|---|
| Toggle **off** (regression) | 129 KB | `Jaffle dashboard` (unchanged) | PDF |
| Toggle **on**, custom message | **0 bytes** | the message, verbatim | PDF |
| Toggle **on**, no message, weekly cron | **0 bytes** | `Hello, here is your weekly report for Jaffle dashboard.` | PDF |
| Toggle **on**, no message, monthly cron, CSV + attach | **0 bytes** | `Hello, here is your monthly report for Jaffle dashboard.` | 5 CSVs |

Raw structure of a plain-text send is `multipart/mixed` → `text/plain` + the file: no `multipart/alternative`, no HTML part, no inline images.

Also: `pnpm -F {common,backend,frontend} typecheck` clean, affected test files green (212 tests), react-doctor reports no diagnostics on the touched frontend files.

## Known limitations (called out rather than half-done)

- The delivery preview panel still renders the branded mock when plain-text mode is on — it draws a stylised placeholder that doesn't reflect this setting.
- Threshold alerts build their message as markdown (`**Metric** exceeded **5**`). In plain-text mode that reaches the recipient as literal asterisks. The requested use case is scheduled report deliveries rather than alerts, so this is recorded rather than fixed here.
