### PR TITLE
ci: remove Socket Firewall from the remaining 8 workflows

### DIFF
--- a/.github/workflows/_setup_node_pnpm_cypress/action.yml
+++ b/.github/workflows/_setup_node_pnpm_cypress/action.yml
@@ -8,12 +8,6 @@ runs:
         - name: Checkout
           uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-        - name: Setup Socket Firewall
-          uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-          with:
-              mode: firewall-free
-              firewall-version: 1.15.0
-
         - name: Setup PNPM
           uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         - name: Setup Node
@@ -24,10 +18,10 @@ runs:
               cache-dependency-path: 'pnpm-lock.yaml'
 
         - name: Install Dependencies
-          run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+          run: pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
           shell: bash
 
         - name: Install Cypress
-          run: sfw pnpm exec cypress install
+          run: pnpm exec cypress install
           working-directory: packages/e2e
           shell: bash

--- a/.github/workflows/ai-agent-integration-tests.yml
+++ b/.github/workflows/ai-agent-integration-tests.yml
@@ -41,12 +41,6 @@ jobs:
 
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-            - name: Setup Socket Firewall
-              uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-              with:
-                  mode: firewall-free
-                  firewall-version: 1.15.0
-
             - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
@@ -55,7 +49,7 @@ jobs:
                   cache-dependency-path: 'pnpm-lock.yaml'
 
             - name: Install packages
-              run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+              run: pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
 
             - name: Build common
               run: pnpm common-build

--- a/.github/workflows/ai-security-advisories.yml
+++ b/.github/workflows/ai-security-advisories.yml
@@ -122,12 +122,6 @@ jobs:
                     echo "Resolved the immutable Docker digest."
                   fi
 
-            - name: Setup Socket Firewall
-              uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-              with:
-                  mode: firewall-free
-                  firewall-version: 1.15.0
-
             - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -137,13 +131,7 @@ jobs:
                   cache-dependency-path: 'pnpm-lock.yaml'
 
             - name: Install root dependencies
-              run: sfw pnpm install --frozen-lockfile --filter . --network-concurrency=16
-
-            # sfw can exit 0 with a partial tree; unset CI so pnpm verifies and relinks it.
-            - name: Repair install without sfw
-              run: |
-                  CI= pnpm install --frozen-lockfile --prefer-offline --filter .
-                  pnpm exec tsx --version
+              run: pnpm install --frozen-lockfile --filter . --network-concurrency=16
 
             - name: Analyze release and create eligible private drafts
               env:

--- a/.github/workflows/mcp-tools-snapshot-check.yml
+++ b/.github/workflows/mcp-tools-snapshot-check.yml
@@ -40,12 +40,6 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-          firewall-version: 1.15.0
-
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -53,20 +47,8 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-      # sfw can exit 0 with a half-installed tree when its proxy dies mid-install
-      # (every registry GET fails with error(23) through the dead proxy, pnpm
-      # gives up, sfw masks the failure). Verify the toolchain actually landed
-      # and repair with plain pnpm — lockfile-pinned and integrity-checked — so
-      # a broken install can never masquerade as a stale snapshot.
       - name: Install dependencies
-        run: |
-          set -euo pipefail
-          sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16 || echo "::warning::sfw install exited non-zero; repairing with plain pnpm"
-          if ! pnpm -F common exec tsx --version >/dev/null 2>&1; then
-            echo "::warning::install incomplete after sfw (tsx missing); repairing with plain pnpm install"
-            pnpm install --frozen-lockfile --prefer-offline
-            pnpm -F common exec tsx --version >/dev/null
-          fi
+        run: pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
 
       - name: Check the committed snapshot is fresh
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -123,11 +123,6 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-          firewall-version: 1.15.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -135,7 +130,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install packages
-        run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+        run: pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
       - name: Build
         run: pnpm build
       - name: Run quality checks in parallel
@@ -168,11 +163,6 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-          firewall-version: 1.15.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -180,7 +170,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install packages
-        run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+        run: pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
       - name: Build SDK bundle
         run: pnpm sdk-build
       - name: Check SDK bundle is CSP-safe
@@ -227,11 +217,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-          firewall-version: 1.15.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -240,14 +225,14 @@ jobs:
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Generate base OpenAPI schema
         run: |
