### PR TITLE
chore(linear-agent): add visual evidence reproduction steps

### DIFF
--- a/linear-agent/README.md
+++ b/linear-agent/README.md
@@ -168,10 +168,12 @@ title and attachment titles are never copied into the PR description.
 After the preview is healthy, a visual-evidence turn plans up to three targeted
 screenshots. A short-lived Browserless container signs in to the seeded demo,
 performs the specified UI actions, and captures the resulting state. The
-controller serves those images from stable artifact URLs and adds them to the
-draft PR under **Visual evidence**, alongside the summary and preview link. A
-capture failure does not discard the implementation; the PR records the failure
-instead of attaching a misleading generic screenshot.
+controller serves those images from stable artifact URLs and adds them to both
+the Linear response and draft PR under **Visual evidence**, alongside the exact
+verified preview URL and plain-language reproduction steps for each screenshot.
+A capture failure does not discard the planned URL or reproduction steps; the
+response and PR explain that the image could not be generated instead of
+attaching a misleading generic screenshot.
 
 On a `prompted` event, the prompt is queued for the existing runner and handled
 with `codex exec resume --last`. Runner VMs expire after 24 hours by default.

--- a/linear-agent/capture-evidence.cjs
+++ b/linear-agent/capture-evidence.cjs
@@ -1,8 +1,8 @@
 const fs = require('node:fs/promises');
 const path = require('node:path');
-const { chromium } = require('playwright');
 
-const [baseUrl, cdpUrl, planPath, outputDir, resultPath] = process.argv.slice(2);
+const [baseUrl, cdpUrl, planPath, outputDir, resultPath, unavailableReason] =
+    process.argv.slice(2);
 
 if (![baseUrl, cdpUrl, planPath, outputDir, resultPath].every(Boolean)) {
     throw new Error('Expected base URL, CDP URL, plan path, output directory, and result path');
@@ -10,6 +10,27 @@ if (![baseUrl, cdpUrl, planPath, outputDir, resultPath].every(Boolean)) {
 
 const boundedRepeat = (value) => Math.max(1, Math.min(Number(value) || 1, 10));
 const boundedDelay = (value) => Math.max(0, Math.min(Number(value) || 0, 5000));
+
+function plannedEvidence(screenshot, index) {
+    const relativePath = String(screenshot.path || '/');
+    const name = String(screenshot.name || `screenshot-${index + 1}`)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 60) || `screenshot-${index + 1}`;
+    return {
+        name,
+        description: String(screenshot.description || name).slice(0, 300),
+        relativeUrl:
+            relativePath.startsWith('/') && !relativePath.startsWith('//')
+                ? relativePath
+                : '',
+        steps: (Array.isArray(screenshot.steps) ? screenshot.steps : [])
+            .map((step) => String(step).replace(/\s+/g, ' ').trim().slice(0, 300))
+            .filter(Boolean)
+            .slice(0, 10),
+    };
+}
 
 async function performAction(page, action) {
     const selector = String(action.selector || '');
@@ -79,8 +100,10 @@ async function main() {
     const plan = JSON.parse(await fs.readFile(planPath, 'utf8'));
     const screenshots = Array.isArray(plan.screenshots) ? plan.screenshots.slice(0, 3) : [];
     if (!screenshots.length) throw new Error('Evidence plan contains no screenshots');
+    if (unavailableReason) throw new Error(unavailableReason);
 
     await fs.mkdir(outputDir, { recursive: true });
+    const { chromium } = require('playwright');
     const browser = await chromium.connectOverCDP(cdpUrl);
     const context = browser.contexts()[0] || await browser.newContext();
     const evidence = [];
@@ -90,15 +113,14 @@ async function main() {
         for (let index = 0; index < screenshots.length; index += 1) {
             const screenshot = screenshots[index];
             const relativePath = String(screenshot.path || '/');
+            const planned = plannedEvidence(screenshot, index);
             if (!relativePath.startsWith('/') || relativePath.startsWith('//')) {
-                errors.push(`Screenshot ${index + 1} has an unsafe path`);
+                const error = `Screenshot ${index + 1} has an unsafe path`;
+                errors.push(error);
+                evidence.push({ ...planned, error });
                 continue;
             }
-            const name = String(screenshot.name || `screenshot-${index + 1}`)
-                .toLowerCase()
-                .replace(/[^a-z0-9]+/g, '-')
-                .replace(/^-+|-+$/g, '')
-                .slice(0, 60) || `screenshot-${index + 1}`;
+            const { name } = planned;
             const outputPath = path.join(outputDir, `${name}.jpg`);
             const page = await context.newPage();
             await page.setViewportSize({ width: 1440, height: 1000 });
@@ -117,27 +139,49 @@ async function main() {
                     fullPage: screenshot.fullPage === true,
                     animations: 'disabled',
                 });
+                const capturedUrl = new URL(page.url());
                 evidence.push({
-                    name,
-                    description: String(screenshot.description || name).slice(0, 300),
+                    ...planned,
+                    relativeUrl: `${capturedUrl.pathname}${capturedUrl.search}${capturedUrl.hash}`,
                     file: outputPath,
                     mimeType: 'image/jpeg',
                 });
             } catch (error) {
-                errors.push(`${name}: ${error.message}`);
+                const message = `${name}: ${error.message}`;
+                errors.push(message);
+                evidence.push({ ...planned, error: message });
             } finally {
-                await page.close();
+                await page.close().catch((error) => {
+                    errors.push(`${name}: page cleanup failed: ${error.message}`);
+                });
             }
         }
     } finally {
-        await browser.close();
+        await browser.close().catch((error) => {
+            errors.push(`Browser cleanup failed: ${error.message}`);
+        });
     }
 
     await fs.writeFile(resultPath, `${JSON.stringify({ evidence, errors })}\n`);
-    if (!evidence.length) process.exitCode = 1;
+    if (!evidence.some((item) => item.file)) process.exitCode = 1;
 }
 
