### PR TITLE
test: remove stale expired invite link expectation

### DIFF
--- a/packages/api-tests/tests/inviteLinks.test.ts
+++ b/packages/api-tests/tests/inviteLinks.test.ts
@@ -159,16 +159,6 @@ describe('Invite links endpoints', () => {
             expect(resp.status).toBe(422);
         });
 
-        // expires_at >= created_at is enforced by a DB check constraint,
-        // which also surfaces as an unhandled 500
-        it('returns 500 when expiresAt is in the past', async () => {
-            const resp = await createInvite({
-                email: uniqueEmail('past-expiry'),
-                expiresAt: new Date(Date.now() - 60 * 1000).toISOString(),
-            });
-            expect(resp.status).toBe(500);
-        });
-
         it('supports personal access token authentication', async () => {
             const patResp = await admin.post<
                 Body<{ token: string; uuid: string }>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates: PROD-9820

### Description:
Removes the stale invite-links E2E case that expected a 500 response for past expiries.
The endpoint now intentionally normalizes invalid expiries to the server-enforced three-day lifetime, which is covered by focused service tests.
Validation: formatting, basic lint, and diff checks passed; the full E2E suite was not run because this workspace has no installed dependencies or local stack.