### PR TITLE
fix: validate bump-target values before writing

### DIFF
--- a/examples/upgrade-automation/scripts/bump-target.py
+++ b/examples/upgrade-automation/scripts/bump-target.py
@@ -113,11 +113,18 @@ def find_yaml_value(lines, keys, replacement=None):
         raise ValueError('bump_target YAML path was not found')
     index, line, match, value, quote, trailing = found
     if replacement is not None:
+        if '\n' in replacement or '\r' in replacement:
+            raise ValueError('bump_target value must be a single line')
         rendered = replacement
         if quote == '"':
             rendered = json.dumps(replacement)
         elif quote == "'":
             rendered = "'" + replacement.replace("'", "''") + "'"
+        elif not re.fullmatch(r'[A-Za-z0-9][A-Za-z0-9._+-]*', replacement):
+            raise ValueError(
+                'bump_target value must be a plain YAML-safe token; '
+                'quote the value in the target file to write other strings'
+            )
         lines[index] = (
             match.group('indent')
             + match.group('quote')


### PR DESCRIPTION
## What

Hardens `examples/upgrade-automation/scripts/bump-target.py`: rejects multi-line replacement values outright, and requires plain (unquoted) YAML scalar targets to receive a YAML-safe token (`[A-Za-z0-9][A-Za-z0-9._+-]*`). Quoted targets are unchanged — they already escape via `json.dumps` / single-quote doubling.

## Why

A replacement containing a newline or ` #` written into a plain scalar would rewrite the line into injected sibling keys or a trailing comment, and the post-write round-trip check only re-reads the bumped path so it would not notice. The workflow's own callers validate versions upstream, so this is defense-in-depth for anyone calling the script directly with their own inputs.

Verified: valid versions round-trip byte-identically; newline, comment, and anchor injections all raise; quoted targets still accept arbitrary strings.

Linear: SPK-968