### PR TITLE
ci: move Sentry uploads off the deploy path

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -17,10 +17,12 @@
 #     is derived from a build id that exists only in Depot, and dies with the
 #     ephemeral runner. It is a handle for `docker inspect`/`docker export`
 #     here, never a publish target.
-#   * Every SENTRY_* build-arg is passed explicitly empty. All Sentry work in
-#     `dockerfile` sits behind `if [ -n "${SENTRY_AUTH_TOKEN}" ] && ...` guards
-#     and sentry-cli is only installed inside those guards, so no release is
-#     created, no sourcemap is uploaded, and no deploy is recorded.
+#   * SENTRY_RELEASE_VERSION is passed explicitly empty. It is the only Sentry
+#     build-arg `dockerfile` declares: debug-ID injection sits behind an
+#     `if [ -n "${SENTRY_RELEASE_VERSION}" ]` guard and sentry-cli is installed
+#     only inside it. The build carries no Sentry credential at all — releases,
+#     uploads and deploy records live in post-release.yml — so this harness
+#     cannot reach Sentry even if that guard were wrong.
 #   * No file on the release path is touched: not `dockerfile`, not
 #     `release.yml`, not `post-release.yml`.
 #   * `permissions: contents: read` only.
@@ -108,12 +110,7 @@ jobs:
             --load \
             --iidfile image-id.txt \
             --metadata-file build-metadata.json \
-            --build-arg SENTRY_AUTH_TOKEN= \
-            --build-arg SENTRY_ORG= \
             --build-arg SENTRY_RELEASE_VERSION= \
-            --build-arg SENTRY_FRONTEND_PROJECT= \
-            --build-arg SENTRY_BACKEND_PROJECT= \
-            --build-arg SENTRY_ENVIRONMENT= \
             2>&1 | tee build.log
           echo "wall_clock=$(( $(date +%s) - start ))" >> "$GITHUB_OUTPUT"
 
