### PR TITLE
feat: add source attribution to AI writeback events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1942,6 +1942,14 @@ export type DataAppEvent =
     | DataAppUploadedEvent
     | DataAppUploadRejectedEvent;
 
+export type AiWritebackEventSource =
+    | 'chat'
+    | 'slack'
+    | 'api'
+    | 'mcp'
+    | 'review_item'
+    | 'unknown';
+
 export type AiWritebackStartedEvent = BaseTrack & {
     event: 'ai_writeback.started';
     userId: string;
@@ -1953,6 +1961,7 @@ export type AiWritebackStartedEvent = BaseTrack & {
         owner: string;
         repo: string;
         workstream: AiWritebackWorkstream;
+        source: AiWritebackEventSource;
         // Whether this turn resumed an existing conversation (and its sandbox)
         // rather than starting a fresh one.
         isResume: boolean;
@@ -1970,6 +1979,7 @@ export type AiWritebackCompletedEvent = BaseTrack & {
         owner: string;
         repo: string;
         workstream: AiWritebackWorkstream;
+        source: AiWritebackEventSource;
         isResume: boolean;
         exitCode: number;
         // Whether the agent changed any files. When false no PR is opened.
@@ -2009,6 +2019,7 @@ export type AiWritebackFailedEvent = BaseTrack & {
         owner: string;
         repo: string;
         workstream: AiWritebackWorkstream;
+        source: AiWritebackEventSource;
         isResume: boolean;
         failureStage: AiWritebackFailureStage;
         errorMessage: string;
@@ -2043,6 +2054,7 @@ export type AiWritebackMergedEvent = BaseTrack & {
         // git-connected projects re-clone on compile, so others are skipped.
         compileScheduled: boolean;
         workstream: AiWritebackWorkstream;
+        source: AiWritebackEventSource;
     };
 };
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -2368,6 +2368,7 @@ describe('AiAgentAdminService.runReviewItemWritebackJob', () => {
                 toolHints: ['editDbtProject'],
                 forceToolHints: true,
                 suppressWritebackPreview: true,
+                writebackSource: 'admin_review',
             }),
         );
         // writeback_completed is emitted by the shared editDbtProject seam, not

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -2097,6 +2097,7 @@ export class AiAgentAdminService extends BaseService {
                     // The review flow owns preview + verification (below), so the
                     // tool must not also create its own preview project.
                     suppressWritebackPreview: true,
+                    writebackSource: 'admin_review',
                     onStepProgress: (message) => {
                         void setProgress(message);
                     },

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -443,6 +443,11 @@ const GITHUB_MCP_PAT_DISABLED_ERROR =
 const GITHUB_MCP_UNAVAILABLE_STATUS =
     'GitHub is not connected. An organization admin can install the Lightdash GitHub App from Organization settings → Integrations to reconnect.';
 
+export const getAiWritebackSourceForPrompt = (
+    prompt: SlackPrompt | AiWebAppPrompt,
+    source: AiWritebackSource | undefined,
+): AiWritebackSource => source ?? (isSlackPrompt(prompt) ? 'slack' : 'web');
+
 const isGithubMcpBearerServer = (
     server: Pick<AiMcpServer, 'url' | 'authType'>,
 ) => isGithubMcpServerUrl(server.url) && server.authType === 'bearer';
@@ -6129,6 +6134,7 @@ export class AiAgentService extends BaseService {
             onStepProgress,
             suppressWritebackPreview,
             isReviewRemediationWorkThread,
+            writebackSource,
             execution = { mode: 'standard' },
         }: {
             agentUuid: string;
@@ -6147,6 +6153,7 @@ export class AiAgentService extends BaseService {
             // Enables the work-thread-only editProjectContext tool so the agent
             // can open/change the project_context PR from this thread.
             isReviewRemediationWorkThread?: boolean;
+            writebackSource?: AiWritebackSource;
             execution?: GenerateAgentExecutionOptions;
         },
     ): Promise<string> {
@@ -6197,6 +6204,7 @@ export class AiAgentService extends BaseService {
                     onSlackStepProgress: onStepProgress,
                     suppressWritebackPreview,
                     isReviewRemediationWorkThread,
+                    writebackSource,
                     execution,
                 },
             );
@@ -8711,9 +8719,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
             suppressWritebackPreview?: boolean;
             onWarehouseQuery?: () => void | Promise<void>;
+            writebackSource?: AiWritebackSource;
         },
     ) {
         const { projectUuid, organizationUuid } = prompt;
+        const writebackSource = getAiWritebackSourceForPrompt(
+            prompt,
+            options?.writebackSource,
+        );
         const runtimeAgentSettings = await this.getAgentSettings(user, prompt);
         const sqlScope = await this.projectModel.getAgentSqlScope(projectUuid);
         const toolsRuntime = this.aiAgentToolsService.createRuntime({
@@ -8950,7 +8963,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         const editDbtProject: EditDbtProjectFn = async (args) => {
             const writebackPrompt = args.prompt;
-            const source = isSlackPrompt(prompt) ? 'slack' : 'web';
 
             if (!args.progressId) {
                 throw new UnexpectedServerError(
@@ -8962,7 +8974,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     user,
                     projectUuid,
                     aiThreadUuid: prompt.threadUuid,
-                    source,
+                    source: writebackSource,
                     promptUuid: prompt.promptUuid,
                     toolCallId: args.progressId,
                 });
@@ -8976,7 +8988,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 isSlackPrompt: isSlackPrompt(prompt),
                 toolCallId: args.progressId,
                 writebackPrompt,
-                source,
+                source: writebackSource,
                 prUrl: args.prUrl,
                 startNewPullRequest: args.startNewPullRequest ?? null,
                 suppressWritebackPreview: options?.suppressWritebackPreview,
@@ -9025,7 +9037,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         startNewPullRequest: args.startNewPullRequest ?? false,
                         aiThreadUuid: prompt.threadUuid,
                         promptUuid: prompt.promptUuid,
-                        source: isSlackPrompt(prompt) ? 'slack' : 'web',
+                        source: writebackSource,
                         onProgress: editRepoProgressCallback,
                     }),
             );
@@ -9495,6 +9507,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             forceToolHints?: boolean;
             // Enables the work-thread-only editProjectContext tool.
             isReviewRemediationWorkThread?: boolean;
+            writebackSource?: AiWritebackSource;
             toolHints?: string[];
             onSlackStepProgress?: (
                 progress: string,
@@ -9538,6 +9551,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             suppressWritebackPreview?: boolean;
             forceToolHints?: boolean;
             isReviewRemediationWorkThread?: boolean;
+            writebackSource?: AiWritebackSource;
             toolHints?: string[];
             onSlackStepProgress?: (
                 progress: string,
@@ -9663,6 +9677,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     : undefined),
             runtimeOptions: options.runtimeOptions,
             suppressWritebackPreview: options.suppressWritebackPreview,
+            writebackSource: options.writebackSource,
             onWarehouseQuery:
                 responseExecution.mode === 'deep_research'
                     ? responseExecution.onWarehouseQuery
@@ -15908,6 +15923,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             agentUuid,
             threadUuid,
             autoApproveSql: true,
+            writebackSource: 'admin_review',
         });
     }
 

