### PR TITLE
fix: restore default input padding on chart type builder title

### DIFF
--- a/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.tsx
+++ b/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.tsx
@@ -33,7 +33,6 @@ const InlineNameInput: FC<{
     return (
         <TextInput
             classNames={{ input: classes.nameInput }}
-            variant="unstyled"
             aria-label="Chart type name"
             value={name}
             w={280}
@@ -134,7 +133,6 @@ const ChartTypeBuilderHeader: FC<Props> = ({
             ) : (
                 <TextInput
                     classNames={{ input: classes.nameInput }}
-                    variant="unstyled"
                     aria-label="Chart type name"
                     value="Untitled chart type"
                     w={280}


### PR DESCRIPTION
## Problem

The chart type name input in the chart type builder header (`Gallery > Untitled chart type`) had no horizontal padding, so the title text sat flush against the input's left border — inconsistent with every other input in the app.

## Cause

The input used `variant="unstyled"`, which strips Mantine's default `TextInput` padding. Nothing compensated for it.

## Fix

Drop `variant="unstyled"` and let the default variant supply padding, then override only `border`/`background` (already done in `ChartTypeBuilderHeader.module.css`). This matches how the codebase's other inline-editable title input, `EditableText` (used for the SQL Runner header title and chart series labels), handles the same pattern.

## Testing

- Verified visually in the chart type builder header — title now has consistent padding matching the rest of the app.
- `oxlint` clean on the changed file.
- `pnpm -F frontend typecheck` — pre-existing, unrelated failure on `main` (`ServiceAccountProjectRoles.tsx`), confirmed present before this change.