### PR TITLE
docs: document self-hosted CVE monitoring

### DIFF
--- a/.github/docs/security-advisory-runbook.md
+++ b/.github/docs/security-advisory-runbook.md
@@ -1,0 +1,87 @@
+# Security advisory runbook
+
+Use this checklist for every Lightdash vulnerability disclosure and every
+material correction to a published advisory.
+
+## Prepare the fix and advisory
+
+- Create a private GitHub repository security advisory and request the CVE
+  while the advisory is still private.
+- Develop and verify the fix without disclosing the vulnerability in public
+  issues, pull requests, commit messages, or release notes.
+- Calculate the CVSS severity and add the relevant CWE identifiers.
+- Identify the last vulnerable version and first patched version. Use GitHub's
+  supported version-range syntax and verify both boundary versions.
+- Add a workaround when one exists. State explicitly when no workaround is
+  available.
+
+Use these affected-product identifiers consistently:
+
+| Product | Ecosystem | Package name |
+| --- | --- | --- |
+| Lightdash server and official container image | Other | `lightdash/lightdash` |
+| Lightdash CLI | npm | `@lightdash/cli` |
+
+Do not use the unscoped npm package `lightdash`; it is unrelated to this
+project.
+
+The advisory must contain all of the following before publication:
+
+- GHSA identifier and reserved CVE identifier;
+- summary, impact, CVSS severity, and CWE identifiers;
+- affected range and first patched version;
+- workaround or an explicit statement that none is available;
+- fixed GitHub release URL;
+- fixed Docker tag and immutable image digest for server vulnerabilities; and
+- clear upgrade or remediation instructions.
+
+## Publish in order
+
+Complete these steps in one coordinated release window:
+
+1. Publish the patched GitHub release and versioned Docker image.
+2. Verify the release, Docker tag, and image digest are publicly retrievable.
+3. Publish the GitHub Security Advisory/CVE.
+4. Verify the public API returns the correct advisory metadata.
+
+Useful release checks:
+
+```bash
+version=0.0.0
+
+gh release view "$version" --repo lightdash/lightdash
+docker buildx imagetools inspect "lightdash/lightdash:$version"
+```
+
+Record the immutable Docker digest from `imagetools inspect` in the advisory.
+Do not treat the mutable `latest` tag as evidence that the fixed artifact is
+available.
+
+## Verify publication
+
+The public endpoint must work without authentication:
+
+```bash
+ghsa_id=GHSA-xxxx-xxxx-xxxx
+
+curl --fail-with-body --silent --show-error \
+  --header 'Accept: application/vnd.github+json' \
+  --header 'X-GitHub-Api-Version: 2026-03-10' \
+  'https://api.github.com/repos/lightdash/lightdash/security-advisories?state=published&sort=updated&direction=desc&per_page=100' |
+  jq --arg ghsa_id "$ghsa_id" '.[] | select(.ghsa_id == $ghsa_id)'
+```
+
+Check that the result includes the CVE, severity, `html_url`, affected product,
+affected range, patched version, `published_at`, `updated_at`, and a null
+`withdrawn_at`. Save the response `ETag` and confirm a request using
+`If-None-Match` returns HTTP `304`.
+
+Test the version boundaries with the same SemVer library used by the consuming
+monitor:
+
+- the last vulnerable version matches the affected range;
+- the first patched version does not match;
+- an advisory without a fixed version remains active;
+- a newer `updated_at` value or changed normalized content hash produces a new
+  notification; and
+- a non-null `withdrawn_at` resolves or annotates the notification.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,15 +1,111 @@
 # Security Policy
 
-## Supported Versions
+## Supported versions
 
-The following versions are currently receiving security updates
+Security fixes are delivered in the latest stable Lightdash release unless a
+published advisory explicitly identifies a supported backport. There is no LTS
+release line.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.4.x   | :white_check_mark: |
+## Reporting a vulnerability
 
-## Reporting a Vulnerability
+Please report suspected vulnerabilities privately to security@lightdash.com.
+Do not open a public issue.
 
-Please report any vulnerabilities to security@lightdash.com
+Include the affected component and version, impact, reproduction steps, and any
+known mitigations. We will acknowledge the report, investigate it, and
+coordinate disclosure with the reporter. Vulnerabilities classified as high
+(CVE) or above will be remedied within 7 days.
 
