### PR TITLE
fix: prefer coarser grain pre-aggregate in matcher tie-break

### DIFF
--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -101,6 +101,12 @@ const baseExplore = (): Explore => ({
                     timeInterval: TimeFrames.MONTH,
                     timeIntervalBaseDimensionName: 'order_date',
                 }),
+                order_date_quarter: makeDimension({
+                    name: 'order_date_quarter',
+                    type: DimensionType.DATE,
+                    timeInterval: TimeFrames.QUARTER,
+                    timeIntervalBaseDimensionName: 'order_date',
+                }),
                 created_at: makeDimension({
                     name: 'created_at',
                     type: DimensionType.TIMESTAMP,
@@ -1843,6 +1849,76 @@ describe('findMatch', () => {
         expect(result).toStrictEqual({
             hit: true,
             preAggregateName: 'orders_narrow_metrics',
+            miss: null,
+        });
+    });
+
+    it('prefers the coarsest matching granularity when dimensions count is equal', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_daily',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                },
+                {
+                    name: 'orders_monthly',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.MONTH,
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_order_date_quarter', 'orders_status'],
+                metrics: ['orders_order_count'],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_monthly',
+            miss: null,
+        });
+    });
+
+    it('prefers a def without time rollup over a time rollup when both match', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_daily',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                },
+                {
+                    name: 'orders_by_status',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_by_status',
             miss: null,
         });
     });

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -1155,12 +1155,23 @@ export const findMatch = (
         };
     }
 
+    // Defs without a time rollup have no time expansion, so treat them as coarsest.
+    const getGranularityCoarseness = (def: PreAggregateDef): number =>
+        def.granularity
+            ? timeFrameOrder.indexOf(def.granularity)
+            : Number.MAX_SAFE_INTEGER;
+
     // TODO: Prefer using materialized row count once available.
     const smallestMatchingDef = matchedDefs.reduce((best, current) => {
         if (current.dimensions.length !== best.dimensions.length) {
             return current.dimensions.length < best.dimensions.length
                 ? current
                 : best;
+        }
+        const currentCoarseness = getGranularityCoarseness(current);
+        const bestCoarseness = getGranularityCoarseness(best);
+        if (currentCoarseness !== bestCoarseness) {
+            return currentCoarseness > bestCoarseness ? current : best;
         }
         return current.metrics.length < best.metrics.length ? current : best;
     });


### PR DESCRIPTION
When multiple pre-aggregates match a query, the tie-break compared only dimension count then metric count — granularity was ignored. With day and month twins of the same pre-aggregate, a quarter-grain query picked whichever was defined first (typically day), scanning ~90x more rows than needed.

## Fix

`findMatch` now prefers the coarsest eligible granularity between the dimension-count and metric-count comparisons. Defs without a time rollup have no time expansion, so they rank coarsest.

## Tests

- Quarter query with day def listed before month def → picks month
- Def without time rollup preferred over day rollup when both match

Closes: ZAP-844

🤖 Generated with [Claude Code](https://claude.com/claude-code)
