### PR TITLE
fix(ai): show compact Deep Research icon in Aurora launcher

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
@@ -20,6 +20,9 @@ const renderInput = ({
     onSubmit = vi.fn(),
     disabled = false,
     threadUuid = 'thread-1',
+    showDeepResearchBelowComposer = false,
+    onSqlModeChange,
+    showAgentSelector = false,
 }: {
     onStartDeepResearch?:
         | ((args: { question: string }) => Promise<void>)
@@ -27,7 +30,17 @@ const renderInput = ({
     onSubmit?: (args: { message: string; toolHints: string[] }) => void;
     disabled?: boolean;
     threadUuid?: string | null;
+    showDeepResearchBelowComposer?: boolean;
+    onSqlModeChange?: (enabled: boolean) => void;
+    showAgentSelector?: boolean;
 } = {}) => {
+    const agent = {
+        uuid: 'agent-1',
+        name: 'Aurora',
+        imageUrl: null,
+        adminOnly: false,
+    };
+
     renderWithProviders(
         <Provider store={store}>
             <MemoryRouter>
@@ -40,6 +53,13 @@ const renderInput = ({
                     threadUuid={threadUuid ?? undefined}
                     defaultValue="Why did enterprise retention fall?"
                     showSuggestions={false}
+                    showDeepResearchBelowComposer={
+                        showDeepResearchBelowComposer
+                    }
+                    sqlMode={false}
+                    onSqlModeChange={onSqlModeChange}
+                    agents={showAgentSelector ? [agent] : undefined}
+                    selectedAgent={showAgentSelector ? agent : undefined}
                 />
             </MemoryRouter>
         </Provider>,
@@ -70,6 +90,58 @@ describe('AgentChatInput Deep Research mode', () => {
                 .getByRole('button', { name: 'Enable deep research' })
                 .closest('[data-accent]'),
         ).not.toBeNull();
+    });
+
+    it('shows the compact toggle below an opted-in new-thread composer', async () => {
+        const user = userEvent.setup();
+        const onSqlModeChange = vi.fn();
+        const { onStartDeepResearch } = renderInput({
+            threadUuid: null,
+            showDeepResearchBelowComposer: true,
+            onSqlModeChange,
+        });
+
+        const getToggle = () =>
+            screen.getByRole('button', {
+                name: 'Enable deep research',
+            });
+        expect(getToggle().closest('[data-accent]')).toBeNull();
+        expect(screen.queryByText('Deep research')).not.toBeInTheDocument();
+
+        const toggle = getToggle();
+        const sqlToggle = screen.getByRole('button', {
+            name: 'Toggle SQL Runner',
+        });
+        expect(sqlToggle.closest('[data-accent]')).toBeNull();
+
+        await user.click(sqlToggle);
+        expect(onSqlModeChange).toHaveBeenCalledWith(true);
+
+        await user.hover(toggle);
+        expect(await screen.findByRole('tooltip')).toHaveTextContent(
+            'Enable deep research',
+        );
+
+        await user.click(toggle);
+        await user.click(
+            screen.getByRole('button', { name: 'Start research' }),
+        );
+
+        expect(onStartDeepResearch).toHaveBeenCalledWith({
+            question: 'Why did enterprise retention fall?',
+        });
+    });
+
+    it('keeps a single SQL toggle in a default new-thread composer', () => {
+        renderInput({
+            threadUuid: null,
+            onSqlModeChange: vi.fn(),
+            showAgentSelector: true,
+        });
+
+        expect(
+            screen.getAllByRole('button', { name: 'Toggle SQL Runner' }),
+        ).toHaveLength(1);
     });
 
     it('starts research with one click and resets the toggle after submission', async () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -119,6 +119,7 @@ interface AgentChatInputProps {
     revealControlsOnFocus?: boolean;
     // Shrinks padding/min-heights for a more compact composer.
     dense?: boolean;
+    showDeepResearchBelowComposer?: boolean;
 }
 
 const extractToolHints = (editor: Editor | null): string[] => {
@@ -164,6 +165,7 @@ export const AgentChatInput = ({
     contentMentionPriorityItems = [],
     revealControlsOnFocus = false,
     dense = false,
+    showDeepResearchBelowComposer = false,
 }: AgentChatInputProps) => {
     const user = useUser(true);
     const [value, setValueState] = useState(defaultValue ?? '');
@@ -579,27 +581,31 @@ export const AgentChatInput = ({
     const showDeepResearchNudge =
         nudgeState === 'shown' && isDeepResearchDraft(value);
 
-    const deepResearchControl = canStartDeepResearch ? (
-        <DeepResearchModeControl
-            mode={composerMode}
-            onModeChange={setComposerMode}
-            disabled={hasActiveDeepResearchRun}
-            disabledReason={ACTIVE_DEEP_RESEARCH_DISABLED_REASON}
-            nudge={showDeepResearchNudge}
-        />
-    ) : null;
-    const compactDeepResearchControl = canStartDeepResearch ? (
-        <DeepResearchModeControl
-            mode={composerMode}
-            onModeChange={setComposerMode}
-            disabled={hasActiveDeepResearchRun}
-            disabledReason={ACTIVE_DEEP_RESEARCH_DISABLED_REASON}
-            iconOnly
-            actionSize="sm"
-            iconSize={14}
-            nudge={showDeepResearchNudge}
-        />
-    ) : null;
+    const shouldShowDeepResearchBelowComposer =
+        isThreadInput || showDeepResearchBelowComposer;
+    const deepResearchControl =
+        canStartDeepResearch && !shouldShowDeepResearchBelowComposer ? (
+            <DeepResearchModeControl
+                mode={composerMode}
+                onModeChange={setComposerMode}
+                disabled={hasActiveDeepResearchRun}
+                disabledReason={ACTIVE_DEEP_RESEARCH_DISABLED_REASON}
+                nudge={showDeepResearchNudge}
+            />
+        ) : null;
+    const compactDeepResearchControl =
+        canStartDeepResearch && shouldShowDeepResearchBelowComposer ? (
+            <DeepResearchModeControl
+                mode={composerMode}
+                onModeChange={setComposerMode}
+                disabled={hasActiveDeepResearchRun}
+                disabledReason={ACTIVE_DEEP_RESEARCH_DISABLED_REASON}
+                iconOnly
+                actionSize="sm"
+                iconSize={14}
+                nudge={showDeepResearchNudge}
+            />
+        ) : null;
     const chipRow = useMemo(() => {
         if (!emptyStateMode && !postResponseMode) return null;
         if (suggestionsQuery.isError) return null;
@@ -688,7 +694,7 @@ export const AgentChatInput = ({
         iconSize: number;
     }) => {
         if (
-            !isThreadInput ||
+            !shouldShowDeepResearchBelowComposer ||
             (!compactDeepResearchControl && !showSqlModeControl)
         ) {
             return null;
@@ -779,14 +785,14 @@ export const AgentChatInput = ({
                         variant="inline"
                         toolbarRight={
                             <Group gap={4} align="center" wrap="nowrap">
-                                {!isThreadInput && deepResearchControl}
+                                {deepResearchControl}
                                 {renderComposerAction('sm')}
                             </Group>
                         }
                     />
                 </Box>
 
-                {isThreadInput
+                {shouldShowDeepResearchBelowComposer
                     ? renderExternalModeControls({
                           actionSize: 'sm',
                           iconSize: 14,
@@ -832,7 +838,7 @@ export const AgentChatInput = ({
                 className={styles.agentComposer}
                 onMouseDown={handleInputCardMouseDown}
                 toolbarLeft={
-                    !isThreadInput &&
+                    !shouldShowDeepResearchBelowComposer &&
                     renderSqlModeControl({
                         actionSize: 30,
                         iconSize: 15,
@@ -840,14 +846,13 @@ export const AgentChatInput = ({
                 }
                 toolbarRight={
                     <Group gap="xs" align="center" wrap="nowrap">
-                        {((!isThreadInput && deepResearchControl) ||
-                            showAgentSelector) && (
+                        {(deepResearchControl || showAgentSelector) && (
                             <Box
                                 className={styles.controlsReveal}
                                 data-visible={hasClickedInput}
                             >
                                 <Group gap="xs" align="center" wrap="nowrap">
-                                    {!isThreadInput && deepResearchControl}
+                                    {deepResearchControl}
 
                                     {showAgentSelector && (
                                         <AgentSelector

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -403,6 +403,7 @@ const NewThreadPanel: FC<{
                     projectUuid={projectUuid}
                     agentUuid={concreteAgent?.uuid}
                     fullWidth
+                    showDeepResearchBelowComposer
                     sqlMode={sqlModeAvailable && !isAuto ? sqlMode : undefined}
                     onSqlModeChange={
                         sqlModeAvailable && !isAuto


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-10116/show-deep-research-as-a-compact-composer-icon-in-aurora

## Summary

Moves Deep Research out of the Aurora launcher composer and into the compact action row beneath it.

This is scoped to the launcher new-thread panel only. The homepage, other new-thread composers, and existing threads keep their current layouts. The existing SQL action remains beside the compact Deep Research action when available.

## Before / after

```text
Before: [ Ask Aurora anything… | Deep research | Send ]
After:  [ Ask Aurora anything…                 | Send ]
                                         [ telescope ] [ SQL ]
```

## Verification

- Chrome DevTools: Aurora launcher with pinned context, normal and focused states
- Chrome DevTools: enable/disable tooltip and pressed state
- Focused Vitest suite: 9/9
- Frontend typecheck
- Frontend lint
- git diff --check

The test coverage also verifies that the launcher retains both compact actions and that ordinary card composers do not gain a duplicate SQL action.
