### PR TITLE
refactor(data-apps): add bounded font metadata inspection

### DIFF
--- a/packages/backend/src/services/OrganizationDesignService/restrictedAppleFonts.test.ts
+++ b/packages/backend/src/services/OrganizationDesignService/restrictedAppleFonts.test.ts
@@ -1,0 +1,123 @@
+import {
+    makeOversizedTestWoff2Font,
+    makeTestTrueTypeFont,
+    makeTestWoff2Font,
+    makeTestWoffFont,
+} from '../../testing/makeTestTrueTypeFont';
+import {
+    APPLE_MONO_SYSTEM_FONT_STACK,
+    APPLE_SANS_SYSTEM_FONT_STACK,
+    APPLE_SERIF_SYSTEM_FONT_STACK,
+    classifyRestrictedAppleFont,
+    inspectAppleFont,
+} from './restrictedAppleFonts';
+
+describe('restricted Apple font policy', () => {
+    it.each([
+        ['SF Pro Display', APPLE_SANS_SYSTEM_FONT_STACK],
+        ['SFCompactText-Regular', APPLE_SANS_SYSTEM_FONT_STACK],
+        ['.SF NS Text', APPLE_SANS_SYSTEM_FONT_STACK],
+        ['SFNSDisplay-Regular', APPLE_SANS_SYSTEM_FONT_STACK],
+        ['SF Arabic Rounded', APPLE_SANS_SYSTEM_FONT_STACK],
+        ['SFMono-Regular', APPLE_MONO_SYSTEM_FONT_STACK],
+        ['.SF NS Mono Light', APPLE_MONO_SYSTEM_FONT_STACK],
+        ['.SFNSRounded-Regular', APPLE_SANS_SYSTEM_FONT_STACK],
+        ['.SF Hebrew Rounded', APPLE_SANS_SYSTEM_FONT_STACK],
+        ['NewYorkSmall-Regular', APPLE_SERIF_SYSTEM_FONT_STACK],
+    ])('classifies %s from internal metadata', (name, fallback) => {
+        expect(
+            classifyRestrictedAppleFont({
+                metadataNames: [name],
+                filename: 'renamed-brand-font.woff2',
+            }),
+        ).toEqual(expect.objectContaining({ evidence: 'metadata', fallback }));
+    });
+
+    it.each([
+        ['New York Streets', 'NewYorkStreets-Regular'],
+        ['San Francisco Nights', 'SanFranciscoNights-Regular'],
+    ])('allows the unrelated family %s', (familyName, postscriptName) => {
+        expect(
+            classifyRestrictedAppleFont({
+                metadataNames: [familyName, postscriptName],
+                filename: 'ordinary-font.ttf',
+            }),
+        ).toBeNull();
+    });
+
+    it('does not let a renamed file hide restricted internal metadata', async () => {
+        const result = await inspectAppleFont({
+            body: makeTestTrueTypeFont({
+                familyName: 'SF Pro',
+                fullName: 'SF Pro Regular',
+                postscriptName: 'SFPro-Regular',
+            }),
+            filename: 'acme-sans.ttf',
+        });
+
+        expect(result).toEqual({
+            status: 'restricted',
+            match: expect.objectContaining({
+                family: 'San Francisco',
+                evidence: 'metadata',
+            }),
+        });
+    });
+
+    it.each([
+        ['TTF', makeTestTrueTypeFont],
+        ['WOFF', makeTestWoffFont],
+        ['WOFF2', makeTestWoff2Font],
+    ])(
+        'reads restricted metadata from a %s name table',
+        async (_, makeFont) => {
+            await expect(
+                inspectAppleFont({
+                    body: makeFont({
+                        familyName: 'New York',
+                        fullName: 'New York Medium',
+                        postscriptName: 'NewYork-Medium',
+                    }),
+                    filename: 'renamed-brand-font.bin',
+                }),
+            ).resolves.toEqual({
+                status: 'restricted',
+                match: expect.objectContaining({ evidence: 'metadata' }),
+            });
+        },
+    );
+
+    it('allows an ordinary web font even when its filename looks restricted', async () => {
+        const result = await inspectAppleFont({
+            body: makeTestTrueTypeFont({
+                familyName: 'Inter',
+                fullName: 'Inter Regular',
+                postscriptName: 'Inter-Regular',
+            }),
+            filename: 'SFPro-Regular.ttf',
+        });
+
+        expect(result).toEqual({ status: 'allowed' });
+    });
+
+    it('uses the filename only when internal metadata is unreadable', async () => {
+        await expect(
+            inspectAppleFont({
+                body: Buffer.from([0x00, 0x01, 0x00, 0x00]),
+                filename: 'SF-Pro-Display.woff2',
+            }),
+        ).resolves.toEqual({
+            status: 'restricted',
+            match: expect.objectContaining({ evidence: 'filename' }),
+        });
+    });
+
+    it('does not decompress WOFF2 data beyond the inspection cap', async () => {
+        await expect(
+            inspectAppleFont({
+                body: makeOversizedTestWoff2Font(),
+                filename: 'ordinary-font.woff2',
+            }),
+        ).resolves.toEqual({ status: 'unreadable' });
+    });
+});

