### PR TITLE
feat(dashboards): persist parameter overrides in URLs

### DIFF
--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -72,6 +72,11 @@ import {
     useSavedDashboardFiltersOverrides,
 } from '../../hooks/useSavedDashboardFiltersOverrides';
 import DashboardContext from './context';
+import {
+    getDashboardParameterOverrides,
+    parseDashboardParametersUrl,
+    toDashboardParameters,
+} from './dashboardParametersUrl';
 import DashboardTileStatusProvider from './DashboardTileStatusProvider';
 import { getActiveTabForTabs } from './getActiveTabForTabs';
 import useDashboardContext from './useDashboardContext';
@@ -284,7 +289,22 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         {},
     );
     // parameters that are currently applied to the dashboard
-    const [parameters, setParameters] = useState<DashboardParameters>({});
+    const urlParameterValuesRef = useRef<ParametersValuesMap | null>(null);
+    const hasInvalidUrlParametersRef = useRef(false);
+    if (urlParameterValuesRef.current === null) {
+        try {
+            urlParameterValuesRef.current =
+                parseDashboardParametersUrl(
+                    new URLSearchParams(search).get('parameters'),
+                ) ?? {};
+        } catch {
+            hasInvalidUrlParametersRef.current = true;
+            urlParameterValuesRef.current = {};
+        }
+    }
+    const [parameters, setParameters] = useState<DashboardParameters>(() =>
+        toDashboardParameters(urlParameterValuesRef.current ?? {}),
+    );
     const [parametersHaveChanged, setParametersHaveChanged] =
         useState<boolean>(false);
 
@@ -374,12 +394,26 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         [],
     );
 
-    // Set parameters to saved parameters when they are loaded
+    // Set parameters to saved parameters when they are loaded, preserving any
+    // values restored from a shared URL.
     useEffect(() => {
         if (savedParameters) {
-            setParameters(savedParameters);
+            setParameters({
+                ...savedParameters,
+                ...toDashboardParameters(urlParameterValuesRef.current ?? {}),
+            });
         }
     }, [savedParameters]);
+
+    useEffect(() => {
+        if (hasInvalidUrlParametersRef.current) {
+            showToastWarning({
+                title: 'Could not restore parameters from URL',
+                subtitle:
+                    'The link appears to be incomplete. Please ask for it to be shared again.',
+            });
+        }
+    }, [showToastWarning]);
 
     // Set pinned parameters when dashboard is loaded
     useEffect(() => {
@@ -632,6 +666,39 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             return acc;
         }, {} as ParametersValuesMap);
     }, [parameters]);
+
+    // Keep runtime parameter overrides in shared dashboard URLs. Saved defaults
+    // are omitted so unchanged dashboards keep clean, stable URLs.
+    useEffect(() => {
+        if (embed.mode === 'sdk') return;
+
+        const currentParams = new URLSearchParams(search);
+        const newParams = new URLSearchParams(search);
+        const overrides = getDashboardParameterOverrides(
+            parameterValues,
+            savedParameters,
+        );
+
+        if (Object.keys(overrides).length === 0) {
+            newParams.delete('parameters');
+        } else {
+            newParams.set('parameters', JSON.stringify(overrides));
+        }
+
+        if (newParams.toString() !== currentParams.toString()) {
+            void navigate(
+                { pathname, search: newParams.toString() },
+                { replace: true },
+            );
+        }
+    }, [
+        embed.mode,
+        navigate,
+        parameterValues,
+        pathname,
+        savedParameters,
+        search,
+    ]);
 
     const selectedParametersCount = useMemo(() => {
         return Object.values(parameterValues).filter(

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -75,6 +75,7 @@ import DashboardContext from './context';
 import {
     getDashboardParameterOverrides,
     parseDashboardParametersUrl,
+    reconcileDashboardParameters,
     toDashboardParameters,
 } from './dashboardParametersUrl';
 import DashboardTileStatusProvider from './DashboardTileStatusProvider';
@@ -289,22 +290,23 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         {},
     );
     // parameters that are currently applied to the dashboard
-    const urlParameterValuesRef = useRef<ParametersValuesMap | null>(null);
     const hasInvalidUrlParametersRef = useRef(false);
-    if (urlParameterValuesRef.current === null) {
+    const [parameters, setParameters] = useState<DashboardParameters>(() => {
+        if (isEditMode) {
+            return {};
+        }
+
         try {
-            urlParameterValuesRef.current =
+            return toDashboardParameters(
                 parseDashboardParametersUrl(
                     new URLSearchParams(search).get('parameters'),
-                ) ?? {};
+                ) ?? {},
+            );
         } catch {
             hasInvalidUrlParametersRef.current = true;
-            urlParameterValuesRef.current = {};
+            return {};
         }
-    }
-    const [parameters, setParameters] = useState<DashboardParameters>(() =>
-        toDashboardParameters(urlParameterValuesRef.current ?? {}),
-    );
+    });
     const [parametersHaveChanged, setParametersHaveChanged] =
         useState<boolean>(false);
 
@@ -394,16 +396,15 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         [],
     );
 
