### PR TITLE
fix(explorer): preserve merged query interactions

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -601,6 +601,7 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
                     projectUuid,
                     mergeQuery: body.mergeQuery,
                     pivotConfiguration: body.pivotConfiguration,
+                    csvLimit: body.csvLimit,
                     parameters: body.parameters,
                     context:
                         getContextFromHeader(req) ??

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -11,6 +11,7 @@ import {
     applyDashboardFiltersForTile,
     assertIsAccountWithOrg,
     assertUnreachable,
+    buildMergeQueryFromSaved,
     buildWarehouseColumnTotals,
     buildWarehouseRowTotals,
     CalculateSubtotalsFromQuery,
@@ -58,6 +59,7 @@ import {
     isCustomBinDimension,
     isCustomDimension,
     isDateItem,
+    isDimension,
     isExploreError,
     isField,
     isJwtUser,
@@ -67,6 +69,7 @@ import {
     ItemsMap,
     KnexPaginateArgs,
     KnexPaginatedData,
+    MERGE_TABLE_NAME,
     MergeQuery,
     MetricQuery,
     MissingConfigError,
@@ -5146,6 +5149,57 @@ export class AsyncQueryService extends ProjectService {
                 savedChartOrganizationUuid,
             );
 
+        if (savedChart.merge) {
+            const mergeQuery = buildMergeQueryFromSaved(
+                metricQuery,
+                savedChart.merge,
+            );
+            const combinedParameters = {
+                ...savedChartParameters,
+                ...parameters,
+            };
+            let pivotConfiguration: PivotConfiguration | undefined;
+            if (pivotResults) {
+                const compiled = await this.compileMergeQuery({
+                    account,
+                    projectUuid,
+                    mergeQuery,
+                    parameters: combinedParameters,
+                });
+                const columnOrder = Object.values(compiled.fieldIdByColumn);
+                const dimensions = columnOrder.filter((fieldId) =>
+                    isDimension(compiled.itemsMap[fieldId]),
+                );
+                const mergedMetricQuery: MetricQuery = {
+                    exploreName: MERGE_TABLE_NAME,
+                    dimensions,
+                    metrics: columnOrder.filter(
+                        (fieldId) => !dimensions.includes(fieldId),
+                    ),
+                    filters: {},
+                    sorts: [],
+                    limit: mergeQuery.limit,
+                    tableCalculations: [],
+                };
+                pivotConfiguration = derivePivotConfigurationFromChart(
+                    savedChart,
+                    mergedMetricQuery,
+                    compiled.itemsMap,
+                );
+            }
+
+            return this.executeAsyncMergeQuery({
+                account,
+                projectUuid,
+                mergeQuery,
+                context,
+                invalidateCache,
+                parameters: combinedParameters,
+                pivotConfiguration,
+                csvLimit: limit,
+            });
+        }
+
         const limitedMetricQuery = applyMetricQueryLimit(
             metricQuery,
             limit,
@@ -6207,15 +6261,17 @@ export class AsyncQueryService extends ProjectService {
         invalidateCache,
         pivotConfiguration,
         parameters,
+        csvLimit,
     }: ExecuteAsyncMergeQueryArgs): Promise<ApiExecuteAsyncMetricQueryResults> {
         assertIsAccountWithOrg(account);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
-        const compiledMerge = await this.compileMergeQuery({
+        let effectiveMergeQuery = mergeQuery;
+        let compiledMerge = await this.compileMergeQuery({
             account,
             projectUuid,
-            mergeQuery,
+            mergeQuery: effectiveMergeQuery,
             parameters,
         });
         if (
@@ -6229,6 +6285,53 @@ export class AsyncQueryService extends ProjectService {
                     .join(' ')}`,
                 { errors: compiledMerge.errors },
             );
+        }
+
+        if (csvLimit !== undefined) {
+            const { csvCellsLimit } = await resolveOrganizationExportLimits(
+                this.organizationSettingsModel,
+                this.lightdashConfig.query,
+                organizationUuid,
+            );
+            const columnCount = Object.keys(
+                compiledMerge.fieldIdByColumn,
+            ).length;
+            const cellLimitedRows = Math.floor(
+                csvCellsLimit / Math.max(columnCount, 1),
+            );
+            const exportLimit =
+                csvLimit === null
+                    ? cellLimitedRows
+                    : Math.min(csvLimit, cellLimitedRows);
+            effectiveMergeQuery = {
+                ...mergeQuery,
+                limit: exportLimit,
+                sources: mergeQuery.sources.map((source) => ({
+                    ...source,
+                    metricQuery: {
+                        ...source.metricQuery,
+                        limit: exportLimit,
+                    },
+                })),
+            };
+            compiledMerge = await this.compileMergeQuery({
+                account,
+                projectUuid,
+                mergeQuery: effectiveMergeQuery,
+                parameters,
+            });
+            if (
+                compiledMerge.coreSql === null ||
+                compiledMerge.typedColumns === null ||
+                compiledMerge.terminalWrapper === null
+            ) {
+                throw new ParameterError(
+                    `This merge cannot be exported: ${compiledMerge.errors
+                        .map((error) => error.message)
+                        .join(' ')}`,
+                    { errors: compiledMerge.errors },
+                );
+            }
         }
 
         // Only for composing SQL — quoting and the pivot stage need the
@@ -6255,7 +6358,7 @@ export class AsyncQueryService extends ProjectService {
                 itemsMap: compiledMerge.itemsMap,
                 typedColumns: compiledMerge.typedColumns,
                 columnOrder: Object.values(compiledMerge.fieldIdByColumn),
-                limit: mergeQuery.limit,
+                limit: effectiveMergeQuery.limit,
                 warehouseClient,
                 pivotConfiguration,
             });
@@ -6277,7 +6380,7 @@ export class AsyncQueryService extends ProjectService {
         const requestParameters: ExecuteAsyncMergeQueryRequestParams = {
             context,
             invalidateCache,
-            mergeQuery,
+            mergeQuery: effectiveMergeQuery,
             parameters,
             pivotConfiguration,
         };

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -176,6 +176,7 @@ export type ExecuteAsyncMergeQueryArgs = CommonAsyncQueryArgs & {
     mergeQuery: MergeQuery;
     /** Standard pivot stage over the merged rows. */
     pivotConfiguration?: PivotConfiguration;
+    csvLimit?: number | null;
 };
 
 export type ExecuteAsyncDashboardSqlChartCommonArgs = CommonAsyncQueryArgs & {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5611,7 +5611,10 @@ export class ProjectService extends BaseService {
                             type: DimensionType.STRING,
                         },
                     }),
-                    origin: { kind: 'joinKey' },
+                    origin: {
+                        kind: 'joinKey',
+                        fieldIdBySourceId: part.fieldIdBySourceId,
+                    },
                 };
             },
         );

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5224,6 +5224,7 @@ export class ProjectService extends BaseService {
                 fields: [],
                 itemsMap: {},
                 fieldOrigins: {},
+                parameterReferences: [],
                 fieldIdByColumn: {},
                 errors,
             };
@@ -5269,6 +5270,9 @@ export class ProjectService extends BaseService {
                 const missingParameters = Array.from(
                     compiled.missingParameterReferences,
                 );
+                const parameterReferences = Array.from(
+                    compiled.parameterReferences,
+                );
 
                 const joinKeyColumnByName = Object.fromEntries(
                     mergeQuery.joinKey.map((part) => [
@@ -5294,6 +5298,7 @@ export class ProjectService extends BaseService {
                     joinKeyColumnByName,
                     valueColumns,
                     missingParameters,
+                    parameterReferences,
                     originBySourceColumn: Object.fromEntries(
                         valueColumns.map((column) => [
                             column,
@@ -5318,6 +5323,9 @@ export class ProjectService extends BaseService {
                       },
                   ],
         );
+        const parameterReferences = Array.from(
+            new Set(sources.flatMap((source) => source.parameterReferences)),
+        );
         if (parameterErrors.length > 0) {
             return {
                 sql: null,
@@ -5328,6 +5336,7 @@ export class ProjectService extends BaseService {
                 fields: [],
                 itemsMap: {},
                 fieldOrigins: {},
+                parameterReferences,
                 fieldIdByColumn: {},
                 errors: parameterErrors,
             };
@@ -5425,6 +5434,7 @@ export class ProjectService extends BaseService {
                 fields: [],
                 itemsMap: {},
                 fieldOrigins: {},
+                parameterReferences,
                 fieldIdByColumn: {},
                 errors: referenceErrors,
             };
@@ -5759,6 +5769,7 @@ export class ProjectService extends BaseService {
                 fields: [],
                 itemsMap: {},
                 fieldOrigins: {},
+                parameterReferences,
                 fieldIdByColumn: {},
                 errors: typeErrors,
             };
@@ -5781,6 +5792,7 @@ export class ProjectService extends BaseService {
             fields: [...joinKeyFields, ...valueFields, ...calculationFields],
             itemsMap,
             fieldOrigins,
+            parameterReferences,
             fieldIdByColumn,
             errors: [],
         };

--- a/packages/backend/src/utils/QueryBuilder/MergeQueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MergeQueryComposer.test.ts
@@ -58,12 +58,18 @@ const typedColumns = [
     {
         reference: 'merge_k0',
         type: DimensionType.DATE,
-        origin: { kind: 'joinKey' as const },
+        origin: {
+            kind: 'joinKey' as const,
+            fieldIdBySourceId: { a: 'a_date', b: 'b_date' },
+        },
     },
     {
         reference: 'merge_k1',
         type: DimensionType.STRING,
-        origin: { kind: 'joinKey' as const },
+        origin: {
+            kind: 'joinKey' as const,
+            fieldIdBySourceId: { a: 'a_name', b: 'b_name' },
+        },
     },
     {
         reference: 'a_followers_count',

--- a/packages/common/src/types/mergeQuery.ts
+++ b/packages/common/src/types/mergeQuery.ts
@@ -415,6 +415,8 @@ export const validateMergeQuery = (
 export type RunMergeQueryRequest = {
     mergeQuery: MergeQuery;
     pivotConfiguration?: PivotConfiguration;
+    /** Export row limit. Null means all rows within the organization's cell cap. */
+    csvLimit?: number | null;
     /**
      * Parameter values for every source query, one map for the whole merge —
      * two sides of one question should never disagree on a parameter.

--- a/packages/common/src/types/mergeQuery.ts
+++ b/packages/common/src/types/mergeQuery.ts
@@ -531,7 +531,10 @@ export type MergeFieldOrigin =
           sourceFieldId: FieldId;
       }
     /** Shared by every source, so it descends from no single one. */
-    | { kind: 'joinKey' }
+    | {
+          kind: 'joinKey';
+          fieldIdBySourceId: Record<string, FieldId>;
+      }
     /** Computed over the merged result, so it descends from no source. */
     | { kind: 'tableCalculation' };
 

--- a/packages/common/src/types/mergeQuery.ts
+++ b/packages/common/src/types/mergeQuery.ts
@@ -483,6 +483,8 @@ export type ApiCompiledMergeQueryResults = {
     itemsMap: ItemsMap;
     /** Provenance of each field in `itemsMap`. */
     fieldOrigins: MergeFieldOrigins;
+    /** User parameters referenced by any source query. */
+    parameterReferences: string[];
     /**
      * Field id for each column the statement returns. Warehouse aliases are
      * short and positional so they cannot breach an identifier length limit;

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -586,6 +586,8 @@ export const createDashboardFilterRuleFromSqlColumn = ({
 type AddFilterRuleArgs = {
     filters: Filters;
     field: FilterableField;
+    /** Override the display field's id when it represents another source. */
+    targetFieldId?: string;
     value?: AnyType;
     timezone?: string;
     operator?: QuickFilterOperator;
@@ -594,6 +596,7 @@ type AddFilterRuleArgs = {
 export const addFilterRule = ({
     filters,
     field,
+    targetFieldId,
     value,
     timezone,
     operator,
@@ -608,6 +611,21 @@ export const addFilterRule = ({
         return 'metrics';
     })(field);
     const group = filters[groupKey];
+    const createdRule = createFilterRuleFromField(
+        field,
+        value,
+        timezone,
+        operator,
+    );
+    const rule = targetFieldId
+        ? {
+              ...createdRule,
+              target: {
+                  ...createdRule.target,
+                  fieldId: targetFieldId,
+              },
+          }
+        : createdRule;
     return {
         ...filters,
         [groupKey]: {
@@ -615,7 +633,7 @@ export const addFilterRule = ({
             ...group,
             [getFilterGroupItemsPropertyName(group)]: [
                 ...getItemsFromFilterGroup(group),
-                createFilterRuleFromField(field, value, timezone, operator),
+                rule,
             ],
         },
     };

--- a/packages/frontend/src/components/Explorer/QuickFilterMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/QuickFilterMenuItems.tsx
@@ -20,6 +20,12 @@ const MAX_FILTER_VALUE_WIDTH = 250;
 type Props = {
     item: FilterableField;
     value: ResultValue;
+    onAddFilter?: (
+        item: FilterableField,
+        value: unknown,
+        timezone: string | undefined,
+        operator: QuickFilterOperator,
+    ) => void;
 };
 
 /**
@@ -27,8 +33,8 @@ type Props = {
  * Requires the explorer store (useFilters) — only render when the
  * visualization is in edit mode with an explorer store available.
  */
-const QuickFilterMenuItems: FC<Props> = ({ item, value }) => {
-    const { addFilter } = useFilters();
+const QuickFilterMenuItems: FC<Props> = ({ item, value, onAddFilter }) => {
+    const { addFilter: defaultAddFilter } = useFilters();
     const { resolvedTimezone } = useMetricQueryDataContext();
     const { track } = useTracking();
 
@@ -44,9 +50,14 @@ const QuickFilterMenuItems: FC<Props> = ({ item, value }) => {
                     ? null // Set as null if value is invalid date or undefined
                     : value.raw;
 
-            addFilter(item, filterValue, resolvedTimezone, operator);
+            (onAddFilter ?? defaultAddFilter)(
+                item,
+                filterValue,
+                resolvedTimezone,
+                operator,
+            );
         },
-        [track, addFilter, item, value, resolvedTimezone],
+        [track, onAddFilter, defaultAddFilter, item, value, resolvedTimezone],
     );
 
     return (

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -15,6 +15,7 @@ import { IconCopy, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';
 import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
+import { useMergeQuickFilter } from '../../../features/mergeQuery/hooks/useMergeQuickFilter';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { Can } from '../../../providers/Ability';
@@ -39,7 +40,9 @@ const CellContextMenu: FC<
         onExpand: (name: string, data: object) => void;
     }
 > = ({ cell, isEditMode, itemsMap, onViewJsonCell }) => {
-    const isMerged = !!useMergeSafe()?.mergeResults;
+    const merge = useMergeSafe();
+    const isMerged = !!merge?.mergeResults;
+    const mergeQuickFilter = useMergeQuickFilter();
     const { openUnderlyingDataModal, metricQuery } =
         useMetricQueryDataContext();
     const { track } = useTracking();
@@ -143,9 +146,20 @@ const CellContextMenu: FC<
                     projectUuid: projectUuid,
                 })}
             >
-                {isEditMode && item && isFilterableField(item) && (
-                    <QuickFilterMenuItems item={item} value={value} />
-                )}
+                {isEditMode &&
+                    item &&
+                    isFilterableField(item) &&
+                    (!isMerged || mergeQuickFilter.canFilter(item)) && (
+                        <QuickFilterMenuItems
+                            item={item}
+                            value={value}
+                            onAddFilter={
+                                isMerged
+                                    ? mergeQuickFilter.addFilter
+                                    : undefined
+                            }
+                        />
+                    )}
 
                 <DrillDownMenuItem
                     item={item}

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -21,6 +21,7 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
@@ -69,8 +70,15 @@ const ResultsCard: FC = memo(() => {
     }, [isGroupedDisabled, viewMode]);
 
     const { queryResults, getDownloadQueryUuid } = useExplorerQuery();
+    const merge = useMergeSafe();
+    const mergeResults = merge?.mergeResults;
 
-    const totalResults = queryResults.totalResults;
+    const mergedTotalResults = mergeResults?.results.totalResults;
+    const totalResults = mergeResults
+        ? mergedTotalResults && mergedTotalResults > 0
+            ? mergedTotalResults
+            : mergeResults.metricQuery.limit
+        : queryResults.totalResults;
 
     const savedChart = useExplorerSelector(selectSavedChart);
 
@@ -107,10 +115,14 @@ const ResultsCard: FC = memo(() => {
     // ResultsCard always downloads raw unpivoted results
     const getResultsCardDownloadQueryUuid = useCallback(
         (limit: number | null) => {
-            return getDownloadQueryUuid(limit, false);
+            return mergeResults
+                ? merge.getDownloadQueryUuid(limit, false)
+                : getDownloadQueryUuid(limit, false);
         },
-        [getDownloadQueryUuid],
+        [getDownloadQueryUuid, merge, mergeResults],
     );
+
+    const exportColumnOrder = mergeResults?.columnOrder ?? columnOrder;
 
     return (
         <CollapsableCard
@@ -196,8 +208,12 @@ const ResultsCard: FC = memo(() => {
                                         getDownloadQueryUuid={
                                             getResultsCardDownloadQueryUuid
                                         }
-                                        getGsheetLink={getGsheetLink}
-                                        columnOrder={columnOrder}
+                                        getGsheetLink={
+                                            mergeResults
+                                                ? undefined
+                                                : getGsheetLink
+                                        }
+                                        columnOrder={exportColumnOrder}
                                         customLabels={undefined} // for results table download, don't override labels
                                         hiddenFields={undefined} // for results table download, don't hide columns
                                         chartName={savedChart?.name}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -509,11 +509,17 @@ const VisualizationCard: FC<Props> = memo((props) => {
                                     {!!projectUuid && (
                                         <ChartDownloadMenu
                                             getDownloadQueryUuid={
-                                                getDownloadQueryUuid
+                                                mergeResults && merge
+                                                    ? merge.getDownloadQueryUuid
+                                                    : getDownloadQueryUuid
                                             }
                                             projectUuid={projectUuid}
                                             chartName={savedChart?.name}
-                                            getGsheetLink={getGsheetLink}
+                                            getGsheetLink={
+                                                mergeResults
+                                                    ? undefined
+                                                    : getGsheetLink
+                                            }
                                         />
                                     )}
                                 </Can>

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -195,6 +195,9 @@ const VisualizationCard: FC<Props> = memo((props) => {
     }, [query.data, queryResults, mergeResults, awaitingRestoredMerge]);
 
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
+    const visualizationMetricQuery = awaitingRestoredMerge
+        ? undefined
+        : (mergeResults?.metricQuery ?? unsavedChartVersion.metricQuery);
 
     const handleSetPivotFields = useCallback(
         (fields: FieldId[] = []) => {
@@ -300,11 +303,11 @@ const VisualizationCard: FC<Props> = memo((props) => {
         (e: EchartsSeriesClickEvent, series: EChartsSeries[]) => {
             setEchartsClickEvent({
                 event: e,
-                dimensions: unsavedChartVersion.metricQuery.dimensions,
+                dimensions: visualizationMetricQuery?.dimensions ?? [],
                 series,
             });
         },
-        [unsavedChartVersion],
+        [visualizationMetricQuery],
     );
 
     const { missingRequiredParameters } = useExplorerQuery();
@@ -328,17 +331,28 @@ const VisualizationCard: FC<Props> = memo((props) => {
     ]);
 
     const dirtyPivotConfiguration = useMemo(() => {
-        return explore
-            ? derivePivotConfigurationFromChart(
-                  unsavedChartVersion,
-                  unsavedChartVersion.metricQuery,
-                  getFieldsFromMetricQuery(
+        const fields =
+            mergeResults?.fields ??
+            (explore
+                ? getFieldsFromMetricQuery(
                       unsavedChartVersion.metricQuery,
                       explore,
-                  ),
+                  )
+                : undefined);
+
+        return visualizationMetricQuery && fields
+            ? derivePivotConfigurationFromChart(
+                  unsavedChartVersion,
+                  visualizationMetricQuery,
+                  fields,
               )
             : undefined;
-    }, [unsavedChartVersion, explore]);
+    }, [
+        unsavedChartVersion,
+        explore,
+        mergeResults?.fields,
+        visualizationMetricQuery,
+    ]);
 
     if (!unsavedChartVersion.tableName) {
         return <CollapsableCard title="Charts" disabled />;
@@ -380,7 +394,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
                     unsavedChartVersion.pivotConfig?.columns
                 }
                 initialPivotRows={unsavedChartVersion.pivotConfig?.rows}
-                unsavedMetricQuery={unsavedChartVersion.metricQuery}
+                unsavedMetricQuery={visualizationMetricQuery}
                 resultsData={resultsData}
                 apiErrorDetail={apiErrorDetail}
                 isLoading={isLoadingQueryResults}

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../features/explorer/store';
 import { MergeAutoRun } from '../../features/mergeQuery/components/MergeAutoRun';
 import { MergeReadOnlyBar } from '../../features/mergeQuery/components/MergeReadOnlyBar';
+import { useMergeSafe } from '../../features/mergeQuery/context/useMerge';
 import { useOrganization } from '../../hooks/organization/useOrganization';
 import { useParameters } from '../../hooks/parameters/useParameters';
 import { useCompiledSql } from '../../hooks/useCompiledSql';
@@ -59,6 +60,8 @@ import SqlCard from './SqlCard/SqlCard';
 import VisualizationCard from './VisualizationCard/VisualizationCard';
 import { WriteBackModal } from './WriteBackModal';
 
+const EMPTY_PARAMETER_REFERENCES: string[] = [];
+
 const Explorer: FC<{ hideHeader?: boolean }> = memo(
     ({ hideHeader = false }) => {
         const tableName = useExplorerSelector(selectTableName);
@@ -72,6 +75,18 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
             selectParameterReferences,
         );
         const parameters = useExplorerSelector(selectParameters);
+        const mergeParameterReferences =
+            useMergeSafe()?.parameterReferences ?? EMPTY_PARAMETER_REFERENCES;
+        const effectiveParameterReferences = useMemo(
+            () =>
+                Array.from(
+                    new Set([
+                        ...(parameterReferencesFromRedux ?? []),
+                        ...mergeParameterReferences,
+                    ]),
+                ),
+            [parameterReferencesFromRedux, mergeParameterReferences],
+        );
 
         const savedChart = useExplorerSelector(selectSavedChart);
 
@@ -178,9 +193,9 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
 
         const { data: projectParameters } = useParameters(
             projectUuid,
-            parameterReferencesFromRedux ?? undefined,
+            effectiveParameterReferences,
             {
-                enabled: !!parameterReferencesFromRedux?.length,
+                enabled: effectiveParameterReferences.length > 0,
             },
         );
 
@@ -208,10 +223,10 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                 Object.keys(
                     getReferencedParameterDefinitions(
                         parameterDefinitions,
-                        parameterReferencesFromRedux ?? undefined,
+                        effectiveParameterReferences,
                     ),
                 ).length > 0,
-            [parameterDefinitions, parameterReferencesFromRedux],
+            [parameterDefinitions, effectiveParameterReferences],
         );
 
         // Seed parameter values from virtual view's savedParameterValues
@@ -264,7 +279,7 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                         hasReferencedUserParameters && (
                             <ParametersCard
                                 parameterReferences={
-                                    parameterReferencesFromRedux ?? undefined
+                                    effectiveParameterReferences
                                 }
                             />
                         )}

--- a/packages/frontend/src/features/mergeQuery/components/MergeFilterSwitch.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeFilterSwitch.tsx
@@ -31,6 +31,7 @@ export const MergeFilterSwitch: FC = () => {
         <SegmentedControl
             size="xs"
             radius="md"
+            styles={{ label: { fontSize: 'var(--mantine-font-size-sm)' } }}
             value={merge.focus}
             onChange={(value) => {
                 if (value === 'a' || value === 'b') merge.setFocus(value);

--- a/packages/frontend/src/features/mergeQuery/components/MergeFilterSwitch.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeFilterSwitch.tsx
@@ -31,7 +31,7 @@ export const MergeFilterSwitch: FC = () => {
         <SegmentedControl
             size="xs"
             radius="md"
-            styles={{ label: { fontSize: 'var(--mantine-font-size-sm)' } }}
+            styles={{ label: { fontSize: 'var(--mantine-font-size-xs)' } }}
             value={merge.focus}
             onChange={(value) => {
                 if (value === 'a' || value === 'b') merge.setFocus(value);

--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
@@ -257,7 +257,9 @@ export const MergeJoinBar: FC = () => {
                                             multiline
                                             w={260}
                                         >
-                                            <Text span>{option.label}</Text>
+                                            <Text span size="xs">
+                                                {option.label}
+                                            </Text>
                                         </Tooltip>
                                     ),
                                 }))}

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -104,7 +104,14 @@ export const MergeProvider: FC<
         errors: MergeQueryError[];
         started: ApiExecuteAsyncMetricQueryResults | null;
         error: ApiError | null;
-    }>({ isRunning: false, errors: [], started: null, error: null });
+        parameterReferences: string[];
+    }>({
+        isRunning: false,
+        errors: [],
+        started: null,
+        error: null,
+        parameterReferences: [],
+    });
 
     const addQuery = useCallback(() => {
         setIsMerging(true);
@@ -123,6 +130,7 @@ export const MergeProvider: FC<
             errors: [],
             started: null,
             error: null,
+            parameterReferences: [],
         });
     }, []);
 
@@ -232,12 +240,13 @@ export const MergeProvider: FC<
             if (!projectUuid) return;
             const runId = activeRun.current + 1;
             activeRun.current = runId;
-            setRunState({
+            setRunState((current) => ({
                 isRunning: true,
                 errors: [],
                 started: null,
                 error: null,
-            });
+                parameterReferences: current.parameterReferences,
+            }));
             executeMergeQuery(projectUuid, mergeQuery, parameters, savedChart)
                 .then((result) => {
                     if (activeRun.current !== runId) return;
@@ -246,16 +255,18 @@ export const MergeProvider: FC<
                         errors: result.errors,
                         started: result.started,
                         error: null,
+                        parameterReferences: result.parameterReferences,
                     });
                 })
                 .catch((error: ApiError) => {
                     if (activeRun.current !== runId) return;
-                    setRunState({
+                    setRunState((current) => ({
                         isRunning: false,
                         errors: [],
                         started: null,
                         error,
-                    });
+                        parameterReferences: current.parameterReferences,
+                    }));
                 });
         },
         [projectUuid],
@@ -293,6 +304,7 @@ export const MergeProvider: FC<
             isRunning: runState.isRunning,
             runErrors: runState.errors,
             runError: runState.error,
+            parameterReferences: runState.parameterReferences,
             mergeResults,
             focus,
             queryB,
@@ -318,6 +330,7 @@ export const MergeProvider: FC<
             runState.isRunning,
             runState.errors,
             runState.error,
+            runState.parameterReferences,
             mergeResults,
             focus,
             queryB,

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -1,5 +1,6 @@
 import {
     MergeJoinType,
+    type ApiCompiledMergeQueryResults,
     type ApiError,
     type ApiExecuteAsyncMetricQueryResults,
     type MergeQuery,
@@ -110,12 +111,14 @@ export const MergeProvider: FC<
         started: ApiExecuteAsyncMetricQueryResults | null;
         error: ApiError | null;
         parameterReferences: string[];
+        fieldOrigins: ApiCompiledMergeQueryResults['fieldOrigins'];
     }>({
         isRunning: false,
         errors: [],
         started: null,
         error: null,
         parameterReferences: [],
+        fieldOrigins: {},
     });
 
     const addQuery = useCallback(() => {
@@ -136,6 +139,7 @@ export const MergeProvider: FC<
             started: null,
             error: null,
             parameterReferences: [],
+            fieldOrigins: {},
         });
     }, []);
 
@@ -252,6 +256,7 @@ export const MergeProvider: FC<
                 started: null,
                 error: null,
                 parameterReferences: current.parameterReferences,
+                fieldOrigins: current.fieldOrigins,
             }));
             executeMergeQuery(projectUuid, mergeQuery, parameters, savedChart)
                 .then((result) => {
@@ -262,6 +267,7 @@ export const MergeProvider: FC<
                         started: result.started,
                         error: null,
                         parameterReferences: result.parameterReferences,
+                        fieldOrigins: result.fieldOrigins,
                     });
                 })
                 .catch((error: ApiError) => {
@@ -272,6 +278,7 @@ export const MergeProvider: FC<
                         started: null,
                         error,
                         parameterReferences: current.parameterReferences,
+                        fieldOrigins: current.fieldOrigins,
                     }));
                 });
         },
@@ -318,10 +325,11 @@ export const MergeProvider: FC<
                           ...started.metricQuery.dimensions,
                           ...started.metricQuery.metrics,
                       ],
+                      fieldOrigins: runState.fieldOrigins,
                       results,
                   }
                 : null,
-        [started, results],
+        [started, results, runState.fieldOrigins],
     );
 
     const value = useMemo(

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -6,6 +6,7 @@ import {
     type Filters,
     type MergeQueryError,
     type ParametersValuesMap,
+    type SavedChartDAO,
     type SavedMergeQuery,
 } from '@lightdash/common';
 import {
@@ -223,7 +224,11 @@ export const MergeProvider: FC<
     );
 
     const run = useCallback(
-        (mergeQuery: MergeQuery, parameters?: ParametersValuesMap) => {
+        (
+            mergeQuery: MergeQuery,
+            parameters?: ParametersValuesMap,
+            savedChart?: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>,
+        ) => {
             if (!projectUuid) return;
             const runId = activeRun.current + 1;
             activeRun.current = runId;
@@ -233,7 +238,7 @@ export const MergeProvider: FC<
                 started: null,
                 error: null,
             });
-            executeMergeQuery(projectUuid, mergeQuery, parameters)
+            executeMergeQuery(projectUuid, mergeQuery, parameters, savedChart)
                 .then((result) => {
                     if (activeRun.current !== runId) return;
                     setRunState({

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -99,6 +99,11 @@ export const MergeProvider: FC<
     );
     const [filtersB, setFiltersB] = useState<Filters>(restored?.filtersB ?? {});
     const activeRun = useRef(0);
+    const lastRun = useRef<{
+        mergeQuery: MergeQuery;
+        parameters?: ParametersValuesMap;
+        savedChart?: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>;
+    } | null>(null);
     const [runState, setRunState] = useState<{
         isRunning: boolean;
         errors: MergeQueryError[];
@@ -238,6 +243,7 @@ export const MergeProvider: FC<
             savedChart?: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>,
         ) => {
             if (!projectUuid) return;
+            lastRun.current = { mergeQuery, parameters, savedChart };
             const runId = activeRun.current + 1;
             activeRun.current = runId;
             setRunState((current) => ({
@@ -272,6 +278,29 @@ export const MergeProvider: FC<
         [projectUuid],
     );
 
+    const getDownloadQueryUuid = useCallback(
+        async (limit: number | null, exportPivotedResults = false) => {
+            if (!projectUuid || !lastRun.current) {
+                throw new Error('Missing merged query');
+            }
+            const { mergeQuery, parameters, savedChart } = lastRun.current;
+            const result = await executeMergeQuery(
+                projectUuid,
+                mergeQuery,
+                parameters,
+                exportPivotedResults ? savedChart : undefined,
+                limit,
+            );
+            if (!result.started) {
+                throw new Error(
+                    result.errors.map((error) => error.message).join(' '),
+                );
+            }
+            return result.started.queryUuid;
+        },
+        [projectUuid],
+    );
+
     const { started } = runState;
     const results = useInfiniteQueryResults(projectUuid, started?.queryUuid);
 
@@ -301,6 +330,7 @@ export const MergeProvider: FC<
             readOnly,
             wasRestored: restored !== null,
             run,
+            getDownloadQueryUuid,
             isRunning: runState.isRunning,
             runErrors: runState.errors,
             runError: runState.error,
@@ -327,6 +357,7 @@ export const MergeProvider: FC<
             readOnly,
             restored,
             run,
+            getDownloadQueryUuid,
             runState.isRunning,
             runState.errors,
             runState.error,

--- a/packages/frontend/src/features/mergeQuery/context/context.ts
+++ b/packages/frontend/src/features/mergeQuery/context/context.ts
@@ -62,6 +62,10 @@ export type MergeContextValue = {
         parameters?: ParametersValuesMap,
         savedChart?: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>,
     ) => void;
+    getDownloadQueryUuid: (
+        limit: number | null,
+        exportPivotedResults?: boolean,
+    ) => Promise<string>;
     isRunning: boolean;
     /** Why a merge was refused. Empty when it compiled. */
     runErrors: MergeQueryError[];

--- a/packages/frontend/src/features/mergeQuery/context/context.ts
+++ b/packages/frontend/src/features/mergeQuery/context/context.ts
@@ -7,6 +7,7 @@ import {
     type MergeQueryError,
     type MetricQuery,
     type ParametersValuesMap,
+    type SavedChartDAO,
 } from '@lightdash/common';
 import { createContext } from 'react';
 import { type InfiniteQueryResults } from '../../../hooks/useQueryResults';
@@ -56,7 +57,11 @@ export type MergeContextValue = {
      */
     wasRestored: boolean;
     /** Runs a merge, replacing any run already on screen. */
-    run: (mergeQuery: MergeQuery, parameters?: ParametersValuesMap) => void;
+    run: (
+        mergeQuery: MergeQuery,
+        parameters?: ParametersValuesMap,
+        savedChart?: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>,
+    ) => void;
     isRunning: boolean;
     /** Why a merge was refused. Empty when it compiled. */
     runErrors: MergeQueryError[];

--- a/packages/frontend/src/features/mergeQuery/context/context.ts
+++ b/packages/frontend/src/features/mergeQuery/context/context.ts
@@ -3,6 +3,7 @@ import {
     type Filters,
     type ItemsMap,
     type MergeJoinType,
+    type MergeFieldOrigins,
     type MergeQuery,
     type MergeQueryError,
     type MetricQuery,
@@ -43,6 +44,7 @@ export type MergeResults = {
     metricQuery: MetricQuery;
     /** Field ids in the order the merged statement returns them. */
     columnOrder: string[];
+    fieldOrigins: MergeFieldOrigins;
     results: InfiniteQueryResults;
 };
 

--- a/packages/frontend/src/features/mergeQuery/context/context.ts
+++ b/packages/frontend/src/features/mergeQuery/context/context.ts
@@ -67,6 +67,8 @@ export type MergeContextValue = {
     runErrors: MergeQueryError[];
     /** Transport or server failure of the last run, if any. */
     runError: ApiError | null;
+    /** User parameters referenced by either source query. */
+    parameterReferences: string[];
     /** The merged run, or null when none has succeeded yet. */
     mergeResults: MergeResults | null;
     focus: MergeFocus;

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.test.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.test.ts
@@ -1,0 +1,91 @@
+import {
+    ChartType,
+    DimensionType,
+    FieldType,
+    MergeJoinType,
+    MetricType,
+} from '@lightdash/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../../api';
+import { executeMergeQuery } from './useMergeQuery';
+
+vi.mock('../../../api', () => ({ lightdashApi: vi.fn() }));
+
+const api = vi.mocked(lightdashApi);
+
+describe('executeMergeQuery', () => {
+    beforeEach(() => api.mockReset());
+
+    it('runs a merged table with its pivot configuration', async () => {
+        api.mockResolvedValueOnce({
+            sql: 'select 1',
+            coreSql: 'select 1',
+            typedColumns: [],
+            terminalWrapper: {},
+            columns: {},
+            fields: [],
+            itemsMap: {
+                merge_join_key_0: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'join_key_0',
+                    label: 'Customer',
+                    table: 'merge',
+                    tableLabel: 'Merged',
+                    sql: '',
+                    hidden: false,
+                },
+                a_orders_count: {
+                    fieldType: FieldType.METRIC,
+                    type: MetricType.COUNT,
+                    name: 'orders_count',
+                    label: 'Orders',
+                    table: 'a',
+                    tableLabel: 'Orders',
+                    sql: '',
+                    hidden: false,
+                },
+            },
+            fieldOrigins: {},
+            fieldIdByColumn: {
+                join_key_0: 'merge_join_key_0',
+                orders_count: 'a_orders_count',
+            },
+            errors: [],
+        } as never);
+        api.mockResolvedValueOnce({ queryUuid: 'query-uuid' } as never);
+
+        await executeMergeQuery(
+            'project-uuid',
+            {
+                sources: [],
+                joinKey: [],
+                joinType: MergeJoinType.FULL,
+                limit: 500,
+                tableCalculations: [],
+            },
+            {},
+            {
+                chartConfig: {
+                    type: ChartType.TABLE,
+                    config: {},
+                },
+                pivotConfig: {
+                    columns: ['merge_join_key_0'],
+                    rows: [],
+                },
+            },
+        );
+
+        expect(
+            JSON.parse((api.mock.calls[1][0].body as string) ?? '{}'),
+        ).toMatchObject({
+            pivotConfiguration: {
+                groupByColumns: [{ reference: 'merge_join_key_0' }],
+                valuesColumns: [
+                    { reference: 'a_orders_count', aggregation: 'any' },
+                ],
+            },
+        });
+    });
+});

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.test.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.test.ts
@@ -47,6 +47,7 @@ describe('executeMergeQuery', () => {
                 },
             },
             fieldOrigins: {},
+            parameterReferences: ['date_dim_parameter'],
             fieldIdByColumn: {
                 join_key_0: 'merge_join_key_0',
                 orders_count: 'a_orders_count',
@@ -55,7 +56,7 @@ describe('executeMergeQuery', () => {
         } as never);
         api.mockResolvedValueOnce({ queryUuid: 'query-uuid' } as never);
 
-        await executeMergeQuery(
+        const result = await executeMergeQuery(
             'project-uuid',
             {
                 sources: [],
@@ -87,5 +88,29 @@ describe('executeMergeQuery', () => {
                 ],
             },
         });
+        expect(result.parameterReferences).toEqual(['date_dim_parameter']);
+        expect(api).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns parameter references when compilation is refused', async () => {
+        api.mockResolvedValueOnce({
+            sql: null,
+            parameterReferences: ['customers.customer_name'],
+            errors: [{ message: 'Missing customer name' }],
+        } as never);
+
+        const result = await executeMergeQuery('project-uuid', {
+            sources: [],
+            joinKey: [],
+            joinType: MergeJoinType.FULL,
+            limit: 500,
+            tableCalculations: [],
+        });
+
+        expect(result).toMatchObject({
+            started: null,
+            parameterReferences: ['customers.customer_name'],
+        });
+        expect(api).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.test.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.test.ts
@@ -76,6 +76,7 @@ describe('executeMergeQuery', () => {
                     rows: [],
                 },
             },
+            42,
         );
 
         expect(
@@ -87,6 +88,7 @@ describe('executeMergeQuery', () => {
                     { reference: 'a_orders_count', aggregation: 'any' },
                 ],
             },
+            csvLimit: 42,
         });
         expect(result.parameterReferences).toEqual(['date_dim_parameter']);
         expect(api).toHaveBeenCalledTimes(2);

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
@@ -42,6 +42,7 @@ const runMergeQuery = (
     mergeQuery: MergeQuery,
     parameters: ParametersValuesMap | undefined,
     pivotConfiguration: PivotConfiguration | undefined,
+    csvLimit?: number | null,
 ) =>
     lightdashApi<ApiExecuteAsyncMetricQueryResults>({
         url: `/projects/${projectUuid}/mergeQuery/run`,
@@ -50,6 +51,7 @@ const runMergeQuery = (
             mergeQuery,
             parameters,
             pivotConfiguration,
+            csvLimit,
         } satisfies RunMergeQueryRequest),
     });
 
@@ -67,6 +69,7 @@ export const executeMergeQuery = async (
     mergeQuery: MergeQuery,
     parameters?: ParametersValuesMap,
     savedChart?: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>,
+    csvLimit?: number | null,
 ): Promise<MergeQueryRun> => {
     const compiled = await compileMergeQuery(
         projectUuid,
@@ -110,6 +113,7 @@ export const executeMergeQuery = async (
             mergeQuery,
             parameters,
             pivotConfiguration,
+            csvLimit,
         ),
     };
 };

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
@@ -34,6 +34,7 @@ export type MergeQueryRun = {
     errors: CompiledMergeQuery['errors'];
     /** The query to page results from, or null when the merge was refused. */
     started: ApiExecuteAsyncMetricQueryResults | null;
+    parameterReferences: string[];
 };
 
 const runMergeQuery = (
@@ -73,7 +74,11 @@ export const executeMergeQuery = async (
         parameters,
     );
     if (!compiled.sql) {
-        return { errors: compiled.errors, started: null };
+        return {
+            errors: compiled.errors,
+            started: null,
+            parameterReferences: compiled.parameterReferences,
+        };
     }
 
     const columnOrder = Object.values(compiled.fieldIdByColumn);
@@ -99,6 +104,7 @@ export const executeMergeQuery = async (
 
     return {
         errors: [],
+        parameterReferences: compiled.parameterReferences,
         started: await runMergeQuery(
             projectUuid,
             mergeQuery,

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
@@ -1,10 +1,15 @@
 import {
+    derivePivotConfigurationFromChart,
+    isDimension,
+    MERGE_TABLE_NAME,
     type ApiCompiledMergeQueryResults,
     type ApiExecuteAsyncMetricQueryResults,
     type CompileMergeQueryRequest,
     type MergeQuery,
     type ParametersValuesMap,
+    type PivotConfiguration,
     type RunMergeQueryRequest,
+    type SavedChartDAO,
 } from '@lightdash/common';
 import { lightdashApi } from '../../../api';
 
@@ -35,6 +40,7 @@ const runMergeQuery = (
     projectUuid: string,
     mergeQuery: MergeQuery,
     parameters: ParametersValuesMap | undefined,
+    pivotConfiguration: PivotConfiguration | undefined,
 ) =>
     lightdashApi<ApiExecuteAsyncMetricQueryResults>({
         url: `/projects/${projectUuid}/mergeQuery/run`,
@@ -42,6 +48,7 @@ const runMergeQuery = (
         body: JSON.stringify({
             mergeQuery,
             parameters,
+            pivotConfiguration,
         } satisfies RunMergeQueryRequest),
     });
 
@@ -58,6 +65,7 @@ export const executeMergeQuery = async (
     projectUuid: string,
     mergeQuery: MergeQuery,
     parameters?: ParametersValuesMap,
+    savedChart?: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>,
 ): Promise<MergeQueryRun> => {
     const compiled = await compileMergeQuery(
         projectUuid,
@@ -67,8 +75,35 @@ export const executeMergeQuery = async (
     if (!compiled.sql) {
         return { errors: compiled.errors, started: null };
     }
+
+    const columnOrder = Object.values(compiled.fieldIdByColumn);
+    const dimensions = columnOrder.filter((fieldId) =>
+        isDimension(compiled.itemsMap[fieldId]),
+    );
+    const metricQuery = {
+        exploreName: MERGE_TABLE_NAME,
+        dimensions,
+        metrics: columnOrder.filter((fieldId) => !dimensions.includes(fieldId)),
+        filters: {},
+        sorts: [],
+        limit: mergeQuery.limit,
+        tableCalculations: [],
+    };
+    const pivotConfiguration = savedChart
+        ? derivePivotConfigurationFromChart(
+              savedChart,
+              metricQuery,
+              compiled.itemsMap,
+          )
+        : undefined;
+
     return {
         errors: [],
-        started: await runMergeQuery(projectUuid, mergeQuery, parameters),
+        started: await runMergeQuery(
+            projectUuid,
+            mergeQuery,
+            parameters,
+            pivotConfiguration,
+        ),
     };
 };

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
@@ -35,6 +35,7 @@ export type MergeQueryRun = {
     /** The query to page results from, or null when the merge was refused. */
     started: ApiExecuteAsyncMetricQueryResults | null;
     parameterReferences: string[];
+    fieldOrigins: ApiCompiledMergeQueryResults['fieldOrigins'];
 };
 
 const runMergeQuery = (
@@ -81,6 +82,7 @@ export const executeMergeQuery = async (
             errors: compiled.errors,
             started: null,
             parameterReferences: compiled.parameterReferences,
+            fieldOrigins: compiled.fieldOrigins,
         };
     }
 
@@ -108,6 +110,7 @@ export const executeMergeQuery = async (
     return {
         errors: [],
         parameterReferences: compiled.parameterReferences,
+        fieldOrigins: compiled.fieldOrigins,
         started: await runMergeQuery(
             projectUuid,
             mergeQuery,

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuickFilter.test.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuickFilter.test.ts
@@ -1,0 +1,80 @@
+import {
+    DimensionType,
+    FieldType,
+    FilterOperator,
+    getTotalFilterRules,
+    type Dimension,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { applyMergeQuickFilter } from './useMergeQuickFilter';
+
+const field: Dimension = {
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.NUMBER,
+    table: 'merge',
+    tableLabel: 'Merged results',
+    name: 'join_key_0',
+    label: 'Customer id',
+    sql: '',
+    hidden: false,
+};
+
+const targetIds = (filters: Parameters<typeof getTotalFilterRules>[0]) =>
+    getTotalFilterRules(filters).map((rule) => rule.target.fieldId);
+
+describe('applyMergeQuickFilter', () => {
+    it('applies a shared join key to both source fields', () => {
+        const result = applyMergeQuickFilter({
+            filtersA: {},
+            filtersB: {},
+            field,
+            origin: {
+                kind: 'joinKey',
+                fieldIdBySourceId: {
+                    a: 'customers_customer_id',
+                    b: 'orders_customer_id',
+                },
+            },
+            value: 1,
+            operator: FilterOperator.EQUALS,
+            focus: 'a',
+        });
+
+        expect(result).not.toBeNull();
+        expect(targetIds(result!.filtersA)).toEqual(['customers_customer_id']);
+        expect(targetIds(result!.filtersB)).toEqual(['orders_customer_id']);
+    });
+
+    it('applies a source field only to its owning query', () => {
+        const result = applyMergeQuickFilter({
+            filtersA: {},
+            filtersB: {},
+            field,
+            origin: {
+                kind: 'source',
+                sourceId: 'b',
+                sourceFieldId: 'orders_order_count',
+            },
+            value: 2,
+            operator: FilterOperator.NOT_EQUALS,
+            focus: 'a',
+        });
+
+        expect(result).not.toBeNull();
+        expect(targetIds(result!.filtersA)).toEqual([]);
+        expect(targetIds(result!.filtersB)).toEqual(['orders_order_count']);
+        expect(result!.focus).toBe('b');
+    });
+
+    it('does not offer a source-less table calculation filter', () => {
+        expect(
+            applyMergeQuickFilter({
+                filtersA: {},
+                filtersB: {},
+                field,
+                origin: { kind: 'tableCalculation' },
+                focus: 'a',
+            }),
+        ).toBeNull();
+    });
+});

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuickFilter.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuickFilter.ts
@@ -1,0 +1,151 @@
+import {
+    addFilterRule,
+    getItemId,
+    type AnyType,
+    type FilterableField,
+    type Filters,
+    type MergeFieldOrigin,
+    type QuickFilterOperator,
+} from '@lightdash/common';
+import { useCallback } from 'react';
+import { ExplorerSection } from '../../../providers/Explorer/types';
+import {
+    explorerActions,
+    selectFilters,
+    selectIsFiltersExpanded,
+    useExplorerDispatch,
+    useExplorerStore,
+} from '../../explorer/store';
+import { SOURCE_A, SOURCE_B } from '../constants';
+import { type MergeFocus } from '../context/context';
+import { useMergeSafe } from '../context/useMerge';
+
+type ApplyMergeQuickFilterArgs = {
+    filtersA: Filters;
+    filtersB: Filters;
+    field: FilterableField;
+    origin: MergeFieldOrigin;
+    value?: AnyType;
+    timezone?: string;
+    operator?: QuickFilterOperator;
+    focus: MergeFocus;
+};
+
+type AppliedMergeQuickFilter = {
+    filtersA: Filters;
+    filtersB: Filters;
+    focus: MergeFocus;
+};
+
+export const applyMergeQuickFilter = ({
+    filtersA,
+    filtersB,
+    field,
+    origin,
+    value,
+    timezone,
+    operator,
+    focus,
+}: ApplyMergeQuickFilterArgs): AppliedMergeQuickFilter | null => {
+    const add = (filters: Filters, targetFieldId: string) =>
+        addFilterRule({
+            filters,
+            field,
+            targetFieldId,
+            value,
+            timezone,
+            operator,
+        });
+
+    if (origin.kind === 'source') {
+        if (origin.sourceId === SOURCE_A) {
+            return {
+                filtersA: add(filtersA, origin.sourceFieldId),
+                filtersB,
+                focus: SOURCE_A,
+            };
+        }
+        if (origin.sourceId === SOURCE_B) {
+            return {
+                filtersA,
+                filtersB: add(filtersB, origin.sourceFieldId),
+                focus: SOURCE_B,
+            };
+        }
+        return null;
+    }
+
+    if (origin.kind === 'joinKey') {
+        const fieldA = origin.fieldIdBySourceId[SOURCE_A];
+        const fieldB = origin.fieldIdBySourceId[SOURCE_B];
+        if (!fieldA || !fieldB) return null;
+
+        return {
+            filtersA: add(filtersA, fieldA),
+            filtersB: add(filtersB, fieldB),
+            focus,
+        };
+    }
+
+    return null;
+};
+
+export const useMergeQuickFilter = () => {
+    const merge = useMergeSafe();
+    const dispatch = useExplorerDispatch();
+    const store = useExplorerStore();
+
+    const canFilter = useCallback(
+        (field: FilterableField) => {
+            const origin = merge?.mergeResults?.fieldOrigins[getItemId(field)];
+            return origin !== undefined && origin.kind !== 'tableCalculation';
+        },
+        [merge?.mergeResults?.fieldOrigins],
+    );
+
+    const addFilter = useCallback(
+        (
+            field: FilterableField,
+            value: AnyType,
+            timezone?: string,
+            operator?: QuickFilterOperator,
+        ) => {
+            if (!merge?.mergeResults) return;
+            const origin = merge.mergeResults.fieldOrigins[getItemId(field)];
+            if (!origin) return;
+
+            const filtersA = selectFilters(store.getState());
+            const result = applyMergeQuickFilter({
+                filtersA,
+                filtersB: merge.filtersB,
+                field,
+                origin,
+                value,
+                timezone,
+                operator,
+                focus: merge.focus,
+            });
+            if (!result) return;
+
+            if (result.filtersA !== filtersA) {
+                dispatch(explorerActions.setFilters(result.filtersA));
+            }
+            if (result.filtersB !== merge.filtersB) {
+                merge.setFiltersB(result.filtersB);
+            }
+            merge.setFocus(result.focus);
+
+            if (!selectIsFiltersExpanded(store.getState())) {
+                dispatch(
+                    explorerActions.toggleExpandedSection(
+                        ExplorerSection.FILTERS,
+                    ),
+                );
+            }
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        },
+        [dispatch, merge, store],
+    );
+
+    return { addFilter, canFilter };
+};

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeSetup.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeSetup.ts
@@ -20,6 +20,7 @@ import {
     selectMetricQuery,
     selectParameters,
     selectTableName,
+    selectUnsavedChartVersion,
     useExplorerSelector,
 } from '../../explorer/store';
 import { EMPTY_MERGE, JOIN_KEY, SOURCE_A, SOURCE_B } from '../constants';
@@ -39,6 +40,7 @@ export const useMergeSetup = () => {
     const tableName = useExplorerSelector(selectTableName);
     const metricQuery = useExplorerSelector(selectMetricQuery);
     const parameters = useExplorerSelector(selectParameters);
+    const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
     const mergeContext = useMergeSafe();
     const { isMerging, queryB, joinParts, joinType, filtersB } =
         mergeContext ?? EMPTY_MERGE;
@@ -378,8 +380,8 @@ export const useMergeSetup = () => {
 
     const handleRun = useCallback(() => {
         if (mergeFlag?.enabled === true && mergeQuery)
-            run?.(mergeQuery, parameters);
-    }, [mergeFlag?.enabled, mergeQuery, run, parameters]);
+            run?.(mergeQuery, parameters, unsavedChartVersion);
+    }, [mergeFlag?.enabled, mergeQuery, run, parameters, unsavedChartVersion]);
     return {
         // state passed through, so callers need only this hook
         isMerging,

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -16,6 +16,7 @@ import {
     useExplorerSelector,
 } from '../features/explorer/store';
 import { MergeProvider } from '../features/mergeQuery/context/MergeContext';
+import { useMergeSafe } from '../features/mergeQuery/context/useMerge';
 import { useExplore } from '../hooks/useExplore';
 import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
 import {
@@ -34,12 +35,14 @@ const ExplorerContent = memo(() => {
 
     const dispatch = useExplorerDispatch();
     const navigate = useNavigate();
+    const merge = useMergeSafe();
 
     // Get table name from Redux
     const tableId = useExplorerSelector(selectTableName);
     const { data } = useExplore(tableId);
 
     const handleClearQuery = useCallback(() => {
+        merge?.removeQuery();
         dispatch(
             explorerActions.clearQuery({
                 defaultState,
@@ -48,23 +51,27 @@ const ExplorerContent = memo(() => {
         );
         // Clear state in URL params
         void navigate({ search: '' }, { replace: true });
-    }, [dispatch, tableId, navigate]);
+    }, [merge, dispatch, tableId, navigate]);
 
     useHotkeys([['mod + alt + k', handleClearQuery]]);
 
     return (
-        <MergeProvider>
-            <Page
-                title={data ? data?.label : 'Tables'}
-                sidebar={<ExploreSideBar />}
-                withFullHeight
-                withPaddedContent
-            >
-                <Explorer />
-            </Page>
-        </MergeProvider>
+        <Page
+            title={data ? data?.label : 'Tables'}
+            sidebar={<ExploreSideBar />}
+            withFullHeight
+            withPaddedContent
+        >
+            <Explorer />
+        </Page>
     );
 });
+
+const ExplorerWithMerge = memo(() => (
+    <MergeProvider>
+        <ExplorerContent />
+    </MergeProvider>
+));
 
 const ExplorerWithUrlParams = memo(() => {
     const { health } = useApp();
@@ -87,7 +94,7 @@ const ExplorerWithUrlParams = memo(() => {
 
     return (
         <Provider store={store}>
-            <ExplorerContent />
+            <ExplorerWithMerge />
         </Provider>
     );
 });


### PR DESCRIPTION
## What changed

- Set the Query A / Query B segmented-control labels in explorer filter cards to the `sm` typography token while keeping the compact `xs` control geometry.
- Make the explorer clear-query shortcut remove Query B and reset merged-query run state along with the normal query.

## Why

The merged-query switch rendered larger than the surrounding explorer UI. The clear-query interaction also only reset Redux and the URL; because merged-query state lives in its provider, the merge remained active and could reappear immediately.

## Impact

Merged-query controls now match explorer typography, and clearing an explorer query reliably returns to a clean single-query state.

## Validation

- Frontend TypeScript typecheck
- Focused merge URL and saved-merge tests: 9 passed
- Pre-commit frontend lint, formatting, and unused-export checks