### PR TITLE
chore(dev): replace Spotlight with Maple local mode for local tracing

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -34,7 +34,7 @@ This gives you:
 - `$LD_COMPOSE_PROJECT` — docker compose project name
 - `$LD_VOLUME_PREFIX` / `$LD_CONTAINER_PREFIX` — prefixes for volumes and containers
 - `$LD_PG_PORT` — per-instance PostgreSQL port
-- `$PORT`, `$FE_PORT`, `$SCHEDULER_PORT`, `$DEBUG_PORT`, `$SDK_TEST_PORT`, `$SPOTLIGHT_PORT`, `$LIGHTDASH_PROMETHEUS_PORT` — per-instance app ports
+- `$PORT`, `$FE_PORT`, `$SCHEDULER_PORT`, `$DEBUG_PORT`, `$SDK_TEST_PORT`, `$MAPLE_PORT`, `$LIGHTDASH_PROMETHEUS_PORT` — per-instance app ports
 - `$PGPORT`, `$SITE_URL`, `$S3_ENDPOINT`, `$HEADLESS_BROWSER_PORT`, `$EMAIL_SMTP_PORT` — app config (shared ports hardcoded: S3=9000, browser=3001, SMTP=1025)
 
 **Shared services** (minio, headless-browser, mailpit, nats) run once on fixed ports via `docker-compose.dev.shared.yml`. Only PostgreSQL is per-instance via `docker-compose.dev.instance.yml`.
@@ -433,7 +433,7 @@ Then the reconcile steps:
 
 Interpreting the result:
 
-- **Exit 0, ends with `READY: ...`** → done. Report the printed frontend/API/Spotlight URLs and start the **Monitor watchers** (see "Monitor Logs with Monitor Tool"). **Do not run any of the agentic steps below** — the environment is up.
+- **Exit 0, ends with `READY: ...`** → done. Report the printed frontend/API/Maple URLs and start the **Monitor watchers** (see "Monitor Logs with Monitor Tool"). **Do not run any of the agentic steps below** — the environment is up.
 - **Non-zero exit with a `FAIL: <step> -- <reason>` line** → enter **self-repair** (next section). Do NOT blindly re-run the script; diagnose first.
 
 The script prints `STEP:`/`OK:`/`SKIP:` markers so you can see exactly how far it got. Steady-state runs (everything cached) finish in well under a minute; a fresh worktree pays for `pnpm install` + builds once.
@@ -518,7 +518,7 @@ FE_PORT=${FE_PORT}
 SCHEDULER_PORT=${SCHEDULER_PORT}
 DEBUG_PORT=${DEBUG_PORT}
 SDK_TEST_PORT=${SDK_TEST_PORT}
-SPOTLIGHT_PORT=${SPOTLIGHT_PORT}
+MAPLE_PORT=${MAPLE_PORT}
 LIGHTDASH_PROMETHEUS_PORT=${LIGHTDASH_PROMETHEUS_PORT}
 SITE_URL=http://localhost:${FE_PORT}
 S3_ENDPOINT=http://localhost:9000
@@ -604,9 +604,9 @@ Symptom if you forget: you change a flag, restart, and nothing changes. \`pm2 jl
 
 ## Debugging
 
-Use the \`/debug-local\` skill for comprehensive debugging combining PM2 logs, Spotlight traces, and browser automation.
+Use the \`/debug-local\` skill for comprehensive debugging combining PM2 logs, Maple traces, and browser automation.
 
-Spotlight UI: http://localhost:${SPOTLIGHT_PORT}
+Maple trace UI: http://localhost:${MAPLE_PORT}
 
 ## Database Snapshots
 
@@ -623,7 +623,7 @@ Spotlight UI: http://localhost:${SPOTLIGHT_PORT}
 - **Backend API**: http://localhost:${PORT}
 - **Demo login**: \`demo@lightdash.com\` / \`demo_password!\`
 - **Mailpit** (email inbox): http://localhost:8025
-- **Spotlight** (traces): http://localhost:${SPOTLIGHT_PORT}
+- **Maple** (traces): http://localhost:${MAPLE_PORT}
 
 ## Service Ports (this instance)
 
@@ -636,7 +636,7 @@ Spotlight UI: http://localhost:${SPOTLIGHT_PORT}
 | MinIO             | 9000/9001 |                                    |
 | Headless Browser  | 3001      |                                    |
 | Mailpit           | 8025/1025 | http://localhost:8025         |
-| Spotlight         | ${SPOTLIGHT_PORT}      | http://localhost:${SPOTLIGHT_PORT}             |
+| Maple (traces)    | ${MAPLE_PORT}      | http://localhost:${MAPLE_PORT}             |
 EOF
 ````
 
@@ -784,7 +784,7 @@ If PM2 shows `MISMATCH`, delete this instance's processes first:
 # One name per call — `pm2 delete a b c` aborts at the first name it cannot
 # find (e.g. sdk-test on an instance that never ran SDK test mode), leaving
 # every later name running.
-for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test spotlight; do
+for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
   pm2 delete "${LD_INSTANCE_ID}-${suffix}" 2>/dev/null || true
 done
 ```
@@ -926,7 +926,7 @@ For permanent worktree removal, use `destroy` instead.
 # One name per call — `pm2 delete a b c` aborts at the first name it cannot
 # find (e.g. sdk-test on an instance that never ran SDK test mode), leaving
 # every later name running.
-for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test spotlight; do
+for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
   pm2 delete "${LD_INSTANCE_ID}-${suffix}" 2>/dev/null || true
 done
 
@@ -943,7 +943,7 @@ Permanently remove this instance's services, PostgreSQL volumes, and port slot. 
 
 ```bash
 # One name per call — see the note under `stop`.
-for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test spotlight; do
+for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
   pm2 delete "${LD_INSTANCE_ID}-${suffix}" 2>/dev/null || true
 done
 
@@ -972,7 +972,7 @@ for f in ~/.lightdash/dev-instances/*.json; do
   [ -f "$f" ] || continue
   INST_ID=$(python3 -c "import json; print(json.load(open('$f'))['instanceId'])")
   # One name per call — see the note under `stop`.
-  for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test spotlight; do
+  for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
     pm2 delete "${INST_ID}-${suffix}" 2>/dev/null || true
   done
 done

--- a/.claude/skills/agent-harness/SKILL.md
+++ b/.claude/skills/agent-harness/SKILL.md
@@ -147,11 +147,11 @@ Password: demo_password!
 # View recent API logs
 ./agent-harness/agent-cli.sh <ID> logs api
 
-# Check for errors using Spotlight MCP
-mcp__spotlight__search_errors with filters: {"timeWindow": 300}
+# Check for errors in Maple (local tracing)
+maple errors --since 5m
 
-# Get trace details
-mcp__spotlight__get_traces with traceId: "<8-char-prefix-from-logs>"
+# Get trace details (full 32-char trace ID from the logs)
+maple trace <trace-id>
 ```
 
 ### Debugging frontend issues

--- a/.claude/skills/debug-local/SKILL.md
+++ b/.claude/skills/debug-local/SKILL.md
@@ -2,7 +2,7 @@
 name: debug-local
 metadata:
   internal: true
-description: Debug the Lightdash app using PM2 logs, Spotlight traces, and browser automation. Use when investigating issues, tracking down bugs, understanding request flow, or correlating frontend actions with backend behavior.
+description: Debug the Lightdash app using PM2 logs, Maple traces, and browser automation. Use when investigating issues, tracking down bugs, understanding request flow, or correlating frontend actions with backend behavior.
 ---
 
 # Debugging Lightdash
@@ -37,10 +37,19 @@ Was this working before? A regression means the root cause is in the diff.
 pnpm exec pm2 logs lightdash-api --lines 50 --nostream
 ```
 
-Then use Spotlight MCP:
-- `mcp__spotlight__search_errors` with `{"timeWindow": 300}` for recent errors with stack traces
-- `mcp__spotlight__search_traces` with `{"timeWindow": 300}` for recent request traces
-- `mcp__spotlight__get_traces` with a trace ID for full span breakdown
+Then query Maple (local mode ingests OTLP traces from the API and scheduler):
+
+```bash
+maple services --format table       # per-service throughput and error rate
+maple errors --since 5m             # errors grouped by fingerprint
+maple traces --since 5m --errors    # recent traces containing errors
+maple trace <trace-id>              # full span tree + correlated logs
+maple slow-traces --since 15m       # slowest traces
+```
+
+The CLI defaults to port 4318, so point it at this instance first:
+`export MAPLE_LOCAL_URL="http://127.0.0.1:${MAPLE_PORT:-4320}"`. See
+[Trace Lookup](#trace-lookup-maple-cli) for the full filter set.
 
 ### 4. Reproduce
 
@@ -61,7 +70,7 @@ Check if the bug matches a known Lightdash pattern:
 | Pattern | Signature | Where to look |
 |---------|-----------|---------------|
 | Permission error | 403 Forbidden | CASL abilities in `projectMemberAbility.ts`, `organizationMemberAbility.ts` |
-| Slow query / N+1 | Response >1s, many db spans | Spotlight span breakdown — count db.* spans, check for loops |
+| Slow query / N+1 | Response >1s, many db spans | `maple trace <id>` span tree — count db.* spans, check for loops |
 | Stale explore cache | Shows old columns/metrics | `cached_explores` table, `CompileService` |
 | Migration issue | Column not found, schema mismatch | `packages/backend/src/database/migrations/`, check rollback |
 | Scheduler job failure | Job not running, stuck | PM2 scheduler logs, `graphile_worker.jobs` table |
@@ -81,7 +90,7 @@ Also check:
 
 Before writing ANY fix, verify your hypothesis.
 
-1. **Confirm:** Add a temporary log, assertion, or use Spotlight/PM2 to check the suspected root cause. Reproduce. Does evidence match?
+1. **Confirm:** Add a temporary log, assertion, or use Maple/PM2 to check the suspected root cause. Reproduce. Does evidence match?
 
 2. **If wrong:** Return to Phase 1. Gather more evidence. Do not guess.
 
@@ -139,14 +148,14 @@ Ensure the development environment is running:
 
 ```bash
 /docker-dev              # Start Docker services (postgres, minio, etc.)
