### PR TITLE
feat(backend): add duration_ms to upgrade telemetry events

### DIFF
--- a/docs/upgrade-telemetry.md
+++ b/docs/upgrade-telemetry.md
@@ -31,6 +31,7 @@ explicit nulls.
 | `span_migrations` | Pending Knex migration count for an attempt, or the preflight pending-migrations check count. |
 | `execution_mode` | Sanitized `LIGHTDASH_MIGRATION_EXECUTION_MODE`, or `unknown`. |
 | `duration_seconds` | Rounded elapsed seconds from attempt start to a terminal event. |
+| `duration_ms` | Elapsed milliseconds from attempt start to a terminal event; null on non-terminal events. Prefer this for typical-run durations — `duration_seconds` floors sub-second runs to 0. |
 | `attempt` | Run-ledger attempt number. Takeover and preflight events use null. |
 | `outcome` | `succeeded`, `retrying`, `parked`, or null for non-terminal events and abandoned runs. |
 | `failure_class` | Stable failure category below, or null when no failure occurred. |

--- a/packages/backend/src/analytics/upgradeTelemetryEvents.ts
+++ b/packages/backend/src/analytics/upgradeTelemetryEvents.ts
@@ -26,6 +26,7 @@ export type UpgradeEventProperties = {
     span_migrations: number | null;
     execution_mode: string;
     duration_seconds: number | null;
+    duration_ms: number | null;
     attempt: number | null;
     outcome: 'succeeded' | 'parked' | 'retrying' | null;
     failure_class: UpgradeFailureClass | null;

--- a/packages/backend/src/scripts/migrate/cli.test.ts
+++ b/packages/backend/src/scripts/migrate/cli.test.ts
@@ -198,6 +198,7 @@ const context = (
 
 const upgradePropertyKeys = [
     'attempt',
+    'duration_ms',
     'duration_seconds',
     'execution_mode',
     'failing_migration',
@@ -248,6 +249,7 @@ describe('runMigrateCli', () => {
             span_migrations: 1,
             attempt: 1,
             duration_seconds: null,
+            duration_ms: null,
             outcome: null,
         });
         expect(command.upgradeEvents[1]?.properties).toMatchObject({
@@ -256,6 +258,7 @@ describe('runMigrateCli', () => {
             span_migrations: 1,
             attempt: 1,
             duration_seconds: 5,
+            duration_ms: 5000,
             outcome: 'succeeded',
         });
         command.upgradeEvents.forEach(({ properties }) => {
@@ -873,6 +876,7 @@ describe('runMigrateCli', () => {
             migration_run_uuid: 'run-1',
             attempt: null,
             duration_seconds: null,
+            duration_ms: null,
             outcome: null,
         });
     });

--- a/packages/backend/src/scripts/migrate/cli.ts
+++ b/packages/backend/src/scripts/migrate/cli.ts
@@ -439,6 +439,7 @@ const createUpgradeRunTracker = (
         span_migrations: run.spanMigrations,
         execution_mode: executionMode,
         duration_seconds: null,
+        duration_ms: null,
         attempt: null,
         outcome: null,
         failure_class: null,
@@ -467,12 +468,12 @@ const createUpgradeRunTracker = (
                       stage: activeRun.failingMigration,
                       error,
                   });
+        const elapsedMs = context.now() - activeRun.startedAtMs;
         context.emitUpgradeEvent({
             event,
             properties: attemptProperties(activeRun, {
-                duration_seconds: Math.round(
-                    (context.now() - activeRun.startedAtMs) / 1_000,
-                ),
+                duration_seconds: Math.round(elapsedMs / 1_000),
+                duration_ms: elapsedMs,
                 attempt: activeRun.attempt,
                 outcome,
                 failure_class: failureClass,
@@ -507,6 +508,7 @@ const createUpgradeRunTracker = (
                         pendingMigrations?.data.migrations.length ?? null,
                     execution_mode: executionMode,
                     duration_seconds: null,
+                    duration_ms: null,
                     attempt: null,
                     outcome: null,
                     failure_class: 'preflight_blocked',

--- a/packages/backend/src/scripts/migrate/telemetry.test.ts
+++ b/packages/backend/src/scripts/migrate/telemetry.test.ts
@@ -31,6 +31,7 @@ const event: UpgradeTelemetryEvent = {
         span_migrations: 2,
         execution_mode: 'compose',
         duration_seconds: null,
+        duration_ms: null,
         attempt: 1,
         outcome: null,
         failure_class: null,


### PR DESCRIPTION
## Summary

Follow-up to #27353. `duration_seconds` is `Math.round(elapsedMs/1000)`, so any migration run under ~500ms reports 0 — which in practice is every routine boot pair observed in the 1.151.0 rollout, including a real 3-migration upgrade. That leaves "how long do typical upgrades take" unanswerable.

This adds `duration_ms` (exact elapsed milliseconds, explicit null on non-terminal events) alongside `duration_seconds` on the terminal upgrade lifecycle events. Additive on purpose: the warehouse already auto-created integer columns for `duration_seconds`, and the staging models that will consume these events (SPK-993) can pick up the new column cleanly. The multi-hour-migration legibility goal was never at risk — this is about resolution for the common case.

Docs table updated; test assertions extended (property-key completeness check now includes the new key).

Closes: SPK-994