### PR TITLE
fix(upgrade-automation): separate plan and verify concurrency groups

### DIFF
--- a/examples/upgrade-automation/template-freeze-workflow.yml
+++ b/examples/upgrade-automation/template-freeze-workflow.yml
@@ -19,7 +19,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: lightdash-upgrade-${{ github.repository }}
+  group: lightdash-upgrade-${{ github.repository }}-plan
   cancel-in-progress: false
 
 env:

--- a/examples/upgrade-automation/template-workflow.yml
+++ b/examples/upgrade-automation/template-workflow.yml
@@ -22,7 +22,11 @@ on:
 permissions: {}
 
 concurrency:
-  group: lightdash-upgrade-${{ github.repository }}
+  group: >-
+    lightdash-upgrade-${{ github.repository }}-${{
+    github.event_name == 'workflow_run' && 'verify'
+    || github.event_name == 'issues' && 'freeze-announce'
+    || 'plan' }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
## What changed

`examples/upgrade-automation/template-workflow.yml` applied one workflow-level concurrency group to every trigger. With `cancel-in-progress: false`, a scheduled planning run held that group while post-deploy verification queued behind it — and verification is the time-critical path, planning is not.

The group key now derives from `github.event_name`, so the three paths queue independently:

| Trigger | Group suffix | Jobs that run |
|---|---|---|
| `schedule`, `workflow_dispatch`, `repository_dispatch` | `-plan` | `freeze-check` + `plan` |
| `workflow_run` | `-verify` | `verify` |
| `issues` | `-freeze-announce` | `freeze-announce` |

The jobs are already mutually exclusive by trigger, so a workflow-level expression splits cleanly along the same seam — and it keeps `freeze-check` + `plan` as one indivisible unit, which per-job groups would have let concurrent planning runs interleave.

`cancel-in-progress` stays `false` on every path, verification included. Each verify run is bound to one deployment's `head_sha` and owns that deployment's verdict, hold and escalation; cancelling it on a newer deploy would drop the older deployment's verification with no verdict and no escalation. Hold/escalation behaviour is unchanged. Serialisation on the verify path is bounded by `LIGHTDASH_VERIFY_WINDOW`.

The key stays anchored on `github.repository` only. `github.ref` is *not* used: it is the default branch on `schedule`, `issues` and `workflow_run`, but whatever ref the operator picked on `workflow_dispatch` — including it would split the planning group and let a dispatched run race a scheduled one.

`template-freeze-workflow.yml` shared the old group string verbatim (concurrency groups are repo-wide, not workflow-scoped), so renaming the planning group would have silently unshared them. It is pinned to the `-plan` key, leaving toggle-vs-planning serialisation exactly as it is today.

## Verification

- `actionlint` clean on both files, identical to the `origin/main` baseline.
- Folded group scalar parsed back with PyYAML to confirm it renders as one line.
- Repeated planning runs still serialise (same `-plan` key, `cancel-in-progress: false`); an in-flight planning run no longer holds a group that verification needs.

Linear: SPK-972