### PR TITLE
fix(embed): only show dashboard parameters on tabs whose charts use them

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -859,6 +859,7 @@ const EmbedDashboard: FC<{
                     <EmbedDashboardHeader
                         dashboard={dashboard}
                         projectUuid={projectUuid}
+                        activeTiles={filteredTiles}
                     />
                     {renderDashboardEditToolbar()}
                     <Box mt="lg">
@@ -880,6 +881,7 @@ const EmbedDashboard: FC<{
                     <EmbedDashboardHeader
                         dashboard={dashboard}
                         projectUuid={projectUuid}
+                        activeTiles={filteredTiles}
                         tabs={
                             <Tabs.List px="lg">
                                 {visibleTabs.map((tab) => (
@@ -904,6 +906,7 @@ const EmbedDashboard: FC<{
                     <EmbedDashboardHeader
                         dashboard={dashboard}
                         projectUuid={projectUuid}
+                        activeTiles={filteredTiles}
                     />
                     {renderDashboardEditToolbar()}
                     {renderGridWithGuidedSetup()}

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
@@ -2,14 +2,16 @@ import {
     canAddDashboardFiltersInEmbed,
     isParameterInteractivityEnabled,
     type Dashboard,
+    type DashboardTile,
     type InteractivityOptions,
 } from '@lightdash/common';
 import { Box, Button, Divider, Group, Tooltip } from '@mantine/core';
 import { IconChevronUp } from '@tabler/icons-react';
-import { useMemo, useState, type FC } from 'react';
+import { useState, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { DashboardFiltersBarSummary } from '../../../../../features/dashboardFilters/DashboardFiltersBarSummary';
 import { DateZoom } from '../../../../../features/dateZoom';
+import { useActiveTabParameters } from '../../../../../hooks/dashboard/useActiveTabParameters';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
 import { embedContractClass } from '../../styles/embedClassContract';
 import styles from './EmbedDashboardFilterBar.module.css';
@@ -19,11 +21,14 @@ import EmbedDashboardParameters from './EmbedDashboardParameters';
 type Props = {
     dashboard: Dashboard & InteractivityOptions;
     shouldShowFilters: boolean;
+    /** Tiles rendered on the active tab */
+    activeTiles: DashboardTile[];
 };
 
 const EmbedDashboardFilterBar: FC<Props> = ({
     dashboard,
     shouldShowFilters,
+    activeTiles,
 }) => {
     const [isCollapsed, setIsCollapsed] = useState(false);
 
@@ -34,13 +39,6 @@ const EmbedDashboardFilterBar: FC<Props> = ({
     const dateZoomGranularity = useDashboardContext(
         (c) => c.dateZoomGranularity,
     );
-    const parameterDefinitions = useDashboardContext(
-        (c) => c.parameterDefinitions,
-    );
-    const parameterReferences = useDashboardContext(
-        (c) => c.dashboardParameterReferences,
-    );
-
     const parametersEnabled = isParameterInteractivityEnabled(
         dashboard.parameterInteractivity,
     );
@@ -52,15 +50,11 @@ const EmbedDashboardFilterBar: FC<Props> = ({
         ? dashboardFilters.dimensions.length +
           dashboardTemporaryFilters.dimensions.length
         : 0;
-    const totalParametersCount = useMemo(
-        () =>
-            parametersEnabled
-                ? Object.keys(parameterDefinitions).filter((key) =>
-                      parameterReferences.has(key),
-                  ).length
-                : 0,
-        [parametersEnabled, parameterDefinitions, parameterReferences],
-    );
+    // Parameters follow the UI: only shown on tabs whose charts reference them
+    const activeTabParameters = useActiveTabParameters(activeTiles);
+    const totalParametersCount = parametersEnabled
+        ? Object.keys(activeTabParameters).length
+        : 0;
     const hasVisibleParameters = totalParametersCount > 0;
 
     // Collapsing only hides filters and parameters — date zoom stays visible
@@ -115,7 +109,11 @@ const EmbedDashboardFilterBar: FC<Props> = ({
                         orientation="vertical"
                     />
                 )}
-                {parametersEnabled && <EmbedDashboardParameters />}
+                {parametersEnabled && (
+                    <EmbedDashboardParameters
+                        parameters={activeTabParameters}
+                    />
+                )}
             </Group>
 
             <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
@@ -2,6 +2,7 @@ import {
     isFilterInteractivityEnabled,
     isParameterInteractivityEnabled,
     type Dashboard,
+    type DashboardTile,
     type InteractivityOptions,
 } from '@lightdash/common';
 import { Box } from '@mantine/core';
@@ -17,9 +18,16 @@ type Props = {
     projectUuid: string;
     /** Tab switcher, pinned on top of the filters when the dashboard has tabs */
     tabs?: ReactNode;
+    /** Tiles rendered on the active tab */
+    activeTiles: DashboardTile[];
 };
 
-const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid, tabs }) => {
+const EmbedDashboardHeader: FC<Props> = ({
+    dashboard,
+    projectUuid,
+    tabs,
+    activeTiles,
+}) => {
     const hasFilterBar =
         dashboard.canDateZoom ||
         isParameterInteractivityEnabled(dashboard.parameterInteractivity) ||
@@ -45,6 +53,7 @@ const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid, tabs }) => {
         <EmbedDashboardFilterBar
             dashboard={dashboard}
             shouldShowFilters={shouldShowFilters}
+            activeTiles={activeTiles}
         />
     ) : null;
 

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
@@ -1,6 +1,7 @@
+import { type ParameterDefinitions } from '@lightdash/common';
 import { Box, Group, Text } from '@mantine/core';
 import { IconAdjustmentsHorizontal } from '@tabler/icons-react';
-import { useMemo, type FC, type ReactNode } from 'react';
+import { type FC, type ReactNode } from 'react';
 import FilterGroupSeparator from '../../../../../features/dashboardFilters/FilterGroupSeparator';
 import { Parameters } from '../../../../../features/parameters';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
@@ -24,30 +25,21 @@ const parametersSeparator: ReactNode = (
     />
 );
 
-const EmbedDashboardParameters: FC = () => {
+type Props = {
+    /** Parameters referenced by the charts on the active tab */
+    parameters: ParameterDefinitions;
+};
+
+const EmbedDashboardParameters: FC<Props> = ({ parameters }) => {
     const parameterValues = useDashboardContext((c) => c.parameterValues);
     const handleParameterChange = useDashboardContext((c) => c.setParameter);
     const clearAllParameters = useDashboardContext((c) => c.clearAllParameters);
-    const parameterDefinitions = useDashboardContext(
-        (c) => c.parameterDefinitions,
-    );
-    const parameterReferences = useDashboardContext(
-        (c) => c.dashboardParameterReferences,
-    );
     const areAllChartsLoaded = useDashboardTileStatusContext(
         (c) => c.areAllChartsLoaded,
     );
     const missingRequiredParameters = useDashboardContext(
         (c) => c.missingRequiredParameters,
     );
-
-    const referencedParameters = useMemo(() => {
-        return Object.fromEntries(
-            Object.entries(parameterDefinitions).filter(([key]) =>
-                parameterReferences.has(key),
-            ),
-        );
-    }, [parameterDefinitions, parameterReferences]);
 
     return (
         <Group
@@ -60,7 +52,7 @@ const EmbedDashboardParameters: FC = () => {
                 parameterValues={parameterValues}
                 onParameterChange={handleParameterChange}
                 onClearAll={clearAllParameters}
-                parameters={referencedParameters}
+                parameters={parameters}
                 isLoading={!areAllChartsLoaded}
                 missingRequiredParameters={missingRequiredParameters}
                 triggerClassName={embedContractClass('ld-dashboard-parameter')}

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -7,7 +7,6 @@ import {
     type DashboardTab,
     type DashboardTile,
     type Dashboard as IDashboard,
-    type LightdashProjectParameter,
     type ParametersValuesMap,
     type ParameterValue,
 } from '@lightdash/common';
@@ -34,6 +33,7 @@ import { ScrollToTop } from '../../components/common/ScrollToTop';
 import { StickyWithDetection } from '../../components/common/StickyWithDetection';
 import EmptyStateNoTiles from '../../components/DashboardTiles/EmptyStateNoTiles';
 import { useIsLauncherMounted } from '../../ee/features/aiCopilot/components/Launcher/useIsLauncherMounted';
+import { useActiveTabParameters } from '../../hooks/dashboard/useActiveTabParameters';
 import useToaster from '../../hooks/toaster/useToaster';
 import { useProject } from '../../hooks/useProject';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
@@ -210,9 +210,6 @@ type DashboardTabsProps = {
     // parameters
     hasTilesThatSupportFilters: boolean;
     parameterValues: ParametersValuesMap;
-    parameters: {
-        [k: string]: LightdashProjectParameter;
-    };
     shadowedReservedNames: string[];
     isParameterLoading: boolean;
     missingRequiredParameters: string[];
@@ -239,7 +236,6 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     // parameters
     hasTilesThatSupportFilters,
     parameterValues,
-    parameters,
     shadowedReservedNames,
     isParameterLoading,
     missingRequiredParameters,
@@ -348,9 +344,6 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     );
     const dashboardTemporaryFilters = useDashboardContext(
         (c) => c.dashboardTemporaryFilters,
-    );
-    const tileParameterReferences = useDashboardContext(
-        (c) => c.tileParameterReferences,
     );
 
     // filters bar state
@@ -611,19 +604,11 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
         ],
     );
 
-    const activeTabParameters = useMemo(() => {
-        if (!dashboardTiles) return parameters;
-
-        const activeParamKeys = dashboardTiles
-            .filter(isActiveTile)
-            .flatMap((tile) => tileParameterReferences[tile.uuid] ?? []);
-
-        return Object.fromEntries(
-            Object.entries(parameters).filter(([key]) =>
-                activeParamKeys.includes(key),
-            ),
-        );
-    }, [dashboardTiles, parameters, tileParameterReferences, isActiveTile]);
+    const activeTiles = useMemo(
+        () => dashboardTiles?.filter(isActiveTile),
+        [dashboardTiles, isActiveTile],
+    );
+    const activeTabParameters = useActiveTabParameters(activeTiles);
 
     // Collapsed summary values
     const totalFiltersCount =

--- a/packages/frontend/src/hooks/dashboard/useActiveTabParameters.test.ts
+++ b/packages/frontend/src/hooks/dashboard/useActiveTabParameters.test.ts
@@ -1,0 +1,84 @@
+import {
+    DashboardTileTypes,
+    type DashboardTile,
+    type ParameterDefinitions,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { getActiveTabParameters } from './useActiveTabParameters';
+
+const tile = (uuid: string, tabUuid: string): DashboardTile => ({
+    uuid,
+    tabUuid,
+    type: DashboardTileTypes.SAVED_CHART,
+    x: 0,
+    y: 0,
+    h: 1,
+    w: 1,
+    properties: { savedChartUuid: uuid },
+});
+
+const parameterDefinitions: ParameterDefinitions = {
+    kpi_metric: { label: 'KPI metric', options: ['revenue'] },
+    region: { label: 'Region', options: ['EU'] },
+};
+
+// Every tile that has rendered reports its references, so they accumulate
+// across tabs once the user has visited them
+const tileParameterReferences = {
+    'tile-tab-1': ['kpi_metric'],
+    'tile-tab-2': ['region'],
+};
+
+const dashboardParameterReferences = new Set(['kpi_metric', 'region']);
+
+describe('getActiveTabParameters', () => {
+    it('only keeps parameters referenced by tiles on the active tab', () => {
+        expect(
+            Object.keys(
+                getActiveTabParameters({
+                    activeTiles: [tile('tile-tab-1', 'tab-1')],
+                    parameterDefinitions,
+                    tileParameterReferences,
+                    dashboardParameterReferences,
+                }),
+            ),
+        ).toEqual(['kpi_metric']);
+    });
+
+    it('drops parameters only referenced by tiles on other tabs', () => {
+        expect(
+            Object.keys(
+                getActiveTabParameters({
+                    activeTiles: [tile('tile-tab-2', 'tab-2')],
+                    parameterDefinitions,
+                    tileParameterReferences,
+                    dashboardParameterReferences,
+                }),
+            ),
+        ).toEqual(['region']);
+    });
+
+    it('shows nothing when no tile on the active tab uses a parameter', () => {
+        expect(
+            getActiveTabParameters({
+                activeTiles: [tile('tile-tab-3', 'tab-3')],
+                parameterDefinitions,
+                tileParameterReferences,
+                dashboardParameterReferences,
+            }),
+        ).toEqual({});
+    });
+
+    it('falls back to all referenced parameters when tiles are unknown', () => {
+        expect(
+            Object.keys(
+                getActiveTabParameters({
+                    activeTiles: undefined,
+                    parameterDefinitions,
+                    tileParameterReferences,
+                    dashboardParameterReferences,
+                }),
+            ),
+        ).toEqual(['kpi_metric', 'region']);
+    });
+});

--- a/packages/frontend/src/hooks/dashboard/useActiveTabParameters.ts
+++ b/packages/frontend/src/hooks/dashboard/useActiveTabParameters.ts
@@ -1,0 +1,67 @@
+import {
+    type DashboardTile,
+    type ParameterDefinitions,
+} from '@lightdash/common';
+import { useMemo } from 'react';
+import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
+
+export const getActiveTabParameters = ({
+    activeTiles,
+    parameterDefinitions,
+    tileParameterReferences,
+    dashboardParameterReferences,
+}: {
+    activeTiles: DashboardTile[] | undefined;
+    parameterDefinitions: ParameterDefinitions;
+    tileParameterReferences: Record<string, string[]>;
+    dashboardParameterReferences: Set<string>;
+}): ParameterDefinitions => {
+    const activeReferences = activeTiles
+        ? new Set(
+              activeTiles.flatMap(
+                  (tile) => tileParameterReferences[tile.uuid] ?? [],
+              ),
+          )
+        : dashboardParameterReferences;
+
+    return Object.fromEntries(
+        Object.entries(parameterDefinitions).filter(([key]) =>
+            activeReferences.has(key),
+        ),
+    );
+};
+
+/**
+ * Parameters referenced by the tiles currently visible on the dashboard, so a
+ * parameter is only shown on the tabs whose charts actually use it. Falls back
+ * to every referenced parameter while the visible tiles are unknown.
+ */
+export const useActiveTabParameters = (
+    activeTiles: DashboardTile[] | undefined,
+): ParameterDefinitions => {
+    const parameterDefinitions = useDashboardContext(
+        (c) => c.parameterDefinitions,
+    );
+    const dashboardParameterReferences = useDashboardContext(
+        (c) => c.dashboardParameterReferences,
+    );
+    const tileParameterReferences = useDashboardContext(
+        (c) => c.tileParameterReferences,
+    );
+
+    return useMemo(
+        () =>
+            getActiveTabParameters({
+                activeTiles,
+                parameterDefinitions,
+                tileParameterReferences,
+                dashboardParameterReferences,
+            }),
+        [
+            activeTiles,
+            dashboardParameterReferences,
+            parameterDefinitions,
+            tileParameterReferences,
+        ],
+    );
+};

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -987,7 +987,6 @@ const Dashboard: FC = () => {
                                 hasTilesThatSupportFilters
                             }
                             // parameters
-                            parameters={referencedParameters}
                             shadowedReservedNames={shadowedReservedNames}
                             parameterValues={parameterValues}
                             onParameterChange={handleParameterChange}


### PR DESCRIPTION
Closes: lightdash/lightdash#27341

### Description:

Embedded dashboards showed every parameter referenced anywhere on the dashboard, so once a user visited a tab that uses a parameter, it stayed visible on all other tabs (tile parameter references accumulate in the dashboard context as tiles render). Users could change it there and nothing updated.

The embed filter bar now filters parameters by the tiles rendered on the active tab, matching the main UI. The tab-filtering logic that lived inline in `dashboardTabs` is extracted into a shared `useActiveTabParameters` hook (with a pure, unit-tested helper) used by both paths, so they can't drift again. The now-redundant `parameters` prop on `DashboardTabs` is removed since the hook reads from context.

Verified with unit tests on the filtering helper plus frontend typecheck/lint; the embed preview itself wasn't exercised in this environment.