--- a/packages/backend/src/ee/services/AiAgentService/writebackSource.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/writebackSource.test.ts
@@ -1,0 +1,68 @@
+import type {
+    AiWebAppPrompt,
+    AiWritebackSource,
+    SlackPrompt,
+} from '@lightdash/common';
+import { getAiWritebackEventSource } from '../AiWritebackService/AiWritebackService';
+import { getAiWritebackSourceForPrompt } from './AiAgentService';
+
+const webPrompt = {
+    promptUuid: 'prompt-1',
+    threadUuid: 'thread-1',
+    organizationUuid: 'organization-1',
+    projectUuid: 'project-1',
+} as AiWebAppPrompt;
+
+const slackPrompt = {
+    ...webPrompt,
+    slackUserId: 'user-1',
+    slackChannelId: 'channel-1',
+    promptSlackTs: '1.1',
+    slackThreadTs: '1.0',
+    response_slack_ts: '1.2',
+} as SlackPrompt;
+
+describe('AI writeback event sources', () => {
+    it.each<{
+        surface: string;
+        source: () => AiWritebackSource;
+        expected: string;
+    }>([
+        {
+            surface: 'chat',
+            source: () => getAiWritebackSourceForPrompt(webPrompt, undefined),
+            expected: 'chat',
+        },
+        {
+            surface: 'slack',
+            source: () => getAiWritebackSourceForPrompt(slackPrompt, undefined),
+            expected: 'slack',
+        },
+        {
+            surface: 'api',
+            source: () => 'api',
+            expected: 'api',
+        },
+        {
+            surface: 'mcp',
+            source: () => 'mcp',
+            expected: 'mcp',
+        },
+        {
+            surface: 'review item',
+            source: () =>
+                getAiWritebackSourceForPrompt(webPrompt, 'admin_review'),
+            expected: 'review_item',
+        },
+    ])('emits $expected for $surface', ({ source, expected }) => {
+        expect(getAiWritebackEventSource(source())).toBe(expected);
+    });
+
+    it('classifies a later user turn on a review thread as chat', () => {
+        expect(
+            getAiWritebackEventSource(
+                getAiWritebackSourceForPrompt(webPrompt, undefined),
+            ),
+        ).toBe('chat');
+    });
+});

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -33,6 +33,7 @@ import {
     AiWritebackService,
     auditReasonForError,
     computeWritableRepoKeys,
+    getAiWritebackEventSource,
     mergeSourceCodeRepoAccess,
     parseOwnerRepo,
     workstreamLockKey,
@@ -1886,6 +1887,7 @@ describe('AiWritebackService.mergePullRequest', () => {
             aiWritebackRunModel: {
                 findLatestByProjectUuidAndPrUrl: vi.fn().mockResolvedValue({
                     prompt_uuid: 'prompt-1',
+                    source: 'web',
                 }),
             } as AnyType,
         });
@@ -1906,6 +1908,7 @@ describe('AiWritebackService.mergePullRequest', () => {
                 mergeCommitSha: 'sha-7',
                 compileScheduled: true,
                 workstream: 'dbt-writeback',
+                source: 'chat',
             },
         });
     });
