### PR TITLE
fix(ai): isolate deep research workers

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -26,13 +26,16 @@ import {
     buildAgentMessages,
     buildDeepResearchExecutionContextSnapshot,
     buildForcedFirstStep,
+    buildPrepareStep,
     generateAgentResponse,
+    getAgentMessages,
     getAgentTools,
     getDeepResearchBudgetInstruction,
     getPromptMcpServers,
     getStepBudgetOverride,
     normalizeToolOutput,
     recordAgentStepUsage,
+    scopeAgentConversation,
     storeInvalidAgentToolCall,
     streamAgentResponse,
     withEarlyToolProgress,
@@ -680,6 +683,94 @@ describe('getStepBudgetOverride', () => {
             ),
         ).toBeUndefined();
     });
+
+    it('reserves a worker final step for findings submission', () => {
+        const execution = {
+            mode: 'deep_research',
+            runUuid: 'run-1',
+            phase: 'investigating',
+            maxSteps: 5,
+            budget: {
+                maxTokens: 10_000,
+                maxToolCalls: 20,
+                maxWarehouseQueries: 10,
+                maxResultRows: 1_000,
+                maxSteps: 5,
+                deadlineMs: 600_000,
+            },
+            canUseRawSql: true,
+            initialTokenUsage: 0,
+            research: {
+                role: 'worker',
+                task: { id: 'task-1', question: 'Why?', focus: 'Orders' },
+                onFindings: vi.fn(),
+            },
+        } as const;
+
+        expect(getStepBudgetOverride(execution, 3)).toBeUndefined();
+        expect(getStepBudgetOverride(execution, 4)).toEqual({
+            message: expect.stringContaining('Submit the best findings packet'),
+            activeTools: ['submitWorkerFindings'],
+            toolChoice: {
+                type: 'tool',
+                toolName: 'submitWorkerFindings',
+            },
+        });
+    });
+});
+
+describe('buildPrepareStep worker isolation', () => {
+    it('does not consume or inject prompt-wide steers for a worker', async () => {
+        const args = buildAgentArgs({
+            mode: 'deep_research',
+            runUuid: 'run-1',
+            phase: 'investigating',
+            maxSteps: 5,
+            budget: {
+                maxTokens: 10_000,
+                maxToolCalls: 20,
+                maxWarehouseQueries: 10,
+                maxResultRows: 1_000,
+                maxSteps: 5,
+                deadlineMs: 600_000,
+            },
+            canUseRawSql: true,
+            initialTokenUsage: 0,
+            research: {
+                role: 'worker',
+                task: { id: 'task-1', question: 'Why?', focus: 'Orders' },
+                onFindings: vi.fn(),
+            },
+        });
+        const consumePromptSteers = vi
+            .fn()
+            .mockResolvedValue([{ message: 'Coordinator-only guidance' }]);
+        const prepareStep = buildPrepareStep({
+            args,
+            dependencies: {
+                ...buildAgentDependencies(vi.fn()),
+                consumePromptSteers,
+            },
+            tools: { submitWorkerFindings: {} as never },
+            mcpToolNames: [],
+            logger: vi.fn(),
+            invalidToolCallIds: new Set(),
+        });
+
+        const result = await prepareStep({ stepNumber: 4, messages: [] });
+
+        expect(consumePromptSteers).not.toHaveBeenCalled();
+        expect(JSON.stringify(result)).not.toContain(
+            'Coordinator-only guidance',
+        );
+        expect(result).toMatchObject({
+            activeTools: ['submitWorkerFindings'],
+            toolChoice: {
+                type: 'tool',
+                toolName: 'submitWorkerFindings',
+            },
+        });
+    });
 });
 
 describe('buildDeepResearchExecutionContextSnapshot', () => {
@@ -1297,5 +1388,143 @@ describe('buildAgentMessages', () => {
 
         expect(messages).toHaveLength(2);
         expect(messages[1]).toEqual({ role: 'user', content: 'Question' });
+    });
+});
+
+describe('scopeAgentConversation', () => {
+    const history: ModelMessage[] = [
+        { role: 'user', content: 'Original user question' },
+        { role: 'assistant', content: 'Coordinator investigation' },
+    ];
+
+    it('removes rebuilt thread, compaction, and memory context from workers', () => {
+        expect(
+            scopeAgentConversation({
+                execution: {
+                    mode: 'deep_research',
+                    runUuid: 'run-1',
+                    phase: 'investigating',
+                    maxSteps: 5,
+                    budget: {
+                        maxTokens: 10_000,
+                        maxToolCalls: 20,
+                        maxWarehouseQueries: 10,
+                        maxResultRows: 1_000,
+                        maxSteps: 5,
+                        deadlineMs: 600_000,
+                    },
+                    canUseRawSql: true,
+                    initialTokenUsage: 0,
+                    research: {
+                        role: 'worker',
+                        task: {
+                            id: 'task-1',
+                            question: 'Why?',
+                            focus: 'Orders',
+                        },
+                        onFindings: vi.fn(),
+                    },
+                },
+                messageHistory: history,
+                compactionSummary: 'Coordinator summary',
+                memoryBlock: 'Agent memory',
+            }),
+        ).toEqual({
+            messageHistory: [
+                {
+                    role: 'user',
+                    content:
+                        'Carry out the isolated task packet in your system instructions.',
+                },
+            ],
+            compactionSummary: null,
+            memoryBlock: null,
+        });
+    });
+
+    it('builds a worker prompt with a conversation kickoff and no coordinator text', () => {
+        const args = buildAgentArgs({
+            mode: 'deep_research',
+            runUuid: 'run-1',
+            phase: 'investigating',
+            maxSteps: 5,
+            budget: {
+                maxTokens: 10_000,
+                maxToolCalls: 20,
+                maxWarehouseQueries: 10,
+                maxResultRows: 1_000,
+                maxSteps: 5,
+                deadlineMs: 600_000,
+            },
+            canUseRawSql: true,
+            initialTokenUsage: 0,
+            research: {
+                role: 'worker',
+                task: { id: 'task-1', question: 'Why?', focus: 'Orders' },
+                onFindings: vi.fn(),
+            },
+        });
+        args.messageHistory = history;
+        args.compactionSummary = 'Coordinator summary';
+        args.toolHints = ['runSql'];
+        args.forceToolHints = true;
+        args.enableGrepFields = true;
+        const messages = getAgentMessages(
+            args,
+            [],
+            mcpToolSetup(),
+            {},
+            new Map(),
+            'Agent memory',
+        );
+
+        expect(messages[0].role).toBe('system');
+        expect(messages.slice(1)).toEqual([
+            {
+                role: 'user',
+                content:
+                    'Carry out the isolated task packet in your system instructions.',
+            },
+        ]);
+        expect(JSON.stringify(messages)).not.toContain('Coordinator');
+        expect(JSON.stringify(messages)).not.toContain(
+            'Original user question',
+        );
+        expect(JSON.stringify(messages)).not.toContain('Agent memory');
+        expect(messages[1].content).not.toContain('runSql');
+        expect(
+            buildForcedFirstStep(args, { runSql: {} as never }),
+        ).toBeUndefined();
+    });
+
+    it('preserves coordinator conversation context', () => {
+        expect(
+            scopeAgentConversation({
+                execution: {
+                    mode: 'deep_research',
+                    runUuid: 'run-1',
+                    phase: 'planning',
+                    maxSteps: 16,
+                    budget: {
+                        maxTokens: 10_000,
+                        maxToolCalls: 20,
+                        maxWarehouseQueries: 10,
+                        maxResultRows: 1_000,
+                        maxSteps: 16,
+                        deadlineMs: 600_000,
+                    },
+                    canUseRawSql: true,
+                    initialTokenUsage: 0,
+                    research: { role: 'coordinator', runTask: vi.fn() },
+                },
+                messageHistory: history,
+                compactionSummary: 'Coordinator summary',
+                memoryBlock: 'Agent memory',
+            }),
+        ).toEqual({
+            messageHistory: history,
+            compactionSummary: 'Coordinator summary',
+            memoryBlock: 'Agent memory',
+        });
     });
 });

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -1,5 +1,6 @@
 import {
     AgentToolOutput,
+    AI_DEEP_RESEARCH_WORKER_FINDINGS_TOOL_NAME,
     AnyType,
     assertUnreachable,
     Explore,
@@ -569,6 +570,12 @@ const buildStopWhenPromptInterrupted =
  * discussing the fix. No-op if the forced tool isn't in the registered set.
  */
 export const buildForcedFirstStep = (args: AiAgentArgs, tools: ToolSet) => {
+    if (
+        args.execution?.mode === 'deep_research' &&
+        args.execution.research?.role === 'worker'
+    ) {
+        return undefined;
+    }
     if (!args.forceToolHints) return undefined;
     const forcedTool = args.toolHints[0];
     if (!forcedTool || !(forcedTool in tools)) return undefined;
@@ -582,6 +589,23 @@ export const getStepBudgetOverride = (
     execution: AiAgentArgs['execution'],
     stepNumber: number,
 ) => {
+    if (
+        execution.mode === 'deep_research' &&
+        execution.research?.role === 'worker'
+    ) {
+        if (stepNumber < Math.max(0, execution.maxSteps - 1)) {
+            return undefined;
+        }
+        return {
+            message: `This is your final step. Submit the best findings packet available now with ${AI_DEEP_RESEARCH_WORKER_FINDINGS_TOOL_NAME}, even if the evidence is incomplete or inconclusive. Do not run another query.`,
+            activeTools: [AI_DEEP_RESEARCH_WORKER_FINDINGS_TOOL_NAME],
+            toolChoice: {
+                type: 'tool' as const,
+                toolName: AI_DEEP_RESEARCH_WORKER_FINDINGS_TOOL_NAME,
+            },
+        };
+    }
+
     if (
         execution.mode !== 'standard' ||
         stepNumber < Math.max(0, execution.maxSteps - AGENT_WRAP_UP_STEPS)
@@ -600,7 +624,7 @@ export const getStepBudgetOverride = (
     return { message: AGENT_WRAP_UP_INSTRUCTION };
 };
 
-const buildPrepareStep = ({
+export const buildPrepareStep = ({
     args,
     dependencies,
     tools,
@@ -688,10 +712,15 @@ const buildPrepareStep = ({
             }
         }
 
-        const steers = await dependencies.consumePromptSteers({
-            promptUuid: args.promptUuid,
-            stepNumber,
-        });
+        const isDeepResearchWorker =
+            args.execution.mode === 'deep_research' &&
+            args.execution.research?.role === 'worker';
+        const steers = isDeepResearchWorker
+            ? []
+            : await dependencies.consumePromptSteers({
+                  promptUuid: args.promptUuid,
+                  stepNumber,
+              });
         if (steers.length > 0) {
             logger(
                 'Prepare Step',
@@ -1298,6 +1327,31 @@ export const buildAgentMessages = ({
     ...messageHistory,
 ];
 
+export const scopeAgentConversation = ({
+    execution,
+    messageHistory,
+    compactionSummary,
+    memoryBlock,
+}: {
+    execution: AiAgentArgs['execution'];
+    messageHistory: ModelMessage[];
+    compactionSummary: string | null;
+    memoryBlock: string | null;
+}) =>
+    execution.mode === 'deep_research' && execution.research?.role === 'worker'
+        ? {
+              messageHistory: [
+                  {
+                      role: 'user' as const,
+                      content:
+                          'Carry out the isolated task packet in your system instructions.',
+                  },
+              ],
+              compactionSummary: null,
+              memoryBlock: null,
+          }
+        : { messageHistory, compactionSummary, memoryBlock };
+
 export const getDeepResearchBudgetInstruction = (
     budget: AiDeepResearchBudget,
 ): string =>
@@ -1317,7 +1371,7 @@ export const getPromptMcpServers = (
         ),
     }));
 
-const getAgentMessages = (
+export const getAgentMessages = (
     args: AiAgentArgs,
     availableExplores: Explore[],
     mcpToolSetup: AgentMcpToolSetup,
@@ -1328,13 +1382,25 @@ const getAgentMessages = (
     const logger = createAiAgentLogger(args.debugLoggingEnabled);
     logger('Agent Messages', 'Getting agent messages.');
 
-    const messageHistory = args.enableGrepFields
-        ? withPreGrepCandidates(
-              withToolHints(args.messageHistory, args.toolHints),
-              availableExplores,
-              verifiedFieldUsage,
-          )
-        : withToolHints(args.messageHistory, args.toolHints);
+    const scopedConversation = scopeAgentConversation({
+        execution: args.execution,
+        messageHistory: args.messageHistory,
+        compactionSummary: args.compactionSummary,
+        memoryBlock,
+    });
+    const isDeepResearchWorker =
+        args.execution.mode === 'deep_research' &&
+        args.execution.research?.role === 'worker';
+    let { messageHistory } = scopedConversation;
+    if (!isDeepResearchWorker) {
+        messageHistory = args.enableGrepFields
+            ? withPreGrepCandidates(
+                  withToolHints(messageHistory, args.toolHints),
+                  availableExplores,
+                  verifiedFieldUsage,
+              )
+            : withToolHints(messageHistory, args.toolHints);
+    }
 
     // Project context is loaded on demand via the loadProjectContext tool; the
     // system prompt only advertises that it exists (when enabled + non-empty).
@@ -1414,9 +1480,9 @@ const getAgentMessages = (
     });
     const messages = buildAgentMessages({
         systemPrompt,
-        compactionSummary: args.compactionSummary,
+        compactionSummary: scopedConversation.compactionSummary,
         messageHistory,
-        memoryBlock,
+        memoryBlock: scopedConversation.memoryBlock,
     });
 
     logger('Agent Messages', `Retrieved ${messages.length} messages.`);


### PR DESCRIPTION
Closes: [PROD-10097](https://linear.app/lightdash/issue/PROD-10097/fix-deep-research-worker-isolation-and-guaranteed-findings-submission)

### Description:

Makes worker isolation real and guarantees a findings handoff:

- removes rebuilt thread history, compaction, memory, prompt hints, pre-grep candidates, forced hints, and live steers from worker calls
- adds a neutral isolated kickoff so Anthropic/Bedrock receive a valid conversation message
- reserves the final worker step for a forced `submitWorkerFindings` call
- leaves coordinator and standard-agent behavior unchanged

Stacked on #27334.

### Validation:

- 85 focused backend tests
- backend typecheck, lint, and format
- correctness, security/tenant-safety, and intent/scope reviews clean