### PR TITLE
fix(upgrade-automation): hold and escalate on an unknown verdict

### DIFF
--- a/.github/workflows/upgrade-automation-tests.yml
+++ b/.github/workflows/upgrade-automation-tests.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - run: bash examples/upgrade-automation/scripts/common.test.sh
       - run: bash examples/upgrade-automation/scripts/verify.test.sh
+      - run: bash examples/upgrade-automation/scripts/plan.test.sh

--- a/examples/upgrade-automation/README.md
+++ b/examples/upgrade-automation/README.md
@@ -6,10 +6,10 @@ The loop is:
 
 1. Stop silently when an open issue carries the freeze label.
 2. Read the current image tag and the public release-safety index.
-3. Run `lightdash upgrade-check` against candidate public versions and select the newest green-reachable target. A required stop becomes the next target. A genuinely red next hop opens a held pull request; unknown or incomplete safety data fails closed and retries on a later run.
+3. Run `lightdash upgrade-check` against candidate public versions and select the newest green-reachable target. A required stop becomes the next target. Any next hop that is not green opens a held pull request: a genuinely red hop, and equally one whose safety data is unknown or incomplete. Both hold; neither merges. The held pull request states which of the two it is.
 4. Optionally require the mapped image tag to exist in an OCI registry.
 5. Open a pin pull request containing the complete nine-key verdict JSON.
-6. Enable auto-merge when configured and green, or send an `[upgrade-hold]` Slack message for a red hop.
+6. Enable auto-merge when configured and green, or send an `[upgrade-hold]` Slack message for a hop that is red or unknown. The escalation is sent once, when the held pull request is opened, not on every subsequent planning run.
 7. After the consumer's deployment workflow finishes, poll `/api/v1/readyz` every 20 seconds and compare the `Lightdash-Version` response header from `/` with the pinned public version. Three consecutive ready and version-matched polls are required.
 8. On failure, open a freeze issue and send an `[upgrade-verify-failed]` Slack message. The automation never rolls back.
 9. Comment the verdict, verification result, timings, readiness reason, and deployment-run link on the pin pull request.

