### PR TITLE
feat: announce upgrade freeze state changes in the upgrade-automation example

### DIFF
--- a/examples/upgrade-automation/README.md
+++ b/examples/upgrade-automation/README.md
@@ -18,9 +18,9 @@ The loop is:
 
 Copy [`template-workflow.yml`](./template-workflow.yml) to `.github/workflows/lightdash-upgrade.yml` in the repository that owns the deployment pin. Change the `Deploy Lightdash` workflow name under `workflow_run` to the exact `name:` of the workflow that deploys the default branch.
 
-The template polls hourly, can be run manually, and accepts a `repository_dispatch` event of type `lightdash-release`. These are detection mechanisms only: each new release is considered as soon as a trigger observes it, with no upgrade window or veto delay.
+The template polls hourly, can be run manually, and accepts a `repository_dispatch` event of type `lightdash-release`. These are detection mechanisms only: each new release is considered as soon as a trigger observes it, with no upgrade window or veto delay. The template also listens for freeze-label changes and issue close/reopen events so it can announce freeze transitions.
 
-The plan and verify jobs call reusable composite actions from this repository. Replace both `REPLACE_WITH_LIGHTDASH_COMMIT_SHA` placeholders with the same reviewed full commit SHA that contains this directory. Keeping the action immutable is important because both jobs receive repository-write credentials and the optional Slack secret.
+The plan, verify, and freeze-announcement jobs call reusable composite actions from this repository. Replace all three `REPLACE_WITH_LIGHTDASH_COMMIT_SHA` placeholders with the same reviewed full commit SHA that contains this directory. Keeping the actions immutable is important because the jobs receive repository-write credentials and the optional Slack secret.
 
 The plan action creates the pin commit through the GitHub API, so GitHub verifies the commit and it satisfies rulesets that require signed commits. Because the action does not use Git to push, its consumer checkout should set `persist-credentials: false`.
 
@@ -37,7 +37,7 @@ The plan action creates the pin commit through the GitHub API, so GitHub verifie
 | `escalation` | `LIGHTDASH_UPGRADE_SLACK_WEBHOOK` secret | Optional Slack incoming-webhook URL. The webhook configuration selects the destination channel. Empty disables Slack while retaining issues and pull-request comments. |
 | `freeze_label` | `LIGHTDASH_FREEZE_LABEL` | Label on any open issue that disarms planning. Verification failures create this label and an issue automatically. |
 
-The composite actions also take `github_token`. The verify action receives `deploy_run_url`, `deploy_conclusion`, and `deployed_sha` from `workflow_run`; customers normally leave those template expressions unchanged.
+The composite actions also take `github_token`. The verify action receives `deploy_run_url`, `deploy_conclusion`, and `deployed_sha` from `workflow_run`; customers normally leave those template expressions unchanged. The freeze announcer receives issue-event metadata from the workflow and sends its optional Slack notification through the same `escalation` webhook.
 
 ## Plan outputs
 
@@ -51,7 +51,7 @@ All three outputs are empty when planning exits early because upgrades are froze
 
 ## Event choreography
 
-The schedule, manual dispatch, and release dispatch run the planning half. A freeze-only job is deliberately first and checkout is skipped when frozen. The plan action repeats the check so direct composite-action consumers retain the same fail-closed behavior.
+The schedule, manual dispatch, and release dispatch run the planning half. A freeze-only job is deliberately first and checkout is skipped when frozen. The plan action repeats the check so direct composite-action consumers retain the same fail-closed behavior. Issue events run only the freeze announcer: planning, freeze checking, and verification do not run for them.
 
 The deployment workflow runs when the pin pull request merges into the default branch. Its completed `workflow_run` event starts verification and supplies the actual deploy-run URL and deployed SHA. Verification identifies the matching merged pin pull request in the deployed commit history, so batched pushes are covered; a pin pull request with an existing verification summary and unrelated deployments exit silently. A failed deployment workflow is itself a verification failure and creates the freeze issue without waiting for readiness polling.
 
@@ -63,14 +63,13 @@ The current CLI includes a required stop equal to the target in `requiredStops`,
 
 ## Tokens and permissions
 
