### PR TITLE
ci: restore the pnpm release-age check on CI installs

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -262,7 +262,7 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         # Force reinstall so pnpm includes optional DuckDB native bindings
         # needed to build both macOS pkg targets from a single runner.
-        run: pnpm install --config.minimumReleaseAge=0 --filter @lightdash/cli --filter @lightdash/common --filter @lightdash/warehouses --frozen-lockfile --prefer-offline --prod=false --force --network-concurrency=16
+        run: pnpm install --filter @lightdash/cli --filter @lightdash/common --filter @lightdash/warehouses --frozen-lockfile --prefer-offline --prod=false --force --network-concurrency=16
 
       - name: Cache common build
         id: cache-common

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
       - name: Install packages
-        run: pnpm install --config.minimumReleaseAge=0 --frozen-lockfile --prefer-offline --network-concurrency=16
+        run: pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
       - name: Generate backend API artifacts
         run: pnpm generate-api:backend
       - name: Build all packages
@@ -84,7 +84,7 @@ jobs:
         run: npm install -g npm@12.0.1
 
       - name: Install dependencies
-        run: pnpm install --config.minimumReleaseAge=0 --frozen-lockfile --prefer-offline --prod=false --network-concurrency=16
+        run: pnpm install --frozen-lockfile --prefer-offline --prod=false --network-concurrency=16
 
       # PROD-8359: install oasdiff so the release-safety marker generator can diff
       # the REST API (swagger.json) between the previous tag and HEAD for breaking
@@ -159,7 +159,7 @@ jobs:
           cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install dependencies
-        run: pnpm install --config.minimumReleaseAge=0 --frozen-lockfile --prefer-offline --prod=false --network-concurrency=16
+        run: pnpm install --frozen-lockfile --prefer-offline --prod=false --network-concurrency=16
 
       - name: Generate backend API artifacts
         run: pnpm generate-api:backend


### PR DESCRIPTION
Removes the `--config.minimumReleaseAge=0` override from the four release-path install lines, restoring the 3-day cooldown check from `pnpm-workspace.yaml` as it was before today's sfw incident work. Safe now that Socket Firewall is out of the release path (#27380): the verifier's ~3k metadata requests go direct to the registry instead of through a collapsing proxy. Cost: ~1–2 min per release-path install; Charlie's call that the always-on supply-chain check is worth it.

Linear: SPK-981

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fs2X73ppqtUpVNHkjSrC4g