### PR TITLE
feat(pre-aggregates): serve non-additive metrics on exact matches

### DIFF
--- a/docs/pre-aggregates/CONTEXT.md
+++ b/docs/pre-aggregates/CONTEXT.md
@@ -105,7 +105,16 @@ from the source tables.
 **Additivity**:
 A metric's capacity to be re-aggregated from pre-computed results: additive
 (sum, count), decomposable (average — derivable from stored components), or
-non-additive (count_distinct, median — cannot be pre-aggregated).
+non-additive (count_distinct, median — cannot be re-aggregated, servable only
+on an exact match).
+
+**Exact match**:
+A match where the query's selected dimensions equal the pre-aggregate's
+dimensions, with the time dimension at exactly the pre-aggregate's
+granularity — so each result row is served from a single materialization row
+and no re-aggregation occurs. The only kind of match that can serve
+non-additive metrics. A definition dimension referenced only by a query
+filter, or reached through a custom bin, does not count as selected.
 
 **Audit**:
 A per-dashboard coverage report classifying each tile as hit, miss (with

--- a/examples/full-jaffle-shop-demo/dbt/macros/external_pre_aggregates.sql
+++ b/examples/full-jaffle-shop-demo/dbt/macros/external_pre_aggregates.sql
@@ -36,6 +36,17 @@
         ON ("customers".customer_id) = ("orders".customer_id)
       GROUP BY 1,2,3
     ') %}
-    {{ log('Created external pre-aggregate matviews: orders_ext_daily_status_mv, orders_ext_daily_joined_mv', info=True) }}
+    {# count_distinct stored as a plain fieldId column (no components). #}
+    {% do run_query('drop materialized view if exists "' ~ target.schema ~ '"."orders_ext_daily_unique_mv"') %}
+    {% do run_query('
+      create materialized view "' ~ target.schema ~ '"."orders_ext_daily_unique_mv" as
+      SELECT
+        "orders".order_source AS "orders_order_source",
+        DATE_TRUNC(\'DAY\', "orders".order_date) AS "orders_order_date_day",
+        COUNT(DISTINCT ("orders".order_id)) AS "orders_unique_order_count"
+      FROM "' ~ target.schema ~ '"."orders" AS "orders"
+      GROUP BY 1,2
+    ') %}
+    {{ log('Created external pre-aggregate matviews: orders_ext_daily_status_mv, orders_ext_daily_joined_mv, orders_ext_daily_unique_mv', info=True) }}
   {% endif %}
 {% endmacro %}

--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -71,6 +71,38 @@ models:
               - average_expression_metric
             time_dimension: order_date
             granularity: day
+          # e2e fixtures: count_distinct defs served on exact matches only,
+          # plus day/month twins for the grain-preference tie-break.
+          - name: orders_daily_unique_demo
+            dimensions:
+              - status
+            metrics:
+              - unique_order_count
+              - total_order_amount
+            time_dimension: order_date
+            granularity: day
+          - name: orders_ext_daily_unique
+            table: '"jaffle"."orders_ext_daily_unique_mv"'
+            dimensions:
+              - order_source
+            metrics:
+              - unique_order_count
+            time_dimension: order_date
+            granularity: day
+          - name: orders_source_daily_twin
+            dimensions:
+              - order_source
+            metrics:
+              - total_shipping_revenue
+            time_dimension: order_date
+            granularity: day
+          - name: orders_source_monthly_twin
+            dimensions:
+              - order_source
+            metrics:
+              - total_shipping_revenue
+            time_dimension: order_date
+            granularity: month
           - name: orders_daily_number_metric_refs_demo
             dimensions:
               - shipping_method

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
@@ -495,14 +495,68 @@ describe('buildPreAggregateExplore', () => {
             buildExplore(sourceExplore(), {
                 name: 'invalid_rollup',
                 dimensions: ['status'],
+                metrics: ['custom_sql'],
+            }),
+        ).toThrow(
+            'Pre-aggregate "invalid_rollup" references unsupported metrics: "custom_sql" (number). Supported metric types: sum, count, min, max, average, count_distinct, sum_distinct, average_distinct, median, percentile',
+        );
+    });
+
+    it('rewrites exact-only metrics to MAX over the stored value column and hides them from the explore', () => {
+        const result = buildExplore(sourceExplore(), {
+            name: 'unique_rollup',
+            dimensions: ['status'],
+            metrics: ['distinct_customer_count', 'median_order_amount'],
+        });
+
+        expect(
+            result.tables.orders.metrics.distinct_customer_count.compiledSql,
+        ).toBe('MAX(orders.orders_distinct_customer_count)');
+        expect(
+            result.tables.orders.metrics.distinct_customer_count.hidden,
+        ).toBe(true);
+        expect(
+            result.tables.orders.metrics.median_order_amount.compiledSql,
+        ).toBe('MAX(orders.orders_median_order_amount)');
+        expect(result.tables.orders.metrics.median_order_amount.hidden).toBe(
+            true,
+        );
+    });
+
+    it('keeps re-aggregatable metrics visible alongside hidden exact-only metrics', () => {
+        const result = buildExplore(sourceExplore(), {
+            name: 'mixed_rollup',
+            dimensions: ['status'],
+            metrics: ['distinct_customer_count', 'order_count'],
+        });
+
+        expect(result.tables.orders.metrics.order_count.hidden).toBe(false);
+        expect(
+            result.tables.orders.metrics.distinct_customer_count.hidden,
+        ).toBe(true);
+    });
+
+    it('rejects number metrics that reference exact-only metrics', () => {
+        const explore = sourceExplore();
+        explore.tables.orders.metrics.distinct_plus_total = makeCustomMetric({
+            name: 'distinct_plus_total',
+            table: 'orders',
+            type: MetricType.NUMBER,
+            sql: '${distinct_customer_count} + ${total_order_amount}',
+        });
+
+        expect(() =>
+            buildExplore(explore, {
+                name: 'invalid_number_rollup',
+                dimensions: ['status'],
                 metrics: [
+                    'distinct_plus_total',
                     'distinct_customer_count',
-                    'median_order_amount',
-                    'custom_sql',
+                    'total_order_amount',
                 ],
             }),
         ).toThrow(
-            'Pre-aggregate "invalid_rollup" references unsupported metrics: "distinct_customer_count" (count_distinct), "median_order_amount" (median), "custom_sql" (number). Supported metric types: sum, count, min, max, average',
+            'Pre-aggregate "invalid_number_rollup" references unsupported metrics: "distinct_plus_total" (number)',
         );
     });
 

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
@@ -123,6 +123,17 @@ const getMetricSqlForPreAggregateExplore = ({
                 ),
             };
         }
+        case PreAggregateMetricRepresentationKind.EXACT_ONLY: {
+            const metricColumnReference = `${tableName}.${getPreAggregateMetricColumnName(
+                fieldId,
+            )}`;
+            // MAX is exact: the matcher only serves exact-only metrics when
+            // each result group maps to a single materialization row.
+            return {
+                sql: metricColumnReference,
+                compiledSql: `MAX(${metricColumnReference})`,
+            };
+        }
         case PreAggregateMetricRepresentationKind.UNSUPPORTED:
             throw new Error(`Unsupported metric type "${metricType}"`);
         default:
@@ -447,11 +458,19 @@ export const buildPreAggregateExplore = (
             servingAdapter,
         });
 
+        // Hide exact-only metrics from the pre-aggregate explore preview:
+        // selecting them with fewer dimensions than the definition would
+        // re-aggregate a non-additive value into a wrong number.
+        const isExactOnly =
+            preAggregateUtils.getMetricRepresentation(metric.type).kind ===
+            PreAggregateMetricRepresentationKind.EXACT_ONLY;
+
         tables[metric.table].metrics[metric.name] = {
             ...metric,
             sql,
             compiledSql,
             tablesReferences: [sourceExplore.baseTable],
+            ...(isExactOnly ? { hidden: true } : {}),
         };
     });
 