-          sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+          pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
           pnpm generate-api
           cp packages/backend/src/generated/swagger.json /tmp/base-swagger.json
       - name: Checkout PR
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Generate PR OpenAPI schema
         run: |
-          sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+          pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
           pnpm generate-api
       - name: Check for OpenAPI breaking changes
         if: ${{ !contains(github.event.pull_request.body, 'allow-api-breaking-change') }}
@@ -543,11 +528,6 @@ jobs:
           egress-policy: audit
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-          firewall-version: 1.15.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -555,7 +535,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install packages
-        run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+        run: pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
       - name: Build packages/common module
         run: pnpm common-build
       - name: Create BigQuery credentials file
@@ -716,7 +696,7 @@ jobs:
       - name: Build packages/warehouses module
         run: pnpm warehouses-build
       - name: Build and install packages/cli module
-        run: cd packages/cli && pnpm build && sfw npm install -g
+        run: cd packages/cli && pnpm build && npm install -g
       - name: Test lightdash version
         run: |
           lightdash_version=$(lightdash --version)
@@ -778,7 +758,7 @@ jobs:
       - name: Build packages/warehouses module
         run: pnpm warehouses-build
       - name: Build and install packages/cli module
-        run: cd packages/cli && pnpm build && sfw npm install -g
+        run: cd packages/cli && pnpm build && npm install -g
       - name: Test lightdash version
         run: |
           lightdash_version=$(lightdash --version)
@@ -853,7 +833,7 @@ jobs:
       - name: Build packages/warehouses module
         run: pnpm warehouses-build
       - name: Build and install packages/cli module
-        run: cd packages/cli && pnpm build && sfw npm install -g
+        run: cd packages/cli && pnpm build && npm install -g
       - name: Test lightdash version
         run: |
           lightdash_version=$(lightdash --version)

--- a/.github/workflows/publish-e2b-template.yml
+++ b/.github/workflows/publish-e2b-template.yml
@@ -82,12 +82,6 @@ jobs:
           fi
           echo "action=$ACTION" >> "$GITHUB_OUTPUT"
 
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-          firewall-version: 1.15.0
-
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -100,11 +94,11 @@ jobs:
 
       - name: Install root deps
         if: steps.plan.outputs.action == 'build' && inputs.install_root_deps
-        run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+        run: pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
 
       - name: Install sandbox deps
         working-directory: ${{ inputs.template_directory }}
-        run: sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+        run: pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
 
       - name: Build and publish template
         if: steps.plan.outputs.action == 'build'

--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -320,12 +320,6 @@ jobs:
         with:
           ref: ${{ needs.changes.outputs.base_sha }}
 
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-          firewall-version: 1.15.0
-
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -342,7 +336,7 @@ jobs:
       - name: Generate base API snapshots
         run: |
           set -euo pipefail
-          sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+          pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
           pnpm generate-api:backend
           pnpm generate:mcp-tools-snapshot
           mkdir -p /tmp/api-snapshots
@@ -355,7 +349,7 @@ jobs:
       - name: Generate PR API snapshots
         run: |
           set -euo pipefail
-          sfw pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
+          pnpm install --frozen-lockfile --prefer-offline --network-concurrency=16
           pnpm generate-api:backend
           pnpm generate:mcp-tools-snapshot
           cp packages/backend/src/generated/swagger.json /tmp/api-snapshots/pr-swagger.json
@@ -390,12 +384,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-          firewall-version: 1.15.0
-
       # SPK-1021: pnpm is set up BEFORE setup-node so that `cache: 'pnpm'` can
       # resolve the store path — setup-node shells out to pnpm to find it, and
       # fails with "Unable to locate executable file: pnpm" if it runs first.
@@ -413,16 +401,13 @@ jobs:
           cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install tsx
-        run: sfw npm install -g tsx@4.19.4
+        run: npm install -g tsx@4.19.4
 
       # SPK-941: scripts/release-safety-index.ts imports
       # packages/cli/src/releaseSafety (ajv-backed index validation), so the
       # otherwise dependency-free preview needs the CLI package's dependencies.
-      # Verify-then-fallback because sfw can exit 0 on a half-completed install.
       - name: Install CLI package dependencies
