### PR TITLE
fix(ai): inherit font size for markdown links

### DIFF
--- a/packages/frontend/src/components/common/AiMarkdown/AiMarkdown.module.css
+++ b/packages/frontend/src/components/common/AiMarkdown/AiMarkdown.module.css
@@ -128,6 +128,7 @@
  * edge. */
 .aiMarkdown a:not([data-content-link]) {
     color: var(--mantine-color-indigo-6);
+    font-size: inherit;
     text-decoration: none;
     border-bottom: 1px solid var(--mantine-color-indigo-3);
     transition: border-color 160ms ease;


### PR DESCRIPTION
## What changed

Ensures links in AI thread markdown match the font size of their surrounding content.

## Visual evidence

_No screenshot was captured. The automated capture step failed._

## References

Closes: ZAP-834

> Generated by the Lightdash Linear agent. Review and test all changes before merging.