-pnpm pm2:start           # Start all PM2 processes including Spotlight
+pnpm pm2:start           # Start all PM2 processes including Maple
 pnpm pm2:status          # Verify all processes are online
 ```
 
 Services:
 - **Frontend**: http://localhost:3000
 - **API**: http://localhost:8080
-- **Spotlight UI**: http://localhost:8969
+- **Maple trace UI**: http://localhost:4320
 
 ## Tools Reference
 
@@ -157,7 +166,7 @@ pnpm pm2:logs              # Stream all logs (Ctrl+C to exit)
 pnpm pm2:logs:api          # API server logs only
 pnpm pm2:logs:scheduler    # Background job scheduler logs
 pnpm pm2:logs:frontend     # Vite dev server logs
-pnpm pm2:logs:spotlight    # Spotlight sidecar logs
+pnpm pm2:logs:maple        # Maple tracing server logs
 ```
 
 For non-blocking log viewing (last N lines):
@@ -175,51 +184,72 @@ Lightdash logs include a 32-character trace ID for correlation:
 [4d40816e5a7d433e88f99008de5f4be5] GET /api/v1/user/login-options 200 - 2 ms
 ```
 
-Use the first 8 characters (e.g., `700aa55e`) to look up traces in Spotlight.
+Pass the full 32-character ID to `maple trace` to pull up the request.
 
-### Trace Lookup (Spotlight MCP)
+### Trace Lookup (Maple CLI)
 
-Use the Spotlight MCP tools to query telemetry programmatically:
+Maple local mode stores traces, logs, and metrics in an embedded ClickHouse and
+exposes them through the `maple` CLI. Every command takes `--since
+<30m|1h|24h|7d>` for the window. Output is JSON — pipe through `jq` to narrow it.
+`--format table` only applies to flat row sets (`services`, `query`); the other
+commands say so and fall back to JSON.
+
+Set the target once per shell — the CLI defaults to port 4318, and each worktree
+runs its own server on its slot port:
+
+```bash
+export MAPLE_LOCAL_URL="http://127.0.0.1:${MAPLE_PORT:-4320}"
+```
+
+#### List services
+
+```bash
+maple services --format table
+```
+
+Throughput, error rate, and P95 latency per service. The API reports as
+`$LD_INSTANCE_ID` (`lightdash` by default) and the worker as
+`$LD_INSTANCE_ID-scheduler`.
 
 #### List recent traces
 
-```
-mcp__spotlight__search_traces with filters: {"timeWindow": 300}
+```bash
+maple traces --since 5m | jq '.traces[] | {traceId, spanName, durationMs}'
+maple traces --since 1h --errors --min-duration-ms 500
+maple slow-traces --since 15m
 ```
 
-Returns summary of recent traces with trace ID, endpoint, duration, span count.
+Filters: `--span-name <substr>`, `--http-method`, `--errors`,
+`--min-duration-ms`, `--max-duration-ms`, `--service`, `--limit`.
 
 #### Get trace details
 
-```
-mcp__spotlight__get_traces with traceId: "700aa55e"
+```bash
+maple trace 700aa55e784a437aa97de9b8c5c3ed3a
 ```
 
-Returns the full span tree with timing breakdown:
-
-```
-GET /api/v1/health [816224a9 · 39ms]
-   ├─ select * from "knex_migrations" [db · 8ms]
-   ├─ select * from "organizations" [db · 2ms]
-   ├─ session [middleware.express · 1ms]
-   └─ /api/v1/health [request_handler.express · 0ms]
-```
+Returns the full span tree plus the logs correlated to that trace.
 
 #### Search for errors
 
+```bash
+maple errors --since 30m        # grouped by fingerprint
+maple error <fingerprint-hash>  # sample traces + timeseries
 ```
-mcp__spotlight__search_errors with filters: {"timeWindow": 300}
-```
-
-Returns runtime errors and exceptions with stack traces.
 
 #### Search logs
 
-```
-mcp__spotlight__search_logs with filters: {"timeWindow": 300}
+```bash
+maple logs --since 5m --severity ERROR
+maple logs --trace-id 700aa55e784a437aa97de9b8c5c3ed3a
+maple logs -q "compile" --since 1h
 ```
 
-Returns application log entries.
+#### Raw SQL escape hatch
+
+```bash
+maple query "SELECT ServiceName, count() FROM traces GROUP BY ServiceName"
+```
 
 ### Browser Debugging (Chrome DevTools MCP)
 
@@ -319,11 +349,11 @@ Traces contain contextual attributes beyond timing:
 | View API logs (non-blocking) | `pnpm exec pm2 logs lightdash-api --lines 20 --nostream` |
 | Check process status | `pnpm pm2:status` |
 | Restart API | `pnpm pm2:restart:api` |
-| Recent traces | `mcp__spotlight__search_traces {"timeWindow": 300}` |
-| Trace details | `mcp__spotlight__get_traces "<8-char-prefix>"` |
-| Recent errors | `mcp__spotlight__search_errors {"timeWindow": 300}` |
+| Recent traces | `maple traces --since 5m` |
+| Trace details | `maple trace <full-trace-id>` |
+| Recent errors | `maple errors --since 5m` |
 | Browser snapshot | `mcp__chrome-devtools__take_snapshot` |
-| Open Spotlight UI | http://localhost:8969 |
+| Open Maple trace UI | http://localhost:4320 |
 
 ## Cross-Agent Validation
 

--- a/.claude/skills/renovate-pr/SKILL.md
+++ b/.claude/skills/renovate-pr/SKILL.md
@@ -203,7 +203,7 @@ For each package, design 1–3 focused checks based on what the package actually
 For each check, use these tools in parallel:
 
 - **PM2 logs** — `pnpm exec pm2 logs lightdash-api --lines 50 --nostream` after exercising the flow
-- **Spotlight** — `mcp__spotlight__search_errors {"timeWindow": 300}` for recent runtime errors; `mcp__spotlight__search_traces {"timeWindow": 300}` to confirm requests completed without warnings
+- **Maple** — `maple errors --since 5m` for recent runtime errors; `maple traces --since 5m` to confirm requests completed without warnings (`maple services --format table` for a quick per-service error-rate view)
 - **Chrome DevTools MCP** — for UI checks: `mcp__chrome-devtools__new_page`, `mcp__chrome-devtools__take_snapshot`, `mcp__chrome-devtools__list_console_messages`
 - **curl + LDPAT** — for API-only checks (faster than browser):
   ```bash
@@ -213,7 +213,7 @@ For each check, use these tools in parallel:
 
 **What counts as a failure signal:**
 - Stack traces or unhandled rejections in PM2 logs
-- Spotlight errors with timestamps after we triggered the flow
+- Maple errors with timestamps after we triggered the flow
 - HTTP 500s on previously-working endpoints
 - Console errors in the browser that weren't there on `main`
 - Behavior change visible to the user (e.g. an email body now missing headers, an editor that won't accept input)

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,10 +11,6 @@
     "sentry": {
       "type": "http",
       "url": "https://mcp.sentry.dev/mcp"
-    },
-    "spotlight": {
-      "command": "pnpx",
-      "args": ["@spotlightjs/spotlight@latest", "mcp"]
     }
   }
 }

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -20,11 +20,13 @@
  *   - <instanceId>-frontend: Vite dev server (default port 3000)
  *   - <instanceId>-common-watch: TypeScript watcher for common package
  *   - <instanceId>-warehouses-watch: TypeScript watcher for warehouses package
- *   - <instanceId>-spotlight: Sentry Spotlight debugging UI (default port 8969)
+ *   - <instanceId>-maple: Maple local-mode tracing server (default port 4320)
  *
  * Logs are stored in ~/.pm2/logs/ (PM2 default location)
  */
 
+const { spawnSync } = require('child_process');
+const os = require('os');
 const path = require('path');
 const dotenv = require('dotenv');
 
@@ -60,11 +62,41 @@ const fePort = env.FE_PORT || undefined; // Vite auto-detects if not set
 const sdkTestPort = env.SDK_TEST_PORT || '3030';
 const sdkTestEnabled =
     (process.env.LD_ENABLE_SDK_TEST ?? env.LD_ENABLE_SDK_TEST) === 'true';
-const spotlightPort = env.SPOTLIGHT_PORT || '8969';
+const maplePort = env.MAPLE_PORT || '4320';
+
+// Maple is a standalone binary (not a node_modules bin), so it may be absent.
+// Resolve it up front: without it there is nothing to export traces to, and an
+// OTLP exporter pointed at a dead port just logs export failures every batch.
+const mapleBin = (() => {
+    const { stdout } = spawnSync('sh', ['-c', 'command -v maple'], {
+        encoding: 'utf8',
+    });
+    return (stdout || '').trim() || undefined;
+})();
+
+// One Maple server per data dir, so namespace it by instance the same way the
+// port is — two worktrees must not fight over ~/.maple/data.
+const mapleDataDir = path.join(os.homedir(), '.maple', `data-${instanceId}`);
+
+// Each app adds its own OTEL_SERVICE_NAME on top of this: service.name is what
+// namespaces traces per checkout in the Maple UI.
+const tracingEnv = mapleBin
+    ? {
+          LIGHTDASH_OTEL_TRACES_ENABLED: 'true',
+          OTEL_EXPORTER_OTLP_ENDPOINT: `http://127.0.0.1:${maplePort}`,
+      }
+    : {};
 
 // Log the root directory so it's obvious which worktree PM2 is running from
 console.log(`\n  Lightdash PM2 root: ${__dirname}`);
 console.log(`  Instance ID: ${instanceId}\n`);
+
+if (!mapleBin) {
+    console.log(
+        '  maple not found on PATH — local tracing disabled.\n' +
+            '  Install it with: curl -fsSL https://maple.dev/cli/install | sh\n',
+    );
+}
 
 const frontendArgs = fePort ? `--port ${fePort}` : undefined;
 
