### PR TITLE
fix: harmonise chart type gallery and builder with app conventions

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -112,8 +112,7 @@ export const ConfigTabs: FC = memo(() => {
                         )}
                     </Text>
                     <Text fz="xs" c="dimmed" lh={1.5}>
-                        {dataAppViz.description ||
-                            'Custom chart type built with the app builder'}
+                        {dataAppViz.description || 'No description'}
                     </Text>
                     {canEditSelectedType && (
                         <Anchor

--- a/packages/frontend/src/features/apps/builder/BuilderCanvas.module.css
+++ b/packages/frontend/src/features/apps/builder/BuilderCanvas.module.css
@@ -8,15 +8,17 @@
     }
 }
 
+/* Stays under full strength throughout: the bars are a placeholder for the
+   chart, not the chart. */
 @keyframes ldBar {
     0%,
     100% {
         transform: scaleY(0.5);
-        opacity: 0.55;
+        opacity: 0.3;
     }
     50% {
         transform: scaleY(1);
-        opacity: 1;
+        opacity: 0.85;
     }
 }
 
@@ -27,19 +29,21 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 18px 80px 10px;
+    padding: var(--mantine-spacing-xl) var(--mantine-spacing-xxl)
+        var(--mantine-spacing-md);
 }
 
 /* Configuration column and preview share one surface, so the panel scrolls,
    resizes and moves with the chart it configures. */
 .card {
     width: 100%;
-    max-width: 1004px;
+    /* The same content width the other builder canvases use. */
+    max-width: 1160px;
     height: 100%;
     display: flex;
     background: var(--mantine-color-background-0);
     border: 1px solid var(--mantine-color-ldGray-2);
-    border-radius: var(--mantine-radius-lg);
+    border-radius: var(--mantine-radius-md);
     box-shadow: var(--mantine-shadow-subtle);
     /* Not clipped: the configure column's chip rides the top border. Each
        column rounds its own corners instead. */
@@ -51,7 +55,7 @@
     min-width: 0;
     /* Rounded on every corner so it sits right both beside the configure
        column and alone, and clipped so the iframe follows the curve. */
-    border-radius: var(--mantine-radius-lg);
+    border-radius: var(--mantine-radius-md);
     overflow: hidden;
     transition: opacity 300ms;
 
@@ -74,7 +78,7 @@
     display: flex;
     align-items: center;
     gap: var(--mantine-spacing-xs);
-    font-size: var(--mantine-font-size-sm);
+    font-size: 13px;
     font-weight: 500;
     color: var(--mantine-color-ldGray-7);
     background: var(--mantine-color-background-0);
@@ -86,42 +90,32 @@
     pointer-events: auto;
 }
 
