### PR TITLE
feat(merge-query): scale saved queries and clarify saved charts

### DIFF
--- a/packages/backend/src/database/migrations/20260812230500_create_saved_query_version_merges.ts
+++ b/packages/backend/src/database/migrations/20260812230500_create_saved_query_version_merges.ts
@@ -4,7 +4,7 @@ const SavedQueriesVersionsTableName = 'saved_queries_versions';
 const SavedQueryVersionMergesTableName = 'saved_queries_version_merges';
 
 /**
- * A chart version can merge its query with a second one.
+ * A chart version can merge its query with additional queries.
  *
  * Kept in its own table rather than as a column on saved_queries_versions,
  * following the same shape as the other per-version tables (fields, sorts,
@@ -31,13 +31,13 @@ export async function up(knex: Knex): Promise<void> {
             .inTable(SavedQueriesVersionsTableName)
             .onDelete('CASCADE');
 
-        // Column, not a key inside the payload, so old shapes can be found
-        // and migrated without scanning jsonb.
-        table.integer('schema_version').notNullable().defaultTo(1);
+        // Column, not a key inside the payload, so future shapes can be found
+        // and migrated without scanning jsonb. Version 1 never shipped; this
+        // table starts at the canonical sources[] representation.
+        table.integer('schema_version').notNullable().defaultTo(2);
 
-        // Holds the second query and the relationship only. The first query
-        // is the chart version itself; storing it again would create two
-        // sources of truth that drift on the next edit.
+        // Holds sources[] and their relationship. The chart query is referenced
+        // rather than copied, avoiding two sources of truth.
         table.jsonb('merge').notNullable();
 
         table

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -40,6 +40,7 @@ import {
     parseSavedMergeQuery,
     Project,
     ResolvedProjectColorPalette,
+    SAVED_MERGE_QUERY_SCHEMA_VERSION,
     SavedChartDAO,
     SessionUser,
     SortField,
@@ -282,7 +283,7 @@ const createSavedChartVersion = async (
         if (merge) {
             await trx('saved_queries_version_merges').insert({
                 saved_queries_version_id: version.saved_queries_version_id,
-                schema_version: 1,
+                schema_version: SAVED_MERGE_QUERY_SCHEMA_VERSION,
                 merge: JSON.stringify(merge),
             });
         }
@@ -1796,7 +1797,7 @@ export class SavedChartModel {
                 ).where('saved_queries_version_id', savedQueriesVersionId);
 
                 const mergeQuery = this.database('saved_queries_version_merges')
-                    .select(['merge'])
+                    .select(['schema_version', 'merge'])
                     .where('saved_queries_version_id', savedQueriesVersionId)
                     .first();
 
@@ -1824,10 +1825,13 @@ export class SavedChartModel {
                     mergeQuery,
                 ]);
 
-                // A payload written by an older shape leaves the chart working
-                // without its merge rather than failing the whole chart.
+                // An unknown future shape leaves the chart working without its
+                // merge rather than failing the whole chart.
                 const merge = mergeRow
-                    ? parseSavedMergeQuery(mergeRow.merge)
+                    ? parseSavedMergeQuery(
+                          mergeRow.schema_version,
+                          mergeRow.merge,
+                      )
                     : null;
 
                 // Filters out "null" fields

--- a/packages/common/src/types/mergeQuery.test.ts
+++ b/packages/common/src/types/mergeQuery.test.ts
@@ -1,8 +1,11 @@
 import { DimensionType } from './field';
 import {
+    buildMergeQueryFromSaved,
     getUnaccountedDimensions,
     MergeJoinType,
     MergeQueryErrorKind,
+    parseSavedMergeQuery,
+    SAVED_MERGE_QUERY_SCHEMA_VERSION,
     validateMergeQuery,
     type MergeQuery,
     type MergeQuerySource,
@@ -329,5 +332,84 @@ describe('getUnaccountedDimensions', () => {
 
     it('reports nothing when every dimension joins', () => {
         expect(getUnaccountedDimensions(queryA(), dateJoinKey)).toEqual([]);
+    });
+});
+
+describe('saved merge query schemas', () => {
+    it('round-trips every source and key in a version 2 payload', () => {
+        const saved = {
+            primarySourceId: 'payments',
+            sources: [
+                { id: 'orders', kind: 'chart' as const },
+                {
+                    id: 'payments',
+                    kind: 'query' as const,
+                    metricQuery: metricQuery(
+                        'payments',
+                        ['payments_month'],
+                        ['payments_total'],
+                    ),
+                },
+                {
+                    id: 'subscriptions',
+                    kind: 'query' as const,
+                    metricQuery: metricQuery(
+                        'subscriptions',
+                        ['subscriptions_month'],
+                        ['subscriptions_mrr'],
+                    ),
+                },
+            ],
+            joinKey: [
+                {
+                    name: 'month',
+                    fieldIdBySourceId: {
+                        orders: 'orders_month',
+                        payments: 'payments_month',
+                        subscriptions: 'subscriptions_month',
+                    },
+                },
+            ],
+            joinType: MergeJoinType.LEFT,
+            tableCalculations: [],
+        };
+
+        const parsed = parseSavedMergeQuery(
+            SAVED_MERGE_QUERY_SCHEMA_VERSION,
+            saved,
+        );
+        expect(parsed).toEqual(saved);
+        expect(
+            buildMergeQueryFromSaved(
+                metricQuery('orders', ['orders_month'], ['orders_total']),
+                parsed!,
+            ).sources.map(({ id }) => id),
+        ).toEqual(['payments', 'orders', 'subscriptions']);
+    });
+
+    it('rejects unknown schemas and incomplete source mappings', () => {
+        expect(parseSavedMergeQuery(1, {})).toBeNull();
+        expect(parseSavedMergeQuery(99, {})).toBeNull();
+        expect(
+            parseSavedMergeQuery(SAVED_MERGE_QUERY_SCHEMA_VERSION, {
+                primarySourceId: 'orders',
+                sources: [
+                    { id: 'orders', kind: 'chart' },
+                    {
+                        id: 'payments',
+                        kind: 'query',
+                        metricQuery: metricQuery('payments', [], []),
+                    },
+                ],
+                joinKey: [
+                    {
+                        name: 'month',
+                        fieldIdBySourceId: { orders: 'orders_month' },
+                    },
+                ],
+                joinType: 'full',
+                tableCalculations: [],
+            }),
+        ).toBeNull();
     });
 });

--- a/packages/common/src/types/mergeQuery.ts
+++ b/packages/common/src/types/mergeQuery.ts
@@ -541,33 +541,37 @@ export type MergeFieldOrigin =
 /** Provenance of every merged field, by field id. */
 export type MergeFieldOrigins = Record<FieldId, MergeFieldOrigin>;
 
