### PR TITLE
fix(release): fail safety marker generation errors

### DIFF
--- a/scripts/gen-release-safety-cli.test.ts
+++ b/scripts/gen-release-safety-cli.test.ts
@@ -82,15 +82,70 @@ try {
         requiredStops: ['1.115.0'],
     });
 
-    const degraded = runGenerator([
+    const degradedLastTag = runGenerator([
         '--version',
         '1.115.0',
         '--last-tag',
         'not-a-release-safety-test-ref',
     ]);
-    assert.strictEqual(degraded.status, 0, degraded.stderr);
-    const degradedMarker = markerFrom(degraded.stdout);
-    assert.deepStrictEqual(degradedMarker.migrations, {
+    assert.strictEqual(degradedLastTag.status, 0, degradedLastTag.stderr);
+    assert.match(degradedLastTag.stderr, /cannot resolve migration diff ref/);
+    const degradedLastTagMarker = markerFrom(degradedLastTag.stdout);
+    assert.deepStrictEqual(degradedLastTagMarker.migrations, {
+        present: 'unknown',
+        count: 0,
+        coreCount: 0,
+        eeCount: 0,
+        files: [],
+    });
+
+    const degradedPreviousVersion = runGenerator([
+        '--version',
+        '1.115.0',
+        '--previous-version',
+        'not-a-release-safety-test-ref',
+    ]);
+    assert.strictEqual(
+        degradedPreviousVersion.status,
+        0,
+        degradedPreviousVersion.stderr,
+    );
+    assert.match(
+        degradedPreviousVersion.stderr,
+        /cannot resolve migration diff ref/,
+    );
+    const degradedPreviousVersionMarker = markerFrom(
+        degradedPreviousVersion.stdout,
+    );
+    assert.deepStrictEqual(degradedPreviousVersionMarker.migrations, {
+        present: 'unknown',
+        count: 0,
+        coreCount: 0,
+        eeCount: 0,
+        files: [],
+    });
+
+    const failedMarkerPath = join(directory, 'failed-marker.json');
+    const malformedIndexPath = join(directory, 'malformed-index.json');
+    writeFileSync(malformedIndexPath, '{');
+    const failed = runGenerator(
+        [
+            '--version',
+            '1.115.0',
+            '--out',
+            failedMarkerPath,
+            '--index',
+            malformedIndexPath,
+        ],
+        { RELEASE_SAFETY_MARKER_ENABLED: 'true' },
+    );
+    assert.notStrictEqual(failed.status, 0);
+    assert.match(failed.stderr, /\[release-safety\] FAILED/);
+    const failedMarker = JSON.parse(
+        readFileSync(failedMarkerPath, 'utf8'),
+    ) as Record<string, unknown>;
+    assert.deepStrictEqual(markerFrom(failed.stdout), failedMarker);
+    assert.deepStrictEqual(failedMarker.migrations, {
         present: 'unknown',
         count: 0,
         coreCount: 0,

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -440,6 +440,17 @@ function gitNameStatus(range: string, dirs: readonly string[]): GitChange[] {
     return changes;
 }
 
+function isResolvableGitRef(ref: string): boolean {
+    try {
+        execFileSync('git', ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], {
+            stdio: 'ignore',
+        });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 export function declarationSourcePaths(changes: GitChange[]): string[] {
     return changes
         .filter(
@@ -490,24 +501,33 @@ export async function generateReleaseSafety(
     let declarationPaths: string[] = [];
     if (args.lastTag) {
         const range = `${args.lastTag}..${args.toRef}`;
-        const changes = gitNameStatus(range, MIGRATION_DIRS);
-        declarationPaths = declarationSourcePaths(
-            gitNameStatus(range, DECLARATION_DIRS),
+        const unresolvableRefs = [args.lastTag, args.toRef].filter(
+            (ref) => !isResolvableGitRef(ref),
         );
-        migrations = detectMigrations(changes);
-        migrationPaths = changes
-            .filter(
-                (change) =>
-                    change.status.startsWith('A') &&
-                    MIGRATION_FILENAME_RE.test(path.basename(change.path)),
-            )
-            .map((change) => change.path)
-            .sort();
-        if (migrations.deletedHistorical.length > 0) {
+        if (unresolvableRefs.length > 0) {
             console.warn(
-                `[release-safety] WARNING: historical migrations deleted in ${range}: ` +
-                    migrations.deletedHistorical.join(', '),
+                `[release-safety] WARNING: cannot resolve migration diff ref(s) ${unresolvableRefs.join(', ')}; emitting migrations.present="unknown"`,
             );
+        } else {
+            const changes = gitNameStatus(range, MIGRATION_DIRS);
+            declarationPaths = declarationSourcePaths(
+                gitNameStatus(range, DECLARATION_DIRS),
+            );
+            migrations = detectMigrations(changes);
+            migrationPaths = changes
+                .filter(
+                    (change) =>
+                        change.status.startsWith('A') &&
+                        MIGRATION_FILENAME_RE.test(path.basename(change.path)),
+                )
+                .map((change) => change.path)
+                .sort();
+            if (migrations.deletedHistorical.length > 0) {
+                console.warn(
+                    `[release-safety] WARNING: historical migrations deleted in ${range}: ` +
+                        migrations.deletedHistorical.join(', '),
+                );
+            }
         }
     } else {
         console.warn(
@@ -834,5 +854,6 @@ if (invokedDirectly) {
             }
         }
         console.log(json);
+        process.exitCode = 1;
     });
 }


### PR DESCRIPTION
## What

- preserve the fallback release-safety marker while returning a non-zero exit code for generator failures
- degrade migration detection to `unknown` with a warning when either Git ref cannot be resolved
- cover failure exit status, fallback artifact output, and both unresolved-ref argument paths

## Why

Generator failures previously exited successfully after writing a degraded marker, allowing release and preview jobs to continue without a trustworthy result. Missing Git history is an evidence limitation rather than a generator failure, so unresolved migration refs remain a supported degraded path.

## Checks

- `pnpm typecheck`
- `pnpm test:release-safety`
- `git diff --check`

Linear: SPK-954