### PR TITLE
fix(data-apps): stop the chart type builder looping on a running build

### DIFF
--- a/packages/frontend/src/features/apps/hooks/useElapsedClock.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useElapsedClock.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useElapsedClock } from './useElapsedClock';
+
+const START = '2026-01-01T00:00:00.000Z';
+
+describe('useElapsedClock', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(START));
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('counts up from the start', () => {
+        const { result } = renderHook(() => useElapsedClock(new Date(START)));
+
+        expect(result.current).toBe('0:00');
+        act(() => {
+            vi.advanceTimersByTime(12_000);
+        });
+        expect(result.current).toBe('0:12');
+    });
+
+    it('reports nothing when nothing is running', () => {
+        const { result } = renderHook(() => useElapsedClock(null));
+
+        expect(result.current).toBeNull();
+    });
+
+    // A caller that derives the start from server data builds a fresh Date on
+    // every render. Keying the timer on the object identity restarted it each
+    // time, and the state it set re-rendered the caller — an endless loop.
+    it('keeps one timer when the caller passes an equal but new Date', () => {
+        const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+        const { rerender, result } = renderHook(
+            ({ at }: { at: Date }) => useElapsedClock(at),
+            { initialProps: { at: new Date(START) } },
+        );
+
+        expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+        rerender({ at: new Date(START) });
+        rerender({ at: new Date(START) });
+
+        expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+        expect(result.current).toBe('0:00');
+    });
+
+    it('restarts when the build genuinely restarts', () => {
+        const { rerender, result } = renderHook(
+            ({ at }: { at: Date }) => useElapsedClock(at),
+            { initialProps: { at: new Date(START) } },
+        );
+
+        act(() => {
+            vi.advanceTimersByTime(30_000);
+        });
+        expect(result.current).toBe('0:30');
+
+        rerender({ at: new Date('2026-01-01T00:00:30.000Z') });
+        expect(result.current).toBe('0:00');
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useElapsedClock.ts
+++ b/packages/frontend/src/features/apps/hooks/useElapsedClock.ts
@@ -8,15 +8,18 @@ import { formatElapsedClock } from '../utils/formatElapsedClock';
  * static "Building…" says nothing about whether it moved.
  */
 export const useElapsedClock = (startedAt: Date | null): string | null => {
+    // Keyed on the instant, not the object: callers derive the start from
+    // server data and hand over a fresh Date every render.
+    const startedAtMs = startedAt?.getTime() ?? null;
     const [now, setNow] = useState(() => Date.now());
 
     useEffect(() => {
-        if (startedAt === null) return;
+        if (startedAtMs === null) return;
         setNow(Date.now());
         const id = setInterval(() => setNow(Date.now()), 1000);
         return () => clearInterval(id);
-    }, [startedAt]);
+    }, [startedAtMs]);
 
-    if (startedAt === null) return null;
-    return formatElapsedClock(now - startedAt.getTime());
+    if (startedAtMs === null) return null;
+    return formatElapsedClock(now - startedAtMs);
 };


### PR DESCRIPTION
Opening the chart type builder while a build is running dropped the page to the "Something went wrong" error boundary with *Maximum update depth exceeded*.

The elapsed clock keyed its `setInterval` effect on the `Date` object it was handed. When the build was not started on this page, the builder derives that date from the in-progress version, so a fresh `Date` arrived on every render — the effect re-ran, set state, re-rendered, and looped until React gave up.

Keyed on the instant (`getTime()`) instead, so an equal-but-new `Date` is a no-op.

Pre-existing on `main`, reproduced on 1.144.3. Standalone against `main` — it does not depend on any other open PR, and touches only the hook and its new test.

Verified in the app: reloading mid-build now renders the chart with a ticking "Building… 0:16" pill. The regression test asserts the timer is created once across renders that pass a new equal `Date`; it fails 3x before the fix.

This should also explain the one-off crash seen right after cancelling a build — cancel clears the locally-tracked start while history still reports in progress, which falls to the same derived-`Date` path. That one was not reproducible, so it is reasoning rather than a verified repro.

https://linear.app/lightdash/issue/GLITCH-670