--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -145,6 +145,14 @@ const baseExplore = (): Explore => ({
                     name: 'unique_customers',
                     type: MetricType.COUNT_DISTINCT,
                 }),
+                median_amount: makeMetric({
+                    name: 'median_amount',
+                    type: MetricType.MEDIAN,
+                }),
+                running_total_amount: makeMetric({
+                    name: 'running_total_amount',
+                    type: MetricType.RUNNING_TOTAL,
+                }),
                 custom_metric: makeMetric({
                     name: 'custom_metric',
                     type: MetricType.NUMBER,
@@ -1104,14 +1112,14 @@ describe('findMatch', () => {
         });
     });
 
-    it('returns non_additive_metric for non-reaggregatable metrics', () => {
+    it('returns non_additive_metric for metrics that can never be served', () => {
         const explore = {
             ...baseExplore(),
             preAggregates: [
                 {
                     name: 'orders_summary',
                     dimensions: ['status'],
-                    metrics: ['unique_customers'],
+                    metrics: ['running_total_amount'],
                 },
             ],
         };
@@ -1119,14 +1127,375 @@ describe('findMatch', () => {
         const result = preAggregateUtils.findMatch(
             makeMetricQuery({
                 dimensions: ['orders_status'],
-                metrics: ['orders_unique_customers'],
+                metrics: ['orders_running_total_amount'],
             }),
             explore,
         );
 
         expect(result.miss).toStrictEqual({
             reason: PreAggregateMissReason.NON_ADDITIVE_METRIC,
-            fieldId: 'orders_unique_customers',
+            fieldId: 'orders_running_total_amount',
+        });
+    });
+
+    describe('exact match serving for non-additive metrics', () => {
+        const exploreWithUniqueCustomersDef = (
+            def?: Partial<PreAggregateDef>,
+        ): Explore => ({
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_unique',
+                    dimensions: ['status'],
+                    metrics: ['unique_customers', 'order_count'],
+                    ...def,
+                },
+            ],
+        });
+
+        it('hits when selected dimensions equal the pre-aggregate dimensions', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status'],
+                    metrics: ['orders_unique_customers'],
+                }),
+                exploreWithUniqueCustomersDef(),
+            );
+
+            expect(result).toStrictEqual({
+                hit: true,
+                preAggregateName: 'orders_unique',
+                miss: null,
+            });
+        });
+
+        it('hits with the time dimension selected at exactly the pre-aggregate granularity', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status', 'orders_order_date_day'],
+                    metrics: ['orders_unique_customers'],
+                }),
+                exploreWithUniqueCustomersDef({
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                }),
+            );
+
+            expect(result).toStrictEqual({
+                hit: true,
+                preAggregateName: 'orders_unique',
+                miss: null,
+            });
+        });
+
+        it('hits for median metrics on an exact match', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status'],
+                    metrics: ['orders_median_amount'],
+                }),
+                exploreWithUniqueCustomersDef({
+                    metrics: ['median_amount'],
+                }),
+            );
+
+            expect(result).toStrictEqual({
+                hit: true,
+                preAggregateName: 'orders_unique',
+                miss: null,
+            });
+        });
+
+        it('misses when the query selects a subset of the pre-aggregate dimensions', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status'],
+                    metrics: ['orders_unique_customers'],
+                }),
+                exploreWithUniqueCustomersDef({
+                    dimensions: ['status', 'amount'],
+                }),
+            );
+
+            expect(result.miss).toStrictEqual({
+                reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH,
+                fieldId: 'orders_unique_customers',
+            });
+        });
+
+        it('misses metrics-only queries because the dimensions are not selected', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: [],
+                    metrics: ['orders_unique_customers'],
+                }),
+                exploreWithUniqueCustomersDef(),
+            );
+
+            expect(result.miss).toStrictEqual({
+                reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH,
+                fieldId: 'orders_unique_customers',
+            });
+        });
+
+        it('misses when the time dimension is queried at a coarser granularity', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status', 'orders_order_date_month'],
+                    metrics: ['orders_unique_customers'],
+                }),
+                exploreWithUniqueCustomersDef({
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                }),
+            );
+
+            expect(result.miss).toStrictEqual({
+                reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH,
+                fieldId: 'orders_unique_customers',
+            });
+        });
+
+        it('misses when a definition dimension is only referenced by a query filter', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status'],
+                    metrics: ['orders_unique_customers'],
+                    filters: {
+                        dimensions: {
+                            id: 'root',
+                            and: [
+                                {
+                                    id: 'f1',
+                                    target: { fieldId: 'orders_amount' },
+                                    operator: FilterOperator.GREATER_THAN,
+                                    values: [10],
+                                },
+                            ],
+                        },
+                    },
+                }),
+                exploreWithUniqueCustomersDef({
+                    dimensions: ['status', 'amount'],
+                }),
+            );
+
+            expect(result.miss).toStrictEqual({
+                reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH,
+                fieldId: 'orders_unique_customers',
+            });
+        });
+
+        it('keeps the exact match when filters target selected dimensions', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status'],
+                    metrics: ['orders_unique_customers'],
+                    filters: {
+                        dimensions: {
+                            id: 'root',
+                            and: [
+                                {
+                                    id: 'f1',
+                                    target: { fieldId: 'orders_status' },
+                                    operator: FilterOperator.EQUALS,
+                                    values: ['completed'],
+                                },
+                            ],
+                        },
+                    },
+                }),
+                exploreWithUniqueCustomersDef(),
+            );
+
+            expect(result).toStrictEqual({
+                hit: true,
+                preAggregateName: 'orders_unique',
+                miss: null,
+            });
+        });
+
+        it('misses when a definition dimension is reached only through a custom bin', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status', 'fixed_width_bin'],
+                    metrics: ['orders_unique_customers'],
+                    customDimensions: [
+                        makeCustomBinDimension(BinType.FIXED_WIDTH),
+                    ],
+                }),
+                exploreWithUniqueCustomersDef({
+                    dimensions: ['status', 'amount'],
+                }),
+            );
+
+            expect(result.miss).toStrictEqual({
+                reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH,
+                fieldId: 'orders_unique_customers',
+            });
+        });
+
+        it('keeps the exact match for a subset of the pre-aggregate metrics', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status'],
+                    metrics: ['orders_order_count'],
+                }),
+                exploreWithUniqueCustomersDef(),
+            );
+
+            expect(result).toStrictEqual({
+                hit: true,
+                preAggregateName: 'orders_unique',
+                miss: null,
+            });
+        });
+
+        it('does not gate additive metrics on exactness', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status'],
+                    metrics: ['orders_order_count'],
+                }),
+                exploreWithUniqueCustomersDef({
+                    dimensions: ['status', 'amount'],
+                    metrics: ['order_count'],
+                }),
+            );
+
+            expect(result).toStrictEqual({
+                hit: true,
+                preAggregateName: 'orders_unique',
+                miss: null,
+            });
+        });
+
+        it('misses when the raw time dimension is selected instead of the granular one', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status', 'orders_order_date'],
+                    metrics: ['orders_unique_customers'],
+                }),
+                exploreWithUniqueCustomersDef({
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                }),
+            );
+
+            expect(result.miss).toStrictEqual({
+                reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH,
+                fieldId: 'orders_unique_customers',
+            });
+        });
+
+        it('keeps definition-filter semantics on exact matches', () => {
+            const definitionFilter = {
+                id: 'def-filter',
+                target: { fieldRef: 'status' },
+                operator: FilterOperator.EQUALS,
+                values: ['completed'],
+            };
+
+            const queryWithoutFilter = makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_unique_customers'],
+            });
+            const queryWithFilter = makeMetricQuery({
+                ...queryWithoutFilter,
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'f1',
+                                target: { fieldId: 'orders_status' },
+                                operator: FilterOperator.EQUALS,
+                                values: ['completed'],
+                            },
+                        ],
+                    },
+                },
+            });
+            const explore = exploreWithUniqueCustomersDef({
+                filters: [definitionFilter],
+            });
+
+            expect(
+                preAggregateUtils.findMatch(queryWithoutFilter, explore).miss,
+            ).toStrictEqual({
+                reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+                fieldId: 'orders_status',
+            });
+            expect(
+                preAggregateUtils.findMatch(queryWithFilter, explore),
+            ).toStrictEqual({
+                hit: true,
+                preAggregateName: 'orders_unique',
+                miss: null,
+            });
+        });
+
+        it('reports the exact-match miss over metric-not-in-pre-aggregate from unrelated defs', () => {
+            const explore = {
+                ...baseExplore(),
+                preAggregates: [
+                    {
+                        name: 'additive_only',
+                        dimensions: ['status'],
+                        metrics: ['order_count'],
+                    },
+                    {
+                        name: 'orders_unique',
+                        dimensions: ['status', 'amount'],
+                        metrics: ['unique_customers'],
+                    },
+                ],
+            };
+
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status'],
+                    metrics: ['orders_unique_customers'],
+                }),
+                explore,
+            );
+
+            expect(result.miss).toStrictEqual({
+                reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH,
+                fieldId: 'orders_unique_customers',
+            });
+        });
+
+        it('keeps the smallest-pre-aggregate tie-break on exact matches', () => {
+            const explore = {
+                ...baseExplore(),
+                preAggregates: [
+                    {
+                        name: 'wide',
+                        dimensions: ['status'],
+                        metrics: ['unique_customers', 'order_count'],
+                    },
+                    {
+                        name: 'narrow',
+                        dimensions: ['status'],
+                        metrics: ['unique_customers'],
+                    },
+                ],
+            };
+
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status'],
+                    metrics: ['orders_unique_customers'],
+                }),
+                explore,
+            );
+
+            expect(result).toStrictEqual({
+                hit: true,
+                preAggregateName: 'narrow',
+                miss: null,
+            });
         });
     });
 