+/** Current JSON schema stored in `saved_queries_version_merges.merge`. */
+export const SAVED_MERGE_QUERY_SCHEMA_VERSION = 2;
+
 /**
- * How a merge is stored against a chart version.
+ * A persisted merge source.
  *
- * Deliberately not the runtime `MergeQuery`. The chart version *is* the first
- * query, so storing it again would create two sources of truth that drift the
- * next time the chart is edited. Only the second query and the relationship
- * are kept, and the two sides of each key part are named rather than addressed
- * by a source id that means nothing outside a single request.
+ * The chart source is a reference: its metric query already lives on the chart
+ * version. Every additional source owns its query. This keeps one source of
+ * truth while allowing more sources without adding `thirdQuery`, `fourthQuery`,
+ * and so on.
  */
+export type SavedMergeQuerySource =
+    | {
+          id: string;
+          kind: 'chart';
+      }
+    | {
+          id: string;
+          kind: 'query';
+          metricQuery: MetricQuery;
+      };
+
+/** Canonical, scalable representation of a merge stored on a chart version. */
 export type SavedMergeQuery = {
-    secondQuery: {
-        metricQuery: MetricQuery;
-    };
-    joinKey: Array<{
-        name: string;
-        /** Field in the chart's own query. */
-        chartFieldId: FieldId;
-        /** Field in the second query. */
-        secondFieldId: FieldId;
-    }>;
+    /** Source whose rows a LEFT merge preserves. */
+    primarySourceId: string;
+    sources: SavedMergeQuerySource[];
+    joinKey: MergeJoinKeyPart[];
     joinType: MergeJoinType;
     tableCalculations: MergeTableCalculation[];
 };
