### PR TITLE
ci: pin Socket Firewall and limit pnpm concurrency

### DIFF
--- a/.github/workflows/_setup_node_pnpm_cypress/action.yml
+++ b/.github/workflows/_setup_node_pnpm_cypress/action.yml
@@ -12,6 +12,7 @@ runs:
           uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
           with:
               mode: firewall-free
+              firewall-version: 1.15.0
 
         - name: Setup PNPM
           uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -23,7 +24,7 @@ runs:
               cache-dependency-path: 'pnpm-lock.yaml'
 
         - name: Install Dependencies
-          run: sfw pnpm install --frozen-lockfile --prefer-offline
+          run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
           shell: bash
 
         - name: Install Cypress

--- a/.github/workflows/ai-agent-integration-tests.yml
+++ b/.github/workflows/ai-agent-integration-tests.yml
@@ -45,6 +45,7 @@ jobs:
               uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
               with:
                   mode: firewall-free
+                  firewall-version: 1.15.0
 
             - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -54,7 +55,7 @@ jobs:
                   cache-dependency-path: 'pnpm-lock.yaml'
 
             - name: Install packages
-              run: sfw pnpm install --frozen-lockfile --prefer-offline
+              run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
 
             - name: Build common
               run: pnpm common-build

--- a/.github/workflows/mcp-tools-snapshot-check.yml
+++ b/.github/workflows/mcp-tools-snapshot-check.yml
@@ -44,6 +44,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+          firewall-version: 1.15.0
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -60,7 +61,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -euo pipefail
-          sfw pnpm install --frozen-lockfile --prefer-offline || echo "::warning::sfw install exited non-zero; repairing with plain pnpm"
+          sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16 || echo "::warning::sfw install exited non-zero; repairing with plain pnpm"
           if ! pnpm -F common exec tsx --version >/dev/null 2>&1; then
             echo "::warning::install incomplete after sfw (tsx missing); repairing with plain pnpm install"
             pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -247,6 +247,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+          firewall-version: 1.15.0
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
@@ -275,7 +276,7 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         # Force reinstall so pnpm includes optional DuckDB native bindings
         # needed to build both macOS pkg targets from a single runner.
-        run: sfw pnpm install --filter @lightdash/cli --filter @lightdash/common --filter @lightdash/warehouses --frozen-lockfile --prefer-offline --prod=false --force
+        run: sfw pnpm install --filter @lightdash/cli --filter @lightdash/common --filter @lightdash/warehouses --frozen-lockfile --prefer-offline --prod=false --force --network-concurrency=16
 
       - name: Cache common build
         id: cache-common

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -127,6 +127,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+          firewall-version: 1.15.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -134,7 +135,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install packages
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
       - name: Build
         run: pnpm build
       - name: Run quality checks in parallel
@@ -171,6 +172,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+          firewall-version: 1.15.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -178,7 +180,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install packages
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
       - name: Build SDK bundle
         run: pnpm sdk-build
       - name: Check SDK bundle is CSP-safe
@@ -229,6 +231,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+          firewall-version: 1.15.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -237,14 +240,14 @@ jobs:
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Generate base OpenAPI schema
         run: |
-          sfw pnpm install --frozen-lockfile --prefer-offline
+          sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
           pnpm generate-api
           cp packages/backend/src/generated/swagger.json /tmp/base-swagger.json
       - name: Checkout PR
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Generate PR OpenAPI schema
         run: |
-          sfw pnpm install --frozen-lockfile --prefer-offline
+          sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
           pnpm generate-api
       - name: Check for OpenAPI breaking changes
         if: ${{ !contains(github.event.pull_request.body, 'allow-api-breaking-change') }}
@@ -544,6 +547,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+          firewall-version: 1.15.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -551,7 +555,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install packages
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
       - name: Build packages/common module
         run: pnpm common-build
       - name: Create BigQuery credentials file

--- a/.github/workflows/publish-e2b-template.yml
+++ b/.github/workflows/publish-e2b-template.yml
@@ -86,6 +86,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+          firewall-version: 1.15.0
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
@@ -99,11 +100,11 @@ jobs:
 
       - name: Install root deps
         if: steps.plan.outputs.action == 'build' && inputs.install_root_deps
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
 
       - name: Install sandbox deps
         working-directory: ${{ inputs.template_directory }}
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
 
       - name: Build and publish template
         if: steps.plan.outputs.action == 'build'

