### PR TITLE
fix(CI): bootstrap uuid extension before migration ledger

### DIFF
--- a/packages/backend/src/database/migrationLease.test.ts
+++ b/packages/backend/src/database/migrationLease.test.ts
@@ -52,6 +52,7 @@ const manager = (token: string) =>
     });
 
 const handleBootstrap = () => {
+    tracker.on.any(/CREATE EXTENSION IF NOT EXISTS "uuid-ossp"/).response([]);
     tracker.on.any(MIGRATION_LEASE_SCHEMA_SQL).response([]);
     tracker.on.any(MIGRATION_RUN_LEDGER_SCHEMA_SQL).response([]);
 };
@@ -86,9 +87,10 @@ describe('MigrationLeaseManager', () => {
     test('uses the runtime schema during bootstrap', async () => {
         handleBootstrap();
         await manager('claim-a').ensureSchema();
-        expect(tracker.history.any).toHaveLength(2);
-        expect(tracker.history.any[0]?.sql).toEqual(MIGRATION_LEASE_SCHEMA_SQL);
-        expect(tracker.history.any[1]?.sql).toEqual(
+        expect(tracker.history.any).toHaveLength(3);
+        expect(tracker.history.any[0]?.sql).toContain('uuid-ossp');
+        expect(tracker.history.any[1]?.sql).toEqual(MIGRATION_LEASE_SCHEMA_SQL);
+        expect(tracker.history.any[2]?.sql).toEqual(
             MIGRATION_RUN_LEDGER_SCHEMA_SQL,
         );
     });

--- a/packages/backend/src/database/migrationLease.ts
+++ b/packages/backend/src/database/migrationLease.ts
@@ -12,6 +12,7 @@ export const MIGRATION_LEASE_EXPIRY_MS = 75_000;
 const BOOTSTRAP_MAX_ATTEMPTS = 10;
 const BOOTSTRAP_RETRY_DELAY_MS = 50;
 const UNLOCK_MAX_ATTEMPTS = 3;
+const UUID_EXTENSION_SQL = 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"';
 const RETRYABLE_BOOTSTRAP_ERROR_CODES = new Set(['23505', '42P07']);
 
 const LEGACY_LEASE_COLUMNS = [
@@ -294,6 +295,7 @@ export class MigrationLeaseManager {
 
     private async ensureSchemaAttempt(attempt: number): Promise<void> {
         try {
+            await this.database.raw(UUID_EXTENSION_SQL);
             await this.database.raw(MIGRATION_LEASE_SCHEMA_SQL);
             await this.database.raw(MIGRATION_RUN_LEDGER_SCHEMA_SQL);
         } catch (error) {


### PR DESCRIPTION
## What

- install `uuid-ossp` before migration lease and ledger bootstrap
- unblock migrations on fresh databases

## Verification

- migration lease unit tests: 16 passed
- touched-file formatting: passed
- remaining checks: CI

Relates: SPK-926
Relates: #27140