### PR TITLE
docs(release-safety): make the required gate self-service

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -478,6 +478,7 @@ jobs:
             --rest-status "${{ steps.rest-result.outputs.status }}" \
             ${{ steps.marker.outputs.draft == 'true' && '--draft' || '' }} \
             ${{ steps.lint.outputs.breaking == 'true' && '--linter-breaking' || '--no-linter-breaking' }} \
+            ${{ (steps.declaration-gate.outcome == 'failure' || steps.sql-declaration-gate.outcome == 'failure') && '--declaration-gate-failed' || '' }} \
             --out /tmp/release-safety-comment.md
 
       - name: Post or update sticky comment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,15 @@ pnpm -F backend rollback-last
 3. **API**: TSOA generates OpenAPI specs from TypeScript controllers
 4. **Authentication**: CASL-based authorization with multiple auth providers
 
+## Release-safety declarations
+
+`Release-safety preview` is a required check on `main`. It protects self-hosted upgrades: `unknown` means we could not confirm the change is safe, while `breaking` means we know it is incompatible. Both hold the upgrade, for different reasons.
+
+- For migration breaks, follow the detailed [migration release-safety declarations](packages/backend/src/database/migrations/CLAUDE.md#release-safety-declarations).
+- For API or type breaks, changed, non-test TypeScript source under `packages/backend/src` or `packages/common/src` may declare `export const breaking = { reason: '<operator-facing reason>', requiredStop: false }`. It must be a top-level, unannotated object literal with exactly those fields: `reason` is a non-empty string literal, `requiredStop` is a boolean literal, and API-gate reasons must be at least 24 characters, use more than one word, and not be placeholder text.
+
+Never declare a break merely to make CI pass. Declaring a break advises every self-hosted customer to use the Recreate strategy. A release that ships as `breaking` or `unknown` stops the internal analytics instance upgrading; every later release inherits the block until someone moves the pin past it by hand. On 2026-08-14 that cost roughly six hours, during which the automation reported success on every run and said nothing.
+
 ## Merge Freeze — Holding `main` While a Release Is Cut
 
 `release.yml` fires on every push to `main`, so the release that goes out is whatever `main` contains at that moment. When something needs to reach a release on its own — a fix someone is waiting on — hold merges rather than asking people in Slack not to merge:

--- a/packages/backend/src/database/migrations/CLAUDE.md
+++ b/packages/backend/src/database/migrations/CLAUDE.md
@@ -32,6 +32,8 @@ The migration system supports both up/down functions and includes 150+ historica
 
 ## Release-safety declarations
 
+For API and type breaks outside migrations, see the root [release-safety declarations](../../../../../CLAUDE.md#release-safety-declarations).
+
 The release-safety gate applies these rules only to migration files changed by the pull request. Existing untouched migrations are grandfathered.
 
 - A migration containing a detected breaking operation must declare it in that file with the exact export `export const breaking = { reason: '<operator-facing reason>', requiredStop: <true | false> }`. The reason must be a non-empty string literal and `requiredStop` must be a boolean literal. The declaration records the break; it does not hide the detector finding.

--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -64,6 +64,17 @@ test('unknown verdict is rendered as unsafe for a ready PR', () => {
     );
     assert.match(body, /Couldn’t confirm it’s safe/);
     assert.match(body, /Double-check the old version/);
+    assert.match(body, /How to unblock this pull request/);
+    assert.match(body, /required check must pass before merge/);
+    assert.match(body, /Never declare a break merely to make CI pass/);
+    assert.match(body, /internal analytics instance upgrading/);
+});
+
+test('a declaration gate failure renders remediation for an otherwise green marker', () => {
+    const body = renderPrComment(baseMarker(), { declarationGateFailed: true });
+    assert.match(body, /How to unblock this pull request/);
+    assert.match(body, /migration break/);
+    assert.match(body, /API or type break/);
 });
 
 test('migration and enterprise counts use the v2 split', () => {
@@ -140,6 +151,7 @@ test('raw v2 JSON is embedded for machines', () => {
     assert.match(body, /Technical details \(raw JSON\)/);
     assert.match(body, /"schemaVersion": "2"/);
     assert.doesNotMatch(body, /"capabilities"/);
+    assert.doesNotMatch(body, /How to unblock this pull request/);
 });
 
 if (failures.length > 0) {

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -52,6 +52,7 @@ export interface RenderOpts {
      * OpenAPI specs it needed — the second is a broken check, not a clean bill.
      */
     restStatus?: 'ran' | 'skipped' | 'failed';
+    declarationGateFailed?: boolean;
 }
 
 const SAFE_HEADLINE = '✅ **Safe to upgrade normally.** No downtime needed.';
@@ -76,6 +77,7 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
     const clearedAsSafeDrop = lintFlagged && rollingUpdateSafe === true;
     // The risk comes from an API change (no DB migration) rather than the schema.
     const apiDriven = (restBreaking || mcpBreaking) && migrationsPresent !== true;
+    const needsUnblock = rollingUpdateSafe !== true || opts.declarationGateFailed === true;
 
     // ---- the answer, in one line + a plain "why" ----------------------------
     const head: string[] = [];
@@ -193,6 +195,17 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
     } else if (requiredStop) {
         advice.push('Call this out in the release notes so customers know they can’t skip this version.');
     }
+    const unblock = needsUnblock
+        ? [
+              '**How to unblock this pull request**',
+              '',
+              'This required check must pass before merge. For a migration break, follow `packages/backend/src/database/migrations/CLAUDE.md`; for an API or type break, add the verified declaration described in [the release-safety guidance](https://github.com/lightdash/lightdash/blob/main/CLAUDE.md#release-safety-declarations).',
+              '',
+              'Never declare a break merely to make CI pass. Declaring a break advises every self-hosted customer to use the Recreate strategy.',
+              '',
+              'A release that ships as `breaking` or `unknown` stops the internal analytics instance upgrading. Every later release inherits the block until someone moves the pin past it by hand. On 2026-08-14, that cost roughly six hours while the automation reported success and said nothing.',
+          ]
+        : [];
 
     // ---- assemble -----------------------------------------------------------
     const baseLine = opts.baseLabel ? `> Comparing against \`${opts.baseLabel}\`.\n` : '';
@@ -208,6 +221,7 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         '',
         table,
         ...(advice.length ? ['', '**What to do**', '', advice.map((a) => `- ${a}`).join('\n')] : []),
+        ...(unblock.length ? ['', ...unblock] : []),
         '',
         '<details><summary>Technical details (raw JSON)</summary>\n',
         '```json',
@@ -239,6 +253,7 @@ function main(): void {
     const body = renderPrComment(marker, {
         baseLabel: arg('base'),
         restStatus: restStatus as RenderOpts['restStatus'],
+        declarationGateFailed: process.argv.includes('--declaration-gate-failed'),
         draft: process.argv.includes('--draft'),
         linterBreaking: process.argv.includes('--linter-breaking')
             ? true


### PR DESCRIPTION
Linear: SPK-1020

`Release-safety preview` became a **required** check on `main` today. A blocked author had no self-service way out, and the case that caused this morning's incident — an API break with **zero migrations** — had no documentation at all.

## What changed

**1. Remediation in the sticky PR comment.** Rendered only when the verdict is not green, or the declare-or-fail gate failed. It's where a blocked person is already looking; until now the comment gave customer advice ("customers should restart the app during the upgrade") and design advice, but never told the author how to make the check pass.

**2. A root `CLAUDE.md` section.** Previously the root `CLAUDE.md` (395 lines) and `AGENTS.md` had **zero** mentions of the gate. The only guidance lived in `packages/backend/src/database/migrations/CLAUDE.md` — a nested file, loaded only inside that directory, and migration-only. Someone editing a type in `packages/common/src` never saw it.

**3. The API-break path, which existed in code and nowhere else.** Cross-referenced both ways between the root and migrations docs.

## The declaration syntax, verified from source

This is the part worth checking in review, because my original spec for this work was **wrong** and the source corrected it:

| I assumed | Actually |
|---|---|
| `breaking-change-declarations.ts` defines `DECLARATION_DIRS` | It's `gen-release-safety.ts:62` |
| Declarations picked up anywhere under `packages/backend` / `packages/common` | Only `packages/{backend,common}/src` — `TYPESCRIPT_SOURCE` at `:63` |
| All source files | Non-test only — `TYPESCRIPT_TEST` at `:64` excludes `__tests__/`, `.test.`, `.spec.` |
| — | Only files **changed by the PR** (`:443-444`) |

The documented shape (`gen-release-safety.ts:632,651`): a top-level, unannotated `export const breaking = { reason, requiredStop }` with exactly those two fields, `reason` a non-empty string literal, `requiredStop` a boolean literal, and API-gate reasons at least 24 characters, more than one word, not placeholder text.

## Two things every piece of new copy carries

- **Never declare a break merely to make CI pass.** It advises every self-hosted customer to use the Recreate strategy — a real decision about their rollout, not a CI formality. This preserves the framing the migrations doc already had.
- **The auto-upgrade consequence**, documented nowhere until now: a release shipping as `breaking` or `unknown` stops the internal analytics instance upgrading, and blocks the whole path forward rather than just that release. Every later release inherits the block until someone moves the pin by hand.

It also distinguishes `unknown` from `breaking` — "we could not confirm this is safe" is not "we know this breaks". Both hold, for different reasons.

## Second commit: wiring a flag that was dead

The renderer gained `--declaration-gate-failed`, but nothing passed it, so it was permanently false. The block would have appeared only when the marker itself was not green — missing the case where the marker is green and only the declare-or-fail gate failed. That's the check going red while the verdict reads clean, which is the most confusing way to be blocked. Now wired from the workflow, mirroring the condition `Fail release-safety gates` already uses.

## Verification

```
scripts/release-safety-pr-comment.test.ts      ✅ 8 tests passed
scripts/release-safety-workflow-shape.test.ts  ✅ passed
YAML parse of release-safety-pr.yml            ✅
```

New tests cover the unknown-verdict case, the green-marker-plus-failed-gate case, and assert the block is **absent** on a clean verdict.

Honest gap: the full `pnpm run test:release-safety` could not run in this worktree — `gen-release-safety-cli.test.ts` needs `ajv` from `packages/cli`, which isn't installed here (this is the SPK-941 dependency, and CI installs it explicitly). CI will cover it.