-The workflow requests:
+The workflow grants each job only the permissions it uses:
 
-- `contents: write` to create the version branch and GitHub-verified commit through the API;
-- `pull-requests: write` to open, comment on, and enable auto-merge for the pin pull request;
-- `issues: write` to inspect freeze issues and create a freeze label and issue on failure;
-- `actions: read` to consume deployment workflow metadata.
+- the planner gets `contents: write`, `pull-requests: write`, and `issues: read` to create the version branch and pull request after checking the freeze state;
+- the verifier gets `contents: read`, `pull-requests: write`, and `issues: write` to inspect the deployed commit, record the result, and create a freeze issue on failure;
+- the freeze check and announcer get `issues: read` only.
 
-The repository `GITHUB_TOKEN` is enough to create the API-authored commit, open a pull request, and leave durable comments when repository policy allows write tokens. The plan action needs Contents read/write and Pull requests read/write permissions; the complete workflow also needs Issues read/write and Actions read for its freeze and verification flows. GitHub suppresses most new workflow runs caused by events created with a workflow's own `GITHUB_TOKEN`. In particular, merging the pin with that token may not trigger the consumer's push-based deployment workflow, so zero-touch auto-merge should use a fine-grained PAT or GitHub App token stored as `UPGRADE_AUTOMATION_TOKEN` with the same repository permissions. Repository rules and required checks still apply.
+The repository `GITHUB_TOKEN` is enough to create the API-authored commit, open a pull request, and leave durable comments when repository policy allows write tokens. The plan action needs Contents read/write, Pull requests read/write, and Issues read permissions; the verifier also needs Contents read, Pull requests read/write, and Issues read/write. GitHub suppresses most new workflow runs caused by events created with a workflow's own `GITHUB_TOKEN`. In particular, merging the pin with that token may not trigger the consumer's push-based deployment workflow, and an automatically created freeze issue does not trigger the issue-event announcer. Zero-touch auto-merge should use a fine-grained PAT or GitHub App token stored as `UPGRADE_AUTOMATION_TOKEN` with the same repository permissions. Repository rules and required checks still apply. When a PAT or GitHub App token does trigger the auto-created issue event, the exact `<!-- upgrade-automation:auto-freeze -->` sentinel in its body suppresses a duplicate pause notification.
 
 `workflow_dispatch` and `repository_dispatch` are exceptions to GitHub's recursion suppression and always create workflow runs. A release-event integration can call:
 
