### PR TITLE
feat: host-side underlying data support for data app vizs

### DIFF
--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -1032,15 +1032,31 @@ export const APP_SDK_COLOR_SCHEME_MESSAGE = 'lightdash:sdk:theme';
 export const APP_SDK_COLOR_SCHEME_REQUEST_MESSAGE =
     'lightdash:sdk:theme-request';
 
+// Bridge-only virtual route: the viz posts semantic click intent here and the
+// host rewrites it into the real underlying-data POST. Never forwarded to the
+// API — `useAppSdkBridge` resolves it before allowlist matching.
+export const APP_SDK_VIZ_UNDERLYING_DATA_PATH = '/__sdk/viz/underlying-data';
+
+// Click intent a viz sends to the virtual route: the untransformed source row
+// (as pushed in the viz context) and the declared field NAME bound to the
+// clicked metric slot. The host resolves everything else at request time.
+export type DataAppVizUnderlyingDataIntent = {
+    row: ResultRow;
+    metric: string;
+    limit?: number | null;
+};
+
 // Host-owned render context pushed into a data app viz: field name → bound query
 // field id, the host-fetched result rows the renderer reads, the effective
 // config option values (stored value ?? declared default), and the palette
 // resolved for this chart (org → project → space → dashboard → chart, dark-mode
 // corrected). `colorPalette` is pushed whether or not the viz declared one, so a
-// viz that colours series never has to check first.
+// viz that colours series never has to check first. `underlyingData.enabled` is
+// required so every push site decides availability explicitly.
 export type DataAppVizContext = {
     fieldMapping: Record<string, string>;
     rows: ResultRow[];
     options: Record<string, DataAppVizOptionValue>;
     colorPalette: string[];
+    underlyingData: { enabled: boolean };
 };

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -43,6 +43,11 @@ const mocks = vi.hoisted(() => ({
     renderMetadataHook: vi.fn(),
     previewTokenHook: vi.fn(),
     setFetchAll: vi.fn(),
+    canViewUnderlyingData: { current: true },
+    explore: { current: undefined as { name: string } | undefined },
+    exploreHook: vi.fn(),
+    // Extra keys merged into the useVisualizationContext mock return value.
+    vizContextOverrides: { current: {} as Record<string, unknown> },
 }));
 
 vi.mock('react-router', () => ({
@@ -71,10 +76,15 @@ vi.mock('../../features/apps/previewOrigin', () => ({
     usePreviewOrigin: () => 'https://preview.example.com',
 }));
 vi.mock('../../hooks/useContextMenuPermissions', () => ({
-    useContextMenuPermissions: () => ({ canViewUnderlyingData: true }),
+    useContextMenuPermissions: () => ({
+        canViewUnderlyingData: mocks.canViewUnderlyingData.current,
+    }),
 }));
 vi.mock('../../hooks/useExplore', () => ({
-    useExplore: () => ({ data: undefined }),
+    useExplore: (...args: unknown[]) => {
+        mocks.exploreHook(...args);
+        return { data: mocks.explore.current };
+    },
 }));
 vi.mock('../LightdashVisualization/types', () => ({
     isDataAppVizVisualizationConfig: () => true,
@@ -96,6 +106,7 @@ vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
             setFetchAll: mocks.setFetchAll,
         },
         colorPalette: ['#7162FF'],
+        ...mocks.vizContextOverrides.current,
     }),
 }));
 