-    // Set parameters to saved parameters when they are loaded, preserving any
-    // values restored from a shared URL.
     useEffect(() => {
-        if (savedParameters) {
-            setParameters({
-                ...savedParameters,
-                ...toDashboardParameters(urlParameterValuesRef.current ?? {}),
-            });
-        }
-    }, [savedParameters]);
+        setParameters((currentParameters) =>
+            reconcileDashboardParameters(
+                currentParameters,
+                savedParameters,
+                isEditMode,
+            ),
+        );
+    }, [isEditMode, savedParameters]);
 
     useEffect(() => {
         if (hasInvalidUrlParametersRef.current) {
@@ -670,7 +671,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     // Keep runtime parameter overrides in shared dashboard URLs. Saved defaults
     // are omitted so unchanged dashboards keep clean, stable URLs.
     useEffect(() => {
-        if (embed.mode === 'sdk') return;
+        if (embed.mode === 'sdk' || isEditMode) return;
 
         const currentParams = new URLSearchParams(search);
         const newParams = new URLSearchParams(search);
@@ -693,6 +694,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         }
     }, [
         embed.mode,
+        isEditMode,
         navigate,
         parameterValues,
         pathname,

--- a/packages/frontend/src/providers/Dashboard/dashboardParametersUrl.test.ts
+++ b/packages/frontend/src/providers/Dashboard/dashboardParametersUrl.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     getDashboardParameterOverrides,
     parseDashboardParametersUrl,
+    reconcileDashboardParameters,
     toDashboardParameters,
 } from './dashboardParametersUrl';
 
@@ -13,9 +14,15 @@ describe('dashboard parameter URL helpers', () => {
                     metric: 'revenue',
                     limit: 10,
                     regions: ['EU', 'US'],
+                    limits: [10, 20],
                 }),
             ),
-        ).toEqual({ metric: 'revenue', limit: 10, regions: ['EU', 'US'] });
+        ).toEqual({
+            metric: 'revenue',
+            limit: 10,
+            regions: ['EU', 'US'],
+            limits: [10, 20],
+        });
     });
 
     it.each([
@@ -23,6 +30,8 @@ describe('dashboard parameter URL helpers', () => {
         '[]',
         '{"metric":true}',
         '{"metric":{"value":"revenue"}}',
+        '{"metric":["revenue",10]}',
+        '{"metric":1e309}',
     ])('rejects an invalid parameters value: %s', (value) => {
         expect(() => parseDashboardParametersUrl(value)).toThrow();
     });
@@ -43,5 +52,39 @@ describe('dashboard parameter URL helpers', () => {
                 },
             ),
         ).toEqual({ region: 'EU' });
+    });
+
+    it('preserves runtime overrides in view mode', () => {
+        expect(
+            reconcileDashboardParameters(
+                {
+                    metric: { parameterName: 'metric', value: 'profit' },
+                },
+                {
+                    metric: { parameterName: 'metric', value: 'revenue' },
+                    region: { parameterName: 'region', value: 'EU' },
+                },
+                false,
+            ),
+        ).toEqual({
+            metric: { parameterName: 'metric', value: 'profit' },
+            region: { parameterName: 'region', value: 'EU' },
+        });
+    });
+
+    it('drops runtime overrides in edit mode', () => {
+        const savedParameters = {
+            metric: { parameterName: 'metric', value: 'revenue' },
+        };
+
+        expect(
+            reconcileDashboardParameters(
+                {
+                    metric: { parameterName: 'metric', value: 'profit' },
+                },
+                savedParameters,
+                true,
+            ),
+        ).toEqual(savedParameters);
     });
 });

--- a/packages/frontend/src/providers/Dashboard/dashboardParametersUrl.test.ts
+++ b/packages/frontend/src/providers/Dashboard/dashboardParametersUrl.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getDashboardParameterOverrides,
+    parseDashboardParametersUrl,
+    toDashboardParameters,
+} from './dashboardParametersUrl';
+
+describe('dashboard parameter URL helpers', () => {
+    it('parses supported parameter values', () => {
+        expect(
+            parseDashboardParametersUrl(
+                JSON.stringify({
+                    metric: 'revenue',
+                    limit: 10,
+                    regions: ['EU', 'US'],
+                }),
+            ),
+        ).toEqual({ metric: 'revenue', limit: 10, regions: ['EU', 'US'] });
+    });
+
+    it.each([
+        'null',
+        '[]',
+        '{"metric":true}',
+        '{"metric":{"value":"revenue"}}',
+    ])('rejects an invalid parameters value: %s', (value) => {
+        expect(() => parseDashboardParametersUrl(value)).toThrow();
+    });
+
+    it('converts URL values to dashboard parameter state', () => {
+        expect(toDashboardParameters({ metric: 'revenue' })).toEqual({
+            metric: { parameterName: 'metric', value: 'revenue' },
+        });
+    });
+
+    it('only serializes values that differ from saved defaults', () => {
+        expect(
+            getDashboardParameterOverrides(
+                { metric: 'revenue', region: 'EU' },
+                {
+                    metric: { parameterName: 'metric', value: 'revenue' },
+                    region: { parameterName: 'region', value: 'US' },
+                },
+            ),
+        ).toEqual({ region: 'EU' });
+    });
+});

