### PR TITLE
fix(frontend): align PasswordInput font size with other inputs

### DIFF
--- a/packages/frontend/src/theme/components.ts
+++ b/packages/frontend/src/theme/components.ts
@@ -269,6 +269,9 @@ export const themeComponents: MantineThemeOverride['components'] = {
     PasswordInput: PasswordInput.extend({
         defaultProps: {
             radius: 'md',
+            // Mantine leaves PasswordInput's size unset, so `--input-fz` never
+            // lands and the input falls back to 16px instead of TextInput's 14px.
+            size: 'sm',
         },
         styles: (theme, props) =>
             props.variant === 'subtle' ? subtlePasswordInputStyles(theme) : {},


### PR DESCRIPTION
### Description:

The password placeholder on the sign-in form rendered larger than the email one. Mantine's `PasswordInput` ships no default `size`, so the `Input` vars resolver never emits `--input-fz` and the input's `font-size` falls back to `var(--mantine-font-size-md)` (16px) instead of the `sm` (14px) every other input gets via `InputBase`.

Fixed by defaulting `size: 'sm'` on `PasswordInput` in the theme, so it matches `TextInput`. Explicit `size` props (e.g. the `size="xs"` warehouse forms) still override it — and now get the correct font size too.

Verified by rendering `TextInput` + `PasswordInput` under the app's `MantineProvider`: before the change the password wrapper had no `--input-fz`; after it emits `--input-fz: var(--mantine-font-size-sm)`, matching the text input. (No browser available in this environment for a screenshot.)