--- a/packages/backend/src/services/OrganizationDesignService/restrictedAppleFonts.ts
+++ b/packages/backend/src/services/OrganizationDesignService/restrictedAppleFonts.ts
@@ -1,0 +1,635 @@
+import {
+    MAX_THEME_FILE_BYTES,
+    type OrganizationDesignFileKind,
+} from '@lightdash/common';
+import { brotliDecompress, inflate } from 'node:zlib';
+import type { Logger } from 'winston';
+
+// Canonical fallback values. Keep the two static authoring references linked
+// below aligned when these change:
+// - sandboxes/data-apps/template/references/themes.md
+// - skills/developing-in-lightdash/resources/data-app-themes-reference.md
+export const APPLE_SANS_SYSTEM_FONT_STACK =
+    'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+export const APPLE_MONO_SYSTEM_FONT_STACK =
+    'ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, monospace';
+export const APPLE_SERIF_SYSTEM_FONT_STACK = 'ui-serif, Georgia, serif';
+
+type RestrictedAppleFontPolicy = {
+    family: string;
+    fallback: string;
+    identifiers: string[];
+};
+
+const RESTRICTED_APPLE_FONT_POLICIES: RestrictedAppleFontPolicy[] = [
+    {
+        family: 'SF Mono',
+        fallback: APPLE_MONO_SYSTEM_FONT_STACK,
+        identifiers: ['sf ns mono', 'sfns mono', 'sf mono', 'sfmono'],
+    },
+    {
+        family: 'San Francisco',
+        fallback: APPLE_SANS_SYSTEM_FONT_STACK,
+        identifiers: [
+            'san francisco display',
+            'san francisco text',
+            'san francisco',
+            'sf compact rounded',
+            'sf compact display',
+            'sf compact text',
+            'sf compact',
+            'sfcompact rounded',
+            'sfcompact display',
+            'sfcompact text',
+            'sfcompact',
+            'sf pro rounded',
+            'sf pro display',
+            'sf pro text',
+            'sf pro',
+            'sfpro rounded',
+            'sfpro display',
+            'sfpro text',
+            'sfpro',
+            'sf arabic rounded',
+            'sf arabic',
+            'sfarabic rounded',
+            'sfarabic',
+            'sf armenian rounded',
+            'sf armenian',
+            'sfarmenian rounded',
+            'sfarmenian',
+            'sf georgian rounded',
+            'sf georgian',
+            'sfgeorgian rounded',
+            'sfgeorgian',
+            'sf hebrew rounded',
+            'sf hebrew',
+            'sfhebrew rounded',
+            'sfhebrew',
+            'sf ui display',
+            'sf ui text',
+            'sf ui',
+            'sfui display',
+            'sfui text',
+            'sfui',
+            'sf ns rounded',
+            'sf ns display',
+            'sf ns text',
+            'sf ns',
+            'sfns rounded',
+            'sfns display',
+            'sfns text',
+            'sfns',
+            'sf hello',
+            'sfhello',
+        ],
+    },
+    {
+        family: 'New York',
+        fallback: APPLE_SERIF_SYSTEM_FONT_STACK,
+        identifiers: [
+            'new york extra large',
+            'new york small',
+            'new york medium',
+            'new york large',
+            'new york',
+            'newyork extra large',
+            'newyork small',
+            'newyork medium',
+            'newyork large',
+            'newyork',
+        ],
+    },
+];
+
+const FONT_STYLE_TOKENS = new Set([
+    'black',
+    'bold',
+    'compressed',
+    'condensed',
+    'display',
+    'expanded',
+    'extra',
+    'heavy',
+    'italic',
+    'light',
+    'medium',
+    'oblique',
+    'regular',
+    'roman',
+    'semi',
+    'semibold',
+    'text',
+    'thin',
+    'ultra',
+    'ultralight',
+]);
+const FONT_FILE_EXTENSION = /\.(?:woff2?|ttf|otf)$/i;
+const FONT_NAME_IDS = new Set([1, 4, 6, 16]);
+const MAX_FONT_NAME_TABLE_BYTES = 1024 * 1024;
+
+const WOFF2_KNOWN_TAGS = [
+    'cmap',
+    'head',
+    'hhea',
+    'hmtx',
+    'maxp',
+    'name',
+    'OS/2',
+    'post',
+    'cvt ',
+    'fpgm',
+    'glyf',
+    'loca',
+    'prep',
+    'CFF ',
+    'VORG',
+    'EBDT',
+    'EBLC',
+    'gasp',
+    'hdmx',
+    'kern',
+    'LTSH',
+    'PCLT',
+    'VDMX',
+    'vhea',
+    'vmtx',
+    'BASE',
+    'GDEF',
+    'GPOS',
+    'GSUB',
+    'EBSC',
+    'JSTF',
+    'MATH',
+    'CBDT',
+    'CBLC',
+    'COLR',
+    'CPAL',
+    'SVG ',
+    'sbix',
+    'acnt',
+    'avar',
+    'bdat',
+    'bloc',
+    'bsln',
+    'cvar',
+    'fdsc',
+    'feat',
+    'fmtx',
+    'fvar',
+    'gvar',
+    'hsty',
+    'just',
+    'lcar',
+    'mort',
+    'morx',
+    'opbd',
+    'prop',
+    'trak',
+    'Zapf',
+    'Silf',
+    'Glat',
+    'Gloc',
+    'Feat',
+    'Sill',
+] as const;
+
+export type RestrictedAppleFontMatch = {
+    family: string;
+    fallback: string;
+    evidence: 'metadata' | 'filename';
+    matchedValue: string;
+};
+
+export type AppleFontInspectionResult =
+    | { status: 'allowed' }
+    | { status: 'restricted'; match: RestrictedAppleFontMatch }
+    | { status: 'unreadable' };
+
+const normalizeFontIdentifier = (value: string): string =>
+    value
+        .normalize('NFKD')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+        .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+        .toLowerCase()
+        .replace(/[^a-z\d]+/g, ' ')
+        .trim();
+
+const isKnownStyleSuffix = (suffix: string): boolean => {
+    const tokens = suffix.split(' ');
+    return (
+        tokens.length > 0 &&
+        tokens.every(
+            (token) => FONT_STYLE_TOKENS.has(token) || /^\d{2,3}$/.test(token),
+        )
+    );
+};
+
+const matchesRestrictedIdentifier = (
+    normalized: string,
+    identifier: string,
+): boolean => {
+    if (normalized === identifier) return true;
+    if (!normalized.startsWith(`${identifier} `)) return false;
+    return isKnownStyleSuffix(normalized.slice(identifier.length + 1));
+};
+
+const matchRestrictedAppleFont = (
+    value: string,
+    evidence: RestrictedAppleFontMatch['evidence'],
+): RestrictedAppleFontMatch | null => {
+    const candidate =
+        evidence === 'filename'
+            ? value.replace(FONT_FILE_EXTENSION, '')
+            : value;
+    const normalized = normalizeFontIdentifier(candidate);
+    const policy = RESTRICTED_APPLE_FONT_POLICIES.find(({ identifiers }) =>
+        identifiers.some((identifier) =>
+            matchesRestrictedIdentifier(normalized, identifier),
+        ),
+    );
+    return policy
+        ? {
+              family: policy.family,
+              fallback: policy.fallback,
+              evidence,
+              matchedValue: value,
+          }
+        : null;
+};
+
+export const classifyRestrictedAppleFont = ({
+    metadataNames,
+    filename,
+}: {
+    metadataNames: string[];
+    filename: string;
+}): RestrictedAppleFontMatch | null => {
+    for (const name of metadataNames) {
+        const match = matchRestrictedAppleFont(name, 'metadata');
+        if (match) return match;
+    }
+
+    // Internal names are authoritative when present. Filename matching is a
+    // fallback for malformed or unusually subsetted fonts whose name table
+    // cannot be read.
+    if (metadataNames.length > 0) return null;
+    return matchRestrictedAppleFont(filename, 'filename');
+};
+
+const hasRange = (body: Buffer, offset: number, length: number): boolean =>
+    Number.isSafeInteger(offset) &&
+    Number.isSafeInteger(length) &&
+    offset >= 0 &&
+    length >= 0 &&
+    offset <= body.length &&
+    length <= body.length - offset;
+
+const decodeUtf16Be = (value: Buffer): string | null => {
+    if (value.length % 2 !== 0) return null;
+    try {
+        return Buffer.from(value).swap16().toString('utf16le');
+    } catch {
+        return null;
+    }
+};
+
+const decodeNameRecord = (value: Buffer, platformId: number): string | null => {
+    let decoded: string | null = null;
+    if (platformId === 0 || platformId === 3) {
+        decoded = decodeUtf16Be(value);
+    } else if (platformId === 1) {
+        decoded = value.toString('latin1');
+    }
+    const trimmed = decoded?.replaceAll('\0', '').trim();
+    return trimmed ? trimmed : null;
+};
+
+const readNamesFromNameTable = (table: Buffer): string[] => {
+    if (table.length < 6) return [];
+    const count = table.readUInt16BE(2);
+    const stringOffset = table.readUInt16BE(4);
+    const recordsLength = count * 12;
+    if (
+        !hasRange(table, 6, recordsLength) ||
+        stringOffset < 6 + recordsLength
+    ) {
+        return [];
+    }
+
+    const names = new Set<string>();
+    for (let index = 0; index < count; index += 1) {
+        const recordOffset = 6 + index * 12;
+        const platformId = table.readUInt16BE(recordOffset);
+        const nameId = table.readUInt16BE(recordOffset + 6);
+        if (FONT_NAME_IDS.has(nameId)) {
+            const length = table.readUInt16BE(recordOffset + 8);
+            const relativeOffset = table.readUInt16BE(recordOffset + 10);
+            const valueOffset = stringOffset + relativeOffset;
+            if (hasRange(table, valueOffset, length)) {
+                const decoded = decodeNameRecord(
+                    table.subarray(valueOffset, valueOffset + length),
+                    platformId,
+                );
+                if (decoded) names.add(decoded);
+            }
+        }
+    }
+    return [...names];
+};
+
+const readSfntNameTable = (body: Buffer): Buffer | null => {
+    if (body.length < 12) return null;
+    const numTables = body.readUInt16BE(4);
+    if (!hasRange(body, 12, numTables * 16)) return null;
+
+    for (let index = 0; index < numTables; index += 1) {
+        const recordOffset = 12 + index * 16;
+        if (body.toString('ascii', recordOffset, recordOffset + 4) === 'name') {
+            const offset = body.readUInt32BE(recordOffset + 8);
+            const length = body.readUInt32BE(recordOffset + 12);
+            if (
+                length > MAX_FONT_NAME_TABLE_BYTES ||
+                !hasRange(body, offset, length)
+            ) {
+                return null;
+            }
+            return body.subarray(offset, offset + length);
+        }
+    }
+    return null;
+};
+
+const inflateAsync = (body: Buffer, maxOutputLength: number): Promise<Buffer> =>
+    new Promise((resolve, reject) => {
+        inflate(body, { maxOutputLength }, (error, result) => {
+            if (error) reject(error);
+            else resolve(Buffer.from(result));
+        });
+    });
+
+const readWoffNameTable = async (body: Buffer): Promise<Buffer | null> => {
+    const WOFF_HEADER_BYTES = 44;
+    const WOFF_DIRECTORY_ENTRY_BYTES = 20;
+    if (body.length < WOFF_HEADER_BYTES) return null;
+
+    const numTables = body.readUInt16BE(12);
+    if (
+        !hasRange(
+            body,
+            WOFF_HEADER_BYTES,
+            numTables * WOFF_DIRECTORY_ENTRY_BYTES,
+        )
+    ) {
+        return null;
+    }
+
+    let nameTable:
+        | { offset: number; compressedLength: number; originalLength: number }
+        | undefined;
+    for (let index = 0; index < numTables; index += 1) {
+        const recordOffset =
+            WOFF_HEADER_BYTES + index * WOFF_DIRECTORY_ENTRY_BYTES;
+        if (body.toString('ascii', recordOffset, recordOffset + 4) === 'name') {
+            nameTable = {
+                offset: body.readUInt32BE(recordOffset + 4),
+                compressedLength: body.readUInt32BE(recordOffset + 8),
+                originalLength: body.readUInt32BE(recordOffset + 12),
+            };
+        }
+    }
+    if (!nameTable) return null;
+
+    if (
+        nameTable.originalLength > MAX_FONT_NAME_TABLE_BYTES ||
+        nameTable.compressedLength > nameTable.originalLength ||
+        !hasRange(body, nameTable.offset, nameTable.compressedLength)
+    ) {
+        return null;
+    }
+
+    const compressed = body.subarray(
+        nameTable.offset,
+        nameTable.offset + nameTable.compressedLength,
+    );
+    if (nameTable.compressedLength === nameTable.originalLength) {
+        return compressed;
+    }
+    const decompressed = await inflateAsync(
+        compressed,
+        nameTable.originalLength,
+    );
+    return decompressed.length === nameTable.originalLength
+        ? decompressed
+        : null;
+};
+
+const readUIntBase128 = (
+    body: Buffer,
+    initialOffset: number,
+): { value: number; nextOffset: number } => {
+    let value = 0;
+    let offset = initialOffset;
+    for (let index = 0; index < 5; index += 1) {
+        if (!hasRange(body, offset, 1)) throw new Error('Invalid UIntBase128');
+        const byte = body[offset];
+        offset += 1;
+        if (index === 0 && byte === 0x80) {
+            throw new Error('Invalid UIntBase128 leading zero');
+        }
+        if (value > 0x01ffffff) throw new Error('UIntBase128 overflow');
+        value = value * 128 + (byte % 128);
+        if (value > 0xffffffff) throw new Error('UIntBase128 overflow');
+        if (byte < 0x80) return { value, nextOffset: offset };
+    }
+    throw new Error('Invalid UIntBase128 length');
+};
+
+const brotliDecompressAsync = (
+    body: Buffer,
+    maxOutputLength: number,
+): Promise<Buffer> =>
+    new Promise((resolve, reject) => {
+        brotliDecompress(body, { maxOutputLength }, (error, result) => {
+            if (error) reject(error);
+            else resolve(Buffer.from(result));
+        });
+    });
+
+const readWoff2NameTable = async (body: Buffer): Promise<Buffer | null> => {
+    const WOFF2_HEADER_BYTES = 48;
+    if (body.length < WOFF2_HEADER_BYTES) return null;
+
+    // Collections have an additional variable-length directory. They are not
+    // accepted as TTF/OTF uploads, so preserve rather than deeply parsing an
+    // unusual legacy WOFF2 collection.
+    if (body.toString('ascii', 4, 8) === 'ttcf') return null;
+
+    const declaredLength = body.readUInt32BE(8);
+    const numTables = body.readUInt16BE(12);
+    const compressedLength = body.readUInt32BE(20);
+    if (declaredLength > body.length || declaredLength < WOFF2_HEADER_BYTES) {
+        return null;
+    }
+
+    let directoryOffset = WOFF2_HEADER_BYTES;
+    let decompressedLength = 0;
+    let nameTableOffset: number | null = null;
+    let nameTableLength = 0;
+
+    for (let index = 0; index < numTables; index += 1) {
+        if (!hasRange(body, directoryOffset, 1)) return null;
+        const flags = body[directoryOffset];
+        directoryOffset += 1;
+
+        const tagIndex = flags % 64;
+        let tag: string;
+        if (tagIndex === 0x3f) {
+            if (!hasRange(body, directoryOffset, 4)) return null;
+            tag = body.toString('ascii', directoryOffset, directoryOffset + 4);
+            directoryOffset += 4;
+        } else {
+            tag = WOFF2_KNOWN_TAGS[tagIndex];
+            if (!tag) return null;
+        }
+
+        const original = readUIntBase128(body, directoryOffset);
+        directoryOffset = original.nextOffset;
+        const transformVersion = Math.floor(flags / 64);
+        let transformed = transformVersion !== 0;
+        if (tag === 'glyf' || tag === 'loca') {
+            transformed = transformVersion === 0;
+        }
+        let storedLength = original.value;
+        if (transformed) {
+            const transform = readUIntBase128(body, directoryOffset);
+            directoryOffset = transform.nextOffset;
+            storedLength = transform.value;
+        }
+
+        if (tag === 'name') {
+            if (transformed || original.value > MAX_FONT_NAME_TABLE_BYTES) {
+                return null;
+            }
+            nameTableOffset = decompressedLength;
+            nameTableLength = original.value;
+        }
+
+        decompressedLength += storedLength;
+        if (
+            !Number.isSafeInteger(decompressedLength) ||
+            decompressedLength > MAX_THEME_FILE_BYTES
+        ) {
+            return null;
+        }
+    }
+
+    if (
+        nameTableOffset === null ||
+        decompressedLength === 0 ||
+        !hasRange(body, directoryOffset, compressedLength)
+    ) {
+        return null;
+    }
+
+    const decompressed = await brotliDecompressAsync(
+        body.subarray(directoryOffset, directoryOffset + compressedLength),
+        decompressedLength,
+    );
+    if (
+        decompressed.length !== decompressedLength ||
+        !hasRange(decompressed, nameTableOffset, nameTableLength)
+    ) {
+        return null;
+    }
+    return decompressed.subarray(
+        nameTableOffset,
+        nameTableOffset + nameTableLength,
+    );
+};
+
+const readFontMetadataNames = async (body: Buffer): Promise<string[]> => {
+    try {
+        const signature = body.toString('ascii', 0, 4);
+        let nameTable: Buffer | null;
+        if (signature === 'wOFF') {
+            nameTable = await readWoffNameTable(body);
+        } else if (signature === 'wOF2') {
+            nameTable = await readWoff2NameTable(body);
+        } else {
+            nameTable = readSfntNameTable(body);
+        }
+        return nameTable ? readNamesFromNameTable(nameTable) : [];
+    } catch {
+        return [];
+    }
+};
+
+export const inspectAppleFont = async ({
+    body,
+    filename,
+}: {
+    body: Buffer;
+    filename: string;
+}): Promise<AppleFontInspectionResult> => {
+    const metadataNames = await readFontMetadataNames(body);
+    const match = classifyRestrictedAppleFont({ metadataNames, filename });
+    if (match) return { status: 'restricted', match };
+    return metadataNames.length > 0
+        ? { status: 'allowed' }
+        : { status: 'unreadable' };
+};
+
+export const restrictedAppleFontUploadMessage = ({
+    filename,
+    match,
+}: {
+    filename: string;
+    match: RestrictedAppleFontMatch;
+}): string =>
+    `Font file "${filename}" matches the restricted Apple system font ${match.family} (${match.evidence}: "${match.matchedValue}") and can't be uploaded as a web font. Remove the file and use this system font stack instead: ${match.fallback}.`;
+
+export const inspectThemeFileForBundling = async ({
+    file,
+    body,
+    designUuid,
+    logger,
+}: {
+    file: { kind: OrganizationDesignFileKind; filename: string };
+    body: Buffer;
+    designUuid: string;
+    logger: Logger;
+}): Promise<
+    { status: 'include' } | { status: 'omit'; match: RestrictedAppleFontMatch }
+> => {
+    if (file.kind !== 'font') return { status: 'include' };
+
+    const inspection = await inspectAppleFont({
+        body,
+        filename: file.filename,
+    });
+    if (inspection.status === 'restricted') {
+        logger.warn(
+            `Theme ${designUuid}: omitted restricted Apple font filename=${file.filename} family=${inspection.match.family} evidence=${inspection.match.evidence}`,
+        );
+        return { status: 'omit', match: inspection.match };
+    }
+    if (inspection.status === 'unreadable') {
+        logger.warn(
+            `Theme ${designUuid}: could not inspect font metadata; preserving filename=${file.filename}`,
+        );
+    }
+    return { status: 'include' };
+};
+
+export const omittedThemeFontGuidance = (
+    matches: RestrictedAppleFontMatch[],
+): string => {
+    const stacks = [...new Set(matches.map(({ fallback }) => fallback))];
+    const count = matches.length;
+    return [
+        `${count} theme font file${count === 1 ? ' was' : 's were'} omitted because ${count === 1 ? 'it matches' : 'they match'} the restricted Apple system-font policy.`,
+        'Do not recreate, embed, or download the omitted font files. Preserve the intended typography with these system font stacks:',
+        ...stacks.map((fallback) => `- \`${fallback}\``),
+    ].join('\n');
+};

