### PR TITLE
fix(ci): harden the merge freeze - no reason box, name the freezer, owner-only unfreeze

### DIFF
--- a/.github/workflows/merge-freeze-status.yml
+++ b/.github/workflows/merge-freeze-status.yml
@@ -48,17 +48,25 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           SHA: ${{ github.event.pull_request.head.sha }}
+          FREEZE_ACTOR: ${{ vars.MERGE_FREEZE_ACTOR }}
           FREEZE_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/merge-freeze.yml
         run: |
           set -euo pipefail
 
-          # Fixed text, matching what merge-freeze.yml posts. The reason a
-          # freeze is on goes to #engineering and never here: this workflow's
-          # log and the statuses it writes are both public.
+          # Names the person, never the reason: this workflow's log and the
+          # statuses it writes are both public, and a freeze reason is exactly
+          # the sort of sentence that names a customer. A username carries
+          # nothing sensitive and tells the author who to go and ask.
+          if [ -n "${FREEZE_ACTOR:-}" ]; then
+            description="Merges to main are frozen by $FREEZE_ACTOR - ask them in Slack"
+          else
+            description="Merges to main are frozen while a release is cut"
+          fi
+
           gh api --method POST "repos/$REPO/statuses/$SHA" \
             -f state=failure \
             -f context=merge-freeze \
-            -f description="Merges to main are frozen while a release is cut" \
+            -f description="${description:0:140}" \
             -f target_url="$FREEZE_URL" >/dev/null
 
           echo "Flagged PR #${{ github.event.pull_request.number }} as blocked by the active merge freeze."

--- a/.github/workflows/merge-freeze-status.yml
+++ b/.github/workflows/merge-freeze-status.yml
@@ -48,17 +48,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           SHA: ${{ github.event.pull_request.head.sha }}
-          REASON: ${{ vars.MERGE_FREEZE_REASON }}
           FREEZE_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/merge-freeze.yml
         run: |
           set -euo pipefail
 
-          description=${REASON:-Merges to main are frozen while a release is cut}
-
+          # Fixed text, matching what merge-freeze.yml posts. The reason a
+          # freeze is on goes to #engineering and never here: this workflow's
+          # log and the statuses it writes are both public.
           gh api --method POST "repos/$REPO/statuses/$SHA" \
             -f state=failure \
             -f context=merge-freeze \
-            -f description="${description:0:140}" \
+            -f description="Merges to main are frozen while a release is cut" \
             -f target_url="$FREEZE_URL" >/dev/null
 
-          echo "Flagged PR #${{ github.event.pull_request.number }} as blocked: $description"
+          echo "Flagged PR #${{ github.event.pull_request.number }} as blocked by the active merge freeze."

--- a/.github/workflows/merge-freeze-status.yml
+++ b/.github/workflows/merge-freeze-status.yml
@@ -2,7 +2,7 @@ name: Merge freeze status
 
 # Companion to merge-freeze.yml. That workflow stamps every PR that was already
 # open when the freeze went on; this one covers PRs opened or pushed during the
-# window, so their blocked merge carries the same reason instead of GitHub's
+# window, so their blocked merge names whoever froze it instead of GitHub's
 # bare "Expected - Waiting for status to be reported".
 #
 # Messaging only: the required status check on the main ruleset is what blocks

--- a/.github/workflows/merge-freeze.yml
+++ b/.github/workflows/merge-freeze.yml
@@ -34,7 +34,7 @@ on:
           - freeze
           - unfreeze
       reason:
-        description: Why - shown on every blocked PR (e.g. "cutting a release for an escalation")
+        description: Why - posted to #engineering, not shown on the public PR checks
         required: false
         type: string
 
