### PR TITLE
docs(themes): document theme-as-code workflow

### DIFF
--- a/docs/content-as-code.md
+++ b/docs/content-as-code.md
@@ -183,10 +183,12 @@ organization resources will use the same root.
 | Custom roles         | Organization | Exact role name                  | `lightdash/custom-roles/`                |
 | Users                | Organization | Lowercase primary email          | `lightdash/users/`                       |
 | Groups               | Organization | Exact, case-sensitive group name | `lightdash/groups/`                      |
+| Data App themes      | Organization | Immutable organization slug      | `lightdash/themes/<slug>/`               |
 
-Data apps are deliberately outside the YAML resource registry because they are
-multi-file source bundles. They may reuse shared path-safety and reporting
-utilities without pretending to be single-document resources.
+Data apps and organization Data App themes are deliberately outside the
+single-document YAML resource registry because they are multi-file bundles.
+They reuse shared path-safety, dependency-ordering, and reporting utilities
+without pretending to be single-document resources.
 
 Project APIs use `/api/v1/projects/{projectUuid}/code/{resource}`. Organization
 APIs use `/api/v2/orgs/{orgUuid}/code/{resource}`. The resource segments are
@@ -195,6 +197,10 @@ APIs use `/api/v2/orgs/{orgUuid}/code/{resource}`. The resource segments are
 `roles`, `users`, and `groups`.
 The legacy resource-first routes are deprecated in OpenAPI and should not be
 used by new clients.
+
+Organization themes use the organization-design package endpoints instead of a
+`/code/{resource}` endpoint because their portable representation is an
+uncompressed tar archive rather than one JSON document.
 
 ## Optional project resources
 
@@ -210,6 +216,39 @@ uploads validate the payload and permissions but do not call Google Drive to
 validate the spreadsheet URL. This allows CI and service-account deployments
 without the uploader's personal Google OAuth token. Executing an enabled sync
 still requires usable Google credentials for the scheduler owner.
+
+## Organization Data App themes
+
+Themes live under `lightdash/themes/<slug>/` with a strict
+`lightdash-theme.yml` manifest and optional files directly inside `css/`,
+`fonts/`, `images/`, and `instructions/`. The immutable, organization-scoped
+manifest slug is the portable identity. Existing imports preserve the design
+UUID and default status; a new slug creates a non-default theme.
+
+The endpoints are:
+
+- `GET /api/v1/org/designs/` to list themes in the authenticated organization;
+- `GET /api/v1/org/designs/{uuidOrSlug}/package` to export one canonical tar;
+- `PUT /api/v1/org/designs/package` to atomically import one canonical tar.
+
+The shared validation contract in `packages/common/src/ee/designs/` is used by
+both the backend package parser and the CLI's local-directory preflight. This
+is an intentional exception to the normal single-document responsibility
+split: the CLI must reject an unsafe or incomplete local bundle before any
+organization resource is mutated, while the backend must repeat every security
+and domain check before persistence.
+
+Download stages and validates every remote package before atomically replacing
+the local `themes/` directory, so a failed batch preserves the previous local
+snapshot. Upload preflights every local theme first, processes organization
+documents in dependency order, then imports themes sequentially. Each theme
+replacement is atomic, but the batch is not: successful siblings remain active
+when another import fails, and the summary names completed slugs and failures.
+
+Missing or empty local theme directories are no-ops. Omitting one theme never
+deletes it remotely, and theme sync never changes the organization default.
+There are no standalone theme commands or theme-specific include, skip, or only
+flags.
 
 ## External connections
 
@@ -491,10 +530,11 @@ access, user attributes, and ownership metadata. Changing the name creates a
 new group and leaves the original group intact; missing files do not delete
 groups.
 
-Organization uploads run dependency phases sequentially: custom roles, then
-users, then groups. A failed phase prevents every dependent phase from
-starting, so group emails are resolved only after the complete users phase has
-succeeded.
+Organization uploads preflight theme packages, then run remote phases
+sequentially: custom roles, users, groups, and themes. A failed document phase
+prevents later phases from starting, so group emails are resolved only after
+the complete users phase has succeeded and theme imports begin only after the
+groups phase succeeds.
 
 SCIM and content as code should not manage the same group. Groups do not yet
 record management provenance, so this limitation cannot be enforced by the

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -953,7 +953,7 @@ const downloadCommand = program
     )
     .option(
         '--organization',
-        'download all organization-scoped resources without selecting a project',
+        'download all organization-scoped resources, including Data App themes, without selecting a project',
         false,
     );
 