-Vulnerabilities classified as high (CVE) or above will be remedied within 7 days.
+## Published advisories
+
+[GitHub Security Advisories](https://github.com/lightdash/lightdash/security/advisories)
+are the canonical source for published Lightdash vulnerabilities. Each advisory
+identifies affected versions, the first patched version, severity, mitigation,
+and upgrade information.
+
+Self-hosted operators should not rely on Docker Hub or Docker Scout for
+notification. Container scanners can provide useful supplemental findings, but
+pulling an image does not subscribe an operator to security updates and running
+containers do not update automatically.
+
+### Machine-readable monitoring
+
+DevOps teams can opt in by polling GitHub's public repository-advisories API:
+
+```text
+GET https://api.github.com/repos/lightdash/lightdash/security-advisories?state=published&sort=updated&direction=desc&per_page=100
+Accept: application/vnd.github+json
+X-GitHub-Api-Version: 2026-03-10
+```
+
+The endpoint is publicly readable without authentication. Poll at most every
+six hours, follow the `Link` response header when it is present, and cache the
+response with `ETag` and `If-None-Match`:
+
+```bash
+advisories_url='https://api.github.com/repos/lightdash/lightdash/security-advisories?state=published&sort=updated&direction=desc&per_page=100'
+etag_value="$(cat lightdash-advisories.etag 2>/dev/null || true)"
+
+http_code="$(curl --fail-with-body --silent --show-error \
+  --dump-header lightdash-advisories.headers \
+  --output lightdash-advisories.json.new \
+  --write-out '%{http_code}' \
+  --header 'Accept: application/vnd.github+json' \
+  --header 'X-GitHub-Api-Version: 2026-03-10' \
+  --header "If-None-Match: $etag_value" \
+  "$advisories_url")"
+
+if [[ "$http_code" == 200 ]]; then
+  mv lightdash-advisories.json.new lightdash-advisories.json
+  awk 'tolower($1) == "etag:" { sub(/^[^:]+:[[:space:]]*/, ""); sub(/\r$/, ""); print; exit }' \
+    lightdash-advisories.headers > lightdash-advisories.etag
+elif [[ "$http_code" == 304 ]]; then
+  rm -f lightdash-advisories.json.new
+else
+  exit 1
+fi
+```
+
+Production integrations should keep the last observed `ghsa_id`, `updated_at`,
+and a hash of the normalized advisory record and:
+
+- alert when an advisory is new, its `updated_at` value changes, or its content
+  hash changes;
+- close or annotate the alert when `withdrawn_at` becomes non-null;
+- evaluate every entry in `vulnerabilities` that describes the deployed
+  Lightdash product;
+- compare the installed version with `vulnerable_version_range` using a SemVer
+  library rather than string comparison;
+- treat a missing `patched_versions` value as affected until the advisory says
+  otherwise; and
+- link responders to `html_url`, which is the canonical human-readable
+  advisory.
+
+The content hash is required because GitHub can update affected-product
+metadata without advancing `updated_at`.
+
+An unauthenticated instance reports its running version at
+`GET /api/v1/health` in `results.version`:
+
+```bash
+curl --fail --silent https://lightdash.example.com/api/v1/health |
+  jq --raw-output '.results.version'
+```
+
+Operators that pin `lightdash/lightdash:<version>` may instead obtain the
+version from their deployment manifest. Always pull and redeploy the patched
+version; moving the Docker Hub `latest` tag does not replace a running
+container.
+
+See the
+[repository security advisory API documentation](https://docs.github.com/en/rest/security-advisories/repository-advisories)
+and the
+[Lightdash update guide](https://docs.lightdash.com/self-host/update-lightdash)
+for more information.
+
+## Maintainer disclosure process
+
+Maintainers publishing or correcting an advisory must follow the
+[security advisory runbook](.github/docs/security-advisory-runbook.md), which
+defines the required metadata, release ordering, Docker-image verification,
+and post-publication checks.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates: SPK-904

### Description:

Documents GitHub repository security advisories as the canonical machine-readable CVE feed for self-hosted operators, including six-hour polling, pagination, ETag caching, deployed-version detection, and alert handling.
Adds a maintainer runbook covering advisory metadata, product identifiers, coordinated release ordering, Docker artifact verification, and post-publication validation.
Replaces the stale supported-version table with the latest-stable security-fix policy and clarifies that Docker Hub and Docker Scout are supplemental rather than notification or automatic-update channels.
Validated with `git diff --check`, live unauthenticated API and conditional-request checks, advisory version boundaries, GitHub releases, and Docker image digests.
