### PR TITLE
refactor: title the page Gallery with a Chart types section

### DIFF
--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -137,7 +137,8 @@ describe('ChartTypeGallery', () => {
         renderPage();
 
         expect(screen.getByText('Bar race')).toBeInTheDocument();
-        expect(screen.getByText('2 available')).toBeInTheDocument();
+        expect(screen.getByText('Chart types')).toBeInTheDocument();
+        expect(screen.getByText('(2)')).toBeInTheDocument();
 
         fireEvent.click(screen.getByText('Radial gauge'));
 

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -8,6 +8,7 @@ import {
     Stack,
     Text,
     TextInput,
+    Title,
 } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconPlus, IconSearch } from '@tabler/icons-react';
@@ -76,102 +77,111 @@ const ChartTypeGallery = () => {
 
     return (
         <Page
-            title="Chart types"
+            title="Gallery"
             withCenteredRoot
             withCenteredContent
             withXLargePaddedContent
             withLargeContent
         >
             <Stack gap="xxl" w="100%">
-                <Group justify="space-between" align="flex-end">
-                    <Stack gap={4}>
-                        <PageBreadcrumbs
-                            items={[
-                                { title: 'Home', to: '/home' },
-                                { title: 'Chart types', active: true },
-                            ]}
-                        />
-                        {totalCount !== null && (
-                            <Text fz="sm" c="ldGray.6">
-                                {totalCount} available
-                            </Text>
-                        )}
-                    </Stack>
+                <PageBreadcrumbs
+                    items={[
+                        { title: 'Home', to: '/home' },
+                        { title: 'Gallery', active: true },
+                    ]}
+                />
 
-                    <Group gap="sm">
-                        <TextInput
-                            w={260}
-                            placeholder="Search chart types…"
-                            leftSection={<MantineIcon icon={IconSearch} />}
-                            value={search}
-                            onChange={(e) => setSearch(e.currentTarget.value)}
-                        />
-                        <Can
-                            I="create"
-                            this={subject('DataApp', {
-                                organizationUuid: user.data?.organizationUuid,
-                                projectUuid,
-                            })}
-                        >
-                            <Button
-                                component={Link}
-                                to={`/projects/${projectUuid}/chart-types/new`}
-                                leftSection={
-                                    <MantineIcon icon={IconPlus} size={18} />
+                <Stack gap="md">
+                    <Group justify="space-between" align="center">
+                        <Group gap={6} align="baseline">
+                            <Title order={4}>Chart types</Title>
+                            {totalCount !== null && (
+                                <Text fz="sm" c="ldGray.6">
+                                    ({totalCount})
+                                </Text>
+                            )}
+                        </Group>
+
+                        <Group gap="sm">
+                            <TextInput
+                                w={260}
+                                placeholder="Search chart types…"
+                                leftSection={<MantineIcon icon={IconSearch} />}
+                                value={search}
+                                onChange={(e) =>
+                                    setSearch(e.currentTarget.value)
                                 }
+                            />
+                            <Can
+                                I="create"
+                                this={subject('DataApp', {
+                                    organizationUuid:
+                                        user.data?.organizationUuid,
+                                    projectUuid,
+                                })}
                             >
-                                New chart type
-                            </Button>
-                        </Can>
+                                <Button
+                                    component={Link}
+                                    to={`/projects/${projectUuid}/chart-types/new`}
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconPlus}
+                                            size={18}
+                                        />
+                                    }
+                                >
+                                    New chart type
+                                </Button>
+                            </Can>
+                        </Group>
                     </Group>
-                </Group>
-
-                {isInitialLoading ? (
-                    <EmptyStateLoader title="Loading chart types…" />
-                ) : error ? (
-                    <InlineErrorState
-                        message="Failed to load chart types"
-                        onRetry={() => refetch()}
-                    />
-                ) : dataAppVizs.length === 0 ? (
-                    <Paper variant="dotted" p="xl">
-                        <Text ta="center" fz="sm" c="ldGray.6">
-                            {debouncedSearch
-                                ? `No chart types match “${debouncedSearch}”`
-                                : 'No chart types yet. Describe one in the builder to get started.'}
-                        </Text>
-                    </Paper>
-                ) : (
-                    <>
-                        <SimpleGrid
-                            cols={{ base: 1, sm: 2, lg: 3 }}
-                            spacing="lg"
-                        >
-                            {dataAppVizs.map((viz) => (
-                                <ChartTypeGalleryCard
-                                    key={viz.dataAppVizUuid}
-                                    dataAppViz={viz}
-                                    onClick={() =>
-                                        setSelectedUuid(viz.dataAppVizUuid)
-                                    }
-                                    onDelete={() =>
-                                        setDeleteUuid(viz.dataAppVizUuid)
-                                    }
-                                />
-                            ))}
-                        </SimpleGrid>
-                        {hasNextPage && (
-                            <Button
-                                variant="default"
-                                loading={isFetchingNextPage}
-                                onClick={() => fetchNextPage()}
-                                mx="auto"
+                    {isInitialLoading ? (
+                        <EmptyStateLoader title="Loading chart types…" />
+                    ) : error ? (
+                        <InlineErrorState
+                            message="Failed to load chart types"
+                            onRetry={() => refetch()}
+                        />
+                    ) : dataAppVizs.length === 0 ? (
+                        <Paper variant="dotted" p="xl">
+                            <Text ta="center" fz="sm" c="ldGray.6">
+                                {debouncedSearch
+                                    ? `No chart types match “${debouncedSearch}”`
+                                    : 'No chart types yet. Describe one in the builder to get started.'}
+                            </Text>
+                        </Paper>
+                    ) : (
+                        <>
+                            <SimpleGrid
+                                cols={{ base: 1, sm: 2, lg: 3 }}
+                                spacing="lg"
                             >
-                                Load more
-                            </Button>
-                        )}
-                    </>
-                )}
+                                {dataAppVizs.map((viz) => (
+                                    <ChartTypeGalleryCard
+                                        key={viz.dataAppVizUuid}
+                                        dataAppViz={viz}
+                                        onClick={() =>
+                                            setSelectedUuid(viz.dataAppVizUuid)
+                                        }
+                                        onDelete={() =>
+                                            setDeleteUuid(viz.dataAppVizUuid)
+                                        }
+                                    />
+                                ))}
+                            </SimpleGrid>
+                            {hasNextPage && (
+                                <Button
+                                    variant="default"
+                                    loading={isFetchingNextPage}
+                                    onClick={() => fetchNextPage()}
+                                    mx="auto"
+                                >
+                                    Load more
+                                </Button>
+                            )}
+                        </>
+                    )}
+                </Stack>
             </Stack>
 
             {selected && (


### PR DESCRIPTION
Settles the gallery naming split (page header said "Chart types" while the builder back link, the Explorer's "Browse the gallery" footer, and the `/gallery` URL said Gallery):

- Breadcrumb + browser tab now say **Gallery**. Gallery is the destination, deliberately not chart-type-specific so it can hold other kinds of shared content later.
- The grid gets a **"Chart types (N)"** section heading, replacing the bare "N available" subtitle — so the page still names what it currently contains, and a future content kind slots in as a sibling section.
- The search input and "New chart type" button move from the page header down to the section heading row, since they act on the chart types section, not the gallery as a whole.
- Item-level wording is untouched: "New chart type", "Search chart types…", "Delete chart type".

Relates: GLITCH-660