### PR TITLE
feat(ci): add merge-freeze dispatch to hold main while a release is cut

### DIFF
--- a/.github/workflows/merge-freeze-status.yml
+++ b/.github/workflows/merge-freeze-status.yml
@@ -1,0 +1,64 @@
+name: Merge freeze status
+
+# Companion to merge-freeze.yml. That workflow stamps every PR that was already
+# open when the freeze went on; this one covers PRs opened or pushed during the
+# window, so their blocked merge carries the same reason instead of GitHub's
+# bare "Expected - Waiting for status to be reported".
+#
+# Messaging only: the required status check on the main ruleset is what blocks
+# the merge, and `vars.MERGE_FREEZE` is a mirror the toggle maintains, so a
+# stale variable degrades the message and never the enforcement.
+#
+# Fork PRs are skipped - a pull_request run from a fork gets a read-only token
+# and cannot post a status. They stay blocked by the missing required check,
+# which is the outcome we want anyway; reaching for pull_request_target to
+# prettify that would expose secrets to fork PRs for no enforcement gain.
+#
+# SPK-985.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  statuses: write
+
+concurrency:
+  group: merge-freeze-status-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  flag:
+    name: freeze
+    # Stacked PRs merging into their parent are not covered by the main ruleset
+    # and are not blocked, so they are not flagged either.
+    if: >-
+      vars.MERGE_FREEZE == 'true'
+      && github.event.pull_request.base.ref == github.event.repository.default_branch
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Explain the freeze on this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          REASON: ${{ vars.MERGE_FREEZE_REASON }}
+          FREEZE_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/merge-freeze.yml
+        run: |
+          set -euo pipefail
+
+          description=${REASON:-Merges to main are frozen while a release is cut}
+
+          gh api --method POST "repos/$REPO/statuses/$SHA" \
+            -f state=failure \
+            -f context=merge-freeze \
+            -f description="${description:0:140}" \
+            -f target_url="$FREEZE_URL" >/dev/null
+
+          echo "Flagged PR #${{ github.event.pull_request.number }} as blocked: $description"

