### PR TITLE
fix: validate preview catalog snapshots

### DIFF
--- a/packages/api-tests/tests/catalog.test.ts
+++ b/packages/api-tests/tests/catalog.test.ts
@@ -221,9 +221,50 @@ describe('Lightdash catalog all tables and fields', () => {
 
 describe('Lightdash catalog search', () => {
     let admin: ApiClient;
+    let adminAttributeUuid: string;
+
+    const setAdminAttribute = async (value: string | null) => {
+        const response = await admin.put(
+            `${apiUrl}/org/attributes/${adminAttributeUuid}`,
+            {
+                name: 'is_admin',
+                users:
+                    value === null
+                        ? []
+                        : [
+                              {
+                                  userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                                  value,
+                              },
+                          ],
+                groups: [],
+                attributeDefault: null,
+            },
+        );
+        expect(response.status).toBe(201);
+    };
 
     beforeAll(async () => {
         admin = await login();
+        const response = await admin.post<{ results: { uuid: string } }>(
+            `${apiUrl}/org/attributes`,
+            {
+                name: 'is_admin',
+                users: [],
+                groups: [],
+                attributeDefault: null,
+            },
+        );
+        expect(response.status).toBe(201);
+        adminAttributeUuid = response.body.results.uuid;
+    });
+
+    afterAll(async () => {
+        if (!adminAttributeUuid) return;
+        const response = await admin.delete(
+            `${apiUrl}/org/attributes/${adminAttributeUuid}`,
+        );
+        expect(response.status).toBe(200);
     });
 
     it('Should search for customer tables and fields', async () => {
@@ -326,6 +367,16 @@ describe('Lightdash catalog search', () => {
 
     it('Should filter fields with required attributes (age)', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
+        await setAdminAttribute('true');
+        const visibleResp = await admin.get<{
+            results: Array<{ name: string; type: string }>;
+        }>(`${apiUrl}/projects/${projectUuid}/dataCatalog?search=average_age`);
+        expect(visibleResp.status).toBe(200);
+        expect(visibleResp.body.results).toContainEqual(
+            expect.objectContaining({ name: 'average_age', type: 'field' }),
+        );
+
+        await setAdminAttribute(null);
         const resp = await admin.get<{ results: unknown[] }>(
             `${apiUrl}/projects/${projectUuid}/dataCatalog?search=average_age`,
         );
@@ -335,6 +386,16 @@ describe('Lightdash catalog search', () => {
 
     it('Should filter table with required attributes (memberships)', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
+        await setAdminAttribute('true');
+        const visibleResp = await admin.get<{
+            results: Array<{ name: string; type: string }>;
+        }>(`${apiUrl}/projects/${projectUuid}/dataCatalog?search=memberships`);
+        expect(visibleResp.status).toBe(200);
+        expect(visibleResp.body.results).toContainEqual(
+            expect.objectContaining({ name: 'membership', type: 'table' }),
+        );
+
+        await setAdminAttribute(null);
         const resp = await admin.get<{ results: unknown[] }>(
             `${apiUrl}/projects/${projectUuid}/dataCatalog?search=memberships`,
         );

--- a/packages/api-tests/tests/v2/metricsWithTimeDimensions.test.ts
+++ b/packages/api-tests/tests/v2/metricsWithTimeDimensions.test.ts
@@ -2,20 +2,125 @@ import {
     CatalogField,
     KnexPaginatedData,
     SEED_PROJECT,
+    Tag,
 } from '@lightdash/common';
 import { ApiClient, Body } from '../../helpers/api-client';
 import { login } from '../../helpers/auth';
 
 const projectUuid = SEED_PROJECT.project_uuid;
+const v1Url = `/api/v1/projects/${projectUuid}`;
 const v2Url = `/api/v2/projects/${projectUuid}/dataCatalog/metrics-with-time-dimensions`;
 
 type PaginatedMetrics = Body<KnexPaginatedData<CatalogField[]>>;
+type YamlTag = Pick<Tag, 'name' | 'color'> & { yamlReference: string };
+
+const fixtureYamlTags: YamlTag[] = [
+    { name: 'Sales', color: 'green', yamlReference: 'sales' },
+    {
+        name: 'Revenue Growth',
+        color: 'violet',
+        yamlReference: 'revenue_growth',
+    },
+];
 
 describe('v2 metrics with time dimensions', () => {
     let admin: ApiClient;
+    let fixtureMetricUuid: string | undefined;
+    let originalYamlTags: YamlTag[] = [];
+    const addedTagUuids: string[] = [];
 
     beforeAll(async () => {
         admin = await login();
+
+        const originalTagsResp = await admin.get<Body<Tag[]>>(`${v1Url}/tags`);
+        expect(originalTagsResp.status).toBe(200);
+        originalYamlTags = originalTagsResp.body.results.flatMap((tag) =>
+            tag.yamlReference === null
+                ? []
+                : [
+                      {
+                          name: tag.name,
+                          color: tag.color,
+                          yamlReference: tag.yamlReference,
+                      },
+                  ],
+        );
+
+        const mergedYamlTags = [
+            ...originalYamlTags.filter(
+                (tag) =>
+                    !fixtureYamlTags.some(
+                        (fixtureTag) =>
+                            fixtureTag.yamlReference === tag.yamlReference,
+                    ),
+            ),
+            ...fixtureYamlTags,
+        ];
+        const replaceResp = await admin.put(
+            `${v1Url}/tags/yaml`,
+            mergedYamlTags,
+        );
+        expect(replaceResp.status).toBe(200);
+
+        const currentTagsResp = await admin.get<Body<Tag[]>>(`${v1Url}/tags`);
+        expect(currentTagsResp.status).toBe(200);
+        const fixtureTags = fixtureYamlTags.map((fixtureTag) =>
+            currentTagsResp.body.results.find(
+                (tag) => tag.yamlReference === fixtureTag.yamlReference,
+            ),
+        );
+        if (fixtureTags.some((tag) => tag === undefined)) {
+            throw new Error('Failed to create spotlight category fixtures');
+        }
+
+        const metricsResp = await admin.get<PaginatedMetrics>(
+            `${v2Url}?page=1&pageSize=100`,
+        );
+        expect(metricsResp.status).toBe(200);
+        expect(metricsResp.body.results.data.length).toBeGreaterThan(0);
+        const metric =
+            metricsResp.body.results.data.find((item) =>
+                fixtureYamlTags.every((fixtureTag) =>
+                    item.categories.every(
+                        (category) =>
+                            category.yamlReference !== fixtureTag.yamlReference,
+                    ),
+                ),
+            ) ?? metricsResp.body.results.data[0];
+        fixtureMetricUuid = metric.catalogSearchUuid;
+
+        for (const fixtureTag of fixtureTags) {
+            if (fixtureTag) {
+                const isAlreadyLinked = metric.categories.some(
+                    (category) => category.tagUuid === fixtureTag.tagUuid,
+                );
+                if (!isAlreadyLinked) {
+                    const addResp = await admin.post(
+                        `${v1Url}/dataCatalog/${fixtureMetricUuid}/categories`,
+                        { tagUuid: fixtureTag.tagUuid },
+                    );
+                    expect(addResp.status).toBe(200);
+                    addedTagUuids.push(fixtureTag.tagUuid);
+                }
+            }
+        }
+    });
+
+    afterAll(async () => {
+        if (!admin) return;
+        if (fixtureMetricUuid) {
+            for (const tagUuid of addedTagUuids) {
+                const removeResp = await admin.delete(
+                    `${v1Url}/dataCatalog/${fixtureMetricUuid}/categories/${tagUuid}`,
+                );
+                expect(removeResp.status).toBe(200);
+            }
+        }
+        const restoreResp = await admin.put(
+            `${v1Url}/tags/yaml`,
+            originalYamlTags,
+        );
+        expect(restoreResp.status).toBe(200);
     });
 
     it('should filter by dbt tags', async () => {
@@ -24,6 +129,8 @@ describe('v2 metrics with time dimensions', () => {
         );
         const totalWithoutFilter =
             allResp.body.results.pagination!.totalResults;
+        expect(allResp.status).toBe(200);
+        expect(totalWithoutFilter).toBeGreaterThan(0);
 
         const resp = await admin.get<PaginatedMetrics>(
             `${v2Url}?page=1&pageSize=50&tags=core`,

--- a/scripts/preview-db-seed-readiness.test.ts
+++ b/scripts/preview-db-seed-readiness.test.ts
@@ -1,0 +1,27 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const root = process.cwd();
+const readinessSql = fs.readFileSync(
+    path.join(root, 'scripts/preview-db-seed-ready.sql'),
+    'utf8',
+);
+const snapshotScript = fs.readFileSync(
+    path.join(root, 'scripts/preview-db-snapshot.sh'),
+    'utf8',
+);
+
+for (const sentinel of [
+    "to_regclass('jaffle.orders') IS NOT NULL",
+    "email = 'demo@lightdash.com'",
+    'FROM catalog_search',
+    "project_uuid = '3675b69e-8324-4110-bdca-059031aa8da3'",
+    't.yaml_reference IS NOT NULL',
+]) {
+    assert.ok(readinessSql.includes(sentinel), `missing sentinel: ${sentinel}`);
+}
+
+assert.ok(snapshotScript.includes('preview-db-seed-ready.sql'));
+
+console.log('preview-db-seed-readiness: all tests passed');

--- a/scripts/preview-db-seed-ready.sql
+++ b/scripts/preview-db-seed-ready.sql
@@ -1,0 +1,15 @@
+SELECT
+    to_regclass('jaffle.orders') IS NOT NULL
+    AND EXISTS (
+        SELECT 1
+        FROM emails
+        WHERE email = 'demo@lightdash.com'
+    )
+    AND EXISTS (
+        SELECT 1
+        FROM catalog_search cs
+        JOIN catalog_search_tags cst USING (catalog_search_uuid)
+        JOIN tags t USING (tag_uuid)
+        WHERE cs.project_uuid = '3675b69e-8324-4110-bdca-059031aa8da3'
+          AND t.yaml_reference IS NOT NULL
+    ) AS seeded;

--- a/scripts/preview-db-snapshot.sh
+++ b/scripts/preview-db-snapshot.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 NAMESPACE="${DB_SNAPSHOT_NAMESPACE:-db-snapshot}"
 SUFFIX="${1:?usage: preview-db-snapshot.sh <suffix, e.g. short sha>}"
+SEED_READY_SQL="$(dirname "$0")/preview-db-seed-ready.sql"
 # GCP rate-limits disk creation per source snapshot, so publish several
 # identical copies and let previews spread their restores across them
 # (okteto.preview.yaml picks one at random). Keep two generations.
@@ -16,9 +17,8 @@ COPIES=3
 KEEP=6
 
 is_seeded() {
-    [ "$(kubectl -n "$NAMESPACE" exec statefulset/db-preview -- psql -U postgres -tAc \
-        "SELECT to_regclass('jaffle.orders') IS NOT NULL AND EXISTS (SELECT 1 FROM emails WHERE email = 'demo@lightdash.com')" \
-        2>/dev/null)" = "t" ]
+    [ "$(kubectl -n "$NAMESPACE" exec -i statefulset/db-preview -- psql -U postgres -tA -f - \
+        < "$SEED_READY_SQL" 2>/dev/null)" = "t" ]
 }
 
 echo "Waiting for the seeder to finish (dbt + migrate + seed)..."


### PR DESCRIPTION
## Summary

- require a seed-project YAML category link before publishing preview DB snapshots
- create and clean up spotlight category fixtures through public APIs, so existing stale previews remain testable without a full refresh
- give catalog access tests positive controls and metrics tests a nonempty baseline

## Root cause

Snapshot readiness became true after early seed records existed, before catalog indexing finished. Incomplete snapshots could therefore be published and later produce zero-result category filters or missing access metadata. Catalog rows, category links, time-dimension flags, and access metadata are written atomically, so one seed-project YAML category link is the completion signal.

## Test plan

- catalog API tests: 23 passed
- metrics-with-time-dimensions API tests: 5 passed
- API lint, formatting, and typecheck passed
- snapshot readiness structural test and shell syntax passed
- repeat PR CI verification in progress