### PR TITLE
fix: allow supported multi-release migration upgrades

### DIFF
--- a/packages/backend/src/scripts/migrate/preflight.test.ts
+++ b/packages/backend/src/scripts/migrate/preflight.test.ts
@@ -448,6 +448,34 @@ describe('preflight checks', () => {
         expect(check(result, 'version-path').outcome).toBe('pass');
     });
 
+    test('allows pending migrations from skipped releases when there are no required stops', async () => {
+        const result = await report({
+            artifactValue: artifact({
+                previousVersion: '1.121.1',
+                upgrade: {
+                    minPreviousVersion: '1.111.0',
+                    requiredStops: [],
+                },
+            }),
+            migrationState: state({
+                pending: [
+                    '20260810150000_older_pending.js',
+                    '20260811110000_create_grants.js',
+                ],
+            }),
+        });
+
+        expect(check(result, 'version-path')).toMatchObject({
+            outcome: 'pass',
+            data: {
+                pendingMigrationsOutsideArtifact: [
+                    '20260810150000_older_pending.js',
+                ],
+            },
+        });
+        expect(result.decision).toBe('proceed');
+    });
+
     test('fails unresolved historical boundaries when older migrations remain pending', async () => {
         const result = await report({
             artifactValue: artifact({

--- a/packages/backend/src/scripts/migrate/preflight.ts
+++ b/packages/backend/src/scripts/migrate/preflight.ts
@@ -532,10 +532,7 @@ const versionPathCheck = (
             data,
         };
     }
-    if (
-        !directPredecessorOrUpToDate &&
-        unresolvedHistoricalStops.length > 0
-    ) {
+    if (!directPredecessorOrUpToDate && unresolvedHistoricalStops.length > 0) {
         return {
             id: 'version-path',
             severity: 'red',

--- a/packages/backend/src/scripts/migrate/preflight.ts
+++ b/packages/backend/src/scripts/migrate/preflight.ts
@@ -534,15 +534,14 @@ const versionPathCheck = (
     }
     if (
         !directPredecessorOrUpToDate &&
-        (artifact.upgrade.minPreviousVersion !== null ||
-            unresolvedHistoricalStops.length > 0)
+        unresolvedHistoricalStops.length > 0
     ) {
         return {
             id: 'version-path',
             severity: 'red',
             outcome: 'fail',
             message:
-                'The ledger has pending migrations outside this release artifact, and contract v2 does not map the unresolved historical path boundaries to migration-ledger entries',
+                'The ledger has pending migrations outside this release artifact, and contract v2 does not map the unresolved required stops to migration-ledger entries',
             data,
         };
     }


### PR DESCRIPTION
## Summary

- allow migration preflight to proceed when the database has migrations pending from skipped releases and the release contract declares no required stops
- continue blocking genuinely diverged Knex ledgers and unresolved required stops
- add regression coverage for upgrading across skipped releases

## Root cause

The v2 release-safety artifact contains migration metadata for the current release only. Preflight treated any older pending migration as a red failure whenever `minPreviousVersion` was set, even though that semver floor cannot be mapped to entries in `knex_migrations`. Normal supported upgrades that skipped intermediate releases therefore exited before migration and caused deployment containers to restart.

`minPreviousVersion` remains visible in the report. Only concrete unresolved `requiredStops` block a non-direct upgrade.

## Validation

- `pnpm -F backend exec vitest run --config vitest.config.ts src/scripts/migrate/preflight.test.ts` — 25 passed
- `~/forge/harness/verify.sh 2 --quick` — backend typecheck, lint, changed-file tests passed
- `~/forge/harness/verify.sh 2` — backend typecheck, lint, changed-file tests passed
- broad backend suite: 6,601 passed; 2 unrelated existing failures in `AiWritebackService/scripts.test.ts` for shell-path fixtures
