### PR TITLE
fix: read migration transaction config from module instead of regex

### DIFF
--- a/packages/backend/src/scripts/migrate/preflight.test.ts
+++ b/packages/backend/src/scripts/migrate/preflight.test.ts
@@ -2,6 +2,7 @@ import { type Knex } from 'knex';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import 'tsx/cjs';
 import { type KnexMigrationState } from './migrationState';
 import {
     getPendingMigrationInventory,
@@ -353,6 +354,42 @@ describe('release-safety artifact handling', () => {
 });
 
 describe('pending migration inventory', () => {
+    const loadMigrationTransaction = async ({
+        source,
+        extension = '.ts',
+        relativeDirectory = false,
+    }: {
+        source: string;
+        extension?: '.js' | '.ts';
+        relativeDirectory?: boolean;
+    }): Promise<boolean | null> => {
+        const directory = await mkdtemp(
+            path.join(tmpdir(), 'migration-transaction-'),
+        );
+        const migrationName = `20260813120000_test_transaction${extension}`;
+
+        try {
+            await writeFile(
+                path.join(directory, migrationName),
+                source,
+                'utf8',
+            );
+            const result = await getPendingMigrationInventory({
+                migrationState: state({ pending: [migrationName] }),
+                migrationConfig: {
+                    directory: relativeDirectory
+                        ? path.relative(process.cwd(), directory)
+                        : directory,
+                    loadExtensions: [extension],
+                },
+                artifact: null,
+            });
+            return result[0]?.transaction ?? null;
+        } finally {
+            await rm(directory, { recursive: true });
+        }
+    };
+
     test('matches artifact .ts names to production .js names and reports transaction false', async () => {
         const getTransaction = vi.fn(
             async (_config: Knex.MigratorConfig, _name: string) => false,
@@ -395,6 +432,51 @@ describe('pending migration inventory', () => {
                 metadataAvailable: false,
             },
         ]);
+    });
+
+    test.each<[string, string, boolean]>([
+        [
+            'as const',
+            'export const config = { transaction: false } as const;',
+            false,
+        ],
+        [
+            'spread configuration',
+            'const base = { transaction: false } as const; export const config = { ...base };',
+            false,
+        ],
+        [
+            'nested configuration',
+            'export const config = { metadata: { transaction: true }, transaction: false } as const;',
+            false,
+        ],
+        [
+            'commented-out transaction flag',
+            'export const config = { /* transaction: false */ };',
+            true,
+        ],
+    ])('loads %s from the migration module', async (_, source, transaction) => {
+        await expect(loadMigrationTransaction({ source })).resolves.toBe(
+            transaction,
+        );
+    });
+
+    test('reports an unknown transaction when the migration module fails to load', async () => {
+        await expect(
+            loadMigrationTransaction({
+                source: "throw new Error('load failed');",
+            }),
+        ).resolves.toBeNull();
+    });
+
+    test('loads transaction configuration from a compiled CommonJS migration', async () => {
+        await expect(
+            loadMigrationTransaction({
+                source: 'exports.config = { transaction: false };',
+                extension: '.js',
+                relativeDirectory: true,
+            }),
+        ).resolves.toBe(false);
     });
 });
 

--- a/packages/backend/src/scripts/migrate/preflight.ts
+++ b/packages/backend/src/scripts/migrate/preflight.ts
@@ -1,5 +1,6 @@
 import { type Knex } from 'knex';
 import { promises as fs } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { type KnexMigrationState } from './migrationState';
 
@@ -388,6 +389,8 @@ const migrationDirectories = (config: Knex.MigratorConfig): string[] => {
         : [...config.directory];
 };
 
+const requireMigration = createRequire(__filename);
+
 const readMigrationTransaction = async (
     config: Knex.MigratorConfig,
     migrationName: string,
@@ -395,19 +398,18 @@ const readMigrationTransaction = async (
     if (path.basename(migrationName) !== migrationName) {
         return null;
     }
-    const reads = await Promise.all(
+    const candidates = await Promise.all(
         migrationDirectories(config).map(async (directory) => {
+            const migrationPath = path.join(
+                path.resolve(process.cwd(), directory),
+                migrationName,
+            );
             try {
-                return {
-                    source: await fs.readFile(
-                        path.join(directory, migrationName),
-                        'utf8',
-                    ),
-                    error: null,
-                };
+                await fs.access(migrationPath);
+                return { migrationPath, error: null };
             } catch (error) {
                 return {
-                    source: null,
+                    migrationPath: null,
                     error:
                         isRecord(error) && error.code === 'ENOENT'
                             ? null
@@ -416,15 +418,23 @@ const readMigrationTransaction = async (
             }
         }),
     );
-    if (reads.some((read) => read.error !== null)) {
+    if (candidates.some((candidate) => candidate.error !== null)) {
         return null;
     }
-    const source = reads.find((read) => read.source !== null)?.source ?? null;
-    return source === null
-        ? null
-        : !/(?:export\s+const\s+config(?:\s*:[^=]+)?|exports\.config)\s*=\s*\{[^}]*\btransaction\s*:\s*false\b[^}]*\}/s.test(
-              source,
-          );
+    const migrationPath = candidates.find(
+        (candidate) => candidate.migrationPath !== null,
+    )?.migrationPath;
+    if (migrationPath === undefined || migrationPath === null) {
+        return null;
+    }
+    try {
+        const migration = requireMigration(migrationPath) as {
+            config?: { transaction?: unknown };
+        };
+        return migration.config?.transaction !== false;
+    } catch {
+        return null;
+    }
 };
 
 export const getPendingMigrationInventory = async ({


### PR DESCRIPTION
## What changed

- Load pending migration modules and read their exported `config.transaction` value directly.
- Resolve migration directories the same way as Knex in development and compiled production builds.
- Return unknown metadata when a migration module cannot be located or loaded.
- Add regression coverage for `as const`, spreads, nested objects, commented-out flags, load failures, and compiled CommonJS migrations.

## Why

The previous source regex could misreport transaction behavior for valid TypeScript shapes and could treat a commented-out flag as active. Reading the runtime export matches the behavior Knex uses when it loads the migration.

## Validation

- Backend typecheck
- Focused preflight tests: 31 passed
- Full backend suite: 6,841 passed; one unrelated timeout passed on immediate isolated rerun (18 passed)
- Touched-path lint and formatting
- DeepSec K3: 0 findings

Linear: SPK-939