### PR TITLE
feat(data-apps): support Codex coding agent

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -46,6 +46,7 @@ import {
     type AppVersionDependencyEntry,
     type DataAppClaudeEffort,
     type DataAppClaudeModel,
+    type DataAppCodingAgent,
     type DataAppCreationExperience,
     type DataAppTemplate,
     type PersistentDownloadFileAccessMode,
@@ -1697,7 +1698,9 @@ export type DataAppVersionCompletedEvent = BaseTrack & {
         isIteration: boolean;
         isUpgrade: boolean;
         claudeModel: DataAppClaudeModel;
-        claudeProvider: 'anthropic' | 'bedrock';
+        codingAgent: DataAppCodingAgent;
+        codingAgentModel: string;
+        claudeProvider: 'anthropic' | 'bedrock' | 'openai';
         schedulerWaitMs: number;
         claudeEffort: DataAppClaudeEffort;
         wasResumed: boolean;
@@ -1752,7 +1755,9 @@ export type DataAppVersionFailedEvent = BaseTrack & {
         isIteration: boolean;
         isUpgrade: boolean;
         claudeModel: DataAppClaudeModel;
-        claudeProvider?: 'anthropic' | 'bedrock';
+        codingAgent?: DataAppCodingAgent;
+        codingAgentModel?: string;
+        claudeProvider?: 'anthropic' | 'bedrock' | 'openai';
         schedulerWaitMs?: number;
         claudeEffort: DataAppClaudeEffort;
         failureStage:

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -47,6 +47,7 @@ import {
     type DataAppClaudeEffort,
     type DataAppClaudeModel,
     type DataAppCodingAgent,
+    type DataAppCodingAgentModel,
     type DataAppCreationExperience,
     type DataAppTemplate,
     type PersistentDownloadFileAccessMode,
@@ -1622,7 +1623,9 @@ export type DataAppCreatedEvent = BaseTrack & {
         imageCount: number;
         fileCount: number;
         template: DataAppTemplate | null;
-        claudeModel: DataAppClaudeModel;
+        claudeModel?: DataAppClaudeModel;
+        codingAgent: DataAppCodingAgent;
+        codingAgentModel: DataAppCodingAgentModel;
         samplesRequested: number;
         samplesAvailable: number;
         clarificationCount: number;
@@ -1643,7 +1646,9 @@ export type DataAppIteratedEvent = BaseTrack & {
         promptLength: number;
         imageCount: number;
         fileCount: number;
-        claudeModel: DataAppClaudeModel;
+        claudeModel?: DataAppClaudeModel;
+        codingAgent: DataAppCodingAgent;
+        codingAgentModel: DataAppCodingAgentModel;
         themeChanged: boolean;
         designUuid: string | null;
         claudeEffort: DataAppClaudeEffort;
@@ -1697,9 +1702,9 @@ export type DataAppVersionCompletedEvent = BaseTrack & {
         version: number;
         isIteration: boolean;
         isUpgrade: boolean;
-        claudeModel: DataAppClaudeModel;
+        claudeModel?: DataAppClaudeModel;
         codingAgent: DataAppCodingAgent;
-        codingAgentModel: string;
+        codingAgentModel: DataAppCodingAgentModel;
         claudeProvider: 'anthropic' | 'bedrock' | 'openai';
         schedulerWaitMs: number;
         claudeEffort: DataAppClaudeEffort;
@@ -1717,7 +1722,7 @@ export type DataAppVersionCompletedEvent = BaseTrack & {
         buildFixAttempts: number;
         buildFixGenerationMs: number;
         toolCallCount: number;
-        // Token/turn/cost usage summed across every `claude` invocation and
+        // Token/turn/cost usage summed across every coding-agent invocation and
         // retry in the build (main generation + build-fix + metadata). Used
         // to decompose `generateMs` into output volume vs turn count and to
         // confirm prompt caching is landing (`cacheReadInputTokens > 0`).
@@ -1727,7 +1732,7 @@ export type DataAppVersionCompletedEvent = BaseTrack & {
         cacheCreationInputTokens: number;
         numTurns: number;
         durationApiMs: number;
-        totalCostUsd: number;
+        totalCostUsd: number | null;
         generationAttemptCount: number;
         // Latency shape of the logical main generation, including retries:
         // time-to-first-token and the slowest single turn. Not combined with
@@ -1754,9 +1759,9 @@ export type DataAppVersionFailedEvent = BaseTrack & {
         version: number;
         isIteration: boolean;
         isUpgrade: boolean;
-        claudeModel: DataAppClaudeModel;
+        claudeModel?: DataAppClaudeModel;
         codingAgent?: DataAppCodingAgent;
-        codingAgentModel?: string;
+        codingAgentModel?: DataAppCodingAgentModel;
         claudeProvider?: 'anthropic' | 'bedrock' | 'openai';
         schedulerWaitMs?: number;
         claudeEffort: DataAppClaudeEffort;
@@ -1790,7 +1795,7 @@ export type DataAppVersionFailedEvent = BaseTrack & {
         cacheCreationInputTokens?: number;
         numTurns?: number;
         durationApiMs?: number;
-        totalCostUsd?: number;
+        totalCostUsd?: number | null;
         generationAttemptCount?: number;
         timeToFirstTokenMs?: number | null;
         slowestTurnMs?: number;

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -414,6 +414,7 @@ export const lightdashConfigMock: LightdashConfig = {
     },
     appRuntime: {
         enabled: false,
+        dataAppCodingAgent: 'claude',
         lightdashOrigin: 'https://test.lightdash.cloud',
         cdnOrigin: null,
         previewOrigin: null,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -1868,3 +1868,19 @@ describe('SANDBOX_PROVIDER', () => {
         expect(parseConfig().appRuntime.sandboxProvider).toBe('e2b');
     });
 });
+
+describe('APPS_CODING_AGENT', () => {
+    test('defaults to claude when unset', () => {
+        expect(parseConfig().appRuntime.dataAppCodingAgent).toBe('claude');
+    });
+
+    test('parses codex case-insensitively', () => {
+        process.env.APPS_CODING_AGENT = ' Codex ';
+        expect(parseConfig().appRuntime.dataAppCodingAgent).toBe('codex');
+    });
+
+    test('throws on an unknown coding agent', () => {
+        process.env.APPS_CODING_AGENT = 'cursor';
+        expect(() => parseConfig()).toThrowError(ParseError);
+    });
+});

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1785,6 +1785,8 @@ export type S3Config = {
 };
 export type AppRuntimeConfig = {
     enabled: boolean;
+    /** Coding agent invoked by the data-app generation pipeline. */
+    dataAppCodingAgent: 'claude' | 'codex';
     lightdashOrigin: string;
     cdnOrigin: string | null;
     /**
@@ -2252,6 +2254,14 @@ const parseDataAppOtelConfig = (): DataAppOtelConfig => {
 
 const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
     const enabled = process.env.APPS_RUNTIME_ENABLED === 'true';
+    const dataAppCodingAgent = (() => {
+        const value = process.env.APPS_CODING_AGENT?.trim().toLowerCase();
+        if (!value || value === 'claude') return 'claude' as const;
+        if (value === 'codex') return 'codex' as const;
+        throw new ParseError(
+            `Cannot parse environment variable "APPS_CODING_AGENT". Value must be one of claude, codex but APPS_CODING_AGENT=${process.env.APPS_CODING_AGENT}`,
+        );
+    })();
     const appsBucket = process.env.APPS_S3_BUCKET;
 
     const baseS3Config = parseBaseS3Config();
@@ -2299,6 +2309,7 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
 
     return {
         enabled,
+        dataAppCodingAgent,
         lightdashOrigin: process.env.APP_RUNTIME_LIGHTDASH_ORIGIN || siteUrl,
         cdnOrigin: process.env.APP_RUNTIME_CDN_ORIGIN || null,
         previewOrigin: process.env.APP_RUNTIME_PREVIEW_ORIGIN || null,

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -99,6 +99,7 @@ export class AppGenerateController extends BaseController {
                 creationExperience: body.creationExperience,
                 designUuidInput: body.designUuid,
                 externalConnections: body.externalConnections,
+                codexModelInput: body.codexModel,
             },
         );
         return {
@@ -505,6 +506,7 @@ export class AppGenerateController extends BaseController {
                 creationExperience: body.creationExperience,
                 designUuidInput: body.designUuid,
                 externalConnections: body.externalConnections,
+                codexModelInput: body.codexModel,
             },
         );
         return {

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -429,6 +429,8 @@ export class AiOrganizationSettingsService extends BaseService {
                 aiAgentReviewsAvailable: false,
                 defaultAiAgentModelConfig: null,
                 defaultAiAgentModelOptions: [],
+                dataAppCodingAgent:
+                    this.lightdashConfig.appRuntime.dataAppCodingAgent,
                 visibleDataAppModels: getVisibleDataAppClaudeModels(
                     dataAppModelVisibility,
                 ),
@@ -446,6 +448,8 @@ export class AiOrganizationSettingsService extends BaseService {
                 settings.aiAgentReviewsPausedByByok !== true,
             defaultAiAgentModelConfig: settings.defaultAiAgentModelConfig,
             defaultAiAgentModelOptions: settings.defaultAiAgentModelOptions,
+            dataAppCodingAgent:
+                this.lightdashConfig.appRuntime.dataAppCodingAgent,
             visibleDataAppModels: getVisibleDataAppClaudeModels(
                 settings.dataAppModelVisibility,
             ),

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.activity.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.activity.test.ts
@@ -1,0 +1,78 @@
+import { type DbAppActivityRow } from '../../../database/entities/apps';
+import { AppGenerateService } from './AppGenerateService';
+
+vi.mock('e2b', () => ({
+    Sandbox: class {},
+    CommandExitError: class extends Error {},
+    ALL_TRAFFIC: '*',
+}));
+vi.mock('ai', () => ({
+    generateObject: vi.fn(),
+}));
+
+const BASE_ROW = {
+    app_id: 'app-1',
+    app_name: 'Revenue',
+    app_deleted_at: null,
+    version: 1,
+    status: 'ready',
+    prompt: 'Build a revenue app',
+    created_at: new Date('2026-08-17T12:00:00Z'),
+    created_by_user_uuid: 'user-1',
+    created_by_user_first_name: 'Ada',
+    created_by_user_last_name: 'Lovelace',
+    project_uuid: 'project-1',
+    project_name: 'Analytics',
+} as const;
+
+const mapActivity = (row: DbAppActivityRow) =>
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    AppGenerateService['toActivityEvent'](row);
+
+describe('AppGenerateService data app activity mapping', () => {
+    it('reports Codex model and unknown cost without a Claude model', () => {
+        const event = mapActivity({
+            ...BASE_ROW,
+            resources: { codexModel: 'gpt-5.6-terra' } as never,
+            generation_usage: {
+                inputTokens: 100,
+                outputTokens: 20,
+                cacheReadInputTokens: 50,
+                cacheCreationInputTokens: 0,
+                numTurns: 2,
+                durationApiMs: 0,
+                costUsd: 0,
+            },
+        });
+
+        expect(event).toMatchObject({
+            codingAgent: 'codex',
+            codingAgentModel: 'gpt-5.6-terra',
+            usage: { costUsd: null },
+        });
+        expect(event).not.toHaveProperty('claudeModel');
+    });
+
+    it('preserves the legacy Claude model and its estimated cost', () => {
+        const event = mapActivity({
+            ...BASE_ROW,
+            resources: null,
+            generation_usage: {
+                inputTokens: 100,
+                outputTokens: 20,
+                cacheReadInputTokens: 50,
+                cacheCreationInputTokens: 0,
+                numTurns: 2,
+                durationApiMs: 10,
+                costUsd: 0.12,
+            },
+        });
+
+        expect(event).toMatchObject({
+            codingAgent: 'claude',
+            codingAgentModel: 'sonnet',
+            claudeModel: 'sonnet',
+            usage: { costUsd: 0.12 },
+        });
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
@@ -21,6 +21,7 @@ function buildService(
     overrides: {
         appModel?: Record<string, unknown>;
         schedulerClient?: Record<string, unknown>;
+        codingAgent?: 'claude' | 'codex';
     } = {},
 ) {
     const analytics = { track: vi.fn() };
@@ -47,7 +48,10 @@ function buildService(
     };
     const service = new AppGenerateService({
         lightdashConfig: {
-            appRuntime: { sampleDataEnabled: true },
+            appRuntime: {
+                sampleDataEnabled: true,
+                dataAppCodingAgent: overrides.codingAgent,
+            },
         } as never,
         analytics: analytics as never,
         analyticsModel: {} as never,
@@ -185,6 +189,35 @@ describe('AppGenerateService.generateApp with the data app viz template', () => 
                 }),
             }),
         );
+    });
+
+    it('tracks the selected Codex model without a fake Claude model', async () => {
+        const { service, analytics } = buildService({ codingAgent: 'codex' });
+
+        await service.generateApp(
+            USER,
+            'project-1',
+            'Build a visualization',
+            [],
+            'app-1',
+            undefined,
+            undefined,
+            DATA_APP_VIZ_TEMPLATE,
+            undefined,
+            undefined,
+            undefined,
+            { codexModelInput: 'gpt-5.6-sol' },
+        );
+
+        const event = analytics.track.mock.calls[0][0];
+        expect(event).toMatchObject({
+            event: 'data_app.created',
+            properties: {
+                codingAgent: 'codex',
+                codingAgentModel: 'gpt-5.6-sol',
+            },
+        });
+        expect(event.properties).not.toHaveProperty('claudeModel');
     });
 });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.statusHistory.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.statusHistory.test.ts
@@ -60,3 +60,14 @@ describe('filterStatusHistoryForApi', () => {
         ]);
     });
 });
+
+describe('toolDescriptionToStatusMessage', () => {
+    it('keeps Codex command executions in the tool activity history', () => {
+        expect(
+            // eslint-disable-next-line @typescript-eslint/dot-notation
+            AppGenerateService['toolDescriptionToStatusMessage'](
+                'Command sed -n 1,120p App.tsx',
+            ),
+        ).toBe('Running command');
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -252,6 +252,8 @@ import {
     codexCodeAllowedHosts,
     codexSkillDirective,
     describeCodexCodeEnv,
+    getCodexCodeProvider,
+    getCodexModelId,
     PREPARE_CODEX_SKILLS_COMMAND,
 } from './codexCodeEnv';
 import { CodexStreamProcessor } from './CodexStreamProcessor';
@@ -813,7 +815,11 @@ export class AppGenerateService extends BaseService {
     private getCodingAgentProvider(
         env: Record<string, string>,
     ): 'anthropic' | 'bedrock' | 'openai' {
-        if (this.dataAppCodingAgent === 'codex') return 'openai';
+        if (this.dataAppCodingAgent === 'codex') {
+            return getCodexCodeProvider(env) === 'amazon-bedrock'
+                ? 'bedrock'
+                : 'openai';
+        }
         return env.CLAUDE_CODE_USE_BEDROCK === '1' ? 'bedrock' : 'anthropic';
     }
 
@@ -3586,7 +3592,9 @@ export class AppGenerateService extends BaseService {
                 structuredOutputSchema,
             );
         }
+        const provider = getCodexCodeProvider(codexEnv);
         const codexCommand = buildCodexExecCommand({
+            provider,
             reasoningEffort,
             outputSchemaPath: structuredOutputSchema
                 ? '/tmp/output-schema.json'
@@ -4345,8 +4353,13 @@ export class AppGenerateService extends BaseService {
             copilot = await this.getCodingAgentConfig(payload.organizationUuid);
             codingAgentEnv = this.getCodingAgentEnv(copilot);
             if (this.dataAppCodingAgent === 'codex') {
-                codingAgentEnv.DATA_APP_CODEX_MODEL =
+                const codexModel =
                     payload.codexModel ?? DEFAULT_DATA_APP_CODEX_MODEL;
+                codingAgentEnv.DATA_APP_CODEX_MODEL = codexModel;
+                codingAgentEnv.DATA_APP_CODEX_MODEL_ID = getCodexModelId(
+                    getCodexCodeProvider(codingAgentEnv),
+                    codexModel,
+                );
             }
             ({ client: s3Client, bucket } = this.getS3Client());
         } catch (error) {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -84,9 +84,11 @@ import {
     type DataAppCodeFile,
     type DataAppCodexModel,
     type DataAppCodingAgent,
+    type DataAppCodingAgentModel,
     type DataAppContext,
     type DataAppCreationExperience,
     type DataAppDependencies,
+    type DataAppGenerationUsage,
     type DataAppManifestExternalConnection,
     type DataAppTemplate,
     type DataAppViz,
@@ -407,7 +409,7 @@ type ModelFile = {
 type DataAppVersionFailureTelemetry = {
     wasResumed?: boolean;
     codingAgent?: DataAppCodingAgent;
-    codingAgentModel?: string;
+    codingAgentModel?: DataAppCodingAgentModel;
     claudeProvider?: 'anthropic' | 'bedrock' | 'openai';
     keyManagement?: AiKeyManagement;
     schedulerWaitMs?: number;
@@ -1921,7 +1923,7 @@ export class AppGenerateService extends BaseService {
 
     private static emitDataAppAiUsage(
         payload: AppGeneratePipelineJobPayload,
-        model: string,
+        model: DataAppCodingAgentModel,
         provider: 'anthropic' | 'bedrock' | 'openai',
         keyManagement: AiKeyManagement,
         usage: ClaudeGenerationUsage,
@@ -1969,10 +1971,15 @@ export class AppGenerateService extends BaseService {
         usage: ClaudeGenerationUsage,
     ): Promise<void> {
         try {
+            const persistedUsage: DataAppGenerationUsage = {
+                ...usage,
+                costUsd:
+                    this.dataAppCodingAgent === 'codex' ? null : usage.costUsd,
+            };
             await this.appModel.recordVersionGenerationUsage(
                 payload.appUuid,
                 payload.version,
-                usage,
+                persistedUsage,
             );
         } catch (error) {
             this.logger.warn(
@@ -2001,6 +2008,12 @@ export class AppGenerateService extends BaseService {
         const { generationUsage } = telemetry;
         const claudeModel =
             payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL;
+        const codingAgent = telemetry.codingAgent ?? this.dataAppCodingAgent;
+        const codingAgentModel =
+            telemetry.codingAgentModel ??
+            (codingAgent === 'codex'
+                ? (payload.codexModel ?? DEFAULT_DATA_APP_CODEX_MODEL)
+                : claudeModel);
 
         if (
             generationUsage &&
@@ -2013,7 +2026,7 @@ export class AppGenerateService extends BaseService {
         ) {
             AppGenerateService.emitDataAppAiUsage(
                 payload,
-                telemetry.codingAgentModel ?? claudeModel,
+                codingAgentModel,
                 telemetry.claudeProvider ?? 'anthropic',
                 telemetry.keyManagement ?? 'lightdash-managed',
                 generationUsage,
@@ -2036,9 +2049,9 @@ export class AppGenerateService extends BaseService {
                 isIteration: payload.isIteration,
                 isUpgrade: payload.isUpgrade ?? false,
                 creationExperience: payload.creationExperience ?? null,
-                claudeModel,
-                codingAgent: telemetry.codingAgent,
-                codingAgentModel: telemetry.codingAgentModel,
+                ...(codingAgent === 'claude' ? { claudeModel } : {}),
+                codingAgent,
+                codingAgentModel,
                 claudeProvider: telemetry.claudeProvider,
                 schedulerWaitMs: telemetry.schedulerWaitMs,
                 claudeEffort,
@@ -2071,7 +2084,8 @@ export class AppGenerateService extends BaseService {
                     generationUsage?.cacheCreationInputTokens,
                 numTurns: generationUsage?.numTurns,
                 durationApiMs: generationUsage?.durationApiMs,
-                totalCostUsd: generationUsage?.costUsd,
+                totalCostUsd:
+                    codingAgent === 'codex' ? null : generationUsage?.costUsd,
                 generationAttemptCount: telemetry.generationAttemptCount,
                 timeToFirstTokenMs: telemetry.timeToFirstTokenMs,
                 slowestTurnMs: telemetry.slowestTurnMs,
@@ -3692,8 +3706,8 @@ export class AppGenerateService extends BaseService {
                     try {
                         structuredOutput = JSON.parse(responseText);
                     } catch (error) {
-                        throw new Error(
-                            `Codex returned invalid structured output: ${getErrorMessage(error)}`,
+                        this.logger.warn(
+                            `App ${appUuid}: Codex returned invalid structured output; leaving viz_schema null: ${getErrorMessage(error)}`,
                         );
                     }
                 }
@@ -4642,9 +4656,9 @@ export class AppGenerateService extends BaseService {
             payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL;
         const claudeEffort = payloadClaudeEffort(payload, pipelineApp.template);
         const claudeProvider = this.getCodingAgentProvider(codingAgentEnv);
-        const codingAgentModel =
+        const codingAgentModel: DataAppCodingAgentModel =
             this.dataAppCodingAgent === 'codex'
-                ? codingAgentEnv.DATA_APP_CODEX_MODEL
+                ? (payload.codexModel ?? DEFAULT_DATA_APP_CODEX_MODEL)
                 : claudeModel;
         const claudeKeyManagement = resolveKeyManagement(
             copilot,
@@ -5262,7 +5276,9 @@ export class AppGenerateService extends BaseService {
                 isIteration: payload.isIteration,
                 isUpgrade: payload.isUpgrade ?? false,
                 creationExperience: payload.creationExperience ?? null,
-                claudeModel,
+                ...(this.dataAppCodingAgent === 'claude'
+                    ? { claudeModel }
+                    : {}),
                 codingAgent: this.dataAppCodingAgent,
                 codingAgentModel,
                 claudeProvider,
@@ -5289,7 +5305,10 @@ export class AppGenerateService extends BaseService {
                     generationUsage.cacheCreationInputTokens,
                 numTurns: generationUsage.numTurns,
                 durationApiMs: generationUsage.durationApiMs,
-                totalCostUsd: generationUsage.costUsd,
+                totalCostUsd:
+                    this.dataAppCodingAgent === 'codex'
+                        ? null
+                        : generationUsage.costUsd,
                 generationAttemptCount,
                 timeToFirstTokenMs,
                 slowestTurnMs,
@@ -6097,7 +6116,11 @@ export class AppGenerateService extends BaseService {
                 imageCount: stagedFiles.filter((f) => f.isImage).length,
                 fileCount: stagedFiles.filter((f) => !f.isImage).length,
                 template: template ?? null,
-                claudeModel,
+                ...(this.dataAppCodingAgent === 'claude'
+                    ? { claudeModel }
+                    : {}),
+                codingAgent: this.dataAppCodingAgent,
+                codingAgentModel,
                 claudeEffort,
                 samplesRequested: sampleStats.requested,
                 samplesAvailable: sampleStats.available,
@@ -6314,7 +6337,11 @@ export class AppGenerateService extends BaseService {
                 promptLength: prompt.length,
                 imageCount: stagedFiles.filter((f) => f.isImage).length,
                 fileCount: stagedFiles.filter((f) => !f.isImage).length,
-                claudeModel,
+                ...(this.dataAppCodingAgent === 'claude'
+                    ? { claudeModel }
+                    : {}),
+                codingAgent: this.dataAppCodingAgent,
+                codingAgentModel,
                 claudeEffort,
                 themeChanged: isThemeChange,
                 designUuid: effectiveDesignUuid,
@@ -8447,6 +8474,10 @@ export class AppGenerateService extends BaseService {
     private static toActivityEvent(
         row: DbAppActivityRow,
     ): DataAppActivityEvent {
+        const codexModel = row.resources?.codexModel;
+        const claudeModel =
+            row.resources?.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL;
+        const codingAgent = codexModel ? 'codex' : 'claude';
         return {
             appUuid: row.app_id,
             appName: row.app_name,
@@ -8454,8 +8485,9 @@ export class AppGenerateService extends BaseService {
             version: row.version,
             status: row.status,
             prompt: row.prompt,
-            claudeModel:
-                row.resources?.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL,
+            codingAgent,
+            codingAgentModel: codexModel ?? claudeModel,
+            ...(codingAgent === 'claude' ? { claudeModel } : {}),
             createdAt: row.created_at,
             projectUuid: row.project_uuid,
             projectName: row.project_name,
@@ -8470,7 +8502,16 @@ export class AppGenerateService extends BaseService {
                           firstName: row.created_by_user_first_name,
                           lastName: row.created_by_user_last_name,
                       },
-            usage: row.generation_usage,
+            usage:
+                row.generation_usage === null
+                    ? null
+                    : {
+                          ...row.generation_usage,
+                          costUsd:
+                              codingAgent === 'codex'
+                                  ? null
+                                  : row.generation_usage.costUsd,
+                      },
         };
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -19,11 +19,13 @@ import {
     ChartType,
     checkThemeLimits,
     DATA_APP_CLAUDE_MODELS,
+    DATA_APP_CODEX_MODELS,
     DATA_APP_VIZ_TEMPLATE,
     DATA_REFERENCE_EXTRACTOR_VERSION,
     dataAppVizJsonSchema,
     dataAppVizSchema,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
+    DEFAULT_DATA_APP_CODEX_MODEL,
     extractDataAppDataReferences,
     extractLockfilePackages,
     FeatureFlags,
@@ -80,6 +82,8 @@ import {
     type DataAppCode,
     type DataAppCodeDownload,
     type DataAppCodeFile,
+    type DataAppCodexModel,
+    type DataAppCodingAgent,
     type DataAppContext,
     type DataAppCreationExperience,
     type DataAppDependencies,
@@ -239,6 +243,17 @@ import {
     type ClaudeGenerationUsage,
 } from './ClaudeStreamProcessor';
 import {
+    buildCodexCodeEnv,
+    buildCodexExecCommand,
+    CODEX_PROJECT_INSTRUCTIONS,
+    CODEX_PROJECT_INSTRUCTIONS_PATH,
+    codexCodeAllowedHosts,
+    codexSkillDirective,
+    describeCodexCodeEnv,
+    PREPARE_CODEX_SKILLS_COMMAND,
+} from './codexCodeEnv';
+import { CodexStreamProcessor } from './CodexStreamProcessor';
+import {
     buildDashboardBlueprint,
     DASHBOARD_BLUEPRINT_PATH,
     dashboardBlueprintPromptBlock,
@@ -332,6 +347,7 @@ type GenerateAppOptions = {
     creationExperience?: DataAppCreationExperience;
     designUuidInput?: string | null;
     externalConnections?: AppExternalConnectionReference[];
+    codexModelInput?: DataAppCodexModel;
 };
 
 type GenerateAppResult = {
@@ -390,7 +406,9 @@ type ModelFile = {
 
 type DataAppVersionFailureTelemetry = {
     wasResumed?: boolean;
-    claudeProvider?: 'anthropic' | 'bedrock';
+    codingAgent?: DataAppCodingAgent;
+    codingAgentModel?: string;
+    claudeProvider?: 'anthropic' | 'bedrock' | 'openai';
     keyManagement?: AiKeyManagement;
     schedulerWaitMs?: number;
     generationUsage?: ClaudeGenerationUsage;
@@ -406,6 +424,17 @@ type DataAppBuildFixTelemetry = {
     buildMs: number;
     fixAttempts: number;
     fixGenerationMs: number;
+};
+
+type CodingAgentGenerationResult = {
+    durationMs: number;
+    responseText: string | null;
+    structuredOutput: unknown;
+    toolCallCount: number;
+    usage: ClaudeGenerationUsage;
+    timeToFirstTokenMs: number | null;
+    turnDurationsMs: number[];
+    generationAttemptCount: number;
 };
 
 // Wall-clock heartbeat to bump status_updated_at while the pipeline is
@@ -429,16 +458,16 @@ const DATA_APP_WORKSPACE: PersistentWorkspace = {
     ],
     exclude: ['node_modules'],
 };
-// Kill any in-flight `claude` process before a cancelled sandbox is paused.
+// Kill any in-flight coding-agent process before a cancelled sandbox is paused.
 // Native-pause backends (E2B) freeze running processes into the snapshot, so
 // without this the cancelled generation resumes execution the next time the
 // sandbox is resumed. `[c]laude` keeps pkill from matching this command's own
 // shell; pkill exits 1 when nothing matched, hence the trailing `true`. The
 // prompt file is removed so nothing left in the sandbox can replay the
 // cancelled prompt (the next iteration writes a fresh one).
-const INTERRUPT_CLAUDE_COMMAND =
-    "pkill -TERM -f '[c]laude' 2>/dev/null; sleep 1; " +
-    "pkill -KILL -f '[c]laude' 2>/dev/null; rm -f /tmp/prompt.txt 2>/dev/null; true";
+const INTERRUPT_CODING_AGENT_COMMAND =
+    "pkill -TERM -f '[c]laude|[c]odex' 2>/dev/null; sleep 1; " +
+    "pkill -KILL -f '[c]laude|[c]odex' 2>/dev/null; rm -f /tmp/prompt.txt 2>/dev/null; true";
 
 // Prepended to the prompt when a version since the last ready one was
 // cancelled: the resumed `--continue` session still ends with the cancelled
@@ -753,6 +782,39 @@ export class AppGenerateService extends BaseService {
         );
     }
 
+    private get dataAppCodingAgent(): DataAppCodingAgent {
+        return this.lightdashConfig.appRuntime?.dataAppCodingAgent ?? 'claude';
+    }
+
+    private getCodingAgentConfig(
+        organizationUuid: string | null | undefined,
+    ): Promise<ResolvedCopilotConfig> {
+        return this.dataAppCodingAgent === 'codex'
+            ? this.orgAiCopilotConfigResolver.getCodexConfig(organizationUuid)
+            : this.orgAiCopilotConfigResolver.getClaudeCodeConfig(
+                  organizationUuid,
+              );
+    }
+
+    private getCodingAgentEnv(copilot: CopilotConfig): Record<string, string> {
+        return this.dataAppCodingAgent === 'codex'
+            ? buildCodexCodeEnv(copilot)
+            : AppGenerateService.getClaudeCodeEnv(copilot);
+    }
+
+    private describeCodingAgentEnv(env: Record<string, string>): string {
+        return this.dataAppCodingAgent === 'codex'
+            ? describeCodexCodeEnv(env)
+            : describeClaudeCodeEnv(env);
+    }
+
+    private getCodingAgentProvider(
+        env: Record<string, string>,
+    ): 'anthropic' | 'bedrock' | 'openai' {
+        if (this.dataAppCodingAgent === 'codex') return 'openai';
+        return env.CLAUDE_CODE_USE_BEDROCK === '1' ? 'bedrock' : 'anthropic';
+    }
+
     /**
      * Builds the Claude Code OTEL env injected into the sandbox for this build,
      * minting fresh OTLP export auth headers (e.g. a GCP bearer token) at
@@ -913,16 +975,22 @@ export class AppGenerateService extends BaseService {
         copilot: CopilotConfig,
         extraEgressHosts: string[] = [],
     ): SandboxSpec {
+        const codingAgentHosts =
+            this.dataAppCodingAgent === 'codex'
+                ? codexCodeAllowedHosts(copilot)
+                : claudeCodeAllowedHosts(copilot);
         return {
             templateRef: this.getSandboxTemplateRef(),
             timeoutMs: 60 * 60 * 1000,
             egress: {
                 allow: [
-                    ...claudeCodeAllowedHosts(copilot),
+                    ...codingAgentHosts,
                     ...extraEgressHosts,
-                    ...claudeCodeOtelAllowedHosts(
-                        this.lightdashConfig.appRuntime.otel,
-                    ),
+                    ...(this.dataAppCodingAgent === 'claude'
+                        ? claudeCodeOtelAllowedHosts(
+                              this.lightdashConfig.appRuntime.otel,
+                          )
+                        : []),
                 ],
             },
         };
@@ -1398,6 +1466,23 @@ export class AppGenerateService extends BaseService {
         return claudeModel;
     }
 
+    /** Resolve a Codex picker value without changing Claude's model policy. */
+    private static resolveCodexModel(
+        codexModel: DataAppCodexModel | undefined,
+    ): DataAppCodexModel {
+        if (codexModel === undefined) return DEFAULT_DATA_APP_CODEX_MODEL;
+        if (
+            !(DATA_APP_CODEX_MODELS as readonly string[]).includes(codexModel)
+        ) {
+            throw new ParameterError(
+                `Invalid codexModel: ${codexModel}. Allowed: ${DATA_APP_CODEX_MODELS.join(
+                    ', ',
+                )}`,
+            );
+        }
+        return codexModel;
+    }
+
     /** Reads the app's own template for the pre-field effort fallback. A
      *  failure here must not sink the telemetry event it feeds. */
     private async getTemplateForEffort(
@@ -1836,8 +1921,8 @@ export class AppGenerateService extends BaseService {
 
     private static emitDataAppAiUsage(
         payload: AppGeneratePipelineJobPayload,
-        model: DataAppClaudeModel,
-        provider: 'anthropic' | 'bedrock',
+        model: string,
+        provider: 'anthropic' | 'bedrock' | 'openai',
         keyManagement: AiKeyManagement,
         usage: ClaudeGenerationUsage,
     ): void {
@@ -1928,7 +2013,7 @@ export class AppGenerateService extends BaseService {
         ) {
             AppGenerateService.emitDataAppAiUsage(
                 payload,
-                claudeModel,
+                telemetry.codingAgentModel ?? claudeModel,
                 telemetry.claudeProvider ?? 'anthropic',
                 telemetry.keyManagement ?? 'lightdash-managed',
                 generationUsage,
@@ -1952,6 +2037,8 @@ export class AppGenerateService extends BaseService {
                 isUpgrade: payload.isUpgrade ?? false,
                 creationExperience: payload.creationExperience ?? null,
                 claudeModel,
+                codingAgent: telemetry.codingAgent,
+                codingAgentModel: telemetry.codingAgentModel,
                 claudeProvider: telemetry.claudeProvider,
                 schedulerWaitMs: telemetry.schedulerWaitMs,
                 claudeEffort,
@@ -2351,14 +2438,18 @@ export class AppGenerateService extends BaseService {
                 copilot,
                 extraEgressHosts,
             );
-            const result = await oldSandbox.commands.run(
-                `tar -cf /tmp/claude-session.tar --ignore-failed-read -C / ${AppGenerateService.CLAUDE_SESSION_PATHS}`,
-                { timeoutMs: 60_000 },
-            );
-            if (result.exitCode === 0) {
-                sessionTar = Buffer.from(
-                    await oldSandbox.files.readBytes('/tmp/claude-session.tar'),
+            if (this.dataAppCodingAgent === 'claude') {
+                const result = await oldSandbox.commands.run(
+                    `tar -cf /tmp/claude-session.tar --ignore-failed-read -C / ${AppGenerateService.CLAUDE_SESSION_PATHS}`,
+                    { timeoutMs: 60_000 },
                 );
+                if (result.exitCode === 0) {
+                    sessionTar = Buffer.from(
+                        await oldSandbox.files.readBytes(
+                            '/tmp/claude-session.tar',
+                        ),
+                    );
+                }
             }
         } catch (error) {
             this.logger.warn(
@@ -2788,6 +2879,10 @@ export class AppGenerateService extends BaseService {
             finalPrompt = `${referenceLines}\n\n${finalPrompt}`;
         }
 
+        if (this.dataAppCodingAgent === 'codex') {
+            finalPrompt = `${codexSkillDirective(isDataAppViz)}\n\n${finalPrompt}`;
+        }
+
         // Write only the latest prompt — Claude is stateless between runs, but
         // the sandbox filesystem preserves all code from previous iterations.
         // Claude can read existing files to understand what was built so far,
@@ -3083,6 +3178,8 @@ export class AppGenerateService extends BaseService {
                 return 'Searching codebase';
             case 'TodoWrite':
                 return 'Updating TODOs';
+            case 'Command':
+                return 'Running command';
             default:
                 return null;
         }
@@ -3092,12 +3189,7 @@ export class AppGenerateService extends BaseService {
 
     private static readonly GENERATION_RETRY_DELAY_MS = 5_000;
 
-    /**
-     * Effective system-prompt file passed to Claude via
-     * `--append-system-prompt-file`. Always assembled fresh at the start of
-     * every pipeline run by `assembleEffectiveSkill`, so the CLI flag can
-     * point at a single stable path regardless of theme.
-     */
+    /** Effective Lightdash reference assembled fresh for every agent run. */
     private static readonly EFFECTIVE_SKILL_PATH = '/app/effective-skill.md';
 
     /**
@@ -3163,6 +3255,18 @@ export class AppGenerateService extends BaseService {
         );
     }
 
+    private static async prepareCodexProjectContext(
+        sandbox: SandboxHandle,
+    ): Promise<void> {
+        await sandbox.commands.run(PREPARE_CODEX_SKILLS_COMMAND, {
+            timeoutMs: 10_000,
+        });
+        await sandbox.files.write(
+            CODEX_PROJECT_INSTRUCTIONS_PATH,
+            CODEX_PROJECT_INSTRUCTIONS,
+        );
+    }
+
     private async runClaudeGeneration(
         sandbox: SandboxHandle,
         appUuid: string,
@@ -3177,16 +3281,7 @@ export class AppGenerateService extends BaseService {
         // for runs that don't collect a structured schema (metadata, builds).
         structuredOutputSchema: string | null,
         onTelemetry?: (telemetry: ClaudeGenerationTelemetry) => void,
-    ): Promise<{
-        durationMs: number;
-        responseText: string | null;
-        structuredOutput: unknown;
-        toolCallCount: number;
-        usage: ClaudeGenerationUsage;
-        timeToFirstTokenMs: number | null;
-        turnDurationsMs: number[];
-        generationAttemptCount: number;
-    }> {
+    ): Promise<CodingAgentGenerationResult> {
         const start = performance.now();
         let telemetry = ZERO_CLAUDE_GENERATION_TELEMETRY;
 
@@ -3224,16 +3319,7 @@ export class AppGenerateService extends BaseService {
         const runAttempt = async (
             attempt: number,
             forceContinue: boolean,
-        ): Promise<{
-            durationMs: number;
-            responseText: string | null;
-            structuredOutput: unknown;
-            toolCallCount: number;
-            usage: ClaudeGenerationUsage;
-            timeToFirstTokenMs: number | null;
-            turnDurationsMs: number[];
-            generationAttemptCount: number;
-        }> => {
+        ): Promise<CodingAgentGenerationResult> => {
             // Bail before spawning claude when the version is no longer in
             // progress (typically cancelled). This gates the retry and
             // build-fix paths, which have no advanceStage check between
@@ -3460,6 +3546,241 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
+     * Codex prototype runner. Each invocation is deliberately ephemeral: app
+     * source is the durable state between iterations and build-fix turns. This
+     * avoids coupling the first usable version to Codex session migration.
+     */
+    private async runCodexGeneration(
+        sandbox: SandboxHandle,
+        appUuid: string,
+        version: number,
+        codexEnv: Record<string, string>,
+        reasoningEffort: DataAppClaudeEffort,
+        structuredOutputSchema: string | null,
+        onTelemetry?: (telemetry: ClaudeGenerationTelemetry) => void,
+    ): Promise<CodingAgentGenerationResult> {
+        const start = performance.now();
+        let telemetry = ZERO_CLAUDE_GENERATION_TELEMETRY;
+
+        if (structuredOutputSchema) {
+            await sandbox.commands.run(
+                'rm -f /tmp/output-schema.json 2>/dev/null; true',
+                { timeoutMs: 10_000 },
+            );
+            await sandbox.files.write(
+                '/tmp/output-schema.json',
+                structuredOutputSchema,
+            );
+        }
+        const codexCommand = buildCodexExecCommand({
+            reasoningEffort,
+            outputSchemaPath: structuredOutputSchema
+                ? '/tmp/output-schema.json'
+                : null,
+        });
+
+        const runAttempt = async (
+            attempt: number,
+        ): Promise<CodingAgentGenerationResult> => {
+            const status = await this.appModel.getVersionStatus(
+                appUuid,
+                version,
+            );
+            if (!isAppVersionInProgress(status)) {
+                throw new Error(
+                    `Codex generation aborted — version ${version} is ${status} (likely cancelled)`,
+                );
+            }
+
+            const attemptStartedAfterMs = AppGenerateService.elapsed(start);
+            const processor = new CodexStreamProcessor();
+            let responseText: string | null = null;
+            const result = await sandbox.commands
+                .run(codexCommand, {
+                    cwd: '/app',
+                    timeoutMs: 55 * 60 * 1000,
+                    envs: codexEnv,
+                    onStdout: (chunk) => {
+                        for (const event of processor.feedChunk(chunk)) {
+                            switch (event.kind) {
+                                case 'thinking_started':
+                                    this.logger.info(
+                                        `App ${appUuid}: codex turn #${event.turn}: thinking`,
+                                    );
+                                    this.updateAppStatus(
+                                        appUuid,
+                                        version,
+                                        'Thinking',
+                                        null,
+                                    );
+                                    break;
+                                case 'thinking_snippet':
+                                    this.updateAppStatus(
+                                        appUuid,
+                                        version,
+                                        event.snippet,
+                                        'thinking',
+                                    );
+                                    break;
+                                case 'tool_use': {
+                                    this.logger.info(
+                                        `App ${appUuid}: codex tool #${event.index}: ${event.description}`,
+                                    );
+                                    const toolStatus =
+                                        AppGenerateService.toolDescriptionToStatusMessage(
+                                            event.description,
+                                        );
+                                    this.updateAppStatus(
+                                        appUuid,
+                                        version,
+                                        toolStatus ??
+                                            AppGenerateService.randomCodingPhrase(),
+                                        toolStatus ? 'tool' : null,
+                                    );
+                                    break;
+                                }
+                                case 'result':
+                                    if (event.text) {
+                                        responseText = event.text;
+                                    }
+                                    break;
+                                default:
+                                    assertUnreachable(
+                                        event,
+                                        'Unhandled Codex stream event',
+                                    );
+                            }
+                        }
+                    },
+                    onStderr: (chunk) => {
+                        this.logger.debug(
+                            `App ${appUuid}: codex stderr: ${chunk.trimEnd()}`,
+                        );
+                    },
+                })
+                .catch((err: unknown) => {
+                    if (!(err instanceof SandboxCommandError)) throw err;
+                    return {
+                        exitCode: err.exitCode,
+                        stdout: err.stdout,
+                        stderr: err.stderr,
+                    };
+                });
+
+            const usage = processor.lastUsage;
+            const toolCallCount = processor.totalToolCalls;
+            const { timeToFirstTokenMs, turnDurationsMs } = processor;
+            telemetry = addClaudeGenerationAttempt(
+                telemetry,
+                {
+                    usage,
+                    toolCallCount,
+                    timeToFirstTokenMs,
+                    turnDurationsMs,
+                },
+                attemptStartedAfterMs,
+            );
+            onTelemetry?.(telemetry);
+            const durationMs = AppGenerateService.elapsed(start);
+            this.logger.info(
+                `App ${appUuid}: Codex generation completed (model=${codexEnv.DATA_APP_CODEX_MODEL}, effort=${reasoningEffort}, exit=${result.exitCode}, toolCalls=${toolCallCount}, outputTokens=${usage?.outputTokens ?? 0}, ${durationMs}ms, attempt ${attempt}/${AppGenerateService.MAX_GENERATION_ATTEMPTS})`,
+            );
+
+            if (result.exitCode === 0) {
+                let structuredOutput: unknown = null;
+                if (structuredOutputSchema && responseText) {
+                    try {
+                        structuredOutput = JSON.parse(responseText);
+                    } catch (error) {
+                        throw new Error(
+                            `Codex returned invalid structured output: ${getErrorMessage(error)}`,
+                        );
+                    }
+                }
+                return {
+                    durationMs,
+                    responseText,
+                    structuredOutput,
+                    toolCallCount: telemetry.toolCallCount,
+                    usage: telemetry.usage,
+                    timeToFirstTokenMs: telemetry.timeToFirstTokenMs,
+                    turnDurationsMs: telemetry.turnDurationsMs,
+                    generationAttemptCount: telemetry.attemptCount,
+                };
+            }
+
+            const stderrTail = AppGenerateService.truncateEnd(
+                result.stderr,
+                4000,
+            );
+            const stdoutTail = AppGenerateService.truncateEnd(
+                result.stdout,
+                4000,
+            );
+            if (attempt >= AppGenerateService.MAX_GENERATION_ATTEMPTS) {
+                this.logger.info(
+                    `App ${appUuid}: Codex stderr (tail): ${stderrTail}`,
+                );
+                this.logger.info(
+                    `App ${appUuid}: Codex stdout (tail): ${stdoutTail}`,
+                );
+                throw new Error(
+                    `Codex generation failed (exit ${result.exitCode}): ${stderrTail || stdoutTail}`,
+                );
+            }
+
+            this.logger.warn(
+                `App ${appUuid}: Codex generation failed (exit ${result.exitCode}), retrying (attempt ${attempt}/${AppGenerateService.MAX_GENERATION_ATTEMPTS})`,
+            );
+            this.updateAppStatus(appUuid, version, 'Hit a snag, retrying');
+            await new Promise<void>((resolve) => {
+                setTimeout(
+                    resolve,
+                    AppGenerateService.GENERATION_RETRY_DELAY_MS,
+                );
+            });
+            return runAttempt(attempt + 1);
+        };
+
+        return runAttempt(1);
+    }
+
+    private runCodingAgentGeneration(
+        sandbox: SandboxHandle,
+        appUuid: string,
+        version: number,
+        continueSession: boolean,
+        codingAgentEnv: Record<string, string>,
+        claudeModel: DataAppClaudeModel,
+        reasoningEffort: DataAppClaudeEffort,
+        structuredOutputSchema: string | null,
+        onTelemetry?: (telemetry: ClaudeGenerationTelemetry) => void,
+    ): Promise<CodingAgentGenerationResult> {
+        if (this.dataAppCodingAgent === 'codex') {
+            return this.runCodexGeneration(
+                sandbox,
+                appUuid,
+                version,
+                codingAgentEnv,
+                reasoningEffort,
+                structuredOutputSchema,
+                onTelemetry,
+            );
+        }
+        return this.runClaudeGeneration(
+            sandbox,
+            appUuid,
+            version,
+            continueSession,
+            codingAgentEnv,
+            claudeModel,
+            reasoningEffort,
+            structuredOutputSchema,
+            onTelemetry,
+        );
+    }
+
+    /**
      * Fire-and-forget app status message update. Logs (but does not propagate)
      * failures so transient DB errors during a long generation don't kill the
      * pipeline. `kind` tags the entry in the narration history; `null` shows
@@ -3633,7 +3954,7 @@ export class AppGenerateService extends BaseService {
         sandbox: SandboxHandle,
         appUuid: string,
         version: number,
-        claudeCodeEnv: Record<string, string>,
+        codingAgentEnv: Record<string, string>,
         claudeModel: DataAppClaudeModel,
         claudeEffort: DataAppClaudeEffort,
         onTelemetry?: (telemetry: DataAppBuildFixTelemetry) => void,
@@ -3733,12 +4054,12 @@ export class AppGenerateService extends BaseService {
             const buildMsBeforeAttempt = buildMs;
             const currentFixAttempt = fixAttempts;
             const fixGenerationMsBeforeAttempt = fixGenerationMs;
-            const generation = await this.runClaudeGeneration(
+            const generation = await this.runCodingAgentGeneration(
                 sandbox,
                 appUuid,
                 version,
                 true, // --continue: keep conversation context from generation
-                claudeCodeEnv,
+                codingAgentEnv,
                 claudeModel,
                 claudeEffort,
                 null, // build-fix run collects no structured schema
@@ -4002,15 +4323,17 @@ export class AppGenerateService extends BaseService {
             return;
         }
 
-        let claudeCodeEnv: Record<string, string>;
+        let codingAgentEnv: Record<string, string>;
         let copilot: ResolvedCopilotConfig;
         let s3Client: S3Client;
         let bucket: string;
         try {
-            copilot = await this.orgAiCopilotConfigResolver.getClaudeCodeConfig(
-                payload.organizationUuid,
-            );
-            claudeCodeEnv = AppGenerateService.getClaudeCodeEnv(copilot);
+            copilot = await this.getCodingAgentConfig(payload.organizationUuid);
+            codingAgentEnv = this.getCodingAgentEnv(copilot);
+            if (this.dataAppCodingAgent === 'codex') {
+                codingAgentEnv.DATA_APP_CODEX_MODEL =
+                    payload.codexModel ?? DEFAULT_DATA_APP_CODEX_MODEL;
+            }
             ({ client: s3Client, bucket } = this.getS3Client());
         } catch (error) {
             // Config errors (missing/incomplete provider, E2B, or S3 setup) carry
@@ -4058,8 +4381,10 @@ export class AppGenerateService extends BaseService {
 
         this.logger.info(
             `App ${appUuid}: pipeline started (version=${version}, status=${currentStatus}, isIteration=${isIteration}, model=${
-                payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL
-            }, designUuid=${payload.designUuid ?? 'none'}, llm=${describeClaudeCodeEnv(claudeCodeEnv)})`,
+                this.dataAppCodingAgent === 'codex'
+                    ? (payload.codexModel ?? DEFAULT_DATA_APP_CODEX_MODEL)
+                    : (payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL)
+            }, designUuid=${payload.designUuid ?? 'none'}, llm=${this.describeCodingAgentEnv(codingAgentEnv)})`,
         );
 
         // --- Stage: sandbox ---
@@ -4242,20 +4567,27 @@ export class AppGenerateService extends BaseService {
                         'app.claude_model':
                             payload.claudeModel ??
                             DEFAULT_DATA_APP_CLAUDE_MODEL,
-                        'app.claude_provider':
-                            claudeCodeEnv.CLAUDE_CODE_USE_BEDROCK === '1'
-                                ? 'bedrock'
-                                : 'anthropic',
+                        'app.coding_agent': this.dataAppCodingAgent,
+                        'app.coding_agent_model':
+                            this.dataAppCodingAgent === 'codex'
+                                ? codingAgentEnv.DATA_APP_CODEX_MODEL
+                                : (payload.claudeModel ??
+                                  DEFAULT_DATA_APP_CLAUDE_MODEL),
+                        'app.coding_agent_provider':
+                            this.getCodingAgentProvider(codingAgentEnv),
                         ...(process.env.LIGHTDASH_INSTALL_ID
                             ? { installId: process.env.LIGHTDASH_INSTALL_ID }
                             : {}),
                     },
                 },
                 async () => {
-                    const otelEnv = await this.resolveSandboxOtelEnv(
-                        appUuid,
-                        getOtelTraceHeaders().traceparent,
-                    );
+                    const otelEnv =
+                        this.dataAppCodingAgent === 'claude'
+                            ? await this.resolveSandboxOtelEnv(
+                                  appUuid,
+                                  getOtelTraceHeaders().traceparent,
+                              )
+                            : {};
                     await this.runPipelineStages(
                         sandbox,
                         payload,
@@ -4265,7 +4597,7 @@ export class AppGenerateService extends BaseService {
                         overallStart,
                         currentStatus,
                         wasResumed,
-                        { ...claudeCodeEnv, ...otelEnv },
+                        { ...codingAgentEnv, ...otelEnv },
                         copilot,
                         fileIds,
                         chartReferences,
@@ -4289,7 +4621,7 @@ export class AppGenerateService extends BaseService {
         overallStart: number,
         currentStatus: AppVersionStatus,
         wasResumed: boolean,
-        claudeCodeEnv: Record<string, string>,
+        codingAgentEnv: Record<string, string>,
         copilot: ResolvedCopilotConfig,
         fileIds: string[] | undefined,
         chartReferences: ChartReference[] | undefined,
@@ -4309,10 +4641,11 @@ export class AppGenerateService extends BaseService {
         const claudeModel: DataAppClaudeModel =
             payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL;
         const claudeEffort = payloadClaudeEffort(payload, pipelineApp.template);
-        const claudeProvider: 'anthropic' | 'bedrock' =
-            claudeCodeEnv.CLAUDE_CODE_USE_BEDROCK === '1'
-                ? 'bedrock'
-                : 'anthropic';
+        const claudeProvider = this.getCodingAgentProvider(codingAgentEnv);
+        const codingAgentModel =
+            this.dataAppCodingAgent === 'codex'
+                ? codingAgentEnv.DATA_APP_CODEX_MODEL
+                : claudeModel;
         const claudeKeyManagement = resolveKeyManagement(
             copilot,
             claudeProvider,
@@ -4418,6 +4751,9 @@ export class AppGenerateService extends BaseService {
             logger: this.logger,
         });
         await this.assembleEffectiveSkill(sandbox, designCopy);
+        if (this.dataAppCodingAgent === 'codex') {
+            await AppGenerateService.prepareCodexProjectContext(sandbox);
+        }
 
         let catalogStats = {
             tableCount: 0,
@@ -4453,6 +4789,8 @@ export class AppGenerateService extends BaseService {
         };
         const failureTelemetry = (): DataAppVersionFailureTelemetry => ({
             wasResumed,
+            codingAgent: this.dataAppCodingAgent,
+            codingAgentModel,
             claudeProvider,
             keyManagement: claudeKeyManagement,
             schedulerWaitMs,
@@ -4566,12 +4904,12 @@ export class AppGenerateService extends BaseService {
                 // the conversation where it left off.
                 const continueSession =
                     currentStatus === 'generating' || wasResumed;
-                const generation = await this.runClaudeGeneration(
+                const generation = await this.runCodingAgentGeneration(
                     sandbox,
                     appUuid,
                     version,
                     continueSession,
-                    claudeCodeEnv,
+                    codingAgentEnv,
                     claudeModel,
                     claudeEffort,
                     // Data app vizs collect a validated schema as the run's
@@ -4620,7 +4958,7 @@ export class AppGenerateService extends BaseService {
                         error.providerDetail,
                         500,
                     )}`;
-                } else if (claudeCodeEnv.CLAUDE_CODE_USE_BEDROCK === '1') {
+                } else if (codingAgentEnv.CLAUDE_CODE_USE_BEDROCK === '1') {
                     userMessage =
                         'Failed to generate the app. If this keeps happening, check that the selected model is enabled in your AWS Bedrock region (see server logs).';
                 } else {
@@ -4734,7 +5072,7 @@ export class AppGenerateService extends BaseService {
                     sandbox,
                     appUuid,
                     version,
-                    claudeCodeEnv,
+                    codingAgentEnv,
                     claudeModel,
                     claudeEffort,
                     (telemetry) => {
@@ -4892,7 +5230,7 @@ export class AppGenerateService extends BaseService {
             durations.metadataMs = await metadataPromise;
         }
         this.logger.info(
-            `App ${appUuid}: generation completed successfully in ${totalMs}ms (model=${claudeModel}, ${Object.entries(
+            `App ${appUuid}: generation completed successfully in ${totalMs}ms (agent=${this.dataAppCodingAgent}, model=${codingAgentModel}, ${Object.entries(
                 durations,
             )
                 .map(([k, v]) => `${k}=${v}ms`)
@@ -4906,7 +5244,7 @@ export class AppGenerateService extends BaseService {
         // usage stream and stamps the app/version onto the accompanying span.
         AppGenerateService.emitDataAppAiUsage(
             payload,
-            claudeModel,
+            codingAgentModel,
             claudeProvider,
             claudeKeyManagement,
             generationUsage,
@@ -4925,6 +5263,8 @@ export class AppGenerateService extends BaseService {
                 isUpgrade: payload.isUpgrade ?? false,
                 creationExperience: payload.creationExperience ?? null,
                 claudeModel,
+                codingAgent: this.dataAppCodingAgent,
+                codingAgentModel,
                 claudeProvider,
                 schedulerWaitMs,
                 claudeEffort,
@@ -5566,8 +5906,12 @@ export class AppGenerateService extends BaseService {
         claudeModelInput?: DataAppClaudeModel,
         options: GenerateAppOptions = {},
     ): Promise<GenerateAppResult> {
-        const { creationExperience, designUuidInput, externalConnections } =
-            options;
+        const {
+            creationExperience,
+            designUuidInput,
+            externalConnections,
+            codexModelInput,
+        } = options;
         await this.assertDataAppsEnabled(user);
         const { organizationUuid } = await this.assertDataAppAbility(
             user,
@@ -5575,10 +5919,18 @@ export class AppGenerateService extends BaseService {
             projectUuid,
             'Insufficient permissions to create data apps',
         );
-        const claudeModel = await this.resolveClaudeModel(
-            organizationUuid,
-            claudeModelInput,
-        );
+        const claudeModel =
+            this.dataAppCodingAgent === 'claude'
+                ? await this.resolveClaudeModel(
+                      organizationUuid,
+                      claudeModelInput,
+                  )
+                : DEFAULT_DATA_APP_CLAUDE_MODEL;
+        const codexModel =
+            this.dataAppCodingAgent === 'codex'
+                ? AppGenerateService.resolveCodexModel(codexModelInput)
+                : undefined;
+        const codingAgentModel = codexModel ?? claudeModel;
 
         // When the caller wants the app to live in a space directly, also
         // require manage rights on that space — same gate space EDITOR/ADMIN
@@ -5627,7 +5979,7 @@ export class AppGenerateService extends BaseService {
         );
 
         this.logger.info(
-            `App ${appUuid}: generation started (model=${claudeModel}, promptLength=${prompt.length}, clarifications=${
+            `App ${appUuid}: generation started (model=${codingAgentModel}, promptLength=${prompt.length}, clarifications=${
                 clarifications?.length ?? 0
             })`,
         );
@@ -5699,7 +6051,7 @@ export class AppGenerateService extends BaseService {
             dashboardName,
             dashboardUuid: dashboardBlueprint?.dashboardUuid ?? null,
             clarifications: clarifications ?? [],
-            claudeModel,
+            ...(codexModel ? { codexModel } : { claudeModel }),
             design: designSnapshot,
         };
 
@@ -5769,7 +6121,7 @@ export class AppGenerateService extends BaseService {
             chartReferences:
                 chartReferences.length > 0 ? chartReferences : undefined,
             dashboardBlueprint: dashboardBlueprint ?? undefined,
-            claudeModel,
+            ...(codexModel ? { codexModel } : { claudeModel }),
             designUuid: resolvedDesignUuid,
         });
 
@@ -5787,8 +6139,12 @@ export class AppGenerateService extends BaseService {
         claudeModelInput?: DataAppClaudeModel,
         options: GenerateAppOptions = {},
     ): Promise<GenerateAppResult> {
-        const { creationExperience, designUuidInput, externalConnections } =
-            options;
+        const {
+            creationExperience,
+            designUuidInput,
+            externalConnections,
+            codexModelInput,
+        } = options;
         await this.assertDataAppsEnabled(user);
 
         AppGenerateService.validateFileIds(fileIds);
@@ -5816,10 +6172,18 @@ export class AppGenerateService extends BaseService {
         // Resolved after the permission check so an unauthorized caller gets a
         // 403 rather than a model-visibility error. Scoped to the project's
         // organization (not the caller's) to match generateApp.
-        const claudeModel = await this.resolveClaudeModel(
-            organizationUuid,
-            claudeModelInput,
-        );
+        const claudeModel =
+            this.dataAppCodingAgent === 'claude'
+                ? await this.resolveClaudeModel(
+                      organizationUuid,
+                      claudeModelInput,
+                  )
+                : DEFAULT_DATA_APP_CLAUDE_MODEL;
+        const codexModel =
+            this.dataAppCodingAgent === 'codex'
+                ? AppGenerateService.resolveCodexModel(codexModelInput)
+                : undefined;
+        const codingAgentModel = codexModel ?? claudeModel;
 
         const externalConnectionResources = await this.linkExternalConnections(
             user,
@@ -5841,7 +6205,7 @@ export class AppGenerateService extends BaseService {
         const newVersion = (latestVersion?.version ?? 0) + 1;
         const claudeEffort = resolveClaudeEffort(newVersion, app.template);
         this.logger.info(
-            `App ${appUuid}: iteration started (version=${newVersion}, model=${claudeModel}, promptLength=${prompt.length}, designUuidInput=${
+            `App ${appUuid}: iteration started (version=${newVersion}, model=${codingAgentModel}, promptLength=${prompt.length}, designUuidInput=${
                 designUuidInput === undefined
                     ? 'inherit'
                     : (designUuidInput ?? 'none')
@@ -5911,7 +6275,7 @@ export class AppGenerateService extends BaseService {
             dashboardName,
             dashboardUuid: dashboardBlueprint?.dashboardUuid ?? null,
             clarifications: [],
-            claudeModel,
+            ...(codexModel ? { codexModel } : { claudeModel }),
             design: designSnapshot,
         };
 
@@ -5978,7 +6342,7 @@ export class AppGenerateService extends BaseService {
             chartReferences:
                 chartReferences.length > 0 ? chartReferences : undefined,
             dashboardBlueprint: dashboardBlueprint ?? undefined,
-            claudeModel,
+            ...(codexModel ? { codexModel } : { claudeModel }),
             designUuid: effectiveDesignUuid,
         });
 
@@ -6256,10 +6620,9 @@ export class AppGenerateService extends BaseService {
         if (app.sandbox_id) {
             let sandbox: SandboxHandle | null = null;
             try {
-                const copilot =
-                    await this.orgAiCopilotConfigResolver.getClaudeCodeConfig(
-                        app.organization_uuid,
-                    );
+                const copilot = await this.getCodingAgentConfig(
+                    app.organization_uuid,
+                );
                 const resumed = await this.resumeSandbox(
                     app.sandbox_id,
                     appUuid,
@@ -6278,12 +6641,14 @@ export class AppGenerateService extends BaseService {
                 // the working tree was reset and doesn't try to diff
                 // against code we've undone. Failures here don't fail the
                 // restore — worst case the next reply is mildly confused.
-                await this.notifyClaudeOfRestore(
-                    sandbox,
-                    appUuid,
-                    sourceVersion,
-                    copilot,
-                );
+                if (this.dataAppCodingAgent === 'claude') {
+                    await this.notifyClaudeOfRestore(
+                        sandbox,
+                        appUuid,
+                        sourceVersion,
+                        copilot,
+                    );
+                }
             } catch (error) {
                 // A half-synced sandbox would corrupt the next iteration —
                 // surface the failure and roll back the S3 copy.
@@ -6598,6 +6963,9 @@ export class AppGenerateService extends BaseService {
             clarifications: [],
             ...(sourceResources?.claudeModel
                 ? { claudeModel: sourceResources.claudeModel }
+                : {}),
+            ...(sourceResources?.codexModel
+                ? { codexModel: sourceResources.codexModel }
                 : {}),
         };
     }
@@ -7487,7 +7855,7 @@ export class AppGenerateService extends BaseService {
                     beforeSuspend: async (handle) => {
                         try {
                             await handle.commands.run(
-                                INTERRUPT_CLAUDE_COMMAND,
+                                INTERRUPT_CODING_AGENT_COMMAND,
                                 {
                                     timeoutMs: 15_000,
                                 },
@@ -7661,6 +8029,7 @@ export class AppGenerateService extends BaseService {
                               dashboardName: v.resources?.dashboardName ?? null,
                               clarifications: v.resources?.clarifications ?? [],
                               claudeModel: v.resources?.claudeModel,
+                              codexModel: v.resources?.codexModel,
                               design: v.resources?.design,
                               vizSchema: v.viz_schema ?? null,
                           }
@@ -10694,10 +11063,7 @@ export class AppGenerateService extends BaseService {
     ): Promise<void> {
         const { appUuid, version, organizationUuid, projectUuid } = payload;
         const { client, bucket } = this.getS3Client();
-        const copilot =
-            await this.orgAiCopilotConfigResolver.getClaudeCodeConfig(
-                organizationUuid,
-            );
+        const copilot = await this.getCodingAgentConfig(organizationUuid);
 
         // Look up the version's custom dependency set once — null means the
         // build uses the template set only (no install step).

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
@@ -64,6 +64,7 @@ function buildService(opts: { canManage?: boolean } = {}) {
     const lightdashConfig = {
         appRuntime: {
             dependencyRegistryHosts: ['registry.npmjs.org'],
+            dataAppCodingAgent: 'claude',
         },
     };
 

--- a/packages/backend/src/ee/services/AppGenerateService/CodexStreamProcessor.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/CodexStreamProcessor.test.ts
@@ -1,0 +1,99 @@
+import { CodexStreamProcessor } from './CodexStreamProcessor';
+
+const line = (value: unknown) => `${JSON.stringify(value)}\n`;
+
+describe('CodexStreamProcessor', () => {
+    test('maps reasoning, commands, the final message, and usage', () => {
+        const processor = new CodexStreamProcessor();
+        const events = processor.feedChunk(
+            line({ type: 'turn.started' }) +
+                line({
+                    type: 'item.completed',
+                    item: {
+                        id: 'reasoning-1',
+                        type: 'reasoning',
+                        text: 'I will inspect the existing app first.',
+                    },
+                }) +
+                line({
+                    type: 'item.started',
+                    item: {
+                        id: 'command-1',
+                        type: 'command_execution',
+                        command: 'sed -n 1,120p App.tsx',
+                    },
+                }) +
+                line({
+                    type: 'item.completed',
+                    item: {
+                        id: 'command-1',
+                        type: 'command_execution',
+                        command: 'sed -n 1,120p App.tsx',
+                    },
+                }) +
+                line({
+                    type: 'item.completed',
+                    item: {
+                        id: 'message-1',
+                        type: 'agent_message',
+                        text: '{"fields":[]}',
+                    },
+                }) +
+                line({
+                    type: 'turn.completed',
+                    usage: {
+                        input_tokens: 1_000,
+                        cached_input_tokens: 700,
+                        output_tokens: 250,
+                    },
+                }),
+        );
+
+        expect(events).toEqual([
+            { kind: 'thinking_started', turn: 1 },
+            {
+                kind: 'thinking_snippet',
+                snippet: 'I will inspect the existing app first.',
+            },
+            {
+                kind: 'tool_use',
+                index: 1,
+                description: 'Command sed -n 1,120p App.tsx',
+            },
+            {
+                kind: 'result',
+                text: '{"fields":[]}',
+                structuredOutput: null,
+            },
+        ]);
+        expect(processor.totalToolCalls).toBe(1);
+        expect(processor.lastUsage).toEqual({
+            inputTokens: 300,
+            outputTokens: 250,
+            cacheReadInputTokens: 700,
+            cacheCreationInputTokens: 0,
+            numTurns: 1,
+            durationApiMs: 0,
+            costUsd: 0,
+        });
+    });
+
+    test('measures first-item latency and turn duration across chunks', () => {
+        const clock = { now: 0 };
+        const processor = new CodexStreamProcessor(() => clock.now);
+        clock.now = 10;
+        processor.feedChunk(line({ type: 'turn.started' }));
+        clock.now = 50;
+        processor.feedChunk(
+            line({
+                type: 'item.started',
+                item: { id: 'cmd', type: 'command_execution', command: 'ls' },
+            }),
+        );
+        clock.now = 110;
+        processor.feedChunk(line({ type: 'turn.completed', usage: {} }));
+
+        expect(processor.timeToFirstTokenMs).toBe(50);
+        expect(processor.turnDurationsMs).toEqual([100]);
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/CodexStreamProcessor.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/CodexStreamProcessor.test.ts
@@ -96,4 +96,43 @@ describe('CodexStreamProcessor', () => {
         expect(processor.timeToFirstTokenMs).toBe(50);
         expect(processor.turnDurationsMs).toEqual([100]);
     });
+
+    test('maps file change paths from the Codex changes array', () => {
+        const processor = new CodexStreamProcessor();
+        const events = processor.feedChunk(
+            line({
+                type: 'item.started',
+                item: {
+                    id: 'change-1',
+                    type: 'file_change',
+                    changes: [
+                        { path: 'src/App.tsx', kind: 'update' },
+                        { path: 'src/index.css', kind: 'update' },
+                    ],
+                    status: 'in_progress',
+                },
+            }) +
+                line({
+                    type: 'item.completed',
+                    item: {
+                        id: 'change-1',
+                        type: 'file_change',
+                        changes: [
+                            { path: 'src/App.tsx', kind: 'update' },
+                            { path: 'src/index.css', kind: 'update' },
+                        ],
+                        status: 'completed',
+                    },
+                }),
+        );
+
+        expect(events).toEqual([
+            {
+                kind: 'tool_use',
+                index: 1,
+                description: 'Edit src/App.tsx, src/index.css',
+            },
+        ]);
+        expect(processor.totalToolCalls).toBe(1);
+    });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/CodexStreamProcessor.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/CodexStreamProcessor.ts
@@ -13,6 +13,16 @@ const compact = (value: string, maxLength = 180): string => {
     return flat.length > maxLength ? `${flat.slice(0, maxLength - 1)}…` : flat;
 };
 
+const describeFileChanges = (item: Record<string, unknown>): string => {
+    const changes = Array.isArray(item.changes)
+        ? (item.changes as Array<{ path?: unknown }>)
+        : [];
+    const paths = changes
+        .map(({ path }) => (typeof path === 'string' ? path : null))
+        .filter((path): path is string => path !== null);
+    return paths.length > 0 ? compact(paths.join(', ')) : 'files';
+};
+
 /** Parses the stable JSONL event stream emitted by `codex exec --json`. */
 export class CodexStreamProcessor {
     private lineBuffer = '';
@@ -111,7 +121,7 @@ export class CodexStreamProcessor {
                 const description =
                     itemType === 'command_execution'
                         ? `Command ${compact(String(item.command ?? ''))}`
-                        : `Edit ${String(item.path ?? item.file_path ?? 'files')}`;
+                        : `Edit ${describeFileChanges(item)}`;
                 events.push({
                     kind: 'tool_use',
                     index: this.toolCallCount,

--- a/packages/backend/src/ee/services/AppGenerateService/CodexStreamProcessor.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/CodexStreamProcessor.ts
@@ -1,0 +1,161 @@
+import {
+    addClaudeUsage,
+    ZERO_CLAUDE_USAGE,
+    type ClaudeGenerationUsage,
+    type ClaudeStreamEvent,
+} from './ClaudeStreamProcessor';
+
+const asFiniteNumber = (value: unknown): number =>
+    typeof value === 'number' && Number.isFinite(value) ? value : 0;
+
+const compact = (value: string, maxLength = 180): string => {
+    const flat = value.replace(/\s+/g, ' ').trim();
+    return flat.length > maxLength ? `${flat.slice(0, maxLength - 1)}…` : flat;
+};
+
+/** Parses the stable JSONL event stream emitted by `codex exec --json`. */
+export class CodexStreamProcessor {
+    private lineBuffer = '';
+
+    private toolCallCount = 0;
+
+    private turnCount = 0;
+
+    private readonly seenToolItems = new Set<string>();
+
+    private lastUsageValue: ClaudeGenerationUsage | null = null;
+
+    private firstItemAt: number | null = null;
+
+    private turnStartedAt: number | null = null;
+
+    private readonly turnDurations: number[] = [];
+
+    private readonly now: () => number;
+
+    private readonly createdAt: number;
+
+    constructor(now: () => number = () => Date.now()) {
+        this.now = now;
+        this.createdAt = now();
+    }
+
+    get totalToolCalls(): number {
+        return this.toolCallCount;
+    }
+
+    get lastUsage(): ClaudeGenerationUsage | null {
+        return this.lastUsageValue;
+    }
+
+    get timeToFirstTokenMs(): number | null {
+        return this.firstItemAt === null
+            ? null
+            : this.firstItemAt - this.createdAt;
+    }
+
+    get turnDurationsMs(): number[] {
+        return [...this.turnDurations];
+    }
+
+    feedChunk(chunk: string): ClaudeStreamEvent[] {
+        this.lineBuffer += chunk;
+        const lines = this.lineBuffer.split('\n');
+        this.lineBuffer = lines.pop() ?? '';
+        const events: ClaudeStreamEvent[] = [];
+        for (const line of lines) {
+            if (line.trim()) this.consumeLine(line, events);
+        }
+        return events;
+    }
+
+    private consumeLine(line: string, events: ClaudeStreamEvent[]): void {
+        let event: Record<string, unknown>;
+        try {
+            event = JSON.parse(line) as Record<string, unknown>;
+        } catch {
+            return;
+        }
+
+        if (event.type === 'turn.started') {
+            this.turnCount += 1;
+            this.turnStartedAt = this.now();
+            events.push({ kind: 'thinking_started', turn: this.turnCount });
+            return;
+        }
+
+        if (event.type === 'item.started' || event.type === 'item.completed') {
+            if (this.firstItemAt === null) this.firstItemAt = this.now();
+            const item = event.item as Record<string, unknown> | undefined;
+            if (!item) return;
+            const itemType = String(item.type ?? '');
+
+            if (
+                event.type === 'item.completed' &&
+                itemType === 'reasoning' &&
+                typeof item.text === 'string'
+            ) {
+                const snippet = compact(item.text);
+                if (snippet) events.push({ kind: 'thinking_snippet', snippet });
+                return;
+            }
+
+            if (
+                itemType === 'command_execution' ||
+                itemType === 'file_change'
+            ) {
+                const itemId = String(item.id ?? `${itemType}:${line}`);
+                if (this.seenToolItems.has(itemId)) return;
+                this.seenToolItems.add(itemId);
+                this.toolCallCount += 1;
+                const description =
+                    itemType === 'command_execution'
+                        ? `Command ${compact(String(item.command ?? ''))}`
+                        : `Edit ${String(item.path ?? item.file_path ?? 'files')}`;
+                events.push({
+                    kind: 'tool_use',
+                    index: this.toolCallCount,
+                    description,
+                });
+                return;
+            }
+
+            if (
+                event.type === 'item.completed' &&
+                itemType === 'agent_message'
+            ) {
+                events.push({
+                    kind: 'result',
+                    text: typeof item.text === 'string' ? item.text : '',
+                    structuredOutput: null,
+                });
+            }
+            return;
+        }
+
+        if (event.type === 'turn.completed') {
+            if (this.turnStartedAt !== null) {
+                this.turnDurations.push(this.now() - this.turnStartedAt);
+                this.turnStartedAt = null;
+            }
+            const usage = (event.usage ?? {}) as Record<string, unknown>;
+            const inputTokens = asFiniteNumber(usage.input_tokens);
+            const cachedInputTokens = asFiniteNumber(usage.cached_input_tokens);
+            const turnUsage: ClaudeGenerationUsage = {
+                // Codex reports cached input as a subset of input_tokens;
+                // the shared usage path stores uncached + cache separately.
+                inputTokens: Math.max(0, inputTokens - cachedInputTokens),
+                outputTokens: asFiniteNumber(usage.output_tokens),
+                cacheReadInputTokens: cachedInputTokens,
+                cacheCreationInputTokens: 0,
+                numTurns: 1,
+                durationApiMs: 0,
+                costUsd: 0,
+            };
+            this.lastUsageValue = addClaudeUsage(
+                this.lastUsageValue ?? ZERO_CLAUDE_USAGE,
+                turnUsage,
+            );
+        }
+    }
+}

--- a/packages/backend/src/ee/services/AppGenerateService/codexCodeEnv.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/codexCodeEnv.test.ts
@@ -1,0 +1,101 @@
+import { MissingConfigError } from '@lightdash/common';
+import {
+    buildCodexCodeEnv,
+    buildCodexExecCommand,
+    CODEX_PROJECT_INSTRUCTIONS,
+    CODEX_PROJECT_INSTRUCTIONS_PATH,
+    codexCodeAllowedHosts,
+    codexSkillDirective,
+    describeCodexCodeEnv,
+    PREPARE_CODEX_SKILLS_COMMAND,
+} from './codexCodeEnv';
+
+describe('Codex sandbox configuration', () => {
+    test('builds invocation-scoped credentials and egress', () => {
+        const config = {
+            providers: {
+                openai: {
+                    apiKey: 'sk-secret',
+                    modelName: 'gpt-5.4',
+                },
+            },
+        };
+
+        const env = buildCodexCodeEnv(config);
+        expect(env).toEqual({
+            CODEX_API_KEY: 'sk-secret',
+            OPENAI_BASE_URL: 'https://api.openai.com/v1',
+        });
+        expect(codexCodeAllowedHosts(config)).toEqual(['api.openai.com']);
+        const selectedEnv = {
+            ...env,
+            DATA_APP_CODEX_MODEL: 'gpt-5.6-terra',
+        };
+        expect(describeCodexCodeEnv(selectedEnv)).toBe(
+            'Codex/OpenAI (model=gpt-5.6-terra)',
+        );
+        expect(describeCodexCodeEnv(selectedEnv)).not.toContain('sk-secret');
+    });
+
+    test('uses only the custom base URL host for egress', () => {
+        const config = {
+            providers: {
+                openai: {
+                    apiKey: 'sk-secret',
+                    modelName: 'custom-model',
+                    baseUrl: 'https://openai.example.com/v1',
+                },
+            },
+        };
+
+        expect(buildCodexCodeEnv(config).OPENAI_BASE_URL).toBe(
+            'https://openai.example.com/v1',
+        );
+        expect(codexCodeAllowedHosts(config)).toEqual(['openai.example.com']);
+    });
+
+    test('fails before sandbox launch when OpenAI is unavailable', () => {
+        expect(() => buildCodexCodeEnv({ providers: {} })).toThrowError(
+            MissingConfigError,
+        );
+    });
+
+    test('builds a non-interactive, networkless command that hides credentials from tools', () => {
+        const command = buildCodexExecCommand({
+            reasoningEffort: 'high',
+            outputSchemaPath: '/tmp/output-schema.json',
+        });
+
+        expect(command).toContain('--ephemeral');
+        expect(command).toContain('--sandbox workspace-write');
+        expect(command).toContain('approval_policy="never"');
+        expect(command).toContain('model_reasoning_summary="detailed"');
+        expect(command).toContain('model_supports_reasoning_summaries=true');
+        expect(command).toContain(
+            'sandbox_workspace_write.network_access=false',
+        );
+        expect(command).toContain(
+            'shell_environment_policy.exclude=["CODEX_API_KEY","OPENAI_API_KEY"]',
+        );
+        expect(command).not.toContain('model_instructions_file');
+        expect(command).toContain('--cd /app/src');
+        expect(command).toContain('--output-schema /tmp/output-schema.json');
+    });
+
+    test('uses native project instructions and exposes the applicable skills', () => {
+        expect(CODEX_PROJECT_INSTRUCTIONS_PATH).toBe('/app/src/AGENTS.md');
+        expect(CODEX_PROJECT_INSTRUCTIONS).toContain(
+            'read `/app/effective-skill.md` completely',
+        );
+        expect(CODEX_PROJECT_INSTRUCTIONS).toContain('`$frontend-design`');
+        expect(CODEX_PROJECT_INSTRUCTIONS).toContain(
+            '`$reusable-visualization`',
+        );
+        expect(CODEX_PROJECT_INSTRUCTIONS).toContain('`$sdk-features`');
+        expect(PREPARE_CODEX_SKILLS_COMMAND).toContain(
+            '/app/src/.agents/skills',
+        );
+        expect(codexSkillDirective(false)).toContain('$frontend-design');
+        expect(codexSkillDirective(true)).toContain('$reusable-visualization');
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/codexCodeEnv.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/codexCodeEnv.test.ts
@@ -7,12 +7,15 @@ import {
     codexCodeAllowedHosts,
     codexSkillDirective,
     describeCodexCodeEnv,
+    getCodexCodeProvider,
+    getCodexModelId,
     PREPARE_CODEX_SKILLS_COMMAND,
 } from './codexCodeEnv';
 
 describe('Codex sandbox configuration', () => {
     test('builds invocation-scoped credentials and egress', () => {
         const config = {
+            defaultProvider: 'openai',
             providers: {
                 openai: {
                     apiKey: 'sk-secret',
@@ -23,6 +26,7 @@ describe('Codex sandbox configuration', () => {
 
         const env = buildCodexCodeEnv(config);
         expect(env).toEqual({
+            DATA_APP_CODEX_PROVIDER: 'openai',
             CODEX_API_KEY: 'sk-secret',
             OPENAI_BASE_URL: 'https://api.openai.com/v1',
         });
@@ -35,10 +39,15 @@ describe('Codex sandbox configuration', () => {
             'Codex/OpenAI (model=gpt-5.6-terra)',
         );
         expect(describeCodexCodeEnv(selectedEnv)).not.toContain('sk-secret');
+        expect(getCodexCodeProvider(env)).toBe('openai');
+        expect(getCodexModelId('openai', 'gpt-5.6-terra')).toBe(
+            'gpt-5.6-terra',
+        );
     });
 
     test('uses only the custom base URL host for egress', () => {
         const config = {
+            defaultProvider: 'openai',
             providers: {
                 openai: {
                     apiKey: 'sk-secret',
@@ -55,13 +64,88 @@ describe('Codex sandbox configuration', () => {
     });
 
     test('fails before sandbox launch when OpenAI is unavailable', () => {
-        expect(() => buildCodexCodeEnv({ providers: {} })).toThrowError(
-            MissingConfigError,
+        expect(() =>
+            buildCodexCodeEnv({ defaultProvider: 'openai', providers: {} }),
+        ).toThrowError(MissingConfigError);
+    });
+
+    test('builds native Bedrock API-key credentials, model id, and egress', () => {
+        const config = {
+            defaultProvider: 'bedrock',
+            providers: {
+                bedrock: {
+                    apiKey: 'bedrock-secret',
+                    region: 'us-east-2',
+                },
+            },
+        };
+
+        const env = buildCodexCodeEnv(config);
+        expect(env).toEqual({
+            DATA_APP_CODEX_PROVIDER: 'amazon-bedrock',
+            AWS_REGION: 'us-east-2',
+            AWS_BEARER_TOKEN_BEDROCK: 'bedrock-secret',
+        });
+        expect(getCodexCodeProvider(env)).toBe('amazon-bedrock');
+        expect(getCodexModelId('amazon-bedrock', 'gpt-5.6-terra')).toBe(
+            'openai.gpt-5.6-terra',
         );
+        expect(codexCodeAllowedHosts(config)).toEqual([
+            'bedrock-mantle.us-east-2.api.aws',
+        ]);
+        expect(
+            describeCodexCodeEnv({
+                ...env,
+                DATA_APP_CODEX_MODEL: 'gpt-5.6-terra',
+            }),
+        ).toBe(
+            'Codex/Bedrock (API key, region=us-east-2, model=gpt-5.6-terra)',
+        );
+        expect(describeCodexCodeEnv(env)).not.toContain('bedrock-secret');
+    });
+
+    test('builds native Bedrock IAM credentials', () => {
+        expect(
+            buildCodexCodeEnv({
+                defaultProvider: 'bedrock',
+                providers: {
+                    bedrock: {
+                        region: 'eu-west-1',
+                        accessKeyId: 'access-key',
+                        secretAccessKey: 'secret-key',
+                        sessionToken: 'session-token',
+                    },
+                },
+            }),
+        ).toEqual({
+            DATA_APP_CODEX_PROVIDER: 'amazon-bedrock',
+            AWS_REGION: 'eu-west-1',
+            AWS_ACCESS_KEY_ID: 'access-key',
+            AWS_SECRET_ACCESS_KEY: 'secret-key',
+            AWS_SESSION_TOKEN: 'session-token',
+        });
+    });
+
+    test('fails before sandbox launch when Bedrock is incomplete', () => {
+        expect(() =>
+            buildCodexCodeEnv({
+                defaultProvider: 'bedrock',
+                providers: {},
+            }),
+        ).toThrow('BEDROCK_API_KEY');
+        expect(() =>
+            buildCodexCodeEnv({
+                defaultProvider: 'bedrock',
+                providers: {
+                    bedrock: { apiKey: 'bedrock-secret', region: '' },
+                },
+            }),
+        ).toThrow('BEDROCK_REGION');
     });
 
     test('builds a non-interactive, networkless command that hides credentials from tools', () => {
         const command = buildCodexExecCommand({
+            provider: 'openai',
             reasoningEffort: 'high',
             outputSchemaPath: '/tmp/output-schema.json',
         });
@@ -74,12 +158,34 @@ describe('Codex sandbox configuration', () => {
         expect(command).toContain(
             'sandbox_workspace_write.network_access=false',
         );
-        expect(command).toContain(
-            'shell_environment_policy.exclude=["CODEX_API_KEY","OPENAI_API_KEY"]',
-        );
+        for (const secret of [
+            'CODEX_API_KEY',
+            'OPENAI_API_KEY',
+            'AWS_BEARER_TOKEN_BEDROCK',
+            'AWS_ACCESS_KEY_ID',
+            'AWS_SECRET_ACCESS_KEY',
+            'AWS_SESSION_TOKEN',
+        ]) {
+            expect(command).toContain(secret);
+        }
         expect(command).not.toContain('model_instructions_file');
         expect(command).toContain('--cd /app/src');
+        expect(command).toContain('--model "$DATA_APP_CODEX_MODEL_ID"');
+        expect(command).toContain('openai_base_url="$OPENAI_BASE_URL"');
+        expect(command).not.toContain('model_provider="amazon-bedrock"');
         expect(command).toContain('--output-schema /tmp/output-schema.json');
+    });
+
+    test('builds a native Amazon Bedrock command', () => {
+        const command = buildCodexExecCommand({
+            provider: 'amazon-bedrock',
+            reasoningEffort: 'low',
+            outputSchemaPath: null,
+        });
+
+        expect(command).toContain('model_provider="amazon-bedrock"');
+        expect(command).not.toContain('openai_base_url');
+        expect(command).toContain('--model "$DATA_APP_CODEX_MODEL_ID"');
     });
 
     test('uses native project instructions and exposes the applicable skills', () => {

--- a/packages/backend/src/ee/services/AppGenerateService/codexCodeEnv.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/codexCodeEnv.ts
@@ -1,0 +1,95 @@
+import { MissingConfigError } from '@lightdash/common';
+
+export type CodexProviderConfig = {
+    providers: {
+        openai?: {
+            apiKey: string;
+            modelName: string;
+            baseUrl?: string;
+        };
+    };
+};
+
+const getOpenAiConfig = (copilot: CodexProviderConfig) => {
+    const config = copilot.providers.openai;
+    if (!config?.apiKey) {
+        throw new MissingConfigError(
+            'OpenAI API key is not configured for Codex (OPENAI_API_KEY)',
+        );
+    }
+    return config;
+};
+
+/** Invocation-scoped environment for `codex exec`. */
+export const buildCodexCodeEnv = (
+    copilot: CodexProviderConfig,
+): Record<string, string> => {
+    const config = getOpenAiConfig(copilot);
+    return {
+        CODEX_API_KEY: config.apiKey,
+        OPENAI_BASE_URL: config.baseUrl ?? 'https://api.openai.com/v1',
+    };
+};
+
+export const describeCodexCodeEnv = (env: Record<string, string>): string =>
+    `Codex/OpenAI (model=${env.DATA_APP_CODEX_MODEL})`;
+
+export const CODEX_PROJECT_INSTRUCTIONS_PATH = '/app/src/AGENTS.md';
+
+export const CODEX_PROJECT_INSTRUCTIONS = `# Lightdash data app
+
+Before planning or editing, read \`/app/effective-skill.md\` completely when it exists. It is the authoritative Lightdash environment, data, SDK, and design reference for hosted generation, including any active organization theme instructions.
+
+Use the applicable skills under \`.agents/skills\`:
+
+- Use \`$frontend-design\` before writing or materially redesigning UI.
+- Use \`$reusable-visualization\` for a single reusable visualization hosted by Lightdash.
+- Use \`$sdk-features\` when wiring or discussing Lightdash host capabilities such as Inspect data, drill-down, exports, URL state, screenshots, or external APIs.
+
+Only edit files under this \`src/\` directory. Do not install dependencies or change project configuration. When working outside the hosted Lightdash sandbox, where \`/app/effective-skill.md\` may not exist, use these skills and the existing source as your guide.`;
+
+export const PREPARE_CODEX_SKILLS_COMMAND =
+    'mkdir -p /app/src/.agents/skills && cp -R /app/.claude/skills/. /app/src/.agents/skills/';
+
+export const codexSkillDirective = (isDataAppViz: boolean): string =>
+    isDataAppViz
+        ? '[Codex skills: use $reusable-visualization and $frontend-design before writing code.]'
+        : '[Codex skills: use $frontend-design before writing UI code.]';
+
+export const buildCodexExecCommand = ({
+    reasoningEffort,
+    outputSchemaPath,
+}: {
+    reasoningEffort: 'low' | 'high';
+    outputSchemaPath: string | null;
+}): string =>
+    `cat /tmp/prompt.txt | codex exec ` +
+    `--json --color never --ephemeral ` +
+    `--sandbox workspace-write --skip-git-repo-check ` +
+    `--ignore-user-config --ignore-rules ` +
+    `--model "$DATA_APP_CODEX_MODEL" --cd /app/src ` +
+    `-c openai_base_url="$OPENAI_BASE_URL" ` +
+    `-c 'approval_policy="never"' ` +
+    `-c 'model_reasoning_effort="${reasoningEffort}"' ` +
+    `-c 'model_reasoning_summary="detailed"' ` +
+    `-c 'model_supports_reasoning_summaries=true' ` +
+    `-c 'sandbox_workspace_write.network_access=false' ` +
+    `-c 'shell_environment_policy.inherit="core"' ` +
+    `-c 'shell_environment_policy.ignore_default_excludes=false' ` +
+    `-c 'shell_environment_policy.exclude=["CODEX_API_KEY","OPENAI_API_KEY"]' ` +
+    `${outputSchemaPath ? `--output-schema ${outputSchemaPath} ` : ''}-`;
+
+/** Egress remains host-scoped; custom OpenAI base URLs add only their host. */
+export const codexCodeAllowedHosts = (
+    copilot: CodexProviderConfig,
+): string[] => {
+    const { openai } = copilot.providers;
+    if (!openai?.baseUrl) return ['api.openai.com'];
+    try {
+        return [new URL(openai.baseUrl).hostname];
+    } catch {
+        throw new MissingConfigError(
+            `OpenAI base URL is invalid for Codex: ${openai.baseUrl}`,
+        );
+    }
+};

--- a/packages/backend/src/ee/services/AppGenerateService/codexCodeEnv.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/codexCodeEnv.ts
@@ -1,12 +1,17 @@
-import { MissingConfigError } from '@lightdash/common';
+import { MissingConfigError, type DataAppCodexModel } from '@lightdash/common';
+import type { ClaudeCodeBedrockConfig } from './claudeCodeEnv';
+
+export type CodexCodeProvider = 'openai' | 'amazon-bedrock';
 
 export type CodexProviderConfig = {
+    defaultProvider: string;
     providers: {
         openai?: {
             apiKey: string;
             modelName: string;
             baseUrl?: string;
         };
+        bedrock?: ClaudeCodeBedrockConfig;
     };
 };
 
@@ -20,19 +25,82 @@ const getOpenAiConfig = (copilot: CodexProviderConfig) => {
     return config;
 };
 
+const getBedrockConfig = (
+    copilot: CodexProviderConfig,
+): ClaudeCodeBedrockConfig | null => {
+    if (copilot.defaultProvider !== 'bedrock') return null;
+    const { bedrock } = copilot.providers;
+    if (!bedrock) {
+        throw new MissingConfigError(
+            'AI_DEFAULT_PROVIDER is set to "bedrock" but no Bedrock credentials are configured. Set BEDROCK_API_KEY, BEDROCK_ACCESS_KEY_ID and BEDROCK_SECRET_ACCESS_KEY, or BEDROCK_USE_DEFAULT_CREDENTIALS (with BEDROCK_REGION).',
+        );
+    }
+    if (!bedrock.region) {
+        throw new MissingConfigError(
+            'AI_DEFAULT_PROVIDER is set to "bedrock" but BEDROCK_REGION is not set.',
+        );
+    }
+    return bedrock;
+};
+
+export const getCodexCodeProvider = (
+    env: Record<string, string>,
+): CodexCodeProvider =>
+    env.DATA_APP_CODEX_PROVIDER === 'amazon-bedrock'
+        ? 'amazon-bedrock'
+        : 'openai';
+
+export const getCodexModelId = (
+    provider: CodexCodeProvider,
+    model: DataAppCodexModel,
+): DataAppCodexModel | `openai.${DataAppCodexModel}` =>
+    provider === 'amazon-bedrock' ? `openai.${model}` : model;
+
 /** Invocation-scoped environment for `codex exec`. */
 export const buildCodexCodeEnv = (
     copilot: CodexProviderConfig,
 ): Record<string, string> => {
+    const bedrock = getBedrockConfig(copilot);
+    if (bedrock) {
+        const base = {
+            DATA_APP_CODEX_PROVIDER: 'amazon-bedrock',
+            AWS_REGION: bedrock.region,
+        };
+        if ('apiKey' in bedrock) {
+            return {
+                ...base,
+                AWS_BEARER_TOKEN_BEDROCK: bedrock.apiKey,
+            };
+        }
+        if ('accessKeyId' in bedrock) {
+            return {
+                ...base,
+                AWS_ACCESS_KEY_ID: bedrock.accessKeyId,
+                AWS_SECRET_ACCESS_KEY: bedrock.secretAccessKey,
+                ...(bedrock.sessionToken
+                    ? { AWS_SESSION_TOKEN: bedrock.sessionToken }
+                    : {}),
+            };
+        }
+        return base;
+    }
+
     const config = getOpenAiConfig(copilot);
     return {
+        DATA_APP_CODEX_PROVIDER: 'openai',
         CODEX_API_KEY: config.apiKey,
         OPENAI_BASE_URL: config.baseUrl ?? 'https://api.openai.com/v1',
     };
 };
 
-export const describeCodexCodeEnv = (env: Record<string, string>): string =>
-    `Codex/OpenAI (model=${env.DATA_APP_CODEX_MODEL})`;
+export const describeCodexCodeEnv = (env: Record<string, string>): string => {
+    if (getCodexCodeProvider(env) === 'amazon-bedrock') {
+        const method =
+            'AWS_BEARER_TOKEN_BEDROCK' in env ? 'API key' : 'AWS credentials';
+        return `Codex/Bedrock (${method}, region=${env.AWS_REGION}, model=${env.DATA_APP_CODEX_MODEL})`;
+    }
+    return `Codex/OpenAI (model=${env.DATA_APP_CODEX_MODEL})`;
+};
 
 export const CODEX_PROJECT_INSTRUCTIONS_PATH = '/app/src/AGENTS.md';
 
@@ -57,32 +125,45 @@ export const codexSkillDirective = (isDataAppViz: boolean): string =>
         : '[Codex skills: use $frontend-design before writing UI code.]';
 
 export const buildCodexExecCommand = ({
+    provider,
     reasoningEffort,
     outputSchemaPath,
 }: {
+    provider: CodexCodeProvider;
     reasoningEffort: 'low' | 'high';
     outputSchemaPath: string | null;
-}): string =>
-    `cat /tmp/prompt.txt | codex exec ` +
-    `--json --color never --ephemeral ` +
-    `--sandbox workspace-write --skip-git-repo-check ` +
-    `--ignore-user-config --ignore-rules ` +
-    `--model "$DATA_APP_CODEX_MODEL" --cd /app/src ` +
-    `-c openai_base_url="$OPENAI_BASE_URL" ` +
-    `-c 'approval_policy="never"' ` +
-    `-c 'model_reasoning_effort="${reasoningEffort}"' ` +
-    `-c 'model_reasoning_summary="detailed"' ` +
-    `-c 'model_supports_reasoning_summaries=true' ` +
-    `-c 'sandbox_workspace_write.network_access=false' ` +
-    `-c 'shell_environment_policy.inherit="core"' ` +
-    `-c 'shell_environment_policy.ignore_default_excludes=false' ` +
-    `-c 'shell_environment_policy.exclude=["CODEX_API_KEY","OPENAI_API_KEY"]' ` +
-    `${outputSchemaPath ? `--output-schema ${outputSchemaPath} ` : ''}-`;
+}): string => {
+    const providerConfig =
+        provider === 'amazon-bedrock'
+            ? `-c 'model_provider="amazon-bedrock"' `
+            : `-c openai_base_url="$OPENAI_BASE_URL" `;
+    return [
+        `cat /tmp/prompt.txt | codex exec `,
+        `--json --color never --ephemeral `,
+        `--sandbox workspace-write --skip-git-repo-check `,
+        `--ignore-user-config --ignore-rules `,
+        `--model "$DATA_APP_CODEX_MODEL_ID" --cd /app/src `,
+        providerConfig,
+        `-c 'approval_policy="never"' `,
+        `-c 'model_reasoning_effort="${reasoningEffort}"' `,
+        `-c 'model_reasoning_summary="detailed"' `,
+        `-c 'model_supports_reasoning_summaries=true' `,
+        `-c 'sandbox_workspace_write.network_access=false' `,
+        `-c 'shell_environment_policy.inherit="core"' `,
+        `-c 'shell_environment_policy.ignore_default_excludes=false' `,
+        `-c 'shell_environment_policy.exclude=["CODEX_API_KEY","OPENAI_API_KEY","AWS_BEARER_TOKEN_BEDROCK","AWS_ACCESS_KEY_ID","AWS_SECRET_ACCESS_KEY","AWS_SESSION_TOKEN"]' `,
+        `${outputSchemaPath ? `--output-schema ${outputSchemaPath} ` : ''}-`,
+    ].join('');
+};
 
-/** Egress remains host-scoped; custom OpenAI base URLs add only their host. */
+/** Egress remains host-scoped to the selected provider endpoint. */
 export const codexCodeAllowedHosts = (
     copilot: CodexProviderConfig,
 ): string[] => {
+    const bedrock = getBedrockConfig(copilot);
+    if (bedrock) {
+        return [`bedrock-mantle.${bedrock.region}.api.aws`];
+    }
     const { openai } = copilot.providers;
     if (!openai?.baseUrl) return ['api.openai.com'];
     try {

--- a/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.test.ts
+++ b/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.test.ts
@@ -314,6 +314,36 @@ describe('OrgAiCopilotConfigResolver', () => {
         });
     });
 
+    describe('getCodexConfig', () => {
+        it('returns the instance config unchanged without an organization uuid', async () => {
+            const result = await makeResolver({
+                flagEnabled: true,
+                instanceConfig: bothProvidersConfig,
+            }).getCodexConfig(null);
+            expect(result.providers.openai?.apiKey).toBe('instance-openai-key');
+        });
+
+        it('runs a BYO org on its own OpenAI key', async () => {
+            const result = await makeResolver({
+                flagEnabled: true,
+                orgKeys: { openai: 'org-openai-key' },
+                instanceConfig: bothProvidersConfig,
+            }).getCodexConfig('org-uuid');
+            expect(result.defaultProvider).toBe('openai');
+            expect(result.providers.openai?.apiKey).toBe('org-openai-key');
+        });
+
+        it('never leaks the instance OpenAI key to a BYO org that only keyed Anthropic', async () => {
+            const result = await makeResolver({
+                flagEnabled: true,
+                orgKeys: { anthropic: 'org-anthropic-key' },
+                instanceConfig: bothProvidersConfig,
+            }).getCodexConfig('org-uuid');
+            expect(result.providers.openai).toBeUndefined();
+            expect(result.defaultProvider).toBe('openai');
+        });
+    });
+
     describe('resolveEffectiveModelVisibilityForOrg', () => {
         it('merges the implicit auto-hide under the submitted visibility', async () => {
             const resolver = makeResolver({

--- a/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.test.ts
+++ b/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.test.ts
@@ -62,6 +62,25 @@ const bothProvidersConfig: CopilotConfig = aiCopilotConfigSchema.parse({
     },
 });
 
+const bedrockConfig: CopilotConfig = aiCopilotConfigSchema.parse({
+    enabled: true,
+    requiresFeatureFlag: false,
+    telemetryEnabled: false,
+    debugLoggingEnabled: false,
+    askAiButtonEnabled: false,
+    embeddingEnabled: false,
+    maxQueryLimit: 100,
+    runSqlMaxLimit: 100,
+    defaultProvider: 'bedrock',
+    defaultEmbeddingModelProvider: 'openai',
+    providers: {
+        bedrock: {
+            apiKey: 'instance-bedrock-key',
+            region: 'us-east-2',
+        },
+    },
+});
+
 describe('overlayOrgProviderApiKeys', () => {
     it('switches the default provider to the org key when the instance default is not BYO-supplied', () => {
         const result = overlayOrgProviderApiKeys(bothProvidersConfig, {
@@ -315,6 +334,16 @@ describe('OrgAiCopilotConfigResolver', () => {
     });
 
     describe('getCodexConfig', () => {
+        it('keeps instance Bedrock as the managed Codex provider', async () => {
+            const result = await makeResolver({
+                flagEnabled: true,
+                orgKeys: null,
+                instanceConfig: bedrockConfig,
+            }).getCodexConfig('org-uuid');
+            expect(result.defaultProvider).toBe('bedrock');
+            expect(result.providers.bedrock?.region).toBe('us-east-2');
+        });
+
         it('returns the instance config unchanged without an organization uuid', async () => {
             const result = await makeResolver({
                 flagEnabled: true,

--- a/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.ts
+++ b/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.ts
@@ -192,6 +192,34 @@ export class OrgAiCopilotConfigResolver {
     }
 
     /**
+     * Copilot config for a data-app sandbox running Codex. Mirrors the Claude
+     * resolver's BYOK boundary: once an org supplies any provider key, Codex
+     * may use only that org's OpenAI key and never the instance OpenAI key.
+     */
+    async getCodexConfig(
+        organizationUuid: string | null | undefined,
+    ): Promise<ResolvedCopilotConfig> {
+        const base = this.lightdashConfig.ai.copilot;
+        const managed: ResolvedCopilotConfig = { ...base, byoProviders: [] };
+        if (!organizationUuid) return managed;
+        if (!(await this.isEnabled(organizationUuid))) return managed;
+        const orgKeys =
+            await this.aiOrganizationSettingsModel.findDecryptedProviderApiKeys(
+                organizationUuid,
+            );
+        if (!orgKeys) return managed;
+        const overlaid = overlayOrgProviderApiKeys(base, orgKeys);
+        return {
+            ...overlaid,
+            defaultProvider: 'openai',
+            providers: {
+                ...overlaid.providers,
+                openai: orgKeys.openai ? overlaid.providers.openai : undefined,
+            },
+        };
+    }
+
+    /**
      * Org overrides for model LISTINGS (visibility settings + which hidden
      * models the org's own Anthropic key unlocks). Both are null unless the
      * feature flag is on AND the org has at least one BYO key, so deleting

--- a/packages/backend/src/models/AppModel.test.ts
+++ b/packages/backend/src/models/AppModel.test.ts
@@ -1,6 +1,10 @@
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
-import { AppsTableName, type DbApp } from '../database/entities/apps';
+import {
+    AppsTableName,
+    AppVersionsTableName,
+    type DbApp,
+} from '../database/entities/apps';
 import { DashboardTileDataAppsTableName } from '../database/entities/dashboards';
 import { AppModel } from './AppModel';
 
@@ -25,6 +29,73 @@ const appRow: DbApp = {
     views_count: 0,
     search_vector: '',
 };
+
+describe('AppModel.recordVersionGenerationUsage', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new AppModel({ database });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('persists an unknown generation cost as null', async () => {
+        tracker.on.update(AppVersionsTableName).responseOnce(1);
+
+        await model.recordVersionGenerationUsage(appId, 1, {
+            inputTokens: 100,
+            outputTokens: 20,
+            cacheReadInputTokens: 50,
+            cacheCreationInputTokens: 0,
+            numTurns: 2,
+            durationApiMs: 0,
+            costUsd: null,
+        });
+
+        expect(tracker.history.update[0].sql).toContain("'costUsd', NULL");
+        expect(tracker.history.update[0].bindings).not.toContain(null);
+    });
+});
+
+describe('AppModel.getOrganizationActivity', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new AppModel({ database });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('filters on the resolved Claude or Codex model', async () => {
+        tracker.on.select(AppVersionsTableName).responseOnce([]);
+
+        const result = await model.getOrganizationActivity(
+            'organization-1',
+            undefined,
+            { models: ['sonnet', 'gpt-5.6-terra'] },
+        );
+
+        expect(result).toEqual({ data: [] });
+        expect(tracker.history.select[0].sql).toContain(
+            "COALESCE(app_versions.resources->>'codexModel', app_versions.resources->>'claudeModel'",
+        );
+        expect(tracker.history.select[0].bindings).toEqual(
+            expect.arrayContaining([
+                'organization-1',
+                'sonnet',
+                'gpt-5.6-terra',
+            ]),
+        );
+    });
+});
 
 describe('AppModel.setMetadataIfUnset', () => {
     const database = knex({ client: MockClient, dialect: 'pg' });

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -215,6 +215,7 @@ export class AppModel {
     ): Promise<void> {
         const sum = (field: keyof DataAppGenerationUsage) =>
             `COALESCE((generation_usage->>'${field}')::numeric, 0) + ?`;
+        const costSql = usage.costUsd === null ? 'NULL' : sum('costUsd');
         await this.database(AppVersionsTableName)
             .where({ app_id: appId, version })
             .update({
@@ -228,7 +229,7 @@ export class AppModel {
                         )},
                         'numTurns', ${sum('numTurns')},
                         'durationApiMs', ${sum('durationApiMs')},
-                        'costUsd', ${sum('costUsd')}
+                        'costUsd', ${costSql}
                     )`,
                     [
                         usage.inputTokens,
@@ -237,7 +238,7 @@ export class AppModel {
                         usage.cacheCreationInputTokens,
                         usage.numTurns,
                         usage.durationApiMs,
-                        usage.costUsd,
+                        ...(usage.costUsd === null ? [] : [usage.costUsd]),
                     ],
                 ) as unknown as DataAppGenerationUsage,
             });
@@ -1399,23 +1400,12 @@ export class AppModel {
                 }
                 if (filters?.models?.length) {
                     const { models } = filters;
-                    void queryBuilder.where((modelQueryBuilder) => {
-                        void modelQueryBuilder.whereRaw(
-                            `${AppVersionsTableName}.resources->>'claudeModel' IN (${models
-                                .map(() => '?')
-                                .join(', ')})`,
-                            models,
-                        );
-                        // A version with no stored model ran on the default, and
-                        // that is what the API reports for it — so filtering on
-                        // the default has to match those rows too, or the filter
-                        // contradicts the value shown in the row.
-                        if (models.includes(DEFAULT_DATA_APP_CLAUDE_MODEL)) {
-                            void modelQueryBuilder.orWhereRaw(
-                                `${AppVersionsTableName}.resources->>'claudeModel' IS NULL`,
-                            );
-                        }
-                    });
+                    void queryBuilder.whereRaw(
+                        `COALESCE(${AppVersionsTableName}.resources->>'codexModel', ${AppVersionsTableName}.resources->>'claudeModel', ?) IN (${models
+                            .map(() => '?')
+                            .join(', ')})`,
+                        [DEFAULT_DATA_APP_CLAUDE_MODEL, ...models],
+                    );
                 }
                 if (filters?.dateFrom) {
                     void queryBuilder.where(

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -1,6 +1,10 @@
 import type { ApiSuccess, KnexPaginatedData } from '../..';
 import type { AiDeepResearchLimits } from '../aiDeepResearch/types';
-import type { DataAppClaudeModel, DataAppModelVisibility } from '../apps/types';
+import type {
+    DataAppClaudeModel,
+    DataAppCodingAgent,
+    DataAppModelVisibility,
+} from '../apps/types';
 import type {
     AiAgentEvaluationRunSummary,
     AiAgentMemoryScope,
@@ -375,6 +379,7 @@ export type AiOrganizationRuntimeSettings = {
     aiAgentReviewsAvailable: boolean;
     defaultAiAgentModelConfig: AiAgentModelConfig | null;
     defaultAiAgentModelOptions: AiModelOption[];
+    dataAppCodingAgent: DataAppCodingAgent;
     visibleDataAppModels: DataAppClaudeModel[];
 };
 

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -688,14 +688,14 @@ export type ApiMyAppsResponse = ApiSuccess<{
 }>;
 
 /**
- * What one generation cost, aggregated across every `claude` CLI invocation in
- * that version's pipeline — including build-fix retries.
+ * Usage for one generation, aggregated across every coding-agent invocation in
+ * that version's pipeline, including build-fix retries.
  *
  * This is spend attributable to a generation, not all data-app AI spend: the
  * short prompt-clarification and app-naming calls happen outside any version.
  *
- * `costUsd` is the CLI's own figure, computed from public list prices, so treat
- * it as an estimate rather than an invoice.
+ * `costUsd` is an estimate rather than an invoice. It is null when the coding
+ * agent reports tokens without a trustworthy price.
  */
 export type DataAppGenerationUsage = {
     inputTokens: number;
@@ -704,7 +704,7 @@ export type DataAppGenerationUsage = {
     cacheCreationInputTokens: number;
     numTurns: number;
     durationApiMs: number;
-    costUsd: number;
+    costUsd: number | null;
 };
 
 /**
@@ -722,9 +722,11 @@ export type DataAppActivityEvent = {
     version: number;
     status: AppVersionStatus;
     prompt: string;
-    // Versions built before the model picker shipped carry no model on their
-    // resources; they ran on the default, so that is what we report.
-    claudeModel: DataAppClaudeModel;
+    codingAgent: DataAppCodingAgent;
+    codingAgentModel: DataAppCodingAgentModel;
+    // Backwards-compatible Claude-only field. Codex activity omits it rather
+    // than reporting the Claude default for a model that did not run.
+    claudeModel?: DataAppClaudeModel;
     createdAt: Date;
     projectUuid: string;
     projectName: string;
@@ -745,7 +747,7 @@ export type DataAppActivityFilters = {
     // Matches the model as reported, so filtering on the default model also
     // returns versions that carry no model of their own — the ones that ran on
     // the default before the picker shipped.
-    models?: DataAppClaudeModel[];
+    models?: DataAppCodingAgentModel[];
     // ISO-8601, inclusive.
     dateFrom?: string;
     dateTo?: string;

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -117,6 +117,10 @@ export const DATA_APP_CREATION_EXPERIENCES = [
 export type DataAppCreationExperience =
     (typeof DATA_APP_CREATION_EXPERIENCES)[number];
 
+/** Coding agent used inside the data-app sandbox. */
+export const DATA_APP_CODING_AGENTS = ['claude', 'codex'] as const;
+export type DataAppCodingAgent = (typeof DATA_APP_CODING_AGENTS)[number];
+
 /**
  * Claude model used to generate / iterate the data app inside the sandbox.
  * Mapped to the Claude CLI's `--model <alias>` flag verbatim. Persisted
@@ -126,6 +130,22 @@ export type DataAppCreationExperience =
 export const DATA_APP_CLAUDE_MODELS = ['opus', 'sonnet', 'haiku'] as const;
 export type DataAppClaudeModel = (typeof DATA_APP_CLAUDE_MODELS)[number];
 export const DEFAULT_DATA_APP_CLAUDE_MODEL: DataAppClaudeModel = 'sonnet';
+
+/**
+ * Codex model used to generate / iterate the data app inside the sandbox.
+ * These are passed to `codex exec --model` verbatim. Kept separate from the
+ * Claude model contract because Claude visibility is managed by org admins,
+ * while Codex currently exposes this fixed instance-level set.
+ */
+export const DATA_APP_CODEX_MODELS = [
+    'gpt-5.6-sol',
+    'gpt-5.6-terra',
+    'gpt-5.6-luna',
+] as const;
+export type DataAppCodexModel = (typeof DATA_APP_CODEX_MODELS)[number];
+export const DEFAULT_DATA_APP_CODEX_MODEL: DataAppCodexModel = 'gpt-5.6-terra';
+
+export type DataAppCodingAgentModel = DataAppClaudeModel | DataAppCodexModel;
 
 /**
  * Reasoning effort passed to the Claude CLI as `--effort`. Resolved from the
@@ -298,6 +318,9 @@ export type GenerateAppRequestBody = {
     // switched between iterations — `claude --continue` keeps the prior
     // conversation context but accepts a fresh `--model` flag per turn.
     claudeModel?: DataAppClaudeModel;
+    // Codex model to use when APPS_CODING_AGENT=codex. Defaults to
+    // DEFAULT_DATA_APP_CODEX_MODEL on the backend when absent.
+    codexModel?: DataAppCodexModel;
     // Theme (org design) to apply to this app's source tree and system
     // prompt. On initial creation, omit to use the org default, null for no
     // theme, or pass a uuid for a specific theme. On iteration, omit to
@@ -399,6 +422,9 @@ export type AppVersionResources = {
     // shipped don't carry the field; readers should fall back to
     // DEFAULT_DATA_APP_CLAUDE_MODEL.
     claudeModel?: DataAppClaudeModel;
+    // Codex model picked for this version. Separate from claudeModel so the
+    // existing Claude visibility and history contract stays unchanged.
+    codexModel?: DataAppCodexModel;
     // Snapshot of the theme used to generate this version (org design). Null
     // when no theme was applied. Captured at generation time so the chat
     // history reflects which theme was active even if it was later renamed

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -13,6 +13,7 @@ import {
     type DashboardBlueprint,
     type DataAppClaudeEffort,
     type DataAppClaudeModel,
+    type DataAppCodexModel,
     type DataAppCreationExperience,
     type DataAppTemplate,
     type EmbedArtifactVersionJobPayload,
@@ -82,6 +83,9 @@ export type AppGeneratePipelineJobPayload = TraceTaskBase & {
     // before the picker shipped — the pipeline falls back to
     // DEFAULT_DATA_APP_CLAUDE_MODEL in that case.
     claudeModel?: DataAppClaudeModel;
+    // Codex model selected for this version. Only used by Codex workers;
+    // absent jobs fall back to DEFAULT_DATA_APP_CODEX_MODEL.
+    codexModel?: DataAppCodexModel;
     // Reasoning effort resolved at enqueue time, where the app's template is
     // known. Absent on jobs enqueued before this field shipped — the pipeline
     // resolves it from the app row instead.

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -3,7 +3,8 @@ import {
     ChartKind,
     type ChartContent,
     type AiModelOption,
-    type DataAppClaudeModel,
+    type DataAppCodingAgent,
+    type DataAppCodingAgentModel,
     type ExternalConnection,
 } from '@lightdash/common';
 import {
@@ -184,7 +185,7 @@ export const InspectButton: FC<{
 );
 
 type ModelOption = {
-    value: DataAppClaudeModel;
+    value: DataAppCodingAgentModel;
     label: string;
     // Short advantage line shown in the popover. Together with the order
     // below, these form a capability spectrum (premium → balanced → budget)
@@ -196,7 +197,7 @@ type ModelOption = {
 // Order: capability descending — Opus (highest quality) → Sonnet (default) →
 // Haiku (fastest). The "Default" tag on Sonnet anchors the recommendation
 // without forcing it to position 0.
-const MODEL_OPTIONS: ModelOption[] = [
+const CLAUDE_MODEL_OPTIONS: ModelOption[] = [
     {
         value: 'opus',
         label: 'Opus',
@@ -215,69 +216,97 @@ const MODEL_OPTIONS: ModelOption[] = [
     },
 ];
 
-// Lookup helper. The type union and MODEL_OPTIONS are kept in sync via
-// DATA_APP_CLAUDE_MODELS, but the underlying value can ultimately come from
-// the JSONB `resources.claudeModel` column — so a stale or hand-edited row
+const CODEX_MODEL_OPTIONS: ModelOption[] = [
+    {
+        value: 'gpt-5.6-sol',
+        label: 'Sol',
+        tagline: 'Highest quality. Best for complex builds.',
+    },
+    {
+        value: 'gpt-5.6-terra',
+        label: 'Terra',
+        tagline: 'Balanced intelligence and cost. Good fit for most work.',
+        isDefault: true,
+    },
+    {
+        value: 'gpt-5.6-luna',
+        label: 'Luna',
+        tagline: 'Lowest cost. Best for simple iterations and high volume.',
+    },
+];
+
+// Lookup helper. The underlying value ultimately comes from JSONB version
+// resources, so a stale or hand-edited row
 // could land here as a string outside the union at runtime. Fall back to the
 // default option rather than throw, so a corrupt row never crashes the
 // AppGenerate page; the user can still pick a valid model from the popover.
-const findModelOption = (value: DataAppClaudeModel): ModelOption =>
-    MODEL_OPTIONS.find((o) => o.value === value) ??
-    MODEL_OPTIONS.find((o) => o.isDefault) ??
-    MODEL_OPTIONS[0];
+const findModelOption = (
+    value: DataAppCodingAgentModel,
+    options: ModelOption[],
+): ModelOption =>
+    options.find((o) => o.value === value) ??
+    options.find((o) => o.isDefault) ??
+    options[0];
 
-// All data-app models are Anthropic's; the shared selector keys models by
-// "provider:name".
-const DATA_APP_MODEL_PROVIDER = 'anthropic';
+const toModelKey = (
+    value: DataAppCodingAgentModel,
+    provider: 'anthropic' | 'openai',
+): string => `${provider}:${value}`;
 
-const toModelKey = (value: DataAppClaudeModel): string =>
-    `${DATA_APP_MODEL_PROVIDER}:${value}`;
-
-const toModelOption = (opt: ModelOption): AiModelOption => ({
+const toModelOption = (
+    opt: ModelOption,
+    provider: 'anthropic' | 'openai',
+): AiModelOption => ({
     name: opt.value,
     modelId: opt.value,
     displayName: opt.label,
     description: opt.tagline,
-    provider: DATA_APP_MODEL_PROVIDER,
+    provider,
     default: opt.isDefault === true,
     supportsReasoning: false,
     deprecated: false,
 });
 
 /**
- * Picker for the Claude model the agent uses to build the data app.
+ * Picker for the configured coding agent's model.
  *
  * Inline next to the send button so the choice is visible at submit time;
- * also editable mid-iteration — `claude --continue` accepts a fresh
- * `--model` flag each turn while preserving the prior conversation context.
+ * also editable mid-iteration.
  *
  * Renders the shared `ModelSelector` so the data-app composer and the AI
  * agent chat offer the same control; the data-app model union is mapped onto
  * the provider-qualified model options that selector expects.
  */
 export const ModelPicker: FC<{
-    value: DataAppClaudeModel;
-    onChange: (value: DataAppClaudeModel) => void;
+    value: DataAppCodingAgentModel;
+    onChange: (value: DataAppCodingAgentModel) => void;
     disabled?: boolean;
     /** Restrict the picker to these models (org admin visibility settings).
      *  Defaults to all models when omitted. */
-    visibleModels?: DataAppClaudeModel[];
-}> = ({ value, onChange, disabled, visibleModels }) => {
+    visibleModels?: DataAppCodingAgentModel[];
+    codingAgent?: DataAppCodingAgent;
+}> = ({ value, onChange, disabled, visibleModels, codingAgent = 'claude' }) => {
+    const options =
+        codingAgent === 'codex' ? CODEX_MODEL_OPTIONS : CLAUDE_MODEL_OPTIONS;
+    const provider = codingAgent === 'codex' ? 'openai' : 'anthropic';
     const models = useMemo(
         () =>
-            MODEL_OPTIONS.filter(
-                (opt) => !visibleModels || visibleModels.includes(opt.value),
-            ).map(toModelOption),
-        [visibleModels],
+            options
+                .filter(
+                    (opt) =>
+                        !visibleModels || visibleModels.includes(opt.value),
+                )
+                .map((option) => toModelOption(option, provider)),
+        [options, provider, visibleModels],
     );
 
     return (
         <ModelSelector
             models={models}
-            value={toModelKey(findModelOption(value).value)}
+            value={toModelKey(findModelOption(value, options).value, provider)}
             onChange={(modelKey) => {
-                const picked = MODEL_OPTIONS.find(
-                    (opt) => toModelKey(opt.value) === modelKey,
+                const picked = options.find(
+                    (opt) => toModelKey(opt.value, provider) === modelKey,
                 );
                 if (picked) onChange(picked.value);
             }}

--- a/packages/frontend/src/features/apps/builder/BuilderPromptBar.test.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptBar.test.tsx
@@ -1,3 +1,7 @@
+import {
+    type DataAppClaudeModel,
+    type DataAppCodexModel,
+} from '@lightdash/common';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { forwardRef, useImperativeHandle, useRef, type ReactNode } from 'react';
@@ -112,9 +116,18 @@ const buildState = (
 
 const modelSelection = (
     selectedModel: DataAppModelSelection['selectedModel'],
+    codingAgent: DataAppModelSelection['codingAgent'] = 'claude',
 ): DataAppModelSelection => ({
+    codingAgent,
     selectedModel,
-    visibleModels: ['opus', 'sonnet', 'haiku'],
+    modelRequest:
+        codingAgent === 'codex'
+            ? { codexModel: selectedModel as DataAppCodexModel }
+            : { claudeModel: selectedModel as DataAppClaudeModel },
+    visibleModels:
+        codingAgent === 'codex'
+            ? ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']
+            : ['opus', 'sonnet', 'haiku'],
     isLoading: false,
     setModel: vi.fn(),
     clearPick: vi.fn(),
@@ -181,6 +194,28 @@ describe('BuilderPromptBar', () => {
         renderWithProviders(promptBar({ model: modelSelection('opus') }));
 
         expect(screen.getByText('Opus')).toBeInTheDocument();
+    });
+
+    it('builds with the picked Codex model', async () => {
+        const send = vi.fn();
+        renderWithProviders(
+            promptBar({
+                build: buildState({ send }),
+                model: modelSelection('gpt-5.6-sol', 'codex'),
+            }),
+        );
+
+        await userEvent.type(
+            screen.getByPlaceholderText('Ask for a change…'),
+            'a complex cohort analysis',
+        );
+        await userEvent.click(screen.getByLabelText('Send'));
+
+        expect(send).toHaveBeenCalledWith({
+            description: 'a complex cohort analysis',
+            fileIds: [],
+            codexModel: 'gpt-5.6-sol',
+        });
     });
 
     it('queues a prompt during a build and drains it when the build finishes', async () => {

--- a/packages/frontend/src/features/apps/builder/BuilderPromptBar.test.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptBar.test.tsx
@@ -215,6 +215,7 @@ describe('BuilderPromptBar', () => {
             description: 'a complex cohort analysis',
             fileIds: [],
             codexModel: 'gpt-5.6-sol',
+            clarifications: [],
         });
     });
 

--- a/packages/frontend/src/features/apps/builder/BuilderPromptBar.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptBar.tsx
@@ -192,7 +192,7 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                     attachments.fileIds.length > 0
                         ? attachments.fileIds
                         : (editing?.request.fileIds ?? []),
-                claudeModel: modelSelection.selectedModel,
+                ...modelSelection.modelRequest,
                 clarifications: [],
             };
             const queuedPrompt: QueuedPrompt = {
@@ -225,7 +225,9 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                 current.filter((queued) => queued.id !== item.id),
             );
             editingPrompt.current = item;
-            modelSelection.setModel(item.request.claudeModel);
+            modelSelection.setModel(
+                item.request.codexModel ?? item.request.claudeModel,
+            );
             composerRef.current?.clear();
             composerRef.current?.insertContent([
                 { type: 'text', text: item.request.description },
@@ -527,6 +529,7 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                                     onChange={modelSelection.setModel}
                                     disabled={modelSelection.isLoading}
                                     visibleModels={modelSelection.visibleModels}
+                                    codingAgent={modelSelection.codingAgent}
                                 />
                             )}
                             <input

--- a/packages/frontend/src/features/apps/hooks/useDataAppModelSelection.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppModelSelection.test.ts
@@ -14,16 +14,26 @@ vi.mock(
 const setVisibleModels = (
     visibleDataAppModels: string[] | undefined,
     isLoading = false,
+    dataAppCodingAgent: 'claude' | 'codex' = 'claude',
 ) =>
     vi.mocked(useAiOrganizationSettings).mockReturnValue({
-        data: visibleDataAppModels ? { visibleDataAppModels } : undefined,
+        data: visibleDataAppModels
+            ? { visibleDataAppModels, dataAppCodingAgent }
+            : undefined,
         isLoading,
     } as unknown as ReturnType<typeof useAiOrganizationSettings>);
 
 const setup = (
     props: {
         appUuid: string | null;
-        latestVersionModel: 'opus' | 'sonnet' | 'haiku' | null;
+        latestVersionModel:
+            | 'opus'
+            | 'sonnet'
+            | 'haiku'
+            | 'gpt-5.6-sol'
+            | 'gpt-5.6-terra'
+            | 'gpt-5.6-luna'
+            | null;
     } = { appUuid: 'viz-1', latestVersionModel: null },
 ) =>
     renderHookWithProviders(useDataAppModelSelection, undefined, {
@@ -40,6 +50,35 @@ describe('useDataAppModelSelection', () => {
         const { result } = setup();
 
         expect(result.current.selectedModel).toBe('sonnet');
+        expect(result.current.codingAgent).toBe('claude');
+    });
+
+    it('offers the Codex models and defaults to Terra', () => {
+        setVisibleModels(['opus', 'sonnet', 'haiku'], false, 'codex');
+        const { result } = setup();
+
+        expect(result.current.codingAgent).toBe('codex');
+        expect(result.current.selectedModel).toBe('gpt-5.6-terra');
+        expect(result.current.visibleModels).toEqual([
+            'gpt-5.6-sol',
+            'gpt-5.6-terra',
+            'gpt-5.6-luna',
+        ]);
+        expect(result.current.modelRequest).toEqual({
+            codexModel: 'gpt-5.6-terra',
+        });
+    });
+
+    it('lets Codex users select Sol', () => {
+        setVisibleModels(['opus', 'sonnet', 'haiku'], false, 'codex');
+        const { result } = setup();
+
+        act(() => result.current.setModel('gpt-5.6-sol'));
+
+        expect(result.current.selectedModel).toBe('gpt-5.6-sol');
+        expect(result.current.modelRequest).toEqual({
+            codexModel: 'gpt-5.6-sol',
+        });
     });
 
     it('pre-selects the model the latest version was built with', () => {

--- a/packages/frontend/src/features/apps/hooks/useDataAppModelSelection.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppModelSelection.ts
@@ -1,31 +1,43 @@
 import {
+    DATA_APP_CODEX_MODELS,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
+    DEFAULT_DATA_APP_CODEX_MODEL,
     resolveDefaultDataAppClaudeModel,
     type DataAppClaudeModel,
+    type DataAppCodexModel,
+    type DataAppCodingAgent,
+    type DataAppCodingAgentModel,
 } from '@lightdash/common';
 import { useCallback, useMemo, useState } from 'react';
 import { useAiOrganizationSettings } from '../../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 
 const NO_MODELS: DataAppClaudeModel[] = [];
+const CODEX_MODELS: DataAppCodexModel[] = [...DATA_APP_CODEX_MODELS];
 
 type Args = {
     /** The app the picker is for; null before the first build claims one. */
     appUuid: string | null;
     /** The most recent version's persisted model, whatever its status — a
      *  still-building version's model is already a valid signal of intent. */
-    latestVersionModel: DataAppClaudeModel | null;
+    latestVersionModel: DataAppCodingAgentModel | null;
 };
 
 export type DataAppModelSelection = {
+    codingAgent: DataAppCodingAgent;
     /** What the next submit sends. */
-    selectedModel: DataAppClaudeModel;
+    selectedModel: DataAppCodingAgentModel;
+    /** Provider-specific request field. Claude and Codex remain separate on
+     *  the wire so Claude's existing contract is unchanged. */
+    modelRequest:
+        | { claudeModel: DataAppClaudeModel; codexModel?: never }
+        | { codexModel: DataAppCodexModel; claudeModel?: never };
     /** Models the org admin left visible; empty while still loading. */
-    visibleModels: DataAppClaudeModel[];
+    visibleModels: DataAppCodingAgentModel[];
     /** Loading and unrestricted are indistinguishable until the org settings
      *  resolve, so surfaces disable the picker rather than offer a model the
      *  server would then reject. */
     isLoading: boolean;
-    setModel: (model: DataAppClaudeModel) => void;
+    setModel: (model: DataAppCodingAgentModel) => void;
     /** Drops the pick so the next app derives its own. Surfaces that stay
      *  mounted across apps must call this when they navigate between them. */
     clearPick: () => void;
@@ -45,13 +57,17 @@ export const useDataAppModelSelection = ({
 }: Args): DataAppModelSelection => {
     const [pick, setPick] = useState<{
         appUuid: string | null;
-        model: DataAppClaudeModel;
+        model: DataAppCodingAgentModel;
     } | null>(null);
 
     const { data: aiOrganizationSettings, isLoading } =
         useAiOrganizationSettings();
-    const visibleModels =
+    const codingAgent =
+        aiOrganizationSettings?.dataAppCodingAgent ?? ('claude' as const);
+    const visibleClaudeModels =
         aiOrganizationSettings?.visibleDataAppModels ?? NO_MODELS;
+    const visibleModels: DataAppCodingAgentModel[] =
+        codingAgent === 'codex' ? CODEX_MODELS : visibleClaudeModels;
 
     const selectedModel = useMemo(() => {
         if (
@@ -64,18 +80,38 @@ export const useDataAppModelSelection = ({
         if (latestVersionModel && visibleModels.includes(latestVersionModel)) {
             return latestVersionModel;
         }
-        return (
-            resolveDefaultDataAppClaudeModel(visibleModels) ??
-            DEFAULT_DATA_APP_CLAUDE_MODEL
-        );
-    }, [pick, appUuid, latestVersionModel, visibleModels]);
+        return codingAgent === 'codex'
+            ? DEFAULT_DATA_APP_CODEX_MODEL
+            : (resolveDefaultDataAppClaudeModel(visibleClaudeModels) ??
+                  DEFAULT_DATA_APP_CLAUDE_MODEL);
+    }, [
+        pick,
+        appUuid,
+        latestVersionModel,
+        visibleModels,
+        visibleClaudeModels,
+        codingAgent,
+    ]);
 
     const setModel = useCallback(
-        (model: DataAppClaudeModel) => setPick({ appUuid, model }),
+        (model: DataAppCodingAgentModel) => setPick({ appUuid, model }),
         [appUuid],
     );
 
     const clearPick = useCallback(() => setPick(null), []);
 
-    return { selectedModel, visibleModels, isLoading, setModel, clearPick };
+    const modelRequest: DataAppModelSelection['modelRequest'] =
+        codingAgent === 'codex'
+            ? { codexModel: selectedModel as DataAppCodexModel }
+            : { claudeModel: selectedModel as DataAppClaudeModel };
+
+    return {
+        codingAgent,
+        selectedModel,
+        modelRequest,
+        visibleModels,
+        isLoading,
+        setModel,
+        clearPick,
+    };
 };

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
@@ -4,6 +4,7 @@ import {
     type ApiAppVersionSummary,
     type AppClarification,
     type DataAppClaudeModel,
+    type DataAppCodexModel,
     type DataAppVizFieldMapping,
     type ItemsMap,
 } from '@lightdash/common';
@@ -33,11 +34,13 @@ type Args = {
 export type VizBuildRequest = {
     description: string;
     fileIds: string[];
-    claudeModel: DataAppClaudeModel;
     /** Answers to the pre-build clarifying round; empty when it was skipped,
      *  fell through, or never ran. Only a first build can carry them. */
     clarifications: AppClarification[];
-};
+} & (
+    | { claudeModel: DataAppClaudeModel; codexModel?: never }
+    | { codexModel: DataAppCodexModel; claudeModel?: never }
+);
 
 /** The app claimed by a build before it has a renderable version. */
 export type DataAppVizDraft = {
@@ -178,7 +181,9 @@ export const useDataAppVizBuild = ({
                         creationExperience: 'chart_type_builder',
                         appUuid: draftAppUuid,
                         fileIds: files,
-                        claudeModel: request.claudeModel,
+                        ...(request.codexModel
+                            ? { codexModel: request.codexModel }
+                            : { claudeModel: request.claudeModel }),
                         clarifications:
                             request.clarifications.length > 0
                                 ? request.clarifications
@@ -206,7 +211,9 @@ export const useDataAppVizBuild = ({
                     prompt,
                     creationExperience: 'chart_type_builder',
                     fileIds: files,
-                    claudeModel: request.claudeModel,
+                    ...(request.codexModel
+                        ? { codexModel: request.codexModel }
+                        : { claudeModel: request.claudeModel }),
                 },
                 {
                     onSuccess: ({ version }) =>

--- a/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
@@ -6,6 +6,7 @@ import {
     type AppDashboardReference,
     type AppExternalConnectionReference,
     type DataAppClaudeModel,
+    type DataAppCodexModel,
     type DataAppCreationExperience,
     type DataAppTemplate,
 } from '@lightdash/common';
@@ -24,6 +25,7 @@ type GenerateAppParams = {
     clarifications?: AppClarification[];
     spaceUuid?: string; // create directly inside this space (skips the personal-app step)
     claudeModel?: DataAppClaudeModel;
+    codexModel?: DataAppCodexModel;
     // Theme (org design) to apply. `undefined` lets the server fall back to
     // the org default; `null` explicitly opts out of any theme; a uuid picks
     // a specific theme.
@@ -46,6 +48,7 @@ const generateApp = async ({
     clarifications,
     spaceUuid,
     claudeModel,
+    codexModel,
     designUuid,
     externalConnections,
 }: GenerateAppParams): Promise<GenerateAppResult> => {
@@ -63,6 +66,7 @@ const generateApp = async ({
             clarifications,
             spaceUuid,
             claudeModel,
+            codexModel,
             externalConnections,
             // Send only when defined: `null` means "no theme"; `undefined`
             // means "honor org default" and omitting from the JSON body lets

--- a/packages/frontend/src/features/apps/hooks/useIterateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useIterateApp.ts
@@ -5,6 +5,7 @@ import {
     type AppDashboardReference,
     type AppExternalConnectionReference,
     type DataAppClaudeModel,
+    type DataAppCodexModel,
     type DataAppCreationExperience,
 } from '@lightdash/common';
 import { useMutation } from '@tanstack/react-query';
@@ -19,6 +20,7 @@ type IterateAppParams = {
     charts?: AppChartReference[];
     dashboard?: AppDashboardReference;
     claudeModel?: DataAppClaudeModel;
+    codexModel?: DataAppCodexModel;
     externalConnections?: AppExternalConnectionReference[];
     designUuid?: string | null;
 };
@@ -34,6 +36,7 @@ const iterateApp = async ({
     charts,
     dashboard,
     claudeModel,
+    codexModel,
     externalConnections,
     designUuid,
 }: IterateAppParams): Promise<IterateAppResult> => {
@@ -47,6 +50,7 @@ const iterateApp = async ({
             charts,
             dashboard,
             claudeModel,
+            codexModel,
             externalConnections,
             ...(designUuid !== undefined ? { designUuid } : {}),
         }),

--- a/packages/frontend/src/features/apps/hooks/useVizClarification.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useVizClarification.test.ts
@@ -15,7 +15,9 @@ vi.mock('../../../providers/Tracking/useTracking', () => ({
 const mockedClarify = vi.mocked(useClarifyApp);
 
 const request = (
-    overrides: Partial<VizBuildRequest> = {},
+    overrides: Partial<
+        Omit<VizBuildRequest, 'claudeModel' | 'codexModel'>
+    > = {},
 ): VizBuildRequest => ({
     description: 'show revenue split by team',
     fileIds: [],

--- a/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
+++ b/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
@@ -70,9 +70,11 @@ const TokensCell: FC<{ usage: DataAppGenerationUsage | null }> = ({
                     <Text fz="xs">{`Output: ${exactTokens.format(usage.outputTokens)}`}</Text>
                     <Text fz="xs">{`Cached: ${exactTokens.format(cached)}`}</Text>
                     <Text fz="xs">{`${usage.numTurns} turns`}</Text>
-                    <Text fz="xs">{`Estimated cost: ${formatCost(
-                        usage.costUsd,
-                    )}`}</Text>
+                    <Text fz="xs">
+                        {usage.costUsd === null
+                            ? 'Estimated cost: Not available'
+                            : `Estimated cost: ${formatCost(usage.costUsd)}`}
+                    </Text>
                 </Stack>
             }
         >
@@ -262,14 +264,14 @@ export const DataAppActivityTable: FC = () => {
                 ),
             },
             {
-                id: 'claudeModel',
-                accessorFn: (row) => row.claudeModel,
+                id: 'codingAgentModel',
+                accessorFn: (row) => row.codingAgentModel,
                 header: 'Model',
-                size: 78,
+                size: 140,
                 enableSorting: false,
                 Cell: ({ row }) => (
                     <Text fz="sm" c="ldGray.9">
-                        {row.original.claudeModel}
+                        {row.original.codingAgentModel}
                     </Text>
                 ),
             },

--- a/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTopToolbar.tsx
+++ b/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTopToolbar.tsx
@@ -1,4 +1,7 @@
-import { DATA_APP_CLAUDE_MODELS } from '@lightdash/common';
+import {
+    DATA_APP_CLAUDE_MODELS,
+    DATA_APP_CODEX_MODELS,
+} from '@lightdash/common';
 import {
     Box,
     Button,
@@ -99,10 +102,12 @@ export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
 
     const modelOptions = useMemo<FilterFacetOption[]>(
         () =>
-            DATA_APP_CLAUDE_MODELS.map((model) => ({
-                value: model,
-                label: model,
-            })),
+            [...DATA_APP_CLAUDE_MODELS, ...DATA_APP_CODEX_MODELS].map(
+                (model) => ({
+                    value: model,
+                    label: model,
+                }),
+            ),
         [],
     );
 

--- a/packages/frontend/src/features/dataAppActivity/hooks/useDataAppActivityFilters.ts
+++ b/packages/frontend/src/features/dataAppActivity/hooks/useDataAppActivityFilters.ts
@@ -1,7 +1,8 @@
 import {
     DATA_APP_CLAUDE_MODELS,
+    DATA_APP_CODEX_MODELS,
     type DataAppActivityFilters,
-    type DataAppClaudeModel,
+    type DataAppCodingAgentModel,
 } from '@lightdash/common';
 import { useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router';
@@ -27,7 +28,7 @@ const DEFAULT_PERIOD: DataAppActivityPeriod = 'all';
 type DataAppActivityFiltersState = {
     projectUuids: string[];
     userUuids: string[];
-    models: DataAppClaudeModel[];
+    models: DataAppCodingAgentModel[];
     period: DataAppActivityPeriod;
 };
 
@@ -35,8 +36,10 @@ const isPeriod = (value: string | null): value is DataAppActivityPeriod =>
     value !== null &&
     (DATA_APP_ACTIVITY_PERIODS as readonly string[]).includes(value);
 
-const isModel = (value: string): value is DataAppClaudeModel =>
-    (DATA_APP_CLAUDE_MODELS as readonly string[]).includes(value);
+const isModel = (value: string): value is DataAppCodingAgentModel =>
+    [...DATA_APP_CLAUDE_MODELS, ...DATA_APP_CODEX_MODELS].includes(
+        value as DataAppCodingAgentModel,
+    );
 
 /** Data app activity filters, persisted in the URL so a view is shareable. */
 export const useDataAppActivityFilters = () => {

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -12,7 +12,6 @@ import {
     type AppDashboardReference,
     type AppExternalConnectionReference,
     type AppVersionDependencyEntry,
-    type DataAppClaudeModel,
     type DataAppTemplate,
     type DataAppVizContext,
 } from '@lightdash/common';
@@ -113,7 +112,10 @@ import { useAppThumbnailUpload } from '../features/apps/hooks/useAppThumbnail';
 import { useBuildNotification } from '../features/apps/hooks/useBuildNotification';
 import { useCancelAppVersion } from '../features/apps/hooks/useCancelAppVersion';
 import { useClarifyApp } from '../features/apps/hooks/useClarifyApp';
-import { useDataAppModelSelection } from '../features/apps/hooks/useDataAppModelSelection';
+import {
+    useDataAppModelSelection,
+    type DataAppModelSelection,
+} from '../features/apps/hooks/useDataAppModelSelection';
 import { useGenerateApp } from '../features/apps/hooks/useGenerateApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useIterateApp } from '../features/apps/hooks/useIterateApp';
@@ -560,11 +562,11 @@ const AppGenerate: FC = () => {
         dashboard: AppDashboardReference | undefined;
         externalConnections: AppExternalConnectionReference[] | undefined;
         spaceUuid: string | undefined;
-        // Snapshot of `selectedModel` at submit time so a mid-clarification
+        // Snapshot of the provider-specific model request at submit time so a mid-clarification
         // model switch doesn't change which model the build kicks off with —
         // the user's intent was captured when they pressed send.
-        claudeModel: DataAppClaudeModel;
-        // Same intent-snapshot reasoning as claudeModel — capture the picked
+        modelRequest: DataAppModelSelection['modelRequest'];
+        // Same intent-snapshot reasoning as modelRequest — capture the picked
         // theme at submit time so flipping the picker mid-clarification
         // doesn't change what the build runs against.
         designUuid: string | null;
@@ -917,13 +919,18 @@ const AppGenerate: FC = () => {
     }, [allVersions]);
 
     const {
+        codingAgent,
         selectedModel,
+        modelRequest,
         visibleModels,
         isLoading: isModelVisibilityLoading,
         setModel: handleModelChange,
     } = useDataAppModelSelection({
         appUuid: activeAppUuid ?? null,
-        latestVersionModel: latestVersion?.resources?.claudeModel ?? null,
+        latestVersionModel:
+            latestVersion?.resources?.codexModel ??
+            latestVersion?.resources?.claudeModel ??
+            null,
     });
 
     // Theme (org design) picker state. New apps pre-populate with the org's
@@ -994,7 +1001,7 @@ const AppGenerate: FC = () => {
                     appUuid: activeAppUuid,
                     prompt,
                     creationExperience: 'app_builder',
-                    claudeModel: selectedModel,
+                    ...modelRequest,
                     designUuid,
                 },
                 {
@@ -1034,7 +1041,7 @@ const AppGenerate: FC = () => {
             projectUuid,
             invalidateAppData,
             resetIterate,
-            selectedModel,
+            modelRequest,
             user.data?.firstName,
             user.data?.lastName,
         ],
@@ -1706,7 +1713,7 @@ const AppGenerate: FC = () => {
                             dashboard,
                             externalConnections,
                             spaceUuid: targetSpaceUuid,
-                            claudeModel: selectedModel,
+                            modelRequest,
                             designUuid: selectedThemeUuid,
                         });
                         setClarificationAnswers(
@@ -1739,7 +1746,7 @@ const AppGenerate: FC = () => {
                         fileIds,
                         charts,
                         dashboard,
-                        claudeModel: selectedModel,
+                        ...modelRequest,
                         externalConnections,
                     },
                     callbacks,
@@ -1756,7 +1763,7 @@ const AppGenerate: FC = () => {
                         charts,
                         dashboard,
                         spaceUuid: targetSpaceUuid,
-                        claudeModel: selectedModel,
+                        ...modelRequest,
                         designUuid: selectedThemeUuid,
                         externalConnections,
                     },
@@ -1828,7 +1835,7 @@ const AppGenerate: FC = () => {
                 clarifications:
                     clarifications.length > 0 ? clarifications : undefined,
                 spaceUuid: captured.spaceUuid,
-                claudeModel: captured.claudeModel,
+                ...captured.modelRequest,
                 designUuid: captured.designUuid,
             },
             buildSubmitCallbacks(),
@@ -3065,6 +3072,7 @@ const AppGenerate: FC = () => {
                                                 <ModelPicker
                                                     value={selectedModel}
                                                     onChange={handleModelChange}
+                                                    codingAgent={codingAgent}
                                                     disabled={
                                                         isSubmitting ||
                                                         isModelVisibilityLoading

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -101,7 +101,10 @@ const ChartTypeBuilder: FC = () => {
     // pre-selects it, so reopening a chart type keeps building the way it was.
     const modelSelection = useDataAppModelSelection({
         appUuid: activeVizUuid ?? null,
-        latestVersionModel: history.latest?.resources?.claudeModel ?? null,
+        latestVersionModel:
+            history.latest?.resources?.codexModel ??
+            history.latest?.resources?.claudeModel ??
+            null,
     });
     const { clearPick: clearModelPick } = modelSelection;
 

--- a/sandboxes/data-apps/e2b.Dockerfile
+++ b/sandboxes/data-apps/e2b.Dockerfile
@@ -2,7 +2,10 @@ FROM node:22
 
 # Global tooling
 RUN npm install -g pnpm@11.17.0
-RUN npm install -g @anthropic-ai/claude-code@2.1.220
+RUN npm install -g sfw@2.0.6
+RUN sfw npm install -g \
+    @anthropic-ai/claude-code@2.1.220 \
+    @openai/codex@0.147.0
 
 WORKDIR /app
 
@@ -42,9 +45,9 @@ RUN npx shadcn@2.3.0 add --overwrite --yes \
 # raw `var(--x)` + complete oklch colors is the single convention.
 COPY template/tailwind.config.js ./tailwind.config.js
 
-# Claude Code skills — first-party plus vendored (frontend-design @ Apache-2.0).
-# The whole directory is copied, so a new skill needs no change here. Read from
-# /app/.claude/skills/ inside the sandbox.
+# Coding-agent skills — first-party plus vendored (frontend-design @ Apache-2.0).
+# Claude reads these directly. Codex mirrors them into its native project skill
+# directory at runtime, so both agents keep using this single source of truth.
 COPY template/.claude/ ./.claude/
 
 # E2B sandbox runs as 'user' — make /app writable


### PR DESCRIPTION
## Summary

- make `APPS_CODING_AGENT` select Claude or Codex while preserving the existing Claude defaults and model policy
- add Codex Sol, Terra, and Luna model selection across data-app creation, iteration, reusable visualizations, version history, and job payloads
- run `codex exec` in E2B with OpenAI/BYOK resolution, scoped egress, retries, build-fix turns, usage telemetry, and streamed reasoning/tool progress
- expose the existing data-app skills through Codex-native `AGENTS.md` and `.agents/skills`, explicitly invoking the applicable design/visualization skill
- keep the generated agent guidance with app source so customers can reuse it with compatible coding agents outside E2B

## Why

Data-app generation was hard-wired to Claude Code. A customer needs Codex support now, and the first prototype revealed two experience gaps: Codex stream events were not visible in the UI, and the shared frontend/visualization skills were only installed under Claude's skill directory. This PR provides a usable configurable Codex path without changing Claude behavior.

## Configuration

Set `APPS_CODING_AGENT=codex` to enable Codex. Omitted or `claude` keeps the existing path.

Codex exposes:

- `gpt-5.6-sol`
- `gpt-5.6-terra` (default)
- `gpt-5.6-luna`

## Validation

- `pnpm -F backend test` — 454 files passed; 7,097 tests passed, 1 skipped
- `pnpm -F backend typecheck`
- `pnpm -F common typecheck`
- `pnpm -F frontend typecheck`
- focused frontend model-picker tests — 21 passed
- targeted backend/common/frontend lint across all changed source files
- repository pre-commit secret scan, formatting, lint, and unused-export checks
- `git diff --check`

## Manual follow-up

- rebuild/publish the E2B data-app template so the image includes the pinned Codex CLI
- rerun a real Codex generation after deployment to visually assess the native skill-loading improvement