### PR TITLE
fix(ai): render adjusted deep research reports

### DIFF
--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -1504,7 +1504,9 @@ describe('AiDeepResearchService', () => {
             const { service, model, queryHistoryModel } = buildService({
                 executor: vi.fn().mockResolvedValue({
                     status: 'completed',
-                    report: chartReport,
+                    report: {
+                        markdown: `# Evidence report\n\n${chartReportMarkdown}`,
+                    },
                     warehouseQueryUuids: [chart.queryUuid],
                 }),
             });
@@ -1525,6 +1527,16 @@ describe('AiDeepResearchService', () => {
             expect(model.markCompleted).toHaveBeenCalledWith(
                 'run-1',
                 expect.stringContaining('The baseline trend is stable.'),
+                {
+                    repaired: [],
+                    dropped: [{ key: chart.queryUuid, reason: 'unverifiable' }],
+                },
+            );
+            expect(model.markCompleted).toHaveBeenCalledWith(
+                'run-1',
+                expect.stringMatching(
+                    /^# Evidence report\n\n<warning title="Report adjusted">/,
+                ),
                 {
                     repaired: [],
                     dropped: [{ key: chart.queryUuid, reason: 'unverifiable' }],

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -79,6 +79,21 @@ const STALE_RUN_ERROR_MESSAGE =
     'Deep Research stopped unexpectedly before it could finish.';
 const FAILED_RUN_ERROR_MESSAGE =
     'Deep Research could not finish. Please try again.';
+const REPORT_ADJUSTED_WARNING =
+    '<warning title="Report adjusted">Some chart evidence was omitted because it could not be verified. The remaining narrative and verified evidence are preserved.</warning>';
+
+const addReportAdjustedWarning = (markdown: string): string => {
+    const reportTitle = markdown.match(/^# +.+$/m);
+    if (!reportTitle || reportTitle.index === undefined) {
+        return `${REPORT_ADJUSTED_WARNING}\n\n${markdown}`;
+    }
+
+    const reportTitleEnd = reportTitle.index + reportTitle[0].length;
+    return `${markdown.slice(
+        0,
+        reportTitleEnd,
+    )}\n\n${REPORT_ADJUSTED_WARNING}${markdown.slice(reportTitleEnd)}`;
+};
 
 const getCompletionClass = (
     status: DbAiDeepResearchRun['status'],
@@ -1395,7 +1410,7 @@ export class AiDeepResearchService extends BaseService {
         const hasDroppedCharts = chartReport.adjustments.dropped.length > 0;
         return {
             markdown: hasDroppedCharts
-                ? `<warning title="Report adjusted">Some chart evidence was omitted because it could not be verified. The remaining narrative and verified evidence are preserved.</warning>\n\n${chartReport.markdown}`
+                ? addReportAdjustedWarning(chartReport.markdown)
                 : chartReport.markdown,
             adjustments: chartReport.adjustments,
         };

--- a/packages/common/src/ee/aiDeepResearch/markdown.test.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.test.ts
@@ -534,6 +534,35 @@ describe('report parsing', () => {
                 '[Revenue grew steadily](https://example.com) until spring.\n\nThe dip aligns with contract renewals.',
         });
     });
+
+    it('parses adjusted reports with a warning before the title', () => {
+        const markdown = `<warning title="Report adjusted">Some chart evidence was omitted.</warning>\n\n${validReport}`;
+
+        expect(parseDeepResearchReport(markdown)).toMatchObject({
+            title: 'Revenue Reversal Explained',
+            introductionMarkdown: expect.stringContaining(
+                'The seasonal dip is driven by B2B churn rather than a broad demand decline.',
+            ),
+        });
+    });
+
+    it('returns null when arbitrary content precedes the title', () => {
+        expect(
+            parseDeepResearchReport(`Unexpected preamble\n\n${validReport}`),
+        ).toBeNull();
+    });
+
+    it('preserves fenced blocks in the introduction', () => {
+        const markdown = validReport.replace(
+            'The seasonal dip is driven by B2B churn rather than a broad demand decline.',
+            '```text\nThe seasonal dip is driven by B2B churn rather than a broad demand decline.\n```',
+        );
+
+        expect(parseDeepResearchReport(markdown)?.introductionMarkdown).toBe(
+            '```text\nThe seasonal dip is driven by B2B churn rather than a broad demand decline.\n```',
+        );
+    });
+
     it('returns null for malformed model output', () => {
         const invalid = validReport.replace(
             /## Renewals drove[\s\S]*?(?=## Conclusion)/,

--- a/packages/common/src/ee/aiDeepResearch/markdown.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.ts
@@ -439,15 +439,22 @@ const getSectionContent = (
 const getWordCount = (value: string): number =>
     value.trim().split(/\s+/).filter(Boolean).length;
 
+const isSupportedReportTitlePrefix = (prefix: string): boolean =>
+    /^(?:\s*<warning title="Report adjusted">[\s\S]*?<\/warning>)?\s*$/.test(
+        prefix,
+    );
+
 const getReportHeader = (
     preamble: string,
+    titleLineIndex?: number,
 ): { title: string | null; introductionMarkdown: string } => {
     const lines = preamble.split('\n');
     const firstContentLine = lines.findIndex((line) => line.trim().length > 0);
+    const reportTitleLine = titleLineIndex ?? firstContentLine;
     const titleMatch =
-        firstContentLine === -1
+        reportTitleLine === -1
             ? null
-            : lines[firstContentLine].match(/^# +(.+?)\s*$/);
+            : lines[reportTitleLine].match(/^# +(.+?)\s*$/);
 
     if (!titleMatch) {
         return { title: null, introductionMarkdown: preamble.trim() };
@@ -456,7 +463,7 @@ const getReportHeader = (
     return {
         title: titleMatch[1].trim(),
         introductionMarkdown: lines
-            .filter((_line, index) => index !== firstContentLine)
+            .filter((_line, index) => index !== reportTitleLine)
             .join('\n')
             .trim(),
     };
@@ -674,9 +681,21 @@ export const lintDeepResearchReport = (markdown: string): string[] => {
 export const parseDeepResearchReport = (
     markdown: string,
 ): ParsedDeepResearchReport | null => {
-    const { preamble, sections } = splitSections(maskFencedBlocks(markdown));
-    const { title: reportTitle, introductionMarkdown } =
-        getReportHeader(preamble);
+    const maskedMarkdown = maskFencedBlocks(markdown);
+    const { preamble: maskedPreamble, sections } =
+        splitSections(maskedMarkdown);
+    const reportTitleLine = maskedPreamble
+        .split('\n')
+        .findIndex((line) => /^# +(.+?)\s*$/.test(line));
+    const preamble = markdown.slice(0, maskedPreamble.length);
+    const reportTitlePrefix = preamble
+        .split('\n')
+        .slice(0, reportTitleLine)
+        .join('\n');
+    const { title: reportTitle, introductionMarkdown } = getReportHeader(
+        preamble,
+        isSupportedReportTitlePrefix(reportTitlePrefix) ? reportTitleLine : -1,
+    );
     const conclusionIndex = sections.findIndex(
         ({ title }) => title.trim().toLowerCase() === 'conclusion',
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -190,6 +190,23 @@ describe('DeepResearchReport', () => {
         ).toBeVisible();
     });
 
+    it('renders adjusted reports in the structured view', async () => {
+        renderReport(vi.fn(), {
+            ...deepResearchRunFixture,
+            resultMarkdown: `<warning title="Report adjusted">Some chart evidence was omitted.</warning>\n\n${canonicalMarkdown}`,
+        });
+
+        expect(
+            await screen.findByRole('heading', {
+                name: 'Reliability Drove Retention Losses',
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('heading', { name: 'Conclusion' }),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Report adjusted')).toBeInTheDocument();
+    });
+
     it('renders inline markdown in the generated report title', async () => {
         mocks.useChartQuery.mockReturnValue({
             isLoading: false,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-10091

## Summary

Adjusted Deep Research reports render in the structured report view again. The parser also preserves fenced Markdown in report introductions.

## Root cause

Chart repair prepended a `Report adjusted` warning before the report H1. The structured parser required the first meaningful line to be the H1 and derived rendered introduction content from a fence-masked copy.

## Fix

The parser accepts the exact legacy adjustment-warning prefix while keeping arbitrary pre-title content on the fallback renderer. New reports place the adjustment warning immediately after the H1, and structural scans no longer replace rendered introduction Markdown.

## Before and after

- Before
  - adjusted report → plain/failing fallback
  - fenced introduction → blank masked content
- After
  - adjusted report → structured title, findings, and conclusion
  - fenced introduction → original Markdown content

## Test plan

- [x] Common Deep Research Markdown suite — 45 tests
- [x] Backend Deep Research service suite — 73 tests
- [x] Frontend `DeepResearchReport` component suite
- [x] Common, backend, and frontend typechecks
- [x] Common, backend, and frontend lint and format checks