### PR TITLE
ci: non-destructive docker build test harness

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,213 @@
+# Non-destructive Docker image build test (SPK-992).
+#
+# PURPOSE
+# Prove that a change to `dockerfile` produces the same image as main, without
+# going anywhere near the release path. Future dockerfile PRs download this
+# workflow's artifacts from a main run (baseline) and from their own run
+# (candidate) and diff them with scripts/ci/compare-image-builds.py.
+#
+# SAFETY PROPERTIES
+#   * `depot build` runs with neither `--push` nor `--tag`. Depot leaves the
+#     result in the remote builder cache and `--load` pulls it to the runner's
+#     local daemon. There is no registry credential in this workflow at all —
+#     no Docker Hub login, no GCP auth — so a push is not merely disabled, it
+#     is impossible.
+#   * Every SENTRY_* build-arg is passed explicitly empty. All Sentry work in
+#     `dockerfile` sits behind `if [ -n "${SENTRY_AUTH_TOKEN}" ] && ...` guards
+#     and sentry-cli is only installed inside those guards, so no release is
+#     created, no sourcemap is uploaded, and no deploy is recorded.
+#   * No file on the release path is touched: not `dockerfile`, not
+#     `release.yml`, not `post-release.yml`.
+#   * `permissions: contents: read` only.
+#
+# WHY THE depot CLI RATHER THAN depot/build-push-action
+# The action gives no control over BuildKit progress output and writes no log
+# file, so per-stage timings and cache-hit counts cannot be recovered from it.
+# The CLI with `--progress plain` yields both. The build itself is equivalent to
+# the release build: same Depot project (bgbbt3d0kc), same DEPOT_PROJECT_TOKEN,
+# same platform, same dockerfile, same (absent) TURBO_TOKEN secret mount.
+#
+# VERIFICATION PROTOCOL — WHAT IS AND IS NOT AUTOMATED HERE
+#   Automated by this workflow (artifacts uploaded for diffing):
+#     1. Image config    — entrypoint, cmd, env, workdir, exposed ports,
+#                          labels, user, volumes. Gated: any diff fails.
+#     2. Filesystem      — every path with size, mode, uid/gid and content
+#                          sha256, sorted. Gated: any diff fails.
+#     3. Build timing    — per-stage seconds and BuildKit cache hit/miss
+#                          counts. Informational; never fails a comparison.
+#   Enforced elsewhere, already:
+#     4. DuckDB extension/ABI match — `dockerfile` asserts at build time that
+#        the bundled extensions match @duckdb/node-api, so drift fails here
+#        by failing the build.
+#   Still manual, deliberately out of scope for v1:
+#     5. dbt --version sweep across the nine pinned venvs (dbt1.4 .. dbt1.12).
+#     6. Offline DuckDB extension load check (no network in the container).
+#     7. Container boot + health endpoint.
+#   5-7 need a running container plus a database; adding them would turn this
+#   from a build-comparison harness into an integration environment. They are
+#   run by hand against the loaded image until a follow-up ticket automates
+#   them.
+
+name: Docker Build Test
+
+on:
+  pull_request:
+    paths:
+      - dockerfile
+      - docker/**
+      - scripts/ci/**
+      - .github/workflows/docker-build-test.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-describe:
+    name: Build image (no push) and describe it
+    # Fork PRs cannot see DEPOT_PROJECT_TOKEN. Skip rather than fail red.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: depot-ubuntu-24.04-8
+    timeout-minutes: 90
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Depot CLI
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
+
+      - name: Report free disk before build
+        run: df -h /
+
+      - name: Build image (no push, no tags)
+        id: build
+        env:
+          DEPOT_TOKEN: ${{ secrets.DEPOT_PROJECT_TOKEN }}
+        run: |
+          set -euo pipefail
+          start=$(date +%s)
+          depot build . \
+            --project bgbbt3d0kc \
+            --platform linux/amd64 \
+            --file dockerfile \
+            --progress plain \
+            --load \
+            --iidfile image-id.txt \
+            --metadata-file build-metadata.json \
+            --build-arg SENTRY_AUTH_TOKEN= \
+            --build-arg SENTRY_ORG= \
+            --build-arg SENTRY_RELEASE_VERSION= \
+            --build-arg SENTRY_FRONTEND_PROJECT= \
+            --build-arg SENTRY_BACKEND_PROJECT= \
+            --build-arg SENTRY_ENVIRONMENT= \
+            2>&1 | tee build.log
+          echo "wall_clock=$(( $(date +%s) - start ))" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve loaded image id
+        id: image
+        run: |
+          set -euo pipefail
+          image_id="$(tr -d '[:space:]' < image-id.txt || true)"
+          if [ -z "$image_id" ]; then
+            image_id="$(jq -r '."containerimage.config.digest" // ."containerimage.digest" // empty' build-metadata.json)"
+          fi
+          if [ -z "$image_id" ]; then
+            echo "could not determine the loaded image id" >&2
+            exit 1
+          fi
+          docker image inspect "$image_id" > /dev/null
+          echo "id=$image_id" >> "$GITHUB_OUTPUT"
+
+      - name: Collect image config
+        env:
+          IMAGE_ID: ${{ steps.image.outputs.id }}
+        run: |
+          set -euo pipefail
+          mkdir -p image-artifacts
+          docker image inspect "$IMAGE_ID" \
+            | python3 scripts/ci/image-artifacts.py config --output image-artifacts/image-config.json
+          cat image-artifacts/image-config.json
+
+      - name: Collect filesystem manifest
+        env:
+          IMAGE_ID: ${{ steps.image.outputs.id }}
+        run: |
+          set -euo pipefail
+          container="$(docker create "$IMAGE_ID")"
+          trap 'docker rm -f "$container" > /dev/null 2>&1 || true' EXIT
+          # Streamed straight into the hasher: a multi-GB export never lands on disk.
+          docker export "$container" \
+            | python3 scripts/ci/image-artifacts.py manifest \
+                --output image-artifacts/fs-manifest.tsv.gz \
+                --summary image-artifacts/fs-summary.json
+
+      - name: Parse build log for timings and cache stats
+        env:
+          WALL_CLOCK: ${{ steps.build.outputs.wall_clock }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/image-artifacts.py buildlog \
+            --log build.log \
+            --wall-clock "$WALL_CLOCK" \
+            --output image-artifacts/build-timing.json
+          gzip -c build.log > image-artifacts/build.log.gz
+
+      - name: Record build identity
+        env:
+          IMAGE_ID: ${{ steps.image.outputs.id }}
+          WALL_CLOCK: ${{ steps.build.outputs.wall_clock }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg sha "$GITHUB_SHA" \
+            --arg ref "$GITHUB_REF_NAME" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            --arg image_id "$IMAGE_ID" \
+            --argjson wall_clock "$WALL_CLOCK" \
+            '{sha: $sha, ref: $ref, run_id: $run_id, image_id: $image_id, wall_clock_seconds: $wall_clock}' \
+            > image-artifacts/build-info.json
+          cp build-metadata.json image-artifacts/build-metadata.json
+
+      - name: Job summary
+        run: |
+          set -euo pipefail
+          {
+            echo "## Docker build test"
+            echo
+            echo "Built \`dockerfile\` with \`push: false\` and empty SENTRY_* build-args. Nothing was tagged or pushed."
+            echo
+            jq -r '
+              "| metric | value |",
+              "| --- | --- |",
+              "| wall clock (s) | \(.wall_clock_seconds) |",
+              "| steps | \(.totals.steps) |",
+              "| cache hits | \(.totals.cache_hits) |",
+              "| cache misses | \(.totals.cache_misses) |",
+              "| cache hit ratio | \(.totals.cache_hit_ratio) |"
+            ' image-artifacts/build-timing.json
+            echo
+            echo "### Slowest stages"
+            echo
+            echo "| stage | seconds | steps | cached |"
+            echo "| --- | --- | --- | --- |"
+            jq -r '.per_stage | to_entries | .[:12][] | "| \(.key) | \(.value.seconds) | \(.value.steps) | \(.value.cached) |"' \
+              image-artifacts/build-timing.json
+            echo
+            jq -r '"Filesystem: \(.entries) entries, \(.total_file_bytes) bytes of file content."' \
+              image-artifacts/fs-summary.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: docker-image-artifacts-${{ github.run_id }}
+          path: image-artifacts/
+          retention-days: 30

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -12,6 +12,11 @@
 #     local daemon. There is no registry credential in this workflow at all —
 #     no Docker Hub login, no GCP auth — so a push is not merely disabled, it
 #     is impossible.
+#     Depot does name the loaded image itself, as
+#     `depot-project-<project>:build-<buildID>`. That name has no registry host,
+#     is derived from a build id that exists only in Depot, and dies with the
+#     ephemeral runner. It is a handle for `docker inspect`/`docker export`
+#     here, never a publish target.
 #   * Every SENTRY_* build-arg is passed explicitly empty. All Sentry work in
 #     `dockerfile` sits behind `if [ -n "${SENTRY_AUTH_TOKEN}" ] && ...` guards
 #     and sentry-cli is only installed inside those guards, so no release is
@@ -112,60 +117,58 @@ jobs:
             2>&1 | tee build.log
           echo "wall_clock=$(( $(date +%s) - start ))" >> "$GITHUB_OUTPUT"
 
-      # The image is loaded untagged (deliberately — see the header), so it has
-      # to be found by digest. `--iidfile` records the digest BuildKit built,
-      # which is not the id the docker daemon assigns when it imports the
-      # docker-format tarball, so every candidate is probed rather than trusted.
-      - name: Resolve loaded image id
+      # We pass no --tag, but depot names the loaded image after its own build id
+      # (depot-project-<project>:build-<buildID>) and reports it as `image.name`.
+      # That local name is the only reliable handle: the digests in --iidfile and
+      # containerimage.digest identify the image BuildKit built, not the id the
+      # docker daemon assigns when it imports the tarball. Every candidate is
+      # probed rather than trusted, and the runner's preinstalled images mean
+      # "the only image in the daemon" is never a safe assumption.
+      - name: Resolve loaded image
         id: image
         run: |
           set -euo pipefail
-          echo "--- depot metadata ---"
-          cat build-metadata.json || true
-          echo
+          echo "--- depot metadata (imageConfigs elided) ---"
+          jq 'del(.imageConfigs)' build-metadata.json || true
           echo "--- images in the local daemon ---"
           docker images --all --no-trunc --format '{{.ID}} {{.Repository}}:{{.Tag}} {{.Size}}'
 
+          from_name="$(jq -r '."image.name" // empty' build-metadata.json 2>/dev/null || true)"
           from_iidfile="$(tr -d '[:space:]' < image-id.txt 2>/dev/null || true)"
-          from_metadata="$(jq -r '[."containerimage.config.digest", ."containerimage.digest"] | map(select(type == "string")) | join(" ")' build-metadata.json 2>/dev/null || true)"
-          # depot --load leaves exactly one image behind: builds run remotely, so
-          # nothing else is ever imported into this daemon.
-          from_daemon=""
-          if [ "$(docker images --quiet --no-trunc | sort -u | wc -l)" -eq 1 ]; then
-            from_daemon="$(docker images --quiet --no-trunc | sort -u)"
-          fi
+          from_digests="$(jq -r '[."containerimage.config.digest", ."containerimage.digest"] | map(select(type == "string")) | join(" ")' build-metadata.json 2>/dev/null || true)"
+          from_repo="$(docker images --no-trunc --format '{{.Repository}}:{{.Tag}}' --filter 'reference=depot-project-*' | head -n 1)"
 
-          image_id=""
-          for candidate in "$from_iidfile" $from_metadata "$from_daemon"; do
+          image_ref=""
+          for candidate in "$from_name" "$from_iidfile" $from_digests "$from_repo"; do
             if [ -n "$candidate" ] && docker image inspect "$candidate" > /dev/null 2>&1; then
-              image_id="$candidate"
+              image_ref="$candidate"
               break
             fi
           done
 
-          if [ -z "$image_id" ]; then
-            echo "could not resolve the loaded image id from iidfile, metadata or daemon" >&2
+          if [ -z "$image_ref" ]; then
+            echo "could not resolve the loaded image from metadata, iidfile or daemon" >&2
             exit 1
           fi
-          echo "resolved image id: $image_id"
-          echo "id=$image_id" >> "$GITHUB_OUTPUT"
+          echo "resolved image: $image_ref"
+          echo "ref=$image_ref" >> "$GITHUB_OUTPUT"
 
       - name: Collect image config
         env:
-          IMAGE_ID: ${{ steps.image.outputs.id }}
+          IMAGE_REF: ${{ steps.image.outputs.ref }}
         run: |
           set -euo pipefail
           mkdir -p image-artifacts
-          docker image inspect "$IMAGE_ID" \
+          docker image inspect "$IMAGE_REF" \
             | python3 scripts/ci/image-artifacts.py config --output image-artifacts/image-config.json
           cat image-artifacts/image-config.json
 
       - name: Collect filesystem manifest
         env:
-          IMAGE_ID: ${{ steps.image.outputs.id }}
+          IMAGE_REF: ${{ steps.image.outputs.ref }}
         run: |
           set -euo pipefail
-          container="$(docker create "$IMAGE_ID")"
+          container="$(docker create "$IMAGE_REF")"
           trap 'docker rm -f "$container" > /dev/null 2>&1 || true' EXIT
           # Streamed straight into the hasher: a multi-GB export never lands on disk.
           docker export "$container" \
@@ -186,7 +189,7 @@ jobs:
 
       - name: Record build identity
         env:
-          IMAGE_ID: ${{ steps.image.outputs.id }}
+          IMAGE_REF: ${{ steps.image.outputs.ref }}
           WALL_CLOCK: ${{ steps.build.outputs.wall_clock }}
         run: |
           set -euo pipefail
@@ -194,9 +197,9 @@ jobs:
             --arg sha "$GITHUB_SHA" \
             --arg ref "$GITHUB_REF_NAME" \
             --arg run_id "$GITHUB_RUN_ID" \
-            --arg image_id "$IMAGE_ID" \
+            --arg image_ref "$IMAGE_REF" \
             --argjson wall_clock "$WALL_CLOCK" \
-            '{sha: $sha, ref: $ref, run_id: $run_id, image_id: $image_id, wall_clock_seconds: $wall_clock}' \
+            '{sha: $sha, ref: $ref, run_id: $run_id, image_ref: $image_ref, wall_clock_seconds: $wall_clock}' \
             > image-artifacts/build-info.json
           cp build-metadata.json image-artifacts/build-metadata.json
 

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -112,19 +112,42 @@ jobs:
             2>&1 | tee build.log
           echo "wall_clock=$(( $(date +%s) - start ))" >> "$GITHUB_OUTPUT"
 
+      # The image is loaded untagged (deliberately — see the header), so it has
+      # to be found by digest. `--iidfile` records the digest BuildKit built,
+      # which is not the id the docker daemon assigns when it imports the
+      # docker-format tarball, so every candidate is probed rather than trusted.
       - name: Resolve loaded image id
         id: image
         run: |
           set -euo pipefail
-          image_id="$(tr -d '[:space:]' < image-id.txt || true)"
-          if [ -z "$image_id" ]; then
-            image_id="$(jq -r '."containerimage.config.digest" // ."containerimage.digest" // empty' build-metadata.json)"
+          echo "--- depot metadata ---"
+          cat build-metadata.json || true
+          echo
+          echo "--- images in the local daemon ---"
+          docker images --all --no-trunc --format '{{.ID}} {{.Repository}}:{{.Tag}} {{.Size}}'
+
+          from_iidfile="$(tr -d '[:space:]' < image-id.txt 2>/dev/null || true)"
+          from_metadata="$(jq -r '[."containerimage.config.digest", ."containerimage.digest"] | map(select(type == "string")) | join(" ")' build-metadata.json 2>/dev/null || true)"
+          # depot --load leaves exactly one image behind: builds run remotely, so
+          # nothing else is ever imported into this daemon.
+          from_daemon=""
+          if [ "$(docker images --quiet --no-trunc | sort -u | wc -l)" -eq 1 ]; then
+            from_daemon="$(docker images --quiet --no-trunc | sort -u)"
           fi
+
+          image_id=""
+          for candidate in "$from_iidfile" $from_metadata "$from_daemon"; do
+            if [ -n "$candidate" ] && docker image inspect "$candidate" > /dev/null 2>&1; then
+              image_id="$candidate"
+              break
+            fi
+          done
+
           if [ -z "$image_id" ]; then
-            echo "could not determine the loaded image id" >&2
+            echo "could not resolve the loaded image id from iidfile, metadata or daemon" >&2
             exit 1
           fi
-          docker image inspect "$image_id" > /dev/null
+          echo "resolved image id: $image_id"
           echo "id=$image_id" >> "$GITHUB_OUTPUT"
 
       - name: Collect image config

--- a/scripts/ci/compare-image-builds.py
+++ b/scripts/ci/compare-image-builds.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Compare two docker-build-test artifact directories.
+
+    compare-image-builds.py BASELINE_DIR CANDIDATE_DIR
+
+Reports an image config diff, a filesystem manifest diff, and a build timing
+comparison. Exits non-zero when the config or the filesystem differs, so a PR
+can gate on "this dockerfile change produced an identical image". Timing
+differences are informational and never fail.
+"""
+
+import argparse
+import gzip
+import json
+import os
+import sys
+
+CONFIG_FILE = "image-config.json"
+MANIFEST_CANDIDATES = ("fs-manifest.tsv.gz", "fs-manifest.tsv")
+TIMING_FILE = "build-timing.json"
+
+MANIFEST_FIELDS = ("type", "mode", "uid", "gid", "size", "sha256", "link")
+
+
+def load_json(directory, name, required=True):
+    path = os.path.join(directory, name)
+    if not os.path.exists(path):
+        if required:
+            sys.exit(f"missing {path}")
+        return None
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_manifest(directory):
+    for name in MANIFEST_CANDIDATES:
+        path = os.path.join(directory, name)
+        if not os.path.exists(path):
+            continue
+        opener = gzip.open if path.endswith(".gz") else open
+        entries = {}
+        with opener(path, "rt", encoding="utf-8") as handle:
+            header = handle.readline().rstrip("\n").split("\t")
+            for line in handle:
+                parts = line.rstrip("\n").split("\t")
+                row = dict(zip(header, parts))
+                entries[row["path"]] = row
+        return entries
+    sys.exit(f"no filesystem manifest found in {directory}")
+
+
+def flatten(value, prefix=""):
+    """Flatten nested config JSON to dotted leaf paths for a precise diff.
+
+    An empty dict must stay a leaf: docker encodes `EXPOSE 8080` as
+    {"ExposedPorts": {"8080/tcp": {}}}, so recursing into the empty value would
+    drop the port key entirely and make differing ports compare equal.
+    """
+    if isinstance(value, dict) and value:
+        for key in sorted(value):
+            yield from flatten(value[key], f"{prefix}.{key}" if prefix else key)
+    else:
+        yield prefix, json.dumps(value, sort_keys=True)
+
+
+def diff_config(baseline, candidate):
+    base = dict(flatten(baseline))
+    cand = dict(flatten(candidate))
+    rows = []
+    for key in sorted(set(base) | set(cand)):
+        before = base.get(key, "<absent>")
+        after = cand.get(key, "<absent>")
+        if before != after:
+            rows.append((key, before, after))
+    return rows
+
+
+def diff_manifest(baseline, candidate, ignore_prefixes):
+    def keep(path):
+        return not any(path.startswith(prefix) for prefix in ignore_prefixes)
+
+    base_paths = {p for p in baseline if keep(p)}
+    cand_paths = {p for p in candidate if keep(p)}
+
+    removed = sorted(base_paths - cand_paths)
+    added = sorted(cand_paths - base_paths)
+    changed = []
+    for path in sorted(base_paths & cand_paths):
+        before, after = baseline[path], candidate[path]
+        fields = [f for f in MANIFEST_FIELDS if before.get(f) != after.get(f)]
+        if fields:
+            changed.append((path, fields, before, after))
+    return removed, added, changed
+
+
+def print_section(title):
+    print(f"\n{title}")
+    print("=" * len(title))
+
+
+def print_capped(items, limit, render):
+    for item in items[:limit]:
+        print(render(item))
+    if len(items) > limit:
+        print(f"  ... and {len(items) - limit} more (raise --max-lines to see them)")
+
+
+def report_timing(baseline, candidate):
+    print_section("Build timing (informational)")
+    if not baseline or not candidate:
+        print("  build-timing.json missing on one side; skipping")
+        return
+
+    bt, ct = baseline["totals"], candidate["totals"]
+    print(f"  {'metric':<22} {'baseline':>12} {'candidate':>12} {'delta':>12}")
+    for label, key in (
+        ("wall clock (s)", None),
+        ("sum step seconds", "sum_step_seconds"),
+        ("steps", "steps"),
+        ("cache hits", "cache_hits"),
+        ("cache misses", "cache_misses"),
+    ):
+        if key is None:
+            before = baseline.get("wall_clock_seconds")
+            after = candidate.get("wall_clock_seconds")
+        else:
+            before, after = bt.get(key), ct.get(key)
+        if before is None or after is None:
+            print(f"  {label:<22} {'n/a':>12} {'n/a':>12} {'n/a':>12}")
+            continue
+        delta = after - before
+        print(f"  {label:<22} {before:>12.2f} {after:>12.2f} {delta:>+12.2f}")
+
+    stages = sorted(set(baseline["per_stage"]) | set(candidate["per_stage"]))
+    print(f"\n  {'stage':<28} {'baseline s':>11} {'candidate s':>12} {'delta s':>10}")
+    for stage in stages:
+        before = baseline["per_stage"].get(stage, {}).get("seconds", 0.0)
+        after = candidate["per_stage"].get(stage, {}).get("seconds", 0.0)
+        print(f"  {stage:<28} {before:>11.2f} {after:>12.2f} {after - before:>+10.2f}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("baseline", help="directory of baseline artifacts")
+    parser.add_argument("candidate", help="directory of candidate artifacts")
+    parser.add_argument("--max-lines", type=int, default=60, help="cap per diff section")
+    parser.add_argument(
+        "--ignore-path-prefix",
+        action="append",
+        default=[],
+        metavar="PREFIX",
+        help="waive filesystem differences under PREFIX (repeatable)",
+    )
+    args = parser.parse_args()
+
+    failures = []
+
+    print_section("Image config diff")
+    config_rows = diff_config(
+        load_json(args.baseline, CONFIG_FILE),
+        load_json(args.candidate, CONFIG_FILE),
+    )
+    if not config_rows:
+        print("  identical")
+    else:
+        failures.append(f"{len(config_rows)} image config difference(s)")
+        print_capped(
+            config_rows,
+            args.max_lines,
+            lambda row: f"  {row[0]}\n    baseline:  {row[1]}\n    candidate: {row[2]}",
+        )
+
+    print_section("Filesystem manifest diff")
+    removed, added, changed = diff_manifest(
+        load_manifest(args.baseline),
+        load_manifest(args.candidate),
+        tuple(args.ignore_path_prefix),
+    )
+    total = len(removed) + len(added) + len(changed)
+    if total == 0:
+        print("  identical")
+    else:
+        failures.append(
+            f"{len(removed)} removed, {len(added)} added, {len(changed)} changed path(s)"
+        )
+        if removed:
+            print(f"\n  Only in baseline ({len(removed)}):")
+            print_capped(removed, args.max_lines, lambda p: f"    - {p}")
+        if added:
+            print(f"\n  Only in candidate ({len(added)}):")
+            print_capped(added, args.max_lines, lambda p: f"    + {p}")
+        if changed:
+            print(f"\n  Changed ({len(changed)}):")
+
+            def render(item):
+                path, fields, before, after = item
+                detail = ", ".join(
+                    f"{f}: {before.get(f)} -> {after.get(f)}" for f in fields
+                )
+                return f"    ~ {path}\n        {detail}"
+
+            print_capped(changed, args.max_lines, render)
+
+    report_timing(
+        load_json(args.baseline, TIMING_FILE, required=False),
+        load_json(args.candidate, TIMING_FILE, required=False),
+    )
+
+    print_section("Verdict")
+    if failures:
+        for failure in failures:
+            print(f"  FAIL: {failure}")
+        print("\n  Images are NOT equivalent.")
+        return 1
+    print("  PASS: image config and filesystem are identical.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/image-artifacts.py
+++ b/scripts/ci/image-artifacts.py
@@ -159,8 +159,12 @@ VERTEX_NAME_RE = re.compile(r"^#(\d+) \[([^\]]*)\] (.*)$")
 VERTEX_DONE_RE = re.compile(r"^#(\d+) DONE ([0-9.]+)s$")
 VERTEX_CACHED_RE = re.compile(r"^#(\d+) CACHED$")
 VERTEX_ERROR_RE = re.compile(r"^#(\d+) ERROR: (.*)$")
-# "[build-backend 3/7]", "[internal]", "[duckdb-extensions 1/2]", "[stage-5 4/9]"
-STAGE_RE = re.compile(r"^(.*?)(?: (\d+)/(\d+))?$")
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+# "[build-backend 3/7]", "[internal]", "[duckdb-extensions 1/2]".
+# BuildKit right-aligns the index, so a stage with 10+ steps prints
+# "[build-final  1/10]" but "[build-final 10/10]" — match any run of spaces or
+# the stage name picks up a trailing one and splits into two buckets.
+STAGE_RE = re.compile(r"^(.*?)\s*(?:(\d+)/(\d+))?$")
 
 
 def cmd_buildlog(args):
@@ -168,7 +172,7 @@ def cmd_buildlog(args):
     order = []
     with open(args.log, "r", encoding="utf-8", errors="replace") as handle:
         for line in handle:
-            line = line.rstrip("\n")
+            line = ANSI_RE.sub("", line.rstrip("\n"))
 
             match = VERTEX_NAME_RE.match(line)
             if match:
@@ -186,7 +190,7 @@ def cmd_buildlog(args):
                     order.append(vertex)
                     stage_match = STAGE_RE.match(bracket.strip())
                     stage, index, total = stage_match.groups()
-                    steps[vertex]["stage"] = stage or bracket.strip()
+                    steps[vertex]["stage"] = (stage or "").strip() or bracket.strip()
                     if index:
                         steps[vertex]["step"] = f"{index}/{total}"
                 continue

--- a/scripts/ci/image-artifacts.py
+++ b/scripts/ci/image-artifacts.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Generate comparable artifacts describing a built Docker image.
+
+Subcommands:
+  config    normalise `docker image inspect` output into a stable config JSON
+  manifest  read a `docker export` tar stream on stdin, emit a sorted fs manifest
+  buildlog  parse a `--progress plain` BuildKit log into timing + cache stats
+"""
+
+import argparse
+import gzip
+import hashlib
+import json
+import re
+import sys
+import tarfile
+from collections import defaultdict
+
+# Fields that describe what the image *is*. Everything else reported by
+# `docker image inspect` (Id, Created, RepoTags, RootFS layer digests, GraphDriver)
+# varies between builds of identical inputs and would make every diff fail.
+CONFIG_FIELDS = (
+    "Entrypoint",
+    "Cmd",
+    "Env",
+    "WorkingDir",
+    "ExposedPorts",
+    "Labels",
+    "User",
+    "Volumes",
+    "StopSignal",
+    "Shell",
+    "Healthcheck",
+    "OnBuild",
+)
+
+# Labels stamped with per-build identity. Present in the release build via
+# docker/metadata-action; excluded so a harness build and a release build of the
+# same tree still compare equal.
+VOLATILE_LABEL_PREFIXES = ("org.opencontainers.image.created", "org.opencontainers.image.revision")
+
+# `docker export` serialises the *container* rootfs, so it includes files the
+# daemon injects at container-create time rather than anything the image built.
+RUNTIME_INJECTED_PATHS = frozenset(
+    {"/.dockerenv", "/etc/hostname", "/etc/hosts", "/etc/resolv.conf"}
+)
+RUNTIME_INJECTED_PREFIXES = ("/dev/", "/proc/", "/sys/")
+
+TAR_TYPES = {
+    tarfile.REGTYPE: "file",
+    tarfile.AREGTYPE: "file",
+    tarfile.LNKTYPE: "hardlink",
+    tarfile.SYMTYPE: "symlink",
+    tarfile.DIRTYPE: "dir",
+    tarfile.FIFOTYPE: "fifo",
+    tarfile.CHRTYPE: "char",
+    tarfile.BLKTYPE: "block",
+}
+
+MANIFEST_HEADER = "path\ttype\tmode\tuid\tgid\tsize\tsha256\tlink"
+
+
+def normalise_path(name):
+    name = name.lstrip("./")
+    return "/" + name.rstrip("/") if name else "/"
+
+
+def is_runtime_injected(path):
+    return path in RUNTIME_INJECTED_PATHS or path.startswith(RUNTIME_INJECTED_PREFIXES)
+
+
+def cmd_config(args):
+    inspected = json.load(sys.stdin)
+    if isinstance(inspected, list):
+        if not inspected:
+            sys.exit("image inspect output was an empty list")
+        inspected = inspected[0]
+
+    raw_config = inspected.get("Config") or {}
+    config = {}
+    for field in CONFIG_FIELDS:
+        value = raw_config.get(field)
+        if field == "Env" and value:
+            value = sorted(value)
+        if field == "Labels" and value:
+            value = {
+                k: v
+                for k, v in sorted(value.items())
+                if not k.startswith(VOLATILE_LABEL_PREFIXES)
+            }
+        config[field] = value
+
+    out = {
+        "architecture": inspected.get("Architecture"),
+        "os": inspected.get("Os"),
+        "config": config,
+    }
+    with open(args.output, "w", encoding="utf-8") as handle:
+        json.dump(out, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def cmd_manifest(args):
+    rows = []
+    skipped = 0
+    # Stream mode ("r|"): the tar is consumed once, forwards only, so nothing is
+    # buffered to disk. A multi-GB image never lands on the runner twice.
+    with tarfile.open(fileobj=sys.stdin.buffer, mode="r|*") as tar:
+        for member in tar:
+            path = normalise_path(member.name)
+            if is_runtime_injected(path):
+                skipped += 1
+                continue
+
+            kind = TAR_TYPES.get(member.type, "other")
+            digest = "-"
+            size = member.size if member.isreg() else 0
+            if member.isreg():
+                stream = tar.extractfile(member)
+                if stream is not None:
+                    hasher = hashlib.sha256()
+                    for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                        hasher.update(chunk)
+                    digest = hasher.hexdigest()
+
+            rows.append(
+                (
+                    path,
+                    kind,
+                    format(member.mode & 0o7777, "04o"),
+                    str(member.uid),
+                    str(member.gid),
+                    str(size),
+                    digest,
+                    member.linkname or "-",
+                )
+            )
+
+    rows.sort(key=lambda row: row[0])
+    opener = gzip.open if args.output.endswith(".gz") else open
+    with opener(args.output, "wt", encoding="utf-8") as handle:
+        handle.write(MANIFEST_HEADER + "\n")
+        for row in rows:
+            handle.write("\t".join(row) + "\n")
+
+    summary = {
+        "entries": len(rows),
+        "runtime_injected_skipped": skipped,
+        "total_file_bytes": sum(int(row[5]) for row in rows),
+    }
+    if args.summary:
+        with open(args.summary, "w", encoding="utf-8") as handle:
+            json.dump(summary, handle, indent=2)
+            handle.write("\n")
+    print(json.dumps(summary), file=sys.stderr)
+
+
+VERTEX_NAME_RE = re.compile(r"^#(\d+) \[([^\]]*)\] (.*)$")
+VERTEX_DONE_RE = re.compile(r"^#(\d+) DONE ([0-9.]+)s$")
+VERTEX_CACHED_RE = re.compile(r"^#(\d+) CACHED$")
+VERTEX_ERROR_RE = re.compile(r"^#(\d+) ERROR: (.*)$")
+# "[build-backend 3/7]", "[internal]", "[duckdb-extensions 1/2]", "[stage-5 4/9]"
+STAGE_RE = re.compile(r"^(.*?)(?: (\d+)/(\d+))?$")
+
+
+def cmd_buildlog(args):
+    steps = {}
+    order = []
+    with open(args.log, "r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            line = line.rstrip("\n")
+
+            match = VERTEX_NAME_RE.match(line)
+            if match:
+                vertex, bracket, instruction = match.groups()
+                if vertex not in steps:
+                    steps[vertex] = {
+                        "vertex": int(vertex),
+                        "stage": None,
+                        "step": None,
+                        "instruction": instruction.strip(),
+                        "seconds": None,
+                        "cached": False,
+                        "error": None,
+                    }
+                    order.append(vertex)
+                    stage_match = STAGE_RE.match(bracket.strip())
+                    stage, index, total = stage_match.groups()
+                    steps[vertex]["stage"] = stage or bracket.strip()
+                    if index:
+                        steps[vertex]["step"] = f"{index}/{total}"
+                continue
+
+            match = VERTEX_CACHED_RE.match(line)
+            if match and match.group(1) in steps:
+                steps[match.group(1)]["cached"] = True
+                continue
+
+            match = VERTEX_DONE_RE.match(line)
+            if match and match.group(1) in steps:
+                steps[match.group(1)]["seconds"] = float(match.group(2))
+                continue
+
+            match = VERTEX_ERROR_RE.match(line)
+            if match and match.group(1) in steps:
+                steps[match.group(1)]["error"] = match.group(2)
+
+    ordered = [steps[vertex] for vertex in order]
+    per_stage = defaultdict(lambda: {"seconds": 0.0, "steps": 0, "cached": 0})
+    for step in ordered:
+        bucket = per_stage[step["stage"]]
+        bucket["steps"] += 1
+        bucket["seconds"] += step["seconds"] or 0.0
+        bucket["cached"] += 1 if step["cached"] else 0
+
+    cached = sum(1 for step in ordered if step["cached"])
+    result = {
+        "wall_clock_seconds": args.wall_clock,
+        "totals": {
+            "steps": len(ordered),
+            "cache_hits": cached,
+            "cache_misses": len(ordered) - cached,
+            "cache_hit_ratio": round(cached / len(ordered), 4) if ordered else 0.0,
+            "sum_step_seconds": round(sum(s["seconds"] or 0.0 for s in ordered), 2),
+        },
+        "per_stage": {
+            stage: {
+                "steps": data["steps"],
+                "cached": data["cached"],
+                "seconds": round(data["seconds"], 2),
+            }
+            for stage, data in sorted(per_stage.items(), key=lambda kv: -kv[1]["seconds"])
+        },
+        "steps": ordered,
+    }
+    with open(args.output, "w", encoding="utf-8") as handle:
+        json.dump(result, handle, indent=2)
+        handle.write("\n")
+    print(json.dumps(result["totals"]), file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    config = sub.add_parser("config", help="normalise docker image inspect JSON from stdin")
+    config.add_argument("--output", required=True)
+    config.set_defaults(func=cmd_config)
+
+    manifest = sub.add_parser("manifest", help="build an fs manifest from a docker export tar on stdin")
+    manifest.add_argument("--output", required=True, help="path; .gz suffix enables gzip")
+    manifest.add_argument("--summary", help="optional JSON summary path")
+    manifest.set_defaults(func=cmd_manifest)
+
+    buildlog = sub.add_parser("buildlog", help="parse a BuildKit plain-progress log")
+    buildlog.add_argument("--log", required=True)
+    buildlog.add_argument("--output", required=True)
+    buildlog.add_argument("--wall-clock", type=float, default=None)
+    buildlog.set_defaults(func=cmd_buildlog)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Linear: SPK-992

Adds a CI harness that builds `./dockerfile` and describes the result, so upcoming dockerfile changes can be proven to produce an equivalent image before anything is released. Nothing here runs on the release path.

## Safety properties

This harness is the mechanism the follow-up dockerfile PRs will rely on, so its own safety is the point:

- **`push: false`, and structurally so.** The build runs `depot build` with neither `--push` nor `--tag`. Depot leaves the result in the remote builder cache and `--load` pulls it to the runner's local daemon. The workflow holds **no registry credential of any kind** — no Docker Hub login, no GCP auth, no `gcloud auth configure-docker`. A push isn't disabled by a flag, it's impossible for want of anywhere to push to.
- **No real Sentry token.** Every `SENTRY_*` build-arg is passed explicitly empty. All Sentry work in `dockerfile` sits behind `if [ -n "${SENTRY_AUTH_TOKEN}" ] && ...` guards, and `sentry-cli` is only installed inside those guards, so no release is created, no sourcemap uploaded, no deploy recorded.
- **No release-path file is touched.** `dockerfile`, `release.yml` and `post-release.yml` are unmodified. This PR adds one new workflow and two new scripts.
- **`permissions: contents: read`** only, and the job is skipped on fork PRs (which cannot see `DEPOT_PROJECT_TOKEN`) rather than failing red.

The build is otherwise equivalent to the release build: same Depot project (`bgbbt3d0kc`), same `DEPOT_PROJECT_TOKEN`, same `linux/amd64` platform, same dockerfile, same (absent) `TURBO_TOKEN` secret mount.

## What it produces

`.github/workflows/docker-build-test.yml` runs on PRs touching `dockerfile`, `docker/**` or the harness itself, plus `workflow_dispatch`, and uploads:

| artifact | contents |
| --- | --- |
| `image-config.json` | entrypoint, cmd, env, workdir, exposed ports, labels, user, volumes — normalised so per-build identity (image id, created timestamp, layer digests) can't cause spurious diffs |
| `fs-manifest.tsv.gz` | every path in the image with type, mode, uid/gid, size and content sha256, sorted |
| `build-timing.json` | per-stage seconds and BuildKit cache hit/miss counts |
| `build.log.gz`, `build-metadata.json`, `build-info.json` | raw evidence and build identity |

`scripts/ci/compare-image-builds.py BASELINE_DIR CANDIDATE_DIR` diffs two of those artifact sets and **exits non-zero on any image config or filesystem difference**, so a PR can gate on image equivalence. Timing differences are reported but never fail. `--ignore-path-prefix` waives known-acceptable filesystem differences.

## Verification protocol coverage

From SPK-992, what this harness covers now versus what stays manual:

- ✅ **Image config diff** — automated and gated.
- ✅ **Filesystem diff** — automated and gated.
- ✅ **Build timing / cache stats** — automated, informational.
- ✅ **DuckDB extension ABI match** — already enforced by `dockerfile` itself at build time, so drift fails the build.
- ⛔️ **`dbt --version` sweep** across the nine pinned venvs — manual.
- ⛔️ **Offline DuckDB load check** — manual.
- ⛔️ **Container boot + health** — manual, deliberately out of scope for v1.

The last three need a running container plus a database; adding them would turn a build-comparison harness into an integration environment. The workflow header documents this split.

## Notes

- The harness drives the `depot` CLI rather than `depot/build-push-action`. The action exposes no control over BuildKit progress output and writes no log file, so per-stage timings and cache-hit counts can't be recovered from it. `--progress plain` on the CLI yields both, and a CLI invocation without `--push`/`--tag` is the stronger safety posture.
- The manifest is generated by streaming `docker export` straight into the hasher, so a multi-GB image is never written to the runner's disk a second time.

---

## Harness validation (run [31740136269](https://github.com/lightdash/lightdash/actions/runs/31740136269))

The harness ran against this PR and is green. Nothing was tagged or pushed; the workflow holds no registry credential.

| | |
| --- | --- |
| Build wall clock | **287s** (4m47s) |
| Whole job | 325s (5m25s) |
| Image size | 9.68 GB |
| BuildKit steps | 83 — 34 cached, 49 miss (41% hit) |
| Sum of step time | 168.2s |
| Filesystem manifest | 464,120 entries, hashed in **21s** |

Slowest stages: `prod-builder` 49.9s/15 steps, `build-final` 37.4s/10, `build-backend` 20.0s/7, `prod` 18.7s/17.

Treat this as a **harness-internal baseline**, not a release-time comparison: the harness has no push phase, and it pays an ~80s `--load` import that the release build never does. For judging whether a dockerfile change saved real build work, `sum_step_seconds` and the per-stage table are the apples-to-apples signal.

### Gate behaviour verified against these real artifacts

- Baseline vs itself → **exit 0**, "image config and filesystem are identical" (2.2s over 464k entries).
- Drop `/usr/local/bin/dbt1.12` → **exit 1**, reported as an added/removed path.
- Change one file's sha256 → **exit 1**, reported under `Changed` with both hashes.
- Remove `COREPACK_ENABLE_NETWORK` from env → **exit 1**, reported as a config diff.

Spot-checked for correctness: the config artifact reproduces the dockerfile's `ENTRYPOINT`, `CMD`, `WORKDIR` and `EXPOSE 8080` exactly, and the manifest captures all nine `dbt1.4`–`dbt1.12` symlinks with their targets.

### Notes for the follow-up dockerfile PRs

- **The manifest is built from `docker export`, i.e. the merged rootfs**, not layer digests. That is deliberate: proposal 1 (`COPY --link`, restructured final stage) is *supposed* to change layer structure, and a digest-based manifest would block the optimisation it exists to validate. This answers "does the running container see identical files?" while staying blind to layering.
- **`docker create` writes the daemon's default `ExposedPorts`/env into the container config, not the image's** — the config artifact therefore comes from `docker image inspect`, never from the container.
- **If proposal 3 moves `SENTRY_AUTH_TOKEN` to a BuildKit secret mount**, the `--build-arg SENTRY_AUTH_TOKEN=` here becomes an unused build-arg. buildx warns but does not fail, so the harness stays green while silently stopping exercising that path — add the matching empty `--secret` at the same time.
