### PR TITLE
feat(cli): ship upgrade-preflight skill

### DIFF
--- a/skills/upgrade-preflight/SKILL.md
+++ b/skills/upgrade-preflight/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: upgrade-preflight
+description: Checks whether a self-hosted Lightdash upgrade is safe to run, and reads the tooling's answer without over-reading it. Use when upgrading a self-hosted instance, planning a maintenance window, answering "is this upgrade safe", or recovering a failed, hung, parked or lock-stuck migration — covers `lightdash upgrade-check` and `migrate preflight`, how to gate on their exit codes and JSON, and the readings that look calm but mean "could not check".
+---
+
+# Upgrade preflight
+
+Decide whether a self-hosted Lightdash upgrade is safe to run, and report the answer accurately.
+
+## Scope
+
+**Use this when** helping an operator upgrade a self-hosted instance: choosing a target version, planning a window, gating a pipeline, or recovering a migration that failed or hung.
+
+**Don't use this for** Lightdash Cloud (upgrades are managed), dbt or semantic-layer work, or developing Lightdash itself.
+
+The human-facing references are [upgrade safety](https://docs.lightdash.com/self-host/upgrade-safety) (what the signals mean) and the [upgrade runbook](https://docs.lightdash.com/self-host/upgrade-runbook) (execution sequences, per-platform invocation, recovery, rollback). This skill is the agent-facing layer: what to run, what to branch on, and what not to conclude. Link the operator to those pages rather than paraphrasing them.
+
+## Vocabulary
+
+One term per concept, matching the docs: a **span** is a from-version to a to-version; **verdict** is `upgrade-check`'s answer about a span; a **check** is one item the preflight reports; **decision** is the preflight's overall answer; the **lease** is the row a migrating node holds while it works.
+
+## Two layers, in this order
+
+Two commands. They answer different questions and neither substitutes for the other.
+
+|            | `lightdash upgrade-check`                                      | `migrate preflight`                                                          |
+| ---------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Question   | Is this **span** safe in principle?                            | Will **this database** take it right now?                                    |
+| Where      | Anywhere — the `@lightdash/cli`, no login, no database         | Inside the image, with database env credentials                              |
+| Reads      | The public release-safety index on GitHub                      | The live database + the artifact baked into the image                        |
+| Invocation | `lightdash upgrade-check --from 1.130.0 --to 1.138.0 [--json]` | `pnpm -F backend migrate-production preflight [--json] [--strict] [--force]` |
+
+**Run `upgrade-check` first.** It is the decision layer: it can tell the operator not to attempt the span at all, or that they must stop at an intermediate release, before anyone touches the instance. `migrate preflight` is the execution layer and cannot see the span — it knows only the image it runs in and the ledger in front of it. A preflight `decision` of `proceed` never licenses a span whose `verdict` was not `true`.
+
+## Gate on exit codes and JSON
+
+Both commands print human text by default and a machine payload under `--json`. Branch on the exit code, then read named fields — not the rendered text. The words `RED`, `UNSAFE` and `abort` all appear in the prose of runs that are fine, and the human renderer is not a contract.
+
+**Exit codes are binary in both commands: `0` success, `1` everything else** — an unsafe verdict, an aborted decision, or an error such as an unreachable index or a rejected flag. There is no severity ladder in the exit code; the severity lives in the payload. A non-zero exit means "stop and read the payload", never "this specific thing went wrong".
+
+**`upgrade-check`** — branch on `safe` (boolean). It is `true` only when `verdict` is `true`, `requiredStops` is empty, and the from-version is not below `minPreviousVersion`.
+
+- `verdict` is tri-state: `true`, `false`, or `"unknown"`. **`"unknown"` is not a pass** — a release in the span is unindexed or indexed as unknown, so the command fails closed. Report it as **"cannot verify this span"**, never as "clear" or "probably fine". This is the output most likely to be mis-summarised into an all-clear.
+- `requiredStops` non-empty means the span must be split into several upgrades, not that it is forbidden.
+- A rollback span is rejected with an error rather than a verdict; rollback guidance is in the runbook.
+
+**`migrate preflight`** — branch on `decision`: `proceed`, `proceed-with-warnings`, `abort`, or `force-proceed`. Equivalently, gate on `summary.red` and `summary.yellow`.
+
+- `severity` is the **class of a check, not its result.** `postgres-version` is always a red-class check; on a healthy server it reports `{"severity": "red", "outcome": "pass"}` and renders as `[RED PASS]`. Only `severity: "red"` **with** `outcome: "fail"` is a failure — that pairing is what `summary.red` counts. Read `outcome`, or read `summary`.
+- `summary.red > 0` ⇒ `abort` (or `force-proceed` if `--force` was passed). `summary.yellow > 0` alone ⇒ `proceed-with-warnings`; under `--strict` ⇒ `abort`. `info` checks never gate.
+- The payload prints **before** the command exits, so on an `abort` you get the full JSON on stdout and the reason on stderr with exit 1. Parse the payload rather than treating the exit code as opaque.
+- `migrate up` runs this same gate internally before claiming the lease, so a red check blocks the upgrade whether or not anyone ran preflight first. Running it separately buys the answer _before_ the window, not a different answer.
+
+Full worked payloads for both commands, with every field annotated: [output reference](./resources/output-reference.md).
+
+## The readings that look calm but are not
+
+**`proceed-with-warnings` is not `proceed`.** It is a distinct decision and it exits 0. Every yellow check is something a human chose to be told about — surface each one with its `message`, rather than collapsing the run to "preflight passed".
+
+**A `version-path` yellow means the image cannot verify its own upgrade path.** `{"id": "version-path", "severity": "yellow", "outcome": "warn"}` means no baked `release-safety.json` was found. Required-stop verification was _skipped_, not satisfied — and because that artifact is also what tells the preflight which tables the pending migrations touch, its absence blinds three more checks:
+
+- `held-locks` and `long-transactions` get no table list, so they report **pass** — "No other sessions hold relation locks on pending-migration DDL tables" — having looked at nothing.
+- `disk-headroom` reports pass with `data.applicable: false`.
+- Every `pending-migrations` entry carries `metadataAvailable: false` and an empty `tables` array.
+
+An artifact-less image therefore produces one yellow and three reassuring passes. **When `version-path` warns, describe the lock, transaction and disk checks as unverified rather than clear**, and rely on `upgrade-check` for the span question — it reads the public index and does not depend on the image. `metadataAvailable: false` on individual migrations means the same thing at a finer grain.
+
+**A quiet activity reading can mean "could not look".** `held-locks` and `long-transactions` report `outcome: "warn"` with a non-null `data.probeError` when the probe itself failed — a restricted role, a dropped connection — and `data.locks` / `data.transactions` are empty in that case exactly as they are in a clean read. Check `probeError` before describing a table as quiet.
+
+**A `disk-headroom` pass has three meanings.** Read `data`: `applicable: false` means no pending migration is known to scan or rewrite, so nothing was measured; `source: "unavailable"` means PostgreSQL cannot report free space and no external signal was configured (the operator sets `MIGRATION_PREFLIGHT_DISK_HEADROOM_BYTES` to give the check a number to compare against `data.minimumBytes`). Only `source: "configured"` with sufficient `availableBytes` is a measured pass.
+
+**A fresh-install pass says nothing about upgrading.** An empty `knex_migrations` ledger makes `version-path` pass with "this is a fresh install rather than an upgrade path" — a statement about the ledger, not a verdict on a span.
+
+**Severity encodes consequence, not size.** `pending-migrations` is `info` however many migrations it lists, and a single held `AccessExclusiveLock` on a small table is a yellow worth stopping for. Rank findings by what they do, never by counts in the payload — and note the preflight emits **no** timing or row-count figures at all, so any duration quoted for a migration window is invented. Describe the shape of the risk and let the operator time it.
+
+## Decisions that belong to the operator
+
+Four actions are deliberately reserved for a human. The agent's job in each is to produce the evidence and hand over.
+
+- **`--force`** — report the failing checks from the `abort` payload and stop there. It is the operator's override: pass `--force` only when they instruct it after seeing those checks, and echo back which checks are being overridden first. It converts an `abort` into `force-proceed`, exits 0, and prints an override banner to stderr.
+- **`--actor`** — `migrate unlock` requires an attribution string, and it is written into the lease and run history as the person who cleared it. Ask the operator for their identity and pass exactly that (`--actor "alex@example.com"`); a placeholder, a hostname or the agent's own name would attribute the unlock to someone who did not authorise it.
+- **A parked lease** — `parked` means the migrator exhausted its retries and stopped on purpose, and it refuses to re-run the same app version. Report the parked state with its failing migration and error, and point to the runbook's recovery section. Retrying is the operator's call once the cause is fixed or a corrected version is deployed.
+- **Remediation SQL** — the preflight reports conditions and emits no fix script. Hand each finding to the operator and their DBA rather than composing DDL from it.
+
+The verdict is deterministic for a given index, so a re-run that disagrees means the span or the index changed — not that the first answer was noise.
+
+## Upgrade checklist
+
+Copy this into the working notes and tick as you go:
+
+```markdown
+- [ ] Operator has confirmed a database backup (there are no down-migrations)
+- [ ] Span checked: `upgrade-check` returns `safe: true` (or every required stop planned as its own hop)
+- [ ] Preflight run against the instance: `decision` is `proceed`, or every yellow check surfaced and accepted by the operator
+- [ ] Upgrade executed per the runbook for this platform
+- [ ] Migrations finished: `migrate status --json` shows `state: idle` with no pending migrations
+- [ ] Readiness verified: `/api/v1/readyz` returns 200
+```
+
+## Running the commands
+
+Run these exactly as written, substituting only the `<angle-bracket>` placeholders. `upgrade-check` runs anywhere the CLI is installed; the `migrate` commands must run **inside** the image, with the database environment present.
+
+```bash
+# 1. Check the span (no login, no database access needed)
+lightdash upgrade-check --from <current-version> --to <target-version> --json
+
+# 2. Preflight — Kubernetes, as a one-off run
+kubectl exec deploy/<release>-lightdash -- \
+  pnpm -F backend migrate-production preflight --json
+
+# 2. Preflight — docker compose, in a throwaway container
+docker compose run --rm --entrypoint pnpm lightdash \
+  -F backend migrate-production preflight --json
+
+# 3. Inspect state at any point
+kubectl exec deploy/<release>-lightdash -- \
+  pnpm -F backend migrate-production status --json
+
+# 4. Verify readiness after the upgrade
+curl -sS -o /dev/null -w '%{http_code}\n' https://<host>/api/v1/readyz
+```
+
+**In CI, add `--strict`** so warnings block the pipeline rather than passing with a decision no one reads.
+
+Preflight opens a database connection but changes nothing, so it is safe to run ahead of a window. Prefer a one-off Job over exec-ing into a serving pod when you want a clean run — the runbook has the full manifests, the Helm sequence and the readiness checks.
+
+## When a migration is already in flight
+
+`migrate status [--json]` reports a `state` of `idle`, `migrating`, `stale` or `parked`, plus the lease holder and run history.
+
+- `migrating` with a recent heartbeat is healthy work in progress — wait.
+- `stale` recovers on its own when another node takes over the expired lease.
+- `parked` is the operator's call (above).
+
+`migrate wait [--timeout-ms <ms>]` blocks until migrations finish (default 30 minutes, or `MIGRATION_WAIT_TIMEOUT_MS`) and takes over an expired lease. Give a hung migration time before anyone touches the lease; the runbook's recovery section is the authority on what comes next.

--- a/skills/upgrade-preflight/resources/output-reference.md
+++ b/skills/upgrade-preflight/resources/output-reference.md
@@ -1,0 +1,235 @@
+# Output reference
+
+Worked `--json` payloads and field meanings for the two upgrade commands. Read this when you need to gate on a field the [SKILL](../SKILL.md) does not spell out.
+
+- [upgrade-check](#upgrade-check) — [safe span](#a-safe-span), [unverifiable span](#an-unverifiable-span), [fields](#upgrade-check-fields)
+- [migrate preflight](#migrate-preflight) — [an abort](#an-abort), [a blind pass](#a-blind-pass), [the checks](#the-checks)
+- [migrate status](#migrate-status)
+
+## upgrade-check
+
+`lightdash upgrade-check --from <current> --to <target> --json`
+
+### A safe span
+
+```json
+{
+  "fromVersion": "1.130.0",
+  "toVersion": "1.138.0",
+  "direction": "upgrade",
+  "safe": true,
+  "verdict": true,
+  "requiredStops": [],
+  "minPreviousVersion": null,
+  "coveredVersions": ["1.131.0", "1.132.0", "1.138.0"],
+  "missingRanges": []
+}
+```
+
+Exit 0. Proceed to the preflight.
+
+### An unverifiable span
+
+```json
+{
+  "fromVersion": "1.118.0",
+  "toVersion": "1.138.0",
+  "direction": "upgrade",
+  "safe": false,
+  "verdict": "unknown",
+  "requiredStops": ["1.123.0"],
+  "minPreviousVersion": "1.110.0",
+  "coveredVersions": ["1.123.0", "1.138.0"],
+  "missingRanges": [{ "afterVersion": "1.123.0", "beforeVersion": "1.138.0" }]
+}
+```
+
+Exit 1. Two separate things are true here and both must be reported: releases between 1.123.0 and 1.138.0 are absent from the index (so the span **cannot be verified**), and 1.123.0 is a required stop (so the upgrade must be run as two hops regardless). Neither is "unsafe" in the sense of a known-bad release — do not report it as one, and do not report it as clear.
+
+### upgrade-check fields
+
+| Field                | Type                              | Meaning                                                                           |
+| -------------------- | --------------------------------- | --------------------------------------------------------------------------------- |
+| `safe`               | boolean                           | **The gate.** `verdict === true` and no `requiredStops` and not below the minimum |
+| `verdict`            | `true` \| `false` \| `"unknown"`  | Rolling-update safety composed across the span. `"unknown"` fails closed          |
+| `direction`          | `"upgrade"` \| `"same-version"`   | A rollback span throws instead of returning                                       |
+| `requiredStops`      | string[]                          | Releases that must each be landed on in turn                                      |
+| `minPreviousVersion` | string \| null                    | Oldest version the target can be upgraded from directly                           |
+| `coveredVersions`    | string[]                          | Releases in the span the index does describe                                      |
+| `missingRanges`      | `{afterVersion, beforeVersion}[]` | Gaps in index coverage; the reason a verdict is `"unknown"`                       |
+
+## migrate preflight
+
+`pnpm -F backend migrate-production preflight --json`
+
+Every run emits all seven checks in a fixed order; the `checks` arrays below are abridged to the ones each example is about.
+
+### An abort
+
+```json
+{
+  "schemaVersion": "1",
+  "decision": "abort",
+  "force": false,
+  "strict": false,
+  "summary": { "red": 1, "yellow": 1, "info": 1 },
+  "checks": [
+    {
+      "id": "version-path",
+      "severity": "red",
+      "outcome": "pass",
+      "message": "The migration ledger structurally matches the target artifact direct-predecessor or up-to-date path",
+      "data": {
+        "artifactPath": "/usr/app/release-safety.json",
+        "targetVersion": "1.138.0",
+        "previousVersion": "1.137.0",
+        "minPreviousVersion": null,
+        "requiredStops": [],
+        "completedMigrationCount": 812,
+        "pendingMigrationsOutsideArtifact": [],
+        "artifactError": null
+      }
+    },
+    {
+      "id": "postgres-version",
+      "severity": "red",
+      "outcome": "fail",
+      "message": "PostgreSQL 11.19 is unsupported; version 12 or newer is required",
+      "data": {
+        "serverVersion": "11.19",
+        "serverVersionNum": 110019,
+        "minimumSupportedMajor": 12,
+        "probeError": null
+      }
+    },
+    {
+      "id": "held-locks",
+      "severity": "yellow",
+      "outcome": "warn",
+      "message": "2 held relation lock(s) may delay DDL on pending-migration tables",
+      "data": {
+        "tables": ["saved_queries"],
+        "locks": [
+          {
+            "pid": 4821,
+            "table": "saved_queries",
+            "lockMode": "RowExclusiveLock",
+            "transactionAgeSeconds": 12
+          }
+        ],
+        "probeError": null
+      }
+    },
+    {
+      "id": "pending-migrations",
+      "severity": "info",
+      "outcome": "info",
+      "message": "3 pending migration(s)",
+      "data": {
+        "migrations": [
+          {
+            "name": "20260801120000_add_column.ts",
+            "transaction": true,
+            "tables": ["saved_queries"],
+            "metadataAvailable": true
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Exit 1, payload on stdout, reason on stderr. Note `version-path`: `severity: "red"` with `outcome: "pass"` is a **healthy** check. The single failure is `postgres-version`, and it alone produced `summary.red: 1` and the `abort`.
+
+### A blind pass
+
+The same command on an image with no baked artifact:
+
+```json
+{
+  "schemaVersion": "1",
+  "decision": "proceed-with-warnings",
+  "force": false,
+  "strict": false,
+  "summary": { "red": 0, "yellow": 1, "info": 1 },
+  "checks": [
+    {
+      "id": "version-path",
+      "severity": "yellow",
+      "outcome": "warn",
+      "message": "No baked release-safety artifact is present; required-stop verification was skipped; upgrade-path safety cannot be verified on this image",
+      "data": {
+        "artifactPath": "/usr/app/release-safety.json",
+        "targetVersion": null,
+        "requiredStops": [],
+        "pendingMigrationsOutsideArtifact": ["20260801120000_add_column.ts"],
+        "artifactError": null
+      }
+    },
+    {
+      "id": "held-locks",
+      "severity": "yellow",
+      "outcome": "pass",
+      "message": "No other sessions hold relation locks on pending-migration DDL tables",
+      "data": { "tables": [], "locks": [], "probeError": null }
+    },
+    {
+      "id": "disk-headroom",
+      "severity": "yellow",
+      "outcome": "pass",
+      "message": "Disk headroom is not applicable because no pending artifact migration scans or rewrites a table",
+      "data": {
+        "applicable": false,
+        "availableBytes": null,
+        "minimumBytes": 5368709120,
+        "source": "unavailable"
+      }
+    },
+    {
+      "id": "pending-migrations",
+      "severity": "info",
+      "outcome": "info",
+      "message": "3 pending migration(s)",
+      "data": {
+        "migrations": [
+          {
+            "name": "20260801120000_add_column.ts",
+            "transaction": true,
+            "tables": [],
+            "metadataAvailable": false
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Exit 0. `held-locks` and `disk-headroom` pass because `data.tables` is empty and `applicable` is false — nothing was examined. Report this run as "one check could not be verified; three others had nothing to examine", not as a pass with a minor warning.
+
+### The checks
+
+| `id`                   | Class  | Passes when                                                     | Blind spot                                                                                                   |
+| ---------------------- | ------ | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `version-path`         | red \* | Ledger matches the artifact's predecessor/up-to-date path       | Yellow-class when no artifact is baked — verification skipped                                                |
+| `migration-privileges` | red    | Migration user can create in schema and owns the pending tables | Fails closed on probe error (`data.probeError`); empty table list without an artifact                        |
+| `postgres-version`     | red    | Server major ≥ 12                                               | Fails closed on probe error                                                                                  |
+| `held-locks`           | yellow | No other session holds a relation lock on the DDL tables        | Passes vacuously when the table list is empty; warns with `probeError` on failure                            |
+| `long-transactions`    | yellow | No transaction ≥ 300s holds those locks                         | Same as above                                                                                                |
+| `disk-headroom`        | yellow | `availableBytes ≥ minimumBytes` (5 GiB)                         | Passes when `applicable: false`; warns "unavailable" unless `MIGRATION_PREFLIGHT_DISK_HEADROOM_BYTES` is set |
+| `pending-migrations`   | info   | Never gates                                                     | `metadataAvailable: false` ⇒ that migration's tables were never probed                                       |
+
+\* `version-path` is the one check whose class varies: red normally, yellow when the artifact is absent.
+
+`data.transaction` on a pending migration is `true` when the migration runs inside a transaction, `false` when it opts out (`config = { transaction: false }`), and `null` when the file could not be read. A non-transactional migration cannot be rolled back by the database if it fails partway.
+
+## migrate status
+
+`pnpm -F backend migrate-production status --json` returns `{ state, lease, knex, runHistory }`.
+
+`state` is `idle`, `migrating`, `stale` or `parked`.
+
+`knex.classification` is `up-to-date`, `database-behind`, `database-ahead` or `diverged`. `database-ahead` means the ledger contains migrations this image does not have but the image recognises them as its own future — normal after a rollback, and not blocking. `diverged` means it cannot account for them: `knex.offending` names those, and both `up` and `preflight` refuse to run (`version-path` reports `severity: "red"`, `outcome: "fail"`). `knex.missing` is the wider list of database-only migrations, most of which are benign under `database-ahead`.
+
+`runHistory.runs[]` carries per-attempt `outcome`, `failingMigration`, `failureDetail`, and the `lastUnlockedBy` / `lastUnlockForced` attribution of any unlock that preceded the run.


### PR DESCRIPTION
Adds `skills/upgrade-preflight`, shipped to Claude, Cursor and Codex by `lightdash install-skills`.

The skill teaches an agent the two-layer upgrade model — `lightdash upgrade-check` for whether a version span is safe in principle, `migrate preflight` for whether this database will take it — and to gate on the binary exit codes and `--json` fields rather than parsing the rendered prose. It documents the readings that look calm but are not: an `unknown` verdict fails closed and must be reported as "cannot verify"; `proceed-with-warnings` is not `proceed`; `severity` is the class of a check rather than its result, so `[RED PASS]` is healthy; and an image with no baked release-safety artifact reports three vacuous passes because the checks had no table list to probe. Four actions — `--force`, `unlock --actor`, retrying a parked lease, and running remediation SQL — are framed as the operator's decision, with the agent's job being to produce the evidence.

Content only: no source changes. `packages/cli/src/skills.test.ts` already covers the frontmatter contract and resource links for every directory under `skills/`, and `install-skills` discovers skills dynamically, so there is no registry to update. The docs pages `self-host/upgrade-safety` and `self-host/upgrade-runbook` remain the human-facing references and are linked rather than duplicated.

Linear: SPK-896