### PR TITLE
refactor(merge-query): address editor sources by id

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -81,12 +81,13 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
     );
     const { data: mergeFlag } = useServerFeatureFlag(FeatureFlags.MergeQueries);
     const merge = useMergeSafe();
+    const additionalSource = merge?.additionalSources[0];
     const [isChoosingMergeExplore, setIsChoosingMergeExplore] = useState(
-        !merge?.queryB.exploreName,
+        !additionalSource?.exploreName,
     );
     useEffect(() => {
-        if (!merge?.queryB.exploreName) setIsChoosingMergeExplore(true);
-    }, [merge?.queryB.exploreName]);
+        if (!additionalSource?.exploreName) setIsChoosingMergeExplore(true);
+    }, [additionalSource?.exploreName]);
     const isGuidedMerge =
         mergeFlag?.enabled === true &&
         merge?.isMerging === true &&
@@ -243,7 +244,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
             >
                 {merge?.isMerging && merge.readOnly && <MergeJoinBar />}
                 {/* The breadcrumbs, warnings and menu all belong to the
-                    first query's explore; shown above the second query's
+                    primary source's explore; shown above an added source's
                     picker they read as its header, which they are not. */}
                 <Group
                     justify="space-between"
@@ -395,10 +396,12 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
 
                 {isGuidedMerge ? (
                     <MergeQuerySidebar
-                        exploreA={explore}
-                        onFieldChangeA={toggleActiveField}
-                        isChoosingExploreB={isChoosingMergeExplore}
-                        setIsChoosingExploreB={setIsChoosingMergeExplore}
+                        primaryExplore={explore}
+                        onPrimaryFieldChange={toggleActiveField}
+                        isChoosingAdditionalExplore={isChoosingMergeExplore}
+                        setIsChoosingAdditionalExplore={
+                            setIsChoosingMergeExplore
+                        }
                     />
                 ) : (
                     <ItemDetailProvider>

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -349,7 +349,7 @@ const QueryAFiltersCard: FC = memo(() => {
  */
 const FiltersCard: FC = memo(() => {
     const merge = useMergeSafe();
-    if (merge?.isMerging && merge.queryB.exploreName) {
+    if (merge?.isMerging && merge.additionalSources[0]?.exploreName) {
         return <MergeFiltersCard />;
     }
     return <QueryAFiltersCard />;

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -86,7 +86,7 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
         enabled: !!unsavedChartVersionTableName && !cannotViewSqlAuthoredFields,
     });
     // With a merge configured, the merged statement is what Run executes;
-    // the card's copy and open-in-SQL-runner must carry it, not Query A's.
+    // the card's copy and open-in-SQL-runner must carry it, not the primary source's.
     const merge = useMergeCompiledSql();
 
     const hasPivotQuery = !merge.isMergeActive && !!data?.pivotQuery;

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -152,7 +152,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
     // show one of them.
     const merge = useMergeSafe();
     const mergeResults = merge?.mergeResults ?? null;
-    // A restored merge is the chart. Until it lands, Query A's rows are the
+    // A restored merge is the chart. Until it lands, the primary source's rows are the
     // wrong numbers wearing the right config — show loading, not them.
     const awaitingRestoredMerge =
         !!merge?.isMerging &&
@@ -175,7 +175,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
         }
         // No fields and no rows while the restored merge is pending: the
         // chart config validates its layout against whatever fields it is
-        // given, and Query A's fields would fail the saved merged layout and
+        // given, and primary-source fields would fail the saved merged layout and
         // rebuild it from defaults — silently discarding the saved config.
         if (awaitingRestoredMerge) {
             return {

--- a/packages/frontend/src/features/mergeQuery/components/MergeAutoRun.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeAutoRun.tsx
@@ -6,7 +6,7 @@ import { useMergeSetup } from '../hooks/useMergeSetup';
  * Runs a restored merge once, headlessly.
  *
  * A merge that arrived with the chart has to run itself: without this a saved
- * merged chart opens showing Query A's results — the wrong numbers, presented
+ * merged chart opens showing only the primary source's results — the wrong numbers, presented
  * as the chart that was saved. It lives in the main column rather than the
  * sidebar because the saved-chart view opens with the sidebar closed.
  */

--- a/packages/frontend/src/features/mergeQuery/components/MergeFiltersCard.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeFiltersCard.tsx
@@ -28,14 +28,15 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../explorer/store';
+import { PRIMARY_SOURCE_ID } from '../constants';
 import { useMerge } from '../context/useMerge';
 import { syncMergeJoinFilters } from '../utils/syncMergeJoinFilters';
 
 const FilterSectionTitle: FC<{
     label: string;
-    side: 'a' | 'b';
+    primary: boolean;
     count: number;
-}> = ({ label, side, count }) => (
+}> = ({ label, primary, count }) => (
     <Group justify="space-between" gap="xs" px="xs" pt={4} pb={2}>
         <Group gap={7}>
             <Box
@@ -43,10 +44,9 @@ const FilterSectionTitle: FC<{
                 h={7}
                 style={{
                     borderRadius: 2,
-                    background:
-                        side === 'a'
-                            ? 'var(--mantine-color-blue-6)'
-                            : 'var(--mantine-color-orange-6)',
+                    background: primary
+                        ? 'var(--mantine-color-blue-6)'
+                        : 'var(--mantine-color-orange-6)',
                 }}
             />
             <Text size="xs" fw={600}>
@@ -64,10 +64,11 @@ export const MergeFiltersCard: FC = () => {
     const projectUuid = useProjectUuid();
     const project = useProject(projectUuid);
     const merge = useMerge();
+    const additionalSource = merge.additionalSources[0];
     const dispatch = useExplorerDispatch();
 
     const tableName = useExplorerSelector(selectTableName);
-    const filtersA = useExplorerSelector(selectFilters);
+    const primaryFilters = useExplorerSelector(selectFilters);
     const filterIsOpen = useExplorerSelector(selectIsFiltersExpanded);
     const isEditMode = useExplorerSelector(selectIsEditMode);
     const parameterValues = useExplorerSelector(selectParameters);
@@ -76,60 +77,77 @@ export const MergeFiltersCard: FC = () => {
     const customDimensions = useExplorerSelector(selectCustomDimensions);
     const tableCalculations = useExplorerSelector(selectTableCalculations);
 
-    const { data: exploreA } = useExplore(tableName);
-    const { data: exploreB } = useExplore(
-        merge.queryB.exploreName ?? undefined,
+    const { data: primaryExplore } = useExplore(tableName);
+    const { data: additionalExplore } = useExplore(
+        additionalSource?.exploreName ?? undefined,
     );
     const [hasEverOpened, setHasEverOpened] = useState(false);
     useEffect(() => {
         if (filterIsOpen) setHasEverOpened(true);
     }, [filterIsOpen]);
 
-    const fieldsA = useFieldsWithSuggestions({
-        exploreData: exploreA,
+    const primaryFields = useFieldsWithSuggestions({
+        exploreData: primaryExplore,
         rows: undefined,
         customDimensions,
         additionalMetrics,
         tableCalculations,
         includeHiddenFields: false,
     });
-    const fieldsB = useFieldsWithSuggestions({
-        exploreData: exploreB,
+    const additionalFields = useFieldsWithSuggestions({
+        exploreData: additionalExplore,
         rows: undefined,
-        customDimensions: merge.queryB.customDimensions,
-        additionalMetrics: merge.queryB.additionalMetrics,
+        customDimensions: additionalSource?.customDimensions,
+        additionalMetrics: additionalSource?.additionalMetrics,
         tableCalculations: undefined,
         includeHiddenFields: false,
     });
 
-    const countA = useMemo(() => countTotalFilterRules(filtersA), [filtersA]);
-    const countB = useMemo(
-        () => countTotalFilterRules(merge.filtersB),
-        [merge.filtersB],
+    const primaryCount = useMemo(
+        () => countTotalFilterRules(primaryFilters),
+        [primaryFilters],
+    );
+    const additionalCount = useMemo(
+        () => countTotalFilterRules(additionalSource?.filters ?? {}),
+        [additionalSource?.filters],
     );
     const total = useMemo(
         () =>
             new Set(
                 [
-                    ...getTotalFilterRules(filtersA),
-                    ...getTotalFilterRules(merge.filtersB),
+                    ...getTotalFilterRules(primaryFilters),
+                    ...getTotalFilterRules(additionalSource?.filters ?? {}),
                 ].map((rule) => rule.id),
             ).size,
-        [filtersA, merge.filtersB],
+        [primaryFilters, additionalSource?.filters],
     );
 
     const setBoth = useCallback(
-        (changedSide: 'a' | 'b', nextA: Filters, nextB: Filters) => {
+        (
+            changedSourceId: string,
+            nextPrimary: Filters,
+            nextAdditional: Filters,
+        ) => {
+            if (!additionalSource) return;
             const synced = syncMergeJoinFilters({
-                changedSide,
-                filtersA: nextA,
-                filtersB: nextB,
+                changedSourceId,
+                filtersBySourceId: {
+                    [PRIMARY_SOURCE_ID]: nextPrimary,
+                    [additionalSource.id]: nextAdditional,
+                },
                 joinParts: merge.joinParts,
             });
-            dispatch(explorerActions.setFilters(synced.filtersA));
-            merge.setFiltersB(synced.filtersB);
+            dispatch(
+                explorerActions.setFilters(
+                    synced[PRIMARY_SOURCE_ID] ?? nextPrimary,
+                ),
+            );
+            merge.setSourceFilters(
+                additionalSource.id,
+                synced[additionalSource.id] ?? nextAdditional,
+            );
         },
-        [dispatch, merge],
+        [additionalSource, dispatch, merge],
     );
 
     return (
@@ -156,19 +174,19 @@ export const MergeFiltersCard: FC = () => {
                 <Stack gap="md">
                     <Stack gap="xs">
                         <FilterSectionTitle
-                            label={exploreA?.label ?? 'First table'}
-                            side="a"
-                            count={countA}
+                            label={primaryExplore?.label ?? 'First table'}
+                            primary
+                            count={primaryCount}
                         />
                         <FiltersProvider
                             projectUuid={projectUuid}
-                            itemsMap={fieldsA}
+                            itemsMap={primaryFields}
                             startOfWeek={
                                 project.data?.warehouseConnection
                                     ?.startOfWeek ?? undefined
                             }
                             popoverProps={{ withinPortal: true }}
-                            baseTable={exploreA?.baseTable}
+                            baseTable={primaryExplore?.baseTable}
                             parameterValues={parameterValues}
                             metricQueryTimezone={
                                 metricQuery.timezone &&
@@ -179,9 +197,13 @@ export const MergeFiltersCard: FC = () => {
                         >
                             <FiltersForm
                                 isEditMode={isEditMode}
-                                filters={filtersA}
+                                filters={primaryFilters}
                                 setFilters={(next) =>
-                                    setBoth('a', next, merge.filtersB)
+                                    setBoth(
+                                        PRIMARY_SOURCE_ID,
+                                        next,
+                                        additionalSource?.filters ?? {},
+                                    )
                                 }
                             />
                         </FiltersProvider>
@@ -191,26 +213,31 @@ export const MergeFiltersCard: FC = () => {
 
                     <Stack gap="xs">
                         <FilterSectionTitle
-                            label={exploreB?.label ?? 'Second table'}
-                            side="b"
-                            count={countB}
+                            label={additionalExplore?.label ?? 'Second table'}
+                            primary={false}
+                            count={additionalCount}
                         />
                         <FiltersProvider
                             projectUuid={projectUuid}
-                            itemsMap={fieldsB}
+                            itemsMap={additionalFields}
                             startOfWeek={
                                 project.data?.warehouseConnection
                                     ?.startOfWeek ?? undefined
                             }
                             popoverProps={{ withinPortal: true }}
-                            baseTable={exploreB?.baseTable}
+                            baseTable={additionalExplore?.baseTable}
                             parameterValues={parameterValues}
                         >
                             <FiltersForm
                                 isEditMode={isEditMode}
-                                filters={merge.filtersB}
+                                filters={additionalSource?.filters ?? {}}
                                 setFilters={(next) =>
-                                    setBoth('b', filtersA, next)
+                                    additionalSource &&
+                                    setBoth(
+                                        additionalSource.id,
+                                        primaryFilters,
+                                        next,
+                                    )
                                 }
                             />
                         </FiltersProvider>

--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
@@ -24,7 +24,7 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../explorer/store';
-import { EMPTY_MERGE } from '../constants';
+import { EMPTY_MERGE, PRIMARY_SOURCE_ID } from '../constants';
 import { useMergeSafe } from '../context/useMerge';
 import { useMergeSetup } from '../hooks/useMergeSetup';
 import styles from './MergeJoinBar.module.css';
@@ -63,14 +63,16 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
     const {
         isMerging,
         readOnly,
-        queryB,
+        additionalSources,
         joinType,
         setJoinField,
         addJoinPart,
         removeJoinPart,
         setJoinType,
-        toggleFieldB,
+        toggleSourceField,
     } = mergeContext ?? EMPTY_MERGE;
+    const additionalSource = additionalSources[0];
+    const additionalSourceId = additionalSource?.id;
     const { runErrors, mergeResults } = mergeContext ?? {};
 
     const {
@@ -79,13 +81,13 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
         fanOut,
         joinKeyErrors,
         joinFieldLabel,
-        joinItemsA,
-        joinItemsB,
-        availableJoinItemsA,
-        availableJoinItemsB,
+        primaryJoinItems,
+        additionalJoinItems,
+        availablePrimaryJoinItems,
+        availableAdditionalJoinItems,
         suggestedAvailablePair,
-        exploreALabel,
-        exploreBLabel,
+        primaryExploreLabel,
+        additionalExploreLabel,
         isIncomplete,
         blockingReason,
     } = useMergeSetup();
@@ -97,15 +99,15 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
     );
     const expanded =
         !readOnly &&
-        !!queryB.exploreName &&
+        !!additionalSource?.exploreName &&
         (guided || (editingOverride ?? isIncomplete));
 
     if (!mergeContext || !tableName || mergeFlag?.enabled !== true) return null;
     if (!isMerging) return null;
-    if (!queryB.exploreName) return null;
+    if (!additionalSource?.exploreName || !additionalSourceId) return null;
 
-    const thisQuery = exploreALabel || 'this query';
-    const otherQuery = exploreBLabel || 'the other query';
+    const thisQuery = primaryExploreLabel || 'this query';
+    const otherQuery = additionalExploreLabel || 'the other query';
     const keepOptions = [
         {
             value: MergeJoinType.FULL,
@@ -137,7 +139,11 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
             joined on{' '}
             <b>
                 {effectiveParts
-                    .map((part) => (part.fieldA ? labelFor(part.fieldA) : '?'))
+                    .map((part) => {
+                        const fieldId =
+                            part.fieldIdBySourceId[PRIMARY_SOURCE_ID];
+                        return fieldId ? labelFor(fieldId) : '?';
+                    })
                     .join(' + ')}
             </b>{' '}
             · keep <b>{activeKeep.label}</b>
@@ -175,8 +181,10 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
                             <Box className={styles.pair} key={index}>
                                 <Box className={styles.pairHeader}>
                                     <Text span size="xs" c="dimmed">
-                                        {exploreALabel} matches{' '}
-                                        {exploreBLabel ?? 'the second query'} on
+                                        {primaryExploreLabel} matches{' '}
+                                        {additionalExploreLabel ??
+                                            'the second query'}{' '}
+                                        on
                                     </Text>
                                     {effectiveParts.length > 1 && (
                                         <ActionIcon
@@ -196,8 +204,12 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
                                     )}
                                 </Box>
                                 {index === 0 &&
-                                    !part.fieldA &&
-                                    !part.fieldB &&
+                                    !part.fieldIdBySourceId[
+                                        PRIMARY_SOURCE_ID
+                                    ] &&
+                                    !part.fieldIdBySourceId[
+                                        additionalSourceId
+                                    ] &&
                                     suggestedAvailablePair && (
                                         <Anchor
                                             component="button"
@@ -205,49 +217,68 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
                                             size="xs"
                                             ta="left"
                                             onClick={() => {
-                                                const { fieldA, fieldB } =
-                                                    suggestedAvailablePair;
+                                                const primaryField =
+                                                    suggestedAvailablePair[
+                                                        PRIMARY_SOURCE_ID
+                                                    ];
+                                                const additionalField =
+                                                    suggestedAvailablePair[
+                                                        additionalSourceId
+                                                    ];
                                                 if (
-                                                    !joinItemsA.some(
+                                                    !primaryField ||
+                                                    !additionalField
+                                                )
+                                                    return;
+                                                if (
+                                                    !primaryJoinItems.some(
                                                         (item) =>
                                                             getItemId(item) ===
-                                                            fieldA,
+                                                            primaryField,
                                                     )
                                                 ) {
                                                     dispatch(
                                                         explorerActions.toggleDimension(
-                                                            fieldA,
+                                                            primaryField,
                                                         ),
                                                     );
                                                 }
                                                 if (
-                                                    !joinItemsB.some(
+                                                    !additionalJoinItems.some(
                                                         (item) =>
                                                             getItemId(item) ===
-                                                            fieldB,
+                                                            additionalField,
                                                     )
                                                 ) {
-                                                    toggleFieldB(fieldB, true);
+                                                    toggleSourceField(
+                                                        additionalSourceId,
+                                                        additionalField,
+                                                        true,
+                                                    );
                                                 }
                                                 setJoinField(
                                                     index,
-                                                    'fieldA',
-                                                    fieldA,
+                                                    PRIMARY_SOURCE_ID,
+                                                    primaryField,
                                                 );
                                                 setJoinField(
                                                     index,
-                                                    'fieldB',
-                                                    fieldB,
+                                                    additionalSourceId,
+                                                    additionalField,
                                                 );
                                             }}
                                         >
                                             Suggested:{' '}
                                             {labelFor(
-                                                suggestedAvailablePair.fieldA,
+                                                suggestedAvailablePair[
+                                                    PRIMARY_SOURCE_ID
+                                                ],
                                             )}{' '}
                                             ↔{' '}
                                             {labelFor(
-                                                suggestedAvailablePair.fieldB,
+                                                suggestedAvailablePair[
+                                                    additionalSourceId
+                                                ],
                                             )}
                                         </Anchor>
                                     )}
@@ -255,11 +286,13 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
                                     size="xs"
                                     placeholder="choose or add a field"
                                     hasGrouping
-                                    items={availableJoinItemsA}
-                                    item={availableJoinItemsA.find(
+                                    items={availablePrimaryJoinItems}
+                                    item={availablePrimaryJoinItems.find(
                                         (candidate) =>
                                             getItemId(candidate) ===
-                                            part.fieldA,
+                                            part.fieldIdBySourceId[
+                                                PRIMARY_SOURCE_ID
+                                            ],
                                     )}
                                     onChange={(value) => {
                                         const fieldId = value
@@ -267,7 +300,7 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
                                             : null;
                                         if (
                                             fieldId &&
-                                            !joinItemsA.some(
+                                            !primaryJoinItems.some(
                                                 (item) =>
                                                     getItemId(item) === fieldId,
                                             )
@@ -278,18 +311,24 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
                                                 ),
                                             );
                                         }
-                                        setJoinField(index, 'fieldA', fieldId);
+                                        setJoinField(
+                                            index,
+                                            PRIMARY_SOURCE_ID,
+                                            fieldId,
+                                        );
                                     }}
                                 />
                                 <FieldSelect
                                     size="xs"
                                     placeholder="choose or add a field"
                                     hasGrouping
-                                    items={availableJoinItemsB}
-                                    item={availableJoinItemsB.find(
+                                    items={availableAdditionalJoinItems}
+                                    item={availableAdditionalJoinItems.find(
                                         (candidate) =>
                                             getItemId(candidate) ===
-                                            part.fieldB,
+                                            part.fieldIdBySourceId[
+                                                additionalSourceId
+                                            ],
                                     )}
                                     onChange={(value) => {
                                         const fieldId = value
@@ -297,14 +336,22 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
                                             : null;
                                         if (
                                             fieldId &&
-                                            !joinItemsB.some(
+                                            !additionalJoinItems.some(
                                                 (item) =>
                                                     getItemId(item) === fieldId,
                                             )
                                         ) {
-                                            toggleFieldB(fieldId, true);
+                                            toggleSourceField(
+                                                additionalSourceId,
+                                                fieldId,
+                                                true,
+                                            );
                                         }
-                                        setJoinField(index, 'fieldB', fieldId);
+                                        setJoinField(
+                                            index,
+                                            additionalSourceId,
+                                            fieldId,
+                                        );
                                     }}
                                 />
                             </Box>
@@ -372,12 +419,14 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
             ))}
 
             {!isIncomplete &&
-                fanOut.map(({ side, fields }) => (
-                    <Note key={side} tone="warn">
-                        Query {side.toUpperCase()} is split by{' '}
-                        {fields.map(labelFor).join(' and ')}, which the other
-                        query does not have. Merging would repeat the other
-                        query's rows once per value. Remove{' '}
+                fanOut.map(({ sourceId, fields }) => (
+                    <Note key={sourceId} tone="warn">
+                        {sourceId === PRIMARY_SOURCE_ID
+                            ? primaryExploreLabel
+                            : additionalExploreLabel}{' '}
+                        is split by {fields.map(labelFor).join(' and ')}, which
+                        the other query does not have. Merging would repeat the
+                        other query's rows once per value. Remove{' '}
                         {fields.length === 1 ? 'it' : 'them'}, or select{' '}
                         {fields.length === 1 ? 'it' : 'them'} on both queries
                         and join on {fields.length === 1 ? 'it' : 'them'}.

--- a/packages/frontend/src/features/mergeQuery/components/MergeQueryOptions.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeQueryOptions.tsx
@@ -5,6 +5,7 @@ import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { selectMetricQuery, useExplorerSelector } from '../../explorer/store';
+import { DEFAULT_ADDITIONAL_SOURCE_ID, PRIMARY_SOURCE_ID } from '../constants';
 import { useMergeSafe } from '../context/useMerge';
 import { isMergeSourceReady } from '../utils/mergeWorkflow';
 
@@ -23,7 +24,7 @@ export const MergeQueryOptions: FC = () => {
         return null;
     }
 
-    const queryAReady = isMergeSourceReady(metricQuery);
+    const primarySourceReady = isMergeSourceReady(metricQuery);
 
     return (
         <Menu position="bottom-end" withinPortal shadow="subtle">
@@ -42,8 +43,15 @@ export const MergeQueryOptions: FC = () => {
             <Menu.Dropdown>
                 <Menu.Item
                     leftSection={<MantineIcon icon={IconGitMerge} size={14} />}
-                    onClick={() => merge.addQuery(queryAReady ? 'b' : 'a')}
-                    data-testid="MergeTabStrip/AddQueryB"
+                    onClick={() =>
+                        merge.addSource(DEFAULT_ADDITIONAL_SOURCE_ID, {
+                            kind: 'source',
+                            sourceId: primarySourceReady
+                                ? DEFAULT_ADDITIONAL_SOURCE_ID
+                                : PRIMARY_SOURCE_ID,
+                        })
+                    }
+                    data-testid="MergeQueryOptions/AddSource"
                 >
                     Merge another query
                 </Menu.Item>

--- a/packages/frontend/src/features/mergeQuery/components/MergeQuerySidebar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeQuerySidebar.tsx
@@ -22,31 +22,35 @@ import SelectedFieldsSection, {
 } from '../../../components/Explorer/ExploreTree/SelectedFieldsSection';
 import { ItemDetailProvider } from '../../../components/Explorer/ExploreTree/TableTree/ItemDetailProvider';
 import { selectMetricQuery, useExplorerSelector } from '../../explorer/store';
+import { PRIMARY_SOURCE_ID } from '../constants';
 import { useMerge } from '../context/useMerge';
 import { useMergeSetup } from '../hooks/useMergeSetup';
 import styles from './MergeQuerySidebar.module.css';
-import { QueryBTree } from './QueryBTree';
+import { MergeSourceTree } from './MergeSourceTree';
 
-type Side = 'a' | 'b';
+type SourceRole = 'primary' | 'additional';
 
 const DatasetHeader: FC<{
-    side: Side;
+    sourceRole: SourceRole;
     label: string;
     count: number;
     open: boolean;
     onClick: () => void;
     onRemove?: () => void;
-}> = ({ side, label, count, open, onClick, onRemove }) => (
+}> = ({ sourceRole, label, count, open, onClick, onRemove }) => (
     <Box className={styles.header} data-open={open}>
         <UnstyledButton className={styles.headerButton} onClick={onClick}>
-            <Box className={styles.dot} data-side={side} />
+            <Box
+                className={styles.dot}
+                data-side={sourceRole === 'primary' ? 'a' : 'b'}
+            />
             <Box className={styles.headerCopy}>
                 <Text size="sm" fw={600} truncate title={label}>
                     {label}
                 </Text>
                 <Text size="xs" c="dimmed">
                     {count === 0
-                        ? side === 'b'
+                        ? sourceRole === 'additional'
                             ? 'Select data and fields'
                             : 'Choose fields'
                         : `${count} selected`}
@@ -75,45 +79,55 @@ const DatasetHeader: FC<{
 
 /** One continuous field builder: shared output, then one expandable dataset at a time. */
 export const MergeQuerySidebar: FC<{
-    exploreA: Explore;
-    onFieldChangeA: (fieldId: string, isDimension: boolean) => void;
-    isChoosingExploreB: boolean;
-    setIsChoosingExploreB: Dispatch<SetStateAction<boolean>>;
+    primaryExplore: Explore;
+    onPrimaryFieldChange: (fieldId: string, isDimension: boolean) => void;
+    isChoosingAdditionalExplore: boolean;
+    setIsChoosingAdditionalExplore: Dispatch<SetStateAction<boolean>>;
 }> = ({
-    exploreA,
-    onFieldChangeA,
-    isChoosingExploreB,
-    setIsChoosingExploreB,
+    primaryExplore,
+    onPrimaryFieldChange,
+    isChoosingAdditionalExplore,
+    setIsChoosingAdditionalExplore,
 }) => {
     const merge = useMerge();
+    const additionalSource = merge.additionalSources[0];
+    const additionalSourceId = additionalSource?.id;
     const metricQuery = useExplorerSelector(selectMetricQuery);
     const mergeSetup = useMergeSetup();
-    const [openSide, setOpenSide] = useState<Side | null>(
-        merge.focus === 'b' ? 'b' : 'a',
+    const [openSourceId, setOpenSourceId] = useState<string | null>(
+        merge.focus.kind === 'source' ? merge.focus.sourceId : null,
     );
 
     useEffect(() => {
-        if (!merge.queryB.exploreName) setOpenSide('b');
-    }, [merge.queryB.exploreName]);
+        if (additionalSourceId && !additionalSource?.exploreName) {
+            setOpenSourceId(additionalSourceId);
+        }
+    }, [additionalSource?.exploreName, additionalSourceId]);
 
-    const toggle = (side: Side) => {
-        setOpenSide((current) => (current === side ? null : side));
-        if (openSide !== side) merge.setFocus(side);
+    const toggle = (sourceId: string) => {
+        setOpenSourceId((current) => (current === sourceId ? null : sourceId));
+        if (openSourceId !== sourceId) {
+            merge.setFocus({ kind: 'source', sourceId });
+        }
     };
-    const countA = metricQuery.dimensions.length + metricQuery.metrics.length;
-    const countB = merge.queryB.dimensions.length + merge.queryB.metrics.length;
-    const labelB = merge.queryB.exploreName
-        ? (mergeSetup.exploreBLabel ?? 'Combined data')
+    const primaryCount =
+        metricQuery.dimensions.length + metricQuery.metrics.length;
+    const additionalCount =
+        (additionalSource?.dimensions.length ?? 0) +
+        (additionalSource?.metrics.length ?? 0);
+    const additionalLabel = additionalSource?.exploreName
+        ? (mergeSetup.additionalExploreLabel ?? 'Combined data')
         : 'Choose data to combine';
     const selectedFields = useMemo<SelectedField[]>(() => {
-        const labelA = mergeSetup.exploreALabel ?? 'First data';
-        const sourceBLabel = mergeSetup.exploreBLabel ?? 'Combined data';
-        const sameLabel = labelA === sourceBLabel;
-        const selectedA = [
+        const primaryLabel = mergeSetup.primaryExploreLabel ?? 'First data';
+        const additionalSourceLabel =
+            mergeSetup.additionalExploreLabel ?? 'Combined data';
+        const sameLabel = primaryLabel === additionalSourceLabel;
+        const selectedPrimary = [
             ...metricQuery.dimensions,
             ...metricQuery.metrics,
         ].flatMap((fieldId) => {
-            const item = mergeSetup.itemMapA[fieldId];
+            const item = mergeSetup.primaryItemMap[fieldId];
             if (
                 !item ||
                 (!isDimension(item) &&
@@ -126,20 +140,22 @@ export const MergeQuerySidebar: FC<{
             return [
                 {
                     fieldId,
-                    selectionKey: `a:${fieldId}`,
+                    selectionKey: `${PRIMARY_SOURCE_ID}:${fieldId}`,
                     item,
-                    tableLabel: sameLabel ? `${labelA} · First` : labelA,
+                    tableLabel: sameLabel
+                        ? `${primaryLabel} · First`
+                        : primaryLabel,
                     isDimension: metricQuery.dimensions.includes(fieldId),
-                    onDeselect: onFieldChangeA,
+                    onDeselect: onPrimaryFieldChange,
                     hideActions: true,
                 },
             ];
         });
-        const selectedB = [
-            ...merge.queryB.dimensions,
-            ...merge.queryB.metrics,
+        const selectedAdditional = [
+            ...(additionalSource?.dimensions ?? []),
+            ...(additionalSource?.metrics ?? []),
         ].flatMap((fieldId) => {
-            const item = mergeSetup.itemMapB[fieldId];
+            const item = mergeSetup.additionalItemMap[fieldId];
             if (
                 !item ||
                 (!isDimension(item) &&
@@ -152,26 +168,40 @@ export const MergeQuerySidebar: FC<{
             return [
                 {
                     fieldId,
-                    selectionKey: `b:${fieldId}`,
+                    selectionKey: `${additionalSourceId}:${fieldId}`,
                     item,
                     tableLabel: sameLabel
-                        ? `${sourceBLabel} · Second`
-                        : sourceBLabel,
-                    isDimension: merge.queryB.dimensions.includes(fieldId),
-                    onDeselect: merge.toggleFieldB,
+                        ? `${additionalSourceLabel} · Second`
+                        : additionalSourceLabel,
+                    isDimension:
+                        additionalSource?.dimensions.includes(fieldId) ?? false,
+                    onDeselect: (id: string, isDimension: boolean) =>
+                        additionalSourceId &&
+                        merge.toggleSourceField(
+                            additionalSourceId,
+                            id,
+                            isDimension,
+                        ),
                     hideActions: true,
                 },
             ];
         });
 
-        return [...selectedA, ...selectedB];
-    }, [merge, mergeSetup, metricQuery, onFieldChangeA]);
+        return [...selectedPrimary, ...selectedAdditional];
+    }, [
+        additionalSource,
+        additionalSourceId,
+        merge,
+        mergeSetup,
+        metricQuery,
+        onPrimaryFieldChange,
+    ]);
 
     return (
         <Box className={styles.root}>
             <SelectedFieldsSection
                 fields={selectedFields}
-                onDeselect={onFieldChangeA}
+                onDeselect={onPrimaryFieldChange}
                 heading={`Selected for result · ${selectedFields.length}`}
                 showAllFieldsDivider={false}
             />
@@ -180,38 +210,48 @@ export const MergeQuerySidebar: FC<{
                 <Text className={styles.sourcesLabel}>Data sources</Text>
                 <Box className={styles.sourceList}>
                     <DatasetHeader
-                        side="a"
-                        label={mergeSetup.exploreALabel ?? exploreA.label}
-                        count={countA}
-                        open={openSide === 'a'}
-                        onClick={() => toggle('a')}
+                        sourceRole="primary"
+                        label={
+                            mergeSetup.primaryExploreLabel ??
+                            primaryExplore.label
+                        }
+                        count={primaryCount}
+                        open={openSourceId === PRIMARY_SOURCE_ID}
+                        onClick={() => toggle(PRIMARY_SOURCE_ID)}
                     />
-                    <DatasetHeader
-                        side="b"
-                        label={labelB}
-                        count={countB}
-                        open={openSide === 'b'}
-                        onClick={() => toggle('b')}
-                        onRemove={merge.removeQuery}
-                    />
+                    {additionalSourceId && (
+                        <DatasetHeader
+                            sourceRole="additional"
+                            label={additionalLabel}
+                            count={additionalCount}
+                            open={openSourceId === additionalSourceId}
+                            onClick={() => toggle(additionalSourceId)}
+                            onRemove={() =>
+                                merge.removeSource(additionalSourceId)
+                            }
+                        />
+                    )}
                 </Box>
 
-                {openSide === 'a' && (
+                {openSourceId === PRIMARY_SOURCE_ID && (
                     <Box className={styles.body}>
                         <ItemDetailProvider>
                             <ExploreTree
-                                explore={exploreA}
-                                onSelectedFieldChange={onFieldChangeA}
+                                explore={primaryExplore}
+                                onSelectedFieldChange={onPrimaryFieldChange}
                                 hideSelectedFields
                             />
                         </ItemDetailProvider>
                     </Box>
                 )}
-                {openSide === 'b' && (
+                {additionalSourceId && openSourceId === additionalSourceId && (
                     <Box className={styles.body}>
-                        <QueryBTree
-                            isChoosingExplore={isChoosingExploreB}
-                            setIsChoosingExplore={setIsChoosingExploreB}
+                        <MergeSourceTree
+                            sourceId={additionalSourceId}
+                            isChoosingExplore={isChoosingAdditionalExplore}
+                            setIsChoosingExplore={
+                                setIsChoosingAdditionalExplore
+                            }
                             selectedFields={selectedFields}
                             hideSelectedFields
                         />

--- a/packages/frontend/src/features/mergeQuery/components/MergeReadOnlyBar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeReadOnlyBar.tsx
@@ -3,6 +3,7 @@ import { Box, Group, Paper, Text, ThemeIcon } from '@mantine/core';
 import { IconArrowMerge } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { PRIMARY_SOURCE_ID } from '../constants';
 import { useMergeSafe } from '../context/useMerge';
 import { useMergeSetup } from '../hooks/useMergeSetup';
 
@@ -16,8 +17,9 @@ export const MergeReadOnlyBar: FC = () => {
     const {
         effectiveParts,
         labelFor,
-        exploreALabel,
-        exploreBLabel,
+        primaryExploreLabel,
+        additionalExploreLabel,
+        additionalSourceId,
         isIncomplete,
     } = useMergeSetup();
 
@@ -25,15 +27,24 @@ export const MergeReadOnlyBar: FC = () => {
 
     const keys = effectiveParts
         .map((part) => {
-            const fieldA = part.fieldA ? labelFor(part.fieldA) : '?';
-            const fieldB = part.fieldB ? labelFor(part.fieldB) : '?';
+            const primaryFieldId = part.fieldIdBySourceId[PRIMARY_SOURCE_ID];
+            const additionalFieldId =
+                part.fieldIdBySourceId[additionalSourceId];
+            const primaryField = primaryFieldId
+                ? labelFor(primaryFieldId)
+                : '?';
+            const additionalField = additionalFieldId
+                ? labelFor(additionalFieldId)
+                : '?';
 
-            return fieldA === fieldB ? fieldA : `${fieldA} ↔ ${fieldB}`;
+            return primaryField === additionalField
+                ? primaryField
+                : `${primaryField} ↔ ${additionalField}`;
         })
         .join(' + ');
     const keepLabel =
         merge.joinType === MergeJoinType.LEFT
-            ? `Keep ${exploreALabel}`
+            ? `Keep ${primaryExploreLabel}`
             : merge.joinType === MergeJoinType.INNER
               ? 'Matches only'
               : 'Keep all rows';
@@ -58,7 +69,7 @@ export const MergeReadOnlyBar: FC = () => {
                             style={{ borderRadius: '50%', flexShrink: 0 }}
                         />
                         <Text size="sm" fw={600} truncate>
-                            {exploreALabel}
+                            {primaryExploreLabel}
                         </Text>
                         <Text size="xs" c="dimmed">
                             +
@@ -70,7 +81,7 @@ export const MergeReadOnlyBar: FC = () => {
                             style={{ borderRadius: '50%', flexShrink: 0 }}
                         />
                         <Text size="sm" fw={600} truncate>
-                            {exploreBLabel}
+                            {additionalExploreLabel}
                         </Text>
                     </Group>
                     <Text size="xs" c="dimmed" truncate>

--- a/packages/frontend/src/features/mergeQuery/components/MergeRelationshipCard.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeRelationshipCard.tsx
@@ -6,7 +6,8 @@ import { useMergeSetup } from '../hooks/useMergeSetup';
 import { MergeJoinBar } from './MergeJoinBar';
 
 const MergeRelationshipCardContent: FC = () => {
-    const { exploreALabel, exploreBLabel, isIncomplete } = useMergeSetup();
+    const { primaryExploreLabel, additionalExploreLabel, isIncomplete } =
+        useMergeSetup();
     const [isOpen, setIsOpen] = useState(true);
 
     return (
@@ -18,8 +19,8 @@ const MergeRelationshipCardContent: FC = () => {
                 <Badge variant="light" color={isIncomplete ? 'orange' : 'gray'}>
                     {isIncomplete
                         ? 'Needs a matching field'
-                        : `${exploreALabel ?? 'First data'} + ${
-                              exploreBLabel ?? 'combined data'
+                        : `${primaryExploreLabel ?? 'First data'} + ${
+                              additionalExploreLabel ?? 'combined data'
                           }`}
                 </Badge>
             }
@@ -34,7 +35,11 @@ const MergeRelationshipCardContent: FC = () => {
 /** The relationship belongs to the result, so it lives with result controls—not inside either dataset. */
 export const MergeRelationshipCard: FC = () => {
     const merge = useMergeSafe();
-    if (!merge?.isMerging || merge.readOnly || !merge.queryB.exploreName) {
+    if (
+        !merge?.isMerging ||
+        merge.readOnly ||
+        !merge.additionalSources[0]?.exploreName
+    ) {
         return null;
     }
 

--- a/packages/frontend/src/features/mergeQuery/components/MergeSourceTree.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeSourceTree.tsx
@@ -10,43 +10,44 @@ import { ItemDetailProvider } from '../../../components/Explorer/ExploreTree/Tab
 import { useExplore } from '../../../hooks/useExplore';
 import { useMerge } from '../context/useMerge';
 
-/**
- * The field picker for the second query, shown when its tab has the focus.
- *
- * The explorer's own tree, pointed at the second query's explore and its
- * selection. Picking fields is picking fields: search, grouping, descriptions
- * and field detail all work here because it is the same component, not a
- * second and worse one that has to be kept in step.
- */
-export const QueryBTree: FC<{
+/** Field picker for a source owned by the merge editor. */
+export const MergeSourceTree: FC<{
+    sourceId: string;
     isChoosingExplore: boolean;
     setIsChoosingExplore: Dispatch<SetStateAction<boolean>>;
     selectedFields: SelectedField[];
     hideSelectedFields?: boolean;
 }> = ({
+    sourceId,
     isChoosingExplore,
     setIsChoosingExplore,
     selectedFields,
     hideSelectedFields = false,
 }) => {
-    const { queryB, setExploreB, toggleFieldB } = useMerge();
+    const merge = useMerge();
+    const source = merge.additionalSources.find(({ id }) => id === sourceId);
     const { data: explore, isInitialLoading } = useExplore(
-        queryB.exploreName ?? undefined,
+        source?.exploreName ?? undefined,
     );
 
     const selection = useMemo(
         () => ({
-            activeFields: new Set([...queryB.dimensions, ...queryB.metrics]),
-            selectedDimensions: queryB.dimensions,
+            activeFields: new Set([
+                ...(source?.dimensions ?? []),
+                ...(source?.metrics ?? []),
+            ]),
+            selectedDimensions: source?.dimensions ?? [],
         }),
-        [queryB.dimensions, queryB.metrics],
+        [source?.dimensions, source?.metrics],
     );
+    if (!source) return null;
+
     if (isChoosingExplore) {
         return (
             <Box h="100%" mih={0} style={{ overflow: 'hidden' }}>
                 <BasePanel
                     onExploreClick={(selectedExplore) => {
-                        setExploreB(selectedExplore.name);
+                        merge.setSourceExplore(source.id, selectedExplore.name);
                         setIsChoosingExplore(false);
                     }}
                 />
@@ -66,7 +67,7 @@ export const QueryBTree: FC<{
                 Change table
             </Button>
 
-            {queryB.exploreName && isInitialLoading && <LoadingSkeleton />}
+            {source.exploreName && isInitialLoading && <LoadingSkeleton />}
 
             {explore && (
                 <Box style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
@@ -74,7 +75,13 @@ export const QueryBTree: FC<{
                         <ExploreTree
                             explore={explore}
                             selection={selection}
-                            onSelectedFieldChange={toggleFieldB}
+                            onSelectedFieldChange={(fieldId, isDimension) =>
+                                merge.toggleSourceField(
+                                    source.id,
+                                    fieldId,
+                                    isDimension,
+                                )
+                            }
                             selectedFieldsOverride={selectedFields}
                             hideSelectedFields={hideSelectedFields}
                         />

--- a/packages/frontend/src/features/mergeQuery/constants.ts
+++ b/packages/frontend/src/features/mergeQuery/constants.ts
@@ -1,33 +1,43 @@
 import { MergeJoinType } from '@lightdash/common';
+import { type MergeEditorSource, type MergeJoinPart } from './context/context';
 
-export const SOURCE_A = 'a';
-export const SOURCE_B = 'b';
+export const PRIMARY_SOURCE_ID = 'a';
+export const DEFAULT_ADDITIONAL_SOURCE_ID = 'b';
+export const MAX_MERGE_SOURCES = 2;
 export const JOIN_KEY = 'join_key';
+
+export const emptyMergeSource = (id: string): MergeEditorSource => ({
+    id,
+    exploreName: null,
+    dimensions: [],
+    metrics: [],
+    filters: {},
+});
 
 /** Stand-in when no provider is mounted; the setup panel renders nothing. */
 export const EMPTY_MERGE = {
     isMerging: false,
     readOnly: false,
     wasRestored: false,
-    focus: 'a' as const,
-    queryB: {
-        exploreName: null,
-        dimensions: [] as string[],
-        metrics: [] as string[],
-        additionalMetrics: undefined,
-        customDimensions: undefined,
-    },
-    joinParts: [{ fieldA: null, fieldB: null }],
+    focus: { kind: 'source' as const, sourceId: PRIMARY_SOURCE_ID },
+    additionalSources: [] as MergeEditorSource[],
+    joinParts: [
+        {
+            fieldIdBySourceId: {
+                [PRIMARY_SOURCE_ID]: null,
+                [DEFAULT_ADDITIONAL_SOURCE_ID]: null,
+            },
+        },
+    ] as MergeJoinPart[],
     joinType: MergeJoinType.FULL,
-    filtersB: {},
-    addQuery: () => {},
-    removeQuery: () => {},
+    addSource: () => {},
+    removeSource: () => {},
     setFocus: () => {},
-    setExploreB: () => {},
-    toggleFieldB: () => {},
+    setSourceExplore: () => {},
+    toggleSourceField: () => {},
     setJoinField: () => {},
     addJoinPart: () => {},
     removeJoinPart: () => {},
     setJoinType: () => {},
-    setFiltersB: () => {},
+    setSourceFilters: () => {},
 };

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -21,25 +21,20 @@ import {
 } from 'react';
 import { useParams, useSearchParams } from 'react-router';
 import { useInfiniteQueryResults } from '../../../hooks/useQueryResults';
-import { executeMergeQuery } from '../hooks/useMergeQuery';
 import {
-    MergeContext,
-    type MergeFocus,
-    type MergeJoinPart,
-    type MergeQueryBState,
-} from './context';
+    DEFAULT_ADDITIONAL_SOURCE_ID,
+    emptyMergeSource,
+    MAX_MERGE_SOURCES,
+    PRIMARY_SOURCE_ID,
+} from '../constants';
+import { executeMergeQuery } from '../hooks/useMergeQuery';
+import { MergeContext, type MergeFocus, type MergeJoinPart } from './context';
 import {
     MERGE_URL_PARAM,
     parseMergeState,
     serializeMergeState,
 } from './mergeUrlState';
 import { restoreSavedMerge } from './restoreSavedMerge';
-
-const EMPTY_QUERY_B: MergeQueryBState = {
-    exploreName: null,
-    dimensions: [],
-    metrics: [],
-};
 
 /**
  * Merge state lives above the explorer page because the field picker and the
@@ -65,18 +60,29 @@ export const MergeProvider: FC<
             (savedMerge ? restoreSavedMerge(savedMerge) : null),
     );
 
-    const [isMerging, setIsMerging] = useState(restored !== null);
-    const [focus, setFocus] = useState<MergeFocus>(restored?.focus ?? 'a');
-    const [queryB, setQueryB] = useState<MergeQueryBState>(
-        restored?.queryB ?? EMPTY_QUERY_B,
+    const [focus, setFocus] = useState<MergeFocus>(
+        restored?.focus ?? {
+            kind: 'source',
+            sourceId: PRIMARY_SOURCE_ID,
+        },
+    );
+    const [additionalSources, setAdditionalSources] = useState(
+        restored?.additionalSources ?? [],
     );
     const [joinParts, setJoinParts] = useState<MergeJoinPart[]>(
-        restored?.joinParts ?? [{ fieldA: null, fieldB: null }],
+        restored?.joinParts ?? [
+            {
+                fieldIdBySourceId: {
+                    [PRIMARY_SOURCE_ID]: null,
+                    [DEFAULT_ADDITIONAL_SOURCE_ID]: null,
+                },
+            },
+        ],
     );
     const [joinType, setJoinType] = useState<MergeJoinType>(
         restored?.joinType ?? MergeJoinType.FULL,
     );
-    const [filtersB, setFiltersB] = useState<Filters>(restored?.filtersB ?? {});
+    const isMerging = additionalSources.length > 0;
     const activeRun = useRef(0);
     const lastRun = useRef<{
         mergeQuery: MergeQuery;
@@ -99,18 +105,48 @@ export const MergeProvider: FC<
         fieldOrigins: {},
     });
 
-    const addQuery = useCallback((initialFocus: MergeFocus = 'b') => {
-        setIsMerging(true);
-        setFocus(initialFocus);
-    }, []);
+    const addSource = useCallback(
+        (
+            sourceId: string,
+            initialFocus: MergeFocus = { kind: 'source', sourceId },
+        ) => {
+            if (
+                additionalSources.some((source) => source.id === sourceId) ||
+                additionalSources.length + 1 >= MAX_MERGE_SOURCES
+            ) {
+                return;
+            }
+            setAdditionalSources((current) => [
+                ...current,
+                emptyMergeSource(sourceId),
+            ]);
+            setJoinParts((current) =>
+                current.map((part) => ({
+                    ...part,
+                    fieldIdBySourceId: {
+                        ...part.fieldIdBySourceId,
+                        [sourceId]: null,
+                    },
+                })),
+            );
+            setFocus(initialFocus);
+        },
+        [additionalSources],
+    );
 
-    const removeQuery = useCallback(() => {
+    const removeSource = useCallback((sourceId: string) => {
         activeRun.current += 1;
-        setIsMerging(false);
-        setFocus('a');
-        setQueryB(EMPTY_QUERY_B);
-        setJoinParts([{ fieldA: null, fieldB: null }]);
-        setFiltersB({});
+        setFocus({ kind: 'source', sourceId: PRIMARY_SOURCE_ID });
+        setAdditionalSources((current) =>
+            current.filter((source) => source.id !== sourceId),
+        );
+        setJoinParts((current) =>
+            current.map((part) => {
+                const { [sourceId]: _, ...fieldIdBySourceId } =
+                    part.fieldIdBySourceId;
+                return { fieldIdBySourceId };
+            }),
+        );
         setRunState({
             isRunning: false,
             errors: [],
@@ -121,21 +157,46 @@ export const MergeProvider: FC<
         });
     }, []);
 
-    const setExploreB = useCallback((exploreName: string | null) => {
-        // Fields belong to an explore, so changing it clears what was picked
-        // rather than leaving ids that no longer resolve.
-        setQueryB({ exploreName, dimensions: [], metrics: [] });
-        setJoinParts((current) =>
-            current.map((part) => ({ ...part, fieldB: null })),
-        );
-        setFiltersB({});
-    }, []);
+    const setSourceExplore = useCallback(
+        (sourceId: string, exploreName: string | null) => {
+            // Fields belong to an explore, so changing it clears what was picked
+            // rather than leaving ids that no longer resolve.
+            setAdditionalSources((current) =>
+                current.map((source) =>
+                    source.id === sourceId
+                        ? {
+                              ...emptyMergeSource(sourceId),
+                              exploreName,
+                          }
+                        : source,
+                ),
+            );
+            setJoinParts((current) =>
+                current.map((part) => ({
+                    ...part,
+                    fieldIdBySourceId: {
+                        ...part.fieldIdBySourceId,
+                        [sourceId]: null,
+                    },
+                })),
+            );
+        },
+        [],
+    );
 
     const setJoinField = useCallback(
-        (index: number, side: 'fieldA' | 'fieldB', fieldId: string | null) => {
+        (index: number, sourceId: string, fieldId: string | null) => {
             setJoinParts((current) =>
                 current.map((part, partIndex) =>
-                    partIndex === index ? { ...part, [side]: fieldId } : part,
+                    partIndex === index
+                        ? {
+                              ...part,
+                              fieldIdBySourceId: {
+                                  ...part.fieldIdBySourceId,
+                                  [sourceId]: fieldId,
+                              },
+                          }
+                        : part,
                 ),
             );
         },
@@ -143,8 +204,18 @@ export const MergeProvider: FC<
     );
 
     const addJoinPart = useCallback(() => {
-        setJoinParts((current) => [...current, { fieldA: null, fieldB: null }]);
-    }, []);
+        setJoinParts((current) => [
+            ...current,
+            {
+                fieldIdBySourceId: Object.fromEntries(
+                    [
+                        PRIMARY_SOURCE_ID,
+                        ...additionalSources.map((source) => source.id),
+                    ].map((sourceId) => [sourceId, null]),
+                ),
+            },
+        ]);
+    }, [additionalSources]);
 
     const removeJoinPart = useCallback((index: number) => {
         setJoinParts((current) =>
@@ -156,18 +227,32 @@ export const MergeProvider: FC<
         // leave it pointing at a different one.
     }, []);
 
-    const toggleFieldB = useCallback(
-        (fieldId: string, isDimension: boolean) => {
-            setQueryB((current) => {
-                const key = isDimension ? 'dimensions' : 'metrics';
-                const selected = current[key];
-                return {
-                    ...current,
-                    [key]: selected.includes(fieldId)
-                        ? selected.filter((id) => id !== fieldId)
-                        : [...selected, fieldId],
-                };
-            });
+    const toggleSourceField = useCallback(
+        (sourceId: string, fieldId: string, isDimension: boolean) => {
+            setAdditionalSources((current) =>
+                current.map((source) => {
+                    if (source.id !== sourceId) return source;
+                    const key = isDimension ? 'dimensions' : 'metrics';
+                    const selected = source[key];
+                    return {
+                        ...source,
+                        [key]: selected.includes(fieldId)
+                            ? selected.filter((id) => id !== fieldId)
+                            : [...selected, fieldId],
+                    };
+                }),
+            );
+        },
+        [],
+    );
+
+    const setSourceFilters = useCallback(
+        (sourceId: string, filters: Filters) => {
+            setAdditionalSources((current) =>
+                current.map((source) =>
+                    source.id === sourceId ? { ...source, filters } : source,
+                ),
+            );
         },
         [],
     );
@@ -187,10 +272,9 @@ export const MergeProvider: FC<
                         MERGE_URL_PARAM,
                         serializeMergeState({
                             focus,
-                            queryB,
+                            additionalSources,
                             joinParts,
                             joinType,
-                            filtersB,
                         }),
                     );
                 } else {
@@ -204,10 +288,9 @@ export const MergeProvider: FC<
         readOnly,
         isMerging,
         focus,
-        queryB,
+        additionalSources,
         joinParts,
         joinType,
-        filtersB,
         setSearchParams,
     ]);
 
@@ -323,20 +406,19 @@ export const MergeProvider: FC<
             parameterReferences: runState.parameterReferences,
             mergeResults,
             focus,
-            queryB,
+            additionalSources,
             joinParts,
             joinType,
-            filtersB,
-            addQuery,
-            removeQuery,
+            addSource,
+            removeSource,
             setFocus,
-            setExploreB,
-            toggleFieldB,
+            setSourceExplore,
+            toggleSourceField,
             setJoinField,
             addJoinPart,
             removeJoinPart,
             setJoinType,
-            setFiltersB,
+            setSourceFilters,
         }),
         [
             isMerging,
@@ -350,17 +432,17 @@ export const MergeProvider: FC<
             runState.parameterReferences,
             mergeResults,
             focus,
-            queryB,
+            additionalSources,
             joinParts,
             joinType,
-            filtersB,
-            addQuery,
-            removeQuery,
-            setExploreB,
-            toggleFieldB,
+            addSource,
+            removeSource,
+            setSourceExplore,
+            toggleSourceField,
             setJoinField,
             addJoinPart,
             removeJoinPart,
+            setSourceFilters,
         ],
     );
 

--- a/packages/frontend/src/features/mergeQuery/context/context.ts
+++ b/packages/frontend/src/features/mergeQuery/context/context.ts
@@ -13,22 +13,24 @@ import {
 import { createContext } from 'react';
 import { type InfiniteQueryResults } from '../../../hooks/useQueryResults';
 
-/** Which part of the merge workflow the sidebar is editing. */
-export type MergeFocus = 'a' | 'b' | 'join';
-
-export type MergeQueryBState = {
+export type MergeEditorSource = {
+    id: string;
     exploreName: string | null;
     dimensions: string[];
     metrics: string[];
+    filters: Filters;
     /** Keep saved-query-only fields intact while the merge is edited. */
     additionalMetrics?: MetricQuery['additionalMetrics'];
     customDimensions?: MetricQuery['customDimensions'];
 };
 
-/** One part of the join key: the field each query contributes. */
+export type MergeFocus =
+    | { kind: 'source'; sourceId: string }
+    | { kind: 'join' };
+
+/** One part of the join key: the field each source contributes. */
 export type MergeJoinPart = {
-    fieldA: string | null;
-    fieldB: string | null;
+    fieldIdBySourceId: Record<string, string | null>;
 };
 
 /**
@@ -49,7 +51,7 @@ export type MergeResults = {
 };
 
 export type MergeContextValue = {
-    /** True once a second query has been added. */
+    /** True once another source has been added to the chart query. */
     isMerging: boolean;
     /** A saved chart in view mode shows its merge; it does not edit it. */
     readOnly: boolean;
@@ -78,25 +80,28 @@ export type MergeContextValue = {
     /** The merged run, or null when none has succeeded yet. */
     mergeResults: MergeResults | null;
     focus: MergeFocus;
-    queryB: MergeQueryBState;
-    /** Query B's own filters, pushed down into that side's compile. */
-    filtersB: Filters;
+    /** Sources owned by the merge; the chart-owned source stays in Explorer. */
+    additionalSources: MergeEditorSource[];
     joinParts: MergeJoinPart[];
     joinType: MergeJoinType;
-    addQuery: (initialFocus?: MergeFocus) => void;
-    removeQuery: () => void;
+    addSource: (sourceId: string, initialFocus?: MergeFocus) => void;
+    removeSource: (sourceId: string) => void;
     setFocus: (focus: MergeFocus) => void;
-    setExploreB: (exploreName: string | null) => void;
-    toggleFieldB: (fieldId: string, isDimension: boolean) => void;
+    setSourceExplore: (sourceId: string, exploreName: string | null) => void;
+    toggleSourceField: (
+        sourceId: string,
+        fieldId: string,
+        isDimension: boolean,
+    ) => void;
     setJoinField: (
         index: number,
-        side: 'fieldA' | 'fieldB',
+        sourceId: string,
         fieldId: string | null,
     ) => void;
     addJoinPart: () => void;
     removeJoinPart: (index: number) => void;
     setJoinType: (joinType: MergeJoinType) => void;
-    setFiltersB: (filters: Filters) => void;
+    setSourceFilters: (sourceId: string, filters: Filters) => void;
 };
 
 export const MergeContext = createContext<MergeContextValue | undefined>(

--- a/packages/frontend/src/features/mergeQuery/context/mergeUrlState.test.ts
+++ b/packages/frontend/src/features/mergeQuery/context/mergeUrlState.test.ts
@@ -7,33 +7,46 @@ import {
 } from './mergeUrlState';
 
 const state: MergeUrlState = {
-    focus: 'b',
-    queryB: {
-        exploreName: 'subscriptions',
-        dimensions: ['subscriptions_subscription_start_month'],
-        metrics: ['subscriptions_total_subscriptions'],
-    },
+    focus: { kind: 'source', sourceId: 'subscriptions' },
+    additionalSources: [
+        {
+            id: 'subscriptions',
+            exploreName: 'subscriptions',
+            dimensions: ['subscriptions_subscription_start_month'],
+            metrics: ['subscriptions_total_subscriptions'],
+            filters: {},
+        },
+    ],
     joinParts: [
         {
-            fieldA: 'orders_order_date_month',
-            fieldB: 'subscriptions_subscription_start_month',
+            fieldIdBySourceId: {
+                a: 'orders_order_date_month',
+                subscriptions: 'subscriptions_subscription_start_month',
+            },
         },
-        { fieldA: 'orders_status', fieldB: 'subscriptions_status' },
+        {
+            fieldIdBySourceId: {
+                a: 'orders_status',
+                subscriptions: 'subscriptions_status',
+            },
+        },
     ],
     joinType: MergeJoinType.LEFT,
-    filtersB: {},
 };
 
 describe('merge url state', () => {
-    it('round-trips the whole relationship', () => {
+    it('round-trips source-addressed editor state', () => {
         expect(parseMergeState(serializeMergeState(state))).toEqual(state);
     });
 
-    it('round-trips the combine step', () => {
-        const combineState = { ...state, focus: 'join' as const };
+    it('round-trips the relationship step', () => {
+        const relationshipState = {
+            ...state,
+            focus: { kind: 'join' as const },
+        };
 
-        expect(parseMergeState(serializeMergeState(combineState))).toEqual(
-            combineState,
+        expect(parseMergeState(serializeMergeState(relationshipState))).toEqual(
+            relationshipState,
         );
     });
 
@@ -42,51 +55,92 @@ describe('merge url state', () => {
         expect(parseMergeState('')).toBeNull();
     });
 
-    // A shared link can be stale or hand-edited. Dropping back to the ordinary
-    // explorer is the right failure; throwing away the page is not.
-    it('returns null for anything that is not JSON', () => {
+    it('returns null for malformed JSON or a non-object value', () => {
         expect(parseMergeState('not json')).toBeNull();
         expect(parseMergeState('{oops')).toBeNull();
-    });
-
-    it('returns null for JSON that is not an object', () => {
         expect(parseMergeState('"a string"')).toBeNull();
         expect(parseMergeState('null')).toBeNull();
     });
 
-    it('falls back to safe defaults for missing or wrong-typed fields', () => {
-        expect(parseMergeState('{}')).toEqual({
-            focus: 'a',
-            queryB: { exploreName: null, dimensions: [], metrics: [] },
-            // A merge always has at least one key part, even an unfilled one.
-            joinParts: [{ fieldA: null, fieldB: null }],
-            joinType: MergeJoinType.FULL,
-            filtersB: {},
+    it('adapts legacy two-source links at the URL boundary', () => {
+        const parsed = parseMergeState(
+            JSON.stringify({
+                e: 'subscriptions',
+                d: ['subscriptions_month', 3, null],
+                m: ['subscriptions_mrr'],
+                k: [
+                    ['orders_month', 'subscriptions_month'],
+                    'invalid',
+                    [1, 'subscriptions_status'],
+                ],
+                j: MergeJoinType.LEFT,
+                w: {},
+                f: 'b',
+            }),
+        );
+
+        expect(parsed).toEqual({
+            focus: { kind: 'source', sourceId: 'b' },
+            additionalSources: [
+                {
+                    id: 'b',
+                    exploreName: 'subscriptions',
+                    dimensions: ['subscriptions_month'],
+                    metrics: ['subscriptions_mrr'],
+                    filters: {},
+                    additionalMetrics: undefined,
+                    customDimensions: undefined,
+                },
+            ],
+            joinParts: [
+                {
+                    fieldIdBySourceId: {
+                        a: 'orders_month',
+                        b: 'subscriptions_month',
+                    },
+                },
+                {
+                    fieldIdBySourceId: {
+                        a: null,
+                        b: 'subscriptions_status',
+                    },
+                },
+            ],
+            joinType: MergeJoinType.LEFT,
         });
     });
 
-    it('drops non-string entries rather than carrying them into a query', () => {
-        const parsed = parseMergeState(
-            JSON.stringify({ d: ['ok', 3, null, 'fine'] }),
-        );
-
-        expect(parsed?.queryB.dimensions).toEqual(['ok', 'fine']);
+    it('falls back to safe defaults for an empty legacy shape', () => {
+        expect(parseMergeState('{}')).toEqual({
+            focus: { kind: 'source', sourceId: 'a' },
+            additionalSources: [
+                {
+                    id: 'b',
+                    exploreName: null,
+                    dimensions: [],
+                    metrics: [],
+                    filters: {},
+                    additionalMetrics: undefined,
+                    customDimensions: undefined,
+                },
+            ],
+            joinParts: [{ fieldIdBySourceId: { a: null, b: null } }],
+            joinType: MergeJoinType.FULL,
+        });
     });
 
-    it('rejects a join type it does not recognise', () => {
+    it('rejects malformed current sources', () => {
+        expect(parseMergeState(JSON.stringify({ s: [{}] }))).toBeNull();
+        expect(parseMergeState(JSON.stringify({ s: [] }))).toBeNull();
         expect(
-            parseMergeState(JSON.stringify({ j: 'sideways' }))?.joinType,
-        ).toBe(MergeJoinType.FULL);
-    });
-
-    it('keeps composite key parts and drops malformed ones', () => {
-        const parsed = parseMergeState(
-            JSON.stringify({ k: [['a', 'b'], 'nope', [1, 'c']] }),
-        );
-
-        expect(parsed?.joinParts).toEqual([
-            { fieldA: 'a', fieldB: 'b' },
-            { fieldA: null, fieldB: 'c' },
-        ]);
+            parseMergeState(
+                JSON.stringify({
+                    s: [
+                        { i: 'b', e: null, d: [], m: [], w: {} },
+                        { i: 'c', e: null, d: [], m: [], w: {} },
+                    ],
+                }),
+            ),
+        ).toBeNull();
     });
 });

--- a/packages/frontend/src/features/mergeQuery/context/mergeUrlState.ts
+++ b/packages/frontend/src/features/mergeQuery/context/mergeUrlState.ts
@@ -1,8 +1,13 @@
 import { MergeJoinType, type Filters } from '@lightdash/common';
 import {
+    DEFAULT_ADDITIONAL_SOURCE_ID,
+    MAX_MERGE_SOURCES,
+    PRIMARY_SOURCE_ID,
+} from '../constants';
+import {
+    type MergeEditorSource,
     type MergeFocus,
     type MergeJoinPart,
-    type MergeQueryBState,
 } from './context';
 
 /** Search param the merge relationship is kept in. */
@@ -10,29 +15,40 @@ export const MERGE_URL_PARAM = 'merge';
 
 export type MergeUrlState = {
     focus: MergeFocus;
-    queryB: MergeQueryBState;
+    additionalSources: MergeEditorSource[];
     joinParts: MergeJoinPart[];
     joinType: MergeJoinType;
-    /** Query B's own filters. */
-    filtersB: Filters;
 };
 
-/**
- * Short keys because this rides in the URL alongside the chart state, which is
- * already long enough to strain what a browser and a Slack unfurl will carry.
- */
-type SerializedMerge = {
+type SerializedSource = {
+    i: string;
     e: string | null;
     d: string[];
     m: string[];
-    /** Join key parts as [queryA field, queryB field] pairs. */
-    k: Array<[string | null, string | null]>;
-    j: MergeJoinType;
-    /** Query B's filters ("where"). */
     w: Filters;
-    a?: MergeQueryBState['additionalMetrics'];
-    c?: MergeQueryBState['customDimensions'];
-    f: MergeFocus;
+    a?: MergeEditorSource['additionalMetrics'];
+    c?: MergeEditorSource['customDimensions'];
+};
+
+/** Short keys because this rides beside the already-large chart URL state. */
+type SerializedMerge = {
+    s: SerializedSource[];
+    k: Array<Record<string, string | null>>;
+    j: MergeJoinType;
+    f: string;
+};
+
+/** URL shape emitted before editor state became source-addressed. */
+type LegacySerializedMerge = {
+    e?: unknown;
+    d?: unknown;
+    m?: unknown;
+    k?: unknown;
+    j?: unknown;
+    w?: unknown;
+    a?: MergeEditorSource['additionalMetrics'];
+    c?: MergeEditorSource['customDimensions'];
+    f?: unknown;
 };
 
 const isJoinType = (value: unknown): value is MergeJoinType =>
@@ -44,68 +60,162 @@ const asStringArray = (value: unknown): string[] =>
         ? value.filter((item): item is string => typeof item === 'string')
         : [];
 
+const asFilters = (value: unknown): Filters =>
+    typeof value === 'object' && value !== null && !Array.isArray(value)
+        ? (value as Filters)
+        : {};
+
+const focusFor = (value: unknown): MergeFocus =>
+    value === 'join'
+        ? { kind: 'join' }
+        : {
+              kind: 'source',
+              sourceId: typeof value === 'string' ? value : PRIMARY_SOURCE_ID,
+          };
+
 export const serializeMergeState = (state: MergeUrlState): string =>
     JSON.stringify({
-        e: state.queryB.exploreName,
-        d: state.queryB.dimensions,
-        m: state.queryB.metrics,
-        k: state.joinParts.map((part) => [part.fieldA, part.fieldB]),
+        s: state.additionalSources.map((source) => ({
+            i: source.id,
+            e: source.exploreName,
+            d: source.dimensions,
+            m: source.metrics,
+            w: source.filters,
+            a: source.additionalMetrics,
+            c: source.customDimensions,
+        })),
+        k: state.joinParts.map((part) => part.fieldIdBySourceId),
         j: state.joinType,
-        w: state.filtersB,
-        a: state.queryB.additionalMetrics,
-        c: state.queryB.customDimensions,
-        f: state.focus,
+        f: state.focus.kind === 'join' ? 'join' : state.focus.sourceId,
     } satisfies SerializedMerge);
 
-const asJoinParts = (value: unknown): MergeJoinPart[] => {
-    if (!Array.isArray(value)) return [{ fieldA: null, fieldB: null }];
-    const parts = value.flatMap((entry) =>
+const parseSource = (value: unknown): MergeEditorSource | null => {
+    if (value === null || typeof value !== 'object') return null;
+    const source = value as Partial<SerializedSource>;
+    if (typeof source.i !== 'string' || source.i.length === 0) return null;
+    return {
+        id: source.i,
+        exploreName: typeof source.e === 'string' ? source.e : null,
+        dimensions: asStringArray(source.d),
+        metrics: asStringArray(source.m),
+        filters: asFilters(source.w),
+        additionalMetrics: source.a,
+        customDimensions: source.c,
+    };
+};
+
+const parseJoinParts = (
+    value: unknown,
+    sourceIds: string[],
+): MergeJoinPart[] => {
+    if (!Array.isArray(value)) return [];
+    return value.flatMap((entry) => {
+        if (entry === null || typeof entry !== 'object') return [];
+        const fields = entry as Record<string, unknown>;
+        return [
+            {
+                fieldIdBySourceId: Object.fromEntries(
+                    sourceIds.map((sourceId) => [
+                        sourceId,
+                        typeof fields[sourceId] === 'string'
+                            ? fields[sourceId]
+                            : null,
+                    ]),
+                ),
+            },
+        ];
+    });
+};
+
+const parseCurrent = (value: Record<string, unknown>): MergeUrlState | null => {
+    if (!Array.isArray(value.s)) return null;
+    const additionalSources = value.s.flatMap((entry) => {
+        const source = parseSource(entry);
+        return source ? [source] : [];
+    });
+    if (additionalSources.length !== value.s.length) return null;
+    const additionalSourceIds = additionalSources.map((source) => source.id);
+    if (
+        additionalSources.length === 0 ||
+        additionalSources.length + 1 > MAX_MERGE_SOURCES ||
+        additionalSourceIds.includes(PRIMARY_SOURCE_ID) ||
+        new Set(additionalSourceIds).size !== additionalSourceIds.length
+    ) {
+        return null;
+    }
+    const sourceIds = [PRIMARY_SOURCE_ID, ...additionalSourceIds];
+    const joinParts = parseJoinParts(value.k, sourceIds);
+    return {
+        focus: focusFor(value.f),
+        additionalSources,
+        joinParts:
+            joinParts.length > 0
+                ? joinParts
+                : [
+                      {
+                          fieldIdBySourceId: Object.fromEntries(
+                              sourceIds.map((id) => [id, null]),
+                          ),
+                      },
+                  ],
+        joinType: isJoinType(value.j) ? value.j : MergeJoinType.FULL,
+    };
+};
+
+const parseLegacy = (value: LegacySerializedMerge): MergeUrlState => {
+    const source: MergeEditorSource = {
+        id: DEFAULT_ADDITIONAL_SOURCE_ID,
+        exploreName: typeof value.e === 'string' ? value.e : null,
+        dimensions: asStringArray(value.d),
+        metrics: asStringArray(value.m),
+        filters: asFilters(value.w),
+        additionalMetrics: value.a,
+        customDimensions: value.c,
+    };
+    const legacyParts = Array.isArray(value.k) ? value.k : [];
+    const joinParts = legacyParts.flatMap((entry) =>
         Array.isArray(entry)
             ? [
                   {
-                      fieldA: typeof entry[0] === 'string' ? entry[0] : null,
-                      fieldB: typeof entry[1] === 'string' ? entry[1] : null,
+                      fieldIdBySourceId: {
+                          [PRIMARY_SOURCE_ID]:
+                              typeof entry[0] === 'string' ? entry[0] : null,
+                          [source.id]:
+                              typeof entry[1] === 'string' ? entry[1] : null,
+                      },
                   },
               ]
             : [],
     );
-    // A merge always has at least one key part, even an unfilled one.
-    return parts.length > 0 ? parts : [{ fieldA: null, fieldB: null }];
+    return {
+        focus: focusFor(value.f),
+        additionalSources: [source],
+        joinParts:
+            joinParts.length > 0
+                ? joinParts
+                : [
+                      {
+                          fieldIdBySourceId: {
+                              [PRIMARY_SOURCE_ID]: null,
+                              [source.id]: null,
+                          },
+                      },
+                  ],
+        joinType: isJoinType(value.j) ? value.j : MergeJoinType.FULL,
+    };
 };
 
-/**
- * Returns null for anything that does not parse. A merge shared with a stale or
- * hand-edited link should drop back to the ordinary explorer rather than throw
- * the page away.
- */
+/** Invalid links fail closed; legacy two-source links adapt at this seam. */
 export const parseMergeState = (raw: string | null): MergeUrlState | null => {
     if (!raw) return null;
-
-    let parsed: unknown;
     try {
-        parsed = JSON.parse(raw);
+        const parsed: unknown = JSON.parse(raw);
+        if (parsed === null || typeof parsed !== 'object') return null;
+        const value = parsed as Record<string, unknown>;
+        return 's' in value
+            ? parseCurrent(value)
+            : parseLegacy(value as LegacySerializedMerge);
     } catch {
         return null;
     }
-    if (parsed === null || typeof parsed !== 'object') return null;
-
-    const value = parsed as Partial<SerializedMerge>;
-    return {
-        focus: value.f === 'b' || value.f === 'join' ? value.f : 'a',
-        queryB: {
-            exploreName: typeof value.e === 'string' ? value.e : null,
-            dimensions: asStringArray(value.d),
-            metrics: asStringArray(value.m),
-            additionalMetrics: value.a,
-            customDimensions: value.c,
-        },
-        joinParts: asJoinParts(value.k),
-        joinType: isJoinType(value.j) ? value.j : MergeJoinType.FULL,
-        filtersB:
-            typeof value.w === 'object' &&
-            value.w !== null &&
-            !Array.isArray(value.w)
-                ? value.w
-                : {},
-    };
 };

--- a/packages/frontend/src/features/mergeQuery/context/restoreSavedMerge.test.ts
+++ b/packages/frontend/src/features/mergeQuery/context/restoreSavedMerge.test.ts
@@ -48,15 +48,20 @@ describe('restoreSavedMerge', () => {
                 tableCalculations: [],
             }),
         ).toMatchObject({
-            queryB: {
-                exploreName: 'subscriptions',
-                dimensions: ['subscriptions_month'],
-                metrics: ['subscriptions_mrr'],
-            },
+            additionalSources: [
+                {
+                    id: 'subscriptions',
+                    exploreName: 'subscriptions',
+                    dimensions: ['subscriptions_month'],
+                    metrics: ['subscriptions_mrr'],
+                },
+            ],
             joinParts: [
                 {
-                    fieldA: 'orders_month',
-                    fieldB: 'subscriptions_month',
+                    fieldIdBySourceId: {
+                        orders: 'orders_month',
+                        subscriptions: 'subscriptions_month',
+                    },
                 },
             ],
             joinType: MergeJoinType.FULL,

--- a/packages/frontend/src/features/mergeQuery/context/restoreSavedMerge.ts
+++ b/packages/frontend/src/features/mergeQuery/context/restoreSavedMerge.ts
@@ -2,7 +2,7 @@ import {
     parseSavedMergeQuery,
     SAVED_MERGE_QUERY_SCHEMA_VERSION,
 } from '@lightdash/common';
-import { type MergeFocus } from './context';
+import { MAX_MERGE_SOURCES } from '../constants';
 
 /**
  * Turns a chart's stored merge back into editable state.
@@ -19,31 +19,35 @@ export const restoreSavedMerge = (value: unknown) => {
         (source) => source.kind === 'query',
     );
     const chartSource = saved.sources.find((source) => source.kind === 'chart');
-    // The persisted shape supports more sources than today's editor. Keep the
-    // chart usable if a newer producer writes a merge this UI cannot edit yet.
+    // Persistence is N-shaped; the current editor's product limit stays
+    // explicit here rather than leaking positional A/B state through callers.
     if (
         !chartSource ||
         saved.primarySourceId !== chartSource.id ||
-        additionalSources.length !== 1
+        saved.sources.length > MAX_MERGE_SOURCES
     ) {
         return null;
     }
-    const [secondSource] = additionalSources;
 
     return {
-        focus: 'a' as MergeFocus,
-        queryB: {
-            exploreName: secondSource.metricQuery.exploreName,
-            dimensions: secondSource.metricQuery.dimensions,
-            metrics: secondSource.metricQuery.metrics,
-            additionalMetrics: secondSource.metricQuery.additionalMetrics,
-            customDimensions: secondSource.metricQuery.customDimensions,
-        },
+        focus: { kind: 'source' as const, sourceId: chartSource.id },
+        additionalSources: additionalSources.map((source) => ({
+            id: source.id,
+            exploreName: source.metricQuery.exploreName,
+            dimensions: source.metricQuery.dimensions,
+            metrics: source.metricQuery.metrics,
+            filters: source.metricQuery.filters ?? {},
+            additionalMetrics: source.metricQuery.additionalMetrics,
+            customDimensions: source.metricQuery.customDimensions,
+        })),
         joinParts: saved.joinKey.map((part) => ({
-            fieldA: part.fieldIdBySourceId[chartSource.id],
-            fieldB: part.fieldIdBySourceId[secondSource.id],
+            fieldIdBySourceId: Object.fromEntries(
+                saved.sources.map((source) => [
+                    source.id,
+                    part.fieldIdBySourceId[source.id] ?? null,
+                ]),
+            ),
         })),
         joinType: saved.joinType,
-        filtersB: secondSource.metricQuery.filters ?? {},
     };
 };

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeCompiledSql.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeCompiledSql.ts
@@ -14,7 +14,7 @@ import { useMergeSetup } from './useMergeSetup';
  * The merged statement, compiled for the SQL card.
  *
  * With a merge configured, the merged statement is what Run executes — a SQL
- * card showing Query A's SQL alone would be showing SQL that does not run.
+ * card showing the primary source's SQL alone would show SQL that does not run.
  * `isMergeActive` is false until the merge is complete enough to compile, so
  * callers fall back to the single-query SQL while the join is being set up.
  */

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuickFilter.test.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuickFilter.test.ts
@@ -23,57 +23,67 @@ const targetIds = (filters: Parameters<typeof getTotalFilterRules>[0]) =>
     getTotalFilterRules(filters).map((rule) => rule.target.fieldId);
 
 describe('applyMergeQuickFilter', () => {
-    it('applies a shared join key to both source fields', () => {
+    it('applies a shared join key to every source field', () => {
         const result = applyMergeQuickFilter({
-            filtersA: {},
-            filtersB: {},
+            filtersBySourceId: { a: {}, b: {}, c: {} },
             field,
             origin: {
                 kind: 'joinKey',
                 fieldIdBySourceId: {
                     a: 'customers_customer_id',
                     b: 'orders_customer_id',
+                    c: 'accounts_customer_id',
                 },
             },
             value: 1,
             operator: FilterOperator.EQUALS,
-            focus: 'a',
+            focus: { kind: 'source', sourceId: 'a' },
         });
 
         expect(result).not.toBeNull();
-        expect(targetIds(result!.filtersA)).toEqual(['customers_customer_id']);
-        expect(targetIds(result!.filtersB)).toEqual(['orders_customer_id']);
+        expect(targetIds(result!.filtersBySourceId.a)).toEqual([
+            'customers_customer_id',
+        ]);
+        expect(targetIds(result!.filtersBySourceId.b)).toEqual([
+            'orders_customer_id',
+        ]);
+        expect(targetIds(result!.filtersBySourceId.c)).toEqual([
+            'accounts_customer_id',
+        ]);
     });
 
-    it('applies a source field only to its owning query', () => {
+    it('applies a source field only to its owning source', () => {
         const result = applyMergeQuickFilter({
-            filtersA: {},
-            filtersB: {},
+            filtersBySourceId: { a: {}, subscriptions: {} },
             field,
             origin: {
                 kind: 'source',
-                sourceId: 'b',
-                sourceFieldId: 'orders_order_count',
+                sourceId: 'subscriptions',
+                sourceFieldId: 'subscriptions_count',
             },
             value: 2,
             operator: FilterOperator.NOT_EQUALS,
-            focus: 'a',
+            focus: { kind: 'source', sourceId: 'a' },
         });
 
         expect(result).not.toBeNull();
-        expect(targetIds(result!.filtersA)).toEqual([]);
-        expect(targetIds(result!.filtersB)).toEqual(['orders_order_count']);
-        expect(result!.focus).toBe('b');
+        expect(targetIds(result!.filtersBySourceId.a)).toEqual([]);
+        expect(targetIds(result!.filtersBySourceId.subscriptions)).toEqual([
+            'subscriptions_count',
+        ]);
+        expect(result!.focus).toEqual({
+            kind: 'source',
+            sourceId: 'subscriptions',
+        });
     });
 
     it('does not offer a source-less table calculation filter', () => {
         expect(
             applyMergeQuickFilter({
-                filtersA: {},
-                filtersB: {},
+                filtersBySourceId: { a: {}, b: {} },
                 field,
                 origin: { kind: 'tableCalculation' },
-                focus: 'a',
+                focus: { kind: 'source', sourceId: 'a' },
             }),
         ).toBeNull();
     });

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuickFilter.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuickFilter.ts
@@ -16,13 +16,12 @@ import {
     useExplorerDispatch,
     useExplorerStore,
 } from '../../explorer/store';
-import { SOURCE_A, SOURCE_B } from '../constants';
+import { PRIMARY_SOURCE_ID } from '../constants';
 import { type MergeFocus } from '../context/context';
 import { useMergeSafe } from '../context/useMerge';
 
 type ApplyMergeQuickFilterArgs = {
-    filtersA: Filters;
-    filtersB: Filters;
+    filtersBySourceId: Record<string, Filters>;
     field: FilterableField;
     origin: MergeFieldOrigin;
     value?: AnyType;
@@ -32,14 +31,12 @@ type ApplyMergeQuickFilterArgs = {
 };
 
 type AppliedMergeQuickFilter = {
-    filtersA: Filters;
-    filtersB: Filters;
+    filtersBySourceId: Record<string, Filters>;
     focus: MergeFocus;
 };
 
 export const applyMergeQuickFilter = ({
-    filtersA,
-    filtersB,
+    filtersBySourceId,
     field,
     origin,
     value,
@@ -58,31 +55,36 @@ export const applyMergeQuickFilter = ({
         });
 
     if (origin.kind === 'source') {
-        if (origin.sourceId === SOURCE_A) {
-            return {
-                filtersA: add(filtersA, origin.sourceFieldId),
-                filtersB,
-                focus: SOURCE_A,
-            };
-        }
-        if (origin.sourceId === SOURCE_B) {
-            return {
-                filtersA,
-                filtersB: add(filtersB, origin.sourceFieldId),
-                focus: SOURCE_B,
-            };
-        }
-        return null;
+        const sourceFilters = filtersBySourceId[origin.sourceId];
+        if (!sourceFilters) return null;
+        return {
+            filtersBySourceId: {
+                ...filtersBySourceId,
+                [origin.sourceId]: add(sourceFilters, origin.sourceFieldId),
+            },
+            focus: { kind: 'source', sourceId: origin.sourceId },
+        };
     }
 
     if (origin.kind === 'joinKey') {
-        const fieldA = origin.fieldIdBySourceId[SOURCE_A];
-        const fieldB = origin.fieldIdBySourceId[SOURCE_B];
-        if (!fieldA || !fieldB) return null;
+        const entries = Object.entries(origin.fieldIdBySourceId);
+        if (
+            entries.some(
+                ([sourceId]) => filtersBySourceId[sourceId] === undefined,
+            )
+        )
+            return null;
 
         return {
-            filtersA: add(filtersA, fieldA),
-            filtersB: add(filtersB, fieldB),
+            filtersBySourceId: {
+                ...filtersBySourceId,
+                ...Object.fromEntries(
+                    entries.map(([sourceId, fieldId]) => [
+                        sourceId,
+                        add(filtersBySourceId[sourceId], fieldId),
+                    ]),
+                ),
+            },
             focus,
         };
     }
@@ -114,10 +116,16 @@ export const useMergeQuickFilter = () => {
             const origin = merge.mergeResults.fieldOrigins[getItemId(field)];
             if (!origin) return;
 
-            const filtersA = selectFilters(store.getState());
+            const primaryFiltersBefore = selectFilters(store.getState());
+            const filtersBySourceId = Object.fromEntries([
+                [PRIMARY_SOURCE_ID, primaryFiltersBefore],
+                ...merge.additionalSources.map((source) => [
+                    source.id,
+                    source.filters,
+                ]),
+            ]);
             const result = applyMergeQuickFilter({
-                filtersA,
-                filtersB: merge.filtersB,
+                filtersBySourceId,
                 field,
                 origin,
                 value,
@@ -127,12 +135,16 @@ export const useMergeQuickFilter = () => {
             });
             if (!result) return;
 
-            if (result.filtersA !== filtersA) {
-                dispatch(explorerActions.setFilters(result.filtersA));
+            const primaryFilters = result.filtersBySourceId[PRIMARY_SOURCE_ID];
+            if (primaryFilters && primaryFilters !== primaryFiltersBefore) {
+                dispatch(explorerActions.setFilters(primaryFilters));
             }
-            if (result.filtersB !== merge.filtersB) {
-                merge.setFiltersB(result.filtersB);
-            }
+            merge.additionalSources.forEach((source) => {
+                const nextFilters = result.filtersBySourceId[source.id];
+                if (nextFilters && nextFilters !== source.filters) {
+                    merge.setSourceFilters(source.id, nextFilters);
+                }
+            });
             merge.setFocus(result.focus);
 
             if (!selectIsFiltersExpanded(store.getState())) {

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeSetup.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeSetup.ts
@@ -24,11 +24,17 @@ import {
     selectUnsavedChartVersion,
     useExplorerSelector,
 } from '../../explorer/store';
-import { EMPTY_MERGE, JOIN_KEY, SOURCE_A, SOURCE_B } from '../constants';
+import {
+    DEFAULT_ADDITIONAL_SOURCE_ID,
+    EMPTY_MERGE,
+    emptyMergeSource,
+    JOIN_KEY,
+    PRIMARY_SOURCE_ID,
+} from '../constants';
 import { useMergeSafe } from '../context/useMerge';
 
 /**
- * Everything derived from the two queries and the relationship between them:
+ * Everything derived from the selected sources and their relationship:
  * the merge to run, whether it can run, and what is stopping it.
  *
  * Lives in a hook rather than the setup panel because the run control is not
@@ -43,52 +49,58 @@ export const useMergeSetup = () => {
     const parameters = useExplorerSelector(selectParameters);
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
     const mergeContext = useMergeSafe();
-    const { isMerging, queryB, joinParts, joinType, filtersB } =
+    const { isMerging, additionalSources, joinParts, joinType } =
         mergeContext ?? EMPTY_MERGE;
     const { run, isRunning, runErrors, mergeResults } = mergeContext ?? {};
+    const additionalSource =
+        additionalSources[0] ?? emptyMergeSource(DEFAULT_ADDITIONAL_SOURCE_ID);
+    const additionalSourceId = additionalSource.id;
 
-    const { data: exploreA } = useExplore(tableName, { refetchOnMount: false });
-    const { data: exploreB } = useExplore(queryB.exploreName ?? undefined, {
+    const { data: primaryExplore } = useExplore(tableName, {
         refetchOnMount: false,
     });
+    const { data: additionalExplore } = useExplore(
+        additionalSource.exploreName ?? undefined,
+        { refetchOnMount: false },
+    );
 
-    const metricQueryB = useMemo<MetricQuery>(
+    const additionalMetricQuery = useMemo<MetricQuery>(
         () => ({
-            exploreName: queryB.exploreName ?? '',
-            dimensions: queryB.dimensions,
-            metrics: queryB.metrics,
-            filters: filtersB,
+            exploreName: additionalSource.exploreName ?? '',
+            dimensions: additionalSource.dimensions,
+            metrics: additionalSource.metrics,
+            filters: additionalSource.filters,
             sorts: [],
             limit: metricQuery.limit,
             tableCalculations: [],
-            additionalMetrics: queryB.additionalMetrics,
-            customDimensions: queryB.customDimensions,
+            additionalMetrics: additionalSource.additionalMetrics,
+            customDimensions: additionalSource.customDimensions,
         }),
-        [filtersB, queryB, metricQuery.limit],
+        [additionalSource, metricQuery.limit],
     );
-    const itemMapA = useMemo(
+    const primaryItemMap = useMemo(
         () =>
-            exploreA
+            primaryExplore
                 ? getItemMap(
-                      exploreA,
+                      primaryExplore,
                       metricQuery.additionalMetrics,
                       metricQuery.tableCalculations,
                       metricQuery.customDimensions,
                   )
                 : {},
-        [exploreA, metricQuery],
+        [primaryExplore, metricQuery],
     );
-    const itemMapB = useMemo(
+    const additionalItemMap = useMemo(
         () =>
-            exploreB
+            additionalExplore
                 ? getItemMap(
-                      exploreB,
-                      metricQueryB.additionalMetrics,
-                      metricQueryB.tableCalculations,
-                      metricQueryB.customDimensions,
+                      additionalExplore,
+                      additionalMetricQuery.additionalMetrics,
+                      additionalMetricQuery.tableCalculations,
+                      additionalMetricQuery.customDimensions,
                   )
                 : {},
-        [exploreB, metricQueryB],
+        [additionalExplore, additionalMetricQuery],
     );
 
     /**
@@ -98,61 +110,67 @@ export const useMergeSetup = () => {
      * Only pairs the validator would accept are ever suggested — a suggestion
      * that gets refused is worse than none.
      */
-    const suggestedPair = useMemo<{
-        fieldA: string;
-        fieldB: string;
-    } | null>(() => {
-        if (!exploreA || !exploreB) return null;
+    const suggestedPair = useMemo<Record<string, string> | null>(() => {
+        if (!primaryExplore || !additionalExplore) return null;
         const classOf = (type: DimensionType) =>
             type === DimensionType.DATE || type === DimensionType.TIMESTAMP
                 ? 'temporal'
                 : type;
 
-        let best: { fieldA: string; fieldB: string } | null = null;
+        let best: Record<string, string> | null = null;
         let bestScore = 0;
-        metricQuery.dimensions.forEach((fieldA) => {
-            const itemA = itemMapA[fieldA];
-            if (!itemA || (!isDimension(itemA) && !isCustomDimension(itemA)))
+        metricQuery.dimensions.forEach((primaryFieldId) => {
+            const primaryItem = primaryItemMap[primaryFieldId];
+            if (
+                !primaryItem ||
+                (!isDimension(primaryItem) && !isCustomDimension(primaryItem))
+            )
                 return;
-            queryB.dimensions.forEach((fieldB) => {
-                const itemB = itemMapB[fieldB];
+            additionalSource.dimensions.forEach((additionalFieldId) => {
+                const additionalItem = additionalItemMap[additionalFieldId];
                 if (
-                    !itemB ||
-                    (!isDimension(itemB) && !isCustomDimension(itemB))
+                    !additionalItem ||
+                    (!isDimension(additionalItem) &&
+                        !isCustomDimension(additionalItem))
                 )
                     return;
-                const typeA = convertItemTypeToDimensionType(itemA);
-                const typeB = convertItemTypeToDimensionType(itemB);
-                if (classOf(typeA) !== classOf(typeB)) return;
-                const isTemporal = classOf(typeA) === 'temporal';
+                const primaryType = convertItemTypeToDimensionType(primaryItem);
+                const additionalType =
+                    convertItemTypeToDimensionType(additionalItem);
+                if (classOf(primaryType) !== classOf(additionalType)) return;
+                const isTemporal = classOf(primaryType) === 'temporal';
                 if (
                     isTemporal &&
-                    (isDimension(itemA)
-                        ? (itemA.timeInterval ?? null)
+                    (isDimension(primaryItem)
+                        ? (primaryItem.timeInterval ?? null)
                         : null) !==
-                        (isDimension(itemB)
-                            ? (itemB.timeInterval ?? null)
+                        (isDimension(additionalItem)
+                            ? (additionalItem.timeInterval ?? null)
                             : null)
                 ) {
                     return;
                 }
                 let score = 1;
                 if (isTemporal) score += 3;
-                if (itemA.name === itemB.name) score += 4;
+                if (primaryItem.name === additionalItem.name) score += 4;
                 if (score > bestScore) {
                     bestScore = score;
-                    best = { fieldA, fieldB };
+                    best = {
+                        [PRIMARY_SOURCE_ID]: primaryFieldId,
+                        [additionalSourceId]: additionalFieldId,
+                    };
                 }
             });
         });
         return best;
     }, [
-        exploreA,
-        exploreB,
-        itemMapA,
-        itemMapB,
+        primaryExplore,
+        additionalExplore,
+        primaryItemMap,
+        additionalItemMap,
         metricQuery.dimensions,
-        queryB.dimensions,
+        additionalSource.dimensions,
+        additionalSourceId,
     ]);
 
     // The first key part defaults to the suggested pair, falling back to each
@@ -161,61 +179,82 @@ export const useMergeSetup = () => {
     const effectiveParts = useMemo(
         () =>
             joinParts.map((part, index) => ({
-                fieldA:
-                    part.fieldA ??
-                    (index === 0
-                        ? (suggestedPair?.fieldA ??
-                          metricQuery.dimensions[0] ??
-                          null)
-                        : null),
-                fieldB:
-                    part.fieldB ??
-                    (index === 0
-                        ? (suggestedPair?.fieldB ??
-                          queryB.dimensions[0] ??
-                          null)
-                        : null),
+                fieldIdBySourceId: {
+                    [PRIMARY_SOURCE_ID]:
+                        part.fieldIdBySourceId[PRIMARY_SOURCE_ID] ??
+                        (index === 0
+                            ? (suggestedPair?.[PRIMARY_SOURCE_ID] ??
+                              metricQuery.dimensions[0] ??
+                              null)
+                            : null),
+                    [additionalSourceId]:
+                        part.fieldIdBySourceId[additionalSourceId] ??
+                        (index === 0
+                            ? (suggestedPair?.[additionalSourceId] ??
+                              additionalSource.dimensions[0] ??
+                              null)
+                            : null),
+                },
             })),
-        [joinParts, suggestedPair, metricQuery.dimensions, queryB.dimensions],
+        [
+            joinParts,
+            suggestedPair,
+            metricQuery.dimensions,
+            additionalSource.dimensions,
+            additionalSourceId,
+        ],
     );
     const completeParts = effectiveParts.filter(
-        (part) => part.fieldA && part.fieldB,
+        (part) =>
+            part.fieldIdBySourceId[PRIMARY_SOURCE_ID] &&
+            part.fieldIdBySourceId[additionalSourceId],
     );
 
     // Field ids are how the merge is addressed, but they are not what anyone
     // calls these things. Everything the user reads says the label.
     const labelFor = useCallback(
         (fieldId: string) => {
-            const item = itemMapA[fieldId] ?? itemMapB[fieldId];
+            const item = primaryItemMap[fieldId] ?? additionalItemMap[fieldId];
             return item ? getItemLabelWithoutTableName(item) : fieldId;
         },
-        [itemMapA, itemMapB],
+        [primaryItemMap, additionalItemMap],
     );
 
     // Either query can be the finer-grained one. Both are checked, because a
     // merge is refused for whichever side carries the extra dimension and the
     // refusal has to name where the problem is.
-    const unaccountedA = useMemo(
+    const unaccountedPrimary = useMemo(
         () =>
             getUnaccountedDimensions(
-                { id: SOURCE_A, metricQuery },
+                { id: PRIMARY_SOURCE_ID, metricQuery },
                 completeParts.map((part, index) => ({
                     name: `${JOIN_KEY}_${index}`,
-                    fieldIdBySourceId: { [SOURCE_A]: part.fieldA as string },
+                    fieldIdBySourceId: {
+                        [PRIMARY_SOURCE_ID]: part.fieldIdBySourceId[
+                            PRIMARY_SOURCE_ID
+                        ] as string,
+                    },
                 })),
             ),
         [metricQuery, completeParts],
     );
-    const unaccountedB = useMemo(
+    const unaccountedAdditional = useMemo(
         () =>
             getUnaccountedDimensions(
-                { id: SOURCE_B, metricQuery: metricQueryB },
+                {
+                    id: additionalSourceId,
+                    metricQuery: additionalMetricQuery,
+                },
                 completeParts.map((part, index) => ({
                     name: `${JOIN_KEY}_${index}`,
-                    fieldIdBySourceId: { [SOURCE_B]: part.fieldB as string },
+                    fieldIdBySourceId: {
+                        [additionalSourceId]: part.fieldIdBySourceId[
+                            additionalSourceId
+                        ] as string,
+                    },
                 })),
             ),
-        [metricQueryB, completeParts],
+        [additionalMetricQuery, completeParts, additionalSourceId],
     );
 
     /**
@@ -225,173 +264,217 @@ export const useMergeSetup = () => {
      */
     const fanOut = useMemo(
         () => [
-            ...(unaccountedA.length > 0
-                ? [{ side: 'a' as const, fields: unaccountedA }]
+            ...(unaccountedPrimary.length > 0
+                ? [
+                      {
+                          sourceId: PRIMARY_SOURCE_ID,
+                          fields: unaccountedPrimary,
+                      },
+                  ]
                 : []),
-            ...(unaccountedB.length > 0
-                ? [{ side: 'b' as const, fields: unaccountedB }]
+            ...(unaccountedAdditional.length > 0
+                ? [
+                      {
+                          sourceId: additionalSourceId,
+                          fields: unaccountedAdditional,
+                      },
+                  ]
                 : []),
         ],
-        [unaccountedA, unaccountedB],
+        [unaccountedPrimary, unaccountedAdditional, additionalSourceId],
     );
 
     // The join selects take the fields themselves, not ids, so they can show
     // the same icons and labels as every other field picker.
-    const joinItemsA = useMemo(
+    const primaryJoinItems = useMemo(
         () =>
             metricQuery.dimensions
-                .map((id) => itemMapA[id])
+                .map((id) => primaryItemMap[id])
                 .filter(
                     (item) =>
                         !!item &&
                         (isDimension(item) || isCustomDimension(item)),
                 ),
-        [itemMapA, metricQuery.dimensions],
+        [primaryItemMap, metricQuery.dimensions],
     );
-    const joinItemsB = useMemo(
+    const additionalJoinItems = useMemo(
         () =>
-            queryB.dimensions
-                .map((id) => itemMapB[id])
+            additionalSource.dimensions
+                .map((id) => additionalItemMap[id])
                 .filter(
                     (item) =>
                         !!item &&
                         (isDimension(item) || isCustomDimension(item)),
                 ),
-        [itemMapB, queryB.dimensions],
+        [additionalItemMap, additionalSource.dimensions],
     );
 
     // Join keys are dimensions, but they do not need to be selected before
     // opening this editor. The picker can add a dimension to its query and use
     // it as the key in one action. Custom dimensions remain limited to ones
     // already present in the query because they cannot be recreated by id.
-    const availableJoinItemsA = useMemo(
+    const availablePrimaryJoinItems = useMemo(
         () =>
-            Object.entries(itemMapA).flatMap(([id, item]) =>
+            Object.entries(primaryItemMap).flatMap(([id, item]) =>
                 isDimension(item) ||
                 (isCustomDimension(item) && metricQuery.dimensions.includes(id))
                     ? [item]
                     : [],
             ),
-        [itemMapA, metricQuery.dimensions],
+        [primaryItemMap, metricQuery.dimensions],
     );
-    const availableJoinItemsB = useMemo(
+    const availableAdditionalJoinItems = useMemo(
         () =>
-            Object.entries(itemMapB).flatMap(([id, item]) =>
+            Object.entries(additionalItemMap).flatMap(([id, item]) =>
                 isDimension(item) ||
-                (isCustomDimension(item) && queryB.dimensions.includes(id))
+                (isCustomDimension(item) &&
+                    additionalSource.dimensions.includes(id))
                     ? [item]
                     : [],
             ),
-        [itemMapB, queryB.dimensions],
+        [additionalItemMap, additionalSource.dimensions],
     );
 
     // Recommend only strong semantic matches. Type compatibility alone is
     // too weak (many explores have several strings or dates), so a suggestion
     // also needs the same field name or user-facing label. Identifiers win
     // over dates when both are available.
-    const suggestedAvailablePair = useMemo<{
-        fieldA: string;
-        fieldB: string;
-    } | null>(() => {
-        let best: { fieldA: string; fieldB: string } | null = null;
+    const suggestedAvailablePair = useMemo<Record<
+        string,
+        string
+    > | null>(() => {
+        let best: Record<string, string> | null = null;
         let bestScore = 0;
         const normalize = (value: string) =>
             value.toLocaleLowerCase().replace(/[^a-z0-9]/g, '');
 
-        availableJoinItemsA.forEach((itemA) => {
-            availableJoinItemsB.forEach((itemB) => {
-                const typeA = convertItemTypeToDimensionType(itemA);
-                const typeB = convertItemTypeToDimensionType(itemB);
-                const temporalA =
-                    typeA === DimensionType.DATE ||
-                    typeA === DimensionType.TIMESTAMP;
-                const temporalB =
-                    typeB === DimensionType.DATE ||
-                    typeB === DimensionType.TIMESTAMP;
-                if (temporalA !== temporalB || (!temporalA && typeA !== typeB))
+        availablePrimaryJoinItems.forEach((primaryItem) => {
+            availableAdditionalJoinItems.forEach((additionalItem) => {
+                const primaryType = convertItemTypeToDimensionType(primaryItem);
+                const additionalType =
+                    convertItemTypeToDimensionType(additionalItem);
+                const primaryIsTemporal =
+                    primaryType === DimensionType.DATE ||
+                    primaryType === DimensionType.TIMESTAMP;
+                const additionalIsTemporal =
+                    additionalType === DimensionType.DATE ||
+                    additionalType === DimensionType.TIMESTAMP;
+                if (
+                    primaryIsTemporal !== additionalIsTemporal ||
+                    (!primaryIsTemporal && primaryType !== additionalType)
+                )
                     return;
                 if (
-                    temporalA &&
-                    (isDimension(itemA) ? itemA.timeInterval : null) !==
-                        (isDimension(itemB) ? itemB.timeInterval : null)
+                    primaryIsTemporal &&
+                    (isDimension(primaryItem)
+                        ? primaryItem.timeInterval
+                        : null) !==
+                        (isDimension(additionalItem)
+                            ? additionalItem.timeInterval
+                            : null)
                 )
                     return;
 
                 const sameName =
-                    normalize(itemA.name) === normalize(itemB.name);
+                    normalize(primaryItem.name) ===
+                    normalize(additionalItem.name);
                 const sameLabel =
-                    normalize(getItemLabelWithoutTableName(itemA)) ===
-                    normalize(getItemLabelWithoutTableName(itemB));
+                    normalize(getItemLabelWithoutTableName(primaryItem)) ===
+                    normalize(getItemLabelWithoutTableName(additionalItem));
                 if (!sameName && !sameLabel) return;
 
-                const identifier = /(^|_)id$|(^|_)key$/i.test(itemA.name);
-                const fieldBId = getItemId(itemB);
-                const belongsToQueryBRoot = fieldBId.startsWith(
-                    `${queryB.exploreName}_`,
+                const identifier = /(^|_)id$|(^|_)key$/i.test(primaryItem.name);
+                const additionalFieldId = getItemId(additionalItem);
+                const belongsToAdditionalRoot = additionalFieldId.startsWith(
+                    `${additionalSource.exploreName}_`,
                 );
                 const score =
                     (sameName ? 6 : 0) +
                     (sameLabel ? 4 : 0) +
                     (identifier ? 4 : 0) +
-                    (belongsToQueryBRoot ? 3 : 0) +
-                    (temporalA ? 2 : 0);
+                    (belongsToAdditionalRoot ? 3 : 0) +
+                    (primaryIsTemporal ? 2 : 0);
                 if (score > bestScore) {
                     bestScore = score;
                     best = {
-                        fieldA: getItemId(itemA),
-                        fieldB: fieldBId,
+                        [PRIMARY_SOURCE_ID]: getItemId(primaryItem),
+                        [additionalSourceId]: additionalFieldId,
                     };
                 }
             });
         });
 
         return best;
-    }, [availableJoinItemsA, availableJoinItemsB, queryB.exploreName]);
+    }, [
+        availablePrimaryJoinItems,
+        availableAdditionalJoinItems,
+        additionalSource.exploreName,
+        additionalSourceId,
+    ]);
 
     // What people call these tables, not what dbt does.
-    const exploreALabel = exploreA?.label ?? tableName;
-    const exploreBLabel = exploreB?.label ?? queryB.exploreName;
+    const primaryExploreLabel = primaryExplore?.label ?? tableName;
+    const additionalExploreLabel =
+        additionalExplore?.label ?? additionalSource.exploreName;
 
-    const joinFieldLabel = effectiveParts[0]?.fieldA
-        ? labelFor(effectiveParts[0].fieldA)
+    const primaryJoinField =
+        effectiveParts[0]?.fieldIdBySourceId[PRIMARY_SOURCE_ID];
+    const joinFieldLabel = primaryJoinField
+        ? labelFor(primaryJoinField)
         : 'the join key';
 
-    const unaccountedTotal = unaccountedA.length + unaccountedB.length;
+    const unaccountedTotal =
+        unaccountedPrimary.length + unaccountedAdditional.length;
     // Built here rather than inside the run handler so the same object can be
     // validated while it is being configured. The rules that refuse a merge do
     // not need it to have run.
     const mergeQuery = useMemo<MergeQuery | null>(() => {
-        // Query A hydrates from the saved chart after mount; a merge built
+        // The primary source hydrates from the saved chart after mount; a merge built
         // before that carries an empty explore and compiles to a 404.
         if (!metricQuery.exploreName) return null;
-        if (!queryB.exploreName || completeParts.length === 0) return null;
+        if (!additionalSource.exploreName || completeParts.length === 0)
+            return null;
 
         const joinKey = completeParts.map((part, index) => ({
             name: `${JOIN_KEY}_${index}`,
             fieldIdBySourceId: {
-                [SOURCE_A]: part.fieldA as string,
-                [SOURCE_B]: part.fieldB as string,
+                [PRIMARY_SOURCE_ID]: part.fieldIdBySourceId[
+                    PRIMARY_SOURCE_ID
+                ] as string,
+                [additionalSourceId]: part.fieldIdBySourceId[
+                    additionalSourceId
+                ] as string,
             },
         }));
 
         return {
             sources: [
-                { id: SOURCE_A, metricQuery },
-                { id: SOURCE_B, metricQuery: metricQueryB },
+                { id: PRIMARY_SOURCE_ID, metricQuery },
+                {
+                    id: additionalSourceId,
+                    metricQuery: additionalMetricQuery,
+                },
             ],
             joinKey,
             joinType,
             tableCalculations: [],
             limit: metricQuery.limit,
         };
-    }, [queryB, completeParts, metricQuery, metricQueryB, joinType]);
+    }, [
+        additionalSource.exploreName,
+        additionalSourceId,
+        completeParts,
+        metricQuery,
+        additionalMetricQuery,
+        joinType,
+    ]);
 
     // The same rules the server refuses on, run here as the merge is built.
     // Whether two fields can be joined depends only on the two fields, so
     // making the user press Run to find out is a round trip for an answer we
     // already have.
     const joinFieldTypes = useMemo<MergeFieldTypes>(() => {
-        const collect = (itemMap: typeof itemMapA) =>
+        const collect = (itemMap: typeof primaryItemMap) =>
             Object.entries(itemMap).flatMap(([id, item]) =>
                 isDimension(item) || isCustomDimension(item)
                     ? [
@@ -411,10 +494,12 @@ export const useMergeSetup = () => {
                     : [],
             );
         return {
-            [SOURCE_A]: Object.fromEntries(collect(itemMapA)),
-            [SOURCE_B]: Object.fromEntries(collect(itemMapB)),
+            [PRIMARY_SOURCE_ID]: Object.fromEntries(collect(primaryItemMap)),
+            [additionalSourceId]: Object.fromEntries(
+                collect(additionalItemMap),
+            ),
         };
-    }, [itemMapA, itemMapB]);
+    }, [primaryItemMap, additionalItemMap, additionalSourceId]);
 
     const joinKeyErrors = useMemo(
         () =>
@@ -434,16 +519,20 @@ export const useMergeSetup = () => {
     // different problems. Saying both at once is what makes the panel
     // unreadable: a grain warning means nothing until there is a merge to
     // warn about.
-    const setupStep = !queryB.exploreName
+    const setupStep = !additionalSource.exploreName
         ? 'Choose data to combine'
-        : queryB.metrics.length === 0
-          ? `Add at least one metric from ${exploreBLabel ?? 'the second table'}`
+        : additionalSource.metrics.length === 0
+          ? `Add at least one metric from ${additionalExploreLabel ?? 'the second table'}`
           : !effectiveParts.every(
                   (part) =>
-                      part.fieldA &&
-                      part.fieldB &&
-                      metricQuery.dimensions.includes(part.fieldA) &&
-                      queryB.dimensions.includes(part.fieldB),
+                      part.fieldIdBySourceId[PRIMARY_SOURCE_ID] &&
+                      part.fieldIdBySourceId[additionalSourceId] &&
+                      metricQuery.dimensions.includes(
+                          part.fieldIdBySourceId[PRIMARY_SOURCE_ID] as string,
+                      ) &&
+                      additionalSource.dimensions.includes(
+                          part.fieldIdBySourceId[additionalSourceId] as string,
+                      ),
               )
             ? 'Pick a field from each query to join on'
             : null;
@@ -462,8 +551,8 @@ export const useMergeSetup = () => {
         !!mergeQuery &&
         completeParts.length > 0 &&
         completeParts.length === effectiveParts.length &&
-        !!queryB.exploreName &&
-        queryB.metrics.length > 0 &&
+        !!additionalSource.exploreName &&
+        additionalSource.metrics.length > 0 &&
         joinKeyErrors.length === 0 &&
         fanOut.length === 0;
 
@@ -474,7 +563,8 @@ export const useMergeSetup = () => {
     return {
         // state passed through, so callers need only this hook
         isMerging,
-        queryB,
+        additionalSource,
+        additionalSourceId,
         joinType,
         run,
         isRunning,
@@ -483,20 +573,20 @@ export const useMergeSetup = () => {
         // derived
         effectiveParts,
         labelFor,
-        itemMapA,
-        itemMapB,
-        unaccountedA,
-        unaccountedB,
+        primaryItemMap,
+        additionalItemMap,
+        unaccountedPrimary,
+        unaccountedAdditional,
         unaccountedTotal,
         fanOut,
         joinFieldLabel,
-        joinItemsA,
-        joinItemsB,
-        availableJoinItemsA,
-        availableJoinItemsB,
+        primaryJoinItems,
+        additionalJoinItems,
+        availablePrimaryJoinItems,
+        availableAdditionalJoinItems,
         suggestedAvailablePair,
-        exploreALabel,
-        exploreBLabel,
+        primaryExploreLabel,
+        additionalExploreLabel,
         joinKeyErrors,
         setupStep,
         isIncomplete,

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeSourceCell.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeSourceCell.ts
@@ -17,7 +17,7 @@ import { useMetricQueryDataContext } from '../../../components/MetricQueryData/u
 import { useExplore } from '../../../hooks/useExplore';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { convertDateFilters } from '../../../utils/dateFilter';
-import { SOURCE_A, SOURCE_B } from '../constants';
+import { PRIMARY_SOURCE_ID } from '../constants';
 import { useMergeSafe } from '../context/useMerge';
 
 export const getMergeSourceFieldValues = (
@@ -75,54 +75,77 @@ export const useMergeSourceCell = () => {
     const merge = useMergeSafe();
     const {
         tableName,
-        metricQuery: metricQueryA,
+        metricQuery: primaryMetricQuery,
         parameters,
         resolvedTimezone,
     } = useMetricQueryDataContext();
-    const { data: exploreA } = useExplore(tableName, { refetchOnMount: false });
-    const { data: exploreB } = useExplore(
-        merge?.queryB.exploreName ?? undefined,
+    const additionalSource = merge?.additionalSources[0];
+    const { data: primaryExplore } = useExplore(tableName, {
+        refetchOnMount: false,
+    });
+    const { data: additionalExplore } = useExplore(
+        additionalSource?.exploreName ?? undefined,
         { refetchOnMount: false },
     );
 
-    const metricQueryB = useMemo<MetricQuery | null>(() => {
-        if (!merge?.queryB.exploreName || !metricQueryA) return null;
+    const additionalMetricQuery = useMemo<MetricQuery | null>(() => {
+        if (!additionalSource?.exploreName || !primaryMetricQuery) return null;
         return {
-            exploreName: merge.queryB.exploreName,
-            dimensions: merge.queryB.dimensions,
-            metrics: merge.queryB.metrics,
-            filters: merge.filtersB,
+            exploreName: additionalSource.exploreName,
+            dimensions: additionalSource.dimensions,
+            metrics: additionalSource.metrics,
+            filters: additionalSource.filters,
             sorts: [],
-            limit: metricQueryA.limit,
+            limit: primaryMetricQuery.limit,
             tableCalculations: [],
-            additionalMetrics: merge.queryB.additionalMetrics,
-            customDimensions: merge.queryB.customDimensions,
+            additionalMetrics: additionalSource.additionalMetrics,
+            customDimensions: additionalSource.customDimensions,
         };
-    }, [merge, metricQueryA]);
+    }, [additionalSource, primaryMetricQuery]);
 
-    const itemMapA = useMemo(
+    const primaryItemMap = useMemo(
         () =>
-            exploreA && metricQueryA
+            primaryExplore && primaryMetricQuery
                 ? getItemMap(
-                      exploreA,
-                      metricQueryA.additionalMetrics,
-                      metricQueryA.tableCalculations,
-                      metricQueryA.customDimensions,
+                      primaryExplore,
+                      primaryMetricQuery.additionalMetrics,
+                      primaryMetricQuery.tableCalculations,
+                      primaryMetricQuery.customDimensions,
                   )
                 : {},
-        [exploreA, metricQueryA],
+        [primaryExplore, primaryMetricQuery],
     );
-    const itemMapB = useMemo(
+    const additionalItemMap = useMemo(
         () =>
-            exploreB && metricQueryB
+            additionalExplore && additionalMetricQuery
                 ? getItemMap(
-                      exploreB,
-                      metricQueryB.additionalMetrics,
-                      metricQueryB.tableCalculations,
-                      metricQueryB.customDimensions,
+                      additionalExplore,
+                      additionalMetricQuery.additionalMetrics,
+                      additionalMetricQuery.tableCalculations,
+                      additionalMetricQuery.customDimensions,
                   )
                 : {},
-        [exploreB, metricQueryB],
+        [additionalExplore, additionalMetricQuery],
+    );
+    const metricQueryBySourceId = useMemo<Record<string, MetricQuery>>(
+        () => ({
+            ...(primaryMetricQuery
+                ? { [PRIMARY_SOURCE_ID]: primaryMetricQuery }
+                : {}),
+            ...(additionalSource && additionalMetricQuery
+                ? { [additionalSource.id]: additionalMetricQuery }
+                : {}),
+        }),
+        [additionalMetricQuery, additionalSource, primaryMetricQuery],
+    );
+    const itemMapBySourceId = useMemo<Record<string, ItemsMap>>(
+        () => ({
+            [PRIMARY_SOURCE_ID]: primaryItemMap,
+            ...(additionalSource
+                ? { [additionalSource.id]: additionalItemMap }
+                : {}),
+        }),
+        [additionalItemMap, additionalSource, primaryItemMap],
     );
 
     const resolve = useCallback(
@@ -131,18 +154,15 @@ export const useMergeSourceCell = () => {
             fieldValues: Record<string, ResultValue>,
         ): ResolvedMergeSourceCell | null => {
             const mergeResults = merge?.mergeResults;
-            if (!mergeResults || !metricQueryA || !metricQueryB) return null;
+            if (!mergeResults) return null;
 
             const origin = mergeResults.fieldOrigins[getItemId(mergedItem)];
             if (origin?.kind !== 'source') return null;
 
-            const isA = origin.sourceId === SOURCE_A;
-            const isB = origin.sourceId === SOURCE_B;
-            if (!isA && !isB) return null;
-            const sourceItem = (isA ? itemMapA : itemMapB)[
-                origin.sourceFieldId
-            ];
-            if (!sourceItem) return null;
+            const sourceItem =
+                itemMapBySourceId[origin.sourceId]?.[origin.sourceFieldId];
+            const sourceMetricQuery = metricQueryBySourceId[origin.sourceId];
+            if (!sourceItem || !sourceMetricQuery) return null;
 
             return {
                 item: sourceItem,
@@ -152,12 +172,12 @@ export const useMergeSourceCell = () => {
                     origin.sourceId,
                 ),
                 source: {
-                    tableName: isA ? tableName : metricQueryB.exploreName,
-                    metricQuery: isA ? metricQueryA : metricQueryB,
+                    tableName: sourceMetricQuery.exploreName,
+                    metricQuery: sourceMetricQuery,
                 },
             };
         },
-        [itemMapA, itemMapB, merge, metricQueryA, metricQueryB, tableName],
+        [itemMapBySourceId, merge, metricQueryBySourceId],
     );
 
     const prepareUnderlyingData = useCallback(

--- a/packages/frontend/src/features/mergeQuery/hooks/useSavedMerge.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useSavedMerge.ts
@@ -1,16 +1,16 @@
 import { type MergeQuery, type SavedMergeQuery } from '@lightdash/common';
 import { useMemo } from 'react';
-import { SOURCE_A } from '../constants';
+import { PRIMARY_SOURCE_ID } from '../constants';
 import { useMergeSetup } from './useMergeSetup';
 
 export const toSavedMerge = (mergeQuery: MergeQuery): SavedMergeQuery => {
-    if (!mergeQuery.sources.some((source) => source.id === SOURCE_A)) {
+    if (!mergeQuery.sources.some((source) => source.id === PRIMARY_SOURCE_ID)) {
         throw new Error('A saved merge requires the chart query.');
     }
     return {
-        primarySourceId: mergeQuery.sources[0].id,
+        primarySourceId: PRIMARY_SOURCE_ID,
         sources: mergeQuery.sources.map((source) =>
-            source.id === SOURCE_A
+            source.id === PRIMARY_SOURCE_ID
                 ? {
                       id: source.id,
                       kind: 'chart' as const,

--- a/packages/frontend/src/features/mergeQuery/utils/mergeWorkflow.test.ts
+++ b/packages/frontend/src/features/mergeQuery/utils/mergeWorkflow.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-    getEffectiveMergeFocus,
-    isMergeSourceBReady,
-    isMergeSourceReady,
-} from './mergeWorkflow';
+import { isMergeSourceReady } from './mergeWorkflow';
 
 describe('merge workflow', () => {
     it('requires a dimension and metric in each source', () => {
@@ -13,33 +9,5 @@ describe('merge workflow', () => {
         expect(
             isMergeSourceReady({ dimensions: ['id'], metrics: ['count'] }),
         ).toBe(true);
-    });
-
-    it('keeps the second source incomplete while its table picker is open', () => {
-        const query = {
-            exploreName: 'customers',
-            dimensions: ['customer_id'],
-            metrics: ['customer_count'],
-        };
-
-        expect(isMergeSourceBReady(query, true)).toBe(false);
-        expect(isMergeSourceBReady(query, false)).toBe(true);
-    });
-
-    it('returns users to the earliest incomplete step', () => {
-        expect(
-            getEffectiveMergeFocus({
-                requested: 'join',
-                queryAReady: false,
-                queryBReady: false,
-            }),
-        ).toBe('a');
-        expect(
-            getEffectiveMergeFocus({
-                requested: 'join',
-                queryAReady: true,
-                queryBReady: false,
-            }),
-        ).toBe('b');
     });
 });

--- a/packages/frontend/src/features/mergeQuery/utils/mergeWorkflow.ts
+++ b/packages/frontend/src/features/mergeQuery/utils/mergeWorkflow.ts
@@ -1,5 +1,3 @@
-import { type MergeFocus, type MergeQueryBState } from '../context/context';
-
 type SelectedFields = {
     dimensions: string[];
     metrics: string[];
@@ -7,23 +5,3 @@ type SelectedFields = {
 
 export const isMergeSourceReady = (query: SelectedFields): boolean =>
     query.dimensions.length > 0 && query.metrics.length > 0;
-
-export const isMergeSourceBReady = (
-    query: MergeQueryBState,
-    isChoosingExplore = false,
-): boolean =>
-    !isChoosingExplore && !!query.exploreName && isMergeSourceReady(query);
-
-export const getEffectiveMergeFocus = ({
-    requested,
-    queryAReady,
-    queryBReady,
-}: {
-    requested: MergeFocus;
-    queryAReady: boolean;
-    queryBReady: boolean;
-}): MergeFocus => {
-    if (!queryAReady) return 'a';
-    if (requested === 'join' && !queryBReady) return 'b';
-    return requested;
-};

--- a/packages/frontend/src/features/mergeQuery/utils/syncMergeJoinFilters.test.ts
+++ b/packages/frontend/src/features/mergeQuery/utils/syncMergeJoinFilters.test.ts
@@ -22,33 +22,47 @@ const filters = (...rules: FilterRule[]): Filters => ({
 const fieldIds = (value: Filters) =>
     getTotalFilterRules(value).map((item) => item.target.fieldId);
 
-const joinParts = [{ fieldA: 'a_customer_id', fieldB: 'b_customer_id' }];
+const joinParts = [
+    {
+        fieldIdBySourceId: {
+            a: 'a_customer_id',
+            b: 'b_customer_id',
+            c: 'c_customer_id',
+        },
+    },
+];
 
 describe('syncMergeJoinFilters', () => {
-    it('mirrors a join-key filter to the other query', () => {
+    it('mirrors a join-key filter to every other source', () => {
         const result = syncMergeJoinFilters({
-            changedSide: 'a',
-            filtersA: filters(rule('shared', 'a_customer_id')),
-            filtersB: {},
+            changedSourceId: 'a',
+            filtersBySourceId: {
+                a: filters(rule('shared', 'a_customer_id')),
+                b: {},
+                c: {},
+            },
             joinParts,
         });
 
-        expect(fieldIds(result.filtersA)).toEqual(['a_customer_id']);
-        expect(fieldIds(result.filtersB)).toEqual(['b_customer_id']);
+        expect(fieldIds(result.a)).toEqual(['a_customer_id']);
+        expect(fieldIds(result.b)).toEqual(['b_customer_id']);
+        expect(fieldIds(result.c)).toEqual(['c_customer_id']);
     });
 
-    it('keeps query-specific filters while replacing shared filters', () => {
+    it('keeps source-specific filters while replacing shared filters', () => {
         const result = syncMergeJoinFilters({
-            changedSide: 'a',
-            filtersA: {},
-            filtersB: filters(
-                rule('old-shared', 'b_customer_id'),
-                rule('specific', 'b_status'),
-            ),
+            changedSourceId: 'a',
+            filtersBySourceId: {
+                a: {},
+                b: filters(
+                    rule('old-shared', 'b_customer_id'),
+                    rule('specific', 'b_status'),
+                ),
+            },
             joinParts,
         });
 
-        expect(fieldIds(result.filtersB)).toEqual(['b_status']);
+        expect(fieldIds(result.b)).toEqual(['b_status']);
     });
 
     it('preserves nested boolean structure for shared filters', () => {
@@ -63,13 +77,12 @@ describe('syncMergeJoinFilters', () => {
             ],
         };
         const result = syncMergeJoinFilters({
-            changedSide: 'a',
-            filtersA: { dimensions },
-            filtersB: {},
+            changedSourceId: 'a',
+            filtersBySourceId: { a: { dimensions }, b: {} },
             joinParts,
         });
 
-        expect(result.filtersB.dimensions).toMatchObject({
+        expect(result.b.dimensions).toMatchObject({
             id: 'outer',
             or: [
                 { target: { fieldId: 'b_customer_id' } },
@@ -81,14 +94,16 @@ describe('syncMergeJoinFilters', () => {
         });
     });
 
-    it('mirrors in either direction', () => {
+    it('mirrors in any direction', () => {
         const result = syncMergeJoinFilters({
-            changedSide: 'b',
-            filtersA: {},
-            filtersB: filters(rule('shared', 'b_customer_id')),
+            changedSourceId: 'b',
+            filtersBySourceId: {
+                a: {},
+                b: filters(rule('shared', 'b_customer_id')),
+            },
             joinParts,
         });
 
-        expect(fieldIds(result.filtersA)).toEqual(['a_customer_id']);
+        expect(fieldIds(result.a)).toEqual(['a_customer_id']);
     });
 });

--- a/packages/frontend/src/features/mergeQuery/utils/syncMergeJoinFilters.ts
+++ b/packages/frontend/src/features/mergeQuery/utils/syncMergeJoinFilters.ts
@@ -6,7 +6,7 @@ import {
 } from '@lightdash/common';
 import { type MergeJoinPart } from '../context/context';
 
-type MergeSide = 'a' | 'b';
+export type FiltersBySourceId = Record<string, Filters>;
 
 const itemsOf = (group: FilterGroup): FilterGroupItem[] =>
     'and' in group ? group.and : group.or;
@@ -65,50 +65,42 @@ const replaceJoinKeyRules = (
 };
 
 export const syncMergeJoinFilters = ({
-    changedSide,
-    filtersA,
-    filtersB,
+    changedSourceId,
+    filtersBySourceId,
     joinParts,
 }: {
-    changedSide: MergeSide;
-    filtersA: Filters;
-    filtersB: Filters;
+    changedSourceId: string;
+    filtersBySourceId: FiltersBySourceId;
     joinParts: MergeJoinPart[];
-}): { filtersA: Filters; filtersB: Filters } => {
-    const fieldMap = new Map<string, string>();
-    joinParts.forEach(({ fieldA, fieldB }) => {
-        if (!fieldA || !fieldB) return;
-        fieldMap.set(
-            changedSide === 'a' ? fieldA : fieldB,
-            changedSide === 'a' ? fieldB : fieldA,
-        );
-    });
+}): FiltersBySourceId => {
+    const changedFilters = filtersBySourceId[changedSourceId];
+    if (!changedFilters) return filtersBySourceId;
 
-    if (fieldMap.size === 0) return { filtersA, filtersB };
-
-    if (changedSide === 'a') {
-        return {
-            filtersA,
-            filtersB: {
-                ...filtersB,
-                dimensions: replaceJoinKeyRules(
-                    filtersB.dimensions,
-                    filtersA.dimensions,
-                    fieldMap,
-                ),
-            },
-        };
-    }
-
-    return {
-        filtersA: {
-            ...filtersA,
-            dimensions: replaceJoinKeyRules(
-                filtersA.dimensions,
-                filtersB.dimensions,
-                fieldMap,
-            ),
-        },
-        filtersB,
-    };
+    return Object.fromEntries(
+        Object.entries(filtersBySourceId).map(([targetSourceId, filters]) => {
+            if (targetSourceId === changedSourceId) {
+                return [targetSourceId, filters];
+            }
+            const fieldMap = new Map<string, string>();
+            joinParts.forEach(({ fieldIdBySourceId }) => {
+                const changedField = fieldIdBySourceId[changedSourceId];
+                const targetField = fieldIdBySourceId[targetSourceId];
+                if (changedField && targetField) {
+                    fieldMap.set(changedField, targetField);
+                }
+            });
+            if (fieldMap.size === 0) return [targetSourceId, filters];
+            return [
+                targetSourceId,
+                {
+                    ...filters,
+                    dimensions: replaceJoinKeyRules(
+                        filters.dimensions,
+                        changedFilters.dimensions,
+                        fieldMap,
+                    ),
+                },
+            ];
+        }),
+    );
 };

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -42,7 +42,9 @@ const ExplorerContent = memo(() => {
     const { data } = useExplore(tableId);
 
     const handleClearQuery = useCallback(() => {
-        merge?.removeQuery();
+        merge?.additionalSources.forEach((source) =>
+            merge.removeSource(source.id),
+        );
         dispatch(
             explorerActions.clearQuery({
                 defaultState,


### PR DESCRIPTION
## What changed

- replaces positional Query A / Query B editor state with source-addressed collections and field maps
- makes URL state, saved-merge restore, filters, quick filters, cell/drill resolution, and sidebar source-aware
- keeps the current two-source product limit explicit at editor boundaries
- retains compatibility for existing legacy two-source merge URLs

## Why

The persisted and compiled merge model is already source-addressed, but the editor translated it back into A/B state. That made every interaction assume exactly two positions and made future source expansion risky. This keeps today’s UX unchanged while aligning editor state with the domain model.

## Validation

- frontend typecheck
- changed-file lint: 0 warnings/errors
- merge-query + ExplorePanel tests: 11 files, 33 tests
- local browser regression: ordinary explorer, saved merged chart restore, edit restore, both source accordions

Follow-up to #27394. It was originally stacked on that PR; after #27394 merged and its branch was deleted, this commit was rebased onto current `main`.