### PR TITLE
fix: refuse ambiguous explore write-back

### DIFF
--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.mock.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.mock.ts
@@ -15,13 +15,30 @@ export const PROJECT_MODEL = {
     get: vi.fn(() =>
         Promise.resolve({
             projectUuid: 'projectUuid',
+            name: 'Project',
             dbtVersion: SupportedDbtVersions.V1_9,
+            dbtConnection: {
+                type: 'github',
+                repository: 'owner/repo',
+                branch: 'main',
+                project_sub_path: 'path',
+            },
         }),
     ),
 };
+export const PROJECT_DBT_SOURCES_MODEL = {
+    getSources: vi.fn().mockResolvedValue([]),
+};
 export const SAVED_CHART_MODEL = {};
 export const SPACE_MODEL = {};
-export const GITHUB_APP_MODEL = {};
+export const GITHUB_APP_MODEL = {
+    getInstallationId: vi.fn().mockResolvedValue('installation-id'),
+    getAuth: vi.fn().mockResolvedValue({
+        token: 'token',
+        refreshToken: 'refresh-token',
+    }),
+    updateAuth: vi.fn(),
+};
 
 // Mock schema file with comments, different multi-line strings, different types of quotes, different types of arrays
 export const SCHEMA_YML = `

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
@@ -1,13 +1,20 @@
-import { DbtProjectType } from '@lightdash/common';
+import { DbtProjectType, SupportedDbtVersions } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
-import { updateFile } from '../../clients/github/Github';
+import {
+    createBranch,
+    createPullRequest,
+    getFileContent,
+    updateFile,
+} from '../../clients/github/Github';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { GithubAppInstallationsModel } from '../../models/GithubAppInstallations/GithubAppInstallationsModel';
+import { ProjectDbtSourcesModel } from '../../models/ProjectDbtSourcesModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { PullRequestsModel } from '../../models/PullRequestsModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { GithubAppService } from '../GithubAppService/GithubAppService';
+import { user } from '../ProjectService/ProjectService.mock';
 import { GitIntegrationService } from './GitIntegrationService';
 import {
     CUSTOM_DIMENSION,
@@ -15,6 +22,7 @@ import {
     EXPECTED_SCHEMA_YML_WITH_CUSTOM_DIMENSION,
     EXPECTED_SCHEMA_YML_WITH_CUSTOM_METRIC,
     GITHUB_APP_MODEL,
+    PROJECT_DBT_SOURCES_MODEL,
     PROJECT_MODEL,
     SAVED_CHART_MODEL,
     SCHEMA_YML,
@@ -22,11 +30,19 @@ import {
 } from './GitIntegrationService.mock';
 
 vi.mock('../../clients/github/Github.ts', () => ({
-    getFileContent: vi.fn().mockImplementation(() => ({
-        content: SCHEMA_YML,
-        sha: 'sha',
+    getFileContent: vi.fn(),
+    updateFile: vi.fn().mockResolvedValue(undefined),
+    getLastCommit: vi.fn().mockResolvedValue({ sha: 'main-sha' }),
+    createBranch: vi.fn().mockResolvedValue(undefined),
+    createPullRequest: vi.fn().mockResolvedValue({
+        html_url: 'https://example.com/pull/1',
+        title: 'Adds custom metric',
+        number: 1,
+    }),
+    getOrRefreshToken: vi.fn().mockImplementation((token, refreshToken) => ({
+        token,
+        refreshToken,
     })),
-    updateFile: vi.fn().mockImplementation(() => undefined),
 }));
 
 describe('GitIntegrationService', () => {
@@ -35,6 +51,8 @@ describe('GitIntegrationService', () => {
         analytics: analyticsMock,
         savedChartModel: SAVED_CHART_MODEL as unknown as SavedChartModel,
         projectModel: PROJECT_MODEL as unknown as ProjectModel,
+        projectDbtSourcesModel:
+            PROJECT_DBT_SOURCES_MODEL as unknown as ProjectDbtSourcesModel,
         spaceModel: SPACE_MODEL as unknown as SpaceModel,
         githubAppInstallationsModel:
             GITHUB_APP_MODEL as unknown as GithubAppInstallationsModel,
@@ -44,6 +62,13 @@ describe('GitIntegrationService', () => {
         pullRequestsModel: {
             create: vi.fn(),
         } as unknown as PullRequestsModel,
+    });
+
+    beforeEach(() => {
+        vi.mocked(getFileContent).mockResolvedValue({
+            content: SCHEMA_YML,
+            sha: 'sha',
+        });
     });
 
     afterEach(() => {
@@ -91,6 +116,116 @@ describe('GitIntegrationService', () => {
             expect(updateFile.mock.calls[0][0].content).toEqual(
                 EXPECTED_SCHEMA_YML_WITH_CUSTOM_DIMENSION,
             );
+        });
+    });
+
+    describe('createPullRequest', () => {
+        const writebackUser = {
+            ...user,
+            organizationUuid: 'organizationUuid',
+        };
+
+        const additionalSource = {
+            projectDbtSourceUuid: 'additional-source-uuid',
+            name: 'Additional source',
+            dbtConnection: {
+                type: DbtProjectType.GITHUB,
+            },
+        };
+
+        it('refuses write-back for an explore from an additional source without calling Git', async () => {
+            PROJECT_DBT_SOURCES_MODEL.getSources.mockResolvedValueOnce([
+                additionalSource,
+            ]);
+
+            await expect(
+                service.createPullRequest(writebackUser, 'projectUuid', "'", {
+                    type: 'customMetrics',
+                    fields: [CUSTOM_METRIC],
+                }),
+            ).rejects.toThrow(
+                'Explore write-back cannot determine which dbt source owns this model on a project with multiple git-backed dbt sources: "Project dbt connection", "Additional source"',
+            );
+
+            expect(createBranch).not.toHaveBeenCalled();
+            expect(getFileContent).not.toHaveBeenCalled();
+            expect(updateFile).not.toHaveBeenCalled();
+            expect(createPullRequest).not.toHaveBeenCalled();
+        });
+
+        it('keeps single-source Explore write-back unchanged', async () => {
+            const result = await service.createPullRequest(
+                writebackUser,
+                'projectUuid',
+                "'",
+                {
+                    type: 'customMetrics',
+                    fields: [CUSTOM_METRIC],
+                },
+            );
+
+            expect(PROJECT_DBT_SOURCES_MODEL.getSources).toHaveBeenCalledWith(
+                'projectUuid',
+            );
+            expect(createBranch).toHaveBeenCalledTimes(1);
+            expect(getFileContent).toHaveBeenCalledTimes(1);
+            expect(updateFile).toHaveBeenCalledTimes(1);
+            expect(createPullRequest).toHaveBeenCalledTimes(1);
+            expect(result).toEqual({
+                prTitle: 'Adds custom metric',
+                prUrl: 'https://example.com/pull/1',
+            });
+        });
+
+        it('keeps the existing non-git primary connection error', async () => {
+            PROJECT_MODEL.get.mockResolvedValueOnce({
+                projectUuid: 'projectUuid',
+                name: 'Project',
+                dbtVersion: SupportedDbtVersions.V1_9,
+                dbtConnection: {
+                    type: DbtProjectType.DBT,
+                    repository: '',
+                    branch: '',
+                    project_sub_path: '',
+                },
+            });
+
+            await expect(
+                service.createPullRequest(writebackUser, 'projectUuid', "'", {
+                    type: 'customMetrics',
+                    fields: [CUSTOM_METRIC],
+                }),
+            ).rejects.toThrow(
+                'invalid dbt connection type dbt for project Project',
+            );
+
+            expect(PROJECT_DBT_SOURCES_MODEL.getSources).toHaveBeenCalledWith(
+                'projectUuid',
+            );
+            expect(createBranch).not.toHaveBeenCalled();
+            expect(getFileContent).not.toHaveBeenCalled();
+            expect(updateFile).not.toHaveBeenCalled();
+            expect(createPullRequest).not.toHaveBeenCalled();
+        });
+
+        it('refuses write-back for a primary-source explore on a multi-source project', async () => {
+            PROJECT_DBT_SOURCES_MODEL.getSources.mockResolvedValueOnce([
+                additionalSource,
+            ]);
+
+            await expect(
+                service.createPullRequest(writebackUser, 'projectUuid', "'", {
+                    type: 'customMetrics',
+                    fields: [{ ...CUSTOM_METRIC, table: 'primary_table' }],
+                }),
+            ).rejects.toThrow(
+                'Explore write-back cannot determine which dbt source owns this model on a project with multiple git-backed dbt sources: "Project dbt connection", "Additional source"',
+            );
+
+            expect(createBranch).not.toHaveBeenCalled();
+            expect(getFileContent).not.toHaveBeenCalled();
+            expect(updateFile).not.toHaveBeenCalled();
+            expect(createPullRequest).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -41,6 +41,7 @@ import * as GitlabClient from '../../clients/gitlab/Gitlab';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { GithubAppInstallationsModel } from '../../models/GithubAppInstallations/GithubAppInstallationsModel';
+import { ProjectDbtSourcesModel } from '../../models/ProjectDbtSourcesModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { PullRequestsModel } from '../../models/PullRequestsModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
@@ -52,6 +53,7 @@ type GitIntegrationServiceArguments = {
     lightdashConfig: LightdashConfig;
     savedChartModel: SavedChartModel;
     projectModel: ProjectModel;
+    projectDbtSourcesModel: ProjectDbtSourcesModel;
     spaceModel: SpaceModel;
     githubAppInstallationsModel: GithubAppInstallationsModel;
     githubAppService: GithubAppService;
@@ -83,6 +85,8 @@ export class GitIntegrationService extends BaseService {
 
     private readonly projectModel: ProjectModel;
 
+    private readonly projectDbtSourcesModel: ProjectDbtSourcesModel;
+
     private readonly spaceModel: SpaceModel;
 
     private readonly githubAppInstallationsModel: GithubAppInstallationsModel;
@@ -98,6 +102,7 @@ export class GitIntegrationService extends BaseService {
         this.lightdashConfig = args.lightdashConfig;
         this.savedChartModel = args.savedChartModel;
         this.projectModel = args.projectModel;
+        this.projectDbtSourcesModel = args.projectDbtSourcesModel;
         this.spaceModel = args.spaceModel;
         this.githubAppInstallationsModel = args.githubAppInstallationsModel;
         this.githubAppService = args.githubAppService;
@@ -495,6 +500,33 @@ Affected charts:
         };
     }
 
+    private async assertExploreWritebackSourceIsUnambiguous(
+        projectUuid: string,
+    ): Promise<void> {
+        const additionalGitBackedSources = (
+            await this.projectDbtSourcesModel.getSources(projectUuid)
+        ).filter(
+            (source) =>
+                source.dbtConnection?.type === DbtProjectType.GITHUB ||
+                source.dbtConnection?.type === DbtProjectType.GITLAB,
+        );
+
+        if (additionalGitBackedSources.length === 0) {
+            return;
+        }
+
+        const sourceNames = [
+            'Project dbt connection',
+            ...additionalGitBackedSources.map((source) => source.name),
+        ]
+            .map((name) => `"${name}"`)
+            .join(', ');
+
+        throw new ParameterError(
+            `Explore write-back cannot determine which dbt source owns this model on a project with multiple git-backed dbt sources: ${sourceNames}`,
+        );
+    }
+
     /**
      * Get the protected branch for a project.
      * For normal projects: the project's configured branch (e.g., "main")
@@ -629,6 +661,7 @@ Affected charts:
             throw new ForbiddenError();
         }
 
+        await this.assertExploreWritebackSourceIsUnambiguous(projectUuid);
         const gitProps = await this.getGitProps(user, projectUuid, quoteChar);
 
         await GitIntegrationService.createBranch(gitProps);

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -464,6 +464,8 @@ export class ServiceRepository
                     lightdashConfig: this.context.lightdashConfig,
                     savedChartModel: this.models.getSavedChartModel(),
                     projectModel: this.models.getProjectModel(),
+                    projectDbtSourcesModel:
+                        this.models.getProjectDbtSourcesModel(),
                     spaceModel: this.models.getSpaceModel(),
                     githubAppInstallationsModel:
                         this.models.getGithubAppInstallationsModel(),


### PR DESCRIPTION
## Summary

- Refuse Explore custom-field write-back when additional git-backed dbt sources are configured.
- Name the configured dbt sources in the error and leave other Git integration flows unchanged.
- Add regression coverage for multi-source refusal and the unchanged single-source path.

## Behaviour change

Explore write-back is refused on multi-source projects, including for models that genuinely do live in the primary source, because nothing in the system distinguishes the safe models from the unsafe ones. Refusing loudly avoids committing to the wrong repository silently.

## Validation

- `pnpm -F backend typecheck`
- `pnpm -F backend test:dev:nowatch`
- `pnpm --filter backend run linter src/services/GitIntegrationService/GitIntegrationService.ts src/services/GitIntegrationService/GitIntegrationService.test.ts src/services/GitIntegrationService/GitIntegrationService.mock.ts src/services/ServiceRepository.ts`

Linear: SPK-1023