### PR TITLE
ci: harden release installs against sfw metadata-burst half-installs

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -284,7 +284,7 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         # Force reinstall so pnpm includes optional DuckDB native bindings
         # needed to build both macOS pkg targets from a single runner.
-        run: sfw pnpm install --filter @lightdash/cli --filter @lightdash/common --filter @lightdash/warehouses --frozen-lockfile --prefer-offline --prod=false --force --network-concurrency=16
+        run: sfw pnpm install --config.minimumReleaseAge=0 --filter @lightdash/cli --filter @lightdash/common --filter @lightdash/warehouses --frozen-lockfile --prefer-offline --prod=false --force --network-concurrency=16
 
       - name: Cache common build
         id: cache-common
@@ -654,7 +654,14 @@ jobs:
           cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install dependencies
-        run: sfw pnpm install --frozen-lockfile --prefer-offline --prod=false --network-concurrency=16
+        run: sfw pnpm install --config.minimumReleaseAge=0 --frozen-lockfile --prefer-offline --prod=false --network-concurrency=16
+
+      # sfw's proxy can die mid-install and still exit 0, leaving a partial
+      # node_modules (missing .bin links — releases 1.151.3 attempts 1+2 both
+      # failed on `tsoa: not found`). Same repair pattern as release.config.js:
+      # plain pnpm relinks from the lockfile with honest exit codes.
+      - name: Repair install without sfw
+        run: pnpm install --prefer-offline
 
       - name: Generate backend API artifacts
         run: pnpm generate-api:backend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
       - name: Install packages
-        run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+        run: sfw pnpm install --config.minimumReleaseAge=0 --frozen-lockfile --prefer-offline --network-concurrency=16
       - name: Generate backend API artifacts
         run: pnpm generate-api:backend
       - name: Build all packages
@@ -86,7 +86,7 @@ jobs:
         run: sfw npm install -g npm@12.0.1
 
       - name: Install dependencies
-        run: sfw pnpm install --frozen-lockfile --prefer-offline --prod=false --network-concurrency=16
+        run: sfw pnpm install --config.minimumReleaseAge=0 --frozen-lockfile --prefer-offline --prod=false --network-concurrency=16
 
       # PROD-8359: install oasdiff so the release-safety marker generator can diff
       # the REST API (swagger.json) between the previous tag and HEAD for breaking


### PR DESCRIPTION
Linear: SPK-981

## Summary

pnpm 11 minimumReleaseAge causes roughly 3,000 metadata GETs per install. Sending that fan-out through sfw can collapse its proxy and leave node_modules half-installed even though sfw exits successfully. This was redundant for these frozen-lockfile installs: the lockfile already gated versions under the release-age policy when it was written.

The 1.151.3 publish runs, 31729466368 attempts 1 and 2, both then failed with `tsoa: not found`.

Release installs now set `minimumReleaseAge=0`, avoiding the redundant metadata recheck. The npm-publish job also performs a plain pnpm repair install after sfw, following the `release.config.js` precedent, so a half-install is relinked with pnpm’s normal exit semantics before API generation and publishing.

## Non-destructive test plan

- Dispatch `post-release.yml` from this branch with `tag=1.151.3`. This workflow_dispatch path runs only `publish-npm-packages`; the other post-release jobs remain gated on `github.event_name == release`.
- Confirm the job checks out the existing 1.151.3 tag, completes its package publication path, and report whether `Repair install without sfw` performed any work.
- Verify the already-published package versions with `npm view @lightdash/common@1.151.3 version` and `npm view @lightdash/cli@1.151.3 version`.

This does not create a release or change the tag.