### PR TITLE
feat(data-apps): show linked app counts for connections

### DIFF
--- a/packages/backend/src/ee/controllers/externalConnectionController.ts
+++ b/packages/backend/src/ee/controllers/externalConnectionController.ts
@@ -12,6 +12,7 @@ import {
     type ApiTestExternalConnectionResponse,
     type CreateExternalConnection,
     type ExternalConnection,
+    type ExternalConnectionListItem,
     type ExternalFetchRequest,
     type ExternalFetchResponse,
     type UpdateExternalConnection,
@@ -47,7 +48,7 @@ type ApiExternalConnectionResponse = {
 
 type ApiExternalConnectionListResponse = {
     status: 'ok';
-    results: ExternalConnection[];
+    results: ExternalConnectionListItem[];
 };
 
 type ApiAppExternalConnectionListResponse = {

--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -5,6 +5,7 @@ import {
     NotFoundError,
     type CreateExternalConnection,
     type ExternalConnection,
+    type ExternalConnectionListItem,
     type ExternalConnectionSample,
     type ExternalConnectionSampleRequest,
     type UpdateExternalConnection,
@@ -335,12 +336,38 @@ export class ExternalConnectionModel {
     async list(
         projectUuid: string,
         organizationUuid: string,
-    ): Promise<ExternalConnection[]> {
+    ): Promise<ExternalConnectionListItem[]> {
+        const linkedDataAppCounts = this.database(
+            AppExternalConnectionsTableName,
+        )
+            .select(
+                `${AppExternalConnectionsTableName}.external_connection_uuid`,
+                this.database.raw('COUNT(DISTINCT ??) AS ??', [
+                    `${AppsTableName}.app_id`,
+                    'linked_data_app_count',
+                ]),
+            )
+            .innerJoin(
+                AppsTableName,
+                `${AppsTableName}.app_id`,
+                `${AppExternalConnectionsTableName}.app_id`,
+            )
+            .whereNull(`${AppsTableName}.deleted_at`)
+            .groupBy(
+                `${AppExternalConnectionsTableName}.external_connection_uuid`,
+            )
+            .as('linked_data_app_counts');
+
         const rows = await this.database(ExternalConnectionsTableName)
             .leftJoin(
                 ExternalConnectionSecretsTableName,
                 `${ExternalConnectionSecretsTableName}.external_connection_uuid`,
                 `${ExternalConnectionsTableName}.external_connection_uuid`,
+            )
+            .leftJoin(
+                linkedDataAppCounts,
+                `${ExternalConnectionsTableName}.external_connection_uuid`,
+                'linked_data_app_counts.external_connection_uuid',
             )
             .where(`${ExternalConnectionsTableName}.project_uuid`, projectUuid)
             .where(
@@ -351,19 +378,27 @@ export class ExternalConnectionModel {
             .orderBy(`${ExternalConnectionsTableName}.created_at`, 'desc')
             .select<
                 Array<
-                    DbExternalConnection & { encrypted_payload: Buffer | null }
+                    DbExternalConnection & {
+                        encrypted_payload: Buffer | null;
+                        linked_data_app_count: string;
+                    }
                 >
             >(
                 `${ExternalConnectionsTableName}.*`,
                 `${ExternalConnectionSecretsTableName}.encrypted_payload`,
+                this.database.raw('COALESCE(??, 0) AS ??', [
+                    'linked_data_app_counts.linked_data_app_count',
+                    'linked_data_app_count',
+                ]),
             );
 
-        return rows.map((row) =>
-            ExternalConnectionModel.mapToExternalConnection(
+        return rows.map((row) => ({
+            ...ExternalConnectionModel.mapToExternalConnection(
                 row,
                 row.encrypted_payload !== null,
             ),
-        );
+            linkedDataAppCount: Number(row.linked_data_app_count),
+        }));
     }
 
     /**

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -6,6 +6,7 @@ import {
     ParameterError,
     type ExternalConnection,
     type ExternalConnectionConfigProposal,
+    type ExternalConnectionListItem,
     type ExternalConnectionSample,
     type ExternalFetchResponse,
     type PossibleAbilities,
@@ -66,6 +67,11 @@ const connection: ExternalConnection = {
     updatedAt: new Date('2026-01-01T00:00:00Z'),
 };
 
+const listedConnection: ExternalConnectionListItem = {
+    ...connection,
+    linkedDataAppCount: 2,
+};
+
 const sampleRequest = {
     method: 'GET' as const,
     path: '/v1/weather',
@@ -111,7 +117,7 @@ function buildService(opts: {
     linkToAppFn?: import('vitest').Mock;
     findAppFn?: import('vitest').Mock;
     getCopilotConfigFn?: import('vitest').Mock;
-    connections?: ExternalConnection[];
+    connections?: ExternalConnectionListItem[];
 }) {
     const model = {
         findByUuid: vi
@@ -120,7 +126,7 @@ function buildService(opts: {
                 opts.connection !== undefined ? opts.connection : connection,
             ),
         getProjectOrganizationUuid: vi.fn().mockResolvedValue(orgUuid),
-        list: vi.fn().mockResolvedValue(opts.connections ?? [connection]),
+        list: vi.fn().mockResolvedValue(opts.connections ?? [listedConnection]),
         getDecryptedSecret: vi.fn().mockResolvedValue(opts.secret ?? 's3cr3t'),
         update:
             opts.updateFn ??
@@ -260,7 +266,7 @@ describe('ExternalConnectionService reads (view, not manage)', () => {
 
         const result = await service.list(viewerAccount, projectUuid);
 
-        expect(result).toEqual([connection]);
+        expect(result).toEqual([listedConnection]);
         expect(model.list).toHaveBeenCalledWith(projectUuid, orgUuid);
     });
 
@@ -269,14 +275,15 @@ describe('ExternalConnectionService reads (view, not manage)', () => {
             ...connection,
             externalConnectionUuid: 'private-connection',
             allowDataAppBuilderLinking: false,
+            linkedDataAppCount: 1,
         };
         const { service } = buildService({
-            connections: [connection, privateConnection],
+            connections: [listedConnection, privateConnection],
         });
         mockBuilderAbility(service);
 
         await expect(service.list(viewerAccount, projectUuid)).resolves.toEqual(
-            [connection],
+            [listedConnection],
         );
     });
 
@@ -285,14 +292,15 @@ describe('ExternalConnectionService reads (view, not manage)', () => {
             ...connection,
             externalConnectionUuid: 'private-connection',
             allowDataAppBuilderLinking: false,
+            linkedDataAppCount: 1,
         };
         const { service } = buildService({
-            connections: [connection, privateConnection],
+            connections: [listedConnection, privateConnection],
         });
         mockAdminAbility(service);
 
         await expect(service.list(adminAccount, projectUuid)).resolves.toEqual([
-            connection,
+            listedConnection,
             privateConnection,
         ]);
     });

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -14,6 +14,7 @@ import {
     type CreateExternalConnection,
     type ExternalConnection,
     type ExternalConnectionConfigProposal,
+    type ExternalConnectionListItem,
     type ExternalConnectionMethod,
     type ExternalConnectionSample,
     type ExternalConnectionSampleRequest,
@@ -219,7 +220,7 @@ export class ExternalConnectionService extends BaseService {
     async list(
         account: RegisteredAccount,
         projectUuid: string,
-    ): Promise<ExternalConnection[]> {
+    ): Promise<ExternalConnectionListItem[]> {
         // Derive the org from the project, not the caller, and filter by both,
         // so an org admin cannot list another org's project's connections.
         const organizationUuid =

--- a/packages/common/src/ee/externalConnections/types.ts
+++ b/packages/common/src/ee/externalConnections/types.ts
@@ -86,6 +86,10 @@ export type ExternalConnection = {
     updatedAt: Date;
 };
 
+export type ExternalConnectionListItem = ExternalConnection & {
+    linkedDataAppCount: number;
+};
+
 /** WRITE shape — includes the secret. */
 export type CreateExternalConnection = {
     name: string;

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
@@ -1,4 +1,8 @@
-import { assertUnreachable, type ExternalConnection } from '@lightdash/common';
+import {
+    assertUnreachable,
+    type ExternalConnection,
+    type ExternalConnectionListItem,
+} from '@lightdash/common';
 import { ActionIcon, Badge, Menu, Paper, Table, Text } from '@mantine/core';
 import { IconDots, IconPencil, IconTrash } from '@tabler/icons-react';
 import { type Dispatch, type FC, type SetStateAction } from 'react';
@@ -6,7 +10,7 @@ import tableStyles from '../../../hooks/styles/tableStyles.module.css';
 import MantineIcon from '../../common/MantineIcon';
 
 type Props = {
-    connections: ExternalConnection[];
+    connections: ExternalConnectionListItem[];
     setConnectionToEdit: Dispatch<
         SetStateAction<ExternalConnection | undefined>
     >;
@@ -31,7 +35,7 @@ const authLabel = (type: ExternalConnection['type']): string => {
 };
 
 const ConnectionRow: FC<
-    { connection: ExternalConnection } & Pick<
+    { connection: ExternalConnectionListItem } & Pick<
         Props,
         'setConnectionToEdit' | 'setConnectionToDelete'
     >
@@ -53,6 +57,11 @@ const ConnectionRow: FC<
         <Table.Td>
             <Text fz="sm" c="ldGray.6">
                 {connection.allowedMethods.join(', ')}
+            </Text>
+        </Table.Td>
+        <Table.Td>
+            <Text fz="sm" c="ldGray.6">
+                {connection.linkedDataAppCount}
             </Text>
         </Table.Td>
         <Table.Td>
@@ -114,6 +123,7 @@ export const ConnectionsTable: FC<Props> = ({
                         <Table.Th>Origin</Table.Th>
                         <Table.Th>Auth</Table.Th>
                         <Table.Th>Methods</Table.Th>
+                        <Table.Th>Linked apps</Table.Th>
                         <Table.Th>Builder linking</Table.Th>
                         <Table.Th></Table.Th>
                     </Table.Tr>

--- a/packages/frontend/src/features/externalConnections/hooks/useExternalConnections.ts
+++ b/packages/frontend/src/features/externalConnections/hooks/useExternalConnections.ts
@@ -1,16 +1,19 @@
-import { type ApiError, type ExternalConnection } from '@lightdash/common';
+import {
+    type ApiError,
+    type ExternalConnectionListItem,
+} from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
 const getExternalConnections = async (projectUuid: string) =>
-    lightdashApi<ExternalConnection[]>({
+    lightdashApi<ExternalConnectionListItem[]>({
         url: `/ee/projects/${projectUuid}/external-connections`,
         method: 'GET',
         body: undefined,
     });
 
 export const useExternalConnections = (projectUuid: string | undefined) =>
-    useQuery<ExternalConnection[], ApiError>({
+    useQuery<ExternalConnectionListItem[], ApiError>({
         queryKey: ['external-connections', projectUuid],
         queryFn: () => getExternalConnections(projectUuid!),
         enabled: !!projectUuid,


### PR DESCRIPTION
## What changed

- Include a required `linkedDataAppCount` in the project external-connections list response.
- Count distinct, non-deleted data apps for each connection.
- Show the count in a new **Linked apps** column in the settings table.

## Why

Connection admins currently cannot see whether a connection is in use from the list, which makes management actions harder to assess.

## Implementation notes

The count is pre-aggregated by external connection before it is joined into the existing connection/secret query. This keeps the outer query free of grouping, excludes soft-deleted apps, and avoids counting multiple aliases from the same app more than once.

## Validation

- Focused external-connection service suite: 51 tests passed
- Common, backend, and frontend typechecks
- Targeted backend/common/frontend lint and formatting
- API generation
- Browser verification at `localhost:3000`: the new column rendered and showed the expected counts for local connections
- `git diff --check`