### PR TITLE
fix: correct font size in tables configuration table selection

### DIFF
--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -192,7 +192,7 @@ const ProjectTablesConfiguration: FC<Props> = ({ projectUuid, onSuccess }) => {
             <SettingsGridCard>
                 <div>
                     <Title order={5}>Table selection</Title>
-                    <Text c="ldGray.6" my={'xs'}>
+                    <Text size="sm" c="ldGray.6" my={'xs'}>
                         You have selected <b>{modelsIncluded.length}</b> models{' '}
                         {modelsIncluded.length > 0 && (
                             <Anchor
@@ -212,6 +212,7 @@ const ProjectTablesConfiguration: FC<Props> = ({ projectUuid, onSuccess }) => {
                                     key={name}
                                     title={name}
                                     truncate
+                                    size="sm"
                                     c="ldGray.6"
                                 >
                                     {name}


### PR DESCRIPTION
### Description:

On the Tables configuration screen, the "You have selected N models" line and the model list rendered at Mantine's default `md` size, while the rest of the card (radio descriptions, the show/hide list anchor) uses `sm`. Added `size="sm"` to both so the left column matches.