### PR TITLE
docs(skills): update CI reference to node24-runtime actions

### DIFF
--- a/skills/developing-in-lightdash/resources/workflows-reference.md
+++ b/skills/developing-in-lightdash/resources/workflows-reference.md
@@ -63,10 +63,10 @@ jobs:
       LIGHTDASH_PROJECT: ${{ secrets.PROJECT_UUID }}
       CI: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 
@@ -74,7 +74,7 @@ jobs:
         run: npm install -g @lightdash/cli
 
       - name: Setup Python (for dbt)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -173,10 +173,10 @@ jobs:
       LIGHTDASH_URL: https://app.lightdash.cloud
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 
@@ -190,7 +190,7 @@ jobs:
         run: lightdash start-preview --name "pr-${{ github.event.number }}"
 
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({
@@ -332,7 +332,7 @@ jobs:
       LIGHTDASH_URL: https://app.lightdash.cloud
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install tools
         run: |


### PR DESCRIPTION
## What

`skills/developing-in-lightdash/resources/workflows-reference.md` still recommended GitHub Actions whose **declared runtime is node20**:

| action | was | now |
|---|---|---|
| `actions/checkout` | v4 ×3 | **v6** |
| `actions/setup-node` | v4 ×2 | **v6** |
| `actions/setup-python` | v5 | **v6** |
| `actions/github-script` | v7 | **v9** |

`node-version` in the examples was already `'24'` — only the action pins were behind.

## Why this file specifically

This skill is shipped by the **`lightdash install-skills`** CLI command, which downloads it into the consumer's `.claude/skills`, `.cursor/skills` and `.codex/skills`. It is therefore not internal documentation but the CI setup we actively recommend to whoever runs that command, and it is the source every downstream copy is pulled from — installs are snapshots, so fixing it here is what reaches future installs.

Left as-is deliberately: nothing. Every action referenced in the file is now on a node24-native major, matching what `lightdash/cli-actions` publishes after its own recent update.

## Verification

Documentation only, no behaviour change. All seven fenced YAML examples in the file still parse (`yaml.safe_load`).

Note that existing installs hold snapshots and will not update until someone re-runs `lightdash install-skills`.

Linear: PROD-10128