### PR TITLE
feat: improve chart types gallery empty state

### DIFF
--- a/packages/frontend/src/features/apps/components/ChartTypeGalleryEmptyState.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeGalleryEmptyState.tsx
@@ -1,0 +1,50 @@
+import { subject } from '@casl/ability';
+import { Button, Stack, Text } from '@mantine/core';
+import { IconPlus, IconPuzzle } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { Can } from '../../../providers/Ability';
+import useApp from '../../../providers/App/useApp';
+
+type Props = {
+    projectUuid: string;
+};
+
+const ChartTypeGalleryEmptyState: FC<Props> = ({ projectUuid }) => {
+    const { user } = useApp();
+
+    return (
+        <Stack align="center" gap="xl" pt="7xl" pb="7xl">
+            <MantineIcon
+                icon={IconPuzzle}
+                color="ldGray.5"
+                stroke={1.5}
+                size={40}
+            />
+
+            <Text ta="center" fz="sm" c="ldGray.6" maw={460} lh={1.55}>
+                Chart types are custom visualizations you build once and reuse
+                across your project.
+            </Text>
+
+            <Can
+                I="create"
+                this={subject('DataApp', {
+                    organizationUuid: user.data?.organizationUuid,
+                    projectUuid,
+                })}
+            >
+                <Button
+                    component={Link}
+                    to={`/projects/${projectUuid}/chart-types/new`}
+                    leftSection={<MantineIcon icon={IconPlus} size={18} />}
+                >
+                    New chart type
+                </Button>
+            </Can>
+        </Stack>
+    );
+};
+
+export default ChartTypeGalleryEmptyState;

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -256,7 +256,28 @@ describe('ChartTypeGallery', () => {
         setData([]);
         renderPage();
 
-        expect(screen.getByText(/No chart types yet/)).toBeInTheDocument();
+        expect(
+            screen.getByText(/Chart types are custom visualizations/),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByPlaceholderText('Search chart types…'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows a no-results message when a search matches nothing', async () => {
+        setData([makeDataAppViz({})]);
+        renderPage();
+
+        fireEvent.change(screen.getByPlaceholderText('Search chart types…'), {
+            target: { value: 'nonexistent' },
+        });
+        setData([]);
+
+        await waitFor(() =>
+            expect(
+                screen.getByText(/No chart types match/),
+            ).toBeInTheDocument(),
+        );
     });
 
     it('redirects home when data apps are disabled', () => {

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -22,6 +22,7 @@ import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ChartTypeDeleteModal from '../features/apps/components/ChartTypeDeleteModal';
 import ChartTypeDetailModal from '../features/apps/components/ChartTypeDetailModal';
 import ChartTypeGalleryCard from '../features/apps/components/ChartTypeGalleryCard';
+import ChartTypeGalleryEmptyState from '../features/apps/components/ChartTypeGalleryEmptyState';
 import { useDataAppVisualizations } from '../features/apps/hooks/useDataAppVisualizations';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../providers/Ability';
@@ -62,6 +63,10 @@ const ChartTypeGallery = () => {
         !debouncedSearch && data?.pages[0]?.pagination
             ? data.pages[0].pagination.totalResults
             : null;
+    // Nothing to search or create-from-header when the project has no chart
+    // types at all yet: the empty state below carries its own CTA.
+    const isEmptyGallery =
+        !isInitialLoading && !error && !debouncedSearch && totalCount === 0;
 
     if (!projectUuid) {
         return null;
@@ -95,45 +100,49 @@ const ChartTypeGallery = () => {
                     <Group justify="space-between" align="center">
                         <Group gap={6} align="baseline">
                             <Title order={4}>Chart types</Title>
-                            {totalCount !== null && (
+                            {!isEmptyGallery && totalCount !== null && (
                                 <Text fz="sm" c="ldGray.6">
                                     ({totalCount})
                                 </Text>
                             )}
                         </Group>
 
-                        <Group gap="sm">
-                            <TextInput
-                                w={260}
-                                placeholder="Search chart types…"
-                                leftSection={<MantineIcon icon={IconSearch} />}
-                                value={search}
-                                onChange={(e) =>
-                                    setSearch(e.currentTarget.value)
-                                }
-                            />
-                            <Can
-                                I="create"
-                                this={subject('DataApp', {
-                                    organizationUuid:
-                                        user.data?.organizationUuid,
-                                    projectUuid,
-                                })}
-                            >
-                                <Button
-                                    component={Link}
-                                    to={`/projects/${projectUuid}/chart-types/new`}
+                        {!isEmptyGallery && (
+                            <Group gap="sm">
+                                <TextInput
+                                    w={260}
+                                    placeholder="Search chart types…"
                                     leftSection={
-                                        <MantineIcon
-                                            icon={IconPlus}
-                                            size={18}
-                                        />
+                                        <MantineIcon icon={IconSearch} />
                                     }
+                                    value={search}
+                                    onChange={(e) =>
+                                        setSearch(e.currentTarget.value)
+                                    }
+                                />
+                                <Can
+                                    I="create"
+                                    this={subject('DataApp', {
+                                        organizationUuid:
+                                            user.data?.organizationUuid,
+                                        projectUuid,
+                                    })}
                                 >
-                                    New chart type
-                                </Button>
-                            </Can>
-                        </Group>
+                                    <Button
+                                        component={Link}
+                                        to={`/projects/${projectUuid}/chart-types/new`}
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconPlus}
+                                                size={18}
+                                            />
+                                        }
+                                    >
+                                        New chart type
+                                    </Button>
+                                </Can>
+                            </Group>
+                        )}
                     </Group>
                     {isInitialLoading ? (
                         <EmptyStateLoader title="Loading chart types…" />
@@ -143,13 +152,18 @@ const ChartTypeGallery = () => {
                             onRetry={() => refetch()}
                         />
                     ) : dataAppVizs.length === 0 ? (
-                        <Paper variant="dotted" p="xl">
-                            <Text ta="center" fz="sm" c="ldGray.6">
-                                {debouncedSearch
-                                    ? `No chart types match “${debouncedSearch}”`
-                                    : 'No chart types yet. Describe one in the builder to get started.'}
-                            </Text>
-                        </Paper>
+                        debouncedSearch ? (
+                            <Paper variant="dotted" p="xl">
+                                <Text ta="center" fz="sm" c="ldGray.6">
+                                    No chart types match &ldquo;
+                                    {debouncedSearch}&rdquo;
+                                </Text>
+                            </Paper>
+                        ) : (
+                            <ChartTypeGalleryEmptyState
+                                projectUuid={projectUuid}
+                            />
+                        )
                     ) : (
                         <>
                             <SimpleGrid


### PR DESCRIPTION
### Description

Improves the empty state for the Chart types gallery. Previously it was a plain "No chart types yet" line inside a dashed box; now it shows an illustrated hero state with mock chart cards, a heading, a short description, and a "New chart type" CTA.

While there, the search bar and header "New chart type" button are hidden until the project actually has chart types (or a search is active), since there's no point searching an empty gallery and no need for a duplicate CTA once the empty state has its own.

Docs link from the design will follow once the doc page is published.
