### PR TITLE
fix: add starter prompt examples to the chart type builder

### DIFF
--- a/packages/frontend/src/features/apps/builder/BuilderCanvas.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderCanvas.tsx
@@ -3,6 +3,7 @@ import { Anchor, Box, Stack, Text } from '@mantine/core';
 import { type FC, type ReactNode } from 'react';
 import AppPreview from '../components/AppPreview';
 import classes from './BuilderCanvas.module.css';
+import BuilderPromptExamples from './BuilderPromptExamples';
 
 type Props = {
     projectUuid: string;
@@ -21,6 +22,9 @@ type Props = {
     previewContext: DataAppVizContext | null;
     /** The card's configuration column; null until a version declares a schema. */
     configurePanel: ReactNode;
+    /** Fills the composer with a starter prompt; null while no composer is
+     *  mounted to receive one. */
+    onPickExample: ((prompt: string) => void) | null;
 };
 
 const CancelBuildLink: FC<{ onCancel: () => void }> = ({ onCancel }) => (
@@ -53,6 +57,7 @@ const BuilderCanvas: FC<Props> = ({
     failureMessage,
     previewContext,
     configurePanel,
+    onPickExample,
 }) => {
     const hasPreview = appUuid !== null && previewVersion !== null;
     const isFirstBuild = isBuilding && !hasPreview;
@@ -126,15 +131,22 @@ const BuilderCanvas: FC<Props> = ({
                     </Text>
                 </Stack>
             ) : (
-                <Stack gap={8} align="center" maw={420}>
-                    <Text fz={17} fw={600} c="ldGray.8">
-                        Start with a prompt
-                    </Text>
-                    <Text fz="sm" c="ldGray.6" ta="center" lh={1.6}>
-                        Describe the chart type you need, like “a stream graph
-                        of category share over time”, and the first version will
-                        be generated. Iterate from there.
-                    </Text>
+                <Stack gap={40} align="center">
+                    <Stack gap={8} align="center" maw={420}>
+                        <Text fz={17} fw={600} c="ldGray.8">
+                            Start with a prompt
+                        </Text>
+                        <Text fz="sm" c="ldGray.6" ta="center" lh={1.6}>
+                            Describe the chart type you need. Iterate from
+                            there.
+                        </Text>
+                    </Stack>
+                    {onPickExample && (
+                        <BuilderPromptExamples
+                            projectUuid={projectUuid}
+                            onPick={onPickExample}
+                        />
+                    )}
                 </Stack>
             )}
 

--- a/packages/frontend/src/features/apps/builder/BuilderPromptBar.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptBar.tsx
@@ -5,11 +5,12 @@ import {
     IconPlayerStop,
 } from '@tabler/icons-react';
 import {
+    forwardRef,
+    useImperativeHandle,
     useRef,
     useState,
     type ClipboardEventHandler,
     type DragEventHandler,
-    type FC,
 } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { ComposerSubmitButton } from '../../../components/common/PromptComposer/ComposerSubmitButton';
@@ -30,153 +31,173 @@ type Props = {
     onCancelBuild: (() => void) | null;
 };
 
-const PromptPill: FC<Props> = ({
-    projectUuid,
-    composerAppUuid,
-    hasVersions,
-    build,
-    onCancelBuild,
-}) => {
-    const attachments = useVizComposerAttachments({
-        projectUuid,
-        appUuid: composerAppUuid,
-    });
-    const composerRef = useRef<PromptComposerHandle>(null);
-    const fileInputRef = useRef<HTMLInputElement>(null);
-    const [isEmpty, setIsEmpty] = useState(true);
-
-    const canSend = !build.isBuilding && !attachments.isUploading;
-
-    const handleSubmit = () => {
-        const description = composerRef.current?.getText().trim() ?? '';
-        if (!description || !canSend) return;
-        composerRef.current?.clear();
-        build.send({ description, fileIds: attachments.fileIds });
-        attachments.clear();
-    };
-
-    const handlePaste: ClipboardEventHandler = (event) => {
-        if (build.isBuilding || event.clipboardData.files.length === 0) return;
-        event.preventDefault();
-        attachments.add(Array.from(event.clipboardData.files));
-    };
-
-    const handleDragOver: DragEventHandler = (event) => {
-        event.preventDefault();
-    };
-
-    const handleDrop: DragEventHandler = (event) => {
-        event.preventDefault();
-        if (build.isBuilding) return;
-        attachments.add(Array.from(event.dataTransfer.files));
-    };
-
-    return (
-        <Box
-            className={classes.pillHost}
-            onDragOver={handleDragOver}
-            onDrop={handleDrop}
-        >
-            <PromptComposer
-                ref={composerRef}
-                variant="inline"
-                placeholder={
-                    hasVersions
-                        ? 'Ask for a change…'
-                        : 'Describe a new chart type…'
-                }
-                submitDisabled={!canSend}
-                onEmptyChange={setIsEmpty}
-                onSubmit={handleSubmit}
-                onPaste={handlePaste}
-                attachments={
-                    attachments.attachments.length > 0 ? (
-                        <SelectedAttachmentSection
-                            attachments={attachments.attachments.map((a) => ({
-                                id: a.key,
-                                previewUrl: a.previewUrl,
-                                filename: a.filename,
-                            }))}
-                            onRemove={attachments.remove}
-                            disabled={build.isBuilding}
-                        />
-                    ) : undefined
-                }
-                toolbarRight={
-                    <Group gap={4} align="center" wrap="nowrap">
-                        <input
-                            ref={fileInputRef}
-                            type="file"
-                            multiple
-                            hidden
-                            onChange={(e) => {
-                                attachments.add(
-                                    Array.from(e.target.files ?? []),
-                                );
-                                e.target.value = '';
-                            }}
-                        />
-                        <Tooltip withArrow label="Attach an image or file">
-                            <ActionIcon
-                                variant="subtle"
-                                color="gray"
-                                size="sm"
-                                disabled={build.isBuilding}
-                                aria-label="Attach"
-                                onClick={() => fileInputRef.current?.click()}
-                            >
-                                <MantineIcon icon={IconPaperclip} />
-                            </ActionIcon>
-                        </Tooltip>
-                        {build.isBuilding && onCancelBuild ? (
-                            <ComposerSubmitButton
-                                icon={IconPlayerStop}
-                                label="Stop generation"
-                                size="sm"
-                                destructive
-                                onClick={onCancelBuild}
-                            />
-                        ) : (
-                            <ComposerSubmitButton
-                                icon={IconArrowUp}
-                                label="Send"
-                                size="sm"
-                                disabled={isEmpty || !canSend}
-                                loading={build.isBuilding}
-                                onClick={handleSubmit}
-                            />
-                        )}
-                    </Group>
-                }
-            />
-        </Box>
-    );
+export type BuilderPromptBarHandle = {
+    /** Replaces the draft with `text` and focuses the composer. */
+    setPrompt: (text: string) => void;
 };
 
-/** The floating prompt pill; a failed send reports itself right above it. */
-const BuilderPromptBar: FC<Props> = (props) => (
-    <Box className={classes.wrap}>
-        {props.build.error !== null && (
-            <Box className={classes.failedPill}>
-                <Text fz={13} c="red.7" lineClamp={1}>
-                    {props.build.error}
-                </Text>
-                {props.build.retry && (
-                    <Anchor
-                        component="button"
-                        type="button"
-                        size="xs"
-                        onClick={props.build.retry}
-                    >
-                        Retry
-                    </Anchor>
-                )}
+const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
+    function PromptPill(
+        { projectUuid, composerAppUuid, hasVersions, build, onCancelBuild },
+        ref,
+    ) {
+        const attachments = useVizComposerAttachments({
+            projectUuid,
+            appUuid: composerAppUuid,
+        });
+        const composerRef = useRef<PromptComposerHandle>(null);
+        const fileInputRef = useRef<HTMLInputElement>(null);
+        const [isEmpty, setIsEmpty] = useState(true);
+
+        useImperativeHandle(ref, () => ({
+            setPrompt: (text) => {
+                composerRef.current?.clear();
+                composerRef.current?.insertContent([{ type: 'text', text }]);
+            },
+        }));
+
+        const canSend = !build.isBuilding && !attachments.isUploading;
+
+        const handleSubmit = () => {
+            const description = composerRef.current?.getText().trim() ?? '';
+            if (!description || !canSend) return;
+            composerRef.current?.clear();
+            build.send({ description, fileIds: attachments.fileIds });
+            attachments.clear();
+        };
+
+        const handlePaste: ClipboardEventHandler = (event) => {
+            if (build.isBuilding || event.clipboardData.files.length === 0)
+                return;
+            event.preventDefault();
+            attachments.add(Array.from(event.clipboardData.files));
+        };
+
+        const handleDragOver: DragEventHandler = (event) => {
+            event.preventDefault();
+        };
+
+        const handleDrop: DragEventHandler = (event) => {
+            event.preventDefault();
+            if (build.isBuilding) return;
+            attachments.add(Array.from(event.dataTransfer.files));
+        };
+
+        return (
+            <Box
+                className={classes.pillHost}
+                onDragOver={handleDragOver}
+                onDrop={handleDrop}
+            >
+                <PromptComposer
+                    ref={composerRef}
+                    variant="inline"
+                    placeholder={
+                        hasVersions
+                            ? 'Ask for a change…'
+                            : 'Describe a new chart type…'
+                    }
+                    submitDisabled={!canSend}
+                    onEmptyChange={setIsEmpty}
+                    onSubmit={handleSubmit}
+                    onPaste={handlePaste}
+                    attachments={
+                        attachments.attachments.length > 0 ? (
+                            <SelectedAttachmentSection
+                                attachments={attachments.attachments.map(
+                                    (a) => ({
+                                        id: a.key,
+                                        previewUrl: a.previewUrl,
+                                        filename: a.filename,
+                                    }),
+                                )}
+                                onRemove={attachments.remove}
+                                disabled={build.isBuilding}
+                            />
+                        ) : undefined
+                    }
+                    toolbarRight={
+                        <Group gap={4} align="center" wrap="nowrap">
+                            <input
+                                ref={fileInputRef}
+                                type="file"
+                                multiple
+                                hidden
+                                onChange={(e) => {
+                                    attachments.add(
+                                        Array.from(e.target.files ?? []),
+                                    );
+                                    e.target.value = '';
+                                }}
+                            />
+                            <Tooltip withArrow label="Attach an image or file">
+                                <ActionIcon
+                                    variant="subtle"
+                                    color="gray"
+                                    size="sm"
+                                    disabled={build.isBuilding}
+                                    aria-label="Attach"
+                                    onClick={() =>
+                                        fileInputRef.current?.click()
+                                    }
+                                >
+                                    <MantineIcon icon={IconPaperclip} />
+                                </ActionIcon>
+                            </Tooltip>
+                            {build.isBuilding && onCancelBuild ? (
+                                <ComposerSubmitButton
+                                    icon={IconPlayerStop}
+                                    label="Stop generation"
+                                    size="sm"
+                                    destructive
+                                    onClick={onCancelBuild}
+                                />
+                            ) : (
+                                <ComposerSubmitButton
+                                    icon={IconArrowUp}
+                                    label="Send"
+                                    size="sm"
+                                    disabled={isEmpty || !canSend}
+                                    loading={build.isBuilding}
+                                    onClick={handleSubmit}
+                                />
+                            )}
+                        </Group>
+                    }
+                />
             </Box>
-        )}
-        {/* Remount on app change so drafted text and attachments never leak
+        );
+    },
+);
+
+/** The floating prompt pill; a failed send reports itself right above it. */
+const BuilderPromptBar = forwardRef<BuilderPromptBarHandle, Props>(
+    function BuilderPromptBar(props, ref) {
+        return (
+            <Box className={classes.wrap}>
+                {props.build.error !== null && (
+                    <Box className={classes.failedPill}>
+                        <Text fz={13} c="red.7" lineClamp={1}>
+                            {props.build.error}
+                        </Text>
+                        {props.build.retry && (
+                            <Anchor
+                                component="button"
+                                type="button"
+                                size="xs"
+                                onClick={props.build.retry}
+                            >
+                                Retry
+                            </Anchor>
+                        )}
+                    </Box>
+                )}
+                {/* Remount on app change so drafted text and attachments never leak
             across visualizations. */}
-        <PromptPill key={props.composerAppUuid} {...props} />
-    </Box>
+                <PromptPill key={props.composerAppUuid} ref={ref} {...props} />
+            </Box>
+        );
+    },
 );
 
 export default BuilderPromptBar;

--- a/packages/frontend/src/features/apps/builder/BuilderPromptExamples.module.css
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptExamples.module.css
@@ -1,0 +1,31 @@
+.label {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.card {
+    width: 200px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-sm);
+    padding: var(--mantine-spacing-md);
+    background: var(--mantine-color-background-0);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-lg);
+    text-align: left;
+    transition:
+        transform 150ms,
+        box-shadow 150ms,
+        border-color 150ms;
+}
+
+.card:hover {
+    transform: translateY(-3px);
+    border-color: var(--mantine-color-ldGray-3);
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.thumbnail {
+    display: block;
+    width: 100%;
+}

--- a/packages/frontend/src/features/apps/builder/BuilderPromptExamples.test.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptExamples.test.tsx
@@ -1,0 +1,61 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import BuilderPromptExamples from './BuilderPromptExamples';
+
+vi.mock('../../../hooks/appearance/useOrganizationAppearance', () => ({
+    useColorPalettes: () => ({ data: [] }),
+}));
+vi.mock('../../../hooks/appearance/useProjectColorPalette', () => ({
+    useProjectColorPalette: () => ({
+        data: { colors: ['#112233', '#445566', '#778899', '#aabbcc'] },
+    }),
+}));
+
+describe('BuilderPromptExamples', () => {
+    it('offers short starter prompts', () => {
+        renderWithProviders(
+            <BuilderPromptExamples projectUuid="p1" onPick={vi.fn()} />,
+        );
+
+        expect(
+            screen.getByText('A stream graph of share over time'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText('A funnel of signup steps'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText('A calendar heatmap of daily orders'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText('A waterfall of revenue changes'),
+        ).toBeInTheDocument();
+    });
+
+    it('hands the picked prompt back to the composer', async () => {
+        const onPick = vi.fn();
+        renderWithProviders(
+            <BuilderPromptExamples projectUuid="p1" onPick={onPick} />,
+        );
+
+        await userEvent.click(screen.getByText('A funnel of signup steps'));
+
+        expect(onPick).toHaveBeenCalledWith('A funnel of signup steps');
+    });
+
+    it('previews the examples in the project palette', () => {
+        renderWithProviders(
+            <BuilderPromptExamples projectUuid="p1" onPick={vi.fn()} />,
+        );
+
+        const card = screen
+            .getByText('A funnel of signup steps')
+            .closest('button');
+        const fills = Array.from(card?.querySelectorAll('[fill]') ?? []).map(
+            (el) => el.getAttribute('fill'),
+        );
+
+        expect(fills).toEqual(['#112233', '#445566', '#778899', '#aabbcc']);
+    });
+});

--- a/packages/frontend/src/features/apps/builder/BuilderPromptExamples.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptExamples.tsx
@@ -1,0 +1,139 @@
+import { ECHARTS_DEFAULT_COLORS } from '@lightdash/common';
+import { Group, Stack, Text, UnstyledButton } from '@mantine/core';
+import { type FC } from 'react';
+import { useResolvedColorPalette } from '../../../hooks/appearance/useResolvedColorPalette';
+import classes from './BuilderPromptExamples.module.css';
+
+type ThumbnailProps = {
+    /** The project palette; every fill comes from it so the cards never
+     *  introduce colors the project doesn't use. */
+    colors: string[];
+};
+
+const StreamThumbnail: FC<ThumbnailProps> = ({ colors }) => (
+    <svg viewBox="0 0 160 64" className={classes.thumbnail} aria-hidden>
+        <path
+            d="M6,26 C38,8 68,12 88,24 C113,38 133,36 154,22 L154,38 C132,50 107,52 82,42 C57,32 26,36 6,42 Z"
+            fill={colors[0]}
+            opacity="0.85"
+        />
+        <path
+            d="M6,42 C26,36 57,32 82,42 C107,52 132,50 154,38 L154,52 C122,60 58,60 6,52 Z"
+            fill={colors[1]}
+            opacity="0.85"
+        />
+    </svg>
+);
+
+const FUNNEL_BARS = [
+    { x: 10, y: 8, width: 30, height: 48 },
+    { x: 48, y: 18, width: 30, height: 38 },
+    { x: 86, y: 28, width: 30, height: 28 },
+    { x: 124, y: 40, width: 26, height: 16 },
+];
+
+const FunnelThumbnail: FC<ThumbnailProps> = ({ colors }) => (
+    <svg viewBox="0 0 160 64" className={classes.thumbnail} aria-hidden>
+        {FUNNEL_BARS.map((bar, index) => (
+            <rect
+                key={bar.x}
+                {...bar}
+                rx="3"
+                fill={colors[index]}
+                opacity="0.9"
+            />
+        ))}
+    </svg>
+);
+
+/** Row-major intensities, so one project color reads as a full scale. */
+const HEATMAP_CELLS = [
+    [0.15, 0.4, 0.85, 0.4, 0.15, 0.6],
+    [0.4, 0.85, 1, 0.85, 0.4, 0.15],
+    [0.15, 0.4, 0.6, 0.15, 0.4, 0.15],
+];
+
+const HeatmapThumbnail: FC<ThumbnailProps> = ({ colors }) => (
+    <svg viewBox="0 0 160 64" className={classes.thumbnail} aria-hidden>
+        {HEATMAP_CELLS.map((row, rowIndex) =>
+            row.map((intensity, cellIndex) => (
+                <rect
+                    key={`${rowIndex}-${cellIndex}`}
+                    x={10 + cellIndex * 24}
+                    y={8 + rowIndex * 18}
+                    width="20"
+                    height="14"
+                    rx="3"
+                    fill={colors[0]}
+                    opacity={intensity}
+                />
+            )),
+        )}
+    </svg>
+);
+
+/** A staircase: a base, two steps up, one step down, then the total. */
+const WATERFALL_BARS = [
+    { x: 10, y: 30, width: 22, height: 26, color: 0 },
+    { x: 38, y: 20, width: 22, height: 10, color: 1 },
+    { x: 66, y: 12, width: 22, height: 8, color: 1 },
+    { x: 94, y: 12, width: 22, height: 6, color: 2 },
+    { x: 122, y: 18, width: 24, height: 38, color: 0 },
+];
+
+const WaterfallThumbnail: FC<ThumbnailProps> = ({ colors }) => (
+    <svg viewBox="0 0 160 64" className={classes.thumbnail} aria-hidden>
+        {WATERFALL_BARS.map(({ color, ...bar }) => (
+            <rect key={bar.x} {...bar} rx="3" fill={colors[color]} />
+        ))}
+    </svg>
+);
+
+const EXAMPLES: { prompt: string; Thumbnail: FC<ThumbnailProps> }[] = [
+    { prompt: 'A stream graph of share over time', Thumbnail: StreamThumbnail },
+    { prompt: 'A funnel of signup steps', Thumbnail: FunnelThumbnail },
+    {
+        prompt: 'A calendar heatmap of daily orders',
+        Thumbnail: HeatmapThumbnail,
+    },
+    {
+        prompt: 'A waterfall of revenue changes',
+        Thumbnail: WaterfallThumbnail,
+    },
+];
+
+type Props = {
+    projectUuid: string;
+    /** Drops the prompt into the composer so it can still be edited. */
+    onPick: (prompt: string) => void;
+};
+
+/** Starter prompts for the empty builder, previewed in the project's colors. */
+const BuilderPromptExamples: FC<Props> = ({ projectUuid, onPick }) => {
+    const palette = useResolvedColorPalette(projectUuid);
+    const colors = palette.length > 0 ? palette : ECHARTS_DEFAULT_COLORS;
+
+    return (
+        <Stack gap="md" align="center">
+            <Text className={classes.label} fz={11} fw={700} c="ldGray.6">
+                Or try one of these
+            </Text>
+            <Group gap="md" align="stretch" justify="center">
+                {EXAMPLES.map(({ prompt, Thumbnail }) => (
+                    <UnstyledButton
+                        key={prompt}
+                        className={classes.card}
+                        onClick={() => onPick(prompt)}
+                    >
+                        <Thumbnail colors={colors} />
+                        <Text fz={13} c="ldGray.8" lh={1.45}>
+                            {prompt}
+                        </Text>
+                    </UnstyledButton>
+                ))}
+            </Group>
+        </Stack>
+    );
+};
+
+export default BuilderPromptExamples;

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -215,6 +215,11 @@ describe('ChartTypeBuilder', () => {
         expect(
             screen.getByPlaceholderText('Describe a new chart type…'),
         ).toBeInTheDocument();
+        // Starter prompts sit under the copy so the page is never a blank ask.
+        expect(screen.getByText('Or try one of these')).toBeInTheDocument();
+        expect(
+            screen.getByText('A funnel of signup steps'),
+        ).toBeInTheDocument();
         expect(screen.queryByText('Preview in explorer')).toBeNull();
         // Nothing to configure before a schema exists.
         expect(screen.queryByText('Builder options · Generated')).toBeNull();

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -19,7 +19,9 @@ import { validate as isUuidString } from 'uuid';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import BuilderCanvas from '../features/apps/builder/BuilderCanvas';
-import BuilderPromptBar from '../features/apps/builder/BuilderPromptBar';
+import BuilderPromptBar, {
+    type BuilderPromptBarHandle,
+} from '../features/apps/builder/BuilderPromptBar';
 import ChartTypeBuilderHeader from '../features/apps/builder/ChartTypeBuilderHeader';
 import ConfigurePanel from '../features/apps/builder/ConfigurePanel';
 import VersionHistoryPanel from '../features/apps/builder/VersionHistoryPanel';
@@ -205,6 +207,12 @@ const ChartTypeBuilder: FC = () => {
         setPin(null);
     }, []);
 
+    const promptBarRef = useRef<BuilderPromptBarHandle>(null);
+    const handlePickExample = useCallback(
+        (prompt: string) => promptBarRef.current?.setPrompt(prompt),
+        [],
+    );
+
     const { mutate: updateApp } = useUpdateApp({ resourceLabel: 'Chart type' });
     const handleSaveMeta = useCallback(
         (patch: { name?: string; description?: string }) => {
@@ -308,6 +316,10 @@ const ChartTypeBuilder: FC = () => {
     const hasHistory =
         activeVizUuid !== undefined && history.versions.length > 0;
 
+    // The composer captures its placeholder at mount, so wait for history
+    // before choosing create vs revise wording.
+    const isPromptBarMounted = !(activeVizUuid && history.isLoading);
+
     return (
         <Box className={classes.root}>
             <DocumentTitle title="Chart type builder" />
@@ -344,11 +356,13 @@ const ChartTypeBuilder: FC = () => {
                         failureMessage={failureMessage}
                         previewContext={previewContext}
                         configurePanel={configurePanel}
+                        onPickExample={
+                            isPromptBarMounted ? handlePickExample : null
+                        }
                     />
-                    {/* The composer captures its placeholder at mount, so wait
-                        for history before choosing create vs revise wording. */}
-                    {!(activeVizUuid && history.isLoading) && (
+                    {isPromptBarMounted && (
                         <BuilderPromptBar
+                            ref={promptBarRef}
                             projectUuid={projectUuid}
                             composerAppUuid={
                                 activeVizUuid ?? build.draftAppUuid


### PR DESCRIPTION
### Description:

The chart type builder opened on an empty canvas with just a prompt box, so there was no hint of what it can actually make.

This adds four starter cards under the intro copy. Each previews a chart shape and drops an editable prompt into the composer when you click it, so you can tweak the wording before sending.

The previews are painted from the project's own color palette rather than hardcoded brand colors, so they look like the charts that project actually produces.

Also trims the intro copy, which used to spell out an example inline and is now redundant.

Relates: GLITCH-660
Relates: GLITCH-661
