### PR TITLE
fix(pre-aggregates): apply start of week to week re-aggregation

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1108,11 +1108,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectModel: models.getProjectModel(),
                     projectService: repository.getProjectService(),
                     schedulerClient: clients.getSchedulerClient(),
-                    exploreEnhancer: (explores) =>
+                    exploreEnhancer: (explores, { startOfWeek }) =>
                         enhanceExploresForPreAggregates({
                             explores,
                             enabled:
                                 context.lightdashConfig.preAggregates.enabled,
+                            startOfWeek,
                         }),
                 }),
         },

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
@@ -7,11 +7,19 @@ import {
     PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
     SupportedDbtAdapter,
     TimeFrames,
+    WeekDay,
     type CompiledDimension,
     type CompiledMetric,
     type Explore,
+    type PreAggregateDef,
 } from '@lightdash/common';
 import { buildPreAggregateExplore } from './buildPreAggregateExplore';
+
+const buildExplore = (
+    explore: Explore,
+    preAggregateDef: PreAggregateDef,
+    startOfWeek: WeekDay | null = null,
+) => buildPreAggregateExplore(explore, preAggregateDef, startOfWeek);
 
 const makeDimension = ({
     name,
@@ -149,6 +157,13 @@ const sourceExplore = (): Explore => ({
                     timeInterval: TimeFrames.DAY,
                     timeIntervalBaseDimensionName: 'order_date',
                 }),
+                order_date_week: makeDimension({
+                    name: 'order_date_week',
+                    table: 'orders',
+                    type: DimensionType.DATE,
+                    timeInterval: TimeFrames.WEEK,
+                    timeIntervalBaseDimensionName: 'order_date',
+                }),
                 order_date_month: makeDimension({
                     name: 'order_date_month',
                     table: 'orders',
@@ -253,7 +268,7 @@ const sourceExplore = (): Explore => ({
 
 describe('buildPreAggregateExplore', () => {
     it('builds a deterministic internal pre-aggregate explore', () => {
-        const result = buildPreAggregateExplore(
+        const result = buildExplore(
             sourceExplore(),
             sourceExplore().preAggregates![0],
         );
@@ -299,7 +314,7 @@ describe('buildPreAggregateExplore', () => {
             throw new Error('Expected pre-aggregate definition');
         }
 
-        const result = buildPreAggregateExplore(
+        const result = buildExplore(
             exploreWithRequiredFilters,
             preAggregateDef,
         );
@@ -310,7 +325,7 @@ describe('buildPreAggregateExplore', () => {
     });
 
     it('rewrites supported metrics', () => {
-        const result = buildPreAggregateExplore(
+        const result = buildExplore(
             sourceExplore(),
             sourceExplore().preAggregates![0],
         );
@@ -330,7 +345,7 @@ describe('buildPreAggregateExplore', () => {
     });
 
     it('maps joined dimensions to materialized field-id columns', () => {
-        const result = buildPreAggregateExplore(
+        const result = buildExplore(
             sourceExplore(),
             sourceExplore().preAggregates![0],
         );
@@ -341,7 +356,7 @@ describe('buildPreAggregateExplore', () => {
     });
 
     it('keeps compatible time intervals and drops finer intervals than rollup granularity', () => {
-        const result = buildPreAggregateExplore(
+        const result = buildExplore(
             sourceExplore(),
             sourceExplore().preAggregates![0],
         );
@@ -356,7 +371,7 @@ describe('buildPreAggregateExplore', () => {
     });
 
     it('uses DuckDB-compatible date truncation SQL regardless of source warehouse adapter', () => {
-        const result = buildPreAggregateExplore(
+        const result = buildExplore(
             {
                 ...sourceExplore(),
                 targetDatabase: SupportedDbtAdapter.BIGQUERY, // doesn't matter what's the warehouse type
@@ -371,9 +386,36 @@ describe('buildPreAggregateExplore', () => {
         );
     });
 
+    it('applies startOfWeek to week re-truncation', () => {
+        const result = buildExplore(
+            sourceExplore(),
+            sourceExplore().preAggregates![0],
+            WeekDay.SUNDAY,
+        );
+
+        expect(
+            result.tables.orders.dimensions.order_date_week.compiledSql,
+        ).toBe(
+            "(DATE_TRUNC('WEEK', (CAST(orders.orders_order_date_day AS TIMESTAMP) - interval '6 days')) + interval '6 days')",
+        );
+    });
+
+    it('uses default week truncation when startOfWeek is not configured', () => {
+        const result = buildExplore(
+            sourceExplore(),
+            sourceExplore().preAggregates![0],
+        );
+
+        expect(
+            result.tables.orders.dimensions.order_date_week.compiledSql,
+        ).toBe(
+            "DATE_TRUNC('WEEK', CAST(orders.orders_order_date_day AS TIMESTAMP))",
+        );
+    });
+
     it('throws when pre-aggregate references unknown fields', () => {
         expect(() =>
-            buildPreAggregateExplore(sourceExplore(), {
+            buildExplore(sourceExplore(), {
                 name: 'invalid_rollup',
                 dimensions: ['unknown_dimension'],
                 metrics: ['order_count'],
@@ -383,7 +425,7 @@ describe('buildPreAggregateExplore', () => {
 
     it('throws when pre-aggregate references unsupported metric types', () => {
         expect(() =>
-            buildPreAggregateExplore(sourceExplore(), {
+            buildExplore(sourceExplore(), {
                 name: 'invalid_rollup',
                 dimensions: ['status'],
                 metrics: [
@@ -399,7 +441,7 @@ describe('buildPreAggregateExplore', () => {
 
     it('requires dependent metrics for supported number metrics', () => {
         expect(() =>
-            buildPreAggregateExplore(sourceExplore(), {
+            buildExplore(sourceExplore(), {
                 name: 'number_metric_preagg',
                 dimensions: ['status'],
                 metrics: ['gross_total', 'total_order_amount'],
@@ -410,7 +452,7 @@ describe('buildPreAggregateExplore', () => {
     });
 
     it('keeps supported number metrics on the pre-aggregate explore and rewrites them to use materialized dependencies', () => {
-        const result = buildPreAggregateExplore(sourceExplore(), {
+        const result = buildExplore(sourceExplore(), {
             name: 'number_metric_preagg',
             dimensions: ['status'],
             metrics: ['gross_total', 'total_order_amount', 'shipping_total'],
@@ -428,7 +470,7 @@ describe('buildPreAggregateExplore', () => {
     });
 
     it('rewrites supported cross-model number metrics to use materialized dependencies from joined tables', () => {
-        const result = buildPreAggregateExplore(sourceExplore(), {
+        const result = buildExplore(sourceExplore(), {
             name: 'cross_model_number_metric_preagg',
             dimensions: ['status'],
             metrics: [
@@ -450,7 +492,7 @@ describe('buildPreAggregateExplore', () => {
     });
 
     it('includes time dimension even when not in dimensions array', () => {
-        const result = buildPreAggregateExplore(sourceExplore(), {
+        const result = buildExplore(sourceExplore(), {
             name: 'time_dim_separate',
             dimensions: ['status'],
             metrics: ['order_count'],
@@ -466,7 +508,7 @@ describe('buildPreAggregateExplore', () => {
     });
 
     it('supports legacy metric fieldIds in pre-aggregate definitions', () => {
-        const result = buildPreAggregateExplore(sourceExplore(), {
+        const result = buildExplore(sourceExplore(), {
             name: 'legacy_field_id_rollup',
             dimensions: ['status'],
             metrics: ['orders_order_count'],
@@ -484,7 +526,7 @@ describe('buildPreAggregateExplore', () => {
             compiledSql: "concat(orders.status, '-ok')",
         });
 
-        const result = buildPreAggregateExplore(explore, {
+        const result = buildExplore(explore, {
             name: 'derived_dimension_rollup',
             dimensions: ['status_label'],
             metrics: ['order_count'],
@@ -511,7 +553,7 @@ describe('buildPreAggregateExplore', () => {
         });
 
         expect(() =>
-            buildPreAggregateExplore(explore, {
+            buildExplore(explore, {
                 name: 'invalid_rollup',
                 dimensions: ['parameterized_status'],
                 metrics: ['order_count'],
@@ -530,7 +572,7 @@ describe('buildPreAggregateExplore', () => {
         });
 
         expect(() =>
-            buildPreAggregateExplore(explore, {
+            buildExplore(explore, {
                 name: 'invalid_rollup',
                 dimensions: ['region_aware_status'],
                 metrics: ['order_count'],
@@ -560,7 +602,7 @@ describe('buildPreAggregateExplore', () => {
         });
 
         expect(() =>
-            buildPreAggregateExplore(explore, {
+            buildExplore(explore, {
                 name: 'invalid_rollup',
                 dimensions: ['status_wrapper'],
                 metrics: ['order_count'],
@@ -587,7 +629,7 @@ describe('buildPreAggregateExplore', () => {
             compiledSql: 'SUM(orders.amount)',
         });
 
-        const result = buildPreAggregateExplore(explore, {
+        const result = buildExplore(explore, {
             name: 'metric_rollup',
             dimensions: ['status'],
             metrics: ['order_revenue'],
@@ -615,7 +657,7 @@ describe('buildPreAggregateExplore', () => {
         });
 
         expect(() =>
-            buildPreAggregateExplore(explore, {
+            buildExplore(explore, {
                 name: 'invalid_rollup',
                 dimensions: ['status'],
                 metrics: ['parameterized_revenue'],
@@ -657,7 +699,7 @@ describe('buildPreAggregateExplore', () => {
         });
 
         expect(() =>
-            buildPreAggregateExplore(explore, {
+            buildExplore(explore, {
                 name: 'invalid_rollup',
                 dimensions: ['status'],
                 metrics: ['filtered_revenue'],

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
@@ -21,6 +21,7 @@ import {
     type FieldId,
     type PreAggregateDef,
     type TimeFrames,
+    type WeekDay,
 } from '@lightdash/common';
 import { assertDimensionEligibleForDirectMaterialization } from './eligibility';
 import {
@@ -227,10 +228,12 @@ const buildDimensionSql = ({
     sourceExplore,
     dimension,
     preAggregateDef,
+    startOfWeek,
 }: {
     sourceExplore: Explore;
     dimension: CompiledDimension;
     preAggregateDef: PreAggregateDef;
+    startOfWeek: WeekDay | null;
 }): string => {
     const dimensionBaseName = preAggregateUtils.getDimensionBaseName(dimension);
     const materializedBaseColumnName = getMaterializedDimensionColumnName({
@@ -263,6 +266,7 @@ const buildDimensionSql = ({
         dimension.timeInterval,
         timeDimensionReference,
         getBaseDimensionType(sourceExplore, dimension),
+        startOfWeek,
     );
 };
 
@@ -363,6 +367,7 @@ const getEmptyTable = (
 export const buildPreAggregateExplore = (
     sourceExplore: Explore,
     preAggregateDef: PreAggregateDef,
+    startOfWeek: WeekDay | null,
 ): Explore => {
     const includedDimensions = getIncludedDimensions(
         sourceExplore,
@@ -402,6 +407,7 @@ export const buildPreAggregateExplore = (
             sourceExplore,
             dimension,
             preAggregateDef,
+            startOfWeek,
         });
 
         tables[dimension.table].dimensions[dimension.name] = {

--- a/packages/backend/src/ee/preAggregates/enhanceExploresForPreAggregates.ts
+++ b/packages/backend/src/ee/preAggregates/enhanceExploresForPreAggregates.ts
@@ -3,15 +3,18 @@ import {
     ExploreError,
     ExploreType,
     isExploreError,
+    type WeekDay,
 } from '@lightdash/common';
 import { generatePreAggregateExplores } from './generatePreAggregateExplores';
 
 export const enhanceExploresForPreAggregates = ({
     explores,
     enabled,
+    startOfWeek,
 }: {
     explores: (Explore | ExploreError)[];
     enabled: boolean;
+    startOfWeek: WeekDay | null;
 }): (Explore | ExploreError)[] => {
     if (!enabled) {
         return explores;
@@ -36,6 +39,7 @@ export const enhanceExploresForPreAggregates = ({
         const generatedExplores = generatePreAggregateExplores({
             compiledExplores: [explore],
             parsedPreAggregates: explore.preAggregates,
+            startOfWeek,
         });
 
         const enhancedSourceExplore =

--- a/packages/backend/src/ee/preAggregates/generatePreAggregateExplores.ts
+++ b/packages/backend/src/ee/preAggregates/generatePreAggregateExplores.ts
@@ -4,6 +4,7 @@ import {
     type Explore,
     type ExploreError,
     type PreAggregateDef,
+    type WeekDay,
 } from '@lightdash/common';
 import { buildPreAggregateExplore } from './buildPreAggregateExplore';
 
@@ -13,9 +14,11 @@ const shouldGeneratePreAggregatesForExplore = (explore: Explore): boolean =>
 export const generatePreAggregateExplores = ({
     compiledExplores,
     parsedPreAggregates,
+    startOfWeek,
 }: {
     compiledExplores: Array<Explore | ExploreError>;
     parsedPreAggregates: PreAggregateDef[];
+    startOfWeek: WeekDay | null;
 }): Array<Explore | ExploreError> => {
     if (process.env.PRE_AGGREGATES_ENABLED !== 'true') {
         return compiledExplores;
@@ -40,7 +43,11 @@ export const generatePreAggregateExplores = ({
         parsedPreAggregates.forEach((preAggregateDef) => {
             try {
                 generatedPreAggregateExplores.push(
-                    buildPreAggregateExplore(compiled, preAggregateDef),
+                    buildPreAggregateExplore(
+                        compiled,
+                        preAggregateDef,
+                        startOfWeek,
+                    ),
                 );
                 validPreAggregates.push(preAggregateDef);
             } catch (error) {

--- a/packages/backend/src/ee/preAggregates/postProcessor.ts
+++ b/packages/backend/src/ee/preAggregates/postProcessor.ts
@@ -10,7 +10,7 @@ import { generatePreAggregateExplores } from './generatePreAggregateExplores';
 
 export const preAggregatePostProcessor: ExplorePostProcessor = (
     compiledExplores,
-    { model, meta },
+    { model, meta, startOfWeek },
 ) => {
     const parsedPreAggregates = attempt(
         parseDbtPreAggregates,
@@ -51,5 +51,6 @@ export const preAggregatePostProcessor: ExplorePostProcessor = (
     return generatePreAggregateExplores({
         compiledExplores: exploresWithPreAggregates,
         parsedPreAggregates,
+        startOfWeek,
     });
 };

--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -11,6 +11,7 @@ import {
     SessionUser,
     type ApiDeployExploresResults,
     type ProjectDefaults,
+    type WeekDay,
 } from '@lightdash/common';
 import { DeploySessionModel } from '../models/DeploySessionModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
@@ -19,6 +20,7 @@ import { BaseService } from './BaseService';
 
 export type DeployExploreEnhancer = (
     explores: (Explore | ExploreError)[],
+    context: { startOfWeek: WeekDay | null },
 ) => (Explore | ExploreError)[];
 
 type ProjectServiceInterface = {
@@ -210,11 +212,16 @@ export class DeployService extends BaseService {
                 DeploySessionStatus.FINALIZING,
             );
 
+            const project =
+                await this.projectModel.getWithSensitiveFields(projectUuid);
+
             // Get all explores from the session and enhance them
             // (e.g., EE generates virtual pre-aggregate explores from attached defs)
             const uploadedExplores =
                 await this.deploySessionModel.getAllExplores(sessionUuid);
-            const explores = this.exploreEnhancer(uploadedExplores);
+            const explores = this.exploreEnhancer(uploadedExplores, {
+                startOfWeek: project.warehouseConnection?.startOfWeek ?? null,
+            });
 
             this.logger.info(
                 `Finalizing deploy session ${sessionUuid} with ${explores.length} explores`,
@@ -233,8 +240,6 @@ export class DeployService extends BaseService {
             });
 
             // Schedule validation (same as in original finalizeDeploy)
-            const project =
-                await this.projectModel.getWithSensitiveFields(projectUuid);
             await this.schedulerClient.generateValidation({
                 userUuid: user.userUuid,
                 projectUuid,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3140,6 +3140,7 @@ export class ProjectService extends BaseService {
         const exploresWithPreAggregates = enhanceExploresForPreAggregates({
             explores,
             enabled: this.lightdashConfig.preAggregates.enabled,
+            startOfWeek: project.warehouseConnection?.startOfWeek ?? null,
         });
 
         await this.saveExploresToCacheAndIndexCatalog({

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1097,6 +1097,7 @@ export type ExplorePostProcessor = (
     context: {
         model: DbtModelNode;
         meta: Record<string, unknown>;
+        startOfWeek: WeekDay | null;
     },
 ) => (Explore | ExploreError)[];
 
@@ -1433,6 +1434,7 @@ export const convertExplores = async (
         const postProcessorContext = {
             model,
             meta,
+            startOfWeek: warehouseSqlBuilder.getStartOfWeek() ?? null,
         };
         const postProcessedExplores = (postProcessors ?? []).reduce<
             (Explore | ExploreError)[]


### PR DESCRIPTION
Fixes https://linear.app/lightdash/issue/ZAP-840/pre-aggregate-week-re-aggregation-ignores-start-of-week

Pre-aggregate explore generation baked DuckDB week-truncation SQL without the project's Start of Week setting, so weekly buckets from pre-aggregate hits diverged from the warehouse path (e.g. Sunday-start weeks instead of configured Monday).

**Fix:** thread `startOfWeek` (from warehouse credentials) into pre-aggregate explore generation on all three paths:
- dbt compile: via new `startOfWeek` field on the `ExplorePostProcessor` context (`convertExplores` supplies `warehouseSqlBuilder.getStartOfWeek()`)
- `ProjectService.setExplores`: from the project's warehouse connection
- `DeployService.finalizeDeploySession`: enhancer context now carries `startOfWeek`

`buildDimensionSql` passes it to `getSqlForTruncatedDate`, producing the same week-shift formula the warehouse path uses (`(DATE_TRUNC('WEEK', (x - interval 'N days')) + interval 'N days')`).

**Not covered (pre-existing, filed as ZAP-841):** `WEEK_NUM` / `DAY_OF_WEEK_INDEX` variants route through truncation SQL and fail on pre-aggregate serving regardless of this change.

**Test plan:** unit tests for Sunday-start and default week truncation in `buildPreAggregateExplore.test.ts`; generated SQL validated directly against DuckDB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