@@ -82,7 +114,8 @@ module.exports = {
                 LIGHTDASH_MODE: 'development',
                 HEADLESS: 'true',
                 NODE_ENV: 'development',
-                SENTRY_SPOTLIGHT: `http://localhost:${spotlightPort}/stream`,
+                ...tracingEnv,
+                OTEL_SERVICE_NAME: instanceId,
                 PORT: apiPort,
             },
             watch: ['src'],
@@ -119,7 +152,8 @@ module.exports = {
             env: {
                 ...envWithPath,
                 NODE_ENV: 'development',
-                SENTRY_SPOTLIGHT: `http://localhost:${spotlightPort}/stream`,
+                ...tracingEnv,
+                OTEL_SERVICE_NAME: `${instanceId}-scheduler`,
                 PORT: schedulerPort,
                 LIGHTDASH_PROMETHEUS_ENABLED: 'false',
             },
@@ -139,7 +173,6 @@ module.exports = {
             cwd: path.join(__dirname, 'packages/frontend'),
             env: {
                 NODE_ENV: 'development',
-                VITE_SENTRY_SPOTLIGHT: `http://localhost:${spotlightPort}/stream`,
                 PORT: apiPort,
             },
             watch: false,
@@ -213,21 +246,29 @@ module.exports = {
               ]
             : []),
 
-        // Spotlight.js Sidecar (Sentry Dev Debugging UI)
-        {
-            name: `${instanceId}-spotlight`,
-            script: 'node_modules/.bin/spotlight',
-            args: `--port ${spotlightPort}`,
-            interpreter: 'none',
-            cwd: __dirname,
-            env: {
-                NODE_ENV: 'development',
-            },
-            watch: false,
-            autorestart: true,
-            kill_timeout: 3000,
-            merge_logs: true,
-            time: true,
-        },
+        // Maple local mode: OTLP ingest + embedded ClickHouse + trace UI.
+        // --offline serves the UI from the binary (same-origin, no internet, no
+        // Chrome local-network prompt). --on-dirty-store wipe keeps it from
+        // refusing to boot after PM2 SIGKILLs it; local traces are disposable.
+        ...(mapleBin
+            ? [
+                  {
+                      name: `${instanceId}-maple`,
+                      script: mapleBin,
+                      args: `start --port ${maplePort} --data-dir ${mapleDataDir} --offline --on-dirty-store wipe`,
+                      interpreter: 'none',
+                      cwd: __dirname,
+                      env: {
+                          NODE_ENV: 'development',
+                          MAPLE_NO_UPDATE_CHECK: '1',
+                      },
+                      watch: false,
+                      autorestart: true,
+                      kill_timeout: 3000,
+                      merge_logs: true,
+                      time: true,
+                  },
+              ]
+            : []),
     ],
 };

--- a/linear-agent/runner.sh
+++ b/linear-agent/runner.sh
@@ -338,7 +338,7 @@ JS
 warm_vite_dependencies() {
     write_preview_vite_config
     cd "$repository_dir"
-    VITE_SENTRY_SPOTLIGHT='' pnpm -F frontend exec vite optimize \
+    pnpm -F frontend exec vite optimize \
         --config "$preview_vite_config" >/dev/null
 }
 
