### PR TITLE
fix(release-safety): write the describes-stamp, gated on the verdict

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -166,11 +166,17 @@ jobs:
               per_page: 100,
             });
             const existing = comments.find((c) => c.body.includes(marker));
+            // SPK-1017: `gate` is part of the stamp because this check is
+            // required. A job skipped by an `if:` reports SKIPPED, and SKIPPED
+            // satisfies a required check — so reusing a FAILED verdict would
+            // turn a red gate green by editing the PR title. Only a verdict
+            // that passed may be short-circuited.
             const m = existing?.body.match(
-              /<!-- release-safety-describes head:([0-9a-f]{7,40}) base:([0-9a-f]{7,40}) -->/,
+              /<!-- release-safety-describes head:([0-9a-f]{7,40}) base:([0-9a-f]{7,40}) gate:(pass|fail) -->/,
             );
             core.setOutput('head', m ? m[1] : '');
             core.setOutput('base', m ? m[2] : '');
+            core.setOutput('gate', m ? m[3] : '');
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.watched.outputs.watched == 'true'
@@ -204,8 +210,9 @@ jobs:
           set -euo pipefail
           if [ -n "${{ steps.sticky.outputs.head }}" ] \
             && [ "${{ steps.sticky.outputs.head }}" = "${{ github.event.pull_request.head.sha }}" ] \
-            && [ "${{ steps.sticky.outputs.base }}" = "${{ steps.base.outputs.sha }}" ]; then
-            echo "The sticky comment already describes this head+base; skipping recompute."
+            && [ "${{ steps.sticky.outputs.base }}" = "${{ steps.base.outputs.sha }}" ] \
+            && [ "${{ steps.sticky.outputs.gate }}" = "pass" ]; then
+            echo "The sticky comment already describes this head+base and its gates passed; skipping recompute."
             echo "fresh=true" >> "$GITHUB_OUTPUT"
           else
             echo "fresh=false" >> "$GITHUB_OUTPUT"
@@ -563,6 +570,7 @@ jobs:
             ${{ steps.marker.outputs.draft == 'true' && '--draft' || '' }} \
             ${{ steps.lint.outputs.breaking == 'true' && '--linter-breaking' || '--no-linter-breaking' }} \
             ${{ (steps.declaration-gate.outcome == 'failure' || steps.sql-declaration-gate.outcome == 'failure') && '--declaration-gate-failed' || '' }} \
+            ${{ (steps.rest-result.outputs.broken == 'true' || steps.mcp-result.outputs.broken == 'true' || steps.declaration-gate.outcome == 'failure' || steps.sql-declaration-gate.outcome == 'failure') && '--gate-failed' || '' }} \
             --out /tmp/release-safety-comment.md
 
       - name: Post or update sticky comment

