### PR TITLE
fix: prevent SSRF in scheduled delivery webhooks

### DIFF
--- a/packages/backend/src/clients/GoogleChat/GoogleChatClient.test.ts
+++ b/packages/backend/src/clients/GoogleChat/GoogleChatClient.test.ts
@@ -1,6 +1,63 @@
 import { PartialFailureType, type PartialFailure } from '@lightdash/common';
+import { postSchedulerWebhook } from '../../utils/schedulerWebhookValidation';
 import { type AttachmentUrl } from '../EmailClient/EmailClient';
 import { GoogleChatClient } from './GoogleChatClient';
+
+vi.mock('../../utils/schedulerWebhookValidation', () => ({
+    postSchedulerWebhook: vi.fn(),
+}));
+
+const mockedPostSchedulerWebhook = vi.mocked(postSchedulerWebhook);
+const successfulWebhookResponse = {
+    status: 200,
+    contentType: '',
+    bodyText: '',
+    truncated: false,
+};
+
+describe('webhook delivery', () => {
+    const client = new GoogleChatClient();
+    const args: Parameters<GoogleChatClient['postImageWithWebhook']>[0] = {
+        webhookUrl: 'https://chat.googleapis.com/v1/spaces/abc/messages',
+        title: 'Delivery',
+        name: 'Chart',
+        description: undefined,
+        ctaUrl: 'https://app.lightdash.com/chart',
+        image: 'https://app.lightdash.com/image.png',
+        footer: 'Footer',
+    };
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('posts through the secured webhook helper', async () => {
+        mockedPostSchedulerWebhook.mockResolvedValueOnce({
+            ...successfulWebhookResponse,
+            status: 204,
+        });
+
+        await client.postImageWithWebhook(args);
+
+        expect(mockedPostSchedulerWebhook).toHaveBeenCalledWith(
+            args.webhookUrl,
+            expect.objectContaining({ cardsV2: expect.any(Array) }),
+            'application/json; charset=UTF-8',
+        );
+    });
+
+    it('preserves provider errors for non-success responses', async () => {
+        mockedPostSchedulerWebhook.mockResolvedValueOnce({
+            ...successfulWebhookResponse,
+            status: 500,
+            bodyText: 'upstream failure',
+        });
+
+        await expect(client.postImageWithWebhook(args)).rejects.toThrow(
+            'Google Chat webhook returned an error',
+        );
+    });
+});
 
 describe('postCsvsWithWebhook app failure lines', () => {
     const client = new GoogleChatClient();
@@ -21,52 +78,42 @@ describe('postCsvsWithWebhook app failure lines', () => {
         failures: PartialFailure[],
         csvUrls: AttachmentUrl[],
     ): Promise<string> => {
-        const fetchMock = vi
-            .spyOn(globalThis, 'fetch')
-            .mockResolvedValue({ ok: true, status: 200 } as Response);
-        try {
-            await client.postCsvsWithWebhook({
-                webhookUrl: 'https://chat.googleapis.com/v1/spaces/abc',
-                title: 'App delivery',
-                name: 'App delivery',
-                description: 'desc',
-                ctaUrl: 'https://app.lightdash.com/apps/abc',
-                csvUrls,
-                footer: 'footer',
-                failures,
-            });
-            const [, init] = fetchMock.mock.calls[0];
-            const payload = JSON.parse(init?.body as string);
-            const texts: string[] = payload.cardsV2[0].card.sections[0].widgets
-                .map(
-                    (widget: { textParagraph?: { text: string } }) =>
-                        widget.textParagraph?.text ?? '',
-                )
-                .filter((text: string) => text.includes('failed to export'));
-            expect(texts).toHaveLength(1);
-            return texts[0];
-        } finally {
-            fetchMock.mockRestore();
-        }
+        mockedPostSchedulerWebhook.mockResolvedValueOnce(
+            successfulWebhookResponse,
+        );
+        await client.postCsvsWithWebhook({
+            webhookUrl: 'https://chat.googleapis.com/v1/spaces/abc',
+            title: 'App delivery',
+            name: 'App delivery',
+            description: 'desc',
+            ctaUrl: 'https://app.lightdash.com/apps/abc',
+            csvUrls,
+            footer: 'footer',
+            failures,
+        });
+        const [, payload] = mockedPostSchedulerWebhook.mock.calls.at(-1)!;
+        const texts: string[] = payload.cardsV2[0].card.sections[0].widgets
+            .map(
+                (widget: { textParagraph?: { text: string } }) =>
+                    widget.textParagraph?.text ?? '',
+            )
+            .filter((text: string) => text.includes('failed to export'));
+        expect(texts).toHaveLength(1);
+        return texts[0];
     };
 
     const widgetTexts = async (
         args: Parameters<GoogleChatClient['postCsvsWithWebhook']>[0],
     ): Promise<string[]> => {
-        const fetchMock = vi
-            .spyOn(globalThis, 'fetch')
-            .mockResolvedValue({ ok: true, status: 200 } as Response);
-        try {
-            await client.postCsvsWithWebhook(args);
-            const [, init] = fetchMock.mock.calls[0];
-            const payload = JSON.parse(init?.body as string);
-            return payload.cardsV2[0].card.sections[0].widgets.map(
-                (widget: { textParagraph?: { text: string } }) =>
-                    widget.textParagraph?.text ?? '',
-            );
-        } finally {
-            fetchMock.mockRestore();
-        }
+        mockedPostSchedulerWebhook.mockResolvedValueOnce(
+            successfulWebhookResponse,
+        );
+        await client.postCsvsWithWebhook(args);
+        const [, payload] = mockedPostSchedulerWebhook.mock.calls.at(-1)!;
+        return payload.cardsV2[0].card.sections[0].widgets.map(
+            (widget: { textParagraph?: { text: string } }) =>
+                widget.textParagraph?.text ?? '',
+        );
     };
 
     // Limit notices reached email and Slack but were silently dropped here.

--- a/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
+++ b/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
@@ -13,6 +13,7 @@ import {
 } from '@lightdash/common';
 import Logger from '../../logging/logger';
 import { buildFailureCountPhrase } from '../../utils/partialFailureUtils';
+import { postSchedulerWebhook } from '../../utils/schedulerWebhookValidation';
 import { AttachmentUrl } from '../EmailClient/EmailClient';
 
 // Google Chat renders a subset of HTML in textParagraph.text, and app delivery
@@ -23,18 +24,15 @@ const stripMarkup = (text: string): string =>
 /* eslint-disable class-methods-use-this */
 export class GoogleChatClient {
     private async sendWebhook(webhookUrl: string, payload: AnyType) {
-        const response = await fetch(webhookUrl, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json; charset=UTF-8',
-            },
-            body: JSON.stringify(payload),
-        });
+        const response = await postSchedulerWebhook(
+            webhookUrl,
+            payload,
+            'application/json; charset=UTF-8',
+        );
 
-        if (!response.ok) {
-            const responseText = await response.text();
+        if (response.status < 200 || response.status >= 300) {
             Logger.error(
-                `Google Chat webhook returned an error: ${response.status} ${responseText}`,
+                `Google Chat webhook returned an error: ${response.status} ${response.bodyText}`,
             );
             Logger.debug(
                 `Google Chat webhook payload ${JSON.stringify(

--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.test.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.test.ts
@@ -1,10 +1,71 @@
 import { PartialFailureType, type PartialFailure } from '@lightdash/common';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { postSchedulerWebhook } from '../../utils/schedulerWebhookValidation';
 import { type AttachmentUrl } from '../EmailClient/EmailClient';
 import {
     MicrosoftTeamsClient,
     redactWebhookIdentity,
 } from './MicrosoftTeamsClient';
+
+vi.mock('../../utils/schedulerWebhookValidation', () => ({
+    postSchedulerWebhook: vi.fn(),
+}));
+
+const mockedPostSchedulerWebhook = vi.mocked(postSchedulerWebhook);
+const successfulWebhookResponse = {
+    status: 200,
+    contentType: '',
+    bodyText: '',
+    truncated: false,
+};
+
+describe('webhook delivery', () => {
+    const client = new MicrosoftTeamsClient({
+        lightdashConfig: {
+            ...lightdashConfigMock,
+            microsoftTeams: { enabled: true },
+        },
+    });
+    const args: Parameters<MicrosoftTeamsClient['postImageWithWebhook']>[0] = {
+        webhookUrl: 'https://outlook.office.com/webhook/abc',
+        title: 'Delivery',
+        name: 'Chart',
+        description: undefined,
+        ctaUrl: 'https://app.lightdash.com/chart',
+        image: 'https://app.lightdash.com/image.png',
+        footer: 'Footer',
+    };
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('accepts a 202 response from the secured webhook helper', async () => {
+        mockedPostSchedulerWebhook.mockResolvedValueOnce({
+            ...successfulWebhookResponse,
+            status: 202,
+        });
+
+        await client.postImageWithWebhook(args);
+
+        expect(mockedPostSchedulerWebhook).toHaveBeenCalledWith(
+            args.webhookUrl,
+            expect.objectContaining({ attachments: expect.any(Array) }),
+        );
+    });
+
+    it('preserves provider errors for non-success responses', async () => {
+        mockedPostSchedulerWebhook.mockResolvedValueOnce({
+            ...successfulWebhookResponse,
+            status: 500,
+            bodyText: 'upstream failure',
+        });
+
+        await expect(client.postImageWithWebhook(args)).rejects.toThrow(
+            'Microsoft teams webhook returned an error',
+        );
+    });
+});
 
 describe('redactWebhookIdentity', () => {
     const teamsWebhookUrl =
@@ -91,25 +152,21 @@ describe('postCsvsWithWebhook app failure lines', () => {
         failures: PartialFailure[],
         csvUrls: AttachmentUrl[],
     ): Promise<string> => {
-        const fetchMock = vi
-            .spyOn(globalThis, 'fetch')
-            .mockResolvedValue({ ok: true, status: 200 } as Response);
-        try {
-            await client.postCsvsWithWebhook({
-                webhookUrl: 'https://outlook.office.com/webhook/abc',
-                title: 'App delivery',
-                name: 'App delivery',
-                description: 'desc',
-                ctaUrl: 'https://app.lightdash.com/apps/abc',
-                csvUrls,
-                footer: 'footer',
-                failures,
-            });
-            const [, init] = fetchMock.mock.calls[0];
-            return init?.body as string;
-        } finally {
-            fetchMock.mockRestore();
-        }
+        mockedPostSchedulerWebhook.mockResolvedValueOnce(
+            successfulWebhookResponse,
+        );
+        await client.postCsvsWithWebhook({
+            webhookUrl: 'https://outlook.office.com/webhook/abc',
+            title: 'App delivery',
+            name: 'App delivery',
+            description: 'desc',
+            ctaUrl: 'https://app.lightdash.com/apps/abc',
+            csvUrls,
+            footer: 'footer',
+            failures,
+        });
+        const [, payload] = mockedPostSchedulerWebhook.mock.calls.at(-1)!;
+        return JSON.stringify(payload);
     };
 
     const expectNoLiveMarkup = (body: string) => {
@@ -127,19 +184,14 @@ describe('postCsvsWithWebhook app failure lines', () => {
     const cardTextBlocks = async (
         args: Parameters<MicrosoftTeamsClient['postCsvsWithWebhook']>[0],
     ): Promise<string[]> => {
-        const fetchMock = vi
-            .spyOn(globalThis, 'fetch')
-            .mockResolvedValue({ ok: true, status: 200 } as Response);
-        try {
-            await client.postCsvsWithWebhook(args);
-            const [, init] = fetchMock.mock.calls[0];
-            const payload = JSON.parse(init?.body as string);
-            return payload.attachments[0].content.body.map(
-                (block: { text?: string }) => block.text ?? '',
-            );
-        } finally {
-            fetchMock.mockRestore();
-        }
+        mockedPostSchedulerWebhook.mockResolvedValueOnce(
+            successfulWebhookResponse,
+        );
+        await client.postCsvsWithWebhook(args);
+        const [, payload] = mockedPostSchedulerWebhook.mock.calls.at(-1)!;
+        return payload.attachments[0].content.body.map(
+            (block: { text?: string }) => block.text ?? '',
+        );
     };
 
     // Limit notices reached email and Slack but were silently dropped here.

--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
@@ -16,6 +16,7 @@ import { createHash } from 'crypto';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { buildFailureCountPhrase } from '../../utils/partialFailureUtils';
+import { postSchedulerWebhook } from '../../utils/schedulerWebhookValidation';
 import { AttachmentUrl } from '../EmailClient/EmailClient';
 
 // Adaptive Card TextBlocks render a markdown subset (links, emphasis, code) and
@@ -73,24 +74,17 @@ export class MicrosoftTeamsClient {
             throw new MissingConfigError('Microsoft Teams is not enabled');
         }
         const webhookIdentity = redactWebhookIdentity(webhookUrl);
-        const response = await fetch(webhookUrl, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(payload),
-        });
+        const response = await postSchedulerWebhook(webhookUrl, payload);
 
         const classification = classifyHttpStatus(response.status);
 
         // Accept any 2xx status: legacy webhooks return 200, Power Automate Workflows return 202
-        if (!response.ok) {
-            const responseText = await response.text();
+        if (response.status < 200 || response.status >= 300) {
             Logger.error('msteams.webhook_failed', {
                 webhookIdentity,
                 httpStatus: response.status,
                 classification,
-                responseBody: responseText.slice(0, 500),
+                responseBody: response.bodyText.slice(0, 500),
             });
             Logger.info(
                 `Microsoft teams webhook payload ${JSON.stringify(

--- a/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
+++ b/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
@@ -65,6 +65,39 @@ describe('Scheduler model test', () => {
         ]);
     });
 
+    describe('webhook validation', () => {
+        const database = { transaction: vi.fn() };
+        const model = new SchedulerModel({ database: database as AnyType });
+
+        afterEach(() => {
+            vi.clearAllMocks();
+        });
+
+        it('rejects private webhook targets before creating a scheduler', async () => {
+            await expect(
+                model.createScheduler({
+                    targets: [{ webhook: 'https://169.254.169.254/hook' }],
+                } as AnyType),
+            ).rejects.toThrow('must use a public URL');
+
+            expect(database.transaction).not.toHaveBeenCalled();
+        });
+
+        it('rejects private webhook targets before updating a scheduler', async () => {
+            await expect(
+                model.updateScheduler({
+                    targets: [
+                        {
+                            googleChatWebhook: 'https://127.0.0.1/hook',
+                        },
+                    ],
+                } as AnyType),
+            ).rejects.toThrow('must use a public URL');
+
+            expect(database.transaction).not.toHaveBeenCalled();
+        });
+    });
+
     describe('getRuns pagination with filtering', () => {
         test('should return correct totalResults when filtering by status', () => {
             // Scenario: DB has 50 total runs, 25 are COMPLETED

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -79,6 +79,7 @@ import { SpaceTableName } from '../../database/entities/spaces';
 import { UserTableName } from '../../database/entities/users';
 import KnexPaginate from '../../database/pagination';
 import { ServiceAccountsTableName } from '../../ee/database/entities/serviceAccounts';
+import { validateSchedulerWebhookTargets } from '../../utils/schedulerWebhookValidation';
 
 type SelectScheduler = SchedulerDb & {
     created_by_name: string | null;
@@ -1159,6 +1160,8 @@ export class SchedulerModel {
     async createScheduler(
         newScheduler: CreateSchedulerAndTargets,
     ): Promise<SchedulerAndTargets> {
+        await validateSchedulerWebhookTargets(newScheduler.targets);
+
         const schedulerUuid = await this.database.transaction(async (trx) => {
             const { projectUuid, slug } = await SchedulerModel.getCreateSlug(
                 trx,
@@ -1240,6 +1243,8 @@ export class SchedulerModel {
     async updateScheduler(
         scheduler: UpdateSchedulerAndTargets,
     ): Promise<SchedulerAndTargets> {
+        await validateSchedulerWebhookTargets(scheduler.targets);
+
         await this.database.transaction(async (trx) => {
             await trx(SchedulerTableName)
                 .update({

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -297,6 +297,25 @@ describe('SchedulerService', () => {
             );
         });
 
+        test.each([
+            { webhook: 'https://169.254.169.254/latest/meta-data' },
+            { googleChatWebhook: 'https://127.0.0.1/hook' },
+        ])(
+            'rejects an unsafe webhook before enqueueing a send-now job',
+            async (target) => {
+                await expect(
+                    service.sendScheduler(userWhoCanSend, {
+                        ...sendNowPayload,
+                        targets: [target],
+                    }),
+                ).rejects.toThrowError(ParameterError);
+
+                expect(
+                    schedulerClient.addScheduledDeliveryJob,
+                ).not.toHaveBeenCalled();
+            },
+        );
+
         describe('app payloads', () => {
             const sendAppUuid = 'appUuid';
             const sendAppRow = {

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -76,6 +76,7 @@ import { SchedulerModel } from '../../models/SchedulerModel';
 import { UserModel } from '../../models/UserModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { getAdjustedCronByOffset } from '../../utils/cronUtils';
+import { validateSchedulerWebhookTargets } from '../../utils/schedulerWebhookValidation';
 import { BaseService } from '../BaseService';
 import type { SoftDeleteOptions } from '../SoftDeletableService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
@@ -1690,6 +1691,8 @@ export class SchedulerService extends BaseService {
         if (!isValidTimezone(scheduler.timezone)) {
             throw new ParameterError('Timezone string is not valid');
         }
+
+        await validateSchedulerWebhookTargets(scheduler.targets);
 
         // Validate PDF format is not used with webhook destinations
         if (scheduler.format === SchedulerFormat.PDF) {

--- a/packages/backend/src/utils/schedulerWebhookValidation.test.ts
+++ b/packages/backend/src/utils/schedulerWebhookValidation.test.ts
@@ -1,0 +1,142 @@
+import { lookup } from 'node:dns/promises';
+import {
+    postSchedulerWebhook,
+    validateSchedulerWebhookTargets,
+} from './schedulerWebhookValidation';
+import { secureFetch } from './secureFetch/secureFetch';
+
+vi.mock('node:dns/promises', () => ({
+    lookup: vi.fn(),
+}));
+
+vi.mock('./secureFetch/secureFetch', () => ({
+    secureFetch: vi.fn(),
+}));
+
+const mockedLookup = lookup as unknown as import('vitest').MockedFunction<
+    () => Promise<{ address: string; family: number }[]>
+>;
+const mockedSecureFetch = vi.mocked(secureFetch);
+
+describe('validateSchedulerWebhookTargets', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockedLookup.mockResolvedValue([
+            { address: '93.184.216.34', family: 4 },
+        ]);
+    });
+
+    it.each([
+        { webhook: 'https://outlook.office.com/webhook/abc' },
+        {
+            googleChatWebhook:
+                'https://chat.googleapis.com/v1/spaces/abc/messages',
+        },
+    ])('accepts a public HTTPS webhook target', async (target) => {
+        await expect(
+            validateSchedulerWebhookTargets([target]),
+        ).resolves.toBeUndefined();
+    });
+
+    it('ignores non-webhook targets', async () => {
+        await validateSchedulerWebhookTargets([
+            { recipient: 'recipient@example.com' },
+            { channel: 'C123' },
+        ]);
+
+        expect(mockedLookup).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['malformed URL', 'not-a-url', 'Enter a valid webhook URL'],
+        ['HTTP URL', 'http://example.com', 'must start with https://'],
+        [
+            'embedded credentials',
+            'https://user:pass@example.com',
+            'Remove the username or password',
+        ],
+        ['localhost', 'https://localhost/hook', 'must use a public URL'],
+        ['loopback address', 'https://127.0.0.1/hook', 'must use a public URL'],
+        [
+            'link-local address',
+            'https://169.254.169.254/latest/meta-data',
+            'must use a public URL',
+        ],
+    ])('rejects a %s', async (_label, url, expectedMessage) => {
+        await expect(
+            validateSchedulerWebhookTargets([{ webhook: url }]),
+        ).rejects.toThrow(expectedMessage);
+    });
+
+    it.each([
+        [[{ address: '10.0.0.2', family: 4 }]],
+        [
+            [
+                { address: '93.184.216.34', family: 4 },
+                { address: '192.168.1.2', family: 4 },
+            ],
+        ],
+    ])('rejects a hostname with private DNS results', async (addresses) => {
+        mockedLookup.mockResolvedValueOnce(addresses);
+
+        await expect(
+            validateSchedulerWebhookTargets([
+                { googleChatWebhook: 'https://webhook.example.com/hook' },
+            ]),
+        ).rejects.toThrow('must use a public URL');
+    });
+
+    it('rejects an unresolved hostname', async () => {
+        mockedLookup.mockRejectedValueOnce(new Error('ENOTFOUND'));
+
+        await expect(
+            validateSchedulerWebhookTargets([
+                { webhook: 'https://missing.example.com/hook' },
+            ]),
+        ).rejects.toThrow("We couldn't find a server at that webhook URL");
+    });
+
+    it('fails closed when DNS returns no addresses', async () => {
+        mockedLookup.mockResolvedValueOnce([]);
+
+        await expect(
+            validateSchedulerWebhookTargets([
+                { webhook: 'https://empty.example.com/hook' },
+            ]),
+        ).rejects.toThrow('must use a public URL');
+    });
+});
+
+describe('postSchedulerWebhook', () => {
+    it('uses the pinned secure fetch path with bounded webhook options', async () => {
+        mockedSecureFetch.mockResolvedValueOnce({
+            status: 202,
+            contentType: '',
+            bodyText: '',
+            truncated: false,
+        });
+        const payload = { text: 'hello' };
+
+        await expect(
+            postSchedulerWebhook(
+                'https://webhook.example.com/hook',
+                payload,
+                'application/json; charset=UTF-8',
+            ),
+        ).resolves.toMatchObject({ status: 202 });
+
+        expect(mockedSecureFetch).toHaveBeenCalledWith(
+            'https://webhook.example.com/hook',
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json; charset=UTF-8',
+                },
+                body: JSON.stringify(payload),
+                timeoutMs: 30_000,
+                maxResponseBytes: 64 * 1024,
+                allowedContentTypes: [],
+            },
+        );
+    });
+});

--- a/packages/backend/src/utils/schedulerWebhookValidation.ts
+++ b/packages/backend/src/utils/schedulerWebhookValidation.ts
@@ -1,0 +1,52 @@
+import {
+    AnyType,
+    isCreateSchedulerGoogleChatTarget,
+    isCreateSchedulerMsTeamsTarget,
+    type SchedulerEmailTarget,
+    type SchedulerGoogleChatTarget,
+    type SchedulerMsTeamsTarget,
+    type SchedulerSlackTarget,
+} from '@lightdash/common';
+import { secureFetch } from './secureFetch/secureFetch';
+import { validatePublicHttpUrl } from './ssrfProtection';
+
+type SchedulerTarget =
+    | Pick<SchedulerSlackTarget, 'channel'>
+    | Pick<SchedulerEmailTarget, 'recipient'>
+    | Pick<SchedulerMsTeamsTarget, 'webhook'>
+    | Pick<SchedulerGoogleChatTarget, 'googleChatWebhook'>;
+
+export const validateSchedulerWebhookTargets = async (
+    targets: SchedulerTarget[],
+): Promise<void> => {
+    await Promise.all(
+        targets.map(async (target) => {
+            if (isCreateSchedulerMsTeamsTarget(target)) {
+                await validatePublicHttpUrl(target.webhook, {
+                    context: 'webhook',
+                });
+            }
+            if (isCreateSchedulerGoogleChatTarget(target)) {
+                await validatePublicHttpUrl(target.googleChatWebhook, {
+                    context: 'webhook',
+                });
+            }
+        }),
+    );
+};
+
+export const postSchedulerWebhook = async (
+    webhookUrl: string,
+    payload: AnyType,
+    contentType = 'application/json',
+) =>
+    secureFetch(webhookUrl, {
+        method: 'POST',
+        headers: {
+            'Content-Type': contentType,
+        },
+        body: JSON.stringify(payload),
+        timeoutMs: 30_000,
+        maxResponseBytes: 64 * 1024,
+        allowedContentTypes: [],
+    });

--- a/packages/backend/src/utils/secureFetch/secureFetch.test.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.test.ts
@@ -80,6 +80,14 @@ describe('secureFetch blocks private/internal resolved IPs', () => {
             'IPv4 192.0.2.1 reserved (TEST-NET)',
             { address: '192.0.2.1', family: 4 },
         ],
+        [
+            'IPv4 192.88.99.1 deprecated 6to4 relay',
+            { address: '192.88.99.1', family: 4 },
+        ],
+        [
+            'IPv4 198.18/15 benchmarking range',
+            { address: '198.18.0.1', family: 4 },
+        ],
         ['IPv6 ::1 loopback', { address: '::1', family: 6 }],
         ['IPv6 fc00::/7 unique-local', { address: 'fc00::1', family: 6 }],
         ['IPv6 fe80::/10 link-local', { address: 'fe80::1', family: 6 }],
@@ -95,6 +103,10 @@ describe('secureFetch blocks private/internal resolved IPs', () => {
         [
             'IPv6 NAT64 64:ff9b::7f00:1 (maps to 127.0.0.1)',
             { address: '64:ff9b::7f00:1', family: 6 },
+        ],
+        [
+            'IPv6 2001::/23 special-purpose range',
+            { address: '2001:2::1', family: 6 },
         ],
     ];
 

--- a/packages/backend/src/utils/secureFetch/secureFetch.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.ts
@@ -3,6 +3,7 @@ import https from 'https';
 import * as ipaddr from 'ipaddr.js';
 import { LookupFunction } from 'net';
 import fetch, { FetchError } from 'node-fetch';
+import { isPrivateAddress } from '../ssrfProtection';
 
 export type SecureFetchReason =
     | 'non_https'
@@ -68,11 +69,8 @@ const parseHttpsUrl = (rawUrl: string): URL => {
 // (64:ff9b::/96) collapse to their IPv4 range via ipaddr.process(). Fail-closed:
 // if the address cannot be parsed it is treated as blocked.
 const isNonPublicAddress = (address: string): boolean => {
-    try {
-        return ipaddr.process(address).range() !== 'unicast';
-    } catch {
-        return true; // unparseable — fail closed
-    }
+    if (!ipaddr.isValid(address)) return true;
+    return isPrivateAddress(address);
 };
 
 const resolveAndValidateHost = async (

--- a/packages/backend/src/utils/ssrfProtection.ts
+++ b/packages/backend/src/utils/ssrfProtection.ts
@@ -3,16 +3,46 @@ import * as ipaddr from 'ipaddr.js';
 import { lookup } from 'node:dns/promises';
 
 const PRIVATE_HOSTNAMES = new Set(['localhost']);
-const PRIVATE_ADDRESS_ERROR_MESSAGE =
+const MCP_PRIVATE_ADDRESS_ERROR_MESSAGE =
     'MCP servers must use a public URL. Localhost and private network addresses are not supported.';
-const INVALID_URL_ERROR_MESSAGE =
+const MCP_INVALID_URL_ERROR_MESSAGE =
     'Enter a valid MCP server URL, including http:// or https://.';
-const INVALID_PROTOCOL_ERROR_MESSAGE =
+const MCP_INVALID_PROTOCOL_ERROR_MESSAGE =
     'MCP server URLs must start with http:// or https://.';
-const URL_CREDENTIALS_ERROR_MESSAGE =
+const MCP_URL_CREDENTIALS_ERROR_MESSAGE =
     'Remove the username or password from the MCP server URL. Use the auth settings instead.';
-const HOSTNAME_LOOKUP_ERROR_MESSAGE =
+const MCP_HOSTNAME_LOOKUP_ERROR_MESSAGE =
     "We couldn't find a server at that URL. Check the hostname and try again.";
+
+const WEBHOOK_PRIVATE_ADDRESS_ERROR_MESSAGE =
+    'Webhook destinations must use a public URL. Localhost and private network addresses are not supported.';
+const WEBHOOK_INVALID_URL_ERROR_MESSAGE =
+    'Enter a valid webhook URL, including https://.';
+const WEBHOOK_INVALID_PROTOCOL_ERROR_MESSAGE =
+    'Webhook URLs must start with https://.';
+const WEBHOOK_URL_CREDENTIALS_ERROR_MESSAGE =
+    'Remove the username or password from the webhook URL.';
+const WEBHOOK_HOSTNAME_LOOKUP_ERROR_MESSAGE =
+    "We couldn't find a server at that webhook URL. Check the hostname and try again.";
+
+type PublicHttpUrlContext = 'mcp' | 'webhook';
+
+const getErrorMessages = (context: PublicHttpUrlContext) =>
+    context === 'webhook'
+        ? {
+              privateAddress: WEBHOOK_PRIVATE_ADDRESS_ERROR_MESSAGE,
+              invalidUrl: WEBHOOK_INVALID_URL_ERROR_MESSAGE,
+              invalidProtocol: WEBHOOK_INVALID_PROTOCOL_ERROR_MESSAGE,
+              urlCredentials: WEBHOOK_URL_CREDENTIALS_ERROR_MESSAGE,
+              hostnameLookup: WEBHOOK_HOSTNAME_LOOKUP_ERROR_MESSAGE,
+          }
+        : {
+              privateAddress: MCP_PRIVATE_ADDRESS_ERROR_MESSAGE,
+              invalidUrl: MCP_INVALID_URL_ERROR_MESSAGE,
+              invalidProtocol: MCP_INVALID_PROTOCOL_ERROR_MESSAGE,
+              urlCredentials: MCP_URL_CREDENTIALS_ERROR_MESSAGE,
+              hostnameLookup: MCP_HOSTNAME_LOOKUP_ERROR_MESSAGE,
+          };
 
 const normalizeHostname = (hostname: string): string =>
     hostname.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
@@ -76,23 +106,25 @@ export const validatePublicHttpUrl = async (
     options: {
         allowedProtocols?: string[];
         allowPrivateAddresses?: boolean;
+        context?: PublicHttpUrlContext;
     } = {},
 ): Promise<URL> => {
     const allowedProtocols = options.allowedProtocols ?? ['https:'];
+    const errorMessages = getErrorMessages(options.context ?? 'mcp');
 
     let parsedUrl: URL;
     try {
         parsedUrl = new URL(rawUrl);
     } catch {
-        throw new ParameterError(INVALID_URL_ERROR_MESSAGE);
+        throw new ParameterError(errorMessages.invalidUrl);
     }
 
     if (!allowedProtocols.includes(parsedUrl.protocol)) {
-        throw new ParameterError(INVALID_PROTOCOL_ERROR_MESSAGE);
+        throw new ParameterError(errorMessages.invalidProtocol);
     }
 
     if (parsedUrl.username || parsedUrl.password) {
-        throw new ParameterError(URL_CREDENTIALS_ERROR_MESSAGE);
+        throw new ParameterError(errorMessages.urlCredentials);
     }
 
     if (options.allowPrivateAddresses) {
@@ -101,18 +133,21 @@ export const validatePublicHttpUrl = async (
 
     const hostname = normalizeHostname(parsedUrl.hostname);
     if (isPrivateAddress(hostname)) {
-        throw new ParameterError(PRIVATE_ADDRESS_ERROR_MESSAGE);
+        throw new ParameterError(errorMessages.privateAddress);
     }
 
     let addresses: { address: string }[];
     try {
         addresses = await lookup(hostname, { all: true });
     } catch {
-        throw new ParameterError(HOSTNAME_LOOKUP_ERROR_MESSAGE);
+        throw new ParameterError(errorMessages.hostnameLookup);
     }
 
-    if (addresses.some(({ address }) => isPrivateAddress(address))) {
-        throw new ParameterError(PRIVATE_ADDRESS_ERROR_MESSAGE);
+    if (
+        addresses.length === 0 ||
+        addresses.some(({ address }) => isPrivateAddress(address))
+    ) {
+        throw new ParameterError(errorMessages.privateAddress);
     }
 
     return parsedUrl;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-8339
Closes: #24389

### Description:
Scheduled-delivery webhook URLs were accepted and passed directly to outbound requests, allowing authenticated users to target internal services. This change validates Google Chat and Microsoft Teams destinations before persistence or send-now enqueueing, then sends them through the DNS-pinned secure fetch path with HTTPS-only URLs, private and reserved address blocking, redirect rejection, response limits, and timeouts. Focused coverage verifies both scheduler boundaries, both webhook clients, shared URL classification, and the secured request path; backend tests, typecheck, formatting, lint, secret scanning, and unused-export checks pass.