@@ -1089,7 +1089,7 @@ const uploadCommand = program
     )
     .option(
         '--organization',
-        'upload all organization-scoped resources without selecting a project',
+        'upload all organization-scoped resources, including Data App themes, without selecting a project',
         false,
     )
     .option(

--- a/packages/cli/src/skills.test.ts
+++ b/packages/cli/src/skills.test.ts
@@ -103,7 +103,7 @@ describe('effective-dbt-sql skill content policy', () => {
     });
 });
 
-describe('developing-in-lightdash catalog workflow', () => {
+describe('developing-in-lightdash routed workflows', () => {
     const skillDir = path.join(SKILLS_DIR, 'developing-in-lightdash');
     const skillMd = fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf-8');
     const workflowPath = path.join(
@@ -119,6 +119,18 @@ describe('developing-in-lightdash catalog workflow', () => {
         );
         expect(skillMd).toMatch(
             /no usable dbt project[\s\S]*always read and follow/i,
+        );
+    });
+
+    it('routes organization Data App theme work through its focused reference', () => {
+        const { description } = parseFrontmatter(skillMd);
+
+        expect(description?.toLowerCase()).toContain(
+            'organization data app themes',
+        );
+        expect(skillMd).toContain('./resources/data-app-themes-reference.md');
+        expect(skillMd).toMatch(
+            /any task that creates, edits, migrates, downloads, uploads, or tests an organization Data App theme,[\s\S]*always read and follow/i,
         );
     });
 

--- a/skills/developing-in-lightdash/SKILL.md
+++ b/skills/developing-in-lightdash/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developing-in-lightdash
-description: Use when working with Lightdash YAML files, dbt models with Lightdash metadata, the lightdash CLI (deploy, upload, download, preview, lint, warehouse-catalog, sql, set-warehouse, apps create/preview/validate), or managing charts, dashboards, spaces and access, AI agents, scheduled content, data apps, data-app external connections, users, groups, custom roles, metrics, and dimensions as code
+description: Use when working with Lightdash YAML files, dbt models with Lightdash metadata, the lightdash CLI (deploy, upload, download, preview, lint, warehouse-catalog, sql, set-warehouse, apps create/preview/validate), or managing charts, dashboards, spaces and access, AI agents, scheduled content, data apps, organization Data App themes, data-app external connections, users, groups, custom roles, metrics, and dimensions as code
 ---
 
 # Developing in Lightdash
@@ -14,6 +14,7 @@ Build and deploy Lightdash analytics projects. This skill covers the **semantic 
 - Defining metrics, dimensions, joins, or tables in dbt or pure Lightdash projects
 - Creating or editing charts and dashboards as code
 - Downloading, uploading, or locally developing data apps (enterprise)
+- Creating, editing, migrating, downloading, or uploading organization Data App themes
 
 **Don't use for:** Developing the Lightdash application itself (use the codebase CLAUDE.md), general dbt work without Lightdash metadata, or raw SQL unrelated to Lightdash models.
 
@@ -30,6 +31,7 @@ Build and deploy Lightdash analytics projects. This skill covers the **semantic 
 | Build dashboards | `lightdash download`, edit YAML, `lightdash upload` | [Dashboard Reference](./resources/dashboard-reference.md) |
 | Manage content as code across project and organization resources | `lightdash download`, `lightdash upload` | [Content as Code](./resources/content-as-code-reference.md) |
 | Manage data apps as code (enterprise) | `lightdash download --apps <ref>` (one app) or `--include-apps` (all), edit bundle, `lightdash upload --apps <ref>`; local dev via `lightdash apps create/preview/validate` | [Data Apps](#working-with-data-apps-enterprise), [Content as Code](./resources/content-as-code-reference.md) |
+| Manage organization Data App themes as code | `lightdash download --organization`, edit `themes/<slug>/`, `lightdash upload --organization` | [Data App Themes](./resources/data-app-themes-reference.md) |
 | Manage data-app external connections (enterprise) | `lightdash download --include-external-connections`, edit YAML, `lightdash upload` | [Content as Code](./resources/content-as-code-reference.md) |
 | Lint yaml files | `lightdash lint` | [CLI Reference](./resources/cli-reference.md) |
 | Set warehouse connection | `lightdash set-warehouse` from profiles.yml | [CLI Reference](./resources/cli-reference.md) |
@@ -48,10 +50,13 @@ Build and deploy Lightdash analytics projects. This skill covers the **semantic 
 | **Missing `contentType` field** | Content type can't be determined without relying on directory structure | Always include `contentType: chart`, `contentType: dashboard`, or `contentType: sql_chart` at the top level |
 | **Adding `--include-apps` to an `--apps <ref>` selection** | `--include-apps` always requests ALL project apps (capped at 50), so the command downloads every app plus the ref — not just the one app | `--apps <ref>` alone downloads/uploads only that app (by slug, app URL, or UUID). Use `--include-apps` only when you want every app |
 | **Editing a data app without reading its bundled skills** | App code violates the SDK-only data access and dependency boundaries (direct `fetch`, `pnpm add`, vendored libraries) and the upload rejects or the app breaks when deployed | Every app bundle ships `.claude/skills/developing-data-apps-locally` and `.claude/skills/lightdash-data-app` — read them before editing files in an app folder (see [Data Apps](#working-with-data-apps-enterprise)) |
+| **Inventing a theme-only CLI command or treating a missing folder as deletion** | The command does not exist, or a supposedly deleted remote theme returns on the next download | Use organization download/upload, and read [Data App Themes](./resources/data-app-themes-reference.md) before changing `themes/` |
 
 ## Before You Start
 
-When a task uses `lightdash download` or `lightdash upload`, especially for bulk edits, spaces and access, scheduled content, AI agents, data apps, external connections, users, groups, or custom roles, **read and follow [Content as Code](./resources/content-as-code-reference.md) first**. Project and organization content require separate commands, and a default download is not a complete snapshot.
+When a task uses `lightdash download` or `lightdash upload`, especially for bulk edits, spaces and access, scheduled content, AI agents, data apps, organization themes, external connections, users, groups, or custom roles, **read and follow [Content as Code](./resources/content-as-code-reference.md) first**. Project and organization content require separate commands, and a default download is not a complete snapshot.
+
+For any task that creates, edits, migrates, downloads, uploads, or tests an organization Data App theme, **always read and follow [Data App Themes](./resources/data-app-themes-reference.md) before touching `themes/`**. Theme packages are strict multi-file resources, organization upload has no theme-only mode, and `lightdash lint` does not validate them.
 
 ### Check Your Target Project
 
@@ -243,6 +248,12 @@ lightdash apps validate                    # check source, manifest, dependencie
 
 When editing files inside an app folder, **read those bundled skills first**. They are version-matched to the app and authoritative for local development — this skill only covers moving apps between disk and Lightdash.
 
+### Working with Organization Data App Themes
+
+Organization Data App themes are multi-file packages under `themes/<slug>/` and participate automatically in `lightdash download --organization` and `lightdash upload --organization`. They do not have a standalone command group or theme-specific selectors.
+
+Before creating, editing, migrating, synchronizing, or testing a theme, **read and follow [Data App Themes](./resources/data-app-themes-reference.md)** for the manifest contract, asset rules, synchronization behavior, and generation boundaries.
+
 ### Creating New Content
 
 Charts and dashboards are typically created in the UI first, then managed as code:
@@ -416,6 +427,7 @@ See [Workflows Reference](./resources/workflows-reference.md) for detailed examp
 ### Dashboards & Workflows
 - [Dashboard Reference](./resources/dashboard-reference.md)
 - [Dashboard Best Practices](./resources/dashboard-best-practices.md)
+- [Data App Themes Reference](./resources/data-app-themes-reference.md)
 - [Content as Code Reference](./resources/content-as-code-reference.md)
 - [CLI Reference](./resources/cli-reference.md)
 - [Workflows Reference](./resources/workflows-reference.md)

--- a/skills/developing-in-lightdash/resources/cli-reference.md
+++ b/skills/developing-in-lightdash/resources/cli-reference.md
@@ -109,6 +109,10 @@ lightdash upload --charts my-chart --dashboards my-dashboard
 # Upload dashboard with all its referenced charts
 lightdash upload --dashboards my-dashboard --include-charts
 
+# Download or upload every organization resource, including Data App themes
+lightdash download --organization
+lightdash upload --organization
+
 # Data-app external connections (enterprise; secrets via env var — see Content as Code)
 lightdash download --include-external-connections
 LIGHTDASH_EXTERNAL_CONNECTION_SECRET_STRIPE_API=sk-... lightdash upload --external-connections stripe-api
@@ -297,8 +301,8 @@ lightdash set-warehouse --project-dir ./dbt --profiles-dir ./profiles --assume-y
 | `lightdash login`     | Authenticate with Lightdash      |
 | `lightdash config`    | Manage project selection         |
 | `lightdash deploy`    | Sync semantic layer to Lightdash |
-| `lightdash upload`    | Upload charts/dashboards         |
-| `lightdash download`  | Download charts/dashboards       |
+| `lightdash upload`    | Upload project or organization content as code |
+| `lightdash download`  | Download project or organization content as code |
 | `lightdash preview`   | Create temporary test project    |
 | `lightdash validate`  | Validate against server          |
 | `lightdash lint`      | Validate YAML locally            |

--- a/skills/developing-in-lightdash/resources/content-as-code-reference.md
+++ b/skills/developing-in-lightdash/resources/content-as-code-reference.md
@@ -37,16 +37,19 @@ Downloads reuse an existing managed path when the document at that path has the 
 | Custom roles | Role name | `custom-roles/*.yml` |
 | Users | Case-insensitive email | `users/*.yml` |
 | Groups and memberships | Group name | `groups/*.yml` |
+| Data App themes | Immutable theme slug | `themes/<slug>/` |
 
 Organization upload applies resources in dependency order:
 
 ```text
-custom roles → users → groups
+custom roles → users → groups → themes
 ```
 
-If custom roles fail, dependent users and groups are skipped. If users fail, dependent groups are skipped. User invitation emails are not sent unless `lightdash upload --organization --send-invites` is used intentionally.
+Theme packages are preflighted locally before any organization mutation; remote theme imports run after the three document phases. If custom roles fail, dependent users and groups are skipped and themes do not start. If users fail, dependent groups and themes do not start. User invitation emails are not sent unless `lightdash upload --organization --send-invites` is used intentionally.
 
 Organization documents use their resource folders to determine their type and do not require a `contentType` property. Do not add one merely to make them look like project documents.
+
+Themes are strict multi-file packages rather than organization documents. Before editing or synchronizing `themes/`, read [Data App Themes](./data-app-themes-reference.md). There is no theme-only selector: organization download fetches every theme, and organization upload processes every valid local theme after custom roles, users, and groups.
 
 ## Data Apps (Enterprise)
 
@@ -157,6 +160,7 @@ Content as code does not manage:
 - dbt or Lightdash semantic-layer models, metrics, dimensions, or joins; use `lightdash deploy`;
 - warehouse credentials, secrets, or external-service authentication — external connection *configs* are managed, but their secrets travel only through environment variables at upload time (see [External Connections](#external-connections-enterprise));
 - general project and organization settings outside the registered resources;
+- theme deletion or default-theme selection; use the Lightdash UI;
 - every data app when the project contains more than the configured apps limit;
 - resources that the authenticated user cannot read or that are unavailable on the server edition.
 
@@ -203,7 +207,7 @@ Follow this sequence for agent-driven changes:
 
 1. Check for uncommitted content-as-code changes or choose a fresh download path; do not overwrite work that has not been reviewed.
 2. Run `lightdash config get-project` and confirm the intended target.
-3. Download `--include-all`; also download `--organization` when users, groups, roles, or space access are involved.
+3. Download `--include-all`; also download `--organization` when users, groups, roles, themes, or space access are involved.
 4. Inspect structured document fields rather than inferring resource identity or dependencies from filenames. For example, match charts using the top-level `tableName`, not arbitrary text occurrences.
 5. Preserve resource identities, slugs, filenames, folder conventions, and unknown fields unless the requested change requires modifying them. Slugs are portable references but are not guaranteed to be unique in every existing project.
 6. Make the smallest coherent edit across every affected resource. Update dashboard chart references, scheduled content, space definitions, and access together when applicable.
@@ -230,7 +234,7 @@ If data apps should also be uploaded, add `--include-apps` for all app folders o
 lightdash upload --path ./lightdash --include-apps
 ```
 
-The first command ensures custom roles, users, and groups exist before project space access is reconciled. The project upload handles the project YAML files found on disk; data-app bundles require an explicit app flag (see [Data Apps](#data-apps-enterprise)).
+The first command synchronizes custom roles, users, groups, and organization Data App themes before project space access is reconciled. The project upload handles the project YAML files found on disk; data-app bundles require an explicit app flag (see [Data Apps](#data-apps-enterprise)).
 
 For an access-only change:
 

--- a/skills/developing-in-lightdash/resources/data-app-themes-reference.md
+++ b/skills/developing-in-lightdash/resources/data-app-themes-reference.md
@@ -1,0 +1,186 @@
+# Data App Themes as Code
+
+Use organization Data App themes to give generated and iterated Data Apps a shared visual direction through CSS, fonts, images, and generation instructions. Themes are organization resources: manage them through the existing organization content workflow, not through a standalone theme command.
+
+## Contents
+
+- [Supported workflow](#supported-workflow)
+- [Theme package layout](#theme-package-layout)
+- [Authoring assets and instructions](#authoring-assets-and-instructions)
+- [Validation and limits](#validation-and-limits)
+- [Synchronization semantics](#synchronization-semantics)
+- [Evaluating a theme](#evaluating-a-theme)
+- [What a Data App theme is not](#what-a-data-app-theme-is-not)
+
+## Supported workflow
+
+Use the same commands for existing UI-created themes and themes created locally:
+
+```bash
+lightdash download --organization --path ./lightdash
+# Edit or add ./lightdash/themes/<slug>/
+lightdash upload --organization --path ./lightdash
+```
+
+Theme package export and import require `manage:OrganizationDesign`. If organization download fails with a permission error, use an appropriately authorized account; do not interpret the failure as an organization with no themes.
+
+Before downloading into an existing repository, check for uncommitted changes. A successful organization download replaces the complete local `themes/` directory with the remote theme set and can overwrite local theme edits.
+
+Before uploading, review the complete organization-content diff and obtain approval when the target is shared or production. There is no theme-only selector: organization upload also processes custom roles, users, and groups found under the same content root.
+
+After uploading, inspect every resource summary. To prove a theme round-trips, download the organization content into a clean directory and compare the resulting manifest and asset bytes.
+
+### Move an existing UI-created theme into version control
+
+1. Run `lightdash download --organization`.
+2. Find the theme under `themes/<slug>/`; keep its downloaded slug and directory name unchanged.
+3. Review and commit the manifest and assets.
+4. Edit and upload through the normal organization workflow.
+
+Do not recreate an existing theme manually from its display name. The downloaded slug is its immutable identity.
+
+### Create a theme locally
+
+1. Choose a new lowercase hyphenated slug.
+2. Create `themes/<slug>/lightdash-theme.yml` with every required manifest field.
+3. Add only the asset directories and files the theme needs. Empty asset directories are optional because Git does not preserve them.
+4. Review the package, then run `lightdash upload --organization`.
+
+Upload creates the theme when its manifest slug does not exist and updates the same theme when it does.
+
+## Theme package layout
+
+```text
+lightdash/
+  themes/
+    acme-brand/
+      lightdash-theme.yml
+      css/
+        theme.css
+      fonts/
+        acme-sans.woff2
+      images/
+        logo.svg
+      instructions/
+        usage.md
+```
+
+The directory basename must exactly match the manifest slug. Files may appear only directly inside the four asset directories; nested directories and symlinks are rejected.
+
+The manifest is strict: all five fields are required and unknown fields are rejected.
+
+```yaml
+codeVersion: 1
+slug: acme-brand
+name: Acme Brand
+description: Brand theme for customer-facing Data Apps
+extraInstructions: |-
+  Use the horizontal logo in page headers.
+  Keep data-dense tables compact.
+```
+
+Use `null` when either optional text value has no content:
+
+```yaml
+description: null
+extraInstructions: null
+```
+
+Slug rules:
+
+- Use lowercase letters and numbers separated by single hyphens.
+- Do not use leading, trailing, or repeated hyphens.
+- Do not use a UUID-shaped slug.
+- Keep the slug at or below 255 characters.
+- Treat the slug as immutable. To rename a theme for display, change `name`, not `slug`.
+
+## Authoring assets and instructions
+
+### CSS
+
+Put `.css` files under `css/`. Prefer reusable variables and styles that communicate the brand rather than page-specific application code. Give variables and classes clear names, and keep light/dark behavior intentional.
+
+Theme CSS is an input to Data App generation, not a stylesheet injected into every existing app at runtime. The generation agent inspects and imports applicable CSS when building or iterating an app.
+
+### Fonts
+
+Put ordinary licensed web fonts under `fonts/`. Supported formats are `.woff`, `.woff2`, `.ttf`, and `.otf`. Reference bundled fonts through `@font-face` rather than an external font CDN.
+
+Do not commit or upload restricted Apple system-font binaries such as SF-family or New York fonts. Use a system stack instead, for example:
+
+```css
+font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+```
+
+The current package validator checks font format, not every font's licensing metadata. Treat this as an authoring requirement even if an upload is technically accepted.
+
+### Images
+
+Put `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, or `.svg` files under `images/`. Use descriptive filenames and explain ambiguous assets in the instructions: distinguish logos and product imagery from design references, screenshots, and mood boards.
+
+### Instructions
+
+Put Markdown instruction files under `instructions/`. Their contents and `extraInstructions` are appended to the generation prompt when the theme is active. Use them for precise rules about asset roles, typography, chart colors, density, spacing, and allowed exceptions.
+
+Do not put secrets in theme files or instructions. Theme content is copied into Data App generation context and may influence generated source.
+
+## Validation and limits
+
+Theme upload performs local preflight before any organization resource is mutated. There is no standalone theme validator, and `lightdash lint` does not validate theme packages.
+
+The local package must satisfy these rules:
+
+- `lightdash-theme.yml` must be valid UTF-8 YAML, at most 64 KiB, with unique keys and the exact manifest shape above.
+- Each asset must be a non-empty regular file at most 10 MiB.
+- All assets together must be at most 100 MiB. There is no separate file-count limit.
+- The generated uncompressed tar package must be at most 110 MiB.
+- CSS and Markdown must be valid UTF-8 text. SVG must begin with an SVG/XML marker.
+- Binary font and image bytes must match the filename extension.
+- Filenames must be at most 255 characters, have no surrounding whitespace, and contain no slash, backslash, null byte, or `..`.
+- Paths are checked case-insensitively for duplicates.
+- Unknown files or directories, nested directories, and symlinks reject the package. `.DS_Store` is ignored.
+
+Preflight reports every invalid local theme it can discover in one error. Fix all reported paths before retrying.
+
+## Synchronization semantics
+
+### Download
+
+- Downloads every theme visible to the authenticated organization account; there is no per-theme selector.
+- Writes deterministic manifests and asset paths under `themes/<slug>/`.
+- Stages the complete remote theme set before replacing the local `themes/` directory.
+- Leaves the previous local theme set intact if listing, package download, or package validation fails.
+- Removes stale local theme directories that no longer exist remotely after a fully successful download.
+
+### Upload
+
+- Preflights every local theme before uploading custom roles, users, groups, or themes. One invalid local theme prevents all organization mutations.
+- Applies remote organization phases as custom roles, then users, then groups, then themes. A failure in an earlier phase prevents theme imports from starting.
+- Upserts each theme by manifest slug. Existing UUIDs and existing default status are preserved; newly created themes are not made default.
+- Skips a theme when its manifest and complete file set are unchanged.
+- Treats a missing or empty `themes/` directory as a no-op. Removing a local theme directory does not delete the remote theme; the next download restores it.
+- Imports each theme atomically, but does not wrap the whole theme batch in one transaction. Successful themes remain applied when a sibling import fails, and the CLI reports all completed slugs and failures.
+
+There is no CLI operation to delete a theme or select the organization default. Use the Lightdash UI for those actions. There are also no theme-specific include, skip, only, force, create, list, download, upload, validate, or preview commands.
+
+The CLI and server must have compatible theme-package support. An endpoint `404` from organization theme sync usually means the CLI is newer than the server, not that the organization has no themes.
+
+## Evaluating a theme
+
+Separate package verification from visual evaluation:
+
+1. Verify the package through the CLI: upload it, inspect the organization-resource summary, download into a clean directory, and compare the manifest and asset bytes.
+2. Explain that evaluating the theme's visual effect requires one new Data App generation or an iteration of an existing app with that theme selected. Uploading the theme does not rebuild or restyle existing app versions.
+3. Do not assume access to the user's Lightdash UI. Ask the user to select the theme and start the generation or iteration. If they want the resulting app reviewed locally, ask for its app reference, download it with `lightdash download --apps <ref>`, and follow the normal Data App inspection and preview workflow.
+4. When the generated result is available, review both relevant host color schemes unless the theme deliberately requires one fixed scheme. Check that CSS, fonts, images, instructions, and chart colors were applied as intended.
+
+If the task only covers authoring or synchronizing the package, report the CLI verification separately and be explicit that generation quality was not visually evaluated.
+
+There is no supported standalone local preview for an organization theme. A downloaded app's `.lightdash/context/theme/` directory is a read-only snapshot for local app authoring, not the source package to edit. During server-side generation, the active theme is copied under `/app/src/design/`; that path is also generated context, not the organization source of truth.
+
+## What a Data App theme is not
+
+- **Lightdash appearance or chart palettes:** these configure Lightdash UI and visualization colors. They are not organization Data App theme packages and are not synchronized under `themes/`.
+- **SDK light/dark mode:** the Data App SDK follows the viewer's Lightdash color scheme at runtime. An organization theme supplies brand direction during generation; it does not replace that runtime protocol. Theme CSS may deliberately constrain color-scheme behavior, but that decision must be explicit.
+- **Organization brand settings:** saved brand colors, logos, and fonts are a separate source used by other Lightdash workflows. They are not automatically converted into this v1 file package.
+- **An app manifest selection:** `lightdash-app.yml` does not pin an organization theme in v1.


### PR DESCRIPTION
## What changed

- extend the existing `developing-in-lightdash` skill with progressively disclosed organization Data App theme guidance
- document the canonical package, authoring rules, validation limits, synchronization semantics, and evaluation handoff
- update content-as-code and CLI references so themes are discoverable through the existing organization commands
- add a focused skill-routing assertion and clarify the `--organization` CLI help

## Why

Theme packages now participate in the normal organization download/upload workflow. Agents need enough product-specific guidance to edit and synchronize them safely without inventing a standalone theme command, assuming deletion semantics, or requiring browser access for package verification.

This implements GLITCH-659 while keeping theme guidance in the existing skill users already install.

## Verification

- `python3 .../skill-creator/scripts/quick_validate.py skills/developing-in-lightdash`
- `pnpm -F cli format`
- `pnpm -F cli test -- src/skills.test.ts` — 45 files, 541 tests passed
- `pnpm -F cli typecheck`
- `pnpm -F cli lint`
- `git diff --check`
- authenticated local CLI E2E: UI-created theme download, edit/upload/download round trip, create-by-slug, unchanged skip, invalid-package preflight with no mutation, missing/empty themes directories, and no remote pruning

## Manual follow-up

The browser integration was unavailable in this session, so themed Data App generation was not visually evaluated. Package synchronization is fully verified; acceptance criterion 9 still needs one UI smoke test before merge.