@@ -209,7 +206,7 @@ jobs:
           {
             echo "## Docker build test"
             echo
-            echo "Built \`dockerfile\` with \`push: false\` and empty SENTRY_* build-args. Nothing was tagged or pushed."
+            echo "Built \`dockerfile\` with \`push: false\` and an empty SENTRY_RELEASE_VERSION build-arg. Nothing was tagged or pushed."
             echo
             jq -r '
               "| metric | value |",

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -113,16 +113,103 @@ jobs:
             europe-west2-docker.pkg.dev/lightdash-containers/lightdash/lightdash:beta
             europe-west2-docker.pkg.dev/lightdash-containers/lightdash/lightdash:${{ steps.version.outputs.timestamp }}
           labels: ${{ steps.meta.outputs.labels }}
+          # The image build only stamps the release and injects debug IDs. It
+          # needs no Sentry credentials and makes no call to Sentry — see
+          # upload-sentry-sourcemaps below.
           build-args: |
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-            SENTRY_ORG=lightdash
             SENTRY_RELEASE_VERSION=${{ steps.version.outputs.version }}
-            SENTRY_FRONTEND_PROJECT=lightdash-frontend
-            SENTRY_BACKEND_PROJECT=lightdash-backend
-            SENTRY_ENVIRONMENT=cloud_beta
 
   # ============================================================================
-  # Job 2: QA Blast Radius
+  # Job 2: Upload Sentry sourcemaps (deliberately off the deploy critical path)
+  # ============================================================================
+  # A Sentry outage used to hold every production deploy hostage: the upload ran
+  # inside the image build with no timeout. In the 13 Aug incident a normally
+  # ~14s step went silent for 3.5+ minutes before the build was cancelled by
+  # hand; nothing but the 6-hour job limit bounded it.
+  # The build now only injects debug IDs; this job exports those exact injected
+  # files from the same Depot build and does all the network work afterwards.
+  # Nothing depends on it, so a red run here never blocks a release, and because
+  # every step is idempotent the job can simply be re-run once Sentry is healthy.
+  upload-sentry-sourcemaps:
+    name: Upload Sentry Sourcemaps
+    needs: build-and-push-images
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ github.event.release.tag_name }}
+      SENTRY_ORG: lightdash
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_FRONTEND_PROJECT: lightdash-frontend
+      SENTRY_BACKEND_PROJECT: lightdash-backend
+      SENTRY_ENVIRONMENT: cloud_beta
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name }}
+          # `releases set-commits --auto` needs history to resolve the commit range
+          fetch-depth: 0
+
+      - name: Set up Depot CLI
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
+
+      # Same project, same dockerfile, same build-arg as the pushed image, so
+      # this resolves to the layers Depot already built and exports the very
+      # files the image ships. Debug IDs are content-derived, so even a cold
+      # cache reproduces them rather than minting new ones.
+      - name: Export injected sourcemaps from the release build
+        env:
+          DEPOT_TOKEN: ${{ secrets.DEPOT_PROJECT_TOKEN }}
+        run: |
+          set -euo pipefail
+          depot build . \
+            --project bgbbt3d0kc \
+            --platform linux/amd64 \
+            --file dockerfile \
+            --target sentry-artifacts \
+            --build-arg "SENTRY_RELEASE_VERSION=${VERSION}" \
+            --output "type=local,dest=sentry-artifacts"
+          find sentry-artifacts -name '*.map' | head -n 20
+          echo "$(find sentry-artifacts -name '*.map' | wc -l) sourcemaps exported"
+
+      # Keep this version in step with the one `dockerfile` injects with.
+      - name: Install Sentry CLI
+        run: npm install -g @sentry/cli@3.6.2
+
+      - name: Create releases
+        run: |
+          set -euo pipefail
+          sentry-cli releases new "$VERSION" --project "$SENTRY_FRONTEND_PROJECT"
+          sentry-cli releases new "$VERSION" --project "$SENTRY_BACKEND_PROJECT"
+          sentry-cli releases set-commits "$VERSION" --auto || echo "Could not determine commits automatically"
+
+      # Run from the export root so the uploaded paths — and therefore the
+      # artifact names Sentry stores — match what the in-image upload produced.
+      - name: Upload sourcemaps
+        working-directory: sentry-artifacts
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2088 # "~/" is Sentry's artifact URL prefix, not a home dir
+          sentry-cli sourcemaps upload --release "$VERSION" \
+            --url-prefix "~/assets" ./packages/frontend/build/assets/ --project "$SENTRY_FRONTEND_PROJECT"
+          # shellcheck disable=SC2088
+          sentry-cli sourcemaps upload --release "$VERSION" \
+            --url-prefix "~/" ./packages/backend/dist/ --project "$SENTRY_BACKEND_PROJECT"
+
+      - name: Finalize release and record deploys
+        run: |
+          set -euo pipefail
+          sentry-cli releases finalize "$VERSION"
+          sentry-cli releases deploys "$VERSION" new -e "$SENTRY_ENVIRONMENT" --project "$SENTRY_FRONTEND_PROJECT"
+          sentry-cli releases deploys "$VERSION" new -e "$SENTRY_ENVIRONMENT" --project "$SENTRY_BACKEND_PROJECT"
+
+  # ============================================================================
+  # Job 3: QA Blast Radius
   # ============================================================================
   qa-blast-radius:
     name: Generate QA Blast Radius
@@ -176,7 +263,7 @@ jobs:
             --clobber
 
   # ============================================================================
-  # Job 3: CLI Release Binaries
+  # Job 4: CLI Release Binaries
   # ============================================================================
   check-cli-changes:
     name: Check if CLI files changed
@@ -470,7 +557,7 @@ jobs:
           git push origin main
 
   # ============================================================================
-  # Job 4: Update Helm chart default version
+  # Job 5: Update Helm chart default version
   # ============================================================================
   update-helm-chart:
     name: Update Helm Chart Version