--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -209,6 +209,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+          firewall-version: 1.15.0
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -226,7 +227,7 @@ jobs:
       - name: Generate base API snapshots
         run: |
           set -euo pipefail
-          sfw pnpm install --frozen-lockfile --prefer-offline
+          sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
           pnpm generate-api:backend
           pnpm generate:mcp-tools-snapshot
           mkdir -p /tmp/api-snapshots
@@ -239,7 +240,7 @@ jobs:
       - name: Generate PR API snapshots
         run: |
           set -euo pipefail
-          sfw pnpm install --frozen-lockfile --prefer-offline
+          sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
           pnpm generate-api:backend
           pnpm generate:mcp-tools-snapshot
           cp packages/backend/src/generated/swagger.json /tmp/api-snapshots/pr-swagger.json
@@ -278,6 +279,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+          firewall-version: 1.15.0
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -294,7 +296,7 @@ jobs:
 
       - name: Install CLI package dependencies
         run: |
-          sfw pnpm install --frozen-lockfile --filter @lightdash/cli || true
+          sfw pnpm install --frozen-lockfile --filter @lightdash/cli --network-concurrency=16 || true
           node -e "require.resolve('ajv', { paths: ['packages/cli'] })" 2>/dev/null || pnpm install --frozen-lockfile --filter @lightdash/cli
 
       - name: Install oasdiff

--- a/.github/workflows/release-safety-tests.yml
+++ b/.github/workflows/release-safety-tests.yml
@@ -35,6 +35,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+          firewall-version: 1.15.0
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -44,7 +45,7 @@ jobs:
 
       - name: Install root dependencies
         run: |
-          sfw pnpm install --frozen-lockfile --filter . || true
+          sfw pnpm install --frozen-lockfile --filter . --network-concurrency=16 || true
           node -e "require.resolve('ajv')" 2>/dev/null || pnpm install --frozen-lockfile --filter .
 
       - name: Install tsx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+          firewall-version: 1.15.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -29,7 +30,7 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
       - name: Install packages
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
       - name: Generate backend API artifacts
         run: pnpm generate-api:backend
       - name: Build all packages
@@ -57,6 +58,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
+          firewall-version: 1.15.0
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
@@ -72,7 +74,7 @@ jobs:
         run: sfw npm install -g npm@12.0.1
 
       - name: Install dependencies
-        run: sfw pnpm install --frozen-lockfile --prefer-offline --prod=false
+        run: sfw pnpm install --frozen-lockfile --prefer-offline --prod=false --network-concurrency=16
 
       # PROD-8359: install oasdiff so the release-safety marker generator can diff
       # the REST API (swagger.json) between the previous tag and HEAD for breaking


### PR DESCRIPTION
## Summary

Pins Socket Firewall to 1.15.0 and caps every `sfw pnpm install` at 16 concurrent network requests.

Forensics found synchronized post-install registry and attestation request storms through the `sfw`-mediated path, followed by Socket Firewall TCP timeouts; the two sampled storms were [Build & Release run 31680711946](https://github.com/lightdash/lightdash/actions/runs/31680711946) and [Release-safety script tests run 31685538617](https://github.com/lightdash/lightdash/actions/runs/31685538617). This mitigates burst size and makes the Firewall binary reproducible without attributing the underlying timeout to a single provider.

## Changed call sites

- `.github/workflows/_setup_node_pnpm_cypress/action.yml`
- `.github/workflows/ai-agent-integration-tests.yml`
- `.github/workflows/mcp-tools-snapshot-check.yml`
- `.github/workflows/post-release.yml`
- `.github/workflows/pr.yml` (4 Socket setup / 5 install sites)
- `.github/workflows/publish-e2b-template.yml`
- `.github/workflows/release-safety-pr.yml` (2 Socket setup / 3 install sites)
- `.github/workflows/release-safety-tests.yml`
- `.github/workflows/release.yml` (2 Socket setup / 2 install sites)

## Validation

- Parsed all `.github/workflows` YAML files with Ruby Psych
- Confirmed 14/14 `socketdev/action` call sites have `firewall-version: 1.15.0`
- Confirmed 17/17 `sfw pnpm install` calls have `--network-concurrency=16`
- `git diff --check`
- `actionlint` unavailable locally

Linear: SPK-981