### PR TITLE
fix: authenticate and scope local CSV downloads

### DIFF
--- a/packages/backend/src/models/DownloadFileModel.ts
+++ b/packages/backend/src/models/DownloadFileModel.ts
@@ -56,6 +56,31 @@ export class DownloadFileModel {
         };
     }
 
+    async getDownloadFileForProject(
+        projectUuid: string,
+        fileId: string,
+    ): Promise<DownloadFile> {
+        const row = await this.database(DownloadFileTableName)
+            .where({
+                nanoid: fileId,
+                project_uuid: projectUuid,
+            })
+            .select('*')
+            .first();
+
+        if (row === undefined) {
+            throw new NotFoundError(`Cannot find file`);
+        }
+
+        return {
+            nanoid: row.nanoid,
+            path: row.path,
+            createdAt: row.created_at,
+            type: row.type as DownloadFileType,
+            projectUuid: row.project_uuid,
+        };
+    }
+
     // TODO: consider removing this method in milestone #212
     async streamResultsToCloudStorage(
         urlPrefix: string,

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -94,13 +94,18 @@ projectRouter.get(
 
 projectRouter.get(
     '/csv/:nanoId',
-
+    allowApiKeyAuthentication,
+    isAuthenticated,
     async (req, res, next) => {
         try {
             const { nanoId } = req.params;
             const { path: filePath } = await req.services
                 .getDownloadFileService()
-                .getDownloadFile(nanoId);
+                .getDownloadFileForProject(
+                    req.account!,
+                    getObjectValue(req.params, 'projectUuid'),
+                    nanoId,
+                );
             const filename = path.basename(filePath);
             const normalizedPath = path.resolve('/tmp/', filename);
             if (!normalizedPath.startsWith('/tmp/')) {

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -51,6 +51,7 @@ import { CsvService } from './CsvService';
 import { itemMap, metricQuery } from './CsvService.mock';
 
 describe('Csv service', () => {
+    const createDownloadFile = vi.fn();
     const csvService = new CsvService({
         lightdashConfig,
         analytics: analyticsMock,
@@ -103,10 +104,14 @@ describe('Csv service', () => {
                 additionalMetrics: new Set(),
             }),
         }),
-        fileStorageClient: {} as FileStorageClient,
+        fileStorageClient: {
+            isEnabled: () => false,
+        } as FileStorageClient,
         savedChartModel: {} as SavedChartModel,
         dashboardModel: {} as DashboardModel,
-        downloadFileModel: {} as DownloadFileModel,
+        downloadFileModel: {
+            createDownloadFile,
+        } as unknown as DownloadFileModel,
         schedulerClient: {} as SchedulerClient,
         projectModel: {} as ProjectModel,
         savedSqlModel: {} as SavedSqlModel,
@@ -118,6 +123,27 @@ describe('Csv service', () => {
             organizationSettingsModel: {} as OrganizationSettingsModel,
         }),
         persistentDownloadFileService: {} as PersistentDownloadFileService,
+    });
+
+    it('persists the owning project for a local CSV download', async () => {
+        createDownloadFile.mockClear();
+        createDownloadFile.mockResolvedValue(undefined);
+
+        const download = await csvService.downloadCsvFile({
+            csvContent: 'column\nvalue\n',
+            fileName: 'test-file',
+            projectUuid: 'project-uuid',
+            organizationUuid: 'organization-uuid',
+            createdByUserUuid: 'user-uuid',
+        });
+
+        expect(createDownloadFile).toHaveBeenCalledWith(
+            expect.any(String),
+            download.localPath,
+            'csv',
+            'project-uuid',
+        );
+        await fs.unlink(download.localPath);
     });
 
     it('Should convert rows to CSV with format', async () => {

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -553,6 +553,7 @@ export class CsvService extends BaseService {
             downloadFileId,
             filePath,
             DownloadFileType.CSV,
+            projectUuid,
         );
 
         const localUrl = new URL(

--- a/packages/backend/src/services/DownloadFileService/DownloadFileService.ts
+++ b/packages/backend/src/services/DownloadFileService/DownloadFileService.ts
@@ -1,12 +1,20 @@
-import { DownloadFile, ForbiddenError, NotFoundError } from '@lightdash/common';
+import { subject } from '@casl/ability';
+import {
+    DownloadFile,
+    ForbiddenError,
+    NotFoundError,
+    type Account,
+} from '@lightdash/common';
 import fs from 'fs';
 import { LightdashConfig } from '../../config/parseConfig';
 import { DownloadFileModel } from '../../models/DownloadFileModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../BaseService';
 
 type DownloadFileServiceArguments = {
     downloadFileModel: DownloadFileModel;
     lightdashConfig: Pick<LightdashConfig, 's3'>;
+    projectModel: ProjectModel;
 };
 
 export class DownloadFileService extends BaseService {
@@ -14,28 +22,63 @@ export class DownloadFileService extends BaseService {
 
     private readonly downloadFileModel: DownloadFileModel;
 
+    private readonly projectModel: ProjectModel;
+
     constructor(args: DownloadFileServiceArguments) {
         super();
         this.lightdashConfig = args.lightdashConfig;
         this.downloadFileModel = args.downloadFileModel;
+        this.projectModel = args.projectModel;
     }
 
     private isS3Enabled = () =>
         this.lightdashConfig.s3?.endpoint && this.lightdashConfig.s3.region;
 
-    async getDownloadFile(nanoid: string): Promise<DownloadFile> {
+    private assertLocalDownloadsEnabled() {
         if (this.isS3Enabled()) {
             throw new ForbiddenError(
                 'Downloading files is not available if S3 is enabled',
             );
         }
+    }
 
-        const file = await this.downloadFileModel.getDownloadFile(nanoid);
-
+    private assertFileExists(file: DownloadFile) {
         if (!fs.existsSync(file.path)) {
             const error = `This file ${file.path} doesn't exist on this server, this may be happening if you are running multiple containers or because files are not persisted. You can check out our docs to learn more on how to enable cloud storage: https://docs.lightdash.com/self-host/customize-deployment/configure-lightdash-to-use-external-object-storage`;
             throw new NotFoundError(error);
         }
+    }
+
+    async getDownloadFile(nanoid: string): Promise<DownloadFile> {
+        this.assertLocalDownloadsEnabled();
+        const file = await this.downloadFileModel.getDownloadFile(nanoid);
+        this.assertFileExists(file);
+        return file;
+    }
+
+    async getDownloadFileForProject(
+        account: Account,
+        projectUuid: string,
+        nanoid: string,
+    ): Promise<DownloadFile> {
+        this.assertLocalDownloadsEnabled();
+
+        const project = await this.projectModel.getSummary(projectUuid);
+        if (
+            this.createAuditedAbility(account).cannot(
+                'view',
+                subject('Project', project),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const file = await this.downloadFileModel.getDownloadFileForProject(
+            projectUuid,
+            nanoid,
+        );
+
+        this.assertFileExists(file);
         return file;
     }
 }

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -409,6 +409,7 @@ export class PivotTableService extends BaseService {
             downloadFileId,
             filePath,
             DownloadFileType.CSV,
+            projectUuid,
         );
 
         const localUrl = new URL(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -451,6 +451,7 @@ export class ServiceRepository
                 new DownloadFileService({
                     lightdashConfig: this.context.lightdashConfig,
                     downloadFileModel: this.models.getDownloadFileModel(),
+                    projectModel: this.models.getProjectModel(),
                 }),
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-10054

### Description:
Authenticates the local CSV download route and authorizes access against the project in the URL.
Scopes file lookup by both project UUID and nanoid so cross-project and ownerless records fail closed.
Persists project ownership for locally generated CSV and pivot downloads while preserving global lookup for non-project assets.
Validated with the focused CSV service suite, backend typecheck, backend formatting, and backend lint with an 8 GB Node heap.