-        run: |
-          sfw pnpm install --frozen-lockfile --filter @lightdash/cli --network-concurrency=16 || true
-          node -e "require.resolve('ajv', { paths: ['packages/cli'] })" 2>/dev/null || pnpm install --frozen-lockfile --filter @lightdash/cli
+        run: pnpm install --frozen-lockfile --filter @lightdash/cli --network-concurrency=16
 
       - name: Install oasdiff
         env:

--- a/.github/workflows/release-safety-tests.yml
+++ b/.github/workflows/release-safety-tests.yml
@@ -31,12 +31,6 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-          firewall-version: 1.15.0
-
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: '.nvmrc'
@@ -44,14 +38,10 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Install root dependencies
-        run: |
-          sfw pnpm install --frozen-lockfile --filter . --network-concurrency=16 || true
-          node -e "require.resolve('ajv')" 2>/dev/null || pnpm install --frozen-lockfile --filter .
+        run: pnpm install --frozen-lockfile --filter . --network-concurrency=16
 
       - name: Install tsx
-        run: |
-          sfw npm install -g tsx@4.19.4 || true
-          command -v tsx >/dev/null || npm install -g tsx@4.19.4
+        run: npm install -g tsx@4.19.4
 
       - name: Run release-safety script tests
         run: npm run test:release-safety


### PR DESCRIPTION
Linear: SPK-1022

Completes what #27380 started. That removed sfw from the release pipeline on 2026-08-13; this removes it from everywhere else.

## Why

**It is a known-broken upstream with no fix available.**

- `sfw-free#61`, filed against the exact version we pin (1.15.0), quotes the shipped binary's `uncaughtErrorHandler` tearing down the proxy and **exiting 0** — a half-linked `node_modules` behind a green step. That broke the `1.151.3` npm publish twice with `tsoa: not found`.
- `sfw-free#37` matches our timeout-storm signature exactly. Three reporters, four months, no maintainer reply. Filed 2026-04-06, **two weeks before Lightdash adopted sfw**.
- 1.15.0 is the newest release and its only change is RubyGems support. A version bump cannot help.
- The Free edition is explicitly zero-config. There is no timeout or concurrency lever.

**Mitigation is exhausted.** #27316 pinned the version and capped concurrency — did not touch the cause. #27375, which would have generalised the workaround to every install site, is **closed**. The alternative to removal is maintaining bespoke defences against a tool whose maintainer has not replied in four months.

**The measured cost.** pnpm 11's frozen-install verifier fired ~3,000 registry GETs through the proxy per full install, adding 1–2 minutes even when self-healing; storms added 2–3.5 minutes; the collapse mode cost two failed publishes and a ~56-minute npm artifact gap. Removing it from releases took merge-to-deployable from a 21.2 min baseline to **12m49s**.

**And since this morning it gated merges.** SPK-960 made `Release-safety preview` a required check, and its install ran through sfw. A tool with a documented silent-exit-0 failure mode should not stand in front of everyone's merges.

## What changed

13 `Setup Socket Firewall` steps and **21** wrapped commands across 8 workflows. 114 deletions for 21 insertions.

The install-recovery blocks go with it. Every one existed *only* because sfw could report success while corrupting the tree — their own comments said so, e.g. *"sfw can exit 0 with a half-installed tree when its proxy dies mid-install… sfw masks the failure"*. A plain `pnpm install` already fails its step on a non-zero exit, so these are now a defence against a problem that cannot occur.

Unrelated `|| true` uses were left alone — notably the kubectl log dumps in `pr.yml`, which are diagnostic and genuinely want to tolerate failure.

## Verification

```
grep -rn "socketdev/action|sfw " .github/     → clean, zero matches
YAML parse, all 8 touched files                → OK
release-safety-workflow-shape.test.ts          → passed
release-safety-pr-comment.test.ts              → 12 tests passed
```

Neither guard was weakened to make this pass; both encode invariants from today's incident work.

## Worth knowing

**We lose sfw's actual value** — blocking malicious package downloads at install time. Tracked on the ticket rather than silently dropped; the research notes Socket's scanning is available through integrations that do not sit in the install path.

**Follow-up spotted, not fixed here:** `release-safety-tests.yml` has the same pattern SPK-1021 just fixed in `release-safety-pr.yml` — no pnpm cache, and `setup-node` running before `pnpm/action-setup`. Out of scope for this diff.