### PR TITLE
fix(data-apps): stop the rebuild indicator flashing and show its prompt

### DIFF
--- a/packages/frontend/src/features/apps/builder/BuilderCanvas.module.css
+++ b/packages/frontend/src/features/apps/builder/BuilderCanvas.module.css
@@ -1,13 +1,3 @@
-@keyframes ldPulse {
-    0%,
-    100% {
-        opacity: 1;
-    }
-    50% {
-        opacity: 0.45;
-    }
-}
-
 /* Stays under full strength throughout: the bars are a placeholder for the
    chart, not the chart. */
 @keyframes ldBar {
@@ -77,20 +67,33 @@
     pointer-events: none;
 }
 
+/* Holds still: it sits over the chart, so pulsing it reads as the chart
+   flickering. The spinner carries the motion instead. */
 .buildingPill {
     display: flex;
-    align-items: center;
-    gap: var(--mantine-spacing-xs);
+    flex-direction: column;
+    gap: 2px;
+    max-width: min(420px, 80%);
     font-size: 13px;
     font-weight: 500;
     color: var(--mantine-color-ldGray-7);
     background: var(--mantine-color-background-0);
     border: 1px solid var(--mantine-color-ldGray-2);
-    border-radius: 20px;
-    padding: 6px 8px 6px 18px;
+    border-radius: var(--mantine-radius-lg);
+    padding: 8px 10px 8px 14px;
     box-shadow: var(--mantine-shadow-heavy);
-    animation: ldPulse 1.2s ease-in-out infinite;
     pointer-events: auto;
+}
+
+.buildingStatus {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+}
+
+/* Aligns with the status line's text, not the pill edge. */
+.buildingPrompt {
+    padding-left: calc(14px + var(--mantine-spacing-xs));
 }
 
 /* The same width an example card's thumbnail gets, so the build reads as the
@@ -120,8 +123,4 @@
 }
 .skeletonBar:nth-child(6) {
     animation-delay: 0.6s;
-}
-
-.buildingLabel {
-    animation: ldPulse 1.2s ease-in-out infinite;
 }

--- a/packages/frontend/src/features/apps/builder/BuilderCanvas.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderCanvas.tsx
@@ -2,7 +2,7 @@ import {
     ECHARTS_DEFAULT_COLORS,
     type DataAppVizContext,
 } from '@lightdash/common';
-import { Anchor, Box, Stack, Text } from '@mantine/core';
+import { Anchor, Box, Loader, Stack, Text } from '@mantine/core';
 import { type FC, type ReactNode } from 'react';
 import { useResolvedColorPalette } from '../../../hooks/appearance/useResolvedColorPalette';
 import AppPreview from '../components/AppPreview';
@@ -16,7 +16,7 @@ type Props = {
     /** The version the preview renders; null when nothing is renderable. */
     previewVersion: number | null;
     isBuilding: boolean;
-    /** Echoed under the first-build state. */
+    /** Echoed under the building state, first build or rebuild. */
     buildingPrompt: string | null;
     elapsed: string | null;
     onCancelBuild: (() => void) | null;
@@ -123,12 +123,7 @@ const BuilderCanvas: FC<Props> = ({
                 <Stack gap="xl" align="center">
                     <SkeletonBars projectUuid={projectUuid} />
                     <Stack gap="xs" align="center">
-                        <Text
-                            className={classes.buildingLabel}
-                            size="md"
-                            fw={600}
-                            c="ldGray.8"
-                        >
+                        <Text size="md" fw={600} c="ldGray.8">
                             Building your chart type…
                         </Text>
                         {buildingPrompt && (
@@ -188,12 +183,26 @@ const BuilderCanvas: FC<Props> = ({
             {isBuilding && hasPreview && (
                 <Box className={classes.overlay}>
                     <Box className={classes.buildingPill}>
-                        <Text span inherit>
-                            Building…
-                            {elapsed ? ` ${elapsed}` : ''}
-                        </Text>
-                        {onCancelBuild && (
-                            <CancelBuildLink onCancel={onCancelBuild} />
+                        <Box className={classes.buildingStatus}>
+                            <Loader size={14} color="ldGray.6" />
+                            <Text span inherit>
+                                Building…
+                                {elapsed ? ` ${elapsed}` : ''}
+                            </Text>
+                            {onCancelBuild && (
+                                <CancelBuildLink onCancel={onCancelBuild} />
+                            )}
+                        </Box>
+                        {buildingPrompt && (
+                            <Text
+                                className={classes.buildingPrompt}
+                                fz="xs"
+                                c="dimmed"
+                                lh={1.5}
+                                lineClamp={2}
+                            >
+                                “{buildingPrompt}”
+                            </Text>
                         )}
                     </Box>
                 </Box>

--- a/packages/frontend/src/features/apps/builder/VersionHistoryPanel.module.css
+++ b/packages/frontend/src/features/apps/builder/VersionHistoryPanel.module.css
@@ -1,13 +1,3 @@
-@keyframes ldPulse {
-    0%,
-    100% {
-        opacity: 1;
-    }
-    50% {
-        opacity: 0.45;
-    }
-}
-
 .panel {
     width: 264px;
     flex-shrink: 0;
@@ -96,7 +86,6 @@
 
     &[data-state='building'] {
         color: var(--mantine-color-ldBrandViolet-7);
-        animation: ldPulse 1.2s ease-in-out infinite;
     }
 }
 

--- a/packages/frontend/src/features/apps/builder/VersionHistoryPanel.test.tsx
+++ b/packages/frontend/src/features/apps/builder/VersionHistoryPanel.test.tsx
@@ -1,9 +1,19 @@
 import { fireEvent, screen } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import { appVersion } from '../testing/appVersionHistory';
 import { buildStub } from '../testing/dataAppVizBuildStub';
 import VersionHistoryPanel from './VersionHistoryPanel';
+
+const styles = readFileSync(
+    join(
+        process.cwd(),
+        'src/features/apps/builder/VersionHistoryPanel.module.css',
+    ),
+    'utf8',
+);
 
 vi.mock('./RestoreVersionModal', () => ({
     default: ({ version }: { version: number }) => (
@@ -91,6 +101,11 @@ describe('VersionHistoryPanel', () => {
         );
 
         expect(screen.getByText('Building…')).toBeInTheDocument();
+    });
+
+    it('does not pulse an in-progress version', () => {
+        expect(styles).not.toMatch(/@keyframes\s+ldPulse/);
+        expect(styles).not.toMatch(/animation:\s*ldPulse/);
     });
 
     it('writes a live entry for a build not yet in history', () => {

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -333,6 +333,8 @@ describe('ChartTypeBuilder', () => {
         );
         expect(screen.getByText(/Building…/)).toBeInTheDocument();
         expect(screen.queryByText('Building your chart type…')).toBeNull();
+        // A rebuild echoes its prompt too, not just the first build.
+        expect(screen.getByText('“make the bars teal”')).toBeInTheDocument();
     });
 
     it('renders the current version and lists its history on demand', () => {


### PR DESCRIPTION
The building pill sat over the previous chart pulsing its own opacity, which read as the chart flickering, and a rebuild never showed what it was building.

A spinner carries the motion instead, and the pill echoes the prompt the way the first-build state already did. Same pulse removed from the first-build label, where the skeleton bars already supply the motion.

https://linear.app/lightdash/issue/GLITCH-666