### PR TITLE
fix(ci): move the release job back to a GitHub-hosted runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,10 @@ jobs:
 
   release:
     if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
-    runs-on: depot-ubuntu-24.04-8
+    # Must stay on a GitHub-hosted runner: npm's trusted-publishing provenance
+    # rejects self-hosted/Depot runners (422 "Unsupported GitHub Actions runner
+    # environment", run 31724064116).
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: build-and-test
     concurrency: ${{ github.ref }}


### PR DESCRIPTION
## Problem

The depot runner switch in #27361 broke npm package publishing: npm's trusted publishing rejects provenance bundles generated on self-hosted runners — run 31724064116 failed with `422 Unprocessable Entity — Error verifying sigstore provenance bundle: Unsupported GitHub Actions runner environment` on `pnpm publish` of @lightdash/common.

Because publish aborted mid-release, 1.151.1 is half-cut: the tag and `chore(release): 1.151.1` commit exist on main, but there is no GitHub release, no npm packages, and no Docker image for it.

## Fix

Move the `release` job back to `ubuntu-latest` (GitHub-hosted). The other #27361 changes are unaffected and stay:
- `fetch-depth: 0` — validated: the 3–7 min silent unshallow inside semantic-release is gone (release job reached publish in 4.4 min vs ~7+ before)
- `chore(release)` skip guard — validated: the 1.151.1 chore push was skipped
- shallow checkout in post-release — unrelated to this failure

## Recovery

This commit is typed `fix(ci)` so merging it cuts **1.151.2**, which ships the stranded `fix(data-apps)` change (npm + Docker + helm). The orphaned `1.151.1` tag stays — semantic-release will simply release 1.151.2 on top; 1.151.1 becomes a version gap on npm/DockerHub (its changes are documented in CHANGELOG under 1.151.1 but ship in 1.151.2).

Linear: SPK-991

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fs2X73ppqtUpVNHkjSrC4g