### PR TITLE
feat: add Chart types entry to the Browse menu

### DIFF
--- a/packages/frontend/src/components/NavBar/BrowseMenu.test.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.test.tsx
@@ -1,0 +1,121 @@
+import {
+    FeatureFlags,
+    type LightdashUserWithAbilityRules,
+} from '@lightdash/common';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useHasMetricsInCatalog } from '../../features/metricsCatalog/hooks/useMetricsCatalog';
+import { useFavorites } from '../../hooks/favorites/useFavorites';
+import { useProject } from '../../hooks/useProject';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
+import { useSpaceSummaries } from '../../hooks/useSpaces';
+import { renderWithProviders } from '../../testing/testUtils';
+import BrowseMenu from './BrowseMenu';
+
+vi.mock('../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(),
+}));
+
+vi.mock('../../hooks/useSpaces', () => ({
+    useSpaceSummaries: vi.fn(),
+}));
+
+vi.mock('../../features/metricsCatalog/hooks/useMetricsCatalog', () => ({
+    useHasMetricsInCatalog: vi.fn(),
+}));
+
+vi.mock('../../hooks/favorites/useFavorites', () => ({
+    useFavorites: vi.fn(),
+}));
+
+vi.mock('../../hooks/useProject', () => ({
+    useProject: vi.fn(),
+}));
+
+const projectUuid = 'project-1';
+
+const setDataAppsFlag = (enabled: boolean) => {
+    vi.mocked(useServerFeatureFlag).mockReturnValue({
+        data: { id: FeatureFlags.EnableDataApps, enabled },
+        isLoading: false,
+    } as ReturnType<typeof useServerFeatureFlag>);
+};
+
+const renderMenu = (
+    abilityRules?: LightdashUserWithAbilityRules['abilityRules'],
+) => {
+    const result = renderWithProviders(
+        <MemoryRouter>
+            <BrowseMenu projectUuid={projectUuid} />
+        </MemoryRouter>,
+        abilityRules ? { user: { abilityRules } } : undefined,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Browse' }));
+    return result;
+};
+
+describe('BrowseMenu', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setDataAppsFlag(true);
+        vi.mocked(useSpaceSummaries).mockReturnValue({
+            data: [],
+            isInitialLoading: false,
+        } as unknown as ReturnType<typeof useSpaceSummaries>);
+        vi.mocked(useHasMetricsInCatalog).mockReturnValue({
+            data: true,
+        } as ReturnType<typeof useHasMetricsInCatalog>);
+        vi.mocked(useFavorites).mockReturnValue({
+            data: [],
+        } as unknown as ReturnType<typeof useFavorites>);
+        vi.mocked(useProject).mockReturnValue({
+            data: undefined,
+        } as unknown as ReturnType<typeof useProject>);
+    });
+
+    it('links to the gallery when data apps are enabled and the user can manage explores', async () => {
+        renderMenu();
+
+        const item = await screen.findByText('Chart types');
+        expect(item.closest('a')).toHaveAttribute(
+            'href',
+            `/projects/${projectUuid}/gallery`,
+        );
+    });
+
+    it('hides chart types when the data apps flag is off', async () => {
+        setDataAppsFlag(false);
+        renderMenu();
+
+        await screen.findByText('All saved charts');
+        expect(screen.queryByText('Chart types')).not.toBeInTheDocument();
+    });
+
+    it('hides chart types when the user cannot manage explores', async () => {
+        renderMenu([
+            { action: 'view', subject: 'Project' },
+            { action: 'view', subject: 'SavedChart' },
+        ]);
+
+        await screen.findByText('All saved charts');
+        await waitFor(() => {
+            expect(screen.queryByText('Chart types')).not.toBeInTheDocument();
+        });
+    });
+
+    it('hides chart types when the user can only manage explores in another organization', async () => {
+        renderMenu([
+            {
+                action: 'manage',
+                subject: 'Explore',
+                conditions: { organizationUuid: 'another-org' },
+            },
+        ]);
+
+        await screen.findByText('All saved charts');
+        await waitFor(() => {
+            expect(screen.queryByText('Chart types')).not.toBeInTheDocument();
+        });
+    });
+});

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     assertUnreachable,
     FeatureFlags,
@@ -25,6 +26,7 @@ import {
     IconFolder,
     IconFolders,
     IconLayoutDashboard,
+    IconPuzzle,
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { Link } from 'react-router';
@@ -93,6 +95,15 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
     const { user } = useApp();
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
     const canViewDataApps = user.data?.ability?.can('view', 'DataApp') ?? false;
+    // The gallery list endpoint is gated on `manage Explore`, not on data app access.
+    const canViewChartTypes =
+        user.data?.ability?.can(
+            'manage',
+            subject('Explore', {
+                organizationUuid: user.data.organizationUuid,
+                projectUuid,
+            }),
+        ) ?? false;
 
     const hasFavorites = favorites && favorites.length > 0;
     const hasSpaces = isInitialLoading || (spaces && spaces.length > 0);
@@ -157,6 +168,16 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                         leftSection={<MantineIcon icon={IconAppWindow} />}
                     >
                         All data apps
+                    </Menu.Item>
+                )}
+
+                {dataAppsFlag.data?.enabled && canViewChartTypes && (
+                    <Menu.Item
+                        component={Link}
+                        to={`/projects/${projectUuid}/gallery`}
+                        leftSection={<MantineIcon icon={IconPuzzle} />}
+                    >
+                        Chart types
                     </Menu.Item>
                 )}
 


### PR DESCRIPTION
Adds a **Chart types** entry to the top-bar Browse menu, pointing at `/projects/:projectUuid/gallery`. Until now the gallery was only reachable from inside the chart config panel or by typing the URL.

- Uses `IconPuzzle`, already the chart-type icon in `ChartTypeSamplePreview`, `DataAppVizRenderer` and `CustomChartTypePicker`.
- Label is "Chart types", not "All chart types". The gallery is a library you browse rather than a collection of your own content, and the neighbouring "Metrics" item already skips the prefix.

### Permissions

The entry is gated on two things, matching what the page actually needs:

- the `EnableDataApps` server feature flag — same gate `ChartTypeGallery` uses to redirect to home;
- `manage` on `Explore` for the project — this is what `AppGenerateService.listDataAppVisualizations` enforces, so anyone below that would land on a page whose only request 403s.

Note this is deliberately *not* the `view DataApp` check used by the sibling "All data apps" item: picking a renderer is part of configuring a chart, not data app access, so the two entries have genuinely different audiences.

Covered by `BrowseMenu.test.tsx` — shows for a user who can manage explores, hidden with the flag off, hidden without the ability, and hidden when the ability is scoped to another organization.

Relates: GLITCH-660
