### PR TITLE
fix(data-apps): lock the composer while the first version builds

### DIFF
--- a/packages/frontend/src/features/apps/builder/BuilderPromptBar.test.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptBar.test.tsx
@@ -82,6 +82,7 @@ describe('BuilderPromptBar', () => {
                 projectUuid="p1"
                 composerAppUuid="draft-1"
                 hasVersions={false}
+                isBuildingFirstVersion={false}
                 build={buildState(send)}
                 onCancelBuild={null}
                 modelSelection={modelSelection('haiku')}
@@ -107,6 +108,7 @@ describe('BuilderPromptBar', () => {
                 projectUuid="p1"
                 composerAppUuid="draft-1"
                 hasVersions
+                isBuildingFirstVersion={false}
                 build={buildState(vi.fn())}
                 onCancelBuild={null}
                 modelSelection={modelSelection('opus')}

--- a/packages/frontend/src/features/apps/builder/BuilderPromptBar.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptBar.tsx
@@ -28,6 +28,8 @@ type Props = {
     /** The viz, or the pre-claimed draft uuid while nothing exists yet. */
     composerAppUuid: string;
     hasVersions: boolean;
+    /** No ready version to revise yet, and one is on its way. */
+    isBuildingFirstVersion: boolean;
     build: DataAppVizBuildState;
     onCancelBuild: (() => void) | null;
     modelSelection: DataAppModelSelection;
@@ -44,6 +46,7 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
             projectUuid,
             composerAppUuid,
             hasVersions,
+            isBuildingFirstVersion,
             build,
             onCancelBuild,
             modelSelection,
@@ -106,10 +109,14 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                     ref={composerRef}
                     variant="inline"
                     placeholder={
-                        hasVersions
-                            ? 'Ask for a change…'
-                            : 'Describe a new chart type…'
+                        isBuildingFirstVersion
+                            ? 'Building your chart type…'
+                            : hasVersions
+                              ? 'Ask for a change…'
+                              : 'Describe a new chart type…'
                     }
+                    // Revisions stay editable so the next prompt can be drafted.
+                    disabled={isBuildingFirstVersion}
                     submitDisabled={!canSend}
                     onEmptyChange={setIsEmpty}
                     onSubmit={handleSubmit}

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -60,9 +60,13 @@ vi.mock('../features/apps/components/AppPreview', () => ({
     ),
 }));
 vi.mock('../components/common/PromptComposer/PromptComposer', () => ({
-    default: ({ placeholder }: { placeholder: string }) => (
-        <input placeholder={placeholder} />
-    ),
+    default: ({
+        placeholder,
+        disabled,
+    }: {
+        placeholder: string;
+        disabled?: boolean;
+    }) => <input placeholder={placeholder} disabled={disabled} />,
 }));
 vi.mock('../features/apps/hooks/useVizComposerAttachments', () => ({
     useVizComposerAttachments: () => ({
@@ -300,7 +304,7 @@ describe('ChartTypeBuilder', () => {
         // The edit route re-renders with the uuid param; its useGetApp stub
         // has no data, so the header stays bare.
         expect(
-            screen.getByPlaceholderText('Describe a new chart type…'),
+            screen.getByPlaceholderText('Building your chart type…'),
         ).toBeInTheDocument();
         // First build: the skeleton state echoes what was asked for.
         expect(
@@ -335,6 +339,30 @@ describe('ChartTypeBuilder', () => {
         expect(screen.queryByText('Building your chart type…')).toBeNull();
         // A rebuild echoes its prompt too, not just the first build.
         expect(screen.getByText('“make the bars teal”')).toBeInTheDocument();
+    });
+
+    it('closes the composer while the first version builds', () => {
+        // The in-progress v1 is already in history; "has versions" is not the signal.
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub([appVersion({ version: 1, status: 'building' })], null),
+        );
+        vi.mocked(useDataAppVizBuild).mockReturnValue(
+            buildStub({
+                isBuilding: true,
+                appUuid: '1e9a3b2c-0000-4000-8000-000000000001',
+                claimedVersion: 1,
+                pendingPrompt: 'give me a chart type',
+                startedAt: new Date('2026-05-15T10:00:00Z'),
+            }),
+        );
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        expect(screen.queryByPlaceholderText('Ask for a change…')).toBeNull();
+        expect(
+            screen.getByPlaceholderText('Building your chart type…'),
+        ).toBeDisabled();
     });
 
     it('renders the current version and lists its history on demand', () => {
@@ -524,8 +552,7 @@ describe('ChartTypeBuilder', () => {
 
         expect(screen.getByText('The build failed')).toBeInTheDocument();
         expect(screen.getByText('Sandbox crashed')).toBeInTheDocument();
-        expect(
-            screen.getByPlaceholderText('Ask for a change…'),
-        ).toBeInTheDocument();
+        // Nothing is running any more, so the retry has to be typeable.
+        expect(screen.getByPlaceholderText('Ask for a change…')).toBeEnabled();
     });
 });

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -369,6 +369,10 @@ const ChartTypeBuilder: FC = () => {
                                 activeVizUuid ?? build.draftAppUuid
                             }
                             hasVersions={history.versions.length > 0}
+                            isBuildingFirstVersion={
+                                isBuilding &&
+                                history.latestReadyVersion === null
+                            }
                             build={build}
                             onCancelBuild={onCancelBuild}
                             modelSelection={modelSelection}


### PR DESCRIPTION
The in-progress v1 lands in version history as soon as the first build starts, so `hasVersions` went true immediately and the composer flipped to "Ask for a change…" while staying editable — inviting a change to a chart that did not exist yet.

Gated on a *ready* version instead: while the first one builds the composer is read-only and says "Building your chart type…". Revisions stay editable on purpose, so the next prompt can still be drafted while one runs, and a failed first build still offers "Ask for a change…" to retry.

https://linear.app/lightdash/issue/GLITCH-669