@@ -528,7 +615,7 @@ jobs:
           git push origin main
 
   # ============================================================================
-  # Job 5: Publish versioned E2B templates
+  # Job 6: Publish versioned E2B templates
   # ============================================================================
   e2b-templates:
     name: Publish ${{ matrix.template.display_name }} (${{ matrix.region }})

--- a/dockerfile
+++ b/dockerfile
@@ -219,10 +219,6 @@ ENV PATH="/usr/app/node_modules/.bin:$PATH"
 # Increase Node.js heap size for TypeScript compilation
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
-RUN if [ -n "${SENTRY_AUTH_TOKEN}" ] && [ -n "${SENTRY_ORG}" ] && [ -n "${SENTRY_RELEASE_VERSION}" ]; then \
-    npm install -g @sentry/cli; \
-    fi
-
 # -----------------------------
 # Stage 3: Build packages
 # -----------------------------
@@ -265,17 +261,12 @@ COPY packages/backend/src/ ./packages/backend/src/
 # Build MCP chart app (pnpm workspace member — deps already installed in prod-builder)
 RUN pnpm -F @lightdash/mcp-chart-app build
 
-ARG SENTRY_AUTH_TOKEN=""
-ARG SENTRY_ORG=""
 ARG SENTRY_RELEASE_VERSION=""
-ARG SENTRY_FRONTEND_PROJECT=""
-ARG SENTRY_BACKEND_PROJECT=""
-ARG SENTRY_ENVIRONMENT=""
 
-# Conditionally build backend with sourcemaps if Sentry environment variables are set
+# Conditionally build backend with sourcemaps if a Sentry release version is set
 RUN --mount=type=secret,id=TURBO_TOKEN \
     export TURBO_TOKEN=$(cat /run/secrets/TURBO_TOKEN 2>/dev/null || echo "") && \
-    if [ -n "${SENTRY_AUTH_TOKEN}" ] && [ -n "${SENTRY_ORG}" ] && [ -n "${SENTRY_RELEASE_VERSION}" ] && [ -n "${SENTRY_FRONTEND_PROJECT}" ] && [ -n "${SENTRY_BACKEND_PROJECT}" ] && [ -n "${SENTRY_ENVIRONMENT}" ]; then \
+    if [ -n "${SENTRY_RELEASE_VERSION}" ]; then \
     echo "Building backend with sourcemaps for Sentry"; \
     pnpm -F backend build-sourcemaps && pnpm -F backend postbuild; \
     else \
@@ -289,16 +280,14 @@ COPY --from=build-common /usr/app/packages/common/ ./packages/common/
 COPY --from=build-formula /usr/app/packages/formula/ ./packages/formula/
 COPY packages/frontend ./packages/frontend
 
-ARG SENTRY_AUTH_TOKEN=""
-ARG SENTRY_ORG=""
 ARG SENTRY_RELEASE_VERSION=""
 
 # Build frontend with sourcemaps (Vite generates them by default)
 RUN --mount=type=secret,id=TURBO_TOKEN \
     export TURBO_TOKEN=$(cat /run/secrets/TURBO_TOKEN 2>/dev/null || echo "") && \
-    if [ -n "${SENTRY_AUTH_TOKEN}" ] && [ -n "${SENTRY_ORG}" ] && [ -n "${SENTRY_RELEASE_VERSION}" ]; then \
+    if [ -n "${SENTRY_RELEASE_VERSION}" ]; then \
     echo "Building frontend with Sentry integration"; \
-    SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN} SENTRY_RELEASE_VERSION=${SENTRY_RELEASE_VERSION} turbo build --filter=@lightdash/frontend; \
+    SENTRY_RELEASE_VERSION=${SENTRY_RELEASE_VERSION} turbo build --filter=@lightdash/frontend; \
     else \
     echo "Building frontend without Sentry integration"; \
     turbo build --filter=@lightdash/frontend; \
