### PR TITLE
feat(analytics): report repo-context size on writeback outcome events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1988,6 +1988,9 @@ export type AiWritebackCompletedEvent = BaseTrack & {
         numTurns: number | null;
         // Time (ms) spent in LLM API calls — the rest is local tool execution.
         durationApiMs: number | null;
+        repoContextBytes: number | null;
+        repoContextCapped: boolean | null;
+        repoContextFileCount: number | null;
     };
 };
 
@@ -2010,6 +2013,9 @@ export type AiWritebackFailedEvent = BaseTrack & {
         failureStage: AiWritebackFailureStage;
         errorMessage: string;
         totalDurationMs: number;
+        repoContextBytes: number | null;
+        repoContextCapped: boolean | null;
+        repoContextFileCount: number | null;
     };
 };
 

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -2005,6 +2005,114 @@ describe('AiWritebackService.startTracking', () => {
             }),
         });
     });
+
+    it('derives uncapped repository context analytics from a full listing', () => {
+        const track = vi.fn();
+        const service = buildService({ analytics: { track } as AnyType });
+        const tracker = (service as AnyType).startTracking({
+            user: { userUuid: 'u1' },
+            projectUuid: 'p1',
+            turn: turnContext(),
+            workstream: 'dbt-writeback',
+            aiThreadUuid: undefined,
+            promptUuid: undefined,
+        });
+        const listing = 'models/orders.sql\nREADME.md\n';
+
+        tracker.completed({
+            exitCode: 0,
+            hasChanges: true,
+            prCreated: true,
+            usage: null,
+            repoContext: { kind: 'full', listing },
+        });
+
+        expect(track).toHaveBeenLastCalledWith({
+            event: 'ai_writeback.completed',
+            userId: 'u1',
+            properties: expect.objectContaining({
+                repoContextBytes: Buffer.byteLength(listing, 'utf8'),
+                repoContextCapped: false,
+                repoContextFileCount: 2,
+            }),
+        });
+    });
+
+    it('uses pre-cap measurements for summarised repository context', () => {
+        const track = vi.fn();
+        const service = buildService({ analytics: { track } as AnyType });
+        const tracker = (service as AnyType).startTracking({
+            user: { userUuid: 'u1' },
+            projectUuid: 'p1',
+            turn: turnContext(),
+            workstream: 'general',
+            aiThreadUuid: undefined,
+            promptUuid: undefined,
+        });
+
+        tracker.failed('agent', new Error('agent failed'), {
+            kind: 'summarised',
+            listing: 'models/ (600 files)',
+            bytes: 123456,
+            fileCount: 600,
+        });
+
+        expect(track).toHaveBeenLastCalledWith({
+            event: 'ai_writeback.failed',
+            userId: 'u1',
+            properties: expect.objectContaining({
+                repoContextBytes: 123456,
+                repoContextCapped: true,
+                repoContextFileCount: 600,
+            }),
+        });
+    });
+
+    it('tracks unavailable repository context as explicit nulls', () => {
+        const track = vi.fn();
+        const service = buildService({ analytics: { track } as AnyType });
+        const tracker = (service as AnyType).startTracking({
+            user: { userUuid: 'u1' },
+            projectUuid: 'p1',
+            turn: turnContext(),
+            workstream: 'general',
+            aiThreadUuid: undefined,
+            promptUuid: undefined,
+        });
+
+        tracker.completed({
+            exitCode: 0,
+            hasChanges: false,
+            prCreated: false,
+            usage: null,
+            repoContext: null,
+        });
+
+        expect(track).toHaveBeenLastCalledWith({
+            event: 'ai_writeback.completed',
+            userId: 'u1',
+            properties: expect.objectContaining({
+                repoContextBytes: null,
+                repoContextCapped: null,
+                repoContextFileCount: null,
+            }),
+        });
+
+        tracker.failed('agent', new Error('agent failed'), {
+            kind: 'full',
+            listing: '\n  \n',
+        });
+
+        expect(track).toHaveBeenLastCalledWith({
+            event: 'ai_writeback.failed',
+            userId: 'u1',
+            properties: expect.objectContaining({
+                repoContextBytes: null,
+                repoContextCapped: null,
+                repoContextFileCount: null,
+            }),
+        });
+    });
 });
 
 describe('mergeSourceCodeRepoAccess', () => {
@@ -2416,6 +2524,32 @@ describe('AiWritebackService.resolveWritableRepoTarget (fail-closed authz)', () 
     });
 });
 
