### PR TITLE
fix(merge-query): align result column headers

### DIFF
--- a/packages/frontend/src/features/mergeQuery/components/MergeColumnProvenance.module.css
+++ b/packages/frontend/src/features/mergeQuery/components/MergeColumnProvenance.module.css
@@ -1,7 +1,20 @@
+.header {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+    white-space: nowrap;
+}
+
+.header > svg {
+    flex: none;
+}
+
 .source {
     display: inline-flex;
     align-items: center;
     gap: 4px;
+    vertical-align: middle;
 }
 
 .dot {

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -697,6 +697,11 @@ export const useColumns = (): TableColumn[] => {
                     header: () => (
                         <TableHeaderLabelContainer
                             color={fieldColors.columnHeaderColor}
+                            className={
+                                mergeResults
+                                    ? provenanceStyles.header
+                                    : undefined
+                            }
                         >
                             {isField(item) ? (
                                 <>


### PR DESCRIPTION
## What changed

- lays merged column-header content out as one centered row
- aligns the shared-key icon with its field label
- aligns source color dots, table labels, and field labels consistently

## Root cause

The key icon renders as a block SVG inside a normal-flow container, while provenance labels used a separate inline-flex wrapper. Their baselines therefore diverged.

## Validation

- local saved-chart visual check
- 31 existing useColumns tests
- frontend typecheck
- changed-file lint