### PR TITLE
feat: support boolean fields in table conditional formatting

### DIFF
--- a/packages/common/src/types/conditionalFormatting.ts
+++ b/packages/common/src/types/conditionalFormatting.ts
@@ -24,21 +24,24 @@ export type ConditionalFormattingTextStyle = {
     underline?: boolean;
 };
 
-export type ConditionalFormattingWithValues<T = number | string> =
+export type ConditionalFormattingWithValues<T = number | string | boolean> =
     BaseFilterRule<FilterOperator, T> & {
         /** Values to compare against */
         values: T[];
     };
 
-export type ConditionalFormattingWithCompareTarget<T = number | string> =
-    BaseFilterRule<FilterOperator, T> & {
-        /** Target field to compare against */
-        compareTarget: FieldTarget | null;
-        /** Values to compare against */
-        values?: T[];
-    };
+export type ConditionalFormattingWithCompareTarget<
+    T = number | string | boolean,
+> = BaseFilterRule<FilterOperator, T> & {
+    /** Target field to compare against */
+    compareTarget: FieldTarget | null;
+    /** Values to compare against */
+    values?: T[];
+};
 
-export type ConditionalFormattingWithFilterOperator<T = number | string> =
+export type ConditionalFormattingWithFilterOperator<
+    T = number | string | boolean,
+> =
     | ConditionalFormattingWithValues<T>
     | ConditionalFormattingWithCompareTarget<T>;
 

--- a/packages/common/src/types/conditionalFormatting.ts
+++ b/packages/common/src/types/conditionalFormatting.ts
@@ -60,8 +60,16 @@ export type ConditionalFormattingConfigWithSingleColor = {
     color: string;
     /** Color for dark mode */
     darkColor?: string;
-    /** Rules for single-color conditional formatting */
-    rules: ConditionalFormattingWithFilterOperator[];
+    /** Rules for single-color conditional formatting.
+     * The number|string members are redundant for TypeScript (absorbed by the
+     * boolean-capable defaults) but keep the pre-boolean schema components in
+     * the generated OpenAPI anyOf, so the API change stays expand-only. */
+    rules: Array<
+        | ConditionalFormattingWithValues<number | string>
+        | ConditionalFormattingWithCompareTarget<number | string>
+        | ConditionalFormattingWithValues
+        | ConditionalFormattingWithCompareTarget
+    >;
     /** Apply formatting to cell background or text */
     applyTo?: ConditionalFormattingColorApplyTo;
     /** Text styling (bold/italic/underline) applied to matching cell text */

--- a/packages/common/src/utils/conditionalFormatting.test.ts
+++ b/packages/common/src/utils/conditionalFormatting.test.ts
@@ -177,6 +177,158 @@ describe('hasMatchingConditionalRules', () => {
     });
 });
 