+describe('AiWritebackService.dbtWritebackConfig', () => {
+    it('returns gathered repository context through the agent setup', async () => {
+        const service = buildService();
+        const repoContext = {
+            kind: 'full',
+            listing: 'models/orders.sql\nmodels/schema.yml\n',
+        };
+        vi.spyOn(service as AnyType, 'gatherRepoContext').mockResolvedValue(
+            repoContext,
+        );
+        vi.spyOn(service as AnyType, 'prepareProfiles').mockResolvedValue(
+            false,
+        );
+
+        const setup = await (service as AnyType)
+            .dbtWritebackConfig()
+            .buildAgentSetup({
+                sandbox: {},
+                turn: turnContext(),
+                repository: 'acme/analytics',
+            });
+
+        expect(setup.repoContext).toBe(repoContext);
+    });
+});
+
 describe('AiWritebackService.generalCodingAgentConfig (general-agent invariants, H3)', () => {
     const buildGeneralService = () =>
         buildService({
@@ -2456,6 +2590,10 @@ describe('AiWritebackService.generalCodingAgentConfig (general-agent invariants,
         });
         expect(setup.allowedTools).toBe(GENERAL_ALLOWED_TOOLS);
         expect(setup.disallowedTools).toBe(GENERAL_DISALLOWED_TOOLS);
+        expect(setup.repoContext).toEqual({
+            kind: 'full',
+            listing: 'models/a.sql\nREADME.md',
+        });
     });
 
     it('mints a scoped contents:read clone token and revokes it after clone (R2)', async () => {

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -422,6 +422,36 @@ export const workstreamLockKey = (
         : `${aiThreadUuid}::new::${repository}`;
 };
 
+const getRepoContextAnalyticsProperties = (repoContext: RepoContext | null) => {
+    if (repoContext === null) {
+        return {
+            repoContextBytes: null,
+            repoContextCapped: null,
+            repoContextFileCount: null,
+        };
+    }
+    if (repoContext.kind === 'summarised') {
+        return {
+            repoContextBytes: repoContext.bytes,
+            repoContextCapped: true,
+            repoContextFileCount: repoContext.fileCount,
+        };
+    }
+    const { fileCount } = summarizeRepoListing(repoContext.listing);
+    if (fileCount === 0) {
+        return {
+            repoContextBytes: null,
+            repoContextCapped: null,
+            repoContextFileCount: null,
+        };
+    }
+    return {
+        repoContextBytes: Buffer.byteLength(repoContext.listing, 'utf8'),
+        repoContextCapped: false,
+        repoContextFileCount: fileCount,
+    };
+};
+
 export class AiWritebackService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
 
@@ -2162,6 +2192,7 @@ export class AiWritebackService extends BaseService {
 
         let sandbox: SandboxHandle | undefined;
         let sandboxUuid: string | undefined;
+        let repoContext: RepoContext | null = null;
         // Default to preserving a resumed sandbox through failures — its
         // sandbox_uuid is referenced by an ai_writeback_thread row and killing
         // it would poison the row for every future turn. Fresh turns have no
@@ -2247,6 +2278,7 @@ export class AiWritebackService extends BaseService {
                 turn,
                 repository,
             });
+            repoContext = setup.repoContext;
             const agent = await this.runAgentInSandbox({
                 sandbox,
                 systemPrompt: setup.systemPrompt,
@@ -2352,6 +2384,7 @@ export class AiWritebackService extends BaseService {
                 hasChanges,
                 prCreated: applied.prCreated,
                 usage: agent.usage,
+                repoContext,
             });
 
             this.logger.info('AI writeback run completed', {
@@ -2433,7 +2466,7 @@ export class AiWritebackService extends BaseService {
                     sandboxId: sandbox?.sandboxId ?? null,
                 },
             });
-            tracker.failed(failureStage, error);
+            tracker.failed(failureStage, error, repoContext);
             await persistRunFailed(error);
             throw error;
         } finally {
@@ -3281,6 +3314,7 @@ export class AiWritebackService extends BaseService {
                 hasChanges: boolean;
                 prCreated: boolean;
                 usage: AiWritebackUsage | null;
+                repoContext: RepoContext | null;
             }) =>
                 this.analytics.track({
                     event: 'ai_writeback.completed',
@@ -3300,9 +3334,14 @@ export class AiWritebackService extends BaseService {
                             props.usage?.cacheCreationInputTokens ?? null,
                         numTurns: props.usage?.numTurns ?? null,
                         durationApiMs: props.usage?.durationApiMs ?? null,
+                        ...getRepoContextAnalyticsProperties(props.repoContext),
                     },
                 }),
-            failed: (stage: AiWritebackFailureStage, error: unknown) =>
+            failed: (
+                stage: AiWritebackFailureStage,
+                error: unknown,
+                repoContext: RepoContext | null,
+            ) =>
                 this.analytics.track({
                     event: 'ai_writeback.failed',
                     userId: user.userUuid,
@@ -3311,6 +3350,7 @@ export class AiWritebackService extends BaseService {
                         failureStage: stage,
                         errorMessage: getErrorMessage(error),
                         totalDurationMs: Date.now() - startedAt,
+                        ...getRepoContextAnalyticsProperties(repoContext),
                     },
                 }),
         };
@@ -4082,6 +4122,7 @@ export class AiWritebackService extends BaseService {
                 );
                 return {
                     systemPrompt,
+                    repoContext,
                     allowedTools: ALLOWED_TOOLS,
                     addDirs: ['/tmp', SKILLS_DIR, CLAUDE_SKILLS_DIR],
                     model: CLAUDE_MODEL,
@@ -4253,6 +4294,7 @@ export class AiWritebackService extends BaseService {
                         repository,
                         repoContext,
                     }),
+                    repoContext,
                     allowedTools: GENERAL_ALLOWED_TOOLS,
                     disallowedTools: GENERAL_DISALLOWED_TOOLS,
                     addDirs: ['/tmp', GENERAL_SKILLS_DIR],

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -116,6 +116,7 @@ export type SetStage = (stage: AiWritebackFailureStage) => void;
  */
 export type CodingAgentSetup = {
     systemPrompt: string;
+    repoContext: RepoContext | null;
     /** Claude Code `--allowedTools` string for this mode. */
     allowedTools: string;
     /**


### PR DESCRIPTION
> **Stacked on #27400** (`feature/spk-1007`). Base that first; this PR's diff is only the top commit.

## Summary

#27400 caps the repo listing injected into the writeback prompt, but nothing measures whether the cap works or is set at the right value. The byte count was already computed in `gatherRepoContext` and thrown away into a log line.

Reported on `ai_writeback.completed` and `ai_writeback.failed`:

| property | meaning |
|---|---|
| `repoContextBytes` | size of the gathered listing **before** capping |
| `repoContextCapped` | whether the summarised path was taken |
| `repoContextFileCount` | files in the gathered listing |

## Questions this answers

1. Did the cap fix big-repo customers? Success rate, summarised vs full path, over time.
2. Is 96KB right? Distribution of listing sizes, and who sits either side of the line.
3. Is the summarised path worse? It trades turns for completion — this shows whether that pays.

## Design notes

**Threading.** The gatherers run inside `buildAgentSetup`; the analytics fire in the run-lifecycle wrapper. The value rides `CodingAgentSetup`, which both gatherers already return through, and is captured into a **per-invocation local** — not an instance field. The service runs concurrent turns, so shared mutable state would cross-contaminate runs.

**Explicit nulls, never zero.** Unavailable context reports `null` so "could not gather" stays distinguishable from "empty repo". A zero would read as a tiny repo and skew the very distribution these properties exist to measure.

**Deliberately not on `ai_writeback.started`.** That event fires before the repo is cloned, so the values would be null on every row — a permanently-null column is a trap for whoever queries it later.

## Security triage

**LOW** — no authorization, endpoint, or input-handling changes. Adds three numeric/boolean properties to existing internal analytics events. No repo content or paths are emitted, only sizes and counts.

## Testing

- `pnpm -F backend exec vitest run src/ee/services/AiWritebackService/` — 10 files, 295 tests passing, including coverage for the full, summarised, and unavailable paths
- `pnpm -F backend run typecheck` — clean
- `pnpm --filter backend run linter <touched paths>` — clean

Linear: SPK-1008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DicvpsqAifVhH3S2PiBkL4