### PR TITLE
fix(ai): allow repaired Deep Research report events

### DIFF
--- a/packages/backend/src/ee/database/migrations/20260813083849_add_deep_research_report_adjusted_event_type.ts
+++ b/packages/backend/src/ee/database/migrations/20260813083849_add_deep_research_report_adjusted_event_type.ts
@@ -1,0 +1,38 @@
+import type { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Expands the accepted Deep Research event types without removing existing values',
+} as const;
+
+const EventsTableName = 'ai_deep_research_events';
+const EventTypeConstraintName = 'ai_deep_research_events_event_type_check';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+    await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+        EventsTableName,
+        EventTypeConstraintName,
+    ]);
+    await knex.raw(
+        `ALTER TABLE ?? ADD CONSTRAINT ?? CHECK (
+            event_type IN ('status_changed', 'cancellation_requested', 'progress', 'report_adjusted')
+        )`,
+        [EventsTableName, EventTypeConstraintName],
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+    await knex(EventsTableName).where('event_type', 'report_adjusted').delete();
+    await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+        EventsTableName,
+        EventTypeConstraintName,
+    ]);
+    await knex.raw(
+        `ALTER TABLE ?? ADD CONSTRAINT ?? CHECK (
+            event_type IN ('status_changed', 'cancellation_requested', 'progress')
+        )`,
+        [EventsTableName, EventTypeConstraintName],
+    );
+}


### PR DESCRIPTION
Closes: N/A

## Summary

Deep Research runs no longer fail after successfully repairing a report. Upgraded databases now accept the `report_adjusted` event emitted when the repaired report is saved.

## Root cause

The application added `report_adjusted` to the event type union, but existing databases retained the original three-value PostgreSQL check constraint. Saving the event therefore raised a check-constraint violation after the research queries had completed.

```text
Before: repaired report -> report_adjusted -> constraint violation -> failed run
After:  repaired report -> report_adjusted -> event saved          -> completed run
```

## Fix

Adds a conventional transactional migration that drops and recreates the named check constraint with the four supported event types. This follows the existing check-constraint migration pattern and keeps the change intentionally small.

Rollback deletes `report_adjusted` event records before restoring the original three-value constraint. This prioritises a reliable application rollback over retaining events introduced by the newer code.

## Test plan

- [x] Reproduced the legacy constraint rejecting `report_adjusted` in local PostgreSQL.
- [x] Ran the simplified migration through the `ld0` backend migration runner.
- [x] Verified PostgreSQL records a validated four-value constraint and accepts `report_adjusted`.
- [x] Inserted a marked `report_adjusted` event and ran `rollback-last`.
- [x] Verified rollback deletes that event and restores the validated three-value constraint.
- [x] Migrated forward again successfully.
- [x] Enforced SQL migration safety lint: 0 errors, 0 warnings.
- [x] Changed-file oxlint, oxfmt, and `git diff --check`.
- [ ] Backend typecheck currently stops on the unchanged Bedrock `reasoningConfig.type = 'adaptive'` provider-type mismatch.