### PR TITLE
fix(data-apps): restore the From scratch app template

### DIFF
--- a/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
@@ -4,7 +4,13 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import AppTemplatePicker from './AppTemplatePicker';
 
 const setup = (
-    selected: 'dashboard' | 'slideshow' | 'pdf' | 'data_app_viz' | null,
+    selected:
+        | 'dashboard'
+        | 'slideshow'
+        | 'pdf'
+        | 'custom'
+        | 'data_app_viz'
+        | null,
     onSelectedChange = vi.fn(),
 ) => {
     render(
@@ -30,6 +36,9 @@ describe('AppTemplatePicker', () => {
         expect(
             screen.getByRole('button', { name: /PDF Report/i }),
         ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /From scratch/i }),
+        ).toBeInTheDocument();
         // Vizs (custom chart types) are created from Explorer, not here.
         expect(
             screen.queryByRole('button', { name: /Data app visualization/i }),
@@ -50,6 +59,12 @@ describe('AppTemplatePicker', () => {
         const { onSelectedChange } = setup(null);
         fireEvent.click(screen.getByRole('button', { name: /Slide Show/i }));
         expect(onSelectedChange).toHaveBeenCalledWith('slideshow');
+    });
+
+    it('selecting From scratch reports the custom template', () => {
+        const { onSelectedChange } = setup(null);
+        fireEvent.click(screen.getByRole('button', { name: /From scratch/i }));
+        expect(onSelectedChange).toHaveBeenCalledWith('custom');
     });
 
     it('clicking the selected card deselects it', () => {

--- a/packages/frontend/src/features/apps/templates.ts
+++ b/packages/frontend/src/features/apps/templates.ts
@@ -2,6 +2,7 @@ import { type DataAppTemplate } from '@lightdash/common';
 import {
     IconFileText,
     IconLayoutDashboard,
+    IconPencil,
     IconPresentation,
     IconPuzzle,
     type Icon as TablerIcon,
@@ -34,6 +35,12 @@ const TEMPLATES: TemplateDefinition[] = [
         description:
             'A print-friendly document with sections and supporting charts.',
         icon: IconFileText,
+    },
+    {
+        id: 'custom',
+        title: 'From scratch',
+        description: 'Start from scratch and describe whatever you want.',
+        icon: IconPencil,
     },
     {
         id: 'data_app_viz',


### PR DESCRIPTION
Puts the **From scratch** card back in the data app template picker at `/projects/:projectUuid/apps/generate`.

It was dropped in #24952, where the new **Data app visualization** card took over its slot in the fan. #27192 then removed the viz card from the picker (vizs are created from Explorer's chart type picker now), which left the picker with three cards and no way to start an app without committing to a starter layout.

### What's here

- `templates.ts` — re-adds the `custom` entry ("From scratch", pencil icon) so it flows into `PICKER_TEMPLATES`. Picker is Dashboard / Slide Show / PDF Report / From scratch again.
- `AppTemplatePicker.test.tsx` — asserts the card renders and that selecting it reports `custom`. The existing "no viz card in the picker" assertion stays.

### Why nothing else changed

- The backend already handles `custom` end to end: `getTemplateInstructions` returns `null` for it, and `AppGenerateService` persists it as `template: null`. No prompt or schema changes.
- The fan CSS already defines four `data-pos` slots and was tuned for four cards. With only three it has been sitting off-centre (`-249 / -83 / +83`); the fourth card makes the arch symmetric again.
- `getTemplate('custom')` resolves again, so the "Starting from From scratch" chip on the landing composer works. The header template chip still hides `custom`, which is the intended "no template" behaviour.

No Linear ticket for this one — confirmed with the author.