--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
 import {
     COMMENT_MARKER,
     Marker,
@@ -152,6 +153,47 @@ test('raw v2 JSON is embedded for machines', () => {
     assert.match(body, /"schemaVersion": "2"/);
     assert.doesNotMatch(body, /"capabilities"/);
     assert.doesNotMatch(body, /How to unblock this pull request/);
+});
+
+const HEAD = '4146779f7a801f252b99ddfa68a5e8217d08fefb';
+const BASE = 'd92d59798a4f0207927eea6c1ac31eafb6b1090e';
+
+test('a passing verdict stamps the revision it describes', () => {
+    const body = renderPrComment(baseMarker(), { headSha: HEAD, baseSha: BASE });
+    assert.match(
+        body,
+        new RegExp(`<!-- release-safety-describes head:${HEAD} base:${BASE} gate:pass -->`),
+    );
+});
+
+test('a failed gate stamps gate:fail so it can never be short-circuited', () => {
+    const body = renderPrComment(baseMarker(), { headSha: HEAD, baseSha: BASE, gateFailed: true });
+    assert.match(body, /release-safety-describes .* gate:fail -->/);
+    assert.doesNotMatch(body, /gate:pass/);
+});
+
+test('the stamp is omitted when the revision is unknown', () => {
+    assert.doesNotMatch(renderPrComment(baseMarker()), /release-safety-describes/);
+    assert.doesNotMatch(
+        renderPrComment(baseMarker(), { headSha: HEAD }),
+        /release-safety-describes/,
+    );
+});
+
+test('the stamp matches the regex the workflow reads it with', () => {
+    const workflow = fs.readFileSync('.github/workflows/release-safety-pr.yml', 'utf-8');
+    const declared = workflow.match(
+        /\/<!-- release-safety-describes head:\(\[0-9a-f\]\{7,40\}\) base:\(\[0-9a-f\]\{7,40\}\) gate:\(pass\|fail\) -->\//,
+    );
+    assert.ok(declared, 'the workflow reader regex is not in the expected form');
+
+    const reader =
+        /<!-- release-safety-describes head:([0-9a-f]{7,40}) base:([0-9a-f]{7,40}) gate:(pass|fail) -->/;
+    const emitted = renderPrComment(baseMarker(), { headSha: HEAD, baseSha: BASE }).match(reader);
+    assert.ok(emitted, 'the rendered stamp does not match the reader regex');
+    assert.strictEqual(emitted[1], HEAD);
+    assert.strictEqual(emitted[2], BASE);
+    assert.strictEqual(emitted[3], 'pass');
 });
 
 if (failures.length > 0) {

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -53,6 +53,20 @@ export interface RenderOpts {
      */
     restStatus?: 'ran' | 'skipped' | 'failed';
     declarationGateFailed?: boolean;
+    /**
+     * The revision this verdict describes. Stamped into the comment so a later
+     * `edited` event can tell whether the verdict on the page still applies, and
+     * skip recomputing it if so.
+     */
+    headSha?: string;
+    baseSha?: string;
+    /**
+     * Whether the release-safety gates failed for this revision. The stamp
+     * carries it because the check is required: a skipped job reports SKIPPED,
+     * which satisfies a required check, so short-circuiting a failed verdict
+     * would turn a red gate green. Only a passing verdict may be reused.
+     */
+    gateFailed?: boolean;
 }
 
 const SAFE_HEADLINE = '✅ **Safe to upgrade normally.** No downtime needed.';
@@ -210,9 +224,18 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
     // ---- assemble -----------------------------------------------------------
     const baseLine = opts.baseLabel ? `> Comparing against \`${opts.baseLabel}\`.\n` : '';
     const rawJson = JSON.stringify(marker, null, 2);
+    const describes =
+        opts.headSha && opts.baseSha
+            ? [
+                  `<!-- release-safety-describes head:${opts.headSha} base:${opts.baseSha} gate:${
+                      opts.gateFailed ? 'fail' : 'pass'
+                  } -->`,
+              ]
+            : [];
 
     return [
         COMMENT_MARKER,
+        ...describes,
         '## 🛡️ Upgrade safety for self-hosted customers',
         baseLine,
         head.map((l) => `- ${l}`).join('\n'),
@@ -254,6 +277,9 @@ function main(): void {
         baseLabel: arg('base'),
         restStatus: restStatus as RenderOpts['restStatus'],
         declarationGateFailed: process.argv.includes('--declaration-gate-failed'),
+        headSha: arg('head-sha'),
+        baseSha: arg('base-sha'),
+        gateFailed: process.argv.includes('--gate-failed'),
         draft: process.argv.includes('--draft'),
         linterBreaking: process.argv.includes('--linter-breaking')
             ? true

--- a/scripts/release-safety-workflow-shape.test.ts
+++ b/scripts/release-safety-workflow-shape.test.ts
@@ -86,4 +86,28 @@ assert.ok(
     'the pending notice must not emit a release-safety-describes stamp (SPK-1013 / SPK-1017)',
 );
 
+// SPK-1017: the short-circuit may only reuse a verdict whose gates PASSED.
+// `preview` is skipped when fresh, a skipped job reports SKIPPED, and SKIPPED
+// satisfies a required status check — so reusing a failed verdict would clear a
+// red gate by editing the pull request title.
+assert.ok(
+    workflow.includes('steps.sticky.outputs.gate }}" = "pass"'),
+    'the freshness check must require the previous run\'s gates to have passed (SPK-1017)',
+);
+assert.ok(
+    /gate:\(pass\|fail\)/.test(workflow),
+    'the describes-stamp reader must capture the gate outcome (SPK-1017)',
+);
+
+// The condition deciding "did the gates fail" now appears twice: once to fail
+// the job, once to stamp the comment. They must stay identical, or the stamp
+// will claim a pass the job did not give.
+const gateCondition =
+    /steps\.rest-result\.outputs\.broken == 'true' \|\| steps\.mcp-result\.outputs\.broken == 'true' \|\| steps\.declaration-gate\.outcome == 'failure' \|\| steps\.sql-declaration-gate\.outcome == 'failure'/g;
+const gateConditions = workflow.match(gateCondition) ?? [];
+assert.ok(
+    gateConditions.length >= 2,
+    `the gate-failure condition must be identical where the job fails and where the stamp is written; found ${gateConditions.length} matching occurrence(s)`,
+);
+
 process.stdout.write('release-safety workflow shape tests passed\n');


### PR DESCRIPTION
Linear: SPK-1017

## The dead mechanism

The workflow reads a stamp out of the sticky comment to decide whether an edit-only event can skip the heavy jobs. **Nothing ever wrote it.** The workflow already passed `--head-sha` and `--base-sha` to the renderer, and the reader already looked for the result — only the emission in between was missing, so `RenderOpts` had no reference to either value.

The short-circuit has therefore never fired once. Every title or body edit pays a full run: **median 9.0 min, p90 12.3** over 25 consecutive runs. Since SPK-960 made this check required, that also blocks the author's own merge for the duration. Fixing a typo in your description costs you nine minutes.

## Why the obvious fix would have been a bypass

Emitting the stamp as the ticket originally specified would have quietly undone SPK-960. Each link verified:

1. `preview` is gated on `fresh != 'true'`, so a short-circuit **skips** it.
2. A job skipped by an `if:` reports a check run with conclusion `SKIPPED`.
3. `SKIPPED` **satisfies** a required status check — confirmed on PR #27332, which is `CLEAN` / `MERGEABLE` with `Release-safety preview = SKIPPED`.

So:

> Failing gate → author edits the title → stamp matches head+base → `fresh=true` → `preview` skipped → required check satisfied → **merge allowed.**

Editing your own PR description would clear a red gate.

## What this does instead

The stamp records the **gate outcome** as well as the revision:

```
<!-- release-safety-describes head:<sha> base:<sha> gate:pass|fail -->
```

Only a `pass` may be reused. A failed verdict always recomputes and goes red again.

The short-circuit can now only engage on: an `edited` event, same head, same merge-base, and a previously passing gate. Worth noting what still cannot reach it — `synchronize` and `ready_for_review` are not `edited` events, so a push or a draft flip always recomputes. `ready_for_review` in particular must, since it is what newly enables the AI review.

SPK-858's original case is unaffected by construction: a changed base branch means a different merge-base, so the stamp cannot match.

## One thing to watch in review

The condition deciding whether the gates failed now appears **twice** — once to fail the job, once to stamp the comment. A test asserts they remain identical, because a stamp claiming a pass the job did not give is the same bypass by a slower route. If you would rather have it computed once into a step output and referenced twice, say so and I will restructure it.

## Verification

```
scripts/release-safety-pr-comment.test.ts      ✅ 12 tests passed (4 new)
scripts/release-safety-workflow-shape.test.ts  ✅ passed (3 new assertions)
```

One new test renders the stamp and matches it against the **actual regex read out of the workflow file**, so the emitter and reader cannot drift into different formats.

Both new guards were verified to **fail** when the protection is removed, not merely to pass today:

```
removing the gate:pass requirement →
  must require the previous run's gates to have passed (SPK-1017)

drifting one of the two gate conditions →
  gate-failure condition must be identical where the job fails and where
  the stamp is written; found 1 matching occurrence(s)
```

## Residual risk

This turns on a code path that has never executed in production. The blast radius is bounded — it can only ever skip work for an `edited` event whose verdict already passed for exactly this head and base — but it is worth watching the first few short-circuits land to confirm they engage when expected and, more importantly, that they do not engage when they should not.