### PR TITLE
fix(data-apps): configure the version the builder is previewing

### DIFF
--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -162,6 +162,7 @@ export class AppGenerateController extends BaseController {
 
     /**
      * @summary Get a data app visualization
+     * @param version Answer with this version's schema instead of the latest ready one
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -171,6 +172,7 @@ export class AppGenerateController extends BaseController {
         @Request() req: express.Request,
         @Path() projectUuid: string,
         @Path() dataAppVizUuid: string,
+        @Query() version?: number,
     ): Promise<ApiGetDataAppVizResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -179,6 +181,7 @@ export class AppGenerateController extends BaseController {
                 toSessionUser(req.account),
                 projectUuid,
                 dataAppVizUuid,
+                version,
             );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -337,6 +337,114 @@ describe('AppGenerateService data app vizs', () => {
         ).rejects.toThrow(NotFoundError);
     });
 
+    describe('reading a schema at a version', () => {
+        // The options a version declares live on that version's row, so an
+        // older one describes a different chart than the latest ready.
+        const olderSchema: DataAppVizSchema = {
+            fields: [
+                {
+                    name: 'category',
+                    label: 'Category',
+                    type: 'dimension',
+                    required: true,
+                },
+            ],
+            configOptions: [
+                {
+                    name: 'showLegend',
+                    label: 'Show legend',
+                    type: 'boolean',
+                    default: true,
+                },
+            ],
+            colorPalette: null,
+        };
+
+        const olderVersionRow = (overrides: Record<string, unknown> = {}) => ({
+            app_version_id: 'app-version-2',
+            app_id: 'data-app-viz-1',
+            version: 2,
+            prompt: 'add a legend toggle',
+            status: 'ready',
+            error: null,
+            status_message: null,
+            status_history: [],
+            status_updated_at: new Date('2026-06-30'),
+            resources: null,
+            dependencies: null,
+            viz_schema: olderSchema,
+            generation_usage: null,
+            created_at: new Date('2026-06-30'),
+            created_by_user_uuid: 'user-1',
+            ...overrides,
+        });
+
+        it('answers with the asked-for version schema, not the latest ready one', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getVersion: vi.fn().mockResolvedValue(olderVersionRow()),
+            };
+            const service = buildService(appModel);
+
+            const result = await service.getDataAppVisualization(
+                USER,
+                'project-1',
+                'data-app-viz-1',
+                2,
+            );
+
+            expect(appModel.getVersion).toHaveBeenCalledWith(
+                'data-app-viz-1',
+                2,
+            );
+            expect(result.schema).toEqual(olderSchema);
+        });
+
+        it('answers with the latest ready schema when no version is asked for', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getVersion: vi.fn(),
+            };
+            const service = buildService(appModel);
+
+            const result = await service.getDataAppVisualization(
+                USER,
+                'project-1',
+                'data-app-viz-1',
+            );
+
+            expect(appModel.getVersion).not.toHaveBeenCalled();
+            expect(result.schema).toEqual(vizSchema);
+        });
+
+        it('404s a version that never became renderable', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getVersion: vi
+                    .fn()
+                    .mockResolvedValue(
+                        olderVersionRow({ status: 'error', viz_schema: null }),
+                    ),
+            };
+            const service = buildService(appModel);
+
+            await expect(
+                service.getDataAppVisualization(
+                    USER,
+                    'project-1',
+                    'data-app-viz-1',
+                    2,
+                ),
+            ).rejects.toThrow(NotFoundError);
+        });
+    });
+
     describe('viz-only render metadata', () => {
         const makeVersion = (overrides: Record<string, unknown> = {}) => ({
             app_version_id: 'app-version-1',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7748,10 +7748,17 @@ export class AppGenerateService extends BaseService {
         return { data: data.map(AppGenerateService.mapDataAppViz), pagination };
     }
 
+    /**
+     * `version` answers with that version's own schema instead of the latest
+     * ready one, so a builder previewing an older version can configure the
+     * options that version declares. It resolves through the same guard as the
+     * preview token: whatever can be previewed can be configured.
+     */
     async getDataAppVisualization(
         user: SessionUser,
         projectUuid: string,
         dataAppVizUuid: string,
+        version?: number,
     ): Promise<DataAppViz> {
         await this.assertDataAppsEnabled(user);
         const dataAppViz = await this.appModel.findVisualizationApp(
@@ -7769,7 +7776,18 @@ export class AppGenerateService extends BaseService {
             organization_uuid: dataAppViz.organization_uuid,
             created_by_user_uuid: dataAppViz.created_by_user_uuid,
         });
-        return AppGenerateService.mapDataAppViz(dataAppViz);
+        if (version === undefined) {
+            return AppGenerateService.mapDataAppViz(dataAppViz);
+        }
+        const appVersion = await resolveRenderableDataAppVizVersion(
+            this.appModel,
+            dataAppViz.app_id,
+            version,
+        );
+        return AppGenerateService.mapDataAppViz({
+            ...dataAppViz,
+            viz_schema: appVersion.viz_schema,
+        });
     }
 
     /**

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -38,9 +38,12 @@ export const ConfigTabs: FC = memo(() => {
         ? visualizationConfig.chartConfig.dataAppVizUuid
         : '';
 
+    // A chart renders the viz's latest ready version, so its options come from
+    // that version's declaration.
     const { data: dataAppViz } = useDataAppVisualization(
         projectUuid,
         dataAppVizUuid || undefined,
+        null,
     );
 
     const configOptions = useMemo(

--- a/packages/frontend/src/features/apps/builder/BuilderCanvas.module.css
+++ b/packages/frontend/src/features/apps/builder/BuilderCanvas.module.css
@@ -47,9 +47,17 @@
     box-shadow: var(--mantine-shadow-subtle);
     /* Not clipped: the configure column's chip rides the top border. Each
        column rounds its own corners instead. */
+    transition: opacity 300ms;
+
+    /* Chart and options are one version, so a rebuild takes both out of play —
+       dimming half of it would say one side is still live. The card is marked
+       `inert` alongside this, so it cannot be reached by pointer or keyboard;
+       the cancel link sits in the overlay above and stays clickable. */
+    &[data-dimmed='true'] {
+        opacity: 0.35;
+    }
 }
 
