### PR TITLE
fix: limit request metadata in application logs

### DIFF
--- a/packages/backend/src/logging/winston.test.ts
+++ b/packages/backend/src/logging/winston.test.ts
@@ -1,7 +1,22 @@
+import {
+    JWT_HEADER_NAME,
+    LightdashAppPreviewTokenHeader,
+    LightdashAppUuidHeader,
+    LightdashBuildHashHeader,
+    LightdashCliVersionHeader,
+    LightdashMode,
+    LightdashRequestMethodHeader,
+    LightdashSdkVersionHeader,
+    LightdashSignedDownloadHeader,
+    LightdashVersionHeader,
+} from '@lightdash/common';
+import type { NextFunction, Request, Response } from 'express';
 import { vi } from 'vitest';
 import { lightdashConfig } from '../config/lightdashConfig';
 import { AuditLogEvent } from './auditLog';
 import {
+    expressWinstonMiddleware,
+    expressWinstonPreResponseMiddleware,
     formatAuditAction,
     formatAuditActor,
     formatAuditMessage,
@@ -9,6 +24,119 @@ import {
     logAuditEvent,
     winstonLogger,
 } from './winston';
+
+describe('request logging', () => {
+    const originalMode = lightdashConfig.mode;
+    const secretValues = [
+        'ApiKey ldpat_secret',
+        'connect.sid=session_secret',
+        'embed_token_secret',
+        'preview_token_secret',
+    ];
+
+    const createRequest = (): Request => {
+        const headers: Request['headers'] = {
+            authorization: secretValues[0],
+            cookie: secretValues[1],
+            [JWT_HEADER_NAME]: secretValues[2],
+            [LightdashAppPreviewTokenHeader.toLowerCase()]: secretValues[3],
+            host: 'lightdash.example.com',
+            'user-agent': 'logging-test',
+            'x-request-id': 'request-id',
+            [LightdashAppUuidHeader.toLowerCase()]: 'app-uuid',
+            [LightdashBuildHashHeader.toLowerCase()]: 'build-hash',
+            [LightdashCliVersionHeader.toLowerCase()]: '1.2.3',
+            [LightdashRequestMethodHeader.toLowerCase()]: 'CLI',
+            [LightdashSdkVersionHeader.toLowerCase()]: '4.5.6',
+            [LightdashSignedDownloadHeader.toLowerCase()]: 'true',
+            [LightdashVersionHeader.toLowerCase()]: '7.8.9',
+        };
+
+        return {
+            method: 'GET',
+            url: '/api/v1/user',
+            headers,
+            header: (name: string) => {
+                const value = headers[name.toLowerCase()];
+                return Array.isArray(value) ? value[0] : value;
+            },
+            session: {},
+        } as unknown as Request;
+    };
+
+    const createResponse = (): Response =>
+        ({
+            statusCode: 200,
+            end: vi.fn(),
+        }) as unknown as Response;
+
+    afterEach(() => {
+        lightdashConfig.mode = originalMode;
+        vi.restoreAllMocks();
+    });
+
+    it('omits headers from pre-response logs', () => {
+        const logSpy = vi
+            .spyOn(winstonLogger, 'log')
+            .mockImplementation(() => winstonLogger);
+        lightdashConfig.mode = LightdashMode.DEFAULT;
+
+        expressWinstonPreResponseMiddleware(
+            createRequest(),
+            createResponse(),
+            vi.fn() as NextFunction,
+        );
+
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                req: {
+                    method: 'GET',
+                    url: '/api/v1/user',
+                },
+            }),
+        );
+        const serializedLog = JSON.stringify(logSpy.mock.calls[0][0]);
+        secretValues.forEach((secret) => {
+            expect(serializedLog).not.toContain(secret);
+        });
+    });
+
+    it('only includes allowlisted headers in completed request logs', () => {
+        const logSpy = vi
+            .spyOn(winstonLogger, 'log')
+            .mockImplementation(() => winstonLogger);
+        const request = createRequest();
+        const response = createResponse();
+
+        expressWinstonMiddleware(request, response, vi.fn() as NextFunction);
+        response.end();
+
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                req: {
+                    method: 'GET',
+                    url: '/api/v1/user',
+                    headers: {
+                        host: 'lightdash.example.com',
+                        'user-agent': 'logging-test',
+                        'x-request-id': 'request-id',
+                        [LightdashAppUuidHeader.toLowerCase()]: 'app-uuid',
+                        [LightdashBuildHashHeader.toLowerCase()]: 'build-hash',
+                        [LightdashCliVersionHeader.toLowerCase()]: '1.2.3',
+                        [LightdashRequestMethodHeader.toLowerCase()]: 'CLI',
+                        [LightdashSdkVersionHeader.toLowerCase()]: '4.5.6',
+                        [LightdashSignedDownloadHeader.toLowerCase()]: 'true',
+                        [LightdashVersionHeader.toLowerCase()]: '7.8.9',
+                    },
+                },
+            }),
+        );
+        const serializedLog = JSON.stringify(logSpy.mock.calls[0][0]);
+        secretValues.forEach((secret) => {
+            expect(serializedLog).not.toContain(secret);
+        });
+    });
+});
 
 describe('formatAuditAction', () => {
     it('converts known actions to past tense', () => {

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -1,8 +1,11 @@
 import {
     LightdashAppUuidHeader,
+    LightdashBuildHashHeader,
+    LightdashCliVersionHeader,
     LightdashMode,
     LightdashRequestMethodHeader,
     LightdashSdkVersionHeader,
+    LightdashSignedDownloadHeader,
     LightdashVersionHeader,
     SessionUser,
 } from '@lightdash/common';
@@ -287,6 +290,31 @@ declare global {
 export const sanitizeRequestUrl = (url: string): string =>
     url.replace(/([?&]downloadToken=)[^&#\s]*/gi, '$1[REDACTED]');
 
+const safeRequestHeaderNames = new Set([
+    'content-length',
+    'content-type',
+    'host',
+    'user-agent',
+    'x-amzn-trace-id',
+    'x-request-id',
+    LightdashAppUuidHeader.toLowerCase(),
+    LightdashBuildHashHeader.toLowerCase(),
+    LightdashCliVersionHeader.toLowerCase(),
+    LightdashRequestMethodHeader.toLowerCase(),
+    LightdashSdkVersionHeader.toLowerCase(),
+    LightdashSignedDownloadHeader.toLowerCase(),
+    LightdashVersionHeader.toLowerCase(),
+]);
+
+const filterRequestHeaders = (
+    headers: express.Request['headers'],
+): express.Request['headers'] =>
+    Object.fromEntries(
+        Object.entries(headers).filter(([name]) =>
+            safeRequestHeaderNames.has(name.toLowerCase()),
+        ),
+    );
+
 export const expressWinstonMiddleware: express.RequestHandler =
     expressWinston.logger({
         winstonInstance: winstonLogger,
@@ -309,15 +337,12 @@ export const expressWinstonMiddleware: express.RequestHandler =
         requestWhitelist: ['url', 'headers', 'method'],
         requestFilter: (req, propertyName) => {
             if (propertyName === 'url') return sanitizeRequestUrl(req.url);
+            if (propertyName === 'headers') {
+                return filterRequestHeaders(req.headers);
+            }
             return (req as unknown as Record<string, unknown>)[propertyName];
         },
         responseWhitelist: ['statusCode'],
-        headerBlacklist: [
-            'cookie',
-            'authorization',
-            'connection',
-            'accept-encoding',
-        ],
     });
 
 // Logs the request before the response is sent
@@ -333,7 +358,6 @@ export const expressWinstonPreResponseMiddleware: express.RequestHandler = (
             req: {
                 method: req.method,
                 url: sanitizeRequestUrl(req.url),
-                headers: req.headers,
             },
             includesResponse: false,
             userUuid: req.user?.userUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: SPK-973

### Description:
This keeps HTTP request logs useful while limiting which request headers are included in structured metadata.

Pre-response records now contain the method and sanitized URL only, while completed records retain a small allowlist of operational and Lightdash app/CLI headers.

Adds regression coverage to keep session and authentication metadata out of both logging paths.

Validated with focused tests, backend typecheck, lint, and formatting.