### PR TITLE
fix(embed): show suggestions for parameterized dimensions

### DIFF
--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -616,6 +616,7 @@ export class EmbedController extends BaseController {
             tableName?: string;
             fieldId?: string;
             timezone?: string;
+            parameters?: ParametersValuesMap;
         },
     ): Promise<{
         status: 'ok';
@@ -630,6 +631,7 @@ export class EmbedController extends BaseController {
             tableName,
             fieldId,
             timezone,
+            parameters,
         } = body;
 
         assertEmbeddedAuth(req.account);
@@ -645,6 +647,7 @@ export class EmbedController extends BaseController {
             tableName,
             fieldId,
             timezone,
+            parameters,
         });
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -6,6 +6,7 @@ import {
     type PossibleAbilities,
     type SessionUser,
 } from '@lightdash/common';
+import { validExplore } from '../../../services/ProjectService/ProjectService.mock';
 import { EmbedService } from './EmbedService';
 import {
     EmbedServiceArgumentsMock,
@@ -643,5 +644,123 @@ describe('EmbedService', () => {
                 { projectUuid: mockProjectUuid },
             );
         });
+
+        test.each([
+            {
+                isInteractivityEnabled: true,
+                expectedRequestParameters: { date_granularity: 'Month' },
+            },
+            {
+                isInteractivityEnabled: false,
+                expectedRequestParameters: {},
+            },
+        ])(
+            'combines embed autocomplete parameters when interactivity is $isInteractivityEnabled',
+            async ({ isInteractivityEnabled, expectedRequestParameters }) => {
+                const dashboardUuid = 'dashboard-1';
+                const field = validExplore.tables.a.dimensions.dim1;
+                const effectiveParameters = { date_granularity: 'Month' };
+                const combineParameters = vi
+                    .fn()
+                    .mockResolvedValue(effectiveParameters);
+                const runEmbedQuery = vi.fn().mockResolvedValue({
+                    rows: [{ a_dim1: 'result' }],
+                    cacheMetadata: { cacheHit: false },
+                });
+                const scopedService = new EmbedService({
+                    ...EmbedServiceArgumentsMock,
+                    embedModel: {
+                        get: vi.fn().mockResolvedValue({
+                            dashboardUuids: [dashboardUuid],
+                            allowAllDashboards: false,
+                            user: { userUuid: mockUserUuid },
+                        }),
+                    },
+                    dashboardModel: {
+                        getByIdOrSlug: vi.fn().mockResolvedValue({
+                            uuid: dashboardUuid,
+                            projectUuid: mockProjectUuid,
+                            organizationUuid: mockOrganizationUuid,
+                            filters: {
+                                dimensions: [
+                                    {
+                                        id: 'filter-uuid',
+                                        target: {
+                                            tableName: 'a',
+                                            fieldId: 'a_dim1',
+                                        },
+                                    },
+                                ],
+                            },
+                            parameters: {
+                                date_granularity: {
+                                    value: 'Week',
+                                    isPinned: true,
+                                },
+                            },
+                            tiles: [],
+                        }),
+                    },
+                    projectService: {
+                        _getFieldValuesMetricQuery: vi.fn().mockResolvedValue({
+                            metricQuery: {
+                                exploreName: validExplore.name,
+                                dimensions: ['a_dim1'],
+                                metrics: [],
+                                filters: {},
+                                sorts: [],
+                                limit: 50,
+                                tableCalculations: [],
+                            },
+                            explore: validExplore,
+                            field,
+                        }),
+                        combineParameters,
+                        isTimezoneSupportEnabled: vi
+                            .fn()
+                            .mockResolvedValue(false),
+                        getQueryTimezoneForProject: vi
+                            .fn()
+                            .mockResolvedValue('UTC'),
+                    },
+                } as unknown as ConstructorParameters<typeof EmbedService>[0]);
+                Object.assign(scopedService, {
+                    _runEmbedQuery: runEmbedQuery,
+                });
+                const account = {
+                    access: {
+                        content: { dashboardUuid },
+                        parameters: { enabled: isInteractivityEnabled },
+                    },
+                    user: { id: mockUserUuid },
+                    organization: {
+                        organizationUuid: mockOrganizationUuid,
+                    },
+                } as unknown as AnonymousAccount;
+
+                await scopedService.searchFilterValues({
+                    account,
+                    projectUuid: mockProjectUuid,
+                    filterUuid: 'filter-uuid',
+                    search: '',
+                    limit: 50,
+                    filters: undefined,
+                    forceRefresh: false,
+                    parameters: { date_granularity: 'Month' },
+                });
+
+                expect(combineParameters).toHaveBeenCalledWith(
+                    mockProjectUuid,
+                    validExplore,
+                    expectedRequestParameters,
+                    { date_granularity: 'Week' },
+                );
+                expect(runEmbedQuery).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        combinedParameters: effectiveParameters,
+                    }),
+                );
+            },
+        );
     });
 });

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -2360,6 +2360,7 @@ export class EmbedService extends BaseService {
         tableName: fallbackTableName,
         fieldId: fallbackFieldId,
         timezone: sessionTimezoneParam,
+        parameters,
     }: {
         account: AnonymousAccount;
         projectUuid: string;
@@ -2371,6 +2372,7 @@ export class EmbedService extends BaseService {
         tableName?: string;
         fieldId?: string;
         timezone?: string;
+        parameters?: ParametersValuesMap;
     }): Promise<FieldValueSearchResult> {
         const { dashboardUuids, allowAllDashboards, user } =
             await this.embedModel.get(projectUuid);
@@ -2462,6 +2464,18 @@ export class EmbedService extends BaseService {
                 organizationUuid: dashboard.organizationUuid,
             });
 
