### PR TITLE
feat: add freeze and unfreeze dispatch entry points to the upgrade-automation example

### DIFF
--- a/examples/upgrade-automation/README.md
+++ b/examples/upgrade-automation/README.md
@@ -16,11 +16,11 @@ The loop is:
 
 ## Copy the workflow
 
-Copy [`template-workflow.yml`](./template-workflow.yml) to `.github/workflows/lightdash-upgrade.yml` in the repository that owns the deployment pin. Change the `Deploy Lightdash` workflow name under `workflow_run` to the exact `name:` of the workflow that deploys the default branch.
+Copy [`template-workflow.yml`](./template-workflow.yml) to `.github/workflows/lightdash-upgrade.yml` in the repository that owns the deployment pin. Change the `Deploy Lightdash` workflow name under `workflow_run` to the exact `name:` of the workflow that deploys the default branch. Copy [`template-freeze-workflow.yml`](./template-freeze-workflow.yml) to `.github/workflows/lightdash-upgrade-freeze.yml` to provide the recommended dispatch-based pause and resume path.
 
 The template polls hourly, can be run manually, and accepts a `repository_dispatch` event of type `lightdash-release`. These are detection mechanisms only: each new release is considered as soon as a trigger observes it, with no upgrade window or veto delay. The template also listens for freeze-label changes and issue close/reopen events so it can announce freeze transitions.
 
-The plan, verify, and freeze-announcement jobs call reusable composite actions from this repository. Replace all three `REPLACE_WITH_LIGHTDASH_COMMIT_SHA` placeholders with the same reviewed full commit SHA that contains this directory. Keeping the actions immutable is important because the jobs receive repository-write credentials and the optional Slack secret.
+The plan, verify, and freeze-announcement jobs call reusable composite actions from this repository. Replace all three `REPLACE_WITH_LIGHTDASH_COMMIT_SHA` placeholders with the same reviewed full commit SHA that contains this directory. Replace the placeholder in the freeze workflow with that same pinned SHA before using it. Keeping these references immutable is important because the workflows receive repository-write credentials and the optional Slack secret.
 
 The plan action creates the pin commit through the GitHub API, so GitHub verifies the commit and it satisfies rulesets that require signed commits. Because the action does not use Git to push, its consumer checkout should set `persist-credentials: false`.
 
