### PR TITLE
fix(slack): prevent large workspace sync timeouts

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.test.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.test.ts
@@ -124,7 +124,7 @@ describe('SlackClient.postMessage invalid_blocks retry', () => {
 });
 
 describe('SlackClient.fetchAllChannelsForCache', () => {
-    it('does not spend more than six seconds pacing a two-page workspace sync', async () => {
+    it('does not spend more than twenty seconds pacing a two-page workspace sync', async () => {
         vi.useFakeTimers();
         try {
             const client = new SlackClient({
@@ -157,7 +157,7 @@ describe('SlackClient.fetchAllChannelsForCache', () => {
             const resultPromise = client.fetchAllChannelsForCache('org-uuid');
             const result = resultPromise.then(() => true);
 
-            await vi.advanceTimersByTimeAsync(6_001);
+            await vi.advanceTimersByTimeAsync(20_001);
 
             await expect(result).resolves.toBe(true);
             await expect(resultPromise).resolves.toHaveLength(2);

--- a/packages/backend/src/clients/Slack/SlackClient.test.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.test.ts
@@ -122,3 +122,47 @@ describe('SlackClient.postMessage invalid_blocks retry', () => {
         expect(postMessageMock).toHaveBeenCalledTimes(2);
     });
 });
+
+describe('SlackClient.fetchAllChannelsForCache', () => {
+    it('does not spend more than six seconds pacing a two-page workspace sync', async () => {
+        vi.useFakeTimers();
+        try {
+            const client = new SlackClient({
+                slackAuthenticationModel: {},
+                slackChannelCacheModel: {},
+                lightdashConfig: { slack: {} },
+                analytics: {},
+                schedulerClient: {},
+            } as unknown as ConstructorParameters<typeof SlackClient>[0]);
+            const conversationsListMock = vi
+                .fn()
+                .mockResolvedValueOnce({
+                    channels: [{ id: 'C1', name: 'first' }],
+                    response_metadata: { next_cursor: 'next-page' },
+                })
+                .mockResolvedValueOnce({
+                    channels: [{ id: 'C2', name: 'second' }],
+                    response_metadata: { next_cursor: '' },
+                });
+            const usersListMock = vi.fn().mockResolvedValue({
+                members: [],
+                response_metadata: { next_cursor: '' },
+            });
+
+            vi.spyOn(client, 'getWebClient').mockResolvedValue({
+                conversations: { list: conversationsListMock },
+                users: { list: usersListMock },
+            } as unknown as WebClient);
+
+            const resultPromise = client.fetchAllChannelsForCache('org-uuid');
+            const result = resultPromise.then(() => true);
+
+            await vi.advanceTimersByTimeAsync(6_001);
+
+            await expect(result).resolves.toBe(true);
+            await expect(resultPromise).resolves.toHaveLength(2);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/packages/backend/src/clients/Slack/SlackClient.test.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.test.ts
@@ -124,7 +124,7 @@ describe('SlackClient.postMessage invalid_blocks retry', () => {
 });
 
 describe('SlackClient.fetchAllChannelsForCache', () => {
-    it('does not spend more than twenty seconds pacing a two-page workspace sync', async () => {
+    it('does not spend more than ten seconds pacing a two-page workspace sync', async () => {
         vi.useFakeTimers();
         try {
             const client = new SlackClient({
@@ -157,7 +157,7 @@ describe('SlackClient.fetchAllChannelsForCache', () => {
             const resultPromise = client.fetchAllChannelsForCache('org-uuid');
             const result = resultPromise.then(() => true);
 
-            await vi.advanceTimersByTimeAsync(20_001);
+            await vi.advanceTimersByTimeAsync(10_001);
 
             await expect(result).resolves.toBe(true);
             await expect(resultPromise).resolves.toHaveLength(2);

--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -90,10 +90,10 @@ const SYNC_POLL_INTERVAL_MS = 1000; // 1 second
 // Tier 2 allows at least 20 requests/minute. Use the documented minimum while
 // leaving the retry path below to handle workspace-specific rate limits.
 const TIER_2_REQUESTS_PER_MIN = 20;
-const RATE_LIMIT_USAGE_PERCENT = 1;
+const RATE_LIMIT_USAGE_PERCENT = 0.3;
 const THROTTLE_MIN_DELAY_MS = Math.ceil(
     60000 / (TIER_2_REQUESTS_PER_MIN * RATE_LIMIT_USAGE_PERCENT),
-); // 3000ms = 3 seconds between requests
+); // 10000ms = 10 seconds between requests
 
 /**
  * Creates a throttled executor for Slack API calls.

--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -87,8 +87,8 @@ const INITIAL_SYNC_TIMEOUT_MS = 60000; // 60 seconds
 const SYNC_POLL_INTERVAL_MS = 1000; // 1 second
 
 // Slack Tier 2 rate limit throttling configuration
-// Tier 2 allows at least 20 requests/minute. Use the documented minimum while
-// leaving the retry path below to handle workspace-specific rate limits.
+// Tier 2 allows at least 20 requests/minute. Use 60% of that documented minimum
+// to balance sync throughput with headroom for workspace-specific rate limits.
 const TIER_2_REQUESTS_PER_MIN = 20;
 const RATE_LIMIT_USAGE_PERCENT = 0.6;
 const THROTTLE_MIN_DELAY_MS = Math.ceil(
@@ -97,7 +97,7 @@ const THROTTLE_MIN_DELAY_MS = Math.ceil(
 
 /**
  * Creates a throttled executor for Slack API calls.
- * Uses lodash throttle pattern to proactively stay within 20% of Tier 2 rate limits.
+ * Uses lodash throttle pattern to proactively stay within 60% of Tier 2 rate limits.
  * This prevents rate limit errors instead of reacting to them.
  * Includes a simple retry as safety net for unexpected rate limits (e.g., from other integrations).
  */

--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -87,12 +87,13 @@ const INITIAL_SYNC_TIMEOUT_MS = 60000; // 60 seconds
 const SYNC_POLL_INTERVAL_MS = 1000; // 1 second
 
 // Slack Tier 2 rate limit throttling configuration
-// Tier 2 allows 20+ requests/minute - we use only 20% to be a good API citizen
+// Tier 2 allows at least 20 requests/minute. Use the documented minimum while
+// leaving the retry path below to handle workspace-specific rate limits.
 const TIER_2_REQUESTS_PER_MIN = 20;
-const RATE_LIMIT_USAGE_PERCENT = 0.2; // Use only 20% of the rate limit
+const RATE_LIMIT_USAGE_PERCENT = 1;
 const THROTTLE_MIN_DELAY_MS = Math.ceil(
     60000 / (TIER_2_REQUESTS_PER_MIN * RATE_LIMIT_USAGE_PERCENT),
-); // 15000ms = 15 seconds between requests
+); // 3000ms = 3 seconds between requests
 
 /**
  * Creates a throttled executor for Slack API calls.
@@ -123,7 +124,7 @@ const createThrottledSlackExecutor = () => {
         if (lastCallTime > 0 && timeSinceLastCall < THROTTLE_MIN_DELAY_MS) {
             const waitTime = THROTTLE_MIN_DELAY_MS - timeSinceLastCall;
             Logger.debug(
-                `Throttling ${context}: waiting ${waitTime}ms to stay within 20% of Tier 2 rate limit`,
+                `Throttling ${context}: waiting ${waitTime}ms to stay within the Tier 2 rate limit`,
             );
             // eslint-disable-next-line no-await-in-loop
             await sleep(waitTime);

--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -90,10 +90,10 @@ const SYNC_POLL_INTERVAL_MS = 1000; // 1 second
 // Tier 2 allows at least 20 requests/minute. Use the documented minimum while
 // leaving the retry path below to handle workspace-specific rate limits.
 const TIER_2_REQUESTS_PER_MIN = 20;
-const RATE_LIMIT_USAGE_PERCENT = 0.3;
+const RATE_LIMIT_USAGE_PERCENT = 0.6;
 const THROTTLE_MIN_DELAY_MS = Math.ceil(
     60000 / (TIER_2_REQUESTS_PER_MIN * RATE_LIMIT_USAGE_PERCENT),
-); // 10000ms = 10 seconds between requests
+); // 5000ms = 5 seconds between requests
 
 /**
  * Creates a throttled executor for Slack API calls.


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-10046/integrations-background-slack-channeluser-sync-job-times-out-for-large

## Summary

Large Slack workspaces can cause the background channel and user cache sync to exceed the scheduler timeout. The sync still enumerates all Slack data visible to the installation, but avoids unnecessary pacing that made large workspaces fail.

## Root cause

The sync paginates `conversations.list` and `users.list`, then applies a 15-second delay before every request after the first. That rate is only 20% of Slack's documented Tier 2 minimum and can turn a large workspace sync into a 10+ minute job.

```ts
const RATE_LIMIT_USAGE_PERCENT = 0.2;
```

Slack documents both APIs as Tier 2 and recommends cursor-paginated pages of no more than 200 results: [conversations.list](https://api.slack.com/methods/conversations.list), [users.list](https://api.slack.com/methods/users.list).

## Fix

The sync now spaces requests by 5 seconds, staying at about 12 requests per minute—below Slack's documented minimum of 20 while leaving meaningful headroom. The existing `Retry-After` handling remains responsible for workspace-specific rate limits.

```text
Before: Slack page -> 15s -> Slack page -> 15s -> Slack page
After:  Slack page ->  5s -> Slack page ->  5s -> Slack page
```

- `packages/backend/src/clients/Slack/SlackClient.ts` — use a 5-second cadence.
- `packages/backend/src/clients/Slack/SlackClient.test.ts` — add paginated sync regression coverage.
- Intentionally out of scope: changing the all-visible-channels product behavior or scheduler timeout.

## Test plan

- [x] `pnpm -F backend exec vitest run --config vitest.config.ts src/clients/Slack/SlackClient.test.ts` — 5 tests pass.
- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint -- src/clients/Slack/SlackClient.ts src/clients/Slack/SlackClient.test.ts`
- [x] Local `ld1` API health check returned HTTP 200 after restarting API and scheduler.
- [ ] Manual large-workspace Slack sync — unavailable locally because no authorized Slack test installation is configured.

## Verification note

The regression test fails with the previous 15-second pacing and passes with the new 5-second cadence. Live production-scale Slack verification remains outstanding.