### PR TITLE
refactor: extract underlying-data filter construction into shared util

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -370,6 +370,7 @@ const VisualizationProvider: FC<
         hasExplorerStore,
         isTouchDevice,
         resolvedTimezone: lastValidResultsData?.resolvedTimezone,
+        dateZoom,
     };
 
     switch (chartConfig.type) {

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -2,6 +2,7 @@ import type {
     ApiErrorDetail,
     ChartConfig,
     ChartType,
+    DateZoom,
     EChartsSeries,
     ItemsMap,
     MetricQuery,
@@ -61,6 +62,8 @@ type VisualizationContext = {
     isTouchDevice: boolean;
     // Resolved timezone for formatting (undefined when EnableTimezoneSupport flag is off)
     resolvedTimezone?: string;
+    // Date-zoom granularity applied by the surface (dashboards); undefined elsewhere.
+    dateZoom?: DateZoom;
 };
 
 const Context = createContext<VisualizationContext | undefined>(undefined);

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
@@ -1,29 +1,21 @@
 import { subject } from '@casl/ability';
 import {
     ChartType,
-    convertFieldRefToFieldId,
-    FilterOperator,
     getDimensions,
     getFields,
-    getFiltersFromGroup,
     getItemId,
     isCustomBinDimension,
-    isDimension,
     isField,
     isMetric,
-    normalizeCellRawForFilter,
     QueryExecutionContext,
     type CreateSavedChartVersion,
-    type FilterRule,
     type Filters,
-    type Metric,
     type SortField,
 } from '@lightdash/common';
 import { Button, Divider, Group, Popover } from '@mantine/core';
 import { IconShare2, IconStack, IconTelescope } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
-import { v4 as uuidv4 } from 'uuid';
 import { useOrganization } from '../../hooks/organization/useOrganization';
 import { useExplore } from '../../hooks/useExplore';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
@@ -42,8 +34,11 @@ import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
 import { type TableColumn } from '../common/Table/types';
 import ExportResults from '../ExportResults';
-import { getZoomedDimFilter } from './dateZoomFilter';
 import UnderlyingDataFilterBadges from './UnderlyingDataFilterBadges';
+import {
+    combineUnderlyingDataFilters,
+    getUnderlyingDataFilterParts,
+} from './underlyingDataFilters';
 import UnderlyingDataResultsTable from './UnderlyingDataResultsTable';
 import { useMetricQueryDataContext } from './useMetricQueryDataContext';
 
@@ -157,119 +152,25 @@ const UnderlyingDataModalContent: FC = () => {
 
         if (item === undefined) return null;
 
-        // If we are viewing data from a metric or a table calculation, we filter using all existing dimensions in the table
-        const dimensionFilters = !isDimension(item)
-            ? Object.entries(fieldValues).reduce((acc, r) => {
-                  const [key, { raw }] = r;
-
-                  const isValidDimension = allDimensions.find(
-                      (dimension) => getItemId(dimension) === key,
-                  );
-                  if (!isValidDimension) return acc;
-
-                  const zoomedFilters = getZoomedDimFilter(key, raw, dateZoom);
-                  if (zoomedFilters) return [...acc, ...zoomedFilters];
-
-                  const dimensionFilter: FilterRule = {
-                      id: uuidv4(),
-                      target: {
-                          fieldId: key,
-                      },
-                      operator:
-                          raw === null
-                              ? FilterOperator.NULL
-                              : FilterOperator.EQUALS,
-                      values:
-                          raw === null
-                              ? undefined
-                              : [
-                                    normalizeCellRawForFilter(
-                                        raw,
-                                        isValidDimension,
-                                        resolvedTimezone,
-                                    ),
-                                ],
-                  };
-                  return [...acc, dimensionFilter];
-              }, [] as FilterRule[])
-            : (getZoomedDimFilter(getItemId(item), value.raw, dateZoom) ?? [
-                  {
-                      id: uuidv4(),
-                      target: {
-                          fieldId: getItemId(item),
-                      },
-                      operator:
-                          value.raw === null
-                              ? FilterOperator.NULL
-                              : FilterOperator.EQUALS,
-                      values:
-                          value.raw === null
-                              ? undefined
-                              : [
-                                    normalizeCellRawForFilter(
-                                        value.raw,
-                                        item,
-                                        resolvedTimezone,
-                                    ),
-                                ],
-                  },
-              ]);
-
-        const pivotFilter: FilterRule[] = (
-            pivotReference?.pivotValues || []
-        ).map((pivot) => ({
-            id: uuidv4(),
-            target: {
-                fieldId: pivot.field,
-            },
-            operator:
-                pivot.value === null
-                    ? FilterOperator.NULL
-                    : FilterOperator.EQUALS,
-            values: pivot.value === null ? undefined : [pivot.value],
-        }));
-
-        const metric: Metric | undefined =
-            isField(item) && isMetric(item) ? item : undefined;
-
-        const metricFilters =
-            metric?.filters?.map((filter) => ({
-                ...filter,
-                target: {
-                    fieldId: convertFieldRefToFieldId(
-                        filter.target.fieldRef,
-                        metric.table,
-                    ),
-                },
-            })) || [];
-
-        return {
-            pointFilterRules: [...dimensionFilters, ...pivotFilter],
-            metricFilterRules: metricFilters,
-        };
+        return getUnderlyingDataFilterParts({
+            item,
+            value,
+            fieldValues,
+            pivotReference,
+            dateZoom,
+            allDimensions,
+            resolvedTimezone,
+        });
     }, [underlyingDataConfig, allDimensions, resolvedTimezone]);
 
     const filters = useMemo<Filters>(() => {
         if (!filterParts) return {};
 
-        const exploreFilters =
-            metricQuery?.filters?.dimensions !== undefined
-                ? [metricQuery.filters.dimensions]
-                : [];
-
-        const combinedFilters = [
-            ...exploreFilters,
-            ...filterParts.pointFilterRules,
-            ...filterParts.metricFilterRules,
-        ];
-
-        return getFiltersFromGroup(
-            {
-                id: uuidv4(),
-                and: combinedFilters,
-            },
+        return combineUnderlyingDataFilters({
+            filterParts,
+            exploreDimensionFilters: metricQuery?.filters?.dimensions,
             allFields,
-        );
+        });
     }, [filterParts, metricQuery, allFields]);
 
     const {

--- a/packages/frontend/src/components/MetricQueryData/underlyingDataFilters.test.ts
+++ b/packages/frontend/src/components/MetricQueryData/underlyingDataFilters.test.ts
@@ -1,0 +1,308 @@
+/// <reference types="vitest/globals" />
+import {
+    DateGranularity,
+    DimensionType,
+    FieldType,
+    FilterOperator,
+    MetricType,
+    TimeFrames,
+    type Dimension,
+    type FilterGroup,
+    type FilterRule,
+    type Metric,
+} from '@lightdash/common';
+import {
+    combineUnderlyingDataFilters,
+    getUnderlyingDataFilterParts,
+} from './underlyingDataFilters';
+
+const dimension = (
+    name: string,
+    overrides: Partial<Dimension> = {},
+): Dimension =>
+    ({
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.STRING,
+        name,
+        label: name,
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: `\${TABLE}.${name}`,
+        hidden: false,
+        ...overrides,
+    }) as Dimension;
+
+const metric = (name: string, filters?: Metric['filters']): Metric =>
+    ({
+        fieldType: FieldType.METRIC,
+        type: MetricType.SUM,
+        name,
+        label: name,
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: `\${TABLE}.${name}`,
+        hidden: false,
+        ...(filters ? { filters } : {}),
+    }) as Metric;
+
+const statusDim = dimension('status');
+const amountMetric = metric('amount');
+
+// Recursively collect FilterRules from a possibly-nested group.
+const flattenRules = (group: FilterGroup | undefined): FilterRule[] => {
+    if (!group) return [];
+    const items = 'and' in group ? group.and : group.or;
+    return items.flatMap((item) =>
+        'target' in item ? [item as FilterRule] : flattenRules(item),
+    );
+};
+
+describe('getUnderlyingDataFilterParts', () => {
+    const baseArgs = {
+        pivotReference: undefined,
+        dateZoom: undefined,
+        allDimensions: [statusDim],
+        resolvedTimezone: undefined,
+    };
+
+    test('metric click: one equals filter per valid dimension in fieldValues', () => {
+        const parts = getUnderlyingDataFilterParts({
+            ...baseArgs,
+            item: amountMetric,
+            value: { raw: 100, formatted: '100' },
+            fieldValues: {
+                orders_status: { raw: 'completed', formatted: 'completed' },
+                orders_amount: { raw: 100, formatted: '100' }, // metric — skipped
+                not_a_dimension: { raw: 'x', formatted: 'x' }, // unknown — skipped
+            },
+        });
+        expect(parts.pointFilterRules).toHaveLength(1);
+        expect(parts.pointFilterRules[0]).toMatchObject({
+            target: { fieldId: 'orders_status' },
+            operator: FilterOperator.EQUALS,
+            values: ['completed'],
+        });
+        expect(parts.metricFilterRules).toHaveLength(0);
+    });
+
+    test('metric click: null dimension value becomes isNull with no values', () => {
+        const parts = getUnderlyingDataFilterParts({
+            ...baseArgs,
+            item: amountMetric,
+            value: { raw: 100, formatted: '100' },
+            fieldValues: {
+                orders_status: { raw: null, formatted: '∅' },
+            },
+        });
+        expect(parts.pointFilterRules).toHaveLength(1);
+        expect(parts.pointFilterRules[0]).toMatchObject({
+            target: { fieldId: 'orders_status' },
+            operator: FilterOperator.NULL,
+        });
+        expect(parts.pointFilterRules[0].values).toBeUndefined();
+    });
+
+    test('dimension click: single filter on the clicked dimension itself', () => {
+        const parts = getUnderlyingDataFilterParts({
+            ...baseArgs,
+            item: statusDim,
+            value: { raw: 'completed', formatted: 'completed' },
+            fieldValues: {
+                orders_status: { raw: 'completed', formatted: 'completed' },
+                orders_other: { raw: 'y', formatted: 'y' },
+            },
+        });
+        expect(parts.pointFilterRules).toHaveLength(1);
+        expect(parts.pointFilterRules[0]).toMatchObject({
+            target: { fieldId: 'orders_status' },
+            operator: FilterOperator.EQUALS,
+            values: ['completed'],
+        });
+    });
+
+    test('date-zoomed dimension becomes a [start, nextStart) range, not equals', () => {
+        const dateDim = dimension('order_date_month', {
+            type: DimensionType.DATE,
+        });
+        const parts = getUnderlyingDataFilterParts({
+            ...baseArgs,
+            allDimensions: [dateDim],
+            item: amountMetric,
+            value: { raw: 100, formatted: '100' },
+            fieldValues: {
+                orders_order_date_month: {
+                    raw: '2024-11-01T00:00:00Z',
+                    formatted: 'November 2024',
+                },
+            },
+            dateZoom: {
+                granularity: DateGranularity.MONTH,
+                xAxisFieldId: 'orders_order_date_month',
+            },
+        });
+        expect(parts.pointFilterRules).toHaveLength(2);
+        expect(parts.pointFilterRules[0]).toMatchObject({
+            target: { fieldId: 'orders_order_date_month' },
+            operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+            values: ['2024-11-01T00:00:00Z'],
+        });
+        expect(parts.pointFilterRules[1]).toMatchObject({
+            target: { fieldId: 'orders_order_date_month' },
+            operator: FilterOperator.LESS_THAN,
+            values: ['2024-12-01T00:00:00Z'],
+        });
+    });
+
+    test('DATE-base interval dimension value passes through unshifted', () => {
+        const intervalDim = dimension('created_at_month', {
+            type: DimensionType.DATE,
+            timeInterval: TimeFrames.MONTH,
+            timeIntervalBaseDimensionType: DimensionType.DATE,
+        } as Partial<Dimension>);
+        const parts = getUnderlyingDataFilterParts({
+            ...baseArgs,
+            allDimensions: [intervalDim],
+            item: amountMetric,
+            value: { raw: 100, formatted: '100' },
+            fieldValues: {
+                orders_created_at_month: {
+                    raw: '2024-11-01T00:00:00Z',
+                    formatted: 'November 2024',
+                },
+            },
+            resolvedTimezone: 'Asia/Tokyo',
+        });
+        expect(parts.pointFilterRules[0]).toMatchObject({
+            operator: FilterOperator.EQUALS,
+            values: ['2024-11-01T00:00:00Z'],
+        });
+    });
+
+    test('pivotReference values become equals filters', () => {
+        const parts = getUnderlyingDataFilterParts({
+            ...baseArgs,
+            item: amountMetric,
+            value: { raw: 100, formatted: '100' },
+            fieldValues: {},
+            pivotReference: {
+                field: 'orders_amount',
+                pivotValues: [{ field: 'orders_region', value: 'EMEA' }],
+            },
+        });
+        expect(parts.pointFilterRules).toHaveLength(1);
+        expect(parts.pointFilterRules[0]).toMatchObject({
+            target: { fieldId: 'orders_region' },
+            operator: FilterOperator.EQUALS,
+            values: ['EMEA'],
+        });
+    });
+
+    test('metric intrinsic filters are converted to fieldIds in metricFilterRules', () => {
+        const filteredMetric = metric('amount', [
+            {
+                id: 'mf1',
+                target: { fieldRef: 'orders.status' },
+                operator: FilterOperator.EQUALS,
+                values: ['completed'],
+            },
+        ]);
+        const parts = getUnderlyingDataFilterParts({
+            ...baseArgs,
+            item: filteredMetric,
+            value: { raw: 100, formatted: '100' },
+            fieldValues: {},
+        });
+        expect(parts.metricFilterRules).toHaveLength(1);
+        expect(parts.metricFilterRules[0]).toMatchObject({
+            target: { fieldId: 'orders_status' },
+            operator: FilterOperator.EQUALS,
+            values: ['completed'],
+        });
+    });
+});
+
+describe('combineUnderlyingDataFilters', () => {
+    const pointRule: FilterRule = {
+        id: 'p1',
+        target: { fieldId: 'orders_status' },
+        operator: FilterOperator.EQUALS,
+        values: ['completed'],
+    };
+
+    test('merges explore dimension filters + point rules + metric rules into one AND group', () => {
+        const exploreDimensionFilters: FilterGroup = {
+            id: 'g1',
+            and: [
+                {
+                    id: 'e1',
+                    target: { fieldId: 'orders_region' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['EMEA'],
+                },
+            ],
+        };
+        const result = combineUnderlyingDataFilters({
+            filterParts: {
+                pointFilterRules: [pointRule],
+                metricFilterRules: [],
+            },
+            exploreDimensionFilters,
+            allFields: [statusDim, dimension('region')],
+        });
+        const rules = flattenRules(result.dimensions);
+        expect(rules).toHaveLength(2);
+        expect(rules).toContainEqual(
+            expect.objectContaining({ target: { fieldId: 'orders_region' } }),
+        );
+        expect(rules).toContainEqual(
+            expect.objectContaining({ target: { fieldId: 'orders_status' } }),
+        );
+    });
+
+    test('keeps a metric intrinsic filter targeting an UNSELECTED dimension when it is in allFields', () => {
+        const metricRule: FilterRule = {
+            id: 'm1',
+            target: { fieldId: 'orders_is_completed' },
+            operator: FilterOperator.EQUALS,
+            values: [true],
+        };
+        const result = combineUnderlyingDataFilters({
+            filterParts: {
+                pointFilterRules: [pointRule],
+                metricFilterRules: [metricRule],
+            },
+            exploreDimensionFilters: undefined,
+            // orders_is_completed is NOT in the query selection but IS a
+            // dimension of the explore — must survive classification.
+            allFields: [statusDim, dimension('is_completed')],
+        });
+        const rules = flattenRules(result.dimensions);
+        expect(rules).toContainEqual(
+            expect.objectContaining({
+                target: { fieldId: 'orders_is_completed' },
+            }),
+        );
+    });
+
+    test('drops rules whose target is absent from allFields (documents core behavior)', () => {
+        const strayRule: FilterRule = {
+            id: 's1',
+            target: { fieldId: 'orders_ghost' },
+            operator: FilterOperator.EQUALS,
+            values: ['x'],
+        };
+        const result = combineUnderlyingDataFilters({
+            filterParts: {
+                pointFilterRules: [pointRule, strayRule],
+                metricFilterRules: [],
+            },
+            exploreDimensionFilters: undefined,
+            allFields: [statusDim],
+        });
+        const rules = flattenRules(result.dimensions);
+        expect(rules).toHaveLength(1);
+        expect(rules[0]).toMatchObject({
+            target: { fieldId: 'orders_status' },
+        });
+    });
+});

--- a/packages/frontend/src/components/MetricQueryData/underlyingDataFilters.ts
+++ b/packages/frontend/src/components/MetricQueryData/underlyingDataFilters.ts
@@ -1,0 +1,165 @@
+import {
+    convertFieldRefToFieldId,
+    FilterOperator,
+    getFiltersFromGroup,
+    getItemId,
+    isDimension,
+    isField,
+    isMetric,
+    normalizeCellRawForFilter,
+    type DateZoom,
+    type FilterGroup,
+    type FilterRule,
+    type Filters,
+    type ItemsMap,
+    type Metric,
+    type PivotReference,
+    type ResultValue,
+} from '@lightdash/common';
+import { v4 as uuidv4 } from 'uuid';
+import { getZoomedDimFilter } from './dateZoomFilter';
+
+export type UnderlyingDataFilterParts = {
+    pointFilterRules: FilterRule[];
+    metricFilterRules: FilterRule[];
+};
+
+// Point-filter construction shared by UnderlyingDataModal and the data-app viz
+// underlying-data path — one implementation so zoom ranges, tz normalization
+// and metric intrinsic filters can never diverge between the two.
+export const getUnderlyingDataFilterParts = ({
+    item,
+    value,
+    fieldValues,
+    pivotReference,
+    dateZoom,
+    allDimensions,
+    resolvedTimezone,
+}: {
+    item: ItemsMap[string];
+    value: ResultValue;
+    fieldValues: Record<string, ResultValue>;
+    pivotReference: PivotReference | undefined;
+    dateZoom: DateZoom | undefined;
+    allDimensions: ItemsMap[string][];
+    resolvedTimezone: string | undefined;
+}): UnderlyingDataFilterParts => {
+    // If we are viewing data from a metric or a table calculation, we filter
+    // using all existing dimensions in the table
+    const dimensionFilters = !isDimension(item)
+        ? Object.entries(fieldValues).reduce((acc, r) => {
+              const [key, { raw }] = r;
+
+              const isValidDimension = allDimensions.find(
+                  (dimension) => getItemId(dimension) === key,
+              );
+              if (!isValidDimension) return acc;
+
+              const zoomedFilters = getZoomedDimFilter(key, raw, dateZoom);
+              if (zoomedFilters) return [...acc, ...zoomedFilters];
+
+              const dimensionFilter: FilterRule = {
+                  id: uuidv4(),
+                  target: {
+                      fieldId: key,
+                  },
+                  operator:
+                      raw === null
+                          ? FilterOperator.NULL
+                          : FilterOperator.EQUALS,
+                  values:
+                      raw === null
+                          ? undefined
+                          : [
+                                normalizeCellRawForFilter(
+                                    raw,
+                                    isValidDimension,
+                                    resolvedTimezone,
+                                ),
+                            ],
+              };
+              return [...acc, dimensionFilter];
+          }, [] as FilterRule[])
+        : (getZoomedDimFilter(getItemId(item), value.raw, dateZoom) ?? [
+              {
+                  id: uuidv4(),
+                  target: {
+                      fieldId: getItemId(item),
+                  },
+                  operator:
+                      value.raw === null
+                          ? FilterOperator.NULL
+                          : FilterOperator.EQUALS,
+                  values:
+                      value.raw === null
+                          ? undefined
+                          : [
+                                normalizeCellRawForFilter(
+                                    value.raw,
+                                    item,
+                                    resolvedTimezone,
+                                ),
+                            ],
+              },
+          ]);
+
+    const pivotFilter: FilterRule[] = (pivotReference?.pivotValues || []).map(
+        (pivot) => ({
+            id: uuidv4(),
+            target: {
+                fieldId: pivot.field,
+            },
+            operator:
+                pivot.value === null
+                    ? FilterOperator.NULL
+                    : FilterOperator.EQUALS,
+            values: pivot.value === null ? undefined : [pivot.value],
+        }),
+    );
+
+    const metric: Metric | undefined =
+        isField(item) && isMetric(item) ? item : undefined;
+
+    const metricFilters =
+        metric?.filters?.map((filter) => ({
+            ...filter,
+            target: {
+                fieldId: convertFieldRefToFieldId(
+                    filter.target.fieldRef,
+                    metric.table,
+                ),
+            },
+        })) || [];
+
+    return {
+        pointFilterRules: [...dimensionFilters, ...pivotFilter],
+        metricFilterRules: metricFilters,
+    };
+};
+
+export const combineUnderlyingDataFilters = ({
+    filterParts,
+    exploreDimensionFilters,
+    allFields,
+}: {
+    filterParts: UnderlyingDataFilterParts;
+    exploreDimensionFilters: FilterGroup | undefined;
+    allFields: ItemsMap[string][];
+}): Filters => {
+    const exploreFilters =
+        exploreDimensionFilters !== undefined ? [exploreDimensionFilters] : [];
+
+    const combinedFilters = [
+        ...exploreFilters,
+        ...filterParts.pointFilterRules,
+        ...filterParts.metricFilterRules,
+    ];
+
+    return getFiltersFromGroup(
+        {
+            id: uuidv4(),
+            and: combinedFilters,
+        },
+        allFields,
+    );
+};


### PR DESCRIPTION
Relates: GLITCH-589

### Description:

Groundwork for underlying data on data-app viz charts (GLITCH-589). **No behavior change.** Three commits:

1. **Extract** the underlying-data point-filter construction out of `UnderlyingDataModal` into `underlyingDataFilters.ts`:
   - `getUnderlyingDataFilterParts` — point filter rules (dimension equality/null/date-zoom range filters, pivot value filters) and metric intrinsic filter rules from a clicked cell's context.
   - `combineUnderlyingDataFilters` — merges explore-level dimension filters, point rules, and metric rules into a single `AND` group.
2. **Rewire** `UnderlyingDataModal` onto the shared util (its two filter memos now delegate; ~120 lines of inline construction removed).
3. **Expose `dateZoom` on `VisualizationContext`** — the provider already received the prop but only forwarded it to table config; the viz renderer will need it as the canonical source.

The upcoming viz path consumes the same functions, so date-zoom ranges, timezone normalization, and metric intrinsic filters can never diverge from the modal's behavior.

Test suite (`underlyingDataFilters.test.ts`, 10 cases) covers: metric-click equality/isNull per valid dimension (unknown keys skipped), dimension-click single filter, date-zoomed `[start, nextStart)` ranges instead of equality, DATE-base interval pass-through, pivot values, metric intrinsic `fieldRef→fieldId` conversion, explore-filter merging, and a metric intrinsic filter targeting an unselected dimension surviving when the field list is Explore-derived (plus the documented drop when absent from `allFields`). All 29 MetricQueryData tests stay green.