--- a/.github/workflows/merge-freeze.yml
+++ b/.github/workflows/merge-freeze.yml
@@ -1,0 +1,283 @@
+name: Merge freeze
+
+# Holds `main` while a release is cut. `release.yml` fires on every push to
+# `main`, so the release that goes out is whatever `main` happens to contain at
+# that moment: a merge landing in the gap between "merge the fix someone is
+# waiting on" and "the release job picks it up" either delays that release or
+# widens it past the change we meant to ship. Until now the only lever was
+# asking people in Slack not to merge.
+#
+# Freezing adds a `merge-freeze` context to the `main` ruleset's required status
+# checks; unfreezing takes it off again. Nothing ever reports that context, so
+# while it is required the merge button is blocked for everyone without a
+# ruleset bypass. Enforcement is that rule alone - the commit statuses this
+# posts on open PRs only replace GitHub's opaque "Expected - Waiting for status
+# to be reported" with a reason. That split is the fail-safe one: if the status
+# half breaks, merges stay blocked while frozen and unblock the moment the rule
+# comes off.
+#
+# The ruleset and variables APIs need Administration: write, which GITHUB_TOKEN
+# cannot be granted (`administration` is not a workflow permission scope), so
+# this runs on a PAT/App token - see the preflight step. workflow_dispatch
+# already requires write access, so whoever can run this can already merge.
+#
+# SPK-985.
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Freeze or unfreeze merges to main
+        required: true
+        type: choice
+        options:
+          - freeze
+          - unfreeze
+      reason:
+        description: Why - shown on every blocked PR (e.g. "cutting a release for an escalation")
+        required: false
+        type: string
+
+permissions: {}
+
+# Two toggles at once would read-modify-write the same ruleset, and the loser of
+# the race would PUT back a rules array built from a stale read.
+concurrency:
+  group: merge-freeze-${{ github.repository }}
+  cancel-in-progress: false
+
+env:
+  FREEZE_CONTEXT: merge-freeze
+
+jobs:
+  toggle:
+    name: ${{ inputs.action }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Preflight - token can administer rulesets
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_FREEZE_TOKEN || secrets.CI_GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::No token available. Add a MERGE_FREEZE_TOKEN secret - a fine-grained PAT or App installation token on $REPO with Administration: write (rulesets), Variables: write and Commit statuses: write."
+            exit 1
+          fi
+
+          # Listing rulesets is itself an Administration-scoped read, so this
+          # doubles as the permission check. Failing here costs seconds; failing
+          # after a half-applied freeze costs a confusing repo.
+          if ! gh api "repos/$REPO/rulesets" >/dev/null 2>&1; then
+            echo "::error::The configured token cannot read repository rulesets on $REPO. It needs Administration: write (fine-grained) or repo admin (classic). GITHUB_TOKEN can never do this - 'administration' is not a grantable workflow permission scope."
+            exit 1
+          fi
+
+      - name: ${{ inputs.action }} merges to main
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_FREEZE_TOKEN || secrets.CI_GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ACTION: ${{ inputs.action }}
+          REASON: ${{ inputs.reason }}
+          ACTOR_LOGIN: ${{ github.actor }}
+          CONTEXT: ${{ env.FREEZE_CONTEXT }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          reason=${REASON:-}
+
+          # `rulesets` also returns org-level rulesets that apply here but
+          # cannot be edited from this repo, hence the source_type filter. The
+          # list response carries no conditions, so each candidate is fetched to
+          # see whether it actually covers the default branch.
+          default_branch=$(gh api "repos/$REPO" --jq .default_branch)
+          candidates=$(gh api "repos/$REPO/rulesets" \
+            --jq '.[] | select(.target == "branch" and .source_type == "Repository" and .enforcement == "active") | .id')
+
+          matching=()
+          for id in $candidates; do
+            covers=$(gh api "repos/$REPO/rulesets/$id" \
+              | jq --arg branch "refs/heads/$default_branch" '
+                  (.conditions.ref_name.include // [])
+                  | any(. == "~ALL" or . == "~DEFAULT_BRANCH" or . == $branch)
+                ')
+            if [ "$covers" = "true" ]; then
+              matching+=("$id")
+            fi
+          done
+
+          if [ "${#matching[@]}" -eq 0 ]; then
+            echo "::error::No active repository branch ruleset covers $default_branch on $REPO, so there is nothing to attach the $CONTEXT check to."
+            exit 1
+          fi
+          if [ "${#matching[@]}" -gt 1 ]; then
+            echo "::error::${#matching[@]} active rulesets cover $default_branch (ids: ${matching[*]}). Refusing to guess which one owns merge protection - consolidate them, or pin one in this workflow."
+            exit 1
+          fi
+
+          ruleset_id=${matching[0]}
+          ruleset=$(gh api "repos/$REPO/rulesets/$ruleset_id")
+          ruleset_name=$(jq -r .name <<<"$ruleset")
+          echo "Editing ruleset $ruleset_name (id $ruleset_id) on $default_branch"
+
+          was_required=$(jq --arg ctx "$CONTEXT" '
+            [.rules[]? | select(.type == "required_status_checks")
+                       | .parameters.required_status_checks[]?
+                       | select(.context == $ctx)] | length > 0
+          ' <<<"$ruleset")
+
+          if [ "$ACTION" = "freeze" ]; then
+            new_rules=$(jq --arg ctx "$CONTEXT" '
+              (.rules // []) as $rules
+              | if any($rules[]; .type == "required_status_checks") then
+                  [$rules[] | if .type == "required_status_checks" and
+                       (any(.parameters.required_status_checks[]?; .context == $ctx) | not)
+                     then .parameters.required_status_checks += [{context: $ctx}]
+                     else . end]
+                else
+                  $rules + [{
+                    type: "required_status_checks",
+                    parameters: {
+                      strict_required_status_checks_policy: false,
+                      do_not_enforce_on_create: false,
+                      required_status_checks: [{context: $ctx}]
+                    }
+                  }]
+                end
+            ' <<<"$ruleset")
+          else
+            new_rules=$(jq --arg ctx "$CONTEXT" '
+              [(.rules // [])[]
+               | if .type == "required_status_checks"
+                 then .parameters.required_status_checks |=
+                        [.[] | select(.context != $ctx)]
+                 else . end]
+              | [.[] | select(.type != "required_status_checks"
+                              or (.parameters.required_status_checks | length) > 0)]
+            ' <<<"$ruleset")
+          fi
+
+          # PUT the whole object rather than a rules-only patch: bypass_actors is
+          # what lets the release bot push to main, and it is not worth finding
+          # out the hard way whether an omitted field is preserved or cleared.
+          payload=$(jq -n --argjson r "$ruleset" --argjson rules "$new_rules" '{
+            name: $r.name,
+            target: $r.target,
+            enforcement: $r.enforcement,
+            conditions: $r.conditions,
+            bypass_actors: [$r.bypass_actors[]? | {actor_id, actor_type, bypass_mode}],
+            rules: $rules
+          }')
+          gh api --method PUT "repos/$REPO/rulesets/$ruleset_id" --input - <<<"$payload" >/dev/null
+
+          # Read back rather than trust the write: a silently no-op'd PUT would
+          # leave everyone believing main is frozen when it is not.
+          now_required=$(gh api "repos/$REPO/rulesets/$ruleset_id" \
+            | jq --arg ctx "$CONTEXT" '
+                [.rules[]? | select(.type == "required_status_checks")
+                           | .parameters.required_status_checks[]?
+                           | select(.context == $ctx)] | length > 0
+              ')
+
+          if [ "$ACTION" = "freeze" ] && [ "$now_required" != "true" ]; then
+            echo "::error::Wrote the ruleset but '$CONTEXT' is still not required - main is NOT frozen."
+            exit 1
+          fi
+          if [ "$ACTION" = "unfreeze" ] && [ "$now_required" != "false" ]; then
+            echo "::error::Wrote the ruleset but '$CONTEXT' is still required - main is still frozen."
+            exit 1
+          fi
+
+          if [ "$ACTION" = "freeze" ]; then
+            state=failure
+            if [ -n "$reason" ]; then
+              description="Merges to main are frozen: $reason"
+            else
+              description="Merges to main are frozen while a release is cut"
+            fi
+          else
+            state=success
+            description="Merges to main are open"
+          fi
+          # The statuses API rejects a description over 140 characters outright.
+          description=${description:0:140}
+
+          # Mirrored into repo variables so merge-freeze-status.yml can label PRs
+          # opened mid-freeze without an admin token of its own. Non-fatal: the
+          # ruleset is what blocks merges, so a stale variable degrades the
+          # message, never the enforcement.
+          if [ "$ACTION" = "freeze" ]; then freeze_var=true; else freeze_var=false; fi
+          gh variable set MERGE_FREEZE --repo "$REPO" --body "$freeze_var" \
+            || echo "::warning::Could not write the MERGE_FREEZE variable. The freeze is applied, but PRs opened during it will show an unexplained blocked check."
+          gh variable set MERGE_FREEZE_REASON --repo "$REPO" --body "$description" \
+            || echo "::warning::Could not write the MERGE_FREEZE_REASON variable."
+
+          # Only PRs targeting the default branch: the ruleset covers main
+          # alone, so a stacked PR merging into its parent is not blocked and
+          # must not be told it is. Assigned before the loop so a failure to
+          # list is fatal here, rather than a process substitution silently
+          # yielding zero PRs to update.
+          open_prs=$(gh pr list --repo "$REPO" --state open --limit 500 \
+            --json number,headRefOid,baseRefName \
+            | jq -r --arg branch "$default_branch" \
+                '.[] | select(.baseRefName == $branch) | "\(.number)\t\(.headRefOid)"')
+
+          # Best-effort by design: the freeze is already in force by this point,
+          # and one unpostable status must not fail the run. Fork PRs are
+          # expected to fail here - their head commits live in another repo - and
+          # stay blocked by the missing required status, which is still the
+          # correct outcome, just a quieter one.
+          posted=0
+          unreachable=0
+          if [ -n "$open_prs" ]; then
+            while IFS=$'\t' read -r number sha; do
+              [ -n "$sha" ] || continue
+              if gh api --method POST "repos/$REPO/statuses/$sha" \
+                   -f state="$state" \
+                   -f context="$CONTEXT" \
+                   -f description="$description" \
+                   -f target_url="$RUN_URL" >/dev/null 2>&1; then
+                posted=$((posted + 1))
+              else
+                unreachable=$((unreachable + 1))
+                echo "Could not post status to PR #$number ($sha)"
+              fi
+            done <<<"$open_prs"
+          fi
+
+          {
+            if [ "$ACTION" = "freeze" ]; then
+              echo "## Merges to main are frozen"
+            else
+              echo "## Merges to main are open"
+            fi
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| Actor | @$ACTOR_LOGIN |"
+            echo "| Reason | ${reason:-_none given_} |"
+            echo "| Ruleset | \`$ruleset_name\` (id $ruleset_id) |"
+            echo "| Required check | \`$CONTEXT\` |"
+            echo "| Open PRs updated | $posted (couldn't reach $unreachable) |"
+            echo
+            if [ "$ACTION" = "freeze" ]; then
+              if [ "$was_required" = "true" ]; then
+                echo "> Main was **already frozen** - this run refreshed the reason and the PR statuses."
+                echo
+              fi
+              echo "Run this workflow again with **unfreeze** to reopen merges."
+            else
+              if [ "$was_required" = "false" ]; then
+                echo "> Main was **not frozen** - this run only cleared any stale \`$CONTEXT\` statuses."
+                echo
+              fi
+              echo "Merges are unblocked. Anyone whose PR still shows a stale \`$CONTEXT\` failure can push or reopen it to clear."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,19 @@ pnpm -F backend rollback-last
 3. **API**: TSOA generates OpenAPI specs from TypeScript controllers
 4. **Authentication**: CASL-based authorization with multiple auth providers
 
+## Merge Freeze — Holding `main` While a Release Is Cut
+
+`release.yml` fires on every push to `main`, so the release that goes out is whatever `main` contains at that moment. When something needs to reach a release on its own — a fix someone is waiting on — hold merges rather than asking people in Slack not to merge:
+
+-   **Freeze**: `gh workflow run merge-freeze.yml -f action=freeze -f reason="cutting a release for an escalation"`. This adds a `merge-freeze` required status check to the `main` ruleset. Nothing ever reports that check, so merges into `main` are blocked for everyone without a ruleset bypass.
+-   **Unfreeze**: the same workflow with `action=unfreeze`. Do it as soon as the release is cut — a freeze left on blocks the whole team, and there is no auto-expiry.
+-   The `reason` is shown on every blocked PR, so make it specific and say roughly how long.
+-   **Only `main` is affected.** Stacked PRs merging into their parent branch are untouched.
+-   **Check the current state**: the `MERGE_FREEZE` repo variable, or `merge-freeze` in the `main` ruleset's required status checks (`gh api repos/lightdash/lightdash/rulesets`).
+-   **Agents: never freeze or unfreeze on your own initiative.** It blocks every engineer in the repo. Ask, and let a human dispatch it.
+
+Freezing analytics/customer *deployments* is a different mechanism in a different repo — see the `lightdash-cloud` CLAUDE.md.
+
 ## Package-Specific Notes
 
 **Backend (`packages/backend/`):**


### PR DESCRIPTION
## What

A `Merge freeze` dispatch that holds `main` while a release is cut, and takes the hold off again.

`release.yml` fires on every push to `main`, so the release that goes out is whatever `main` happens to contain at that moment. When something needs to reach a release on its own — a fix someone is waiting on — a merge landing in the gap between "merge it" and "the release job picks it up" either delays that release or widens it past the change we meant to ship. The only lever today is asking people in Slack not to merge.

* **freeze** adds a `merge-freeze` context to the `main` ruleset's required status checks. Nothing ever reports that context, so the merge button is blocked for everyone without a ruleset bypass.
* **unfreeze** takes the context off again, dropping the whole rule if it was the only one, so the ruleset returns to exactly its pre-freeze shape.

Both directions also post a `merge-freeze` commit status to every open PR targeting `main`, because otherwise GitHub renders the block as `Expected — Waiting for status to be reported`, which says nothing about why or for how long.

## How it's put together

**Enforcement is the ruleset rule alone; the statuses are messaging.** That split is the fail-safe one — if the status half breaks, merges stay blocked while frozen and unblock the moment the rule comes off. It's also why the status loop is best-effort and never fails the run.

**The rule is added and removed rather than left permanently required.** The `main` ruleset has no `required_status_checks` rule today, so a permanently-required `merge-freeze` would change the merge model for every PR in the repo (including forks, which would need the status to report or be blocked indefinitely). Toggling the rule keeps the footprint at zero when unfrozen.

**Only PRs based on the default branch are touched.** The ruleset covers `main`, so a stacked PR merging into its parent is not blocked and is not told it is.

**`merge-freeze-status.yml`** covers PRs opened or pushed *during* a window, gated on a `MERGE_FREEZE` repo variable the toggle maintains. A stale variable degrades the message, never the enforcement. Fork PRs are skipped — a `pull_request` run from a fork gets a read-only token — and stay blocked by the missing check, which is the outcome we want anyway; `pull_request_target` would expose secrets to fork PRs for no enforcement gain.

## Token

`MERGE_FREEZE_TOKEN` is configured on this repo (added 2026-08-13): a fine-grained PAT owned by the `lightdash` org, scoped to this repository only, expiring **14 Aug 2027** (the org's ceiling). Permissions: Administration write (rulesets), Commit statuses write, Variables write, Metadata read.

Verified against the live API: the rulesets read that the preflight performs succeeds, so the permission is active and not sitting in the org's pending-approval queue.

Worth knowing: the token expires 14 Aug 2027, and when it does, freezing fails at the preflight with a clear message rather than silently doing nothing.

The rulesets and variables APIs need `Administration: write`, which `GITHUB_TOKEN` cannot be granted — `administration` is not a workflow permission scope. The workflow reads `secrets.MERGE_FREEZE_TOKEN || secrets.CI_GITHUB_TOKEN`, so the fallback stays in place if the dedicated token is ever removed.

## Verification

Not dispatched — a real run would block 113 open PRs, so it wants your go-ahead.

* **Rule surgery, 18 assertions against the live ruleset JSON**: freeze adds the context and preserves all 5 existing rules (`required_signatures`, squash-only `pull_request`, linear history…); unfreeze round-trips the rules array back to byte-identical; freeze is idempotent; unfreeze on an unfrozen ruleset is a no-op; with a hypothetical pre-existing required check the freeze appends to that rule instead of adding a second, unfreeze removes only our context and leaves theirs standing, and their `strict_required_status_checks_policy` is untouched.
* **Full dry run against the live API** with every write intercepted: resolved ruleset `main` (id 7546338) from the default branch, built the correct 6-rule PUT payload preserving `bypass_actors` and `conditions`, and iterated the 113 open PRs targeting `main`. The unfreeze direction produced the original 5-rule payload.
* This caught one real bug: `gh api --jq` takes a bare filter and rejects `--arg`, so both parameterised reads would have died at runtime. Fixed by piping into `jq`.
* YAML parses; every `run:` block passes `bash -n`.

The PUT itself, the variable writes and the status posts are the parts no dry run can prove. First freeze is worth doing when the repo is quiet, with someone watching.

## Not in scope

* Slack announce on freeze/unfreeze (cf. SPK-982 for the upgrade-freeze equivalent) — worth adding, needs a channel decision
* Auto-expiry or a reminder for a freeze left on

Also documents the mechanism in `CLAUDE.md` so agents know it exists — and know not to dispatch it on their own initiative.

Linear: SPK-985