@@ -85,8 +84,8 @@ The CLI is exactly pinned and its complete dependency tree is locked in `cli/pac
 
 ## Freeze and recovery
 
-To disarm upgrades manually, open an issue with the configured freeze label. The first planning job detects it before checkout and exits without a pull request, Slack message, or other side effect.
+To disarm upgrades manually, open an issue with the configured freeze label. The first planning job detects it before checkout and exits without a pull request or other side effect. When that issue becomes the only open freeze-labelled issue, the issue-event announcer posts one `[upgrade-freeze-on]` Slack message saying that automated Lightdash upgrades are paused and that closing the issue resumes them. The first active freeze issue is the pause transition; additional labelled issues do not announce another pause.
 
-Verification failure creates the same kind of issue automatically. Investigate the linked deployment run and the recorded readiness reason, restore the deployment forward, and confirm that `readyz` is 200 with three stable version matches. Close every open freeze-labelled issue to re-arm planning; the next scheduled or manual run resumes from the version currently pinned in the default branch.
+Verification failure creates the same kind of issue automatically, with the auto-freeze sentinel in its body. Investigate the linked deployment run and the recorded readiness reason, restore the deployment forward, and confirm that `readyz` is 200 with three stable version matches. Close or unlabel every open freeze-labelled issue to re-arm planning; when the count reaches zero, the announcer posts one `[upgrade-freeze-off]` Slack message that automated Lightdash upgrades are resumed. The next scheduled or manual run resumes from the version currently pinned in the default branch.
 
 No step sends telemetry or calls back to Lightdash. Network calls are limited to GitHub, the public Lightdash release-safety index and npm package registry, the configured deployment and registry, and the optional Slack webhook. The planner installs the reviewed CLI dependency tree from its committed lockfile with lifecycle scripts disabled, in an isolated runner-temporary prefix so a different CLI version in the consumer repository cannot shadow `upgrade-check`.

--- a/examples/upgrade-automation/freeze-announce/action.yml
+++ b/examples/upgrade-automation/freeze-announce/action.yml
@@ -1,0 +1,51 @@
+name: Announce upgrade freeze transitions
+description: Announce when a freeze-labelled issue pauses or resumes automated Lightdash upgrades
+inputs:
+  event_action:
+    description: GitHub issues event action
+    required: true
+  issue_url:
+    description: URL of the issue that triggered the event
+    required: true
+  issue_title:
+    description: Title of the issue that triggered the event
+    required: true
+  issue_state:
+    description: Current state of the issue that triggered the event
+    required: true
+  issue_body:
+    description: Body of the issue that triggered the event
+    required: true
+  actor_login:
+    description: Login of the actor that triggered the event
+    required: true
+  label_name:
+    description: Freeze label associated with the triggering event
+    required: true
+  freeze_label:
+    description: Open-issue label that disarms upgrade planning
+    required: true
+  escalation:
+    description: Optional Slack incoming webhook from a repository secret; never commit the URL in plaintext
+    required: false
+    default: ''
+  github_token:
+    description: GitHub token used to inspect open freeze issues
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Announce the upgrade freeze transition
+      shell: bash
+      env:
+        EVENT_ACTION: ${{ inputs.event_action }}
+        ISSUE_URL: ${{ inputs.issue_url }}
+        ISSUE_TITLE: ${{ inputs.issue_title }}
+        ISSUE_STATE: ${{ inputs.issue_state }}
+        ISSUE_BODY: ${{ inputs.issue_body }}
+        ACTOR_LOGIN: ${{ inputs.actor_login }}
+        LABEL_NAME: ${{ inputs.label_name }}
+        FREEZE_LABEL: ${{ inputs.freeze_label }}
+        ESCALATION: ${{ inputs.escalation }}
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: "$GITHUB_ACTION_PATH/../scripts/freeze-announce.sh"

--- a/examples/upgrade-automation/scripts/freeze-announce.sh
+++ b/examples/upgrade-automation/scripts/freeze-announce.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+require_value event_action "${EVENT_ACTION:-}"
+require_value issue_url "${ISSUE_URL:-}"
+require_value issue_title "${ISSUE_TITLE:-}"
+require_value issue_state "${ISSUE_STATE:-}"
+require_value actor_login "${ACTOR_LOGIN:-}"
+require_value label_name "${LABEL_NAME:-}"
+require_value freeze_label "${FREEZE_LABEL:-}"
+require_value github_token "${GH_TOKEN:-}"
+
+if [[ "$LABEL_NAME" != "$FREEZE_LABEL" ]]; then
+    exit 0
+fi
+
+open_freeze_issue_count() {
+    gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "$FREEZE_LABEL" --limit 2 --json number --jq 'length'
+}
+
+case "$EVENT_ACTION" in
+    labeled|reopened)
+        if [[ "$ISSUE_STATE" != "open" ]]; then
+            exit 0
+        fi
+        if [[ "$(open_freeze_issue_count)" != "1" ]]; then
+            exit 0
+        fi
+        if [[ "${ISSUE_BODY:-}" == *'<!-- upgrade-automation:auto-freeze -->'* ]]; then
+            exit 0
+        fi
+        post_slack "[upgrade-freeze-on] $ISSUE_URL | actor: $ACTOR_LOGIN | Automated Lightdash upgrades are paused. Close the issue to resume."
+        ;;
+    closed|unlabeled)
+        if [[ "$EVENT_ACTION" == "unlabeled" && "$ISSUE_STATE" != "open" ]]; then
+            exit 0
+        fi
+        if [[ "$(open_freeze_issue_count)" != "0" ]]; then
+            exit 0
+        fi
+        post_slack "[upgrade-freeze-off] $ISSUE_URL | actor: $ACTOR_LOGIN | Automated Lightdash upgrades are resumed."
+        ;;
+esac

--- a/examples/upgrade-automation/scripts/verify.sh
+++ b/examples/upgrade-automation/scripts/verify.sh
@@ -167,6 +167,8 @@ fi
 gh label create "$FREEZE_LABEL" --repo "$GITHUB_REPOSITORY" --force --color B60205 --description 'Disarms automated Lightdash upgrades'
 issue_title="Lightdash $pinned_public upgrade verification failed"
 cat >"$issue_body" <<EOF
+<!-- upgrade-automation:auto-freeze -->
+
 The automated verification for \`$from_version\` → \`$pinned_public\` failed and future upgrades are frozen.
 
 - Pull request: $pr_url

--- a/examples/upgrade-automation/template-workflow.yml
+++ b/examples/upgrade-automation/template-workflow.yml
@@ -7,17 +7,19 @@ on:
   repository_dispatch:
     types:
       - lightdash-release
+  issues:
+    types:
+      - labeled
+      - unlabeled
+      - closed
+      - reopened
   workflow_run:
     workflows:
       - Deploy Lightdash
     types:
       - completed
 
-permissions:
-  actions: read
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: lightdash-upgrade-${{ github.repository }}
@@ -34,7 +36,9 @@ env:
 
 jobs:
   freeze-check:
-    if: github.event_name != 'workflow_run'
+    if: github.event_name != 'workflow_run' && github.event_name != 'issues'
+    permissions:
+      issues: read
     runs-on: ubuntu-latest
     outputs:
       frozen: ${{ steps.freeze.outputs.frozen }}
@@ -54,7 +58,11 @@ jobs:
 
   plan:
     needs: freeze-check
-    if: needs.freeze-check.outputs.frozen == 'false'
+    if: github.event_name != 'issues' && needs.freeze-check.outputs.frozen == 'false'
+    permissions:
+      contents: write
+      issues: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -78,6 +86,10 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.head_branch == github.event.repository.default_branch
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -96,4 +108,28 @@ jobs:
           deploy_run_url: ${{ github.event.workflow_run.html_url }}
           deploy_conclusion: ${{ github.event.workflow_run.conclusion }}
           deployed_sha: ${{ github.event.workflow_run.head_sha }}
+          github_token: ${{ secrets.UPGRADE_AUTOMATION_TOKEN || github.token }}
+
+  freeze-announce:
+    if: github.event_name == 'issues'
+    permissions:
+      issues: read
+    runs-on: ubuntu-latest
+    steps:
+      - if: >-
+          ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+          github.event.label.name == env.LIGHTDASH_FREEZE_LABEL) ||
+          ((github.event.action == 'closed' || github.event.action == 'reopened') &&
+          contains(github.event.issue.labels.*.name, env.LIGHTDASH_FREEZE_LABEL))
+        uses: lightdash/lightdash/examples/upgrade-automation/freeze-announce@REPLACE_WITH_LIGHTDASH_COMMIT_SHA
+        with:
+          event_action: ${{ github.event.action }}
+          issue_url: ${{ github.event.issue.html_url }}
+          issue_title: ${{ github.event.issue.title }}
+          issue_state: ${{ github.event.issue.state }}
+          issue_body: ${{ github.event.issue.body }}
+          actor_login: ${{ github.actor }}
+          label_name: ${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name || env.LIGHTDASH_FREEZE_LABEL }}
+          freeze_label: ${{ env.LIGHTDASH_FREEZE_LABEL }}
+          escalation: ${{ secrets.LIGHTDASH_UPGRADE_SLACK_WEBHOOK }}
           github_token: ${{ secrets.UPGRADE_AUTOMATION_TOKEN || github.token }}


### PR DESCRIPTION
Adds a reusable issue-event announcer that reports the first active freeze and the final resume transition through the configured Slack webhook.

This makes automated upgrade pauses and resumptions visible while avoiding duplicate pause messages for verification-created freeze issues.

Linear: SPK-982