### PR TITLE
ci: run the release job in parallel with the build gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,9 @@ jobs:
     # environment", run 31724064116).
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: build-and-test
+    # Deliberately no `needs: build-and-test`: a broken build aborts
+    # semantic-release during prepare, before the git plugin pushes the
+    # chore commit/tag, so gating on the build only adds serial latency.
     concurrency: ${{ github.ref }}
     permissions:
       contents: read


### PR DESCRIPTION
Drops `needs: build-and-test` from the release job in `release.yml` — ~1.5–2 min of serial latency on every release's critical path.

**Why it's safe**: the gate only builds (it runs no tests), and semantic-release's prepare phase (`generate-api:backend` + `build-published-packages`) rebuilds the same packages anyway. Plugin order in `release.config.js` means a broken build fails prepare **before** the git plugin pushes the chore commit and before any tag/release exists — so a broken build on main produces a red run, not a broken release. The build-and-test job itself stays (turbo cache priming + independent signal).

**Interaction note**: if SPK-995 (moving npm packaging to post-release) lands, prepare will only build common+backend, and this parallel gate becomes the main full-build validation without blocking tagging — residual risk assessed on the ticket.

Part of the release-latency work: baseline ~21 min merge→deployable, see SPK-991.

Linear: SPK-996

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fs2X73ppqtUpVNHkjSrC4g