### PR TITLE
fix(data-apps): drop forced uppercase from chart type builder labels

### DIFF
--- a/packages/frontend/src/features/apps/builder/ConfigurePanel.module.css
+++ b/packages/frontend/src/features/apps/builder/ConfigurePanel.module.css
@@ -29,8 +29,6 @@
     color: var(--mantine-color-ldGray-6);
     font-size: 11px;
     font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
     white-space: nowrap;
 }
 

--- a/packages/frontend/src/features/apps/builder/VersionHistoryPanel.module.css
+++ b/packages/frontend/src/features/apps/builder/VersionHistoryPanel.module.css
@@ -19,10 +19,8 @@
 }
 
 .title {
-    font-size: 11px;
+    font-size: 12px;
     font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
     color: var(--mantine-color-ldGray-6);
 }
 

--- a/packages/frontend/src/features/apps/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/apps/components/ChartTypeDetailModal.tsx
@@ -97,13 +97,7 @@ const ChartTypeDetailModal: FC<Props> = ({
                 <SimpleGrid cols={2} className={classes.metaPanel}>
                     {builtBy !== null && (
                         <Box>
-                            <Text
-                                fz={11}
-                                fw={600}
-                                c="ldGray.6"
-                                tt="uppercase"
-                                lts="0.06em"
-                            >
+                            <Text fz={12} fw={600} c="ldGray.6">
                                 Built by
                             </Text>
                             <Text fz="sm" fw={500} c="ldGray.8">
@@ -112,13 +106,7 @@ const ChartTypeDetailModal: FC<Props> = ({
                         </Box>
                     )}
                     <Box>
-                        <Text
-                            fz={11}
-                            fw={600}
-                            c="ldGray.6"
-                            tt="uppercase"
-                            lts="0.06em"
-                        >
+                        <Text fz={12} fw={600} c="ldGray.6">
                             Last updated
                         </Text>
                         <Text fz="sm" fw={500} c="ldGray.8">
@@ -126,13 +114,7 @@ const ChartTypeDetailModal: FC<Props> = ({
                         </Text>
                     </Box>
                     <Box>
-                        <Text
-                            fz={11}
-                            fw={600}
-                            c="ldGray.6"
-                            tt="uppercase"
-                            lts="0.06em"
-                        >
+                        <Text fz={12} fw={600} c="ldGray.6">
                             Inputs
                         </Text>
                         <Text fz="sm" fw={500} c="ldGray.8">
@@ -144,13 +126,7 @@ const ChartTypeDetailModal: FC<Props> = ({
                         </Text>
                     </Box>
                     <Box>
-                        <Text
-                            fz={11}
-                            fw={600}
-                            c="ldGray.6"
-                            tt="uppercase"
-                            lts="0.06em"
-                        >
+                        <Text fz={12} fw={600} c="ldGray.6">
                             Version
                         </Text>
                         <Text fz="sm" fw={500} c="ldGray.8">


### PR DESCRIPTION
The version history title, the generated-options chip and the chart type detail modal's four meta labels all ran through the same 11px uppercase-with-tracking recipe, which shouts in a surface that is otherwise sentence case.

https://linear.app/lightdash/issue/GLITCH-668