@@ -85,14 +85,11 @@ jobs:
           GH_TOKEN: ${{ secrets.MERGE_FREEZE_TOKEN || secrets.CI_GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           ACTION: ${{ inputs.action }}
-          REASON: ${{ inputs.reason }}
           ACTOR_LOGIN: ${{ github.actor }}
           CONTEXT: ${{ env.FREEZE_CONTEXT }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-
-          reason=${REASON:-}
 
           # `rulesets` also returns org-level rulesets that apply here but
           # cannot be edited from this repo, hence the source_type filter. The
@@ -196,19 +193,18 @@ jobs:
             exit 1
           fi
 
+          # This repo is public, so commit statuses are world-readable. The
+          # reason stays out of them deliberately and goes to Slack instead -
+          # "we are holding main for an escalation" is exactly the sort of
+          # sentence that names a customer. PRs still learn that a freeze is
+          # on, which is the part that stops people being confused.
           if [ "$ACTION" = "freeze" ]; then
             state=failure
-            if [ -n "$reason" ]; then
-              description="Merges to main are frozen: $reason"
-            else
-              description="Merges to main are frozen while a release is cut"
-            fi
+            description="Merges to main are frozen while a release is cut"
           else
             state=success
             description="Merges to main are open"
           fi
-          # The statuses API rejects a description over 140 characters outright.
-          description=${description:0:140}
 
           # `changed` is false when this run was a no-op (freezing an already
           # frozen main, or unfreezing an open one). The announce step reads it
@@ -220,20 +216,16 @@ jobs:
           else
             changed=true
           fi
-          {
-            echo "changed=$changed"
-            echo "description=$description"
-          } >> "$GITHUB_OUTPUT"
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
-          # Mirrored into repo variables so merge-freeze-status.yml can label PRs
-          # opened mid-freeze without an admin token of its own. Non-fatal: the
-          # ruleset is what blocks merges, so a stale variable degrades the
-          # message, never the enforcement.
+          # Mirrored into a repo variable so merge-freeze-status.yml can label
+          # PRs opened mid-freeze without an admin token of its own. It carries
+          # the state only, never the reason: that workflow's log is public.
+          # Non-fatal - the ruleset is what blocks merges, so a stale variable
+          # degrades the message, never the enforcement.
           if [ "$ACTION" = "freeze" ]; then freeze_var=true; else freeze_var=false; fi
           gh variable set MERGE_FREEZE --repo "$REPO" --body "$freeze_var" \
             || echo "::warning::Could not write the MERGE_FREEZE variable. The freeze is applied, but PRs opened during it will show an unexplained blocked check."
-          gh variable set MERGE_FREEZE_REASON --repo "$REPO" --body "$description" \
-            || echo "::warning::Could not write the MERGE_FREEZE_REASON variable."
 
           # Only PRs targeting the default branch: the ruleset covers main
           # alone, so a stacked PR merging into its parent is not blocked and
@@ -278,14 +270,14 @@ jobs:
             echo "| | |"
             echo "| --- | --- |"
             echo "| Actor | @$ACTOR_LOGIN |"
-            echo "| Reason | ${reason:-_none given_} |"
+            echo "| Reason | _sent to #engineering, kept out of this public run page_ |"
             echo "| Ruleset | \`$ruleset_name\` (id $ruleset_id) |"
             echo "| Required check | \`$CONTEXT\` |"
             echo "| Open PRs updated | $posted (couldn't reach $unreachable) |"
             echo
             if [ "$ACTION" = "freeze" ]; then
               if [ "$was_required" = "true" ]; then
-                echo "> Main was **already frozen** - this run refreshed the reason and the PR statuses."
+                echo "> Main was **already frozen** - this run only refreshed the PR statuses."
                 echo
               fi
               echo "Run this workflow again with **unfreeze** to reopen merges."
@@ -315,7 +307,6 @@ jobs:
           ACTION: ${{ inputs.action }}
           REASON: ${{ inputs.reason }}
           ACTOR_LOGIN: ${{ github.actor }}
-          DESCRIPTION: ${{ steps.toggle.outputs.description }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/merge-freeze.yml
         run: |

--- a/.github/workflows/merge-freeze.yml
+++ b/.github/workflows/merge-freeze.yml
@@ -213,11 +213,15 @@ jobs:
           # This repo is public, so commit statuses are world-readable. The
           # reason stays out of them deliberately and goes to Slack instead -
           # "we are holding main for an escalation" is exactly the sort of
-          # sentence that names a customer. PRs still learn that a freeze is
-          # on, which is the part that stops people being confused.
+          # sentence that names a customer.
+          #
+          # The person is named instead of the reason: it carries nothing
+          # sensitive, and it gives whoever is blocked something to act on -
+          # go and ask them in Slack, rather than hunting through the Actions
+          # tab to find out who to ask.
           if [ "$ACTION" = "freeze" ]; then
             state=failure
-            description="Merges to main are frozen while a release is cut"
+            description="Merges to main are frozen by $ACTOR_LOGIN - ask them in Slack"
           else
             state=success
             description="Merges to main are open"

--- a/.github/workflows/merge-freeze.yml
+++ b/.github/workflows/merge-freeze.yml
@@ -12,9 +12,9 @@ name: Merge freeze
 # while it is required the merge button is blocked for everyone without a
 # ruleset bypass. Enforcement is that rule alone - the commit statuses this
 # posts on open PRs only replace GitHub's opaque "Expected - Waiting for status
-# to be reported" with a reason. That split is the fail-safe one: if the status
-# half breaks, merges stay blocked while frozen and unblock the moment the rule
-# comes off.
+# to be reported" with the name of whoever froze it. That split is the
+# fail-safe one: if the status half breaks, merges stay blocked while frozen
+# and unblock the moment the rule comes off.
 #
 # The ruleset and variables APIs need Administration: write, which GITHUB_TOKEN
 # cannot be granted (`administration` is not a workflow permission scope), so
@@ -33,10 +33,6 @@ on:
         options:
           - freeze
           - unfreeze
-      reason:
-        description: Why - posted to #engineering, not shown on the public PR checks
-        required: false
-        type: string
 
 permissions: {}
 
@@ -210,15 +206,14 @@ jobs:
             exit 1
           fi
 
-          # This repo is public, so commit statuses are world-readable. The
-          # reason stays out of them deliberately and goes to Slack instead -
-          # "we are holding main for an escalation" is exactly the sort of
-          # sentence that names a customer.
+          # This repo is public, so commit statuses are world-readable. There is
+          # no free-text reason anywhere in this workflow by design: "we are
+          # holding main for an escalation" is exactly the sort of sentence
+          # that names a customer, and a text box invites someone to write it.
           #
-          # The person is named instead of the reason: it carries nothing
-          # sensitive, and it gives whoever is blocked something to act on -
-          # go and ask them in Slack, rather than hunting through the Actions
-          # tab to find out who to ask.
+          # Naming the person instead carries nothing sensitive and gives
+          # whoever is blocked something to act on - go and ask them - rather
+          # than hunting the Actions tab to work out who to ask.
           if [ "$ACTION" = "freeze" ]; then
             state=failure
             description="Merges to main are frozen by $ACTOR_LOGIN - ask them in Slack"
@@ -302,7 +297,6 @@ jobs:
             echo "| | |"
             echo "| --- | --- |"
             echo "| Actor | @$ACTOR_LOGIN |"
-            echo "| Reason | _sent to #engineering, kept out of this public run page_ |"
             echo "| Ruleset | \`$ruleset_name\` (id $ruleset_id) |"
             echo "| Required check | \`$CONTEXT\` |"
             echo "| Open PRs updated | $posted (couldn't reach $unreachable) |"
@@ -339,7 +333,6 @@ jobs:
         env:
           WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           ACTION: ${{ inputs.action }}
-          REASON: ${{ inputs.reason }}
           ACTOR_LOGIN: ${{ github.actor }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/merge-freeze.yml
@@ -351,9 +344,11 @@ jobs:
             exit 0
           fi
 
+          # No reason is carried anywhere, by design: this repo is public and a
+          # free-text box invites someone to name a customer in it. Whoever
+          # froze main can say why in the thread if it matters.
           if [ "$ACTION" = "freeze" ]; then
             text=":lock: *[merge-freeze-on]* Merges to \`main\` are frozen by @${ACTOR_LOGIN}."
-            text="$text"$'\n'"Reason: ${REASON:-_none given_}"
             text="$text"$'\n'"Your PRs will show a red \`merge-freeze\` check until it lifts. Only @${ACTOR_LOGIN} can lift it: <${WORKFLOW_URL}|Merge freeze / unfreeze>. If they are unavailable, a repo admin can remove the check from the main ruleset by hand."
           else
             text=":unlock: *[merge-freeze-off]* Merges to \`main\` are open again, lifted by @${ACTOR_LOGIN}."
@@ -361,8 +356,6 @@ jobs:
           fi
           text="$text"$'\n'"<${RUN_URL}|View run>"
 
-          # jq builds the payload so a reason containing quotes, backslashes or
-          # newlines cannot break the JSON.
           payload=$(jq -n --arg text "$text" '{channel: "#engineering", username: "Merge freeze", text: $text}')
 
           # Never fail the run on a Slack problem: the freeze is already applied

--- a/.github/workflows/merge-freeze.yml
+++ b/.github/workflows/merge-freeze.yml
@@ -86,6 +86,7 @@ jobs:
           REPO: ${{ github.repository }}
           ACTION: ${{ inputs.action }}
           ACTOR_LOGIN: ${{ github.actor }}
+          FREEZE_ACTOR: ${{ vars.MERGE_FREEZE_ACTOR }}
           CONTEXT: ${{ env.FREEZE_CONTEXT }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -130,6 +131,22 @@ jobs:
                        | .parameters.required_status_checks[]?
                        | select(.context == $ctx)] | length > 0
           ' <<<"$ruleset")
+
+          # A freeze belongs to whoever started it: they know what they are
+          # holding main for and when it is safe to let go. Checked before the
+          # ruleset is touched, so a refused unfreeze changes nothing.
+          #
+          # Three deliberate ways out, because a freeze nobody can lift is worse
+          # than one lifted early: an unknown owner allows anyone (the variable
+          # write is best-effort, and a hand-made freeze has no owner at all);
+          # unfreezing an already-open main is a no-op cleanup and is always
+          # allowed; and a repo admin can always remove the check from the
+          # ruleset by hand.
+          if [ "$ACTION" = "unfreeze" ] && [ "$was_required" = "true" ] \
+             && [ -n "${FREEZE_ACTOR:-}" ] && [ "$FREEZE_ACTOR" != "$ACTOR_LOGIN" ]; then
+            echo "::error::@$FREEZE_ACTOR froze main, so only they can unfreeze it here. Ask them to run this workflow, or ask a repo admin to remove the '$CONTEXT' check from the $ruleset_name ruleset by hand."
+            exit 1
+          fi
 
           if [ "$ACTION" = "freeze" ]; then
             new_rules=$(jq --arg ctx "$CONTEXT" '
@@ -227,6 +244,17 @@ jobs:
           gh variable set MERGE_FREEZE --repo "$REPO" --body "$freeze_var" \
             || echo "::warning::Could not write the MERGE_FREEZE variable. The freeze is applied, but PRs opened during it will show an unexplained blocked check."
 
+          # Ownership is recorded only on a real freeze, never on a repeat one:
+          # otherwise a second person re-freezing an already-frozen main would
+          # quietly take the freeze off whoever actually started it.
+          if [ "$ACTION" = "freeze" ] && [ "$changed" = "true" ]; then
+            gh variable set MERGE_FREEZE_ACTOR --repo "$REPO" --body "$ACTOR_LOGIN" \
+              || echo "::warning::Could not record who froze main, so anyone will be able to unfreeze it."
+          elif [ "$ACTION" = "unfreeze" ]; then
+            gh variable delete MERGE_FREEZE_ACTOR --repo "$REPO" 2>/dev/null \
+              || echo "Nothing to clear: no freeze owner was recorded."
+          fi
+
           # Only PRs targeting the default branch: the ruleset covers main
           # alone, so a stacked PR merging into its parent is not blocked and
           # must not be told it is. Assigned before the loop so a failure to
@@ -281,6 +309,8 @@ jobs:
                 echo
               fi
               echo "Run this workflow again with **unfreeze** to reopen merges."
+              echo
+              echo "Only **@$ACTOR_LOGIN** can do that here. If they are unavailable, a repo admin can remove the \`$CONTEXT\` check from the \`$ruleset_name\` ruleset by hand."
             else
               if [ "$was_required" = "false" ]; then
                 echo "> Main was **not frozen** - this run only cleared any stale \`$CONTEXT\` statuses."
@@ -320,7 +350,7 @@ jobs:
           if [ "$ACTION" = "freeze" ]; then
             text=":lock: *[merge-freeze-on]* Merges to \`main\` are frozen by @${ACTOR_LOGIN}."
             text="$text"$'\n'"Reason: ${REASON:-_none given_}"
-            text="$text"$'\n'"Your PRs will show a red \`merge-freeze\` check until it lifts. Anyone can lift it: <${WORKFLOW_URL}|run Merge freeze with unfreeze>."
+            text="$text"$'\n'"Your PRs will show a red \`merge-freeze\` check until it lifts. Only @${ACTOR_LOGIN} can lift it: <${WORKFLOW_URL}|Merge freeze / unfreeze>. If they are unavailable, a repo admin can remove the check from the main ruleset by hand."
           else
             text=":unlock: *[merge-freeze-off]* Merges to \`main\` are open again, lifted by @${ACTOR_LOGIN}."
             text="$text"$'\n'"If your PR still shows a stale \`merge-freeze\` failure, push or reopen it to clear."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,9 +164,10 @@ pnpm -F backend rollback-last
 
 `release.yml` fires on every push to `main`, so the release that goes out is whatever `main` contains at that moment. When something needs to reach a release on its own — a fix someone is waiting on — hold merges rather than asking people in Slack not to merge:
 
--   **Freeze**: `gh workflow run merge-freeze.yml -f action=freeze -f reason="cutting a release for an escalation"`. This adds a `merge-freeze` required status check to the `main` ruleset. Nothing ever reports that check, so merges into `main` are blocked for everyone without a ruleset bypass.
+-   **Freeze**: `gh workflow run merge-freeze.yml -f action=freeze`. This adds a `merge-freeze` required status check to the `main` ruleset. Nothing ever reports that check, so merges into `main` are blocked for everyone without a ruleset bypass.
 -   **Unfreeze**: the same workflow with `action=unfreeze`. Do it as soon as the release is cut — a freeze left on blocks the whole team, and there is no auto-expiry.
--   The `reason` is shown on every blocked PR, so make it specific and say roughly how long.
+-   **Only the person who froze can unfreeze it** from the Actions tab. If they're unavailable, a repo admin can remove the `merge-freeze` check from the `main` ruleset by hand.
+-   **There is no free-text reason, deliberately** — this repo is public, and a reason box invites someone to name a customer in it. Blocked PRs show who froze it so people know who to ask, and `#engineering` gets the same on both directions. Say why in Slack.
 -   **Only `main` is affected.** Stacked PRs merging into their parent branch are untouched.
 -   **Check the current state**: the `MERGE_FREEZE` repo variable, or `merge-freeze` in the `main` ruleset's required status checks (`gh api repos/lightdash/lightdash/rulesets`).
 -   **Agents: never freeze or unfreeze on your own initiative.** It blocks every engineer in the repo. Ask, and let a human dispatch it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ pnpm -F backend rollback-last
 -   **Only the person who froze can unfreeze it** from the Actions tab. If they're unavailable, a repo admin can remove the `merge-freeze` check from the `main` ruleset by hand.
 -   **There is no free-text reason, deliberately** — this repo is public, and a reason box invites someone to name a customer in it. Blocked PRs show who froze it so people know who to ask, and `#engineering` gets the same on both directions. Say why in Slack.
 -   **Only `main` is affected.** Stacked PRs merging into their parent branch are untouched.
--   **Check the current state**: the `MERGE_FREEZE` repo variable, or `merge-freeze` in the `main` ruleset's required status checks (`gh api repos/lightdash/lightdash/rulesets`).
+-   **Check the current state**: the `MERGE_FREEZE` repo variable (`true`/`false`), and `MERGE_FREEZE_ACTOR` for who froze it — `gh variable list -R lightdash/lightdash`. The authority is the ruleset itself: `merge-freeze` in the `main` ruleset's required status checks (`gh api repos/lightdash/lightdash/rulesets`). The variables are a mirror, so trust the ruleset if they ever disagree.
 -   **Agents: never freeze or unfreeze on your own initiative.** It blocks every engineer in the repo. Ask, and let a human dispatch it.
 
 Freezing analytics/customer *deployments* is a different mechanism in a different repo — see the `lightdash-cloud` CLAUDE.md.


### PR DESCRIPTION
Three hardening changes to the merge freeze, from the announcement thread.

## 1. No freeze reason anywhere (SPK-987)

`lightdash/lightdash` is public, so everything the freeze wrote about *why* main was held was readable by anyone: the commit status on every open PR, the `| Reason |` row on a public Actions run page, and a `MERGE_FREEZE_REASON` variable that `merge-freeze-status.yml` echoed straight into its own public log.

"Holding main for an escalation" is precisely the sentence that ends up naming a customer, so this was a confidentiality problem waiting to happen rather than a theoretical one.

**The `reason` input is removed entirely**, not just kept off public surfaces. `workflow_dispatch` inputs can be displayed on the public run page, so a free-text box on a public repo still invites someone to type a customer name into it — leaving the box in place while promising the value stays private would have been the worst of both. Anyone wanting to explain a freeze can say so in the Slack thread.

`MERGE_FREEZE_REASON` is gone; `MERGE_FREEZE` (the state) stays, since the status workflow still needs to know whether to stamp a PR. The 140-character truncation goes too — the remaining strings are bounded.

## 2. Blocked PRs name who froze it (SPK-989)

Jose's suggestion in the thread:

> I can see people writing PII in the reason. Maybe the freeze message in the PRs should only say "freezed by X user" so we can at least tag people in slack.

Removing the reason left the PR check saying nothing actionable — you know you're blocked, not who to ask. A username carries nothing sensitive and points at a person:

* frozen: `Merges to main are frozen by <login> - ask them in Slack`
* open: `Merges to main are open`

`merge-freeze-status.yml` reads the same `MERGE_FREEZE_ACTOR` variable the owner-only rule below maintains, so PRs opened mid-freeze get the same message, falling back to generic text when no owner was recorded. This is also why that workflow survives: its only job was surfacing the reason, and naming the person restores its purpose without the risk.

Worst case is 88 characters against the API's 140 limit, given GitHub's 39-character username cap.

## 3. Only the person who froze can unfreeze (SPK-988)

Tatiana's question in the thread, and her follow-up — "I can see an agent war of freeze/unfreeze coming up".

A freeze belongs to whoever started it: they know what they're holding main for and when it's safe to let go. `MERGE_FREEZE_ACTOR` records the owner and the unfreeze refuses for anyone else, checked **before** the ruleset is touched so a refusal changes nothing.

Ownership is recorded **only on a real freeze**, never a repeat one — otherwise a second person re-freezing an already-frozen main would quietly take the freeze off whoever started it.

A freeze nobody can lift is worse than one lifted early, so it fails open three ways:

* **Unknown owner allows anyone** — the variable write is best-effort, and a hand-made freeze has no owner at all
* **Unfreezing an already-open main is always allowed**, since that's cleanup of stale state rather than a real unfreeze
* **Repo admins can always remove the check from the ruleset by hand** — this workflow is a convenience, not the enforcement

The refusal names who froze it and both routes out.

## Also

`CLAUDE.md` is updated to match: it still documented a `-f reason` flag and told people the reason shows on blocked PRs. It now covers the owner-only rule and says explicitly why there's no reason box.

## Verification

Not dispatched.

* **12 assertions over the ownership branch table**, lifted verbatim from the workflow: owner allowed, non-owner denied, unknown owner allowed, both cleanup no-ops allowed, freezes never blocked regardless of owner, re-freeze leaves ownership untouched, unfreeze clears it.
* Both workflows parse; every `run:` block passes `bash -n`; the dispatch now exposes a single `action` input; the removed `description` output has no remaining references.
* Comments describing the old reason behaviour were corrected rather than left to mislead.

Linear: SPK-987, SPK-988, SPK-989
