### PR TITLE
fix(ai): harden deep research frontend recovery

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchRegistry.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchRegistry.test.ts
@@ -98,6 +98,49 @@ describe('deepResearchRegistry', () => {
         ]);
     });
 
+    it('keeps working from memory when localStorage writes fail', () => {
+        vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+            throw new DOMException('Quota exceeded', 'QuotaExceededError');
+        });
+
+        expect(() =>
+            registerDeepResearchRun(
+                failedRegistration({ runUuid: 'memory-run' }),
+            ),
+        ).not.toThrow();
+        expect(
+            findRetryableDeepResearchRun({
+                projectUuid: 'project-1',
+                agentUuid: 'agent-1',
+                threadUuid: 'thread-1',
+                userUuid: 'user-1',
+                question: 'Why did retention fall?',
+            }),
+        ).toMatchObject({ runUuid: 'memory-run' });
+    });
+
+    it('keeps working from memory when localStorage reads fail', () => {
+        registerDeepResearchRun(
+            failedRegistration({
+                runUuid: 'memory-read-run',
+                createdAt: '2026-07-24T09:02:00.000Z',
+            }),
+        );
+        vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+            throw new DOMException('Storage blocked', 'SecurityError');
+        });
+
+        expect(
+            findRetryableDeepResearchRun({
+                projectUuid: 'project-1',
+                agentUuid: 'agent-1',
+                threadUuid: 'thread-1',
+                userUuid: 'user-1',
+                question: 'Why did retention fall?',
+            }),
+        ).toMatchObject({ runUuid: 'memory-read-run' });
+    });
+
     it('restores the failed prompt in the matching thread composer', () => {
         const listener = vi.fn();
         const unsubscribe = subscribeToDeepResearchComposerPrompt(listener);

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchRegistry.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchRegistry.ts
@@ -3,16 +3,21 @@ import { type DeepResearchRunRegistration } from './types';
 
 const STORAGE_KEY = 'lightdash.deep-research-runs.v1';
 const REGISTRY_EVENT = 'lightdash:deep-research-runs-changed';
+let memoryRegistry: DeepResearchRunRegistration[] = [];
+let storageAvailable = true;
 
 const readRegistry = (): DeepResearchRunRegistration[] => {
     if (typeof window === 'undefined') {
         return [];
     }
+    if (!storageAvailable) {
+        return memoryRegistry;
+    }
     try {
         const value: unknown = JSON.parse(
             window.localStorage.getItem(STORAGE_KEY) ?? '[]',
         );
-        return Array.isArray(value)
+        const registrations = Array.isArray(value)
             ? value.filter(
                   (item): item is DeepResearchRunRegistration =>
                       typeof item === 'object' &&
@@ -31,8 +36,10 @@ const readRegistry = (): DeepResearchRunRegistration[] => {
                       typeof item.question === 'string',
               )
             : [];
+        memoryRegistry = registrations;
+        return registrations;
     } catch {
-        return [];
+        return memoryRegistry;
     }
 };
 
@@ -40,8 +47,16 @@ let snapshot = readRegistry();
 const EMPTY_REGISTRY: DeepResearchRunRegistration[] = [];
 
 const emitChange = (registrations: DeepResearchRunRegistration[]) => {
+    memoryRegistry = registrations;
     snapshot = registrations;
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(registrations));
+    try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(registrations));
+        storageAvailable = true;
+    } catch {
+        storageAvailable = false;
+        // The in-memory registry keeps Deep Research usable when storage is
+        // blocked or full. It intentionally lasts only for this page session.
+    }
     window.dispatchEvent(new Event(REGISTRY_EVENT));
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runPolling.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runPolling.test.ts
@@ -1,8 +1,15 @@
+import { type ApiError } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import {
     DEEP_RESEARCH_TERMINAL_REFETCH_MAX_MS,
     getDeepResearchRunRefetchInterval,
 } from './runPolling';
+
+const apiError = (statusCode: number): ApiError =>
+    ({
+        error: { statusCode, name: 'ApiError', message: 'failed', data: {} },
+        status: 'error',
+    }) as ApiError;
 
 const now = Date.parse('2026-07-30T12:00:00.000Z');
 
@@ -58,5 +65,47 @@ describe('getDeepResearchRunRefetchInterval', () => {
                 now,
             ),
         ).toBe(false);
+    });
+
+    it.each([403, 404])('stops polling after a %s response', (statusCode) => {
+        expect(
+            getDeepResearchRunRefetchInterval(undefined, 2_000, now, {
+                error: apiError(statusCode),
+                failureCount: 1,
+            }),
+        ).toBe(false);
+    });
+
+    it('backs off transient polling failures with a cap', () => {
+        expect(
+            getDeepResearchRunRefetchInterval(undefined, 2_000, now, {
+                error: apiError(500),
+                failureCount: 2,
+            }),
+        ).toBe(8_000);
+        expect(
+            getDeepResearchRunRefetchInterval(undefined, 2_000, now, {
+                error: apiError(500),
+                failureCount: 20,
+            }),
+        ).toBe(30_000);
+    });
+
+    it('backs off transient failures even when a terminal run is cached', () => {
+        expect(
+            getDeepResearchRunRefetchInterval(
+                {
+                    status: 'completed',
+                    isReportExpired: false,
+                    reportExpiresAt: '2026-08-29T12:00:00.000Z',
+                },
+                2_000,
+                now,
+                {
+                    error: apiError(500),
+                    failureCount: 2,
+                },
+            ),
+        ).toBe(8_000);
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runPolling.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runPolling.ts
@@ -1,7 +1,13 @@
-import { type AiDeepResearchRun } from '@lightdash/common';
+import { type AiDeepResearchRun, type ApiError } from '@lightdash/common';
 import { isDeepResearchRunTerminal } from './runProgress';
 
 export const DEEP_RESEARCH_TERMINAL_REFETCH_MAX_MS = 24 * 60 * 60 * 1_000;
+const DEEP_RESEARCH_ERROR_REFETCH_MAX_MS = 30_000;
+
+type PollFailure = {
+    error: ApiError;
+    failureCount: number;
+};
 
 export const getDeepResearchRunRefetchInterval = (
     run:
@@ -12,7 +18,18 @@ export const getDeepResearchRunRefetchInterval = (
         | undefined,
     activePollIntervalMs: number,
     nowMs = Date.now(),
+    failure?: PollFailure,
 ): number | false => {
+    const statusCode = failure?.error.error?.statusCode;
+    if (statusCode === 403 || statusCode === 404) {
+        return false;
+    }
+    if (failure) {
+        return Math.min(
+            activePollIntervalMs * 2 ** failure.failureCount,
+            DEEP_RESEARCH_ERROR_REFETCH_MAX_MS,
+        );
+    }
     if (!run || !isDeepResearchRunTerminal(run.status)) {
         return activePollIntervalMs;
     }

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
@@ -446,6 +446,165 @@ describe('useDeepResearchRun', () => {
         expect(lightdashApiMock).toHaveBeenCalledTimes(callsAtCompletion);
     });
 
+    it.each([403, 404])(
+        'stops run and event polling after a %s run response',
+        async (statusCode) => {
+            lightdashApiMock.mockImplementation(({ url }: { url: string }) => {
+                if (url.includes('/events')) {
+                    return Promise.resolve({
+                        events: [],
+                        nextCursor: null,
+                    });
+                }
+                return Promise.reject({
+                    error: {
+                        message: 'Run is unavailable',
+                        statusCode,
+                    },
+                });
+            });
+
+            const { result } = renderHook(
+                () => useDeepResearchRun(registration),
+                { wrapper: getWrapper() },
+            );
+
+            await waitFor(() => expect(result.current.isError).toBe(true));
+            const callsAfterFailure = lightdashApiMock.mock.calls.length;
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(10_000);
+            });
+
+            expect(lightdashApiMock).toHaveBeenCalledTimes(callsAfterFailure);
+            expect(
+                lightdashApiMock.mock.calls.filter(([args]) =>
+                    (args as { url: string }).url.includes('/events'),
+                ),
+            ).toHaveLength(1);
+        },
+    );
+
+    it.each([403, 404])(
+        'stops event polling after a %s event response',
+        async (statusCode) => {
+            lightdashApiMock.mockImplementation(({ url }: { url: string }) =>
+                url.includes('/events')
+                    ? Promise.reject({
+                          error: {
+                              message: 'Events are unavailable',
+                              statusCode,
+                          },
+                      })
+                    : Promise.resolve(getRun('running')),
+            );
+
+            const { result } = renderHook(
+                () => useDeepResearchRun(registration),
+                { wrapper: getWrapper() },
+            );
+
+            await waitFor(() =>
+                expect(result.current.eventsQuery.isError).toBe(true),
+            );
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(10_000);
+            });
+
+            expect(
+                lightdashApiMock.mock.calls.filter(([args]) =>
+                    (args as { url: string }).url.includes('/events'),
+                ),
+            ).toHaveLength(1);
+            expect(
+                lightdashApiMock.mock.calls.filter(
+                    ([args]) =>
+                        !(args as { url: string }).url.includes('/events'),
+                ).length,
+            ).toBeGreaterThan(1);
+        },
+    );
+
+    it('backs off consecutive event failures and resets after success', async () => {
+        let eventReads = 0;
+        const eventReadTimes: number[] = [];
+        lightdashApiMock.mockImplementation(({ url }: { url: string }) => {
+            if (!url.includes('/events')) {
+                return Promise.resolve(getRun('running'));
+            }
+            eventReads += 1;
+            eventReadTimes.push(Date.now());
+            return eventReads <= 2
+                ? Promise.reject({
+                      error: {
+                          message: 'Events are temporarily unavailable',
+                          statusCode: 500,
+                      },
+                  })
+                : Promise.resolve({ events: [], nextCursor: null });
+        });
+
+        renderHook(() => useDeepResearchRun(registration), {
+            wrapper: getWrapper(),
+        });
+
+        await waitFor(() => expect(eventReads).toBe(1));
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(30_000);
+        });
+
+        expect(eventReadTimes.length).toBeGreaterThanOrEqual(4);
+        expect(eventReadTimes[1] - eventReadTimes[0]).toBeGreaterThanOrEqual(
+            4_000,
+        );
+        expect(eventReadTimes[2] - eventReadTimes[1]).toBeGreaterThanOrEqual(
+            8_000,
+        );
+        expect(
+            (eventReadTimes.at(-1) ?? 0) - (eventReadTimes.at(-2) ?? 0),
+        ).toBeLessThanOrEqual(2_100);
+    });
+
+    it('resumes polling when a mounted hook switches away from an unavailable run', async () => {
+        lightdashApiMock.mockImplementation(({ url }: { url: string }) => {
+            if (url.includes('/events')) {
+                return Promise.resolve({ events: [], nextCursor: null });
+            }
+            if (url.includes('/run-1')) {
+                return Promise.reject({
+                    error: {
+                        message: 'Run is unavailable',
+                        statusCode: 404,
+                    },
+                });
+            }
+            return Promise.resolve({
+                ...getRun('running'),
+                aiDeepResearchRunUuid: 'run-2',
+            });
+        });
+        let currentRegistration = registration;
+        const { result, rerender } = renderHook(
+            () => useDeepResearchRun(currentRegistration),
+            { wrapper: getWrapper() },
+        );
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        currentRegistration = { ...registration, runUuid: 'run-2' };
+        rerender();
+        await waitFor(() => expect(result.current.data?.uuid).toBe('run-2'));
+        const callsAfterSwitch = lightdashApiMock.mock.calls.length;
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(2_100);
+        });
+
+        expect(lightdashApiMock.mock.calls.length).toBeGreaterThan(
+            callsAfterSwitch,
+        );
+    });
+
     it('loads every event page before calculating activity counts', async () => {
         lightdashApiMock.mockImplementation(({ url }: { url: string }) => {
             if (url.includes('/events') && !url.includes('cursor=')) {

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -15,7 +15,7 @@ import {
     isAiDeepResearchRunTerminal,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { lightdashApi } from '../../../../api';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import useUser from '../../../../hooks/user/useUser';
@@ -44,6 +44,17 @@ import {
 const DEEP_RESEARCH_QUERY_KEY = 'deepResearch';
 const DEEP_RESEARCH_POLL_INTERVAL_MS = 2_000;
 const DEEP_RESEARCH_EVENT_PAGE_SIZE = 100;
+
+type PollFailureState = {
+    queryIdentity: string;
+    error: ApiError;
+    failureCount: number;
+};
+
+const getPollFailureForQuery = (
+    failure: PollFailureState | undefined,
+    queryIdentity: string,
+) => (failure?.queryIdentity === queryIdentity ? failure : undefined);
 
 const getBaseUrl = (projectUuid: string) =>
     `/ee/projects/${projectUuid}/ai-deep-research`;
@@ -447,6 +458,8 @@ export const useHasActiveDeepResearchRun = ({
 export const useDeepResearchRun = (
     registration: DeepResearchRunRegistration,
 ) => {
+    const queryIdentity = `${registration.projectUuid}:${registration.runUuid}`;
+    const pollFailure = useRef<PollFailureState | undefined>(undefined);
     const runQuery = useQuery<AiDeepResearchRun, ApiError>({
         queryKey: [
             DEEP_RESEARCH_QUERY_KEY,
@@ -460,11 +473,29 @@ export const useDeepResearchRun = (
             getDeepResearchRunRefetchInterval(
                 run,
                 DEEP_RESEARCH_POLL_INTERVAL_MS,
+                Date.now(),
+                getPollFailureForQuery(pollFailure.current, queryIdentity),
             ),
+        onSuccess: () => {
+            pollFailure.current = undefined;
+        },
+        onError: (error) => {
+            pollFailure.current = {
+                queryIdentity,
+                error,
+                failureCount:
+                    (getPollFailureForQuery(pollFailure.current, queryIdentity)
+                        ?.failureCount ?? 0) + 1,
+            };
+        },
     });
     const isRunActive = runQuery.data
         ? !isDeepResearchRunTerminal(runQuery.data.status)
         : true;
+    const eventsPollFailure = useRef<PollFailureState | undefined>(undefined);
+    const runAccessUnavailable = [403, 404].includes(
+        runQuery.error?.error.statusCode ?? 0,
+    );
     const eventsQuery = useQuery<AiDeepResearchEventsPage, ApiError>({
         queryKey: [
             DEEP_RESEARCH_QUERY_KEY,
@@ -477,8 +508,33 @@ export const useDeepResearchRun = (
                 registration.projectUuid,
                 registration.runUuid,
             ),
-        enabled: registration.state === 'started',
-        refetchInterval: isRunActive ? DEEP_RESEARCH_POLL_INTERVAL_MS : false,
+        enabled: registration.state === 'started' && !runAccessUnavailable,
+        refetchInterval: () =>
+            isRunActive
+                ? getDeepResearchRunRefetchInterval(
+                      undefined,
+                      DEEP_RESEARCH_POLL_INTERVAL_MS,
+                      Date.now(),
+                      getPollFailureForQuery(
+                          eventsPollFailure.current,
+                          queryIdentity,
+                      ),
+                  )
+                : false,
+        onSuccess: () => {
+            eventsPollFailure.current = undefined;
+        },
+        onError: (error) => {
+            eventsPollFailure.current = {
+                queryIdentity,
+                error,
+                failureCount:
+                    (getPollFailureForQuery(
+                        eventsPollFailure.current,
+                        queryIdentity,
+                    )?.failureCount ?? 0) + 1,
+            };
+        },
     });
 
     return {
@@ -498,6 +554,8 @@ export const useDeepResearchReport = (
     projectUuid: string | undefined,
     runUuid: string | undefined,
 ) => {
+    const queryIdentity = `${projectUuid}:${runUuid}`;
+    const pollFailure = useRef<PollFailureState | undefined>(undefined);
     const runQuery = useQuery<AiDeepResearchRun, ApiError>({
         queryKey: [DEEP_RESEARCH_QUERY_KEY, projectUuid, runUuid],
         queryFn: () => getDeepResearchRun(projectUuid ?? '', runUuid ?? ''),
@@ -506,7 +564,21 @@ export const useDeepResearchReport = (
             getDeepResearchRunRefetchInterval(
                 run,
                 DEEP_RESEARCH_POLL_INTERVAL_MS,
+                Date.now(),
+                getPollFailureForQuery(pollFailure.current, queryIdentity),
             ),
+        onSuccess: () => {
+            pollFailure.current = undefined;
+        },
+        onError: (error) => {
+            pollFailure.current = {
+                queryIdentity,
+                error,
+                failureCount:
+                    (getPollFailureForQuery(pollFailure.current, queryIdentity)
+                        ?.failureCount ?? 0) + 1,
+            };
+        },
     });
     const report = useMemo<DeepResearchReportView | undefined>(
         () =>


### PR DESCRIPTION
## Summary

Fixes PROD-10100.

- stop run and event polling after forbidden or not-found responses
- apply capped exponential backoff to transient failures, including terminal-report refreshes
- isolate polling failure state by project and run so navigation always starts cleanly
- fall back to page-session memory when localStorage reads or writes fail, keeping start and retry flows usable

## Validation

- 27 focused frontend tests
- frontend typecheck, lint, formatting, and unused-export checks
- correctness, security/tenant-safety, and intent/scope reviews