### PR TITLE
fix: use news icon for "What's new?" nav button

### DIFF
--- a/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
+++ b/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Tooltip } from '@mantine/core';
-import { IconSparkles } from '@tabler/icons-react';
+import { IconNews } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
 import useHeadway from '../../hooks/thirdPartyServices/useHeadway';
 import useApp from '../../providers/App/useApp';
@@ -72,7 +72,7 @@ const HeadwayMenuItem: FC<Props> = ({ projectUuid }) => {
                 pos="relative"
                 id="headway-trigger"
             >
-                <MantineIcon icon={IconSparkles} />
+                <MantineIcon icon={IconNews} />
                 <Box
                     id="headway-badge"
                     pos="absolute"


### PR DESCRIPTION
Closes: lightdash/lightdash#27323

### Description:

The "What's new?" changelog trigger in the nav bar used `IconSparkles`, which reads as "AI" (the sparkle glyph is used across Lightdash for actual AI features) and caused mis-clicks. Swapped it for Tabler `IconNews`; behavior and tooltip are unchanged.

<img src="https://github.com/user-attachments/assets/9a49d02a-6e0c-4264-bc30-d0bc4b453224 " alt="CleanShot 2026-08-13 at 12 29 40" width="375" data-linear-height="87" />