+describe('Boolean fields', () => {
+    const mockBooleanField = {
+        name: 'is_completed',
+        table: 'orders',
+        type: DimensionType.BOOLEAN,
+        fieldType: FieldType.DIMENSION,
+        sql: 'is_completed',
+        tableLabel: 'Orders',
+        label: 'Is completed',
+        hidden: false,
+    };
+
+    const makeConfig = (
+        operator: FilterOperator,
+        values: (number | string | boolean)[],
+    ) => {
+        const config =
+            createConditionalFormattingConfigWithSingleColor('#ff0000');
+        const rule = createConditionalFormattingRuleWithValues();
+        rule.operator = operator;
+        rule.values = values;
+        config.rules = [rule];
+        return config;
+    };
+
+    it('matches EQUALS when boolean value equals rule value', () => {
+        const config = makeConfig(FilterOperator.EQUALS, [true]);
+        expect(
+            hasMatchingConditionalRules(mockBooleanField, true, {}, config),
+        ).toBe(true);
+        expect(
+            hasMatchingConditionalRules(mockBooleanField, false, {}, config),
+        ).toBe(false);
+    });
+
+    it('matches EQUALS false', () => {
+        const config = makeConfig(FilterOperator.EQUALS, [false]);
+        expect(
+            hasMatchingConditionalRules(mockBooleanField, false, {}, config),
+        ).toBe(true);
+        expect(
+            hasMatchingConditionalRules(mockBooleanField, true, {}, config),
+        ).toBe(false);
+    });
+
+    it('matches NOT_EQUALS', () => {
+        const config = makeConfig(FilterOperator.NOT_EQUALS, [true]);
+        expect(
+            hasMatchingConditionalRules(mockBooleanField, false, {}, config),
+        ).toBe(true);
+        expect(
+            hasMatchingConditionalRules(mockBooleanField, true, {}, config),
+        ).toBe(false);
+    });
+
+    it('matches string-encoded boolean cell values', () => {
+        const config = makeConfig(FilterOperator.EQUALS, [true]);
+        expect(
+            hasMatchingConditionalRules(mockBooleanField, 'true', {}, config),
+        ).toBe(true);
+        expect(
+            hasMatchingConditionalRules(mockBooleanField, 'false', {}, config),
+        ).toBe(false);
+    });
+
+    it('does not match EQUALS false for null values', () => {
+        const config = makeConfig(FilterOperator.EQUALS, [false]);
+        expect(
+            hasMatchingConditionalRules(mockBooleanField, null, {}, config),
+        ).toBe(false);
+    });
+
+    it('matches NULL and NOT_NULL operators', () => {
+        const nullConfig = makeConfig(FilterOperator.NULL, []);
+        expect(
+            hasMatchingConditionalRules(mockBooleanField, null, {}, nullConfig),
+        ).toBe(true);
+        expect(
+            hasMatchingConditionalRules(mockBooleanField, true, {}, nullConfig),
+        ).toBe(false);
+
+        const notNullConfig = makeConfig(FilterOperator.NOT_NULL, []);
+        expect(
+            hasMatchingConditionalRules(
+                mockBooleanField,
+                false,
+                {},
+                notNullConfig,
+            ),
+        ).toBe(true);
+    });
+
+    it('compares boolean field to another boolean field via compare target', () => {
+        const otherBooleanField = {
+            ...mockBooleanField,
+            name: 'is_paid',
+            label: 'Is paid',
+        };
+        const config =
+            createConditionalFormattingConfigWithSingleColor('#ff0000');
+        config.rules = [
+            {
+                id: 'rule-1',
+                operator: FilterOperator.EQUALS,
+                compareTarget: { fieldId: 'orders_is_paid' },
+            },
+        ];
+
+        const rowFields = {
+            orders_is_paid: { field: otherBooleanField, value: true },
+        };
+
+        expect(
+            hasMatchingConditionalRules(
+                mockBooleanField,
+                true,
+                {},
+                config,
+                rowFields,
+            ),
+        ).toBe(true);
+        expect(
+            hasMatchingConditionalRules(
+                mockBooleanField,
+                false,
+                {},
+                config,
+                rowFields,
+            ),
+        ).toBe(false);
+    });
+
+    it('does not match numeric operators for boolean fields', () => {
+        const config = makeConfig(FilterOperator.GREATER_THAN, [0]);
+        expect(
+            hasMatchingConditionalRules(mockBooleanField, true, {}, config),
+        ).toBe(false);
+    });
+
+    it('is eligible in getConditionalFormattingConfig', () => {
+        const config = makeConfig(FilterOperator.EQUALS, [false]);
+        expect(
+            getConditionalFormattingConfig({
+                field: mockBooleanField,
+                value: false,
+                minMaxMap: {},
+                conditionalFormattings: [config],
+            }),
+        ).toBe(config);
+    });
+});
+
 describe('getConditionalFormattingConfig', () => {
     it('selects the last matching rule for a specific apply target', () => {
         const cellConfig =

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -32,7 +32,31 @@ import {
 } from '../types/field';
 import { FilterOperator, type FieldTarget } from '../types/filter';
 import assertUnreachable from './assertUnreachable';
-import { getItemId, isNumericItem, isStringDimension } from './item';
+import {
+    getItemId,
+    isBooleanItem,
+    isNumericItem,
+    isStringDimension,
+} from './item';
+
+// Coerces warehouse boolean representations ('true'/'false' strings) to real
+// booleans; leaves anything else (incl. null) untouched so equality fails
+// rather than treating null as false
+const parseBooleanValue = (value: unknown): unknown => {
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (normalized === 'true') return true;
+        if (normalized === 'false') return false;
+    }
+    return value;
+};
+
+const parseValueForField = (field: ItemsMap[string], value: unknown) => {
+    if (isNumericItem(field)) return Number(value);
+    if (isBooleanItem(field)) return parseBooleanValue(value);
+    return value;
+};
 
 export const createConditionalFormattingRuleWithValues =
     (): ConditionalFormattingWithFilterOperator => ({
@@ -130,7 +154,7 @@ export const hasMatchingConditionalRules = (
 ) => {
     if (!config) return false;
 
-    const parsedValue = isNumericItem(field) ? Number(value) : value;
+    const parsedValue = parseValueForField(field, value);
     const convertedValue = convertFormattedValue(parsedValue, field);
 
     const currentFieldId = getItemId(field);
@@ -155,9 +179,10 @@ export const hasMatchingConditionalRules = (
 
                 compareField = rowField.field;
 
-                const parsedCompareValue = isNumericItem(compareField)
-                    ? Number(rowField.value)
-                    : rowField.value;
+                const parsedCompareValue = parseValueForField(
+                    compareField,
+                    rowField.value,
+                );
                 convertedCompareValue = convertFormattedValue(
                     parsedCompareValue,
                     compareField,
@@ -542,6 +567,7 @@ export const getConditionalFormattingConfig = ({
         !field ||
         (!isNumericItem(field) &&
             !isStringDimension(field) &&
+            !isBooleanItem(field) &&
             !isCalculationTypeUndefined)
     )
         return undefined;

--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -112,6 +112,27 @@ export function isNumericItem(
     return isNumericType(getItemType(item));
 }
 
+export const isBooleanType = (
+    type: DimensionType | MetricType | TableCalculationType,
+) =>
+    type === DimensionType.BOOLEAN ||
+    type === MetricType.BOOLEAN ||
+    type === TableCalculationType.BOOLEAN;
+
+export function isBooleanItem(
+    item:
+        | Field
+        | AdditionalMetric
+        | TableCalculation
+        | CustomDimension
+        | undefined,
+) {
+    if (!item) {
+        return false;
+    }
+    return isBooleanType(getItemType(item));
+}
+
 export const isStringDimension = (
     item:
         | Field

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -13,6 +13,7 @@ import {
     getItemLabelWithoutTableName,
     isConditionalFormattingConfigWithColorRange,
     isConditionalFormattingConfigWithSingleColor,
+    isBooleanItem,
     isConditionalFormattingWithCompareTarget,
     isConditionalFormattingWithValues,
     isNumericItem,
@@ -125,13 +126,20 @@ export const ConditionalFormattingItem: FC<Props> = ({
                     const currentField = draft.target?.fieldId
                         ? itemsMap?.[draft.target?.fieldId]
                         : undefined;
-                    // Reset the config if the field type changes
-                    // TODO: move to a helper function
+                    // Reset the config if the field type family changes,
+                    // since operators and values are type-specific
+                    const getTypeFamily = (
+                        f: typeof newField | typeof currentField,
+                    ) => {
+                        if (isNumericItem(f)) return 'numeric';
+                        if (isStringDimension(f)) return 'string';
+                        if (isBooleanItem(f)) return 'boolean';
+                        return undefined;
+                    };
+                    const currentFamily =
+                        getTypeFamily(currentField) ?? 'numeric';
                     const shouldReset =
-                        ((!currentField || isNumericItem(currentField)) &&
-                            isStringDimension(newField)) ||
-                        (isStringDimension(currentField) &&
-                            isNumericItem(newField));
+                        currentFamily !== getTypeFamily(newField);
 
                     if (shouldReset && newField) {
                         // Reset the config if the field type changes

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
@@ -1,6 +1,7 @@
 import {
     createConditionalFormattingConfigWithSingleColor,
     getItemId,
+    isBooleanItem,
     isFilterableItem,
     isNumericItem,
     isStringDimension,
@@ -46,7 +47,9 @@ const ConditionalFormattingList = ({}) => {
             .filter((field) => activeFields.has(getItemId(field)))
             .filter(
                 (field) =>
-                    (isNumericItem(field) || isStringDimension(field)) &&
+                    (isNumericItem(field) ||
+                        isStringDimension(field) ||
+                        isBooleanItem(field)) &&
                     isFilterableItem(field),
             ) as FilterableItem[];
     }, [itemsMap, activeFields]);

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -3,6 +3,7 @@ import {
     FilterOperator,
     FilterType,
     getItemId,
+    isBooleanItem,
     isConditionalFormattingWithCompareTarget,
     isConditionalFormattingWithValues,
     isNumericItem,
@@ -88,23 +89,27 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
         }
     }, [fields, rule]);
 
-    // conditional formatting only supports number filters or string filters
-    const filterType: FilterType.NUMBER | FilterType.STRING | undefined =
-        useMemo(() => {
-            let fieldToFilter = field;
+    // conditional formatting only supports number, string or boolean filters
+    const filterType:
+        | FilterType.NUMBER
+        | FilterType.STRING
+        | FilterType.BOOLEAN
+        | undefined = useMemo(() => {
+        let fieldToFilter = field;
 
-            if (
-                isConditionalFormattingWithCompareTarget(rule) &&
-                isConditionalFormattingWithValues(rule) &&
-                compareField
-            ) {
-                fieldToFilter = compareField;
-            }
+        if (
+            isConditionalFormattingWithCompareTarget(rule) &&
+            isConditionalFormattingWithValues(rule) &&
+            compareField
+        ) {
+            fieldToFilter = compareField;
+        }
 
-            if (isNumericItem(fieldToFilter)) return FilterType.NUMBER;
-            if (isStringDimension(fieldToFilter)) return FilterType.STRING;
-            return undefined;
-        }, [field, compareField, rule]);
+        if (isNumericItem(fieldToFilter)) return FilterType.NUMBER;
+        if (isStringDimension(fieldToFilter)) return FilterType.STRING;
+        if (isBooleanItem(fieldToFilter)) return FilterType.BOOLEAN;
+        return undefined;
+    }, [field, compareField, rule]);
 
     const filterOperatorOptions = useMemo(() => {
         if (!filterType) return [];
@@ -131,6 +136,20 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                 FilterOperator.INCLUDE,
             ]);
         }
+        if (filterType === FilterType.BOOLEAN) {
+            const options = getFilterOperatorOptions(filterType);
+
+            if (isConditionalFormattingWithCompareTarget(rule)) {
+                const ignoredOperators = getFilterOptions([
+                    FilterOperator.NULL,
+                    FilterOperator.NOT_NULL,
+                ]);
+
+                return differenceBy(options, ignoredOperators, 'value');
+            }
+
+            return options;
+        }
         return [];
     }, [filterType, rule]);
 
@@ -151,7 +170,8 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
             ) {
                 return (
                     ((isNumericItem(f) && isNumericItem(field)) ||
-                        (isStringDimension(f) && isStringDimension(field))) &&
+                        (isStringDimension(f) && isStringDimension(field)) ||
+                        (isBooleanItem(f) && isBooleanItem(field))) &&
                     field &&
                     getItemId(f) !== getItemId(field)
                 );
@@ -180,17 +200,23 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
     const handleChangeRule = useCallback(
         (newRule: ConditionalFormattingWithFilterOperator) => {
             if (isConditionalFormattingWithValues(newRule)) {
+                const valuesField = isConditionalFormattingWithCompareTarget(
+                    newRule,
+                )
+                    ? compareField
+                    : field;
+
                 onChangeRule({
                     ...newRule,
                     values: newRule.values.map((v) => {
-                        // FIXME: check if we can fix this problem in number input
-                        if (
-                            isConditionalFormattingWithCompareTarget(newRule)
-                                ? isStringDimension(compareField)
-                                : isStringDimension(field)
-                        ) {
+                        if (isStringDimension(valuesField)) {
                             return String(v);
                         }
+                        // Boolean inputs already emit real booleans; keep them
+                        if (isBooleanItem(valuesField)) {
+                            return v;
+                        }
+                        // FIXME: check if we can fix this problem in number input
                         return Number(v);
                     }),
                 });


### PR DESCRIPTION
## Description

Boolean fields (dimensions, metrics, and boolean-typed table calculations) can now be used as targets of conditional formatting rules on table charts. Previously they were silently excluded from the "Select field" dropdown, so a rule like "Is completed = False → red" could not be created at all.

Boolean rules support **Single** color mode with `is null / is not null / is / is not` operators and a True/False value picker (the existing `FilterType.BOOLEAN` filter inputs, reused). Color **Range** mode stays numeric-only. Cell, Text, and Row apply-to modes all work, as does comparing a boolean field to another boolean field.

### Changes

- `common/utils/item.ts`: new `isBooleanType` / `isBooleanItem` helpers
- `common/utils/conditionalFormatting.ts`: boolean fields pass the eligibility gate in `getConditionalFormattingConfig`; cell values that arrive as `'true'`/`'false'` strings are coerced to real booleans before comparison (null stays null so it never matches `is false`)
- `common/types/conditionalFormatting.ts`: rule `values` widened to `number | string | boolean`
- `frontend .../TableConfigPanel`: boolean fields included in the field selector; `FilterType.BOOLEAN` operator set (null operators dropped for compare-target rules, mirroring numeric); value coercion keeps booleans intact instead of `Number()`-ing them to `1`/`0`; boolean-to-boolean compare targets allowed; config reset generalised to type-family changes (numeric/string/boolean)

### How to test

1. Explore `Orders` in the Jaffle demo with `Is completed` + any metric, chart type Table
2. Configure → Conditional formatting → Add → select `Is completed` (previously absent from the dropdown)
3. Set `is` `False`, pick a color — the False cells highlight; Row/Text modes and `is null / is not null` also work
4. Unit tests: `pnpm -F common test -- conditionalFormatting.test`

Closes: PROD-9827
Closes: #27181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WkN1aqSJuRS4tcRafxKnY

### OpenAPI note

The generated schema gains boolean-capable rule components; the pre-boolean `number-or-string` components are deliberately kept in the `rules` anyOf so the REST API change is expand-only — verified locally with the same `oasdiff breaking` check CI runs (no breaking changes vs main).