+        const acceptedUserParameters =
+            isParameterInteractivityEnabled(account.access.parameters) &&
+            parameters
+                ? parameters
+                : {};
+        const combinedParameters = await this.projectService.combineParameters(
+            projectUuid,
+            explore,
+            acceptedUserParameters,
+            getDashboardParametersValuesMap(dashboard),
+        );
+
         const useTimezoneAwareDateTrunc =
             await this.projectService.isTimezoneSupportEnabled({
                 userUuid: user?.userUuid ?? account.user.id,
@@ -2497,6 +2511,7 @@ export class EmbedService extends BaseService {
             account,
             timezone,
             useTimezoneAwareDateTrunc,
+            combinedParameters,
         });
 
         return {

--- a/packages/frontend/src/hooks/useFieldValues.test.ts
+++ b/packages/frontend/src/hooks/useFieldValues.test.ts
@@ -7,6 +7,7 @@ import {
 import { waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { lightdashApi } from '../api';
+import useEmbed from '../ee/providers/Embed/useEmbed';
 import { renderHookWithProviders } from '../testing/testUtils';
 import {
     getFieldValuesAsync,
@@ -385,6 +386,49 @@ describe('useFieldValues', () => {
                 { value: 'prospect' },
                 { value: 'trial', label: 'Trial account' },
             ]);
+        });
+    });
+
+    it('forwards parameter values to embedded filter autocomplete', async () => {
+        vi.mocked(useEmbed).mockReturnValue({
+            embedToken: 'embed-token',
+        } as ReturnType<typeof useEmbed>);
+        vi.mocked(lightdashApi).mockResolvedValueOnce({
+            search: '',
+            results: [],
+            cached: false,
+            refreshedAt: new Date('2026-08-13T09:00:00.000Z'),
+        } as never);
+
+        renderHookWithProviders(() =>
+            useFieldValues(
+                '',
+                [],
+                'project-uuid',
+                {
+                    ...fieldWithWarehouseAutocomplete,
+                    filterAutocomplete: {
+                        values: [],
+                        fetchFromWarehouse: true,
+                    },
+                },
+                'filter-uuid',
+                undefined,
+                false,
+                false,
+                undefined,
+                { date_granularity: 'Month' },
+            ),
+        );
+
+        await waitFor(() => {
+            expect(lightdashApi).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: expect.stringContaining(
+                        '"parameters":{"date_granularity":"Month"}',
+                    ),
+                }),
+            );
         });
     });
 });

--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -109,6 +109,7 @@ const getEmbedFilterValues = async (options: {
     tableName: string | undefined;
     fieldId: string | undefined;
     timezone: string | null;
+    parameters: ParametersValuesMap | undefined;
 }) => {
     return lightdashApi<FieldValueSearchResult>({
         url: `/embed/${options.projectId}/filter/${options.filterId}/search`,
@@ -121,6 +122,7 @@ const getEmbedFilterValues = async (options: {
             tableName: options.tableName,
             fieldId: options.fieldId,
             timezone: options.timezone ?? undefined,
+            parameters: options.parameters,
         }),
     });
 };
@@ -393,6 +395,7 @@ export const useFieldValues = (
                     tableName,
                     fieldId,
                     timezone: sessionTimezone,
+                    parameters: parameterValues,
                 });
             }
             if (useAsyncPath) {


### PR DESCRIPTION
Closes lightdash/lightdash#27314

## Summary

Embedded dashboard filter dropdowns now return suggestions for dimensions whose SQL references parameters. The fix applies to saved dashboard filters and SDK-injected filters without changing native dashboard autocomplete.

## Root cause

The embed frontend already had the active parameter values, but its autocomplete request omitted them. The embed service then compiled the field-value query without resolved dashboard or project parameter values, which allowed raw `${lightdash.parameters...}` syntax to reach the warehouse.

```text
Before: embed dropdown -> no parameters -> unresolved SQL -> warehouse error
After:  embed dropdown -> JWT gate -> merge pinned/defaults -> compiled SQL -> suggestions
```

## Fix

The autocomplete request accepts an optional parameter map. The service accepts interactive overrides only when the signed embed token enables parameter interactivity, merges them with pinned dashboard and project defaults through the existing parameter resolver, and passes the effective values into embed query compilation.

Existing clients can omit the new field. When interactivity is disabled, request overrides remain ignored and saved/default values still resolve.

## Before

The real embedded dropdown returned HTTP 400 with a warehouse syntax error and showed no suggestions.

## After

The same embedded dropdown returns HTTP 200 and displays `param is greater`, `param is smaller`, and `(null)`. An explicit interactive override changes the result to only `param is smaller`.

## Test plan

- [X] Frontend `useFieldValues` tests — 10 passed, including embedded parameter forwarding
- [X] Backend `EmbedService` tests — 28 passed, including enabled and disabled parameter interactivity
- [X] Frontend typecheck and focused frontend/backend lint
- [X] `pnpm generate-api`
- [X] Chrome DevTools: reproduce the failure on a real local embedded dashboard and capture the before screenshot
- [X] Chrome DevTools: verify the fixed dropdown, HTTP 200 response, interactive override, and capture the after screenshot
- [X] Restore the local dashboard fixture after verification

Backend typecheck is blocked by the existing `packages/backend/src/ee/services/ai/models/bedrock.ts:86` adaptive reasoning configuration error; this change does not touch that path.