-main().catch((error) => {
+main().catch(async (error) => {
+    try {
+        const plan = JSON.parse(await fs.readFile(planPath, 'utf8'));
+        const screenshots = Array.isArray(plan.screenshots) ? plan.screenshots.slice(0, 3) : [];
+        const message = `Image capture failed: ${error.message}`;
+        const evidence = screenshots.map((screenshot, index) => ({
+            ...plannedEvidence(screenshot, index),
+            error: message,
+        }));
+        await fs.writeFile(
+            resultPath,
+            `${JSON.stringify({ evidence, errors: [message] })}\n`,
+        );
+    } catch (writeError) {
+        process.stderr.write(`Could not preserve evidence details: ${writeError.message}\n`);
+    }
     process.stderr.write(`${error.stack || error.message}\n`);
     process.exitCode = 1;
 });

--- a/linear-agent/core.mjs
+++ b/linear-agent/core.mjs
@@ -192,3 +192,32 @@ export function evidenceFileName(value, index) {
         .slice(0, 60);
     return `${stem || `screenshot-${index}`}.jpg`;
 }
+
+export function evidencePreviewUrl(previewUrl, relativeUrl) {
+    try {
+        const preview = new URL(String(previewUrl || ''));
+        const path = String(relativeUrl || '');
+        if (!path.startsWith('/') || path.startsWith('//')) return null;
+        const resolved = new URL(path, preview);
+        return resolved.origin === preview.origin ? resolved.href : null;
+    } catch {
+        return null;
+    }
+}
+
+export function evidenceMarkdown(item, previewUrl) {
+    const description = String(item.description || 'Visual evidence').replace(/[\[\]]/g, '');
+    const sections = item.url
+        ? [`![${description}](${item.url})`, `_${description}_`]
+        : ['> It was not possible to generate the image.', `_${description}_`];
+    const verifiedUrl = evidencePreviewUrl(previewUrl, item.relativeUrl);
+    const steps = Array.isArray(item.steps) ? item.steps.filter(Boolean) : [];
+    if (verifiedUrl) sections.push(`**Verified URL:** <${verifiedUrl}>`);
+    if (steps.length) {
+        const reproductionSteps = steps
+            .map((step, index) => `${index + 1}. ${step}`)
+            .join('\n');
+        sections.push(`**Reproduction steps**\n\n${reproductionSteps}`);
+    }
+    return sections.join('\n\n');
+}

--- a/linear-agent/core.test.mjs
+++ b/linear-agent/core.test.mjs
@@ -5,6 +5,8 @@ import test from 'node:test';
 import {
     branchName,
     evidenceFileName,
+    evidenceMarkdown,
+    evidencePreviewUrl,
     extractParentIssueIdentifier,
     extractPrompt,
     githubIssueNumberFromUrl,
@@ -151,6 +153,78 @@ test('builds canonical direct and parent pull request references', () => {
 test('creates safe evidence filenames', () => {
     assert.equal(evidenceFileName('Login lockout state', 1), 'login-lockout-state.jpg');
     assert.equal(evidenceFileName('../../', 2), 'screenshot-2.jpg');
+});
+
+test('builds evidence details with a verified preview URL and reproduction steps', () => {
+    assert.equal(
+        evidencePreviewUrl(
+            'https://preview.example',
+            '/projects/demo/dashboards/orders?parameters=%7B%22region%22%3A%22EU%22%7D',
+        ),
+        'https://preview.example/projects/demo/dashboards/orders' +
+            '?parameters=%7B%22region%22%3A%22EU%22%7D',
+    );
+    assert.equal(evidencePreviewUrl('https://preview.example', '//other.example/path'), null);
+    assert.equal(evidencePreviewUrl('https://preview.example', '/\\other.example/path'), null);
+    assert.equal(
+        evidenceMarkdown(
+            {
+                description: 'The dashboard shows the EU parameter value.',
+                url: 'https://agent.example/evidence.jpg',
+                relativeUrl: '/projects/demo/dashboards/orders?parameters=eu',
+                steps: [
+                    'Open the dashboard parameters menu.',
+                    'Set Region to EU and confirm the dashboard updates.',
+                ],
+            },
+            'https://preview.example',
+        ),
+        `![The dashboard shows the EU parameter value.](https://agent.example/evidence.jpg)
+
+_The dashboard shows the EU parameter value._
+
+**Verified URL:** <https://preview.example/projects/demo/dashboards/orders?parameters=eu>
+
+**Reproduction steps**
+
+1. Open the dashboard parameters menu.
+2. Set Region to EU and confirm the dashboard updates.`,
+    );
+    assert.equal(
+        evidenceMarkdown(
+            {
+                description: 'Legacy evidence remains readable.',
+                url: 'https://agent.example/legacy.jpg',
+            },
+            null,
+        ),
+        `![Legacy evidence remains readable.](https://agent.example/legacy.jpg)
+
+_Legacy evidence remains readable._`,
+    );
+    assert.equal(
+        evidenceMarkdown(
+            {
+                description: 'The dashboard should show the selected parameter.',
+                relativeUrl: '/projects/demo/dashboards/orders',
+                steps: [
+                    'Open the dashboard parameters menu.',
+                    'Select a parameter value and confirm the dashboard updates.',
+                ],
+            },
+            'https://preview.example',
+        ),
+        `> It was not possible to generate the image.
+
+_The dashboard should show the selected parameter._
+
+**Verified URL:** <https://preview.example/projects/demo/dashboards/orders>
+
+**Reproduction steps**
+
+1. Open the dashboard parameters menu.
+2. Select a parameter value and confirm the dashboard updates.`,
+    );
 });
 
 test('maps Codex reasoning and commands to Linear activities', () => {

--- a/linear-agent/runner.sh
+++ b/linear-agent/runner.sh
@@ -493,6 +493,18 @@ JS
     curl --fail --silent --output /dev/null "http://localhost:${FE_PORT}/login"
 }
 
+write_failed_evidence_result() {
+    local prompt_id="$1" plan_file="$2" result_file="$3" reason="$4"
+    NODE_PATH="$repository_dir/packages/backend/node_modules" node \
+        "$workspace/capture-evidence.cjs" \
+        "http://host.docker.internal:${FE_PORT}" \
+        unavailable \
+        "$plan_file" \
+        "$workspace/evidence-${prompt_id}" \
+        "$result_file" \
+        "$reason" >"$workspace/evidence-capture-${prompt_id}.log" 2>&1 || true
+}
+
 capture_visual_evidence() {
     local prompt_id="$1"
     local plan_file="$workspace/evidence-plan-${prompt_id}.json"
@@ -506,30 +518,6 @@ capture_visual_evidence() {
         printf '%s\n' 'The evidence capture helper is missing.' >"$error_file"
         return 1
     }
-    docker rm -f "$browser_container" >/dev/null 2>&1 || true
-    if ! docker run --detach --rm \
-        --name "$browser_container" \
-        --add-host host.docker.internal:host-gateway \
-        --shm-size=512m \
-        --publish 127.0.0.1:3001:3000 \
-        --env CONNECTION_TIMEOUT=120000 \
-        ghcr.io/browserless/chromium:v2.49.0 >"$workspace/evidence-browser-${prompt_id}.id"; then
-        printf '%s\n' 'Browserless failed to start.' >"$error_file"
-        return 1
-    fi
-    for _ in $(seq 1 30); do
-        if curl --fail --silent --output /dev/null http://127.0.0.1:3001/json/version; then
-            browser_ready=true
-            break
-        fi
-        sleep 1
-    done
-    if [ "$browser_ready" != true ]; then
-        printf '%s\n' 'Browserless did not become ready.' >"$error_file"
-        docker rm -f "$browser_container" >/dev/null 2>&1 || true
-        return 1
-    fi
-
     cat >"$evidence_prompt" <<EOF
 The Lightdash preview for the implementation is running locally. Prepare a visual evidence plan that demonstrates the fix or functionality you just implemented. Do not modify repository files and do not take a generic homepage screenshot unless the change itself is on the homepage.
 
@@ -540,6 +528,11 @@ Respond with only valid JSON using this shape:
       "name": "short-kebab-name",
       "description": "What this screenshot proves",
       "path": "/relevant/lightdash/path",
+      "steps": [
+        "Open the relevant dashboard or page.",
+        "Use the visible controls to reproduce the changed state.",
+        "Confirm the expected result shown in the screenshot."
+      ],
       "authenticated": true,
       "fullPage": false,
       "actions": [
@@ -554,7 +547,7 @@ Respond with only valid JSON using this shape:
   ]
 }
 
-Use at most three screenshots. Set authenticated to false for login or authentication states. The capture uses the seeded demo user automatically when authenticated is true. Use only seeded demo data. Never put client or customer names, organization names, or customer-provided data examples in screenshot names, descriptions, actions, assertions, or visible form values. Set force to true for repeated clicks that may be covered by transient notifications. End each screenshot with assertText for the visible result that proves its description. Inspect routes, selectors, and seeded data as needed so the plan targets the implemented behavior. Omit unnecessary actions and ensure the final state visibly demonstrates the change.
+Use at most three screenshots. For each screenshot, write 2-6 steps in plain language that let a reviewer reproduce the visual result. Name visible controls and the expected result; do not mention CSS selectors or include login as a step. Make the description explain the page, changed state, and what visibly confirms success. Set authenticated to false for login or authentication states. The capture uses the seeded demo user automatically when authenticated is true. Use only seeded demo data. Never put client or customer names, organization names, or customer-provided data examples in screenshot names, descriptions, steps, actions, assertions, or visible form values. Set force to true for repeated clicks that may be covered by transient notifications. End each screenshot with assertText for the visible result that proves its description. Inspect routes, selectors, and seeded data as needed so the plan targets the implemented behavior. Omit unnecessary actions and ensure the final state visibly demonstrates the change.
 EOF
     set +e
     (
@@ -580,7 +573,17 @@ try:
     except json.JSONDecodeError:
         value = json.loads(text[text.index('{'):text.rindex('}') + 1])
     shots = value.get('screenshots', [])
-    valid = isinstance(shots, list) and 0 < len(shots) <= 3
+    valid = (
+        isinstance(shots, list)
+        and 0 < len(shots) <= 3
+        and all(
+            isinstance(shot, dict)
+            and isinstance(shot.get('steps'), list)
+            and 2 <= len(shot['steps']) <= 6
+            and all(isinstance(step, str) and step.strip() for step in shot['steps'])
+            for shot in shots
+        )
+    )
     if valid:
         path.write_text(json.dumps(value), encoding='utf-8')
     print('true' if valid else 'false')
@@ -591,6 +594,33 @@ PY
     fi
     if [ "$plan_valid" != true ]; then
         printf '%s\n' 'The visual evidence agent did not produce a valid screenshot plan.' >"$error_file"
+        return 1
+    fi
+
+    docker rm -f "$browser_container" >/dev/null 2>&1 || true
+    if ! docker run --detach --rm \
+        --name "$browser_container" \
+        --add-host host.docker.internal:host-gateway \
+        --shm-size=512m \
+        --publish 127.0.0.1:3001:3000 \
+        --env CONNECTION_TIMEOUT=120000 \
+        ghcr.io/browserless/chromium:v2.49.0 >"$workspace/evidence-browser-${prompt_id}.id"; then
+        write_failed_evidence_result \
+            "$prompt_id" "$plan_file" "$result_file" 'Browserless failed to start.'
+        printf '%s\n' 'Browserless failed to start.' >"$error_file"
+        return 1
+    fi
+    for _ in $(seq 1 30); do
+        if curl --fail --silent --output /dev/null http://127.0.0.1:3001/json/version; then
+            browser_ready=true
+            break
+        fi
+        sleep 1
+    done
+    if [ "$browser_ready" != true ]; then
+        write_failed_evidence_result \
+            "$prompt_id" "$plan_file" "$result_file" 'Browserless did not become ready.'
+        printf '%s\n' 'Browserless did not become ready.' >"$error_file"
         docker rm -f "$browser_container" >/dev/null 2>&1 || true
         return 1
     fi
@@ -778,19 +808,28 @@ try:
     capture = json.loads(pathlib.Path(evidence_path).read_text())
     evidence_errors.extend(capture.get("errors", []))
     for item in capture.get("evidence", [])[:3]:
+        evidence_item = {
+            "name": str(item.get("name", "screenshot"))[:80],
+            "description": str(item.get("description", "Visual evidence"))[:300],
+            "relativeUrl": str(item.get("relativeUrl", ""))[:2000],
+            "steps": [str(step)[:300] for step in item.get("steps", [])[:10]],
+        }
         image_path = pathlib.Path(item.get("file", ""))
         if not image_path.is_file() or image_path.stat().st_size > 2 * 1024 * 1024:
+            evidence_item["error"] = str(item.get("error", "Image capture failed"))[:1000]
+            evidence.append(evidence_item)
             continue
         if evidence_bytes + image_path.stat().st_size > 4 * 1024 * 1024:
             evidence_errors.append(f"Skipped {image_path.name}: total evidence size exceeded 4 MB")
+            evidence_item["error"] = "Image capture exceeded the total evidence size limit"
+            evidence.append(evidence_item)
             continue
         evidence_bytes += image_path.stat().st_size
-        evidence.append({
-            "name": str(item.get("name", "screenshot"))[:80],
-            "description": str(item.get("description", "Visual evidence"))[:300],
+        evidence_item.update({
             "mimeType": "image/jpeg",
             "dataBase64": base64.b64encode(image_path.read_bytes()).decode(),
         })
+        evidence.append(evidence_item)
 except (FileNotFoundError, json.JSONDecodeError):
     pass
 try:

--- a/linear-agent/server.mjs
+++ b/linear-agent/server.mjs
@@ -17,6 +17,7 @@ import { spawn } from 'node:child_process';
 import {
     branchName,
     evidenceFileName,
+    evidenceMarkdown,
     extractParentIssueIdentifier,
     extractPrompt,
     githubIssueNumbersFromUrls,
@@ -565,26 +566,36 @@ async function persistEvidence(job, event) {
     const stored = [];
     const items = Array.isArray(event.evidence) ? event.evidence : [];
     for (const [index, item] of items.slice(0, 3).entries()) {
-        if (item.mimeType !== 'image/jpeg' || typeof item.dataBase64 !== 'string') continue;
-        if (item.dataBase64.length > 3 * 1024 * 1024) continue;
-        const image = Buffer.from(item.dataBase64, 'base64');
+        let url = null;
         if (
-            image.length > 2 * 1024 * 1024 ||
-            image.length < 3 ||
-            image[0] !== 0xff ||
-            image[1] !== 0xd8 ||
-            image[2] !== 0xff
+            item.mimeType === 'image/jpeg' &&
+            typeof item.dataBase64 === 'string' &&
+            item.dataBase64.length <= 3 * 1024 * 1024
         ) {
-            continue;
+            const image = Buffer.from(item.dataBase64, 'base64');
+            if (
+                image.length <= 2 * 1024 * 1024 &&
+                image.length >= 3 &&
+                image[0] === 0xff &&
+                image[1] === 0xd8 &&
+                image[2] === 0xff
+            ) {
+                const fileName = evidenceFileName(`${index + 1}-${item.name}`, index + 1);
+                await writeFile(join(artifactRoot, fileName), image, { mode: 0o600 });
+                url = `${config.publicUrl}/artifacts/${job.id}/${promptId}/${fileName}`;
+            }
         }
-        const fileName = evidenceFileName(`${index + 1}-${item.name}`, index + 1);
-        await writeFile(join(artifactRoot, fileName), image, { mode: 0o600 });
         stored.push({
             description: String(item.description || item.name || `Screenshot ${index + 1}`)
                 .replace(/\s+/g, ' ')
                 .trim()
                 .slice(0, 300),
-            url: `${config.publicUrl}/artifacts/${job.id}/${promptId}/${fileName}`,
+            relativeUrl: String(item.relativeUrl || '').trim().slice(0, 2000),
+            steps: (Array.isArray(item.steps) ? item.steps : [])
+                .map((step) => String(step).replace(/\s+/g, ' ').trim().slice(0, 300))
+                .filter(Boolean)
+                .slice(0, 10),
+            url,
         });
     }
     return stored;
@@ -598,10 +609,7 @@ function pullRequestBody(job, event, evidence) {
         `## What changed\n\n${summary}`,
     ];
     if (evidence.length) {
-        const images = evidence.map((item) => {
-            const description = item.description.replace(/[\[\]]/g, '');
-            return `![${description}](${item.url})\n\n_${description}_`;
-        });
+        const images = evidence.map((item) => evidenceMarkdown(item, job.previewUrl));
         sections.push(`## Visual evidence\n\n${images.join('\n\n')}`);
     } else {
         const detail = event.evidenceError
@@ -631,10 +639,10 @@ function linearResponseBody(job, event, evidence, prUrl, previewUrl) {
     const response = String(event.body || event.summary || 'Implementation complete.').trim();
     const sections = [/^#{1,6}\s/m.test(response) ? response : `## Result\n\n${response}`];
     if (evidence.length) {
-        sections.push(`## Visual evidence\n\n${evidence.map((item) => {
-            const description = item.description.replace(/[\[\]]/g, '');
-            return `![${description}](${item.url})\n\n_${description}_`;
-        }).join('\n\n')}`);
+        const evidenceBody = evidence
+            .map((item) => evidenceMarkdown(item, previewUrl))
+            .join('\n\n');
+        sections.push(`## Visual evidence\n\n${evidenceBody}`);
     } else if (event.evidenceError) {
         sections.push(
             `## Visual evidence\n\n> Screenshot capture failed: ${String(event.evidenceError).trim().slice(0, 1000)}`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-10105

### Description:
Adds exact verified preview URLs and plain-language reproduction steps below each visual evidence item in Linear responses and draft PRs.

Preserves this context when screenshot capture fails, showing a clear image-generation message while retaining the planned URL and steps, including Browserless startup failures.

Validated with the Linear agent unit tests, Node and Bash syntax checks, and `git diff --check`.