### PR TITLE
feat(ai): support Claude Sonnet 5 and Opus 5 on the Amazon Bedrock provider

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -50,7 +50,7 @@
         "upload-autopilot-skill": "tsx src/scripts/upload-autopilot-skill.ts"
     },
     "dependencies": {
-        "@ai-sdk/amazon-bedrock": "4.0.48",
+        "@ai-sdk/amazon-bedrock": "4.0.148",
         "@ai-sdk/anthropic": "3.0.104",
         "@ai-sdk/azure": "3.0.26",
         "@ai-sdk/mcp": "1.0.41",

--- a/packages/backend/src/ee/services/ai/models/bedrock.ts
+++ b/packages/backend/src/ee/services/ai/models/bedrock.ts
@@ -74,6 +74,8 @@ export const getBedrockModel = (
     const reasoningEnabled =
         options?.enableReasoning && preset.supportsReasoning;
 
+    const reasoningStyle = preset.reasoningStyle ?? 'budget';
+
     return {
         model,
         callOptions: {
@@ -83,12 +85,25 @@ export const getBedrockModel = (
         providerOptions: {
             [PROVIDER]: {
                 ...(preset.providerOptions || {}),
-                ...(reasoningEnabled && {
-                    reasoningConfig: {
-                        type: 'enabled',
-                        budgetTokens: 2048,
-                    },
-                }),
+                ...(reasoningEnabled &&
+                    (reasoningStyle === 'adaptive'
+                        ? {
+                              // Claude 4.7+ models reject `budget_tokens` and
+                              // require adaptive thinking with an effort level.
+                              // @ai-sdk/amazon-bedrock maps this to
+                              // `thinking.type: 'adaptive'` + `output_config.effort`
+                              // for Anthropic models from 4.0.148+.
+                              reasoningConfig: {
+                                  type: 'adaptive' as const,
+                                  maxReasoningEffort: 'medium' as const,
+                              },
+                          }
+                        : {
+                              reasoningConfig: {
+                                  type: 'enabled' as const,
+                                  budgetTokens: 2048,
+                              },
+                          })),
             },
         },
     };

--- a/packages/backend/src/ee/services/ai/models/presets.ts
+++ b/packages/backend/src/ee/services/ai/models/presets.ts
@@ -261,6 +261,31 @@ export const MODEL_PRESETS: {
     ],
     bedrock: [
         {
+            name: 'claude-sonnet-5',
+            provider: 'bedrock',
+            modelId: 'anthropic.claude-sonnet-5',
+            displayName: 'Claude Sonnet 5',
+            description: 'Newest Sonnet model balancing speed and intelligence',
+            contextWindowTokens: 200000,
+            supportsReasoning: true,
+            reasoningStyle: 'adaptive',
+            callOptions: {},
+            providerOptions: undefined,
+        },
+        {
+            name: 'claude-opus-5',
+            provider: 'bedrock',
+            modelId: 'anthropic.claude-opus-5',
+            displayName: 'Claude Opus 5',
+            description:
+                'Most intelligent Opus model for complex agentic coding and enterprise work',
+            contextWindowTokens: 200000,
+            supportsReasoning: true,
+            reasoningStyle: 'adaptive',
+            callOptions: {},
+            providerOptions: undefined,
+        },
+        {
             name: 'claude-opus-4-5',
             provider: 'bedrock',
             modelId: 'anthropic.claude-opus-4-5-20251101-v1:0',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
   packages/backend:
     dependencies:
       '@ai-sdk/amazon-bedrock':
-        specifier: 4.0.48
-        version: 4.0.48(zod@3.25.55)
+        specifier: 4.0.148
+        version: 4.0.148(zod@3.25.55)
       '@ai-sdk/anthropic':
         specifier: 3.0.104
         version: 3.0.104(zod@3.25.55)
@@ -1861,8 +1861,8 @@ packages:
   '@adobe/css-tools@4.4.2':
     resolution: {integrity: sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==}
 
-  '@ai-sdk/amazon-bedrock@4.0.48':
-    resolution: {integrity: sha512-eo4f+RGWnj4LAJRtqOl3nkEz27e6L5LYCesa7cTyzmuC0fKbGgcveK8/6u8Cbl6GYahpRzEdV+YsaCGRjBADcg==}
+  '@ai-sdk/amazon-bedrock@4.0.148':
+    resolution: {integrity: sha512-BMPgT4X/8u0Z1wO1X6d0HxjYS7F7tl9m1jgkE3rO+KBMXtPWpHU0agxQgAsS8HAH3zJQv0gF0bvkpi/01UV79g==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1873,8 +1873,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/anthropic@3.0.36':
-    resolution: {integrity: sha512-GHQccfwC0j1JltN9M47RSlBpOyHoUam0mvbYMf8zpE0UD1tzIX5sDw2m/8nRlrTz6wGuKfaDxmoC3XH7uhTrXg==}
+  '@ai-sdk/anthropic@3.0.107':
+    resolution: {integrity: sha512-aXwAv1v9ezU3lkAvcz4dfuzJb30ioLk0WRhwpuDgCGKN0dEZiNLeDuyVcRqxWRlYc4Zg4Z4rJcZBKmzJTdzrtw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1909,6 +1909,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai@3.0.91':
+    resolution: {integrity: sha512-NJQ1ukJ/c2uKVHCJiVToMlSKEhtWnGHBO/klxQwyV3JY/zOlsgrTilGj/t3KX48B1a6dYYnRxu0Pnand12vrsA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.13':
     resolution: {integrity: sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og==}
     engines: {node: '>=18'}
@@ -1929,6 +1935,12 @@ packages:
 
   '@ai-sdk/provider-utils@4.0.41':
     resolution: {integrity: sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.42':
+    resolution: {integrity: sha512-Q07lZsq4ir+xwAGVfSbY2WNGLrbfWINFaL2I/vTBFrkuXeP7VZh+UtQgLOKZS6Z/6flNFW22jDYdbINvwTV/PA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -12338,11 +12350,6 @@ packages:
       react: '*'
       react-dom: '*'
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.17:
     resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -16266,11 +16273,12 @@ snapshots:
 
   '@adobe/css-tools@4.4.2': {}
 
-  '@ai-sdk/amazon-bedrock@4.0.48(zod@3.25.55)':
+  '@ai-sdk/amazon-bedrock@4.0.148(zod@3.25.55)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.36(zod@3.25.55)
-      '@ai-sdk/provider': 3.0.7
-      '@ai-sdk/provider-utils': 4.0.13(zod@3.25.55)
+      '@ai-sdk/anthropic': 3.0.107(zod@3.25.55)
+      '@ai-sdk/openai': 3.0.91(zod@3.25.55)
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.42(zod@3.25.55)
       '@smithy/eventstream-codec': 4.2.8
       '@smithy/util-utf8': 4.2.1
       aws4fetch: 1.0.20
@@ -16282,10 +16290,10 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.41(zod@3.25.55)
       zod: 3.25.55
 
-  '@ai-sdk/anthropic@3.0.36(zod@3.25.55)':
+  '@ai-sdk/anthropic@3.0.107(zod@3.25.55)':
     dependencies:
-      '@ai-sdk/provider': 3.0.7
-      '@ai-sdk/provider-utils': 4.0.13(zod@3.25.55)
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.42(zod@3.25.55)
       zod: 3.25.55
 
   '@ai-sdk/azure@3.0.26(zod@3.25.55)':
@@ -16321,6 +16329,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@3.25.55)
       zod: 3.25.55
 
+  '@ai-sdk/openai@3.0.91(zod@3.25.55)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.42(zod@3.25.55)
+      zod: 3.25.55
+
   '@ai-sdk/provider-utils@4.0.13(zod@3.25.55)':
     dependencies:
       '@ai-sdk/provider': 3.0.7
@@ -16343,6 +16357,14 @@ snapshots:
       zod: 3.25.55
 
   '@ai-sdk/provider-utils@4.0.41(zod@3.25.55)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      undici: 6.27.0
+      zod: 3.25.55
+
+  '@ai-sdk/provider-utils@4.0.42(zod@3.25.55)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@standard-schema/spec': 1.1.0
@@ -29480,8 +29502,6 @@ snapshots:
       stacktrace-js: 2.0.2
       stylis: 4.4.0
 
-  nanoid@3.3.16: {}
-
   nanoid@3.3.17: {}
 
   napi-build-utils@2.0.0: {}
@@ -30581,7 +30601,7 @@ snapshots:
 
   postcss@8.5.10:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
Organizations running AI agents through AWS Bedrock could only select Claude models up to Opus 4.5 / Haiku 4.5: the newer Claude models reject the budget-tokens thinking API the Bedrock integration used, so Bedrock orgs were stuck a generation behind the Anthropic provider.

Closes: #27179