--- a/packages/backend/src/ee/preAggregates/postProcessor.test.ts
+++ b/packages/backend/src/ee/preAggregates/postProcessor.test.ts
@@ -360,7 +360,7 @@ describe('pre-aggregate virtual explore generation', () => {
         ).toBe(true);
     });
 
-    it('surfaces unsupported pre-aggregate metric types in explore warnings', async () => {
+    it('accepts non-additive metric definitions without warnings', async () => {
         process.env.PRE_AGGREGATES_ENABLED = 'true';
 
         const explores = await convertExplores(
@@ -370,7 +370,7 @@ describe('pre-aggregate virtual explore generation', () => {
                     meta: {
                         pre_aggregates: [
                             {
-                                name: 'broken_rollup',
+                                name: 'unique_rollup',
                                 dimensions: ['user_id'],
                                 metrics: ['myTable_user_count'],
                             },
@@ -387,13 +387,12 @@ describe('pre-aggregate virtual explore generation', () => {
             { postProcessors: [preAggregatePostProcessor] },
         );
 
-        expect(explores).toHaveLength(1);
-        expect((explores[0] as Explore).name).toBe('myTable');
-        expect((explores[0] as Explore).warnings).toContainEqual({
-            type: InlineErrorType.FIELD_ERROR,
-            message:
-                'Pre-aggregate "broken_rollup" references unsupported metrics: "user_count" (count_distinct). Supported metric types: sum, count, min, max, average',
-        });
+        expect(explores).toHaveLength(2);
+        const baseExplore = explores.find(
+            (explore) => explore.name === 'myTable',
+        ) as Explore;
+        expect(baseExplore.warnings ?? []).toStrictEqual([]);
+        expect(baseExplore.preAggregates).toHaveLength(1);
     });
 
     it('keeps only successfully generated pre-aggregates on the base explore', async () => {

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -249,6 +249,18 @@ const getSourceExplore = (): Explore =>
                         compiledSql: 'SUM("orders".amount)',
                         tablesReferences: ['orders'],
                     },
+                    distinct_customer_count: {
+                        fieldType: FieldType.METRIC,
+                        type: MetricType.COUNT_DISTINCT,
+                        name: 'distinct_customer_count',
+                        label: 'Distinct customer count',
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        sql: '${TABLE}.customer_id',
+                        hidden: false,
+                        compiledSql: 'COUNT(DISTINCT "orders".customer_id)',
+                        tablesReferences: ['orders'],
+                    },
                 },
                 lineageGraph: {},
             },
@@ -624,6 +636,33 @@ describe('buildMaterializationMetricQuery', () => {
             ],
         });
         expect(result.timeDimensionFieldId).toBeNull();
+    });
+
+    it('stores exact-only metrics as single plain value columns', () => {
+        const preAggregateDef: PreAggregateDef = {
+            name: 'orders_rollup',
+            dimensions: ['status'],
+            metrics: ['distinct_customer_count'],
+        };
+
+        const result = buildMaterializationMetricQuery({
+            sourceExplore: getSourceExplore(),
+            preAggregateDef,
+            materializationConfig: { maxRows: null },
+        });
+
+        expect(result.metricQuery.metrics).toEqual([
+            'orders_distinct_customer_count',
+        ]);
+        expect(result.metricQuery.additionalMetrics).toBeUndefined();
+        expect(result.metricComponents).toEqual({
+            orders_distinct_customer_count: [
+                {
+                    componentFieldId: 'orders_distinct_customer_count',
+                    aggregation: MetricType.MAX,
+                },
+            ],
+        });
     });
 
     it('emits pre-aggregate filters into materialization dimension filters', () => {
@@ -1100,6 +1139,44 @@ describe('renderMaterializationSql', () => {
                 granularity: null,
                 aggregation: MetricType.COUNT,
                 parentMetricFieldId: 'orders_avg_order_amount',
+            },
+        ]);
+    });
+
+    it('includes exact-only metrics as single metric columns in the column contract', () => {
+        const sourceExplore = getSourceExplore();
+        const preAggregateDef: PreAggregateDef = {
+            name: 'orders_rollup',
+            dimensions: ['status'],
+            metrics: ['distinct_customer_count'],
+        };
+
+        const { sql, columns } =
+            preAggregateMaterialization.renderMaterializationSql({
+                sourceExplore,
+                preAggregateDef,
+                warehouseSqlBuilder: warehouseSqlBuilderFromType(
+                    SupportedDbtAdapter.POSTGRES,
+                ),
+            });
+
+        expect(normalizeSql(sql)).toContain(
+            'COUNT(DISTINCT "orders".customer_id) AS "orders_distinct_customer_count"',
+        );
+        expect(columns).toEqual([
+            {
+                name: 'orders_status',
+                role: 'dimension',
+                granularity: null,
+                aggregation: null,
+                parentMetricFieldId: null,
+            },
+            {
+                name: 'orders_distinct_customer_count',
+                role: 'metric',
+                granularity: null,
+                aggregation: MetricType.COUNT_DISTINCT,
+                parentMetricFieldId: null,
             },
         ]);
     });

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -26,6 +26,7 @@ import {
     type PreAggregateMatchMiss,
 } from '../../types/preAggregate';
 import { TimeFrames } from '../../types/timeFrames';
+import assertUnreachable from '../../utils/assertUnreachable';
 import { getMetricsMapFromTables } from '../../utils/fields';
 import {
     createFilterRuleFromModelRequiredFilterRule,
@@ -33,8 +34,15 @@ import {
 } from '../../utils/filters';
 import { getItemId } from '../../utils/item';
 import { timeFrameOrder } from '../../utils/timeFrames';
-import { isCompatible } from './additivity';
-import { getDimensionReferences, getMetricReferences } from './references';
+import {
+    getMetricRepresentation,
+    PreAggregateMetricRepresentationKind,
+} from './metricRepresentation';
+import {
+    getDimensionBaseName,
+    getDimensionReferences,
+    getMetricReferences,
+} from './references';
 
 export type PreAggregateMatchResult =
     | { hit: true; preAggregateName: string; miss: null }
@@ -829,6 +837,73 @@ const getUnsatisfiedPreAggregateFilterMiss = ({
     };
 };
 
+const isRawTimeInterval = (timeInterval: TimeFrames | undefined): boolean =>
+    !timeInterval || timeInterval === TimeFrames.RAW;
+
+// Exact match (see docs/pre-aggregates/CONTEXT.md): selected dimensions
+// set-equal to the definition's, time dimension at exactly its granularity.
+const isExactDimensionSetMatch = ({
+    metricQuery,
+    explore,
+    preAggregateDef,
+    defDimensions,
+    dimensionsByFieldId,
+    customDimensionIds,
+}: {
+    metricQuery: MetricQuery;
+    explore: Explore;
+    preAggregateDef: PreAggregateDef;
+    defDimensions: ReadonlySet<string>;
+    dimensionsByFieldId: Map<
+        FieldId,
+        Explore['tables'][string]['dimensions'][string]
+    >;
+    customDimensionIds: ReadonlySet<string>;
+}): boolean => {
+    const coveredDefDimensions = new Set<string>();
+
+    for (const fieldId of metricQuery.dimensions) {
+        if (customDimensionIds.has(fieldId)) {
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+
+        const dimension = dimensionsByFieldId.get(fieldId);
+        if (!dimension) {
+            return false;
+        }
+
+        const matchedReferences = getDimensionReferences({
+            dimension,
+            baseTable: explore.baseTable,
+        }).filter((reference) => defDimensions.has(reference));
+        if (matchedReferences.length === 0) {
+            return false;
+        }
+
+        const isDefTimeDimension =
+            !!preAggregateDef.timeDimension &&
+            !!preAggregateDef.granularity &&
+            getDimensionBaseName(dimension) === preAggregateDef.timeDimension;
+        if (isDefTimeDimension) {
+            if (dimension.timeInterval !== preAggregateDef.granularity) {
+                return false;
+            }
+        } else if (!isRawTimeInterval(dimension.timeInterval)) {
+            // A truncated variant collapses the stored raw values.
+            return false;
+        }
+
+        matchedReferences.forEach((reference) =>
+            coveredDefDimensions.add(reference),
+        );
+    }
+
+    return [...defDimensions].every((reference) =>
+        coveredDefDimensions.has(reference),
+    );
+};
+
 const getGranularityMissForDef = (
     metricQuery: MetricQuery,
     explore: Explore,
@@ -894,6 +969,33 @@ const getMissForDef = ({
     unoverriddenRequiredFilterTargetFieldIds: readonly FieldId[];
     requiredFilterTargetFieldIds: ReadonlySet<FieldId>;
 }): PreAggregateMatchMiss | null => {
+    const defDimensions = new Set(preAggregateDef.dimensions);
+    if (
+        preAggregateDef.timeDimension &&
+        preAggregateDef.granularity &&
+        !defDimensions.has(preAggregateDef.timeDimension)
+    ) {
+        defDimensions.add(preAggregateDef.timeDimension);
+    }
+    const customDimensionIds = new Set(
+        (metricQuery.customDimensions || []).map(getItemId),
+    );
+
+    let exactDimensionSetMatch: boolean | null = null;
+    const isExactMatch = (): boolean => {
+        if (exactDimensionSetMatch === null) {
+            exactDimensionSetMatch = isExactDimensionSetMatch({
+                metricQuery,
+                explore,
+                preAggregateDef,
+                defDimensions,
+                dimensionsByFieldId,
+                customDimensionIds,
+            });
+        }
+        return exactDimensionSetMatch;
+    };
+
     const defMetrics = new Set(preAggregateDef.metrics);
     for (const metricFieldId of metricQuery.metrics) {
         const metric = metricsByFieldId[metricFieldId];
@@ -919,21 +1021,30 @@ const getMissForDef = ({
             // eslint-disable-next-line no-continue
             continue;
         }
-        if (!isCompatible(metric.type)) {
-            return {
-                reason: PreAggregateMissReason.NON_ADDITIVE_METRIC,
-                fieldId: metricFieldId,
-            };
+        const representation = getMetricRepresentation(metric.type);
+        switch (representation.kind) {
+            case PreAggregateMetricRepresentationKind.DIRECT:
+            case PreAggregateMetricRepresentationKind.DECOMPOSED:
+                break;
+            case PreAggregateMetricRepresentationKind.EXACT_ONLY:
+                if (!isExactMatch()) {
+                    return {
+                        reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH,
+                        fieldId: metricFieldId,
+                    };
+                }
+                break;
+            case PreAggregateMetricRepresentationKind.UNSUPPORTED:
+                return {
+                    reason: PreAggregateMissReason.NON_ADDITIVE_METRIC,
+                    fieldId: metricFieldId,
+                };
+            default:
+                return assertUnreachable(
+                    representation,
+                    'Unknown pre-aggregate metric representation',
+                );
         }
-    }
-
-    const defDimensions = new Set(preAggregateDef.dimensions);
-    if (
-        preAggregateDef.timeDimension &&
-        preAggregateDef.granularity &&
-        !defDimensions.has(preAggregateDef.timeDimension)
-    ) {
-        defDimensions.add(preAggregateDef.timeDimension);
     }
 
     const missingCustomDimension = (metricQuery.customDimensions || []).find(
@@ -966,9 +1077,6 @@ const getMissForDef = ({
         };
     }
 
-    const customDimensionIds = new Set(
-        (metricQuery.customDimensions || []).map(getItemId),
-    );
     const missingQueryDimensionFieldId = metricQuery.dimensions.find(
         (dimensionFieldId) =>
             !customDimensionIds.has(dimensionFieldId) &&

--- a/packages/common/src/ee/preAggregates/materialization/buildMaterializationMetricQuery.ts
+++ b/packages/common/src/ee/preAggregates/materialization/buildMaterializationMetricQuery.ts
@@ -374,6 +374,24 @@ export const buildMaterializationMetricQuery = ({
                 ];
 
                 return acc;
+            case PreAggregateMetricRepresentationKind.EXACT_ONLY:
+                // Stored as a single plain value column named by the field id;
+                // served with MAX, which is exact on the exact matches the
+                // matcher restricts these metrics to.
+                assertUniqueMetricFieldId({
+                    preAggregateName: preAggregateDef.name,
+                    fieldId: metricFieldId,
+                    selectedMetricFieldIds,
+                });
+
+                acc[metricFieldId] = [
+                    {
+                        componentFieldId: metricFieldId,
+                        aggregation: MetricType.MAX,
+                    },
+                ];
+
+                return acc;
             default:
                 return assertUnreachable(
                     representation,

--- a/packages/common/src/ee/preAggregates/metricRepresentation.ts
+++ b/packages/common/src/ee/preAggregates/metricRepresentation.ts
@@ -6,11 +6,19 @@ export type PreAggregateSupportedMetricType =
     | MetricType.COUNT
     | MetricType.MIN
     | MetricType.MAX
-    | MetricType.AVERAGE;
+    | MetricType.AVERAGE
+    | MetricType.COUNT_DISTINCT
+    | MetricType.SUM_DISTINCT
+    | MetricType.AVERAGE_DISTINCT
+    | MetricType.MEDIAN
+    | MetricType.PERCENTILE;
 
 export enum PreAggregateMetricRepresentationKind {
     DIRECT = 'direct',
     DECOMPOSED = 'decomposed',
+    // Stored as a single plain value column; servable only on an exact match,
+    // where each result row maps to one materialization row.
+    EXACT_ONLY = 'exact_only',
     UNSUPPORTED = 'unsupported',
 }
 
@@ -25,6 +33,9 @@ export type PreAggregateMetricRepresentation =
           components: readonly ['sum', 'count'];
       }
     | {
+          kind: PreAggregateMetricRepresentationKind.EXACT_ONLY;
+      }
+    | {
           kind: PreAggregateMetricRepresentationKind.UNSUPPORTED;
       };
 
@@ -34,6 +45,11 @@ export const supportedMetricTypes: PreAggregateSupportedMetricType[] = [
     MetricType.MIN,
     MetricType.MAX,
     MetricType.AVERAGE,
+    MetricType.COUNT_DISTINCT,
+    MetricType.SUM_DISTINCT,
+    MetricType.AVERAGE_DISTINCT,
+    MetricType.MEDIAN,
+    MetricType.PERCENTILE,
 ];
 
 export const getMetricRepresentation = (
@@ -67,6 +83,9 @@ export const getMetricRepresentation = (
         case MetricType.AVERAGE_DISTINCT:
         case MetricType.MEDIAN:
         case MetricType.PERCENTILE:
+            return {
+                kind: PreAggregateMetricRepresentationKind.EXACT_ONLY,
+            };
         case MetricType.NUMBER:
         case MetricType.STRING:
         case MetricType.DATE:
@@ -88,3 +107,13 @@ export const isSupportedMetricType = (
 ): metricType is PreAggregateSupportedMetricType =>
     getMetricRepresentation(metricType).kind !==
     PreAggregateMetricRepresentationKind.UNSUPPORTED;
+
+// Re-aggregatable = safe to combine across materialization rows (direct or
+// decomposed). Exact-only metrics are supported but never re-aggregatable.
+export const isReAggregatableMetricType = (metricType: MetricType): boolean => {
+    const { kind } = getMetricRepresentation(metricType);
+    return (
+        kind === PreAggregateMetricRepresentationKind.DIRECT ||
+        kind === PreAggregateMetricRepresentationKind.DECOMPOSED
+    );
+};

--- a/packages/common/src/ee/preAggregates/numberMetricDependencies.test.ts
+++ b/packages/common/src/ee/preAggregates/numberMetricDependencies.test.ts
@@ -115,7 +115,7 @@ describe('analyzePreAggregateNumberMetricDependencies', () => {
         );
     });
 
-    it('rejects number metrics whose leaf dependencies are not materializable', () => {
+    it('rejects number metrics whose leaf dependencies are not re-aggregatable', () => {
         const distinctCustomerCount = makeMetric({
             name: 'distinct_customer_count',
             type: MetricType.COUNT_DISTINCT,

--- a/packages/common/src/ee/preAggregates/numberMetricDependencies.ts
+++ b/packages/common/src/ee/preAggregates/numberMetricDependencies.ts
@@ -8,7 +8,7 @@ import {
     type FieldId,
 } from '../../types/field';
 import { getItemId } from '../../utils/item';
-import { isSupportedMetricType } from './metricRepresentation';
+import { isReAggregatableMetricType } from './metricRepresentation';
 import {
     getReferencedMetricForPreAggregation,
     type PreAggregateReferenceLookup,
@@ -194,7 +194,9 @@ const analyzeNumberMetricDependencies = ({
                 continue;
             }
 
-            if (!isSupportedMetricType(referencedMetric.type)) {
+            // Exact-only leaves stay ineligible: a number metric re-aggregates
+            // its references, which is never safe for them.
+            if (!isReAggregatableMetricType(referencedMetric.type)) {
                 result = getIneligibleResult({
                     reason: PreAggregateNumberMetricDependencyIneligibilityReason.UNSUPPORTED_LEAF_METRIC_TYPE,
                     ineligibleMetricFieldId: referencedMetricFieldId,

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -67,6 +67,7 @@ export enum PreAggregateMissReason {
     DIMENSION_NOT_IN_PRE_AGGREGATE = 'dimension_not_in_pre_aggregate',
     METRIC_NOT_IN_PRE_AGGREGATE = 'metric_not_in_pre_aggregate',
     NON_ADDITIVE_METRIC = 'non_additive_metric',
+    NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH = 'non_additive_metric_requires_exact_match',
     CUSTOM_SQL_METRIC = 'custom_sql_metric',
     FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE = 'filter_dimension_not_in_pre_aggregate',
     PRE_AGGREGATE_FILTER_NOT_SATISFIED = 'pre_aggregate_filter_not_satisfied',
@@ -93,6 +94,10 @@ export type PreAggregateMatchMiss =
       }
     | {
           reason: PreAggregateMissReason.NON_ADDITIVE_METRIC;
+          fieldId: FieldId;
+      }
+    | {
+          reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH;
           fieldId: FieldId;
       }
     | {
@@ -191,6 +196,8 @@ export const preAggregateMissReasonLabels: Record<
     [PreAggregateMissReason.METRIC_NOT_IN_PRE_AGGREGATE]:
         'Metric not in pre-aggregate',
     [PreAggregateMissReason.NON_ADDITIVE_METRIC]: 'Non-additive metric',
+    [PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH]:
+        'Non-additive metric: select exactly the pre-aggregate dimensions',
     [PreAggregateMissReason.CUSTOM_SQL_METRIC]: 'Custom SQL metric',
     [PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE]:
         'Filter dimension not in pre-aggregate',


### PR DESCRIPTION
## Summary

Queries whose *selected* dimensions exactly equal a pre-aggregate's dimensions (time dimension at exactly the definition's granularity) are served from a single materialization row — no re-aggregation occurs — so any metric type is safe to serve.

- New `EXACT_ONLY` metric representation: `count_distinct`, `sum_distinct`, `average_distinct`, `median`, `percentile` become definable in pre-aggregates.
- Matcher computes dimension-set equality before the additivity gate; non-additive metrics pass only on an exact match. Definition dimensions referenced only by query filters, or reached through custom bins, don't count as selected. New miss reason `non_additive_metric_requires_exact_match`.
- Materialization stores exact-only metrics as plain value columns (no `__sum`/`__count` components); external-table column contract and CLI check inherit automatically.
- Serving keeps the single compile path — exact-only metrics compile as `MAX(col)` (exact, since one row per group).
- Exact-only metrics are omitted from generated pre-aggregate explores (direct queries there have no dimension validation).
- `type: number` metrics referencing exact-only metrics stay ineligible.

Precedent: Looker's exact-match exception ("If an aggregate table is an exact match of an Explore query, Looker is able to use aggregate tables that include any type of measure").

## Test plan

- Unit tests at the three existing seams: matcher (exactness detection, gating, miss reason), pre-aggregate explore builder (MAX serving SQL, omission), materialization metric-query builder (plain value columns).
- E2E harness (7 scenarios against the seed project with verified baseline) validated locally; jaffle defs included in this branch.

Closes: ZAP-847

🤖 Generated with [Claude Code](https://claude.com/claude-code)
