### PR TITLE
feat(merge-query): add selected field actions

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.test.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.test.tsx
@@ -1,0 +1,63 @@
+import { DimensionType, FieldType, type Dimension } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { createExplorerStore } from '../../../features/explorer/store';
+import { renderWithProviders } from '../../../testing/testUtils';
+import SelectedFieldsSection from './SelectedFieldsSection';
+
+const item = {
+    table: 'subscriptions',
+    tableLabel: 'Subscriptions',
+    name: 'customer_id',
+    label: 'Customer id',
+    description: 'The customer identifier',
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.NUMBER,
+    hidden: false,
+} as Dimension;
+
+describe('SelectedFieldsSection source-aware actions', () => {
+    it('shows filter and basic overflow actions for a merged source field', async () => {
+        const user = userEvent.setup();
+        const onAddFilter = vi.fn();
+
+        renderWithProviders(
+            <Provider store={createExplorerStore()}>
+                <SelectedFieldsSection
+                    fields={[
+                        {
+                            fieldId: 'subscriptions_customer_id',
+                            selectionKey: 'b:subscriptions_customer_id',
+                            item,
+                            tableLabel: 'Subscriptions',
+                            isDimension: true,
+                            onAddFilter,
+                            basicActionsOnly: true,
+                        },
+                    ]}
+                    onDeselect={vi.fn()}
+                />
+            </Provider>,
+        );
+
+        await user.hover(
+            screen.getByTestId('selected-field-b:subscriptions_customer_id'),
+        );
+        await user.click(screen.getByRole('button', { name: 'Add filter' }));
+
+        expect(onAddFilter).toHaveBeenCalledWith(item);
+
+        await user.click(screen.getByRole('button', { name: 'View options' }));
+
+        expect(
+            screen.getByRole('menuitem', { name: 'Add filter' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('menuitem', { name: 'View description' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('menuitem', { name: 'Create custom metric' }),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -45,8 +45,13 @@ export type SelectedField = {
     tableLabel: string | null;
     isDimension: boolean;
     onDeselect?: (fieldId: string, isDimension: boolean) => void;
-    /** Cross-query rows only expose the safe, source-aware deselect action. */
+    /** Hides every secondary action for contexts that only support deselect. */
     hideActions?: boolean;
+    /** Routes filter creation to the field's owning query. */
+    onAddFilter?: (field: FilterableField) => void;
+    isFiltered?: boolean;
+    /** Limits the overflow menu to filter and description actions. */
+    basicActionsOnly?: boolean;
 };
 
 type RenderedRow = SelectedField & { isExiting: boolean };
@@ -78,6 +83,9 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
         isExiting,
         hideActions,
         onDeselect: fieldOnDeselect,
+        onAddFilter: fieldOnAddFilter,
+        isFiltered: isFilteredOverride,
+        basicActionsOnly,
     } = row;
 
     const dispatch = useExplorerDispatch();
@@ -97,7 +105,7 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
         (a, b) => a === b,
     );
 
-    const isFiltered = isField(item) && isFieldFiltered;
+    const isFiltered = isFilteredOverride ?? (isField(item) && isFieldFiltered);
     const showFilterAction =
         !hideActions &&
         (isFiltered || isHover) &&
@@ -134,10 +142,16 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
     const handleFilterClick = useCallback(
         (e: React.MouseEvent<HTMLButtonElement>) => {
             track({ name: EventName.ADD_FILTER_CLICKED });
-            if (!isFiltered) addFilter(item as FilterableField, undefined);
+            if (!isFiltered) {
+                if (fieldOnAddFilter) {
+                    fieldOnAddFilter(item as FilterableField);
+                } else {
+                    addFilter(item as FilterableField, undefined);
+                }
+            }
             e.stopPropagation();
         },
-        [isFiltered, addFilter, item, track],
+        [isFiltered, fieldOnAddFilter, addFilter, item, track],
     );
 
     const onOpenDescriptionView = useCallback(() => {
@@ -184,6 +198,9 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                         }
                     >
                         <ActionIcon
+                            aria-label={
+                                isFiltered ? 'Field is filtered' : 'Add filter'
+                            }
                             variant="subtle"
                             color="gray"
                             onClick={handleFilterClick}
@@ -204,17 +221,24 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                     </Tooltip>
                 )}
                 {/* Mounted on hover only so the labels get the space at rest */}
-                {!hideActions && (isHover || isMenuOpen) && (
-                    <TreeSingleNodeActions
-                        item={item}
-                        isHovered={isHover}
-                        isSelected={false}
-                        isOpened={isMenuOpen}
-                        hasDescription={!!description}
-                        onViewDescription={onOpenDescriptionView}
-                        onMenuChange={onToggleMenu}
-                    />
-                )}
+                {!hideActions &&
+                    (!basicActionsOnly ||
+                        !!description ||
+                        (!isAdditionalMetric(item) &&
+                            isFilterableField(item))) &&
+                    (isHover || isMenuOpen) && (
+                        <TreeSingleNodeActions
+                            item={item}
+                            isHovered={isHover}
+                            isSelected={false}
+                            isOpened={isMenuOpen}
+                            hasDescription={!!description}
+                            onViewDescription={onOpenDescriptionView}
+                            onMenuChange={onToggleMenu}
+                            onAddFilter={fieldOnAddFilter}
+                            basicActionsOnly={basicActionsOnly}
+                        />
+                    )}
             </span>
         </UnstyledButton>
     );

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -14,6 +14,7 @@ import {
     type AdditionalMetric,
     type CustomDimension,
     type Dimension,
+    type FilterableField,
     type Metric,
 } from '@lightdash/common';
 import { Box, Menu, type MenuProps, ActionIcon, Tooltip } from '@mantine/core';
@@ -52,6 +53,8 @@ type Props = {
     isOpened: MenuProps['opened'];
     onMenuChange: MenuProps['onChange'];
     onViewDescription: () => void;
+    onAddFilter?: (field: FilterableField) => void;
+    basicActionsOnly?: boolean;
 };
 
 const TreeSingleNodeActions: FC<Props> = ({
@@ -62,6 +65,8 @@ const TreeSingleNodeActions: FC<Props> = ({
     onMenuChange,
     hasDescription,
     onViewDescription,
+    onAddFilter,
+    basicActionsOnly = false,
 }) => {
     const projectUuid = useProjectUuid();
     const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
@@ -148,14 +153,20 @@ const TreeSingleNodeActions: FC<Props> = ({
                             track({
                                 name: EventName.ADD_FILTER_CLICKED,
                             });
-                            addFilter(item, undefined);
+                            if (onAddFilter) {
+                                onAddFilter(item);
+                            } else {
+                                addFilter(item, undefined);
+                            }
                         }}
                     >
                         Add filter
                     </Menu.Item>
                 ) : null}
 
-                {isMetric(item) && isAggregateMetricType(item.type) ? (
+                {!basicActionsOnly &&
+                isMetric(item) &&
+                isAggregateMetricType(item.type) ? (
                     <Menu.Item
                         component="button"
                         leftSection={<MantineIcon icon={IconCopy} />}
@@ -177,7 +188,7 @@ const TreeSingleNodeActions: FC<Props> = ({
                     </Menu.Item>
                 ) : null}
 
-                {isAdditionalMetric(item) ? (
+                {!basicActionsOnly && isAdditionalMetric(item) ? (
                     <>
                         <Menu.Item
                             component="button"
@@ -291,7 +302,7 @@ const TreeSingleNodeActions: FC<Props> = ({
                     </Menu.Item>
                 )}
 
-                {isCustomDimension(item) && (
+                {!basicActionsOnly && isCustomDimension(item) && (
                     <>
                         {!(
                             isCustomSqlDimension(item) && cannotAuthorCustomSql
@@ -408,7 +419,8 @@ const TreeSingleNodeActions: FC<Props> = ({
                     </>
                 )}
 
-                {customMetrics.length > 0 &&
+                {!basicActionsOnly &&
+                customMetrics.length > 0 &&
                 (isDimension(item) || isCustomSqlDimension(item)) ? (
                     <>
                         <Menu.Divider />
@@ -449,7 +461,8 @@ const TreeSingleNodeActions: FC<Props> = ({
                     </>
                 ) : null}
 
-                {isDimension(item) &&
+                {!basicActionsOnly &&
+                isDimension(item) &&
                 (item.type === DimensionType.NUMBER ||
                     (item.type === DimensionType.STRING &&
                         isCustomGroupBinsEnabled)) ? (
@@ -495,7 +508,11 @@ const TreeSingleNodeActions: FC<Props> = ({
                         label="View options"
                         disabled={isOpened}
                     >
-                        <ActionIcon color="gray" variant="transparent">
+                        <ActionIcon
+                            aria-label="View options"
+                            color="gray"
+                            variant="transparent"
+                        >
                             <MantineIcon
                                 icon={IconDots}
                                 color={isOpened ? 'black' : undefined}

--- a/packages/frontend/src/features/mergeQuery/components/MergeQuerySidebar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeQuerySidebar.tsx
@@ -3,7 +3,9 @@ import {
     isCustomDimension,
     isDimension,
     isMetric,
+    getTotalFilterRules,
     type Explore,
+    type FilterableField,
 } from '@lightdash/common';
 import { ActionIcon, Box, Text, UnstyledButton } from '@mantine/core';
 import { IconChevronDown, IconChevronRight, IconX } from '@tabler/icons-react';
@@ -21,10 +23,15 @@ import SelectedFieldsSection, {
     type SelectedField,
 } from '../../../components/Explorer/ExploreTree/SelectedFieldsSection';
 import { ItemDetailProvider } from '../../../components/Explorer/ExploreTree/TableTree/ItemDetailProvider';
-import { selectMetricQuery, useExplorerSelector } from '../../explorer/store';
+import {
+    selectFilters,
+    selectMetricQuery,
+    useExplorerSelector,
+} from '../../explorer/store';
 import { PRIMARY_SOURCE_ID } from '../constants';
 import { useMerge } from '../context/useMerge';
 import { useMergeSetup } from '../hooks/useMergeSetup';
+import { useMergeSourceFilter } from '../hooks/useMergeSourceFilter';
 import styles from './MergeQuerySidebar.module.css';
 import { MergeSourceTree } from './MergeSourceTree';
 
@@ -93,7 +100,9 @@ export const MergeQuerySidebar: FC<{
     const additionalSource = merge.additionalSources[0];
     const additionalSourceId = additionalSource?.id;
     const metricQuery = useExplorerSelector(selectMetricQuery);
+    const primaryFilters = useExplorerSelector(selectFilters);
     const mergeSetup = useMergeSetup();
+    const addSourceFilter = useMergeSourceFilter();
     const [openSourceId, setOpenSourceId] = useState<string | null>(
         merge.focus.kind === 'source' ? merge.focus.sourceId : null,
     );
@@ -118,6 +127,29 @@ export const MergeQuerySidebar: FC<{
     const additionalLabel = additionalSource?.exploreName
         ? (mergeSetup.additionalExploreLabel ?? 'Combined data')
         : 'Choose data to combine';
+    const filteredFieldIds = useMemo<Record<string, Set<string>>>(
+        () => ({
+            [PRIMARY_SOURCE_ID]: new Set(
+                getTotalFilterRules(primaryFilters).flatMap((rule) =>
+                    'fieldId' in rule.target ? [rule.target.fieldId] : [],
+                ),
+            ),
+            ...(additionalSourceId
+                ? {
+                      [additionalSourceId]: new Set(
+                          getTotalFilterRules(
+                              additionalSource?.filters ?? {},
+                          ).flatMap((rule) =>
+                              'fieldId' in rule.target
+                                  ? [rule.target.fieldId]
+                                  : [],
+                          ),
+                      ),
+                  }
+                : {}),
+        }),
+        [additionalSource?.filters, additionalSourceId, primaryFilters],
+    );
     const selectedFields = useMemo<SelectedField[]>(() => {
         const primaryLabel = mergeSetup.primaryExploreLabel ?? 'First data';
         const additionalSourceLabel =
@@ -147,7 +179,12 @@ export const MergeQuerySidebar: FC<{
                         : primaryLabel,
                     isDimension: metricQuery.dimensions.includes(fieldId),
                     onDeselect: onPrimaryFieldChange,
-                    hideActions: true,
+                    onAddFilter: (field: FilterableField) =>
+                        addSourceFilter(PRIMARY_SOURCE_ID, field),
+                    isFiltered:
+                        filteredFieldIds[PRIMARY_SOURCE_ID]?.has(fieldId) ??
+                        false,
+                    basicActionsOnly: true,
                 },
             ];
         });
@@ -182,7 +219,14 @@ export const MergeQuerySidebar: FC<{
                             id,
                             isDimension,
                         ),
-                    hideActions: true,
+                    onAddFilter: (field: FilterableField) =>
+                        additionalSourceId &&
+                        addSourceFilter(additionalSourceId, field),
+                    isFiltered:
+                        (additionalSourceId
+                            ? filteredFieldIds[additionalSourceId]?.has(fieldId)
+                            : false) ?? false,
+                    basicActionsOnly: true,
                 },
             ];
         });
@@ -191,6 +235,8 @@ export const MergeQuerySidebar: FC<{
     }, [
         additionalSource,
         additionalSourceId,
+        addSourceFilter,
+        filteredFieldIds,
         merge,
         mergeSetup,
         metricQuery,

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeSourceFilter.test.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeSourceFilter.test.ts
@@ -1,0 +1,58 @@
+import {
+    DimensionType,
+    FieldType,
+    getTotalFilterRules,
+    type FilterableField,
+} from '@lightdash/common';
+import { addMergeSourceFilter } from './useMergeSourceFilter';
+
+vi.mock('uuid', () => ({ v4: () => 'filter-id' }));
+
+const field = (table: string, name: string) =>
+    ({
+        table,
+        tableLabel: table,
+        name,
+        label: name,
+        type: DimensionType.STRING,
+        fieldType: FieldType.DIMENSION,
+        hidden: false,
+    }) as FilterableField;
+
+const fieldIds = (filters: ReturnType<typeof addMergeSourceFilter>[string]) =>
+    getTotalFilterRules(filters).flatMap((rule) =>
+        'fieldId' in rule.target ? [rule.target.fieldId] : [],
+    );
+
+describe('addMergeSourceFilter', () => {
+    it('adds an ordinary field filter only to its source', () => {
+        const result = addMergeSourceFilter({
+            sourceId: 'b',
+            field: field('subscriptions', 'status'),
+            filtersBySourceId: { a: {}, b: {} },
+            joinParts: [],
+        });
+
+        expect(fieldIds(result.a)).toEqual([]);
+        expect(fieldIds(result.b)).toEqual(['subscriptions_status']);
+    });
+
+    it('mirrors a matching-field filter to the other source', () => {
+        const result = addMergeSourceFilter({
+            sourceId: 'b',
+            field: field('subscriptions', 'customer_id'),
+            filtersBySourceId: { a: {}, b: {} },
+            joinParts: [
+                {
+                    fieldIdBySourceId: {
+                        a: 'orders_customer_id',
+                        b: 'subscriptions_customer_id',
+                    },
+                },
+            ],
+        });
+
+        expect(fieldIds(result.a)).toEqual(['orders_customer_id']);
+        expect(fieldIds(result.b)).toEqual(['subscriptions_customer_id']);
+    });
+});

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeSourceFilter.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeSourceFilter.ts
@@ -1,0 +1,96 @@
+import {
+    addFilterRule,
+    type FilterableField,
+    type Filters,
+} from '@lightdash/common';
+import { useCallback } from 'react';
+import { ExplorerSection } from '../../../providers/Explorer/types';
+import {
+    explorerActions,
+    selectFilters,
+    selectIsFiltersExpanded,
+    useExplorerDispatch,
+    useExplorerStore,
+} from '../../explorer/store';
+import { PRIMARY_SOURCE_ID } from '../constants';
+import { type MergeJoinPart } from '../context/context';
+import { useMerge } from '../context/useMerge';
+import {
+    syncMergeJoinFilters,
+    type FiltersBySourceId,
+} from '../utils/syncMergeJoinFilters';
+
+export const addMergeSourceFilter = ({
+    sourceId,
+    field,
+    filtersBySourceId,
+    joinParts,
+}: {
+    sourceId: string;
+    field: FilterableField;
+    filtersBySourceId: FiltersBySourceId;
+    joinParts: MergeJoinPart[];
+}): FiltersBySourceId => {
+    const sourceFilters = filtersBySourceId[sourceId];
+    if (!sourceFilters) return filtersBySourceId;
+
+    return syncMergeJoinFilters({
+        changedSourceId: sourceId,
+        filtersBySourceId: {
+            ...filtersBySourceId,
+            [sourceId]: addFilterRule({
+                filters: sourceFilters,
+                field,
+            }),
+        },
+        joinParts,
+    });
+};
+
+export const useMergeSourceFilter = () => {
+    const merge = useMerge();
+    const dispatch = useExplorerDispatch();
+    const store = useExplorerStore();
+
+    return useCallback(
+        (sourceId: string, field: FilterableField) => {
+            const primaryFiltersBefore = selectFilters(store.getState());
+            const filtersBySourceId: Record<string, Filters> =
+                Object.fromEntries([
+                    [PRIMARY_SOURCE_ID, primaryFiltersBefore],
+                    ...merge.additionalSources.map((source) => [
+                        source.id,
+                        source.filters,
+                    ]),
+                ]);
+            const nextFilters = addMergeSourceFilter({
+                sourceId,
+                field,
+                filtersBySourceId,
+                joinParts: merge.joinParts,
+            });
+
+            const nextPrimary = nextFilters[PRIMARY_SOURCE_ID];
+            if (nextPrimary && nextPrimary !== primaryFiltersBefore) {
+                dispatch(explorerActions.setFilters(nextPrimary));
+            }
+            merge.additionalSources.forEach((source) => {
+                const nextSource = nextFilters[source.id];
+                if (nextSource && nextSource !== source.filters) {
+                    merge.setSourceFilters(source.id, nextSource);
+                }
+            });
+            merge.setFocus({ kind: 'source', sourceId });
+
+            if (!selectIsFiltersExpanded(store.getState())) {
+                dispatch(
+                    explorerActions.toggleExpandedSection(
+                        ExplorerSection.FILTERS,
+                    ),
+                );
+            }
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        },
+        [dispatch, merge, store],
+    );
+};


### PR DESCRIPTION
## What changed

- restores hover filter and three-dot actions on selected fields while merging
- exposes a safe overflow menu with **Add filter** and **View description**
- routes filters to the selected field's owning query
- mirrors matching-field filters across both sources
- adds accessible labels to the filter and overflow buttons

## Why restricted actions

Primary-query-only actions such as creating or editing custom fields are intentionally omitted from the merged-source overflow menu. They would otherwise mutate the wrong query.

## Validation

- live sidebar hover, overflow-menu, and filter interaction
- source-specific and matching-field filter tests
- selected-field action behavior test
- frontend typecheck
- changed-file lint