### PR TITLE
fix(ai-writeback): report why the agent subprocess exited non-zero

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -81,6 +81,7 @@ import {
 } from '../SandboxRuntime';
 import {
     ALLOWED_TOOLS,
+    ASSISTANT_TEXT_TAIL_CHARS,
     CLAUDE_MODEL,
     CLAUDE_SKILLS_DIR,
     COMPILE_STRIPPED_ENV_VARS,
@@ -3611,6 +3612,15 @@ export class AiWritebackService extends BaseService {
             stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_BYTES);
         };
 
+        // The CLI's own verdict on the run, kept so the failure path can report
+        // *why* `claude -p` exited non-zero. The `result` event arrives and is
+        // parsed moments before the subprocess exit propagates, so on a failed
+        // run this is populated by the time the catch block reads it.
+        let agentResult: { isError: boolean | null; subtype: string | null } = {
+            isError: null,
+            subtype: null,
+        };
+
         const handleEvent = (event: unknown): void => {
             const interpreted = interpretAgentEvent(event);
             if (interpreted.type === 'result') {
@@ -3624,6 +3634,10 @@ export class AiWritebackService extends BaseService {
                     interpreted.durationApiMs !== null
                         ? interpreted.durationMs - interpreted.durationApiMs
                         : null;
+                agentResult = {
+                    isError: interpreted.isError,
+                    subtype: interpreted.subtype,
+                };
                 agentUsage = {
                     costUsd: interpreted.costUsd,
                     inputTokens: interpreted.inputTokens,
@@ -3650,6 +3664,8 @@ export class AiWritebackService extends BaseService {
                         event: 'ai_writeback.run.summary',
                         source,
                         sandboxId: sandbox.sandboxId,
+                        resultIsError: interpreted.isError,
+                        resultSubtype: interpreted.subtype,
                         costUsd: interpreted.costUsd,
                         durationMs: interpreted.durationMs,
                         durationApiMs: interpreted.durationApiMs,
@@ -3762,6 +3778,12 @@ export class AiWritebackService extends BaseService {
             const stderrSnippet = (errStderr || stderrTail).slice(
                 -STDERR_TAIL_BYTES,
             );
+            // On the dominant failure mode (agent gives up, CLI exits 1) stderr
+            // is empty and the only account of what happened is the CLI's own
+            // result classification plus the agent's closing message.
+            const assistantTextTail = assistantText
+                ? assistantText.slice(-ASSISTANT_TEXT_TAIL_CHARS)
+                : null;
             this.logger.error('AI writeback agent subprocess failed', {
                 event: 'ai_writeback.run.agent_failed',
                 sandboxId: sandbox.sandboxId,
@@ -3771,11 +3793,16 @@ export class AiWritebackService extends BaseService {
                 exitCode,
                 errorMessage: getErrorMessage(error),
                 stderrTail: stderrSnippet || null,
+                resultIsError: agentResult.isError,
+                resultSubtype: agentResult.subtype,
+                assistantTextTail,
+                toolCounts,
             });
             Sentry.captureException(error, {
                 tags: {
                     errorType: 'AiWritebackAgentSubprocessFailed',
                     timedOut: String(timedOut),
+                    resultSubtype: agentResult.subtype ?? 'unknown',
                 },
                 extra: {
                     sandboxId: sandbox.sandboxId,
@@ -3783,6 +3810,9 @@ export class AiWritebackService extends BaseService {
                     runTimeoutMs: RUN_TIMEOUT_MS,
                     exitCode,
                     stderrTail: stderrSnippet,
+                    resultIsError: agentResult.isError,
+                    resultSubtype: agentResult.subtype,
+                    assistantTextTail,
                     toolCounts,
                 },
             });

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -237,3 +237,10 @@ export const GATHER_REPO_CONTEXT_SANDBOX_PATH = '/tmp/gather-repo-context.sh';
 // Last N bytes of the agent's stderr kept for diagnostics on a non-zero exit /
 // timeout, so the Sentry payload carries the real error without inflating it.
 export const STDERR_TAIL_BYTES = 4096;
+
+// Last N characters of the agent's final assistant message kept for diagnostics
+// on a failed run. When the agent gives up it says why in prose ("I cannot find
+// a dbt project at ..."), and on that path the CLI writes nothing to stderr, so
+// this is the only human-readable explanation available. Clipped because the
+// message is model output over customer files — enough to diagnose, not a dump.
+export const ASSISTANT_TEXT_TAIL_CHARS = 2000;

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -267,6 +267,18 @@ export type AgentStreamEvent =
           type: 'result';
           /** Total agent wall-clock (ms) as reported by Claude Code. */
           durationMs: number | null;
+          /**
+           * Whether the CLI classified its own run as failed. When `claude -p`
+           * exits non-zero this is the only machine-readable statement of why —
+           * the subprocess writes nothing to stderr in that case.
+           */
+          isError: boolean | null;
+          /**
+           * The CLI's result classification: `success`, `error_max_turns`,
+           * `error_during_execution`, … Retained verbatim rather than mapped to
+           * an enum so a new upstream subtype reaches the logs unchanged.
+           */
+          subtype: string | null;
       } & AiWritebackUsage)
     | { type: 'ignored' };
 

--- a/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
@@ -422,6 +422,8 @@ describe('interpretAgentEvent', () => {
                 duration_ms: 90000,
                 duration_api_ms: 30000,
                 num_turns: 7,
+                subtype: 'success',
+                is_error: false,
                 usage: {
                     input_tokens: 12,
                     output_tokens: 345,
@@ -432,6 +434,8 @@ describe('interpretAgentEvent', () => {
         ).toEqual({
             type: 'result',
             costUsd: 0.42,
+            isError: false,
+            subtype: 'success',
             durationMs: 90000,
             durationApiMs: 30000,
             numTurns: 7,
@@ -448,9 +452,34 @@ describe('interpretAgentEvent', () => {
         ).toEqual({
             type: 'result',
             costUsd: 0.42,
+            isError: null,
+            subtype: null,
             durationMs: null,
             durationApiMs: null,
             numTurns: null,
+            inputTokens: null,
+            outputTokens: null,
+            cacheReadInputTokens: null,
+            cacheCreationInputTokens: null,
+        });
+    });
+
+    it('reads the failure classification from an errored result event', () => {
+        expect(
+            interpretAgentEvent({
+                type: 'result',
+                subtype: 'error_during_execution',
+                is_error: true,
+                num_turns: 2,
+            }),
+        ).toEqual({
+            type: 'result',
+            costUsd: null,
+            isError: true,
+            subtype: 'error_during_execution',
+            durationMs: null,
+            durationApiMs: null,
+            numTurns: 2,
             inputTokens: null,
             outputTokens: null,
             cacheReadInputTokens: null,

--- a/packages/backend/src/ee/services/AiWritebackService/utils.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.ts
@@ -362,6 +362,8 @@ export const interpretAgentEvent = (event: unknown): AgentStreamEvent => {
         duration_ms?: number;
         duration_api_ms?: number;
         num_turns?: number;
+        is_error?: boolean;
+        subtype?: string;
         // Token counts live nested under `usage` on the result event; the rest
         // are top-level. Same shape data apps reads in ClaudeStreamProcessor.
         usage?: {
@@ -376,6 +378,8 @@ export const interpretAgentEvent = (event: unknown): AgentStreamEvent => {
         return {
             type: 'result',
             costUsd: typed.total_cost_usd ?? null,
+            isError: typed.is_error ?? null,
+            subtype: typed.subtype ?? null,
             durationMs: typed.duration_ms ?? null,
             durationApiMs: typed.duration_api_ms ?? null,
             numTurns: typed.num_turns ?? null,


### PR DESCRIPTION
## Summary

`claude -p` exiting 1 is the dominant AI writeback failure mode, and it has been undiagnosable in production. Sentry and Cloud Logging only ever recorded the bare `Sandbox command failed with exit code 1`, with `stderrTail` null.

The reason `stderrTail` is empty is that the CLI writes nothing to stderr on this path — so capturing stderr harder was never going to help. The explanation was already inside the process and being thrown away.

`interpretAgentEvent` parses the stream-json `result` event; that is where `ai_writeback.run.summary` gets its cost and token counts, and it is logged roughly a second *before* the subprocess exit propagates. But it never read `is_error` or `subtype` — the CLI's own statement of why the run ended. They were not present in its type cast at all.

## Changes

- `utils.ts` — read `is_error` / `subtype` off the `result` event
- `types.ts` — carry them on the `result` variant of `AgentStreamEvent`
- `AiWritebackService.ts` — report `resultIsError` / `resultSubtype` on `ai_writeback.run.agent_failed`, plus `assistantTextTail`, the agent's closing message (on a give-up that's the human-readable reason). `resultSubtype` also becomes a Sentry tag so these group by cause instead of collapsing into one opaque bucket. Both fields ride `run.summary` too, so a run that self-reports an error is visible even when the exit code doesn't say so.
- `constants.ts` — `ASSISTANT_TEXT_TAIL_CHARS = 2000`

## Evidence this is the right seam

From production over the last 30 days, the failing runs bill real money and return usage — $0.12 on a 2-turn run, $0.71 on 3-turn runs — with `timedOut: false` and 1–2 `Read` calls before exit. So the model ran and the harness then exited non-zero, rather than the API rejecting the call. That is exactly the case the `result` subtype describes and nothing else records.

Affected instances still see this today; one has never had a successful writeback.

## Security triage

**LOW** — no authorization, endpoint, or input-handling changes. The one surface worth naming is that this writes bounded model output to logs. It is error-path only, clipped to 2000 chars, and goes into the same log line that already carries a 4096-byte raw stderr tail, so it matches the existing data posture rather than widening it. Full scan not warranted.

## Testing

- `pnpm -F backend exec vitest run src/ee/services/AiWritebackService/` — 10 files, 286 tests passing (3 new/updated cases in `utils.test.ts`, including an errored-result case)
- `pnpm -F backend run typecheck` — clean
- `pnpm --filter backend run linter <touched paths>` — clean

Linear: SPK-559

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DicvpsqAifVhH3S2PiBkL4