-/* Only the chart dims while rebuilding; the panel stays readable. */
 .preview {
     flex: 1;
     min-width: 0;
@@ -57,11 +65,6 @@
        column and alone, and clipped so the iframe follows the curve. */
     border-radius: var(--mantine-radius-md);
     overflow: hidden;
-    transition: opacity 300ms;
-
-    &[data-dimmed='true'] {
-        opacity: 0.35;
-    }
 }
 
 .overlay {

--- a/packages/frontend/src/features/apps/builder/BuilderCanvas.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderCanvas.tsx
@@ -81,8 +81,8 @@ const CancelBuildLink: FC<{ onCancel: () => void }> = ({ onCancel }) => (
 /**
  * The center of the builder: empty, building, failure, and rendered states.
  * A first build gets a full skeleton; a rebuild keeps the previous version
- * dimmed underneath a pill, with the configuration column beside it staying
- * legible throughout.
+ * legible underneath a pill — chart and options together, dimmed and inert,
+ * since both belong to the version being replaced.
  */
 const BuilderCanvas: FC<Props> = ({
     projectUuid,
@@ -103,9 +103,13 @@ const BuilderCanvas: FC<Props> = ({
     return (
         <Box className={classes.canvas}>
             {hasPreview ? (
-                <Box className={classes.card}>
+                <Box
+                    className={classes.card}
+                    data-dimmed={isBuilding}
+                    inert={isBuilding}
+                >
                     {configurePanel}
-                    <Box className={classes.preview} data-dimmed={isBuilding}>
+                    <Box className={classes.preview}>
                         <AppPreview
                             projectUuid={projectUuid}
                             appUuid={appUuid}

--- a/packages/frontend/src/features/apps/builder/ConfigurePanel.module.css
+++ b/packages/frontend/src/features/apps/builder/ConfigurePanel.module.css
@@ -10,6 +10,12 @@
     border-radius: var(--mantine-radius-md) 0 0 var(--mantine-radius-md);
 }
 
+/* Mid version switch these options still describe the version being left, so
+   they stay readable but go inert until the previewed one's arrive. */
+.panel[data-stale='true'] {
+    opacity: 0.5;
+}
+
 /* A soft chip is the whole treatment: the options below it came from the
    generated declaration, not from Lightdash chart config. It rides the card's
    top border, half in and half out. */

--- a/packages/frontend/src/features/apps/builder/ConfigurePanel.test.tsx
+++ b/packages/frontend/src/features/apps/builder/ConfigurePanel.test.tsx
@@ -33,6 +33,7 @@ const renderPanel = (
             onOptionChange={vi.fn()}
             colorPaletteUuid={null}
             onPaletteChange={vi.fn()}
+            isStale={false}
             {...props}
         />,
     );

--- a/packages/frontend/src/features/apps/builder/ConfigurePanel.tsx
+++ b/packages/frontend/src/features/apps/builder/ConfigurePanel.tsx
@@ -21,6 +21,9 @@ type Props = {
     /** Preview-only; a chart using the viz owns the palette the normal way. */
     colorPaletteUuid: string | null;
     onPaletteChange: (colorPaletteUuid: string | null) => void;
+    /** The schema on screen belongs to a version being navigated away from;
+     *  held legible but inert until the one being previewed arrives. */
+    isStale: boolean;
 };
 
 /**
@@ -35,6 +38,7 @@ const ConfigurePanel: FC<Props> = ({
     onOptionChange,
     colorPaletteUuid,
     onPaletteChange,
+    isStale,
 }) => {
     const { data: palettes = [] } = useColorPalettes();
 
@@ -57,7 +61,7 @@ const ConfigurePanel: FC<Props> = ({
         : (optionGroups[0]?.id ?? null);
 
     return (
-        <Box className={classes.panel}>
+        <Box className={classes.panel} data-stale={isStale} inert={isStale}>
             {/* The options are the generated contract, not Lightdash chart
                 config, and the chip says so. */}
             <Text className={classes.generatedChip}>Generated options</Text>

--- a/packages/frontend/src/features/apps/hooks/useDataAppVisualization.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVisualization.ts
@@ -5,21 +5,32 @@ import { lightdashApi } from '../../../api';
 const getDataAppVisualization = async (
     projectUuid: string,
     dataAppVizUuid: string,
+    version: number | null,
 ): Promise<DataAppViz> =>
     lightdashApi<DataAppViz>({
         method: 'GET',
-        url: `/ee/projects/${projectUuid}/apps/visualizations/${dataAppVizUuid}`,
+        url: `/ee/projects/${projectUuid}/apps/visualizations/${dataAppVizUuid}${
+            version === null ? '' : `?version=${version}`
+        }`,
         body: undefined,
     });
 
-// Fetches a single saved data app viz (incl. its field schema) by id — used by
-// the config panel to render one FieldSelect per declared field.
+// Fetches a single saved data app viz by id, at one version. A schema belongs to
+// the version that generated it, so a caller showing a particular version names
+// it and gets that version's fields and options. `null` asks for the latest
+// ready version — the one charts render, and the one the builder shows until it
+// is pinned to an older one.
 export const useDataAppVisualization = (
     projectUuid: string | undefined,
     dataAppVizUuid: string | undefined,
+    version: number | null,
 ) =>
     useQuery<DataAppViz, ApiError>({
-        queryKey: ['data-app-viz', projectUuid, dataAppVizUuid],
-        queryFn: () => getDataAppVisualization(projectUuid!, dataAppVizUuid!),
+        queryKey: ['data-app-viz', projectUuid, dataAppVizUuid, version],
+        queryFn: () =>
+            getDataAppVisualization(projectUuid!, dataAppVizUuid!, version),
         enabled: !!projectUuid && !!dataAppVizUuid,
+        // Switching version keeps the panel on the previous schema until the new
+        // one lands, so the configuration column doesn't collapse mid-swap.
+        keepPreviousData: true,
     });

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -278,8 +278,11 @@ describe('ChartTypeBuilder', () => {
             '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
         );
 
-        // The chart dims under the building pill; the options stay usable.
+        // Chart and options are one version: both stay legible under the
+        // building pill, and both go out of play until the next one lands.
         expect(screen.getByLabelText('Show grid')).toBeInTheDocument();
+        const card = screen.getByText('Generated options').closest('[inert]');
+        expect(card).toHaveAttribute('data-dimmed', 'true');
         expect(screen.getByText(/Building…/)).toBeInTheDocument();
     });
 
@@ -382,6 +385,91 @@ describe('ChartTypeBuilder', () => {
         expect(screen.getByTestId('app-preview')).toHaveTextContent(
             'preview-v2',
         );
+    });
+
+    // The schema belongs to the version that generated it, so a v1 preview must
+    // not be configured with v2's options.
+    const setSchemaPerVersion = () =>
+        vi.mocked(useDataAppVisualization).mockImplementation(
+            (_projectUuid, _dataAppVizUuid, version) =>
+                ({
+                    data: {
+                        schema: {
+                            fields: [],
+                            configOptions: [
+                                version === 1
+                                    ? {
+                                          name: 'grid',
+                                          label: 'Show grid',
+                                          type: 'boolean',
+                                          default: true,
+                                      }
+                                    : {
+                                          name: 'markers',
+                                          label: 'Show markers',
+                                          type: 'boolean',
+                                          default: true,
+                                      },
+                            ],
+                            colorPalette: null,
+                        },
+                    },
+                }) as unknown as ReturnType<typeof useDataAppVisualization>,
+        );
+
+    it('configures the version being previewed, not the current one', () => {
+        setApp(appMeta());
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub(
+                [appVersion({ version: 2 }), appVersion({ version: 1 })],
+                2,
+            ),
+        );
+        setSchemaPerVersion();
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        expect(screen.getByLabelText('Show markers')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('History'));
+        fireEvent.click(screen.getByLabelText('View v1'));
+
+        // The uuid comes from the loaded app row, the version from the pin.
+        expect(vi.mocked(useDataAppVisualization)).toHaveBeenLastCalledWith(
+            'p1',
+            'viz-1',
+            1,
+        );
+        expect(screen.getByLabelText('Show grid')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Show markers')).toBeNull();
+
+        fireEvent.click(screen.getByLabelText('Close history'));
+        expect(screen.getByLabelText('Show markers')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Show grid')).toBeNull();
+    });
+
+    it('keeps a value set on the current version across a visit to an older one', () => {
+        setApp(appMeta());
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub(
+                [appVersion({ version: 2 }), appVersion({ version: 1 })],
+                2,
+            ),
+        );
+        setSchemaPerVersion();
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        fireEvent.click(screen.getByLabelText('Show markers'));
+        expect(screen.getByLabelText('Show markers')).not.toBeChecked();
+
+        fireEvent.click(screen.getByText('History'));
+        fireEvent.click(screen.getByLabelText('View v1'));
+        fireEvent.click(screen.getByLabelText('Close history'));
+
+        expect(screen.getByLabelText('Show markers')).not.toBeChecked();
     });
 
     it('offers no history toggle before the first version exists', () => {

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -76,10 +76,6 @@ const ChartTypeBuilder: FC = () => {
 
     const historyUuid = activeVizUuid ?? build.appUuid;
     const history = useAppVersionHistory(projectUuid ?? '', historyUuid);
-    const { data: dataAppViz } = useDataAppVisualization(
-        projectUuid,
-        activeVizUuid,
-    );
 
     // Covers builds sent here and builds found already running in history.
     const historyLatestInProgress =
@@ -172,6 +168,11 @@ const ChartTypeBuilder: FC = () => {
     }, [pin, activeVizUuid, history.latestReadyVersion, history.versions]);
 
     const previewVersion = effectiveViewedVersion ?? history.latestReadyVersion;
+
+    // The schema follows the preview: the options beside a version are the ones
+    // that version declares, and the sample data is built from its fields.
+    const { data: dataAppViz, isFetching: isFetchingSchema } =
+        useDataAppVisualization(projectUuid, activeVizUuid, previewVersion);
 
     const colorPalette = useResolvedColorPalette(projectUuid, colorPaletteUuid);
     // The sample-data preview context, rebuilt on any option or palette edit.
@@ -320,6 +321,7 @@ const ChartTypeBuilder: FC = () => {
             onOptionChange={handleOptionChange}
             colorPaletteUuid={colorPaletteUuid}
             onPaletteChange={setColorPaletteUuid}
+            isStale={isFetchingSchema}
         />
     ) : null;
 


### PR DESCRIPTION
In the chart type builder, selecting an older version from the version history panel swapped the preview but left the Configure panel showing the latest version's options. If a version added, removed or renamed an option, the controls next to the preview belonged to a different version: editing them either did nothing visible, or targeted an option the previewed version never declared.

## Why

A visualization's schema is stored per version (`app_versions.viz_schema`), but the builder only ever asked for the latest ready one — `GET .../apps/visualizations/{uuid}` resolves through the latest-ready join, and the page fed that single schema to both the Configure panel and the sample preview context while the iframe rendered the pinned version. The preview followed the pin and the schema did not. The fabricated sample data was skewed the same way, since it is built from `schema.fields`.

## What changed

- The endpoint takes an optional `version` and re-resolves the schema through `resolveRenderableDataAppVizVersion` — the same guard behind the preview token, so anything you can preview you can configure. Omitting it keeps the latest-ready behaviour for existing callers.
- `useDataAppVisualization` takes the version and keys on it. `null` means "the latest ready version", which is what the explorer's chart config wants; the builder passes the version it is previewing.
- Option values needed no pruning: the shared resolver already drops values a declaration no longer covers and falls back to the declared default. Keeping the raw edits in page state means a value set on the current version survives a round trip through an older one that doesn't declare it.
- While a build runs, the chart and its options now dim and go `inert` together rather than only the chart — both belong to the version being replaced, and neither should accept edits meant for the version that is about to land.

## Testing

- Backend: a version returns that version's schema, no version returns latest-ready, a version that never became renderable is a 404.
- Frontend: the panel follows the pin and returns to the current version's options when history closes; a value set on the current version survives a visit to an older one; the card dims and goes inert during a rebuild.
- Verified in the app on a local chart type with three distinct option sets across its versions: pinning an older version dropped the newer version's tab and control, editing an option there updated that version's preview, and closing history restored the current options with the previously set value intact.

Closes: GLITCH-671
