### PR TITLE
fix: keep Sentry browser parents out of OTLP traces

### DIFF
--- a/packages/backend/src/tracing/tracing.test.ts
+++ b/packages/backend/src/tracing/tracing.test.ts
@@ -1,8 +1,9 @@
-import { context, SpanKind } from '@opentelemetry/api';
+import { context, ROOT_CONTEXT, SpanKind, trace } from '@opentelemetry/api';
 import { SamplingDecision, type Sampler } from '@opentelemetry/sdk-trace-base';
 import { describe, expect, it, vi } from 'vitest';
 import {
     AlwaysSampleAiRootsSampler,
+    LightdashTraceContextPropagator,
     sentryTraceToTraceparent,
 } from './tracing';
 
@@ -136,5 +137,43 @@ describe('sentryTraceToTraceparent', () => {
         expect(
             sentryTraceToTraceparent(`${TRACE_ID}-${SPAN_ID}-2`),
         ).toBeUndefined();
+    });
+});
+
+describe('LightdashTraceContextPropagator', () => {
+    const getter = {
+        keys: (carrier: Record<string, string>) => Object.keys(carrier),
+        get: (carrier: Record<string, string>, key: string) => carrier[key],
+    };
+
+    it('does not adopt a Sentry browser span as the OTel parent', () => {
+        const sentryTrace = `${TRACE_ID}-${SPAN_ID}-1`;
+        const propagator = new LightdashTraceContextPropagator();
+        const extracted = propagator.extract(
+            ROOT_CONTEXT,
+            {
+                'sentry-trace': sentryTrace,
+                traceparent: sentryTraceToTraceparent(sentryTrace)!,
+            },
+            getter,
+        );
+
+        expect(trace.getSpanContext(extracted)).toBeUndefined();
+    });
+
+    it('continues genuine W3C trace context', () => {
+        const traceparent = `00-${TRACE_ID}-${SPAN_ID}-01`;
+        const propagator = new LightdashTraceContextPropagator();
+        const extracted = propagator.extract(
+            ROOT_CONTEXT,
+            { traceparent },
+            getter,
+        );
+
+        expect(trace.getSpanContext(extracted)).toMatchObject({
+            traceId: TRACE_ID,
+            spanId: SPAN_ID,
+            isRemote: true,
+        });
     });
 });

--- a/packages/backend/src/tracing/tracing.ts
+++ b/packages/backend/src/tracing/tracing.ts
@@ -220,6 +220,29 @@ export const sentryTraceToTraceparent = (
     return `00-${match[1]}-${match[2]}-${match[3] === '0' ? '00' : '01'}`;
 };
 
+export class LightdashTraceContextPropagator extends W3CTraceContextPropagator {
+    extract(
+        extractionContext: Context,
+        carrier: unknown,
+        getter: Parameters<W3CTraceContextPropagator['extract']>[2],
+    ): Context {
+        const first = (value: string | string[] | undefined) =>
+            Array.isArray(value) ? value[0] : value;
+        const sentryTrace = first(getter.get(carrier, 'sentry-trace'));
+        const traceparent = first(getter.get(carrier, 'traceparent'));
+
+        // Sentry's browser span is exported elsewhere, so it cannot parent OTLP.
+        if (
+            sentryTrace &&
+            traceparent === sentryTraceToTraceparent(sentryTrace)
+        ) {
+            return extractionContext;
+        }
+
+        return super.extract(extractionContext, carrier, getter);
+    }
+}
+
 const toOtelAttributes = (
     attributes: TraceSpanOptions['attributes'],
 ): Attributes => {
@@ -341,7 +364,7 @@ class OtelTracingStrategy implements TracingStrategy {
             metricReaders: [],
             textMapPropagator: new CompositePropagator({
                 propagators: [
-                    new W3CTraceContextPropagator(),
+                    new LightdashTraceContextPropagator(),
                     new W3CBaggagePropagator(),
                 ],
             }),


### PR DESCRIPTION
### Description

Prevents browser Sentry spans, exported outside OTLP, from becoming remote parents of backend OTLP traces. Matching Sentry-derived context now starts a backend root; genuine W3C context still propagates.

### Tests

- `pnpm -F backend test --run src/tracing/tracing.test.ts`
- `pnpm -F backend typecheck`
- Local AI stream trace exported with one stored root and appeared in the normal trace list