@@ -316,41 +305,19 @@ COPY --from=build-warehouses /usr/app/packages/warehouses/dist/ ./packages/wareh
 COPY --from=build-backend /usr/app/packages/backend/dist/ ./packages/backend/dist/
 COPY --from=build-frontend /usr/app/packages/frontend/build/ ./packages/frontend/build/
 
-# Install Sentry CLI and process sourcemaps if environment variables are set
-ARG SENTRY_AUTH_TOKEN=""
-ARG SENTRY_ORG=""
+# Inject Sentry debug IDs into the artifacts this image ships. Injection stays
+# here because it mutates shipped files; every network call to Sentry (release
+# create, sourcemap upload, finalize, deploy) is done afterwards by the
+# upload-sentry-sourcemaps job in post-release.yml, off the deploy path.
 ARG SENTRY_RELEASE_VERSION=""
-ARG SENTRY_FRONTEND_PROJECT=""
-ARG SENTRY_BACKEND_PROJECT=""
-ARG SENTRY_ENVIRONMENT=""
 
-RUN if [ -n "${SENTRY_AUTH_TOKEN}" ] && [ -n "${SENTRY_ORG}" ] && [ -n "${SENTRY_RELEASE_VERSION}" ] && [ -n "${SENTRY_FRONTEND_PROJECT}" ] && [ -n "${SENTRY_BACKEND_PROJECT}" ] && [ -n "${SENTRY_ENVIRONMENT}" ]; then \
-    npm install -g @sentry/cli; \
-    echo "Creating Sentry releases and processing sourcemaps"; \
-    # Create releases for both projects \
-    sentry-cli releases new "${SENTRY_RELEASE_VERSION}" --project "${SENTRY_FRONTEND_PROJECT}"; \
-    sentry-cli releases new "${SENTRY_RELEASE_VERSION}" --project "${SENTRY_BACKEND_PROJECT}"; \
-    # Set commits for the releases \
-    sentry-cli releases set-commits "${SENTRY_RELEASE_VERSION}" --auto || echo "Could not determine commits automatically"; \
-    # Inject debug IDs into frontend artifacts \
+# Keep the pinned sentry-cli in step with the one that job installs.
+RUN if [ -n "${SENTRY_RELEASE_VERSION}" ]; then \
+    npm install -g @sentry/cli@3.6.2; \
     echo "Injecting debug IDs into frontend artifacts"; \
     sentry-cli sourcemaps inject ./packages/frontend/build/assets/; \
-    # Upload frontend sourcemaps \
-    echo "Uploading frontend sourcemaps"; \
-    sentry-cli sourcemaps upload --release "${SENTRY_RELEASE_VERSION}" \
-    --url-prefix "~/assets" ./packages/frontend/build/assets/ --project "${SENTRY_FRONTEND_PROJECT}"; \
-    # Inject debug IDs into backend artifacts \
     echo "Injecting debug IDs into backend artifacts"; \
     sentry-cli sourcemaps inject ./packages/backend/dist/; \
-    # Upload backend sourcemaps \
-    echo "Uploading backend sourcemaps"; \
-    sentry-cli sourcemaps upload --release "${SENTRY_RELEASE_VERSION}" \
-    --url-prefix "~/" ./packages/backend/dist/ --project "${SENTRY_BACKEND_PROJECT}"; \
-    # Finalize releases \
-    sentry-cli releases finalize "${SENTRY_RELEASE_VERSION}"; \
-    # Create deploys for both projects \
-    sentry-cli releases deploys "${SENTRY_RELEASE_VERSION}" new -e "${SENTRY_ENVIRONMENT}" --project "${SENTRY_FRONTEND_PROJECT}"; \
-    sentry-cli releases deploys "${SENTRY_RELEASE_VERSION}" new -e "${SENTRY_ENVIRONMENT}" --project "${SENTRY_BACKEND_PROJECT}"; \
     fi
 
 # Cleanup development dependencies
