### PR TITLE
fix(mcp): hide unauthorized metric query tool

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1679,6 +1679,7 @@ export class McpService extends BaseService {
             mcpContentWritesEnabled: boolean;
             scheduledDeliveryEnabled: boolean;
             runSqlEnabled: boolean;
+            runMetricQueryEnabled?: boolean;
         } = {
             projectPinned: false,
             aiWritebackEnabled: false,
@@ -1686,6 +1687,7 @@ export class McpService extends BaseService {
             mcpContentWritesEnabled: true,
             scheduledDeliveryEnabled: true,
             runSqlEnabled: false,
+            runMetricQueryEnabled: true,
         },
     ): void {
         this.registerTrackedTool(
@@ -2699,115 +2701,127 @@ export class McpService extends BaseService {
             },
         );
 
-        this.registerTrackedTool(
-            mcpRunMetricQueryTool.name,
-            {
-                title: mcpRunMetricQueryTool.title,
-                description: mcpRunMetricQueryTool.description,
-                inputSchema: mcpRunMetricQueryTool.inputSchema.shape,
-                outputSchema: mcpRunMetricQueryTool.outputSchema,
-                annotations: mcpRunMetricQueryTool.annotations,
-            },
-            async (_args, extra) => {
-                const ctx = getMcpContext(extra);
+        if (options.runMetricQueryEnabled ?? true) {
+            this.registerTrackedTool(
+                mcpRunMetricQueryTool.name,
+                {
+                    title: mcpRunMetricQueryTool.title,
+                    description: mcpRunMetricQueryTool.description,
+                    inputSchema: mcpRunMetricQueryTool.inputSchema.shape,
+                    outputSchema: mcpRunMetricQueryTool.outputSchema,
+                    annotations: mcpRunMetricQueryTool.annotations,
+                },
+                async (_args, extra) => {
+                    const ctx = getMcpContext(extra);
 
-                const projectUuid = await this.resolveProjectUuid(ctx);
-                const argsWithProject = { ..._args, projectUuid };
+                    const projectUuid = await this.resolveProjectUuid(ctx);
+                    const argsWithProject = { ..._args, projectUuid };
 
-                try {
-                    const deadlineMs =
-                        Date.now() + McpService.getMcpQueryWaitMs(extra);
-                    const { account } = McpService.getAccount(ctx);
-                    const queryTool =
-                        toolRunQueryArgsSchemaTransformed.parse(
-                            argsWithProject,
-                        );
-                    const {
-                        query,
-                        userAttributeOverrides,
-                        appliedParametersNote,
-                    } = await this.buildMcpMetricQuery({
-                        ctx,
-                        projectUuid,
-                        queryTool,
-                    });
+                    try {
+                        const deadlineMs =
+                            Date.now() + McpService.getMcpQueryWaitMs(extra);
+                        const { account } = McpService.getAccount(ctx);
+                        const queryTool =
+                            toolRunQueryArgsSchemaTransformed.parse(
+                                argsWithProject,
+                            );
+                        const {
+                            query,
+                            userAttributeOverrides,
+                            appliedParametersNote,
+                        } = await this.buildMcpMetricQuery({
+                            ctx,
+                            projectUuid,
+                            queryTool,
+                        });
 
-                    const { queryUuid } =
-                        await this.asyncQueryService.executeAsyncMetricQuery({
-                            account,
+                        const { queryUuid } =
+                            await this.asyncQueryService.executeAsyncMetricQuery(
+                                {
+                                    account,
+                                    projectUuid,
+                                    metricQuery: query,
+                                    context:
+                                        QueryExecutionContext.MCP_RUN_METRIC_QUERY,
+                                    userAttributeOverrides,
+                                    parameters:
+                                        queryTool.queryConfig.parameters ??
+                                        undefined,
+                                },
+                            );
+
+                        const queryHistory =
+                            await this.asyncQueryService.pollQueryHistoryUntilDeadline(
+                                {
+                                    account,
+                                    projectUuid,
+                                    queryUuid,
+                                    deadlineMs,
+                                    pollIntervalMs: MCP_QUERY_POLL_INTERVAL_MS,
+                                    signal: extra.signal,
+                                },
+                            );
+
+                        if (
+                            McpService.isQueryRunningStatus(queryHistory.status)
+                        ) {
+                            return McpService.getRunningQueryResponse(
+                                queryUuid,
+                            );
+                        }
+
+                        if (queryHistory.status !== QueryHistoryStatus.READY) {
+                            throw new UnexpectedServerError(
+                                queryHistory.error ??
+                                    `Metric query finished with status ${queryHistory.status}`,
+                            );
+                        }
+
+                        const results =
+                            await this.asyncQueryService.getRawAsyncQueryResults(
+                                {
+                                    account,
+                                    projectUuid,
+                                    queryUuid,
+                                },
+                            );
+                        const exploreUrl = await this.buildMetricExploreUrl({
+                            ctx,
                             projectUuid,
                             metricQuery: query,
-                            context: QueryExecutionContext.MCP_RUN_METRIC_QUERY,
-                            userAttributeOverrides,
-                            parameters:
-                                queryTool.queryConfig.parameters ?? undefined,
+                            fieldsMap: results.fields,
+                            columnOrder: results.rows[0]
+                                ? Object.keys(results.rows[0])
+                                : Object.keys(results.fields),
+                            queryTool,
                         });
 
-                    const queryHistory =
-                        await this.asyncQueryService.pollQueryHistoryUntilDeadline(
-                            {
-                                account,
-                                projectUuid,
-                                queryUuid,
-                                deadlineMs,
-                                pollIntervalMs: MCP_QUERY_POLL_INTERVAL_MS,
-                                signal: extra.signal,
-                            },
-                        );
-
-                    if (McpService.isQueryRunningStatus(queryHistory.status)) {
-                        return McpService.getRunningQueryResponse(queryUuid);
-                    }
-
-                    if (queryHistory.status !== QueryHistoryStatus.READY) {
-                        throw new UnexpectedServerError(
-                            queryHistory.error ??
-                                `Metric query finished with status ${queryHistory.status}`,
-                        );
-                    }
-
-                    const results =
-                        await this.asyncQueryService.getRawAsyncQueryResults({
-                            account,
-                            projectUuid,
+                        return McpService.buildMetricQueryPollResult({
                             queryUuid,
+                            rows: results.rows,
+                            fields: results.fields,
+                            exploreUrl,
+                            appliedParametersNote,
                         });
-                    const exploreUrl = await this.buildMetricExploreUrl({
-                        ctx,
-                        projectUuid,
-                        metricQuery: query,
-                        fieldsMap: results.fields,
-                        columnOrder: results.rows[0]
-                            ? Object.keys(results.rows[0])
-                            : Object.keys(results.fields),
-                        queryTool,
-                    });
-
-                    return McpService.buildMetricQueryPollResult({
-                        queryUuid,
-                        rows: results.rows,
-                        fields: results.fields,
-                        exploreUrl,
-                        appliedParametersNote,
-                    });
-                } catch (e) {
-                    const errorMessage =
-                        e instanceof Error ? e.message : String(e);
-                    this.logger.error(
-                        `[McpService] Error in run_metric_query tool: ${errorMessage}`,
-                    );
-                    return {
-                        content: [
-                            {
-                                type: 'text' as const,
-                                text: `Error running metric query: ${errorMessage}`,
-                            },
-                        ],
-                        isError: true,
-                    };
-                }
-            },
-        );
+                    } catch (e) {
+                        const errorMessage =
+                            e instanceof Error ? e.message : String(e);
+                        this.logger.error(
+                            `[McpService] Error in run_metric_query tool: ${errorMessage}`,
+                        );
+                        return {
+                            content: [
+                                {
+                                    type: 'text' as const,
+                                    text: `Error running metric query: ${errorMessage}`,
+                                },
+                            ],
+                            isError: true,
+                        };
+                    }
+                },
+            );
+        }
 
         registerAppTool(
             this.mcpServer,
@@ -3640,6 +3654,7 @@ export class McpService extends BaseService {
         mcpContentWritesEnabled?: boolean;
         scheduledDeliveryEnabled?: boolean;
         runSqlEnabled?: boolean;
+        runMetricQueryEnabled?: boolean;
     }): Promise<McpServer> {
         const newServer = this.buildMcpServer({
             enableGrepFields: options?.grepFieldsEnabled ?? false,
@@ -3658,6 +3673,7 @@ export class McpService extends BaseService {
             mcpContentWritesEnabled: options?.mcpContentWritesEnabled ?? true,
             scheduledDeliveryEnabled: options?.scheduledDeliveryEnabled ?? true,
             runSqlEnabled: options?.runSqlEnabled ?? false,
+            runMetricQueryEnabled: options?.runMetricQueryEnabled ?? false,
         });
         this.mcpServer = originalServer;
 
@@ -3944,6 +3960,43 @@ export class McpService extends BaseService {
         }
 
         return ability.can('manage', 'SqlRunner');
+    }
+
+    /**
+     * Whether the run_metric_query tool should be registered for this caller.
+     *
+     * Query execution performs a more specific explore-level authorization
+     * check. This registration gate uses the project-level manage:Explore
+     * capability so viewers do not see a tool that will always reject them.
+     */
+    public async isRunMetricQueryEnabled(
+        user: SessionUser,
+        headerProjectUuid?: string,
+    ): Promise<boolean> {
+        const ability = this.createAuditedAbility(user);
+
+        const projectUuid =
+            headerProjectUuid ??
+            (user.organizationUuid
+                ? (
+                      await this.mcpContextModel.getContext(
+                          user.userUuid,
+                          user.organizationUuid,
+                      )
+                  )?.context.projectUuid
+                : undefined);
+
+        if (projectUuid && user.organizationUuid) {
+            return ability.can(
+                'manage',
+                subject('Explore', {
+                    organizationUuid: user.organizationUuid,
+                    projectUuid,
+                }),
+            );
+        }
+
+        return ability.can('manage', 'Explore');
     }
 
     public getLightdashVersion(context: McpProtocolContext): string {

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -128,6 +128,24 @@ const makeMcpService = (mcpContentWritesEnabled = true): McpService =>
         userAttributesModel: {},
     } as unknown as ConstructorParameters<typeof McpService>[0]);
 
+const makeServiceWithContextProject = (projectUuid?: string): McpService => {
+    const service = makeMcpService();
+    (
+        service as unknown as {
+            mcpContextModel: {
+                getContext: (...args: unknown[]) => unknown;
+            };
+        }
+    ).mcpContextModel = {
+        getContext: vi
+            .fn()
+            .mockResolvedValue(
+                projectUuid ? { context: { projectUuid } } : undefined,
+            ),
+    };
+    return service;
+};
+
 const sharedMcpToolDefinitionNames = mcpToolDefinitions.map(
     (toolDefinition) => toolDefinition.for('mcp').name,
 );
@@ -159,6 +177,7 @@ describe('MCP tool contracts', () => {
         await mcpService.createServer({
             aiWritebackEnabled: true,
             runSqlEnabled: true,
+            runMetricQueryEnabled: true,
         });
 
         const prompts = mockRegisteredMcpPrompts.map(({ name, config }) => ({
@@ -208,6 +227,22 @@ describe('MCP tool contracts', () => {
         );
     });
 
+    it('registers run_metric_query only when runMetricQueryEnabled', async () => {
+        const mcpService = makeMcpService();
+
+        mockRegisteredMcpTools.length = 0;
+        await mcpService.createServer({ runMetricQueryEnabled: true });
+        expect(mockRegisteredMcpTools.map(({ name }) => name)).toContain(
+            McpToolName.RUN_METRIC_QUERY,
+        );
+
+        mockRegisteredMcpTools.length = 0;
+        await mcpService.createServer({ runMetricQueryEnabled: false });
+        expect(mockRegisteredMcpTools.map(({ name }) => name)).not.toContain(
+            McpToolName.RUN_METRIC_QUERY,
+        );
+    });
+
     describe('isRunSqlEnabled', () => {
         const ORG_UUID = 'org-1';
         const PROJECT_A = 'project-a';
@@ -239,26 +274,6 @@ describe('MCP tool contracts', () => {
                 organizationUuid: ORG_UUID,
                 ability,
             } as unknown as SessionUser;
-        };
-
-        const makeServiceWithContextProject = (
-            projectUuid?: string,
-        ): McpService => {
-            const service = makeMcpService();
-            (
-                service as unknown as {
-                    mcpContextModel: {
-                        getContext: (...args: unknown[]) => unknown;
-                    };
-                }
-            ).mcpContextModel = {
-                getContext: vi
-                    .fn()
-                    .mockResolvedValue(
-                        projectUuid ? { context: { projectUuid } } : undefined,
-                    ),
-            };
-            return service;
         };
 
         it('is false for a viewer of the pinned project', async () => {
@@ -305,6 +320,68 @@ describe('MCP tool contracts', () => {
             const orgViewer = buildUser(OrganizationMemberRole.VIEWER);
             expect(await service.isRunSqlEnabled(orgDeveloper)).toBe(true);
             expect(await service.isRunSqlEnabled(orgViewer)).toBe(false);
+        });
+    });
+
+    describe('isRunMetricQueryEnabled', () => {
+        const ORG_UUID = 'org-1';
+        const PROJECT_UUID = 'project-a';
+
+        const buildUser = (
+            orgRole: OrganizationMemberRole,
+            projectRole?: ProjectMemberRole,
+        ): SessionUser => {
+            const userUuid = 'user-1';
+            const ability = defineUserAbility(
+                {
+                    role: orgRole,
+                    organizationUuid: ORG_UUID,
+                    userUuid,
+                    roleUuid: undefined,
+                },
+                projectRole
+                    ? [
+                          {
+                              projectUuid: PROJECT_UUID,
+                              role: projectRole,
+                              userUuid,
+                              roleUuid: undefined,
+                          },
+                      ]
+                    : [],
+            );
+            return {
+                userUuid,
+                organizationUuid: ORG_UUID,
+                ability,
+            } as unknown as SessionUser;
+        };
+
+        it('is false for a viewer of the pinned project', async () => {
+            const service = makeServiceWithContextProject();
+            const viewer = buildUser(
+                OrganizationMemberRole.VIEWER,
+                ProjectMemberRole.VIEWER,
+            );
+
+            expect(
+                await service.isRunMetricQueryEnabled(viewer, PROJECT_UUID),
+            ).toBe(false);
+        });
+
+        it('is true for an interactive viewer of the pinned project', async () => {
+            const service = makeServiceWithContextProject();
+            const interactiveViewer = buildUser(
+                OrganizationMemberRole.VIEWER,
+                ProjectMemberRole.INTERACTIVE_VIEWER,
+            );
+
+            expect(
+                await service.isRunMetricQueryEnabled(
+                    interactiveViewer,
+                    PROJECT_UUID,
+                ),
+            ).toBe(true);
         });
     });
 

--- a/packages/backend/src/routers/mcpRouter.authorization.test.ts
+++ b/packages/backend/src/routers/mcpRouter.authorization.test.ts
@@ -60,6 +60,7 @@ const createMcpService = () =>
         isContentToolsEnabled: vi.fn().mockResolvedValue(false),
         isCreateScheduledDeliveryEnabled: vi.fn().mockResolvedValue(false),
         isEnabled: vi.fn().mockResolvedValue(true),
+        isRunMetricQueryEnabled: vi.fn().mockResolvedValue(false),
         isRunSqlEnabled: vi.fn().mockResolvedValue(false),
     }) as McpService;
 
@@ -256,6 +257,10 @@ describe('project-scoped MCP route', () => {
             status: 200,
         });
         expect(mcpService.isRunSqlEnabled).toHaveBeenCalledWith(
+            expect.objectContaining({ userUuid: 'user-uuid' }),
+            PROJECT_UUID,
+        );
+        expect(mcpService.isRunMetricQueryEnabled).toHaveBeenCalledWith(
             expect.objectContaining({ userUuid: 'user-uuid' }),
             PROJECT_UUID,
         );

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -315,11 +315,16 @@ mcpRouter.all(
                     mcpContentWritesEnabled,
                     scheduledDeliveryEnabled,
                     runSqlEnabled,
+                    runMetricQueryEnabled,
                 ] = await Promise.all([
                     mcpService.isAiGrepFieldsEnabled(req.user!),
                     mcpService.isContentToolsEnabled(req.user!),
                     mcpService.isCreateScheduledDeliveryEnabled(req.user!),
                     mcpService.isRunSqlEnabled(req.user!, pinnedProjectUuid),
+                    mcpService.isRunMetricQueryEnabled(
+                        req.user!,
+                        pinnedProjectUuid,
+                    ),
                 ]);
                 const mcpServer = await mcpService.createServer({
                     projectPinned: pinnedProjectUuid !== undefined,
@@ -330,6 +335,7 @@ mcpRouter.all(
                     mcpContentWritesEnabled,
                     scheduledDeliveryEnabled,
                     runSqlEnabled,
+                    runMetricQueryEnabled,
                 });
                 const transport = new StreamableHTTPServerTransport({
                     enableJsonResponse: true,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9726/mcp-inconsistent-tool-visibility-permission-gated-tools-should-not

## Summary

Plain Viewer MCP callers could see `run_metric_query` in `tools/list`, then receive `ForbiddenError` when attempting to use it. The tool remains visible for callers with `manage:Explore`.

## Root cause

`run_metric_query` was registered unconditionally, although `AsyncQueryService.executeAsyncMetricQuery` enforces explore authorization at execution time.

```text
Before: Viewer -> tools/list -> run_metric_query -> ForbiddenError
After:  Viewer -> manage:Explore gate -> omitted from tools/list
        Authorized caller -> manage:Explore gate -> listed and callable
```

## Fix

The MCP router resolves a project-aware `manage:Explore` capability at request time and passes it to `createServer`. `setupHandlers` conditionally registers `run_metric_query`; the existing execution-time authorization remains unchanged.

- `packages/backend/src/routers/mcpRouter.ts` — resolve and pass the registration gate.
- `packages/backend/src/ee/services/McpService/McpService.ts` — add project-aware permission resolution and conditional registration.
- `packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts` — cover registration and Viewer/Interactive Viewer permission behavior.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [x] `pnpm -F backend run formatter --check ...`
- [x] MCP contract suite — 21 tests pass.
- [x] MCP query polling suite — 30 tests pass.
- [x] Runtime MCP initialize/tools/list with seeded authorized admin confirms `run_metric_query` remains advertised.
- [ ] Real Viewer MCP credential — covered by CASL-backed service tests; no separate Viewer credential was available locally.