@@ -367,7 +367,7 @@ start_preview() {
     set_env_value SCHEDULER_PORT "$SCHEDULER_PORT" .env.development.local
     set_env_value DEBUG_PORT "$DEBUG_PORT" .env.development.local
     set_env_value SDK_TEST_PORT "$SDK_TEST_PORT" .env.development.local
-    set_env_value SPOTLIGHT_PORT "$SPOTLIGHT_PORT" .env.development.local
+    set_env_value MAPLE_PORT "$MAPLE_PORT" .env.development.local
     set_env_value LIGHTDASH_PROMETHEUS_PORT "$LIGHTDASH_PROMETHEUS_PORT" .env.development.local
     set_env_value SITE_URL "$preview_url" .env.development.local
     set_env_value INTERNAL_LIGHTDASH_HOST "http://localhost:${FE_PORT}" .env.development.local
@@ -389,8 +389,7 @@ start_preview() {
     set_env_value SENTRY_DSN '' .env.development.local
     set_env_value SENTRY_BE_DSN '' .env.development.local
     set_env_value SENTRY_FE_DSN '' .env.development.local
-    set_env_value SENTRY_SPOTLIGHT '' .env.development.local
-    set_env_value VITE_SENTRY_SPOTLIGHT '' .env.development.local
+    set_env_value LIGHTDASH_OTEL_TRACES_ENABLED false .env.development.local
     db_container="${LD_CONTAINER_PREFIX}-db-dev-1"
     cat >"$preview_compose" <<YAML
 volumes:
@@ -473,8 +472,7 @@ module.exports = {
             SENTRY_DSN: '',
             SENTRY_BE_DSN: '',
             SENTRY_FE_DSN: '',
-            SENTRY_SPOTLIGHT: '',
-            VITE_SENTRY_SPOTLIGHT: '',
+            LIGHTDASH_OTEL_TRACES_ENABLED: 'false',
         },
     })),
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
         "tslib": "2.8.1"
     },
     "devDependencies": {
-        "@spotlightjs/spotlight": "4.10.0",
         "@types/node": "24.13.2",
         "@types/pegjs": "0.10.3",
         "@vitest/eslint-plugin": "1.6.23",
@@ -140,9 +139,8 @@
         "pm2:restart:api": "pm2 restart lightdash-api",
         "pm2:restart:scheduler": "pm2 restart lightdash-scheduler",
         "pm2:restart:frontend": "pm2 restart lightdash-frontend",
-        "pm2:logs:spotlight": "pm2 logs lightdash-spotlight --lines 50",
-        "pm2:restart:spotlight": "pm2 restart lightdash-spotlight",
-        "spotlight": "pnpm dlx @spotlightjs/spotlight@latest",
+        "pm2:logs:maple": "pm2 logs lightdash-maple --lines 50",
+        "pm2:restart:maple": "pm2 restart lightdash-maple",
         "dev:pm2": "pm2 start ecosystem.config.js && pm2 logs --lines 50"
     },
     "lint-staged": {

--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -9,16 +9,7 @@ import {
 import { otelTracingEnabled } from './tracing/tracing';
 import { VERSION } from './version';
 
-const spotlightEnabled =
-    process.env.NODE_ENV === 'development' && !!process.env.SENTRY_SPOTLIGHT;
-
-// Use a dummy DSN when Spotlight is enabled but no real DSN is configured.
-// This allows Sentry to initialize and send events to Spotlight locally.
-const SPOTLIGHT_DUMMY_DSN = 'https://0@o0.ingest.sentry.io/0';
-
-const sentryDsn =
-    lightdashConfig.sentry.backend.dsn ||
-    (spotlightEnabled ? SPOTLIGHT_DUMMY_DSN : '');
+const sentryDsn = lightdashConfig.sentry.backend.dsn;
 
 // Register the global OTel MeterProvider before Sentry.init() so the http
 // instrumentation emits http.server.request.duration into it. Register our own
@@ -118,10 +109,6 @@ const anrIntegrations = lightdashConfig.sentry.anr.enabled
     : [];
 
 const tracesSampler: NodeOptions['tracesSampler'] = (context) => {
-    if (spotlightEnabled) {
-        return 1.0;
-    }
-
     const request = context.normalizedRequest;
     if (
         request?.url?.endsWith('/status') ||
@@ -182,12 +169,12 @@ Sentry.init({
             : lightdashConfig.mode,
     skipOpenTelemetrySetup: otelTracingEnabled(),
     registerEsmLoaderHooks: !otelTracingEnabled(),
-    spotlight: spotlightEnabled,
     /**
-     * OTel mode (LIGHTDASH_OTEL_TRACES_ENABLED): Sentry is errors-only — span
-     * integrations are stripped and no sampler/profiler is configured; traces
-     * are owned by the OTel SDK (see tracing.ts). Otherwise Sentry tracing
-     * behaves as it always has (self-hosted, local Spotlight).
+     * OTel mode (LIGHTDASH_OTEL_TRACES_ENABLED — Lightdash Cloud, and local dev
+     * exporting to Maple): Sentry is errors-only — span integrations are
+     * stripped and no sampler/profiler is configured; traces are owned by the
+     * OTel SDK (see tracing.ts). Otherwise Sentry tracing behaves as it always
+     * has (self-hosted).
      * @ref https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/
      */
     integrations: otelTracingEnabled()

--- a/packages/backend/src/tracing/tracing.ts
+++ b/packages/backend/src/tracing/tracing.ts
@@ -2,12 +2,12 @@
  * Tracing runs in one of two exclusive modes, selected by
  * LIGHTDASH_OTEL_TRACES_ENABLED:
  *
- * - OTel mode (Lightdash Cloud): spans are created via the OTel SDK and
- *   exported over OTLP (GCP Cloud Trace). Sentry does NOT receive or create
- *   spans — it is errors-only (see sentry.ts, which strips Sentry's
- *   span-emitting integrations in this mode).
- * - Sentry mode (self-hosted / local Spotlight dev): spans are created via
- *   Sentry's SDK exactly as before OTLP export existed.
+ * - OTel mode (Lightdash Cloud, and local dev): spans are created via the OTel
+ *   SDK and exported over OTLP — GCP Cloud Trace in Cloud, Maple local mode in
+ *   dev. Sentry does NOT receive or create spans — it is errors-only (see
+ *   sentry.ts, which strips Sentry's span-emitting integrations in this mode).
+ * - Sentry mode (self-hosted): spans are created via Sentry's SDK exactly as
+ *   before OTLP export existed.
  *
  * The modes must not run together: the previous dual export created two spans
  * per traceSpan call and oddly-parented traces.

--- a/packages/frontend/rollup.config.mjs
+++ b/packages/frontend/rollup.config.mjs
@@ -116,7 +116,6 @@ const mainBuild = {
                 'import.meta.env.VITEST': JSON.stringify('false'),
                 'import.meta.env.BASE_URL': JSON.stringify('/'),
                 'import.meta.env.DEV': 'false',
-                'import.meta.env.VITE_SENTRY_SPOTLIGHT': 'undefined',
             },
         }),
         stripSvgrQuery(),

--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -7,7 +7,6 @@ import {
     setTag,
     setTags,
     setUser,
-    spotlightBrowserIntegration,
 } from '@sentry/react';
 import { useEffect } from 'react';
 import {
@@ -23,35 +22,19 @@ import {
     RouteChunkLoadError,
 } from '../../features/chunkErrorHandler';
 
-const sentrySpotlightEnabled =
-    import.meta.env.DEV && import.meta.env.VITE_SENTRY_SPOTLIGHT;
-
-// Dummy DSN for Spotlight-only mode (no real Sentry account needed)
-const SPOTLIGHT_DUMMY_DSN = 'https://0@o0.ingest.sentry.io/0';
-
 const useSentry = (
     sentryConfig: HealthState['sentry'] | undefined,
     user: LightdashUser | undefined,
     disableDashboardTracing?: boolean,
 ) => {
     useEffect(() => {
-        const dsn =
-            sentryConfig?.frontend.dsn ||
-            (sentrySpotlightEnabled ? SPOTLIGHT_DUMMY_DSN : '');
+        const dsn = sentryConfig?.frontend.dsn;
         if (sentryConfig && dsn && !isInitialized()) {
             init({
                 dsn,
                 release: sentryConfig.release,
                 environment: sentryConfig.environment,
                 integrations: [
-                    ...(sentrySpotlightEnabled
-                        ? [
-                              spotlightBrowserIntegration({
-                                  sidecarUrl: import.meta.env
-                                      .VITE_SENTRY_SPOTLIGHT,
-                              }),
-                          ]
-                        : []),
                     reactRouterV7BrowserTracingIntegration({
                         useEffect,
                         useLocation,
@@ -62,8 +45,6 @@ const useSentry = (
                     replayIntegration(),
                 ],
                 tracesSampler(samplingContext) {
-                    // Skip dashboard tracing before the Spotlight branch so the
-                    // opt-out also applies in Spotlight dev (100% sampling).
                     if (disableDashboardTracing) {
                         const name =
                             samplingContext.name ||
@@ -72,10 +53,6 @@ const useSentry = (
                         if (name.includes('/dashboards/')) {
                             return 0;
                         }
-                    }
-
-                    if (sentrySpotlightEnabled) {
-                        return 1.0;
                     }
 
                     if (samplingContext.parentSampled !== undefined) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
         specifier: 2.8.1
         version: 2.8.1
     devDependencies:
-      '@spotlightjs/spotlight':
-        specifier: 4.10.0
-        version: 4.10.0(hono-rate-limiter@0.4.2(hono@4.12.27))(supports-color@9.1.0)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -1975,12 +1972,6 @@ packages:
       zod:
         optional: true
 
-  '@apm-js-collab/code-transformer@0.8.2':
-    resolution: {integrity: sha512-YRjJjNq5KFSjDUoqu5pFUWrrsvGOxl6c3bu+uMFc9HNNptZ2rNU/TI2nLw4jnhQNtka972Ee2m3uqbvDQtPeCA==}
-
-  '@apm-js-collab/tracing-hooks@0.3.1':
-    resolution: {integrity: sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw==}
-
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
@@ -3787,14 +3778,6 @@ packages:
       react: ^16.8.5 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.5 || ^17.0.0 || ^18.0.0
 
-  '@hono/mcp@0.2.3':
-    resolution: {integrity: sha512-wrYKVQSjnBg4/ZinnnP/1t3jlvP3Z9fqZv8OzuhLXV4gVTLOHOHDhnXsIwD0nFVKk2pMOvA+sDfrKyRzw4yUPg==}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.1
-      hono: 4.12.27
-      hono-rate-limiter: ^0.4.2
-      zod: ^3.25.0 || ^4.0.0
-
   '@hono/node-server@1.19.9':
     resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
     engines: {node: '>=18.14.1'}
@@ -4327,16 +4310,6 @@ packages:
       react-dom:
         optional: true
 
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      '@cfworker/json-schema':
-        optional: true
-
   '@modelcontextprotocol/sdk@1.30.0':
     resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
@@ -4631,14 +4604,6 @@ packages:
   '@openrouter/sdk@0.1.27':
     resolution: {integrity: sha512-RH//L10bSmc81q25zAZudiI4kNkLgxF2E+WU42vghp3N6TEvZ6F0jK7uT3tOxkEn91gzmMw9YVmDENy7SJsajQ==}
 
-  '@opentelemetry/api-logs@0.207.0':
-    resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
-    engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/api-logs@0.211.0':
-    resolution: {integrity: sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==}
-    engines: {node: '>=8.0.0'}
-
   '@opentelemetry/api-logs@0.212.0':
     resolution: {integrity: sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==}
     engines: {node: '>=8.0.0'}
@@ -4676,12 +4641,6 @@ packages:
   '@opentelemetry/core@1.30.1':
     resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
     engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/core@2.5.0':
-    resolution: {integrity: sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
@@ -4763,21 +4722,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-amqplib@0.58.0':
-    resolution: {integrity: sha512-fjpQtH18J6GxzUZ+cwNhWUpb71u+DzT7rFkg5pLssDGaEber91Y2WNGdpVpwGivfEluMlNMZumzjEqfg8DeKXQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/instrumentation-connect@0.43.1':
     resolution: {integrity: sha512-ht7YGWQuV5BopMcw5Q2hXn3I8eG8TH0J/kc/GMcW4CuNTgiP6wCu44BOnucJWL3CmFWaRHI//vWyAhaC8BwePw==}
     engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-connect@0.54.0':
-    resolution: {integrity: sha512-43RmbhUhqt3uuPnc16cX6NsxEASEtn8z/cYV8Zpt6EP4p2h9s4FNuJ4Q9BbEQ2C0YlCCB/2crO1ruVz/hWt8fA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -4787,21 +4734,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-dataloader@0.28.0':
-    resolution: {integrity: sha512-ExXGBp0sUj8yhm6Znhf9jmuOaGDsYfDES3gswZnKr4MCqoBWQdEFn6EoDdt5u+RdbxQER+t43FoUihEfTSqsjA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/instrumentation-express@0.47.1':
     resolution: {integrity: sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==}
     engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-express@0.59.0':
-    resolution: {integrity: sha512-pMKV/qnHiW/Q6pmbKkxt0eIhuNEtvJ7sUAyee192HErlr+a1Jx+FZ3WjfmzhQL1geewyGEiPGkmjjAgNY8TgDA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -4817,21 +4752,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-fs@0.30.0':
-    resolution: {integrity: sha512-n3Cf8YhG7reaj5dncGlRIU7iT40bxPOjsBEA5Bc1a1g6e9Qvb+JFJ7SEiMlPbUw4PBmxE3h40ltE8LZ3zVt6OA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/instrumentation-generic-pool@0.43.1':
     resolution: {integrity: sha512-M6qGYsp1cURtvVLGDrPPZemMFEbuMmCXgQYTReC/IbimV5sGrLBjB+/hANUpRZjX67nGLdKSVLZuQQAiNz+sww==}
     engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-generic-pool@0.54.0':
-    resolution: {integrity: sha512-8dXMBzzmEdXfH/wjuRvcJnUFeWzZHUnExkmFJ2uPfa31wmpyBCMxO59yr8f/OXXgSogNgi/uPo9KW9H7LMIZ+g==}
-    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -4841,27 +4764,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-graphql@0.58.0':
-    resolution: {integrity: sha512-+yWVVY7fxOs3j2RixCbvue8vUuJ1inHxN2q1sduqDB0Wnkr4vOzVKRYl/Zy7B31/dcPS72D9lo/kltdOTBM3bQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/instrumentation-hapi@0.45.2':
     resolution: {integrity: sha512-7Ehow/7Wp3aoyCrZwQpU7a2CnoMq0XhIcioFuKjBb0PLYfBfmTsFTUyatlHu0fRxhwcRsSQRTvEhmZu8CppBpQ==}
     engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-hapi@0.57.0':
-    resolution: {integrity: sha512-Os4THbvls8cTQTVA8ApLfZZztuuqGEeqog0XUnyRW7QVF0d/vOVBEcBCk1pazPFmllXGEdNbbat8e2fYIWdFbw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-http@0.211.0':
-    resolution: {integrity: sha512-n0IaQ6oVll9PP84SjbOCwDjaJasWRHi6BLsbMLiT6tNj7QbVOkuA5sk/EfZczwI0j5uTKl1awQPivO/ldVtsqA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -4883,18 +4788,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-ioredis@0.59.0':
-    resolution: {integrity: sha512-875UxzBHWkW+P4Y45SoFM2AR8f8TzBMD8eO7QXGCyFSCUMP5s9vtt/BS8b/r2kqLyaRPK6mLbdnZznK3XzQWvw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-kafkajs@0.20.0':
-    resolution: {integrity: sha512-yJXOuWZROzj7WmYCUiyT27tIfqBrVtl1/TwVbQyWPz7rL0r1Lu7kWjD0PiVeTCIL6CrIZ7M2s8eBxsTAOxbNvw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/instrumentation-kafkajs@0.7.1':
     resolution: {integrity: sha512-OtjaKs8H7oysfErajdYr1yuWSjMAectT7Dwr+axIoZqT9lmEOkD/H/3rgAs8h/NIuEi2imSXD+vL4MZtOuJfqQ==}
     engines: {node: '>=14'}
@@ -4907,33 +4800,15 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-knex@0.55.0':
-    resolution: {integrity: sha512-FtTL5DUx5Ka/8VK6P1VwnlUXPa3nrb7REvm5ddLUIeXXq4tb9pKd+/ThB1xM/IjefkRSN3z8a5t7epYw1JLBJQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/instrumentation-koa@0.47.1':
     resolution: {integrity: sha512-l/c+Z9F86cOiPJUllUCt09v+kICKvT+Vg1vOAJHtHPsJIzurGayucfCMq2acd/A/yxeNWunl9d9eqZ0G+XiI6A==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-koa@0.59.0':
-    resolution: {integrity: sha512-K9o2skADV20Skdu5tG2bogPKiSpXh4KxfLjz6FuqIVvDJNibwSdu5UvyyBzRVp1rQMV6UmoIk6d3PyPtJbaGSg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-
   '@opentelemetry/instrumentation-lru-memoizer@0.44.1':
     resolution: {integrity: sha512-5MPkYCvG2yw7WONEjYj5lr5JFehTobW7wX+ZUFy81oF2lr9IPfZk9qO+FTaM0bGEiymwfLwKe6jE15nHn1nmHg==}
     engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-lru-memoizer@0.55.0':
-    resolution: {integrity: sha512-FDBfT7yDGcspN0Cxbu/k8A0Pp1Jhv/m7BMTzXGpcb8ENl3tDj/51U65R5lWzUH15GaZA15HQ5A5wtafklxYj7g==}
-    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -4943,21 +4818,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-mongodb@0.64.0':
-    resolution: {integrity: sha512-pFlCJjweTqVp7B220mCvCld1c1eYKZfQt1p3bxSbcReypKLJTwat+wbL2YZoX9jPi5X2O8tTKFEOahO5ehQGsA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/instrumentation-mongoose@0.46.1':
     resolution: {integrity: sha512-3kINtW1LUTPkiXFRSSBmva1SXzS/72we/jL22N+BnF3DFcoewkdkHPYOIdAAk9gSicJ4d5Ojtt1/HeibEc5OQg==}
     engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-mongoose@0.57.0':
-    resolution: {integrity: sha512-MthiekrU/BAJc5JZoZeJmo0OTX6ycJMiP6sMOSRTkvz5BrPMYDqaJos0OgsLPL/HpcgHP7eo5pduETuLguOqcg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -4967,21 +4830,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-mysql2@0.57.0':
-    resolution: {integrity: sha512-nHSrYAwF7+aV1E1V9yOOP9TchOodb6fjn4gFvdrdQXiRE7cMuffyLLbCZlZd4wsspBzVwOXX8mpURdRserAhNA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/instrumentation-mysql@0.45.1':
     resolution: {integrity: sha512-TKp4hQ8iKQsY7vnp/j0yJJ4ZsP109Ht6l4RHTj0lNEG1TfgTrIH5vJMbgmoYXWzNHAqBH2e7fncN12p3BP8LFg==}
     engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-mysql@0.57.0':
-    resolution: {integrity: sha512-HFS/+FcZ6Q7piM7Il7CzQ4VHhJvGMJWjx7EgCkP5AnTntSN5rb5Xi3TkYJHBKeR27A0QqPlGaCITi93fUDs++Q==}
-    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -4991,21 +4842,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-pg@0.63.0':
-    resolution: {integrity: sha512-dKm/ODNN3GgIQVlbD6ZPxwRc3kleLf95hrRWXM+l8wYo+vSeXtEpQPT53afEf6VFWDVzJK55VGn8KMLtSve/cg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/instrumentation-redis-4@0.46.1':
     resolution: {integrity: sha512-UMqleEoabYMsWoTkqyt9WAzXwZ4BlFZHO40wr3d5ZvtjKCHlD4YXLm+6OLCeIi/HkX7EXvQaz8gtAwkwwSEvcQ==}
     engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-redis@0.59.0':
-    resolution: {integrity: sha512-JKv1KDDYA2chJ1PC3pLP+Q9ISMQk6h5ey+99mB57/ARk0vQPGZTTEb4h4/JlcEpy7AYT8HIGv7X6l+br03Neeg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -5015,35 +4854,11 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-tedious@0.30.0':
-    resolution: {integrity: sha512-bZy9Q8jFdycKQ2pAsyuHYUHNmCxCOGdG6eg1Mn75RvQDccq832sU5OWOBnc12EFUELI6icJkhR7+EQKMBam2GA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/instrumentation-undici@0.10.1':
     resolution: {integrity: sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.7.0
-
-  '@opentelemetry/instrumentation-undici@0.21.0':
-    resolution: {integrity: sha512-gok0LPUOTz2FQ1YJMZzaHcOzDFyT64XJ8M9rNkugk923/p6lDGms/cRW1cqgqp6N6qcd6K6YdVHwPEhnx9BWbw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.7.0
-
-  '@opentelemetry/instrumentation@0.207.0':
-    resolution: {integrity: sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation@0.211.0':
-    resolution: {integrity: sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
 
   '@opentelemetry/instrumentation@0.212.0':
     resolution: {integrity: sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==}
@@ -5096,10 +4911,6 @@ packages:
   '@opentelemetry/redis-common@0.36.2':
     resolution: {integrity: sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==}
     engines: {node: '>=14'}
-
-  '@opentelemetry/redis-common@0.38.2':
-    resolution: {integrity: sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
 
   '@opentelemetry/resources@1.30.1':
     resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
@@ -5160,12 +4971,6 @@ packages:
   '@opentelemetry/sql-common@0.40.1':
     resolution: {integrity: sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==}
     engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-
-  '@opentelemetry/sql-common@0.41.2':
-    resolution: {integrity: sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
@@ -5641,11 +5446,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.8
 
-  '@prisma/instrumentation@7.2.0':
-    resolution: {integrity: sha512-Rh9Z4x5kEj1OdARd7U18AtVrnL6rmLSI0qYShaB4W7Wx5BKbgzndWF+QnuzMb7GLfVdlT5aYCXoPQVYuYtVu0g==}
-    peerDependencies:
-      '@opentelemetry/api': ^1.8
-
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -6079,10 +5879,6 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@sentry/core@10.38.0':
-    resolution: {integrity: sha512-1pubWDZE5y5HZEPMAZERP4fVl2NH3Ihp1A+vMoVkb3Qc66Diqj1WierAnStlZP7tCx0TBa0dK85GTW/ZFYyB9g==}
-    engines: {node: '>=18'}
-
   '@sentry/core@9.31.0':
     resolution: {integrity: sha512-6JeoPGvBgT9m2YFIf2CrW+KrrOYzUqb9+Xwr/Dw25kPjVKy+WJjWqK8DKCNLgkBA22OCmSOmHuRwFR0YxGVdZQ==}
     engines: {node: '>=18'}
@@ -6090,18 +5886,6 @@ packages:
   '@sentry/core@9.46.0':
     resolution: {integrity: sha512-it7JMFqxVproAgEtbLgCVBYtQ9fIb+Bu0JD+cEplTN/Ukpe6GaolyYib5geZqslVxhp2sQgT+58aGvfd/k0N8Q==}
     engines: {node: '>=18'}
-
-  '@sentry/node-core@10.38.0':
-    resolution: {integrity: sha512-ErXtpedrY1HghgwM6AliilZPcUCoNNP1NThdO4YpeMq04wMX9/GMmFCu46TnCcg6b7IFIOSr2S4yD086PxLlHQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
-      '@opentelemetry/core': ^1.30.1 || ^2.1.0
-      '@opentelemetry/instrumentation': '>=0.57.1 <1'
-      '@opentelemetry/resources': ^1.30.1 || ^2.1.0
-      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
-      '@opentelemetry/semantic-conventions': ^1.39.0
 
   '@sentry/node-core@9.46.0':
     resolution: {integrity: sha512-XRVu5pqoklZeh4wqhxCLZkz/ipoKhitctgEFXX9Yh1e1BoHM2pIxT52wf+W6hHM676TFmFXW3uKBjsmRM3AjgA==}
@@ -6115,23 +5899,9 @@ packages:
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.0.0
       '@opentelemetry/semantic-conventions': ^1.34.0
 
-  '@sentry/node@10.38.0':
-    resolution: {integrity: sha512-wriyDtWDAoatn8EhOj0U4PJR1WufiijTsCGALqakOHbFiadtBJANLe6aSkXoXT4tegw59cz1wY4NlzHjYksaPw==}
-    engines: {node: '>=18'}
-
   '@sentry/node@9.46.0':
     resolution: {integrity: sha512-pRLqAcd7GTGvN8gex5FtkQR5Mcol8gOy1WlyZZFq4rBbVtMbqKOQRhohwqnb+YrnmtFpj7IZ7KNDo077MvNeOQ==}
     engines: {node: '>=18'}
-
-  '@sentry/opentelemetry@10.38.0':
-    resolution: {integrity: sha512-YPVhWfYmC7nD3EJqEHGtjp4fp5LwtAbE5rt9egQ4hqJlYFvr8YEz9sdoqSZxO0cZzgs2v97HFl/nmWAXe52G2Q==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
-      '@opentelemetry/core': ^1.30.1 || ^2.1.0
-      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
-      '@opentelemetry/semantic-conventions': ^1.39.0
 
   '@sentry/opentelemetry@9.46.0':
     resolution: {integrity: sha512-w2zTxqrdmwRok0cXBoh+ksXdGRUHUZhlpfL/H2kfTodOL+Mk8rW72qUmfqQceXoqgbz8UyK8YgJbyt+XS5H4Qg==}
@@ -6495,11 +6265,6 @@ packages:
   '@smithy/uuid@1.1.1':
     resolution: {integrity: sha512-dSfDCeihDmZlV2oyr0yWPTUfh07suS+R5OB+FZGiv/hHyK3hrFBW5rR1UYjfa57vBsrP9lciFkRPzebaV1Qujw==}
     engines: {node: '>=18.0.0'}
-
-  '@spotlightjs/spotlight@4.10.0':
-    resolution: {integrity: sha512-d2raVmMqQQbSUguhYdui4tmkGvibSzRVM3dVvq/jPbxqRDB+vNELSsDlbEwweOIFDTXZEYoWBSHEW2pRqCtmjQ==}
-    engines: {node: '>=20'}
-    hasBin: true
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -7372,9 +7137,6 @@ packages:
   '@types/mysql@2.15.26':
     resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
 
-  '@types/mysql@2.15.27':
-    resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
-
   '@types/node-fetch@2.5.12':
     resolution: {integrity: sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==}
 
@@ -7453,14 +7215,8 @@ packages:
   '@types/pg-pool@2.0.6':
     resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
 
-  '@types/pg-pool@2.0.7':
-    resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
-
   '@types/pg@8.11.10':
     resolution: {integrity: sha512-LczQUW4dbOQzsH2RQ5qoeJ6qJPdrcM/DcMLoqWQkMLMsq83J5lAX3LXjdkWdpscFy67JSOWDnh7Ny/sPFykmkg==}
-
-  '@types/pg@8.15.6':
-    resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
 
   '@types/pg@8.6.1':
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
@@ -8033,9 +7789,6 @@ packages:
 
   amp@0.3.1:
     resolution: {integrity: sha512-OwIuC4yZaRogHKiuU5WlMR5Xk/jAcpPtawWL05Gj8Lvm2F6mwoJt4O/bHI+DHwG79vWd+8OFYM4/BzYqyRd3qw==}
-
-  anser@2.3.5:
-    resolution: {integrity: sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==}
 
   ansi-colors@4.1.1:
     resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==}
@@ -10047,10 +9800,6 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  eventsource@4.1.0:
-    resolution: {integrity: sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==}
-    engines: {node: '>=20.0.0'}
-
   exceljs@4.4.0:
     resolution: {integrity: sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==}
     engines: {node: '>=8.3.0'}
@@ -10140,9 +9889,6 @@ packages:
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
-
-  fast-fuzzy@1.12.0:
-    resolution: {integrity: sha512-sXxGgHS+ubYpsdLnvOvJ9w5GYYZrtL9mkosG3nfuD446ahvoWEsSKBP7ieGmWIKVLnaxRDgUJkZMdxRgA2Ni+Q==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -10645,9 +10391,6 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  graphemesplit@2.6.0:
-    resolution: {integrity: sha512-rG9w2wAfkpg0DILa1pjnjNfucng3usON360shisqIMUBw/87pojcBSrHmeE4UwryAuBih7g8m1oilf5/u8EWdQ==}
-
   graphile-worker@0.13.0:
     resolution: {integrity: sha512-8Hl5XV6hkabZRhYzvbUfvjJfPFR5EPxYRVWlzQC2rqYHrjULTLBgBYZna5R9ukbnsbWSvn4vVrzOBIOgIC1jjw==}
     engines: {node: '>=10.0.0'}
@@ -10796,11 +10539,6 @@ packages:
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
-
-  hono-rate-limiter@0.4.2:
-    resolution: {integrity: sha512-AAtFqgADyrmbDijcRTT/HJfwqfvhalya2Zo+MgfdrMPas3zSMD8SU03cv+ZsYwRU1swv7zgVt0shwN059yzhjw==}
-    peerDependencies:
-      hono: 4.12.27
 
   hono@4.12.27:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
@@ -11370,9 +11108,6 @@ packages:
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
-  js-base64@3.7.8:
-    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
-
   js-cookie@2.2.1:
     resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
 
@@ -11672,9 +11407,6 @@ packages:
       openai:
         optional: true
 
-  launch-editor@2.12.0:
-    resolution: {integrity: sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==}
-
   launder@1.7.1:
     resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
 
@@ -11941,10 +11673,6 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
-  logfmt@1.4.0:
-    resolution: {integrity: sha512-p1Ow0C2dDJYaQBhRHt+HVMP6ELuBm4jYSYNHPMfz0J5wJ9qA6/7oBOlBZBfT1InqguTYcvJzNea5FItDxTcbyw==}
-    hasBin: true
-
   logform@2.7.0:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
@@ -12061,10 +11789,6 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-
-  mcp-proxy@5.12.5:
-    resolution: {integrity: sha512-Vawdc8vi36fXxKCaDpluRvbGcmrUXJdvXcDhkh30HYsws8XqX2rWPBflZpavzeS+6SwijRFV7g+9ypQRJZlrEQ==}
-    hasBin: true
 
   md5@2.3.0:
     resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
@@ -14627,10 +14351,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
-    engines: {node: '>= 0.4'}
-
   shelljs@0.10.0:
     resolution: {integrity: sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==}
     engines: {node: '>=18'}
@@ -14796,9 +14516,6 @@ packages:
   split2@4.1.0:
     resolution: {integrity: sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==}
     engines: {node: '>= 10.x'}
-
-  split@0.2.10:
-    resolution: {integrity: sha512-e0pKq+UUH2Xq/sXbYpZBZc3BawsfDZ7dgv+JtRTUPNcvF5CMR4Y9cvJqkMY0MoxWzTHvZuz1beg6pNEKlszPiQ==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -15208,9 +14925,6 @@ packages:
     resolution: {integrity: sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==}
     engines: {node: '>=8'}
 
-  tiny-inflate@1.0.3:
-    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
-
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -15560,9 +15274,6 @@ packages:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
 
-  unicode-trie@2.0.0:
-    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
-
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -15777,10 +15488,6 @@ packages:
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuidv7@1.1.0:
-    resolution: {integrity: sha512-2VNnOC0+XQlwogChUDzy6pe8GQEys9QFZBGOh54l6qVfwoCUwwRvk7rDTgaIsRgsF5GFa5oiNg8LqXE3jofBBg==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -16576,16 +16283,6 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 3.25.55
-
-  '@apm-js-collab/code-transformer@0.8.2': {}
-
-  '@apm-js-collab/tracing-hooks@0.3.1(supports-color@9.1.0)':
-    dependencies:
-      '@apm-js-collab/code-transformer': 0.8.2
-      debug: 4.4.3(supports-color@9.1.0)
-      module-details-from-path: 1.0.4
-    transitivePeerDependencies:
-      - supports-color
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -19308,14 +19005,6 @@ snapshots:
       - '@types/react-dom'
       - react-native
 
-  '@hono/mcp@0.2.3(@modelcontextprotocol/sdk@1.29.0(supports-color@9.1.0)(zod@4.1.5))(hono-rate-limiter@0.4.2(hono@4.12.27))(hono@4.12.27)(zod@4.1.5)':
-    dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(supports-color@9.1.0)(zod@4.1.5)
-      hono: 4.12.27
-      hono-rate-limiter: 0.4.2(hono@4.12.27)
-      pkce-challenge: 5.0.0
-      zod: 4.1.5
-
   '@hono/node-server@1.19.9(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
@@ -19789,28 +19478,6 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@modelcontextprotocol/sdk@1.29.0(supports-color@9.1.0)(zod@4.1.5)':
-    dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.27)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      content-type: 1.0.5
-      cors: 2.8.5
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.8
-      express: 5.2.1(supports-color@9.1.0)
-      express-rate-limit: 8.3.0(express@5.2.1(supports-color@9.1.0))
-      hono: 4.12.27
-      jose: 6.1.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.0
-      raw-body: 3.0.1
-      zod: 4.1.5
-      zod-to-json-schema: 3.25.1(zod@4.1.5)
-    transitivePeerDependencies:
-      - supports-color
-
   '@modelcontextprotocol/sdk@1.30.0(supports-color@5.5.0)(zod@3.25.55)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.27)
@@ -20148,14 +19815,6 @@ snapshots:
     dependencies:
       zod: 3.25.55
 
-  '@opentelemetry/api-logs@0.207.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-
-  '@opentelemetry/api-logs@0.211.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-
   '@opentelemetry/api-logs@0.212.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -20188,11 +19847,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.28.0
-
-  '@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -20314,30 +19968,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-amqplib@0.58.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation-connect@0.43.1(@opentelemetry/api@1.9.0)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@types/connect': 3.4.38
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-connect@0.54.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
       '@opentelemetry/semantic-conventions': 1.41.1
       '@types/connect': 3.4.38
     transitivePeerDependencies:
@@ -20350,27 +19985,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-dataloader@0.28.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation-express@0.47.1(@opentelemetry/api@1.9.0)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-express@0.59.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
       '@opentelemetry/semantic-conventions': 1.41.1
     transitivePeerDependencies:
       - supports-color
@@ -20392,25 +20011,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-fs@0.30.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation-generic-pool@0.43.1(@opentelemetry/api@1.9.0)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-generic-pool@0.54.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -20421,38 +20025,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-graphql@0.58.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation-hapi@0.45.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-hapi@0.57.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-http@0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.5.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      forwarded-parse: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -20486,23 +20064,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-ioredis@0.59.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/redis-common': 0.38.2
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-kafkajs@0.20.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation-kafkajs@0.7.1(@opentelemetry/api@1.9.0)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -20519,28 +20080,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-knex@0.55.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation-koa@0.47.1(@opentelemetry/api@1.9.0)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-koa@0.59.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
       '@opentelemetry/semantic-conventions': 1.41.1
     transitivePeerDependencies:
       - supports-color
@@ -20552,25 +20096,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-lru-memoizer@0.55.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation-mongodb@0.52.0(@opentelemetry/api@1.9.0)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-mongodb@0.64.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
       '@opentelemetry/semantic-conventions': 1.41.1
     transitivePeerDependencies:
       - supports-color
@@ -20584,15 +20113,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mongoose@0.57.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation-mysql2@0.45.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -20602,30 +20122,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mysql2@0.57.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation-mysql@0.45.1(@opentelemetry/api@1.9.0)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.41.1
       '@types/mysql': 2.15.26
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-mysql@0.57.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@types/mysql': 2.15.27
     transitivePeerDependencies:
       - supports-color
 
@@ -20641,32 +20143,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-pg@0.63.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
-      '@types/pg': 8.15.6
-      '@types/pg-pool': 2.0.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation-redis-4@0.46.1(@opentelemetry/api@1.9.0)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
       '@opentelemetry/redis-common': 0.36.2
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-redis@0.59.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/redis-common': 0.38.2
       '@opentelemetry/semantic-conventions': 1.41.1
     transitivePeerDependencies:
       - supports-color
@@ -20680,47 +20161,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-tedious@0.30.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@types/tedious': 4.0.14
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation-undici@0.10.1(@opentelemetry/api@1.9.0)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-undici@0.21.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.207.0
-      import-in-the-middle: 2.0.6
-      require-in-the-middle: 8.0.1(supports-color@9.1.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.211.0
-      import-in-the-middle: 2.0.6
-      require-in-the-middle: 8.0.1(supports-color@9.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -20789,8 +20234,6 @@ snapshots:
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/redis-common@0.36.2': {}
-
-  '@opentelemetry/redis-common@0.38.2': {}
 
   '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -20879,11 +20322,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
 
   '@oxc-project/types@0.122.0': {}
 
@@ -21144,13 +20582,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@prisma/instrumentation@7.2.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -21484,27 +20915,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/core@10.38.0': {}
-
   '@sentry/core@9.31.0': {}
 
   '@sentry/core@9.46.0': {}
-
-  '@sentry/node-core@10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)(supports-color@9.1.0)':
-    dependencies:
-      '@apm-js-collab/tracing-hooks': 0.3.1(supports-color@9.1.0)
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/context-async-hooks': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@sentry/core': 10.38.0
-      '@sentry/opentelemetry': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)
-      import-in-the-middle: 2.0.6
-    transitivePeerDependencies:
-      - supports-color
 
   '@sentry/node-core@9.46.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)':
     dependencies:
@@ -21518,46 +20931,6 @@ snapshots:
       '@sentry/core': 9.46.0
       '@sentry/opentelemetry': 9.46.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)
       import-in-the-middle: 1.14.2
-
-  '@sentry/node@10.38.0(supports-color@9.1.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/context-async-hooks': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-amqplib': 0.58.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-connect': 0.54.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-dataloader': 0.28.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-express': 0.59.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-fs': 0.30.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-generic-pool': 0.54.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-graphql': 0.58.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-hapi': 0.57.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-http': 0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-ioredis': 0.59.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-kafkajs': 0.20.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-knex': 0.55.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-koa': 0.59.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-lru-memoizer': 0.55.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-mongodb': 0.64.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-mongoose': 0.57.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-mysql': 0.57.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-mysql2': 0.57.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-pg': 0.63.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-redis': 0.59.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-tedious': 0.30.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/instrumentation-undici': 0.21.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@prisma/instrumentation': 7.2.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0)
-      '@sentry/core': 10.38.0
-      '@sentry/node-core': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0)(supports-color@9.1.0))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)(supports-color@9.1.0)
-      '@sentry/opentelemetry': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)
-      import-in-the-middle: 2.0.6
-      minimatch: 9.0.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@sentry/node@9.46.0(supports-color@5.5.0)':
     dependencies:
@@ -21598,15 +20971,6 @@ snapshots:
       minimatch: 9.0.5
     transitivePeerDependencies:
       - supports-color
-
-  '@sentry/opentelemetry@10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/context-async-hooks': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@sentry/core': 10.38.0
 
   '@sentry/opentelemetry@9.46.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)':
     dependencies:
@@ -22153,31 +21517,6 @@ snapshots:
   '@smithy/uuid@1.1.1':
     dependencies:
       tslib: 2.8.1
-
-  '@spotlightjs/spotlight@4.10.0(hono-rate-limiter@0.4.2(hono@4.12.27))(supports-color@9.1.0)':
-    dependencies:
-      '@hono/mcp': 0.2.3(@modelcontextprotocol/sdk@1.29.0(supports-color@9.1.0)(zod@4.1.5))(hono-rate-limiter@0.4.2(hono@4.12.27))(hono@4.12.27)(zod@4.1.5)
-      '@hono/node-server': 1.19.9(hono@4.12.27)
-      '@jridgewell/trace-mapping': 0.3.31
-      '@modelcontextprotocol/sdk': 1.29.0(supports-color@9.1.0)(zod@4.1.5)
-      '@sentry/core': 10.38.0
-      '@sentry/node': 10.38.0(supports-color@9.1.0)
-      anser: 2.3.5
-      chalk: 5.6.2
-      eventsource: 4.1.0
-      fast-fuzzy: 1.12.0
-      hono: 4.12.27
-      launch-editor: 2.12.0
-      logfmt: 1.4.0
-      mcp-proxy: 5.12.5
-      semver: 7.8.5
-      uuidv7: 1.1.0
-      yaml: 2.8.3
-      zod: 4.1.5
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - hono-rate-limiter
-      - supports-color
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -23166,10 +22505,6 @@ snapshots:
     dependencies:
       '@types/node': 24.13.2
 
-  '@types/mysql@2.15.27':
-    dependencies:
-      '@types/node': 24.13.2
-
   '@types/node-fetch@2.5.12':
     dependencies:
       '@types/node': 24.13.2
@@ -23270,21 +22605,11 @@ snapshots:
     dependencies:
       '@types/pg': 8.11.10
 
-  '@types/pg-pool@2.0.7':
-    dependencies:
-      '@types/pg': 8.11.10
-
   '@types/pg@8.11.10':
     dependencies:
       '@types/node': 24.13.2
       pg-protocol: 1.10.3
       pg-types: 4.0.1
-
-  '@types/pg@8.15.6':
-    dependencies:
-      '@types/node': 24.13.2
-      pg-protocol: 1.10.3
-      pg-types: 2.2.0
 
   '@types/pg@8.6.1':
     dependencies:
@@ -24147,8 +23472,6 @@ snapshots:
       amp: 0.3.1
 
   amp@0.3.1: {}
-
-  anser@2.3.5: {}
 
   ansi-colors@4.1.1: {}
 
@@ -26595,10 +25918,6 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.8
 
-  eventsource@4.1.0:
-    dependencies:
-      eventsource-parser: 3.0.8
-
   exceljs@4.4.0:
     dependencies:
       archiver: 5.3.2
@@ -26812,10 +26131,6 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
-
-  fast-fuzzy@1.12.0:
-    dependencies:
-      graphemesplit: 2.6.0
 
   fast-glob@3.3.3:
     dependencies:
@@ -27502,11 +26817,6 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphemesplit@2.6.0:
-    dependencies:
-      js-base64: 3.7.8
-      unicode-trie: 2.0.0
-
   graphile-worker@0.13.0:
     dependencies:
       '@graphile/logger': 0.2.0
@@ -27769,10 +27079,6 @@ snapshots:
   homedir-polyfill@1.0.3:
     dependencies:
       parse-passwd: 1.0.0
-
-  hono-rate-limiter@0.4.2(hono@4.12.27):
-    dependencies:
-      hono: 4.12.27
 
   hono@4.12.27: {}
 
@@ -28333,8 +27639,6 @@ snapshots:
 
   jose@6.1.3: {}
 
-  js-base64@3.7.8: {}
-
   js-cookie@2.2.1: {}
 
   js-git@0.7.8:
@@ -28686,11 +27990,6 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
       openai: 4.80.1(encoding@0.1.13)(ws@8.20.0)(zod@3.25.55)
 
-  launch-editor@2.12.0:
-    dependencies:
-      picocolors: 1.1.1
-      shell-quote: 1.8.3
-
   launder@1.7.1:
     dependencies:
       dayjs: 1.11.10
@@ -28923,11 +28222,6 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
-  logfmt@1.4.0:
-    dependencies:
-      split: 0.2.10
-      through: 2.3.8
-
   logform@2.7.0:
     dependencies:
       '@colors/colors': 1.6.0
@@ -29046,8 +28340,6 @@ snapshots:
   marked@9.0.3: {}
 
   math-intrinsics@1.1.0: {}
-
-  mcp-proxy@5.12.5: {}
 
   md5@2.3.0:
     dependencies:
@@ -31864,13 +31156,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  require-in-the-middle@8.0.1(supports-color@9.1.0):
-    dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
-      module-details-from-path: 1.0.4
-    transitivePeerDependencies:
-      - supports-color
-
   require-main-filename@2.0.0: {}
 
   requireindex@1.2.0: {}
@@ -32385,8 +31670,6 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
-
   shelljs@0.10.0:
     dependencies:
       execa: 5.1.1
@@ -32631,10 +31914,6 @@ snapshots:
   split-ca@1.0.1: {}
 
   split2@4.1.0: {}
-
-  split@0.2.10:
-    dependencies:
-      through: 2.3.8
 
   sprintf-js@1.0.3: {}
 
@@ -33129,8 +32408,6 @@ snapshots:
 
   tildify@2.0.0: {}
 
-  tiny-inflate@1.0.3: {}
-
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -33473,11 +32750,6 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.2.0: {}
 
-  unicode-trie@2.0.0:
-    dependencies:
-      pako: 0.2.9
-      tiny-inflate: 1.0.3
-
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -33698,8 +32970,6 @@ snapshots:
   uuid@8.3.2: {}
 
   uuid@9.0.1: {}
-
-  uuidv7@1.1.0: {}
 
   v8-compile-cache-lib@3.0.1:
     optional: true
@@ -34563,10 +33833,6 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@3.25.55):
     dependencies:
       zod: 3.25.55
-
-  zod-to-json-schema@3.25.1(zod@4.1.5):
-    dependencies:
-      zod: 4.1.5
 
   zod-to-json-schema@3.25.1(zod@4.4.3):
     dependencies:

--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -46,7 +46,7 @@ fail() { echo "FAIL: $1 -- $2" >&2; exit 1; }
 step() { echo "STEP: $1"; }
 
 instance_pm2_names() {
-    for suffix in api api-routes-watch scheduler frontend common-watch formula-watch warehouses-watch sdk-test spotlight; do
+    for suffix in api api-routes-watch scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
         echo "${LD_INSTANCE_ID}-${suffix}"
     done
 }
@@ -105,6 +105,27 @@ else
     sfw pnpm install || fail "deps" "sfw pnpm install failed"
     pnpm -F common build && pnpm -F warehouses build && pnpm -F @lightdash/formula build || fail "deps" "package builds failed"
     echo "OK: installed and built"
+fi
+
+# ---------------------------------------------------------------------------
+step "Ensure Maple tracing CLI"
+# Maple local mode receives OTLP traces from the API and scheduler (see
+# ecosystem.config.js). It is a standalone binary, not a node_modules bin.
+# Non-fatal: without it the stack runs fine, just untraced.
+if command -v maple >/dev/null 2>&1; then
+    echo "SKIP: maple present ($(command -v maple))"
+else
+    if [ ! -x "$HOME/.maple/bin/maple" ]; then
+        curl -fsSL https://maple.dev/cli/install | sh >/dev/null 2>&1 || true
+    fi
+    if [ -x "$HOME/.maple/bin/maple" ]; then
+        # ecosystem.config.js resolves `maple` off PATH, and PM2 inherits this
+        # shell's PATH, so exporting it here is what makes the sidecar start.
+        export PATH="$HOME/.maple/bin:$PATH"
+        echo "OK: maple available at $HOME/.maple/bin/maple"
+    else
+        echo "SKIP: maple unavailable — stack will run without local tracing"
+    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -198,7 +219,10 @@ if test -f .env.development.local; then
     reconcile_env SCHEDULER_PORT "${SCHEDULER_PORT}"
     reconcile_env DEBUG_PORT "${DEBUG_PORT}"
     reconcile_env SDK_TEST_PORT "${SDK_TEST_PORT}"
-    reconcile_env SPOTLIGHT_PORT "${SPOTLIGHT_PORT}"
+    reconcile_env MAPLE_PORT "${MAPLE_PORT}"
+    # The maple CLI defaults to port 4318; point it at this instance so a
+    # `source .env.development.local` shell can query the right server.
+    reconcile_env MAPLE_LOCAL_URL "http://127.0.0.1:${MAPLE_PORT}"
     reconcile_env LIGHTDASH_PROMETHEUS_PORT "${LIGHTDASH_PROMETHEUS_PORT}"
     reconcile_env SITE_URL "http://localhost:${FE_PORT}"
     reconcile_env INTERNAL_LIGHTDASH_HOST "http://localhost:${FE_PORT}"
@@ -244,7 +268,8 @@ FE_PORT=${FE_PORT}
 SCHEDULER_PORT=${SCHEDULER_PORT}
 DEBUG_PORT=${DEBUG_PORT}
 SDK_TEST_PORT=${SDK_TEST_PORT}
-SPOTLIGHT_PORT=${SPOTLIGHT_PORT}
+MAPLE_PORT=${MAPLE_PORT}
+MAPLE_LOCAL_URL=http://127.0.0.1:${MAPLE_PORT}
 LIGHTDASH_PROMETHEUS_PORT=${LIGHTDASH_PROMETHEUS_PORT}
 SITE_URL=http://localhost:${FE_PORT}
 S3_ENDPOINT=http://localhost:9000
@@ -652,4 +677,21 @@ done
 [ "$HEALTH" = "200" ] || fail "health" "backend /api/v1/health returned '${HEALTH:-no response}' after 120s (check 'pm2 logs ${LD_INSTANCE_ID}-api --lines 80 --nostream')"
 
 echo "OK: backend healthy"
-echo "READY: instance=$LD_INSTANCE_ID frontend=http://localhost:${FE_PORT} api=http://localhost:${PORT} spotlight=http://localhost:${SPOTLIGHT_PORT}"
+
+# Maple is optional, so only advertise it once its liveness route answers.
+MAPLE_READY=""
+if command -v maple >/dev/null 2>&1; then
+    for _ in $(seq 1 15); do
+        MAPLE_READY="$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${MAPLE_PORT}/health" 2>/dev/null || true)"
+        [ "$MAPLE_READY" = "200" ] && break
+        sleep 1
+    done
+fi
+if [ "$MAPLE_READY" = "200" ]; then
+    echo "OK: maple tracing on http://localhost:${MAPLE_PORT}"
+    MAPLE_READY_FRAGMENT=" maple=http://localhost:${MAPLE_PORT}"
+else
+    echo "SKIP: maple not serving on ${MAPLE_PORT} — traces unavailable (pnpm pm2:logs:maple)"
+    MAPLE_READY_FRAGMENT=""
+fi
+echo "READY: instance=$LD_INSTANCE_ID frontend=http://localhost:${FE_PORT} api=http://localhost:${PORT}${MAPLE_READY_FRAGMENT}"

--- a/scripts/dev-ports.sh
+++ b/scripts/dev-ports.sh
@@ -90,7 +90,7 @@ compute_ports() {
     SCHEDULER_PORT=$((8081 + slot * 10))
     DEBUG_PORT=$((9229 + slot * 10))
     SDK_TEST_PORT=$((3030 + slot * 10))
-    SPOTLIGHT_PORT=$((8969 + slot * 10))
+    MAPLE_PORT=$((4320 + slot * 10))
     PROMETHEUS_PORT=$((9090 + slot * 10))
 }
 
@@ -135,7 +135,7 @@ validate_slot_ports() {
     compute_ports "$slot"
 
     # Only check per-instance ports (shared services are not our concern)
-    local all_ports="$PG_PORT $API_PORT $SCHEDULER_PORT $DEBUG_PORT $SDK_TEST_PORT $SPOTLIGHT_PORT $PROMETHEUS_PORT"
+    local all_ports="$PG_PORT $API_PORT $SCHEDULER_PORT $DEBUG_PORT $SDK_TEST_PORT $MAPLE_PORT $PROMETHEUS_PORT"
     # Amp reserves the declared portal port before this script runs. It is not
     # an application listener, so allow the matching frontend slot in an orb.
     if [ "${LD_FRONTEND_PORT_RESERVED:-}" != true ] || [ "$FRONTEND_PORT" != "${PORT:-}" ]; then
@@ -177,7 +177,7 @@ write_instance_file() {
     "scheduler": ${SCHEDULER_PORT},
     "debug": ${DEBUG_PORT},
     "sdkTest": ${SDK_TEST_PORT},
-    "spotlight": ${SPOTLIGHT_PORT},
+    "maple": ${MAPLE_PORT},
     "prometheus": ${PROMETHEUS_PORT}
   },
   "shared": {
@@ -374,7 +374,10 @@ print(f\"export FE_PORT={p['frontend']}\")
 print(f\"export SCHEDULER_PORT={p['scheduler']}\")
 print(f\"export DEBUG_PORT={p['debug']}\")
 print(f\"export SDK_TEST_PORT={p['sdkTest']}\")
-print(f\"export SPOTLIGHT_PORT={p['spotlight']}\")
+
+# Instance files claimed before Maple replaced Spotlight have no 'maple' port,
+# and are never rewritten — derive it from the slot rather than failing.
+print(f\"export MAPLE_PORT={p.get('maple', 4320 + d['slot'] * 10)}\")
 print(f\"export LIGHTDASH_PROMETHEUS_PORT={p['prometheus']}\")
 print(f\"export PGPORT={p['pg']}\")
 print(f\"export SITE_URL=http://localhost:{p['frontend']}\")


### PR DESCRIPTION
Closes:

### Description:

Docker dev traced through the Sentry Spotlight sidecar, which meant the API had to run a dummy Sentry DSN to get spans out, and the scheduler was never traced at all. The backend already has an OTLP export path (`LIGHTDASH_OTEL_TRACES_ENABLED`, used in Cloud for Cloud Trace), so this points that at [Maple local mode](https://maple.dev/docs/local-mode/) instead of adding a second tracing mechanism.

- PM2 runs `maple start` in place of the Spotlight sidecar, on a per-slot port (`4320 + slot * 10`, replacing `8969 + slot * 10`) and a per-instance data dir — Maple allows one server per data dir, so worktrees can't share one.
- API and scheduler get `LIGHTDASH_OTEL_TRACES_ENABLED=true`, `OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:$MAPLE_PORT`, and `OTEL_SERVICE_NAME` (`$LD_INSTANCE_ID` / `$LD_INSTANCE_ID-scheduler`) so traces are namespaced per checkout and the two services are distinguishable in `maple services`.
- `maple` is a standalone binary, not a `node_modules` bin, so `dev-fast-start.sh` installs it best-effort and `ecosystem.config.js` resolves it off `PATH`. If it's missing, the sidecar and the exporter env are both omitted — the dev stack is otherwise unchanged rather than crash-looping or logging an OTLP export failure per batch.
- Drops `@spotlightjs/spotlight`, the `SENTRY_SPOTLIGHT`/`VITE_SENTRY_SPOTLIGHT` plumbing, the frontend `spotlightBrowserIntegration`, and the Spotlight MCP server. Maple has no MCP server, so `/debug-local` now documents the `maple` query CLI (`maple trace <id>`, `maple errors`, `maple logs --trace-id`, `maple query`).

Frontend traces are dropped rather than migrated: sending them to Maple needs the `@maple-dev/browser` SDK, which is a new runtime dependency and worth its own PR.

Registry files claimed before this change store a `spotlight` port and are never rewritten, so `dev-ports.sh env` derives the Maple port from the slot when the key is absent — existing worktrees keep working without a re-claim.

### Verification

No Docker in this environment, so the full stack wasn't started. Verified instead:

- Installed the Maple CLI, started it with the exact flags the PM2 app uses (`--port 4320 --data-dir ~/.maple/data-lightdash --offline --on-dirty-store wipe`) — `/health` returns 200 and the offline UI serves on `:4320`.
- Emitted a parent/child span through the backend's own OTel deps with exactly the env vars this PR sets. Maple ingested it: `maple services` reports `lightdash`, and `maple trace <id>` returns the full span tree.
- Backwards compat: a legacy instance file at slot 2 resolves to `MAPLE_PORT=4340`; a fresh claim at slot 0 resolves to `4320`.
- `ecosystem.config.js` loads and omits the maple app + exporter env when the binary is absent.
- `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`, `pnpm -F backend lint`, `pnpm -F frontend lint`, backend tracing/prometheus tests (22 passed), `bash -n` on all three changed scripts.
