### PR TITLE
fix: validate paths used by share links

### DIFF
--- a/packages/backend/src/services/ShareService/ShareService.test.ts
+++ b/packages/backend/src/services/ShareService/ShareService.test.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from '@lightdash/common';
+import { ForbiddenError, ParameterError } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { ShareModel } from '../../models/ShareModel';
 import { ShareService } from './ShareService';
@@ -17,6 +17,7 @@ const shareModel = {
     createSharedUrl: vi.fn(async () => SampleShareUrl),
     getSharedUrl: vi.fn(async () => SampleShareUrl),
 };
+const unsafeJavascriptUrl = ['javascript', 'alert(1)'].join(':');
 
 describe('share', () => {
     const shareService = new ShareService({
@@ -38,10 +39,64 @@ describe('share', () => {
             ),
         ).toEqual(FullShareUrl);
     });
+
+    it.each([
+        'https://evil.example.com/pwn',
+        'https://test.lightdash.cloud/pwn',
+        unsafeJavascriptUrl,
+        '//evil.example.com/pwn',
+        '//test.lightdash.cloud/pwn',
+        '/\\evil.example.com/pwn',
+        'projects/uuid/tables/customers',
+        '',
+    ])('Should reject unsafe share path %j before saving', async (path) => {
+        await expect(
+            shareService.createShareUrl(User, path, ''),
+        ).rejects.toThrowError(ParameterError);
+        expect(shareModel.createSharedUrl).not.toHaveBeenCalled();
+    });
+
+    it.each(['/evil.example.com/pwn', '\\evil.example.com/pwn'])(
+        'Should reject unsafe share params %j before saving',
+        async (params) => {
+            await expect(
+                shareService.createShareUrl(User, '/', params),
+            ).rejects.toThrowError(ParameterError);
+            expect(shareModel.createSharedUrl).not.toHaveBeenCalled();
+        },
+    );
+
     it('Should get saved sharedUrl', async () => {
         expect(
             await shareService.getShareUrl(Account, SampleShareUrl.nanoid),
         ).toEqual(FullShareUrl);
+    });
+
+    it('Should reject an unsafe saved share path', async () => {
+        (
+            shareModel.getSharedUrl as import('vitest').Mock
+        ).mockImplementationOnce(async () => ({
+            ...SampleShareUrl,
+            path: unsafeJavascriptUrl,
+        }));
+
+        await expect(
+            shareService.getShareUrl(Account, SampleShareUrl.nanoid),
+        ).rejects.toThrowError(ParameterError);
+    });
+
+    it('Should reject unsafe params from a saved share URL', async () => {
+        (
+            shareModel.getSharedUrl as import('vitest').Mock
+        ).mockImplementationOnce(async () => ({
+            ...SampleShareUrl,
+            path: '/',
+            params: '/evil.example.com/pwn',
+        }));
+
+        await expect(
+            shareService.getShareUrl(Account, SampleShareUrl.nanoid),
+        ).rejects.toThrowError(ParameterError);
     });
 
     it('Should get saved sharedUrl without params', async () => {

--- a/packages/backend/src/services/ShareService/ShareService.ts
+++ b/packages/backend/src/services/ShareService/ShareService.ts
@@ -5,6 +5,7 @@ import {
     ForbiddenError,
     isUserWithOrg,
     NotFoundError,
+    ParameterError,
     SessionUser,
     ShareUrl,
 } from '@lightdash/common';
@@ -27,6 +28,30 @@ export class ShareService extends BaseService {
 
     private readonly shareModel: ShareModel;
 
+    private validateShareUrl(path: string, params: string) {
+        const error = new ParameterError(
+            'Share URL path must be a relative in-app path starting with /',
+        );
+        const url = `${path}${params}`;
+
+        if (!url.startsWith('/') || url.startsWith('//')) {
+            throw error;
+        }
+
+        let isSameOrigin: boolean;
+        try {
+            isSameOrigin =
+                new URL(url, this.lightdashConfig.siteUrl).origin ===
+                new URL(this.lightdashConfig.siteUrl).origin;
+        } catch {
+            throw error;
+        }
+
+        if (!isSameOrigin) {
+            throw error;
+        }
+    }
+
     constructor(args: ShareServiceArguments) {
         super();
         this.lightdashConfig = args.lightdashConfig;
@@ -35,6 +60,7 @@ export class ShareService extends BaseService {
     }
 
     private shareUrlWithHost(shareUrl: ShareUrl) {
+        this.validateShareUrl(shareUrl.path, shareUrl.params);
         const host = this.lightdashConfig.siteUrl;
         return {
             ...shareUrl,
@@ -82,6 +108,7 @@ export class ShareService extends BaseService {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
+        this.validateShareUrl(path, params);
         const shareUrl = await this.shareModel.createSharedUrl({
             path,
             params,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-10028

### Description:
This tightens share-link input handling so generated links stay within the app.
It validates the combined path and parameters before saving and when reading existing links, while preserving current share-link behavior.
Tests cover relative paths and common URL variants; backend unit tests, lint, formatting, and typechecking pass.