-.skeletonBars {
-    display: flex;
-    align-items: flex-end;
-    gap: 12px;
-    height: 150px;
+/* The same width an example card's thumbnail gets, so the build reads as the
+   next frame of the card you clicked rather than a new piece of furniture. */
+.skeleton {
+    display: block;
+    width: 200px;
 }
 
 .skeletonBar {
-    width: 34px;
-    border-radius: 6px;
-    background: light-dark(#e4e1f7, var(--mantine-color-ldDark-6));
+    transform-box: fill-box;
     transform-origin: bottom;
     animation: ldBar 1.15s ease-in-out infinite;
 }
 
-.skeletonBar:nth-child(1) {
-    height: 62px;
-}
 .skeletonBar:nth-child(2) {
-    height: 104px;
     animation-delay: 0.12s;
 }
 .skeletonBar:nth-child(3) {
-    height: 82px;
     animation-delay: 0.24s;
 }
 .skeletonBar:nth-child(4) {
-    height: 136px;
     animation-delay: 0.36s;
 }
 .skeletonBar:nth-child(5) {
-    height: 96px;
     animation-delay: 0.48s;
 }
 .skeletonBar:nth-child(6) {
-    height: 118px;
     animation-delay: 0.6s;
 }
 

--- a/packages/frontend/src/features/apps/builder/BuilderCanvas.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderCanvas.tsx
@@ -1,6 +1,10 @@
-import { type DataAppVizContext } from '@lightdash/common';
+import {
+    ECHARTS_DEFAULT_COLORS,
+    type DataAppVizContext,
+} from '@lightdash/common';
 import { Anchor, Box, Stack, Text } from '@mantine/core';
 import { type FC, type ReactNode } from 'react';
+import { useResolvedColorPalette } from '../../../hooks/appearance/useResolvedColorPalette';
 import AppPreview from '../components/AppPreview';
 import classes from './BuilderCanvas.module.css';
 import BuilderPromptExamples from './BuilderPromptExamples';
@@ -25,6 +29,40 @@ type Props = {
     /** Fills the composer with a starter prompt; null while no composer is
      *  mounted to receive one. */
     onPickExample: ((prompt: string) => void) | null;
+};
+
+/** Same footprint and viewBox as an example card's thumbnail, so the canvas
+ *  keeps one drawing scale from starter prompts through to the build. */
+const SKELETON_BARS = [
+    { x: 8, y: 34, height: 26 },
+    { x: 34, y: 16, height: 44 },
+    { x: 60, y: 25, height: 35 },
+    { x: 86, y: 2, height: 58 },
+    { x: 112, y: 19, height: 41 },
+    { x: 138, y: 10, height: 50 },
+];
+
+/** The pending chart, drawn in the project's own color. One color at shifting
+ *  intensity rather than the whole palette: a placeholder, not a stand-in
+ *  chart with series of its own. */
+const SkeletonBars: FC<{ projectUuid: string }> = ({ projectUuid }) => {
+    const palette = useResolvedColorPalette(projectUuid);
+    const color = (palette.length > 0 ? palette : ECHARTS_DEFAULT_COLORS)[0];
+
+    return (
+        <svg viewBox="0 0 160 64" className={classes.skeleton} aria-hidden>
+            {SKELETON_BARS.map((bar) => (
+                <rect
+                    key={bar.x}
+                    {...bar}
+                    width="20"
+                    rx="3"
+                    fill={color}
+                    className={classes.skeletonBar}
+                />
+            ))}
+        </svg>
+    );
 };
 
 const CancelBuildLink: FC<{ onCancel: () => void }> = ({ onCancel }) => (
@@ -78,29 +116,22 @@ const BuilderCanvas: FC<Props> = ({
                     </Box>
                 </Box>
             ) : isFirstBuild ? (
-                <Stack gap={28} align="center">
-                    <Box className={classes.skeletonBars} aria-hidden>
-                        <Box className={classes.skeletonBar} />
-                        <Box className={classes.skeletonBar} />
-                        <Box className={classes.skeletonBar} />
-                        <Box className={classes.skeletonBar} />
-                        <Box className={classes.skeletonBar} />
-                        <Box className={classes.skeletonBar} />
-                    </Box>
-                    <Stack gap={7} align="center">
+                <Stack gap="xl" align="center">
+                    <SkeletonBars projectUuid={projectUuid} />
+                    <Stack gap="xs" align="center">
                         <Text
                             className={classes.buildingLabel}
-                            fz="sm"
+                            size="md"
                             fw={600}
-                            c="ldBrandViolet.7"
+                            c="ldGray.8"
                         >
                             Building your chart type…
                         </Text>
                         {buildingPrompt && (
                             <Text
-                                fz={13}
-                                c="ldGray.6"
-                                maw={440}
+                                fz="xs"
+                                c="dimmed"
+                                maw={400}
                                 ta="center"
                                 lh={1.5}
                             >
@@ -119,24 +150,24 @@ const BuilderCanvas: FC<Props> = ({
                     </Stack>
                 </Stack>
             ) : failureMessage !== null ? (
-                <Stack gap="xs" align="center" maw={460}>
-                    <Text fz={17} fw={600} c="ldGray.8">
+                <Stack gap="xs" align="center">
+                    <Text size="md" fw={600} c="ldGray.8">
                         The build failed
                     </Text>
-                    <Text fz="sm" c="ldGray.6" ta="center" lh={1.6}>
+                    <Text fz="xs" c="dimmed" maw={400} ta="center" lh={1.5}>
                         {failureMessage}
                     </Text>
-                    <Text fz="sm" c="ldGray.6" ta="center">
+                    <Text fz="xs" c="dimmed" ta="center">
                         Ask for a change below to try again.
                     </Text>
                 </Stack>
             ) : (
-                <Stack gap={40} align="center">
-                    <Stack gap={8} align="center" maw={420}>
-                        <Text fz={17} fw={600} c="ldGray.8">
+                <Stack gap="xl" align="center">
+                    <Stack gap="xs" align="center">
+                        <Text size="md" fw={600} c="ldGray.8">
                             Start with a prompt
                         </Text>
-                        <Text fz="sm" c="ldGray.6" ta="center" lh={1.6}>
+                        <Text fz="xs" c="dimmed" maw={400} ta="center" lh={1.5}>
                             Describe the chart type you need. Iterate from
                             there.
                         </Text>

--- a/packages/frontend/src/features/apps/builder/BuilderPromptExamples.module.css
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptExamples.module.css
@@ -1,17 +1,12 @@
-.label {
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-}
-
 .card {
     width: 200px;
     display: flex;
     flex-direction: column;
     gap: var(--mantine-spacing-sm);
-    padding: var(--mantine-spacing-md);
+    padding: var(--mantine-spacing-sm);
     background: var(--mantine-color-background-0);
     border: 1px solid var(--mantine-color-ldGray-2);
-    border-radius: var(--mantine-radius-lg);
+    border-radius: var(--mantine-radius-md);
     text-align: left;
     transition:
         transform 150ms,
@@ -20,8 +15,8 @@
 }
 
 .card:hover {
-    transform: translateY(-3px);
-    border-color: var(--mantine-color-ldGray-3);
+    transform: translateY(-2px);
+    border-color: var(--mantine-color-ldGray-4);
     box-shadow: var(--mantine-shadow-subtle);
 }
 

--- a/packages/frontend/src/features/apps/builder/BuilderPromptExamples.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptExamples.tsx
@@ -1,5 +1,5 @@
 import { ECHARTS_DEFAULT_COLORS } from '@lightdash/common';
-import { Group, Stack, Text, UnstyledButton } from '@mantine/core';
+import { Group, Text, UnstyledButton } from '@mantine/core';
 import { type FC } from 'react';
 import { useResolvedColorPalette } from '../../../hooks/appearance/useResolvedColorPalette';
 import classes from './BuilderPromptExamples.module.css';
@@ -114,25 +114,20 @@ const BuilderPromptExamples: FC<Props> = ({ projectUuid, onPick }) => {
     const colors = palette.length > 0 ? palette : ECHARTS_DEFAULT_COLORS;
 
     return (
-        <Stack gap="md" align="center">
-            <Text className={classes.label} fz={11} fw={700} c="ldGray.6">
-                Or try one of these
-            </Text>
-            <Group gap="md" align="stretch" justify="center">
-                {EXAMPLES.map(({ prompt, Thumbnail }) => (
-                    <UnstyledButton
-                        key={prompt}
-                        className={classes.card}
-                        onClick={() => onPick(prompt)}
-                    >
-                        <Thumbnail colors={colors} />
-                        <Text fz={13} c="ldGray.8" lh={1.45}>
-                            {prompt}
-                        </Text>
-                    </UnstyledButton>
-                ))}
-            </Group>
-        </Stack>
+        <Group gap="sm" align="stretch" justify="center">
+            {EXAMPLES.map(({ prompt, Thumbnail }) => (
+                <UnstyledButton
+                    key={prompt}
+                    className={classes.card}
+                    onClick={() => onPick(prompt)}
+                >
+                    <Thumbnail colors={colors} />
+                    <Text fz={13} fw={500} c="ldGray.8" lh={1.35}>
+                        {prompt}
+                    </Text>
+                </UnstyledButton>
+            ))}
+        </Group>
     );
 };
 

--- a/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.module.css
+++ b/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.module.css
@@ -2,9 +2,9 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: var(--mantine-spacing-md);
-    padding: 0 20px;
-    height: 56px;
+    gap: 10px;
+    padding: 0 16px;
+    height: 52px;
     background: var(--mantine-color-background-0);
     border-bottom: 1px solid var(--mantine-color-ldGray-2);
     flex-shrink: 0;
@@ -15,19 +15,20 @@
 .side {
     display: flex;
     align-items: center;
-    gap: var(--mantine-spacing-sm);
+    gap: 10px;
     min-width: 0;
 }
 
 .divider {
     width: 1px;
-    height: 20px;
+    height: 22px;
     background: var(--mantine-color-ldGray-2);
     flex-shrink: 0;
 }
 
+/* Sized by the input's own `size`; this only makes it read as a title that
+   happens to be editable rather than as a form field. */
 .nameInput {
-    font-size: 15px;
     font-weight: 600;
     color: var(--mantine-color-foreground-0);
     background: transparent;

--- a/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.tsx
+++ b/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.tsx
@@ -37,6 +37,7 @@ const InlineNameInput: FC<{
     return (
         <TextInput
             classNames={{ input: classes.nameInput }}
+            size="xs"
             aria-label="Chart type name"
             value={name}
             w={280}
@@ -119,11 +120,11 @@ const ChartTypeBuilderHeader: FC<Props> = ({
     <Box className={classes.header} component="header">
         <Box className={classes.side}>
             <Button
+                size="xs"
                 component={Link}
                 to={`/projects/${projectUuid}/gallery`}
-                variant="subtle"
-                size="compact-sm"
-                leftSection={<MantineIcon icon={IconChevronLeft} />}
+                variant="default"
+                leftSection={<MantineIcon icon={IconChevronLeft} size={15} />}
             >
                 Gallery
             </Button>
@@ -144,6 +145,7 @@ const ChartTypeBuilderHeader: FC<Props> = ({
             ) : (
                 <TextInput
                     classNames={{ input: classes.nameInput }}
+                    size="xs"
                     aria-label="Chart type name"
                     value="Untitled chart type"
                     w={280}
@@ -162,16 +164,17 @@ const ChartTypeBuilderHeader: FC<Props> = ({
         <Group gap="xs" wrap="nowrap">
             {hasHistory && (
                 <Button
+                    size="xs"
                     variant={isHistoryOpen ? 'light' : 'default'}
                     color="gray"
-                    leftSection={<MantineIcon icon={IconHistory} />}
+                    leftSection={<MantineIcon icon={IconHistory} size={15} />}
                     onClick={onToggleHistory}
                 >
                     History
                 </Button>
             )}
             {latestReadyVersion !== null && (
-                <Button onClick={onPreviewInExplorer}>
+                <Button size="xs" onClick={onPreviewInExplorer}>
                     Preview in explorer
                 </Button>
             )}

--- a/packages/frontend/src/features/apps/builder/ConfigurePanel.module.css
+++ b/packages/frontend/src/features/apps/builder/ConfigurePanel.module.css
@@ -1,5 +1,5 @@
 .panel {
-    width: 296px;
+    width: 264px;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
@@ -7,7 +7,7 @@
     background: var(--mantine-color-background-0);
     border-right: 1px solid var(--mantine-color-ldGray-2);
     /* Follows the card's left corners it sits in. */
-    border-radius: var(--mantine-radius-lg) 0 0 var(--mantine-radius-lg);
+    border-radius: var(--mantine-radius-md) 0 0 var(--mantine-radius-md);
 }
 
 /* A soft chip is the whole treatment: the options below it came from the
@@ -16,16 +16,14 @@
 .generatedChip {
     align-self: flex-start;
     margin: -9px var(--mantine-spacing-sm) 10px;
-    padding: 3px 10px;
+    padding: 2px 10px;
     border-radius: var(--mantine-radius-xl);
-    background: light-dark(
-        var(--mantine-color-blue-0),
-        rgba(34, 139, 230, 0.15)
-    );
-    color: light-dark(var(--mantine-color-blue-7), var(--mantine-color-blue-3));
-    font-size: 10px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
+    background: var(--mantine-color-ldGray-0);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    color: var(--mantine-color-ldGray-6);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
     white-space: nowrap;
 }

--- a/packages/frontend/src/features/apps/builder/ConfigurePanel.test.tsx
+++ b/packages/frontend/src/features/apps/builder/ConfigurePanel.test.tsx
@@ -41,9 +41,7 @@ describe('ConfigurePanel', () => {
     it('marks the options as the generated contract', () => {
         renderPanel();
 
-        expect(
-            screen.getByText('Builder options · Generated'),
-        ).toBeInTheDocument();
+        expect(screen.getByText('Generated options')).toBeInTheDocument();
     });
 
     it('splits the declared options into one tab per group', () => {

--- a/packages/frontend/src/features/apps/builder/ConfigurePanel.tsx
+++ b/packages/frontend/src/features/apps/builder/ConfigurePanel.tsx
@@ -60,9 +60,7 @@ const ConfigurePanel: FC<Props> = ({
         <Box className={classes.panel}>
             {/* The options are the generated contract, not Lightdash chart
                 config, and the chip says so. */}
-            <Text className={classes.generatedChip}>
-                Builder options · Generated
-            </Text>
+            <Text className={classes.generatedChip}>Generated options</Text>
 
             {optionGroups.length === 0 ? (
                 <Text fz="xs" c="dimmed" lh={1.5} px="sm" pb="sm">

--- a/packages/frontend/src/features/apps/builder/VersionHistoryPanel.module.css
+++ b/packages/frontend/src/features/apps/builder/VersionHistoryPanel.module.css
@@ -9,7 +9,7 @@
 }
 
 .panel {
-    width: 320px;
+    width: 264px;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
@@ -23,17 +23,17 @@
     align-items: center;
     justify-content: space-between;
     gap: var(--mantine-spacing-xs);
-    padding: 10px 8px 10px 16px;
+    padding: 10px 8px 10px 14px;
     border-bottom: 1px solid var(--mantine-color-ldGray-2);
     flex-shrink: 0;
 }
 
 .title {
     font-size: 11px;
-    font-weight: 700;
+    font-weight: 600;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: var(--mantine-color-ldGray-7);
+    color: var(--mantine-color-ldGray-6);
 }
 
 .list {
@@ -46,7 +46,7 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
-    padding: 12px 16px 12px 13px;
+    padding: 12px 14px 12px 11px;
     border-top: 1px solid var(--mantine-color-ldGray-1);
     border-left: 3px solid transparent;
     transition: background 120ms;
@@ -83,7 +83,7 @@
 
 .versionLabel {
     font-size: 12px;
-    font-weight: 700;
+    font-weight: 600;
     color: var(--mantine-color-ldGray-7);
 
     &[data-state='active'] {
@@ -127,6 +127,6 @@
 }
 
 .earlier {
-    padding: 10px 16px;
+    padding: 10px 14px;
     border-top: 1px solid var(--mantine-color-ldGray-1);
 }

--- a/packages/frontend/src/features/apps/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeDetailModal.tsx
@@ -92,18 +92,17 @@ const ChartTypeDetailModal: FC<Props> = ({
                     />
                 </Box>
                 <Text fz="sm" c="ldGray.7" lh={1.55}>
-                    {dataAppViz.description ||
-                        'Custom chart type built with the app builder'}
+                    {dataAppViz.description || 'No description'}
                 </Text>
                 <SimpleGrid cols={2} className={classes.metaPanel}>
                     {builtBy !== null && (
                         <Box>
                             <Text
                                 fz={11}
-                                fw={500}
+                                fw={600}
                                 c="ldGray.6"
                                 tt="uppercase"
-                                lts="0.04em"
+                                lts="0.06em"
                             >
                                 Built by
                             </Text>
@@ -115,10 +114,10 @@ const ChartTypeDetailModal: FC<Props> = ({
                     <Box>
                         <Text
                             fz={11}
-                            fw={500}
+                            fw={600}
                             c="ldGray.6"
                             tt="uppercase"
-                            lts="0.04em"
+                            lts="0.06em"
                         >
                             Last updated
                         </Text>
@@ -129,10 +128,10 @@ const ChartTypeDetailModal: FC<Props> = ({
                     <Box>
                         <Text
                             fz={11}
-                            fw={500}
+                            fw={600}
                             c="ldGray.6"
                             tt="uppercase"
-                            lts="0.04em"
+                            lts="0.06em"
                         >
                             Inputs
                         </Text>
@@ -147,10 +146,10 @@ const ChartTypeDetailModal: FC<Props> = ({
                     <Box>
                         <Text
                             fz={11}
-                            fw={500}
+                            fw={600}
                             c="ldGray.6"
                             tt="uppercase"
-                            lts="0.04em"
+                            lts="0.06em"
                         >
                             Version
                         </Text>

--- a/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.module.css
+++ b/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.module.css
@@ -26,7 +26,7 @@
 }
 
 .preview {
-    height: 160px;
+    height: 148px;
     background: light-dark(#fdfdfe, var(--mantine-color-ldDark-8));
     border-bottom: 1px solid var(--mantine-color-ldGray-1);
     border-radius: var(--mantine-radius-md) var(--mantine-radius-md) 0 0;

--- a/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeGalleryCard.tsx
@@ -43,13 +43,12 @@ const ChartTypeGalleryCard: FC<Props> = ({ dataAppViz, onClick, onDelete }) => {
                     dataAppVizUuid={dataAppViz.dataAppVizUuid}
                 />
             </Box>
-            <Stack gap="xs" p="md">
-                <Text fz="sm" fw={600} truncate="end">
+            <Stack gap="xs" p="sm">
+                <Text fz={13} fw={600} truncate="end">
                     {displayName}
                 </Text>
-                <Text fz={13} c="ldGray.6" lh={1.45} lineClamp={2}>
-                    {dataAppViz.description ||
-                        'Custom chart type built with the app builder'}
+                <Text fz="xs" c="dimmed" lh={1.35} lineClamp={2}>
+                    {dataAppViz.description || 'No description'}
                 </Text>
             </Stack>
             <FloatingActionsPill className={classes.menuHost}>

--- a/packages/frontend/src/features/apps/components/ChartTypeGalleryEmptyState.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeGalleryEmptyState.tsx
@@ -15,15 +15,19 @@ const ChartTypeGalleryEmptyState: FC<Props> = ({ projectUuid }) => {
     const { user } = useApp();
 
     return (
-        <Stack align="center" gap="xl" pt="7xl" pb="7xl">
+        <Stack align="center" gap="sm" py="7xl">
             <MantineIcon
                 icon={IconPuzzle}
                 color="ldGray.5"
                 stroke={1.5}
-                size={40}
+                size="lg"
             />
 
-            <Text ta="center" fz="sm" c="ldGray.6" maw={460} lh={1.55}>
+            <Text size="md" fw={600} c="ldGray.8">
+                No chart types yet
+            </Text>
+
+            <Text ta="center" fz="xs" c="dimmed" maw={400} lh={1.5}>
                 Chart types are custom visualizations you build once and reuse
                 across your project.
             </Text>
@@ -36,6 +40,7 @@ const ChartTypeGalleryEmptyState: FC<Props> = ({ projectUuid }) => {
                 })}
             >
                 <Button
+                    mt="xs"
                     component={Link}
                     to={`/projects/${projectUuid}/chart-types/new`}
                     leftSection={<MantineIcon icon={IconPlus} size={18} />}

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -216,13 +216,12 @@ describe('ChartTypeBuilder', () => {
             screen.getByPlaceholderText('Describe a new chart type…'),
         ).toBeInTheDocument();
         // Starter prompts sit under the copy so the page is never a blank ask.
-        expect(screen.getByText('Or try one of these')).toBeInTheDocument();
         expect(
             screen.getByText('A funnel of signup steps'),
         ).toBeInTheDocument();
         expect(screen.queryByText('Preview in explorer')).toBeNull();
         // Nothing to configure before a schema exists.
-        expect(screen.queryByText('Builder options · Generated')).toBeNull();
+        expect(screen.queryByText('Generated options')).toBeNull();
     });
 
     it('shows the configure panel as soon as a version declares a schema', () => {
@@ -240,9 +239,7 @@ describe('ChartTypeBuilder', () => {
         );
 
         // No toggle to find: the panel sits beside the preview from the start.
-        expect(
-            screen.getByText('Builder options · Generated'),
-        ).toBeInTheDocument();
+        expect(screen.getByText('Generated options')).toBeInTheDocument();
         expect(
             screen.getByText('This chart type declares no display options.'),
         ).toBeInTheDocument();

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -137,7 +137,7 @@ describe('ChartTypeGallery', () => {
         renderPage();
 
         expect(screen.getByText('Bar race')).toBeInTheDocument();
-        expect(screen.getByText('Chart types')).toBeInTheDocument();
+        expect(screen.getByText('Gallery')).toBeInTheDocument();
         expect(screen.getByText('(2)')).toBeInTheDocument();
 
         fireEvent.click(screen.getByText('Radial gauge'));
@@ -260,7 +260,7 @@ describe('ChartTypeGallery', () => {
             screen.getByText(/Chart types are custom visualizations/),
         ).toBeInTheDocument();
         expect(
-            screen.queryByPlaceholderText('Search chart types…'),
+            screen.queryByPlaceholderText('Search by name'),
         ).not.toBeInTheDocument();
     });
 
@@ -268,7 +268,7 @@ describe('ChartTypeGallery', () => {
         setData([makeDataAppViz({})]);
         renderPage();
 
-        fireEvent.change(screen.getByPlaceholderText('Search chart types…'), {
+        fireEvent.change(screen.getByPlaceholderText('Search by name'), {
             target: { value: 'nonexistent' },
         });
         setData([]);

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -8,7 +8,6 @@ import {
     Stack,
     Text,
     TextInput,
-    Title,
 } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconPlus, IconSearch } from '@tabler/icons-react';
@@ -97,23 +96,31 @@ const ChartTypeGallery = () => {
                 />
 
                 <Stack gap="md">
+                    {/* A section rather than the page title: the gallery holds
+                        only chart types today, other kinds sit beside them. */}
                     <Group justify="space-between" align="center">
                         <Group gap={6} align="baseline">
-                            <Title order={4}>Chart types</Title>
+                            <Text size="md" fw={600} c="ldGray.8">
+                                Chart types
+                            </Text>
                             {!isEmptyGallery && totalCount !== null && (
-                                <Text fz="sm" c="ldGray.6">
+                                <Text fz="xs" c="dimmed">
                                     ({totalCount})
                                 </Text>
                             )}
                         </Group>
 
                         {!isEmptyGallery && (
-                            <Group gap="sm">
+                            <Group gap="xs">
                                 <TextInput
-                                    w={260}
-                                    placeholder="Search chart types…"
+                                    size="xs"
+                                    w={220}
+                                    placeholder="Search by name"
                                     leftSection={
-                                        <MantineIcon icon={IconSearch} />
+                                        <MantineIcon
+                                            icon={IconSearch}
+                                            size={15}
+                                        />
                                     }
                                     value={search}
                                     onChange={(e) =>
@@ -129,12 +136,13 @@ const ChartTypeGallery = () => {
                                     })}
                                 >
                                     <Button
+                                        size="xs"
                                         component={Link}
                                         to={`/projects/${projectUuid}/chart-types/new`}
                                         leftSection={
                                             <MantineIcon
                                                 icon={IconPlus}
-                                                size={18}
+                                                size={15}
                                             />
                                         }
                                     >
@@ -144,6 +152,7 @@ const ChartTypeGallery = () => {
                             </Group>
                         )}
                     </Group>
+
                     {isInitialLoading ? (
                         <EmptyStateLoader title="Loading chart types…" />
                     ) : error ? (
@@ -154,7 +163,7 @@ const ChartTypeGallery = () => {
                     ) : dataAppVizs.length === 0 ? (
                         debouncedSearch ? (
                             <Paper variant="dotted" p="xl">
-                                <Text ta="center" fz="sm" c="ldGray.6">
+                                <Text ta="center" fz="xs" c="dimmed">
                                     No chart types match &ldquo;
                                     {debouncedSearch}&rdquo;
                                 </Text>
@@ -168,7 +177,7 @@ const ChartTypeGallery = () => {
                         <>
                             <SimpleGrid
                                 cols={{ base: 1, sm: 2, lg: 3 }}
-                                spacing="lg"
+                                spacing="md"
                             >
                                 {dataAppVizs.map((viz) => (
                                     <ChartTypeGalleryCard


### PR DESCRIPTION
### Description:

The chart type gallery and builder were built out fast and drifted off the sizes and spacing the rest of the app uses. Next to the homepage builder they read as a different product: a taller toolbar, full-size buttons where the reference uses a compact toolbar scale, 17px empty-state headings, a loud blue "generated" chip, and two side panels at two different widths.

This pass lines them up with the homepage builder's toolbar/rail/canvas scale and with the shared empty-state typography, without changing any behaviour.

**Gallery**

- "Chart types" is now a section heading over the grid rather than a page title, so other kinds of gallery content can sit beside it later. Search and the create button move onto that row with it.
- Search placeholder matches the rest of the app ("Search by name").
- Cards drop to the 13px title / 12px description scale the reference cards use, with tighter padding.
- Empty state gets a title and the shared icon / title / description sizes, so it reads like every other empty state.
- Missing descriptions now say "No description" instead of describing the builder.

**Builder**

- Toolbar: 52px tall, 16px gutters, controls on Mantine's `xs` size so the bar reads as chrome rather than content. The gallery header controls use the same size, so the two pages match.
- Canvas: card radius and gutters come from the theme's radius/spacing tokens, with even gutters instead of the previous 80px sides.
- Empty, building and failure states use the shared 16px title / 12px description sizes instead of one-off 17px and 14px values.
- The building state's bars were a 150px block of hardcoded lavender. They're now an SVG on the same 200px footprint and viewBox as an example card's thumbnail, painted in the project's own first palette color at shifting intensity — a placeholder, not a stand-in chart with series of its own. The heading drops its brand violet for the same neutral the sibling states use.
- Example cards pick up the theme's radius and spacing tokens; the "Or try one of these" label above them is gone, the cards speak for themselves.
- The "Builder options · Generated" chip loses the blue treatment and becomes a neutral "Generated options" label at the standard section-label size.
- The configure and version history panels are both 264px now, instead of 296 and 320.

Relates: GLITCH-660
Relates: GLITCH-661

No new sizing primitives: the control sizes are Mantine's own `size` prop, and the remaining CSS-module values reference theme radius/spacing vars.
