### PR TITLE
feat(ai): disable GitHub MCP personal access tokens by default

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2595,7 +2595,11 @@ export type AiAgentGithubMcpConnectedEvent = BaseTrack & {
         organizationId: string;
         projectId: string;
         mcpServerId: string;
-        method: 'one_click' | 'one_click_reconnect';
+        method:
+            | 'one_click'
+            | 'one_click_reconnect'
+            | 'one_click_app'
+            | 'one_click_app_reconnect';
     };
 };
 

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -318,6 +318,29 @@ export class AiAgentController extends BaseController {
         };
     }
 
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('201', 'Created')
+    @Post('/mcpServers/github/connect-app')
+    @OperationId('connectGithubMcpServerApp')
+    async connectGithubMcpServerApp(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiAiMcpServerResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(201);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().connectGithubMcpServerApp(
+                toSessionUser(req.account),
+                projectUuid,
+            ),
+        };
+    }
+
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('/mcpServers/{mcpServerUuid}/tools')

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -24,6 +24,7 @@ import {
     AiDuplicateSlackPromptError,
     AiMcpCredentialScope,
     AiMcpGithubAvailability,
+    AiMcpGithubConnectMode,
     AiMcpServer,
     AiMetricQueryWithFilters,
     AiModelOption,
@@ -77,6 +78,7 @@ import {
     isAiDeepResearchRunTerminal,
     isAiSqlChartArtifactConfig,
     isAiWritebackRunInProgress,
+    isGithubMcpServerUrl,
     isGitProjectType,
     isSlackMessageTooLongError,
     isSlackPrompt,
@@ -432,6 +434,16 @@ const ALLOWED_AGENT_AVATAR_MIME_TYPES = new Set([
 // comfortably under the usual 30-60s idle timeouts.
 const STREAM_KEEPALIVE_INTERVAL_MS = 15_000;
 const MAX_MCP_BEARER_TOKEN_LENGTH = 8192;
+
+const GITHUB_MCP_PAT_DISABLED_ERROR =
+    'GitHub personal access tokens are disabled. Connect GitHub through the Lightdash GitHub App integration instead';
+
+const GITHUB_MCP_UNAVAILABLE_STATUS =
+    'GitHub is not connected. An organization admin can install the Lightdash GitHub App from Organization settings → Integrations to reconnect.';
+
+const isGithubMcpBearerServer = (
+    server: Pick<AiMcpServer, 'url' | 'authType'>,
+) => isGithubMcpServerUrl(server.url) && server.authType === 'bearer';
 
 type GenerateAgentExecutionOptions =
     | { mode: 'standard' }
@@ -3357,9 +3369,54 @@ export class AiAgentService extends BaseService {
         });
     }
 
+    // Stored credentials don't always match runtime auth: App orgs mint tokens
+    // per run, and stored PATs may be disabled by the ai-mcp-github-pat flag.
+    private async applyGithubMcpDisplayStatus<
+        T extends Pick<
+            AiMcpServer,
+            'url' | 'authType' | 'connectionStatus' | 'error'
+        >,
+    >(user: SessionUser, servers: T[]): Promise<T[]> {
+        const { organizationUuid } = user;
+        if (!servers.some(isGithubMcpBearerServer) || !organizationUuid) {
+            return servers;
+        }
+        const installationId =
+            await this.githubAppInstallationsModel.findInstallationId(
+                organizationUuid,
+            );
+        if (installationId) {
+            return servers.map((server) =>
+                isGithubMcpBearerServer(server) &&
+                server.connectionStatus === 'not_connected'
+                    ? {
+                          ...server,
+                          connectionStatus: 'connected' as const,
+                          error: null,
+                      }
+                    : server,
+            );
+        }
+        if (await this.isGithubMcpPatEnabled(user)) {
+            return servers;
+        }
+        return servers.map((server) =>
+            isGithubMcpBearerServer(server)
+                ? {
+                      ...server,
+                      connectionStatus: 'not_connected' as const,
+                      error: GITHUB_MCP_UNAVAILABLE_STATUS,
+                  }
+                : server,
+        );
+    }
+
     public async listMcpServers(user: SessionUser, projectUuid: string) {
         await this.assertCanManageMcpServers(user, projectUuid);
-        return this.aiAgentModel.listMcpServers(projectUuid, user.userUuid);
+        return this.applyGithubMcpDisplayStatus(
+            user,
+            await this.aiAgentModel.listMcpServers(projectUuid, user.userUuid),
+        );
     }
 
     public async listMcpServerTools(
@@ -3432,7 +3489,8 @@ export class AiAgentService extends BaseService {
                         ...server
                     }) => server,
                 ),
-            );
+            )
+            .then((servers) => this.applyGithubMcpDisplayStatus(user, servers));
     }
 
     private async getAgentRuntimeMcpServers({
@@ -3454,7 +3512,7 @@ export class AiAgentService extends BaseService {
         }
 
         const attachedServers = await this.refreshGithubMcpCredentials(
-            user.organizationUuid,
+            user,
             await this.aiAgentModel.getAgentMcpServersWithSensitiveData(
                 agentUuid,
                 user.userUuid,
@@ -3828,6 +3886,9 @@ export class AiAgentService extends BaseService {
                 }
                 break;
             case 'bearer':
+                if (isGithubMcpServerUrl(normalizedUrl)) {
+                    await this.assertGithubMcpPatAllowed(user);
+                }
                 if (!body.credentials?.bearerToken?.trim()) {
                     throw new ParameterError(
                         'Bearer MCP servers require a bearer token',
@@ -3983,6 +4044,9 @@ export class AiAgentService extends BaseService {
                 'Only bearer-token MCP servers support updating the token',
             );
         }
+        if (isGithubMcpServerUrl(server.url)) {
+            await this.assertGithubMcpPatAllowed(user);
+        }
 
         const bearerToken = body.bearerToken.trim();
         if (!bearerToken) {
@@ -4049,53 +4113,166 @@ export class AiAgentService extends BaseService {
         return updated;
     }
 
-    /**
-     * Whether the one-click "Connect GitHub" affordance should be offered for
-     * this project. It is available only when the org has a GitHub App
-     * installation AND the caller has the same permission required to manage
-     * that integration (manage:GitIntegration) — so a project-level agent
-     * manager who is not an org admin does not see it.
-     */
+    private async isGithubMcpPatEnabled(user: SessionUser): Promise<boolean> {
+        const { enabled } = await this.featureFlagService.get({
+            user,
+            featureFlagId: FeatureFlags.AiMcpGithubPat,
+        });
+        return enabled;
+    }
+
+    private async assertGithubMcpPatAllowed(user: SessionUser): Promise<void> {
+        if (!(await this.isGithubMcpPatEnabled(user))) {
+            throw new ForbiddenError(GITHUB_MCP_PAT_DISABLED_ERROR);
+        }
+    }
+
+    private async findGithubMcpServer(projectUuid: string, userUuid: string) {
+        const servers = await this.aiAgentModel.listMcpServers(
+            projectUuid,
+            userUuid,
+        );
+        return servers.find((server) => isGithubMcpServerUrl(server.url));
+    }
+
+    private async testGithubMcpConnection(
+        bearerToken: string,
+        failureMessage: string,
+    ): Promise<{ iconUrl: string | null }> {
+        try {
+            return await this.aiAgentMcpRuntimeClient.testConnection({
+                name: GITHUB_MCP_SERVER_NAME,
+                url: GITHUB_MCP_SERVER_URL,
+                authType: 'bearer',
+                bearerToken,
+                onUncaughtError: (error) => {
+                    Logger.error(
+                        `[AiAgent][MCP][${GITHUB_MCP_SERVER_NAME}] Uncaught MCP client error while connecting`,
+                        error,
+                    );
+                },
+            });
+        } catch (error) {
+            Logger.error(
+                `[AiAgent][MCP][${GITHUB_MCP_SERVER_NAME}] Failed to connect`,
+                error,
+            );
+            throw new ParameterError(failureMessage);
+        }
+    }
+
+    private async reconnectGithubMcpServer(args: {
+        user: SessionUser;
+        organizationUuid: string;
+        projectUuid: string;
+        server: AiMcpServer;
+        bearerToken: string;
+        scope: AiMcpCredentialScope;
+        iconUrl?: string | null;
+        analyticsMethod: 'one_click_reconnect' | 'one_click_app_reconnect';
+    }): Promise<AiMcpServer> {
+        const { user, projectUuid, server, scope } = args;
+        await this.aiAgentModel.upsertCredential({
+            serverUuid: server.uuid,
+            scope,
+            userUuid: scope === 'user' ? user.userUuid : null,
+            credentials: { type: 'bearer', bearerToken: args.bearerToken },
+            actorUserUuid: user.userUuid,
+        });
+        await this.aiAgentModel.updateMcpServerRuntimeState({
+            serverUuid: server.uuid,
+            connectionStatus: 'connected',
+            error: null,
+            ...(args.iconUrl !== undefined ? { iconUrl: args.iconUrl } : {}),
+            actorUserUuid: user.userUuid,
+        });
+        this.analytics.track({
+            event: 'ai_agent.github_mcp_connected',
+            userId: user.userUuid,
+            properties: {
+                organizationId: args.organizationUuid,
+                projectId: projectUuid,
+                mcpServerId: server.uuid,
+                method: args.analyticsMethod,
+            },
+        });
+        return (
+            (await this.findGithubMcpServer(projectUuid, user.userUuid)) ??
+            server
+        );
+    }
+
+    // 'github_app' also requires manage:GitIntegration so a project-level
+    // agent manager cannot leverage an org-wide installation they don't control.
     public async getGithubMcpAvailability(
         user: SessionUser,
         projectUuid: string,
     ): Promise<AiMcpGithubAvailability> {
+        const unavailable: AiMcpGithubAvailability = {
+            availableModes: [],
+            alreadyConnected: false,
+            hasGithubAppInstallation: false,
+        };
         const { organizationUuid } = user;
         if (!organizationUuid) {
-            return { available: false, alreadyConnected: false };
+            return unavailable;
         }
 
         const isCopilotEnabled = await this.getIsCopilotEnabled(user);
         if (!isCopilotEnabled) {
-            return { available: false, alreadyConnected: false };
+            return unavailable;
         }
         const auditedAbility = this.createAuditedAbility(user);
         const canManageMcpServers = auditedAbility.can(
             'manage',
             subject('AiAgent', { organizationUuid, projectUuid }),
         );
+        const canManageGitIntegration = auditedAbility.can(
+            'manage',
+            subject('GitIntegration', { organizationUuid }),
+        );
 
-        const servers = await this.aiAgentModel.listMcpServers(
+        const installationId =
+            await this.githubAppInstallationsModel.findInstallationId(
+                organizationUuid,
+            );
+        const hasGithubAppInstallation = !!installationId;
+        const patEnabled = await this.isGithubMcpPatEnabled(user);
+
+        const githubServer = await this.findGithubMcpServer(
             projectUuid,
             user.userUuid,
         );
-        const githubServer = servers.find(
-            (server) => server.url === GITHUB_MCP_SERVER_URL,
-        );
 
-        const available = canManageMcpServers || !!githubServer;
-        if (!available) {
-            return { available: false, alreadyConnected: false };
+        const availableModes: AiMcpGithubConnectMode[] = [];
+        if (
+            hasGithubAppInstallation &&
+            canManageMcpServers &&
+            canManageGitIntegration
+        ) {
+            availableModes.push('github_app');
+        }
+        // Non-managers can still connect their own token to an existing server
+        if (patEnabled && (canManageMcpServers || !!githubServer)) {
+            availableModes.push('pat');
         }
 
-        const credential = githubServer
-            ? await this.aiAgentModel.resolveCredential(
-                  githubServer.uuid,
-                  user.userUuid,
-              )
-            : undefined;
+        if (availableModes.length === 0 && !canManageMcpServers) {
+            return unavailable;
+        }
 
-        return { available: true, alreadyConnected: !!credential };
+        // With an App installation a fresh token is minted per run, so the
+        // server is connected regardless of any stored credential.
+        const alreadyConnected =
+            !!githubServer &&
+            (hasGithubAppInstallation ||
+                (patEnabled &&
+                    !!(await this.aiAgentModel.resolveCredential(
+                        githubServer.uuid,
+                        user.userUuid,
+                    ))));
+
+        return { availableModes, alreadyConnected, hasGithubAppInstallation };
     }
 
     public async connectGithubMcpServer(
@@ -4109,6 +4286,8 @@ export class AiAgentService extends BaseService {
             throw new ForbiddenError('Organization not found');
         }
 
+        await this.assertGithubMcpPatAllowed(user);
+
         const bearerToken = personalAccessToken.trim();
         if (!bearerToken) {
             throw new ParameterError(
@@ -4121,12 +4300,9 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        const existing = await this.aiAgentModel.listMcpServers(
+        const githubServer = await this.findGithubMcpServer(
             projectUuid,
             user.userUuid,
-        );
-        const githubServer = existing.find(
-            (server) => server.url === GITHUB_MCP_SERVER_URL,
         );
 
         if (githubServer) {
@@ -4139,63 +4315,20 @@ export class AiAgentService extends BaseService {
                 );
             }
 
-            try {
-                await this.aiAgentMcpRuntimeClient.testConnection({
-                    name: GITHUB_MCP_SERVER_NAME,
-                    url: GITHUB_MCP_SERVER_URL,
-                    authType: 'bearer',
-                    bearerToken,
-                    onUncaughtError: (error) => {
-                        Logger.error(
-                            `[AiAgent][MCP][${GITHUB_MCP_SERVER_NAME}] Uncaught MCP client error while reconnecting`,
-                            error,
-                        );
-                    },
-                });
-            } catch (error) {
-                Logger.error(
-                    `[AiAgent][MCP][${GITHUB_MCP_SERVER_NAME}] Failed to reconnect with provided token`,
-                    error,
-                );
-                throw new ParameterError(
-                    "We couldn't connect to GitHub with that token. Check the token and its repository access, then try again.",
-                );
-            }
+            await this.testGithubMcpConnection(
+                bearerToken,
+                "We couldn't connect to GitHub with that token. Check the token and its repository access, then try again.",
+            );
 
-            await this.aiAgentModel.upsertCredential({
-                serverUuid: githubServer.uuid,
-                scope: credentialScope,
-                userUuid: credentialScope === 'user' ? user.userUuid : null,
-                credentials: { type: 'bearer', bearerToken },
-                actorUserUuid: user.userUuid,
-            });
-            await this.aiAgentModel.updateMcpServerRuntimeState({
-                serverUuid: githubServer.uuid,
-                connectionStatus: 'connected',
-                error: null,
-                actorUserUuid: user.userUuid,
-            });
-
-            this.analytics.track({
-                event: 'ai_agent.github_mcp_connected',
-                userId: user.userUuid,
-                properties: {
-                    organizationId: organizationUuid,
-                    projectId: projectUuid,
-                    mcpServerId: githubServer.uuid,
-                    method: 'one_click_reconnect',
-                },
-            });
-
-            const refreshed = await this.aiAgentModel.listMcpServers(
+            return this.reconnectGithubMcpServer({
+                user,
+                organizationUuid,
                 projectUuid,
-                user.userUuid,
-            );
-            return (
-                refreshed.find(
-                    (server) => server.url === GITHUB_MCP_SERVER_URL,
-                ) ?? githubServer
-            );
+                server: githubServer,
+                bearerToken,
+                scope: credentialScope,
+                analyticsMethod: 'one_click_reconnect',
+            });
         }
 
         const server = await this.createMcpServer(user, projectUuid, {
@@ -4220,22 +4353,109 @@ export class AiAgentService extends BaseService {
         return server;
     }
 
-    /**
-     * The GitHub MCP server is authed with a GitHub App installation token,
-     * which expires after ~1h. Rather than rely on the (stale) stored token,
-     * mint a fresh one per run — mirroring how writeback mints per run — so the
-     * connection can never expire mid-session.
-     */
+    // The stored installation token expires in ~1h; runtime mints a fresh one
+    // per run, so the App path keeps no long-lived secret.
+    public async connectGithubMcpServerApp(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<AiMcpServer> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+
+        await this.assertCanManageMcpServers(user, projectUuid);
+        // manage:GitIntegration so a project-level agent manager cannot
+        // leverage an org-wide installation they don't control.
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('GitIntegration', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const installationId =
+            await this.githubAppInstallationsModel.findInstallationId(
+                organizationUuid,
+            );
+        if (!installationId) {
+            throw new ParameterError(
+                'No GitHub App installation found for this organization. Install the Lightdash GitHub App first.',
+            );
+        }
+        const bearerToken = await getInstallationToken(installationId);
+
+        const mcpConnectionMetadata = await this.testGithubMcpConnection(
+            bearerToken,
+            "We couldn't connect to GitHub with the GitHub App installation. Check the installation's repository access, then try again.",
+        );
+
+        const githubServer = await this.findGithubMcpServer(
+            projectUuid,
+            user.userUuid,
+        );
+
+        if (githubServer) {
+            return this.reconnectGithubMcpServer({
+                user,
+                organizationUuid,
+                projectUuid,
+                server: githubServer,
+                bearerToken,
+                scope: 'shared',
+                iconUrl: mcpConnectionMetadata.iconUrl,
+                analyticsMethod: 'one_click_app_reconnect',
+            });
+        }
+
+        const server = await this.aiAgentModel.createMcpServer({
+            projectUuid,
+            name: GITHUB_MCP_SERVER_NAME,
+            url: GITHUB_MCP_SERVER_URL,
+            iconUrl: mcpConnectionMetadata.iconUrl,
+            authType: 'bearer',
+            allowOAuthCredentialSharing: false,
+            credentials: { bearerToken },
+            credentialScope: 'shared',
+            actorUserUuid: user.userUuid,
+        });
+
+        await this.discoverMcpServerTools({
+            projectUuid,
+            mcpServerUuid: server.uuid,
+            actorUserUuid: user.userUuid,
+        }).catch((error) => {
+            Logger.error(
+                `[AiAgent][MCP][${server.name}] Failed to discover tools after GitHub App connect`,
+                error,
+            );
+        });
+
+        this.analytics.track({
+            event: 'ai_agent.github_mcp_connected',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                mcpServerId: server.uuid,
+                method: 'one_click_app',
+            },
+        });
+
+        return server;
+    }
+
+    // App installation tokens expire after ~1h, so mint a fresh one per run.
+    // Without the App, stored PATs are only used while ai-mcp-github-pat is on.
     private async refreshGithubMcpCredentials(
-        organizationUuid: string | undefined,
+        user: SessionUser,
         servers: AiMcpServerWithSensitiveData[],
     ): Promise<AiMcpServerWithSensitiveData[]> {
-        const hasGithubMcp = servers.some(
-            (server) =>
-                server.url === GITHUB_MCP_SERVER_URL &&
-                server.authType === 'bearer',
-        );
-        if (!hasGithubMcp || !organizationUuid) {
+        const { organizationUuid } = user;
+        if (!servers.some(isGithubMcpBearerServer) || !organizationUuid) {
             return servers;
         }
 
@@ -4244,13 +4464,16 @@ export class AiAgentService extends BaseService {
                 organizationUuid,
             );
         if (!installationId) {
-            return servers;
+            if (await this.isGithubMcpPatEnabled(user)) {
+                return servers;
+            }
+            return servers.filter((server) => !isGithubMcpBearerServer(server));
         }
 
         const bearerToken = await getInstallationToken(installationId);
 
         return servers.map((server) =>
-            server.url === GITHUB_MCP_SERVER_URL && server.authType === 'bearer'
+            isGithubMcpBearerServer(server)
                 ? {
                       ...server,
                       resolvedCredential: { type: 'bearer', bearerToken },

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4209,6 +4209,7 @@ export class AiAgentService extends BaseService {
         projectUuid: string,
     ): Promise<AiMcpGithubAvailability> {
         const unavailable: AiMcpGithubAvailability = {
+            available: false,
             availableModes: [],
             alreadyConnected: false,
             hasGithubAppInstallation: false,
@@ -4272,7 +4273,12 @@ export class AiAgentService extends BaseService {
                         user.userUuid,
                     ))));
 
-        return { availableModes, alreadyConnected, hasGithubAppInstallation };
+        return {
+            available: availableModes.length > 0,
+            availableModes,
+            alreadyConnected,
+            hasGithubAppInstallation,
+        };
     }
 
     public async connectGithubMcpServer(

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -672,6 +672,8 @@ export type ApiConnectGithubMcpServerBody = {
 export type AiMcpGithubConnectMode = 'github_app' | 'pat';
 
 export type AiMcpGithubAvailability = {
+    /** @deprecated Use availableModes */
+    available: boolean;
     availableModes: AiMcpGithubConnectMode[];
     // A GitHub MCP server (matching GITHUB_MCP_SERVER_URL) already exists for
     // this project and is usable by the caller.

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -650,18 +650,35 @@ export type ApiStartAiMcpOAuthResponse = ApiSuccess<{
 export const GITHUB_MCP_SERVER_URL = 'https://api.githubcopilot.com/mcp/';
 export const GITHUB_MCP_SERVER_NAME = 'GitHub';
 
+// Hostname match rather than exact URL so trailing-slash or path variants
+// can't sidestep checks that gate GitHub MCP credentials.
+export const isGithubMcpServerUrl = (url: string): boolean => {
+    try {
+        return (
+            new URL(url).hostname === new URL(GITHUB_MCP_SERVER_URL).hostname
+        );
+    } catch {
+        return false;
+    }
+};
+
 export type ApiConnectGithubMcpServerBody = {
     personalAccessToken: string;
     credentialScope: AiMcpCredentialScope;
 };
 
+// 'github_app' mints a short-lived token per run and stores no long-lived
+// secret; 'pat' stores a user-provided token, gated by ai-mcp-github-pat.
+export type AiMcpGithubConnectMode = 'github_app' | 'pat';
+
 export type AiMcpGithubAvailability = {
-    // The org has a GitHub App installation AND the caller has permission to
-    // manage that integration (manage:GitIntegration).
-    available: boolean;
+    availableModes: AiMcpGithubConnectMode[];
     // A GitHub MCP server (matching GITHUB_MCP_SERVER_URL) already exists for
-    // this project.
+    // this project and is usable by the caller.
     alreadyConnected: boolean;
+    // The org has a Lightdash GitHub App installation. When false and no mode
+    // is available, the UI nudges the user to install the App.
+    hasGithubAppInstallation: boolean;
 };
 export type ApiAiMcpGithubAvailabilityResponse =
     ApiSuccess<AiMcpGithubAvailability>;

--- a/packages/common/src/featureFlags/previewFeatureFlags.ts
+++ b/packages/common/src/featureFlags/previewFeatureFlags.ts
@@ -24,6 +24,8 @@ const PREVIEW_EXCLUDED_FEATURE_FLAGS: ReadonlySet<string> = new Set<string>([
     // Off pending a security review, or only meaningful for eval orgs.
     FeatureFlags.SsoOrganizationSettings,
     FeatureFlags.AiReviewReplayCapture,
+    // Security hardening: previews must not accept long-lived GitHub PATs.
+    FeatureFlags.AiMcpGithubPat,
     // Derived from instance configuration: left to their config handler so a
     // preview never advertises a feature whose backend isn't configured.
     CommercialFeatureFlags.AiCopilot,

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -289,6 +289,17 @@ export enum FeatureFlags {
     OrgAiProviderApiKeys = 'org-ai-provider-api-keys',
 
     /**
+     * Allow storing long-lived GitHub personal access tokens as GitHub MCP
+     * credentials (guided connect flow and generic bearer endpoints targeting
+     * the hosted GitHub MCP URL). Off by default — orgs should authenticate
+     * via the Lightdash GitHub App, which mints a short-lived installation
+     * token per run and stores no long-lived secret. When off, previously
+     * stored PATs are also ignored at runtime. Enable
+     * per-org only as a stopgap for orgs that cannot install the GitHub App.
+     */
+    AiMcpGithubPat = 'ai-mcp-github-pat',
+
+    /**
      * Gate the whole new onboarding experience as one unit: email-only
      * signup (register collects only an email; ownership proven via email
      * OTP), the full-page organization setup experience shown after

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -1,5 +1,5 @@
 import {
-    GITHUB_MCP_SERVER_URL,
+    isGithubMcpServerUrl,
     type AiMcpCredentialScope,
     type AiMcpServer,
     type AiMcpServerAuthType,
@@ -8,6 +8,7 @@ import {
 import {
     ActionIcon,
     Alert,
+    Anchor,
     Badge,
     Box,
     Button,
@@ -50,6 +51,7 @@ import MantineModal from '../../../../components/common/MantineModal';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useProjectUpdateAiAgentMutation } from '../hooks/useProjectAiAgents';
 import {
+    useConnectGithubMcpServerAppMutation,
     useConnectGithubMcpServerMutation,
     useDisconnectMcpOAuthConnectionMutation,
     useGithubMcpAvailability,
@@ -777,6 +779,8 @@ export const AiAgentMcpServersInput = ({
         useDisclosure(false);
     const [isGithubConfirmModalOpen, githubConfirmModalHandlers] =
         useDisclosure(false);
+    const [isGithubNudgeModalOpen, githubNudgeModalHandlers] =
+        useDisclosure(false);
     const [attachSelection, setAttachSelection] = useState<string[]>([]);
     const [expandedMcpServers, setExpandedMcpServers] = useState<string[]>([]);
     const [isPersistingSelection, setIsPersistingSelection] = useState(false);
@@ -818,14 +822,18 @@ export const AiAgentMcpServersInput = ({
         useGithubMcpAvailability(projectUuid);
     const { mutateAsync: connectGithubMcp, isLoading: isConnectingGithubMcp } =
         useConnectGithubMcpServerMutation(projectUuid);
+    const {
+        mutateAsync: connectGithubMcpApp,
+        isLoading: isConnectingGithubMcpApp,
+    } = useConnectGithubMcpServerAppMutation(projectUuid);
 
     // A project-level GitHub MCP server may already exist (e.g. created for
     // another agent, or detached from this one). If so, the one-click flow just
     // re-attaches it rather than creating a duplicate.
     const existingGithubMcpServer = useMemo(
         () =>
-            mcpServers?.find(
-                (mcpServer) => mcpServer.url === GITHUB_MCP_SERVER_URL,
+            mcpServers?.find((mcpServer) =>
+                isGithubMcpServerUrl(mcpServer.url),
             ),
         [mcpServers],
     );
@@ -833,12 +841,24 @@ export const AiAgentMcpServersInput = ({
         !!existingGithubMcpServer &&
         value.includes(existingGithubMcpServer.uuid);
 
-    // One-click GitHub: offered when the org has a GitHub integration the user
-    // can manage and GitHub is not already attached to THIS agent. We gate on
-    // agent attachment (not project-level existence) so the button reappears
-    // after the server is removed from this agent.
+    // One-click GitHub: offered when a connect mode is available and GitHub is
+    // not already attached to THIS agent. We gate on agent attachment (not
+    // project-level existence) so the button reappears after the server is
+    // removed from this agent.
+    const githubConnectModes = githubMcpAvailability?.availableModes ?? [];
+    const canGithubAppConnect = githubConnectModes.includes('github_app');
+    const canGithubPatConnect = githubConnectModes.includes('pat');
     const canOneClickConnectGithub =
-        githubMcpAvailability?.available === true && !isGithubConnectedToAgent;
+        githubConnectModes.length > 0 && !isGithubConnectedToAgent;
+    // This settings surface is only reachable by users who can manage the
+    // agent, so an empty modes list means the org needs the GitHub App.
+    const showGithubAppNudge =
+        !!githubMcpAvailability &&
+        githubConnectModes.length === 0 &&
+        !githubMcpAvailability.hasGithubAppInstallation &&
+        !isGithubConnectedToAgent;
+    const showGithubConnectButton =
+        canOneClickConnectGithub || showGithubAppNudge;
 
     const selectedMcpServers = useMemo(
         () =>
@@ -990,6 +1010,56 @@ export const AiAgentMcpServersInput = ({
             value,
             githubConfirmModalHandlers,
         ],
+    );
+
+    const handleConnectGithubMcpApp = useCallback(async () => {
+        try {
+            const server = await connectGithubMcpApp();
+            if (!server) {
+                return;
+            }
+            if (!value.includes(server.uuid)) {
+                await persistMcpServerSelection([...value, server.uuid], value);
+            }
+        } catch {
+            // Errors surface via the mutation's onError toast.
+        }
+    }, [connectGithubMcpApp, persistMcpServerSelection, value]);
+
+    const handleGithubConnectClick = useCallback(() => {
+        if (canGithubAppConnect) {
+            void handleConnectGithubMcpApp();
+            return;
+        }
+        if (canGithubPatConnect) {
+            githubConfirmModalHandlers.open();
+            return;
+        }
+        githubNudgeModalHandlers.open();
+    }, [
+        canGithubAppConnect,
+        canGithubPatConnect,
+        githubConfirmModalHandlers,
+        githubNudgeModalHandlers,
+        handleConnectGithubMcpApp,
+    ]);
+
+    const githubConnectTooltip = canGithubAppConnect
+        ? "Let the agent read the code behind your metrics, using your organization's GitHub App installation."
+        : canGithubPatConnect
+          ? 'Let the agent read the code behind your metrics, using a GitHub personal access token.'
+          : 'Let the agent read the code behind your metrics. Requires the Lightdash GitHub App.';
+
+    const renderGithubConnectButton = (size: 'xs' | 'compact-xs') => (
+        <Button
+            variant="default"
+            size={size}
+            leftSection={<MantineIcon icon={IconBrandGithub} />}
+            loading={isConnectingGithubMcp || isConnectingGithubMcpApp}
+            onClick={handleGithubConnectClick}
+        >
+            Connect GitHub
+        </Button>
     );
 
     const handleAttachMcpServers = useCallback(async () => {
@@ -1233,19 +1303,21 @@ export const AiAgentMcpServersInput = ({
                         >
                             {isExpanded ? 'Hide tools' : 'View tools'}
                         </Menu.Item>
-                        {mcpServer.authType === 'bearer' && (
-                            <Menu.Item
-                                type="button"
-                                leftSection={<MantineIcon icon={IconKey} />}
-                                onClick={(event) => {
-                                    event.stopPropagation();
-                                    setEditingTokenMcpServer(mcpServer);
-                                }}
-                                disabled={isPersistingSelection}
-                            >
-                                Update token
-                            </Menu.Item>
-                        )}
+                        {mcpServer.authType === 'bearer' &&
+                            (!isGithubMcpServerUrl(mcpServer.url) ||
+                                canGithubPatConnect) && (
+                                <Menu.Item
+                                    type="button"
+                                    leftSection={<MantineIcon icon={IconKey} />}
+                                    onClick={(event) => {
+                                        event.stopPropagation();
+                                        setEditingTokenMcpServer(mcpServer);
+                                    }}
+                                    disabled={isPersistingSelection}
+                                >
+                                    Update token
+                                </Menu.Item>
+                            )}
                         {mcpServer.authType === 'oauth' && (
                             <Menu.Item
                                 type="button"
@@ -1342,6 +1414,7 @@ export const AiAgentMcpServersInput = ({
             );
         },
         [
+            canGithubPatConnect,
             handleDisconnectMcpOAuthConnection,
             handleRemoveMcpServer,
             handleRetestMcpServerConnection,
@@ -1400,28 +1473,14 @@ export const AiAgentMcpServersInput = ({
                                     </Tooltip>
                                 </Group>
                             )}
-                            {canOneClickConnectGithub && (
+                            {showGithubConnectButton && (
                                 <Tooltip
                                     withinPortal
                                     multiline
                                     w={260}
-                                    label="Let the agent read the code behind your metrics, using a GitHub personal access token."
+                                    label={githubConnectTooltip}
                                 >
-                                    <Button
-                                        variant="default"
-                                        size="compact-xs"
-                                        leftSection={
-                                            <MantineIcon
-                                                icon={IconBrandGithub}
-                                            />
-                                        }
-                                        loading={isConnectingGithubMcp}
-                                        onClick={
-                                            githubConfirmModalHandlers.open
-                                        }
-                                    >
-                                        Connect GitHub
-                                    </Button>
+                                    {renderGithubConnectButton('compact-xs')}
                                 </Tooltip>
                             )}
                             <Button
@@ -1444,23 +1503,8 @@ export const AiAgentMcpServersInput = ({
                                     No MCP servers attached
                                 </Text>
                                 <Group gap="xs">
-                                    {canOneClickConnectGithub && (
-                                        <Button
-                                            variant="default"
-                                            size="xs"
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconBrandGithub}
-                                                />
-                                            }
-                                            loading={isConnectingGithubMcp}
-                                            onClick={
-                                                githubConfirmModalHandlers.open
-                                            }
-                                        >
-                                            Connect GitHub
-                                        </Button>
-                                    )}
+                                    {showGithubConnectButton &&
+                                        renderGithubConnectButton('xs')}
                                     <Button
                                         variant="default"
                                         size="xs"
@@ -1800,6 +1844,32 @@ export const AiAgentMcpServersInput = ({
                 canChooseScope
                 onConnect={handleConnectGithubMcp}
             />
+            <MantineModal
+                opened={isGithubNudgeModalOpen}
+                onClose={githubNudgeModalHandlers.close}
+                title="Connect GitHub"
+                icon={IconBrandGithub}
+            >
+                <Stack gap="md">
+                    <Text size="sm">
+                        Connecting GitHub lets the agent read the code behind
+                        your metrics.
+                    </Text>
+                    <Text size="sm">
+                        To get started, an organization admin needs to install
+                        the Lightdash GitHub App from{' '}
+                        <Anchor
+                            href="/generalSettings/integrations"
+                            target="_blank"
+                            fz="inherit"
+                        >
+                            Organization settings → Integrations
+                        </Anchor>
+                        . Once it's installed, you can connect GitHub here with
+                        one click.
+                    </Text>
+                </Stack>
+            </MantineModal>
         </>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx
@@ -16,6 +16,7 @@ import MantineIcon from '../../../../components/common/MantineIcon';
 import { useProjectUpdateAiAgentMutation } from '../hooks/useProjectAiAgents';
 import {
     useAgentAiMcpServers,
+    useConnectGithubMcpServerAppMutation,
     useConnectGithubMcpServerMutation,
     useGithubMcpAvailability,
     useStartMcpOAuthConnectionMutation,
@@ -155,6 +156,10 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
     );
     const { mutateAsync: connectGithubMcp, isLoading: isConnectingGithubMcp } =
         useConnectGithubMcpServerMutation(projectUuid);
+    const {
+        mutateAsync: connectGithubMcpApp,
+        isLoading: isConnectingGithubMcpApp,
+    } = useConnectGithubMcpServerAppMutation(projectUuid);
     const { mutateAsync: updateAgentMcpServers, isLoading: isAttachingGithub } =
         useProjectUpdateAiAgentMutation(projectUuid, {
             showSuccessToast: false,
@@ -169,8 +174,10 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
             ),
         [mcpServers],
     );
+    const githubConnectModes = githubMcpAvailability?.availableModes ?? [];
+    const canGithubAppConnect = githubConnectModes.includes('github_app');
     const canOneClickConnectGithub =
-        githubMcpAvailability?.available === true &&
+        githubConnectModes.length > 0 &&
         githubMcpAvailability?.alreadyConnected === false;
 
     const appNames = useMemo(() => {
@@ -208,6 +215,28 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
         [refetchAgentMcpServers, startMcpOAuthConnection],
     );
 
+    const attachGithubMcpServer = useCallback(
+        async (server: Pick<AiMcpServer, 'uuid'>) => {
+            const attachedUuids = (mcpServers ?? []).map(
+                (mcpServer) => mcpServer.uuid,
+            );
+            if (!attachedUuids.includes(server.uuid)) {
+                await updateAgentMcpServers({
+                    uuid: agentUuid,
+                    mcpServerUuids: [...attachedUuids, server.uuid],
+                });
+            }
+            githubConfirmModalHandlers.close();
+            setJustConnectedGithub(true);
+        },
+        [
+            agentUuid,
+            githubConfirmModalHandlers,
+            mcpServers,
+            updateAgentMcpServers,
+        ],
+    );
+
     const handleConnectGithubMcp = useCallback(
         async (
             personalAccessToken: string,
@@ -221,31 +250,28 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
                 if (!server) {
                     return;
                 }
-                const attachedUuids = (mcpServers ?? []).map(
-                    (mcpServer) => mcpServer.uuid,
-                );
-                if (!attachedUuids.includes(server.uuid)) {
-                    await updateAgentMcpServers({
-                        uuid: agentUuid,
-                        mcpServerUuids: [...attachedUuids, server.uuid],
-                    });
-                }
-                githubConfirmModalHandlers.close();
-                setJustConnectedGithub(true);
+                await attachGithubMcpServer(server);
             } catch {
             } finally {
                 await refetchAgentMcpServers();
             }
         },
-        [
-            agentUuid,
-            connectGithubMcp,
-            githubConfirmModalHandlers,
-            mcpServers,
-            refetchAgentMcpServers,
-            updateAgentMcpServers,
-        ],
+        [attachGithubMcpServer, connectGithubMcp, refetchAgentMcpServers],
     );
+
+    const handleConnectGithubMcpApp = useCallback(async () => {
+        try {
+            const server = await connectGithubMcpApp();
+            if (!server) {
+                return;
+            }
+            await attachGithubMcpServer(server);
+        } catch {
+            // Errors surface via the mutation's onError toast.
+        } finally {
+            await refetchAgentMcpServers();
+        }
+    }, [attachGithubMcpServer, connectGithubMcpApp, refetchAgentMcpServers]);
 
     if (isLoading) return null;
 
@@ -327,8 +353,16 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
             variant="subtle"
             color="gray"
             leftSection={<MantineIcon icon={IconBrandGithub} />}
-            loading={isConnectingGithubMcp || isAttachingGithub}
-            onClick={githubConfirmModalHandlers.open}
+            loading={
+                isConnectingGithubMcp ||
+                isConnectingGithubMcpApp ||
+                isAttachingGithub
+            }
+            onClick={
+                canGithubAppConnect
+                    ? () => void handleConnectGithubMcpApp()
+                    : githubConfirmModalHandlers.open
+            }
         >
             GitHub
         </Button>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
@@ -93,6 +93,16 @@ const connectGithubMcpServer = async (
         body: JSON.stringify(body),
     });
 
+const connectGithubMcpServerApp = async (
+    projectUuid: string,
+): Promise<ApiAiMcpServerResponse['results']> =>
+    lightdashApi<ApiAiMcpServerResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/mcpServers/github/connect-app`,
+        method: 'POST',
+        body: JSON.stringify({}),
+    });
+
 const listAgentAiMcpServerTools = async (
     projectUuid: string,
     agentUuid: string,
@@ -437,6 +447,33 @@ export const useConnectGithubMcpServerMutation = (projectUuid: string) => {
         ApiConnectGithubMcpServerBody
     >({
         mutationFn: (body) => connectGithubMcpServer(projectUuid, body),
+        onSuccess: async (result) => {
+            showToastSuccess({
+                title: 'GitHub connected',
+                subtitle: `${result.name} is ready to use with your agents.`,
+            });
+            await queryClient.invalidateQueries({
+                queryKey: [PROJECT_AI_MCP_SERVERS_KEY, projectUuid],
+            });
+            await queryClient.invalidateQueries({
+                queryKey: [GITHUB_MCP_AVAILABILITY_KEY, projectUuid],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to connect GitHub',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useConnectGithubMcpServerAppMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+
+    return useMutation<ApiAiMcpServerResponse['results'], ApiError, void>({
+        mutationFn: () => connectGithubMcpServerApp(projectUuid),
         onSuccess: async (result) => {
             showToastSuccess({
                 title: 'GitHub connected',


### PR DESCRIPTION
Connecting GitHub now defaults to the Lightdash GitHub App. Accepting, storing, or using PATs for the GitHub MCP host is gated behind the `ai-mcp-github-pat` feature flag, off by default (including in preview environments, which are excluded from flag force-enabling).

<details><summary>screenshots</summary>

Flag off, no GitHub App installed — the connect button explains what to do instead of collecting a token:

![Nudge modal pointing to the GitHub App integration](https://raw.githubusercontent.com/lightdash/lightdash/0c683307a18b5e020eb85ce84e5aa7628aee7c33/github-mcp-nudge-modal.png)

Flag enabled for an org — the existing PAT flow stays available unchanged:

![PAT connect modal](https://raw.githubusercontent.com/lightdash/lightdash/0c683307a18b5e020eb85ce84e5aa7628aee7c33/github-mcp-pat-modal.png)

</details>

Closes: PROD-9828