@@ -150,6 +161,10 @@ describe('DataAppVizRenderer', () => {
         mocks.renderMetadataHook.mockClear();
         mocks.previewTokenHook.mockClear();
         mocks.setFetchAll.mockClear();
+        mocks.canViewUnderlyingData.current = true;
+        mocks.explore.current = undefined;
+        mocks.exploreHook.mockClear();
+        mocks.vizContextOverrides.current = {};
     });
 
     it('prompts for a visualization when none is selected', () => {
@@ -319,6 +334,145 @@ describe('DataAppVizRenderer', () => {
                 isEmbedded: true,
                 savedChartUuid: 'saved-chart-uuid',
             },
+        );
+    });
+});
+
+describe('DataAppVizRenderer underlying-data gating', () => {
+    const happyMetricQuery = {
+        exploreName: 'orders',
+        dimensions: ['orders_category'],
+        metrics: ['orders_count'],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+    };
+    const happyResultsData = () => ({
+        rows: [{ 'orders.category': { value: { raw: 'Hardware' } } }],
+        setFetchAll: mocks.setFetchAll,
+        metricQuery: happyMetricQuery,
+        queryUuid: 'source-query-uuid',
+    });
+
+    const binDimension = {
+        id: 'bin1',
+        name: 'amount_bin',
+        table: 'orders',
+        type: 'bin',
+        dimensionId: 'orders_amount',
+        binType: 'fixed_number',
+        binNumber: 5,
+    };
+
+    const lastIframeProps = () =>
+        (
+            mocks.iframePreview.mock.calls.at(-1) as unknown[] | undefined
+        )?.[0] as {
+            dataAppVizContext?: { underlyingData: { enabled: boolean } };
+            rewriteVizUnderlyingDataRequest?: (intent: unknown) => unknown;
+        };
+
+    beforeEach(() => {
+        mocks.metadata.current = readyMetadata();
+        mocks.metadataError.current = undefined;
+        mocks.token.current = 'preview-token';
+        mocks.tokenError.current = undefined;
+        mocks.embedToken.current = undefined;
+        mocks.dataAppVizUuid.current = 'viz-uuid';
+        mocks.iframePreview.mockClear();
+        mocks.exploreHook.mockClear();
+        mocks.canViewUnderlyingData.current = true;
+        mocks.explore.current = { name: 'orders' };
+        mocks.vizContextOverrides.current = { resultsData: happyResultsData() };
+    });
+
+    it('happy path: pushes enabled and installs the rewrite callback', () => {
+        renderRenderer();
+        const props = lastIframeProps();
+        expect(props.dataAppVizContext?.underlyingData).toEqual({
+            enabled: true,
+        });
+        expect(props.rewriteVizUnderlyingDataRequest).toBeTypeOf('function');
+    });
+
+    it.each([
+        [
+            'permission denied',
+            () => {
+                mocks.canViewUnderlyingData.current = false;
+            },
+        ],
+        [
+            'embed context',
+            () => {
+                mocks.embedToken.current = 'embed-jwt';
+            },
+        ],
+        [
+            'minimal (screenshot) render',
+            () => {
+                mocks.vizContextOverrides.current = {
+                    resultsData: happyResultsData(),
+                    minimal: true,
+                };
+            },
+        ],
+        [
+            'no source query uuid',
+            () => {
+                mocks.vizContextOverrides.current = {
+                    resultsData: {
+                        ...happyResultsData(),
+                        queryUuid: undefined,
+                    },
+                };
+            },
+        ],
+        [
+            'custom bin dimension in the query',
+            () => {
+                mocks.vizContextOverrides.current = {
+                    resultsData: {
+                        ...happyResultsData(),
+                        metricQuery: {
+                            ...happyMetricQuery,
+                            customDimensions: [binDimension],
+                        },
+                    },
+                };
+            },
+        ],
+        [
+            'explore not loaded',
+            () => {
+                mocks.explore.current = undefined;
+            },
+        ],
+    ])('%s: pushes disabled and installs no callback', (_label, arrange) => {
+        arrange();
+        renderRenderer();
+        const props = lastIframeProps();
+        expect(props.dataAppVizContext?.underlyingData).toEqual({
+            enabled: false,
+        });
+        expect(props.rewriteVizUnderlyingDataRequest).toBeUndefined();
+    });
+
+    it('gated surfaces disable the explore fetch itself', () => {
+        mocks.embedToken.current = 'embed-jwt';
+        renderRenderer();
+        expect(mocks.exploreHook).toHaveBeenLastCalledWith(
+            'orders',
+            expect.objectContaining({ enabled: false }),
+        );
+    });
+
+    it('the happy path enables the explore fetch', () => {
+        renderRenderer();
+        expect(mocks.exploreHook).toHaveBeenLastCalledWith(
+            'orders',
+            expect.objectContaining({ enabled: true }),
         );
     });
 });

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -70,6 +70,12 @@ vi.mock('../../features/apps/hooks/useDataAppVizRender', () => ({
 vi.mock('../../features/apps/previewOrigin', () => ({
     usePreviewOrigin: () => 'https://preview.example.com',
 }));
+vi.mock('../../hooks/useContextMenuPermissions', () => ({
+    useContextMenuPermissions: () => ({ canViewUnderlyingData: true }),
+}));
+vi.mock('../../hooks/useExplore', () => ({
+    useExplore: () => ({ data: undefined }),
+}));
 vi.mock('../LightdashVisualization/types', () => ({
     isDataAppVizVisualizationConfig: () => true,
 }));

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -1,5 +1,6 @@
 import {
     getEffectiveOptionValues,
+    hasCustomBinDimension,
     type ApiError,
     type DataAppVizContext,
 } from '@lightdash/common';
@@ -17,9 +18,12 @@ import {
 } from '../../features/apps/hooks/useDataAppVizRender';
 import { usePreviewOrigin } from '../../features/apps/previewOrigin';
 import { reconcileDataAppVizFieldMapping } from '../../features/apps/utils/autoMapDataAppVizFields';
+import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
+import { useExplore } from '../../hooks/useExplore';
 import MantineIcon from '../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
+import { buildVizUnderlyingDataRequest } from './vizUnderlyingDataRequest';
 
 type Props = {
     onScreenshotReady?: () => void;
@@ -57,8 +61,13 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         colorPalette,
         itemsMap,
         savedChartUuid,
+        minimal,
+        parameters,
+        dateZoom,
+        resolvedTimezone,
     } = useVisualizationContext();
     const { embedToken } = useEmbed();
+    const { canViewUnderlyingData } = useContextMenuPermissions();
     const previewOrigin = usePreviewOrigin();
     const hasSignaledScreenshotReady = useRef(false);
 
@@ -106,17 +115,84 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     const configOptions = readyMetadata?.schema.configOptions;
     const fields = readyMetadata?.schema.fields;
 
+    const metricQuery = resultsData?.metricQuery;
+    const sourceQueryUuid = resultsData?.queryUuid;
+    const { data: explore } = useExplore(metricQuery?.exploreName, {
+        refetchOnMount: false,
+    });
+
+    // Reconciled against the contract and columns in force now, so a rebuilt
+    // viz never renders through a binding the panel no longer shows. Shared by
+    // the context push and the rewrite callback, so clicks resolve through
+    // exactly what the iframe was told.
+    const reconciledFieldMapping = useMemo(
+        () =>
+            fields
+                ? reconcileDataAppVizFieldMapping(
+                      fields,
+                      itemsMap ?? {},
+                      fieldMapping ?? {},
+                  )
+                : undefined,
+        [fields, itemsMap, fieldMapping],
+    );
+
+    // Mirrors the regular chart context-menu gating: no query (builder
+    // canvas/sample previews), no permission, custom bin dimensions, embeds
+    // (GLITCH-592) and screenshot renders all disable underlying data.
+    const underlyingDataEnabled =
+        !!sourceQueryUuid &&
+        !!metricQuery &&
+        !!explore &&
+        !!reconciledFieldMapping &&
+        canViewUnderlyingData &&
+        !hasCustomBinDimension(metricQuery) &&
+        !embedToken &&
+        !minimal;
+
+    // enabled:false ⇒ callback undefined ⇒ the bridge answers the virtual
+    // route with an error — enforcement is structural, not menu-side.
+    const rewriteVizUnderlyingDataRequest = useMemo(() => {
+        if (
+            !underlyingDataEnabled ||
+            !projectUuid ||
+            !sourceQueryUuid ||
+            !metricQuery ||
+            !explore ||
+            !reconciledFieldMapping
+        ) {
+            return undefined;
+        }
+        return (intentBody: unknown) =>
+            buildVizUnderlyingDataRequest(intentBody, {
+                projectUuid,
+                queryUuid: sourceQueryUuid,
+                fieldMapping: reconciledFieldMapping,
+                itemsMap: itemsMap ?? {},
+                metricQuery,
+                explore,
+                resolvedTimezone,
+                parameters,
+                dateZoom,
+            });
+    }, [
+        underlyingDataEnabled,
+        projectUuid,
+        sourceQueryUuid,
+        metricQuery,
+        explore,
+        reconciledFieldMapping,
+        itemsMap,
+        resolvedTimezone,
+        parameters,
+        dateZoom,
+    ]);
+
     const dataAppVizContext = useMemo<DataAppVizContext | undefined>(() => {
-        if (!rows || !configOptions || !fields) return undefined;
+        if (!rows || !configOptions || !reconciledFieldMapping)
+            return undefined;
         return {
-            // Reconciled against the contract and columns in force now, so a
-            // rebuilt viz never renders through a binding the panel no longer
-            // shows.
-            fieldMapping: reconcileDataAppVizFieldMapping(
-                fields,
-                itemsMap ?? {},
-                fieldMapping ?? {},
-            ),
+            fieldMapping: reconciledFieldMapping,
             rows,
             options: getEffectiveOptionValues(
                 configOptions,
@@ -125,16 +201,15 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
             // Already resolved through the full palette cascade and dark-mode
             // corrected by the visualization context.
             colorPalette,
-            underlyingData: { enabled: false },
+            underlyingData: { enabled: underlyingDataEnabled },
         };
     }, [
-        fields,
-        itemsMap,
-        fieldMapping,
+        reconciledFieldMapping,
         rows,
         configOptions,
         optionValues,
         colorPalette,
+        underlyingDataEnabled,
     ]);
 
     if (!projectUuid || !dataAppVizUuid) {
@@ -198,6 +273,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
             appUuid={dataAppVizUuid}
             identityKey={dataAppVizUuid}
             dataAppVizContext={dataAppVizContext}
+            rewriteVizUnderlyingDataRequest={rewriteVizUnderlyingDataRequest}
         />
     );
 };

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -125,6 +125,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
             // Already resolved through the full palette cascade and dark-mode
             // corrected by the visualization context.
             colorPalette,
+            underlyingData: { enabled: false },
         };
     }, [
         fields,

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -117,8 +117,26 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
 
     const metricQuery = resultsData?.metricQuery;
     const sourceQueryUuid = resultsData?.queryUuid;
+
+    // Explore-independent gating, mirroring regular chart context menus: no
+    // query (builder canvas/sample previews), no permission, custom bin
+    // dimensions, embeds (GLITCH-592) and screenshot renders all disable
+    // underlying data.
+    const underlyingDataPreconditions =
+        !!sourceQueryUuid &&
+        !!metricQuery &&
+        canViewUnderlyingData &&
+        !hasCustomBinDimension(metricQuery) &&
+        !embedToken &&
+        !minimal;
+
     const { data: explore } = useExplore(metricQuery?.exploreName, {
         refetchOnMount: false,
+        // Passing `enabled` overrides useExplore's own guards — keep them.
+        enabled:
+            underlyingDataPreconditions &&
+            !!metricQuery?.exploreName &&
+            !!projectUuid,
     });
 
     // Reconciled against the contract and columns in force now, so a rebuilt
@@ -137,18 +155,8 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         [fields, itemsMap, fieldMapping],
     );
 
-    // Mirrors the regular chart context-menu gating: no query (builder
-    // canvas/sample previews), no permission, custom bin dimensions, embeds
-    // (GLITCH-592) and screenshot renders all disable underlying data.
     const underlyingDataEnabled =
-        !!sourceQueryUuid &&
-        !!metricQuery &&
-        !!explore &&
-        !!reconciledFieldMapping &&
-        canViewUnderlyingData &&
-        !hasCustomBinDimension(metricQuery) &&
-        !embedToken &&
-        !minimal;
+        underlyingDataPreconditions && !!explore && !!reconciledFieldMapping;
 
     // enabled:false ⇒ callback undefined ⇒ the bridge answers the virtual
     // route with an error — enforcement is structural, not menu-side.

--- a/packages/frontend/src/components/DataAppVizRenderer/vizUnderlyingDataRequest.test.ts
+++ b/packages/frontend/src/components/DataAppVizRenderer/vizUnderlyingDataRequest.test.ts
@@ -1,0 +1,268 @@
+/// <reference types="vitest/globals" />
+import {
+    DateGranularity,
+    DimensionType,
+    FieldType,
+    FilterOperator,
+    MetricType,
+    QueryExecutionContext,
+    type Dimension,
+    type Explore,
+    type FilterGroup,
+    type FilterRule,
+    type ItemsMap,
+    type Metric,
+    type MetricQuery,
+    type TableCalculation,
+} from '@lightdash/common';
+import {
+    buildVizUnderlyingDataRequest,
+    type VizUnderlyingDataRewriteArgs,
+} from './vizUnderlyingDataRequest';
+
+const dimension = (
+    name: string,
+    overrides: Partial<Dimension> = {},
+): Dimension =>
+    ({
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.STRING,
+        name,
+        label: name,
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: `\${TABLE}.${name}`,
+        hidden: false,
+        ...overrides,
+    }) as Dimension;
+
+const metric = (name: string, filters?: Metric['filters']): Metric =>
+    ({
+        fieldType: FieldType.METRIC,
+        type: MetricType.SUM,
+        name,
+        label: name,
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: `\${TABLE}.${name}`,
+        hidden: false,
+        ...(filters ? { filters } : {}),
+    }) as Metric;
+
+const statusDim = dimension('status');
+const isCompletedDim = dimension('is_completed');
+const orderDateMonthDim = dimension('order_date_month', {
+    type: DimensionType.DATE,
+});
+const amountMetric = metric('amount');
+const ratioCalc = {
+    name: 'calc_ratio',
+    displayName: 'Ratio',
+    sql: '${orders.amount} / 100',
+} as TableCalculation;
+
+const explore = {
+    name: 'orders',
+    label: 'Orders',
+    baseTable: 'orders',
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: 'db',
+            schema: 'public',
+            sqlTable: 'orders',
+            dimensions: {
+                status: statusDim,
+                is_completed: isCompletedDim,
+                order_date_month: orderDateMonthDim,
+            },
+            metrics: { amount: amountMetric },
+            lineageGraph: {},
+        },
+    },
+} as unknown as Explore;
+
+const itemsMap: ItemsMap = {
+    orders_status: statusDim,
+    orders_order_date_month: orderDateMonthDim,
+    orders_amount: amountMetric,
+    calc_ratio: ratioCalc,
+};
+
+const metricQuery: MetricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_status'],
+    metrics: ['orders_amount'],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const baseArgs: VizUnderlyingDataRewriteArgs = {
+    projectUuid: 'project-1',
+    queryUuid: 'query-1',
+    fieldMapping: { value: 'orders_amount', category: 'orders_status' },
+    itemsMap,
+    metricQuery,
+    explore,
+    resolvedTimezone: undefined,
+    parameters: undefined,
+    dateZoom: undefined,
+};
+
+const row = {
+    orders_status: { value: { raw: 'completed', formatted: 'Completed' } },
+    orders_amount: { value: { raw: 100, formatted: '$100' } },
+};
+
+// Recursively collect FilterRules from a possibly-nested group.
+const flattenRules = (group: FilterGroup | undefined): FilterRule[] => {
+    if (!group) return [];
+    const items = 'and' in group ? group.and : group.or;
+    return items.flatMap((item) =>
+        'target' in item ? [item as FilterRule] : flattenRules(item),
+    );
+};
+
+describe('buildVizUnderlyingDataRequest', () => {
+    test('rejects a non-object intent', () => {
+        expect(() => buildVizUnderlyingDataRequest(null, baseArgs)).toThrow(
+            /invalid/i,
+        );
+        expect(() =>
+            buildVizUnderlyingDataRequest({ metric: 42, row }, baseArgs),
+        ).toThrow(/invalid/i);
+    });
+
+    test('rejects a metric name not in the reconciled mapping', () => {
+        expect(() =>
+            buildVizUnderlyingDataRequest({ row, metric: 'nope' }, baseArgs),
+        ).toThrow(/not bound/i);
+    });
+
+    test('metric binding: itemId + dimension equality filters from the row', () => {
+        const { method, path, body } = buildVizUnderlyingDataRequest(
+            { row, metric: 'value' },
+            baseArgs,
+        );
+        expect(method).toBe('POST');
+        expect(path).toBe('/api/v2/projects/project-1/query/underlying-data');
+        expect(body.context).toBe(QueryExecutionContext.VIEW_UNDERLYING_DATA);
+        expect(body.underlyingDataSourceQueryUuid).toBe('query-1');
+        expect(body.underlyingDataItemId).toBe('orders_amount');
+        const rules = flattenRules(body.filters.dimensions as FilterGroup);
+        expect(rules).toHaveLength(1);
+        expect(rules[0]).toMatchObject({
+            target: { fieldId: 'orders_status' },
+            operator: FilterOperator.EQUALS,
+            values: ['completed'],
+        });
+    });
+
+    test('table-calculation binding: itemId omitted, dimension scoping still applies', () => {
+        const { body } = buildVizUnderlyingDataRequest(
+            { row, metric: 'value' },
+            {
+                ...baseArgs,
+                fieldMapping: { value: 'calc_ratio' },
+            },
+        );
+        expect(body.underlyingDataItemId).toBeUndefined();
+        const rules = flattenRules(body.filters.dimensions as FilterGroup);
+        expect(rules).toContainEqual(
+            expect.objectContaining({
+                target: { fieldId: 'orders_status' },
+                values: ['completed'],
+            }),
+        );
+    });
+
+    test('stale persisted binding: unmapped field throws instead of resolving', () => {
+        // The reconciled mapping dropped "value" (e.g. schema rebuild) even if
+        // a persisted config still names it.
+        expect(() =>
+            buildVizUnderlyingDataRequest(
+                { row, metric: 'value' },
+                { ...baseArgs, fieldMapping: { category: 'orders_status' } },
+            ),
+        ).toThrow(/not bound/i);
+    });
+
+    test('date zoom: zoomed dim becomes a range filter and dateZoom rides in the body', () => {
+        const dateZoom = {
+            granularity: DateGranularity.MONTH,
+            xAxisFieldId: 'orders_order_date_month',
+        };
+        const { body } = buildVizUnderlyingDataRequest(
+            {
+                row: {
+                    ...row,
+                    orders_order_date_month: {
+                        value: {
+                            raw: '2024-11-01T00:00:00Z',
+                            formatted: 'November 2024',
+                        },
+                    },
+                },
+                metric: 'value',
+            },
+            { ...baseArgs, dateZoom },
+        );
+        expect(body.dateZoom).toEqual(dateZoom);
+        const rules = flattenRules(body.filters.dimensions as FilterGroup);
+        const dateRules = rules.filter(
+            (rule) => rule.target.fieldId === 'orders_order_date_month',
+        );
+        expect(dateRules).toHaveLength(2);
+        expect(dateRules[0].operator).toBe(
+            FilterOperator.GREATER_THAN_OR_EQUAL,
+        );
+        expect(dateRules[1].operator).toBe(FilterOperator.LESS_THAN);
+    });
+
+    test('metric intrinsic filter targeting an unselected dimension survives', () => {
+        const filteredMetric = metric('amount', [
+            {
+                id: 'mf1',
+                target: { fieldRef: 'orders.is_completed' },
+                operator: FilterOperator.EQUALS,
+                values: [true],
+            },
+        ]);
+        const { body } = buildVizUnderlyingDataRequest(
+            { row, metric: 'value' },
+            {
+                ...baseArgs,
+                itemsMap: { ...itemsMap, orders_amount: filteredMetric },
+            },
+        );
+        // orders_is_completed is not in metricQuery.dimensions, but IS in the
+        // explore — the rule must survive field classification.
+        const rules = flattenRules(body.filters.dimensions as FilterGroup);
+        expect(rules).toContainEqual(
+            expect.objectContaining({
+                target: { fieldId: 'orders_is_completed' },
+                values: [true],
+            }),
+        );
+    });
+
+    test('parameters and limit pass through; absent ones are omitted', () => {
+        const withBoth = buildVizUnderlyingDataRequest(
+            { row, metric: 'value', limit: 250 },
+            { ...baseArgs, parameters: { region: 'EMEA' } },
+        );
+        expect(withBoth.body.limit).toBe(250);
+        expect(withBoth.body.parameters).toEqual({ region: 'EMEA' });
+
+        const withNeither = buildVizUnderlyingDataRequest(
+            { row, metric: 'value' },
+            baseArgs,
+        );
+        expect('limit' in withNeither.body).toBe(false);
+        expect('parameters' in withNeither.body).toBe(false);
+    });
+});

