### PR TITLE
fix(ai-writeback): cap repo-context injection, let the agent explore instead

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -97,6 +97,7 @@ import {
     PR_DESCRIPTION_PATH,
     PR_TITLE_PATH,
     PROMPT_PATH,
+    REPO_CONTEXT_MAX_BYTES,
     REPO_CONTEXT_TIMEOUT_MS,
     RUN_TIMEOUT_MS,
     SANDBOX_TIMEOUT_MS,
@@ -130,6 +131,7 @@ import type {
     CodingAgentConfig,
     GitConnection,
     GitInstallation,
+    RepoContext,
     ResolvedTurnTarget,
     SetStage,
     TurnContext,
@@ -150,6 +152,7 @@ import {
     resolveSandboxDbtVersion,
     resolveSandboxTemplateRef,
     splitStreamBuffer,
+    summarizeRepoListing,
     summarizeToolInput,
 } from './utils';
 
@@ -3506,7 +3509,7 @@ export class AiWritebackService extends BaseService {
     private async gatherRepoContext(
         sandbox: SandboxHandle,
         projectSubPath: string,
-    ): Promise<string | null> {
+    ): Promise<RepoContext | null> {
         const start = performance.now();
         try {
             await sandbox.files.write(
@@ -3527,10 +3530,36 @@ export class AiWritebackService extends BaseService {
                 return null;
             }
             const bytes = Buffer.byteLength(result.stdout, 'utf8');
+            // Past the cap the listing no longer fits the model's context
+            // window alongside the prompt and the agent's own file reads, and
+            // the run dies before doing any work. Hand over a directory digest
+            // instead — the prompt then points the agent at Glob/Grep.
+            if (bytes > REPO_CONTEXT_MAX_BYTES) {
+                const { digest, fileCount } = summarizeRepoListing(
+                    result.stdout,
+                );
+                this.logger.warn(
+                    `AiWriteback: repo context too large to inject — summarising (sandboxId=${sandbox.sandboxId}, bytes=${bytes}, cap=${REPO_CONTEXT_MAX_BYTES}, files=${fileCount}, ${AiWritebackService.elapsed(start)}ms)`,
+                    {
+                        event: 'ai_writeback.repo_context.summarised',
+                        sandboxId: sandbox.sandboxId,
+                        bytes,
+                        capBytes: REPO_CONTEXT_MAX_BYTES,
+                        fileCount,
+                        digestBytes: Buffer.byteLength(digest, 'utf8'),
+                    },
+                );
+                return {
+                    kind: 'summarised',
+                    listing: digest,
+                    fileCount,
+                    bytes,
+                };
+            }
             this.logger.info(
                 `AiWriteback: repo context gathered (sandboxId=${sandbox.sandboxId}, bytes=${bytes}, ${AiWritebackService.elapsed(start)}ms)`,
             );
-            return result.stdout;
+            return { kind: 'full', listing: result.stdout };
         } catch (error) {
             this.logger.warn(
                 `AiWriteback: gatherRepoContext failed — running without context: ${getErrorMessage(error)}`,
@@ -4237,7 +4266,7 @@ export class AiWritebackService extends BaseService {
      */
     private async gatherGeneralRepoContext(
         sandbox: SandboxHandle,
-    ): Promise<string | null> {
+    ): Promise<RepoContext | null> {
         const MAX_FILES = 600;
         try {
             const result = await sandbox.commands.run(
@@ -4248,7 +4277,34 @@ export class AiWritebackService extends BaseService {
             if (!listing) {
                 return null;
             }
-            return listing;
+            const bytes = Buffer.byteLength(listing, 'utf8');
+            // `head` truncates silently, so on any repo with more than
+            // MAX_FILES files the agent was being handed a partial listing and
+            // told to treat it as the index — it would conclude a file simply
+            // did not exist. Summarise instead, which flips the prompt to
+            // "explore with Glob/Grep" and stops the false negatives.
+            const truncated = listing.split('\n').length >= MAX_FILES;
+            if (truncated || bytes > REPO_CONTEXT_MAX_BYTES) {
+                const { digest, fileCount } = summarizeRepoListing(listing);
+                this.logger.warn(
+                    `AiCodingAgent: repo listing truncated at ${MAX_FILES} files — summarising (sandboxId=${sandbox.sandboxId}, bytes=${bytes}, files=${fileCount})`,
+                    {
+                        event: 'ai_writeback.repo_context.summarised',
+                        sandboxId: sandbox.sandboxId,
+                        bytes,
+                        capBytes: REPO_CONTEXT_MAX_BYTES,
+                        fileCount,
+                        digestBytes: Buffer.byteLength(digest, 'utf8'),
+                    },
+                );
+                return {
+                    kind: 'summarised',
+                    listing: digest,
+                    fileCount,
+                    bytes,
+                };
+            }
+            return { kind: 'full', listing };
         } catch (error) {
             this.logger.warn(
                 `AiCodingAgent: gatherGeneralRepoContext failed — running without context: ${getErrorMessage(

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -3529,6 +3529,14 @@ export class AiWritebackService extends BaseService {
                 );
                 return null;
             }
+            // An empty listing is worse than no listing: the `full` branch
+            // would emit an empty <repo_context> block alongside the "do NOT
+            // run find/ls/Glob" instruction, leaving the agent with an empty
+            // index and no sanctioned way to search. Fall through to null so
+            // the block is omitted entirely.
+            if (!result.stdout.trim()) {
+                return null;
+            }
             const bytes = Buffer.byteLength(result.stdout, 'utf8');
             // Past the cap the listing no longer fits the model's context
             // window alongside the prompt and the agent's own file reads, and

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -234,6 +234,20 @@ export const REPO_CONTEXT_TIMEOUT_MS = 30 * 1000;
 // before running it (see buildGatherRepoContextScript).
 export const GATHER_REPO_CONTEXT_SANDBOX_PATH = '/tmp/gather-repo-context.sh';
 
+// Largest repo file listing we inject into the system prompt verbatim. Above
+// this the listing is replaced by a directory-level digest and the agent is
+// told to find files with Glob/Grep instead.
+//
+// Sized against the model's context window, not aesthetics. Repo listings are
+// mostly paths, which tokenise far worse than prose — measured at ~2.2
+// chars/token on a real customer project (deep directories, long model names)
+// versus ~4 for English. So 96KB is roughly 45K tokens, leaving the bulk of
+// the 200K window for the system prompt, skills, file reads, and the turns
+// that actually do the work. An uncapped listing has been measured at 410KB
+// (~187K tokens), which overflows the window on its own and fails every run
+// before the agent edits anything.
+export const REPO_CONTEXT_MAX_BYTES = 96 * 1024;
+
 // Last N bytes of the agent's stderr kept for diagnostics on a non-zero exit /
 // timeout, so the Sentry payload carries the real error without inflating it.
 export const STDERR_TAIL_BYTES = 4096;

--- a/packages/backend/src/ee/services/AiWritebackService/templates.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.test.ts
@@ -113,3 +113,80 @@ describe('buildSystemPrompt — dbt/SQL skill guidance', () => {
         expect(general).not.toContain(EFFECTIVE_DBT_SQL_SKILL);
     });
 });
+
+describe('buildSystemPrompt — repo context sizing', () => {
+    const buildWithContext = (
+        repoContext: Parameters<typeof buildSystemPrompt>[1]['repoContext'],
+    ) =>
+        buildSystemPrompt(DBT_PROJECT_DIR, {
+            ...BASE_CONTEXT,
+            repoContext,
+            warehouseType: WarehouseTypes.POSTGRES,
+            hasWarehouseSkill: true,
+            profilesStaged: true,
+        });
+
+    it('injects the full listing and forbids re-discovery when under the cap', () => {
+        const prompt = buildWithContext({
+            kind: 'full',
+            listing: './models/dim_orders.sql\n./models/dim_orders.yml',
+        });
+        expect(prompt).toContain('<repo_context>');
+        expect(prompt).toContain('./models/dim_orders.sql');
+        expect(prompt).toContain('Do NOT run `find`, `ls`, or `Glob`');
+        expect(prompt).not.toContain('<repo_context_summary>');
+    });
+
+    it('swaps to the digest and directs the agent to explore when summarised', () => {
+        const prompt = buildWithContext({
+            kind: 'summarised',
+            listing:
+                './models/marts/ (412 files)\n./models/staging/ (1980 files)',
+            fileCount: 5231,
+            bytes: 410126,
+        });
+        expect(prompt).toContain('<repo_context_summary>');
+        expect(prompt).toContain('./models/staging/ (1980 files)');
+        expect(prompt).toContain('5231');
+        expect(prompt).toContain('Glob');
+        // The whole point: the "don't explore" instruction must NOT survive,
+        // or the agent is left with a partial index and no way to search.
+        expect(prompt).not.toContain('Do NOT run `find`, `ls`, or `Glob`');
+        expect(prompt).not.toContain('<repo_context>\n');
+    });
+
+    it('emits neither block when no context could be gathered', () => {
+        const prompt = buildWithContext(null);
+        expect(prompt).not.toContain('<repo_context>');
+        expect(prompt).not.toContain('<repo_context_summary>');
+    });
+});
+
+describe('buildGeneralSystemPrompt — repo context sizing', () => {
+    it('directs the agent to explore when the listing was summarised', () => {
+        const prompt = buildGeneralSystemPrompt({
+            repository: 'acme/jaffle',
+            repoContext: {
+                kind: 'summarised',
+                listing: 'src/ (600 files)',
+                fileCount: 600,
+                bytes: 51200,
+            },
+        });
+        expect(prompt).toContain('<repo_context_summary>');
+        expect(prompt).toContain('Glob');
+        expect(prompt).not.toContain(
+            'rather than re-discovering paths with Glob',
+        );
+    });
+
+    it('keeps the full listing verbatim when it fits', () => {
+        const prompt = buildGeneralSystemPrompt({
+            repository: 'acme/jaffle',
+            repoContext: { kind: 'full', listing: 'src/index.ts' },
+        });
+        expect(prompt).toContain('<repo_context>');
+        expect(prompt).toContain('src/index.ts');
+        expect(prompt).not.toContain('<repo_context_summary>');
+    });
+});

--- a/packages/backend/src/ee/services/AiWritebackService/templates.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.ts
@@ -12,6 +12,7 @@ import {
     TMP_PROFILES_DIR,
     WAREHOUSE_SKILL_PATH,
 } from './constants';
+import type { RepoContext } from './types';
 
 // Warehouse-aware guidance injected mid-prompt. Points the agent at the skill
 // files before any edit that changes a column's emitted type — the class of
@@ -86,7 +87,7 @@ export const buildSystemPrompt = (
     context: {
         projectName: string;
         repository: string;
-        repoContext: string | null;
+        repoContext: RepoContext | null;
         warehouseType: WarehouseTypes | null;
         hasWarehouseSkill: boolean;
         profilesStaged: boolean;
@@ -112,7 +113,7 @@ ${buildWarehouseSkillGuidance(context.warehouseType, context.hasWarehouseSkill)}
 
 ${buildDbtSqlSkillGuidance()}
 ${
-    context.repoContext
+    context.repoContext?.kind === 'full'
         ? `
 ## Repo context (pre-computed)
 
@@ -132,11 +133,36 @@ not cover the rest of the repository.
   find its real file and edit THAT file — not any copy under \`dbt_packages/\`.
 
 <repo_context>
-${context.repoContext}
+${context.repoContext.listing}
 </repo_context>
 `
         : ''
-}
+}${
+        context.repoContext?.kind === 'summarised'
+            ? `
+## Repo context (directory summary)
+
+This dbt project has ${context.repoContext.fileCount} \`.sql\`/\`.yml\`/\`.yaml\`
+files under \`${dbtProjectDir}\` — too many to list in full here. The block below
+is a directory-level summary instead: one line per directory, with the number of
+files it contains.
+
+- Use it to orient yourself — it shows where models live and how the project is
+  organised — then use \`Glob\` (e.g. \`**/dim_orders*\`) or \`Grep\` to find the
+  specific files you need. This is expected here; the full listing is NOT
+  available, so exploring is the correct approach.
+- The summary covers \`${dbtProjectDir}\` ONLY. In a monorepo the project can
+  import models from \`local:\` packages (declared in \`packages.yml\`) whose real
+  source files live ELSEWHERE in the repository. If a model the request refers
+  to is not under the directories below, \`Glob\`/\`Grep\` from the repo root and
+  edit the real file — not any copy under \`dbt_packages/\`.
+
+<repo_context_summary>
+${context.repoContext.listing}
+</repo_context_summary>
+`
+            : ''
+    }
 If you made any file changes, perform these follow-up steps before you finish:
 ${
     context.profilesStaged
@@ -205,7 +231,7 @@ blocks.
 export const buildGeneralSystemPrompt = (context: {
     repository: string;
     /** Pre-computed file listing of the repo, or null if unavailable. */
-    repoContext: string | null;
+    repoContext: RepoContext | null;
 }): string =>
     `
 You are an autonomous coding agent working inside a checkout of a git repository.
@@ -223,7 +249,7 @@ You are an autonomous coding agent working inside a checkout of a git repository
   credential files). The host rejects any commit touching these.
 - Do NOT commit or push — the host handles git after you finish.
 ${
-    context.repoContext
+    context.repoContext?.kind === 'full'
         ? `
 ## Repo context (pre-computed)
 
@@ -231,11 +257,29 @@ The block below lists files in the repository. Consult it FIRST to locate
 files; \`Read\` them directly rather than re-discovering paths with Glob.
 
 <repo_context>
-${context.repoContext}
+${context.repoContext.listing}
 </repo_context>
 `
         : ''
-}
+}${
+        context.repoContext?.kind === 'summarised'
+            ? `
+## Repo context (directory summary)
+
+This repository has ${context.repoContext.fileCount} files — too many to list in
+full here. The block below is a directory-level summary instead: one line per
+directory, with the number of files it contains.
+
+Use it to orient yourself, then use \`Glob\` or \`Grep\` to find the specific
+files you need. The full listing is NOT available, so exploring is the correct
+approach here.
+
+<repo_context_summary>
+${context.repoContext.listing}
+</repo_context_summary>
+`
+            : ''
+    }
 When you have finished making changes, end your final reply with the three
 structured-output blocks below. The host parses the PR metadata from them and
 strips the blocks before showing your reply to the user, so emit them verbatim,

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -257,6 +257,28 @@ export type AgentToolCall = {
 };
 
 /**
+ * The repo file listing handed to the agent in its system prompt.
+ *
+ * `full` is the complete sorted listing — the agent is told to treat it as the
+ * index and not re-discover paths. `summarised` is a directory-level digest
+ * emitted when the full listing is too large to inject: on a big dbt project
+ * the listing alone can exceed the model's context window, which fails the run
+ * before any work happens. In that case the agent is pointed at `Glob`/`Grep`
+ * instead, which costs turns but actually completes.
+ */
+export type RepoContext =
+    | { kind: 'full'; listing: string }
+    | {
+          kind: 'summarised';
+          /** Directory-level digest, one `path/ (N files)` line per directory. */
+          listing: string;
+          /** Number of files in the full listing this was derived from. */
+          fileCount: number;
+          /** Size of the full listing in bytes, for logging. */
+          bytes: number;
+      };
+
+/**
  * The meaningful shapes of a Claude Code stream-json line. Everything the host
  * reacts to (assistant text, tool calls, the final cost summary) is one of
  * these; every other event type collapses to `ignored`.

--- a/packages/backend/src/ee/services/AiWritebackService/utils.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.ts
@@ -353,6 +353,40 @@ export const parseGitNameStatus = (stdout: string): StagedFileChanges => {
 };
 
 /** Caller owns the side effects (logging, counting, progress). */
+/**
+ * Collapse a flat file listing into one `dir/ (N files)` line per directory.
+ *
+ * Used when the full listing is too large to inject (see
+ * `REPO_CONTEXT_MAX_BYTES`). The digest keeps the shape of the project — where
+ * models live, how the tree is organised — at a fraction of the tokens, and the
+ * agent finds specific files with Glob/Grep from there. Derived host-side from
+ * the listing already gathered, so it costs no extra sandbox round trip.
+ */
+export const summarizeRepoListing = (
+    listing: string,
+): { digest: string; fileCount: number } => {
+    const paths = listing
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+
+    const countsByDir = new Map<string, number>();
+    for (const path of paths) {
+        const lastSlash = path.lastIndexOf('/');
+        // A path with no slash sits at the project root; group those together
+        // rather than emitting a bare "" directory.
+        const dir = lastSlash === -1 ? '.' : path.slice(0, lastSlash);
+        countsByDir.set(dir, (countsByDir.get(dir) ?? 0) + 1);
+    }
+
+    const digest = [...countsByDir.entries()]
+        .sort(([a], [b]) => (a < b ? -1 : 1))
+        .map(([dir, count]) => `${dir}/ (${count} files)`)
+        .join('\n');
+
+    return { digest, fileCount: paths.length };
+};
+
 export const interpretAgentEvent = (event: unknown): AgentStreamEvent => {
     if (!event || typeof event !== 'object') return { type: 'ignored' };
     const typed = event as {


### PR DESCRIPTION
## Summary

The repo file listing is injected into the writeback system prompt **verbatim, with no size cap**. On a large dbt project the listing alone exceeds the model's context window, so every run dies at `stage=agent` with exit 1 before editing anything.

## Evidence

Measured on an affected project:

- repo context: **410,126 bytes ≈ 187,138 tokens**, against `claude-sonnet-4-6`'s **200K** window
- single-request input on every failing run: **204,574 – 205,107 tokens**, including one that read only a single file
- paths tokenise at **~2.2 chars/token** vs ~4 for prose, so a deep tree with long model names costs roughly double what its byte count suggests

Corroborated across instances: failing runs sit at 252K–270K cache creation; successful runs at 13K–124K. Deterministic by repo size, which is why it reads as "100% broken for one customer" while staying low-volume fleet-wide.

## Changes

- `REPO_CONTEXT_MAX_BYTES` (96KB ≈ 45K tokens). Above it, the listing is replaced by a directory digest (`dir/ (N files)` per line), derived host-side from the listing already gathered — no extra sandbox round trip.
- `RepoContext` discriminated union (`full` | `summarised`) so the prompt can tell the two apart.
- Prompt flips when summarised: instead of *"Do NOT run `find`, `ls`, or `Glob`"*, the agent is told the full listing is unavailable and to locate files with `Glob`/`Grep`. That was the aggravating half of the bug — on exactly the repos too big to list, we also suppressed the exploration path that would have worked.
- `ai_writeback.repo_context.summarised` log event with bytes, file count, and digest size, so the cap's effect is measurable.

Projects under the cap are untouched and still get the full listing.

## Also fixed

The general (`editRepo`) agent capped its listing at 600 files with `head` but still instructed the agent to treat it as the index. On any repo above 600 files it would conclude a file simply did not exist. Truncation now routes through the same summarised path. Separate latent bug, same seam.

## Trade-off

Summarised runs spend turns on `Glob`/`Grep` that a full listing would have saved. That is the intended trade: slower runs that finish, instead of fast runs that always fail.

## Security triage

**LOW** — no authorization, endpoint, or input-handling changes. Strictly reduces the volume of repo data sent to the model.

## Testing

- `pnpm -F backend exec vitest run src/ee/services/AiWritebackService/` — 10 files, 291 tests passing (5 new: both prompt modes for both agents, plus the null case). The key assertion is that the "do not explore" instruction does **not** survive into the summarised prompt.
- `pnpm -F backend run typecheck` — clean
- `pnpm --filter backend run linter <touched paths>` — clean

Not yet verified against a real oversized project — see the acceptance criteria on the ticket.

Linear: SPK-1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DicvpsqAifVhH3S2PiBkL4