### PR TITLE
fix: hide redundant PoP time dimension dropdown

### DIFF
--- a/packages/frontend/src/components/Explorer/PeriodOverPeriodComparisonModal/PeriodOverPeriodComparisonModal.tsx
+++ b/packages/frontend/src/components/Explorer/PeriodOverPeriodComparisonModal/PeriodOverPeriodComparisonModal.tsx
@@ -73,6 +73,16 @@ const PeriodOverPeriodComparisonModalContent: FC<{
         [allTimeDimensions, finestRank],
     );
 
+    const availableTimeDimensions = useMemo(
+        () =>
+            allTimeDimensions.filter(
+                (dim) =>
+                    getGranularityRank(dim.timeInterval as TimeFrames) ===
+                    finestRank,
+            ),
+        [allTimeDimensions, finestRank],
+    );
+
     const renderSelectOption: React.ComponentProps<
         typeof Select
     >['renderOption'] = ({ option }) => {
@@ -98,10 +108,13 @@ const PeriodOverPeriodComparisonModalContent: FC<{
     const [periodOffset, setPeriodOffset] = useState<number>(1);
 
     const selectedDimensionObj = useMemo(() => {
+        if (availableTimeDimensions.length === 1) {
+            return availableTimeDimensions[0];
+        }
         if (!selectedTimeDimensionId || !itemsMap) return null;
         const dim = itemsMap[selectedTimeDimensionId];
         return isDimension(dim) ? dim : null;
-    }, [selectedTimeDimensionId, itemsMap]);
+    }, [availableTimeDimensions, selectedTimeDimensionId, itemsMap]);
 
     const selectedGranularityLabel = useMemo(() => {
         if (!selectedDimensionObj?.timeInterval) return null;
@@ -207,21 +220,23 @@ const PeriodOverPeriodComparisonModalContent: FC<{
                         different time dimension or offset.
                     </Callout>
                 ) : null}
-                <Select
-                    label="Time dimension"
-                    placeholder={
-                        canConfigure
-                            ? 'Select time dimension'
-                            : 'Add a time dimension to enable comparison'
-                    }
-                    data={selectData}
-                    value={selectedTimeDimensionId}
-                    onChange={setSelectedTimeDimensionId}
-                    disabled={!canConfigure}
-                    renderOption={renderSelectOption}
-                    searchable
-                    clearable
-                />
+                {availableTimeDimensions.length !== 1 && (
+                    <Select
+                        label="Time dimension"
+                        placeholder={
+                            canConfigure
+                                ? 'Select time dimension'
+                                : 'Add a time dimension to enable comparison'
+                        }
+                        data={selectData}
+                        value={selectedTimeDimensionId}
+                        onChange={setSelectedTimeDimensionId}
+                        disabled={!canConfigure}
+                        renderOption={renderSelectOption}
+                        searchable
+                        clearable
+                    />
+                )}
 
                 <Group gap="xs" align="center">
                     <NumberInput


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/18693

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Hide the time-dimension dropdown when exactly one compatible dimension is available.

<!-- Even better add a screenshot / gif / loom -->

| before | after |
|--------|--------|
| <img width="2216" height="1272" alt="image" src="https://github.com/user-attachments/assets/dc3b2bad-a242-4f60-9ace-ced1e5a7d4b5" /> | <img width="1850" height="1287" alt="image" src="https://github.com/user-attachments/assets/ee166a92-0753-46f9-920c-df8ef10267b5" /> | 





