### PR TITLE
fix(ai): inherit font size for settings links in agent threads

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -277,6 +277,7 @@ export const ContentLink: FC<ContentLinkProps> = ({
                     target="_blank"
                     rel="noreferrer"
                     title={title}
+                    inherit
                 >
                     {children}
                 </Anchor>


### PR DESCRIPTION
Closes:

### Description:

Settings deep-links in agent threads (e.g. the "link your personal GitHub account" nudge) rendered noticeably larger than the surrounding text. They're rendered with Mantine `Anchor`, whose root sets `font-size: var(--text-fz, var(--mantine-font-size-md))` — 16px — while the `.aiMarkdown` body text is 13px. Adding the `inherit` prop makes the anchor pick up the surrounding font size (and weight/line-height), matching every other markdown link.

Verified via Mantine's `Text.css` (`[data-inherit] { font-size: inherit }`); frontend lint and typecheck pass. No browser was available in this environment, so I couldn't capture a screenshot.
