### PR TITLE
fix: stop persisting checkout credentials in upgrade verification

### DIFF
--- a/examples/upgrade-automation/template-workflow.yml
+++ b/examples/upgrade-automation/template-workflow.yml
@@ -97,6 +97,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           token: ${{ secrets.UPGRADE_AUTOMATION_TOKEN || github.token }}
+          persist-credentials: false
       - uses: lightdash/lightdash/examples/upgrade-automation/verify@REPLACE_WITH_LIGHTDASH_COMMIT_SHA
         with:
           instance_url: ${{ env.LIGHTDASH_INSTANCE_URL }}


### PR DESCRIPTION
Sets `persist-credentials: false` on the verification job's checkout in the
upgrade-automation example workflow, matching the plan job (#27243).

Nothing in the verify path relies on ambient git credentials. The only git
invocation is a local `merge-base --is-ancestor` ancestry check against the
already-fetched history; every GitHub interaction goes through `gh` with an
explicitly supplied token. No conversion was needed, unlike the plan path.

### Per-job permissions

Reviewed each job's `permissions:` block against the API calls its steps
actually make. No block can be narrowed:

- `freeze-check` / `freeze-announce` — `issues: read`, one `gh issue list` each.
- `plan` — `contents: write` for the `createCommitOnBranch` mutation and branch
  ref create/update, `pull-requests: write` for create/edit/comment/auto-merge,
  `issues: read` for the freeze-label check.
- `verify` — `issues: write` for label and freeze-issue creation on the failure
  path, `pull-requests: write` for the summary comment, `contents: read` for the
  checkout. `contents: read` is unused when `UPGRADE_AUTOMATION_TOKEN` is
  configured, but removing it would break the documented `github.token`
  fallback, so it stays.

Linear: SPK-971
