### PR TITLE
feat(explorer): drill into merged source fields

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -16,6 +16,7 @@ import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';
 import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
 import { useMergeQuickFilter } from '../../../features/mergeQuery/hooks/useMergeQuickFilter';
+import { useMergeSourceCell } from '../../../features/mergeQuery/hooks/useMergeSourceCell';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { Can } from '../../../providers/Ability';
@@ -46,7 +47,7 @@ const CellContextMenu: FC<
     const { openUnderlyingDataModal, metricQuery } =
         useMetricQueryDataContext();
     const { track } = useTracking();
-    const { showToastSuccess } = useToaster();
+    const { showToastError, showToastSuccess } = useToaster();
     const clipboard = useClipboard({ timeout: 2000 });
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
@@ -62,20 +63,49 @@ const CellContextMenu: FC<
         () => mapValues(cell.row.original, (v) => v?.value) || {},
         [cell.row.original],
     );
+    const { prepareUnderlyingData, resolve: resolveMergeSourceCell } =
+        useMergeSourceCell();
+    const resolvedSourceCell = useMemo(
+        () =>
+            isMerged && item && isField(item)
+                ? resolveMergeSourceCell(item, fieldValues)
+                : null,
+        [fieldValues, isMerged, item, resolveMergeSourceCell],
+    );
+    const underlyingMetricQuery =
+        resolvedSourceCell?.source.metricQuery ?? metricQuery;
 
     const handleCopyToClipboard = useCallback(() => {
         clipboard.copy(value.formatted);
         showToastSuccess({ title: 'Copied to clipboard!' });
     }, [value, clipboard, showToastSuccess]);
 
