### PR TITLE
feat: add select-all to Ask AI admin user filter

### DIFF
--- a/packages/frontend/src/components/common/FilterFacet/FilterFacet.tsx
+++ b/packages/frontend/src/components/common/FilterFacet/FilterFacet.tsx
@@ -57,6 +57,8 @@ export type FilterFacetProps = {
     searchPlaceholder?: string;
     onScrollEnd?: () => void;
     scrollEndOffset?: number;
+    /** Shows a row that selects/deselects every listed option at once */
+    enableSelectAll?: boolean;
 };
 
 const isOptionVisible = (
@@ -86,6 +88,7 @@ const FilterFacet = ({
     searchPlaceholder = 'Search…',
     onScrollEnd,
     scrollEndOffset = 50,
+    enableSelectAll = false,
 }: FilterFacetProps) => {
     const selectedSet = new Set(selected);
     const viewportRef = useRef<HTMLDivElement>(null);
@@ -131,6 +134,34 @@ const FilterFacet = ({
     };
 
     const hasSelection = selected.length > 0;
+
+    const selectableValues = [
+        ...visibleFlatOptions,
+        ...visibleGroups.flatMap((group) => group.options),
+    ]
+        .filter((option) => option.disabled !== true)
+        .map((option) => option.value);
+
+    const showSelectAll =
+        enableSelectAll && mode === 'multi' && selectableValues.length > 0;
+    const allSelected = selectableValues.every((value) =>
+        selectedSet.has(value),
+    );
+    const someSelected =
+        !allSelected &&
+        selectableValues.some((value) => selectedSet.has(value));
+
+    const toggleAll = () => {
+        const selectableSet = new Set(selectableValues);
+        if (allSelected) {
+            onChange(selected.filter((value) => !selectableSet.has(value)));
+        } else {
+            onChange([
+                ...selected,
+                ...selectableValues.filter((value) => !selectedSet.has(value)),
+            ]);
+        }
+    };
 
     const renderOption = (option: FilterFacetOption) => {
         const isChecked = selectedSet.has(option.value);
@@ -267,6 +298,27 @@ const FilterFacet = ({
                             }
                         />
                     </Box>
+                )}
+                {showSelectAll && (
+                    <UnstyledButton
+                        onClick={toggleAll}
+                        px="xs"
+                        py={6}
+                        className={classes.option}
+                    >
+                        <Group gap="xs" wrap="nowrap">
+                            <Checkbox
+                                size="xs"
+                                checked={allSelected}
+                                indeterminate={someSelected}
+                                readOnly
+                                tabIndex={-1}
+                            />
+                            <Text fz="xs" fw={500} c="ldGray.9">
+                                {allSelected ? 'Deselect all' : 'Select all'}
+                            </Text>
+                        </Group>
+                    </UnstyledButton>
                 )}
                 {!hasAnyOption ? (
                     <Text fz="xs" c="ldGray.6" p="xs">

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/UsersFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/UsersFilter.tsx
@@ -72,13 +72,14 @@ const UsersFilter: FC<UsersFilterProps> = ({
             options={options}
             selected={selectedUserUuids}
             onChange={setSelectedUserUuids}
-            tooltipLabel="Filter threads by user"
+            tooltipLabel="Filter by user"
             searchValue={searchValue}
             onSearchChange={setSearchValue}
             searchPlaceholder="Search users..."
             loading={isLoading}
             loadingMore={isFetching && !isLoading}
             onScrollEnd={handleScrollEnd}
+            enableSelectAll
             emptyLabel="No users found."
         />
     );


### PR DESCRIPTION
Closes: #27223

### Description:

The User filter in the Ask AI threads admin view now has a select/deselect-all row. Search was already provided by `FilterFacet`.

- `FilterFacet` gets an opt-in `enableSelectAll` row (checked/indeterminate, "Deselect all" when everything listed is selected), reusable by any other filter that uses the component.
- `UsersFilter` opts in. Select-all applies to the options currently listed, so it respects the active search; with the infinite-scroll user list it covers what has been loaded.

Restricting the filter to users who have actually started a thread (point 1 of the issue) is deliberately not part of this PR — it needs a new backend endpoint and can land separately.

Verified with frontend typecheck + lint and new `FilterFacet` select-all unit tests. No local database in this environment, so this wasn't exercised in the running app.