### PR TITLE
ci: fetch tags at checkout in the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,10 @@ jobs:
           # previous tag's swagger.json lazily).
           fetch-depth: 0
           filter: blob:none
+          # Tags arrive blobless at checkout (~1s) so semantic-release's own
+          # `git fetch --tags` during getLastRelease becomes a no-op instead of
+          # transferring all 7k+ tags (~63s measured on the 1.152.0 release).
+          fetch-tags: true
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 


### PR DESCRIPTION
Follow-up to the 1.152.0 release observation — the one PARTIAL prediction: the semantic-release fetch stall was reduced 175s → 63s by the blobless checkout, not eliminated, because `actions/checkout` fetches `--no-tags` and semantic-release then transfers all 7,351 tags itself during `getLastRelease`.

One line: `fetch-tags: true` on the release job's checkout.

## Non-destructive test evidence (local replication of the CI fetch shape, public repo)

| Scenario | `git fetch --tags` after checkout | Clone cost delta |
|---|---|---|
| blobless, no tags (current CI) | transfers all 7,351 tags | — |
| blobless, with tags (this PR) | **0.5s no-op** | **+0.95s** |

Mechanism proven locally; the CI-measured stall this targets was **63.1s** on the 1.152.0 release (the `Loaded plugin "fail"` → `Run automated release` gap). Post-merge verification: measure that same gap on the first release after this lands — expected to drop to seconds.

Worst case if the estimate is off: the checkout pays ~1s more and the gap stays — no failure mode, the change is additive to an already-working fetch.

Linear: SPK-1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fs2X73ppqtUpVNHkjSrC4g