-
-/** Source ids the stored shape maps onto when it becomes a runnable merge. */
-export const MERGE_CHART_SOURCE_ID = 'chart';
-export const MERGE_SECOND_SOURCE_ID = 'second';
 
 /**
  * Rebuilds a runnable merge from a chart's own query and its stored merge.
@@ -575,67 +579,107 @@ export const MERGE_SECOND_SOURCE_ID = 'second';
 export const buildMergeQueryFromSaved = (
     chartMetricQuery: MetricQuery,
     saved: SavedMergeQuery,
-): MergeQuery => ({
-    sources: [
-        {
-            id: MERGE_CHART_SOURCE_ID,
-            metricQuery: chartMetricQuery,
-        },
-        {
-            id: MERGE_SECOND_SOURCE_ID,
-            metricQuery: saved.secondQuery.metricQuery,
-        },
-    ],
-    joinKey: saved.joinKey.map((part) => ({
-        name: part.name,
-        fieldIdBySourceId: {
-            [MERGE_CHART_SOURCE_ID]: part.chartFieldId,
-            [MERGE_SECOND_SOURCE_ID]: part.secondFieldId,
-        },
-    })),
-    joinType: saved.joinType,
-    tableCalculations: saved.tableCalculations,
-    limit: chartMetricQuery.limit,
-});
+): MergeQuery => {
+    const sources = saved.sources.map((source): MergeQuerySource => {
+        if (source.kind === 'chart') {
+            return { id: source.id, metricQuery: chartMetricQuery };
+        }
+        return { id: source.id, metricQuery: source.metricQuery };
+    });
+    const primaryIndex = sources.findIndex(
+        (source) => source.id === saved.primarySourceId,
+    );
+    if (primaryIndex > 0) {
+        sources.unshift(...sources.splice(primaryIndex, 1));
+    }
+
+    return {
+        sources,
+        joinKey: saved.joinKey,
+        joinType: saved.joinType,
+        tableCalculations: saved.tableCalculations,
+        limit: chartMetricQuery.limit,
+    };
+};
+
+const parseJoinType = (value: unknown): MergeJoinType =>
+    (Object.values(MergeJoinType) as unknown[]).includes(value)
+        ? (value as MergeJoinType)
+        : MergeJoinType.FULL;
 
 /**
  * Reads a stored merge back, returning null for anything that does not hold
- * together. A payload written by an older shape should leave the chart working
- * without its merge rather than break the chart entirely.
+ * together. An unknown future version leaves the chart working without its
+ * merge rather than breaking the chart entirely.
  */
 export const parseSavedMergeQuery = (
+    schemaVersion: number,
     value: unknown,
 ): SavedMergeQuery | null => {
+    if (schemaVersion !== SAVED_MERGE_QUERY_SCHEMA_VERSION) return null;
     if (value === null || typeof value !== 'object') return null;
     const candidate = value as Partial<SavedMergeQuery>;
 
-    const metricQuery = candidate.secondQuery?.metricQuery;
-    if (!metricQuery || typeof metricQuery.exploreName !== 'string') {
+    if (
+        !Array.isArray(candidate.sources) ||
+        candidate.sources.length < 2 ||
+        typeof candidate.primarySourceId !== 'string'
+    ) {
+        return null;
+    }
+    const sourceIds = candidate.sources.map((source) => source?.id);
+    if (
+        sourceIds.some((id) => typeof id !== 'string' || id.length === 0) ||
+        new Set(sourceIds).size !== sourceIds.length ||
+        !sourceIds.includes(candidate.primarySourceId)
+    ) {
+        return null;
+    }
+    const validSources = candidate.sources.every((source) => {
+        if (source?.kind === 'chart') {
+            return true;
+        }
+        return (
+            source?.kind === 'query' &&
+            source.metricQuery !== null &&
+            typeof source.metricQuery === 'object' &&
+            typeof source.metricQuery.exploreName === 'string'
+        );
+    });
+    const chartSources = candidate.sources.filter(
+        (source) => source?.kind === 'chart',
+    );
+    if (!validSources || chartSources.length !== 1) {
         return null;
     }
     if (!Array.isArray(candidate.joinKey) || candidate.joinKey.length === 0) {
         return null;
     }
-    const joinKey = candidate.joinKey.filter(
-        (part) =>
-            typeof part?.name === 'string' &&
-            typeof part?.chartFieldId === 'string' &&
-            typeof part?.secondFieldId === 'string',
-    );
-    if (joinKey.length !== candidate.joinKey.length) return null;
-
-    const joinType = (Object.values(MergeJoinType) as string[]).includes(
-        String(candidate.joinType),
-    )
-        ? (candidate.joinType as MergeJoinType)
-        : MergeJoinType.FULL;
+    const hasCompleteJoinKeys = candidate.joinKey.every((part) => {
+        if (
+            typeof part?.name !== 'string' ||
+            part.fieldIdBySourceId === null ||
+            typeof part.fieldIdBySourceId !== 'object'
+        ) {
+            return false;
+        }
+        const fieldSourceIds = Object.keys(part.fieldIdBySourceId);
+        return (
+            fieldSourceIds.length === sourceIds.length &&
+            sourceIds.every(
+                (sourceId) =>
+                    typeof sourceId === 'string' &&
+                    typeof part.fieldIdBySourceId[sourceId] === 'string',
+            )
+        );
+    });
+    if (!hasCompleteJoinKeys) return null;
 
     return {
-        secondQuery: {
-            metricQuery,
-        },
-        joinKey,
-        joinType,
+        primarySourceId: candidate.primarySourceId,
+        sources: candidate.sources,
+        joinKey: candidate.joinKey,
+        joinType: parseJoinType(candidate.joinType),
         tableCalculations: Array.isArray(candidate.tableCalculations)
             ? candidate.tableCalculations
             : [],

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -33,35 +33,13 @@ import {
     parseMergeState,
     serializeMergeState,
 } from './mergeUrlState';
+import { restoreSavedMerge } from './restoreSavedMerge';
 
 const EMPTY_QUERY_B: MergeQueryBState = {
     exploreName: null,
     dimensions: [],
     metrics: [],
 };
-
-/**
- * Turns a chart's stored merge back into editable state.
- *
- * Without this a saved merged chart opens looking unmerged, and saving it
- * again would drop the merge it arrived with.
- */
-const fromSavedMerge = (saved: SavedMergeQuery) => ({
-    focus: 'a' as MergeFocus,
-    queryB: {
-        exploreName: saved.secondQuery.metricQuery.exploreName,
-        dimensions: saved.secondQuery.metricQuery.dimensions,
-        metrics: saved.secondQuery.metricQuery.metrics,
-        additionalMetrics: saved.secondQuery.metricQuery.additionalMetrics,
-        customDimensions: saved.secondQuery.metricQuery.customDimensions,
-    },
-    joinParts: saved.joinKey.map((part) => ({
-        fieldA: part.chartFieldId,
-        fieldB: part.secondFieldId,
-    })),
-    joinType: saved.joinType,
-    filtersB: saved.secondQuery.metricQuery.filters ?? {},
-});
 
 /**
  * Merge state lives above the explorer page because the field picker and the
@@ -84,7 +62,7 @@ export const MergeProvider: FC<
     const [restored] = useState(
         () =>
             parseMergeState(searchParams.get(MERGE_URL_PARAM)) ??
-            (savedMerge ? fromSavedMerge(savedMerge) : null),
+            (savedMerge ? restoreSavedMerge(savedMerge) : null),
     );
 
     const [isMerging, setIsMerging] = useState(restored !== null);

--- a/packages/frontend/src/features/mergeQuery/context/restoreSavedMerge.test.ts
+++ b/packages/frontend/src/features/mergeQuery/context/restoreSavedMerge.test.ts
@@ -1,0 +1,65 @@
+import { MergeJoinType } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { restoreSavedMerge } from './restoreSavedMerge';
+
+describe('restoreSavedMerge', () => {
+    it('ignores an unsupported cached merge shape', () => {
+        const unsupportedMerge = {
+            secondQuery: {
+                metricQuery: {
+                    exploreName: 'subscriptions',
+                },
+            },
+        };
+
+        expect(restoreSavedMerge(unsupportedMerge)).toBeNull();
+    });
+
+    it('restores the current saved merge shape', () => {
+        expect(
+            restoreSavedMerge({
+                primarySourceId: 'orders',
+                sources: [
+                    { id: 'orders', kind: 'chart' },
+                    {
+                        id: 'subscriptions',
+                        kind: 'query',
+                        metricQuery: {
+                            exploreName: 'subscriptions',
+                            dimensions: ['subscriptions_month'],
+                            metrics: ['subscriptions_mrr'],
+                            filters: {},
+                            sorts: [],
+                            limit: 500,
+                            tableCalculations: [],
+                        },
+                    },
+                ],
+                joinKey: [
+                    {
+                        name: 'month',
+                        fieldIdBySourceId: {
+                            orders: 'orders_month',
+                            subscriptions: 'subscriptions_month',
+                        },
+                    },
+                ],
+                joinType: MergeJoinType.FULL,
+                tableCalculations: [],
+            }),
+        ).toMatchObject({
+            queryB: {
+                exploreName: 'subscriptions',
+                dimensions: ['subscriptions_month'],
+                metrics: ['subscriptions_mrr'],
+            },
+            joinParts: [
+                {
+                    fieldA: 'orders_month',
+                    fieldB: 'subscriptions_month',
+                },
+            ],
+            joinType: MergeJoinType.FULL,
+        });
+    });
+});

--- a/packages/frontend/src/features/mergeQuery/context/restoreSavedMerge.ts
+++ b/packages/frontend/src/features/mergeQuery/context/restoreSavedMerge.ts
@@ -1,0 +1,49 @@
+import {
+    parseSavedMergeQuery,
+    SAVED_MERGE_QUERY_SCHEMA_VERSION,
+} from '@lightdash/common';
+import { type MergeFocus } from './context';
+
+/**
+ * Turns a chart's stored merge back into editable state.
+ *
+ * The runtime boundary accepts unknown because an already-open browser can
+ * retain an older API response after the app updates. Unsupported shapes are
+ * ignored rather than crashing the chart; they are never converted.
+ */
+export const restoreSavedMerge = (value: unknown) => {
+    const saved = parseSavedMergeQuery(SAVED_MERGE_QUERY_SCHEMA_VERSION, value);
+    if (!saved) return null;
+
+    const additionalSources = saved.sources.filter(
+        (source) => source.kind === 'query',
+    );
+    const chartSource = saved.sources.find((source) => source.kind === 'chart');
+    // The persisted shape supports more sources than today's editor. Keep the
+    // chart usable if a newer producer writes a merge this UI cannot edit yet.
+    if (
+        !chartSource ||
+        saved.primarySourceId !== chartSource.id ||
+        additionalSources.length !== 1
+    ) {
+        return null;
+    }
+    const [secondSource] = additionalSources;
+
+    return {
+        focus: 'a' as MergeFocus,
+        queryB: {
+            exploreName: secondSource.metricQuery.exploreName,
+            dimensions: secondSource.metricQuery.dimensions,
+            metrics: secondSource.metricQuery.metrics,
+            additionalMetrics: secondSource.metricQuery.additionalMetrics,
+            customDimensions: secondSource.metricQuery.customDimensions,
+        },
+        joinParts: saved.joinKey.map((part) => ({
+            fieldA: part.fieldIdBySourceId[chartSource.id],
+            fieldB: part.fieldIdBySourceId[secondSource.id],
+        })),
+        joinType: saved.joinType,
+        filtersB: secondSource.metricQuery.filters ?? {},
+    };
+};

--- a/packages/frontend/src/features/mergeQuery/hooks/useSavedMerge.test.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useSavedMerge.test.ts
@@ -41,21 +41,77 @@ describe('toSavedMerge', () => {
         };
 
         expect(toSavedMerge(mergeQuery)).toEqual({
-            secondQuery: { metricQuery: metricQuery('payments') },
+            primarySourceId: 'a',
+            sources: [
+                { id: 'a', kind: 'chart' },
+                {
+                    id: 'b',
+                    kind: 'query',
+                    metricQuery: metricQuery('payments'),
+                },
+            ],
             joinKey: [
                 {
                     name: 'k0',
-                    chartFieldId: 'orders_suggested_date',
-                    secondFieldId: 'payments_suggested_date',
+                    fieldIdBySourceId: {
+                        a: 'orders_suggested_date',
+                        b: 'payments_suggested_date',
+                    },
                 },
                 {
                     name: 'k1',
-                    chartFieldId: 'orders_status',
-                    secondFieldId: 'payments_status',
+                    fieldIdBySourceId: {
+                        a: 'orders_status',
+                        b: 'payments_status',
+                    },
                 },
             ],
             joinType: MergeJoinType.INNER,
             tableCalculations: [],
+        });
+    });
+
+    it('persists additional sources without changing the schema', () => {
+        const mergeQuery: MergeQuery = {
+            sources: [
+                { id: 'a', metricQuery: metricQuery('orders') },
+                { id: 'payments', metricQuery: metricQuery('payments') },
+                {
+                    id: 'subscriptions',
+                    metricQuery: metricQuery('subscriptions'),
+                },
+            ],
+            joinKey: [
+                {
+                    name: 'date',
+                    fieldIdBySourceId: {
+                        a: 'orders_date',
+                        payments: 'payments_date',
+                        subscriptions: 'subscriptions_date',
+                    },
+                },
+            ],
+            joinType: MergeJoinType.FULL,
+            tableCalculations: [],
+            limit: 500,
+        };
+
+        expect(toSavedMerge(mergeQuery)).toMatchObject({
+            primarySourceId: 'a',
+            sources: [
+                { id: 'a', kind: 'chart' },
+                { id: 'payments', kind: 'query' },
+                { id: 'subscriptions', kind: 'query' },
+            ],
+            joinKey: [
+                {
+                    fieldIdBySourceId: {
+                        a: 'orders_date',
+                        payments: 'payments_date',
+                        subscriptions: 'subscriptions_date',
+                    },
+                },
+            ],
         });
     });
 });

