### PR TITLE
ci: rebase-friendly docker final stage

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -366,11 +366,31 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 # do not invalidate production dependency installation or sourcemap processing.
 COPY packages/backend/assets/ ./packages/backend/assets/
 
+# The extension bundle is assembled and verified here rather than in the runtime
+# stage: the check needs the production node_modules, and the runtime stage must
+# stay free of RUN instructions so its application layer can be rebased onto
+# cached parents instead of hydrating them.
+COPY --from=duckdb-extensions \
+    /root/.duckdb/extensions/v1.5.2/*/*.duckdb_extension \
+    /usr/app/packages/warehouses/dist/duckdbExtensions/v1.5.2/
+
+# Never silently restore production runtime downloads after a DuckDB upgrade.
+RUN duckdb_version="$(cd /usr/app/packages/warehouses && node -e "process.stdout.write(require('@duckdb/node-api').version())")" \
+    && extension_directory="/usr/app/packages/warehouses/dist/duckdbExtensions/${duckdb_version}" \
+    && if [ ! -r "${extension_directory}/httpfs.duckdb_extension" ] \
+        || [ ! -r "${extension_directory}/aws.duckdb_extension" ]; then \
+        echo >&2 "Bundled extensions do not match @duckdb/node-api ${duckdb_version}"; \
+        exit 1; \
+    fi
+
 # -----------------------------
-# Stage 5: execution environment for backend
+# Stage 5: runtime base
 # -----------------------------
 
-FROM pnpm-base as prod
+# Everything here is invalidated only by this file: system packages, the dbt
+# virtualenvs and their symlinks. It is deliberately independent of the build
+# context so a release version bump never rebuilds it.
+FROM pnpm-base AS runtime-base
 
 ENV NODE_ENV production
 ENV PLAYGROUND_DATA_DIR=/usr/app/packages/backend/assets/playground
@@ -396,29 +416,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=prod-builder  /usr/local/dbt1.4 /usr/local/dbt1.4
-COPY --from=prod-builder  /usr/local/dbt1.5 /usr/local/dbt1.5
-COPY --from=prod-builder  /usr/local/dbt1.6 /usr/local/dbt1.6
-COPY --from=prod-builder  /usr/local/dbt1.7 /usr/local/dbt1.7
-COPY --from=prod-builder  /usr/local/dbt1.8 /usr/local/dbt1.8
-COPY --from=prod-builder  /usr/local/dbt1.9 /usr/local/dbt1.9
-COPY --from=prod-builder  /usr/local/dbt1.10 /usr/local/dbt1.10
-COPY --from=prod-builder  /usr/local/dbt1.11 /usr/local/dbt1.11
-COPY --from=prod-builder  /usr/local/dbt1.12 /usr/local/dbt1.12
-COPY --from=build-final /usr/app /usr/app
-
-COPY --from=duckdb-extensions \
-    /root/.duckdb/extensions/v1.5.2/*/*.duckdb_extension \
-    /usr/app/packages/warehouses/dist/duckdbExtensions/v1.5.2/
-
-# Never silently restore production runtime downloads after a DuckDB upgrade.
-RUN duckdb_version="$(cd /usr/app/packages/warehouses && node -e "process.stdout.write(require('@duckdb/node-api').version())")" \
-    && extension_directory="/usr/app/packages/warehouses/dist/duckdbExtensions/${duckdb_version}" \
-    && if [ ! -r "${extension_directory}/httpfs.duckdb_extension" ] \
-        || [ ! -r "${extension_directory}/aws.duckdb_extension" ]; then \
-        echo >&2 "Bundled extensions do not match @duckdb/node-api ${duckdb_version}"; \
-        exit 1; \
-    fi
+# Taken from `base` rather than `prod-builder`: the virtualenvs are identical in
+# both, and sourcing them from `base` keeps this stage off the application build
+# graph entirely.
+COPY --link --from=base /usr/local/dbt1.4 /usr/local/dbt1.4
+COPY --link --from=base /usr/local/dbt1.5 /usr/local/dbt1.5
+COPY --link --from=base /usr/local/dbt1.6 /usr/local/dbt1.6
+COPY --link --from=base /usr/local/dbt1.7 /usr/local/dbt1.7
+COPY --link --from=base /usr/local/dbt1.8 /usr/local/dbt1.8
+COPY --link --from=base /usr/local/dbt1.9 /usr/local/dbt1.9
+COPY --link --from=base /usr/local/dbt1.10 /usr/local/dbt1.10
+COPY --link --from=base /usr/local/dbt1.11 /usr/local/dbt1.11
+COPY --link --from=base /usr/local/dbt1.12 /usr/local/dbt1.12
 
 RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt \
     && ln -s /usr/local/dbt1.5/bin/dbt /usr/local/bin/dbt1.5 \