--- a/packages/frontend/src/components/DataAppVizRenderer/vizUnderlyingDataRequest.test.ts
+++ b/packages/frontend/src/components/DataAppVizRenderer/vizUnderlyingDataRequest.test.ts
@@ -137,6 +137,24 @@ describe('buildVizUnderlyingDataRequest', () => {
         ).toThrow(/invalid/i);
     });
 
+    test('malformed row cells are skipped, not turned into filters', () => {
+        const { body } = buildVizUnderlyingDataRequest(
+            {
+                row: {
+                    orders_status: { value: 'bad' },
+                    orders_order_date_month: { value: { formatted: 'x' } },
+                    orders_amount: { value: { raw: 100, formatted: '$100' } },
+                },
+                metric: 'value',
+            },
+            baseArgs,
+        );
+        expect(flattenRules(body.filters.dimensions as FilterGroup)).toEqual(
+            [],
+        );
+        expect(body.filters.dimensions).toBeUndefined();
+    });
+
     test('rejects a metric name not in the reconciled mapping', () => {
         expect(() =>
             buildVizUnderlyingDataRequest({ row, metric: 'nope' }, baseArgs),

--- a/packages/frontend/src/components/DataAppVizRenderer/vizUnderlyingDataRequest.ts
+++ b/packages/frontend/src/components/DataAppVizRenderer/vizUnderlyingDataRequest.ts
@@ -1,0 +1,127 @@
+import {
+    getDimensions,
+    getFields,
+    getItemId,
+    isCustomBinDimension,
+    isField,
+    QueryExecutionContext,
+    type DataAppVizUnderlyingDataIntent,
+    type DateZoom,
+    type ExecuteAsyncUnderlyingDataRequestParams,
+    type Explore,
+    type ItemsMap,
+    type MetricQuery,
+    type ParametersValuesMap,
+    type ResultValue,
+} from '@lightdash/common';
+import { convertDateFilters } from '../../utils/dateFilter';
+import {
+    combineUnderlyingDataFilters,
+    getUnderlyingDataFilterParts,
+} from '../MetricQueryData/underlyingDataFilters';
+
+export type VizUnderlyingDataRewriteArgs = {
+    projectUuid: string;
+    /** queryUuid of the source query the host ran for this chart. */
+    queryUuid: string;
+    /** The RECONCILED mapping — exactly what was pushed to the iframe. */
+    fieldMapping: Record<string, string>;
+    itemsMap: ItemsMap;
+    metricQuery: MetricQuery;
+    explore: Explore;
+    resolvedTimezone: string | undefined;
+    parameters: ParametersValuesMap | undefined;
+    dateZoom: DateZoom | undefined;
+};
+
+export type VizUnderlyingDataRequest = {
+    method: 'POST';
+    path: string;
+    body: ExecuteAsyncUnderlyingDataRequestParams & {
+        parameters?: ParametersValuesMap;
+    };
+};
+
+const isIntent = (input: unknown): input is DataAppVizUnderlyingDataIntent =>
+    typeof input === 'object' &&
+    input !== null &&
+    typeof (input as { metric?: unknown }).metric === 'string' &&
+    typeof (input as { row?: unknown }).row === 'object' &&
+    (input as { row?: unknown }).row !== null;
+
+// Rewrites a viz's semantic click intent (untrusted iframe input) into the
+// real underlying-data request, using the same point-filter construction as
+// UnderlyingDataModal.
+export const buildVizUnderlyingDataRequest = (
+    intent: unknown,
+    args: VizUnderlyingDataRewriteArgs,
+): VizUnderlyingDataRequest => {
+    if (!isIntent(intent)) {
+        throw new Error('Invalid underlying-data request.');
+    }
+
+    const fieldId = args.fieldMapping[intent.metric];
+    const item = fieldId ? args.itemsMap[fieldId] : undefined;
+    if (!fieldId || !item) {
+        throw new Error(
+            `"${intent.metric}" is not bound to a query field on this chart.`,
+        );
+    }
+
+    const nonBinCustomDimensions =
+        args.metricQuery.customDimensions?.filter(
+            (dimension) => !isCustomBinDimension(dimension),
+        ) ?? [];
+    const allFields = [...nonBinCustomDimensions, ...getFields(args.explore)];
+    const allDimensions = [
+        ...nonBinCustomDimensions,
+        ...getDimensions(args.explore),
+    ];
+
+    // ResultRow cells → the { raw, formatted } fieldValues the shared builder
+    // consumes; malformed cells from the untrusted payload are skipped.
+    const fieldValues: Record<string, ResultValue> = Object.fromEntries(
+        Object.entries(intent.row).flatMap(([id, cell]) => {
+            const value =
+                cell && typeof cell === 'object' && 'value' in cell
+                    ? cell.value
+                    : undefined;
+            return value ? [[id, value]] : [];
+        }),
+    );
+
+    const filterParts = getUnderlyingDataFilterParts({
+        item,
+        value: fieldValues[fieldId] ?? { raw: null, formatted: '' },
+        fieldValues,
+        // Vizs receive unpivoted rows.
+        pivotReference: undefined,
+        dateZoom: args.dateZoom,
+        allDimensions,
+        resolvedTimezone: args.resolvedTimezone,
+    });
+
+    const filters = combineUnderlyingDataFilters({
+        filterParts,
+        exploreDimensionFilters: args.metricQuery.filters?.dimensions,
+        allFields,
+    });
+
+    return {
+        method: 'POST',
+        path: `/api/v2/projects/${args.projectUuid}/query/underlying-data`,
+        body: {
+            context: QueryExecutionContext.VIEW_UNDERLYING_DATA,
+            underlyingDataSourceQueryUuid: args.queryUuid,
+            // Table calculations are not fields — the itemId is omitted and
+            // the clicked dimensions scope the raw rows, matching core.
+            ...(isField(item) ? { underlyingDataItemId: getItemId(item) } : {}),
+            filters: convertDateFilters(filters),
+            ...(args.dateZoom ? { dateZoom: args.dateZoom } : {}),
+            ...(intent.limit !== undefined ? { limit: intent.limit } : {}),
+            ...(args.parameters && Object.keys(args.parameters).length > 0
+                ? { parameters: args.parameters }
+                : {}),
+        },
+    };
+};

--- a/packages/frontend/src/components/DataAppVizRenderer/vizUnderlyingDataRequest.ts
+++ b/packages/frontend/src/components/DataAppVizRenderer/vizUnderlyingDataRequest.ts
@@ -4,6 +4,7 @@ import {
     getItemId,
     isCustomBinDimension,
     isField,
+    isResultValue,
     QueryExecutionContext,
     type DataAppVizUnderlyingDataIntent,
     type DateZoom,
@@ -79,15 +80,12 @@ export const buildVizUnderlyingDataRequest = (
     ];
 
     // ResultRow cells → the { raw, formatted } fieldValues the shared builder
-    // consumes; malformed cells from the untrusted payload are skipped.
+    // consumes; cells that fail strict ResultValue validation are skipped —
+    // the payload crosses an untrusted iframe boundary.
     const fieldValues: Record<string, ResultValue> = Object.fromEntries(
-        Object.entries(intent.row).flatMap(([id, cell]) => {
-            const value =
-                cell && typeof cell === 'object' && 'value' in cell
-                    ? cell.value
-                    : undefined;
-            return value ? [[id, value]] : [];
-        }),
+        Object.entries(intent.row).flatMap(([id, cell]) =>
+            isResultValue(cell) ? [[id, cell.value]] : [],
+        ),
     );
 
     const filterParts = getUnderlyingDataFilterParts({

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -117,6 +117,13 @@ type Props = {
     // Render context for data app vizs: the field mapping + host rows, pushed
     // into the iframe over the SDK bridge. Undefined for ordinary data apps.
     dataAppVizContext?: DataAppVizContext;
+    /** Rewrites the viz underlying-data virtual route into the real API
+     *  request. Only set by DataAppVizRenderer when the capability is on. */
+    rewriteVizUnderlyingDataRequest?: (intentBody: unknown) => {
+        method: 'POST';
+        path: string;
+        body: unknown;
+    };
     // Round-trip the app's `useUrlState` controls through the page's `?state=`
     // param. Leave unset where the page URL isn't the app's share surface
     // (dashboard tiles, screenshots).
@@ -177,6 +184,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             onIframeLoad,
             capabilities,
             dataAppVizContext,
+            rewriteVizUnderlyingDataRequest,
             urlStateSync,
             onSdkManifest,
             forceColorScheme,
@@ -274,6 +282,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             onLineageSelected,
             onExternalRequestEvent,
             dataAppVizContext,
+            rewriteVizUnderlyingDataRequest,
             onUrlStateChange: urlStateSync ? handleUrlStateChange : undefined,
             onSdkManifest,
             colorScheme,

--- a/packages/frontend/src/features/apps/components/DataAppVizTestPanel.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizTestPanel.test.tsx
@@ -368,6 +368,7 @@ describe('DataAppVizTestPanel', () => {
                 rows: resultRows,
                 options: { showLegend: true },
                 colorPalette: ['#111111'],
+                underlyingData: { enabled: false },
             }),
         );
 
@@ -380,6 +381,7 @@ describe('DataAppVizTestPanel', () => {
                 rows: resultRows,
                 options: { showLegend: false },
                 colorPalette: ['#111111'],
+                underlyingData: { enabled: false },
             }),
         );
     });
@@ -401,6 +403,7 @@ describe('DataAppVizTestPanel', () => {
                 rows: resultRows,
                 options: { showLegend: true },
                 colorPalette: ['#111111'],
+                underlyingData: { enabled: false },
             }),
         );
 
@@ -413,6 +416,7 @@ describe('DataAppVizTestPanel', () => {
                 rows: resultRows,
                 options: { showLegend: true },
                 colorPalette: ['#123456', '#abcdef'],
+                underlyingData: { enabled: false },
             }),
         );
     });

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -1663,3 +1663,156 @@ describe('delivery-render flag on the ready handshake', () => {
         });
     });
 });
