### PR TITLE
fix: fail upgrade verification loudly when the PR lookup fails

### DIFF
--- a/.github/workflows/upgrade-automation-tests.yml
+++ b/.github/workflows/upgrade-automation-tests.yml
@@ -1,0 +1,17 @@
+name: Upgrade automation tests
+
+on:
+  pull_request:
+    paths:
+      - 'examples/upgrade-automation/**'
+      - '.github/workflows/upgrade-automation-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  verify-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - run: bash examples/upgrade-automation/scripts/verify.test.sh

--- a/examples/upgrade-automation/README.md
+++ b/examples/upgrade-automation/README.md
@@ -55,6 +55,8 @@ The schedule, manual dispatch, and release dispatch run the planning half. A fre
 
 The deployment workflow runs when the pin pull request merges into the default branch. Its completed `workflow_run` event starts verification and supplies the actual deploy-run URL and deployed SHA. Verification identifies the matching merged pin pull request in the deployed commit history, so batched pushes are covered; a pin pull request with an existing verification summary and unrelated deployments exit silently. A failed deployment workflow is itself a verification failure and creates the freeze issue without waiting for readiness polling.
 
+Verification has three outcomes: a matching merged upgrade pull request runs the full readiness and version check, no matching pull request logs a successful no-op, and any pull-request lookup failure fails the job without skipping verification.
+
 `/api/v1/readyz` certifies the schema gate and clean migration run ledger without the per-request database work performed by `/api/v1/health`. The probe does not expose a version, so the action separately reads the public `Lightdash-Version` header from the instance root. A missing or ingress-stripped header fails closed. Old pods can return 404 for `readyz`; polling continues until the new pods answer or the verification budget expires.
 
 The current CLI includes a required stop equal to the target in `requiredStops`, making that hop exit non-zero even when its underlying verdict is true. The plan action accepts only that narrow stop-target case: the verdict must be true, coverage complete, the minimum previous version satisfied, and the target must be the sole required stop. False and unknown verdicts are never treated as green.

--- a/examples/upgrade-automation/scripts/verify.sh
+++ b/examples/upgrade-automation/scripts/verify.sh
@@ -15,14 +15,14 @@ require_value github_token "${GH_TOKEN:-}"
 
 pinned_mapped=$(read_bump_value)
 pinned_public=$(public_version "$pinned_mapped" "${TAG_SUFFIX:-}")
-if ! default_branch=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch')
-if ! VERIFY_COMMENT_AUTHOR=$(gh api user --jq '.login' 2>/dev/null); then
-    VERIFY_COMMENT_AUTHOR='github-actions[bot]'
-fi
-export VERIFY_COMMENT_AUTHOR; then
+if ! default_branch=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch'); then
     echo "Unable to determine the default branch for upgrade verification." >&2
     exit 1
 fi
