### PR TITLE
fix(data-apps): resolve full credential chain in app preview router

### DIFF
--- a/packages/backend/src/clients/Aws/S3BaseClient.ts
+++ b/packages/backend/src/clients/Aws/S3BaseClient.ts
@@ -1,4 +1,4 @@
-import { S3, type S3ClientConfig } from '@aws-sdk/client-s3';
+import { S3, S3Client, type S3ClientConfig } from '@aws-sdk/client-s3';
 import {
     createCredentialChain,
     fromContainerMetadata,
@@ -28,16 +28,27 @@ export type S3BaseConfiguration =
       }
     | undefined;
 
+/** Connection settings every S3 client in the backend is built from. */
+export type S3ConnectionConfig = {
+    region?: string;
+    endpoint?: string;
+    forcePathStyle?: boolean;
+    accessKey?: string;
+    secretKey?: string;
+    useCredentialsFrom?: string[];
+};
+
 /**
  * Resolves S3 credentials from explicit keys, a credential chain, or SDK defaults.
  * Returns the credentials property to assign to an S3ClientConfig, or undefined
  * to let the SDK use its default resolution.
  */
-export function resolveS3Credentials(config: {
-    accessKey?: string;
-    secretKey?: string;
-    useCredentialsFrom?: string[];
-}): S3ClientConfig['credentials'] | undefined {
+export function resolveS3Credentials(
+    config: Pick<
+        S3ConnectionConfig,
+        'accessKey' | 'secretKey' | 'useCredentialsFrom'
+    >,
+): S3ClientConfig['credentials'] | undefined {
     if (config.accessKey && config.secretKey) {
         Logger.debug('Using S3 storage with access key credentials');
         return {
@@ -113,6 +124,29 @@ export function resolveS3Credentials(config: {
     return undefined;
 }
 
+function buildS3ClientConfig(config: S3ConnectionConfig): S3ClientConfig {
+    const clientConfig: S3ClientConfig = {
+        region: config.region,
+        endpoint: config.endpoint || undefined,
+        forcePathStyle: config.forcePathStyle ?? false,
+    };
+
+    const credentials = resolveS3Credentials(config);
+    if (credentials) {
+        clientConfig.credentials = credentials;
+    }
+
+    return clientConfig;
+}
+
+/**
+ * Builds an S3 client for a bucket configuration. Callers that read and write
+ * the same bucket must share this, or one can authenticate where another can't.
+ */
+export function createS3ClientFromConfig(config: S3ConnectionConfig): S3Client {
+    return new S3Client(buildS3ClientConfig(config));
+}
+
 /**
  * Base class that sets up the AWS S3 client and handles credentials logic.
  * - If explicit accessKey/secretKey are provided, uses them.
@@ -133,20 +167,9 @@ export class S3BaseClient {
             return;
         }
 
-        const { endpoint, region, forcePathStyle } = configuration;
-
-        const s3Config: S3ClientConfig = {
-            region,
+        this.s3 = new S3({
+            ...buildS3ClientConfig(configuration),
             apiVersion: '2006-03-01',
-            endpoint,
-            forcePathStyle,
-        };
-
-        const credentials = resolveS3Credentials(configuration);
-        if (credentials) {
-            s3Config.credentials = credentials;
-        }
-
-        this.s3 = new S3(s3Config);
+        });
     }
 }

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -9,7 +9,6 @@ import {
     S3Client,
     S3ServiceException,
     type ObjectIdentifier,
-    type S3ClientConfig,
 } from '@aws-sdk/client-s3';
 import { subject } from '@casl/ability';
 import {
@@ -127,7 +126,7 @@ import {
     type DataAppUploadRejectedEvent,
 } from '../../../analytics/LightdashAnalytics';
 import { fromSession } from '../../../auth/account';
-import { resolveS3Credentials } from '../../../clients/Aws/S3BaseClient';
+import { createS3ClientFromConfig } from '../../../clients/Aws/S3BaseClient';
 import { LightdashConfig } from '../../../config/parseConfig';
 import {
     APP_VERSION_STAGE_ORDER,
@@ -896,19 +895,8 @@ export class AppGenerateService extends BaseService {
             );
         }
 
-        const config: S3ClientConfig = {
-            region: s3Config.region,
-            endpoint: s3Config.endpoint || undefined,
-            forcePathStyle: s3Config.forcePathStyle ?? false,
-        };
-
-        const credentials = resolveS3Credentials(s3Config);
-        if (credentials) {
-            config.credentials = credentials;
-        }
-
         return {
-            client: new S3Client(config),
+            client: createS3ClientFromConfig(s3Config),
             bucket: s3Config.bucket,
         };
     }

--- a/packages/backend/src/ee/services/AppGenerateService/appBundleStorage.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appBundleStorage.test.ts
@@ -9,21 +9,11 @@ const s3Mocks = vi.hoisted(() => {
     class FakeS3ServiceException extends Error {
         $metadata: { httpStatusCode?: number } = {};
     }
-    const send = vi.fn();
-    const createClient = vi.fn();
-    class FakeS3Client {
-        send = send;
-
-        constructor(config: unknown) {
-            createClient(config);
-        }
-    }
     return {
-        send,
-        createClient,
+        send: vi.fn(),
+        createClient: vi.fn(),
         warn: vi.fn(),
         FakeS3ServiceException,
-        FakeS3Client,
     };
 });
 
@@ -32,11 +22,10 @@ vi.mock('@aws-sdk/client-s3', () => ({
         constructor(public readonly input: unknown) {}
     },
     S3ServiceException: s3Mocks.FakeS3ServiceException,
-    S3Client: s3Mocks.FakeS3Client,
 }));
 
 vi.mock('../../../clients/Aws/S3BaseClient', () => ({
-    resolveS3Credentials: vi.fn(() => undefined),
+    createS3ClientFromConfig: s3Mocks.createClient,
 }));
 
 vi.mock('../../../logging/logger', () => ({
@@ -75,6 +64,7 @@ describe('getBundleServableChecker', () => {
         s3Mocks.send.mockReset();
         s3Mocks.warn.mockReset();
         s3Mocks.createClient.mockReset();
+        s3Mocks.createClient.mockReturnValue({ send: s3Mocks.send });
     });
 
     it('heads the version index document', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/appBundleStorage.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appBundleStorage.ts
@@ -1,10 +1,9 @@
 import {
     HeadObjectCommand,
-    S3Client,
     S3ServiceException,
-    type S3ClientConfig,
+    type S3Client,
 } from '@aws-sdk/client-s3';
-import { resolveS3Credentials } from '../../../clients/Aws/S3BaseClient';
+import { createS3ClientFromConfig } from '../../../clients/Aws/S3BaseClient';
 import { type S3Config } from '../../../config/parseConfig';
 import Logger from '../../../logging/logger';
 import { versionPrefix } from './appCode';
@@ -42,16 +41,7 @@ const createBundleServableChecker = (
         try {
             // Built here so a credential-resolution throw fails open too.
             if (!client) {
-                const clientConfig: S3ClientConfig = {
-                    region: s3Config.region,
-                    endpoint: s3Config.endpoint || undefined,
-                    forcePathStyle: s3Config.forcePathStyle ?? false,
-                };
-                const credentials = resolveS3Credentials(s3Config);
-                if (credentials) {
-                    clientConfig.credentials = credentials;
-                }
-                client = new S3Client(clientConfig);
+                client = createS3ClientFromConfig(s3Config);
             }
 
             await client.send(

--- a/packages/backend/src/routers/appPreviewRouter.ts
+++ b/packages/backend/src/routers/appPreviewRouter.ts
@@ -1,7 +1,8 @@
-import { GetObjectCommand, S3, S3ServiceException } from '@aws-sdk/client-s3';
+import { GetObjectCommand, S3ServiceException } from '@aws-sdk/client-s3';
 import express, { type Router } from 'express';
 import path from 'path';
 import { validate as isValidUuid } from 'uuid';
+import { createS3ClientFromConfig } from '../clients/Aws/S3BaseClient';
 import {
     type AppRuntimeConfig,
     type LightdashSecrets,
@@ -149,21 +150,7 @@ export const createAppPreviewRouter = (
         });
     }
 
-    const s3 =
-        config.s3 !== null
-            ? new S3({
-                  region: config.s3.region,
-                  endpoint: config.s3.endpoint,
-                  forcePathStyle: config.s3.forcePathStyle,
-                  credentials:
-                      config.s3.accessKey && config.s3.secretKey
-                          ? {
-                                accessKeyId: config.s3.accessKey,
-                                secretAccessKey: config.s3.secretKey,
-                            }
-                          : undefined,
-              })
-            : null;
+    const s3 = config.s3 !== null ? createS3ClientFromConfig(config.s3) : null;
 
     const setSecurityHeaders = (
         res: express.Response,


### PR DESCRIPTION
## Problem

`appPreviewRouter` built its S3 client from explicit `accessKey`/`secretKey` only. Deployments that authenticate via IAM roles or `S3_USE_CREDENTIALS_FROM` fell through to SDK defaults on this route while the rest of the app resolved the configured credential chain, so the preview route could fail to authenticate where every other S3 consumer succeeded.

## Change

- `S3BaseClient` gains `createS3ClientFromConfig()`, which builds a client through the existing `resolveS3Credentials` chain (explicit keys, then `S3_USE_CREDENTIALS_FROM`, then SDK defaults).
- `appPreviewRouter`, `AppGenerateService.getS3Client()`, and the bundle servable checker from #27294 all build their clients through it, so callers that read and write the same bucket share one construction path and can't diverge on auth.

No behavior change for deployments using explicit keys.

## Testing

- `appBundleStorage.test.ts` updated to mock the shared factory; `appPreviewRouter` and `AppGenerateService` suites pass unchanged.
