### PR TITLE
feat(cli): declare a Node >=24 engines floor

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/lightdash/lightdash.git"
   },
+  "engines": {
+    "node": ">=24"
+  },
   "bin": {
     "lightdash": "dist/index.js"
   },


### PR DESCRIPTION
## What

Adds `"engines": { "node": ">=24" }` to `packages/cli/package.json`.

## Why

We announced Node 24 as a requirement for the CLI, and the repo root already sets `engines: >=24`, but the **published package declared no floor at all**:

```
@lightdash/cli@1.154.1   engines: NONE DECLARED
```

So a user on Node 18 or 20 installs with no `EBADENGINE` warning and no error. The first signal that their runtime is unsupported is whatever happens to break later, in whatever way it breaks — which is a much worse experience than a warning at install time.

Our own `analytics` repo demonstrated the gap: it was running the CLI on Node 20 with green CI until earlier today.

## Blast radius

`npm` **warns** rather than blocks by default, so this is a signal, not a wall. Only users who have explicitly opted into `engine-strict` will get a hard install failure — which is the behaviour they configured. `pnpm` is stricter by default in some configurations, so the warning is worth being aware of in release notes.

## Scope

Deliberately CLI-only. `@lightdash/common` and `@lightdash/warehouses` are also published without an `engines` field, but they are consumed as libraries inside other people's applications, where a floor has a far wider blast radius. That wants a separate decision rather than being folded in here.

Linear: PROD-10130