### PR TITLE
fix(data-apps): edit chart type name and description in a modal

### DIFF
--- a/packages/frontend/src/components/common/modal/AppUpdateModal.tsx
+++ b/packages/frontend/src/components/common/modal/AppUpdateModal.tsx
@@ -6,7 +6,7 @@ import {
     type ModalProps,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
-import { IconAppWindow } from '@tabler/icons-react';
+import { IconAppWindow, type Icon as IconType } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { z } from 'zod';
 import { useUpdateApp } from '../../../features/apps/hooks/useUpdateApp';
@@ -19,6 +19,9 @@ interface AppUpdateModalProps {
     uuid: string;
     initialName: string;
     initialDescription: string;
+    /** What the app is called to the user; chart types are apps too. */
+    resourceLabel?: string;
+    icon?: IconType;
     onConfirm?: () => void;
 }
 
@@ -34,10 +37,14 @@ const AppUpdateModal: FC<AppUpdateModalProps> = ({
     uuid,
     initialName,
     initialDescription,
+    resourceLabel = 'Data App',
+    icon = IconAppWindow,
     onConfirm,
     ...modalProps
 }) => {
-    const { mutateAsync, isLoading: isUpdating } = useUpdateApp();
+    const { mutateAsync, isLoading: isUpdating } = useUpdateApp({
+        resourceLabel,
+    });
 
     const form = useForm<FormState>({
         initialValues: {
@@ -68,9 +75,9 @@ const AppUpdateModal: FC<AppUpdateModalProps> = ({
 
     return (
         <MantineModal
-            title="Update Data App"
+            title={`Update ${resourceLabel}`}
             {...modalProps}
-            icon={IconAppWindow}
+            icon={icon}
             actions={
                 <Button
                     disabled={!form.isValid()}

--- a/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.module.css
+++ b/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.module.css
@@ -26,22 +26,8 @@
     flex-shrink: 0;
 }
 
-/* Sized by the input's own `size`; this only makes it read as a title that
-   happens to be editable rather than as a form field. */
-.nameInput {
-    font-weight: 600;
-    color: var(--mantine-color-foreground-0);
-    background: transparent;
-    border: 1px solid transparent;
-
-    &:hover {
-        border-color: var(--mantine-color-ldGray-2);
-    }
-
-    &:focus {
-        border-color: var(--mantine-color-ldBrandViolet-4);
-        background: var(--mantine-color-background-0);
-    }
+.name {
+    max-width: 280px;
 }
 
 .provenance {

--- a/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.tsx
+++ b/packages/frontend/src/features/apps/builder/ChartTypeBuilderHeader.tsx
@@ -7,86 +7,23 @@ import {
     Box,
     Button,
     Group,
-    Popover,
-    Textarea,
-    TextInput,
+    Text,
+    Title,
     Tooltip,
 } from '@mantine/core';
 import {
     IconChevronLeft,
-    IconFileDescription,
     IconHistory,
+    IconInfoCircle,
+    IconPencil,
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
+import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
 import { getVersionAuthorName } from '../utils/versionsToChatMessages';
 import classes from './ChartTypeBuilderHeader.module.css';
 import VersionProvenance from './VersionProvenance';
-
-const InlineNameInput: FC<{
-    initialName: string;
-    onSave: (name: string) => void;
-}> = ({ initialName, onSave }) => {
-    const [name, setName] = useState(initialName);
-    const submit = () => {
-        const trimmed = name.trim();
-        if (trimmed && trimmed !== initialName) onSave(trimmed);
-        else setName(initialName);
-    };
-    return (
-        <TextInput
-            classNames={{ input: classes.nameInput }}
-            size="xs"
-            aria-label="Chart type name"
-            value={name}
-            w={280}
-            onChange={(e) => setName(e.currentTarget.value)}
-            onBlur={submit}
-            onKeyDown={(e) => {
-                if (e.key === 'Enter') e.currentTarget.blur();
-            }}
-        />
-    );
-};
-
-const DescriptionPopover: FC<{
-    initialDescription: string;
-    onSave: (description: string) => void;
-}> = ({ initialDescription, onSave }) => {
-    const [description, setDescription] = useState(initialDescription);
-    return (
-        <Popover width={320} position="bottom-start" withArrow>
-            <Popover.Target>
-                <Tooltip withArrow label="Edit description">
-                    <ActionIcon
-                        variant="subtle"
-                        color="gray"
-                        size="sm"
-                        aria-label="Edit description"
-                    >
-                        <MantineIcon icon={IconFileDescription} />
-                    </ActionIcon>
-                </Tooltip>
-            </Popover.Target>
-            <Popover.Dropdown>
-                <Textarea
-                    label="Description"
-                    size="xs"
-                    rows={3}
-                    placeholder="What this chart type shows and expects"
-                    value={description}
-                    onChange={(e) => setDescription(e.currentTarget.value)}
-                    onBlur={() => {
-                        if (description.trim() !== initialDescription.trim()) {
-                            onSave(description.trim());
-                        }
-                    }}
-                />
-            </Popover.Dropdown>
-        </Popover>
-    );
-};
 
 type Props = {
     projectUuid: string;
@@ -101,7 +38,6 @@ type Props = {
     hasHistory: boolean;
     isHistoryOpen: boolean;
     onToggleHistory: () => void;
-    onSaveMeta: (patch: { name?: string; description?: string }) => void;
     onPreviewInExplorer: () => void;
 };
 
@@ -114,72 +50,114 @@ const ChartTypeBuilderHeader: FC<Props> = ({
     hasHistory,
     isHistoryOpen,
     onToggleHistory,
-    onSaveMeta,
     onPreviewInExplorer,
-}) => (
-    <Box className={classes.header} component="header">
-        <Box className={classes.side}>
-            <Button
-                size="xs"
-                component={Link}
-                to={`/projects/${projectUuid}/gallery`}
-                variant="default"
-                leftSection={<MantineIcon icon={IconChevronLeft} size={15} />}
-            >
-                Gallery
-            </Button>
-            <Box className={classes.divider} />
-            {app ? (
-                <>
-                    <InlineNameInput
-                        key={`${app.appUuid}:${app.name}`}
-                        initialName={getAppDisplayName(app.name, app.appUuid)}
-                        onSave={(name) => onSaveMeta({ name })}
-                    />
-                    <DescriptionPopover
-                        key={`${app.appUuid}:desc:${app.description}`}
-                        initialDescription={app.description}
-                        onSave={(description) => onSaveMeta({ description })}
-                    />
-                </>
-            ) : (
-                <TextInput
-                    classNames={{ input: classes.nameInput }}
+}) => {
+    const [isEditingDetails, setIsEditingDetails] = useState(false);
+
+    return (
+        <Box className={classes.header} component="header">
+            <Box className={classes.side}>
+                <Button
                     size="xs"
-                    aria-label="Chart type name"
-                    value="Untitled chart type"
-                    w={280}
-                    readOnly
-                />
-            )}
-            {provenanceVersion && (
-                <VersionProvenance
-                    className={classes.provenance}
-                    authorName={getVersionAuthorName(provenanceVersion)}
-                    at={new Date(provenanceVersion.createdAt)}
-                    isOrigin={hasOrigin}
+                    component={Link}
+                    to={`/projects/${projectUuid}/gallery`}
+                    variant="default"
+                    leftSection={
+                        <MantineIcon icon={IconChevronLeft} size={15} />
+                    }
+                >
+                    Gallery
+                </Button>
+                <Box className={classes.divider} />
+                {app ? (
+                    <>
+                        <Title
+                            className={classes.name}
+                            order={6}
+                            c="ldDark.9"
+                            fw={600}
+                            lineClamp={1}
+                        >
+                            {getAppDisplayName(app.name, app.appUuid)}
+                        </Title>
+                        {app.description && (
+                            <Tooltip
+                                withArrow
+                                multiline
+                                w={280}
+                                label={app.description}
+                            >
+                                <ActionIcon
+                                    variant="subtle"
+                                    color="gray"
+                                    size="sm"
+                                    aria-label="Chart type description"
+                                >
+                                    <MantineIcon icon={IconInfoCircle} />
+                                </ActionIcon>
+                            </Tooltip>
+                        )}
+                        <Tooltip withArrow label="Edit details">
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                size="sm"
+                                aria-label="Edit chart type details"
+                                onClick={() => setIsEditingDetails(true)}
+                            >
+                                <MantineIcon icon={IconPencil} />
+                            </ActionIcon>
+                        </Tooltip>
+                    </>
+                ) : (
+                    <Text className={classes.name} fz="sm" fw={600} c="dimmed">
+                        Untitled chart type
+                    </Text>
+                )}
+                {provenanceVersion && (
+                    <VersionProvenance
+                        className={classes.provenance}
+                        authorName={getVersionAuthorName(provenanceVersion)}
+                        at={new Date(provenanceVersion.createdAt)}
+                        isOrigin={hasOrigin}
+                    />
+                )}
+            </Box>
+            <Group gap="xs" wrap="nowrap">
+                {hasHistory && (
+                    <Button
+                        size="xs"
+                        variant={isHistoryOpen ? 'light' : 'default'}
+                        color="gray"
+                        leftSection={
+                            <MantineIcon icon={IconHistory} size={15} />
+                        }
+                        onClick={onToggleHistory}
+                    >
+                        History
+                    </Button>
+                )}
+                {latestReadyVersion !== null && (
+                    <Button size="xs" onClick={onPreviewInExplorer}>
+                        Preview in explorer
+                    </Button>
+                )}
+            </Group>
+            {app && isEditingDetails && (
+                <AppUpdateModal
+                    opened
+                    onClose={() => setIsEditingDetails(false)}
+                    onConfirm={() => setIsEditingDetails(false)}
+                    projectUuid={projectUuid}
+                    uuid={app.appUuid}
+                    initialName={getAppDisplayName(app.name, app.appUuid)}
+                    initialDescription={app.description}
+                    resourceLabel="Chart Type"
+                    icon={IconPencil}
                 />
             )}
         </Box>
-        <Group gap="xs" wrap="nowrap">
-            {hasHistory && (
-                <Button
-                    size="xs"
-                    variant={isHistoryOpen ? 'light' : 'default'}
-                    color="gray"
-                    leftSection={<MantineIcon icon={IconHistory} size={15} />}
-                    onClick={onToggleHistory}
-                >
-                    History
-                </Button>
-            )}
-            {latestReadyVersion !== null && (
-                <Button size="xs" onClick={onPreviewInExplorer}>
-                    Preview in explorer
-                </Button>
-            )}
-        </Group>
-    </Box>
-);
+    );
+};
 
 export default ChartTypeBuilderHeader;

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -46,7 +46,7 @@ vi.mock('../features/apps/hooks/useAppBuildPoller', () => ({
     useAppBuildPoller: vi.fn(),
 }));
 vi.mock('../features/apps/hooks/useUpdateApp', () => ({
-    useUpdateApp: () => ({ mutate: vi.fn() }),
+    useUpdateApp: () => ({ mutateAsync: vi.fn(), isLoading: false }),
 }));
 vi.mock('../hooks/appearance/useOrganizationAppearance', () => ({
     useColorPalettes: () => ({ data: [] }),
@@ -472,6 +472,30 @@ describe('ChartTypeBuilder', () => {
         fireEvent.click(screen.getByLabelText('Close history'));
 
         expect(screen.getByLabelText('Show markers')).not.toBeChecked();
+    });
+
+    it('shows the name and description read-only, and edits them in a modal', () => {
+        setApp(appMeta());
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub([appVersion({ version: 1 })], 1),
+        );
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        // The title is text, not a field you can type over by accident.
+        expect(screen.queryByLabelText('Chart type name')).toBeNull();
+        expect(screen.getByText('Stream graph')).toBeInTheDocument();
+        expect(
+            screen.getByLabelText('Chart type description'),
+        ).toBeInTheDocument();
+
+        fireEvent.click(screen.getByLabelText('Edit chart type details'));
+        expect(screen.getByText('Update Chart Type')).toBeInTheDocument();
+        expect(screen.getByLabelText(/Name/)).toHaveValue('Stream graph');
+        expect(screen.getByLabelText(/Description/)).toHaveValue(
+            'Layered flows',
+        );
     });
 
     it('offers no history toggle before the first version exists', () => {

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -35,7 +35,6 @@ import { useDataAppVisualization } from '../features/apps/hooks/useDataAppVisual
 import { useDataAppVizBuild } from '../features/apps/hooks/useDataAppVizBuild';
 import { useElapsedClock } from '../features/apps/hooks/useElapsedClock';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
-import { useUpdateApp } from '../features/apps/hooks/useUpdateApp';
 import { buildSampleVizContext } from '../features/apps/utils/sampleVizContext';
 import { useResolvedColorPalette } from '../hooks/appearance/useResolvedColorPalette';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
@@ -224,15 +223,6 @@ const ChartTypeBuilder: FC = () => {
         [],
     );
 
-    const { mutate: updateApp } = useUpdateApp({ resourceLabel: 'Chart type' });
-    const handleSaveMeta = useCallback(
-        (patch: { name?: string; description?: string }) => {
-            if (!projectUuid || !appMeta) return;
-            updateApp({ projectUuid, appUuid: appMeta.appUuid, ...patch });
-        },
-        [projectUuid, appMeta, updateApp],
-    );
-
     const canEdit = useCanEditDataApp(projectUuid, {
         spaceUuid: appMeta?.spaceUuid ?? null,
         createdByUserUuid: appMeta?.createdByUserUuid ?? null,
@@ -348,7 +338,6 @@ const ChartTypeBuilder: FC = () => {
                         ? handleCloseHistory()
                         : setIsHistoryOpen(true)
                 }
-                onSaveMeta={handleSaveMeta}
                 onPreviewInExplorer={() =>
                     void navigate(
                         `/projects/${projectUuid}/tables?dataAppVizUuid=${activeVizUuid}`,


### PR DESCRIPTION
The chart type header edited name and description in place: a borderless input that looked like a title but swallowed clicks, and the description hidden behind an icon popover.

Both are now read-only in the header, with a pencil that opens `AppUpdateModal` — the same pattern charts and dashboards use. The modal picks up optional `resourceLabel` and `icon` props so it reads "Update Chart Type".

Note: `resourceLabel` also drives the success toast, so the three existing data-app callers now say "Data App name updated" instead of "App name updated".

https://linear.app/lightdash/issue/GLITCH-667