### PR TITLE
fix(ai): resolve AWS default credential chain for Bedrock

### DIFF
--- a/packages/backend/src/ee/services/ai/models/bedrock.test.ts
+++ b/packages/backend/src/ee/services/ai/models/bedrock.test.ts
@@ -1,4 +1,14 @@
-import { getBedrockModelPrefix } from './bedrock';
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import { getBedrockModelPrefix, getBedrockProvider } from './bedrock';
+
+vi.mock('@ai-sdk/amazon-bedrock', () => ({
+    createAmazonBedrock: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/credential-providers', () => ({
+    fromNodeProviderChain: vi.fn(() => vi.fn()),
+}));
 
 describe('getBedrockModelPrefix', () => {
     test('uses the explicit override prefix when provided', () => {
@@ -12,5 +22,53 @@ describe('getBedrockModelPrefix', () => {
     test('keeps existing us and eu mappings', () => {
         expect(getBedrockModelPrefix('us-east-1')).toBe('us');
         expect(getBedrockModelPrefix('eu-west-1')).toBe('eu');
+    });
+});
+
+describe('getBedrockProvider', () => {
+    const baseConfig = {
+        region: 'us-east-1',
+        modelName: 'model',
+        embeddingModelName: 'embedding-model',
+        customHeaders: {},
+        inferenceProfilePrefix: undefined,
+        supportsStreaming: true,
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('passes apiKey when configured', () => {
+        getBedrockProvider({ ...baseConfig, apiKey: 'key' });
+        expect(createAmazonBedrock).toHaveBeenCalledWith(
+            expect.objectContaining({ apiKey: 'key', region: 'us-east-1' }),
+        );
+    });
+
+    test('passes static keys when configured', () => {
+        getBedrockProvider({
+            ...baseConfig,
+            accessKeyId: 'id',
+            secretAccessKey: 'secret',
+            sessionToken: undefined,
+        });
+        expect(createAmazonBedrock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                accessKeyId: 'id',
+                secretAccessKey: 'secret',
+            }),
+        );
+    });
+
+    test('resolves the AWS default credential chain when using default credentials', () => {
+        getBedrockProvider({ ...baseConfig, useDefaultCredentials: true });
+        expect(fromNodeProviderChain).toHaveBeenCalled();
+        expect(createAmazonBedrock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                region: 'us-east-1',
+                credentialProvider: expect.any(Function),
+            }),
+        );
     });
 });

--- a/packages/backend/src/ee/services/ai/models/bedrock.ts
+++ b/packages/backend/src/ee/services/ai/models/bedrock.ts
@@ -2,6 +2,7 @@ import {
     AmazonBedrockProvider,
     createAmazonBedrock,
 } from '@ai-sdk/amazon-bedrock';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import type { EmbeddingModel } from 'ai';
 import { LightdashConfig } from '../../../../config/parseConfig';
 import { ModelPreset } from './presets';
@@ -51,6 +52,7 @@ export const getBedrockProvider = (
     return createAmazonBedrock({
         region: config.region,
         headers: config.customHeaders,
+        credentialProvider: fromNodeProviderChain(),
     });
 };
 


### PR DESCRIPTION
Closes #27225 (PROD-9854)

## Summary

With `BEDROCK_USE_DEFAULT_CREDENTIALS=true`, every in-process AI call fails with a SigV4 error: the provider is built without credentials.

```
IRSA / instance profile ─► default-creds branch ─► no credentialProvider ─► SigV4 throw
```

## Fix

Pass `credentialProvider: fromNodeProviderChain()` in the default-credentials branch only. Adds regression tests for all three provider branches.

## Test plan

- [x] `pnpm -F backend typecheck` and `lint`
- [x] `bedrock.test.ts` — 6 tests pass
- [x] Reporter verified the identical patch on two EKS/IRSA deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)