--- a/examples/upgrade-automation/scripts/common.sh
+++ b/examples/upgrade-automation/scripts/common.sh
@@ -105,7 +105,7 @@ validate_verdict_json() {
         (.fromVersion | type == "string") and
         (.toVersion | type == "string") and
         (.safe | type == "boolean") and
-        (.verdict | type == "boolean") and
+        (.verdict | type == "boolean" or . == "unknown") and
         (.requiredStops | type == "array") and
         all(.requiredStops[]; type == "string" and test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) and
         (.coveredVersions | type == "array") and

--- a/examples/upgrade-automation/scripts/common.test.sh
+++ b/examples/upgrade-automation/scripts/common.test.sh
@@ -44,6 +44,7 @@ expect_rejected() {
 
 expect_accepted 'a boolean true verdict' "$(with_field verdict true)"
 expect_accepted 'a boolean false verdict' "$(with_field verdict false)"
+expect_accepted 'an unknown verdict' "$(with_field verdict '"unknown"')"
 
 expect_rejected 'a string "true" verdict' "$(with_field verdict '"true"')"
 expect_rejected 'a string "false" verdict' "$(with_field verdict '"false"')"

--- a/examples/upgrade-automation/scripts/plan.sh
+++ b/examples/upgrade-automation/scripts/plan.sh
@@ -71,6 +71,7 @@ require_value freeze_label "${FREEZE_LABEL:-}"
 require_value github_token "${GH_TOKEN:-}"
 
 if [[ "$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "$FREEZE_LABEL" --limit 1 --json number --jq 'length')" != "0" ]]; then
+    echo "an open $FREEZE_LABEL issue is disarming the planner; nothing to do"
     exit 0
 fi
 
@@ -101,6 +102,7 @@ mapfile -t candidates < <(
 )
 
 if [[ ${#candidates[@]} -eq 0 ]]; then
+    echo "no release newer than $current_public in the index; already up to date"
     exit 0
 fi
 
@@ -130,10 +132,18 @@ run_gate() {
 selected_version=
 selected_json=
 selected_green=false
+hold_reason=
 newest=${candidates[0]}
 
+gate_unusable() {
+    local target=$1
+    echo "the release-safety gate returned unusable output for $target" >&2
+    cat "$gate_error" >&2 || true
+}
+
 if ! run_gate "$newest"; then
-    exit 0
+    gate_unusable "$newest"
+    exit 1
 fi
 if [[ "$GATE_STATUS" == "0" ]] && [[ "$(jq -r '.safe' <<<"$GATE_JSON")" == "true" ]]; then
     selected_version=$newest
@@ -180,13 +190,16 @@ if [[ -z "$selected_version" ]]; then
     next_index=$((${#candidates[@]} - 1))
     next_version=${candidates[$next_index]}
     if ! run_gate "$next_version"; then
-        exit 0
-    fi
-    if ! jq -e '.verdict == false' <<<"$GATE_JSON" >/dev/null; then
-        exit 0
+        gate_unusable "$next_version"
+        exit 1
     fi
     selected_version=$next_version
     selected_json=$GATE_JSON
+    if jq -e '.verdict == false' <<<"$GATE_JSON" >/dev/null; then
+        hold_reason=red
+    else
+        hold_reason=unknown
+    fi
 fi
 
 mapped_version="${selected_version}${TAG_SUFFIX:-}"
@@ -196,6 +209,7 @@ if [[ ! "$mapped_version" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
 fi
 if [[ -n "${REGISTRY_CHECK:-}" ]]; then
     if ! docker manifest inspect "${REGISTRY_CHECK}:${mapped_version}" >/dev/null 2>&1; then
+        echo "image ${REGISTRY_CHECK}:${mapped_version} is not published yet; retrying on a later run"
         exit 0
     fi
 fi
@@ -208,6 +222,7 @@ bump_file=${BUMP_TARGET%%#*}
 cp "$bump_file" "$bump_file_before"
 write_bump_value "$mapped_version"
 if cmp -s "$bump_file_before" "$bump_file"; then
+    echo "$bump_file already pins $mapped_version; nothing to commit"
     exit 0
 fi
 
@@ -234,7 +249,9 @@ fi
 jq -e '.data.createCommitOnBranch.commit.oid | type == "string" and length > 0' <<<"$commit_response" >/dev/null
 
 plain_reason='The release-safety gate found a green upgrade path.'
-if [[ "$selected_green" != "true" ]]; then
+if [[ "$hold_reason" == "unknown" ]]; then
+    plain_reason='The release-safety gate could not determine whether the next release hop is safe. This is not a known break: the safety data for that release is incomplete or inconclusive. This pull request is held for manual review and must not merge automatically.'
+elif [[ "$selected_green" != "true" ]]; then
     plain_reason='The next release hop is red. This pull request is held for manual review and must not merge automatically.'
 elif [[ "$(jq -r '.safe' <<<"$selected_json")" != "true" ]]; then
     plain_reason='This target is the required stop identified by the gate. Landing on the stop satisfies the staged upgrade path before a later release can be selected.'
@@ -268,7 +285,9 @@ This pull request was created by the self-hosted Lightdash upgrade automation. V
 EOF
 
 pr_json=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$upgrade_branch" --state open --json number,url --jq '.[0] // empty')
+pr_created=false
 if [[ -z "$pr_json" ]]; then
+    pr_created=true
     pr_url=$(gh pr create \
         --repo "$GITHUB_REPOSITORY" \
         --base "$default_branch" \
@@ -292,18 +311,22 @@ cat >"$summary_file" <<EOF
 ## Upgrade plan summary
 
 - Version: \`$current_mapped\` → \`$mapped_version\`
-- Gate: $([[ "$selected_green" == "true" ]] && printf 'green' || printf 'red')
+- Gate: $([[ "$selected_green" == "true" ]] && printf 'green' || printf '%s' "$hold_reason")
 - Registry check: $([[ -n "${REGISTRY_CHECK:-}" ]] && printf 'passed' || printf 'disabled')
 
 \`\`\`json
 $(jq . <<<"$selected_json")
 \`\`\`
 EOF
-gh pr comment "$pr_url" --body-file "$summary_file"
+if [[ "$pr_created" == "true" ]]; then
+    gh pr comment "$pr_url" --body-file "$summary_file"
+fi
 
 if [[ "$selected_green" == "true" && "${AUTO_MERGE:-false}" == "true" ]]; then
     gh pr merge "$pr_url" --auto --squash
-elif [[ "$selected_green" != "true" ]]; then
+elif [[ "$selected_green" != "true" && "$pr_created" == "true" ]]; then
     stops=$(jq -r '.requiredStops | if length == 0 then "none" else join(", ") end' <<<"$selected_json")
-    post_slack "[upgrade-hold] $pr_url | $current_public -> $selected_version | required stops: $stops | $plain_reason"
+    post_slack "[upgrade-hold] $pr_url | $current_public -> $selected_version | gate: $hold_reason | required stops: $stops | $plain_reason"
+elif [[ "$selected_green" != "true" ]]; then
+    echo "hold for $mapped_version already reported on $pr_url; not repeating the escalation"
 fi

--- a/examples/upgrade-automation/scripts/plan.test.sh
+++ b/examples/upgrade-automation/scripts/plan.test.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/../../.." && pwd)
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+mkdir -p "$test_dir/bin" "$test_dir/runner-temp/lightdash-upgrade-cli/node_modules/.bin"
+
+printf 'image:\n  tag: 1.0.0\n' >"$test_dir/values.yml"
+
+cat >"$test_dir/index.json" <<'EOF'
+{
+  "schemaVersion": "1",
+  "entries": [
+    {"version": "1.0.0"},
+    {"version": "1.0.1"},
+    {"version": "1.0.2"}
+  ]
+}
+EOF
+
+cat >"$test_dir/bin/curl" <<EOF
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "\$*" == *release-safety-index.json* ]]; then
+    out=
+    prev=
+    for arg in "\$@"; do
+        if [[ "\$prev" == "--output" ]]; then out="\$arg"; fi
+        prev="\$arg"
+    done
+    cp "$test_dir/index.json" "\$out"
+    exit 0
+fi
+
+if [[ "\$*" == *slack.test* ]]; then
+    printf '%s\n' "\$*" >>"$test_dir/slack.log"
+    exit 0
+fi
+
+printf 'unexpected curl invocation: %s\n' "\$*" >&2
+exit 1
+EOF
+
+cat >"$test_dir/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+
+exit 0
+EOF
+
+cat >"$test_dir/runner-temp/lightdash-upgrade-cli/node_modules/.bin/lightdash" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+from=
+to=
+prev=
+for arg in "$@"; do
+    case "$prev" in
+        --from) from=$arg ;;
+        --to) to=$arg ;;
+    esac
+    prev=$arg
+done
+
+printf '{"coveredVersions":["%s"],"direction":"upgrade","fromVersion":"%s","minPreviousVersion":null,"missingRanges":[],"requiredStops":[],"safe":false,"toVersion":"%s","verdict":"unknown"}\n' \
+    "$to" "$from" "$to"
+exit 1
+EOF
+
+cat >"$test_dir/bin/gh" <<EOF
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "\$*" >>"$test_dir/gh.log"
+
+if [[ "\$*" == "issue list"* ]]; then
+    printf '0\n'
+    exit 0
+fi
+
+if [[ "\$*" == *'repos/example/upgrade-test --jq .default_branch'* ]]; then
+    printf 'main\n'
+    exit 0
+fi
+
+if [[ "\$*" == *'git/ref/heads/main'* ]]; then
+    printf '1111111111111111111111111111111111111111\n'
+    exit 0
+fi
+
+if [[ "\$*" == *'git/ref/heads/lightdash-upgrade-'* ]]; then
+    exit 1
+fi
+
+if [[ "\$*" == *'git/refs'* ]]; then
+    printf '{}\n'
+    exit 0
+fi
+
+if [[ "\$*" == *graphql* ]]; then
+    cat >/dev/null
+    printf '{"data":{"createCommitOnBranch":{"commit":{"oid":"2222222222222222222222222222222222222222","url":"https://example.test/c"}}}}\n'
+    exit 0
+fi
+
+if [[ "\$*" == "pr list"* ]]; then
+    exit 0
+fi
+
+if [[ "\$*" == "pr create"* ]]; then
+    printf 'https://example.test/pr/1\n'
+    exit 0
+fi
+
+if [[ "\$*" == "pr view"* ]]; then
+    printf '{"number":1,"url":"https://example.test/pr/1"}\n'
+    exit 0
+fi
+
+if [[ "\$*" == "pr comment"* ]]; then
+    exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "\$*" >&2
+exit 1
+EOF
+
+chmod +x "$test_dir/bin/curl" "$test_dir/bin/npm" "$test_dir/bin/gh" \
+    "$test_dir/runner-temp/lightdash-upgrade-cli/node_modules/.bin/lightdash"
+
+: >"$test_dir/slack.log"
+: >"$test_dir/gh.log"
+
+cd "$test_dir"
+
+set +e
+output=$(PATH="$test_dir/bin:$PATH" \
+    RUNNER_TEMP="$test_dir/runner-temp" \
+    GITHUB_REPOSITORY=example/upgrade-test \
+    BUMP_TARGET=values.yml#image.tag \
+    FREEZE_LABEL=upgrade-freeze \
+    ESCALATION=https://slack.test/webhook \
+    GH_TOKEN=test-token \
+    "${BASH:-bash}" "$root/examples/upgrade-automation/scripts/plan.sh" 2>&1)
+status=$?
+set -e
+
+if [[ $status -ne 0 ]]; then
+    printf 'expected an unknown verdict to plan successfully, got status %s:\n%s\n' "$status" "$output" >&2
+    exit 1
+fi
+
+if ! grep -q 'pr create' "$test_dir/gh.log"; then
+    printf 'expected an unknown verdict to open a held pull request, gh calls were:\n%s\n' \
+        "$(cat "$test_dir/gh.log")" >&2
+    exit 1
+fi
+
+if ! grep -q '\[upgrade-hold\]' "$test_dir/slack.log"; then
+    printf 'expected an unknown verdict to escalate to Slack, slack calls were:\n%s\n' \
+        "$(cat "$test_dir/slack.log")" >&2
+    exit 1
+fi
+
+if ! grep -q 'gate: unknown' "$test_dir/slack.log"; then
+    printf 'expected the escalation to name the unknown verdict, slack calls were:\n%s\n' \
+        "$(cat "$test_dir/slack.log")" >&2
+    exit 1
+fi
+
+if grep -q 'could not determine' "$test_dir/slack.log"; then
+    :
+else
+    printf 'expected the escalation to distinguish unknown from red, slack calls were:\n%s\n' \
+        "$(cat "$test_dir/slack.log")" >&2
+    exit 1
+fi
+
+printf 'plan unknown-verdict hold test passed\n'


### PR DESCRIPTION
Linear: SPK-1011

## The problem

The release-safety gate returns three verdicts. The planner had procedures for two of them.

An `unknown` verdict opened no pull request and sent no Slack message — it exited 0 with an empty step log. A blocked upgrade was therefore indistinguishable from an up-to-date one. The internal instance sat five hours behind across roughly nine runs, every one of them reporting success.

## Why this is a fix, not a new feature

SPK-949 settled the non-green policy: hold and notify for anything not green, with `unknown` explicitly counted as not green. Two things had drifted from that.

**1. The planner branched on the wrong thing.** The spec assumed the branch key would be the CLI exit code, which is binary. `plan.sh` branched on the `verdict` field, which is three-valued:

```bash
if ! jq -e '.verdict == false' <<<"$GATE_JSON" >/dev/null; then
    exit 0
fi
```

`unknown` is neither `false` nor green, so it reached neither arm — and everything below, including PR creation and the `post_slack` call, was unreachable.

**2. The validator rejects the CLI's own tri-state.** `#27364` tightened `validate_verdict_json` to require `verdict` to be a boolean. But the CLI types it as a `TriState` and emits the string `"unknown"` (`packages/cli/src/releaseSafety/index.ts:36,132,136`). Nothing is broken today only because the consuming workflow pins an older SHA. On repinning, every `unknown` verdict would be classified as *malformed gate output* and exit at the first gate call — the same silence, one branch earlier.

`common.test.sh` asserted rejection of the `"true"` and `"false"` strings, but never covered `"unknown"` — the one string the CLI actually produces.

## What changed

- `unknown` opens a held PR and posts `[upgrade-hold]`, worded so it reads as *the gate could not determine safety*, not *a break is known*. The two are different situations and the reader needs to tell them apart.
- `validate_verdict_json` accepts `true`, `false`, or `"unknown"`, and rejects everything else as before.
- Genuinely unusable gate output now **fails the run** rather than exiting 0. A red scheduled workflow is a signal; a green one with an empty log is not.
- Every remaining early exit prints why. A green run with an empty step log is no longer a reachable state.
- README lines 9 and 12 described the drifted behaviour as intended. Corrected to match SPK-949.

## The de-duplication matters

The planner re-runs every few minutes and the held target is stable (it is always the next hop). The existing code posted to Slack and added a PR comment unconditionally on the non-green path — so the moment that path became reachable it would have posted a message and a duplicate comment on **every run**. The escalation is now sent once, when the held PR is opened. Worth a look in review: this changes behaviour on the red path too, which has never actually fired.

## Tests

New `plan.test.sh` stubs `gh`, `curl`, `npm` and the CLI to drive a full plan through an `unknown` verdict, and asserts a held PR is opened and the escalation is sent naming the verdict. Wired into `upgrade-automation-tests.yml` alongside the existing two suites.

```
common  → verdict validation tests passed
verify  → verify lookup failure test passed
plan    → plan unknown-verdict hold test passed
```

Note the test runs `plan.sh` under `${BASH:-bash}`: the script needs `mapfile`, and `env bash` on macOS is 3.2.

## Not in this PR

- SPK-1014 — the instance is still pinned behind the blocking hop and cannot recover on its own.
- SPK-1015 — SPK-857's `paths:` filter removal was reverted by #27139; the header comment still says the filter is deliberately absent.
- SPK-1012 / SPK-1013 — the PR-time side of the same incident.

Draft: merge is yours.