### PR TITLE
fix: create upgrade automation pin commits via the GitHub API

### DIFF
--- a/examples/upgrade-automation/README.md
+++ b/examples/upgrade-automation/README.md
@@ -22,6 +22,8 @@ The template polls hourly, can be run manually, and accepts a `repository_dispat
 
 The plan and verify jobs call reusable composite actions from this repository. Replace both `REPLACE_WITH_LIGHTDASH_COMMIT_SHA` placeholders with the same reviewed full commit SHA that contains this directory. Keeping the action immutable is important because both jobs receive repository-write credentials and the optional Slack secret.
 
+The plan action creates the pin commit through the GitHub API, so GitHub verifies the commit and it satisfies rulesets that require signed commits. Because the action does not use Git to push, its consumer checkout should set `persist-credentials: false`.
+
 ## Inputs
 
 | Input | Template setting | Meaning |
@@ -37,6 +39,16 @@ The plan and verify jobs call reusable composite actions from this repository. R
 
 The composite actions also take `github_token`. The verify action receives `deploy_run_url`, `deploy_conclusion`, and `deployed_sha` from `workflow_run`; customers normally leave those template expressions unchanged.
 
+## Plan outputs
+
+| Output | Meaning |
+| --- | --- |
+| `branch` | Name of the upgrade branch created or updated by the plan action. |
+| `pr_number` | Number of the upgrade pull request created or updated by the plan action. |
+| `pr_url` | URL of the upgrade pull request created or updated by the plan action. |
+
+All three outputs are empty when planning exits early because upgrades are frozen, no newer version is available, or the mapped image is unavailable in the configured registry.
+
 ## Event choreography
 
 The schedule, manual dispatch, and release dispatch run the planning half. A freeze-only job is deliberately first and checkout is skipped when frozen. The plan action repeats the check so direct composite-action consumers retain the same fail-closed behavior.
@@ -51,12 +63,12 @@ The current CLI includes a required stop equal to the target in `requiredStops`,
 
 The workflow requests:
 
-- `contents: write` to push the version branch;
+- `contents: write` to create the version branch and GitHub-verified commit through the API;
 - `pull-requests: write` to open, comment on, and enable auto-merge for the pin pull request;
 - `issues: write` to inspect freeze issues and create a freeze label and issue on failure;
 - `actions: read` to consume deployment workflow metadata.
 
-The repository `GITHUB_TOKEN` is enough to open a pull request and leave durable comments when repository policy allows write tokens. GitHub suppresses most new workflow runs caused by events created with a workflow's own `GITHUB_TOKEN`. In particular, merging the pin with that token may not trigger the consumer's push-based deployment workflow, so zero-touch auto-merge should use a fine-grained PAT or GitHub App token stored as `UPGRADE_AUTOMATION_TOKEN`. Grant it repository Contents, Pull requests, and Issues read/write permissions plus Actions read access. Repository rules and required checks still apply.
+The repository `GITHUB_TOKEN` is enough to create the API-authored commit, open a pull request, and leave durable comments when repository policy allows write tokens. The plan action needs Contents read/write and Pull requests read/write permissions; the complete workflow also needs Issues read/write and Actions read for its freeze and verification flows. GitHub suppresses most new workflow runs caused by events created with a workflow's own `GITHUB_TOKEN`. In particular, merging the pin with that token may not trigger the consumer's push-based deployment workflow, so zero-touch auto-merge should use a fine-grained PAT or GitHub App token stored as `UPGRADE_AUTOMATION_TOKEN` with the same repository permissions. Repository rules and required checks still apply.
 
 `workflow_dispatch` and `repository_dispatch` are exceptions to GitHub's recursion suppression and always create workflow runs. A release-event integration can call:
 

--- a/examples/upgrade-automation/plan/action.yml
+++ b/examples/upgrade-automation/plan/action.yml
@@ -25,12 +25,23 @@ inputs:
     required: false
     default: upgrade-freeze
   github_token:
-    description: GitHub token used to inspect issues, push the pin branch, and manage its pull request
+    description: GitHub token used to inspect issues, create the pin commit, and manage its pull request
     required: true
+outputs:
+  branch:
+    description: Upgrade branch name, or empty when no pull request is created or updated
+    value: ${{ steps.plan.outputs.branch }}
+  pr_number:
+    description: Upgrade pull request number, or empty when no pull request is created or updated
+    value: ${{ steps.plan.outputs.pr_number }}
+  pr_url:
+    description: Upgrade pull request URL, or empty when no pull request is created or updated
+    value: ${{ steps.plan.outputs.pr_url }}
 runs:
   using: composite
   steps:
     - name: Plan and open the upgrade pull request
+      id: plan
       shell: bash
       env:
         BUMP_TARGET: ${{ inputs.bump_target }}

--- a/examples/upgrade-automation/scripts/plan.sh
+++ b/examples/upgrade-automation/scripts/plan.sh
@@ -4,6 +4,68 @@ set -euo pipefail
 
 source "$(dirname "$0")/common.sh"
 
+write_output() {
+    local name=$1
+    local value=$2
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        printf '%s=%s\n' "$name" "$value" >>"$GITHUB_OUTPUT"
+    fi
+}
+
+base64_file() {
+    local file=$1
+    if base64 --help 2>&1 | grep -q -- '-w'; then
+        base64 -w0 "$file"
+    else
+        openssl base64 -A -in "$file"
+    fi
+}
+
+create_commit() {
+    local expected_head_oid=$1
+    local file_path=$2
+    local file_contents=$3
+    local commit_message=$4
+    local query
+    query='mutation($input: CreateCommitOnBranchInput!) {
+        createCommitOnBranch(input: $input) {
+            commit {
+                oid
+                url
+            }
+        }
+    }'
+
+    jq -n \
+        --arg query "$query" \
+        --arg repository "$GITHUB_REPOSITORY" \
+        --arg branch "$upgrade_branch" \
+        --arg expected_head_oid "$expected_head_oid" \
+        --arg message "$commit_message" \
+        --arg path "$file_path" \
+        --arg contents "$file_contents" \
+        '{
+            query: $query,
+            variables: {
+                input: {
+                    branch: {
+                        repositoryNameWithOwner: $repository,
+                        branchName: $branch
+                    },
+                    expectedHeadOid: $expected_head_oid,
+                    message: {headline: $message},
+                    fileChanges: {
+                        additions: [{path: $path, contents: $contents}]
+                    }
+                }
+            }
+        }' | gh api graphql --input -
+}
+
+write_output branch ''
+write_output pr_number ''
+write_output pr_url ''
+
 require_value bump_target "${BUMP_TARGET:-}"
 require_value freeze_label "${FREEZE_LABEL:-}"
 require_value github_token "${GH_TOKEN:-}"
@@ -18,7 +80,8 @@ index_file=$(mktemp)
 gate_error=$(mktemp)
 body_file=$(mktemp)
 summary_file=$(mktemp)
-trap 'rm -f "$index_file" "$gate_error" "$body_file" "$summary_file"' EXIT
+bump_file_before=$(mktemp)
+trap 'rm -f "$index_file" "$gate_error" "$body_file" "$summary_file" "$bump_file_before"' EXIT
 
 curl --connect-timeout 10 --max-time 60 --fail --silent --show-error "$RELEASE_INDEX_URL" --output "$index_file"
 jq -e '.schemaVersion == "1" and (.entries | type == "array")' "$index_file" >/dev/null
@@ -140,22 +203,35 @@ fi
 default_branch=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch')
 safe_branch_version=$(tr -c 'A-Za-z0-9._-' '-' <<<"$mapped_version" | sed 's/-$//')
 upgrade_branch="lightdash-upgrade-${safe_branch_version}"
+bump_file=${BUMP_TARGET%%#*}
 
-git fetch origin "$default_branch"
-if git ls-remote --exit-code --heads origin "$upgrade_branch" >/dev/null 2>&1; then
-    git fetch origin "$upgrade_branch"
-fi
-git checkout -B "$upgrade_branch" "origin/$default_branch"
-
+cp "$bump_file" "$bump_file_before"
 write_bump_value "$mapped_version"
-git add -- "${BUMP_TARGET%%#*}"
-if git diff --cached --quiet; then
+if cmp -s "$bump_file_before" "$bump_file"; then
     exit 0
 fi
-git config user.name github-actions[bot]
-git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-git commit -m "chore: upgrade Lightdash to $mapped_version"
-git push --set-upstream --force-with-lease origin "$upgrade_branch"
+
+base_sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$default_branch" --jq '.object.sha')
+if gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$upgrade_branch" >/dev/null 2>&1; then
+    gh api --method PATCH "repos/$GITHUB_REPOSITORY/git/refs/heads/$upgrade_branch" \
+        -f sha="$base_sha" \
+        -F force=true >/dev/null
+else
+    gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+        -f ref="refs/heads/$upgrade_branch" \
+        -f sha="$base_sha" >/dev/null
+fi
+
+file_contents=$(base64_file "$bump_file")
+commit_message="chore: upgrade Lightdash to $mapped_version"
+if ! commit_response=$(create_commit "$base_sha" "$bump_file" "$file_contents" "$commit_message"); then
+    branch_head=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$upgrade_branch" --jq '.object.sha')
+    if [[ "$branch_head" == "$base_sha" ]]; then
+        exit 1
+    fi
+    commit_response=$(create_commit "$branch_head" "$bump_file" "$file_contents" "$commit_message")
+fi
+jq -e '.data.createCommitOnBranch.commit.oid | type == "string" and length > 0' <<<"$commit_response" >/dev/null
 
 plain_reason='The release-safety gate found a green upgrade path.'
 if [[ "$selected_green" != "true" ]]; then
@@ -191,19 +267,26 @@ $formatted_json
 This pull request was created by the self-hosted Lightdash upgrade automation. Verification runs after the configured deployment workflow completes.
 EOF
 
-pr_url=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$upgrade_branch" --state open --json url --jq '.[0].url // empty')
-if [[ -z "$pr_url" ]]; then
+pr_json=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$upgrade_branch" --state open --json number,url --jq '.[0] // empty')
+if [[ -z "$pr_json" ]]; then
     pr_url=$(gh pr create \
         --repo "$GITHUB_REPOSITORY" \
         --base "$default_branch" \
         --head "$upgrade_branch" \
         --title "chore: upgrade Lightdash to $mapped_version" \
         --body-file "$body_file")
+    pr_json=$(gh pr view "$pr_url" --repo "$GITHUB_REPOSITORY" --json number,url)
 else
+    pr_url=$(jq -r '.url' <<<"$pr_json")
     gh pr edit "$pr_url" \
         --title "chore: upgrade Lightdash to $mapped_version" \
         --body-file "$body_file"
 fi
+pr_number=$(jq -r '.number' <<<"$pr_json")
+pr_url=$(jq -r '.url' <<<"$pr_json")
+write_output branch "$upgrade_branch"
+write_output pr_number "$pr_number"
+write_output pr_url "$pr_url"
 
 cat >"$summary_file" <<EOF
 ## Upgrade plan summary

--- a/examples/upgrade-automation/template-workflow.yml
+++ b/examples/upgrade-automation/template-workflow.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           token: ${{ secrets.UPGRADE_AUTOMATION_TOKEN || github.token }}
+          persist-credentials: false
       - uses: lightdash/lightdash/examples/upgrade-automation/plan@REPLACE_WITH_LIGHTDASH_COMMIT_SHA
         with:
           bump_target: ${{ env.LIGHTDASH_BUMP_TARGET }}


### PR DESCRIPTION
## What

- Create and reset the upgrade branch through the GitHub REST API, then create the pin commit with the GraphQL `createCommitOnBranch` mutation.
- Emit `branch`, `pr_number`, and `pr_url` outputs from the plan action, with empty values on early exits.
- Document API-authored verified commits, credential-free checkouts, outputs, and required token permissions.

## Why

Runner-authored Git commits were unsigned and could not satisfy required-signature rulesets. The previous Git push also depended on ambient checkout credentials, and consumers had to rediscover the created pull request from refs because the action exposed no outputs.

## Validation

- YAML-parsed the action and template files.
- Ran `bash -n` across the upgrade automation scripts.
- Dry-tested the bump and cross-platform base64 round trip against a scratch multiline YAML file.
- Validated the GraphQL payload shape against the live GitHub schema and a local stub.

Linear: SPK-967