### PR TITLE
fix(coding-agent): match near-miss filenames in the commit denylist

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/deniedPaths.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/deniedPaths.test.ts
@@ -61,4 +61,52 @@ describe('findDeniedCommitPaths', () => {
         const mixed = ['README.md', '.env', 'src/app.ts', 'Jenkinsfile'];
         expect(findDeniedCommitPaths(mixed)).toEqual(['.env', 'Jenkinsfile']);
     });
+
+    it('denies environment filenames with trailing whitespace', () => {
+        const paths = ['config/.env ', 'config/.env\u00a0'];
+        expect(findDeniedCommitPaths(paths)).toEqual(paths);
+    });
+
+    it('denies names whose segments carry surrounding whitespace', () => {
+        // Each pattern anchors on `^` or `/`, so whitespace hugging a separator
+        // hides the name from it — at the repo root and, more importantly, at
+        // any nesting level, which is where the agent actually writes.
+        const paths = [
+            ' credentials',
+            'ci/ Jenkinsfile',
+            'ci/ .npmrc',
+            'a/b/ id_rsa',
+            '\u00a0credentials',
+            '.github/workflows /deploy.yml',
+        ];
+        expect(findDeniedCommitPaths(paths)).toEqual(paths);
+    });
+
+    it('allows interior spaces in ordinary directory and file names', () => {
+        const paths = ['my docs/notes.md', 'models/env.sql'];
+        expect(findDeniedCommitPaths(paths)).toEqual([]);
+    });
+
+    it('denies Jenkinsfile variants with dot suffixes', () => {
+        const paths = ['Jenkinsfile.groovy', 'ci/Jenkinsfile.production'];
+        expect(findDeniedCommitPaths(paths)).toEqual(paths);
+    });
+
+    it('denies credentials filenames with extensions', () => {
+        const paths = [
+            'credentials.json',
+            'config/credentials.local.json',
+            'config/credentials.',
+        ];
+        expect(findDeniedCommitPaths(paths)).toEqual(paths);
+    });
+
+    it('allows names that only contain denied path terms', () => {
+        const paths = [
+            'models/environment.sql',
+            'docs/credentials-setup.md',
+            'docs/Jenkinsfile-setup.md',
+        ];
+        expect(findDeniedCommitPaths(paths)).toEqual([]);
+    });
 });

--- a/packages/backend/src/ee/services/AiWritebackService/deniedPaths.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/deniedPaths.ts
@@ -29,7 +29,7 @@ const SECRET_PATH_PATTERNS: RegExp[] = [
     /(^|\/)id_ed25519(\.pub)?$/i,
     /(^|\/)\.npmrc$/i,
     /(^|\/)\.pypirc$/i,
-    /(^|\/)credentials$/i,
+    /(^|\/)credentials(\.[^/]*)?$/i,
     /\.keyfile(\.json)?$/i,
 ];
 
@@ -42,7 +42,7 @@ const CI_PATH_PATTERNS: RegExp[] = [
     /(^|\/)\.github\/workflows\//i,
     /(^|\/)\.github\/actions\//i,
     /(^|\/)\.gitlab-ci\.ya?ml$/i,
-    /(^|\/)Jenkinsfile$/i,
+    /(^|\/)Jenkinsfile(\.[^/]*)?$/i,
     /(^|\/)\.circleci\//i,
     /(^|\/)azure-pipelines\.ya?ml$/i,
     /(^|\/)bitbucket-pipelines\.ya?ml$/i,
@@ -75,6 +75,21 @@ export class DeniedPathError extends ForbiddenError {
  * Return the subset of `paths` that a coding-agent commit must not touch.
  */
 export const findDeniedCommitPaths = (paths: string[]): string[] =>
-    paths.filter((path) =>
-        DENIED_PATH_PATTERNS.some((pattern) => pattern.test(path)),
-    );
+    paths.filter((path) => {
+        // The patterns anchor each name on `^` or `/`, so whitespace hugging a
+        // path separator hides a name from them. Trim every segment, not just
+        // the ends of the whole path — the agent writes into directories, so a
+        // nested name is the common case, not the edge one.
+        //
+        // This only ever widens what matches. The patterns still require a dot
+        // or a segment boundary, so ordinary files stay allowed:
+        // `credentials-setup.md`, `environment.sql`, and directories with
+        // interior spaces like `my docs/notes.md` are all untouched.
+        const normalizedPath = path
+            .split('/')
+            .map((segment) => segment.trim())
+            .join('/');
+        return DENIED_PATH_PATTERNS.some((pattern) =>
+            pattern.test(normalizedPath),
+        );
+    });


### PR DESCRIPTION
## Summary

`findDeniedCommitPaths` is the chokepoint that stops the coding agent committing protected files to a customer repository. It anchored each name on a path boundary and matched the raw path, so filenames differing only cosmetically from a listed name were not recognised as the same file.

Detail is on the Linear ticket rather than here — this repo is public.

## Changes

`packages/backend/src/ee/services/AiWritebackService/deniedPaths.ts`

- Normalise **each path segment** before matching, rather than the raw string. Whitespace hugging a separator otherwise hides a name from an anchored pattern — at the repo root and, more to the point, at any nesting level, which is where the agent actually writes.
- Allow a dot-delimited suffix on the two anchored basenames.

## Over-matching was treated as a first-class risk

This list aborts the agent's entire run when it fires, so a greedy fix would be its own defect — writeback would start failing on innocent files with an opaque error. The approach deliberately widens *normalisation* rather than the patterns: they still require a dot or a segment boundary.

Covered by tests as a guard, all of which must stay ALLOWED:

- `docs/credentials-setup.md`
- `models/environment.sql`
- `docs/Jenkinsfile-setup.md`
- `my docs/notes.md` (interior spaces in a directory name)
- `models/env.sql`

## Known residual

Non-dot suffixes on the anchored basenames (e.g. a hyphen- or underscore-suffixed variant) are still allowed, deliberately — matching them would catch legitimate documentation filenames, one of which is in the guard list above. Worth a follow-up if that trade turns out to be wrong; it is a narrower gap than the one this closes.

## Security triage

The change **tightens** an existing control and adds no new surface. No authorization, endpoint, or input-handling changes. Reviewed against the opposite risk (over-matching) as described above.

## Testing

- `pnpm -F backend exec vitest run src/ee/services/AiWritebackService/` — 10 files, 301 tests passing (5 new cases, including the allow-list guard)
- `pnpm -F backend run typecheck` — clean
- `pnpm --filter backend run linter <touched paths>` — clean

Linear: PROD-8684

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DicvpsqAifVhH3S2PiBkL4