### PR TITLE
docs: define dependency release-age bypass process

### DIFF
--- a/docs/dependency-release-age.md
+++ b/docs/dependency-release-age.md
@@ -1,0 +1,39 @@
+# Dependency release-age controls
+
+Lightdash delays newly published npm packages before they can be installed. The
+delay gives the ecosystem time to detect a compromised release before it enters
+the dependency graph.
+
+## Settings
+
+- `pnpm-workspace.yaml` sets `minimumReleaseAge: 4320`, which is three days in
+  minutes. It is the control used by repository installs and CI.
+- `.npmrc` sets `min-release-age=3` for contributors who invoke the npm CLI.
+  The npm CLI does not read pnpm's exclusion list.
+- `renovate.json` waits seven days before proposing a routine update. This is
+  stricter than pnpm's three-day installation gate, so routine Renovate updates
+  have already passed the pnpm gate when Renovate proposes them.
+
+## Vulnerability alerts
+
+The vulnerability-alert path is the exception. It sets Renovate's
+`minimumReleaseAge` to zero and may run at any time, so a fixed version can be
+younger than pnpm's three-day gate.
+
+Renovate handles that collision automatically. Its pnpm artifact updater adds
+the exact fixed version to `minimumReleaseAgeExclude` while preparing the
+security pull request and generates the adjacent `Renovate security update`
+comment. This allows the pull request's lockfile to resolve. It is not a manual
+bypass or a separate approval process.
+
+## Stale entries
+
+Renovate creates version-pinned entries such as
+`hono@4.12.18 || 4.12.21`. They exempt only those exact releases, not the package
+or any future version. Once every listed release is older than three days, the
+entry is inert: pnpm would accept those releases without it and future releases
+remain quarantined.
+
+Renovate does not remove stale entries. They may be deleted for readability
+after the quarantine has elapsed, but this is cosmetic maintenance rather than
+a security control.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,59 +41,9 @@ overrides:
   'postcss@<8.5.10': 8.5.23
 
 minimumReleaseAge: 4320 # 3 days — supply chain protection (matches .npmrc min-release-age)
-minimumReleaseAgeExclude:
-  # Renovate security update: hono@4.12.18 || 4.12.21 || 4.12.25 || 4.12.27
-  - hono@4.12.18 || 4.12.21 || 4.12.25 || 4.12.27
-  # Renovate security update: nunjucks@3.2.4
-  - nunjucks@3.2.4
-  # Renovate security update: next@16.2.6
-  - next@16.2.6
-  # Renovate security update: qs@6.14.2 || 6.15.2
-  - qs@6.14.2 || 6.15.2
-  # Renovate security update: postcss@8.5.10 || 8.5.18 || 8.5.23
-  - postcss@8.5.10 || 8.5.18 || 8.5.23
-  # Renovate security update: i18next-http-backend@3.0.5
-  - i18next-http-backend@3.0.5
-  # Renovate security update: simple-git@3.36.0
-  - simple-git@3.36.0
-  # Renovate security update: dompurify@3.4.0
-  - dompurify@3.4.0
-  # Renovate security update: yaml@2.8.3
-  - yaml@2.8.3
-  # Renovate security update: systeminformation@5.31.6
-  - systeminformation@5.31.6
-  # Renovate security update: basic-ftp@5.3.1
-  - basic-ftp@5.3.1
-  # Renovate security update: uuid@11.1.1
-  - uuid@11.1.1
-  # Renovate security update: pm2@7.0.0
-  - pm2@7.0.0
-  # Renovate security update: sanitize-html@2.17.4
-  - sanitize-html@2.17.4
-  # Renovate security update: nodemailer@8.0.5 || 9.0.1
-  - nodemailer@8.0.5 || 9.0.1
-  # Renovate security update: @tiptap/extension-link@2.10.4
-  - "@tiptap/extension-link@2.10.4"
-  # Renovate security update: @node-oauth/oauth2-server@5.3.0
-  - "@node-oauth/oauth2-server@5.3.0"
-  # Renovate security update: turbo@2.9.14
-  - turbo@2.9.14
-  # Renovate security update: liquidjs@10.26.0 || 10.27.1
-  - liquidjs@10.26.0 || 10.27.1
-  # Renovate security update: axios@1.16.0
-  - axios@1.16.0
-  # Renovate security update: form-data@4.0.6 || 3.0.5
-  - form-data@4.0.6 || 3.0.5
-  # Renovate security update: js-yaml@4.2.0
-  - js-yaml@4.2.0
-  # Renovate security update: vite@7.3.5
-  - vite@7.3.5
-  # Renovate security update: undici@6.27.0
-  - undici@6.27.0
-  # Renovate security update: tar@7.5.21
-  - tar@7.5.21
-  # Renovate security update: nanoid@3.3.17
-  - nanoid@3.3.17
+# Renovate automatically adds exact-version exclusions for vulnerability alerts.
+# Process: docs/dependency-release-age.md.
+minimumReleaseAgeExclude: []
 
 # pnpm 11 defaults verifyDepsBeforeRun to `install`, which re-verifies (and
 # reinstalls) node_modules before running any package script. The production


### PR DESCRIPTION
## What changed

- documented the actual interaction between Renovate's vulnerability-alert path and the repository's release-age settings
- removed 26 stale `minimumReleaseAgeExclude` entries covering 35 exact versions, all already older than pnpm's three-day gate
- left Renovate's post-upgrade command, `fileFilters`, and `executionMode` unchanged

## What the investigation found

Renovate adds the exclusions automatically; they are not manual reactions to a failed install. Its pnpm artifact updater selects dependencies marked as vulnerability alerts, creates or extends `minimumReleaseAgeExclude`, and generates the adjacent `Renovate security update` comment.

The three relevant settings differ:

- routine Renovate updates wait seven days
- pnpm installs wait three days (`minimumReleaseAge: 4320`)
- npm CLI installs wait three days (`min-release-age=3`)

The routine Renovate path is stricter than pnpm's gate, so those updates have already passed the pnpm quarantine when Renovate proposes them. Only the immediate vulnerability-alert path can target a release younger than three days; Renovate handles that collision by adding the exact fixed version to the pnpm exclusion list.

Those entries are version-pinned, not package-wide. Once an exempted version is older than three days, its entry is inert: it cannot exempt a future release. Removing stale entries is therefore cosmetic maintenance rather than a security control.

## Scope correction after review

The initial version added automatic registry-backed cleanup. That has been removed because cosmetic maintenance should not add a failure surface to every Renovate branch, especially a security update.

The initial `fileFilters` change was also based on an incorrect premise. `fileFilters` controls files changed by the post-upgrade command, not Renovate's own dependency edits; bot-authored workspace exclusions landed successfully after the existing filter was introduced. The original `fileFilters: ["pnpm-lock.yaml"]` remains unchanged.

The initial `executionMode: "branch"` change has also been reverted. The existing lockfile-only install continues to run with `executionMode: "update"`, so this PR does not change Renovate execution timing.

## Validation

- `pnpm install --lockfile-only --ignore-scripts` (lockfile unchanged; supply-chain policy verification passed)
- `oxfmt --check docs/dependency-release-age.md`
- `git diff --check`

Linear: PROD-9337
