### PR TITLE
feat(ai): measure Deep Research reliability

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2190,6 +2190,16 @@ export type AiDeepResearchRunCompletedEvent = BaseTrack & {
     userId: string;
     properties: AiDeepResearchRunDimensions & {
         status: AiDeepResearchTerminalStatus;
+        /**
+         * Stable cohorting field for reliability reporting. A partial run is
+         * useful only when it produced a report; otherwise it is an empty
+         * failure from the user's perspective.
+         */
+        completionClass:
+            | 'strict_success'
+            | 'useful_partial'
+            | 'empty_failure'
+            | 'cancelled';
         terminalReason: AiDeepResearchTerminalReason | null;
         durationMs: number | null;
         inputTokens: number | null;
@@ -2204,6 +2214,7 @@ export type AiDeepResearchRunCompletedEvent = BaseTrack & {
         warehouseQueryCount: number | null;
         findingsCount: number | null;
         hasReport: boolean;
+        reportOutcome: 'report' | 'empty';
         chartCount: number | null;
     };
 };

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2227,6 +2227,10 @@ export type AiDeepResearchRunCompletedEvent = BaseTrack & {
             | 'provider'
             | 'data'
             | 'internal';
+        warehouseLimitPreventedCount: number | null;
+        warehouseLimitRetryCount: number | null;
+        warehouseLimitRecoveredCount: number | null;
+        warehouseLimitUnrecoveredCount: number | null;
     };
 };
 

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2216,6 +2216,17 @@ export type AiDeepResearchRunCompletedEvent = BaseTrack & {
         hasReport: boolean;
         reportOutcome: 'report' | 'empty';
         chartCount: number | null;
+        reportStructureValid: boolean;
+        reportEvidenceGrounded: boolean;
+        reportReproducible: boolean;
+        reportQualityClass: 'strong' | 'partial' | 'none';
+        failureCategory:
+            | 'none'
+            | 'user'
+            | 'budget'
+            | 'provider'
+            | 'data'
+            | 'internal';
     };
 };
 

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -234,7 +234,10 @@ export class AiDeepResearchRunModel {
             .filter(({ tool_name: toolName }) =>
                 isDeepResearchWarehouseTool(toolName),
             )
-            .sort((left, right) => left.created_at.getTime() - right.created_at.getTime());
+            .sort(
+                (left, right) =>
+                    left.created_at.getTime() - right.created_at.getTime(),
+            );
         const resultsByCallId = new Map(
             toolResults.map((result) => [result.tool_call_id, result]),
         );
@@ -265,7 +268,10 @@ export class AiDeepResearchRunModel {
         const warehouseLimitRecoveredCount = warehouseFailures.filter(
             ({ created_at: failureCreatedAt }) =>
                 warehouseCalls.some(
-                    ({ tool_call_id: laterCallId, created_at: laterCreatedAt }) =>
+                    ({
+                        tool_call_id: laterCallId,
+                        created_at: laterCreatedAt,
+                    }) =>
                         laterCreatedAt > failureCreatedAt &&
                         !isWarehouseFailure(laterCallId),
                 ),
@@ -275,8 +281,9 @@ export class AiDeepResearchRunModel {
             tool_call_count: attemptedToolCallIds.size,
             tool_error_count: toolErrorIds.size,
             warehouse_query_count: new Set(
-                warehouseCalls
-                    .map(({ tool_call_id: toolCallId }) => toolCallId),
+                warehouseCalls.map(
+                    ({ tool_call_id: toolCallId }) => toolCallId,
+                ),
             ).size,
             warehouse_limit_prevented_count: warehouseLimitPreventedCount,
             warehouse_limit_retry_count: warehouseLimitRetryCount,

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -1309,6 +1309,16 @@ describe('AiDeepResearchService', () => {
                     aiDeepResearchRunUuid: 'run-1',
                 });
 
+                let completionClass:
+                    | 'useful_partial'
+                    | 'cancelled'
+                    | 'empty_failure' = 'empty_failure';
+                if (status === 'partially_completed') {
+                    completionClass = 'useful_partial';
+                } else if (status === 'cancelled') {
+                    completionClass = 'cancelled';
+                }
+
                 expect(analytics.track).toHaveBeenCalledExactlyOnceWith(
                     expect.objectContaining({
                         messageId: `analytics-${status}`,
@@ -1317,6 +1327,11 @@ describe('AiDeepResearchService', () => {
                             status,
                             terminalReason,
                             durationMs: 5_000,
+                            completionClass,
+                            reportOutcome:
+                                status === 'partially_completed'
+                                    ? 'report'
+                                    : 'empty',
                         }),
                     }),
                 );

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -79,6 +79,18 @@ const STALE_RUN_ERROR_MESSAGE =
     'Deep Research stopped unexpectedly before it could finish.';
 const FAILED_RUN_ERROR_MESSAGE =
     'Deep Research could not finish. Please try again.';
+
+const getCompletionClass = (
+    status: DbAiDeepResearchRun['status'],
+    hasReport: boolean,
+): 'strict_success' | 'useful_partial' | 'empty_failure' | 'cancelled' => {
+    if (status === 'completed') return 'strict_success';
+    if (status === 'partially_completed' && hasReport) {
+        return 'useful_partial';
+    }
+    if (status === 'cancelled') return 'cancelled';
+    return 'empty_failure';
+};
 export const AI_DEEP_RESEARCH_NO_RELEVANT_DATA_ERROR_MESSAGE =
     'Deep Research could not find relevant data for this question.';
 const isToolResultFailure = (toolResult: AiAgentToolResult | null): boolean => {
@@ -525,6 +537,10 @@ export class AiDeepResearchService extends BaseService {
             properties: {
                 ...this.getAnalyticsDimensions(args.run),
                 status: args.run.status,
+                completionClass: getCompletionClass(
+                    args.run.status,
+                    args.run.result_markdown !== null,
+                ),
                 terminalReason: args.event.terminal_reason,
                 durationMs: args.run.duration_ms,
                 inputTokens: args.run.input_tokens,
@@ -539,6 +555,8 @@ export class AiDeepResearchService extends BaseService {
                 warehouseQueryCount: args.run.warehouse_query_count,
                 findingsCount: args.run.findings_count,
                 hasReport: args.run.result_markdown !== null,
+                reportOutcome:
+                    args.run.result_markdown !== null ? 'report' : 'empty',
                 chartCount: args.run.chart_count,
             },
         });

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -602,6 +602,13 @@ export class AiDeepResearchService extends BaseService {
                 reportReproducible: reportQuality.reproducible,
                 reportQualityClass: reportQuality.qualityClass,
                 failureCategory: getFailureCategory(args.event.terminal_reason),
+                warehouseLimitPreventedCount:
+                    args.run.warehouse_limit_prevented_count,
+                warehouseLimitRetryCount: args.run.warehouse_limit_retry_count,
+                warehouseLimitRecoveredCount:
+                    args.run.warehouse_limit_recovered_count,
+                warehouseLimitUnrecoveredCount:
+                    args.run.warehouse_limit_unrecovered_count,
             },
         });
         return true;

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -100,15 +100,20 @@ const getReportQuality = (run: DbAiDeepResearchRun) => {
         : false;
     const evidenceGrounded = hasReport && (run.findings_count ?? 0) > 0;
     const reproducible = hasReport && (run.warehouse_query_count ?? 0) > 0;
+    let qualityClass: 'none' | 'strong' | 'partial';
+    if (!hasReport) {
+        qualityClass = 'none';
+    } else if (structureValid && evidenceGrounded && reproducible) {
+        qualityClass = 'strong';
+    } else {
+        qualityClass = 'partial';
+    }
+
     return {
         structureValid,
         evidenceGrounded,
         reproducible,
-        qualityClass: !hasReport
-            ? ('none' as const)
-            : structureValid && evidenceGrounded && reproducible
-              ? ('strong' as const)
-              : ('partial' as const),
+        qualityClass,
     };
 };
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -17,6 +17,7 @@ import {
     isAiDeepResearchEvidencePackEmpty,
     isAiDeepResearchRunTerminal,
     isUserWithOrg,
+    lintDeepResearchReport,
     NotFoundError,
     ParameterError,
     QueryExecutionContext,
@@ -90,6 +91,43 @@ const getCompletionClass = (
     }
     if (status === 'cancelled') return 'cancelled';
     return 'empty_failure';
+};
+
+const getReportQuality = (run: DbAiDeepResearchRun) => {
+    const hasReport = run.result_markdown !== null;
+    const structureValid = hasReport
+        ? lintDeepResearchReport(run.result_markdown ?? '').length === 0
+        : false;
+    const evidenceGrounded = hasReport && (run.findings_count ?? 0) > 0;
+    const reproducible = hasReport && (run.warehouse_query_count ?? 0) > 0;
+    return {
+        structureValid,
+        evidenceGrounded,
+        reproducible,
+        qualityClass: !hasReport
+            ? ('none' as const)
+            : structureValid && evidenceGrounded && reproducible
+              ? ('strong' as const)
+              : ('partial' as const),
+    };
+};
+
+const getFailureCategory = (
+    reason: AiDeepResearchTerminalReason | null,
+): 'none' | 'user' | 'budget' | 'provider' | 'data' | 'internal' => {
+    if (reason === null) return 'none';
+    if (reason === 'user_cancellation') return 'user';
+    if (reason === 'provider_error') return 'provider';
+    if (reason === 'no_relevant_data') return 'data';
+    if (
+        reason === 'tool_limit' ||
+        reason === 'query_limit' ||
+        reason === 'token_limit' ||
+        reason === 'time_limit'
+    ) {
+        return 'budget';
+    }
+    return 'internal';
 };
 export const AI_DEEP_RESEARCH_NO_RELEVANT_DATA_ERROR_MESSAGE =
     'Deep Research could not find relevant data for this question.';
@@ -530,6 +568,7 @@ export class AiDeepResearchService extends BaseService {
         if (!isAiDeepResearchRunTerminal(args.run.status)) {
             return false;
         }
+        const reportQuality = getReportQuality(args.run);
         this.analytics.track({
             messageId: args.event.ai_deep_research_analytics_event_uuid,
             event: 'ai_deep_research.run_completed',
@@ -558,6 +597,11 @@ export class AiDeepResearchService extends BaseService {
                 reportOutcome:
                     args.run.result_markdown !== null ? 'report' : 'empty',
                 chartCount: args.run.chart_count,
+                reportStructureValid: reportQuality.structureValid,
+                reportEvidenceGrounded: reportQuality.evidenceGrounded,
+                reportReproducible: reportQuality.reproducible,
+                reportQualityClass: reportQuality.qualityClass,
+                failureCategory: getFailureCategory(args.event.terminal_reason),
             },
         });
         return true;


### PR DESCRIPTION
## Summary

PR 5 of 5 for [PROD-10040](https://linear.app/lightdash/issue/PROD-10040). Adds per-run reliability and report-quality signals so process completion can be measured separately from useful output.

Stacks on top of [#27258](https://github.com/lightdash/lightdash/pull/27258), which adds warehouse safeguards and recovery counts.

Closes: https://linear.app/lightdash/issue/PROD-10040

## Changes

**Backend**

- Classifies strict success, useful partial, empty failure, and cancellation.
- Records failure category and warehouse-limit prevented/retried/recovered/unrecovered counts.
- Records automated report structure, evidence-grounding, reproducibility, and quality-class signals.
- Keeps metrics bounded to enums, booleans, and numbers. Report text is not added to analytics payloads.

## Measurement flow

```
terminal run → outcome classification → reliability dimensions
             └→ report validation → quality dimensions → cohort/regression queries
```

## Live smoke result

A local Deep Research run completed strictly in 157.6 seconds with 15 warehouse queries, 0 tool errors, 5 findings, and 5 charts. Its event stream was queued → running → completed with no report adjustment event.

## Test plan

- [x] Common, backend, and frontend typechecks.
- [x] Backend analytics regression tests.
- [x] Model regression suite: 20 passed.
- [x] Focused report and warehouse tests pass.
- [x] Linear ticket includes cohort query guidance and the sampled human-review protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)