--- a/packages/backend/src/testing/makeTestTrueTypeFont.ts
+++ b/packages/backend/src/testing/makeTestTrueTypeFont.ts
@@ -1,0 +1,121 @@
+import { brotliCompressSync, deflateSync } from 'node:zlib';
+
+type TestFontNames = {
+    familyName: string;
+    fullName: string;
+    postscriptName: string;
+};
+
+const uint16 = (value: number): Buffer => {
+    const result = Buffer.alloc(2);
+    result.writeUInt16BE(value);
+    return result;
+};
+
+const encodeUtf16Be = (value: string): Buffer =>
+    Buffer.from(value, 'utf16le').swap16();
+
+const makeNameTable = ({
+    familyName,
+    fullName,
+    postscriptName,
+}: TestFontNames): Buffer => {
+    const names = [familyName, fullName, postscriptName].map(encodeUtf16Be);
+    let stringOffset = 0;
+    const records = names.map((name, index) => {
+        const record = Buffer.alloc(12);
+        record.writeUInt16BE(3, 0); // Windows platform
+        record.writeUInt16BE(1, 2); // Unicode BMP encoding
+        record.writeUInt16BE(0x0409, 4); // en-US
+        record.writeUInt16BE([1, 4, 6][index], 6); // family/full/PostScript
+        record.writeUInt16BE(name.length, 8);
+        record.writeUInt16BE(stringOffset, 10);
+        stringOffset += name.length;
+        return record;
+    });
+    return Buffer.concat([
+        uint16(0),
+        uint16(records.length),
+        uint16(6 + records.length * 12),
+        ...records,
+        ...names,
+    ]);
+};
+
+/**
+ * Build a minimal sfnt with a standard name table. It is intentionally not
+ * renderable: tests only need real binary metadata parsing without committing
+ * a third-party font fixture.
+ */
+export const makeTestTrueTypeFont = (names: TestFontNames): Buffer => {
+    const nameTable = makeNameTable(names);
+
+    const sfntHeader = Buffer.alloc(28);
+    sfntHeader.writeUInt32BE(0x00010000, 0);
+    sfntHeader.writeUInt16BE(1, 4);
+    sfntHeader.write('name', 12, 'ascii');
+    sfntHeader.writeUInt32BE(sfntHeader.length, 20);
+    sfntHeader.writeUInt32BE(nameTable.length, 24);
+    return Buffer.concat([sfntHeader, nameTable]);
+};
+
+export const makeTestWoffFont = (names: TestFontNames): Buffer => {
+    const nameTable = makeNameTable(names);
+    const compressed = deflateSync(nameTable);
+    const stored =
+        compressed.length < nameTable.length ? compressed : nameTable;
+    const header = Buffer.alloc(64);
+    header.write('wOFF', 0, 'ascii');
+    header.writeUInt32BE(0x00010000, 4);
+    header.writeUInt32BE(header.length + stored.length, 8);
+    header.writeUInt16BE(1, 12);
+    header.writeUInt32BE(28 + nameTable.length, 16);
+    header.write('name', 44, 'ascii');
+    header.writeUInt32BE(header.length, 48);
+    header.writeUInt32BE(stored.length, 52);
+    header.writeUInt32BE(nameTable.length, 56);
+    return Buffer.concat([header, stored]);
+};
+
+const encodeUIntBase128 = (value: number): Buffer => {
+    const bytes = [value % 128];
+    let remaining = Math.floor(value / 128);
+    while (remaining > 0) {
+        bytes.unshift((remaining % 128) + 128);
+        remaining = Math.floor(remaining / 128);
+    }
+    return Buffer.from(bytes);
+};
+
+export const makeTestWoff2Font = (names: TestFontNames): Buffer => {
+    const nameTable = makeNameTable(names);
+    const compressed = brotliCompressSync(nameTable);
+    const directory = Buffer.concat([
+        Buffer.from([5]), // `name` in the WOFF2 known-tag table, null transform
+        encodeUIntBase128(nameTable.length),
+    ]);
+    const header = Buffer.alloc(48);
+    const totalLength = header.length + directory.length + compressed.length;
+    header.write('wOF2', 0, 'ascii');
+    header.writeUInt32BE(0x00010000, 4);
+    header.writeUInt32BE(totalLength, 8);
+    header.writeUInt16BE(1, 12);
+    header.writeUInt32BE(28 + nameTable.length, 16);
+    header.writeUInt32BE(compressed.length, 20);
+    return Buffer.concat([header, directory, compressed]);
+};
+
+export const makeOversizedTestWoff2Font = (): Buffer => {
+    const directory = Buffer.concat([
+        Buffer.from([5]),
+        encodeUIntBase128(10 * 1024 * 1024 + 1),
+    ]);
+    const header = Buffer.alloc(48);
+    header.write('wOF2', 0, 'ascii');
+    header.writeUInt32BE(0x00010000, 4);
+    header.writeUInt32BE(header.length + directory.length, 8);
+    header.writeUInt16BE(1, 12);
+    header.writeUInt32BE(directory.length, 16);
+    header.writeUInt32BE(0, 20);
+    return Buffer.concat([header, directory]);
+};


### PR DESCRIPTION
## What changed

- add bounded metadata inspection for TTF, OTF, WOFF, and WOFF2 theme fonts
- classify restricted Apple font families using internal names, with filename fallback only when metadata is unavailable
- cap decompression and parsing work to avoid attacker-controlled memory amplification
- add focused parser tests using small synthetic font fixtures

## Why

GLITCH-632 needs to identify restricted Apple system fonts before they can be uploaded or bundled into generated Data Apps. This foundation keeps the security-sensitive binary parsing separate from the behavior change in the follow-up PR.

This PR does not activate the policy in upload or generation paths.

## Validation

- backend test suite: 445 files passed, 6,861 tests passed, 1 skipped
- pre-commit backend lint, formatting, unused-export check, and git-secrets checks passed