### PR TITLE
perf(release-safety): cache the preview job's pnpm store

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -396,9 +396,21 @@ jobs:
           mode: firewall-free
           firewall-version: 1.15.0
 
+      # SPK-1021: pnpm is set up BEFORE setup-node so that `cache: 'pnpm'` can
+      # resolve the store path — setup-node shells out to pnpm to find it, and
+      # fails with "Unable to locate executable file: pnpm" if it runs first.
+      # This is the ordering openapi-specs already uses.
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      # The install below was 75% of this job's runtime (255s median) because it
+      # re-fetched the whole CLI dependency tree, uncached, on every run — to
+      # obtain one library. This check is required, so that is merge latency for
+      # everyone, not background CI cost.
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install tsx
         run: sfw npm install -g tsx@4.19.4
@@ -407,8 +419,6 @@ jobs:
       # packages/cli/src/releaseSafety (ajv-backed index validation), so the
       # otherwise dependency-free preview needs the CLI package's dependencies.
       # Verify-then-fallback because sfw can exit 0 on a half-completed install.
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
       - name: Install CLI package dependencies
         run: |
           sfw pnpm install --frozen-lockfile --filter @lightdash/cli --network-concurrency=16 || true

--- a/scripts/release-safety-workflow-shape.test.ts
+++ b/scripts/release-safety-workflow-shape.test.ts
@@ -110,4 +110,26 @@ assert.ok(
     `the gate-failure condition must be identical where the job fails and where the stamp is written; found ${gateConditions.length} matching occurrence(s)`,
 );
 
+// SPK-1021: the preview job's dependency install was 75% of its runtime because
+// nothing cached it. Losing the cache costs ~4 minutes per run and fails
+// silently — the job still passes, just slowly — so it is asserted here.
+// The ordering matters too: setup-node shells out to pnpm to resolve the store
+// path, so pnpm must be set up first or the cache cannot be configured at all.
+// Comments are stripped first: the prose above this config quotes `cache: 'pnpm'`
+// verbatim, so testing the raw text matches the explanation rather than the
+// setting, and the assertion passes with the cache deleted.
+const configOnly = withoutComments.join('\n');
+const previewJob = configOnly.slice(
+    configOnly.indexOf('\n  preview:'),
+    configOnly.indexOf('\n  retract:'),
+);
+assert.ok(
+    /cache:\s*'pnpm'/.test(previewJob),
+    "the preview job's setup-node must cache the pnpm store (SPK-1021)",
+);
+assert.ok(
+    previewJob.indexOf('pnpm/action-setup') < previewJob.indexOf('actions/setup-node'),
+    'pnpm must be set up before setup-node, or cache: pnpm cannot resolve the store path (SPK-1021)',
+);
+
 process.stdout.write('release-safety workflow shape tests passed\n');


### PR DESCRIPTION
Linear: SPK-1021

## Measurement first

Step-level timings across the `Release-safety preview` job:

| Step | Median | Share |
|---|---|---|
| **Install CLI package dependencies** | **255s** (max 338s) | **75%** |
| `actions/checkout` | 55s | 16% |
| *Compute release-safety marker* — the actual analysis | **1s** | 0.3% |
| everything else | ≤7s each | ~8% |

The job spent over four minutes installing dependencies to do one second of work, to obtain **one library** (`ajv`, needed by the index validation SPK-941 introduced).

## The cause

The `preview` job's `setup-node` had no cache. The `openapi-specs` job in the same file always has. So `preview` refetched the whole `@lightdash/cli` dependency tree over the network, uncached, every run.

Since SPK-960 made this check required, that is everyone's merge latency now, not background CI cost.

## The ordering gotcha

`cache: 'pnpm'` cannot simply be added. `setup-node` shells out to pnpm to resolve the store path and fails with *"Unable to locate executable file: pnpm"* if pnpm is not already installed. In `preview`, `setup-node` ran at step 4 and `pnpm/action-setup` at step 6.

So pnpm now sets up first — the ordering `openapi-specs` already uses.

## The guard was broken, and the way it broke is the point

I added an assertion that the cache stays in place, since losing it costs four minutes **silently** — the job still passes, just slowly.

It passed with the cache deleted.

The regex `/cache:\s*'pnpm'/` was matching the comment I had written directly above the config:

```yaml
# SPK-1021: pnpm is set up BEFORE setup-node so that `cache: 'pnpm'` can
#   resolve the store path ...
```

The prose explaining the guard satisfied the guard. It now tests comment-stripped content.

This is the same failure shape as the rest of this week's findings: something that reads as working because the text it looks for is present, with nothing on the other end of it. It was only caught because I deleted the setting and checked the test went red, rather than observing it pass and moving on.

## Expected impact

`preview` from ~5.7 min to ~1.4 min; the whole required check from ~9 min median to roughly 5.

## Caveats

- Sample is 4 preview jobs. Lopsided enough to act on (75% vs 16%), but worth re-measuring over a day before quoting the saving anywhere external.
- `Compute release-safety marker` is **bimodal**. It reads 1s because none of the sampled PRs triggered the AI review, which only fires on ready PRs carrying migrations. When it fires it is minutes — the 1.157.0 release run took ~3 min for 13 tool calls. The median understates that step for exactly the PRs where it matters most, so this change will help least on the heaviest PRs.

## Verification

```
scripts/release-safety-workflow-shape.test.ts  ✅ passed (2 new assertions)
scripts/release-safety-pr-comment.test.ts      ✅ 12 tests passed
YAML parse + step-order assertion              ✅ pnpm(3) precedes setup-node(4)
```

Guard verified in both directions: fails with `must cache the pnpm store (SPK-1021)` when the setting is removed, passes when restored.