### PR TITLE
feat: show applied parameter values in AI agent chart details

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationParameters.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationParameters.module.css
@@ -1,4 +1,4 @@
-.parameterButton {
+.parameterBadge {
     @mixin light {
         color: var(--mantine-color-ldGray-8);
         background-color: var(--mantine-color-background-0);
@@ -9,14 +9,7 @@
         background-color: var(--mantine-color-ldDark-8);
         border: 1px solid var(--mantine-color-ldDark-7);
     }
-    cursor: default;
-    pointer-events: none;
-}
-
-.parameterButton:active {
-    transform: none;
-}
-
-.parameterButtonLabel {
+    height: auto;
+    padding-block: 4px;
     max-width: 100%;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationParameters.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationParameters.module.css
@@ -1,0 +1,22 @@
+.parameterButton {
+    @mixin light {
+        color: var(--mantine-color-ldGray-8);
+        background-color: var(--mantine-color-background-0);
+        border: 1px solid var(--mantine-color-ldGray-3);
+    }
+    @mixin dark {
+        color: var(--mantine-color-ldDark-3);
+        background-color: var(--mantine-color-ldDark-8);
+        border: 1px solid var(--mantine-color-ldDark-7);
+    }
+    cursor: default;
+    pointer-events: none;
+}
+
+.parameterButton:active {
+    transform: none;
+}
+
+.parameterButtonLabel {
+    max-width: 100%;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationParameters.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationParameters.tsx
@@ -1,0 +1,49 @@
+import { friendlyName, type ParametersValuesMap } from '@lightdash/common';
+import { Button, Flex, Text } from '@mantine/core';
+import { type FC } from 'react';
+import classes from './AgentVisualizationParameters.module.css';
+
+const formatParameterValue = (value: ParametersValuesMap[string]): string =>
+    Array.isArray(value) ? value.join(', ') : String(value);
+
+// Parameter names may be model-scoped ("events.event_status") — label by the
+// final segment, the same way fields drop their table prefix.
+const parameterLabel = (name: string): string =>
+    friendlyName(name.split('.').pop() ?? name);
+
+type Props = {
+    parameterValues: ParametersValuesMap;
+};
+
+const AgentVisualizationParameters: FC<Props> = ({ parameterValues }) => {
+    const entries = Object.entries(parameterValues);
+    if (entries.length === 0) return null;
+
+    return (
+        <Flex gap={4} wrap="wrap" align="center">
+            {entries.map(([name, value]) => (
+                <Button
+                    key={name}
+                    size="xs"
+                    variant="default"
+                    className={classes.parameterButton}
+                    classNames={{ label: classes.parameterButtonLabel }}
+                >
+                    <Text fz="xs" truncate>
+                        <Text fw={600} span fz="xs">
+                            {parameterLabel(name)}
+                        </Text>{' '}
+                        <Text span c="dimmed" fz="xs">
+                            is
+                        </Text>{' '}
+                        <Text fw={700} span fz="xs">
+                            {formatParameterValue(value)}
+                        </Text>
+                    </Text>
+                </Button>
+            ))}
+        </Flex>
+    );
+};
+
+export default AgentVisualizationParameters;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationParameters.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationParameters.tsx
@@ -1,5 +1,5 @@
 import { friendlyName, type ParametersValuesMap } from '@lightdash/common';
-import { Button, Flex, Text } from '@mantine/core';
+import { Badge, Flex, Text } from '@mantine/core';
 import { type FC } from 'react';
 import classes from './AgentVisualizationParameters.module.css';
 
@@ -22,12 +22,13 @@ const AgentVisualizationParameters: FC<Props> = ({ parameterValues }) => {
     return (
         <Flex gap={4} wrap="wrap" align="center">
             {entries.map(([name, value]) => (
-                <Button
+                <Badge
                     key={name}
-                    size="xs"
                     variant="default"
-                    className={classes.parameterButton}
-                    classNames={{ label: classes.parameterButtonLabel }}
+                    radius="sm"
+                    tt="none"
+                    fw={400}
+                    className={classes.parameterBadge}
                 >
                     <Text fz="xs" truncate>
                         <Text fw={600} span fz="xs">
@@ -40,7 +41,7 @@ const AgentVisualizationParameters: FC<Props> = ({ parameterValues }) => {
                             {formatParameterValue(value)}
                         </Text>
                     </Text>
-                </Button>
+                </Badge>
             ))}
         </Flex>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.test.tsx
@@ -203,3 +203,44 @@ describe('AiVisualizationRenderer interaction mode', () => {
         expect(screen.getByTestId('drill-down-modal')).toBeVisible();
     });
 });
+
+describe('AiVisualizationRenderer parameters', () => {
+    const renderWithParameters = (
+        query: Partial<ApiAiAgentThreadMessageVizQuery['query']>,
+    ) =>
+        renderWithProviders(
+            <AiVisualizationRenderer
+                vizQueryData={{
+                    ...vizQueryData,
+                    query: { ...vizQueryData.query, ...query },
+                }}
+                results={results}
+                chartConfig={chartConfig}
+                selectedChartType="line"
+                displayFields={false}
+                displayFilters={false}
+                loadExplore
+            />,
+        );
+
+    it('shows the parameter values the query ran with', () => {
+        renderWithParameters({
+            parameterReferences: ['events.event_status'],
+            usedParametersValues: { 'events.event_status': 'song_played' },
+        });
+
+        expect(screen.getByText('Parameters 1')).toBeVisible();
+        expect(screen.getByText('Event status')).toBeInTheDocument();
+        expect(screen.getByText('song_played')).toBeInTheDocument();
+    });
+
+    it('hides unreferenced project-wide parameter values', () => {
+        renderWithParameters({
+            parameterReferences: [],
+            usedParametersValues: { unrelated_default: 'x' },
+        });
+
+        expect(screen.queryByText(/Parameters/)).toBeNull();
+        expect(screen.queryByText('x')).toBeNull();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -48,6 +48,7 @@ import { isEmbedAiAgentRoute } from '../../hooks/aiAgentRouting';
 import { AgentVisualizationChartTypeSwitcher } from './AgentVisualizationChartTypeSwitcher';
 import AgentVisualizationFilters from './AgentVisualizationFilters';
 import AgentVisualizationMetricsAndDimensions from './AgentVisualizationMetricsAndDimensions';
+import AgentVisualizationParameters from './AgentVisualizationParameters';
 import {
     getVisualizationFieldsCount,
     getVisualizationFiltersCount,
@@ -188,7 +189,23 @@ export const AiVisualizationRenderer: FC<Props> = ({
     const filtersCount = displayFilters
         ? getVisualizationFiltersCount(metricQuery.filters)
         : 0;
-    const displayDetails = fieldsCount > 0 || filtersCount > 0;
+    // Only parameters the query actually references — usedParametersValues
+    // also carries unrelated project-wide defaults.
+    const usedParameters = useMemo(() => {
+        const references = vizQueryData.query.parameterReferences ?? [];
+        if (references.length === 0) return {};
+        return Object.fromEntries(
+            Object.entries(
+                vizQueryData.query.usedParametersValues ?? {},
+            ).filter(([name]) => references.includes(name)),
+        );
+    }, [
+        vizQueryData.query.parameterReferences,
+        vizQueryData.query.usedParametersValues,
+    ]);
+    const parametersCount = Object.keys(usedParameters).length;
+    const displayDetails =
+        fieldsCount > 0 || filtersCount > 0 || parametersCount > 0;
 
     const defaultChartType: AiAgentChartTypeOption =
         webAiChartConfig.type === AiResultType.QUERY_RESULT
@@ -357,6 +374,9 @@ export const AiVisualizationRenderer: FC<Props> = ({
                                         filtersCount > 0
                                             ? `Filters ${filtersCount}`
                                             : null,
+                                        parametersCount > 0
+                                            ? `Parameters ${parametersCount}`
+                                            : null,
                                     ]
                                         .filter(Boolean)
                                         .join(' · ')}
@@ -376,6 +396,12 @@ export const AiVisualizationRenderer: FC<Props> = ({
                                             <AgentVisualizationFilters
                                                 filters={metricQuery.filters}
                                                 fieldsMap={fields}
+                                            />
+                                        ) : null}
+
+                                        {parametersCount > 0 ? (
+                                            <AgentVisualizationParameters
+                                                parameterValues={usedParameters}
                                             />
                                         ) : null}
                                     </ErrorBoundary>


### PR DESCRIPTION
Agents now set Lightdash parameter values on their queries (#27190), but the thread UI didn't show which values a chart ran with — the person reading the thread couldn't tell whether numbers came from an explicitly set parameter or a default. The chart's expandable details now list the applied parameter values as pills next to fields and filters.

Follows up #24203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)