### PR TITLE
ci: repair installs after sfw so a silent exit-0 fails loudly

### DIFF
--- a/.github/workflows/_setup_node_pnpm_cypress/action.yml
+++ b/.github/workflows/_setup_node_pnpm_cypress/action.yml
@@ -26,6 +26,12 @@ runs:
         - name: Install Dependencies
           run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
           shell: bash
+        # sfw can exit 0 with a partial tree; this relinks it with an honest exit code. CI= is
+        # load-bearing: under CI=true pnpm trusts its state file and skips the filesystem check,
+        # so a missing .bin would not be repaired (SPK-981).
+        - name: Repair install without sfw
+          shell: bash
+          run: CI= pnpm install --frozen-lockfile --prefer-offline
 
         - name: Install Cypress
           run: sfw pnpm exec cypress install

--- a/.github/workflows/ai-agent-integration-tests.yml
+++ b/.github/workflows/ai-agent-integration-tests.yml
@@ -56,6 +56,11 @@ jobs:
 
             - name: Install packages
               run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+            # sfw can exit 0 with a partial tree; this relinks it with an honest exit code. CI= is
+            # load-bearing: under CI=true pnpm trusts its state file and skips the filesystem check,
+            # so a missing .bin would not be repaired (SPK-981).
+            - name: Repair install without sfw
+              run: CI= pnpm install --frozen-lockfile --prefer-offline
 
             - name: Build common
               run: pnpm common-build

--- a/.github/workflows/ai-security-advisories.yml
+++ b/.github/workflows/ai-security-advisories.yml
@@ -138,6 +138,11 @@ jobs:
 
             - name: Install root dependencies
               run: sfw pnpm install --frozen-lockfile --filter . --network-concurrency=16
+            # sfw can exit 0 with a partial tree; this relinks it with an honest exit code. CI= is
+            # load-bearing: under CI=true pnpm trusts its state file and skips the filesystem check,
+            # so a missing .bin would not be repaired (SPK-981).
+            - name: Repair install without sfw
+              run: CI= pnpm install --frozen-lockfile --prefer-offline --filter .
 
             - name: Analyze release and create eligible private drafts
               env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -136,6 +136,11 @@ jobs:
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install packages
         run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+      # sfw can exit 0 with a partial tree; this relinks it with an honest exit code. CI= is
+      # load-bearing: under CI=true pnpm trusts its state file and skips the filesystem check,
+      # so a missing .bin would not be repaired (SPK-981).
+      - name: Repair install without sfw
+        run: CI= pnpm install --frozen-lockfile --prefer-offline
       - name: Build
         run: pnpm build
       - name: Run quality checks in parallel
@@ -181,6 +186,11 @@ jobs:
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install packages
         run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+      # sfw can exit 0 with a partial tree; this relinks it with an honest exit code. CI= is
+      # load-bearing: under CI=true pnpm trusts its state file and skips the filesystem check,
+      # so a missing .bin would not be repaired (SPK-981).
+      - name: Repair install without sfw
+        run: CI= pnpm install --frozen-lockfile --prefer-offline
       - name: Build SDK bundle
         run: pnpm sdk-build
       - name: Check SDK bundle is CSP-safe
@@ -241,6 +251,10 @@ jobs:
       - name: Generate base OpenAPI schema
         run: |
           sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+          # sfw can exit 0 with a partial tree; this relinks it with an honest exit code. CI= is
+          # load-bearing: under CI=true pnpm trusts its state file and skips the filesystem check,
+          # so a missing .bin would not be repaired (SPK-981).
+          CI= pnpm install --frozen-lockfile --prefer-offline
           pnpm generate-api
           cp packages/backend/src/generated/swagger.json /tmp/base-swagger.json
       - name: Checkout PR
@@ -248,6 +262,10 @@ jobs:
       - name: Generate PR OpenAPI schema
         run: |
           sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+          # sfw can exit 0 with a partial tree; this relinks it with an honest exit code. CI= is
+          # load-bearing: under CI=true pnpm trusts its state file and skips the filesystem check,
+          # so a missing .bin would not be repaired (SPK-981).
+          CI= pnpm install --frozen-lockfile --prefer-offline
           pnpm generate-api
       - name: Check for OpenAPI breaking changes
         if: ${{ !contains(github.event.pull_request.body, 'allow-api-breaking-change') }}
@@ -556,6 +574,11 @@ jobs:
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install packages
         run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+      # sfw can exit 0 with a partial tree; this relinks it with an honest exit code. CI= is
+      # load-bearing: under CI=true pnpm trusts its state file and skips the filesystem check,
+      # so a missing .bin would not be repaired (SPK-981).
+      - name: Repair install without sfw
+        run: CI= pnpm install --frozen-lockfile --prefer-offline
       - name: Build packages/common module
         run: pnpm common-build
       - name: Create BigQuery credentials file

