### PR TITLE
feat(ai): resume Deep Research from checkpoints

### DIFF
--- a/packages/backend/src/ee/controllers/AiDeepResearchController.ts
+++ b/packages/backend/src/ee/controllers/AiDeepResearchController.ts
@@ -65,6 +65,9 @@ export class AiDeepResearchController extends BaseController {
                 aiThreadUuid: body.threadUuid,
                 promptUuid: body.promptUuid,
                 entryPoint: body.entryPoint,
+                ...(body.resumeFromRunUuid
+                    ? { resumeFromRunUuid: body.resumeFromRunUuid }
+                    : {}),
             }),
         };
     }

--- a/packages/backend/src/ee/database/entities/aiDeepResearch.ts
+++ b/packages/backend/src/ee/database/entities/aiDeepResearch.ts
@@ -21,6 +21,8 @@ export type DbAiDeepResearchRun = {
     prompt_uuid: string;
     tool_call_id: string | null;
     prompt: string;
+    /** Terminal run whose evidence should be reused by this resume. */
+    resume_from_run_uuid: string | null;
     status: AiDeepResearchRunStatus;
     /** Why the run reached its terminal status; null while running or on success. */
     terminal_reason: AiDeepResearchTerminalReason | null;
@@ -63,6 +65,7 @@ export type AiDeepResearchRunsTable = Knex.CompositeTableType<
         | 'prompt_uuid'
         | 'tool_call_id'
         | 'prompt'
+        | 'resume_from_run_uuid'
         | 'entry_point'
         | 'budget_snapshot'
         | 'execution_context_snapshot'

--- a/packages/backend/src/ee/database/migrations/20260812130000_add_deep_research_resume_source.ts
+++ b/packages/backend/src/ee/database/migrations/20260812130000_add_deep_research_resume_source.ts
@@ -1,0 +1,20 @@
+import type { Knex } from 'knex';
+
+const tableName = 'ai_deep_research_runs';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(tableName, (table) => {
+        table
+            .uuid('resume_from_run_uuid')
+            .nullable()
+            .references('ai_deep_research_run_uuid')
+            .inTable(tableName)
+            .onDelete('SET NULL');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(tableName, (table) => {
+        table.dropColumn('resume_from_run_uuid');
+    });
+}

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -56,6 +56,7 @@ type CreateAiDeepResearchRun = {
     promptUuid: string;
     toolCallId: string | null;
     prompt: string;
+    resumeFromRunUuid?: string | null;
     entryPoint: AiDeepResearchEntryPoint;
     budget: AiDeepResearchBudget;
     executionContextSnapshot: AiDeepResearchExecutionContextSnapshot;
@@ -280,6 +281,7 @@ export class AiDeepResearchRunModel {
                     prompt_uuid: data.promptUuid,
                     tool_call_id: data.toolCallId,
                     prompt: data.prompt,
+                    resume_from_run_uuid: data.resumeFromRunUuid ?? null,
                     entry_point: data.entryPoint,
                     budget_snapshot: data.budget,
                     execution_context_snapshot: data.executionContextSnapshot,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -443,6 +443,7 @@ type GenerateAgentExecutionOptions =
           canUseRawSql: boolean;
           abortSignal?: AbortSignal;
           initialTokenUsage?: number;
+          resumeContext?: string;
           onStepUsage?: (
               usage: AiDeepResearchStepUsage,
           ) => void | Promise<void>;
@@ -9647,6 +9648,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 // policy. MCP run_sql is filtered from this same capability.
                 canUseRawSql: canRunSql,
                 initialTokenUsage: responseExecution.initialTokenUsage ?? 0,
+                resumeContext: responseExecution.resumeContext,
                 onStepUsage: responseExecution.onStepUsage,
                 onExecutionContextResolved:
                     responseExecution.onExecutionContextResolved,

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -114,6 +114,7 @@ const run = (
     prompt_uuid: 'prompt-1',
     tool_call_id: null,
     prompt: 'Investigate revenue',
+    resume_from_run_uuid: null,
     status: 'running',
     terminal_reason: null,
     entry_point: 'ask_ai',

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -1146,7 +1146,7 @@ describe('AiDeepResearchExecutor', () => {
         });
     });
 
-    it('keeps provider failure when clean-run finalization fails', async () => {
+    it('keeps evidence as a partial result when clean-run finalization fails', async () => {
         const { executor } = buildExecutor({
             generateDeepResearchReport: vi
                 .fn()
@@ -1158,7 +1158,7 @@ describe('AiDeepResearchExecutor', () => {
                 signal: new AbortController().signal,
             }),
         ).resolves.toMatchObject({
-            status: 'failed',
+            status: 'partially_completed',
             terminalReason: 'provider_error',
         });
     });

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
@@ -49,6 +49,21 @@ const SUBMISSION_TOOL_NAMES = new Set([
     AI_DEEP_RESEARCH_WORKER_FINDINGS_TOOL_NAME,
 ]);
 
+const getResumeContext = (pack: AiDeepResearchEvidencePack): string => {
+    const queries = pack.queries.map((query) => {
+        const shape =
+            query.type === 'sql_query'
+                ? `columns: ${query.columns.join(', ')}`
+                : `dimensions: ${query.dimensions.join(', ') || 'none'}; metrics: ${query.metrics.join(', ') || 'none'}`;
+        return `- ${query.title}: ${query.description || 'no description'} (${query.rowCount} rows${query.truncated ? ', truncated' : ''}; ${shape})`;
+    });
+    const findings = pack.workerFindings.map(
+        (finding) =>
+            `- Finding: ${finding.summary} (confidence: ${finding.confidence})`,
+    );
+    return [...queries, ...findings].join('\n').slice(0, 8_000);
+};
+
 type ToolProvenance = {
     toolCall: AiAgentToolCall;
     toolResult: AiAgentToolResult | null;
@@ -579,6 +594,7 @@ export class AiDeepResearchExecutor {
             };
         };
 
+        let resumeContext: string | null = null;
         const runCoordinator = () =>
             this.dependencies.aiAgentService.generateAgentThreadResponse(user, {
                 agentUuid: run.agent_uuid,
@@ -595,6 +611,7 @@ export class AiDeepResearchExecutor {
                             .canRunSql,
                     abortSignal: runSignal,
                     initialTokenUsage: tokens,
+                    resumeContext: resumeContext ?? undefined,
                     onStepUsage: trackUsage,
                     onWarehouseQuery: trackWarehouseQuery,
                     onExecutionContextResolved: (snapshot) =>
@@ -661,6 +678,17 @@ export class AiDeepResearchExecutor {
         };
 
         let executionError: unknown = null;
+        if (run.resume_from_run_uuid) {
+            const sourceRun =
+                await this.dependencies.aiDeepResearchRunModel.findByUuid(
+                    run.resume_from_run_uuid,
+                );
+            if (sourceRun) {
+                const sourceEvidence =
+                    await this.dependencies.buildEvidencePack(sourceRun);
+                resumeContext = getResumeContext(sourceEvidence.evidencePack);
+            }
+        }
         try {
             await runCoordinator();
         } catch (error) {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
@@ -7,6 +7,7 @@ import {
     type AiAgentToolCall,
     type AiAgentToolResult,
     type AiDeepResearchActivity,
+    type AiDeepResearchEvidencePack,
     type AiDeepResearchPhase,
     type AiDeepResearchProgress,
     type AiDeepResearchSubmittedReport,
@@ -115,6 +116,39 @@ ${reason}
 ## Conclusion
 
 - Run Deep Research again to continue investigating: ${run.prompt}`,
+});
+
+const getEvidenceCheckpointReport = (
+    evidencePack: AiDeepResearchEvidencePack,
+    reason: string,
+): AiDeepResearchSubmittedReport => ({
+    markdown: `The investigation produced evidence, but the final report could not be generated.
+
+<warning title="Incomplete investigation">
+
+${reason}
+
+</warning>
+
+## Available evidence
+
+${evidencePack.queries
+    .map(
+        (query) =>
+            `- **${query.title}** — ${query.description} (${query.rowCount} rows${query.truncated ? ', truncated' : ''})`,
+    )
+    .join('\n')}
+
+${evidencePack.workerFindings
+    .map(
+        (finding) =>
+            `- **Finding:** ${finding.summary} (confidence: ${finding.confidence})`,
+    )
+    .join('\n')}
+
+## Conclusion
+
+- The available evidence is preserved. Resume Deep Research to complete the narrative and analysis.`,
 });
 
 const getActivity = (toolName: string): AiDeepResearchActivity => {
@@ -581,11 +615,16 @@ export class AiDeepResearchExecutor {
          * finalization costs the same either way.
          */
         const finalize = async (reason: string) => {
+            let evidencePack: AiDeepResearchEvidencePack | null = null;
             try {
-                const { evidencePack, hasEvidenceBuildFailures } =
+                const evidenceBuild =
                     await this.dependencies.buildEvidencePack(run);
+                evidencePack = evidenceBuild.evidencePack;
                 if (isAiDeepResearchEvidencePackEmpty(evidencePack)) {
-                    if (hadWorkerExecutionFailure || hasEvidenceBuildFailures) {
+                    if (
+                        hadWorkerExecutionFailure ||
+                        evidenceBuild.hasEvidenceBuildFailures
+                    ) {
                         return { outcome: 'failed' } as const;
                     }
                     return { outcome: 'no_relevant_data' } as const;
@@ -605,6 +644,18 @@ export class AiDeepResearchExecutor {
                 Logger.warn(
                     `[AiDeepResearch] Could not finalize run ${run.ai_deep_research_run_uuid}: ${getErrorMessage(error)}`,
                 );
+                if (
+                    evidencePack &&
+                    !isAiDeepResearchEvidencePackEmpty(evidencePack)
+                ) {
+                    return {
+                        outcome: 'checkpointed',
+                        report: getEvidenceCheckpointReport(
+                            evidencePack,
+                            reason,
+                        ),
+                    } as const;
+                }
                 return { outcome: 'failed' } as const;
             }
         };
@@ -629,7 +680,10 @@ export class AiDeepResearchExecutor {
                           : 'the investigation ran to completion',
                   );
         const finalizedReport =
-            finalization?.outcome === 'reported' ? finalization.report : null;
+            finalization?.outcome === 'reported' ||
+            finalization?.outcome === 'checkpointed'
+                ? finalization.report
+                : null;
         await stopRunMonitor();
 
         if (cancelledByUser || signal.aborted) {
@@ -672,6 +726,14 @@ export class AiDeepResearchExecutor {
                     maxWarehouseQueries: 'query_limit' as const,
                     deadlineMs: 'time_limit' as const,
                 }[budgetExceeded],
+            };
+        }
+        if (finalization?.outcome === 'checkpointed') {
+            return {
+                status: 'partially_completed',
+                report: finalization.report,
+                warehouseQueryUuids: queryUuids,
+                terminalReason: 'provider_error',
             };
         }
         if (executionError) {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -1254,9 +1254,7 @@ export class AiDeepResearchService extends BaseService {
                     return null;
                 }
                 try {
-                    const ownerRun = sourceCharts.has(key)
-                        ? sourceRun
-                        : run;
+                    const ownerRun = sourceCharts.has(key) ? sourceRun : run;
                     const entry = await this.buildWarehouseChartData(
                         ownerRun ?? run,
                         candidate.chart,

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -14,6 +14,7 @@ import {
     findDeepResearchChartRefs,
     ForbiddenError,
     getErrorMessage,
+    isAiDeepResearchEvidencePackEmpty,
     isAiDeepResearchRunTerminal,
     isUserWithOrg,
     NotFoundError,
@@ -284,6 +285,7 @@ const toRun = (row: DbAiDeepResearchRun): AiDeepResearchRun => {
         agentUuid: row.agent_uuid,
         aiThreadUuid: row.ai_thread_uuid,
         promptUuid: row.prompt_uuid,
+        resumedFromRunUuid: row.resume_from_run_uuid,
         entryPoint: row.entry_point,
         prompt: row.prompt,
         status: row.status,
@@ -654,6 +656,7 @@ export class AiDeepResearchService extends BaseService {
         aiThreadUuid: string;
         promptUuid: string;
         entryPoint: AiDeepResearchEntryPoint;
+        resumeFromRunUuid?: string;
         toolCallId?: string;
     }): Promise<AiDeepResearchRun> {
         if (!isUserWithOrg(args.user)) {
@@ -716,6 +719,34 @@ export class AiDeepResearchService extends BaseService {
             );
         }
 
+        let resumeFromRunUuid: string | null = null;
+        if (args.resumeFromRunUuid) {
+            const sourceRun = await this.findCreatorOwnedRun(
+                args.user,
+                args.projectUuid,
+                args.resumeFromRunUuid,
+            );
+            if (
+                sourceRun.ai_thread_uuid !== args.aiThreadUuid ||
+                !isAiDeepResearchRunTerminal(sourceRun.status) ||
+                sourceRun.status === 'completed' ||
+                sourceRun.status === 'cancelled'
+            ) {
+                throw new ParameterError(
+                    'Deep Research can only resume an unfinished terminal run',
+                );
+            }
+            const sourceEvidence = await this.buildEvidencePack(sourceRun);
+            if (
+                isAiDeepResearchEvidencePackEmpty(sourceEvidence.evidencePack)
+            ) {
+                throw new ParameterError(
+                    'This Deep Research run has no preserved evidence to resume',
+                );
+            }
+            resumeFromRunUuid = sourceRun.ai_deep_research_run_uuid;
+        }
+
         const existingRun =
             await this.aiDeepResearchRunModel.findByPromptScoped({
                 promptUuid: args.promptUuid,
@@ -773,6 +804,7 @@ export class AiDeepResearchService extends BaseService {
                 toolCallId: args.toolCallId ?? null,
                 prompt: prompt.prompt.trim(),
                 entryPoint: args.entryPoint,
+                ...(resumeFromRunUuid ? { resumeFromRunUuid } : {}),
                 budget,
                 executionContextSnapshot,
             });
@@ -1295,6 +1327,7 @@ export class AiDeepResearchService extends BaseService {
      */
     async buildEvidencePack(
         run: DbAiDeepResearchRun,
+        depth = 0,
     ): Promise<AiDeepResearchEvidenceBuildResult> {
         const provenance =
             await this.aiAgentModel.getToolCallsAndResultsForPrompt(
@@ -1362,20 +1395,38 @@ export class AiDeepResearchService extends BaseService {
             ),
         );
 
-        return {
-            evidencePack: {
-                question: run.prompt,
-                queries: queryResults.flatMap((query) =>
-                    query ? [query] : [],
-                ),
-                workerFindings,
-            },
-            hasEvidenceBuildFailures:
-                hasToolFailures ||
-                workerFindingResults.some((parsed) => !parsed.success) ||
-                executions.length < evidenceQueryCalls.length ||
-                queryResults.some((query) => query === null),
+        const currentPack: AiDeepResearchEvidencePack = {
+            question: run.prompt,
+            queries: queryResults.flatMap((query) => (query ? [query] : [])),
+            workerFindings,
         };
+        let evidencePack = currentPack;
+        let hasEvidenceBuildFailures =
+            hasToolFailures ||
+            workerFindingResults.some((parsed) => !parsed.success) ||
+            executions.length < evidenceQueryCalls.length ||
+            queryResults.some((query) => query === null);
+        if (run.resume_from_run_uuid && depth === 0) {
+            const sourceRun = await this.aiDeepResearchRunModel.findByUuid(
+                run.resume_from_run_uuid,
+            );
+            if (sourceRun) {
+                const source = await this.buildEvidencePack(sourceRun, 1);
+                evidencePack = {
+                    question: run.prompt,
+                    queries: [
+                        ...source.evidencePack.queries,
+                        ...currentPack.queries,
+                    ].slice(-AI_DEEP_RESEARCH_EVIDENCE_MAX_QUERIES),
+                    workerFindings: [
+                        ...source.evidencePack.workerFindings,
+                        ...currentPack.workerFindings,
+                    ],
+                };
+                hasEvidenceBuildFailures ||= source.hasEvidenceBuildFailures;
+            }
+        }
+        return { evidencePack, hasEvidenceBuildFailures };
     }
 
     private async buildEvidenceQuery(

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -1213,7 +1213,32 @@ export class AiDeepResearchService extends BaseService {
         report: AiDeepResearchSubmittedReport,
         runQueryUuids: Set<string>,
     ): Promise<{ markdown: string }> {
-        const derivable = await this.getRunWarehouseCharts(run);
+        const currentCharts = await this.getRunWarehouseCharts(run);
+        // A resumed report may deliberately cite a chart produced by the
+        // source run. Carry that provenance forward and verify it against the
+        // source execution timestamp; otherwise a valid preserved chart would
+        // be dropped simply because its query predates the new run.
+        const sourceRun = run.resume_from_run_uuid
+            ? await this.aiDeepResearchRunModel.findByUuid(
+                  run.resume_from_run_uuid,
+              )
+            : null;
+        const sourceCharts = sourceRun
+            ? await this.getRunWarehouseCharts(sourceRun)
+            : new Map();
+        const derivable = new Map([
+            ...sourceCharts.entries(),
+            ...currentCharts.entries(),
+        ]);
+        const sourceEvidence = sourceRun
+            ? await this.buildEvidencePack(sourceRun, 1)
+            : null;
+        const trustedQueryUuids = new Set([
+            ...runQueryUuids,
+            ...(sourceEvidence?.evidencePack.queries.map(
+                (query) => query.queryUuid,
+            ) ?? []),
+        ]);
         const requestedKeys = [
             ...new Set(
                 findDeepResearchChartRefs(report.markdown).map(
@@ -1229,10 +1254,13 @@ export class AiDeepResearchService extends BaseService {
                     return null;
                 }
                 try {
+                    const ownerRun = sourceCharts.has(key)
+                        ? sourceRun
+                        : run;
                     const entry = await this.buildWarehouseChartData(
-                        run,
+                        ownerRun ?? run,
                         candidate.chart,
-                        runQueryUuids,
+                        trustedQueryUuids,
                     );
                     return entry
                         ? ([

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -1274,6 +1274,9 @@ const getAgentMessages = (
         const budgetInstruction = getDeepResearchBudgetInstruction(
             args.execution.budget,
         );
+        const resumeInstruction = args.execution.resumeContext
+            ? `A previous Deep Research run already completed the evidence below. Continue only unfinished work; do not repeat these successful queries unless you need a genuinely different slice.\n\n${args.execution.resumeContext}`
+            : null;
         const { research } = args.execution;
         switch (research?.role) {
             case 'coordinator':
@@ -1281,14 +1284,20 @@ const getAgentMessages = (
                     AI_DEEP_RESEARCH_INSTRUCTIONS,
                     getAiDeepResearchCoordinatorInstructions(),
                     budgetInstruction,
+                    resumeInstruction,
                 ];
             case 'worker':
                 return [
                     getAiDeepResearchWorkerInstructions(research.task),
                     budgetInstruction,
+                    resumeInstruction,
                 ];
             case undefined:
-                return [AI_DEEP_RESEARCH_INSTRUCTIONS, budgetInstruction];
+                return [
+                    AI_DEEP_RESEARCH_INSTRUCTIONS,
+                    budgetInstruction,
+                    resumeInstruction,
+                ];
             default:
                 return assertUnreachable(research, 'Unknown research role');
         }

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -161,6 +161,7 @@ export type AiAgentExecutionConfig =
           budget: AiDeepResearchBudget;
           canUseRawSql: boolean;
           initialTokenUsage: number;
+          resumeContext?: string;
           onStepUsage?: (
               usage: AiDeepResearchStepUsage,
           ) => void | Promise<void>;

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -194,6 +194,8 @@ export type AiDeepResearchRequestBody = {
     promptUuid: string;
     /** Product surface that accepted the run. */
     entryPoint: AiDeepResearchEntryPoint;
+    /** Resume unfinished work from a terminal run with preserved evidence. */
+    resumeFromRunUuid?: string;
 };
 
 export const AI_DEEP_RESEARCH_CONFIDENCE_LEVELS = [
@@ -336,6 +338,7 @@ export type AiDeepResearchRun = {
     agentUuid: string;
     aiThreadUuid: string;
     promptUuid: string;
+    resumedFromRunUuid: string | null;
     entryPoint: AiDeepResearchEntryPoint;
     prompt: string;
     status: AiDeepResearchRunStatus;

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runAgain.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runAgain.test.ts
@@ -12,10 +12,11 @@ const registration: DeepResearchRunRegistration = {
     question: 'Why did retention change?',
     createdAt: '2026-07-01T00:00:00.000Z',
     state: 'started',
+    resumeFromRunUuid: 'run-1',
 };
 
 describe('runDeepResearchAgain', () => {
-    it('creates a fresh prompt before starting a separate run with the original question', async () => {
+    it('creates a fresh prompt before resuming unfinished work', async () => {
         const createPrompt = vi.fn().mockResolvedValue({ uuid: 'prompt-2' });
         const startRun = vi.fn().mockResolvedValue(undefined);
 
@@ -29,6 +30,7 @@ describe('runDeepResearchAgain', () => {
         expect(startRun).toHaveBeenCalledWith({
             question: registration.question,
             promptUuid: 'prompt-2',
+            resumeFromRunUuid: registration.runUuid,
         });
         expect(createPrompt.mock.invocationCallOrder[0]).toBeLessThan(
             startRun.mock.invocationCallOrder[0],

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runAgain.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runAgain.ts
@@ -20,5 +20,8 @@ export const runDeepResearchAgain = async ({
     await startRun({
         question: registration.question,
         promptUuid,
+        ...(registration.resumeFromRunUuid
+            ? { resumeFromRunUuid: registration.resumeFromRunUuid }
+            : {}),
     });
 };

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
@@ -112,6 +112,10 @@ export const toDeepResearchRegistration = (
     agentUuid: run.agentUuid,
     threadUuid: args.threadUuid,
     promptUuid: run.promptUuid,
+    resumeFromRunUuid:
+        run.status === 'partially_completed' || run.status === 'failed'
+            ? run.aiDeepResearchRunUuid
+            : undefined,
     userUuid: args.userUuid,
     question: run.prompt,
     createdAt: run.createdAt,

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
@@ -58,6 +58,7 @@ export type DeepResearchRunRegistration = {
     agentUuid: string;
     threadUuid: string;
     promptUuid: string;
+    resumeFromRunUuid?: string;
     userUuid: string;
     question: string;
     createdAt: string;
@@ -67,4 +68,5 @@ export type DeepResearchRunRegistration = {
 
 export type StartDeepResearchArgs = {
     question: string;
+    resumeFromRunUuid?: string;
 };

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -194,6 +194,7 @@ const useStartDeepResearchMutationBase = <
                 threadUuid,
                 promptUuid: variables.promptUuid,
                 entryPoint,
+                resumeFromRunUuid: variables.resumeFromRunUuid,
             });
         },
         onSuccess: (run, variables, context) => {


### PR DESCRIPTION
## Summary

PR 2 of 5 for [PROD-10038](https://linear.app/lightdash/issue/PROD-10038). Adds durable evidence checkpoints and a resume path that continues unfinished Deep Research without rerunning successful work.

Stacks on top of [#27244](https://github.com/lightdash/lightdash/pull/27244), which adds transient MCP recovery.

Closes: https://linear.app/lightdash/issue/PROD-10038

## Changes

**Migration**

- Adds `ai_deep_research_runs.resume_from_run_uuid`, a self-reference with `ON DELETE SET NULL`.

**Backend**

- Persists the source run for a resume.
- Rebuilds bounded query and finding evidence from stored provenance.
- Injects completed evidence into the coordinator context.
- Rejects resume requests with no usable evidence.

**Frontend**

- Carries the resume source through run registration and retry.
- Offers resume for partial or failed runs while keeping completed runs as start-over.

## Resume flow

```
partial/failed run → preserved evidence → resume unfinished work → new report
                                      └─ successful queries are not rerun
```

## Test plan

- [x] Common and backend typechecks.
- [x] Backend service/executor/controller regression tests.
- [x] Frontend resume wiring tests and typecheck.
- [x] Source-run chart/query provenance verified in the finalization path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)