@@ -365,6 +332,18 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 # Keep the versioned playground bundle in a late layer so bundle-only updates
 # do not invalidate production dependency installation or sourcemap processing.
 COPY packages/backend/assets/ ./packages/backend/assets/
+
+# -----------------------------
+# Stage 4b: Sentry sourcemap export target (never part of the published image)
+# -----------------------------
+# Built only when explicitly targeted, so it costs the release build nothing.
+# post-release.yml exports it with `depot build --target sentry-artifacts
+# --output type=local` and uploads exactly these files: same Depot cache, same
+# layers, so the debug IDs are the ones baked into the published image.
+
+FROM scratch AS sentry-artifacts
+COPY --from=build-final /usr/app/packages/frontend/build/assets/ /packages/frontend/build/assets/
+COPY --from=build-final /usr/app/packages/backend/dist/ /packages/backend/dist/
 
 # -----------------------------
 # Stage 5: execution environment for backend

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -43,10 +43,14 @@ export default defineConfig({
             telemetry: false,
             org: 'lightdash',
             project: 'lightdash-frontend',
-            authToken: process.env.SENTRY_AUTH_TOKEN,
             release: {
                 name: process.env.SENTRY_RELEASE_VERSION,
+                // Inject the release into the bundle, but never talk to Sentry:
+                // the release is created, finalized and uploaded to after the
+                // build by the upload-sentry-sourcemaps job in post-release.yml.
                 inject: true,
+                create: false,
+                finalize: false,
             },
             // Sourcemaps are already uploaded by the Sentry CLI
             sourcemaps: {


### PR DESCRIPTION
Linear: SPK-992 (proposals 3 and 6)

Sentry's network work runs inside the release image build today. On 13 Aug,
during a Sentry US ingestion incident, the 1.151.3 build's sourcemap step — a
~14s step in a healthy build — went silent for 3.5+ minutes and the build was
cancelled by hand 8 minutes in; the re-run after Sentry recovered put the net
deploy delay at ~15 minutes. The step has no timeout, so nothing but the 6-hour
job limit bounds the worst case. This takes that work off the deploy critical
path.

## What stays in the image build

Everything that mutates shipped files, unchanged:

- backend sourcemap compilation (`build-sourcemaps` + `postbuild`)
- frontend release injection via the Sentry Vite plugin
- `sentry-cli sourcemaps inject` over `packages/frontend/build/assets/` and
  `packages/backend/dist/`

## What moved to `post-release.yml`

`releases new`, `set-commits`, `sourcemaps upload` (both projects), `releases
finalize` and the two deploy records now run in a new `upload-sentry-sourcemaps`
job. It `needs: build-and-push-images` but nothing needs it, so a red run there
never blocks a release, and every operation is idempotent so the job is safe to
re-run once Sentry is healthy. `timeout-minutes: 30` bounds a hung CLI.

## The uploader gets the image's own bytes

A new `sentry-artifacts` stage (`FROM scratch`, placed before the final stage so
it is never in the published image's graph and costs the release build nothing)
copies the two injected directories out of `build-final`. The upload job exports
it with `depot build --target sentry-artifacts --output type=local` using the
same Depot project, dockerfile and build-arg as the pushed image, so it resolves
to the layers Depot has just built. The job holds no registry credential, so it
cannot push anything.

Debug-ID equality therefore holds by cache hit, and by determinism even without
one: `sentry-cli sourcemaps inject` derives debug IDs from file contents
(`debug_id_from_bytes_hashed`), so re-running it on identical bytes reproduces
the same IDs rather than minting new ones. `@sentry/cli` is pinned to 3.6.2 in
both places so injection and upload can never straddle a CLI version change.
Uploads run from the export root, so the artifact names Sentry stores are
identical to the in-image invocation.

## `SENTRY_AUTH_TOKEN` is gone from the build entirely

The plan was to convert it to a BuildKit secret mount. With uploads moved out
nothing in the build authenticates to Sentry — injection, `tsc`, and the Vite
plugin are all local — so it is removed instead, which is strictly stronger than
a secret mount: no token reaches the builder at all, nothing to leak via
build-args, metadata or provenance. `SENTRY_ORG`, the two project names and
`SENTRY_ENVIRONMENT` are Sentry account coordinates the image build never needed
either; they now live only in the upload job. The dockerfile declares exactly one
Sentry arg, `SENTRY_RELEASE_VERSION`, which is what gates sourcemap emission and
stamps the release. The Vite plugin gets `create: false` / `finalize: false` so
it cannot start talking to Sentry again if someone re-introduces a token to that
environment.

## Proposal 6: the early prod-builder Sentry layer was a genuine no-op

The `RUN` at the top of `prod-builder` tested `${SENTRY_AUTH_TOKEN}`,
`${SENTRY_ORG}` and `${SENTRY_RELEASE_VERSION}`. Verified before removing:

1. `dockerfile` has no global `ARG` before the first `FROM`, and `prod-builder`
   declared only `TURBO_TEAM`. Every `SENTRY_*` `ARG` on main is declared later,
   in `build-backend`, `build-frontend` and `build-final`. Build args are
   per-stage, so those three variables were unset in that stage and the guard
   was always false regardless of what the release workflow passed.
2. Corroborating evidence from the file itself: `build-final` is
   `FROM prod-builder` and installs `@sentry/cli` again. That install would be
   redundant if the earlier one had ever run.

## Contract

Verification protocol per the docker-build-test harness: baseline run on `main`,
candidate run on this branch, compared with `scripts/ci/compare-image-builds.py`
(image config + filesystem manifest gated, timings informational). Evidence in a
comment below.

Expected filesystem diff: none. In the harness both runs pass an empty
`SENTRY_RELEASE_VERSION`, so both take the no-Sentry branch in every stage, no
sourcemaps are emitted and `sentry-cli` is never installed — exactly as before.
The `sentry-artifacts` stage is unreferenced by the default target, so it is not
built. Any diff the comparator reports is a real regression, not an expected
consequence of this change.

The release path (`SENTRY_RELEASE_VERSION` set) cannot be exercised by the
harness. Reasoned, not measured: nothing removed from those stages wrote to the
image. `sentry-cli` global installs land outside `/usr/app`, which is the only
thing the final stage copies from `build-final`, so dropping one install and
pinning the other cannot change the rootfs. The Vite plugin change only disables
two API calls; release and debug-ID injection are unchanged, so the emitted
bundle is byte-identical.

## Trade-offs and residual risk

- **Eventual consistency.** Sourcemaps land a few minutes after the image is
  pushed instead of before, so errors ingested in the first minutes of a deploy
  can be unsymbolicated. Sentry auto-creates a release row from the injected
  release name, and the upload attaches to it by debug ID afterwards, so nothing
  is lost — it is late, not missing. Reversing the trade would put the outage
  back on the deploy path.
- **A red upload job is the failure mode, by design.** No `continue-on-error`:
  an outage or a bad token shows as a failed job on the release run and is
  re-runnable in place.
- **Not eliminated: `npm install -g @sentry/cli` still runs inside the build**
  for injection. That is an npm-registry dependency, and depending on version the
  CLI's install step can fetch its binary from Sentry-hosted downloads. It is a
  much smaller exposure than the upload (no ingestion API, no auth) but it is not
  literally zero. Vendoring the binary would be a follow-up.
- `set-commits --auto` ran inside the build without a `.git` directory, so it
  always fell through to its "could not determine commits" branch. In the new job
  it runs against a full checkout (`fetch-depth: 0`) and may actually populate
  suspect commits. Still best-effort and non-fatal.

## Testing

Nothing in this PR was run against Sentry: no test release, no upload, no deploy
record. The upload job's live behaviour is first exercised by the next real
release, which is why it is built to fail visibly and re-run cleanly.

Stacking note: the final-stage restructure on `ci/docker-rebase-final-stage`
lands first; this branch will be rebased on it before merge.
