### PR TITLE
fix: apply stored parameter values when re-executing AI agent charts

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -88,6 +88,7 @@ import {
     OpenIdIdentity,
     OpenIdIdentityIssuerType,
     ParameterError,
+    ParametersValuesMap,
     parseVizConfig,
     PersistentDownloadFileAccessMode,
     ProjectType,
@@ -2197,6 +2198,7 @@ export class AiAgentService extends BaseService {
         projectUuid: string,
         metricQuery: AiMetricQueryWithFilters,
         vizConfig: AiAgentVizConfig['config'],
+        parameters: ParametersValuesMap | null,
     ) {
         const explore = await this.getExplore(
             user,
@@ -2254,6 +2256,7 @@ export class AiAgentService extends BaseService {
                 metricQuery: metricQueryWithCustomMetrics,
                 context: QueryExecutionContext.AI,
                 pivotConfiguration,
+                parameters: parameters ?? undefined,
             },
         );
 
@@ -6136,6 +6139,7 @@ export class AiAgentService extends BaseService {
             projectUuid,
             parsedVizConfig.metricQuery,
             artifact.chartConfig.config,
+            parsedVizConfig.parameters,
         );
 
         const metadata = {
@@ -6276,6 +6280,7 @@ export class AiAgentService extends BaseService {
             projectUuid,
             parsedVizConfig.metricQuery,
             chartConfig,
+            parsedVizConfig.parameters,
         );
 
         const metadata = {

--- a/packages/common/src/ee/AiAgent/utils.test.ts
+++ b/packages/common/src/ee/AiAgent/utils.test.ts
@@ -136,3 +136,43 @@ describe('parseVizConfig with legacy persisted configs', () => {
         expect(parsed?.vizTool).not.toHaveProperty('followUpTools');
     });
 });
+
+describe('parseVizConfig parameters', () => {
+    const runQueryConfig = {
+        title: 'Add to cart events',
+        description: 'Filtered events',
+        queryConfig: {
+            exploreName: 'events',
+            dimensions: ['events_filtered_event'],
+            metrics: ['events_count'],
+            sorts: [],
+            limit: 500,
+            customMetrics: null,
+            tableCalculations: null,
+            filters: null,
+        },
+        chartConfig: null,
+    };
+
+    it('surfaces stored parameter values from a runQuery artifact', () => {
+        const parsed = parseVizConfig({
+            ...runQueryConfig,
+            queryConfig: {
+                ...runQueryConfig.queryConfig,
+                parameters: { 'events.event_status': 'add_to_cart' },
+            },
+        });
+
+        expect(parsed?.type).toBe(AiResultType.QUERY_RESULT);
+        expect(parsed?.parameters).toEqual({
+            'events.event_status': 'add_to_cart',
+        });
+    });
+
+    it('returns null parameters for artifacts persisted without them', () => {
+        const parsed = parseVizConfig(runQueryConfig);
+
+        expect(parsed?.type).toBe(AiResultType.QUERY_RESULT);
+        expect(parsed?.parameters).toBeNull();
+    });
+});

--- a/packages/common/src/ee/AiAgent/utils.ts
+++ b/packages/common/src/ee/AiAgent/utils.ts
@@ -59,6 +59,7 @@ export const parseVizConfig = (
             type: AiResultType.VERTICAL_BAR_RESULT,
             vizTool,
             metricQuery,
+            parameters: null,
         } as const;
     }
 
@@ -79,6 +80,7 @@ export const parseVizConfig = (
             type: AiResultType.TIME_SERIES_RESULT,
             vizTool,
             metricQuery,
+            parameters: null,
         } as const;
     }
 
@@ -99,6 +101,7 @@ export const parseVizConfig = (
             type: AiResultType.TABLE_RESULT,
             vizTool,
             metricQuery,
+            parameters: null,
         } as const;
     }
 
@@ -135,6 +138,7 @@ export const parseVizConfig = (
             type: AiResultType.QUERY_RESULT,
             vizTool,
             metricQuery,
+            parameters: vizTool.queryConfig.parameters,
         } as const;
     }
 


### PR DESCRIPTION
The agent's original query ran with the parameter values it set, but every chart render in the thread re-executes the query from the stored artifact and dropped those values — parameters resolved back to their defaults, so the rendered chart (and its SQL) contradicted the agent's answer and the parameter pills showed the default instead of what the agent chose.

Stacked on #27255. Follows up #27190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)