### PR TITLE
fix: require a boolean verdict in upgrade-automation gate output

### DIFF
--- a/.github/workflows/upgrade-automation-tests.yml
+++ b/.github/workflows/upgrade-automation-tests.yml
@@ -14,4 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - run: bash examples/upgrade-automation/scripts/common.test.sh
       - run: bash examples/upgrade-automation/scripts/verify.test.sh

--- a/examples/upgrade-automation/scripts/common.sh
+++ b/examples/upgrade-automation/scripts/common.sh
@@ -105,6 +105,7 @@ validate_verdict_json() {
         (.fromVersion | type == "string") and
         (.toVersion | type == "string") and
         (.safe | type == "boolean") and
+        (.verdict | type == "boolean") and
         (.requiredStops | type == "array") and
         all(.requiredStops[]; type == "string" and test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) and
         (.coveredVersions | type == "array") and

--- a/examples/upgrade-automation/scripts/common.test.sh
+++ b/examples/upgrade-automation/scripts/common.test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+base_verdict='{
+  "coveredVersions": ["1.2.4"],
+  "direction": "forward",
+  "fromVersion": "1.2.3",
+  "minPreviousVersion": null,
+  "missingRanges": [],
+  "requiredStops": [],
+  "safe": true,
+  "toVersion": "1.2.4",
+  "verdict": true
+}'
+
+failures=0
+
+with_field() {
+    local field=$1
+    local value=$2
+    jq -c --argjson value "$value" ".${field} = \$value" <<<"$base_verdict"
+}
+
+expect_accepted() {
+    local label=$1
+    local payload=$2
+    if ! printf '%s' "$payload" | validate_verdict_json; then
+        printf 'expected %s to be accepted\n' "$label" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+expect_rejected() {
+    local label=$1
+    local payload=$2
+    if printf '%s' "$payload" | validate_verdict_json 2>/dev/null; then
+        printf 'expected %s to be rejected\n' "$label" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+expect_accepted 'a boolean true verdict' "$(with_field verdict true)"
+expect_accepted 'a boolean false verdict' "$(with_field verdict false)"
+
+expect_rejected 'a string "true" verdict' "$(with_field verdict '"true"')"
+expect_rejected 'a string "false" verdict' "$(with_field verdict '"false"')"
+expect_rejected 'a null verdict' "$(with_field verdict null)"
+expect_rejected 'a numeric verdict' "$(with_field verdict 1)"
+expect_rejected 'an object verdict' "$(with_field verdict '{}')"
+expect_rejected 'a missing verdict' "$(jq -c 'del(.verdict)' <<<"$base_verdict")"
+
+expect_rejected 'a string safe flag' "$(with_field safe '"true"')"
+expect_rejected 'a non-string fromVersion' "$(with_field fromVersion 123)"
+expect_rejected 'a non-array requiredStops' "$(with_field requiredStops '"1.2.4"')"
+expect_rejected 'an unexpected extra key' "$(jq -c '.unexpected = true' <<<"$base_verdict")"
+expect_rejected 'malformed json' 'not json at all'
+
+if [[ $failures -ne 0 ]]; then
+    printf '%s verdict validation assertion(s) failed\n' "$failures" >&2
+    exit 1
+fi
+
+printf 'verdict validation tests passed\n'

--- a/examples/upgrade-automation/scripts/plan.sh
+++ b/examples/upgrade-automation/scripts/plan.sh
@@ -182,7 +182,7 @@ if [[ -z "$selected_version" ]]; then
     if ! run_gate "$next_version"; then
         exit 0
     fi
-    if [[ "$(jq -r '.verdict' <<<"$GATE_JSON")" != "false" ]]; then
+    if ! jq -e '.verdict == false' <<<"$GATE_JSON" >/dev/null; then
         exit 0
     fi
     selected_version=$next_version


### PR DESCRIPTION
## What

`validate_verdict_json` in the upgrade-automation example validated the type of `.safe` but not `.verdict`, while `plan.sh` consumed `.verdict` through two different disciplines:

- a jq boolean predicate (`.verdict == true`), which rejects a string
- a shell string comparison (`[[ "$(jq -r '.verdict')" != "false" ]]`), which accepts one

`jq -r` renders the JSON string `"false"` and the JSON boolean `false` as the same shell text, so a malformed payload could take a different branch depending on which check saw it.

## Changes

- `common.sh` — require `.verdict` to be a boolean in `validate_verdict_json`, alongside the existing `.safe` check.
- `plan.sh` — normalise the remaining string comparison to a boolean predicate, matching the `jq -e ... >/dev/null` idiom used elsewhere in the script.
- `common.test.sh` — new focused coverage for malformed verdict payloads (string, null, numeric, object, missing, plus the neighbouring field guards).
- `upgrade-automation-tests.yml` — run the new test in CI.

The validator runs inside `run_gate()` before every consumption, so the type check fixes the class; normalising the comparison is defence in depth.

## Verification

- `common.test.sh` passes, and fails 5 assertions with the validator line reverted, so the coverage is not vacuous.
- `verify.test.sh` still passes.
- `actionlint` clean on the workflow; `bash -n` clean on all touched scripts; no new `shellcheck` warnings.

Linear: SPK-970