### PR TITLE
fix(ai): close deep research retention gaps

### DIFF
--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -463,6 +463,19 @@ describe('AiDeepResearchRunModel integration', () => {
         );
     });
 
+    it('records the terminal reason when a queued run is cancelled', async () => {
+        const run = await createRun();
+
+        await model.requestCancellation(run.ai_deep_research_run_uuid);
+
+        await expect(
+            model.findByUuid(run.ai_deep_research_run_uuid),
+        ).resolves.toMatchObject({
+            status: 'cancelled',
+            terminal_reason: 'user_cancellation',
+        });
+    });
+
     it('keeps completion and cancellation terminal under contention', async () => {
         const run = await createRun();
         await model.claimQueuedRun(run.ai_deep_research_run_uuid);
@@ -692,7 +705,7 @@ describe('AiDeepResearchRunModel integration', () => {
         const futureRun = await createRun({ promptUuid: futurePromptUuid });
         const expiredToolCallId = `expired-${crypto.randomUUID()}`;
         const futureToolCallId = `future-${crypto.randomUUID()}`;
-        const unrelatedToolCallId = `unrelated-${crypto.randomUUID()}`;
+        const coordinatorToolCallId = `coordinator-${crypto.randomUUID()}`;
 
         await database(AiDeepResearchRunsTableName)
             .where(
@@ -725,7 +738,7 @@ describe('AiDeepResearchRunModel integration', () => {
             },
             {
                 ai_prompt_uuid: promptUuid,
-                tool_call_id: unrelatedToolCallId,
+                tool_call_id: coordinatorToolCallId,
                 tool_name: 'runSql',
                 tool_args: {},
                 ai_mcp_server_uuid: null,
@@ -741,7 +754,7 @@ describe('AiDeepResearchRunModel integration', () => {
                     promptUuid: futurePromptUuid,
                     toolCallId: futureToolCallId,
                 },
-                { promptUuid, toolCallId: unrelatedToolCallId },
+                { promptUuid, toolCallId: coordinatorToolCallId },
             ].map(({ promptUuid: toolPromptUuid, toolCallId }) => ({
                 ai_prompt_uuid: toolPromptUuid,
                 tool_call_id: toolCallId,
@@ -824,22 +837,22 @@ describe('AiDeepResearchRunModel integration', () => {
                         .whereIn('tool_call_id', [
                             expiredToolCallId,
                             futureToolCallId,
-                            unrelatedToolCallId,
+                            coordinatorToolCallId,
                         ])
                         .pluck('tool_call_id')
                 ).sort(),
-            ).toEqual([futureToolCallId, unrelatedToolCallId].sort());
+            ).toEqual([futureToolCallId]);
             expect(
                 (
                     await database(AiAgentToolResultTableName)
                         .whereIn('tool_call_id', [
                             expiredToolCallId,
                             futureToolCallId,
-                            unrelatedToolCallId,
+                            coordinatorToolCallId,
                         ])
                         .pluck('tool_call_id')
                 ).sort(),
-            ).toEqual([futureToolCallId, unrelatedToolCallId].sort());
+            ).toEqual([futureToolCallId]);
             expect(
                 await database(AiSqlApprovalTableName)
                     .where('tool_call_id', expiredToolCallId)
@@ -855,6 +868,72 @@ describe('AiDeepResearchRunModel integration', () => {
                 .where('tool_call_id', expiredToolCallId)
                 .delete();
         }
+    });
+
+    it('scrubs expired provenance for a failed run without a report', async () => {
+        const failedPromptUuid = await createAdditionalPrompt();
+        const failedRun = await createRun({ promptUuid: failedPromptUuid });
+        const toolCallId = `failed-${crypto.randomUUID()}`;
+        const invalidToolCallId = `invalid-${crypto.randomUUID()}`;
+        await database(AiDeepResearchRunsTableName)
+            .where(
+                'ai_deep_research_run_uuid',
+                failedRun.ai_deep_research_run_uuid,
+            )
+            .update({
+                status: 'failed',
+                terminal_reason: 'internal_error',
+                result_markdown: null,
+                completed_at: database.raw("now() - interval '31 days'"),
+            });
+        await database<AiAgentToolCallTable>(AiAgentToolCallTableName).insert({
+            ai_prompt_uuid: failedPromptUuid,
+            tool_call_id: toolCallId,
+            tool_name: 'runSql',
+            tool_args: {},
+            ai_mcp_server_uuid: null,
+            parent_tool_call_id: null,
+        });
+        await database<AiAgentToolResultTable>(
+            AiAgentToolResultTableName,
+        ).insert({
+            ai_prompt_uuid: failedPromptUuid,
+            tool_call_id: toolCallId,
+            tool_name: 'runSql',
+            result: JSON.stringify({ rows: [{ secret: 'expired' }] }),
+        });
+        await database<AiAgentToolCallErrorTable>(
+            AiAgentToolCallErrorTableName,
+        ).insert({
+            ai_prompt_uuid: failedPromptUuid,
+            tool_call_id: invalidToolCallId,
+            tool_name: 'runSql',
+            error_message: 'invalid call',
+            raw_args: JSON.stringify({ secret: 'expired invalid args' }),
+        });
+
+        expect(await model.cleanExpiredReports(100)).toEqual({
+            scanned: 1,
+            expired: 1,
+            failed: 0,
+        });
+        expect(
+            await database(AiAgentToolCallTableName)
+                .where('tool_call_id', toolCallId)
+                .first(),
+        ).toBeUndefined();
+        expect(
+            await database(AiAgentToolCallErrorTableName)
+                .where('tool_call_id', invalidToolCallId)
+                .first(),
+        ).toBeUndefined();
+        await expect(
+            model.findByUuid(failedRun.ai_deep_research_run_uuid),
+        ).resolves.toMatchObject({
+            status: 'failed',
+            result_markdown: null,
+            report_expired_at: expect.any(Date),
+        });
     });
 
     it('rolls provenance deletion back when scrubbing the report fails', async () => {

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
@@ -445,6 +445,9 @@ describe('AiDeepResearchRunModel', () => {
         expect(tracker.history.update[0].bindings).toEqual(
             expect.arrayContaining(['queued', 'cancelled', RUN_UUID]),
         );
+        expect(tracker.history.update[0].bindings).toContain(
+            'user_cancellation',
+        );
         expect(tracker.history.insert).toHaveLength(3);
         expect(tracker.history.insert[0].bindings).toContain(
             'cancellation_requested',
@@ -565,6 +568,12 @@ describe('AiDeepResearchRunModel', () => {
         );
         expect(tracker.history.update.at(-1)?.sql).not.toContain(
             'result_chart_data',
+        );
+        expect(tracker.history.select[0]?.sql).not.toContain(
+            '"result_markdown" is not null',
+        );
+        expect(tracker.history.select[0]?.sql).toContain(
+            '"status" in ($1, $2, $3, $4)',
         );
     });
 });

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -1,8 +1,6 @@
 import {
-    AI_DEEP_RESEARCH_DELEGATE_TOOL_NAME,
     AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS,
     AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
-    AI_DEEP_RESEARCH_WORKER_FINDINGS_TOOL_NAME,
     countDeepResearchFindings,
     findDeepResearchChartRefs,
     getErrorMessage,
@@ -985,6 +983,7 @@ export class AiDeepResearchRunModel {
                 .whereNull('cancellation_requested_at')
                 .update({
                     status: 'cancelled',
+                    terminal_reason: 'user_cancellation',
                     cancellation_requested_at: now,
                     completed_at: now,
                     updated_at: now,
@@ -1221,6 +1220,12 @@ export class AiDeepResearchRunModel {
         )
             .select('ai_deep_research_run_uuid', 'prompt_uuid')
             .whereNull('report_expired_at')
+            .whereIn('status', [
+                'completed',
+                'partially_completed',
+                'failed',
+                'cancelled',
+            ])
             .where((query) =>
                 query
                     .where('report_expires_at', '<=', this.database.fn.now())
@@ -1233,7 +1238,6 @@ export class AiDeepResearchRunModel {
                             ),
                     ),
             )
-            .whereNotNull('result_markdown')
             .orderByRaw(
                 "coalesce(report_expires_at, completed_at + interval '30 days') asc",
             )
@@ -1254,76 +1258,36 @@ export class AiDeepResearchRunModel {
                                         candidate.ai_deep_research_run_uuid,
                                     )
                                     .whereNull('report_expired_at')
+                                    .whereIn('status', [
+                                        'completed',
+                                        'partially_completed',
+                                        'failed',
+                                        'cancelled',
+                                    ])
                                     .whereRaw(
                                         "coalesce(report_expires_at, completed_at + interval '30 days') <= now()",
                                     )
-                                    .whereNotNull('result_markdown')
                                     .forUpdate()
                                     .first();
                             if (!lockedCandidate) {
                                 return 'skipped' as const;
                             }
 
-                            const toolCalls =
-                                await transaction<AiAgentToolCallTable>(
-                                    AiAgentToolCallTableName,
-                                )
-                                    .select(
-                                        'ai_agent_tool_call_uuid',
-                                        'tool_call_id',
-                                    )
-                                    .where(
-                                        'ai_prompt_uuid',
-                                        candidate.prompt_uuid,
-                                    )
-                                    .where((query) =>
-                                        query
-                                            .where(
-                                                'parent_tool_call_id',
-                                                'like',
-                                                `deep-research:${candidate.ai_deep_research_run_uuid}:%`,
-                                            )
-                                            .orWhereIn('tool_name', [
-                                                AI_DEEP_RESEARCH_DELEGATE_TOOL_NAME,
-                                                AI_DEEP_RESEARCH_WORKER_FINDINGS_TOOL_NAME,
-                                                AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
-                                            ]),
-                                    );
-                            const toolCallIds = toolCalls.map(
-                                (toolCall) => toolCall.tool_call_id,
-                            );
-
-                            if (toolCallIds.length > 0) {
-                                await transaction<AiAgentToolResultTable>(
-                                    AiAgentToolResultTableName,
-                                )
-                                    .where(
-                                        'ai_prompt_uuid',
-                                        candidate.prompt_uuid,
-                                    )
-                                    .whereIn('tool_call_id', toolCallIds)
-                                    .delete();
-                                await transaction<AiAgentToolCallErrorTable>(
-                                    AiAgentToolCallErrorTableName,
-                                )
-                                    .where(
-                                        'ai_prompt_uuid',
-                                        candidate.prompt_uuid,
-                                    )
-                                    .whereIn('tool_call_id', toolCallIds)
-                                    .delete();
-                                await transaction<AiAgentToolCallTable>(
-                                    AiAgentToolCallTableName,
-                                )
-                                    .whereIn(
-                                        'ai_agent_tool_call_uuid',
-                                        toolCalls.map(
-                                            (toolCall) =>
-                                                toolCall.ai_agent_tool_call_uuid,
-                                        ),
-                                    )
-                                    .delete();
-                            }
+                            await transaction<AiAgentToolResultTable>(
+                                AiAgentToolResultTableName,
+                            )
+                                .where('ai_prompt_uuid', candidate.prompt_uuid)
+                                .delete();
+                            await transaction<AiAgentToolCallErrorTable>(
+                                AiAgentToolCallErrorTableName,
+                            )
+                                .where('ai_prompt_uuid', candidate.prompt_uuid)
+                                .delete();
+                            await transaction<AiAgentToolCallTable>(
+                                AiAgentToolCallTableName,
+                            )
+                                .where('ai_prompt_uuid', candidate.prompt_uuid)
+                                .delete();
 
                             const expired =
                                 await transaction<AiDeepResearchRunsTable>(


### PR DESCRIPTION
## Summary

Fixes PROD-10099.

- scrub prompt-owned Deep Research tool calls, results, and orphan error rows for every expired terminal run, including failed and cancelled runs without reports
- include top-level coordinator provenance as well as worker provenance while retaining prompt/run isolation
- persist `user_cancellation` on queued cancellations
- preserve transaction locking and rollback behavior during cleanup

## Validation

- 21 focused model unit tests
- backend typecheck, lint, and formatting
- correctness, security/tenant-safety, and intent/scope reviews

## Test note

Integration regressions cover failed-run provenance and queued cancellation state; local integration execution requires `PGCONNECTIONURI`.