### PR TITLE
docs(release-safety): drop the dated incident reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ pnpm -F backend rollback-last
 - For migration breaks, follow the detailed [migration release-safety declarations](packages/backend/src/database/migrations/CLAUDE.md#release-safety-declarations).
 - For API or type breaks, changed, non-test TypeScript source under `packages/backend/src` or `packages/common/src` may declare `export const breaking = { reason: '<operator-facing reason>', requiredStop: false }`. It must be a top-level, unannotated object literal with exactly those fields: `reason` is a non-empty string literal, `requiredStop` is a boolean literal, and API-gate reasons must be at least 24 characters, use more than one word, and not be placeholder text.
 
-Never declare a break merely to make CI pass. Declaring a break advises every self-hosted customer to use the Recreate strategy. A release that ships as `breaking` or `unknown` stops the internal analytics instance upgrading; every later release inherits the block until someone moves the pin past it by hand. On 2026-08-14 that cost roughly six hours, during which the automation reported success on every run and said nothing.
+Never declare a break merely to make CI pass. Declaring a break advises every self-hosted customer to use the Recreate strategy. A release that ships as `breaking` or `unknown` stops the internal analytics instance upgrading; every later release inherits the block until someone moves the pin past it by hand.
 
 ## Merge Freeze — Holding `main` While a Release Is Cut
 

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -203,7 +203,7 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
               '',
               'Never declare a break merely to make CI pass. Declaring a break advises every self-hosted customer to use the Recreate strategy.',
               '',
-              'A release that ships as `breaking` or `unknown` stops the internal analytics instance upgrading. Every later release inherits the block until someone moves the pin past it by hand. On 2026-08-14, that cost roughly six hours while the automation reported success and said nothing.',
+              'A release that ships as `breaking` or `unknown` stops the internal analytics instance upgrading. Every later release inherits the block until someone moves the pin past it by hand.',
           ]
         : [];
 


### PR DESCRIPTION
Linear: SPK-1020

Follow-up trim to #27424.

The release-safety guidance ended by citing a specific outage and its duration:

> On 2026-08-14 that cost roughly six hours, during which the automation reported success on every run and said nothing.

The consequence it was illustrating stands on its own without it, and a date-stamped example ages badly in text that renders on **every blocked pull request** and sits permanently in the root `CLAUDE.md`.

## What changed

Removed that sentence from both places it appeared:

- `scripts/release-safety-pr-comment.ts` — the "How to unblock this pull request" block
- `CLAUDE.md` — the Release-safety declarations section

The preceding statement of the consequence is unchanged in both, so the guidance still says what actually matters:

> A release that ships as `breaking` or `unknown` stops the internal analytics instance upgrading. Every later release inherits the block until someone moves the pin past it by hand.

Note the request named only the PR-comment occurrence; I removed both because the same sentence with the same problem was in `CLAUDE.md`, and trimming one while leaving the other would read as an oversight. Happy to restore the `CLAUDE.md` one if only the comment was meant.

## Verification

```
scripts/release-safety-pr-comment.test.ts      ✅ 8 tests passed
scripts/release-safety-workflow-shape.test.ts  ✅ passed
```

No test needed changing — the assertion covering this block matches `internal analytics instance upgrading`, which is in the surviving sentence.