### PR TITLE
fix(frontend): correct font size in Github auth method description

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
@@ -294,7 +294,7 @@ const GithubForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                         }
                         description={
                             isInstallationValid ? (
-                                <Text>
+                                <>
                                     You are connected to GitHub.{' '}
                                     <Anchor
                                         inherit
@@ -303,7 +303,7 @@ const GithubForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                                     >
                                         Click here to use another account
                                     </Anchor>
-                                </Text>
+                                </>
                             ) : undefined
                         }
                         w={isInstallationValid ? '90%' : '100%'}


### PR DESCRIPTION
### Description:

The "You are connected to GitHub. Click here to use another account" copy under **Authorization method** rendered larger than the other form field descriptions.

Mantine's `Input.Description` sets the `xs` font size on its wrapper, but the content was itself wrapped in a `<Text>`, which reset it to the default `md`. Swapping the `<Text>` for a fragment lets the copy inherit the description size, matching every other `description` in the form.
