### PR TITLE
ci: blobless full-history checkout in the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,11 @@ jobs:
         with:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           persist-credentials: false
+          # Full history for semantic-release, but blobless: old file contents
+          # are fetched on demand (the release-safety oasdiff step pulls the
+          # previous tag's swagger.json lazily).
           fetch-depth: 0
+          filter: blob:none
 
       - name: Setup Socket Firewall
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2


### PR DESCRIPTION
Adds `filter: blob:none` to the release job's `fetch-depth: 0` checkout (54s on the last release run). semantic-release needs commit history and tags — not every historical blob — and the working tree at HEAD is still fully materialised.

Old blobs are fetched on demand: the release-safety oasdiff step reads the previous tag's `swagger.json`, which triggers a single lazy fetch (anonymous, fine on a public repo). Worth watching on the first release after merge — flagged on the ticket.

Expected saving: ~30–40s per push to main. Part of the release-latency work (SPK-991).

Linear: SPK-997

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fs2X73ppqtUpVNHkjSrC4g