### PR TITLE
ci: publish npm packages from release.yml so OIDC trusted publishing matches

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -3,12 +3,6 @@ name: Release to DockerHub, GCP, Homebrew
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: Release tag to publish
-        required: true
-        type: string
 
 permissions:
   id-token: write
@@ -24,7 +18,6 @@ jobs:
   # ============================================================================
   build-and-push-images:
     name: Build and Push Images
-    if: github.event_name == 'release'
     runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -42,7 +35,7 @@ jobs:
       - name: Set version and timestamp
         id: version
         run: |
-          VERSION="${{ github.event.release.tag_name || inputs.tag }}"
+          VERSION="${{ github.event.release.tag_name }}"
           TIMESTAMP=$(date +%Y.%m.%d-%H.%M.%S)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "timestamp=$TIMESTAMP" >> $GITHUB_OUTPUT
@@ -133,7 +126,6 @@ jobs:
   # ============================================================================
   qa-blast-radius:
     name: Generate QA Blast Radius
-    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
@@ -188,7 +180,6 @@ jobs:
   # ============================================================================
   check-cli-changes:
     name: Check if CLI files changed
-    if: github.event_name == 'release'
     runs-on: depot-ubuntu-24.04-4
     outputs:
       should_build: ${{ steps.check.outputs.should_build }}
@@ -204,13 +195,6 @@ jobs:
       - name: Check for CLI-related changes
         id: check
         run: |
-          # For manual triggers, always build
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "Manual trigger - building binaries"
-            echo "should_build=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
           # Get the current and previous tags
           CURRENT_TAG="${{ github.event.release.tag_name }}"
           PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -A1 "^${CURRENT_TAG}$" | tail -1)
@@ -238,7 +222,7 @@ jobs:
   build-macos-binaries:
     name: Build macOS CLI Binaries
     needs: check-cli-changes
-    if: github.event_name == 'release' && needs.check-cli-changes.outputs.should_build == 'true'
+    if: needs.check-cli-changes.outputs.should_build == 'true'
     runs-on: macos-latest
     permissions:
       contents: write
@@ -390,7 +374,6 @@ jobs:
   update-homebrew-formula:
     name: Update Homebrew Formula
     needs: build-macos-binaries
-    if: github.event_name == 'release'
     runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -498,7 +481,6 @@ jobs:
   update-helm-chart:
     name: Update Helm Chart Version
     needs: build-and-push-images
-    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -556,7 +538,6 @@ jobs:
   # ============================================================================
   e2b-templates:
     name: Publish ${{ matrix.template.display_name }} (${{ matrix.region }})
-    if: github.event_name == 'release'
     strategy:
       fail-fast: false
       matrix:
@@ -620,54 +601,3 @@ jobs:
       e2b_domain: ${{ matrix.region == 'eu' && 'e2b-juliett.dev' || '' }}
     secrets:
       e2b_api_key: ${{ matrix.region == 'eu' && secrets.E2B_API_KEY_EU || secrets.E2B_API_KEY }}
-
-  publish-npm-packages:
-    name: Publish npm Packages
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          token: ${{ secrets.CI_GITHUB_TOKEN }}
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
-
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-          firewall-version: 1.15.0
-
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
-
-      - name: Install dependencies
-        run: sfw pnpm install --config.minimumReleaseAge=0 --frozen-lockfile --prefer-offline --prod=false --network-concurrency=16
-
-      # sfw's proxy can die mid-install and still exit 0, leaving a partial
-      # node_modules (missing .bin links — releases 1.151.3 attempts 1+2 both
-      # failed on `tsoa: not found`). Same repair pattern as release.config.js:
-      # plain pnpm relinks from the lockfile with honest exit codes.
-      - name: Repair install without sfw
-        run: pnpm install --prefer-offline
-
-      - name: Generate backend API artifacts
-        run: pnpm generate-api:backend
-
-      - name: Build published packages
-        run: pnpm build-published-packages
-
-      - name: Publish npm packages
-        run: pnpm release-packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,16 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish
+        required: true
+        type: string
 
 jobs:
   build-and-test:
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    if: ${{ github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(release):') }}
     name: Build & Test
     runs-on: depot-ubuntu-24.04-8
     env:
@@ -38,12 +44,15 @@ jobs:
         run: pnpm build
 
   release:
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    if: ${{ github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(release):') }}
     # Must stay on a GitHub-hosted runner: npm's trusted-publishing provenance
     # rejects self-hosted/Depot runners (422 "Unsupported GitHub Actions runner
     # environment", run 31724064116).
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_git_tag: ${{ steps.semantic.outputs.new_release_git_tag }}
     # Deliberately no `needs: build-and-test`: a broken build aborts
     # semantic-release during prepare, before the git plugin pushes the
     # chore commit/tag, so gating on the build only adds serial latency.
@@ -131,3 +140,56 @@ jobs:
             @semantic-release/exec@6
             @semantic-release/git@10
             @semantic-release/github@8
+
+  publish-npm-packages:
+    name: Publish npm Packages
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    needs: release
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.release.outputs.new_release_published == 'true') }}
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || needs.release.outputs.new_release_git_tag }}
+
+      - name: Setup Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          firewall-version: 1.15.0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+
+      - name: Install dependencies
+        run: sfw pnpm install --config.minimumReleaseAge=0 --frozen-lockfile --prefer-offline --prod=false --network-concurrency=16
+
+      # sfw's proxy can die mid-install and still exit 0, leaving a partial
+      # node_modules (missing .bin links — releases 1.151.3 attempts 1+2 both
+      # failed on `tsoa: not found`). Same repair pattern as release.config.js:
+      # plain pnpm relinks from the lockfile with honest exit codes.
+      - name: Repair install without sfw
+        run: pnpm install --prefer-offline
+
+      - name: Generate backend API artifacts
+        run: pnpm generate-api:backend
+
+      - name: Build published packages
+        run: pnpm build-published-packages
+
+      - name: Publish npm packages
+        run: pnpm release-packages


### PR DESCRIPTION
## Summary

- run npm package publishing as a downstream job in `release.yml`
- keep Docker, Helm, Homebrew, and E2B work on the release-event-only `post-release.yml` workflow
- add a required `tag` input to `release.yml` for manual package re-publishing

## Root cause

npm trusted publishers for the Lightdash packages are bound to the workflow filename `release.yml`. PR #27371 moved the publish job to `post-release.yml`, so npm rejected the OIDC token exchange with `ERR_PNPM_AUTH_TOKEN_EXCHANGE` 404 in runs 31731320829 and 31732189809.

## Latency

Publishing remains outside semantic-release and runs as a downstream job only after a new release is published. This preserves the SPK-995 latency win because package build and publication do not return to the tag-cutting path.

## Recovery path

`workflow_dispatch` accepts a required tag and runs only the npm publish job. This provides a manual re-publish path without triggering build-and-test or semantic-release.

## Validation

- `actionlint .github/workflows/release.yml .github/workflows/post-release.yml` (no workflow-expression errors; pre-existing Depot runner-label and shellcheck warnings remain)
- [manual dispatch run 31733536912](https://github.com/lightdash/lightdash/actions/runs/31733536912): `Build & Test` and `release` skipped, `Publish npm Packages` succeeded
- `npm view @lightdash/common@1.151.3 version` → `1.151.3`
- `npm view @lightdash/cli@1.151.3 version` → `1.151.3`

Linear: SPK-999