--- a/.github/workflows/publish-e2b-template.yml
+++ b/.github/workflows/publish-e2b-template.yml
@@ -101,10 +101,22 @@ jobs:
       - name: Install root deps
         if: steps.plan.outputs.action == 'build' && inputs.install_root_deps
         run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+      # sfw can exit 0 with a partial tree; this relinks it with an honest exit code. CI= is
+      # load-bearing: under CI=true pnpm trusts its state file and skips the filesystem check,
+      # so a missing .bin would not be repaired (SPK-981).
+      - name: Repair root install without sfw
+        if: steps.plan.outputs.action == 'build' && inputs.install_root_deps
+        run: CI= pnpm install --frozen-lockfile --prefer-offline
 
       - name: Install sandbox deps
         working-directory: ${{ inputs.template_directory }}
         run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+      # sfw can exit 0 with a partial tree; this relinks it with an honest exit code. CI= is
+      # load-bearing: under CI=true pnpm trusts its state file and skips the filesystem check,
+      # so a missing .bin would not be repaired (SPK-981).
+      - name: Repair sandbox install without sfw
+        working-directory: ${{ inputs.template_directory }}
+        run: CI= pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build and publish template
         if: steps.plan.outputs.action == 'build'


### PR DESCRIPTION
#27380 took Socket Firewall off the release pipeline, but PR CI still installs behind it. This adds the completeness guard to those installs.

## The problem

sfw's uncaught-error handler tears down its proxy **without setting an exit code** — [sfw-free#61](https://github.com/SocketDev/sfw-free/issues/61) quotes it out of the shipped 1.15.0 binary — and registering an `unhandledRejection` listener also suppresses Node's default of dying on unhandled rejections. A dead proxy therefore leaves a partial `node_modules` behind a green install step.

Observed earlier today in `Publish npm Packages` ([job 94548942998](https://github.com/lightdash/lightdash/actions/runs/31731320829/job/94548942998)):

```
18:24:01  install done, 0 downloaded (warm store)
18:25:01  56 registry warnings in one second
18:26:11  49 more
18:26:20  sfw ETIMEDOUT → "Install dependencies" conclusion: SUCCESS (2m41s)
18:26:20  "Generate backend API artifacts" → sh: 1: tsoa: not found → FAILURE
```

The install reported success at the same second sfw errored, with retries still outstanding. It is also why `sfw … || fallback` guards never fire — `||` cannot trigger on exit 0.

## The change

Each unguarded sfw install is followed by `CI= pnpm install --frozen-lockfile --prefer-offline`, which relinks from the unchanged lockfile without a proxy and with an honest exit code.

10 sites: the e2e composite action, `pr.yml` ×5 (3 steps plus 2 inside existing `run` blocks), `ai-agent-integration-tests`, `ai-security-advisories` (matching its `--filter .`), `publish-e2b-template` ×2 (mirroring their `if:` and `working-directory:`).

Left alone, because they already verify-then-repair: `mcp-tools-snapshot-check`, `release-safety-pr`, `release-safety-tests`.

## `CI=` is load-bearing, and this is the part worth reviewing

A repair step that runs as `pnpm install --prefer-offline` under Actions does nothing at all. Measured on pnpm 11.20.0, clean room — fresh good tree, exactly one break, one command, per row:

| Command | missing `.bin` link | missing package dir | time |
|---|---|---|---|
| `CI=true pnpm install --frozen-lockfile --prefer-offline` | not repaired | not repaired | 0.32s |
| `CI=true pnpm install --prefer-offline --force` | not repaired | not repaired | 0.32s |
| `CI=true pnpm install --frozen-lockfile --prefer-offline --force` | not repaired | not repaired | 0.32s |
| **`CI= pnpm install --frozen-lockfile --prefer-offline`** | **repaired** | **repaired** | 0.40s |

Under `CI=true` pnpm trusts its own state file and skips checking the tree on disk, so it reports "Already up to date" over a tree that is missing binaries. `--force` does not change that. With `CI` unset it verifies the filesystem and relinks. `--frozen-lockfile` is passed explicitly so the strictness CI mode would otherwise imply is kept, and the lockfile is verified byte-identical after a repair.

Strict `--offline` is deliberately not used — `release.config.js` records that it already failed with `ERR_PNPM_NO_OFFLINE_TARBALL` (run 30492147529), because the runner store lacks some lockfile tarballs even after an install step.

## Not in scope

No `minimumReleaseAge` overrides — the 3-day publish cooldown stays active on every CI install, per #27381. This PR only makes an incomplete install fail loudly; it does not change what gets installed or which versions are eligible.

`--network-concurrency` is unchanged too. The metadata burst behind these timeouts runs ~60 requests concurrently against a nominal cap of 16, so that phase does not honour the setting, and 16 is pnpm's default anyway.

Linear: SPK-981
