### PR TITLE
fix(ai): repair invalid Deep Research reports

### DIFF
--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -13,6 +13,7 @@ import {
     type AiDeepResearchEventType,
     type AiDeepResearchExecutionContextSnapshot,
     type AiDeepResearchProgress,
+    type AiDeepResearchReportAdjustment,
     type AiDeepResearchRunStatus,
     type AiDeepResearchTerminalReason,
 } from '@lightdash/common';
@@ -644,6 +645,7 @@ export class AiDeepResearchRunModel {
         status: 'completed' | 'partially_completed',
         resultMarkdown: string,
         terminalReason: AiDeepResearchTerminalReason | null,
+        adjustments?: AiDeepResearchReportAdjustment,
     ): Promise<boolean> {
         return this.database.transaction(async (transaction) => {
             const currentRun = await transaction<AiDeepResearchRunsTable>(
@@ -696,6 +698,18 @@ export class AiDeepResearchRunModel {
                 'status_changed',
                 { status },
             );
+            if (
+                adjustments &&
+                (adjustments.repaired.length > 0 ||
+                    adjustments.dropped.length > 0)
+            ) {
+                await AiDeepResearchRunModel.insertEvent(
+                    transaction,
+                    aiDeepResearchRunUuid,
+                    'report_adjusted',
+                    adjustments,
+                );
+            }
             await AiDeepResearchRunModel.insertAnalyticsEvent(
                 transaction,
                 aiDeepResearchRunUuid,
@@ -709,12 +723,14 @@ export class AiDeepResearchRunModel {
     async markCompleted(
         aiDeepResearchRunUuid: string,
         resultMarkdown: string,
+        adjustments?: AiDeepResearchReportAdjustment,
     ): Promise<boolean> {
         return this.markWithReport(
             aiDeepResearchRunUuid,
             'completed',
             resultMarkdown,
             null,
+            adjustments,
         );
     }
 
@@ -722,12 +738,14 @@ export class AiDeepResearchRunModel {
         aiDeepResearchRunUuid: string,
         resultMarkdown: string,
         terminalReason: AiDeepResearchTerminalReason,
+        adjustments?: AiDeepResearchReportAdjustment,
     ): Promise<boolean> {
         return this.markWithReport(
             aiDeepResearchRunUuid,
             'partially_completed',
             resultMarkdown,
             terminalReason,
+            adjustments,
         );
     }
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -1517,10 +1517,18 @@ describe('AiDeepResearchService', () => {
             expect(model.markCompleted).toHaveBeenCalledWith(
                 'run-1',
                 expect.not.stringContaining(chart.queryUuid),
+                {
+                    repaired: [],
+                    dropped: [{ key: chart.queryUuid, reason: 'unverifiable' }],
+                },
             );
             expect(model.markCompleted).toHaveBeenCalledWith(
                 'run-1',
                 expect.stringContaining('The baseline trend is stable.'),
+                {
+                    repaired: [],
+                    dropped: [{ key: chart.queryUuid, reason: 'unverifiable' }],
+                },
             );
         });
 
@@ -1547,10 +1555,18 @@ describe('AiDeepResearchService', () => {
             expect(model.markCompleted).toHaveBeenCalledWith(
                 'run-1',
                 expect.not.stringContaining(chart.queryUuid),
+                {
+                    repaired: [],
+                    dropped: [{ key: chart.queryUuid, reason: 'unverifiable' }],
+                },
             );
             expect(model.markCompleted).toHaveBeenCalledWith(
                 'run-1',
                 expect.stringContaining('The baseline trend is stable.'),
+                {
+                    repaired: [],
+                    dropped: [{ key: chart.queryUuid, reason: 'unverifiable' }],
+                },
             );
         });
 
@@ -1599,10 +1615,18 @@ describe('AiDeepResearchService', () => {
             expect(model.markCompleted).toHaveBeenCalledWith(
                 'run-1',
                 expect.not.stringContaining(chart.queryUuid),
+                {
+                    repaired: [],
+                    dropped: [{ key: chart.queryUuid, reason: 'unverifiable' }],
+                },
             );
             expect(model.markCompleted).toHaveBeenCalledWith(
                 'run-1',
                 expect.stringContaining('The baseline trend is stable.'),
+                {
+                    repaired: [],
+                    dropped: [{ key: chart.queryUuid, reason: 'unverifiable' }],
+                },
             );
         });
 
@@ -1641,10 +1665,18 @@ describe('AiDeepResearchService', () => {
             expect(model.markCompleted).toHaveBeenCalledWith(
                 'run-1',
                 expect.not.stringContaining(chart.queryUuid),
+                {
+                    repaired: [],
+                    dropped: [{ key: chart.queryUuid, reason: 'unverifiable' }],
+                },
             );
             expect(model.markCompleted).toHaveBeenCalledWith(
                 'run-1',
                 expect.stringContaining('The baseline trend is stable.'),
+                {
+                    repaired: [],
+                    dropped: [{ key: chart.queryUuid, reason: 'unverifiable' }],
+                },
             );
         });
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -8,7 +8,7 @@ import {
     AI_DEEP_RESEARCH_WORKER_FINDINGS_TOOL_NAME,
     aiDeepResearchWorkerFindingsInputSchema,
     AiResultType,
-    applyDeepResearchChartRefs,
+    applyDeepResearchChartRefsWithAdjustments,
     ConflictError,
     FeatureFlags,
     findDeepResearchChartRefs,
@@ -36,6 +36,7 @@ import {
     type AiDeepResearchExecutionContextSnapshot,
     type AiDeepResearchJobPayload,
     type AiDeepResearchProgress,
+    type AiDeepResearchReportAdjustment,
     type AiDeepResearchRun,
     type AiDeepResearchTerminalReason,
     type AiDeepResearchTerminalStatus,
@@ -349,6 +350,13 @@ const toEvent = (row: DbAiDeepResearchEvent): AiDeepResearchEvent => {
                 eventType: row.event_type,
                 payload:
                     row.payload as AiDeepResearchEventPayloadMap['progress'],
+            };
+        case 'report_adjusted':
+            return {
+                ...event,
+                eventType: row.event_type,
+                payload:
+                    row.payload as AiDeepResearchEventPayloadMap['report_adjusted'],
             };
         default:
             throw new Error('Unknown Deep Research event type');
@@ -1112,11 +1120,19 @@ export class AiDeepResearchService extends BaseService {
                     result.report,
                     new Set(result.warehouseQueryUuids),
                 );
-                const completed =
-                    await this.aiDeepResearchRunModel.markCompleted(
-                        payload.aiDeepResearchRunUuid,
-                        report.markdown,
-                    );
+                const hasAdjustments =
+                    report.adjustments.repaired.length > 0 ||
+                    report.adjustments.dropped.length > 0;
+                const completed = hasAdjustments
+                    ? await this.aiDeepResearchRunModel.markCompleted(
+                          payload.aiDeepResearchRunUuid,
+                          report.markdown,
+                          report.adjustments,
+                      )
+                    : await this.aiDeepResearchRunModel.markCompleted(
+                          payload.aiDeepResearchRunUuid,
+                          report.markdown,
+                      );
                 if (!completed) {
                     await this.markCancelledAfterCompletedExecution(
                         payload.aiDeepResearchRunUuid,
@@ -1134,12 +1150,21 @@ export class AiDeepResearchService extends BaseService {
                     result.report,
                     new Set(result.warehouseQueryUuids),
                 );
-                const completed =
-                    await this.aiDeepResearchRunModel.markPartiallyCompleted(
-                        payload.aiDeepResearchRunUuid,
-                        report.markdown,
-                        result.terminalReason,
-                    );
+                const hasAdjustments =
+                    report.adjustments.repaired.length > 0 ||
+                    report.adjustments.dropped.length > 0;
+                const completed = hasAdjustments
+                    ? await this.aiDeepResearchRunModel.markPartiallyCompleted(
+                          payload.aiDeepResearchRunUuid,
+                          report.markdown,
+                          result.terminalReason,
+                          report.adjustments,
+                      )
+                    : await this.aiDeepResearchRunModel.markPartiallyCompleted(
+                          payload.aiDeepResearchRunUuid,
+                          report.markdown,
+                          result.terminalReason,
+                      );
                 if (!completed) {
                     await this.markCancelledAfterCompletedExecution(
                         payload.aiDeepResearchRunUuid,
@@ -1212,12 +1237,11 @@ export class AiDeepResearchService extends BaseService {
         run: DbAiDeepResearchRun,
         report: AiDeepResearchSubmittedReport,
         runQueryUuids: Set<string>,
-    ): Promise<{ markdown: string }> {
+    ): Promise<{
+        markdown: string;
+        adjustments: AiDeepResearchReportAdjustment;
+    }> {
         const currentCharts = await this.getRunWarehouseCharts(run);
-        // A resumed report may deliberately cite a chart produced by the
-        // source run. Carry that provenance forward and verify it against the
-        // source execution timestamp; otherwise a valid preserved chart would
-        // be dropped simply because its query predates the new run.
         const sourceRun = run.resume_from_run_uuid
             ? await this.aiDeepResearchRunModel.findByUuid(
                   run.resume_from_run_uuid,
@@ -1289,8 +1313,20 @@ export class AiDeepResearchService extends BaseService {
                 )}`,
             );
         }
+        const chartReport = applyDeepResearchChartRefsWithAdjustments(
+            report.markdown,
+            published,
+            {
+                knownKeys: new Set(derivable.keys()),
+                unverifiableKeys: new Set(omittedKeys),
+            },
+        );
+        const hasDroppedCharts = chartReport.adjustments.dropped.length > 0;
         return {
-            markdown: applyDeepResearchChartRefs(report.markdown, published),
+            markdown: hasDroppedCharts
+                ? `<warning title="Report adjusted">Some chart evidence was omitted because it could not be verified. The remaining narrative and verified evidence are preserved.</warning>\n\n${chartReport.markdown}`
+                : chartReport.markdown,
+            adjustments: chartReport.adjustments,
         };
     }
 

--- a/packages/common/src/ee/aiDeepResearch/markdown.test.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.test.ts
@@ -1,6 +1,7 @@
 import {
     aiDeepResearchChartDefinitionSchema,
     applyDeepResearchChartRefs,
+    applyDeepResearchChartRefsWithAdjustments,
     countDeepResearchFindings,
     findDeepResearchChartRefs,
     lintDeepResearchReport,
@@ -158,6 +159,35 @@ describe('findDeepResearchChartRefs', () => {
 });
 
 describe('applyDeepResearchChartRefs', () => {
+    it('reports repaired and dropped chart references', () => {
+        const result = applyDeepResearchChartRefsWithAdjustments(
+            `${chartTag(UUID_A, 'Model title')} ${chartTag('unknown')}`,
+            published([[UUID_A, { title: 'Server title', description: '' }]]),
+        );
+
+        expect(result.adjustments).toEqual({
+            repaired: [UUID_A],
+            dropped: [{ key: 'unknown', reason: 'unknown_chart' }],
+        });
+    });
+
+    it('classifies malformed, duplicate, and unverifiable references', () => {
+        const result = applyDeepResearchChartRefsWithAdjustments(
+            `${chartTag(UUID_A)} ${chartTag(UUID_A)} <chart title="missing">`,
+            published([]),
+            {
+                knownKeys: new Set([UUID_A]),
+                unverifiableKeys: new Set([UUID_A]),
+            },
+        );
+
+        expect(result.adjustments.dropped).toEqual([
+            { key: UUID_A, reason: 'unverifiable' },
+            { key: UUID_A, reason: 'duplicate' },
+            { key: '', reason: 'malformed' },
+        ]);
+    });
+
     it('rewrites a published reference with the title and description the server derived', () => {
         const result = applyDeepResearchChartRefs(
             `<chart id="${UUID_A}" title="Model guess" description="Model guess.">`,

--- a/packages/common/src/ee/aiDeepResearch/markdown.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.ts
@@ -112,6 +112,14 @@ export type AiDeepResearchChartRef = {
     raw: string;
 };
 
+export type AiDeepResearchReportAdjustment = {
+    repaired: string[];
+    dropped: Array<{
+        key: string;
+        reason: 'malformed' | 'unknown_chart' | 'duplicate' | 'unverifiable';
+    }>;
+};
+
 /** Every `<chart>` tag in the markdown, whether or not it parses into a ref. */
 type AiDeepResearchChartTag = {
     ref: AiDeepResearchChartRef | null;
@@ -287,19 +295,51 @@ export const findDeepResearchChartRefs = (
  * spliced out. A chart the server cannot back costs the report that chart,
  * never the narrative around it.
  */
-export const applyDeepResearchChartRefs = (
+export const applyDeepResearchChartRefsWithAdjustments = (
     markdown: string,
     published: ReadonlyMap<string, { title: string; description: string }>,
-): string => {
-    const rendered = new Set<string>();
-    return spliceDeepResearchRanges(
+    options: {
+        knownKeys?: ReadonlySet<string>;
+        unverifiableKeys?: ReadonlySet<string>;
+    } = {},
+): { markdown: string; adjustments: AiDeepResearchReportAdjustment } => {
+    const seen = new Set<string>();
+    const adjustments: AiDeepResearchReportAdjustment = {
+        repaired: [],
+        dropped: [],
+    };
+    const result = spliceDeepResearchRanges(
         markdown,
         findDeepResearchChartTags(markdown).map((tag) => {
             const chart = tag.ref ? published.get(tag.ref.key) : undefined;
-            if (!tag.ref || !chart || rendered.has(tag.ref.key)) {
+            if (!tag.ref) {
+                adjustments.dropped.push({ key: '', reason: 'malformed' });
                 return { match: tag, replacement: '' };
             }
-            rendered.add(tag.ref.key);
+            if (seen.has(tag.ref.key)) {
+                adjustments.dropped.push({
+                    key: tag.ref.key,
+                    reason: 'duplicate',
+                });
+                return { match: tag, replacement: '' };
+            }
+            seen.add(tag.ref.key);
+            if (!chart) {
+                const isUnverifiable =
+                    options.unverifiableKeys?.has(tag.ref.key) ||
+                    options.knownKeys?.has(tag.ref.key);
+                adjustments.dropped.push({
+                    key: tag.ref.key,
+                    reason: isUnverifiable ? 'unverifiable' : 'unknown_chart',
+                });
+                return { match: tag, replacement: '' };
+            }
+            if (
+                tag.ref.title !== chart.title ||
+                tag.ref.description !== chart.description
+            ) {
+                adjustments.repaired.push(tag.ref.key);
+            }
             return {
                 match: tag,
                 replacement: getDeepResearchChartRefMarkdown(
@@ -310,7 +350,14 @@ export const applyDeepResearchChartRefs = (
             };
         }),
     );
+    return { markdown: result, adjustments };
 };
+
+export const applyDeepResearchChartRefs = (
+    markdown: string,
+    published: ReadonlyMap<string, { title: string; description: string }>,
+): string =>
+    applyDeepResearchChartRefsWithAdjustments(markdown, published).markdown;
 
 export const renderDeepResearchChartRefs = (markdown: string): string =>
     spliceDeepResearchRanges(

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -249,6 +249,7 @@ export const AI_DEEP_RESEARCH_EVENT_TYPES = [
     'status_changed',
     'cancellation_requested',
     'progress',
+    'report_adjusted',
 ] as const;
 
 export type AiDeepResearchEventType =
@@ -285,12 +286,24 @@ export type AiDeepResearchEventPayloadMap = {
     status_changed: { status: AiDeepResearchRunStatus };
     cancellation_requested: Record<string, never>;
     progress: { progress: AiDeepResearchProgress };
+    report_adjusted: {
+        repaired: string[];
+        dropped: Array<{
+            key: string;
+            reason:
+                | 'malformed'
+                | 'unknown_chart'
+                | 'duplicate'
+                | 'unverifiable';
+        }>;
+    };
 };
 
 export type AiDeepResearchEventPayload =
     | { status: AiDeepResearchRunStatus }
     | Record<string, never>
-    | { progress: AiDeepResearchProgress };
+    | { progress: AiDeepResearchProgress }
+    | AiDeepResearchEventPayloadMap['report_adjusted'];
 
 // TSOA cannot resolve the equivalent mapped/indexed discriminated union.
 export type AiDeepResearchEvent =
@@ -313,6 +326,13 @@ export type AiDeepResearchEvent =
           aiDeepResearchRunUuid: string;
           eventType: 'progress';
           payload: { progress: AiDeepResearchProgress };
+          createdAt: string;
+      }
+    | {
+          aiDeepResearchEventUuid: string;
+          aiDeepResearchRunUuid: string;
+          eventType: 'report_adjusted';
+          payload: AiDeepResearchEventPayloadMap['report_adjusted'];
           createdAt: string;
       };
 

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
@@ -39,6 +39,8 @@ const getEventLabel = (event: AiDeepResearchEvent): string => {
             return 'Cancellation requested';
         case 'progress':
             return getActivityLabel(event.payload.progress.activity);
+        case 'report_adjusted':
+            return 'Report adjusted to preserve valid evidence';
         default:
             return assertUnreachable(event, 'Unknown research event');
     }


### PR DESCRIPTION
## Summary

PR 3 of 5 for [PROD-10039](https://linear.app/lightdash/issue/PROD-10039). Repairs invalid chart references and preserves the valid report narrative instead of discarding useful Deep Research output.

Stacks on top of [#27248](https://github.com/lightdash/lightdash/pull/27248), which adds checkpoint and resume support.

Closes: https://linear.app/lightdash/issue/PROD-10039

## Changes

**Backend**

- Classifies malformed, duplicate, unknown, and unverifiable chart references.
- Removes invalid references while preserving findings and narrative text.
- Records repaired and dropped content in a `report_adjusted` event.
- Adds a deterministic report warning when content is omitted.

**Frontend**

- Shows report-adjustment activity in the run timeline.

## Adjustment flow

```
submitted report → validate chart refs → repair/drop invalid refs → publish narrative
                                               └─ report_adjusted event
```

## Test plan

- [x] Common and backend typechecks.
- [x] Regression coverage for valid, missing, malformed, duplicate, and unverifiable references.
- [x] Frontend activity-label typecheck.
- [x] Finalization tests: 15 passed, 58 skipped by focused filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)