@@ -430,13 +439,30 @@ RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt \
     && ln -s /usr/local/dbt1.11/bin/dbt /usr/local/bin/dbt1.11 \
     && ln -s /usr/local/dbt1.12/bin/dbt /usr/local/bin/dbt1.12
 
+# The runtime working directory is set here, not after the application layers.
+# WORKDIR compiles to a mkdir even when the path already exists, and any
+# filesystem mutation after a COPY --link forces BuildKit to materialise the
+# layers it was meant to leave untouched.
+WORKDIR /usr/app/packages/backend
 
-# Run backend
-COPY ./docker/prod-entrypoint.sh /usr/bin/prod-entrypoint.sh
+# -----------------------------
+# Stage 6: execution environment for backend
+# -----------------------------
+
+FROM runtime-base AS prod
+
+# INVARIANT: this stage may contain only COPY --link and image metadata.
+# A RUN, a WORKDIR or a classic COPY placed after the application content has
+# to write onto the parent filesystem, which forces BuildKit to hydrate the
+# ~2.1 GiB of cached runtime and dbt layers below — 252s per release build,
+# even with every one of those layers a cache hit. Keep additions above, in
+# runtime-base.
+# COPY --link also does not follow symlinks in its destination path, so every
+# destination here must stay a real directory.
+COPY --link --from=build-final /usr/app /usr/app
+COPY --link ./docker/prod-entrypoint.sh /usr/bin/prod-entrypoint.sh
 
 EXPOSE 8080
-
-WORKDIR /usr/app/packages/backend
 
 ENTRYPOINT ["dumb-init", "--", "/usr/bin/prod-entrypoint.sh"]
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## What

Makes the release image's final stage rebase-friendly, so BuildKit can stack the small volatile application layer onto its cached parents instead of hydrating them.

Profiling of three release builds (SPK-992) attributed **91–203s per release** to an unlogged wait hydrating ~2.1 GiB of cached runtime/dbt parent layers. The caches all *hit*; the cost is unpacking them. A classic `COPY` mutates the parent filesystem, so every cached parent layer has to be materialised locally before the new layer can be computed. `COPY --link` builds its layer against an empty filesystem and merges by descriptor, so the parents can stay lazy.

That property only holds if nothing after the `--link` copies touches the filesystem, which drives the three changes here:

1. **New `runtime-base` stage** — apt packages, the nine dbt virtualenvs and their `/usr/local/bin` symlinks. Invalidated only by `dockerfile` itself. The virtualenvs now come from `base` rather than `prod-builder` (identical content in both) so the stage sits off the application build graph entirely.
2. **DuckDB extension bundle + ABI check moved into `build-final`** — the check needs the production `node_modules`, which exist there, and it now validates the exact bytes that get shipped. It was the last `RUN` in the final stage.
3. **Runtime `WORKDIR` moved up into `runtime-base`** — `WORKDIR` compiles to a `mkdir` FileOp even when the path already exists, so leaving it after the application layers would have forced BuildKit to materialise the very layers the rebase was meant to skip.

The final stage is now nothing but `COPY --link` and image metadata, with the invariant recorded in a comment so it is not silently undone.

## Evidence

Built with the non-destructive harness from #27383 (`push: false`, no tags, empty `SENTRY_*` build-args) on Depot project `bgbbt3d0kc`.

### The measurement that matters

The same instruction, copying the same 458 MB of `/usr/app`, with every parent layer a cache hit on both sides:

| | baseline (`main`) | candidate (this PR, warm) |
| --- | --- | --- |
| final-stage application copy | `COPY --from=build-final` — **252.4s** | `COPY --link --from=build-final` — **10.2s** |