+if ! VERIFY_COMMENT_AUTHOR=$(gh api user --jq '.login' 2>/dev/null); then
+    VERIFY_COMMENT_AUTHOR='github-actions[bot]'
+fi
+export VERIFY_COMMENT_AUTHOR
 if ! merged_upgrade_prs=$(gh api \
     --paginate \
     "repos/$GITHUB_REPOSITORY/pulls?state=closed&base=$default_branch&per_page=100" \

--- a/examples/upgrade-automation/scripts/verify.sh
+++ b/examples/upgrade-automation/scripts/verify.sh
@@ -46,7 +46,7 @@ if [[ -n "$merged_upgrade_prs" ]]; then
         if [[ "$(jq -r '.toVersion' <<<"$candidate_verdict")" != "$pinned_public" ]]; then
             continue
         fi
-        if ! existing_successful_verification=$(gh pr view "$candidate_number" --repo "$GITHUB_REPOSITORY" --json comments --jq '[.comments[] | select(.author.login == "github-actions[bot]") | .body | select(startswith("## Upgrade verification summary") and contains("Outcome: **success**"))] | any'); then
+        if ! existing_successful_verification=$(gh pr view "$candidate_number" --repo "$GITHUB_REPOSITORY" --json comments --jq "[.comments[] | select(.author.login == \"github-actions[bot]\") | .body | select(startswith(\"## Upgrade verification summary\") and contains(\"Outcome: **success**\") and contains(\"$DEPLOY_RUN_URL\"))] | any"); then
             echo "Unable to inspect verification comments on merged upgrade pull request #$candidate_number." >&2
             exit 1
         fi

--- a/examples/upgrade-automation/scripts/verify.sh
+++ b/examples/upgrade-automation/scripts/verify.sh
@@ -142,9 +142,8 @@ cat >"$summary_file" <<EOF
 $(jq . <<<"$verdict_json")
 \`\`\`
 EOF
-gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body-file "$summary_file"
-
 if [[ "$verified" == "true" ]]; then
+    gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body-file "$summary_file"
     exit 0
 fi
 
@@ -169,5 +168,8 @@ if [[ -z "$existing_issue" ]]; then
     existing_issue=$(gh issue create --repo "$GITHUB_REPOSITORY" --title "$issue_title" --label "$FREEZE_LABEL" --body-file "$issue_body")
 fi
 
-post_slack "[upgrade-verify-failed] $from_version -> $pinned_public | reason: $last_reason | deploy: $DEPLOY_RUN_URL | freeze: $existing_issue"
+gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body-file "$summary_file" \
+    || echo "warning: failed to post the verification summary comment" >&2
+post_slack "[upgrade-verify-failed] $from_version -> $pinned_public | reason: $last_reason | deploy: $DEPLOY_RUN_URL | freeze: $existing_issue" \
+    || echo "warning: failed to post the Slack escalation" >&2
 exit 1

--- a/examples/upgrade-automation/scripts/verify.sh
+++ b/examples/upgrade-automation/scripts/verify.sh
@@ -15,7 +15,11 @@ require_value github_token "${GH_TOKEN:-}"
 
 pinned_mapped=$(read_bump_value)
 pinned_public=$(public_version "$pinned_mapped" "${TAG_SUFFIX:-}")
-if ! default_branch=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch'); then
+if ! default_branch=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch')
+if ! VERIFY_COMMENT_AUTHOR=$(gh api user --jq '.login' 2>/dev/null); then
+    VERIFY_COMMENT_AUTHOR='github-actions[bot]'
+fi
+export VERIFY_COMMENT_AUTHOR; then
     echo "Unable to determine the default branch for upgrade verification." >&2
     exit 1
 fi
@@ -46,7 +50,7 @@ if [[ -n "$merged_upgrade_prs" ]]; then
         if [[ "$(jq -r '.toVersion' <<<"$candidate_verdict")" != "$pinned_public" ]]; then
             continue
         fi
-        if ! existing_successful_verification=$(gh pr view "$candidate_number" --repo "$GITHUB_REPOSITORY" --json comments --jq "[.comments[] | select(.author.login == \"github-actions[bot]\") | .body | select(startswith(\"## Upgrade verification summary\") and contains(\"Outcome: **success**\") and contains(\"$DEPLOY_RUN_URL\"))] | any"); then
+        if ! existing_successful_verification=$(gh pr view "$candidate_number" --repo "$GITHUB_REPOSITORY" --json comments --jq '[.comments[] | select(.author.login == $ENV.VERIFY_COMMENT_AUTHOR) | .body | select(startswith("## Upgrade verification summary") and contains("Outcome: **success**") and contains($ENV.DEPLOY_RUN_URL))] | any'); then
             echo "Unable to inspect verification comments on merged upgrade pull request #$candidate_number." >&2
             exit 1
         fi

--- a/examples/upgrade-automation/scripts/verify.sh
+++ b/examples/upgrade-automation/scripts/verify.sh
@@ -50,7 +50,7 @@ if [[ -n "$merged_upgrade_prs" ]]; then
             echo "Unable to inspect verification comments on merged upgrade pull request #$candidate_number." >&2
             exit 1
         fi
-        if [[ "$existing_successful_verification" == "true" ]]; then
+        if [[ "$existing_successful_verification" == "true" && "$DEPLOY_CONCLUSION" == "success" ]]; then
             exit 0
         fi
         pr_number=$candidate_number
@@ -69,6 +69,10 @@ if [[ -z "$pr_number" ]]; then
 fi
 
 from_version=$(jq -r '.fromVersion' <<<"$verdict_json")
+if ! [[ "$from_version" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]*$ ]]; then
+    echo "The merged upgrade pull request carries an invalid fromVersion." >&2
+    exit 1
+fi
 window_seconds=$(parse_duration "$VERIFY_WINDOW")
 started_at=$(date +%s)
 deadline=$((started_at + window_seconds))

--- a/examples/upgrade-automation/scripts/verify.sh
+++ b/examples/upgrade-automation/scripts/verify.sh
@@ -15,41 +15,56 @@ require_value github_token "${GH_TOKEN:-}"
 
 pinned_mapped=$(read_bump_value)
 pinned_public=$(public_version "$pinned_mapped" "${TAG_SUFFIX:-}")
-default_branch=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch')
-mapfile -t merged_upgrade_prs < <(
-    gh api \
-        --paginate \
-        --slurp \
-        "repos/$GITHUB_REPOSITORY/pulls?state=closed&base=$default_branch&per_page=100" \
-        --jq '.[] | .[] | select(.merged_at != null and ((.head.ref // "") | startswith("lightdash-upgrade-"))) | [.number, (.merge_commit_sha // "")] | @tsv'
-)
+if ! default_branch=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch'); then
+    echo "Unable to determine the default branch for upgrade verification." >&2
+    exit 1
+fi
+if ! merged_upgrade_prs=$(gh api \
+    --paginate \
+    "repos/$GITHUB_REPOSITORY/pulls?state=closed&base=$default_branch&per_page=100" \
+    --jq '.[] | select(.merged_at != null and ((.head.ref // "") | startswith("lightdash-upgrade-"))) | [.number, (.merge_commit_sha // "")] | @tsv'); then
+    echo "Unable to list merged upgrade pull requests; refusing to skip verification." >&2
+    exit 1
+fi
 
 pr_number=
 pr_url=
 verdict_json=
-for merged_upgrade_pr in "${merged_upgrade_prs[@]}"; do
-    IFS=$'\t' read -r candidate_number candidate_merge_sha <<<"$merged_upgrade_pr"
-    if [[ -z "$candidate_merge_sha" ]] || ! git merge-base --is-ancestor "$candidate_merge_sha" "$DEPLOYED_SHA"; then
-        continue
-    fi
-    candidate_body=$(gh pr view "$candidate_number" --repo "$GITHUB_REPOSITORY" --json body --jq '.body')
-    candidate_verdict=$(awk '/^```json$/ { capture=1; next } /^```$/ && capture { exit } capture' <<<"$candidate_body")
-    if ! printf '%s' "$candidate_verdict" | validate_verdict_json; then
-        continue
-    fi
-    if [[ "$(jq -r '.toVersion' <<<"$candidate_verdict")" != "$pinned_public" ]]; then
-        continue
-    fi
-    if gh pr view "$candidate_number" --repo "$GITHUB_REPOSITORY" --json comments --jq '[.comments[] | select(.author.login == "github-actions[bot]") | .body | select(startswith("## Upgrade verification summary") and contains("Outcome: **success**"))] | any' | grep -qx true; then
-        exit 0
-    fi
-    pr_number=$candidate_number
-    pr_url=$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json url --jq '.url')
-    verdict_json=$candidate_verdict
-    break
-done
+if [[ -n "$merged_upgrade_prs" ]]; then
+    while IFS=$'\t' read -r candidate_number candidate_merge_sha; do
+        if [[ -z "$candidate_merge_sha" ]] || ! git merge-base --is-ancestor "$candidate_merge_sha" "$DEPLOYED_SHA"; then
+            continue
+        fi
+        if ! candidate_body=$(gh pr view "$candidate_number" --repo "$GITHUB_REPOSITORY" --json body --jq '.body'); then
+            echo "Unable to read merged upgrade pull request #$candidate_number." >&2
+            exit 1
+        fi
+        candidate_verdict=$(awk '/^```json$/ { capture=1; next } /^```$/ && capture { exit } capture' <<<"$candidate_body")
+        if ! printf '%s' "$candidate_verdict" | validate_verdict_json; then
+            continue
+        fi
+        if [[ "$(jq -r '.toVersion' <<<"$candidate_verdict")" != "$pinned_public" ]]; then
+            continue
+        fi
+        if ! existing_successful_verification=$(gh pr view "$candidate_number" --repo "$GITHUB_REPOSITORY" --json comments --jq '[.comments[] | select(.author.login == "github-actions[bot]") | .body | select(startswith("## Upgrade verification summary") and contains("Outcome: **success**"))] | any'); then
+            echo "Unable to inspect verification comments on merged upgrade pull request #$candidate_number." >&2
+            exit 1
+        fi
+        if [[ "$existing_successful_verification" == "true" ]]; then
+            exit 0
+        fi
+        pr_number=$candidate_number
+        if ! pr_url=$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json url --jq '.url'); then
+            echo "Unable to read the URL for merged upgrade pull request #$pr_number." >&2
+            exit 1
+        fi
+        verdict_json=$candidate_verdict
+        break
+    done <<<"$merged_upgrade_prs"
+fi
 
 if [[ -z "$pr_number" ]]; then
+    echo "No merged upgrade pull request matches this deployment; skipping verification."
     exit 0
 fi
 
@@ -146,7 +161,10 @@ The automated verification for \`$from_version\` → \`$pinned_public\` failed a
 Close this issue only after the deployment is healthy and the running version matches the pin.
 EOF
 
-existing_issue=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "$FREEZE_LABEL" --search "\"$issue_title\" in:title" --json url --jq '.[0].url // empty')
+if ! existing_issue=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "$FREEZE_LABEL" --search "\"$issue_title\" in:title" --json url --jq '.[0].url // empty'); then
+    echo "Unable to inspect existing upgrade freeze issues." >&2
+    exit 1
+fi
 if [[ -z "$existing_issue" ]]; then
     existing_issue=$(gh issue create --repo "$GITHUB_REPOSITORY" --title "$issue_title" --label "$FREEZE_LABEL" --body-file "$issue_body")
 fi

--- a/examples/upgrade-automation/scripts/verify.sh
+++ b/examples/upgrade-automation/scripts/verify.sh
@@ -36,8 +36,17 @@ pr_url=
 verdict_json=
 if [[ -n "$merged_upgrade_prs" ]]; then
     while IFS=$'\t' read -r candidate_number candidate_merge_sha; do
-        if [[ -z "$candidate_merge_sha" ]] || ! git merge-base --is-ancestor "$candidate_merge_sha" "$DEPLOYED_SHA"; then
+        if [[ -z "$candidate_merge_sha" ]]; then
             continue
+        fi
+        ancestry_rc=0
+        git merge-base --is-ancestor "$candidate_merge_sha" "$DEPLOYED_SHA" 2>/dev/null || ancestry_rc=$?
+        if [[ "$ancestry_rc" -eq 1 ]]; then
+            continue
+        fi
+        if [[ "$ancestry_rc" -gt 1 ]]; then
+            echo "Unable to check ancestry for $candidate_merge_sha; the checkout may be too shallow. Use fetch-depth: 0 for verification." >&2
+            exit 1
         fi
         if ! candidate_body=$(gh pr view "$candidate_number" --repo "$GITHUB_REPOSITORY" --json body --jq '.body'); then
             echo "Unable to read merged upgrade pull request #$candidate_number." >&2

--- a/examples/upgrade-automation/scripts/verify.test.sh
+++ b/examples/upgrade-automation/scripts/verify.test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/../../.." && pwd)
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+mkdir -p "$test_dir/bin"
+
+printf 'image:\n  tag: 1.2.3\n' >"$test_dir/values.yml"
+cat >"$test_dir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$*" == *'repos/example/upgrade-test --jq .default_branch'* ]]; then
+    printf 'main\n'
+    exit 0
+fi
+
+if [[ "$*" == *'repos/example/upgrade-test/pulls?'* ]]; then
+    printf 'simulated pull-request lookup failure\n' >&2
+    exit 1
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$test_dir/bin/gh"
+
+cd "$test_dir"
+
+set +e
+output=$(PATH="$test_dir/bin:$PATH" \
+    GITHUB_REPOSITORY=example/upgrade-test \
+    INSTANCE_URL=https://example.test \
+    BUMP_TARGET=values.yml#image.tag \
+    VERIFY_WINDOW=1s \
+    FREEZE_LABEL=upgrade-freeze \
+    DEPLOY_RUN_URL=https://example.test/run/1 \
+    DEPLOY_CONCLUSION=success \
+    DEPLOYED_SHA=0000000000000000000000000000000000000000 \
+    GH_TOKEN=test-token \
+    "$root/examples/upgrade-automation/scripts/verify.sh" 2>&1)
+status=$?
+set -e
+
+if [[ $status -eq 0 ]]; then
+    printf 'expected a failed pull-request lookup to fail verification\n' >&2
+    exit 1
+fi
+
+if [[ "$output" != *'Unable to list merged upgrade pull requests; refusing to skip verification.'* ]]; then
+    printf 'expected a clear lookup failure, got:\n%s\n' "$output" >&2
+    exit 1
+fi
+
+printf 'verify lookup failure test passed\n'


### PR DESCRIPTION
## What

- capture merged upgrade pull-request lookups with explicit failure handling
- remove the incompatible gh api --slurp and --jq combination
- add CI coverage for a failed lookup

## Why

A failed pull-request lookup could previously be treated as an empty result, allowing verification to exit successfully without checking the deployment.

Linear: SPK-974