### PR TITLE
chore: enable new homepage in development seed

### DIFF
--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -125,6 +125,12 @@ export async function seed(knex: Knex): Promise<void> {
     const { organizationId, organizationUuid } =
         await addOrganization(SEED_ORG_1);
 
+    await knex('organization_homepage_settings').insert({
+        organization_uuid: organizationUuid,
+        enabled: true,
+        opening: null,
+    });
+
     // Add user attribute
     await new UserAttributesModel({ database: knex }).create(
         SEED_ORG_1.organization_uuid,


### PR DESCRIPTION
## What

- Enable the new homepage for the seeded Jaffle Shop organization.
- Keep `opening: null`, allowing AI availability to choose Ask-first versus Content-first.

## Why

Local and preview seed environments should open on the new homepage by default so the current homepage experience is available immediately after seeding.

## Impact

Development and preview seed data only. This has no production impact.

## Screenshot

<img width="2583" height="1647" alt="image" src="https://github.com/user-attachments/assets/2e299604-e45a-4047-a3b6-10e634b08374" />

## Validation

- `pnpm -F backend run linter src/database/seeds/development/01_initial_user.ts`
- `pnpm -F backend run formatter src/database/seeds/development/01_initial_user.ts --check`
- `pnpm -F backend typecheck`
- `git diff --check`

The seed itself was not rerun during validation because it resets local seeded data.

<!-- test-frontend -->