### PR TITLE
fix(data-apps): verify chart type bundles server-side

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -1283,6 +1283,26 @@ was tested against that exact source tree.
 
 S3 credentials are configured through the existing `S3_*` environment variables used by the app runtime config.
 
+### S3 bucket permissions
+
+Beyond the object-level permissions the build pipeline needs (`s3:GetObject`, `s3:PutObject`,
+`s3:DeleteObject`, `s3:ListBucket` for prefix listing during copy and cleanup), grant
+**`s3:ListBucket` on the bucket itself** to whichever identity the backend resolves.
+
+Without it, S3 answers `403 AccessDenied` instead of `404 NotFound` when an object is missing.
+The render-metadata bundle check (`getBundleServableChecker`) treats anything other than a
+confirmed missing object as servable, so a 403 makes it fail open: a version whose bundle has
+been purged still reports `ready`, and the iframe frames the preview route's error rather than
+showing "Preview unavailable".
+
+Nothing breaks, so the symptom to watch for is the log line rather than an outage:
+
+```
+Could not verify app bundle for app=<uuid> version=<n>, assuming servable: AccessDenied (403)
+```
+
+It is logged at `warn`, once per render-metadata request.
+
 ---
 
 ## Key Files

--- a/packages/backend/src/clients/Aws/S3BaseClient.ts
+++ b/packages/backend/src/clients/Aws/S3BaseClient.ts
@@ -1,4 +1,4 @@
-import { S3, type S3ClientConfig } from '@aws-sdk/client-s3';
+import { S3, S3Client, type S3ClientConfig } from '@aws-sdk/client-s3';
 import {
     createCredentialChain,
     fromContainerMetadata,
@@ -28,16 +28,27 @@ export type S3BaseConfiguration =
       }
     | undefined;
 
+/** Connection settings every S3 client in the backend is built from. */
+export type S3ConnectionConfig = {
+    region?: string;
+    endpoint?: string;
+    forcePathStyle?: boolean;
+    accessKey?: string;
+    secretKey?: string;
+    useCredentialsFrom?: string[];
+};
+
 /**
  * Resolves S3 credentials from explicit keys, a credential chain, or SDK defaults.
  * Returns the credentials property to assign to an S3ClientConfig, or undefined
  * to let the SDK use its default resolution.
  */
