### PR TITLE
fix(release-safety): remove the trigger-level paths filter again

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -16,7 +16,13 @@ name: Release-safety preview
 # of every PR diff, and diffing it against itself reports "no breaking changes"
 # for an API break it never looked at.
 
-# SPK-857: no `paths:` filter here, deliberately. With a trigger-level filter,
+# SPK-857 / SPK-1015: no `paths:` filter here, deliberately. This has now been
+# removed twice — #26995 took it out for SPK-857 and #27139 put it back, leaving
+# this comment describing code that no longer matched it. If you are about to add
+# one, read the next paragraph first; `release-safety-workflow-shape.test.ts`
+# fails the build if a trigger-level filter reappears.
+#
+# With a trigger-level filter,
 # a PR revision whose diff leaves the watched paths stops launching the workflow
 # entirely — and the sticky comment (write-forward-only) freezes at the last
 # matching revision, describing a diff that no longer exists. Graphite restacks
@@ -35,27 +41,6 @@ on:
     # `edited` too; the `changes` job short-circuits those via the comment's
     # describes-stamp instead of re-running the heavy jobs.
     types: [opened, synchronize, reopened, ready_for_review, edited]
-    # The OpenAPI surface is not a file list: TSOA derives the spec from the
-    # controllers and every type they reach, so any backend or common change can
-    # move it (this is also why `.github/file-filters.yml`'s api_schema filter is
-    # deliberately broad). Migrations and the MCP snapshot live under those two
-    # globs too; the generated swagger.json used to be listed here on its own,
-    # which is what left the REST check unreachable.
-    paths:
-      - 'packages/backend/**'
-      - 'packages/common/**'
-      - 'release-safety.overrides.json'
-      - 'scripts/gen-release-safety.ts'
-      - 'scripts/ai-migration-review.ts'
-      - 'scripts/sql-migration-lint.ts'
-      - 'scripts/rest-api-diff.ts'
-      - 'scripts/mcp-tools-diff.ts'
-      - 'scripts/breaking-change-declarations.ts'
-      - 'scripts/release-safety-pr-gate.ts'
-      - 'scripts/upgrade-overrides.ts'
-      - 'scripts/release-safety-pr-comment.ts'
-      - '.github/file-filters.yml'
-      - '.github/workflows/release-safety-pr.yml'
 
 # Spec generation makes a run long enough that an older run could otherwise
 # finish last and overwrite the sticky comment with a stale verdict.
@@ -114,6 +99,8 @@ jobs:
               - 'scripts/sql-migration-lint.ts'
               - 'scripts/rest-api-diff.ts'
               - 'scripts/mcp-tools-diff.ts'
+              - 'scripts/breaking-change-declarations.ts'
+              - 'scripts/release-safety-pr-gate.ts'
               - 'scripts/upgrade-overrides.ts'
               - 'scripts/release-safety-pr-comment.ts'
               - '.github/file-filters.yml'

--- a/scripts/release-safety-workflow-shape.test.ts
+++ b/scripts/release-safety-workflow-shape.test.ts
@@ -1,0 +1,53 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+
+const WORKFLOW_PATH = '.github/workflows/release-safety-pr.yml';
+const workflow = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+
+const lines = workflow.split('\n');
+const withoutComments = lines.filter((line) => !/^\s*#/.test(line));
+
+const triggerStart = withoutComments.findIndex((line) => /^on:/.test(line));
+assert.notStrictEqual(triggerStart, -1, `no "on:" block in ${WORKFLOW_PATH}`);
+
+const triggerEnd = withoutComments.findIndex(
+    (line, index) => index > triggerStart && /^\S/.test(line),
+);
+const triggerBlock = withoutComments.slice(
+    triggerStart,
+    triggerEnd === -1 ? undefined : triggerEnd,
+);
+
+// SPK-857 removed the trigger-level `paths:` filter; SPK-924 (#27139) restored
+// it and SPK-1015 removed it again. A trigger-level filter stops the workflow
+// launching at all once a PR revision's diff leaves the watched paths, so the
+// sticky comment freezes describing a revision that no longer exists and the
+// `retract` job never runs to correct it. It also makes the check impossible to
+// mark as required: PRs that touch none of the watched paths would never report
+// it and could never merge. The in-job `changes` filter is the supported way to
+// skip unwatched diffs.
+const offending = triggerBlock.filter((line) => /^\s*paths(-ignore)?:/.test(line));
+assert.deepStrictEqual(
+    offending,
+    [],
+    `${WORKFLOW_PATH} must not use a trigger-level paths filter (see SPK-857 / SPK-1015); found:\n${offending.join('\n')}`,
+);
+
+// The in-job filter is what decides whether the heavy jobs run, so it has to
+// cover every path that can move the release-safety verdict. These two were
+// present only in the trigger-level list, which made `retract` unreachable for
+// every other watched path.
+for (const required of [
+    'scripts/breaking-change-declarations.ts',
+    'scripts/release-safety-pr-gate.ts',
+    'scripts/gen-release-safety.ts',
+    'packages/backend/**',
+    'packages/common/**',
+]) {
+    assert.ok(
+        workflow.includes(`- '${required}'`),
+        `${WORKFLOW_PATH} in-job watched filter is missing ${required}`,
+    );
+}
+
+process.stdout.write('release-safety workflow shape tests passed\n');


### PR DESCRIPTION
Linear: SPK-1015

## What happened

SPK-857 removed this filter in #26995 and moved the path list into the in-job `changes` job. **#27139 put it back** — and left SPK-857's header comment in place, so for the last while the file has read:

> SPK-857: no `paths:` filter here, deliberately.

…six lines above a `paths:` filter.

## Why it matters

**1. SPK-857's bug is live again.** For `pull_request`, GitHub evaluates `paths` against the PR's whole diff. A revision that moves the diff off the watched paths stops launching the workflow entirely, so `retract` never runs and the sticky comment freezes describing a revision that no longer exists.

**2. `retract` is almost unreachable.** It is gated on `watched != 'true'`, but the trigger list was a strict superset of the in-job `watched` list — differing by exactly two files. So `retract` could only fire for a PR touching one of those two and nothing else watched. Both are added to the in-job filter here so the lists agree.

**3. It blocks making this check required.** A PR touching none of the watched paths never reports the check at all, so a required check could never be satisfied and the PR could never merge. This is the prerequisite for that.

## The guard

`scripts/release-safety-workflow-shape.test.ts` fails the build if a trigger-level `paths:`/`paths-ignore:` reappears, and if the in-job filter loses a path that can move the verdict. It runs under the existing `test:release-safety` script.

I checked it fails rather than merely passes — reintroducing the filter locally produces:

```
AssertionError: .github/workflows/release-safety-pr.yml must not use a
trigger-level paths filter (see SPK-857 / SPK-1015)
```

A comment was the only thing protecting this before, and it did not survive #27139. Hence a test.

## Cost

Unwatched PRs now start the workflow rather than being filtered out at the trigger. That is one `changes` job — a dorny `paths-filter` step reading the PR file list from the API with no checkout. The heavy `openapi-specs` and `preview` jobs stay gated on `watched == 'true'`, so nothing expensive changes.