### PR TITLE
fix: enforce catalog scope in table descriptions

### DIFF
--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -12,6 +12,7 @@ import {
     RequestMethod,
     SessionUser,
     UnitOfTime,
+    WarehouseTypes,
 } from '@lightdash/common';
 import { CatalogSearchContext } from '../../../models/CatalogModel/CatalogModel';
 import { AiAgentContentValidation } from '../ai/utils/AiAgentContentValidation';
@@ -97,6 +98,8 @@ const makeService = ({
     featureFlagService = {
         get: vi.fn().mockResolvedValue({ enabled: false }),
     },
+    projectModel = {},
+    projectService = {},
 }: {
     explores?: Record<string, Explore>;
     userAttributes?: Record<string, string[]>;
@@ -115,6 +118,8 @@ const makeService = ({
     aiAgentDocumentModel?: Record<string, unknown>;
     aiDeepResearchRunModel?: Record<string, unknown>;
     featureFlagService?: Record<string, unknown>;
+    projectModel?: Record<string, unknown>;
+    projectService?: Record<string, unknown>;
 } = {}) =>
     new AiAgentToolsService({
         builtInSkills: {
@@ -147,11 +152,13 @@ const makeService = ({
             ),
             getAllByOrganizationUuid: vi.fn().mockResolvedValue([]),
             get: vi.fn(),
+            ...projectModel,
         },
         projectService: {
             searchFieldUniqueValues,
             getSpaces: vi.fn().mockResolvedValue(projectSpaces),
             scheduleCompileProject,
+            ...projectService,
         },
         jobModel,
         userAttributesModel: {
@@ -243,6 +250,149 @@ describe('AiAgentToolsService', () => {
             }),
         ).rejects.toThrow('distinct values across an entire field');
         expect(executeMetricQueryAndGetResults).not.toHaveBeenCalled();
+    });
+
+    describe('describeWarehouseTable scope', () => {
+        it('blocks metadata from an excluded default database', async () => {
+            const getWarehouseFields = vi.fn();
+            const service = makeService({
+                projectModel: {
+                    getWarehouseCredentialsForProject: vi
+                        .fn()
+                        .mockResolvedValue({
+                            type: WarehouseTypes.POSTGRES,
+                            dbname: 'postgres3',
+                            schema: 'jaffle',
+                        }),
+                },
+                projectService: { getWarehouseFields },
+            });
+            const runtime = service.createRuntime(
+                makeRuntimeContext({
+                    sqlScope: {
+                        schemas: [],
+                        deniedCatalogs: ['postgres3'],
+                    },
+                }),
+            );
+
+            await expect(
+                runtime.describeWarehouseTable({
+                    table: 'customer_order_payments',
+                    schema: 'jaffle',
+                }),
+            ).rejects.toThrow(
+                'reads from catalog `postgres3`, which is explicitly excluded',
+            );
+            expect(getWarehouseFields).not.toHaveBeenCalled();
+        });
+
+        it('describes a table in an explicitly allowed database', async () => {
+            const getWarehouseFields = vi.fn().mockResolvedValue({
+                customer_id: DimensionType.STRING,
+            });
+            const service = makeService({
+                projectService: { getWarehouseFields },
+            });
+            const runtime = service.createRuntime(
+                makeRuntimeContext({
+                    sqlScope: {
+                        schemas: ['jaffle'],
+                        catalogs: ['analytics'],
+                    },
+                }),
+            );
+
+            await expect(
+                runtime.describeWarehouseTable({
+                    table: 'orders',
+                    schema: 'jaffle',
+                    database: 'analytics',
+                }),
+            ).resolves.toEqual({
+                columns: [{ name: 'customer_id', type: DimensionType.STRING }],
+                resolvedSchema: 'jaffle',
+                resolvedDatabase: 'analytics',
+            });
+            expect(getWarehouseFields).toHaveBeenCalledWith(
+                user,
+                projectUuid,
+                QueryExecutionContext.AI,
+                'orders',
+                'jaffle',
+                'analytics',
+            );
+        });
+
+        it.each([
+            { label: 'empty', database: '' },
+            { label: 'whitespace-only', database: '   ' },
+        ])(
+            'treats a $label optional database as the default database',
+            async ({ database }) => {
+                const getWarehouseFields = vi.fn().mockResolvedValue({
+                    customer_id: DimensionType.STRING,
+                });
+                const service = makeService({
+                    projectModel: {
+                        getWarehouseCredentialsForProject: vi
+                            .fn()
+                            .mockResolvedValue({
+                                type: WarehouseTypes.POSTGRES,
+                                dbname: 'postgres3',
+                                schema: 'jaffle',
+                            }),
+                    },
+                    projectService: { getWarehouseFields },
+                });
+                const runtime = service.createRuntime(makeRuntimeContext());
+
+                await runtime.describeWarehouseTable({
+                    table: 'orders',
+                    schema: 'jaffle',
+                    database,
+                });
+
+                expect(getWarehouseFields).toHaveBeenCalledWith(
+                    user,
+                    projectUuid,
+                    QueryExecutionContext.AI,
+                    'orders',
+                    'jaffle',
+                    'postgres3',
+                );
+            },
+        );
+
+        it('uses the Databricks catalog and schema defaults', async () => {
+            const getWarehouseFields = vi.fn().mockResolvedValue({
+                customer_id: DimensionType.STRING,
+            });
+            const service = makeService({
+                projectModel: {
+                    getWarehouseCredentialsForProject: vi
+                        .fn()
+                        .mockResolvedValue({
+                            type: WarehouseTypes.DATABRICKS,
+                            catalog: 'main',
+                            database: 'analytics',
+                        }),
+                },
+                projectService: { getWarehouseFields },
+            });
+            const runtime = service.createRuntime(makeRuntimeContext());
+
+            await runtime.describeWarehouseTable({ table: 'orders' });
+
+            expect(getWarehouseFields).toHaveBeenCalledWith(
+                user,
+                projectUuid,
+                QueryExecutionContext.AI,
+                'orders',
+                'analytics',
+                'main',
+            );
+        });
     });
 
     it('extends query result retention when the runtime opts in', async () => {

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -13,6 +13,7 @@ import {
     filterStaticFilterAutocompleteValues,
     findFieldByIdInExplore,
     ForbiddenError,
+    getConnectionDefaults,
     getContentAsCodePathFromLtreePath,
     getErrorMessage,
     getItemMap,
@@ -122,8 +123,9 @@ import { getExploreRequiredFilters } from '../ai/utils/requiredFilters';
 import {
     filterWarehouseCatalogToScope,
     findSqlScopeViolations,
+    findWarehouseTableScopeViolation,
     formatSqlScopeError,
-    isSchemaInScope,
+    formatWarehouseTableScopeError,
 } from '../ai/utils/sqlScope';
 import { PreviewDeploySetupService } from '../PreviewDeploySetupService/PreviewDeploySetupService';
 import type { SchedulerAiAugmentationService } from '../SchedulerAiAugmentationService/SchedulerAiAugmentationService';
@@ -2140,7 +2142,7 @@ export class AiAgentToolsService extends BaseService {
 
     private describeWarehouseTable(
         context: AiAgentToolsRuntimeContext,
-        { table, schema }: Parameters<DescribeWarehouseTableFn>[0],
+        { table, schema, database }: Parameters<DescribeWarehouseTableFn>[0],
     ): ReturnType<DescribeWarehouseTableFn> {
         return wrapSentryTransaction(
             `${AiAgentToolsService.transactionPrefix(context)}.describeWarehouseTable`,
@@ -2148,34 +2150,35 @@ export class AiAgentToolsService extends BaseService {
                 projectUuid: context.projectUuid,
                 table,
                 schema: schema ?? null,
+                database: database ?? null,
             },
             async () => {
-                let resolvedSchema = schema ?? null;
-                if (!resolvedSchema) {
+                let resolvedSchema = schema?.trim() || null;
+                let resolvedDatabase = database?.trim() || null;
+                if (!resolvedSchema || resolvedDatabase === null) {
                     const creds =
                         await this.projectModel.getWarehouseCredentialsForProject(
                             context.projectUuid,
                         );
-                    resolvedSchema = creds
-                        ? ('schema' in creds && creds.schema) ||
-                          ('dataset' in creds && creds.dataset) ||
-                          null
-                        : null;
+                    const defaults = getConnectionDefaults(creds);
+                    resolvedSchema = resolvedSchema ?? defaults.schema ?? null;
+                    resolvedDatabase =
+                        resolvedDatabase ?? defaults.database ?? null;
                 }
-                if (
-                    resolvedSchema &&
-                    !isSchemaInScope(context.sqlScope, resolvedSchema)
-                ) {
+
+                const violation = findWarehouseTableScopeViolation(
+                    context.sqlScope,
+                    {
+                        table,
+                        schema: resolvedSchema,
+                        database: resolvedDatabase,
+                    },
+                );
+                if (violation && context.sqlScope) {
                     throw new ForbiddenError(
-                        formatSqlScopeError(
-                            [
-                                {
-                                    kind: 'schema',
-                                    reference: `${resolvedSchema}.${table}`,
-                                    schema: resolvedSchema,
-                                },
-                            ],
-                            context.sqlScope!,
+                        formatWarehouseTableScopeError(
+                            violation,
+                            context.sqlScope,
                         ),
                     );
                 }
@@ -2186,6 +2189,7 @@ export class AiAgentToolsService extends BaseService {
                     context.defaultQueryExecutionContext,
                     table,
                     resolvedSchema ?? undefined,
+                    resolvedDatabase ?? undefined,
                 );
                 return {
                     columns: Object.entries(fields).map(([name, type]) => ({
@@ -2193,6 +2197,7 @@ export class AiAgentToolsService extends BaseService {
                         type: String(type),
                     })),
                     resolvedSchema,
+                    resolvedDatabase,
                 };
             },
         );

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -22,14 +22,19 @@ Do NOT use:
 
 Parameters:
 - table: Required. The unqualified table name (e.g. "raw_parts", not "jaffle.raw_parts").
-- schema: Optional. The schema name (e.g. "jaffle"). If omitted, the project's default schema is used.
+- schema: Optional. The schema name (e.g. "jaffle"). Omit this property to use the project's default schema.
+- database: Optional. Provide the database/catalog returned by listWarehouseTables when targeting a non-default database. Omission uses the project's default database.
 ",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {
+        "database": {
+          "description": "Database/catalog returned by listWarehouseTables when targeting a non-default database. Omission uses the project's default database.",
+          "type": "string",
+        },
         "schema": {
-          "description": "Optional schema name. Defaults to the project's default schema if omitted.",
+          "description": "Optional schema name. Omit this property to use the project's default schema.",
           "type": "string",
         },
         "table": {

--- a/packages/backend/src/ee/services/ai/tools/describeWarehouseTable.ts
+++ b/packages/backend/src/ee/services/ai/tools/describeWarehouseTable.ts
@@ -14,23 +14,29 @@ export const getDescribeWarehouseTable = ({
 }: Dependencies) =>
     tool({
         ...toolDefinition,
-        execute: async ({ table, schema }) => {
+        execute: async ({ table, schema, database }) => {
             try {
-                const { columns, resolvedSchema } =
-                    await describeWarehouseTable({ table, schema });
+                const { columns, resolvedSchema, resolvedDatabase } =
+                    await describeWarehouseTable({ table, schema, database });
+
+                const qualified = [
+                    resolvedDatabase ?? database,
+                    resolvedSchema ?? schema ?? '(default schema)',
+                    table,
+                ]
+                    .filter(
+                        (part) =>
+                            part !== null && part !== undefined && part !== '',
+                    )
+                    .join('.');
 
                 if (columns.length === 0) {
                     return {
-                        result: `No columns found for \`${
-                            resolvedSchema ?? schema ?? '(default schema)'
-                        }.${table}\`. The table may not exist or may be empty of metadata. Confirm the name via listWarehouseTables or ask the user.`,
+                        result: `No columns found for \`${qualified}\`. The table may not exist or may be empty of metadata. Confirm the name via listWarehouseTables or ask the user.`,
                         metadata: { status: 'not_found' },
                     };
                 }
 
-                const qualified = `${
-                    resolvedSchema ?? schema ?? '(default schema)'
-                }.${table}`;
                 const columnLines = columns
                     .map((c) => `  - ${c.name}: ${c.type}`)
                     .join('\n');

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -502,9 +502,11 @@ export type ListWarehouseTablesFn = () => Promise<WarehouseTablesCatalog>;
 export type DescribeWarehouseTableFn = (args: {
     table: string;
     schema?: string;
+    database?: string;
 }) => Promise<{
     columns: Array<{ name: string; type: string }>;
     resolvedSchema: string | null;
+    resolvedDatabase: string | null;
 }>;
 
 export type ListKnowledgeDocumentsFn = () => Promise<AiAgentDocumentSummary[]>;

--- a/packages/backend/src/ee/services/ai/utils/sqlScope.ts
+++ b/packages/backend/src/ee/services/ai/utils/sqlScope.ts
@@ -108,6 +108,75 @@ export const isSchemaInScope = (
     return allowedSchemas.has(schema.toLowerCase());
 };
 
+export const findWarehouseTableScopeViolation = (
+    scope: SqlScope | null | undefined,
+    {
+        table,
+        schema,
+        database,
+    }: {
+        table: string;
+        schema: string | null;
+        database: string | null;
+    },
+): SqlScopeViolation | null => {
+    if (!scope || !isSqlScopeConfigured(scope)) return null;
+
+    const reference = [database, schema, table]
+        .filter((part): part is string => part !== null && part !== '')
+        .join('.');
+    const normalizedSchema = schema?.toLowerCase();
+    const normalizedDatabase = database?.toLowerCase();
+    const deniedSchemas = lowerSet(scope.deniedSchemas);
+    const deniedCatalogs = lowerSet(scope.deniedCatalogs);
+    const allowedSchemas = lowerSet(scope.schemas);
+    const allowedCatalogs = lowerSet(scope.catalogs);
+
+    if (normalizedSchema && deniedSchemas?.has(normalizedSchema)) {
+        return {
+            kind: 'denied_schema',
+            reference,
+            schema: normalizedSchema,
+        };
+    }
+    if (normalizedDatabase && deniedCatalogs?.has(normalizedDatabase)) {
+        return {
+            kind: 'denied_catalog',
+            reference,
+            catalog: normalizedDatabase,
+        };
+    }
+    if (!normalizedDatabase && allowedCatalogs) {
+        return { kind: 'catalog_unqualified', reference };
+    }
+    if (
+        normalizedDatabase &&
+        allowedCatalogs &&
+        !allowedCatalogs.has(normalizedDatabase)
+    ) {
+        return {
+            kind: 'catalog',
+            reference,
+            catalog: normalizedDatabase,
+        };
+    }
+    if (!normalizedSchema && allowedSchemas) {
+        return { kind: 'unqualified', reference };
+    }
+    if (
+        normalizedSchema &&
+        allowedSchemas &&
+        !allowedSchemas.has(normalizedSchema)
+    ) {
+        return {
+            kind: 'schema',
+            reference,
+            schema: normalizedSchema,
+        };
+    }
+    return null;
+};
+
 /**
  * Removes everything the agent may not read from the warehouse catalog it is
  * shown. Out-of-scope objects must be undiscoverable, not merely unqueryable:
@@ -296,4 +365,26 @@ export const formatSqlScopeError = (
             ? [`Excluded catalogs: ${scope.deniedCatalogs.join(', ')}.`]
             : []),
         'Rewrite the query against an allowed schema. Do NOT retry this query, and do NOT substitute a different table without telling the user — if the data you need is not in an allowed schema, say so plainly.',
+    ].join('\n');
+
+export const formatWarehouseTableScopeError = (
+    violation: SqlScopeViolation,
+    scope: SqlScope,
+): string =>
+    [
+        "This table's metadata is outside this project's allowed data scope.",
+        describeViolation(violation),
+        ...(scope.schemas.length
+            ? [`Allowed schemas: ${scope.schemas.join(', ')}.`]
+            : []),
+        ...(scope.catalogs?.length
+            ? [`Allowed catalogs: ${scope.catalogs.join(', ')}.`]
+            : []),
+        ...(scope.deniedSchemas?.length
+            ? [`Excluded schemas: ${scope.deniedSchemas.join(', ')}.`]
+            : []),
+        ...(scope.deniedCatalogs?.length
+            ? [`Excluded catalogs: ${scope.deniedCatalogs.join(', ')}.`]
+            : []),
+        'Choose a table from listWarehouseTables or tell the user the required table is outside the allowed scope.',
     ].join('\n');

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDescribeWarehouseTableArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDescribeWarehouseTableArgs.ts
@@ -23,7 +23,8 @@ Do NOT use:
 
 Parameters:
 - table: Required. The unqualified table name (e.g. "raw_parts", not "jaffle.raw_parts").
-- schema: Optional. The schema name (e.g. "jaffle"). If omitted, the project's default schema is used.
+- schema: Optional. The schema name (e.g. "jaffle"). Omit this property to use the project's default schema.
+- database: Optional. Provide the database/catalog returned by listWarehouseTables when targeting a non-default database. Omission uses the project's default database.
 `;
 
 export const toolDescribeWarehouseTableArgsSchema = createToolSchema()
@@ -38,7 +39,13 @@ export const toolDescribeWarehouseTableArgsSchema = createToolSchema()
             .string()
             .optional()
             .describe(
-                "Optional schema name. Defaults to the project's default schema if omitted.",
+                "Optional schema name. Omit this property to use the project's default schema.",
+            ),
+        database: z
+            .string()
+            .optional()
+            .describe(
+                "Database/catalog returned by listWarehouseTables when targeting a non-default database. Omission uses the project's default database.",
             ),
     })
     .build();


### PR DESCRIPTION
## Summary

- Add optional catalog/database input to `describeWarehouseTable`.
- Resolve omitted, blank, and whitespace database values through canonical connection defaults.
- Apply agent catalog/schema scope before fetching table metadata.
- Cover PostgreSQL defaults and Databricks schema/catalog mapping with focused regressions.

## Scope

This PR covers structured table metadata lookup. The existing raw-SQL lexical guard still needs a separate fix for two-part references that use a denied default catalog.

## Verification

- Common build and typecheck
- Backend typecheck
- 3 focused test files: 113 tests passed
- Real OpenAI and Anthropic agent runs verified omitted and explicit database inputs
- PostgreSQL E2E verified allowed metadata and denied-catalog discovery/description behavior with DB and Jaeger evidence

Closes: https://linear.app/lightdash/issue/PROD-9479/limit-which-schemas-the-agent-can-query-in-a-warehouse-catalog