### PR TITLE
fix(merge-query): preserve fields when changing table

### DIFF
--- a/packages/frontend/src/features/mergeQuery/components/MergeSourceTree.test.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeSourceTree.test.tsx
@@ -1,0 +1,112 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ComponentProps } from 'react';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { MergeSourceTree } from './MergeSourceTree';
+
+const state = vi.hoisted(() => ({
+    setSourceExplore: vi.fn(),
+}));
+
+vi.mock('../context/useMerge', () => ({
+    useMerge: () => ({
+        additionalSources: [
+            {
+                id: 'combined',
+                exploreName: 'subscriptions',
+                dimensions: ['subscriptions_started_at'],
+                metrics: ['subscriptions_count'],
+            },
+        ],
+        setSourceExplore: state.setSourceExplore,
+        toggleSourceField: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../hooks/useExplore', () => ({
+    useExplore: () => ({ data: undefined, isInitialLoading: false }),
+}));
+
+vi.mock('../../../components/Explorer/ExploreSideBar/BasePanel', () => ({
+    default: ({
+        onExploreClick,
+    }: {
+        onExploreClick: (explore: { name: string }) => void;
+    }) => (
+        <>
+            <button
+                type="button"
+                onClick={() => onExploreClick({ name: 'subscriptions' })}
+            >
+                Subscriptions
+            </button>
+            <button
+                type="button"
+                onClick={() => onExploreClick({ name: 'customers' })}
+            >
+                Customers
+            </button>
+        </>
+    ),
+}));
+
+vi.mock('../../../components/Explorer/ExploreTree', () => ({
+    default: () => null,
+}));
+
+const renderPicker = (
+    overrides: Partial<ComponentProps<typeof MergeSourceTree>> = {},
+) => {
+    const setIsChoosingExplore = vi.fn();
+    renderWithProviders(
+        <MergeSourceTree
+            sourceId="combined"
+            isChoosingExplore
+            setIsChoosingExplore={setIsChoosingExplore}
+            selectedFields={[]}
+            {...overrides}
+        />,
+    );
+    return { setIsChoosingExplore };
+};
+
+describe('MergeSourceTree table picker', () => {
+    beforeEach(() => {
+        state.setSourceExplore.mockReset();
+    });
+
+    it('returns to the selected fields without changing the source', async () => {
+        const user = userEvent.setup();
+        const { setIsChoosingExplore } = renderPicker();
+
+        await user.click(
+            screen.getByRole('button', { name: 'Back to fields' }),
+        );
+
+        expect(setIsChoosingExplore).toHaveBeenCalledWith(false);
+        expect(state.setSourceExplore).not.toHaveBeenCalled();
+    });
+
+    it('does not clear fields when the current table is selected again', async () => {
+        const user = userEvent.setup();
+        const { setIsChoosingExplore } = renderPicker();
+
+        await user.click(screen.getByRole('button', { name: 'Subscriptions' }));
+
+        expect(setIsChoosingExplore).toHaveBeenCalledWith(false);
+        expect(state.setSourceExplore).not.toHaveBeenCalled();
+    });
+
+    it('changes the source when a different table is selected', async () => {
+        const user = userEvent.setup();
+        const { setIsChoosingExplore } = renderPicker();
+
+        await user.click(screen.getByRole('button', { name: 'Customers' }));
+
+        expect(state.setSourceExplore).toHaveBeenCalledWith(
+            'combined',
+            'customers',
+        );
+        expect(setIsChoosingExplore).toHaveBeenCalledWith(false);
+    });
+});

--- a/packages/frontend/src/features/mergeQuery/components/MergeSourceTree.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeSourceTree.tsx
@@ -44,14 +44,30 @@ export const MergeSourceTree: FC<{
 
     if (isChoosingExplore) {
         return (
-            <Box h="100%" mih={0} style={{ overflow: 'hidden' }}>
-                <BasePanel
-                    onExploreClick={(selectedExplore) => {
-                        merge.setSourceExplore(source.id, selectedExplore.name);
-                        setIsChoosingExplore(false);
-                    }}
-                />
-            </Box>
+            <Stack gap="xs" h="100%" mih={0}>
+                <Button
+                    variant="subtle"
+                    size="compact-xs"
+                    w="fit-content"
+                    leftSection={<MantineIcon icon={IconArrowLeft} size={13} />}
+                    onClick={() => setIsChoosingExplore(false)}
+                >
+                    Back to fields
+                </Button>
+                <Box style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+                    <BasePanel
+                        onExploreClick={(selectedExplore) => {
+                            if (selectedExplore.name !== source.exploreName) {
+                                merge.setSourceExplore(
+                                    source.id,
+                                    selectedExplore.name,
+                                );
+                            }
+                            setIsChoosingExplore(false);
+                        }}
+                    />
+                </Box>
+            </Stack>
         );
     }
 


### PR DESCRIPTION
## What changed

- adds a **Back to fields** path from the combined-data table picker
- preserves selected dimensions and metrics when the user changes their mind
- treats selecting the current table as a no-op instead of clearing its fields
- still resets source fields when a genuinely different table is selected

## Root cause

The table picker replaced the field tree without an exit, and selecting the current table still called the destructive source-reset path.

## Validation

- 3 focused MergeSourceTree behavior tests
- frontend typecheck
- changed-file lint