### PR TITLE
feat(ai): add persistent deep research report URLs

### DIFF
--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -316,6 +316,16 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
                 },
             },
             {
+                path: 'deep-research/:runUuid',
+                lazy: async () => {
+                    const DeepResearchReportPage = await loadLazyRouteDefault(
+                        './pages/AiAgents/DeepResearchReportPage',
+                        () => import('./pages/AiAgents/DeepResearchReportPage'),
+                    );
+                    return { Component: DeepResearchReportPage };
+                },
+            },
+            {
                 path: ':agentUuid/memories/:slug',
                 lazy: async () => {
                     const AiAgentMemoryPage = await loadLazyRouteDefault(

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -18,14 +18,14 @@ import {
     getDeepResearchReportHeadings,
     getDeepResearchReportSourceCount,
 } from '../../deepResearch/reportDocument';
-import { type DeepResearchRunView } from '../../deepResearch/types';
+import { type DeepResearchReportView } from '../../deepResearch/types';
 import { DeepResearchInlineMarkdown } from './DeepResearchInlineMarkdown';
 import { DeepResearchMarkdownReport } from './DeepResearchMarkdownReport';
 import styles from './DeepResearchReport.module.css';
 import { DeepResearchReportContent } from './DeepResearchReportContent';
 
 type Props = {
-    run: DeepResearchRunView;
+    run: DeepResearchReportView;
     opened: boolean;
     onClose: () => void;
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
@@ -1,5 +1,7 @@
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { type ReactElement } from 'react';
+import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
 import { deepResearchRunFixture } from '../../deepResearch/fixtures';
@@ -15,6 +17,9 @@ vi.mock('../../hooks/useDeepResearch', () => ({
     }),
     useTrackDeepResearchReportEngagement: () => trackReportEngagement,
 }));
+
+const renderRunCard = (card: ReactElement) =>
+    renderWithProviders(<MemoryRouter>{card}</MemoryRouter>);
 
 describe('DeepResearchRunCard', () => {
     beforeEach(() => {
@@ -32,7 +37,7 @@ describe('DeepResearchRunCard', () => {
     ] as const)(
         'renders the %s active state with one beta label and without fake progress',
         (status, label) => {
-            renderWithProviders(
+            renderRunCard(
                 <DeepResearchRunCard
                     run={{
                         ...deepResearchRunFixture,
@@ -57,7 +62,7 @@ describe('DeepResearchRunCard', () => {
 
     it('updates elapsed time once per second without milliseconds', async () => {
         vi.useFakeTimers();
-        renderWithProviders(
+        renderRunCard(
             <DeepResearchRunCard
                 run={{
                     ...deepResearchRunFixture,
@@ -80,7 +85,7 @@ describe('DeepResearchRunCard', () => {
 
     it('cancels an active run and exposes safe activity', async () => {
         const user = userEvent.setup();
-        renderWithProviders(
+        renderRunCard(
             <DeepResearchRunCard
                 run={{
                     ...deepResearchRunFixture,
@@ -111,7 +116,7 @@ describe('DeepResearchRunCard', () => {
     ] as const)(
         'renders the %s terminal state without a stop action',
         (status, label) => {
-            renderWithProviders(
+            renderRunCard(
                 <DeepResearchRunCard
                     run={{
                         ...deepResearchRunFixture,
@@ -152,7 +157,7 @@ describe('DeepResearchRunCard', () => {
     );
 
     it('shows how to refine a question when no relevant data was found', () => {
-        renderWithProviders(
+        renderRunCard(
             <DeepResearchRunCard
                 run={{
                     ...deepResearchRunFixture,
@@ -183,7 +188,7 @@ describe('DeepResearchRunCard', () => {
     });
 
     it('preserves partial findings and offers the report', () => {
-        renderWithProviders(
+        renderRunCard(
             <DeepResearchRunCard
                 run={{
                     ...deepResearchRunFixture,
@@ -201,14 +206,14 @@ describe('DeepResearchRunCard', () => {
         ).toBeInTheDocument();
         expect(screen.getByText('Research summary')).toBeInTheDocument();
         expect(
-            screen.getByRole('button', { name: 'View full report' }),
+            screen.getByRole('link', { name: 'View full report' }),
         ).toBeInTheDocument();
     });
 
     it('replaces expired report content with a stable rerun action', async () => {
         const user = userEvent.setup();
         const onRunAgain = vi.fn();
-        renderWithProviders(
+        renderRunCard(
             <DeepResearchRunCard
                 run={{
                     ...deepResearchRunFixture,
@@ -244,7 +249,7 @@ describe('DeepResearchRunCard', () => {
 
     it('tracks explicitly opening the full report', async () => {
         const user = userEvent.setup();
-        renderWithProviders(
+        renderRunCard(
             <DeepResearchRunCard
                 run={deepResearchRunFixture}
                 projectUuid="project-1"
@@ -252,9 +257,15 @@ describe('DeepResearchRunCard', () => {
         );
 
         await user.click(
-            screen.getByRole('button', { name: 'View full report' }),
+            screen.getByRole('link', { name: 'View full report' }),
         );
 
+        expect(
+            screen.getByRole('link', { name: 'View full report' }),
+        ).toHaveAttribute(
+            'href',
+            `/projects/${deepResearchRunFixture.projectUuid}/ai-agents/deep-research/${deepResearchRunFixture.uuid}`,
+        );
         expect(trackReportEngagement).toHaveBeenCalledWith('opened', {
             aiDeepResearchRunUuid: deepResearchRunFixture.uuid,
             projectUuid: deepResearchRunFixture.projectUuid,
@@ -267,7 +278,7 @@ describe('DeepResearchRunCard', () => {
     });
 
     it('renders the research summary as Markdown', () => {
-        renderWithProviders(
+        renderRunCard(
             <DeepResearchRunCard
                 run={{
                     ...deepResearchRunFixture,
@@ -317,7 +328,7 @@ The full report continues here.`,
         const user = userEvent.setup();
         const onReconnect = vi.fn();
         const onContinue = vi.fn();
-        renderWithProviders(
+        renderRunCard(
             <DeepResearchRunCard
                 run={{
                     ...deepResearchRunFixture,
@@ -349,7 +360,7 @@ The full report continues here.`,
     it('offers a permission action without discarding findings', async () => {
         const user = userEvent.setup();
         const onReviewPermissions = vi.fn();
-        renderWithProviders(
+        renderRunCard(
             <DeepResearchRunCard
                 run={{
                     ...deepResearchRunFixture,
@@ -375,7 +386,7 @@ The full report continues here.`,
     it('explains that starting over does not reuse previous queries', async () => {
         const user = userEvent.setup();
         const onRunAgain = vi.fn();
-        renderWithProviders(
+        renderRunCard(
             <DeepResearchRunCard
                 run={{
                     ...deepResearchRunFixture,

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -24,6 +24,7 @@ import {
     type FC,
     type ReactNode,
 } from 'react';
+import { Link } from 'react-router';
 import { type StreamdownProps } from 'streamdown';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -37,7 +38,6 @@ import {
     useCancelDeepResearchMutation,
     useTrackDeepResearchReportEngagement,
 } from '../../hooks/useDeepResearch';
-import { DeepResearchReport } from './DeepResearchReport';
 import styles from './DeepResearchRunCard.module.css';
 
 const PreviewLink: FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
@@ -189,7 +189,6 @@ export const DeepResearchRunCard = ({
     const status = STATUS_CONFIG[run.status];
     const cancelMutation = useCancelDeepResearchMutation(projectUuid, run.uuid);
     const [isActivityOpen, setIsActivityOpen] = useState(false);
-    const [isReportOpen, setIsReportOpen] = useState(false);
     const activityId = useId();
     const trackReportEngagement = useTrackDeepResearchReportEngagement();
     const [announcedStatus, setAnnouncedStatus] = useState(run.status);
@@ -437,6 +436,8 @@ export const DeepResearchRunCard = ({
                                 </AiMarkdown>
                             )}
                             <Button
+                                component={Link}
+                                to={`/projects/${run.projectUuid}/ai-agents/deep-research/${run.uuid}`}
                                 color="ldDark"
                                 size="xs"
                                 w="fit-content"
@@ -457,7 +458,6 @@ export const DeepResearchRunCard = ({
                                             updatedAt: run.updatedAt,
                                         });
                                     }
-                                    setIsReportOpen(true);
                                 }}
                             >
                                 View full report
@@ -528,12 +528,6 @@ export const DeepResearchRunCard = ({
                     </Stack>
                 )}
             </Stack>
-
-            <DeepResearchReport
-                run={run}
-                opened={isReportOpen}
-                onClose={() => setIsReportOpen(false)}
-            />
         </Paper>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
@@ -52,6 +52,19 @@ export type DeepResearchRunView = {
     errorMessage: string | null;
 };
 
+export type DeepResearchReportView = Pick<
+    DeepResearchRunView,
+    | 'uuid'
+    | 'projectUuid'
+    | 'agentUuid'
+    | 'threadUuid'
+    | 'question'
+    | 'completedAt'
+    | 'sourceCount'
+    | 'resultMarkdown'
+    | 'isReportExpired'
+>;
+
 export type DeepResearchRunRegistration = {
     runUuid: string;
     projectUuid: string;

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
@@ -10,6 +10,7 @@ import { type DeepResearchRunRegistration } from '../deepResearch/types';
 import {
     useHasActiveDeepResearchRun,
     useDeepResearchChartLiveQuery,
+    useDeepResearchReport,
     useDeepResearchRun,
     useStartDeepResearchMutation,
     useTrackDeepResearchFollowUp,
@@ -533,5 +534,45 @@ describe('useDeepResearchRun', () => {
                 (args as { url: string }).url.includes('/events'),
             ),
         ).toHaveLength(2);
+    });
+});
+
+describe('useDeepResearchReport', () => {
+    afterEach(() => {
+        lightdashApiMock.mockReset();
+    });
+
+    it('loads a durable report directly by project and run UUID', async () => {
+        lightdashApiMock.mockResolvedValue({
+            ...getRun('completed'),
+            terminalReason: null,
+            resultMarkdown: '# Durable report',
+            reportExpiresAt: '2026-08-14T09:05:00.000Z',
+            reportExpiredAt: null,
+            isReportExpired: false,
+        });
+
+        const { result } = renderHook(
+            () => useDeepResearchReport('project-1', 'run-1'),
+            { wrapper: getWrapper() },
+        );
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(lightdashApiMock).toHaveBeenCalledWith({
+            version: 'v1',
+            url: '/ee/projects/project-1/ai-deep-research/run-1',
+            method: 'GET',
+            body: undefined,
+        });
+        expect(result.current.data).toEqual(
+            expect.objectContaining({
+                uuid: 'run-1',
+                projectUuid: 'project-1',
+                agentUuid: 'agent-1',
+                threadUuid: 'thread-1',
+                resultMarkdown: '# Durable report',
+            }),
+        );
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -36,6 +36,7 @@ import {
     toDeepResearchRegistration,
 } from '../deepResearch/runProgress';
 import {
+    type DeepResearchReportView,
     type DeepResearchRunRegistration,
     type StartDeepResearchArgs,
 } from '../deepResearch/types';
@@ -491,6 +492,41 @@ export const useDeepResearchRun = (
             : undefined,
         eventsQuery,
     };
+};
+
+export const useDeepResearchReport = (
+    projectUuid: string | undefined,
+    runUuid: string | undefined,
+) => {
+    const runQuery = useQuery<AiDeepResearchRun, ApiError>({
+        queryKey: [DEEP_RESEARCH_QUERY_KEY, projectUuid, runUuid],
+        queryFn: () => getDeepResearchRun(projectUuid ?? '', runUuid ?? ''),
+        enabled: !!projectUuid && !!runUuid,
+        refetchInterval: (run) =>
+            getDeepResearchRunRefetchInterval(
+                run,
+                DEEP_RESEARCH_POLL_INTERVAL_MS,
+            ),
+    });
+    const report = useMemo<DeepResearchReportView | undefined>(
+        () =>
+            runQuery.data
+                ? {
+                      uuid: runQuery.data.aiDeepResearchRunUuid,
+                      projectUuid: runQuery.data.projectUuid,
+                      agentUuid: runQuery.data.agentUuid,
+                      threadUuid: runQuery.data.aiThreadUuid,
+                      question: runQuery.data.prompt,
+                      completedAt: runQuery.data.completedAt,
+                      sourceCount: null,
+                      resultMarkdown: runQuery.data.resultMarkdown,
+                      isReportExpired: runQuery.data.isReportExpired,
+                  }
+                : undefined,
+        [runQuery.data],
+    );
+
+    return { ...runQuery, data: report };
 };
 
 export const useCancelDeepResearchMutation = (

--- a/packages/frontend/src/ee/pages/AiAgents/DeepResearchReportPage.test.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/DeepResearchReportPage.test.tsx
@@ -1,0 +1,205 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+    matchRoutes,
+    MemoryRouter,
+    Route,
+    Routes,
+    useNavigate,
+} from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { CommercialWebAppRoutes } from '../../CommercialRoutes';
+import { deepResearchRunFixture } from '../../features/aiCopilot/deepResearch/fixtures';
+import DeepResearchReportPage from './DeepResearchReportPage';
+
+const { useDeepResearchReport } = vi.hoisted(() => ({
+    useDeepResearchReport: vi.fn(),
+}));
+
+vi.mock('../../features/aiCopilot/hooks/useDeepResearch', () => ({
+    useDeepResearchReport,
+}));
+
+vi.mock(
+    '../../features/aiCopilot/components/DeepResearch/DeepResearchReport',
+    () => ({
+        DeepResearchReport: ({
+            run,
+            onClose,
+        }: {
+            run: typeof deepResearchRunFixture;
+            onClose: () => void;
+        }) => (
+            <>
+                <div>Report {run.uuid}</div>
+                <button type="button" onClick={onClose}>
+                    Back to chat
+                </button>
+            </>
+        ),
+    }),
+);
+
+const reportPath = `/projects/${deepResearchRunFixture.projectUuid}/ai-agents/deep-research/${deepResearchRunFixture.uuid}`;
+
+const AgentThread = () => {
+    const navigate = useNavigate();
+    return (
+        <>
+            <div>Agent thread</div>
+            <button type="button" onClick={() => navigate(-1)}>
+                Browser back
+            </button>
+        </>
+    );
+};
+
+const renderPage = () =>
+    renderWithProviders(
+        <MemoryRouter initialEntries={['/origin', reportPath]} initialIndex={1}>
+            <Routes>
+                <Route path="/origin" element={<div>Origin page</div>} />
+                <Route
+                    path="/projects/:projectUuid/ai-agents/deep-research/:runUuid"
+                    element={<DeepResearchReportPage />}
+                />
+                <Route
+                    path="/projects/:projectUuid/ai-agents/:agentUuid/threads/:threadUuid"
+                    element={<AgentThread />}
+                />
+            </Routes>
+        </MemoryRouter>,
+    );
+
+describe('DeepResearchReportPage', () => {
+    beforeEach(() => {
+        useDeepResearchReport.mockReset();
+        useDeepResearchReport.mockReturnValue({
+            data: deepResearchRunFixture,
+            error: null,
+            isError: false,
+            isLoading: false,
+        });
+    });
+
+    it('is registered at the persistent commercial route', () => {
+        expect(
+            matchRoutes(CommercialWebAppRoutes, reportPath)?.at(-1)?.route.path,
+        ).toBe('deep-research/:runUuid');
+    });
+
+    it('loads a report from its persistent URL and returns to its thread', async () => {
+        const user = userEvent.setup();
+        renderPage();
+
+        expect(useDeepResearchReport).toHaveBeenCalledWith(
+            deepResearchRunFixture.projectUuid,
+            deepResearchRunFixture.uuid,
+        );
+        expect(
+            screen.getByText(`Report ${deepResearchRunFixture.uuid}`),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Back to chat' }));
+
+        expect(screen.getByText('Agent thread')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Browser back' }));
+
+        expect(screen.getByText('Origin page')).toBeInTheDocument();
+    });
+
+    it('shows the retained expiration state with a route back to chat', async () => {
+        const user = userEvent.setup();
+        useDeepResearchReport.mockReturnValue({
+            data: {
+                ...deepResearchRunFixture,
+                resultMarkdown: null,
+                isReportExpired: true,
+            },
+            error: null,
+            isError: false,
+            isLoading: false,
+        });
+
+        renderPage();
+
+        expect(
+            screen.getByText('This report is no longer available'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Deep Research reports are available for 30 days.',
+            ),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Back to chat' }));
+
+        expect(screen.getByText('Agent thread')).toBeInTheDocument();
+    });
+
+    it('shows a loading state while the report is fetched', () => {
+        useDeepResearchReport.mockReturnValue({
+            data: undefined,
+            error: null,
+            isError: false,
+            isLoading: true,
+        });
+
+        renderPage();
+
+        expect(screen.getByTestId('page-spinner')).toBeInTheDocument();
+    });
+
+    it('forwards API errors to the page error state', () => {
+        useDeepResearchReport.mockReturnValue({
+            data: undefined,
+            error: {
+                error: {
+                    name: 'NotFoundError',
+                    message: 'Deep Research report not found',
+                },
+            },
+            isError: true,
+            isLoading: false,
+        });
+
+        renderPage();
+
+        expect(screen.getByText('Not found')).toBeInTheDocument();
+        expect(
+            screen.getByText('Deep Research report not found'),
+        ).toBeInTheDocument();
+    });
+
+    it('shows an incomplete report state with a route back to chat', async () => {
+        const user = userEvent.setup();
+        useDeepResearchReport.mockReturnValue({
+            data: {
+                ...deepResearchRunFixture,
+                completedAt: null,
+                resultMarkdown: null,
+                isReportExpired: false,
+            },
+            error: null,
+            isError: false,
+            isLoading: false,
+        });
+
+        renderPage();
+
+        expect(
+            screen.getByText('This report is not ready yet'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Return to the conversation to check its progress.',
+            ),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Back to chat' }));
+
+        expect(screen.getByText('Agent thread')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/pages/AiAgents/DeepResearchReportPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/DeepResearchReportPage.tsx
@@ -1,0 +1,57 @@
+import { Button, Center } from '@mantine/core';
+import { IconFileOff } from '@tabler/icons-react';
+import { useNavigate, useParams } from 'react-router';
+import ErrorState from '../../../components/common/ErrorState';
+import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
+import PageSpinner from '../../../components/PageSpinner';
+import { DeepResearchReport } from '../../features/aiCopilot/components/DeepResearch/DeepResearchReport';
+import { useDeepResearchReport } from '../../features/aiCopilot/hooks/useDeepResearch';
+
+const DeepResearchReportPage = () => {
+    const { projectUuid, runUuid } = useParams();
+    const navigate = useNavigate();
+    const runQuery = useDeepResearchReport(projectUuid, runUuid);
+
+    if (!projectUuid || !runUuid) {
+        return <ErrorState />;
+    }
+    if (runQuery.isLoading) {
+        return <PageSpinner />;
+    }
+    if (runQuery.isError || !runQuery.data) {
+        return <ErrorState error={runQuery.error?.error} />;
+    }
+
+    const run = runQuery.data;
+    const threadUrl = `/projects/${projectUuid}/ai-agents/${run.agentUuid}/threads/${run.threadUuid}`;
+    const backToChat = () => navigate(threadUrl, { replace: true });
+
+    if (!run.resultMarkdown || !run.completedAt) {
+        return (
+            <Center h="100%">
+                <SuboptimalState
+                    icon={IconFileOff}
+                    title={
+                        run.isReportExpired
+                            ? 'This report is no longer available'
+                            : 'This report is not ready yet'
+                    }
+                    description={
+                        run.isReportExpired
+                            ? 'Deep Research reports are available for 30 days.'
+                            : 'Return to the conversation to check its progress.'
+                    }
+                    action={
+                        <Button variant="default" onClick={backToChat}>
+                            Back to chat
+                        </Button>
+                    }
+                />
+            </Center>
+        );
+    }
+
+    return <DeepResearchReport run={run} opened onClose={backToChat} />;
+};
+
+export default DeepResearchReportPage;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9798/give-deep-research-reports-a-persistent-url

## Description:

Gives each retained Deep Research report a stable, project-scoped URL that users can revisit or bookmark after generation. The route loads the existing durable report by run UUID, preserves current access checks, handles loading/error/expired states, and returns to the source agent thread without reopening the report through browser history.

```text
Research card
    │ View full report
    ▼
/projects/:projectUuid/ai-agents/deep-research/:runUuid
    │ authenticated run fetch
    ▼
Durable report ── Back to chat ──▶ Source agent thread
```

Test plan: full frontend suite (314 files, 2,405 tests), frontend typecheck, lint, and format checks pass.