### PR TITLE
ci: cut release pipeline latency

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           persist-credentials: false
-          fetch-depth: 0
           ref: ${{ github.event.release.tag_name }}
 
       # ========================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build-and-test:
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
     name: Build & Test
     runs-on: depot-ubuntu-24.04-8
     env:
@@ -37,7 +38,8 @@ jobs:
         run: pnpm build
 
   release:
-    runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    runs-on: depot-ubuntu-24.04-8
     timeout-minutes: 20
     needs: build-and-test
     concurrency: ${{ github.ref }}
@@ -53,6 +55,7 @@ jobs:
         with:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Setup Socket Firewall
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2


### PR DESCRIPTION
## What changed

- fetch full Git history in the release checkout before semantic-release runs
- skip both Build & Release jobs for generated `chore(release):` pushes
- run the release job on the existing 8-core Depot runner
- keep the post-release image checkout shallow while still checking out the release tag

## Baseline and expected savings

Feature merge to Helm chart bump averages about 21 minutes across the latest 20 releases.

- **Release history fetch:** semantic-release currently spends 175–415 seconds silently unshallowing the repository. A full checkout normally takes 23–60 seconds in the profiled release workflows, so moving the required history fetch into checkout should save roughly 2–6 minutes on a typical release and make the remaining fetch visible.
- **Generated release commit:** the `chore(release):` push starts a second Build & Release run that cannot publish another release. Skipping it saves about 13.5 billed runner-minutes per release and removes avoidable runner/cache contention; it is not on the release critical path.
- **Release runner:** the release job currently spends about 151 seconds installing dependencies before sequential pnpm builds on a 2-core runner. Moving it to the existing 8-core Depot runner should materially reduce that section; the exact saving will be measured from subsequent releases.
- **Post-release image checkout:** checking out only the tagged commit should save tens of seconds versus the usual 23–60 second full clone and avoid recurrence of the observed 400-second full-clone outlier.

## Chore-run dependency conclusion

Nothing depends on the generated release commit's follow-up Build & Release run. The release-producing run has already generated artifacts, built and published packages, pushed the release commit and tag, and published the GitHub release before that push can trigger another workflow. The follow-up build/test run only contributed about 1.7 minutes of speculative Turbo cache priming, which is too small to justify the duplicate workflow.

## Authentication

The release checkout still uses `CI_GITHUB_TOKEN` with `persist-credentials: false`, and semantic-release still receives the same token through `GITHUB_TOKEN`. Fetching full history does not change the push authentication path or commit-signing configuration.

## Validation

- `git diff --check`
- `actionlint .github/workflows/release.yml .github/workflows/post-release.yml` (the changed syntax passes; the command reports existing custom Depot runner-label and unrelated ShellCheck/expression findings elsewhere in these workflows)

Linear: SPK-991
