### PR TITLE
fix(ai): enforce deep research authorization boundaries

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -219,6 +219,7 @@ export type DbAiPrompt = {
     saved_query_uuid: string | null;
     model_config: { modelName: string; modelProvider: string } | null;
     token_usage: AiPromptTokenUsage | null;
+    execution_mode: 'standard' | 'deep_research' | null;
     // Hidden turn: the agent receives and responds to the prompt, but the UI
     // doesn't render the user bubble (e.g. the post-merge migration prompt).
     hidden: boolean;
@@ -229,7 +230,7 @@ export type AiPromptTable = Knex.CompositeTableType<
     DbAiPrompt,
     // insert
     Pick<DbAiPrompt, 'ai_thread_uuid' | 'created_by_user_uuid' | 'prompt'> &
-        Partial<Pick<DbAiPrompt, 'model_config' | 'hidden'>>,
+        Partial<Pick<DbAiPrompt, 'model_config' | 'hidden' | 'execution_mode'>>,
     // update
     Partial<
         Pick<
@@ -244,6 +245,7 @@ export type AiPromptTable = Knex.CompositeTableType<
             | 'saved_query_uuid'
             | 'model_config'
             | 'token_usage'
+            | 'execution_mode'
         > & {
             responded_at: Knex.Raw;
         }

--- a/packages/backend/src/ee/database/migrations/20260813130000_add_ai_prompt_execution_mode.ts
+++ b/packages/backend/src/ee/database/migrations/20260813130000_add_ai_prompt_execution_mode.ts
@@ -1,0 +1,21 @@
+import type { Knex } from 'knex';
+
+const tableName = 'ai_prompt';
+const columnName = 'execution_mode';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(tableName, (table) => {
+        table
+            .enu(columnName, ['standard', 'deep_research'], {
+                useNative: false,
+                enumName: 'ai_prompt_execution_mode',
+            })
+            .nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(tableName, (table) => {
+        table.dropColumn(columnName);
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -240,7 +240,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         aiOrganizationSettingsModel:
                             models.getAiOrganizationSettingsModel<AiOrganizationSettingsModel>(),
                         projectModel: models.getProjectModel(),
-                        featureFlagModel: models.getFeatureFlagModel(),
                         schedulerClient:
                             clients.getSchedulerClient() as CommercialSchedulerClient,
                         asyncQueryService: repository.getAsyncQueryService(),

--- a/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
@@ -81,6 +81,30 @@ describe('AiAgentModel prompt activity', () => {
         );
     });
 
+    it('atomically assigns one execution mode to a prompt', async () => {
+        const threadUuid = await createWebAppThread();
+        const promptUuid = await model.createWebAppPrompt({
+            threadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            prompt: 'Choose one execution mode',
+        });
+
+        const [standardClaimed, researchClaimed] = await Promise.all([
+            model.claimPromptExecutionMode(promptUuid, 'standard'),
+            model.claimPromptExecutionMode(promptUuid, 'deep_research'),
+        ]);
+
+        expect([standardClaimed, researchClaimed].filter(Boolean)).toHaveLength(
+            1,
+        );
+        expect(
+            await model.claimPromptExecutionMode(
+                promptUuid,
+                standardClaimed ? 'standard' : 'deep_research',
+            ),
+        ).toBe(true);
+    });
+
     it('fails only prompts that are still pending during shutdown', async () => {
         const threadUuid = await createWebAppThread();
         const [pendingPromptUuid, completedPromptUuid, failedPromptUuid] =

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -199,6 +199,7 @@ import {
 } from '../database/entities/aiEvals';
 import { type SqlApprovalDecision } from '../services/ai/tools/sqlApprovals';
 import { AiAgentReviewClassifierModel } from './AiAgentReviewClassifierModel';
+import { claimAiPromptExecutionMode } from './claimAiPromptExecutionMode';
 
 export type AiPromptResponseState = {
     respondedAt: string | null;
@@ -5028,6 +5029,17 @@ export class AiAgentModel {
             .returning<{ ai_prompt_uuid: string }[]>('ai_prompt_uuid');
 
         return rows.length > 0;
+    }
+
+    async claimPromptExecutionMode(
+        promptUuid: string,
+        executionMode: 'standard' | 'deep_research',
+    ): Promise<boolean> {
+        return claimAiPromptExecutionMode(
+            this.database,
+            promptUuid,
+            executionMode,
+        );
     }
 
     async failPendingPrompts(

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -35,6 +35,7 @@ import {
 } from '../database/entities/aiDeepResearch';
 import {
     AiDeepResearchActiveRunError,
+    AiDeepResearchPromptExecutionModeError,
     AiDeepResearchRunModel,
 } from './AiDeepResearchRunModel';
 
@@ -246,6 +247,17 @@ describe('AiDeepResearchRunModel integration', () => {
         );
     };
 
+    it('rejects research after standard execution claims the prompt', async () => {
+        const standardPromptUuid = await createAdditionalPrompt();
+        await database(AiPromptTableName)
+            .update({ execution_mode: 'standard' })
+            .where('ai_prompt_uuid', standardPromptUuid);
+
+        await expect(
+            createRun({ promptUuid: standardPromptUuid }),
+        ).rejects.toBeInstanceOf(AiDeepResearchPromptExecutionModeError);
+    });
+
     it('allows exactly one worker to claim a queued run', async () => {
         const run = await createRun();
 
@@ -303,6 +315,17 @@ describe('AiDeepResearchRunModel integration', () => {
         ).rejects.toMatchObject({
             activeRunUuid: winner.ai_deep_research_run_uuid,
         });
+        await expect(
+            database(AiPromptTableName)
+                .select('execution_mode')
+                .whereIn('ai_prompt_uuid', [
+                    queuedPromptUuid,
+                    runningPromptUuid,
+                ]),
+        ).resolves.toEqual([
+            { execution_mode: null },
+            { execution_mode: null },
+        ]);
     });
 
     it.each<AiDeepResearchRunStatus>([
@@ -646,7 +669,6 @@ describe('AiDeepResearchRunModel integration', () => {
             .update({
                 status: 'completed',
                 result_markdown: 'expired report',
-                result_chart_data: JSON.stringify({}),
                 completed_at: database.raw("now() - interval '31 days'"),
                 report_expires_at: null,
             });
@@ -664,7 +686,6 @@ describe('AiDeepResearchRunModel integration', () => {
             .update({
                 status: 'completed',
                 result_markdown: 'future report',
-                result_chart_data: JSON.stringify({}),
                 completed_at: database.raw("now() - interval '1 day'"),
                 report_expires_at: database.raw("now() + interval '29 days'"),
             });
@@ -778,7 +799,6 @@ describe('AiDeepResearchRunModel integration', () => {
             );
             expect(persistedExpired).toMatchObject({
                 result_markdown: null,
-                result_chart_data: null,
             });
             expect(persistedExpired?.report_expires_at).not.toBeNull();
             expect(persistedExpired?.report_expired_at).not.toBeNull();
@@ -832,7 +852,6 @@ describe('AiDeepResearchRunModel integration', () => {
             .update({
                 status: 'completed',
                 result_markdown: 'must survive',
-                result_chart_data: JSON.stringify({}),
                 completed_at: database.raw("now() - interval '31 days'"),
                 report_expires_at: database.raw("now() - interval '1 day'"),
             });

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
@@ -106,6 +106,23 @@ describe('AiDeepResearchRunModel', () => {
         ]);
     });
 
+    it('loads a prompt run for execution regardless of the acting user', async () => {
+        tracker.on.select(AiDeepResearchRunsTableName).responseOnce([]);
+
+        await model.findByPromptForExecution({
+            promptUuid: 'prompt-1',
+            organizationUuid: 'organization-1',
+            projectUuid: 'project-1',
+        });
+
+        expect(tracker.history.select[0].bindings).toEqual([
+            'prompt-1',
+            'organization-1',
+            'project-1',
+            1,
+        ]);
+    });
+
     it('loads conversation runs by prompt within the organization and project', async () => {
         tracker.on.select(AiDeepResearchRunsTableName).responseOnce([]);
 

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -43,6 +43,7 @@ import {
     type DbAiDeepResearchRun,
 } from '../database/entities/aiDeepResearch';
 import { isDeepResearchWarehouseTool } from '../services/AiDeepResearchService/toolClassification';
+import { claimAiPromptExecutionMode } from './claimAiPromptExecutionMode';
 
 type Dependencies = {
     database: Knex;
@@ -130,6 +131,12 @@ export class AiDeepResearchActiveRunError extends Error {
         super('A Deep Research run is already active in this thread');
         this.name = 'AiDeepResearchActiveRunError';
         this.activeRunUuid = activeRunUuid;
+    }
+}
+
+export class AiDeepResearchPromptExecutionModeError extends Error {
+    constructor() {
+        super('This prompt is already assigned to standard chat execution');
     }
 }
 
@@ -315,6 +322,15 @@ export class AiDeepResearchRunModel {
                 .forUpdate()
                 .first();
 
+            const claimedPrompt = await claimAiPromptExecutionMode(
+                transaction,
+                data.promptUuid,
+                'deep_research',
+            );
+            if (!claimedPrompt) {
+                throw new AiDeepResearchPromptExecutionModeError();
+            }
+
             const activeRun = await transaction<AiDeepResearchRunsTable>(
                 AiDeepResearchRunsTableName,
             )
@@ -427,6 +443,20 @@ export class AiDeepResearchRunModel {
             .where('organization_uuid', args.organizationUuid)
             .where('project_uuid', args.projectUuid)
             .where('created_by_user_uuid', args.createdByUserUuid)
+            .first();
+    }
+
+    async findByPromptForExecution(args: {
+        promptUuid: string;
+        organizationUuid: string;
+        projectUuid: string;
+    }): Promise<DbAiDeepResearchRun | undefined> {
+        return this.database<AiDeepResearchRunsTable>(
+            AiDeepResearchRunsTableName,
+        )
+            .where('prompt_uuid', args.promptUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .where('project_uuid', args.projectUuid)
             .first();
     }
 

--- a/packages/backend/src/ee/models/claimAiPromptExecutionMode.ts
+++ b/packages/backend/src/ee/models/claimAiPromptExecutionMode.ts
@@ -1,0 +1,22 @@
+import type { Knex } from 'knex';
+import { AiPromptTableName, type AiPromptTable } from '../database/entities/ai';
+
+type Queryable = Knex | Knex.Transaction;
+
+export const claimAiPromptExecutionMode = async (
+    database: Queryable,
+    promptUuid: string,
+    executionMode: 'standard' | 'deep_research',
+): Promise<boolean> => {
+    const rows = await database<AiPromptTable>(AiPromptTableName)
+        .update({ execution_mode: executionMode })
+        .where('ai_prompt_uuid', promptUuid)
+        .where((query) =>
+            query
+                .whereNull('execution_mode')
+                .orWhere('execution_mode', executionMode),
+        )
+        .returning<{ ai_prompt_uuid: string }[]>('ai_prompt_uuid');
+
+    return rows.length > 0;
+};

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -478,6 +478,25 @@ export const shouldEnqueueReviewClassifierForPromptUpdate = (
     update.errorMessage !== undefined ||
     (update.response !== undefined && update.tokenUsage !== undefined);
 
+export const assertDeepResearchPromptExecution = ({
+    promptRunUuid,
+    expectedRunUuid,
+}: {
+    promptRunUuid: string | undefined;
+    expectedRunUuid: string | null;
+}): void => {
+    if (expectedRunUuid === null && promptRunUuid) {
+        throw new ConflictError(
+            'This prompt belongs to a Deep Research run and cannot be used for a standard chat response',
+        );
+    }
+    if (expectedRunUuid && promptRunUuid !== expectedRunUuid) {
+        throw new ConflictError(
+            'This prompt does not match the requested Deep Research run',
+        );
+    }
+};
+
 type EmbedAiAgentRuntimeOptions = {
     embedSpaceUuid: string;
     spaceAccess: string[];
@@ -490,7 +509,9 @@ type AiAgentServiceDependencies = {
     aiAgentDocumentModel: AiAgentDocumentModel;
     aiDeepResearchRunModel: Pick<
         AiDeepResearchRunModel,
-        'findAgentContextByThreadScoped' | 'findLatestProgressByRunUuids'
+        | 'findAgentContextByThreadScoped'
+        | 'findByPromptForExecution'
+        | 'findLatestProgressByRunUuids'
     >;
     projectContextModel: ProjectContextModel;
     analytics: LightdashAnalytics;
@@ -741,7 +762,9 @@ export class AiAgentService extends BaseService {
 
     private readonly aiDeepResearchRunModel: Pick<
         AiDeepResearchRunModel,
-        'findAgentContextByThreadScoped' | 'findLatestProgressByRunUuids'
+        | 'findAgentContextByThreadScoped'
+        | 'findByPromptForExecution'
+        | 'findLatestProgressByRunUuids'
     >;
 
     private readonly githubAppInstallationsModel: GithubAppInstallationsModel;
@@ -5179,6 +5202,7 @@ export class AiAgentService extends BaseService {
             retrieveRelevantArtifacts = true,
             onPromptResolved,
             resetErrorForStreamRetry = false,
+            expectedDeepResearchRunUuid,
         }: {
             agentUuid: string;
             threadUuid: string;
@@ -5189,6 +5213,7 @@ export class AiAgentService extends BaseService {
                 responseState: AiPromptResponseState,
             ) => void;
             resetErrorForStreamRetry?: boolean;
+            expectedDeepResearchRunUuid?: string | null;
         },
     ) {
         if (!user.organizationUuid) {
@@ -5251,6 +5276,31 @@ export class AiAgentService extends BaseService {
             prompt.threadUuid !== threadUuid
         ) {
             throw new NotFoundError(`Prompt not found: ${targetPromptUuid}`);
+        }
+        if (expectedDeepResearchRunUuid !== undefined) {
+            const deepResearchRun =
+                await this.aiDeepResearchRunModel.findByPromptForExecution({
+                    promptUuid: prompt.promptUuid,
+                    organizationUuid: user.organizationUuid,
+                    projectUuid: prompt.projectUuid,
+                });
+            assertDeepResearchPromptExecution({
+                promptRunUuid:
+                    deepResearchRun?.ai_deep_research_run_uuid ?? undefined,
+                expectedRunUuid: expectedDeepResearchRunUuid,
+            });
+            const executionModeClaimed =
+                await this.aiAgentModel.claimPromptExecutionMode(
+                    prompt.promptUuid,
+                    expectedDeepResearchRunUuid === null
+                        ? 'standard'
+                        : 'deep_research',
+                );
+            if (!executionModeClaimed) {
+                throw new ConflictError(
+                    'This prompt is already assigned to a different execution mode',
+                );
+            }
         }
         if (
             resetErrorForStreamRetry &&
@@ -5463,6 +5513,7 @@ export class AiAgentService extends BaseService {
                 agentUuid,
                 threadUuid,
                 resetErrorForStreamRetry: true,
+                expectedDeepResearchRunUuid: null,
                 onPromptResolved: (promptUuid, responseState) => {
                     trackedPromptUuid = promptUuid;
                     this.trackStreamPrompt(promptUuid, responseState);
@@ -6070,6 +6121,10 @@ export class AiAgentService extends BaseService {
                 agentUuid,
                 threadUuid,
                 promptUuid,
+                expectedDeepResearchRunUuid:
+                    execution.mode === 'deep_research'
+                        ? execution.runUuid
+                        : null,
             });
             if (!user.organizationUuid) {
                 throw new ForbiddenError();

--- a/packages/backend/src/ee/services/AiAgentService/deepResearchPromptExecution.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/deepResearchPromptExecution.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { assertDeepResearchPromptExecution } from './AiAgentService';
+
+describe('assertDeepResearchPromptExecution', () => {
+    it('rejects a standard response for a Deep Research prompt', () => {
+        expect(() =>
+            assertDeepResearchPromptExecution({
+                promptRunUuid: 'run-1',
+                expectedRunUuid: null,
+            }),
+        ).toThrow(/belongs to a Deep Research run/);
+    });
+
+    it('allows the matching Deep Research execution', () => {
+        expect(() =>
+            assertDeepResearchPromptExecution({
+                promptRunUuid: 'run-1',
+                expectedRunUuid: 'run-1',
+            }),
+        ).not.toThrow();
+    });
+
+    it('rejects a Deep Research execution without a matching run', () => {
+        expect(() =>
+            assertDeepResearchPromptExecution({
+                promptRunUuid: undefined,
+                expectedRunUuid: 'run-1',
+            }),
+        ).toThrow(/does not match the requested Deep Research run/);
+    });
+});

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -5,7 +5,6 @@ import {
     AiResultType,
     AnyType,
     ConflictError,
-    FeatureFlags,
     ForbiddenError,
     NotFoundError,
     ParameterError,
@@ -242,7 +241,6 @@ const buildService = (
         aiAgentService?: Record<string, unknown>;
         aiOrganizationSettingsModel?: Record<string, unknown>;
         projectModel?: Record<string, unknown>;
-        featureFlagModel?: Record<string, unknown>;
         schedulerClient?: Record<string, unknown>;
         asyncQueryService?: Record<string, unknown>;
         queryHistoryModel?: Record<string, unknown>;
@@ -301,6 +299,7 @@ const buildService = (
     };
     const aiAgentService = {
         assertDeepResearchAccess: vi.fn().mockResolvedValue(undefined),
+        getIsCopilotEnabled: vi.fn().mockResolvedValue(true),
         resolveDeepResearchExecutionContext: vi
             .fn()
             .mockResolvedValue(executionContextSnapshot),
@@ -322,13 +321,6 @@ const buildService = (
     const projectModel = {
         getSummary: vi.fn().mockResolvedValue({ organizationUuid: 'org-1' }),
         ...overrides.projectModel,
-    };
-    const featureFlagModel = {
-        get: vi.fn().mockResolvedValue({
-            id: FeatureFlags.AiDeepResearch,
-            enabled: true,
-        }),
-        ...overrides.featureFlagModel,
     };
     const schedulerClient = {
         aiDeepResearch: vi.fn().mockResolvedValue({ jobId: 'job-1' }),
@@ -360,7 +352,6 @@ const buildService = (
         aiAgentService: aiAgentService as AnyType,
         aiOrganizationSettingsModel: aiOrganizationSettingsModel as AnyType,
         projectModel: projectModel as AnyType,
-        featureFlagModel: featureFlagModel as AnyType,
         schedulerClient: schedulerClient as AnyType,
         asyncQueryService: asyncQueryService as AnyType,
         queryHistoryModel: queryHistoryModel as AnyType,
@@ -373,7 +364,6 @@ const buildService = (
         aiAgentService,
         aiOrganizationSettingsModel,
         projectModel,
-        featureFlagModel,
         schedulerClient,
         asyncQueryService,
         queryHistoryModel,
@@ -401,7 +391,6 @@ describe('AiDeepResearchService', () => {
                 aiAgentModel,
                 aiAgentService,
                 schedulerClient,
-                featureFlagModel,
             } = buildService();
 
             const run = await service.createRun({
@@ -446,10 +435,9 @@ describe('AiDeepResearchService', () => {
                 projectUuid: 'project-1',
                 userUuid: 'user-1',
             });
-            expect(featureFlagModel.get).toHaveBeenCalledWith({
-                user: expect.objectContaining({ userUuid: 'user-1' }),
-                featureFlagId: FeatureFlags.AiDeepResearch,
-            });
+            expect(aiAgentService.getIsCopilotEnabled).toHaveBeenCalledWith(
+                expect.objectContaining({ userUuid: 'user-1' }),
+            );
             expect(run.status).toBe('queued');
         });
 
@@ -735,13 +723,10 @@ describe('AiDeepResearchService', () => {
             expect(model.create).not.toHaveBeenCalled();
         });
 
-        it('rejects run creation when Deep Research is disabled', async () => {
+        it('rejects run creation when AI Agents are unavailable', async () => {
             const { service, model } = buildService({
-                featureFlagModel: {
-                    get: vi.fn().mockResolvedValue({
-                        id: FeatureFlags.AiDeepResearch,
-                        enabled: false,
-                    }),
+                aiAgentService: {
+                    getIsCopilotEnabled: vi.fn().mockResolvedValue(false),
                 },
             });
 
@@ -766,7 +751,7 @@ describe('AiDeepResearchService', () => {
                 ...userWithProjectAccess(),
                 ability: build(),
             } as SessionUser;
-            const { service, model, featureFlagModel } = buildService();
+            const { service, model, aiAgentService } = buildService();
 
             await expect(
                 service.createRun({
@@ -774,7 +759,7 @@ describe('AiDeepResearchService', () => {
                     user,
                 }),
             ).rejects.toBeInstanceOf(ForbiddenError);
-            expect(featureFlagModel.get).not.toHaveBeenCalled();
+            expect(aiAgentService.getIsCopilotEnabled).not.toHaveBeenCalled();
             expect(model.create).not.toHaveBeenCalled();
         });
 
@@ -795,7 +780,7 @@ describe('AiDeepResearchService', () => {
                 ...userWithProjectAccess(),
                 ability: build(),
             } as SessionUser;
-            const { service, model, featureFlagModel } = buildService();
+            const { service, model, aiAgentService } = buildService();
 
             await expect(
                 service.createRun({
@@ -803,7 +788,7 @@ describe('AiDeepResearchService', () => {
                     user,
                 }),
             ).rejects.toBeInstanceOf(ForbiddenError);
-            expect(featureFlagModel.get).not.toHaveBeenCalled();
+            expect(aiAgentService.getIsCopilotEnabled).not.toHaveBeenCalled();
             expect(model.create).not.toHaveBeenCalled();
         });
 
@@ -820,7 +805,7 @@ describe('AiDeepResearchService', () => {
                 ...userWithProjectAccess(),
                 ability: build(),
             } as SessionUser;
-            const { service, model, featureFlagModel } = buildService();
+            const { service, model, aiAgentService } = buildService();
 
             await expect(
                 service.createRun({
@@ -828,7 +813,7 @@ describe('AiDeepResearchService', () => {
                     user,
                 }),
             ).rejects.toBeInstanceOf(ForbiddenError);
-            expect(featureFlagModel.get).not.toHaveBeenCalled();
+            expect(aiAgentService.getIsCopilotEnabled).not.toHaveBeenCalled();
             expect(model.create).not.toHaveBeenCalled();
         });
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -10,7 +10,6 @@ import {
     AiResultType,
     applyDeepResearchChartRefsWithAdjustments,
     ConflictError,
-    FeatureFlags,
     findDeepResearchChartRefs,
     ForbiddenError,
     getErrorMessage,
@@ -47,7 +46,6 @@ import {
 } from '@lightdash/common';
 import { validate as isValidUuid } from 'uuid';
 import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
-import { type FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { type QueryHistoryModel } from '../../../models/QueryHistoryModel/QueryHistoryModel';
 import { type AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
@@ -60,6 +58,7 @@ import {
 import { type AiAgentModel } from '../../models/AiAgentModel';
 import {
     AiDeepResearchActiveRunError,
+    AiDeepResearchPromptExecutionModeError,
     type AiDeepResearchRunModel,
     type DbAiDeepResearchEventWithCursor,
 } from '../../models/AiDeepResearchRunModel';
@@ -256,14 +255,15 @@ type Dependencies = {
     >;
     aiAgentService: Pick<
         AiAgentService,
-        'assertDeepResearchAccess' | 'resolveDeepResearchExecutionContext'
+        | 'assertDeepResearchAccess'
+        | 'getIsCopilotEnabled'
+        | 'resolveDeepResearchExecutionContext'
     >;
     aiOrganizationSettingsModel: Pick<
         AiOrganizationSettingsModel,
         'findByOrganizationUuid'
     >;
     projectModel: ProjectModel;
-    featureFlagModel: FeatureFlagModel;
     schedulerClient: CommercialSchedulerClient;
     asyncQueryService: AsyncQueryService;
     queryHistoryModel: Pick<QueryHistoryModel, 'getByQueryUuid'>;
@@ -491,14 +491,14 @@ export class AiDeepResearchService extends BaseService {
 
     private readonly aiAgentService: Pick<
         AiAgentService,
-        'assertDeepResearchAccess' | 'resolveDeepResearchExecutionContext'
+        | 'assertDeepResearchAccess'
+        | 'getIsCopilotEnabled'
+        | 'resolveDeepResearchExecutionContext'
     >;
 
     private readonly aiOrganizationSettingsModel: Dependencies['aiOrganizationSettingsModel'];
 
     private readonly projectModel: ProjectModel;
-
-    private readonly featureFlagModel: FeatureFlagModel;
 
     private readonly schedulerClient: CommercialSchedulerClient;
 
@@ -518,7 +518,6 @@ export class AiDeepResearchService extends BaseService {
         aiAgentService,
         aiOrganizationSettingsModel,
         projectModel,
-        featureFlagModel,
         schedulerClient,
         asyncQueryService,
         queryHistoryModel,
@@ -531,7 +530,6 @@ export class AiDeepResearchService extends BaseService {
         this.aiAgentService = aiAgentService;
         this.aiOrganizationSettingsModel = aiOrganizationSettingsModel;
         this.projectModel = projectModel;
-        this.featureFlagModel = featureFlagModel;
         this.schedulerClient = schedulerClient;
         this.asyncQueryService = asyncQueryService;
         this.queryHistoryModel = queryHistoryModel;
@@ -753,12 +751,8 @@ export class AiDeepResearchService extends BaseService {
             throw new ParameterError('Deep Research prompt is required');
         }
         await this.assertCanCreateRun(args.user, args.projectUuid);
-        const featureFlag = await this.featureFlagModel.get({
-            user: args.user,
-            featureFlagId: FeatureFlags.AiDeepResearch,
-        });
-        if (!featureFlag.enabled) {
-            throw new ForbiddenError('Deep Research is not enabled');
+        if (!(await this.aiAgentService.getIsCopilotEnabled(args.user))) {
+            throw new ForbiddenError('AI Copilot is not enabled');
         }
         const organizationSettings =
             await this.aiOrganizationSettingsModel.findByOrganizationUuid(
@@ -913,6 +907,9 @@ export class AiDeepResearchService extends BaseService {
                     'Only one Deep Research run can be active in a thread at a time',
                     { activeRunUuid: error.activeRunUuid },
                 );
+            }
+            if (error instanceof AiDeepResearchPromptExecutionModeError) {
+                throw new ConflictError(error.message);
             }
             throw error;
         }

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -1,5 +1,11 @@
 import { type AnyType } from '@lightdash/common';
-import { APICallError, generateText, streamText, type ModelMessage } from 'ai';
+import {
+    APICallError,
+    generateText,
+    streamText,
+    type ModelMessage,
+    type ToolSet,
+} from 'ai';
 import {
     registerAiUsageTracker,
     type AiUsageEvent,
@@ -1124,26 +1130,56 @@ describe('getAgentTools workstream tool gate', () => {
     const getResearchTools = (
         research: AiDeepResearchExecutionRole,
         canUseRawSql = true,
-    ) =>
-        Object.keys(
+        includeSpoofedMcp = false,
+    ) => {
+        const args = buildResearchArgs(research, canUseRawSql);
+        args.agentSettings.projectUuid = 'project-1';
+        args.mcpServers = [
+            {
+                uuid: 'lightdash-mcp',
+                url: 'http://localhost/api/v1/mcp/projects/project-1',
+            },
+            ...(includeSpoofedMcp
+                ? [
+                      {
+                          uuid: 'external-mcp',
+                          url: 'https://untrusted.example/mcp',
+                      },
+                  ]
+                : []),
+        ] as AiAgentArgs['mcpServers'];
+        const researchMcpTools: ToolSet = {
+            mcp_github__create_issue: {} as never,
+            mcp_lightdash__run_metric_query: {} as never,
+            mcp_lightdash__run_sql: {} as never,
+        };
+        const researchMcpToolServers: Record<string, string> = {
+            mcp_github__create_issue: 'github-mcp',
+            mcp_lightdash__run_metric_query: 'lightdash-mcp',
+            mcp_lightdash__run_sql: 'lightdash-mcp',
+        };
+        if (includeSpoofedMcp) {
+            researchMcpTools.mcp_external__run_sql = {} as never;
+            researchMcpToolServers.mcp_external__run_sql = 'external-mcp';
+        }
+
+        return Object.keys(
             getAgentTools(
-                buildResearchArgs(research, canUseRawSql),
+                args,
                 depsStub(),
                 [],
                 {
                     ...mcpStub,
-                    tools: {
-                        mcp_github__create_issue: {} as never,
-                        mcp_lightdash__run_metric_query: {} as never,
-                        mcp_lightdash__run_sql: {} as never,
-                    },
+                    tools: researchMcpTools,
+                    mcpToolNameToServerUuid: researchMcpToolServers,
                 },
                 new Map(),
                 {},
             ),
         );
+    };
 
-    it('adds delegation while preserving inherited built-in and MCP tools for the coordinator', () => {
+    it('limits the coordinator to read-only research tools', () => {
         const names = getResearchTools({
             role: 'coordinator',
             runTask: vi.fn(),
@@ -1152,13 +1188,18 @@ describe('getAgentTools workstream tool gate', () => {
         expect(names).toEqual(
             expect.arrayContaining([
                 'delegateResearchTask',
-                'editDbtProject',
+                'findContent',
                 'generateVisualization',
-                'loadMcpTools',
-                'mcp_github__create_issue',
                 'mcp_lightdash__run_sql',
             ]),
         );
+        expect(names).not.toContain('createContent');
+        expect(names).not.toContain('createScheduledDelivery');
+        expect(names).not.toContain('editDbtProject');
+        expect(names).not.toContain('editRepo');
+        expect(names).not.toContain('loadMcpTools');
+        expect(names).not.toContain('mcp_github__create_issue');
+        expect(names).not.toContain('updateUserName');
     });
 
     it('removes native and MCP raw SQL when Deep Research SQL is disabled', () => {
@@ -1170,6 +1211,17 @@ describe('getAgentTools workstream tool gate', () => {
         expect(names).not.toContain('runSql');
         expect(names).not.toContain('mcp_lightdash__run_sql');
         expect(names).toContain('mcp_lightdash__run_metric_query');
+    });
+
+    it('rejects warehouse-named tools from untrusted MCP servers', () => {
+        const names = getResearchTools(
+            { role: 'coordinator', runTask: vi.fn() },
+            true,
+            true,
+        );
+
+        expect(names).toContain('mcp_lightdash__run_sql');
+        expect(names).not.toContain('mcp_external__run_sql');
     });
 
     // Workers are not given attached MCP servers at all (see

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -168,6 +168,68 @@ export const DEEP_RESEARCH_WORKER_TOOL_NAMES = new Set([
     'searchSemanticLayer',
 ]);
 
+export const DEEP_RESEARCH_COORDINATOR_TOOL_NAMES = new Set([
+    'analyzeFieldImpact',
+    'describeWarehouseTable',
+    'discoverFields',
+    'findContent',
+    'generateVisualization',
+    'getDashboardCharts',
+    'getKnowledgeDocumentContent',
+    'getMetadata',
+    'getProjectInfo',
+    'grepFields',
+    'listContent',
+    'listKnowledgeDocuments',
+    'listProjects',
+    'listWarehouseTables',
+    'loadProjectContext',
+    'readContent',
+    'readPinnedThread',
+    'resolveUrl',
+    'runContentQuery',
+    'runSavedChart',
+    'runSql',
+    'searchFieldValues',
+    'searchSemanticLayer',
+]);
+
+const getTrustedDeepResearchMcpToolNames = (
+    args: AiAgentArgs,
+    mcpToolSetup: AgentMcpToolSetup,
+): Set<string> => {
+    const expectedUrl = new URL(
+        `/api/v1/mcp/projects/${args.agentSettings.projectUuid}`,
+        args.siteUrl,
+    );
+    const trustedServerUuids = new Set(
+        (args.mcpServers ?? [])
+            .filter((server) => {
+                try {
+                    const serverUrl = new URL(server.url);
+                    return (
+                        serverUrl.origin === expectedUrl.origin &&
+                        serverUrl.pathname.replace(/\/$/, '') ===
+                            expectedUrl.pathname.replace(/\/$/, '')
+                    );
+                } catch {
+                    return false;
+                }
+            })
+            .map((server) => server.uuid),
+    );
+
+    return new Set(
+        Object.entries(mcpToolSetup.mcpToolNameToServerUuid)
+            .filter(
+                ([toolName, serverUuid]) =>
+                    trustedServerUuids.has(serverUuid) &&
+                    isDeepResearchWarehouseMcpTool(toolName),
+            )
+            .map(([toolName]) => toolName),
+    );
+};
+
 const PERSIST_TIMEOUT_MS = 10_000;
 
 /**
@@ -1084,11 +1146,22 @@ export const getAgentTools = (
         args.execution.mode === 'deep_research'
             ? args.execution.research
             : undefined;
+    const trustedDeepResearchMcpToolNames = research
+        ? getTrustedDeepResearchMcpToolNames(args, mcpToolSetup)
+        : new Set<string>();
     const getResearchTools = (): ToolSet | null => {
         switch (research?.role) {
             case 'coordinator':
                 return {
-                    ...mergedTools,
+                    ...Object.fromEntries(
+                        Object.entries(mergedTools).filter(
+                            ([toolName]) =>
+                                DEEP_RESEARCH_COORDINATOR_TOOL_NAMES.has(
+                                    toolName,
+                                ) ||
+                                trustedDeepResearchMcpToolNames.has(toolName),
+                        ),
+                    ),
                     delegateResearchTask: getDelegateResearchTask({
                         runTask: research.runTask,
                     }),
@@ -1099,7 +1172,7 @@ export const getAgentTools = (
                         Object.entries(mergedTools).filter(
                             ([toolName]) =>
                                 DEEP_RESEARCH_WORKER_TOOL_NAMES.has(toolName) ||
-                                isDeepResearchWarehouseMcpTool(toolName),
+                                trustedDeepResearchMcpToolNames.has(toolName),
                         ),
                     ),
                     submitWorkerFindings: getSubmitWorkerFindings({

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -134,7 +134,8 @@ export enum FeatureFlags {
     AiAutopilot = 'ai-autopilot',
 
     /**
-     * Enable long-running, read-only Deep Research investigations from AI chat.
+     * Legacy no-op retained so existing self-hosted feature flag configuration
+     * remains valid. Deep Research now follows AI Copilot availability.
      */
     AiDeepResearch = 'ai-deep-research',
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -1,5 +1,4 @@
 import {
-    FeatureFlags,
     type AiAgentSummary,
     type AiPromptContext,
     type AiPromptContextInput,
@@ -25,7 +24,6 @@ import {
 } from 'react';
 import { createPath, useLocation, useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
-import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import { findRetryableDeepResearchRun } from '../../deepResearch/deepResearchRegistry';
 import { runDeepResearchAgain } from '../../deepResearch/runAgain';
@@ -40,6 +38,7 @@ import {
     useStartDeepResearchMutation,
     useTrackDeepResearchFollowUp,
 } from '../../hooks/useDeepResearch';
+import { useDeepResearchAccess } from '../../hooks/useDeepResearchAccess';
 import { usePendingThreadRefetch } from '../../hooks/usePendingThreadRefetch';
 import { usePinnedContext } from '../../hooks/usePinnedContext';
 import {
@@ -145,7 +144,7 @@ const NewThreadPanel: FC<{
     const { addItem: addDockItem } = useLauncherDock(projectUuid);
     const isAuto = isLauncherAutoAgent(agent);
     const concreteAgent = getConcreteLauncherAgent(agent);
-    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
+    const canStartDeepResearch = useDeepResearchAccess(projectUuid);
 
     const {
         contextInput,
@@ -239,7 +238,11 @@ const NewThreadPanel: FC<{
 
     const handleStartDeepResearch = useCallback(
         async ({ question }: StartDeepResearchArgs) => {
-            if (!concreteAgent || !isPinnedContextReady) {
+            if (
+                !concreteAgent ||
+                !isPinnedContextReady ||
+                !canStartDeepResearch
+            ) {
                 return;
             }
             const thread = await createAgentThread({
@@ -258,6 +261,7 @@ const NewThreadPanel: FC<{
         },
         [
             concreteAgent,
+            canStartDeepResearch,
             contextInputWithPageContext,
             createAgentThread,
             isPinnedContextReady,
@@ -389,7 +393,7 @@ const NewThreadPanel: FC<{
                     defaultValue={composerSeed ?? undefined}
                     onSubmit={handleSubmit}
                     onStartDeepResearch={
-                        concreteAgent && deepResearchFlag.data?.enabled
+                        concreteAgent && canStartDeepResearch
                             ? handleStartDeepResearch
                             : undefined
                     }
@@ -464,7 +468,7 @@ const ExistingThreadPanel: FC<{
     style?: CSSProperties;
 }> = ({ projectUuid, agent, agents, threadId, style }) => {
     const { user } = useApp();
-    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
+    const canStartDeepResearch = useDeepResearchAccess(projectUuid);
     const navigate = useNavigate();
     const location = useLocation();
     const {
@@ -576,6 +580,9 @@ const ExistingThreadPanel: FC<{
     const handleStartDeepResearch = async ({
         question,
     }: StartDeepResearchArgs) => {
+        if (!canStartDeepResearch) {
+            return;
+        }
         const retryableRun = findRetryableDeepResearchRun({
             projectUuid,
             agentUuid: agent.uuid,
@@ -600,8 +607,12 @@ const ExistingThreadPanel: FC<{
 
     const handleRunDeepResearchAgain = async (
         registration: DeepResearchRunRegistration,
-    ) =>
-        runDeepResearchAgain({
+    ) => {
+        if (!canStartDeepResearch) {
+            return;
+        }
+
+        return runDeepResearchAgain({
             registration,
             createPrompt: (question) =>
                 createAgentThreadMessage({
@@ -611,6 +622,7 @@ const ExistingThreadPanel: FC<{
                 }),
             startRun: startDeepResearch.mutateAsync,
         });
+    };
 
     const headerTitle =
         thread?.title || thread?.firstMessage?.message || agent.name;
@@ -663,7 +675,9 @@ const ExistingThreadPanel: FC<{
                     agentUuid={agent.uuid}
                     renderArtifactsInline
                     onDashboardLinkClick={handleDashboardLinkClick}
-                    canRetryDeepResearch={!isInputDisabled && !isBusy}
+                    canRetryDeepResearch={
+                        canStartDeepResearch && !isInputDisabled && !isBusy
+                    }
                     onRunDeepResearchAgain={(registration) => {
                         void handleRunDeepResearchAgain(registration).catch(
                             () => undefined,
@@ -676,7 +690,7 @@ const ExistingThreadPanel: FC<{
                         loading={isBusy}
                         onSubmit={handleSubmit}
                         onStartDeepResearch={
-                            deepResearchFlag.data?.enabled
+                            canStartDeepResearch
                                 ? handleStartDeepResearch
                                 : undefined
                         }

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearchAccess.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearchAccess.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { canStartDeepResearch } from './useDeepResearchAccess';
+
+describe('canStartDeepResearch', () => {
+    it.each([
+        {
+            canCreate: true,
+            isEnvironmentReady: true,
+            isDemo: false,
+            isImpersonating: false,
+            result: true,
+        },
+        {
+            canCreate: false,
+            isEnvironmentReady: true,
+            isDemo: false,
+            isImpersonating: false,
+            result: false,
+        },
+        {
+            canCreate: true,
+            isEnvironmentReady: true,
+            isDemo: true,
+            isImpersonating: false,
+            result: false,
+        },
+        {
+            canCreate: true,
+            isEnvironmentReady: true,
+            isDemo: false,
+            isImpersonating: true,
+            result: false,
+        },
+        {
+            canCreate: true,
+            isEnvironmentReady: false,
+            isDemo: false,
+            isImpersonating: false,
+            result: false,
+        },
+    ])('returns $result for %#', ({ result, ...access }) => {
+        expect(canStartDeepResearch(access)).toBe(result);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearchAccess.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearchAccess.ts
@@ -1,0 +1,39 @@
+import { subject } from '@casl/ability';
+import { LightdashMode } from '@lightdash/common';
+import useHealth from '../../../../hooks/health/useHealth';
+import { useImpersonation } from '../../../../hooks/user/useImpersonation';
+import useApp from '../../../../providers/App/useApp';
+
+export const canStartDeepResearch = ({
+    canCreate,
+    isEnvironmentReady,
+    isDemo,
+    isImpersonating,
+}: {
+    canCreate: boolean;
+    isEnvironmentReady: boolean;
+    isDemo: boolean;
+    isImpersonating: boolean;
+}): boolean => isEnvironmentReady && canCreate && !isDemo && !isImpersonating;
+
+export const useDeepResearchAccess = (projectUuid: string | undefined) => {
+    const { user } = useApp();
+    const health = useHealth();
+    const { isImpersonating } = useImpersonation();
+    const organizationUuid = user.data?.organizationUuid;
+    const canCreate =
+        !!organizationUuid &&
+        !!projectUuid &&
+        (user.data?.ability.can(
+            'create',
+            subject('AiDeepResearch', { organizationUuid, projectUuid }),
+        ) ??
+            false);
+
+    return canStartDeepResearch({
+        canCreate,
+        isEnvironmentReady: health.data !== undefined,
+        isDemo: health.data?.mode === LightdashMode.DEMO,
+        isImpersonating,
+    });
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
@@ -15,7 +15,7 @@ const {
     agentChatInputProps,
     agents,
     createAgentThread,
-    deepResearchEnabled,
+    deepResearchAccess,
     deepResearchHookArgs,
     navigate,
     sqlModeAvailable,
@@ -34,7 +34,7 @@ const {
         ],
     },
     createAgentThread: vi.fn(),
-    deepResearchEnabled: { current: true },
+    deepResearchAccess: { current: true },
     deepResearchHookArgs: {
         current: undefined as
             | [projectUuid: string, entryPoint: string]
@@ -54,10 +54,8 @@ vi.mock('../../../hooks/useProject', () => ({
     useProject: () => ({ data: undefined }),
 }));
 
-vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
-    useServerFeatureFlag: () => ({
-        data: { enabled: deepResearchEnabled.current },
-    }),
+vi.mock('../aiCopilot/hooks/useDeepResearchAccess', () => ({
+    useDeepResearchAccess: () => deepResearchAccess.current,
 }));
 
 vi.mock('../../../providers/App/useApp', () => ({
@@ -231,7 +229,7 @@ describe('DayOneAskInput', () => {
             uuid: 'thread-1',
             firstMessage: { uuid: 'prompt-1' },
         });
-        deepResearchEnabled.current = true;
+        deepResearchAccess.current = true;
         deepResearchHookArgs.current = undefined;
         startDeepResearch.mockReset();
         startDeepResearch.mockResolvedValue(undefined);
@@ -279,8 +277,8 @@ describe('DayOneAskInput', () => {
         ).toBeUndefined();
     });
 
-    it('hides Deep Research when the feature flag is disabled', () => {
-        deepResearchEnabled.current = false;
+    it('hides Deep Research when the user cannot start a run', () => {
+        deepResearchAccess.current = false;
 
         renderInput();
 

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -1,6 +1,5 @@
 import { subject } from '@casl/ability';
 import {
-    FeatureFlags,
     type AgentSuggestion,
     type AiPromptContextInput,
     type AiPromptContextItem,
@@ -12,7 +11,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -27,6 +25,7 @@ import { useAgentSuggestions } from '../aiCopilot/hooks/useAgentSuggestions';
 import { useCanCreateAiAgentThread } from '../aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentSqlModeAvailable } from '../aiCopilot/hooks/useAiAgentSqlModeAvailable';
 import { useStartDeepResearchForThreadMutation } from '../aiCopilot/hooks/useDeepResearch';
+import { useDeepResearchAccess } from '../aiCopilot/hooks/useDeepResearchAccess';
 import {
     useCreateAgentThreadMutation,
     useProjectAiAgents,
@@ -170,7 +169,9 @@ const DayOneAskInputInner: FC<Props> = ({
         useCreateAgentThreadMutation(projectUuid ?? '');
     const { mutateAsync: startDeepResearch } =
         useStartDeepResearchForThreadMutation(projectUuid ?? '', 'homepage');
-    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
+    const canStartDeepResearch = useDeepResearchAccess(
+        projectUuid ?? undefined,
+    );
 
     const showAutoOption = (agents?.length ?? 0) > 1 && routerEnabled === true;
     const validDefaultAgent = agents?.find(
@@ -259,7 +260,7 @@ const DayOneAskInputInner: FC<Props> = ({
 
     const handleStartDeepResearch = useCallback(
         async ({ question }: StartDeepResearchArgs) => {
-            if (!projectUuid || !selectedAgent) {
+            if (!projectUuid || !selectedAgent || !canStartDeepResearch) {
                 return;
             }
             const thread = await createAgentThread({
@@ -274,7 +275,13 @@ const DayOneAskInputInner: FC<Props> = ({
                 promptUuid: thread.firstMessage.uuid,
             });
         },
-        [createAgentThread, projectUuid, selectedAgent, startDeepResearch],
+        [
+            canStartDeepResearch,
+            createAgentThread,
+            projectUuid,
+            selectedAgent,
+            startDeepResearch,
+        ],
     );
 
     const handleChipPick = (chip: AgentSuggestion, index: number) => {
@@ -373,7 +380,7 @@ const DayOneAskInputInner: FC<Props> = ({
                     }
                     onSubmit={handleSubmit}
                     onStartDeepResearch={
-                        selectedAgent && deepResearchFlag.data?.enabled
+                        selectedAgent && canStartDeepResearch
                             ? handleStartDeepResearch
                             : undefined
                     }

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -1,10 +1,8 @@
 import { subject } from '@casl/ability';
-import { FeatureFlags } from '@lightdash/common';
 import { Box, Center, Flex, Loader } from '@mantine/core';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
 import { matchesModelConfig } from '../../../components/common/ModelSelector/utils';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import { ReviewVerificationPanel } from '../../features/aiCopilot/components/Admin/ReviewVerificationPanel';
 import { AgentChatDisplay } from '../../features/aiCopilot/components/ChatElements/AgentChatDisplay';
@@ -35,6 +33,7 @@ import {
     useStartDeepResearchMutation,
     useTrackDeepResearchFollowUp,
 } from '../../features/aiCopilot/hooks/useDeepResearch';
+import { useDeepResearchAccess } from '../../features/aiCopilot/hooks/useDeepResearchAccess';
 import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
 import { usePendingThreadRefetch } from '../../features/aiCopilot/hooks/usePendingThreadRefetch';
 import { usePinnedContext } from '../../features/aiCopilot/hooks/usePinnedContext';
@@ -178,7 +177,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const updateReviewItemStatus = useUpdateAiAgentReviewItemStatus();
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
-    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
+    const canStartDeepResearch = useDeepResearchAccess(projectUuid);
     const startDeepResearch = useStartDeepResearchMutation({
         projectUuid: projectUuid!,
         agentUuid: agentUuid!,
@@ -303,6 +302,9 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const handleStartDeepResearch = async ({
         question,
     }: StartDeepResearchArgs) => {
+        if (!canStartDeepResearch) {
+            return;
+        }
         const retryableRun = findRetryableDeepResearchRun({
             projectUuid: projectUuid!,
             agentUuid: agentUuid!,
@@ -328,8 +330,12 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     };
     const handleRunDeepResearchAgain = async (
         registration: DeepResearchRunRegistration,
-    ) =>
-        runDeepResearchAgain({
+    ) => {
+        if (!canStartDeepResearch) {
+            return;
+        }
+
+        return runDeepResearchAgain({
             registration,
             createPrompt: (question) =>
                 createAgentThreadMessage({
@@ -341,6 +347,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                 }),
             startRun: startDeepResearch.mutateAsync,
         });
+    };
     const isBusy = Boolean(
         isCreatingMessage ||
         isStreaming ||
@@ -387,7 +394,9 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                     agentUuid={agentUuid}
                     showAddToEvalsButton={canManage}
                     onDashboardLinkClick={handleDashboardLinkClick}
-                    canRetryDeepResearch={!inputDisabled && !isBusy}
+                    canRetryDeepResearch={
+                        canStartDeepResearch && !inputDisabled && !isBusy
+                    }
                     onRunDeepResearchAgain={(registration) => {
                         void handleRunDeepResearchAgain(registration).catch(
                             () => undefined,
@@ -403,7 +412,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                         loading={isBusy}
                         onSubmit={handleSubmit}
                         onStartDeepResearch={
-                            deepResearchFlag.data?.enabled
+                            canStartDeepResearch
                                 ? handleStartDeepResearch
                                 : undefined
                         }

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlags } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -16,7 +15,6 @@ import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { AiAgentNewThreadMcpConnections } from '../../features/aiCopilot/components/AiAgentNewThreadMcpConnections';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import {
@@ -35,6 +33,7 @@ import { emitEmbedAiAgentThreadChange } from '../../features/aiCopilot/hooks/emb
 import { useAiAgentModelSelection } from '../../features/aiCopilot/hooks/useAiAgentModelSelection';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
 import { useStartDeepResearchForThreadMutation } from '../../features/aiCopilot/hooks/useDeepResearch';
+import { useDeepResearchAccess } from '../../features/aiCopilot/hooks/useDeepResearchAccess';
 import { usePinnedContext } from '../../features/aiCopilot/hooks/usePinnedContext';
 import {
     useCreateAgentThreadMutation,
@@ -68,7 +67,7 @@ const AiAgentNewThreadPage: FC = () => {
     const { agent, agents, navigateFromAgentChat } =
         useOutletContext<AgentContext>();
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
-    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
+    const canStartDeepResearch = useDeepResearchAccess(projectUuid);
     const [sqlModeOverride, setSqlModeOverride] = useState<boolean>();
     const sqlMode = sqlModeOverride ?? agent.enableSqlMode;
     const dispatch = useAiAgentStoreDispatch();
@@ -205,7 +204,7 @@ const AiAgentNewThreadPage: FC = () => {
 
     const onStartDeepResearch = useCallback(
         async ({ question }: StartDeepResearchArgs) => {
-            if (!agentUuid || !isPinnedContextReady) {
+            if (!agentUuid || !isPinnedContextReady || !canStartDeepResearch) {
                 return;
             }
             setPendingPrompt('');
@@ -226,6 +225,7 @@ const AiAgentNewThreadPage: FC = () => {
         },
         [
             agentUuid,
+            canStartDeepResearch,
             contextInput,
             createAgentThread,
             isPinnedContextReady,
@@ -357,7 +357,7 @@ const AiAgentNewThreadPage: FC = () => {
                         key={composerSeedKey}
                         onSubmit={onSubmit}
                         onStartDeepResearch={
-                            deepResearchFlag.data?.enabled
+                            canStartDeepResearch
                                 ? onStartDeepResearch
                                 : undefined
                         }

--- a/packages/frontend/src/hooks/settings/deepResearchSettingsAccess.test.ts
+++ b/packages/frontend/src/hooks/settings/deepResearchSettingsAccess.test.ts
@@ -8,20 +8,18 @@ const access = (
 ) =>
     canAccessDeepResearchSettings({
         isAiCopilotEnabledOrTrial: true,
-        isDeepResearchEnabled: true,
         canManageOrgAiAgent: true,
         hasAnyAiAgentAccess: true,
         ...overrides,
     });
 
 describe('canAccessDeepResearchSettings', () => {
-    it('allows organization AI admins when Deep Research is enabled', () => {
+    it('allows organization AI admins when AI Agents are available', () => {
         expect(access()).toBe(true);
     });
 
     it.each([
         'isAiCopilotEnabledOrTrial',
-        'isDeepResearchEnabled',
         'canManageOrgAiAgent',
         'hasAnyAiAgentAccess',
     ] as const)('denies access when %s is false', (gate) => {

--- a/packages/frontend/src/hooks/settings/deepResearchSettingsAccess.ts
+++ b/packages/frontend/src/hooks/settings/deepResearchSettingsAccess.ts
@@ -2,19 +2,12 @@ import { type SettingsContext } from './types';
 
 type DeepResearchSettingsAccess = Pick<
     SettingsContext,
-    | 'isAiCopilotEnabledOrTrial'
-    | 'isDeepResearchEnabled'
-    | 'canManageOrgAiAgent'
-    | 'hasAnyAiAgentAccess'
+    'isAiCopilotEnabledOrTrial' | 'canManageOrgAiAgent' | 'hasAnyAiAgentAccess'
 >;
 
 export const canAccessDeepResearchSettings = ({
     isAiCopilotEnabledOrTrial,
-    isDeepResearchEnabled,
     canManageOrgAiAgent,
     hasAnyAiAgentAccess,
 }: DeepResearchSettingsAccess) =>
-    isAiCopilotEnabledOrTrial &&
-    isDeepResearchEnabled &&
-    canManageOrgAiAgent &&
-    hasAnyAiAgentAccess;
+    isAiCopilotEnabledOrTrial && canManageOrgAiAgent && hasAnyAiAgentAccess;

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -70,7 +70,6 @@ export type SettingsContext = {
     isScimTokenManagementEnabled: FeatureFlag | undefined;
     isServiceAccountsEnabled: boolean;
     isAiCopilotEnabledOrTrial: boolean;
-    isDeepResearchEnabled: boolean;
     shouldShowAiAgentReviews: boolean;
     shouldShowAiAgentMemories: boolean;
     // Org-level AI settings access (router config, org settings, review queue).
@@ -79,7 +78,6 @@ export type SettingsContext = {
     // least one project they can reach. Gates visibility of the "Ask AI" area.
     hasAnyAiAgentAccess: boolean;
     isAiOrganizationSettingsLoading: boolean;
-    isDeepResearchFlagLoading: boolean;
     dataAppsFlag: FeatureFlag | undefined;
     isDataAppsFlagLoading: boolean;
     embeddingEnabled: FeatureFlag | undefined;

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -38,12 +38,6 @@ export const useSettingsContext = (): SettingsContext => {
     const shouldShowAiAgentReviews =
         aiOrganizationSettingsQuery.data?.aiAgentReviewsEnabled === true;
 
-    const deepResearchFlagQuery = useServerFeatureFlag(
-        FeatureFlags.AiDeepResearch,
-    );
-    const { data: deepResearchFlag } = deepResearchFlagQuery;
-    const isDeepResearchEnabled = deepResearchFlag?.enabled ?? false;
-
     const { data: aiAgentMemoryFlag } = useServerFeatureFlag(
         FeatureFlags.AiAgentMemory,
     );
@@ -206,14 +200,12 @@ export const useSettingsContext = (): SettingsContext => {
         isScimTokenManagementEnabled,
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
-        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         isAiOrganizationSettingsLoading:
             aiOrganizationSettingsQuery.isInitialLoading,
-        isDeepResearchFlagLoading: deepResearchFlagQuery.isInitialLoading,
         dataAppsFlag,
         isDataAppsFlagLoading: dataAppsFlagQuery.isInitialLoading,
         embeddingEnabled,

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -83,7 +83,6 @@ export const useSettingsNavigation = (
         isScimTokenManagementEnabled,
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
-        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,
@@ -544,7 +543,6 @@ export const useSettingsNavigation = (
             if (
                 canAccessDeepResearchSettings({
                     isAiCopilotEnabledOrTrial,
-                    isDeepResearchEnabled,
                     canManageOrgAiAgent,
                     hasAnyAiAgentAccess,
                 })
@@ -988,7 +986,6 @@ export const useSettingsNavigation = (
         isScimEnabled,
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
-        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -155,13 +155,11 @@ const Settings: FC = () => {
         dataAppsFlag,
         isDataAppsFlagLoading,
         isAiCopilotEnabledOrTrial,
-        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         isAiOrganizationSettingsLoading,
-        isDeepResearchFlagLoading,
         showImpersonationPanel,
         isLeaveOrganizationEnabled,
         isCustomRolesEnabled,
@@ -662,7 +660,6 @@ const Settings: FC = () => {
                 if (
                     canAccessDeepResearchSettings({
                         isAiCopilotEnabledOrTrial,
-                        isDeepResearchEnabled,
                         canManageOrgAiAgent,
                         hasAnyAiAgentAccess,
                     })
@@ -787,7 +784,6 @@ const Settings: FC = () => {
         isEmailWhitelabelEnabled,
         isLeaveOrganizationEnabled,
         isAiCopilotEnabledOrTrial,
-        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,
@@ -912,11 +908,6 @@ const Settings: FC = () => {
     const isAwaitingAiSettingsRoute =
         isAiOrganizationSettingsLoading &&
         Boolean(matchPath('/generalSettings/ai/*', location.pathname));
-    const isAwaitingDeepResearchRoute =
-        isDeepResearchFlagLoading &&
-        Boolean(
-            matchPath('/generalSettings/ai/deep-research', location.pathname),
-        );
     const isAwaitingRoadmapRoute =
         isOrganizationRoadmapLoading &&
         Boolean(matchPath('/generalSettings/roadmap', location.pathname));
@@ -931,7 +922,6 @@ const Settings: FC = () => {
         isActiveProjectUuidLoading ||
         isProjectLoading ||
         isAwaitingAiSettingsRoute ||
-        isAwaitingDeepResearchRoute ||
         isAwaitingRoadmapRoute ||
         isAwaitingDataAppsRoute
     ) {


### PR DESCRIPTION
Closes: [PROD-10094](https://linear.app/lightdash/issue/PROD-10094)
Closes: [PROD-10089](https://linear.app/lightdash/issue/PROD-10089)

## What this fixes

Deep Research starts and retries were gated by a legacy feature flag rather than the user's scoped permission, and its prompt could still be executed by standard chat. Deep Research also inherited write-capable and untrusted MCP tools.

| Path | Before | After |
| --- | --- | --- |
| Frontend start/retry surfaces | Legacy flag only | Shared create permission, demo, and impersonation gate |
| Standard chat generate/stream | Could execute a research-owned prompt | Atomically claims standard execution and rejects research prompts |
| Research coordinator/worker | Inherited broad tools and suffix-matched MCP tools | Read-only allowlists plus trusted local MCP provenance |

## How

- Adds a shared `useDeepResearchAccess` hook across full-page chat, launcher, homepage, and retry actions.
- Makes Deep Research follow AI Agents availability while retaining the legacy enum as a configuration-compatible no-op.
- Adds an atomic `ai_prompt.execution_mode` claim so standard and research execution cannot race for the same prompt.
- Resolves prompt/run ownership by organization and project rather than the acting user, covering managers accessing another user's thread.
- Restricts research tools to explicit allowlists and verifies MCP warehouse tools against this instance's exact project endpoint and runtime server mapping.

## Who's affected

| User class | Result |
| --- | --- |
| Users with scoped `create:AiDeepResearch` in a normal session | Can start and retry research |
| Custom roles without that permission | Start and retry actions are hidden and rejected by the API |
| Demo users and impersonating admins | Cannot start; stop/cancel remains available |
| Managers opening another user's research thread | Cannot execute its prompt through standard chat |

## Test plan

- [x] Backend focused unit tests: 139 passed
- [x] Frontend focused tests: 16 passed
- [x] AiAgentModel integration tests: 14 passed, including competing atomic claims
- [x] Deep Research model integration: standard-then-research conflict passes
- [x] Backend/common/frontend typecheck, lint, and format
- [x] Backend build and development migration

## Follow-ups in this stack

- PR 3 — prompt-injection and exfiltration hardening (PROD-10095)
- PR 4 — worker isolation and quarantined findings submission (PROD-10097)