In the baseline the 11 preceding steps (apt, the nine dbt `COPY`s, `WORKDIR`) all report `cached=true`, and the copy still cost 252.4s. That is the SPK-992 pathology exactly: cache *hit* is not cache *free*, because BuildKit had to unpack ~2.1 GiB of hits to have a filesystem to write onto. Nothing is copied less — the layer is simply attached by descriptor instead.

The baseline's trailing 3.2s of post-application instructions (extension `COPY` 1.4s, DuckDB check 0.6s, dbt symlinks 0.5s, entrypoint `COPY` 0.4s, `WORKDIR` 0.3s) also leave the final stage: the check moves into `build-final`, the rest into cached `runtime-base`.

### Full run table

| run | ref | builder launch | app copy | export | `--load` pull | wall | cache hits |
| --- | --- | --- | --- | --- | --- | --- | --- |
| baseline | `main` (31742944326) | 0.2s (reused) | **252.4s** | 6.0s | 128.6s | 400s | 80/97 (82%) |
| candidate, cold | branch run 1 (31741721981) | 18.9s | 9.0s | 234.9s | 123.7s | 743s | 25/83 (30%) |
| candidate, warm | branch run 2 (31743780135) | 19.5s (fresh) | **10.2s** | 5.8s | 81.0s | 335s | 67/83 (81%) |
| candidate, merge sha | `884255c713` (31744410826) | — | **9.4s** | — | — | 327s | — |

Run 1 is cold by construction — `runtime-base` is a new stage, so its apt layer and nine dbt copies are built from scratch (plus a one-off `merging 14.9s` to materialise the `--link` set). It is included because even under that handicap the app copy was 9.0s against the baseline's 252.4s.

### What this table does *not* show

Two confounders, stated so the numbers are not over-read:

- **The harness `--load`s the image**, a 81–129s pull the release path never pays (it pushes instead). Wall clock here is not a proxy for release latency.
- **Builder-machine state differs between runs.** The baseline reused a warm machine (0.2s launch) and BuildKit accounts for 398.1s of its 400s wall. The warm candidate got a freshly launched machine (19.5s) and carries **205s of wall clock attributed to no vertex** — presumably that builder pulling cached layers into a cold local cache. So the 400s → 335s wall delta is confounded in both directions and should not be read as the saving.

The defensible claim is the per-instruction one: **−242s on the final-stage copy**, which is the step SPK-992 identified. Whether the release build realises the full amount depends on push-side behaviour this harness cannot exercise.

## Contract

`scripts/ci/compare-image-builds.py` **exits 0** against the main baseline for all three candidate runs, including the merge candidate `884255c713`:

```
Image config diff
=================
  identical

Filesystem manifest diff
========================
  identical

Verdict
=======
  PASS: image config and filesystem are identical.
```

That covers **464,120 filesystem entries** compared on path, type, mode, uid/gid, size, content sha256 and link target, plus entrypoint/cmd/env/workdir/ports/labels/user/volumes. The comparator is deliberately blind to layer digests — the one axis this PR moves.

Spot-checks of the contract items named in the ticket, identical on both sides:

- all nine `dbt` → `dbt1.12` symlinks in `/usr/local/bin`, same targets
- both DuckDB extensions present with matching sha256 (`aws` 23931142 B, `httpfs` 20887942 B) under `v1.5.2/`
- `/usr/bin/prod-entrypoint.sh`, mode 0755, same sha256
- 399,431 files / 55,900 dirs / 8,784 symlinks / 5 hardlinks — including 7,529 pnpm workspace symlinks under `/usr/app`, and the hardlinks preserved as hardlinks

`--link` destination hazard checked separately: `COPY --link` does not follow destination symlinks. `/usr`, `/usr/bin`, `/usr/local` and `/usr/local/bin` are all real directories at mode 755 root:root in `node:24-bookworm-slim`, matching the parent directories `--link` synthesises, so no metadata divergence. `/usr/app` is created by `WORKDIR` in `pnpm-base`.

The release path is unaffected in shape: `post-release.yml` passes no `--target`, so it builds the last stage, and `prod` remains last. The 11-tag block is untouched. The only other consumer of this file is `docker-compose.dev.yml` with `target: dev`, which branches off `base`.

Still manual and out of scope here, as in #27383: the `dbt --version` sweep, the offline DuckDB load check, and container boot + health.

Linear: SPK-992