@@ -84,7 +84,7 @@ The CLI is exactly pinned and its complete dependency tree is locked in `cli/pac
 
 ## Freeze and recovery
 
-To disarm upgrades manually, open an issue with the configured freeze label. The first planning job detects it before checkout and exits without a pull request or other side effect. When that issue becomes the only open freeze-labelled issue, the issue-event announcer posts one `[upgrade-freeze-on]` Slack message saying that automated Lightdash upgrades are paused and that closing the issue resumes them. The first active freeze issue is the pause transition; additional labelled issues do not announce another pause.
+Use the copied freeze workflow's `freeze` dispatch to pause upgrades and its `unfreeze` dispatch to resume them. The workflow creates or closes freeze-labelled issues but posts no Slack messages itself. Announcements come from the PR 1 issue-event announcer in the main upgrade workflow. Manual issue authoring remains supported: open an issue with the configured freeze label to disarm upgrades. The first planning job detects it before checkout and exits without a pull request or other side effect. When that issue becomes the only open freeze-labelled issue, the issue-event announcer posts one `[upgrade-freeze-on]` Slack message saying that automated Lightdash upgrades are paused and that closing the issue resumes them. The first active freeze issue is the pause transition; additional labelled issues do not announce another pause.
 
 Verification failure creates the same kind of issue automatically, with the auto-freeze sentinel in its body. Investigate the linked deployment run and the recorded readiness reason, restore the deployment forward, and confirm that `readyz` is 200 with three stable version matches. Close or unlabel every open freeze-labelled issue to re-arm planning; when the count reaches zero, the announcer posts one `[upgrade-freeze-off]` Slack message that automated Lightdash upgrades are resumed. The next scheduled or manual run resumes from the version currently pinned in the default branch.
 

--- a/examples/upgrade-automation/scripts/freeze-toggle.sh
+++ b/examples/upgrade-automation/scripts/freeze-toggle.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+require_value action "${ACTION:-}"
+require_value actor_login "${ACTOR_LOGIN:-}"
+require_value freeze_label "${FREEZE_LABEL:-}"
+require_value github_token "${GH_TOKEN:-}"
+
+reason=${REASON:-}
+
+create_freeze_label() {
+    gh label create "$FREEZE_LABEL" --repo "$GITHUB_REPOSITORY" --color B60205 \
+        --description 'Disarms automated Lightdash upgrades' --force
+}
+
+open_freeze_issues() {
+    gh api --method GET --paginate "repos/$GITHUB_REPOSITORY/issues" \
+        -f state=open -f labels="$FREEZE_LABEL" -f per_page=100 \
+        --jq '.[] | select(.pull_request == null) | "\(.number)\t\(.html_url)"'
+}
+
+write_freeze_body() {
+    local body_file=$1
+    {
+        printf 'Automated Lightdash upgrades are paused.\n\n'
+        printf 'Actor: %s\n' "$ACTOR_LOGIN"
+        printf 'Reason: %s\n\n' "$reason"
+        printf 'Close this issue or run the unfreeze dispatch to resume automated Lightdash upgrades.\n'
+    } >"$body_file"
+}
+
+write_unfreeze_comment() {
+    local body_file=$1
+    {
+        printf 'Automated Lightdash upgrades are being resumed.\n\n'
+        printf 'Actor: %s\n' "$ACTOR_LOGIN"
+        printf 'Reason: %s\n' "$reason"
+    } >"$body_file"
+}
+
+case "$ACTION" in
+    freeze)
+        create_freeze_label
+        issues=$(open_freeze_issues)
+        existing_issue=${issues%%$'\n'*}
+        if [[ -n "$existing_issue" ]]; then
+            issue_url=${existing_issue#*$'\t'}
+            printf 'NO-OP: automated Lightdash upgrades are already frozen: %s\n' "$issue_url"
+            exit 0
+        fi
+
+        body_file=$(mktemp)
+        trap 'rm -f "$body_file"' EXIT
+        write_freeze_body "$body_file"
+        gh issue create --repo "$GITHUB_REPOSITORY" --title 'Manual upgrade freeze' \
+            --label "$FREEZE_LABEL" --body-file "$body_file"
+        ;;
+    unfreeze)
+        issues=$(open_freeze_issues)
+        if [[ -z "$issues" ]]; then
+            printf 'NO-OP: automated Lightdash upgrades are already unfrozen.\n'
+            exit 0
+        fi
+
+        comment_file=$(mktemp)
+        trap 'rm -f "$comment_file"' EXIT
+        write_unfreeze_comment "$comment_file"
+        while IFS=$'\t' read -r issue_number issue_url; do
+            gh issue comment "$issue_number" --repo "$GITHUB_REPOSITORY" --body-file "$comment_file"
+            gh issue close "$issue_number" --repo "$GITHUB_REPOSITORY"
+            printf 'Unfroze upgrades by closing: %s\n' "$issue_url"
+        done <<<"$issues"
+        ;;
+    *)
+        printf 'unknown action: %s; expected freeze or unfreeze\n' "$ACTION" >&2
+        exit 1
+        ;;
+esac

--- a/examples/upgrade-automation/template-freeze-workflow.yml
+++ b/examples/upgrade-automation/template-freeze-workflow.yml
@@ -1,0 +1,48 @@
+name: Lightdash upgrade freeze
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Freeze or unfreeze automated Lightdash upgrades
+        required: true
+        type: choice
+        options:
+          - freeze
+          - unfreeze
+      reason:
+        description: Optional reason for the change
+        required: false
+        type: string
+
+permissions:
+  issues: write
+
+concurrency:
+  group: lightdash-upgrade-${{ github.repository }}
+  cancel-in-progress: false
+
+env:
+  LIGHTDASH_FREEZE_LABEL: upgrade-freeze
+
+jobs:
+  toggle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout upgrade automation
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init lightdash-upgrade-automation
+          git -C lightdash-upgrade-automation remote add origin https://github.com/lightdash/lightdash.git
+          git -C lightdash-upgrade-automation fetch --depth=1 origin REPLACE_WITH_LIGHTDASH_COMMIT_SHA
+          git -C lightdash-upgrade-automation checkout --detach FETCH_HEAD
+      - name: Toggle upgrade freeze
+        shell: bash
+        env:
+          ACTION: ${{ inputs.action }}
+          REASON: ${{ inputs.reason }}
+          ACTOR_LOGIN: ${{ github.actor }}
+          FREEZE_LABEL: ${{ env.LIGHTDASH_FREEZE_LABEL }}
+          GH_TOKEN: ${{ github.token }}
+        run: lightdash-upgrade-automation/examples/upgrade-automation/scripts/freeze-toggle.sh


### PR DESCRIPTION
Adds a copy-paste dispatch workflow for pausing and resuming automated upgrades through the existing freeze-issue state.

The workflow records the operator and optional reason, handles repeated requests idempotently, and leaves Slack announcements to the issue-event announcer in the parent change.

Linear: SPK-983