-    const handleViewUnderlyingData = useCallback(() => {
+    const handleViewUnderlyingData = useCallback(async () => {
         if (meta?.item === undefined) return;
-
-        openUnderlyingDataModal({
-            item: meta.item,
-            value,
-            fieldValues,
-        });
+        if (isMerged) {
+            if (!resolvedSourceCell) return;
+            try {
+                const prepared =
+                    await prepareUnderlyingData(resolvedSourceCell);
+                openUnderlyingDataModal({
+                    item: prepared.item,
+                    value,
+                    fieldValues: prepared.fieldValues,
+                    source: prepared.source,
+                });
+            } catch {
+                showToastError({
+                    title: 'Could not open underlying data',
+                });
+                return;
+            }
+        } else {
+            openUnderlyingDataModal({
+                item: meta.item,
+                value,
+                fieldValues,
+            });
+        }
         track({
             name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
             properties: {
@@ -92,6 +122,10 @@ const CellContextMenu: FC<
         track,
         user,
         projectUuid,
+        isMerged,
+        prepareUnderlyingData,
+        resolvedSourceCell,
+        showToastError,
     ]);
 
     const jsonValue =
@@ -119,11 +153,10 @@ const CellContextMenu: FC<
             {item &&
                 !isDimension(item) &&
                 !isCustomDimension(item) &&
-                !hasCustomBinDimension(metricQuery) &&
-                // A merged column descends from one of two queries, and
-                // nothing here knows which. Offering the drill would run it
-                // against an explore that does not exist.
-                !isMerged && (
+                !hasCustomBinDimension(underlyingMetricQuery) &&
+                // Merged actions only appear when compile-time lineage can
+                // resolve the display column back to a real source field.
+                (!isMerged || resolvedSourceCell) && (
                     <Can
                         I="view"
                         this={subject('UnderlyingData', {
@@ -161,15 +194,20 @@ const CellContextMenu: FC<
                         />
                     )}
 
-                <DrillDownMenuItem
-                    item={item}
-                    fieldValues={fieldValues}
-                    trackingData={{
-                        organizationId: user.data?.organizationUuid,
-                        userId: user.data?.userUuid,
-                        projectId: projectUuid,
-                    }}
-                />
+                {(!isMerged || resolvedSourceCell) && (
+                    <DrillDownMenuItem
+                        item={resolvedSourceCell?.item ?? item}
+                        fieldValues={
+                            resolvedSourceCell?.fieldValues ?? fieldValues
+                        }
+                        source={resolvedSourceCell?.source}
+                        trackingData={{
+                            organizationId: user.data?.organizationUuid,
+                            userId: user.data?.userUuid,
+                            projectId: projectUuid,
+                        }}
+                    />
+                )}
             </Can>
         </>
     );

--- a/packages/frontend/src/components/MetricQueryData/DrillDownMenuItem.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownMenuItem.tsx
@@ -25,6 +25,7 @@ const DrillDownMenuItem: FC<DrillDownMenuItemProps> = ({
     item,
     fieldValues,
     pivotReference,
+    source,
     trackingData,
 }) => {
     const { explore, metricQuery, openDrillDownModal } =
@@ -50,6 +51,7 @@ const DrillDownMenuItem: FC<DrillDownMenuItemProps> = ({
             item,
             fieldValues,
             pivotReference,
+            source,
         });
         track({
             name: EventName.DRILL_BY_CLICKED,
@@ -64,6 +66,7 @@ const DrillDownMenuItem: FC<DrillDownMenuItemProps> = ({
         item,
         openDrillDownModal,
         pivotReference,
+        source,
         track,
         trackingData.organizationId,
         trackingData.projectId,
@@ -74,9 +77,9 @@ const DrillDownMenuItem: FC<DrillDownMenuItemProps> = ({
         item &&
         isField(item) &&
         isMetric(item) &&
-        explore &&
+        (source || explore) &&
         fieldValues &&
-        metricQuery
+        (source?.metricQuery || metricQuery)
     ) {
         return (
             <Menu.Item

--- a/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
@@ -24,6 +24,7 @@ import { IconArrowBarToDown, IconExternalLink } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import { v4 as uuidv4 } from 'uuid';
+import { useExplore } from '../../hooks/useExplore';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import FieldSelect from '../common/FieldSelect';
 import MantineIcon from '../common/MantineIcon';
@@ -209,11 +210,18 @@ export const DrillDownModal: FC = () => {
     const {
         isDrillDownModalOpen,
         closeDrillDownModal,
-        explore,
-        metricQuery,
+        explore: contextExplore,
+        metricQuery: contextMetricQuery,
+        tableName,
         drillDownConfig,
         resolvedTimezone,
     } = useMetricQueryDataContext();
+    const source = drillDownConfig?.source;
+    const metricQuery = source?.metricQuery ?? contextMetricQuery;
+    const { data: sourceExplore } = useExplore(source?.tableName ?? tableName, {
+        refetchOnMount: false,
+    });
+    const explore = source ? sourceExplore : contextExplore;
 
     const dimensionsAvailable = useMemo(() => {
         if (!explore) return [];

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
@@ -54,13 +54,19 @@ const UnderlyingDataModalContent: FC = () => {
         parameters,
         resolvedTimezone,
     } = useMetricQueryDataContext();
+    const source = underlyingDataConfig?.source;
+    const effectiveTableName = source?.tableName ?? tableName;
+    const effectiveMetricQuery = source?.metricQuery ?? metricQuery;
+    const effectiveQueryUuid = source?.queryUuid ?? queryUuid;
 
     const [sorts, setSorts] = useState<SortField[]>([]);
 
     const { user } = useApp();
     const { data: organization } = useOrganization();
 
-    const { data: explore } = useExplore(tableName, { refetchOnMount: false });
+    const { data: explore } = useExplore(effectiveTableName, {
+        refetchOnMount: false,
+    });
     const ability = useAbilityContext();
 
     const underlyingDataItemId = useMemo(
@@ -74,10 +80,10 @@ const UnderlyingDataModalContent: FC = () => {
 
     const nonBinCustomDimensions = useMemo(
         () =>
-            metricQuery?.customDimensions?.filter(
+            effectiveMetricQuery?.customDimensions?.filter(
                 (dimension) => !isCustomBinDimension(dimension),
             ) || [],
-        [metricQuery?.customDimensions],
+        [effectiveMetricQuery?.customDimensions],
     );
 
     const allFields = useMemo(
@@ -168,10 +174,10 @@ const UnderlyingDataModalContent: FC = () => {
 
         return combineUnderlyingDataFilters({
             filterParts,
-            exploreDimensionFilters: metricQuery?.filters?.dimensions,
+            exploreDimensionFilters: effectiveMetricQuery?.filters?.dimensions,
             allFields,
         });
-    }, [filterParts, metricQuery, allFields]);
+    }, [filterParts, effectiveMetricQuery, allFields]);
 
     const {
         error,
@@ -179,7 +185,7 @@ const UnderlyingDataModalContent: FC = () => {
         isInitialLoading,
     } = useUnderlyingDataResults(
         filters,
-        queryUuid,
+        effectiveQueryUuid,
         underlyingDataItemId,
         underlyingDataConfig?.dateZoom,
         parameters,
@@ -230,7 +236,7 @@ const UnderlyingDataModalContent: FC = () => {
                     projectUuid!,
                     {
                         context: QueryExecutionContext.VIEW_UNDERLYING_DATA,
-                        underlyingDataSourceQueryUuid: queryUuid!,
+                        underlyingDataSourceQueryUuid: effectiveQueryUuid!,
                         underlyingDataItemId,
                         filters: convertDateFilters(filters),
                         dateZoom: underlyingDataConfig?.dateZoom,
@@ -251,7 +257,7 @@ const UnderlyingDataModalContent: FC = () => {
         [
             filters,
             projectUuid,
-            queryUuid,
+            effectiveQueryUuid,
             resultsData,
             underlyingDataConfig?.dateZoom,
             underlyingDataItemId,

--- a/packages/frontend/src/components/MetricQueryData/types.ts
+++ b/packages/frontend/src/components/MetricQueryData/types.ts
@@ -1,9 +1,15 @@
 import {
     type DateZoom,
     type ItemsMap,
+    type MetricQuery,
     type PivotReference,
     type ResultValue,
 } from '@lightdash/common';
+
+export type MetricQueryDataSource = {
+    tableName: string;
+    metricQuery: MetricQuery;
+};
 
 export type UnderlyingDataConfig = {
     item: ItemsMap[string] | undefined;
@@ -12,10 +18,12 @@ export type UnderlyingDataConfig = {
     dimensions?: string[];
     pivotReference?: PivotReference;
     dateZoom?: DateZoom;
+    source?: MetricQueryDataSource & { queryUuid: string };
 };
 
 export type DrillDownConfig = {
     item: ItemsMap[string];
     fieldValues: Record<string, ResultValue>;
     pivotReference?: PivotReference;
+    source?: MetricQueryDataSource;
 };

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeSourceCell.test.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeSourceCell.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getMergeSourceFieldValues } from './useMergeSourceCell';
+
+describe('getMergeSourceFieldValues', () => {
+    it('rekeys owned fields and shared keys to their source ids', () => {
+        const value = (raw: unknown) => ({ raw, formatted: String(raw) });
+        const fieldValues = getMergeSourceFieldValues(
+            {
+                merge_join_key_0: {
+                    kind: 'joinKey',
+                    fieldIdBySourceId: {
+                        a: 'customers_customer_id',
+                        b: 'orders_customer_id',
+                    },
+                },
+                b_orders_order_count: {
+                    kind: 'source',
+                    sourceId: 'b',
+                    sourceFieldId: 'orders_order_count',
+                },
+                a_customers_name: {
+                    kind: 'source',
+                    sourceId: 'a',
+                    sourceFieldId: 'customers_name',
+                },
+            },
+            {
+                merge_join_key_0: value(1),
+                b_orders_order_count: value(2),
+                a_customers_name: value('Ada'),
+            },
+            'b',
+        );
+
+        expect(fieldValues).toEqual({
+            orders_customer_id: value(1),
+            orders_order_count: value(2),
+        });
+    });
+});

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeSourceCell.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeSourceCell.ts
@@ -1,0 +1,186 @@
+import {
+    getItemId,
+    getItemMap,
+    QueryExecutionContext,
+    type ApiExecuteAsyncMetricQueryResults,
+    type ExecuteAsyncMetricQueryRequestParams,
+    type ItemsMap,
+    type MergeFieldOrigins,
+    type MetricQuery,
+    type ParametersValuesMap,
+    type ResultValue,
+} from '@lightdash/common';
+import { useCallback, useMemo } from 'react';
+import { lightdashApi } from '../../../api';
+import { type MetricQueryDataSource } from '../../../components/MetricQueryData/types';
+import { useMetricQueryDataContext } from '../../../components/MetricQueryData/useMetricQueryDataContext';
+import { useExplore } from '../../../hooks/useExplore';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { convertDateFilters } from '../../../utils/dateFilter';
+import { SOURCE_A, SOURCE_B } from '../constants';
+import { useMergeSafe } from '../context/useMerge';
+
+export const getMergeSourceFieldValues = (
+    fieldOrigins: MergeFieldOrigins,
+    fieldValues: Record<string, ResultValue>,
+    sourceId: string,
+): Record<string, ResultValue> =>
+    Object.entries(fieldValues).reduce<Record<string, ResultValue>>(
+        (sourceValues, [mergedFieldId, value]) => {
+            const origin = fieldOrigins[mergedFieldId];
+            if (origin?.kind === 'source' && origin.sourceId === sourceId) {
+                sourceValues[origin.sourceFieldId] = value;
+            } else if (origin?.kind === 'joinKey') {
+                const sourceFieldId = origin.fieldIdBySourceId[sourceId];
+                if (sourceFieldId) sourceValues[sourceFieldId] = value;
+            }
+            return sourceValues;
+        },
+        {},
+    );
+
+const executeSourceQuery = (
+    projectUuid: string,
+    metricQuery: MetricQuery,
+    parameters: ParametersValuesMap | undefined,
+    resolvedTimezone: string | undefined,
+) =>
+    lightdashApi<ApiExecuteAsyncMetricQueryResults>({
+        url: `/projects/${projectUuid}/query/metric-query`,
+        version: 'v2',
+        method: 'POST',
+        body: JSON.stringify({
+            context: QueryExecutionContext.VIEW_UNDERLYING_DATA,
+            query: {
+                ...metricQuery,
+                filters: convertDateFilters(metricQuery.filters),
+                timezone: resolvedTimezone,
+            },
+            parameters,
+        } satisfies ExecuteAsyncMetricQueryRequestParams),
+    });
+
+export type ResolvedMergeSourceCell = {
+    item: ItemsMap[string];
+    fieldValues: Record<string, ResultValue>;
+    source: MetricQueryDataSource;
+};
+
+type PreparedMergeSourceCell = Omit<ResolvedMergeSourceCell, 'source'> & {
+    source: MetricQueryDataSource & { queryUuid: string };
+};
+
+export const useMergeSourceCell = () => {
+    const projectUuid = useProjectUuid();
+    const merge = useMergeSafe();
+    const {
+        tableName,
+        metricQuery: metricQueryA,
+        parameters,
+        resolvedTimezone,
+    } = useMetricQueryDataContext();
+    const { data: exploreA } = useExplore(tableName, { refetchOnMount: false });
+    const { data: exploreB } = useExplore(
+        merge?.queryB.exploreName ?? undefined,
+        { refetchOnMount: false },
+    );
+
+    const metricQueryB = useMemo<MetricQuery | null>(() => {
+        if (!merge?.queryB.exploreName || !metricQueryA) return null;
+        return {
+            exploreName: merge.queryB.exploreName,
+            dimensions: merge.queryB.dimensions,
+            metrics: merge.queryB.metrics,
+            filters: merge.filtersB,
+            sorts: [],
+            limit: metricQueryA.limit,
+            tableCalculations: [],
+            additionalMetrics: merge.queryB.additionalMetrics,
+            customDimensions: merge.queryB.customDimensions,
+        };
+    }, [merge, metricQueryA]);
+
+    const itemMapA = useMemo(
+        () =>
+            exploreA && metricQueryA
+                ? getItemMap(
+                      exploreA,
+                      metricQueryA.additionalMetrics,
+                      metricQueryA.tableCalculations,
+                      metricQueryA.customDimensions,
+                  )
+                : {},
+        [exploreA, metricQueryA],
+    );
+    const itemMapB = useMemo(
+        () =>
+            exploreB && metricQueryB
+                ? getItemMap(
+                      exploreB,
+                      metricQueryB.additionalMetrics,
+                      metricQueryB.tableCalculations,
+                      metricQueryB.customDimensions,
+                  )
+                : {},
+        [exploreB, metricQueryB],
+    );
+
+    const resolve = useCallback(
+        (
+            mergedItem: ItemsMap[string],
+            fieldValues: Record<string, ResultValue>,
+        ): ResolvedMergeSourceCell | null => {
+            const mergeResults = merge?.mergeResults;
+            if (!mergeResults || !metricQueryA || !metricQueryB) return null;
+
+            const origin = mergeResults.fieldOrigins[getItemId(mergedItem)];
+            if (origin?.kind !== 'source') return null;
+
+            const isA = origin.sourceId === SOURCE_A;
+            const isB = origin.sourceId === SOURCE_B;
+            if (!isA && !isB) return null;
+            const sourceItem = (isA ? itemMapA : itemMapB)[
+                origin.sourceFieldId
+            ];
+            if (!sourceItem) return null;
+
+            return {
+                item: sourceItem,
+                fieldValues: getMergeSourceFieldValues(
+                    mergeResults.fieldOrigins,
+                    fieldValues,
+                    origin.sourceId,
+                ),
+                source: {
+                    tableName: isA ? tableName : metricQueryB.exploreName,
+                    metricQuery: isA ? metricQueryA : metricQueryB,
+                },
+            };
+        },
+        [itemMapA, itemMapB, merge, metricQueryA, metricQueryB, tableName],
+    );
+
+    const prepareUnderlyingData = useCallback(
+        async (
+            sourceCell: ResolvedMergeSourceCell,
+        ): Promise<PreparedMergeSourceCell> => {
+            if (!projectUuid) throw new Error('Project is required');
+            const started = await executeSourceQuery(
+                projectUuid,
+                sourceCell.source.metricQuery,
+                parameters,
+                resolvedTimezone,
+            );
+            return {
+                ...sourceCell,
+                source: {
+                    ...sourceCell.source,
+                    queryUuid: started.queryUuid,
+                },
+            };
+        },
+        [parameters, projectUuid, resolvedTimezone],
+    );
+
+    return { prepareUnderlyingData, resolve };
+};


### PR DESCRIPTION
## What changed

- resolves merged cells back to their owning source field and source-row values
- enables Drill into for source metrics in merged results
- enables View underlying data by starting the owning source query on demand
- keeps join keys translated to the corresponding source dimension
- leaves source-less merged calculations without misleading source actions

## Why

Merged display fields use synthetic identities. Existing drill and underlying-data flows require real explore fields, filters, and query UUIDs. Compile-time lineage now bridges that boundary without leaking merge IDs into source queries.

## Validation

- frontend unit tests (15 passing)
- frontend typecheck
- frontend lint
- local browser verification:
  - Query B drill picker used Orders dimensions
  - generated URL used `orders_*` fields and Customer id filter
  - underlying-data modal returned the two matching Orders rows

## Stack

Depends on #27376, which depends on #27357.