-export function resolveS3Credentials(config: {
-    accessKey?: string;
-    secretKey?: string;
-    useCredentialsFrom?: string[];
-}): S3ClientConfig['credentials'] | undefined {
+export function resolveS3Credentials(
+    config: Pick<
+        S3ConnectionConfig,
+        'accessKey' | 'secretKey' | 'useCredentialsFrom'
+    >,
+): S3ClientConfig['credentials'] | undefined {
     if (config.accessKey && config.secretKey) {
         Logger.debug('Using S3 storage with access key credentials');
         return {
@@ -113,6 +124,29 @@ export function resolveS3Credentials(config: {
     return undefined;
 }
 
+function buildS3ClientConfig(config: S3ConnectionConfig): S3ClientConfig {
+    const clientConfig: S3ClientConfig = {
+        region: config.region,
+        endpoint: config.endpoint || undefined,
+        forcePathStyle: config.forcePathStyle ?? false,
+    };
+
+    const credentials = resolveS3Credentials(config);
+    if (credentials) {
+        clientConfig.credentials = credentials;
+    }
+
+    return clientConfig;
+}
+
+/**
+ * Builds an S3 client for a bucket configuration. Callers that read and write
+ * the same bucket must share this, or one can authenticate where another can't.
+ */
+export function createS3ClientFromConfig(config: S3ConnectionConfig): S3Client {
+    return new S3Client(buildS3ClientConfig(config));
+}
+
 /**
  * Base class that sets up the AWS S3 client and handles credentials logic.
  * - If explicit accessKey/secretKey are provided, uses them.
@@ -133,20 +167,9 @@ export class S3BaseClient {
             return;
         }
 
-        const { endpoint, region, forcePathStyle } = configuration;
-
-        const s3Config: S3ClientConfig = {
-            region,
+        this.s3 = new S3({
+            ...buildS3ClientConfig(configuration),
             apiVersion: '2006-03-01',
-            endpoint,
-            forcePathStyle,
-        };
-
-        const credentials = resolveS3Credentials(configuration);
-        if (credentials) {
-            s3Config.credentials = credentials;
-        }
-
-        this.s3 = new S3(s3Config);
+        });
     }
 }

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -74,6 +74,9 @@ function buildService(
         lightdashConfig: {
             lightdashSecret: 'test-secret',
             lightdashSecrets: testLightdashSecrets,
+            // No app-runtime storage configured, so the bundle-existence
+            // check fails open and metadata comes from the DB alone.
+            appRuntime: { s3: null },
         } as never,
         analytics: {} as never,
         analyticsModel: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -9,7 +9,6 @@ import {
     S3Client,
     S3ServiceException,
     type ObjectIdentifier,
-    type S3ClientConfig,
 } from '@aws-sdk/client-s3';
 import { subject } from '@casl/ability';
 import {
@@ -126,7 +125,7 @@ import {
     type DataAppUploadRejectedEvent,
 } from '../../../analytics/LightdashAnalytics';
 import { fromSession } from '../../../auth/account';
-import { resolveS3Credentials } from '../../../clients/Aws/S3BaseClient';
+import { createS3ClientFromConfig } from '../../../clients/Aws/S3BaseClient';
 import { LightdashConfig } from '../../../config/parseConfig';
 import {
     APP_VERSION_STAGE_ORDER,
@@ -188,6 +187,7 @@ import {
     type SandboxSpec,
 } from '../SandboxRuntime';
 import { assertCanViewApp as assertUserCanViewApp } from './appAuthz';
+import { getBundleServableChecker } from './appBundleStorage';
 import {
     buildManifest,
     contentTypeForPath,
@@ -889,19 +889,8 @@ export class AppGenerateService extends BaseService {
             );
         }
 
-        const config: S3ClientConfig = {
-            region: s3Config.region,
-            endpoint: s3Config.endpoint || undefined,
-            forcePathStyle: s3Config.forcePathStyle ?? false,
-        };
-
-        const credentials = resolveS3Credentials(s3Config);
-        if (credentials) {
-            config.credentials = credentials;
-        }
-
         return {
-            client: new S3Client(config),
+            client: createS3ClientFromConfig(s3Config),
             bucket: s3Config.bucket,
         };
     }
@@ -2078,7 +2067,7 @@ export class AppGenerateService extends BaseService {
         version: number,
     ): Promise<number> {
         const start = performance.now();
-        const s3Key = `apps/${appUuid}/versions/${version}/source.tar`;
+        const s3Key = `${versionPrefix(appUuid, version)}source.tar`;
 
         const response = await s3Client.send(
             new GetObjectCommand({ Bucket: bucket, Key: s3Key }),
@@ -2126,7 +2115,7 @@ export class AppGenerateService extends BaseService {
         versionDeps: AppVersionDependencies,
     ): Promise<number> {
         const start = performance.now();
-        const depsPrefix = `apps/${appUuid}/versions/${version}/deps/`;
+        const depsPrefix = `${versionPrefix(appUuid, version)}deps/`;
 
         const [packageJsonBuf, lockfileBuf] = await Promise.all([
             readS3ObjectAsBuffer(s3Client, bucket, `${depsPrefix}package.json`),
@@ -3841,7 +3830,7 @@ export class AppGenerateService extends BaseService {
         sourceTar: Buffer,
     ): Promise<number> {
         const start = performance.now();
-        const s3Prefix = `apps/${appUuid}/versions/${version}`;
+        const s3Prefix = versionPrefix(appUuid, version);
 
         const [distResult] = await Promise.all([
             AppGenerateService.extractAndUploadToS3(
@@ -3854,14 +3843,14 @@ export class AppGenerateService extends BaseService {
                 .send(
                     new PutObjectCommand({
                         Bucket: bucket,
-                        Key: `${s3Prefix}/source.tar`,
+                        Key: `${s3Prefix}source.tar`,
                         Body: sourceTar,
                         ContentType: 'application/x-tar',
                     }),
                 )
                 .then(() => {
                     this.logger.debug(
-                        `App ${appUuid}: uploaded ${s3Prefix}/source.tar`,
+                        `App ${appUuid}: uploaded ${s3Prefix}source.tar`,
                     );
                 }),
         ]);
@@ -6303,8 +6292,8 @@ export class AppGenerateService extends BaseService {
         source: { appUuid: string; version: number },
         target: { appUuid: string; version: number },
     ): Promise<string[]> {
-        const sourcePrefix = `apps/${source.appUuid}/versions/${source.version}/`;
-        const destinationPrefix = `apps/${target.appUuid}/versions/${target.version}/`;
+        const sourcePrefix = versionPrefix(source.appUuid, source.version);
+        const destinationPrefix = versionPrefix(target.appUuid, target.version);
         const copiedKeys: string[] = [];
 
         let continuationToken: string | undefined;
@@ -6372,7 +6361,7 @@ export class AppGenerateService extends BaseService {
             );
         }
 
-        const sourceKey = `apps/${appUuid}/versions/${version}/source.tar`;
+        const sourceKey = `${versionPrefix(appUuid, version)}source.tar`;
         const response = await s3Client.send(
             new GetObjectCommand({ Bucket: bucket, Key: sourceKey }),
         );
@@ -7838,6 +7827,16 @@ export class AppGenerateService extends BaseService {
         return dataAppViz;
     }
 
+    private resolveVizRenderMetadata(
+        appUuid: string,
+    ): Promise<DataAppVizRenderMetadata> {
+        return resolveDataAppVizRenderMetadata(
+            this.appModel,
+            appUuid,
+            getBundleServableChecker(this.lightdashConfig.appRuntime.s3),
+        );
+    }
+
     async getDataAppVizRenderMetadata(
         user: SessionUser,
         projectUuid: string,
@@ -7848,10 +7847,7 @@ export class AppGenerateService extends BaseService {
             projectUuid,
             dataAppVizUuid,
         );
-        return resolveDataAppVizRenderMetadata(
-            this.appModel,
-            dataAppViz.app_id,
-        );
+        return this.resolveVizRenderMetadata(dataAppViz.app_id);
     }
 
     async getDataAppVizPreviewToken(
@@ -7899,10 +7895,7 @@ export class AppGenerateService extends BaseService {
             dataAppVizUuid,
             chartVersionUuid,
         );
-        return resolveDataAppVizRenderMetadata(
-            this.appModel,
-            dataAppViz.app_id,
-        );
+        return this.resolveVizRenderMetadata(dataAppViz.app_id);
     }
 
     async getChartDataAppVizPreviewToken(
@@ -8558,7 +8551,7 @@ export class AppGenerateService extends BaseService {
                                     /^dist\//,
                                     '',
                                 );
-                                const s3Key = `${s3Prefix}/${relativePath}`;
+                                const s3Key = `${s3Prefix}${relativePath}`;
                                 const contentType =
                                     AppGenerateService.getContentType(
                                         relativePath,

--- a/packages/backend/src/ee/services/AppGenerateService/appBundleStorage.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appBundleStorage.test.ts
@@ -1,0 +1,163 @@
+import { type S3Config } from '../../../config/parseConfig';
+import {
+    appVersionAssetKey,
+    appVersionIndexHtmlKey,
+    getBundleServableChecker,
+} from './appBundleStorage';
+
+const s3Mocks = vi.hoisted(() => {
+    class FakeS3ServiceException extends Error {
+        $metadata: { httpStatusCode?: number } = {};
+    }
+    return {
+        send: vi.fn(),
+        createClient: vi.fn(),
+        warn: vi.fn(),
+        FakeS3ServiceException,
+    };
+});
+
+vi.mock('@aws-sdk/client-s3', () => ({
+    HeadObjectCommand: class {
+        constructor(public readonly input: unknown) {}
+    },
+    S3ServiceException: s3Mocks.FakeS3ServiceException,
+}));
+
+vi.mock('../../../clients/Aws/S3BaseClient', () => ({
+    createS3ClientFromConfig: s3Mocks.createClient,
+}));
+
+vi.mock('../../../logging/logger', () => ({
+    __esModule: true,
+    default: { debug: vi.fn(), warn: s3Mocks.warn, error: vi.fn() },
+}));
+
+// A fresh object per call: the module memoises its client per config identity.
+const makeS3Config = (): S3Config =>
+    ({
+        region: 'eu-west-1',
+        endpoint: '',
+        bucket: 'app-bundles',
+    }) as S3Config;
+
+const s3Error = (name: string, httpStatusCode: number) => {
+    const error = new s3Mocks.FakeS3ServiceException(name);
+    error.name = name;
+    error.$metadata = { httpStatusCode };
+    return error;
+};
+
+describe('appVersionIndexHtmlKey / appVersionAssetKey', () => {
+    it('build the keys the preview router serves', () => {
+        expect(appVersionIndexHtmlKey('app-1', 2)).toBe(
+            'apps/app-1/versions/2/index.html',
+        );
+        expect(appVersionAssetKey('app-1', 2, 'main.js')).toBe(
+            'apps/app-1/versions/2/assets/main.js',
+        );
+    });
+});
+
+describe('getBundleServableChecker', () => {
+    beforeEach(() => {
+        s3Mocks.send.mockReset();
+        s3Mocks.warn.mockReset();
+        s3Mocks.createClient.mockReset();
+        s3Mocks.createClient.mockReturnValue({ send: s3Mocks.send });
+    });
+
+    it('heads the version index document', async () => {
+        s3Mocks.send.mockResolvedValue({});
+
+        await expect(
+            getBundleServableChecker(makeS3Config())('app-1', 2),
+        ).resolves.toBe(true);
+        expect(s3Mocks.send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                input: {
+                    Bucket: 'app-bundles',
+                    Key: appVersionIndexHtmlKey('app-1', 2),
+                },
+            }),
+        );
+    });
+
+    it.each(['NotFound', 'NoSuchKey'])(
+        'reports a missing bundle as unservable on %s, and logs it',
+        async (name) => {
+            s3Mocks.send.mockRejectedValue(s3Error(name, 404));
+
+            await expect(
+                getBundleServableChecker(makeS3Config())('app-1', 2),
+            ).resolves.toBe(false);
+            expect(s3Mocks.warn).toHaveBeenCalledWith(
+                expect.stringContaining('App bundle missing'),
+            );
+        },
+    );
+
+    // A missing bucket is also a 404, and S3 answers 403 for a missing key when
+    // the caller lacks `s3:ListBucket`. Treating either as "gone" would report
+    // every preview unavailable across the instance.
+    it.each([
+        ['NoSuchBucket', 404],
+        ['AccessDenied', 403],
+        ['SlowDown', 503],
+    ])('fails open on %s', async (name, status) => {
+        s3Mocks.send.mockRejectedValue(s3Error(name, status));
+
+        await expect(
+            getBundleServableChecker(makeS3Config())('app-1', 2),
+        ).resolves.toBe(true);
+    });
+
+    it('fails open when the check itself errors', async () => {
+        s3Mocks.send.mockRejectedValue(new Error('connection reset'));
+
+        await expect(
+            getBundleServableChecker(makeS3Config())('app-1', 2),
+        ).resolves.toBe(true);
+    });
+
+    it('fails open when building the client throws', async () => {
+        s3Mocks.createClient.mockImplementation(() => {
+            throw new Error('no credential provider');
+        });
+
+        await expect(
+            getBundleServableChecker(makeS3Config())('app-1', 2),
+        ).resolves.toBe(true);
+    });
+
+    it('fails open without contacting storage when none is configured', async () => {
+        await expect(getBundleServableChecker(null)('app-1', 2)).resolves.toBe(
+            true,
+        );
+        expect(s3Mocks.send).not.toHaveBeenCalled();
+    });
+
+    // The result is not cached on purpose: a bundle disappearing is the case
+    // this check exists for, so a confirmed hit must never go stale.
+    it('heads storage on every call, so a purge is noticed immediately', async () => {
+        s3Mocks.send.mockResolvedValue({});
+        const check = getBundleServableChecker(makeS3Config());
+
+        await expect(check('app-1', 2)).resolves.toBe(true);
+
+        s3Mocks.send.mockRejectedValue(s3Error('NotFound', 404));
+
+        await expect(check('app-1', 2)).resolves.toBe(false);
+        expect(s3Mocks.send).toHaveBeenCalledTimes(2);
+    });
+
+    it('builds one client per config object', async () => {
+        s3Mocks.send.mockResolvedValue({});
+        const config = makeS3Config();
+
+        await getBundleServableChecker(config)('app-1', 2);
+        await getBundleServableChecker(config)('app-1', 3);
+
+        expect(s3Mocks.createClient).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/appBundleStorage.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appBundleStorage.ts
@@ -1,0 +1,100 @@
+import {
+    HeadObjectCommand,
+    S3ServiceException,
+    type S3Client,
+} from '@aws-sdk/client-s3';
+import { createS3ClientFromConfig } from '../../../clients/Aws/S3BaseClient';
+import { type S3Config } from '../../../config/parseConfig';
+import Logger from '../../../logging/logger';
+import { versionPrefix } from './appCode';
+
+// Shared with the preview router so the served paths and the existence check
+// can't drift apart.
+export const appVersionIndexHtmlKey = (
+    appUuid: string,
+    version: number,
+): string => `${versionPrefix(appUuid, version)}index.html`;
+
+export const appVersionAssetKey = (
+    appUuid: string,
+    version: number,
+    filename: string,
+): string => `${versionPrefix(appUuid, version)}assets/${filename}`;
+
+export type BundleServableChecker = (
+    appUuid: string,
+    version: number,
+) => Promise<boolean>;
+
+const alwaysServable: BundleServableChecker = async () => true;
+
+/**
+ * Reports whether a version's bundle is still in storage. Fails open: only the
+ * object itself being absent counts as unservable, so a false negative can
+ * never hide a working preview.
+ *
+ * The result is deliberately not cached: bundles disappearing is the case this
+ * check exists for, and the callers already hit the database twice.
+ */
+const createBundleServableChecker = (
+    s3Config: S3Config,
+): BundleServableChecker => {
+    let client: S3Client | null = null;
+
+    return async (appUuid, version) => {
+        const key = appVersionIndexHtmlKey(appUuid, version);
+
+        try {
+            // Built here so a credential-resolution throw fails open too.
+            if (!client) {
+                client = createS3ClientFromConfig(s3Config);
+            }
+
+            await client.send(
+                new HeadObjectCommand({ Bucket: s3Config.bucket, Key: key }),
+            );
+            return true;
+        } catch (error) {
+            // Match the object-level names, not the 404 status: `NoSuchBucket`
+            // is also a 404, and S3 answers 403 for a missing key when the
+            // caller lacks `s3:ListBucket`. Neither proves the bundle is gone.
+            if (
+                error instanceof S3ServiceException &&
+                (error.name === 'NotFound' || error.name === 'NoSuchKey')
+            ) {
+                Logger.warn(
+                    `App bundle missing for app=${appUuid} version=${version}, reporting the version as unavailable`,
+                );
+                return false;
+            }
+
+            Logger.warn(
+                `Could not verify app bundle for app=${appUuid} version=${version}, assuming servable: ${
+                    error instanceof S3ServiceException
+                        ? `${error.name} (${error.$metadata?.httpStatusCode})`
+                        : String(error)
+                }`,
+            );
+            return true;
+        }
+    };
+};
+
+// Keyed on the config object, a per-process singleton, so each deployment builds
+// one S3 client instead of one per render-metadata request.
+const checkersByConfig = new WeakMap<S3Config, BundleServableChecker>();
+
+export const getBundleServableChecker = (
+    s3Config: S3Config | null,
+): BundleServableChecker => {
+    if (!s3Config) {
+        return alwaysServable;
+    }
+    const cached = checkersByConfig.get(s3Config);
+    if (cached) {
+        return cached;
+    }
+    const checker = createBundleServableChecker(s3Config);
+    checkersByConfig.set(s3Config, checker);
+    return checker;
+};

--- a/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.test.ts
@@ -1,0 +1,109 @@
+import { type DataAppVizSchema } from '@lightdash/common';
+import { type AppModel } from '../../../models/AppModel';
+import { resolveDataAppVizRenderMetadata } from './dataAppVizRender';
+
+const APP_UUID = 'data-app-viz-1';
+
+const vizSchema: DataAppVizSchema = {
+    fields: [],
+    configOptions: [],
+    colorPalette: null,
+};
+
+const makeVersion = (overrides: Record<string, unknown> = {}) => ({
+    app_id: APP_UUID,
+    version: 3,
+    status: 'ready',
+    viz_schema: vizSchema,
+    ...overrides,
+});
+
+const makeAppModel = (
+    latestVersion: unknown,
+    latestRenderableVersion: unknown,
+) =>
+    ({
+        getLatestVersion: vi.fn().mockResolvedValue(latestVersion),
+        getLatestRenderableDataAppVizVersion: vi
+            .fn()
+            .mockResolvedValue(latestRenderableVersion),
+    }) as unknown as AppModel;
+
+describe('resolveDataAppVizRenderMetadata', () => {
+    it('reports ready when the version bundle is still in storage', async () => {
+        const isBundleServable = vi.fn().mockResolvedValue(true);
+
+        await expect(
+            resolveDataAppVizRenderMetadata(
+                makeAppModel(makeVersion(), makeVersion()),
+                APP_UUID,
+                isBundleServable,
+            ),
+        ).resolves.toEqual({
+            state: 'ready',
+            version: 3,
+            schema: vizSchema,
+            latestBuildInProgress: false,
+        });
+        expect(isBundleServable).toHaveBeenCalledWith(APP_UUID, 3);
+    });
+
+    // Distinct from `failed`: the build succeeded, the artifact went missing.
+    it('reports unavailable when the version is ready but its bundle is gone', async () => {
+        await expect(
+            resolveDataAppVizRenderMetadata(
+                makeAppModel(makeVersion(), makeVersion()),
+                APP_UUID,
+                vi.fn().mockResolvedValue(false),
+            ),
+        ).resolves.toEqual({
+            state: 'unavailable',
+            latestBuildInProgress: false,
+        });
+    });
+
+    it('reports building when the bundle is gone and a newer build is running', async () => {
+        await expect(
+            resolveDataAppVizRenderMetadata(
+                makeAppModel(
+                    makeVersion({ version: 4, status: 'generating' }),
+                    makeVersion(),
+                ),
+                APP_UUID,
+                vi.fn().mockResolvedValue(false),
+            ),
+        ).resolves.toEqual({
+            state: 'building',
+            latestBuildInProgress: true,
+        });
+    });
+
+    it('skips the storage check when no version is renderable', async () => {
+        const isBundleServable = vi.fn();
+
+        await expect(
+            resolveDataAppVizRenderMetadata(
+                makeAppModel(makeVersion({ status: 'error' }), null),
+                APP_UUID,
+                isBundleServable,
+            ),
+        ).resolves.toEqual({
+            state: 'failed',
+            latestBuildInProgress: false,
+        });
+        expect(isBundleServable).not.toHaveBeenCalled();
+    });
+
+    it('skips the storage check when the renderable version has no schema', async () => {
+        const isBundleServable = vi.fn();
+
+        await expect(
+            resolveDataAppVizRenderMetadata(
+                makeAppModel(makeVersion(), makeVersion({ viz_schema: null })),
+                APP_UUID,
+                isBundleServable,
+            ),
+        ).resolves.toMatchObject({ state: 'failed' });
+        expect(isBundleServable).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.ts
@@ -6,6 +6,7 @@ import {
 } from '@lightdash/common';
 import { type DbAppVersion } from '../../../database/entities/apps';
 import { type AppModel } from '../../../models/AppModel';
+import { type BundleServableChecker } from './appBundleStorage';
 
 export type DataAppVisualizationForRender = NonNullable<
     Awaited<ReturnType<AppModel['findVisualizationApp']>>
@@ -29,6 +30,7 @@ export const resolveDataAppVisualizationForRender = async (
 export const resolveDataAppVizRenderMetadata = async (
     appModel: AppModel,
     appUuid: string,
+    isBundleServable: BundleServableChecker,
 ): Promise<DataAppVizRenderMetadata> => {
     const [latestVersion, latestRenderableVersion] = await Promise.all([
         appModel.getLatestVersion(appUuid),
@@ -37,14 +39,23 @@ export const resolveDataAppVizRenderMetadata = async (
     const latestBuildInProgress =
         latestVersion !== null && isAppVersionInProgress(latestVersion.status);
 
-    if (
+    const renderableVersion =
         latestRenderableVersion !== null &&
         latestRenderableVersion.viz_schema !== null
+            ? latestRenderableVersion
+            : null;
+
+    // A `ready` row whose bundle is gone from storage would frame the preview
+    // route's raw JSON error, so check storage before promising a render.
+    if (
+        renderableVersion !== null &&
+        renderableVersion.viz_schema !== null &&
+        (await isBundleServable(appUuid, renderableVersion.version))
     ) {
         return {
             state: 'ready',
-            version: latestRenderableVersion.version,
-            schema: latestRenderableVersion.viz_schema,
+            version: renderableVersion.version,
+            schema: renderableVersion.viz_schema,
             latestBuildInProgress,
         };
     }
@@ -53,6 +64,15 @@ export const resolveDataAppVizRenderMetadata = async (
         return {
             state: 'building',
             latestBuildInProgress: true,
+        };
+    }
+
+    // A build that succeeded and then lost its bundle is not a build failure,
+    // and the two read very differently to whoever is looking at the chart.
+    if (renderableVersion !== null) {
+        return {
+            state: 'unavailable',
+            latestBuildInProgress: false,
         };
     }
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -112,6 +112,7 @@ import { SubtotalsCalculator } from '../../../utils/SubtotalsCalculator';
 import { EmbedDashboardViewed, EmbedQueryViewed } from '../../analytics';
 import { EmbedModel } from '../../models/EmbedModel';
 import { ExternalConnectionModel } from '../../models/ExternalConnectionModel';
+import { getBundleServableChecker } from '../AppGenerateService/appBundleStorage';
 import {
     resolveDataAppVisualizationForRender,
     resolveDataAppVizRenderMetadata,
@@ -1856,6 +1857,7 @@ export class EmbedService extends BaseService {
         return resolveDataAppVizRenderMetadata(
             this.appModel,
             dataAppViz.app_id,
+            getBundleServableChecker(this.lightdashConfig.appRuntime.s3),
         );
     }
 

--- a/packages/backend/src/routers/appPreviewRouter.test.ts
+++ b/packages/backend/src/routers/appPreviewRouter.test.ts
@@ -1,5 +1,12 @@
+import express from 'express';
+import { request as httpRequest, type Server } from 'http';
+import type { AddressInfo } from 'net';
 import { lightdashConfigMock } from '../config/lightdashConfig.mock';
-import { buildCspHeader } from './appPreviewRouter';
+import { buildCspHeader, createAppPreviewRouter } from './appPreviewRouter';
+
+vi.mock('../logging/logger', () => ({
+    default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
 
 describe('app preview CSP browser image origins', () => {
     it('adds the exact origin only to img-src', () => {
@@ -22,5 +29,70 @@ describe('app preview CSP browser image origins', () => {
         expect(directives['script-src']).not.toContain(
             'https://tiles.example.com',
         );
+    });
+});
+
+describe('app preview version segment', () => {
+    const APP_UUID = 'd15384cb-8326-433a-a9e9-6f6bb22718f6';
+    const servers: Server[] = [];
+
+    afterEach(async () => {
+        await Promise.all(
+            servers.splice(0).map(
+                (server) =>
+                    new Promise<void>((resolve, reject) => {
+                        server.close((error) =>
+                            error ? reject(error) : resolve(),
+                        );
+                    }),
+            ),
+        );
+    });
+
+    const getStatus = async (path: string): Promise<number> => {
+        const app = express();
+        app.use(
+            createAppPreviewRouter(
+                lightdashConfigMock.appRuntime,
+                lightdashConfigMock.lightdashSecrets,
+                ["'self'"],
+            ),
+        );
+        const server = app.listen(0);
+        servers.push(server);
+
+        return new Promise<number>((resolve, reject) => {
+            const req = httpRequest(
+                {
+                    hostname: '127.0.0.1',
+                    port: (server.address() as AddressInfo).port,
+                    method: 'GET',
+                    path,
+                },
+                (res) => {
+                    res.resume();
+                    res.on('end', () => resolve(res.statusCode ?? 0));
+                },
+            );
+            req.on('error', reject);
+            req.end();
+        });
+    };
+
+    // These parse to a valid version number but build a different S3 key than
+    // the token authorises, so the document and its assets would disagree.
+    it.each(['0002', '2.0', '+2', '%202'])(
+        'rejects the non-canonical version %j before the token is read',
+        async (version) => {
+            await expect(
+                getStatus(`/${APP_UUID}/versions/${version}/t/not-a-token/`),
+            ).resolves.toBe(400);
+        },
+    );
+
+    it('lets a canonical version through to the token check', async () => {
+        await expect(
+            getStatus(`/${APP_UUID}/versions/2/t/not-a-token/`),
+        ).resolves.toBe(401);
     });
 });

--- a/packages/backend/src/routers/appPreviewRouter.ts
+++ b/packages/backend/src/routers/appPreviewRouter.ts
@@ -1,11 +1,16 @@
-import { GetObjectCommand, S3, S3ServiceException } from '@aws-sdk/client-s3';
+import { GetObjectCommand, S3ServiceException } from '@aws-sdk/client-s3';
 import express, { type Router } from 'express';
 import path from 'path';
 import { validate as isValidUuid } from 'uuid';
+import { createS3ClientFromConfig } from '../clients/Aws/S3BaseClient';
 import {
     type AppRuntimeConfig,
     type LightdashSecrets,
 } from '../config/parseConfig';
+import {
+    appVersionAssetKey,
+    appVersionIndexHtmlKey,
+} from '../ee/services/AppGenerateService/appBundleStorage';
 import Logger from '../logging/logger';
 import {
     verifyPreviewToken,
@@ -145,21 +150,7 @@ export const createAppPreviewRouter = (
         });
     }
 
-    const s3 =
-        config.s3 !== null
-            ? new S3({
-                  region: config.s3.region,
-                  endpoint: config.s3.endpoint,
-                  forcePathStyle: config.s3.forcePathStyle,
-                  credentials:
-                      config.s3.accessKey && config.s3.secretKey
-                          ? {
-                                accessKeyId: config.s3.accessKey,
-                                secretAccessKey: config.s3.secretKey,
-                            }
-                          : undefined,
-              })
-            : null;
+    const s3 = config.s3 !== null ? createS3ClientFromConfig(config.s3) : null;
 
     const setSecurityHeaders = (
         res: express.Response,
@@ -247,8 +238,14 @@ export const createAppPreviewRouter = (
             return;
         }
 
+        // Canonical form only: "0002" and "2.0" both parse to 2, so the URL
+        // would disagree with the version the token authorises.
         const versionNum = Number(version);
-        if (!Number.isInteger(versionNum) || versionNum < 1) {
+        if (
+            !Number.isInteger(versionNum) ||
+            versionNum < 1 ||
+            String(versionNum) !== version
+        ) {
             res.status(400).json({
                 status: 'error',
                 error: { message: 'Version must be a positive integer' },
@@ -307,8 +304,14 @@ export const createAppPreviewRouter = (
         '/:appUuid/versions/:version/t/:token/',
         requireToken,
         async (req, res) => {
-            const { appUuid, version } = req.params;
-            const s3Key = `apps/${appUuid}/versions/${version}/index.html`;
+            const previewTokenPayload = res.locals
+                .previewTokenPayload as PreviewTokenPayload;
+            // Key off the token's version, not the URL's: it is the one the
+            // middleware validated and the token authorises.
+            const s3Key = appVersionIndexHtmlKey(
+                previewTokenPayload.appUuid,
+                previewTokenPayload.version,
+            );
             const result = await fetchFromS3(s3Key);
 
             if (!result.ok) {
@@ -319,8 +322,6 @@ export const createAppPreviewRouter = (
                 return;
             }
 
-            const previewTokenPayload = res.locals
-                .previewTokenPayload as PreviewTokenPayload;
             setSecurityHeaders(res, previewTokenPayload);
             res.setHeader('Content-Type', 'text/html; charset=utf-8');
             res.setHeader('Cache-Control', 'no-store');
@@ -382,8 +383,13 @@ export const createAppPreviewRouter = (
                 return;
             }
 
-            const { appUuid, version } = req.params;
-            const s3Key = `apps/${appUuid}/versions/${version}/assets/${filename}`;
+            const previewTokenPayload = res.locals
+                .previewTokenPayload as PreviewTokenPayload;
+            const s3Key = appVersionAssetKey(
+                previewTokenPayload.appUuid,
+                previewTokenPayload.version,
+                filename,
+            );
             const result = await fetchFromS3(s3Key);
 
             if (!result.ok) {

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -994,6 +994,11 @@ export type DataAppVizRenderMetadata =
           state: 'building';
           latestBuildInProgress: true;
       }
+    // Built successfully, but its bundle is no longer in storage.
+    | {
+          state: 'unavailable';
+          latestBuildInProgress: false;
+      }
     | {
           state: 'failed';
           latestBuildInProgress: false;

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -25,6 +25,10 @@ const mocks = vi.hoisted(() => ({
                   latestBuildInProgress: true;
               }
             | {
+                  state: 'unavailable';
+                  latestBuildInProgress: false;
+              }
+            | {
                   state: 'failed';
                   latestBuildInProgress: false;
               }
@@ -212,6 +216,24 @@ describe('DataAppVizRenderer', () => {
         expect(
             screen.getByText('Custom chart type failed to generate.'),
         ).toBeInTheDocument();
+    });
+
+    // A version that built fine and then lost its bundle is not a build
+    // failure, and must not read like one.
+    it('distinguishes an unavailable bundle from a build failure', () => {
+        mocks.metadata.current = {
+            state: 'unavailable',
+            latestBuildInProgress: false,
+        };
+
+        renderRenderer();
+
+        expect(
+            screen.getByText('Custom chart type preview is unavailable.'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('Custom chart type failed to generate.'),
+        ).not.toBeInTheDocument();
     });
 
     it.each([

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -252,6 +252,12 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         );
     }
 
+    if (renderMetadata.state === 'unavailable') {
+        return (
+            <DataAppVizPlaceholder message="Custom chart type preview is unavailable." />
+        );
+    }
+
     if (renderMetadata.state === 'failed') {
         return (
             <DataAppVizPlaceholder message="Custom chart type failed to generate." />

--- a/packages/frontend/src/features/apps/components/ChartTypeSamplePreview.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeSamplePreview.tsx
@@ -6,7 +6,6 @@ import { useResolvedColorPalette } from '../../../hooks/appearance/useResolvedCo
 import { useResizeObserver } from '../../../hooks/useResizeObserver';
 import AppIframePreview from '../AppIframePreview';
 import {
-    useDataAppVizBundlePreflight,
     useDataAppVizPreviewToken,
     useDataAppVizRenderMetadata,
 } from '../hooks/useDataAppVizRender';
@@ -54,8 +53,6 @@ const ChartTypeSamplePreview: FC<Props> = ({ projectUuid, dataAppVizUuid }) => {
         readyMetadata && token
             ? `${previewOrigin}/api/apps/${dataAppVizUuid}/versions/${readyMetadata.version}/t/${token}/`
             : undefined;
-    const { data: bundleServable } =
-        useDataAppVizBundlePreflight(previewBaseUrl);
 
     const colorPalette = useResolvedColorPalette(projectUuid);
     const sampleContext = useMemo(
@@ -83,14 +80,14 @@ const ChartTypeSamplePreview: FC<Props> = ({ projectUuid, dataAppVizUuid }) => {
     if (metadata.state === 'building') {
         return <PreviewPlaceholder message="Still generating…" />;
     }
+    if (metadata.state === 'unavailable') {
+        return <PreviewPlaceholder message="Preview unavailable" />;
+    }
     if (metadata.state === 'failed') {
         return <PreviewPlaceholder message="No finished version yet" />;
     }
-    if (!token || !previewBaseUrl || bundleServable === undefined) {
+    if (!token || !previewBaseUrl) {
         return <PreviewPlaceholder message="Loading preview…" />;
-    }
-    if (!bundleServable) {
-        return <PreviewPlaceholder message="Preview unavailable" />;
     }
 
     const previewUrl = `${previewBaseUrl}?r=0#transport=postMessage&projectUuid=${projectUuid}`;

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
@@ -97,32 +97,6 @@ export const useDataAppVizRenderMetadata = (
                 : false,
     });
 
-/**
- * Verifies the served bundle exists before an iframe is pointed at it — a
- * ready version whose files are gone from storage would render the serving
- * route's raw JSON error. On a cross-origin preview host the HEAD is rejected
- * and we assume servable.
- */
-export const useDataAppVizBundlePreflight = (
-    previewBaseUrl: string | undefined,
-) =>
-    useQuery<boolean>({
-        queryKey: ['data-app-viz-bundle-preflight', previewBaseUrl],
-        queryFn: async () => {
-            try {
-                const response = await fetch(previewBaseUrl!, {
-                    method: 'HEAD',
-                });
-                return response.ok;
-            } catch {
-                return true;
-            }
-        },
-        enabled: previewBaseUrl !== undefined,
-        // Existence can't flip for a given version+token URL.
-        staleTime: Infinity,
-    });
-
 export const useDataAppVizPreviewToken = (
     projectUuid: string | undefined,
     dataAppVizUuid: string | undefined,


### PR DESCRIPTION
## Problem

The chart type gallery preflighted every preview bundle from the browser: a `HEAD` at `${previewOrigin}/api/apps/.../t/<token>/` before pointing an iframe at it. The intent was to show a placeholder instead of framing the preview route's raw JSON error when a version is `ready` in the database but its bundle is gone from storage.

The browser is the one party that can't ask that question. The app's CSP sets no `connect-src`, so it falls back to `default-src 'self' <allowlist>`, which doesn't include the data-app preview origin. Every preflight was refused before it left the browser:

```
Fetch API cannot load https://<preview-origin>/api/apps/.../t/<token>/.
Refused to connect because it violates the document's Content Security Policy.
```

The `queryFn` caught the failure and returned "assume servable", so previews still rendered. The costs were a console violation and a CSP report per gallery tile, a wasted query per tile, and a check that only ever worked in same-origin dev.

Making it work from the browser would have meant two policy relaxations: the preview origin added to CSP `connect-src`, and `Access-Control-Allow-Origin` on the preview HTML route, which currently sends CORS headers only for static `/assets/*`. Neither is worth it for a liveness check.

## Change

Resolve the question on the server, where there's no origin boundary.

- New `appBundleStorage.ts`: `getBundleServableChecker()` does an S3 `HeadObject` on the version's `index.html`, plus `appVersionIndexHtmlKey()` as the key builder now shared with the preview router so the served path and the check can't drift.
- `resolveDataAppVizRenderMetadata` takes the checker as a required argument and only reports `ready` when the bundle is actually present. Wired into all three callers — authoring previews, chart previews, and embeds.
- Removed `useDataAppVizBundlePreflight` and its gates in `ChartTypeSamplePreview`.
- `appPreviewRouter` now builds its S3 client through `createS3ClientFromConfig`, so it resolves the full credential chain (`S3_USE_CREDENTIALS_FROM`, IAM roles) instead of only explicit `accessKey`/`secretKey`. Deployments on IAM roles previously fell through to SDK defaults on this route while the rest of the app used the configured chain.

The check **fails open**: unconfigured storage, or any error other than a missing object, reports servable. It gates a placeholder rather than access, so a false negative would hide a working preview — the worse failure.

No CSP or CORS change, and nothing new is exposed to any browser. The guarantee now also covers dashboard tiles, embeds and `DataAppVizRenderer`, none of which had it.

## Notes

- A version whose bundle is gone reports a distinct `unavailable` state, separate from `failed`. The gallery keeps "No finished version yet" for a build that never finished and shows "Preview unavailable" only when a finished build lost its bundle. `DataAppVizRenderer` says the preview is unavailable rather than blaming generation.
- The check result is not cached. Caching a confirmed hit would defeat the point, since a bundle disappearing is exactly what this looks for, and the callers already run two DB queries per request, so one `HeadObject` alongside them is noise.
- Render metadata refetches every 3s while a build is in progress, so that adds one `HeadObject` per poll per tile while building. The checker isn't consulted at all until a version is renderable, which covers the first build.

## Testing

- New `dataAppVizRender.test.ts` (ready / unavailable / failed / building, and that the checker isn't consulted when nothing is renderable) and `appBundleStorage.test.ts` (key shape, 404 → unservable, error → fails open, unconfigured → no S3 call, client reuse, and that storage is re-headed on every call so a purge is seen immediately).
- `AppGenerateService/` + `EmbedService/` (310), `appPreviewRouter` (6), frontend `features/apps` (311) and `DataAppVizRenderer` (33).

---

Closes: GLITCH-665

