### PR TITLE
fix(release-safety): never write a verdict to a merged pull request

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -58,6 +58,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
+      # SPK-1012: 'true' only while the PR is still open and unmerged. Read live
+      # from the API, not from the event payload — the payload describes the PR
+      # as it was when the event fired, which for a post-merge run is precisely
+      # the stale fact we must not trust.
+      open: ${{ steps.openness.outputs.open }}
       watched: ${{ steps.watched.outputs.watched }}
       base_sha: ${{ steps.base.outputs.sha }}
       base_short: ${{ steps.base.outputs.short }}
@@ -70,6 +75,37 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
+
+      # SPK-1012: a merged or closed PR must never receive a verdict. Pushing to
+      # the branch after a merge still fires `synchronize`, and GitHub does not
+      # suppress `pull_request` events on merged PRs — so a run can be created,
+      # and finish, entirely post-merge. Two things then go wrong at once: the
+      # write step's only staleness guard compares head SHAs, and merging does
+      # not move the head, so it passes; and the comparison base is re-resolved
+      # at run time against a `main` that now contains this PR, so the API diff
+      # comes out empty. The result is a comment certifying "no breaking changes"
+      # for a PR that carried them. Observed on #27393, which was stamped safe
+      # 21 minutes after it merged while its release carried 42 breaking REST
+      # changes.
+      #
+      # Checked before the path filter so a post-merge run costs one API call.
+      - name: Check the pull request is still open
+        id: openness
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const open = pr.state === 'open' && !pr.merged;
+            if (!open) {
+              core.info(
+                `PR is ${pr.merged ? 'merged' : pr.state}; no verdict will be written or retracted.`,
+              );
+            }
+            core.setOutput('open', String(open));
 
       # The watched surface — the paths that were previously the trigger-level
       # `paths:` filter (see the `on:` comment). Checked FIRST, without a
@@ -85,6 +121,7 @@ jobs:
       # filter is deliberately broad). Migrations and the MCP snapshot live
       # under those two globs too.
       - name: Check whether the diff touches the watched surface
+        if: steps.openness.outputs.open == 'true'
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: watched
         with:
@@ -177,7 +214,7 @@ jobs:
   openapi-specs:
     name: Generate API snapshots
     needs: changes
-    if: needs.changes.outputs.openapi == 'true' && needs.changes.outputs.fresh != 'true'
+    if: needs.changes.outputs.open == 'true' && needs.changes.outputs.openapi == 'true' && needs.changes.outputs.fresh != 'true'
     runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 30
     env:
@@ -250,7 +287,7 @@ jobs:
     # Skipped entirely when the diff doesn't touch the watched surface — the
     # `retract` job owns the comment in that case — and on an `edited` event
     # whose head+base the comment already describes (SPK-858).