+
+describe('viz underlying-data virtual route', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    const VIRTUAL_PATH = '/__sdk/viz/underlying-data';
+    const INTENT = {
+        row: {
+            orders_status: {
+                value: { raw: 'completed', formatted: 'Completed' },
+            },
+        },
+        metric: 'value',
+    };
+
+    function renderBridgeWithRewrite(
+        rewriteVizUnderlyingDataRequest?: (intentBody: unknown) => {
+            method: 'POST';
+            path: string;
+            body: unknown;
+        },
+    ) {
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        renderHook(() =>
+            useAppSdkBridge({
+                colorScheme: 'light',
+                iframeRef,
+                expectedPreviewOrigin: window.location.origin,
+                projectUuid: PROJECT_UUID,
+                appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
+                rewriteVizUnderlyingDataRequest,
+            }),
+        );
+    }
+
+    function postVirtualRoute() {
+        dispatchFetchMessage({
+            type: 'lightdash:sdk:fetch',
+            id: POST_ID,
+            method: 'POST',
+            path: VIRTUAL_PATH,
+            body: INTENT,
+        });
+    }
+
+    it('rewrites the virtual route and continues through the standard pipeline', async () => {
+        const rewrite = vi.fn((intentBody: unknown) => ({
+            method: 'POST' as const,
+            path: UNDERLYING_DATA_PATH,
+            body: { rewritten: true, original: intentBody },
+        }));
+        renderBridgeWithRewrite(rewrite);
+
+        mockFetchOk({
+            status: 'ok',
+            results: { queryUuid: QUERY_UUID },
+        });
+        const postMessageSpy = vi.spyOn(window, 'postMessage');
+        postVirtualRoute();
+
+        await vi.waitFor(() =>
+            expect(fetch).toHaveBeenCalledWith(
+                UNDERLYING_DATA_PATH,
+                expect.objectContaining({
+                    method: 'POST',
+                    body: JSON.stringify({ rewritten: true, original: INTENT }),
+                }),
+            ),
+        );
+        expect(rewrite).toHaveBeenCalledWith(INTENT);
+        await vi.waitFor(() =>
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'lightdash:sdk:fetch-response',
+                    id: POST_ID,
+                    result: { queryUuid: QUERY_UUID },
+                }),
+                '*',
+            ),
+        );
+    });
+
+    it('answers the virtual route with an error when no rewrite callback is installed', async () => {
+        renderBridgeWithRewrite(undefined);
+        const postMessageSpy = vi.spyOn(window, 'postMessage');
+        postVirtualRoute();
+
+        await vi.waitFor(() =>
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'lightdash:sdk:fetch-response',
+                    id: POST_ID,
+                    error: expect.stringMatching(/not available/i),
+                }),
+                '*',
+            ),
+        );
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('answers with the thrown message when the rewrite callback rejects the intent', async () => {
+        renderBridgeWithRewrite(() => {
+            throw new Error(
+                '"nope" is not bound to a query field on this chart.',
+            );
+        });
+        const postMessageSpy = vi.spyOn(window, 'postMessage');
+        postVirtualRoute();
+
+        await vi.waitFor(() =>
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'lightdash:sdk:fetch-response',
+                    id: POST_ID,
+                    error: '"nope" is not bound to a query field on this chart.',
+                }),
+                '*',
+            ),
+        );
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('a rewritten path is still subject to the allowlist', async () => {
+        renderBridgeWithRewrite(() => ({
+            method: 'POST' as const,
+            path: '/api/v1/org/projects',
+            body: {},
+        }));
+        const postMessageSpy = vi.spyOn(window, 'postMessage');
+        postVirtualRoute();
+
+        await vi.waitFor(() =>
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'lightdash:sdk:fetch-response',
+                    id: POST_ID,
+                    error: expect.stringMatching(/^Blocked:/),
+                }),
+                '*',
+            ),
+        );
+        expect(fetch).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -1172,6 +1172,7 @@ describe('data-app-viz-context push', () => {
         ],
         options: { showLegend: true, barColor: '#ff0000' },
         colorPalette: ['#7162FF', '#1A1B1E'],
+        underlyingData: { enabled: false },
     };
 
     function renderWithDataAppVizContext(ctx: DataAppVizContext | undefined) {

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -3,6 +3,7 @@ import {
     APP_SDK_COLOR_SCHEME_REQUEST_MESSAGE,
     APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
     APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
+    APP_SDK_VIZ_UNDERLYING_DATA_PATH,
     extractAppSdkRouteProjectUuid,
     isAllowedAppSdkRoute,
     isAppSdkScheduleDownloadRoute,
@@ -255,6 +256,19 @@ export type UseAppSdkBridgeParams = {
     // When set, the host pushes this render context into the iframe over the
     // existing bridge — on load and on every change. Only set for data app vizs.
     dataAppVizContext?: DataAppVizContext;
+    /**
+     * Rewrites the viz underlying-data virtual route
+     * (`APP_SDK_VIZ_UNDERLYING_DATA_PATH`) into the real API request, which
+     * then flows through the standard pipeline (allowlist, project pinning,
+     * authenticated fetch). Absent = the capability is off and the virtual
+     * route answers with an error — availability is enforced here, not in the
+     * iframe's menu. Throws on invalid intent (untrusted iframe input).
+     */
+    rewriteVizUnderlyingDataRequest?: (intentBody: unknown) => {
+        method: 'POST';
+        path: string;
+        body: unknown;
+    };
     // When set, `lightdash:sdk:url-state-change` messages from the iframe SDK
     // are validated and forwarded. Left undefined, they're ignored.
     onUrlStateChange?: (state: Record<string, unknown>) => void;
@@ -295,6 +309,7 @@ export function useAppSdkBridge({
     onLineageSelected,
     onExternalRequestEvent,
     dataAppVizContext,
+    rewriteVizUnderlyingDataRequest,
     onUrlStateChange,
     onSdkManifest,
     deliveryCapture,
@@ -678,7 +693,8 @@ export function useAppSdkBridge({
 
             if (data?.type !== 'lightdash:sdk:fetch') return;
 
-            const { id, method, path, body, metadata } = data;
+            const { id, metadata } = data;
+            let { method, path, body } = data;
 
             const respond = (response: {
                 result?: unknown;
@@ -693,6 +709,30 @@ export function useAppSdkBridge({
                     '*',
                 );
             };
+
+            // Bridge-only virtual route: the viz posts semantic click intent;
+            // the host rewrites it into the real underlying-data request, then
+            // the standard pipeline (allowlist, project pinning, auth) applies.
+            if (path === APP_SDK_VIZ_UNDERLYING_DATA_PATH) {
+                if (!rewriteVizUnderlyingDataRequest) {
+                    respond({
+                        error: 'Underlying data is not available for this visualization.',
+                    });
+                    return;
+                }
+                try {
+                    ({ method, path, body } =
+                        rewriteVizUnderlyingDataRequest(body));
+                } catch (err) {
+                    respond({
+                        error:
+                            err instanceof Error
+                                ? err.message
+                                : 'Invalid underlying-data request.',
+                    });
+                    return;
+                }
+            }
 
             if (!isAllowedAppSdkRoute(method, path)) {
                 respond({ error: `Blocked: ${method} ${path}` });
@@ -1043,6 +1083,7 @@ export function useAppSdkBridge({
             onLineageSelected,
             onExternalRequestEvent,
             pushDataAppVizContext,
+            rewriteVizUnderlyingDataRequest,
             pushColorScheme,
             onUrlStateChange,
             onSdkManifest,

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizTestContext.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizTestContext.ts
@@ -138,6 +138,7 @@ export const useDataAppVizTestContext = ({
                 rows,
                 options: effectiveOptions,
                 colorPalette,
+                underlyingData: { enabled: false },
             });
         }
     }, [

--- a/packages/frontend/src/features/apps/utils/sampleVizContext.ts
+++ b/packages/frontend/src/features/apps/utils/sampleVizContext.ts
@@ -79,5 +79,7 @@ export const buildSampleVizContext = (
         rows,
         options: getEffectiveOptionValues(schema.configOptions, optionValues),
         colorPalette,
+        // Sample rows come from no query — there is nothing to drill into.
+        underlyingData: { enabled: false },
     };
 };

--- a/packages/query-sdk/src/vizContext.test.ts
+++ b/packages/query-sdk/src/vizContext.test.ts
@@ -198,6 +198,34 @@ describe('toVizContextState', () => {
             rows: [],
             options: {},
             colorPalette: [],
+            underlyingDataEnabled: false,
         });
+    });
+});
+
+describe('toVizContextState — underlyingData', () => {
+    it('reads enabled:true from the host push', () => {
+        expect(
+            toVizContextState(message({ underlyingData: { enabled: true } }))
+                .underlyingDataEnabled,
+        ).toBe(true);
+    });
+
+    it('defaults to disabled when the host omits underlyingData (old host)', () => {
+        expect(toVizContextState(message({})).underlyingDataEnabled).toBe(
+            false,
+        );
+    });
+
+    it('treats non-boolean enabled values as disabled (untrusted payload)', () => {
+        expect(
+            toVizContextState(
+                message({ underlyingData: { enabled: 'yes' as never } }),
+            ).underlyingDataEnabled,
+        ).toBe(false);
+        expect(
+            toVizContextState(message({ underlyingData: {} as never }))
+                .underlyingDataEnabled,
+        ).toBe(false);
     });
 });

--- a/packages/query-sdk/src/vizContext.ts
+++ b/packages/query-sdk/src/vizContext.ts
@@ -54,6 +54,8 @@ export type DataAppVizContextMessage = {
     options?: Record<string, VizContextOptionValue>;
     /** Absent when the installed host predates palette delivery. */
     colorPalette?: string[];
+    /** Absent when the installed host predates underlying-data delivery. */
+    underlyingData?: { enabled?: boolean };
 };
 
 /** Posted by the iframe on mount so the host pushes the current context. */
@@ -105,6 +107,7 @@ type VizContextValue = {
     rows: VizContextRow[];
     options: Record<string, VizContextOptionValue>;
     colorPalette: string[];
+    underlyingDataEnabled: boolean;
 };
 
 type VizContextState = VizContextValue | null;
@@ -152,6 +155,8 @@ export function toVizContextState(
                   (color): color is string => typeof color === 'string',
               )
             : [],
+        // Strict boolean check — non-boolean payloads read as disabled.
+        underlyingDataEnabled: message.underlyingData?.enabled === true,
     };
 }
 


### PR DESCRIPTION
Relates: GLITCH-589

Stacked on #27268.

### Description:

The host half of underlying data for data-app viz charts. **Ships dark** — nothing consumes it until the SDK/generation PR on top of this one lands.

- **Contract** (`@lightdash/common`): `DataAppVizContext` gains a required `underlyingData: { enabled: boolean }` so every push site decides availability explicitly (builder canvas, sample previews, and the test panel all push `enabled: false` — sample rows have no query). New bridge-only virtual path `APP_SDK_VIZ_UNDERLYING_DATA_PATH` (`/__sdk/viz/underlying-data`) and the `DataAppVizUnderlyingDataIntent` click-intent type (`{ row, metric, limit? }`).
- **Request builder** (`buildVizUnderlyingDataRequest`): rewrites the untrusted iframe intent into the real `POST /query/underlying-data` request using the shared filter util from #27268 — same date-zoom range filters, timezone normalization, metric intrinsic filters, and Explore-derived field classification as `UnderlyingDataModal`. Metrics send `underlyingDataItemId`; table calculations omit it and scope by dimensions, matching core.
- **Bridge** (`useAppSdkBridge`): the virtual route is resolved before allowlist matching via an optional `rewriteVizUnderlyingDataRequest` callback — a pure request-rewrite, after which the standard pipeline (allowlist, project pinning, authenticated fetch, attribution headers) applies. No callback installed ⇒ the route answers with an error, so a forged iframe message gets nothing: availability is enforced at the boundary, not in the iframe's menu.
- **Renderer** (`DataAppVizRenderer`): computes `enabled` with the same gating as regular chart context menus (no `queryUuid` on sample/builder surfaces, CASL `view:UnderlyingData`, `hasCustomBinDimension`, embeds, `minimal`/screenshot renders) and resolves clicks through the reconciled field mapping — the exact mapping pushed to the iframe, never the persisted config.

### Tests

- `vizUnderlyingDataRequest.test.ts` (8): intent validation, metric vs table-calc item dispatch, stale-binding rejection, date-zoom range filters + `dateZoom` in the body, metric intrinsic filter targeting an unselected dimension, parameters/limit passthrough.
- `useAppSdkBridge.test.ts` (+4): rewrite continues through the standard pipeline; error when no callback installed; thrown intent-validation message surfaces; rewritten paths still subject to the allowlist.
- All 306 `features/apps` tests and 117 DataAppViz tests green.