### PR TITLE
feat(embed): support external connections in JWT-embedded data apps

### DIFF
--- a/packages/backend/src/ee/analytics/externalConnections.ts
+++ b/packages/backend/src/ee/analytics/externalConnections.ts
@@ -45,7 +45,6 @@ export type ExternalConnectionEvent = BaseTrack &
           }
         | {
               event: 'external_connection.fetch';
-              userId: string;
               properties: {
                   organizationId: string;
                   projectId: string;

--- a/packages/backend/src/ee/controllers/externalConnectionController.ts
+++ b/packages/backend/src/ee/controllers/externalConnectionController.ts
@@ -1,5 +1,6 @@
 import {
     assertRegisteredAccount,
+    ForbiddenError,
     type ApiErrorPayload,
     type ApiListExternalConnectionSamplesResponse,
     type ApiProposeExternalConnectionConfigRequest,
@@ -31,7 +32,6 @@ import {
     SuccessResponse,
 } from '@tsoa/runtime';
 import express from 'express';
-import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -327,10 +327,12 @@ export class ExternalConnectionController extends BaseController {
         @Path() appUuid: string,
         @Body() body: ExternalFetchRequest,
     ): Promise<ApiExternalFetchResponse> {
-        assertRegisteredAccount(req.account);
+        if (!req.account) {
+            throw new ForbiddenError('Account is required');
+        }
         this.setStatus(200);
         const results = await this.getService().proxyFetch(
-            toSessionUser(req.account),
+            req.account,
             projectUuid,
             appUuid,
             body,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -187,7 +187,10 @@ import {
     type SandboxHandle,
     type SandboxSpec,
 } from '../SandboxRuntime';
-import { assertCanViewApp as assertUserCanViewApp } from './appAuthz';
+import {
+    assertCanViewEmbeddedApp,
+    assertCanViewApp as assertUserCanViewApp,
+} from './appAuthz';
 import { getBundleServableChecker } from './appBundleStorage';
 import {
     buildManifest,
@@ -8659,9 +8662,9 @@ export class AppGenerateService extends BaseService {
      *   self-authorizes it (the project opted in via `allow_all_apps` or the
      *   `app_uuids` allowlist, enforced at account build); a mismatched appUuid
      *   is rejected outright.
-     * - dashboard-tile embed: the app must be referenced by a tile on a
-     *   dashboard in the embed's allowlist (or `allowAllDashboards`), mirroring
-     *   how embedded charts are gated by whitelisted dashboards.
+     * - dashboard-tile embed: the app must be referenced by a tile on the
+     *   dashboard named by the JWT, mirroring how embedded charts are pinned
+     *   to their dashboard.
      * The app must live in the embed's project — source-project apps (preview
      * environments) are out of scope and surface as a 404 to the frontend.
      */
@@ -8681,51 +8684,15 @@ export class AppGenerateService extends BaseService {
             throw new NotFoundError(`App not found: ${appUuid}`);
         }
 
-        const auditedAbility = this.createAuditedAbility(account);
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('DataApp', {
-                    organizationUuid: app.organization_uuid,
-                    projectUuid: app.project_uuid,
-                    metadata: { appUuid },
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'Insufficient permissions to access this data app',
-            );
-        }
-
-        if (account.access.content.type === 'dataApp') {
-            // A standalone data app JWT authorizes EXACTLY its named app
-            // (already gated at account build in
-            // EmbedService.getAccountFromJwt). Requesting any other app is
-            // denied — we must NOT fall through to the dashboard-allowlist gate,
-            // which could otherwise mint a token for an app that merely sits on
-            // an allowlisted dashboard, bypassing the per-app `app_uuids`
-            // allowlist.
-            if (account.access.content.appUuid !== appUuid) {
-                throw new ForbiddenError(
-                    'This embed is not authorized for this data app',
-                );
-            }
-        } else if (!account.embed.allowAllDashboards) {
-            const dashboardsWithApp =
-                await this.appModel.findDashboardsContainingApp(
-                    appUuid,
-                    projectUuid,
-                );
-            const allowedDashboards = new Set(account.embed.dashboardUuids);
-            const onAllowedDashboard = dashboardsWithApp.some((d) =>
-                allowedDashboards.has(d),
-            );
-            if (!onAllowedDashboard) {
-                throw new ForbiddenError(
-                    'Data app is not authorized by this embed',
-                );
-            }
-        }
+        await assertCanViewEmbeddedApp(
+            {
+                createAuditedAbility: (embeddedAccount) =>
+                    this.createAuditedAbility(embeddedAccount),
+                appModel: this.appModel,
+            },
+            account,
+            app,
+        );
 
         const latestReady = await this.appModel.getLatestReadyVersion(appUuid);
         if (!latestReady) {

--- a/packages/backend/src/ee/services/AppGenerateService/appAuthz.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appAuthz.ts
@@ -1,6 +1,11 @@
 import { subject, type Ability } from '@casl/ability';
-import { ForbiddenError, type SessionUser } from '@lightdash/common';
+import {
+    ForbiddenError,
+    type AnonymousAccount,
+    type SessionUser,
+} from '@lightdash/common';
 import { type CaslAuditWrapper } from '../../../logging/caslAuditWrapper';
+import { type AppModel } from '../../../models/AppModel';
 
 export type AppViewAuthzApp = {
     project_uuid: string;
@@ -46,5 +51,68 @@ export async function assertCanViewApp(
         throw new ForbiddenError(
             'Insufficient permissions to access this data app',
         );
+    }
+}
+
+export type EmbeddedAppViewAuthzDeps = {
+    createAuditedAbility: (
+        account: AnonymousAccount,
+    ) => CaslAuditWrapper<Ability>;
+    appModel: Pick<AppModel, 'findDashboardsContainingApp'>;
+};
+
+type EmbeddedAppViewAuthzApp = Pick<
+    AppViewAuthzApp,
+    'organization_uuid' | 'project_uuid'
+> & { app_id: string };
+
+/**
+ * Authorize a JWT account against the app it is trying to render or use.
+ * Standalone app embeds are pinned to one app; dashboard embeds may use only
+ * apps referenced by the dashboard named in the JWT.
+ */
+export async function assertCanViewEmbeddedApp(
+    deps: EmbeddedAppViewAuthzDeps,
+    account: AnonymousAccount,
+    app: EmbeddedAppViewAuthzApp,
+): Promise<void> {
+    const appUuid = app.app_id;
+    const auditedAbility = deps.createAuditedAbility(account);
+    if (
+        auditedAbility.cannot(
+            'view',
+            subject('DataApp', {
+                organizationUuid: app.organization_uuid,
+                projectUuid: app.project_uuid,
+                metadata: { appUuid },
+            }),
+        )
+    ) {
+        throw new ForbiddenError(
+            'Insufficient permissions to access this data app',
+        );
+    }
+
+    if (account.access.content.type === 'dataApp') {
+        if (account.access.content.appUuid !== appUuid) {
+            throw new ForbiddenError(
+                'This embed is not authorized for this data app',
+            );
+        }
+        return;
+    }
+
+    const { dashboardUuid } = account.access.content;
+    if (!dashboardUuid) {
+        throw new ForbiddenError('Data app is not authorized by this embed');
+    }
+
+    const dashboardsWithApp = await deps.appModel.findDashboardsContainingApp(
+        appUuid,
+        app.project_uuid,
+        [dashboardUuid],
+    );
+    if (!dashboardsWithApp.includes(dashboardUuid)) {
+        throw new ForbiddenError('Data app is not authorized by this embed');
     }
 }

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -2,8 +2,9 @@ import {
     ForbiddenError,
     ParameterError,
     type ExternalConnection,
-    type SessionUser,
 } from '@lightdash/common';
+import { fromJwt } from '../../../auth/account';
+import { buildAccount } from '../../../auth/account/account.mock';
 import { SecureFetchError } from '../../../utils/secureFetch/secureFetch';
 import * as secureFetchModule from '../../../utils/secureFetch/secureFetch';
 import { ExternalConnectionService } from './ExternalConnectionService';
@@ -59,11 +60,52 @@ const baseApp = () => ({
     organization_uuid: 'org-1',
 });
 
-const user = {
-    userUuid: 'user-1',
-    organizationUuid: 'org-1',
-    ability: { can: () => true },
-} as unknown as SessionUser;
+const user = buildAccount();
+
+const buildEmbeddedDashboardUser = (allowAllDashboards = false) => {
+    const base = buildAccount({ accountType: 'jwt' });
+    return fromJwt({
+        decodedToken: {
+            user: { externalId: 'dashboard-viewer' },
+            content: {
+                type: 'dashboard',
+                dashboardUuid: 'test-dashboard-uuid',
+                canViewDataApps: true,
+            },
+        },
+        embed: { ...base.embed, allowAllDashboards },
+        source: 'dashboard-embed-token',
+        content: {
+            type: 'dashboard',
+            dashboardUuid: 'test-dashboard-uuid',
+            chartUuids: [],
+            explores: [],
+        },
+        userAttributes: base.access.controls!,
+    });
+};
+
+const buildEmbeddedDataAppUser = (appUuid = 'app-1') => {
+    const base = buildAccount({ accountType: 'jwt' });
+    return fromJwt({
+        decodedToken: {
+            user: { externalId: 'data-app-viewer' },
+            content: { type: 'dataApp', appUuid },
+        },
+        embed: { ...base.embed, allowAllApps: true, appUuids: [appUuid] },
+        source: 'data-app-embed-token',
+        content: {
+            type: 'dataApp',
+            appUuid,
+            chartUuids: [],
+            explores: [],
+        },
+        userAttributes: base.access.controls!,
+    });
+};
+
+const embeddedDashboardUser = buildEmbeddedDashboardUser();
+const embeddedDataAppUser = buildEmbeddedDataAppUser();
 
 function buildService(opts: {
     connection?: ExternalConnection | undefined;
@@ -71,6 +113,8 @@ function buildService(opts: {
     canView?: boolean;
     rateCount?: number;
     googleToken?: string;
+    dashboardsContainingApp?: string[];
+    appExists?: boolean;
 }) {
     const externalConnectionModel = {
         resolveAppAlias: vi.fn().mockResolvedValue(opts.connection),
@@ -84,6 +128,14 @@ function buildService(opts: {
     };
     const appModel = {
         getApp: vi.fn().mockResolvedValue(baseApp()),
+        findApp: vi
+            .fn()
+            .mockResolvedValue(
+                opts.appExists === false ? undefined : baseApp(),
+            ),
+        findDashboardsContainingApp: vi
+            .fn()
+            .mockResolvedValue(opts.dashboardsContainingApp ?? []),
     };
     const projectModel = {
         getSummary: vi.fn().mockResolvedValue({ organizationUuid: 'org-1' }),
@@ -91,7 +143,7 @@ function buildService(opts: {
     const spacePermissionService = {
         getSpaceAccessContext: vi.fn().mockResolvedValue({}),
     };
-    const analytics = { track: vi.fn() };
+    const analytics = { track: vi.fn(), trackAccount: vi.fn() };
 
     const service = new ExternalConnectionService({
         externalConnectionModel,
@@ -131,6 +183,129 @@ beforeEach(() => {
 });
 
 describe('ExternalConnectionService.proxyFetch', () => {
+    it('allows a standalone embed JWT to use a connection linked to its app', async () => {
+        const { service, appModel, analytics } = buildService({
+            connection: baseConnection(),
+        });
+
+        await service.proxyFetch(embeddedDataAppUser, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/today',
+        });
+
+        expect(mockSecureFetch).toHaveBeenCalledTimes(1);
+        expect(appModel.findDashboardsContainingApp).not.toHaveBeenCalled();
+        expect(analytics.trackAccount).toHaveBeenCalledWith(
+            embeddedDataAppUser,
+            expect.not.objectContaining({ userId: expect.anything() }),
+        );
+    });
+
+    it('rejects a standalone embed JWT for a different app', async () => {
+        const { service } = buildService({ connection: baseConnection() });
+
+        await expect(
+            service.proxyFetch(
+                buildEmbeddedDataAppUser('another-app'),
+                'proj-1',
+                'app-1',
+                {
+                    connectionAlias: 'weather',
+                    path: '/v1/today',
+                },
+            ),
+        ).rejects.toThrow('This embed is not authorized for this data app');
+        expect(mockSecureFetch).not.toHaveBeenCalled();
+    });
+
+    it('allows a dashboard embed JWT only when the app is on an allowed dashboard', async () => {
+        const allowedDashboardUuid =
+            embeddedDashboardUser.access.content.dashboardUuid!;
+        const { service, appModel } = buildService({
+            connection: baseConnection(),
+            dashboardsContainingApp: [allowedDashboardUuid],
+        });
+
+        await service.proxyFetch(embeddedDashboardUser, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/today',
+        });
+
+        expect(appModel.findDashboardsContainingApp).toHaveBeenCalledWith(
+            'app-1',
+            'proj-1',
+            [allowedDashboardUuid],
+        );
+        expect(mockSecureFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a dashboard embed JWT when the app is not on an allowed dashboard', async () => {
+        const { service } = buildService({
+            connection: baseConnection(),
+            dashboardsContainingApp: ['another-dashboard'],
+        });
+
+        await expect(
+            service.proxyFetch(embeddedDashboardUser, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/today',
+            }),
+        ).rejects.toThrow('Data app is not authorized by this embed');
+        expect(mockSecureFetch).not.toHaveBeenCalled();
+    });
+
+    it('does not authorize an app outside the JWT dashboard when all dashboards are embeddable', async () => {
+        const allowAllDashboardUser = buildEmbeddedDashboardUser(true);
+        const { service, appModel } = buildService({
+            connection: baseConnection(),
+            dashboardsContainingApp: ['another-dashboard'],
+        });
+
+        await expect(
+            service.proxyFetch(allowAllDashboardUser, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/today',
+            }),
+        ).rejects.toThrow('Data app is not authorized by this embed');
+        expect(appModel.findDashboardsContainingApp).toHaveBeenCalledWith(
+            'app-1',
+            'proj-1',
+            ['test-dashboard-uuid'],
+        );
+        expect(mockSecureFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects an embed JWT denied by the DataApp ability', async () => {
+        const { service, appModel } = buildService({
+            connection: baseConnection(),
+            canView: false,
+        });
+
+        await expect(
+            service.proxyFetch(embeddedDashboardUser, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/today',
+            }),
+        ).rejects.toThrow('Insufficient permissions to access this data app');
+        expect(appModel.findDashboardsContainingApp).not.toHaveBeenCalled();
+        expect(mockSecureFetch).not.toHaveBeenCalled();
+    });
+
+    it('does not reveal whether an app exists to an embed JWT', async () => {
+        const { service, externalConnectionModel } = buildService({
+            connection: baseConnection(),
+            appExists: false,
+        });
+
+        await expect(
+            service.proxyFetch(embeddedDashboardUser, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/today',
+            }),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(externalConnectionModel.resolveAppAlias).not.toHaveBeenCalled();
+    });
+
     it('rejects when the alias is not linked to the app', async () => {
         const { service } = buildService({ connection: undefined });
         await expect(
@@ -549,7 +724,8 @@ describe('ExternalConnectionService.proxyFetch', () => {
         expect(res.body).toEqual({
             error: 'anthropic-version header is required',
         });
-        expect(analytics.track).toHaveBeenCalledWith(
+        expect(analytics.trackAccount).toHaveBeenCalledWith(
+            user,
             expect.objectContaining({
                 properties: expect.objectContaining({
                     status: 400,
@@ -683,7 +859,8 @@ describe('ExternalConnectionService.proxyFetch', () => {
             path: '/v1/x',
             body: { secret_payload: 'do-not-log' },
         });
-        expect(analytics.track).toHaveBeenCalledWith(
+        expect(analytics.trackAccount).toHaveBeenCalledWith(
+            user,
             expect.objectContaining({
                 event: 'external_connection.fetch',
                 properties: expect.objectContaining({
@@ -694,7 +871,7 @@ describe('ExternalConnectionService.proxyFetch', () => {
                 }),
             }),
         );
-        const tracked = JSON.stringify(analytics.track.mock.calls);
+        const tracked = JSON.stringify(analytics.trackAccount.mock.calls);
         expect(tracked).not.toContain('tok_secret');
         expect(tracked).not.toContain('do-not-log');
     });

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -1,12 +1,15 @@
 import { subject } from '@casl/ability';
 import {
+    assertRegisteredAccount,
     EXTERNAL_CONNECTION_DEFAULTS,
     ForbiddenError,
     getErrorMessage,
+    isJwtUser,
     MissingConfigError,
     NotFoundError,
     ParameterError,
     TooManyRequestsError,
+    type Account,
     type ApiSaveExternalConnectionSampleRequest,
     type CreateExternalConnection,
     type ExternalConnection,
@@ -17,11 +20,11 @@ import {
     type ExternalFetchRequest,
     type ExternalFetchResponse,
     type RegisteredAccount,
-    type SessionUser,
     type UpdateExternalConnection,
 } from '@lightdash/common';
 import { performance } from 'node:perf_hooks';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import { toSessionUser } from '../../../auth/account';
 import { type AppModel } from '../../../models/AppModel';
 import { BaseService } from '../../../services/BaseService';
 import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
@@ -35,7 +38,10 @@ import { generateExternalConnectionConfigProposal } from '../ai/agents/externalC
 import { getModel } from '../ai/models';
 import { type GeneratorModelOptions } from '../ai/models/types';
 import { type OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
-import { assertCanViewApp } from '../AppGenerateService/appAuthz';
+import {
+    assertCanViewApp,
+    assertCanViewEmbeddedApp,
+} from '../AppGenerateService/appAuthz';
 import { getExternalConnectionSubject } from './externalConnectionAuthz';
 import {
     validateExternalConnectionConfig,
@@ -569,7 +575,7 @@ export class ExternalConnectionService extends BaseService {
     }
 
     async proxyFetch(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
         appUuid: string,
         req: ExternalFetchRequest,
@@ -577,23 +583,43 @@ export class ExternalConnectionService extends BaseService {
         const start = performance.now();
 
         // 1. Load app + authorize VIEW (same authz as reading the app).
-        const app = await this.appModel.getApp(appUuid, projectUuid);
-        await assertCanViewApp(
-            {
-                auditedAbility: this.createAuditedAbility(user),
-                getSpaceAccessContext: (userUuid, spaceUuid) =>
-                    this.spacePermissionService.getSpaceAccessContext(
-                        userUuid,
-                        spaceUuid,
-                    ),
-            },
-            user,
-            app,
-        );
+        if (isJwtUser(account)) {
+            const app = await this.appModel.findApp(appUuid, projectUuid);
+            if (!app) {
+                throw new ForbiddenError(
+                    'Data app is not authorized by this embed',
+                );
+            }
+            await assertCanViewEmbeddedApp(
+                {
+                    createAuditedAbility: (embeddedAccount) =>
+                        this.createAuditedAbility(embeddedAccount),
+                    appModel: this.appModel,
+                },
+                account,
+                app,
+            );
+        } else {
+            assertRegisteredAccount(account);
+            const app = await this.appModel.getApp(appUuid, projectUuid);
+            const user = toSessionUser(account);
+            await assertCanViewApp(
+                {
+                    auditedAbility: this.createAuditedAbility(user),
+                    getSpaceAccessContext: (userUuid, spaceUuid) =>
+                        this.spacePermissionService.getSpaceAccessContext(
+                            userUuid,
+                            spaceUuid,
+                        ),
+                },
+                user,
+                app,
+            );
+        }
 
         // 2. Resolve the alias → connection (must be linked to this app).
         const connection = await this.externalConnectionModel.resolveAppAlias(
-            app.app_id,
+            appUuid,
             req.connectionAlias,
         );
         if (!connection) {
@@ -610,23 +636,23 @@ export class ExternalConnectionService extends BaseService {
             );
         }
 
-        // 4. Rate limit — all methods, including GET. Reads still spend
-        //    Lightdash egress and upstream quota under the injected auth, so an
-        //    app viewer must not be able to drive unlimited GETs.
+        // 4. Shared app/connection rate limit, including embed viewers. This is
+        //    the credential owner's global ceiling; per-viewer buckets would
+        //    allow aggregate traffic to exceed the configured upstream quota.
         const limit =
             connection.rateLimitPerMinute ??
             ExternalConnectionService.DEFAULT_RATE_LIMIT_PER_MINUTE;
         const window = computeMinuteWindow(new Date());
         const count = await this.externalConnectionModel.incrementRateCounter(
             connection.externalConnectionUuid,
-            app.app_id,
+            appUuid,
             window,
         );
         if (count > limit) {
             this.trackFetch({
-                user,
+                account,
                 projectUuid,
-                appUuid: app.app_id,
+                appUuid,
                 connectionAlias: req.connectionAlias,
                 connection,
                 method,
@@ -669,9 +695,9 @@ export class ExternalConnectionService extends BaseService {
                 error instanceof SecureFetchError;
             const outcome = isKnown ? 'rejected' : 'upstream_error';
             this.trackFetch({
-                user,
+                account,
                 projectUuid,
-                appUuid: app.app_id,
+                appUuid,
                 connectionAlias: req.connectionAlias,
                 connection,
                 method,
@@ -699,9 +725,9 @@ export class ExternalConnectionService extends BaseService {
 
         // 7. Audit the result — never bodies, never the secret.
         this.trackFetch({
-            user,
+            account,
             projectUuid,
-            appUuid: app.app_id,
+            appUuid,
             connectionAlias: req.connectionAlias,
             connection,
             method,
@@ -937,7 +963,7 @@ export class ExternalConnectionService extends BaseService {
     }
 
     private trackFetch(args: {
-        user: SessionUser;
+        account: Account;
         projectUuid: string;
         appUuid: string;
         connectionAlias: string;
@@ -950,9 +976,8 @@ export class ExternalConnectionService extends BaseService {
         requestBytes: number;
         responseBytes: number;
     }): void {
-        this.analytics.track({
+        this.analytics.trackAccount(args.account, {
             event: 'external_connection.fetch',
-            userId: args.user.userUuid,
             properties: {
                 organizationId: args.connection.organizationUuid,
                 projectId: args.projectUuid,

--- a/packages/backend/src/models/AppModel.test.ts
+++ b/packages/backend/src/models/AppModel.test.ts
@@ -1,6 +1,7 @@
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { AppsTableName, type DbApp } from '../database/entities/apps';
+import { DashboardTileDataAppsTableName } from '../database/entities/dashboards';
 import { AppModel } from './AppModel';
 
 const appId = '11111111-1111-4111-8111-111111111111';
@@ -111,5 +112,41 @@ describe('AppModel.setMetadataIfUnset', () => {
         expect(tracker.history.select).toHaveLength(1);
         expect(tracker.history.update[0].sql).not.toContain('"slug"');
         expect(tracker.history.update[0].sql).not.toContain('"name"');
+    });
+});
+
+describe('AppModel.findDashboardsContainingApp', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new AppModel({ database });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('limits the latest-version lookup to the candidate dashboards', async () => {
+        const dashboardUuid = '44444444-4444-4444-8444-444444444444';
+        tracker.on
+            .select(DashboardTileDataAppsTableName)
+            .responseOnce([{ dashboard_uuid: dashboardUuid }]);
+
+        const result = await model.findDashboardsContainingApp(
+            appId,
+            projectUuid,
+            [dashboardUuid],
+        );
+
+        expect(result).toEqual([dashboardUuid]);
+        expect(tracker.history.select).toHaveLength(1);
+        expect(tracker.history.select[0].sql).toContain(
+            '"dashboards"."dashboard_uuid" in ($2)',
+        );
+        expect(tracker.history.select[0].bindings).toEqual(
+            expect.arrayContaining([projectUuid, dashboardUuid, appId]),
+        );
     });
 });

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1542,15 +1542,16 @@ export class AppModel {
     }
 
     /**
-     * Returns the UUIDs of dashboards in `projectUuid` whose latest version
-     * contains a tile referencing `appUuid`. Old versions are intentionally
-     * ignored: if a dashboard once contained the app but no longer does,
-     * embedding that dashboard must not implicitly authorize the app.
+     * Returns candidate dashboard UUIDs whose latest version contains a tile
+     * referencing `appUuid`. Old versions are intentionally ignored.
      */
     async findDashboardsContainingApp(
         appUuid: string,
         projectUuid: string,
+        dashboardUuids: string[],
     ): Promise<string[]> {
+        if (dashboardUuids.length === 0) return [];
+
         const latestVersionsCte = 'latest_dashboard_versions';
         const rows = await this.database
             .with(latestVersionsCte, (qb) => {
@@ -1580,6 +1581,10 @@ export class AppModel {
                         `${DashboardVersionsTableName}.dashboard_id`,
                     )
                     .where(`${ProjectTableName}.project_uuid`, projectUuid)
+                    .whereIn(
+                        `${DashboardsTableName}.dashboard_uuid`,
+                        dashboardUuids,
+                    )
                     .whereNull(`${DashboardsTableName}.deleted_at`)
                     .groupBy(`${DashboardsTableName}.dashboard_uuid`);
             })

--- a/packages/common/src/authorization/jwtAbility.ts
+++ b/packages/common/src/authorization/jwtAbility.ts
@@ -55,9 +55,9 @@ const dashboardAbilities: EmbeddedAbilityBuilder = ({
     // Data app tiles require an explicit opt-in on the JWT — same trust
     // model as canExplore. Off by default, the data app tile renders as a
     // "not authorized" placeholder. With the flag set, the customer is
-    // accepting that the embed user can run the data app's metric queries
-    // (arbitrary against any explore in the project, still filtered at
-    // query time by the JWT's user attributes via getFilteredExplore).
+    // accepting that the embed user can run the app's metric queries and use
+    // its admin-linked external connections. Metric queries remain filtered
+    // by the JWT's user attributes via getFilteredExplore.
     if (
         embedUser.content.type === 'dashboard' &&
         embedUser.content.canViewDataApps
@@ -129,8 +129,8 @@ const dataAppAbilities: EmbeddedAbilityBuilder = ({
     // A standalone data app runs arbitrary metric queries against any explore
     // in the project. The Explore grant MUST be unconstrained (no exploreNames)
     // — a scoped grant would 403 queries the app legitimately needs. Rows are
-    // still filtered at query time by the JWT's user attributes
-    // (getFilteredExplore). Same trust model as a dashboard's canViewDataApps.
+    // still filtered at query time by the JWT's user attributes. The app may
+    // also use admin-linked external connections, matching canViewDataApps.
     can('view', 'Explore', {
         organizationUuid: organization.organizationUuid,
         projectUuid: embed.projectUuid,

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -85,9 +85,9 @@ export const InteractivityOptionsSchema = z.object({
     // Off by default — without it, data app tiles render as a placeholder.
     // Setting it grants the embed JWT the broader CASL abilities a data app
     // needs (view:DataApp + view:Explore project-wide) so it can mint a
-    // preview token and run its arbitrary metric queries. Mirrors the
-    // existing canExplore opt-in: an explicit decision to widen the embed's
-    // surface beyond pre-built chart queries.
+    // preview token, run its arbitrary metric queries, and use external
+    // connections that an admin linked to the app. Mirrors canExplore: an
+    // explicit decision to widen the embed beyond pre-built chart queries.
     canViewDataApps: z.boolean().optional(),
     // Pins tabs and the filter bar to the top while scrolling. Off by default.
     stickyHeader: z.boolean().optional(),

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
@@ -467,7 +467,7 @@ const EmbedPreviewDashboardForm: FC<{
                                                     View data apps
                                                 </Text>
                                                 <Tooltip
-                                                    label="Grants project-wide explore access so the data app can run its metric queries."
+                                                    label="Lets data apps run project-wide metric queries and use external connections linked by an admin."
                                                     withArrow
                                                     withinPortal
                                                     multiline

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -4,6 +4,7 @@ import {
     APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
     APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
     FilterOperator,
+    JWT_HEADER_NAME,
     LightdashAppPreviewTokenHeader,
     LightdashAppUuidHeader,
     LightdashSignedDownloadHeader,
@@ -957,33 +958,39 @@ describe('external-fetch branch', () => {
             query: { limit: '10' },
             body: { amount: 500 },
         });
-        // No app-supplied headers leak through; external fetch never sends the
-        // embed JWT (it is not supported in embed mode).
+        // No app-supplied headers leak through.
         expect(Object.keys(init.headers)).toEqual(['Content-Type']);
     });
 
-    it('rejects external fetch in embed mode without calling the backend', async () => {
+    it('authenticates external fetches in embed mode with the embed JWT', async () => {
         mockUseEmbed.mockReturnValue({
             embedToken: 'embed-jwt',
-            projectUuid: undefined,
+            projectUuid: PROJECT_UUID,
         });
         renderBridge(() => undefined);
-        const { responses } = captureResponses();
+        mockFetchOk({
+            status: 'ok',
+            results: {
+                status: 200,
+                contentType: 'application/json',
+                body: { temperature: 18 },
+                truncated: false,
+            },
+        });
 
         postExternalFetch({ alias: 'weather', path: '/today' });
 
         await vi.waitFor(() =>
-            expect(
-                responses.find(
-                    (r) =>
-                        r['type'] === 'lightdash:sdk:external-fetch-response',
-                ),
-            ).toMatchObject({
-                id: POST_ID,
-                error: 'External data access is not available in embedded apps',
-            }),
+            expect(fetch).toHaveBeenCalledWith(
+                `/api/v1/ee/projects/${PROJECT_UUID}/apps/${APP_UUID}/external-fetch`,
+                expect.objectContaining({ method: 'POST' }),
+            ),
         );
-        expect(fetch).not.toHaveBeenCalled();
+        const [, init] = (fetch as Mock).mock.calls[0];
+        expect(init.headers).toEqual({
+            'Content-Type': 'application/json',
+            [JWT_HEADER_NAME]: 'embed-jwt',
+        });
     });
 
     it('posts back the result on success', async () => {

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -49,6 +49,11 @@ const resolveFetchUrl = (path: string): string => {
     return `${instanceUrl.replace(/\/$/, '')}${path}`;
 };
 
+const getEmbedAuthHeaders = (
+    embedToken: string | undefined,
+): Record<string, string> =>
+    embedToken ? { [JWT_HEADER_NAME]: embedToken } : {};
+
 export type QueryEventTableCalculation = {
     name: string;
     displayName: string;
@@ -608,21 +613,6 @@ export function useAppSdkBridge({
 
                 emitExternal({ status: 'pending' });
 
-                // External fetch is not available to embedded apps: the proxy
-                // endpoint requires a registered session, not an embed JWT.
-                // Fail clearly rather than make a doomed authenticated call.
-                if (embedToken) {
-                    const embedError =
-                        'External data access is not available in embedded apps';
-                    emitExternal({
-                        status: 'error',
-                        error: embedError,
-                        durationMs: Date.now() - startedAt,
-                    });
-                    respondExternal({ error: embedError });
-                    return;
-                }
-
                 // Build the EE request body from app-supplied fields ONLY.
                 // No URL, no headers, no connection UUID — the backend resolves
                 // the alias and attaches the connection's secrets. The
@@ -644,6 +634,7 @@ export function useAppSdkBridge({
                             method: 'POST',
                             headers: {
                                 'Content-Type': 'application/json',
+                                ...getEmbedAuthHeaders(embedToken),
                             },
                             body: JSON.stringify(externalFetchBody),
                         },
@@ -888,9 +879,7 @@ export function useAppSdkBridge({
                     method,
                     headers: {
                         'Content-Type': 'application/json',
-                        ...(embedToken
-                            ? { [JWT_HEADER_NAME]: embedToken }
-                            : {}),
+                        ...getEmbedAuthHeaders(embedToken),
                         // Self-reported app attribution; the backend tags
                         // warehouse queries with it. Tracking only.
                         ...(appUuid


### PR DESCRIPTION
## What changed

- Authenticate Data App external fetches with embed JWTs.
- Authorize standalone embeds against the exact app and dashboard embeds against the exact dashboard UUID in the JWT.
- Forward the embed JWT through the SDK bridge's external-connection fetch path.
- Track embedded requests with account-aware analytics and document the expanded embed capability.

## Why

JWT-embedded Data Apps could run metric queries, but external-connection requests failed because the SDK bridge did not forward the JWT and the backend proxy only accepted registered sessions.

## Security and impact

- External connections remain admin-managed and must be explicitly linked to the app.
- Existing origin pinning, allowed methods and paths, response limits, and rate limits remain unchanged.
- Missing and unauthorized apps return the same forbidden response to embed accounts.
- Dashboard embeds only authorize apps present on the exact dashboard named in the JWT.
- The shared per-app/per-connection bucket remains credential-wide so aggregate upstream usage stays bounded.

## Validation

- `pnpm -F common typecheck`
- `pnpm -F backend typecheck`
- `pnpm -F frontend typecheck`
- Focused oxlint across all changed files
- Backend Vitest: 50 tests passed
- Frontend Vitest: 50 tests passed
- `pnpm generate-api` completed with no generated artifact changes
- `git diff --check`
- Browser E2E: standalone JWT embed fetched PokeAPI and rendered Pikachu (ID 25, height 4)

Closes #27307