### PR TITLE
fix: funnel chart respects the query's sort order

### DIFF
--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/funnel.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/funnel.ts
@@ -55,7 +55,9 @@ export const getFunnelChartEchartsConfig = (
                 label: {
                     position: 'inside',
                 },
-                sort: 'descending',
+                // Row-based steps keep the query's order; metric-column steps
+                // have no query order, so keep the descending taper
+                sort: dimensions.length === 0 ? 'descending' : 'none',
             },
         ],
     };

--- a/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
@@ -59,6 +59,13 @@ export const ConfigTabs: FC = memo(() => {
         legendPositionChange,
     } = visualizationConfig.chartConfig;
 
+    // Match the rendered step order: query order when steps come from rows,
+    // descending taper otherwise
+    const orderedSteps =
+        dataInput === FunnelChartDataInput.COLUMN
+            ? data
+            : [...data].sort((a, b) => b.value - a.value);
+
     return (
         <VisualizationConfigTabs
             tabs={[
@@ -237,36 +244,30 @@ export const ConfigTabs: FC = memo(() => {
                             <Config>
                                 <Config.Section>
                                     <Config.Heading>Steps</Config.Heading>
-                                    {data
-                                        .sort((a, b) => b.value - a.value)
-                                        .map((step) => {
-                                            return (
-                                                <StepConfig
-                                                    key={step.id}
-                                                    id={step.id}
-                                                    defaultColor={
-                                                        colorDefaults[step.id]
-                                                    }
-                                                    defaultLabel={step.name}
-                                                    swatches={[]}
-                                                    color={
-                                                        colorOverrides[step.id]
-                                                    }
-                                                    label={
-                                                        labelOverrides[step.id]
-                                                    }
-                                                    granularityFields={
-                                                        granularityFields
-                                                    }
-                                                    onColorChange={
-                                                        onColorOverridesChange
-                                                    }
-                                                    onLabelChange={
-                                                        onLabelOverridesChange
-                                                    }
-                                                />
-                                            );
-                                        })}
+                                    {orderedSteps.map((step) => {
+                                        return (
+                                            <StepConfig
+                                                key={step.id}
+                                                id={step.id}
+                                                defaultColor={
+                                                    colorDefaults[step.id]
+                                                }
+                                                defaultLabel={step.name}
+                                                swatches={[]}
+                                                color={colorOverrides[step.id]}
+                                                label={labelOverrides[step.id]}
+                                                granularityFields={
+                                                    granularityFields
+                                                }
+                                                onColorChange={
+                                                    onColorOverridesChange
+                                                }
+                                                onLabelChange={
+                                                    onLabelOverridesChange
+                                                }
+                                            />
+                                        );
+                                    })}
                                 </Config.Section>
                             </Config>
                         </Stack>

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.test.ts
@@ -1,19 +1,15 @@
+import { FunnelChartDataInput } from '@lightdash/common';
 import { describe, expect, test } from 'vitest';
-import { FUNNEL_SERIES_DEFAULTS } from './useEchartsFunnelConfig';
+import { getFunnelSeriesSort } from './useEchartsFunnelConfig';
 
-describe('FUNNEL_SERIES_DEFAULTS', () => {
-    test('should keep the step order the query returned', () => {
-        // ECharts defaults a funnel series to `sort: 'descending'`, which
-        // re-orders the steps by value. A funnel's step order is meaningful
-        // and independent of size, so the order has to be preserved.
-        expect(FUNNEL_SERIES_DEFAULTS.sort).toEqual('none');
+describe('getFunnelSeriesSort', () => {
+    test('keeps the step order the query returned when steps come from rows', () => {
+        expect(getFunnelSeriesSort(FunnelChartDataInput.COLUMN)).toBe('none');
     });
 
-    test('should be a funnel series with a gap between steps', () => {
-        expect(FUNNEL_SERIES_DEFAULTS).toEqual({
-            type: 'funnel',
-            gap: 3,
-            sort: 'none',
-        });
+    test('keeps the descending taper when steps are columns, which the query sort cannot order', () => {
+        expect(getFunnelSeriesSort(FunnelChartDataInput.ROW)).toBe(
+            'descending',
+        );
     });
 });

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.test.ts
@@ -1,61 +1,19 @@
-import * as echarts from 'echarts';
 import { describe, expect, test } from 'vitest';
 import { FUNNEL_SERIES_DEFAULTS } from './useEchartsFunnelConfig';
 
-/**
- * A funnel's step order is meaningful and independent of size — a signup flow,
- * an onboarding path, a sales pipeline in stage order. These steps deliberately
- * do not descend by value, so any sorting by ECharts is visible.
- */
-const steps = [
-    { name: 'Visited', value: 1000 },
-    { name: 'Signed up', value: 200 },
-    { name: 'Activated', value: 600 },
-    { name: 'Paid', value: 100 },
-];
-
-const renderedStepOrder = (series: Record<string, unknown>) => {
-    const chart = echarts.init(null, null, {
-        renderer: 'svg',
-        ssr: true,
-        width: 400,
-        height: 300,
-    });
-    chart.setOption({
-        series: [
-            {
-                data: steps,
-                label: { show: true, position: 'inside', formatter: '{b}' },
-                ...series,
-            },
-        ],
-    });
-    const svg = chart.renderToSVGString();
-    chart.dispose();
-
-    const names = steps.map((s) => s.name);
-    return [...svg.matchAll(/<text[^>]*y="([\d.]+)"[^>]*>([^<]*)<\/text>/g)]
-        .map((match) => ({ y: Number(match[1]), text: match[2].trim() }))
-        .filter((label) => names.includes(label.text))
-        .sort((a, b) => a.y - b.y)
-        .map((label) => label.text);
-};
-
-describe('funnel series', () => {
-    test('renders steps in the order the query returned them', () => {
-        expect(renderedStepOrder(FUNNEL_SERIES_DEFAULTS)).toEqual(
-            steps.map((s) => s.name),
-        );
+describe('FUNNEL_SERIES_DEFAULTS', () => {
+    test('should keep the step order the query returned', () => {
+        // ECharts defaults a funnel series to `sort: 'descending'`, which
+        // re-orders the steps by value. A funnel's step order is meaningful
+        // and independent of size, so the order has to be preserved.
+        expect(FUNNEL_SERIES_DEFAULTS.sort).toEqual('none');
     });
 
-    test('ECharts re-orders by value without the `sort` option, which is why it is set', () => {
-        // Guards the fix: if `sort` is dropped from the defaults, the test
-        // above starts matching this order instead.
-        expect(renderedStepOrder({ type: 'funnel' })).toEqual([
-            'Visited',
-            'Activated',
-            'Signed up',
-            'Paid',
-        ]);
+    test('should be a funnel series with a gap between steps', () => {
+        expect(FUNNEL_SERIES_DEFAULTS).toEqual({
+            type: 'funnel',
+            gap: 3,
+            sort: 'none',
+        });
     });
 });

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.test.ts
@@ -48,7 +48,7 @@ describe('funnel series', () => {
         );
     });
 
-    test("ECharts re-orders by value without the `sort` option, which is why it is set", () => {
+    test('ECharts re-orders by value without the `sort` option, which is why it is set', () => {
         // Guards the fix: if `sort` is dropped from the defaults, the test
         // above starts matching this order instead.
         expect(renderedStepOrder({ type: 'funnel' })).toEqual([

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.test.ts
@@ -1,0 +1,61 @@
+import * as echarts from 'echarts';
+import { describe, expect, test } from 'vitest';
+import { FUNNEL_SERIES_DEFAULTS } from './useEchartsFunnelConfig';
+
+/**
+ * A funnel's step order is meaningful and independent of size — a signup flow,
+ * an onboarding path, a sales pipeline in stage order. These steps deliberately
+ * do not descend by value, so any sorting by ECharts is visible.
+ */
+const steps = [
+    { name: 'Visited', value: 1000 },
+    { name: 'Signed up', value: 200 },
+    { name: 'Activated', value: 600 },
+    { name: 'Paid', value: 100 },
+];
+
+const renderedStepOrder = (series: Record<string, unknown>) => {
+    const chart = echarts.init(null, null, {
+        renderer: 'svg',
+        ssr: true,
+        width: 400,
+        height: 300,
+    });
+    chart.setOption({
+        series: [
+            {
+                data: steps,
+                label: { show: true, position: 'inside', formatter: '{b}' },
+                ...series,
+            },
+        ],
+    });
+    const svg = chart.renderToSVGString();
+    chart.dispose();
+
+    const names = steps.map((s) => s.name);
+    return [...svg.matchAll(/<text[^>]*y="([\d.]+)"[^>]*>([^<]*)<\/text>/g)]
+        .map((match) => ({ y: Number(match[1]), text: match[2].trim() }))
+        .filter((label) => names.includes(label.text))
+        .sort((a, b) => a.y - b.y)
+        .map((label) => label.text);
+};
+
+describe('funnel series', () => {
+    test('renders steps in the order the query returned them', () => {
+        expect(renderedStepOrder(FUNNEL_SERIES_DEFAULTS)).toEqual(
+            steps.map((s) => s.name),
+        );
+    });
+
+    test("ECharts re-orders by value without the `sort` option, which is why it is set", () => {
+        // Guards the fix: if `sort` is dropped from the defaults, the test
+        // above starts matching this order instead.
+        expect(renderedStepOrder({ type: 'funnel' })).toEqual([
+            'Visited',
+            'Activated',
+            'Signed up',
+            'Paid',
+        ]);
+    });
+});

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -113,6 +113,12 @@ const useEchartsFunnelConfig = (
         return {
             type: 'funnel',
             gap: 3,
+            // ECharts defaults funnel series to `sort: 'descending'`, which
+            // re-orders the steps by size and discards the order the results
+            // arrived in. A funnel's step order is usually meaningful and
+            // independent of size (a pipeline stage sequence, a signup flow),
+            // so honour the query's own sort instead.
+            sort: 'none',
             data: seriesData.map(({ id, name, value, meta }) => {
                 const labelOverride = labelOverrides?.[id] ?? name;
                 return {

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -24,6 +24,16 @@ import { useVisualizationContext } from '../../components/LightdashVisualization
 import { sanitizeEchartsFontFamily } from '../../utils/sanitizeEchartsFontFamily';
 import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
 
+/**
+ * `sort: 'none'` keeps the step order the query returned. Without it ECharts
+ * applies its own default of `sort: 'descending'` and re-orders by value.
+ */
+export const FUNNEL_SERIES_DEFAULTS = {
+    type: 'funnel',
+    gap: 3,
+    sort: 'none',
+} as const satisfies Partial<FunnelSeriesOption>;
+
 export type FunnelSeriesDataPoint = NonNullable<
     FunnelSeriesOption['data']
 >[number] & {
@@ -111,14 +121,7 @@ const useEchartsFunnelConfig = (
         const granularityMap = getGranularityMapFromItems(itemsMap);
 
         return {
-            type: 'funnel',
-            gap: 3,
-            // ECharts defaults funnel series to `sort: 'descending'`, which
-            // re-orders the steps by size and discards the order the results
-            // arrived in. A funnel's step order is usually meaningful and
-            // independent of size (a pipeline stage sequence, a signup flow),
-            // so honour the query's own sort instead.
-            sort: 'none',
+            ...FUNNEL_SERIES_DEFAULTS,
             data: seriesData.map(({ id, name, value, meta }) => {
                 const labelOverride = labelOverrides?.[id] ?? name;
                 return {

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -1,8 +1,10 @@
 import {
+    assertUnreachable,
     formatColorIndicator,
     formatItemValue,
     formatTooltipRow,
     formatTooltipValue,
+    FunnelChartDataInput,
     FunnelChartLabelPosition,
     FunnelChartLegendPosition,
     getGranularityMapFromItems,
@@ -25,14 +27,26 @@ import { sanitizeEchartsFontFamily } from '../../utils/sanitizeEchartsFontFamily
 import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
 
 /**
- * `sort: 'none'` keeps the step order the query returned. Without it ECharts
- * applies its own default of `sort: 'descending'` and re-orders by value.
+ * When steps come from rows, `sort: 'none'` keeps the step order the query
+ * returned (ECharts defaults to `sort: 'descending'`, re-ordering by value).
+ * When steps are columns, the query's sort cannot order them, so keep the
+ * descending taper.
  */
-export const FUNNEL_SERIES_DEFAULTS = {
-    type: 'funnel',
-    gap: 3,
-    sort: 'none',
-} as const satisfies Partial<FunnelSeriesOption>;
+export const getFunnelSeriesSort = (
+    dataInput: FunnelChartDataInput,
+): NonNullable<FunnelSeriesOption['sort']> => {
+    switch (dataInput) {
+        case FunnelChartDataInput.COLUMN:
+            return 'none';
+        case FunnelChartDataInput.ROW:
+            return 'descending';
+        default:
+            return assertUnreachable(
+                dataInput,
+                `Unknown funnel data input: ${dataInput}`,
+            );
+    }
+};
 
 export type FunnelSeriesDataPoint = NonNullable<
     FunnelSeriesOption['data']
@@ -121,7 +135,9 @@ const useEchartsFunnelConfig = (
         const granularityMap = getGranularityMapFromItems(itemsMap);
 
         return {
-            ...FUNNEL_SERIES_DEFAULTS,
+            type: 'funnel',
+            gap: 3,
+            sort: getFunnelSeriesSort(chartConfig.dataInput),
             data: seriesData.map(({ id, name, value, meta }) => {
                 const labelOverride = labelOverrides?.[id] ?? name;
                 return {

--- a/packages/frontend/src/hooks/useFunnelChartConfig.ts
+++ b/packages/frontend/src/hooks/useFunnelChartConfig.ts
@@ -136,8 +136,8 @@ const useFunnelChartConfig: FunnelChartConfigFn = (
         setFieldId(allNumericFieldIds[0] ?? null);
     }, [allNumericFieldIds, fieldId, isLoading, tableCalculationsMetadata]);
 
-    // Max value is the value at the top of the funnel. This is used to calculate
-    // the percentage of the funnel that each step represents
+    // Max value is the largest step value, used to calculate the percentage
+    // each step represents
     const {
         data,
         maxValue = 0,


### PR DESCRIPTION
Closes: #27348

### Description:

A funnel chart discards the query's sort and orders its steps by value.
`useEchartsFunnelConfig` never sets `sort` on the series, so ECharts applies its
default of `sort: 'descending'`.

Setting `sort: 'none'` makes ECharts keep the order the rows arrive in, so the
chart agrees with the results table below it and with the sort the user chose.

Funnel step order is usually meaningful and independent of size — a signup flow,
an onboarding path, a sales pipeline in stage order. Any of those can have a
later step larger than an earlier one, and today the chart silently reorders
them into a sequence that did not happen.

Rendered from the jaffle_shop demo data (`orders`, dimension `status`, metric
`Total order amount`, sorted by `status` ascending):

![Funnel ordering before and after the fix](https://raw.githubusercontent.com/jredl-va/lightdash/funnel-sort-assets/funnel-sort-jaffle.png)

```
query order   completed → placed → return_pending → returned → shipped
before        completed → placed → shipped → returned → return_pending
after         completed → placed → return_pending → returned → shipped
```

`shipped` ($770.55) was being drawn above `returned` ($54.00) and
`return_pending` ($38.00) purely because it is larger.
