### PR TITLE
fix(release-safety): show a pending state before the verdict lands

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -211,6 +211,90 @@ jobs:
             echo "fresh=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # SPK-1013: claim the sticky comment for this run BEFORE the expensive
+      # jobs, so an unfinished gate is visible rather than silent.
+      #
+      # `cancel-in-progress` is right for a status check reporting on the latest
+      # revision and wrong for a gate: on an actively-pushed PR every run can be
+      # cancelled before it reaches a verdict, and a cancelled gate is
+      # indistinguishable from a clean one — nothing on the page separates
+      # "checked, no breaking changes" from "never finished checking". #27393
+      # merged carrying 42 breaking REST changes after eight runs that failed or
+      # were cancelled; at the moment of merge no run had ever completed.
+      #
+      # Whatever happens to this run, the comment now reads as either a verdict
+      # for a named commit or a check in progress for a named commit. A merged
+      # PR still showing this notice never got a verdict.
+      #
+      # Deliberately omits the `release-safety-describes` stamp: that stamp is
+      # what would let an `edited` event short-circuit the recompute, and a
+      # pending notice must never be mistaken for a current verdict. Its absence
+      # fails safe — the next event recomputes. (Today nothing writes that stamp
+      # at all, so the short-circuit never fires — SPK-1017. This omission is
+      # written to stay correct once it does.)
+      - name: Mark the verdict as pending for this commit
+        if: >-
+          steps.openness.outputs.open == 'true' &&
+          steps.watched.outputs.watched == 'true' &&
+          steps.fresh.outputs.fresh != 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const marker = '<!-- release-safety-marker -->';
+            const pending = '<!-- release-safety-pending -->';
+            const headSha = context.payload.pull_request.head.sha;
+            const short = headSha.slice(0, 7);
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            if (pr.head.sha !== headSha) {
+              core.info(`PR head moved on (${short} -> ${pr.head.sha.slice(0, 7)}); leaving the comment to the newer run.`);
+              return;
+            }
+
+            const body = [
+              marker,
+              pending,
+              '## 🛡️ Upgrade safety for self-hosted customers',
+              '',
+              `- ⏳ **Checking commit \`${short}\`.** No verdict has been reached yet.`,
+              '',
+              'If this notice is still showing when the pull request is merged, the check never finished — usually because a newer push cancelled it — and no upgrade-safety verdict was recorded for this change.',
+              '',
+              '---',
+              '<sub>Automated upgrade-safety check. The verdict replaces this notice when the run completes.</sub>',
+              '',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+            core.info(`Sticky comment marked pending for ${short}.`);
+
   openapi-specs:
     name: Generate API snapshots
     needs: changes

--- a/scripts/release-safety-workflow-shape.test.ts
+++ b/scripts/release-safety-workflow-shape.test.ts
@@ -66,4 +66,24 @@ assert.ok(
     `expected the openness step and both write steps to check pr.merged; found ${mergedChecks.length}`,
 );
 
+// SPK-1013: the sticky comment is claimed as pending before the expensive jobs,
+// so a run that is cancelled or fails leaves a visible "no verdict yet" notice
+// rather than nothing or a stale verdict from an earlier revision.
+assert.ok(
+    workflow.includes('<!-- release-safety-pending -->'),
+    `${WORKFLOW_PATH} must stamp a pending state on the sticky comment (SPK-1013)`,
+);
+
+// The pending notice must not carry the describes-stamp, or an `edited` event
+// could short-circuit against it and treat "not checked yet" as a live verdict.
+// Nothing writes that stamp today (SPK-1017), so this guards the future fix.
+const pendingBlock = workflow.slice(
+    workflow.indexOf('<!-- release-safety-pending -->'),
+    workflow.indexOf('  openapi-specs:'),
+);
+assert.ok(
+    !pendingBlock.includes('release-safety-describes head:'),
+    'the pending notice must not emit a release-safety-describes stamp (SPK-1013 / SPK-1017)',
+);
+
 process.stdout.write('release-safety workflow shape tests passed\n');


### PR DESCRIPTION
Linear: SPK-1013

## What this does

Claims the sticky comment for the current run **before** the expensive jobs start, so at any moment it reads as either a verdict for a named commit, or a check in progress for a named commit.

Previously a run cancelled or failed before its write step left whatever was there before — nothing on a first run, or a verdict describing an earlier revision. Neither state says "no verdict was reached".

## Honest scoping — this would not have prevented #27393

The ticket's premise was that a cancelled gate let #27393 through. Verifying the incident properly showed that isn't what happened, and I'd rather say so here than let this PR claim more than it does.

The gate **did** report, three times, before the merge:

| Time | Verdict on display | `rollingUpdateSafe` | REST breaking |
|---|---|---|---|
| 03:57:53 | ❓ Couldn't confirm it's safe | `"unknown"` | 42 |
| 04:20:19 | ❓ Couldn't confirm it's safe | `"unknown"` | 42 |
| 04:43:38 | ⚠️ Needs care on upgrade | `false` | 42 |
| *04:43:48* | *merged* | | |

All three runs reached `Post or update sticky comment` successfully and then failed `Fail release-safety gates`. The verdict was present, correct, and ignored — because the check is advisory. **SPK-960 is the change that would have stopped this merge**, not this one.

## The real finding, which this only partly addresses

Two of those three gate failures are recorded at **run level** as `cancelled`, because a newer run superseded them after their job had already failed. So:

- `gh run list` says the gate never failed.
- The step data says it failed three times.

That divergence is how this incident was first misread — the investigation that produced this change initially concluded no run had ever completed, from run conclusions alone.

This PR does not repair that. It makes the *comment* honest; the run-level record is still misleading. Worth a follow-up if we want the check list to tell the truth on its own.

## Details

- Gated identically to `preview` — open, watched, not fresh, same-repo — so a run that was never going to write a verdict cannot strand a pending notice.
- Deliberately omits the `release-safety-describes` stamp, so a pending notice can never be mistaken for a current verdict by the `edited` short-circuit. Nothing writes that stamp today (**SPK-1017** — it's read but never written, so the short-circuit has never once fired); this is written to stay correct once it does.
- Guard test extended and verified to fail when either invariant is removed, not merely to pass.

## Verification

Findings behind this PR were put to an independent reviewer briefed to refute them. It confirmed the comment history, the push/ready-for-review sequence and the merge-base, corrected my account of the check state at merge time, and flagged the run-level divergence above as the substantive gap. One claim — what the merge box rendered at 04:43:48 — is unprovable either way and is left as unknown.