### PR TITLE
feat(ai): make Deep Research available with AI Agents

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -239,7 +239,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         aiOrganizationSettingsModel:
                             models.getAiOrganizationSettingsModel<AiOrganizationSettingsModel>(),
                         projectModel: models.getProjectModel(),
-                        featureFlagModel: models.getFeatureFlagModel(),
                         schedulerClient:
                             clients.getSchedulerClient() as CommercialSchedulerClient,
                         asyncQueryService: repository.getAsyncQueryService(),

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -5,7 +5,6 @@ import {
     AiResultType,
     AnyType,
     ConflictError,
-    FeatureFlags,
     ForbiddenError,
     NotFoundError,
     ParameterError,
@@ -242,7 +241,6 @@ const buildService = (
         aiAgentService?: Record<string, unknown>;
         aiOrganizationSettingsModel?: Record<string, unknown>;
         projectModel?: Record<string, unknown>;
-        featureFlagModel?: Record<string, unknown>;
         schedulerClient?: Record<string, unknown>;
         asyncQueryService?: Record<string, unknown>;
         queryHistoryModel?: Record<string, unknown>;
@@ -301,6 +299,7 @@ const buildService = (
     };
     const aiAgentService = {
         assertDeepResearchAccess: vi.fn().mockResolvedValue(undefined),
+        getIsCopilotEnabled: vi.fn().mockResolvedValue(true),
         resolveDeepResearchExecutionContext: vi
             .fn()
             .mockResolvedValue(executionContextSnapshot),
@@ -322,13 +321,6 @@ const buildService = (
     const projectModel = {
         getSummary: vi.fn().mockResolvedValue({ organizationUuid: 'org-1' }),
         ...overrides.projectModel,
-    };
-    const featureFlagModel = {
-        get: vi.fn().mockResolvedValue({
-            id: FeatureFlags.AiDeepResearch,
-            enabled: true,
-        }),
-        ...overrides.featureFlagModel,
     };
     const schedulerClient = {
         aiDeepResearch: vi.fn().mockResolvedValue({ jobId: 'job-1' }),
@@ -360,7 +352,6 @@ const buildService = (
         aiAgentService: aiAgentService as AnyType,
         aiOrganizationSettingsModel: aiOrganizationSettingsModel as AnyType,
         projectModel: projectModel as AnyType,
-        featureFlagModel: featureFlagModel as AnyType,
         schedulerClient: schedulerClient as AnyType,
         asyncQueryService: asyncQueryService as AnyType,
         queryHistoryModel: queryHistoryModel as AnyType,
@@ -373,7 +364,6 @@ const buildService = (
         aiAgentService,
         aiOrganizationSettingsModel,
         projectModel,
-        featureFlagModel,
         schedulerClient,
         asyncQueryService,
         queryHistoryModel,
@@ -401,7 +391,6 @@ describe('AiDeepResearchService', () => {
                 aiAgentModel,
                 aiAgentService,
                 schedulerClient,
-                featureFlagModel,
             } = buildService();
 
             const run = await service.createRun({
@@ -446,10 +435,9 @@ describe('AiDeepResearchService', () => {
                 projectUuid: 'project-1',
                 userUuid: 'user-1',
             });
-            expect(featureFlagModel.get).toHaveBeenCalledWith({
-                user: expect.objectContaining({ userUuid: 'user-1' }),
-                featureFlagId: FeatureFlags.AiDeepResearch,
-            });
+            expect(aiAgentService.getIsCopilotEnabled).toHaveBeenCalledWith(
+                expect.objectContaining({ userUuid: 'user-1' }),
+            );
             expect(run.status).toBe('queued');
         });
 
@@ -735,13 +723,10 @@ describe('AiDeepResearchService', () => {
             expect(model.create).not.toHaveBeenCalled();
         });
 
-        it('rejects run creation when Deep Research is disabled', async () => {
+        it('rejects run creation when AI Agents are unavailable', async () => {
             const { service, model } = buildService({
-                featureFlagModel: {
-                    get: vi.fn().mockResolvedValue({
-                        id: FeatureFlags.AiDeepResearch,
-                        enabled: false,
-                    }),
+                aiAgentService: {
+                    getIsCopilotEnabled: vi.fn().mockResolvedValue(false),
                 },
             });
 
@@ -766,7 +751,7 @@ describe('AiDeepResearchService', () => {
                 ...userWithProjectAccess(),
                 ability: build(),
             } as SessionUser;
-            const { service, model, featureFlagModel } = buildService();
+            const { service, model, aiAgentService } = buildService();
 
             await expect(
                 service.createRun({
@@ -774,7 +759,7 @@ describe('AiDeepResearchService', () => {
                     user,
                 }),
             ).rejects.toBeInstanceOf(ForbiddenError);
-            expect(featureFlagModel.get).not.toHaveBeenCalled();
+            expect(aiAgentService.getIsCopilotEnabled).not.toHaveBeenCalled();
             expect(model.create).not.toHaveBeenCalled();
         });
 
@@ -795,7 +780,7 @@ describe('AiDeepResearchService', () => {
                 ...userWithProjectAccess(),
                 ability: build(),
             } as SessionUser;
-            const { service, model, featureFlagModel } = buildService();
+            const { service, model, aiAgentService } = buildService();
 
             await expect(
                 service.createRun({
@@ -803,7 +788,7 @@ describe('AiDeepResearchService', () => {
                     user,
                 }),
             ).rejects.toBeInstanceOf(ForbiddenError);
-            expect(featureFlagModel.get).not.toHaveBeenCalled();
+            expect(aiAgentService.getIsCopilotEnabled).not.toHaveBeenCalled();
             expect(model.create).not.toHaveBeenCalled();
         });
 
@@ -820,7 +805,7 @@ describe('AiDeepResearchService', () => {
                 ...userWithProjectAccess(),
                 ability: build(),
             } as SessionUser;
-            const { service, model, featureFlagModel } = buildService();
+            const { service, model, aiAgentService } = buildService();
 
             await expect(
                 service.createRun({
@@ -828,7 +813,7 @@ describe('AiDeepResearchService', () => {
                     user,
                 }),
             ).rejects.toBeInstanceOf(ForbiddenError);
-            expect(featureFlagModel.get).not.toHaveBeenCalled();
+            expect(aiAgentService.getIsCopilotEnabled).not.toHaveBeenCalled();
             expect(model.create).not.toHaveBeenCalled();
         });
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -10,7 +10,6 @@ import {
     AiResultType,
     applyDeepResearchChartRefsWithAdjustments,
     ConflictError,
-    FeatureFlags,
     findDeepResearchChartRefs,
     ForbiddenError,
     getErrorMessage,
@@ -47,7 +46,6 @@ import {
 } from '@lightdash/common';
 import { validate as isValidUuid } from 'uuid';
 import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
-import { type FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { type QueryHistoryModel } from '../../../models/QueryHistoryModel/QueryHistoryModel';
 import { type AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
@@ -256,14 +254,15 @@ type Dependencies = {
     >;
     aiAgentService: Pick<
         AiAgentService,
-        'assertDeepResearchAccess' | 'resolveDeepResearchExecutionContext'
+        | 'assertDeepResearchAccess'
+        | 'getIsCopilotEnabled'
+        | 'resolveDeepResearchExecutionContext'
     >;
     aiOrganizationSettingsModel: Pick<
         AiOrganizationSettingsModel,
         'findByOrganizationUuid'
     >;
     projectModel: ProjectModel;
-    featureFlagModel: FeatureFlagModel;
     schedulerClient: CommercialSchedulerClient;
     asyncQueryService: AsyncQueryService;
     queryHistoryModel: Pick<QueryHistoryModel, 'getByQueryUuid'>;
@@ -491,14 +490,14 @@ export class AiDeepResearchService extends BaseService {
 
     private readonly aiAgentService: Pick<
         AiAgentService,
-        'assertDeepResearchAccess' | 'resolveDeepResearchExecutionContext'
+        | 'assertDeepResearchAccess'
+        | 'getIsCopilotEnabled'
+        | 'resolveDeepResearchExecutionContext'
     >;
 
     private readonly aiOrganizationSettingsModel: Dependencies['aiOrganizationSettingsModel'];
 
     private readonly projectModel: ProjectModel;
-
-    private readonly featureFlagModel: FeatureFlagModel;
 
     private readonly schedulerClient: CommercialSchedulerClient;
 
@@ -518,7 +517,6 @@ export class AiDeepResearchService extends BaseService {
         aiAgentService,
         aiOrganizationSettingsModel,
         projectModel,
-        featureFlagModel,
         schedulerClient,
         asyncQueryService,
         queryHistoryModel,
@@ -531,7 +529,6 @@ export class AiDeepResearchService extends BaseService {
         this.aiAgentService = aiAgentService;
         this.aiOrganizationSettingsModel = aiOrganizationSettingsModel;
         this.projectModel = projectModel;
-        this.featureFlagModel = featureFlagModel;
         this.schedulerClient = schedulerClient;
         this.asyncQueryService = asyncQueryService;
         this.queryHistoryModel = queryHistoryModel;
@@ -753,12 +750,8 @@ export class AiDeepResearchService extends BaseService {
             throw new ParameterError('Deep Research prompt is required');
         }
         await this.assertCanCreateRun(args.user, args.projectUuid);
-        const featureFlag = await this.featureFlagModel.get({
-            user: args.user,
-            featureFlagId: FeatureFlags.AiDeepResearch,
-        });
-        if (!featureFlag.enabled) {
-            throw new ForbiddenError('Deep Research is not enabled');
+        if (!(await this.aiAgentService.getIsCopilotEnabled(args.user))) {
+            throw new ForbiddenError('AI Copilot is not enabled');
         }
         const organizationSettings =
             await this.aiOrganizationSettingsModel.findByOrganizationUuid(

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -134,7 +134,8 @@ export enum FeatureFlags {
     AiAutopilot = 'ai-autopilot',
 
     /**
-     * Enable long-running, read-only Deep Research investigations from AI chat.
+     * Legacy no-op retained so existing self-hosted feature flag configuration
+     * remains valid. Deep Research now follows AI Copilot availability.
      */
     AiDeepResearch = 'ai-deep-research',
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -1,5 +1,4 @@
 import {
-    FeatureFlags,
     type AiAgentSummary,
     type AiPromptContext,
     type AiPromptContextInput,
@@ -25,7 +24,6 @@ import {
 } from 'react';
 import { createPath, useLocation, useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
-import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import { findRetryableDeepResearchRun } from '../../deepResearch/deepResearchRegistry';
 import { runDeepResearchAgain } from '../../deepResearch/runAgain';
@@ -145,7 +143,6 @@ const NewThreadPanel: FC<{
     const { addItem: addDockItem } = useLauncherDock(projectUuid);
     const isAuto = isLauncherAutoAgent(agent);
     const concreteAgent = getConcreteLauncherAgent(agent);
-    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
 
     const {
         contextInput,
@@ -389,9 +386,7 @@ const NewThreadPanel: FC<{
                     defaultValue={composerSeed ?? undefined}
                     onSubmit={handleSubmit}
                     onStartDeepResearch={
-                        concreteAgent && deepResearchFlag.data?.enabled
-                            ? handleStartDeepResearch
-                            : undefined
+                        concreteAgent ? handleStartDeepResearch : undefined
                     }
                     loading={isLocked}
                     disabled={!isPinnedContextReady || isPickingAgent}
@@ -464,7 +459,6 @@ const ExistingThreadPanel: FC<{
     style?: CSSProperties;
 }> = ({ projectUuid, agent, agents, threadId, style }) => {
     const { user } = useApp();
-    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
     const navigate = useNavigate();
     const location = useLocation();
     const {
@@ -675,11 +669,7 @@ const ExistingThreadPanel: FC<{
                         disabledReason="This thread is read-only. To continue the conversation, reply in Slack."
                         loading={isBusy}
                         onSubmit={handleSubmit}
-                        onStartDeepResearch={
-                            deepResearchFlag.data?.enabled
-                                ? handleStartDeepResearch
-                                : undefined
-                        }
+                        onStartDeepResearch={handleStartDeepResearch}
                         placeholder={`Ask ${agent.name} anything...`}
                         messageCount={thread.messages?.length || 0}
                         projectUuid={projectUuid}

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
@@ -15,7 +15,6 @@ const {
     agentChatInputProps,
     agents,
     createAgentThread,
-    deepResearchEnabled,
     deepResearchHookArgs,
     navigate,
     sqlModeAvailable,
@@ -34,7 +33,6 @@ const {
         ],
     },
     createAgentThread: vi.fn(),
-    deepResearchEnabled: { current: true },
     deepResearchHookArgs: {
         current: undefined as
             | [projectUuid: string, entryPoint: string]
@@ -52,12 +50,6 @@ vi.mock('react-router', async (importOriginal) => ({
 
 vi.mock('../../../hooks/useProject', () => ({
     useProject: () => ({ data: undefined }),
-}));
-
-vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
-    useServerFeatureFlag: () => ({
-        data: { enabled: deepResearchEnabled.current },
-    }),
 }));
 
 vi.mock('../../../providers/App/useApp', () => ({
@@ -231,7 +223,6 @@ describe('DayOneAskInput', () => {
             uuid: 'thread-1',
             firstMessage: { uuid: 'prompt-1' },
         });
-        deepResearchEnabled.current = true;
         deepResearchHookArgs.current = undefined;
         startDeepResearch.mockReset();
         startDeepResearch.mockResolvedValue(undefined);
@@ -274,16 +265,6 @@ describe('DayOneAskInput', () => {
 
         expect(agentChatInputProps.current?.selectedAgent).toBe('auto');
         expect(agentChatInputProps.current?.agentUuid).toBeUndefined();
-        expect(
-            agentChatInputProps.current?.onStartDeepResearch,
-        ).toBeUndefined();
-    });
-
-    it('hides Deep Research when the feature flag is disabled', () => {
-        deepResearchEnabled.current = false;
-
-        renderInput();
-
         expect(
             agentChatInputProps.current?.onStartDeepResearch,
         ).toBeUndefined();

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -1,6 +1,5 @@
 import { subject } from '@casl/ability';
 import {
-    FeatureFlags,
     type AgentSuggestion,
     type AiPromptContextInput,
     type AiPromptContextItem,
@@ -12,7 +11,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -170,7 +168,6 @@ const DayOneAskInputInner: FC<Props> = ({
         useCreateAgentThreadMutation(projectUuid ?? '');
     const { mutateAsync: startDeepResearch } =
         useStartDeepResearchForThreadMutation(projectUuid ?? '', 'homepage');
-    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
 
     const showAutoOption = (agents?.length ?? 0) > 1 && routerEnabled === true;
     const validDefaultAgent = agents?.find(
@@ -373,9 +370,7 @@ const DayOneAskInputInner: FC<Props> = ({
                     }
                     onSubmit={handleSubmit}
                     onStartDeepResearch={
-                        selectedAgent && deepResearchFlag.data?.enabled
-                            ? handleStartDeepResearch
-                            : undefined
+                        selectedAgent ? handleStartDeepResearch : undefined
                     }
                     loading={isCreatingThread}
                     showSuggestions={false}

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -1,10 +1,8 @@
 import { subject } from '@casl/ability';
-import { FeatureFlags } from '@lightdash/common';
 import { Box, Center, Flex, Loader } from '@mantine/core';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
 import { matchesModelConfig } from '../../../components/common/ModelSelector/utils';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import { ReviewVerificationPanel } from '../../features/aiCopilot/components/Admin/ReviewVerificationPanel';
 import { AgentChatDisplay } from '../../features/aiCopilot/components/ChatElements/AgentChatDisplay';
@@ -178,7 +176,6 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const updateReviewItemStatus = useUpdateAiAgentReviewItemStatus();
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
-    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
     const startDeepResearch = useStartDeepResearchMutation({
         projectUuid: projectUuid!,
         agentUuid: agentUuid!,
@@ -402,11 +399,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                         disabledReason={inputDisabledReason}
                         loading={isBusy}
                         onSubmit={handleSubmit}
-                        onStartDeepResearch={
-                            deepResearchFlag.data?.enabled
-                                ? handleStartDeepResearch
-                                : undefined
-                        }
+                        onStartDeepResearch={handleStartDeepResearch}
                         placeholder={`Ask ${agent.name} anything about your data...`}
                         messageCount={thread.messages?.length || 0}
                         projectUuid={projectUuid}

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlags } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -16,7 +15,6 @@ import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { AiAgentNewThreadMcpConnections } from '../../features/aiCopilot/components/AiAgentNewThreadMcpConnections';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import {
@@ -68,7 +66,6 @@ const AiAgentNewThreadPage: FC = () => {
     const { agent, agents, navigateFromAgentChat } =
         useOutletContext<AgentContext>();
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
-    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
     const [sqlModeOverride, setSqlModeOverride] = useState<boolean>();
     const sqlMode = sqlModeOverride ?? agent.enableSqlMode;
     const dispatch = useAiAgentStoreDispatch();
@@ -356,11 +353,7 @@ const AiAgentNewThreadPage: FC = () => {
                     <AgentChatInput
                         key={composerSeedKey}
                         onSubmit={onSubmit}
-                        onStartDeepResearch={
-                            deepResearchFlag.data?.enabled
-                                ? onStartDeepResearch
-                                : undefined
-                        }
+                        onStartDeepResearch={onStartDeepResearch}
                         loading={isCreatingThread}
                         disabled={!isPinnedContextReady}
                         placeholder={`Ask ${agent.name} anything about your data...`}

--- a/packages/frontend/src/hooks/settings/deepResearchSettingsAccess.test.ts
+++ b/packages/frontend/src/hooks/settings/deepResearchSettingsAccess.test.ts
@@ -8,20 +8,18 @@ const access = (
 ) =>
     canAccessDeepResearchSettings({
         isAiCopilotEnabledOrTrial: true,
-        isDeepResearchEnabled: true,
         canManageOrgAiAgent: true,
         hasAnyAiAgentAccess: true,
         ...overrides,
     });
 
 describe('canAccessDeepResearchSettings', () => {
-    it('allows organization AI admins when Deep Research is enabled', () => {
+    it('allows organization AI admins when AI Agents are available', () => {
         expect(access()).toBe(true);
     });
 
     it.each([
         'isAiCopilotEnabledOrTrial',
-        'isDeepResearchEnabled',
         'canManageOrgAiAgent',
         'hasAnyAiAgentAccess',
     ] as const)('denies access when %s is false', (gate) => {

--- a/packages/frontend/src/hooks/settings/deepResearchSettingsAccess.ts
+++ b/packages/frontend/src/hooks/settings/deepResearchSettingsAccess.ts
@@ -2,19 +2,12 @@ import { type SettingsContext } from './types';
 
 type DeepResearchSettingsAccess = Pick<
     SettingsContext,
-    | 'isAiCopilotEnabledOrTrial'
-    | 'isDeepResearchEnabled'
-    | 'canManageOrgAiAgent'
-    | 'hasAnyAiAgentAccess'
+    'isAiCopilotEnabledOrTrial' | 'canManageOrgAiAgent' | 'hasAnyAiAgentAccess'
 >;
 
 export const canAccessDeepResearchSettings = ({
     isAiCopilotEnabledOrTrial,
-    isDeepResearchEnabled,
     canManageOrgAiAgent,
     hasAnyAiAgentAccess,
 }: DeepResearchSettingsAccess) =>
-    isAiCopilotEnabledOrTrial &&
-    isDeepResearchEnabled &&
-    canManageOrgAiAgent &&
-    hasAnyAiAgentAccess;
+    isAiCopilotEnabledOrTrial && canManageOrgAiAgent && hasAnyAiAgentAccess;

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -70,7 +70,6 @@ export type SettingsContext = {
     isScimTokenManagementEnabled: FeatureFlag | undefined;
     isServiceAccountsEnabled: boolean;
     isAiCopilotEnabledOrTrial: boolean;
-    isDeepResearchEnabled: boolean;
     shouldShowAiAgentReviews: boolean;
     shouldShowAiAgentMemories: boolean;
     // Org-level AI settings access (router config, org settings, review queue).
@@ -79,7 +78,6 @@ export type SettingsContext = {
     // least one project they can reach. Gates visibility of the "Ask AI" area.
     hasAnyAiAgentAccess: boolean;
     isAiOrganizationSettingsLoading: boolean;
-    isDeepResearchFlagLoading: boolean;
     dataAppsFlag: FeatureFlag | undefined;
     isDataAppsFlagLoading: boolean;
     embeddingEnabled: FeatureFlag | undefined;

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -38,12 +38,6 @@ export const useSettingsContext = (): SettingsContext => {
     const shouldShowAiAgentReviews =
         aiOrganizationSettingsQuery.data?.aiAgentReviewsEnabled === true;
 
-    const deepResearchFlagQuery = useServerFeatureFlag(
-        FeatureFlags.AiDeepResearch,
-    );
-    const { data: deepResearchFlag } = deepResearchFlagQuery;
-    const isDeepResearchEnabled = deepResearchFlag?.enabled ?? false;
-
     const { data: aiAgentMemoryFlag } = useServerFeatureFlag(
         FeatureFlags.AiAgentMemory,
     );
@@ -206,14 +200,12 @@ export const useSettingsContext = (): SettingsContext => {
         isScimTokenManagementEnabled,
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
-        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         isAiOrganizationSettingsLoading:
             aiOrganizationSettingsQuery.isInitialLoading,
-        isDeepResearchFlagLoading: deepResearchFlagQuery.isInitialLoading,
         dataAppsFlag,
         isDataAppsFlagLoading: dataAppsFlagQuery.isInitialLoading,
         embeddingEnabled,

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -83,7 +83,6 @@ export const useSettingsNavigation = (
         isScimTokenManagementEnabled,
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
-        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,
@@ -544,7 +543,6 @@ export const useSettingsNavigation = (
             if (
                 canAccessDeepResearchSettings({
                     isAiCopilotEnabledOrTrial,
-                    isDeepResearchEnabled,
                     canManageOrgAiAgent,
                     hasAnyAiAgentAccess,
                 })
@@ -988,7 +986,6 @@ export const useSettingsNavigation = (
         isScimEnabled,
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
-        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -155,13 +155,11 @@ const Settings: FC = () => {
         dataAppsFlag,
         isDataAppsFlagLoading,
         isAiCopilotEnabledOrTrial,
-        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         isAiOrganizationSettingsLoading,
-        isDeepResearchFlagLoading,
         showImpersonationPanel,
         isLeaveOrganizationEnabled,
         isCustomRolesEnabled,
@@ -662,7 +660,6 @@ const Settings: FC = () => {
                 if (
                     canAccessDeepResearchSettings({
                         isAiCopilotEnabledOrTrial,
-                        isDeepResearchEnabled,
                         canManageOrgAiAgent,
                         hasAnyAiAgentAccess,
                     })
@@ -787,7 +784,6 @@ const Settings: FC = () => {
         isEmailWhitelabelEnabled,
         isLeaveOrganizationEnabled,
         isAiCopilotEnabledOrTrial,
-        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,
@@ -912,11 +908,6 @@ const Settings: FC = () => {
     const isAwaitingAiSettingsRoute =
         isAiOrganizationSettingsLoading &&
         Boolean(matchPath('/generalSettings/ai/*', location.pathname));
-    const isAwaitingDeepResearchRoute =
-        isDeepResearchFlagLoading &&
-        Boolean(
-            matchPath('/generalSettings/ai/deep-research', location.pathname),
-        );
     const isAwaitingRoadmapRoute =
         isOrganizationRoadmapLoading &&
         Boolean(matchPath('/generalSettings/roadmap', location.pathname));
@@ -931,7 +922,6 @@ const Settings: FC = () => {
         isActiveProjectUuidLoading ||
         isProjectLoading ||
         isAwaitingAiSettingsRoute ||
-        isAwaitingDeepResearchRoute ||
         isAwaitingRoadmapRoute ||
         isAwaitingDataAppsRoute
     ) {


### PR DESCRIPTION
Related: https://linear.app/lightdash/issue/PROD-10034

## Description

Makes Deep Research available anywhere AI Agents are available, including eligible AI trials. It removes the separate `ai-deep-research` gate while preserving the existing project scope, signed-in-user checks, organization settings, and Beta status.

## Availability

```text
Before: AI Agents entitlement/trial → Deep Research flag → project scope
After:  AI Agents entitlement/trial ───────────────────→ project scope
```

The backend now reuses `AiAgentService.getIsCopilotEnabled`, the same entitlement-or-trial resolver used by AI Agents. Composer and admin-settings entry points no longer fetch the legacy flag; its enum value remains a no-op so existing self-hosted configuration continues to parse.

## Test plan

- [x] Deep Research service tests: 73 passed, including AI Agents unavailable and project-scope denial
- [x] Frontend settings and homepage tests: 10 passed
- [x] Common, backend, and frontend typechecks
- [x] Common, backend, and frontend lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