@@ -1966,6 +1969,49 @@ describe('AiWritebackService.mergePullRequest', () => {
 });
 
 describe('AiWritebackService.startTracking', () => {
+    it.each([
+        ['web', 'chat'],
+        ['slack', 'slack'],
+        ['api', 'api'],
+        ['mcp', 'mcp'],
+        ['admin_review', 'review_item'],
+        ['changeset', 'unknown'],
+    ] as const)(
+        'maps the %s run origin to %s on every run lifecycle event',
+        (source, expectedSource) => {
+            const track = vi.fn();
+            const service = buildService({ analytics: { track } as AnyType });
+            const tracker = (service as AnyType).startTracking({
+                user: { userUuid: 'u1' },
+                projectUuid: 'p1',
+                turn: turnContext(),
+                workstream: 'dbt-writeback',
+                aiThreadUuid: 'thread-1',
+                promptUuid: 'prompt-1',
+                source,
+            });
+
+            tracker.completed({
+                exitCode: 0,
+                hasChanges: true,
+                prCreated: true,
+                usage: null,
+                repoContext: null,
+            });
+            tracker.failed('agent', new Error('failed'), null);
+
+            expect(
+                track.mock.calls.map(([event]) => event.properties.source),
+            ).toEqual([expectedSource, expectedSource, expectedSource]);
+        },
+    );
+
+    it('maps missing and unrecognized origins to unknown', () => {
+        expect(getAiWritebackEventSource(undefined)).toBe('unknown');
+        expect(getAiWritebackEventSource(null)).toBe('unknown');
+        expect(getAiWritebackEventSource('future' as never)).toBe('unknown');
+    });
+
     it('assembles explicit thread and prompt properties for agent and API runs', () => {
         const track = vi.fn();
         const service = buildService({ analytics: { track } as AnyType });
@@ -1978,6 +2024,7 @@ describe('AiWritebackService.startTracking', () => {
             workstream: 'dbt-writeback',
             aiThreadUuid: 'thread-1',
             promptUuid: 'prompt-1',
+            source: 'web',
         });
         expect(track).toHaveBeenLastCalledWith({
             event: 'ai_writeback.started',
@@ -1995,6 +2042,7 @@ describe('AiWritebackService.startTracking', () => {
             workstream: 'dbt-writeback',
             aiThreadUuid: undefined,
             promptUuid: undefined,
+            source: 'api',
         });
         expect(track).toHaveBeenLastCalledWith({
             event: 'ai_writeback.started',
@@ -2016,6 +2064,7 @@ describe('AiWritebackService.startTracking', () => {
             workstream: 'dbt-writeback',
             aiThreadUuid: undefined,
             promptUuid: undefined,
+            source: 'web',
         });
         const listing = 'models/orders.sql\nREADME.md\n';
 
@@ -2048,6 +2097,7 @@ describe('AiWritebackService.startTracking', () => {
             workstream: 'general',
             aiThreadUuid: undefined,
             promptUuid: undefined,
+            source: 'web',
         });
 
         tracker.failed('agent', new Error('agent failed'), {
@@ -2078,6 +2128,7 @@ describe('AiWritebackService.startTracking', () => {
             workstream: 'general',
             aiThreadUuid: undefined,
             promptUuid: undefined,
+            source: 'web',
         });
 
         tracker.completed({

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -29,6 +29,7 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import type {
+    AiWritebackEventSource,
     AiWritebackFailureStage,
     LightdashAnalytics,
 } from '../../../analytics/LightdashAnalytics';
@@ -157,6 +158,20 @@ import {
 } from './utils';
 
 export type { AiWritebackRunArgs, AiWritebackSource } from './types';
+
+const AI_WRITEBACK_EVENT_SOURCES = {
+    slack: 'slack',
+    web: 'chat',
+    mcp: 'mcp',
+    api: 'api',
+    admin_review: 'review_item',
+    changeset: 'unknown',
+} satisfies Record<AiWritebackSource, AiWritebackEventSource>;
+
+export const getAiWritebackEventSource = (
+    source: AiWritebackSource | null | undefined,
+): AiWritebackEventSource =>
+    source ? (AI_WRITEBACK_EVENT_SOURCES[source] ?? 'unknown') : 'unknown';
 
 // What to snapshot between turns: the whole cloned repo at CWD (working tree +
 // .git feature branch + the agent's .claude session dir), minus re-derivable
@@ -696,6 +711,7 @@ export class AiWritebackService extends BaseService {
         let threadId: string | null = null;
         let promptId: string | null = null;
         let workstream: CodingAgentConfig['mode'] = 'dbt-writeback';
+        let source: AiWritebackEventSource = 'unknown';
         try {
             const thread =
                 await this.aiWritebackThreadModel.findByProjectUuidAndPrUrl(
@@ -710,8 +726,10 @@ export class AiWritebackService extends BaseService {
                     properties.prUrl,
                 );
             promptId = run?.prompt_uuid ?? null;
+            source = getAiWritebackEventSource(run?.source);
         } catch {
             workstream = 'dbt-writeback';
+            source = 'unknown';
         }
         this.analytics.track({
             event: 'ai_writeback.merged',
@@ -728,6 +746,7 @@ export class AiWritebackService extends BaseService {
                 mergeCommitSha: properties.mergeCommitSha,
                 compileScheduled: properties.compileScheduled,
                 workstream,
+                source,
             },
         });
     }
@@ -2158,6 +2177,7 @@ export class AiWritebackService extends BaseService {
             workstream: config.mode,
             aiThreadUuid,
             promptUuid: args.promptUuid,
+            source,
         });
 
         let failureStage: AiWritebackFailureStage = 'install';
@@ -3282,6 +3302,7 @@ export class AiWritebackService extends BaseService {
         workstream,
         aiThreadUuid,
         promptUuid,
+        source,
     }: {
         user: SessionUser;
         projectUuid: string;
@@ -3289,6 +3310,7 @@ export class AiWritebackService extends BaseService {
         workstream: CodingAgentConfig['mode'];
         aiThreadUuid: string | undefined;
         promptUuid: string | undefined;
+        source: AiWritebackSource;
     }) {
         const eventBase = {
             organizationId: turn.organizationUuid,
@@ -3299,6 +3321,7 @@ export class AiWritebackService extends BaseService {
             repo: turn.gitConnection.repo,
             isResume: turn.isResume,
             workstream,
+            source: getAiWritebackEventSource(source),
         };
         const startedAt = Date.now();
 


### PR DESCRIPTION
## What changed

- add a required `source` property to `ai_writeback.started`, `completed`, `failed`, and `merged`
- map writeback origins to `chat`, `slack`, `api`, `mcp`, `review_item`, or `unknown`
- preserve the source through both Graphile worker payloads
- mark only review-driven Build-fix turns as `review_item`, while later user turns on the same thread remain `chat`

## Why

AI writeback runs from different surfaces previously converged before analytics was emitted, so the funnel could not be split by its entry point. Required, explicit source values keep every stage attributable and make unclassified paths visible as `unknown`.

## Entry-point map

- web chat -> `AiAgentService` -> `editDbtProject` / `editRepo` -> `AiWritebackService`
- Slack agent turn -> the same `AiAgentService` tool seam, distinguished by its Slack prompt
- REST -> `AiWritebackController.runAiWriteback` -> `AiWritebackService.run`
- MCP -> `McpService.run_ai_writeback` -> `AI_WRITEBACK_PIPELINE` -> `AiWritebackService.runPipeline` -> `run`
- review item `semantic_layer` strategy -> `AiAgentAdminService` -> `generateAgentThreadResponse` -> forced `editDbtProject` -> `AI_AGENT_EDIT_DBT_PROJECT_PIPELINE` -> `run`
- successful PR merge -> `AiWritebackController.mergeWritebackPullRequest` -> `AiWritebackService.mergePullRequest` -> `trackMerged`

## Merge attribution decision

`ai_writeback.merged.source` describes the latest originating writeback run associated with the pull request, rather than the later merge action. This keeps the merged stage compatible with the writeback funnel. Historical or otherwise unlinked pull requests emit `unknown`.

## Open question

The review tool's `project_context` strategy opens pull requests without emitting `ai_writeback.*`. This remains unchanged here; should those pull requests join the writeback event family in a follow-up?

## Verification

- `pnpm -F backend typecheck`
- `pnpm -F backend test` (452 files, 7,072 passed, 1 skipped)
- touched-path backend lint and format checks

Linear: SPK-1016