--- a/packages/frontend/src/providers/Dashboard/dashboardParametersUrl.ts
+++ b/packages/frontend/src/providers/Dashboard/dashboardParametersUrl.ts
@@ -1,0 +1,52 @@
+import {
+    type DashboardParameters,
+    type ParametersValuesMap,
+    type ParameterValue,
+} from '@lightdash/common';
+import isEqual from 'lodash/isEqual';
+
+const isParameterValue = (value: unknown): value is ParameterValue =>
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    (Array.isArray(value) &&
+        value.every(
+            (item) => typeof item === 'string' || typeof item === 'number',
+        ));
+
+export const parseDashboardParametersUrl = (
+    value: string | null,
+): ParametersValuesMap | null => {
+    if (value === null) return null;
+
+    const parsed: unknown = JSON.parse(value);
+    if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed) ||
+        !Object.values(parsed).every(isParameterValue)
+    ) {
+        throw new Error('Invalid dashboard parameters URL value');
+    }
+
+    return parsed as ParametersValuesMap;
+};
+
+export const toDashboardParameters = (
+    values: ParametersValuesMap,
+): DashboardParameters =>
+    Object.fromEntries(
+        Object.entries(values).map(([key, value]) => [
+            key,
+            { parameterName: key, value },
+        ]),
+    );
+
+export const getDashboardParameterOverrides = (
+    values: ParametersValuesMap,
+    savedParameters: DashboardParameters,
+): ParametersValuesMap =>
+    Object.fromEntries(
+        Object.entries(values).filter(
+            ([key, value]) => !isEqual(savedParameters[key]?.value, value),
+        ),
+    );

--- a/packages/frontend/src/providers/Dashboard/dashboardParametersUrl.ts
+++ b/packages/frontend/src/providers/Dashboard/dashboardParametersUrl.ts
@@ -5,13 +5,16 @@ import {
 } from '@lightdash/common';
 import isEqual from 'lodash/isEqual';
 
-const isParameterValue = (value: unknown): value is ParameterValue =>
-    typeof value === 'string' ||
-    typeof value === 'number' ||
-    (Array.isArray(value) &&
-        value.every(
-            (item) => typeof item === 'string' || typeof item === 'number',
-        ));
+const isParameterValue = (value: unknown): value is ParameterValue => {
+    if (typeof value === 'string') return true;
+    if (typeof value === 'number') return Number.isFinite(value);
+    if (!Array.isArray(value)) return false;
+
+    return (
+        value.every((item) => typeof item === 'string') ||
+        value.every((item) => typeof item === 'number' && Number.isFinite(item))
+    );
+};
 
 export const parseDashboardParametersUrl = (
     value: string | null,
@@ -40,6 +43,13 @@ export const toDashboardParameters = (
             { parameterName: key, value },
         ]),
     );
+
+export const reconcileDashboardParameters = (
+    currentParameters: DashboardParameters,
+    savedParameters: DashboardParameters,
+    isEditMode: boolean,
+): DashboardParameters =>
+    isEditMode ? savedParameters : { ...savedParameters, ...currentParameters };
 
 export const getDashboardParameterOverrides = (
     values: ParametersValuesMap,


### PR DESCRIPTION
## What changed

Dashboard parameter overrides now persist in shared and bookmarked URLs and restore on load. Saved defaults remain omitted to keep URLs concise, while malformed values produce a warning.

## Visual evidence

![Shows that dashboard parameter state is read from the URL and malformed shared values produce a clear warning.](https://camo.githubusercontent.com/031d0a835938d186a2d40b124fd6d2ee3752e6bce7b461881028e49c45954da1/68747470733a2f2f6c642d6c696e6561722d6167656e742e6578652e78797a2f6172746966616374732f633732313834346534383865643865612f322f312d706172616d657465722d75726c2d76616c69646174696f6e2e6a7067)

*Shows that dashboard parameter state is read from the URL and malformed shared values produce a clear warning.*

## Preview

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: lightdash/lightdash#25198  <br>Closes: lightdash/lightdash#25198

> Generated by the Lightdash Linear agent. Review and test all changes before merging.

[Open the Lightdash preview](<https://ldlin-c721844e488e.exe.xyz>)