-    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.watched == 'true' && needs.changes.outputs.fresh != 'true' }}
+    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.open == 'true' && needs.changes.outputs.watched == 'true' && needs.changes.outputs.fresh != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -464,6 +501,16 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
+            // SPK-1012: re-checked here and not only in `changes`, because that
+            // gate is evaluated when the job starts and this run takes ~17
+            // minutes. A PR that merges mid-run passes the job gate and reaches
+            // this step, where the base it was compared against is no longer the
+            // base it would be compared against now.
+            if (pr.state !== 'open' || pr.merged) {
+              core.info(`PR is ${pr.merged ? 'merged' : pr.state}; not writing a verdict.`);
+              return;
+            }
+
             const eventHead = context.payload.pull_request.head.sha;
             if (pr.head.sha !== eventHead) {
               core.info(`PR head moved on (${eventHead.slice(0, 7)} -> ${pr.head.sha.slice(0, 7)}); not writing a stale verdict.`);
@@ -509,7 +556,7 @@ jobs:
   retract:
     name: Retract a stale verdict
     needs: changes
-    if: ${{ needs.changes.result == 'success' && needs.changes.outputs.watched != 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ needs.changes.result == 'success' && needs.changes.outputs.open == 'true' && needs.changes.outputs.watched != 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -533,6 +580,11 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
+            if (pr.state !== 'open' || pr.merged) {
+              core.info(`PR is ${pr.merged ? 'merged' : pr.state}; leaving the comment as it stands.`);
+              return;
+            }
+
             if (pr.head.sha !== headSha) {
               core.info(`PR head moved on (${short} -> ${pr.head.sha.slice(0, 7)}); leaving the comment to the newer run.`);
               return;

--- a/scripts/release-safety-workflow-shape.test.ts
+++ b/scripts/release-safety-workflow-shape.test.ts
@@ -50,4 +50,20 @@ for (const required of [
     );
 }
 
+// SPK-1012: a merged or closed PR must never receive a verdict. The job-level
+// gate alone is not enough — it is evaluated when the job starts, and the run
+// takes long enough that a PR can merge mid-run — so the two write steps check
+// again immediately before writing.
+const openGates = workflow.match(/needs\.changes\.outputs\.open == 'true'/g) ?? [];
+assert.ok(
+    openGates.length >= 3,
+    `expected openapi-specs, preview and retract to be gated on the PR being open; found ${openGates.length} gate(s)`,
+);
+
+const mergedChecks = workflow.match(/pr\.merged/g) ?? [];
+assert.ok(
+    mergedChecks.length >= 3,
+    `expected the openness step and both write steps to check pr.merged; found ${mergedChecks.length}`,
+);
+
 process.stdout.write('release-safety workflow shape tests passed\n');


### PR DESCRIPTION
Linear: SPK-1012

> Was stacked on #27414 (SPK-1015); that merged as `15259855`, so this has been rebased onto `main` and retargeted.

## The bug

A push to a branch after its PR merges still fires `synchronize`, and GitHub does not suppress `pull_request` events on merged PRs. So a run can be created, and finish, entirely post-merge. Two things then go wrong together:

- The write step's only staleness guard compares head SHAs — and **merging does not move the head**, so it passes.
- The comparison base is re-resolved at run time against a `main` that now contains the PR, so the API diff comes out empty.

The result is a comment certifying **"✅ Safe to upgrade normally / REST API: no breaking changes"** for a PR that carried breaking changes.

## It already happened

PR #27393, today:

| Event | Time (UTC) | After merge |
|---|---|---|
| Merged | 04:43:48 | — |
| Run created (`pull_request`) | 04:48:21 | +4m33s |
| First job started | 04:56:52 | +13m04s |
| ✅ verdict written | 05:05:10 | **+21m22s** |

The comment declares its base as `938a8ceb34` — #27393's own merge commit on `main`. The true merge-base is `d92d5979`. The release that PR went into recorded `breaking: true, breakingCount: 42` and `rollingUpdateSafe: "unknown"` — and that `unknown` is what then stalled the analytics auto-upgrade for five hours.

So the false green was not cosmetic. It was the first domino.

## The fix

`changes` reads the PR's **live** state — not `github.event.pull_request`, which for a post-merge run describes precisely the stale fact we must not trust — and `openapi-specs`, `preview` and `retract` are gated on it. A post-merge run now costs one API call instead of two full spec builds.

Both write steps re-check immediately before writing. **This is not belt-and-braces:** the job gate is evaluated when the job starts, and the run takes ~17 minutes. A PR that merges mid-run clears the gate and reaches the write. That is the actual shape of what happened to #27393.

## Tests

Extends `release-safety-workflow-shape.test.ts` with both invariants. Verified each fails when removed, e.g. stripping the job gates:

```
AssertionError: expected openapi-specs, preview and retract to be gated
on the PR being open; found 0 gate(s)
```

## Deliberately not here

Reconciling the base: I considered failing loudly when the resolved merge-base equals the PR's own merge commit, since that state is always wrong. The merged/closed check subsumes it — that base can only be resolved after a merge — so the extra check would be unreachable code. Raise it again if a pre-merge path to it turns up.