--- a/packages/frontend/src/features/mergeQuery/hooks/useSavedMerge.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useSavedMerge.ts
@@ -1,22 +1,29 @@
 import { type MergeQuery, type SavedMergeQuery } from '@lightdash/common';
 import { useMemo } from 'react';
-import { SOURCE_A, SOURCE_B } from '../constants';
+import { SOURCE_A } from '../constants';
 import { useMergeSetup } from './useMergeSetup';
 
 export const toSavedMerge = (mergeQuery: MergeQuery): SavedMergeQuery => {
-    const secondQuery = mergeQuery.sources.find(
-        (source) => source.id === SOURCE_B,
-    );
-    if (!secondQuery) {
-        throw new Error('A saved merge requires Query B.');
+    if (!mergeQuery.sources.some((source) => source.id === SOURCE_A)) {
+        throw new Error('A saved merge requires the chart query.');
     }
-
     return {
-        secondQuery: { metricQuery: secondQuery.metricQuery },
+        primarySourceId: mergeQuery.sources[0].id,
+        sources: mergeQuery.sources.map((source) =>
+            source.id === SOURCE_A
+                ? {
+                      id: source.id,
+                      kind: 'chart' as const,
+                  }
+                : {
+                      id: source.id,
+                      kind: 'query' as const,
+                      metricQuery: source.metricQuery,
+                  },
+        ),
         joinKey: mergeQuery.joinKey.map((part) => ({
             name: part.name,
-            chartFieldId: part.fieldIdBySourceId[SOURCE_A],
-            secondFieldId: part.fieldIdBySourceId[SOURCE_B],
+            fieldIdBySourceId: part.fieldIdBySourceId,
         })),
         joinType: mergeQuery.joinType,
         tableCalculations: mergeQuery.tableCalculations,


### PR DESCRIPTION
## Why

The first persisted proposal hard-coded `secondQuery`, making a third source require another schema redesign and leaving source identity implicit. Because merge-query persistence has not shipped, there is no customer data or public contract to migrate.

## Design

- Store the canonical `sources[]` representation from the original table migration.
- Mark the chart-owned query with `kind: chart`; reference it instead of duplicating its metric query.
- Store additional queries as `kind: query` sources with stable IDs.
- Persist `primarySourceId` explicitly so LEFT semantics do not depend on array position.
- Store each join key as `fieldIdBySourceId`, covering every source.
- Keep current two-source execution validation unchanged; persistence is N-shaped without prematurely enabling N-way execution.
- Validate saved payloads again at the browser restoration boundary so stale/unsupported cache data is ignored, never converted, and cannot crash a chart.

## Schema rollout

- The original migration creates `schema_version = 2` rows directly.
- No v1 backfill, down-conversion, legacy parser, or stale-cache adapter.
- Unknown future schema versions still fail closed: the chart loads without the unsupported merge.

## Verification

- Common tests: 3,536 passed, 1 skipped.
- Frontend merge persistence/restoration tests: 4 passed.
- Common/frontend/backend typechecks pass.
- Common/frontend/backend lint pass.
- API generation, generated content schemas, common build, and backend build pass.
- Local migration runner: 0 pending; canonical schema default verified as 2.
- Browser regression: reloaded the reported saved-chart URL; chart, results, and SQL render without the error boundary.
