### PR TITLE
fix(frontend): expand data app connections table

### DIFF
--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -820,6 +820,12 @@ const Settings: FC = () => {
             ) &&
             !matchPath(
                 {
+                    path: '/generalSettings/projectManagement/:projectUuid/dataAppConnections',
+                },
+                location.pathname,
+            ) &&
+            !matchPath(
+                {
                     path: '/generalSettings/customRoles',
                 },
                 location.pathname,


### PR DESCRIPTION
## What changed

- Opt the project Data app connections settings route out of the fixed-width settings wrapper.
- Allow the page header, warning card, and external connections table to use the available settings content width.

## Why

The route inherited the standard fixed content width even though it contains a multi-column table. This constrained the table unnecessarily and made its columns more cramped than other table-heavy settings pages.

## User impact

External connection details now have more horizontal space, reducing wrapping and making the table easier to scan on wide screens.

## Validation

- `pnpm -F frontend typecheck`
- Targeted `oxlint` on `src/pages/Settings.tsx`
- Targeted `oxfmt --check` on `src/pages/Settings.tsx`
- `git diff --check`
- Pre-commit hooks, including unused-export validation
- Browser-verified at `http://localhost:3000`: at a 1470px viewport, the settings main area was 1170px wide, the card 1130px, and the table 1086px (full card width minus padding), with no fixed-width wrapper present