### PR TITLE
fix: preserve unselected explores on selective deploy

### DIFF
--- a/packages/backend/src/controllers/exploreController.ts
+++ b/packages/backend/src/controllers/exploreController.ts
@@ -22,6 +22,7 @@ import {
     Path,
     Post,
     Put,
+    Query,
     Request,
     Response,
     Route,
@@ -57,6 +58,7 @@ export class ExploreController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
         @Body() body: AnyType[], // tsoa doesn't seem to work with explores from CLI
+        @Query() complete?: boolean,
     ): Promise<ApiSetExploresResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -67,6 +69,7 @@ export class ExploreController extends BaseController {
                 projectUuid,
                 body,
                 req.header(LightdashCliVersionHeader),
+                complete,
             );
 
         return {

--- a/packages/backend/src/controllers/v2/DeployController.ts
+++ b/packages/backend/src/controllers/v2/DeployController.ts
@@ -87,6 +87,7 @@ export class DeployController extends BaseController {
                 sessionUuid,
                 (body as unknown as ApiAddDeployBatchRequest).explores,
                 (body as unknown as ApiAddDeployBatchRequest).batchNumber,
+                (body as unknown as ApiAddDeployBatchRequest).complete,
             );
         return {
             status: 'ok',

--- a/packages/backend/src/database/entities/deploySessions.ts
+++ b/packages/backend/src/database/entities/deploySessions.ts
@@ -20,7 +20,7 @@ export type DbDeploySessionBatch = {
     deploy_session_uuid: string;
     project_uuid: string;
     batch_number: number;
-    explores: unknown; // JSONB array of Explore or ExploreError objects
+    explores: unknown;
     explore_count: number;
     created_at: Date;
 };

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -290,6 +290,7 @@ export async function seed(knex: Knex): Promise<void> {
         await projectModel.saveExploresToCache(
             SEED_PROJECT.project_uuid,
             explores,
+            true,
         );
 
         // Index catalog after saving explores to cache

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
@@ -164,6 +164,7 @@ describe('provisionPlaygroundProject', () => {
         expect(mocks.saveExploresToCache).toHaveBeenCalledWith(
             projectUuid,
             expect.any(Array),
+            true,
         );
         expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
             event: 'playground_project.skipped',
@@ -266,6 +267,7 @@ describe('provisionPlaygroundProject', () => {
         expect(mocks.saveExploresToCache).toHaveBeenCalledWith(
             projectUuid,
             expect.any(Array),
+            true,
         );
         expect(mocks.indexCatalog).toHaveBeenCalledWith(
             projectUuid,

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
@@ -157,6 +157,7 @@ export const provisionPlaygroundProject = async ({
                     await projectModel.saveExploresToCache(
                         playground.projectUuid,
                         explores,
+                        true,
                     );
                     trackSkipped(
                         'playground_already_exists',
@@ -229,6 +230,7 @@ export const provisionPlaygroundProject = async ({
                     await projectModel.saveExploresToCache(
                         projectUuid,
                         explores,
+                        true,
                     );
                 } catch (error) {
                     await projectModel

--- a/packages/backend/src/models/DeploySessionModel.test.ts
+++ b/packages/backend/src/models/DeploySessionModel.test.ts
@@ -1,0 +1,106 @@
+import { SupportedDbtAdapter, type Explore } from '@lightdash/common';
+import knex from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { DEPLOY_SESSION_BATCH_EXPLORES_TABLE_NAME } from '../database/entities/deploySessions';
+import { DeploySessionModel } from './DeploySessionModel';
+
+const explore = (name: string): Explore => ({
+    name,
+    label: name,
+    tags: [],
+    tables: {},
+    baseTable: name,
+    joinedTables: [],
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+});
+
+describe('DeploySessionModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new DeploySessionModel(database);
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    test('treats legacy array batches as incomplete', async () => {
+        tracker.on
+            .select(({ sql }) =>
+                sql.includes(DEPLOY_SESSION_BATCH_EXPLORES_TABLE_NAME),
+            )
+            .response([{ explores: [explore('orders')] }]);
+
+        await expect(model.getDeployData('session-uuid')).resolves.toEqual({
+            explores: [explore('orders')],
+            complete: false,
+        });
+    });
+
+    test('reports complete only when every batch asserts completeness', async () => {
+        tracker.on
+            .select(({ sql }) =>
+                sql.includes(DEPLOY_SESSION_BATCH_EXPLORES_TABLE_NAME),
+            )
+            .response([
+                {
+                    explores: {
+                        explores: [explore('orders')],
+                        complete: true,
+                    },
+                },
+                {
+                    explores: {
+                        explores: [explore('customers')],
+                        complete: true,
+                    },
+                },
+            ]);
+
+        await expect(model.getDeployData('session-uuid')).resolves.toEqual({
+            explores: [explore('orders'), explore('customers')],
+            complete: true,
+        });
+
+        tracker.reset();
+        tracker.on
+            .select(({ sql }) =>
+                sql.includes(DEPLOY_SESSION_BATCH_EXPLORES_TABLE_NAME),
+            )
+            .response([
+                {
+                    explores: {
+                        explores: [explore('orders')],
+                        complete: true,
+                    },
+                },
+                {
+                    explores: {
+                        explores: [explore('customers')],
+                        complete: false,
+                    },
+                },
+            ]);
+
+        await expect(model.getDeployData('session-uuid')).resolves.toEqual({
+            explores: [explore('orders'), explore('customers')],
+            complete: false,
+        });
+    });
+
+    test('treats a deploy with no batches as incomplete', async () => {
+        tracker.on
+            .select(({ sql }) =>
+                sql.includes(DEPLOY_SESSION_BATCH_EXPLORES_TABLE_NAME),
+            )
+            .response([]);
+
+        await expect(model.getDeployData('session-uuid')).resolves.toEqual({
+            explores: [],
+            complete: false,
+        });
+    });
+});

--- a/packages/backend/src/models/DeploySessionModel.ts
+++ b/packages/backend/src/models/DeploySessionModel.ts
@@ -14,6 +14,11 @@ import {
     type DbDeploySessionBatchInsert,
 } from '../database/entities/deploySessions';
 
+type StoredDeploySessionBatch = {
+    explores: (Explore | ExploreError)[];
+    complete: boolean;
+};
+
 export class DeploySessionModel {
     private readonly database: Knex;
 
@@ -55,12 +60,16 @@ export class DeploySessionModel {
         projectUuid: string,
         explores: (Explore | ExploreError)[],
         batchNumber: number,
+        complete?: boolean,
     ): Promise<void> {
         const batchInsert: DbDeploySessionBatchInsert = {
             deploy_session_uuid: sessionUuid,
             project_uuid: projectUuid,
             batch_number: batchNumber,
-            explores: JSON.stringify(explores), // Stringify for JSONB
+            explores: JSON.stringify({
+                explores,
+                complete: complete === true,
+            } satisfies StoredDeploySessionBatch),
             explore_count: explores.length,
         };
 
@@ -76,22 +85,30 @@ export class DeploySessionModel {
         });
     }
 
-    async getAllExplores(
-        sessionUuid: string,
-    ): Promise<(Explore | ExploreError)[]> {
+    async getDeployData(sessionUuid: string): Promise<{
+        explores: (Explore | ExploreError)[];
+        complete: boolean;
+    }> {
         const batches = await DeploySessionBatchesTable(this.database)
             .where('deploy_session_uuid', sessionUuid)
             .orderBy('batch_number', 'asc');
 
-        // Flatten all explores from all batches
         const allExplores: (Explore | ExploreError)[] = [];
+        let complete = batches.length > 0;
         for (const batch of batches) {
-            // JSONB fields are automatically parsed by Knex
-            const explores = batch.explores as (Explore | ExploreError)[];
-            allExplores.push(...explores);
+            if (Array.isArray(batch.explores)) {
+                allExplores.push(
+                    ...(batch.explores as (Explore | ExploreError)[]),
+                );
+                complete = false;
+            } else {
+                const storedBatch = batch.explores as StoredDeploySessionBatch;
+                allExplores.push(...storedBatch.explores);
+                complete = complete && storedBatch.complete === true;
+            }
         }
 
-        return allExplores;
+        return { explores: allExplores, complete };
     }
 
     async updateStatus(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -283,6 +283,153 @@ describe('ProjectModel', () => {
     });
 
     describe('saveExploresToCache', () => {
+        test('preserves cached explores when the payload is not explicitly complete', async () => {
+            const cachedExplore = exploresWithSameName[0];
+            const incomingExplore = {
+                ...cachedExplore,
+                name: 'incoming_explore',
+            };
+            const virtualView = {
+                ...cachedExplore,
+                name: 'virtual_view',
+                type: ExploreType.VIRTUAL,
+            };
+
+            tracker.on
+                .select(({ sql }) => sql.includes('"cached_explores"'))
+                .response([]);
+            tracker.on
+                .select(({ sql }) => sql.includes('"cached_explore"'))
+                .response([
+                    { explore: cachedExplore },
+                    { explore: virtualView },
+                ]);
+            tracker.on
+                .insert(({ sql }) => sql.includes('"cached_explore"'))
+                .response([{ cached_explore_uuid: 'incoming-uuid' }]);
+            tracker.on
+                .insert(({ sql }) => sql.includes('"cached_explores"'))
+                .response([]);
+
+            await model.saveExploresToCache(projectUuid, [incomingExplore]);
+
+            expect(tracker.history.delete).toHaveLength(0);
+            expect(tracker.history.select).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({ bindings: [projectUuid] }),
+                ]),
+            );
+            expect(tracker.history.insert).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        sql: expect.stringContaining(
+                            'on conflict ("name", "project_uuid")',
+                        ),
+                    }),
+                    expect.objectContaining({
+                        bindings: expect.arrayContaining([
+                            JSON.stringify([
+                                cachedExplore,
+                                virtualView,
+                                incomingExplore,
+                            ]),
+                        ]),
+                    }),
+                ]),
+            );
+        });
+
+        test('accepts an empty additive payload when cached explores exist', async () => {
+            const cachedExplore = exploresWithSameName[0];
+
+            tracker.on
+                .select(({ sql }) => sql.includes('"cached_explores"'))
+                .response([]);
+            tracker.on
+                .select(({ sql }) => sql.includes('"cached_explore"'))
+                .response([{ explore: cachedExplore }]);
+            tracker.on
+                .insert(({ sql }) => sql.includes('"cached_explores"'))
+                .response([]);
+
+            await expect(
+                model.saveExploresToCache(projectUuid, []),
+            ).resolves.toEqual({ cachedExploreUuids: [] });
+            expect(tracker.history.delete).toHaveLength(0);
+        });
+
+        test('rejects an empty additive payload when no cached explores exist', async () => {
+            tracker.on
+                .insert(({ sql }) => sql.includes('"cached_explores"'))
+                .response([]);
+            tracker.on
+                .select(({ sql }) => sql.includes('"cached_explores"'))
+                .response([]);
+            tracker.on
+                .select(({ sql }) => sql.includes('"cached_explore"'))
+                .response([]);
+
+            await expect(
+                model.saveExploresToCache(projectUuid, []),
+            ).rejects.toThrow('No explores to save');
+        });
+
+        test('replaces absent cached explores only when explicitly complete', async () => {
+            const cachedExplore = exploresWithSameName[0];
+            const incomingExplore = {
+                ...cachedExplore,
+                name: 'incoming_explore',
+            };
+            const virtualView = {
+                ...cachedExplore,
+                name: 'incoming_explore',
+                type: ExploreType.VIRTUAL,
+            };
+
+            tracker.on
+                .select(({ sql }) => sql.includes('"cached_explores"'))
+                .response([]);
+            tracker.on
+                .select(({ sql }) => sql.includes('"cached_explore"'))
+                .response([
+                    { explore: cachedExplore },
+                    { explore: virtualView },
+                ]);
+            tracker.on
+                .delete(({ sql }) => sql.includes('"cached_explore"'))
+                .response([]);
+            tracker.on
+                .insert(({ sql }) => sql.includes('"cached_explore"'))
+                .response([{ cached_explore_uuid: 'virtual-uuid' }]);
+            tracker.on
+                .insert(({ sql }) => sql.includes('"cached_explores"'))
+                .response([]);
+
+            await model.saveExploresToCache(
+                projectUuid,
+                [incomingExplore],
+                true,
+            );
+
+            expect(tracker.history.delete).toHaveLength(1);
+            expect(tracker.history.select).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        bindings: [projectUuid, ExploreType.VIRTUAL],
+                    }),
+                ]),
+            );
+            expect(tracker.history.insert).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        bindings: expect.arrayContaining([
+                            JSON.stringify([virtualView]),
+                        ]),
+                    }),
+                ]),
+            );
+        });
+
         // TODO: this test is skipped because there is an issue in our version of knex-mock-client
         // which makes it not handle batch inserts correctly. If we upgrade to a newer version,
         // we can remove the skip. There are a lot of breaking changes in the new version though.

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -65,6 +65,7 @@ import {
     warehouseClientFromCredentials,
 } from '@lightdash/warehouses';
 import { Knex } from 'knex';
+import chunk from 'lodash/chunk';
 import isEqual from 'lodash/isEqual';
 import NodeCache from 'node-cache';
 import { DatabaseError } from 'pg';
@@ -1648,6 +1649,7 @@ export class ProjectModel {
     async saveExploresToCache(
         projectUuid: string,
         explores: (Explore | ExploreError)[],
+        complete = false,
     ) {
         return wrapSentryTransaction(
             'ProjectModel.saveExploresToCache',
@@ -1658,24 +1660,40 @@ export class ProjectModel {
                         trx,
                         projectUuid,
                     );
-                    // Get custom explores/virtual views before deleting them
-                    const virtualViews = await trx(CachedExploreTableName)
-                        .select('explore')
-                        .where('project_uuid', projectUuid)
-                        .whereRaw("explore->>'type' = ?", [
+                    const cachedExploresQuery = trx(CachedExploreTableName)
+                        .select<{ explore: Explore | ExploreError }[]>(
+                            'explore',
+                        )
+                        .where('project_uuid', projectUuid);
+                    if (complete) {
+                        cachedExploresQuery.whereRaw("explore->>'type' = ?", [
                             ExploreType.VIRTUAL,
                         ]);
-
-                    // Delete previous individually cached explores
-                    await trx(CachedExploreTableName)
-                        .where('project_uuid', projectUuid)
-                        .delete();
+                    }
+                    const cachedExplores = await cachedExploresQuery;
+                    const virtualViews = cachedExplores.filter(
+                        ({ explore }) => explore.type === ExploreType.VIRTUAL,
+                    );
+                    const virtualViewsByName = new Map(
+                        virtualViews.map(({ explore }) => [
+                            explore.name,
+                            explore,
+                        ]),
+                    );
 
                     // NOTE: virtual views with the same name as explores will override the explore.
                     // This isn't new behavior, but it's still a bit of a bug. However, it's
                     // not clear what a better approach would be at the moment.
                     const exploresMap = new Map(
-                        explores.map((e) => [e.name, e]),
+                        complete
+                            ? []
+                            : cachedExplores.map(({ explore }) => [
+                                  explore.name,
+                                  explore,
+                              ]),
+                    );
+                    explores.forEach((explore) =>
+                        exploresMap.set(explore.name, explore),
                     );
                     virtualViews.forEach((e) =>
                         exploresMap.set(e.explore.name, e.explore),
@@ -1686,18 +1704,47 @@ export class ProjectModel {
                         throw new ParameterError('No explores to save');
                     }
 
-                    // Cache explores individually
-                    const individualCachedExplores = await trx
-                        .batchInsert<DbCachedExplore>(
-                            CachedExploreTableName,
-                            uniqueExplores.map((explore) => ({
-                                project_uuid: projectUuid,
-                                name: explore.name,
-                                table_names: Object.keys(explore.tables || {}),
-                                explore: JSON.stringify(explore),
-                            })),
-                        )
-                        .returning('cached_explore_uuid');
+                    const exploresToSave = complete
+                        ? uniqueExplores
+                        : Array.from(
+                              new Map(
+                                  explores.map((explore) => [
+                                      explore.name,
+                                      explore,
+                                  ]),
+                              ).values(),
+                          ).map(
+                              (explore) =>
+                                  virtualViewsByName.get(explore.name) ??
+                                  explore,
+                          );
+
+                    if (complete) {
+                        await trx(CachedExploreTableName)
+                            .where('project_uuid', projectUuid)
+                            .delete();
+                    }
+
+                    const rowsToSave = exploresToSave.map((explore) => ({
+                        project_uuid: projectUuid,
+                        name: explore.name,
+                        table_names: Object.keys(explore.tables || {}),
+                        explore: JSON.stringify(explore),
+                    }));
+                    const savedExploreBatches = await Promise.all(
+                        chunk(rowsToSave, 1000).map((rows) => {
+                            const insertQuery = trx<DbCachedExplore>(
+                                CachedExploreTableName,
+                            ).insert(rows);
+                            return complete
+                                ? insertQuery.returning('cached_explore_uuid')
+                                : insertQuery
+                                      .onConflict(['name', 'project_uuid'])
+                                      .merge(['table_names', 'explore'])
+                                      .returning('cached_explore_uuid');
+                        }),
+                    );
+                    const individualCachedExplores = savedExploreBatches.flat();
 
                     // Cache explores together
                     await trx(CachedExploresTableName)

--- a/packages/backend/src/services/DeployService.test.ts
+++ b/packages/backend/src/services/DeployService.test.ts
@@ -1,12 +1,14 @@
 import { Ability, AbilityBuilder } from '@casl/ability';
 import {
+    DeploySessionStatus,
     ProjectType,
-    type Account,
     type MemberAbility,
+    type RegisteredAccount,
 } from '@lightdash/common';
+import { toSessionUser } from '../auth/account';
 import { DeployService } from './DeployService';
 
-const buildAccount = (ability: MemberAbility): Account =>
+const buildAccount = (ability: MemberAbility): RegisteredAccount =>
     ({
         authentication: {
             type: 'service-account',
@@ -46,7 +48,7 @@ const buildAccount = (ability: MemberAbility): Account =>
         isRegisteredUser: () => true,
         isServiceAccount: () => true,
         isSessionUser: () => false,
-    }) as Account;
+    }) as RegisteredAccount;
 
 describe('DeployService', () => {
     it('allows starting a deploy session for an own preview from a granted upstream project', async () => {
@@ -82,4 +84,57 @@ describe('DeployService', () => {
             ),
         ).resolves.toEqual({ deploySessionUuid: 'deploy-session-uuid' });
     });
+
+    it.each([true, false])(
+        'passes batched completeness %s to the cache write',
+        async (complete) => {
+            const projectService = {
+                saveExploresToCacheAndIndexCatalog: vi
+                    .fn()
+                    .mockResolvedValue('index-job-uuid'),
+            };
+            const deploySessionModel = {
+                getSession: vi.fn().mockResolvedValue({
+                    deploySessionUuid: 'deploy-session-uuid',
+                    projectUuid: 'project-uuid',
+                    userUuid: 'service-account-user-uuid',
+                    status: DeploySessionStatus.UPLOADING,
+                    batchCount: 1,
+                    exploreCount: 0,
+                    createdAt: new Date(),
+                }),
+                updateStatus: vi.fn().mockResolvedValue(undefined),
+                getDeployData: vi.fn().mockResolvedValue({
+                    explores: [],
+                    complete,
+                }),
+                deleteSession: vi.fn().mockResolvedValue(undefined),
+            };
+            const schedulerClient = {
+                generateValidation: vi.fn().mockResolvedValue(undefined),
+            };
+            const service = new DeployService({
+                deploySessionModel,
+                projectModel: {
+                    getWithSensitiveFields: vi.fn().mockResolvedValue({
+                        organizationUuid: 'org-uuid',
+                        warehouseConnection: null,
+                    }),
+                },
+                projectService,
+                schedulerClient,
+            } as never);
+            const user = toSessionUser(buildAccount(new Ability()));
+
+            await service.finalizeDeploy(
+                user,
+                'project-uuid',
+                'deploy-session-uuid',
+            );
+
+            expect(
+                projectService.saveExploresToCacheAndIndexCatalog,
+            ).toHaveBeenCalledWith(expect.objectContaining({ complete }));
+        },
+    );
 });

--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -33,6 +33,7 @@ type ProjectServiceInterface = {
         requestMethod?: string | null;
         projectConfigDefaults?: ProjectDefaults;
         cliVersion?: string | null;
+        complete?: boolean;
     }) => Promise<string>;
 };
 
@@ -117,6 +118,7 @@ export class DeployService extends BaseService {
         sessionUuid: string,
         explores: (Explore | ExploreError)[],
         batchNumber: number,
+        complete?: boolean,
     ): Promise<{ batchNumber: number; exploreCount: number }> {
         try {
             const session =
@@ -147,6 +149,7 @@ export class DeployService extends BaseService {
                 projectUuid,
                 explores,
                 batchNumber,
+                complete,
             );
 
             this.logger.info(
@@ -217,8 +220,9 @@ export class DeployService extends BaseService {
 
             // Get all explores from the session and enhance them
             // (e.g., EE generates virtual pre-aggregate explores from attached defs)
-            const uploadedExplores =
-                await this.deploySessionModel.getAllExplores(sessionUuid);
+            const deployData =
+                await this.deploySessionModel.getDeployData(sessionUuid);
+            const uploadedExplores = deployData.explores;
             const explores = this.exploreEnhancer(uploadedExplores, {
                 startOfWeek: project.warehouseConnection?.startOfWeek ?? null,
             });
@@ -237,6 +241,7 @@ export class DeployService extends BaseService {
                 jobUuid: null,
                 requestMethod: 'cli',
                 cliVersion,
+                complete: deployData.complete,
             });
 
             // Schedule validation (same as in original finalizeDeploy)

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2297,6 +2297,7 @@ export class ProjectService extends BaseService {
         requestMethod?: string | null;
         projectConfigDefaults?: ProjectDefaults;
         cliVersion?: string | null;
+        complete?: boolean;
     }) {
         const {
             userUuid,
@@ -2307,9 +2308,8 @@ export class ProjectService extends BaseService {
             requestMethod,
             projectConfigDefaults,
             cliVersion,
+            complete,
         } = args;
-        // We delete the explores when saving to cache which cascades to the catalog
-        // So we need to get the current tagged catalog items before deleting the explores (to do a best effort re-tag) and icons
         const prevCatalogItemsWithTags =
             await this.catalogModel.getCatalogItemsWithTags(projectUuid, {
                 onlyTagged: true, // We only need the tagged catalog items
@@ -2341,7 +2341,11 @@ export class ProjectService extends BaseService {
         }
 
         const { cachedExploreUuids } =
-            await this.projectModel.saveExploresToCache(projectUuid, explores);
+            await this.projectModel.saveExploresToCache(
+                projectUuid,
+                explores,
+                complete,
+            );
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
@@ -2357,10 +2361,15 @@ export class ProjectService extends BaseService {
             const newNames = explores.map((explore) => explore.name);
             const previousNameSet = new Set(previousExploreNames ?? []);
             const newNameSet = new Set(newNames);
-            const removed = (previousExploreNames ?? []).filter(
-                (name) => !newNameSet.has(name),
-            );
+            const removed = complete
+                ? (previousExploreNames ?? []).filter(
+                      (name) => !newNameSet.has(name),
+                  )
+                : [];
             const added = newNames.filter((name) => !previousNameSet.has(name));
+            const resultingExploreCount = complete
+                ? newNameSet.size
+                : new Set([...(previousExploreNames ?? []), ...newNames]).size;
 
             this.logger.info('compile.completed', {
                 projectUuid,
@@ -2371,7 +2380,7 @@ export class ProjectService extends BaseService {
                 cliVersion: cliVersion ?? null,
                 // null distinguishes "fetch failed" from "no previous explores"
                 previousExploreCount: previousExploreNames?.length ?? null,
-                newExploreCount: newNames.length,
+                newExploreCount: resultingExploreCount,
                 addedExploreCount:
                     previousExploreNames === null ? null : added.length,
                 removedExploreCount:
@@ -3167,6 +3176,7 @@ export class ProjectService extends BaseService {
                             requestMethod: method,
                             projectConfigDefaults:
                                 lightdashProjectConfig.defaults,
+                            complete: true,
                         });
                     }
                     return newProjectUuid;
@@ -3221,6 +3231,7 @@ export class ProjectService extends BaseService {
         projectUuid: string,
         explores: (Explore | ExploreError)[],
         cliVersion?: string | null,
+        complete?: boolean,
     ): Promise<ApiDeployExploresResults> {
         const project =
             await this.projectModel.getWithSensitiveFields(projectUuid);
@@ -3265,6 +3276,7 @@ export class ProjectService extends BaseService {
             jobUuid: null,
             requestMethod: 'cli',
             cliVersion,
+            complete,
         });
 
         await this.schedulerClient.generateValidation({
@@ -3859,6 +3871,7 @@ export class ProjectService extends BaseService {
                                 requestMethod: method,
                                 projectConfigDefaults:
                                     lightdashProjectConfig.defaults,
+                                complete: true,
                             });
                             timings.cacheExplores.end = performance.now();
                         } finally {
@@ -8294,6 +8307,7 @@ export class ProjectService extends BaseService {
                             requestMethod,
                             projectConfigDefaults:
                                 lightdashProjectConfig.defaults,
+                            complete: true,
                         });
                         timings.cacheExplores.end = performance.now();
 
@@ -11411,6 +11425,7 @@ export class ProjectService extends BaseService {
             jobUuid: null,
             requestMethod: 'api',
             projectConfigDefaults: project.projectDefaults,
+            complete: true,
         });
 
         Logger.info(`Schedule validation:`, {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -59,6 +59,11 @@ export type CompileHandlerOptions = DbtCompileOptions & {
     partialCompilation?: boolean;
 };
 
+export type CompileProjectResult = {
+    explores: (Explore | ExploreError)[];
+    isProjectComplete: boolean;
+};
+
 export const hasBlockingCompileError = (
     explore: Explore | ExploreError,
 ): boolean =>
@@ -309,7 +314,9 @@ async function patchDeferredModels(
     }
 }
 
-export const compile = async (options: CompileHandlerOptions) => {
+export const compileProject = async (
+    options: CompileHandlerOptions,
+): Promise<CompileProjectResult> => {
     const dbtVersionResult = await tryGetDbtVersion();
     const executionId = uuidv4();
     const startTime = Date.now();
@@ -339,6 +346,7 @@ export const compile = async (options: CompileHandlerOptions) => {
     // Try lightdash project compile
     let explores: (Explore | ExploreError)[] | null = null;
     let dbtMetrics: DbtManifest['metrics'] | null = null;
+    let isProjectComplete = true;
 
     explores = await getExploresFromLightdashYmlProject({
         projectDir: absoluteProjectPath,
@@ -381,6 +389,10 @@ export const compile = async (options: CompileHandlerOptions) => {
                 options,
             );
         let manifest = await loadManifest({ targetDir: context.targetDir });
+        const projectManifestModels = getModelsFromManifest(manifest);
+        isProjectComplete =
+            getCompiledModels(projectManifestModels, compiledModelIds)
+                .length === projectManifestModels.length;
         let effectiveCompiledModelIds = compiledModelIds;
         if (options.combineManifest) {
             const externalManifest = await loadCombineManifest(
@@ -629,8 +641,13 @@ export const compile = async (options: CompileHandlerOptions) => {
             durationMs: Date.now() - startTime,
         },
     });
-    return explores;
+    return { explores, isProjectComplete };
 };
+
+export const compile = async (
+    options: CompileHandlerOptions,
+): Promise<(Explore | ExploreError)[]> =>
+    (await compileProject(options)).explores;
 
 export const compileHandler = async (
     originalOptions: CompileHandlerOptions,

--- a/packages/cli/src/handlers/compileProject.test.ts
+++ b/packages/cli/src/handlers/compileProject.test.ts
@@ -1,0 +1,229 @@
+import {
+    DimensionType,
+    SupportedDbtVersions,
+    type DbtManifest,
+    type DbtModelNode,
+} from '@lightdash/common';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { getDbtContext } from '../dbt/context';
+import { loadCombineManifest, loadManifest } from '../dbt/manifest';
+import { validateDbtModel } from '../dbt/validation';
+import { loadLightdashModels } from '../lightdash/loader';
+import { compileProject, type CompileHandlerOptions } from './compile';
+import { maybeCompileModelsAndJoins } from './dbt/compile';
+import { tryGetDbtVersion } from './dbt/getDbtVersion';
+
+vi.mock('../analytics/analytics');
+vi.mock('../config', () => ({
+    getConfig: vi.fn().mockResolvedValue({ user: null, context: null }),
+}));
+vi.mock('../dbt/context');
+vi.mock('../dbt/manifest', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../dbt/manifest')>()),
+    loadCombineManifest: vi.fn(),
+    loadManifest: vi.fn(),
+}));
+vi.mock('../dbt/validation');
+vi.mock('../lightdash/loader');
+vi.mock('./dbt/compile');
+vi.mock('./dbt/getDbtVersion');
+
+const dbtNode = (
+    uniqueId: string,
+    resourceType: 'model' | 'seed',
+    compiled: boolean,
+) => ({
+    unique_id: uniqueId,
+    name: uniqueId.split('.').at(-1) ?? uniqueId,
+    resource_type: resourceType,
+    package_name: 'test',
+    path: `${uniqueId}.sql`,
+    original_file_path: `models/${uniqueId}.sql`,
+    alias: uniqueId.split('.').at(-1) ?? uniqueId,
+    checksum: { name: 'sha256', checksum: uniqueId },
+    tags: [],
+    refs: [],
+    sources: [],
+    depends_on: { macros: [], nodes: [] },
+    database: 'db',
+    schema: 'public',
+    fqn: ['test', uniqueId],
+    raw_code: 'SELECT 1',
+    columns: {
+        id: {
+            name: 'id',
+            data_type: DimensionType.NUMBER,
+            meta: {},
+        },
+    },
+    meta: {},
+    description: '',
+    created_at: 0,
+    language: 'sql',
+    relation_name: `"db"."public"."${uniqueId}"`,
+    config: { materialized: 'table' },
+    compiled,
+});
+
+const manifest = (
+    nodes: Record<string, ReturnType<typeof dbtNode>>,
+): DbtManifest =>
+    ({
+        metadata: {
+            dbt_schema_version:
+                'https://schemas.getdbt.com/dbt/manifest/v12.json',
+            generated_at: '2026-01-01T00:00:00Z',
+            adapter_type: 'postgres',
+        },
+        nodes,
+        sources: {},
+        macros: {},
+        docs: {},
+        exposures: {},
+        metrics: {},
+    }) as unknown as DbtManifest;
+
+const compileOptions = (projectDir: string): CompileHandlerOptions => ({
+    projectDir,
+    profilesDir: '',
+    target: undefined,
+    profile: undefined,
+    vars: undefined,
+    verbose: false,
+    startOfWeek: 0,
+    skipWarehouseCatalog: true,
+    skipDbtCompile: true,
+    useDbtList: false,
+    select: undefined,
+    models: undefined,
+    threads: undefined,
+    noVersionCheck: false,
+    exclude: undefined,
+    selector: undefined,
+    state: undefined,
+    fullRefresh: false,
+    defer: false,
+    targetPath: undefined,
+    favorState: false,
+    combineManifest: undefined,
+    warehouseCredentials: false,
+    disableTimestampConversion: false,
+});
+
+describe('compileProject completeness', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'lightdash-compile-project-test-'),
+        );
+        await fs.writeFile(
+            path.join(tempDir, 'lightdash.config.yml'),
+            'warehouse:\n  type: postgres\n',
+        );
+
+        vi.mocked(tryGetDbtVersion).mockResolvedValue({
+            success: true,
+            version: {
+                verboseVersion: '1.10.19',
+                versionOption: SupportedDbtVersions.V1_10,
+                isDbtCloudCLI: false,
+                isDbtFusion: false,
+            },
+        });
+        vi.mocked(getDbtContext).mockResolvedValue({
+            projectName: 'test_project',
+            profileName: 'test_profile',
+            targetDir: path.join(tempDir, 'target'),
+            modelsDir: 'models',
+        });
+        vi.mocked(loadLightdashModels).mockResolvedValue([]);
+        vi.mocked(validateDbtModel).mockImplementation(
+            async (_adapter, _version, models) => ({
+                valid: models as DbtModelNode[],
+                invalid: [],
+                skipped: [],
+            }),
+        );
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    test('reports an unselected model and seed manifest as complete', async () => {
+        const projectManifest = manifest({
+            'model.test.orders': dbtNode('model.test.orders', 'model', true),
+            'seed.test.countries': dbtNode(
+                'seed.test.countries',
+                'seed',
+                false,
+            ),
+        });
+        vi.mocked(loadManifest).mockResolvedValue(projectManifest);
+        vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+            compiledModelIds: ['model.test.orders'],
+            originallySelectedModelIds: undefined,
+        });
+
+        const result = await compileProject(compileOptions(tempDir));
+
+        expect(result.isProjectComplete).toBe(true);
+    });
+
+    test('reports a selected subset as incomplete', async () => {
+        const projectManifest = manifest({
+            'model.test.orders': dbtNode('model.test.orders', 'model', true),
+            'model.test.customers': dbtNode(
+                'model.test.customers',
+                'model',
+                true,
+            ),
+        });
+        vi.mocked(loadManifest).mockResolvedValue(projectManifest);
+        vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+            compiledModelIds: ['model.test.orders'],
+            originallySelectedModelIds: ['model.test.orders'],
+        });
+
+        const result = await compileProject(compileOptions(tempDir));
+
+        expect(result.isProjectComplete).toBe(false);
+    });
+
+    test('derives completeness before combining an external manifest', async () => {
+        const projectManifest = manifest({
+            'model.test.orders': dbtNode('model.test.orders', 'model', true),
+        });
+        const externalManifest = manifest({
+            'model.external.compiled': dbtNode(
+                'model.external.compiled',
+                'model',
+                true,
+            ),
+            'model.external.uncompiled': dbtNode(
+                'model.external.uncompiled',
+                'model',
+                false,
+            ),
+        });
+        vi.mocked(loadManifest).mockResolvedValue(projectManifest);
+        vi.mocked(loadCombineManifest).mockResolvedValue(externalManifest);
+        vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+            compiledModelIds: ['model.test.orders'],
+            originallySelectedModelIds: undefined,
+        });
+
+        const result = await compileProject({
+            ...compileOptions(tempDir),
+            combineManifest: 'external-manifest.json',
+        });
+
+        expect(result.isProjectComplete).toBe(true);
+    });
+});

--- a/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
+++ b/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
@@ -406,7 +406,8 @@ describe('compile warehouse column validation', () => {
                 .mocked(lightdashApi)
                 .mock.calls.find(
                     ([request]) =>
-                        request.url === '/api/v1/projects/projectUuid/explores',
+                        request.url ===
+                        '/api/v1/projects/projectUuid/explores?complete=false',
                 );
             if (deployRequest === undefined) {
                 throw new Error('Expected explores deploy request');

--- a/packages/cli/src/handlers/deploy.test.ts
+++ b/packages/cli/src/handlers/deploy.test.ts
@@ -1,0 +1,138 @@
+import {
+    DeploySessionStatus,
+    SupportedDbtAdapter,
+    type Explore,
+} from '@lightdash/common';
+import { LightdashAnalytics } from '../analytics/analytics';
+import { readAndLoadLightdashProjectConfig } from '../lightdash-config';
+import { lightdashApi } from './dbt/apiClient';
+import { deploy } from './deploy';
+
+vi.mock('../analytics/analytics');
+vi.mock('../lightdash-config');
+vi.mock('./dbt/apiClient', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('./dbt/apiClient')>()),
+    lightdashApi: vi.fn(),
+}));
+
+const compiledExplore: Explore = {
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    tables: {},
+    baseTable: 'orders',
+    joinedTables: [],
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+};
+
+const deployOptions = {
+    projectDir: '/tmp/project',
+    profilesDir: '',
+    target: undefined,
+    profile: undefined,
+    vars: undefined,
+    verbose: false,
+    ignoreErrors: false,
+    validateWarehouseColumns: false,
+    projectUuid: 'project-uuid',
+    skipWarehouseCatalog: true,
+    skipDbtCompile: true,
+    useDbtList: false,
+    select: undefined,
+    models: undefined,
+    threads: undefined,
+    noVersionCheck: false,
+    exclude: undefined,
+    selector: undefined,
+    state: undefined,
+    fullRefresh: false,
+    defer: false,
+    targetPath: undefined,
+    favorState: false,
+    combineManifest: undefined,
+};
+
+describe('deploy completeness transport', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(readAndLoadLightdashProjectConfig).mockResolvedValue({
+            spotlight: { default_visibility: 'show' },
+        });
+        vi.mocked(LightdashAnalytics.track).mockResolvedValue(undefined);
+    });
+
+    it.each([
+        { complete: true, expected: 'true' },
+        { complete: false, expected: 'false' },
+        { complete: undefined, expected: 'false' },
+    ])(
+        'sends complete=$expected on the default upload',
+        async ({ complete, expected }) => {
+            vi.mocked(lightdashApi).mockImplementation(async ({ url }) => {
+                if (url.includes('/explores?')) {
+                    return {
+                        exploreCount: 1,
+                        warnings: {
+                            warningCount: 0,
+                            exploresWithWarnings: [],
+                        },
+                    } as never;
+                }
+                return null as never;
+            });
+
+            await deploy([compiledExplore], {
+                ...deployOptions,
+                complete,
+            });
+
+            expect(lightdashApi).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    method: 'PUT',
+                    url: `/api/v1/projects/project-uuid/explores?complete=${expected}`,
+                    body: JSON.stringify([compiledExplore]),
+                }),
+            );
+        },
+    );
+
+    test('includes the completeness assertion in every batch body', async () => {
+        vi.mocked(lightdashApi).mockImplementation(async ({ url }) => {
+            if (url.endsWith('/deploy')) {
+                return {
+                    deploySessionUuid: 'deploy-session-uuid',
+                } as never;
+            }
+            if (url.endsWith('/batch')) {
+                return { batchNumber: 0, exploreCount: 1 } as never;
+            }
+            if (url.endsWith('/finalize')) {
+                return {
+                    exploreCount: 1,
+                    warnings: {
+                        warningCount: 0,
+                        exploresWithWarnings: [],
+                    },
+                    status: DeploySessionStatus.COMPLETED,
+                } as never;
+            }
+            return null as never;
+        });
+
+        await deploy([compiledExplore], {
+            ...deployOptions,
+            complete: false,
+            useBatchedDeploy: true,
+        });
+
+        expect(lightdashApi).toHaveBeenCalledWith({
+            method: 'POST',
+            url: '/api/v2/projects/project-uuid/deploy/deploy-session-uuid/batch',
+            body: JSON.stringify({
+                explores: [compiledExplore],
+                batchNumber: 0,
+                complete: false,
+            }),
+        });
+    });
+});

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -26,7 +26,7 @@ import { readAndLoadLightdashProjectConfig } from '../lightdash-config';
 import { CliProjectType, detectProjectType } from '../lightdash/projectType';
 import * as styles from '../styles';
 import {
-    compile,
+    compileProject,
     hasBlockingCompileError,
     stripWarehouseColumnErrors,
 } from './compile';
@@ -72,6 +72,7 @@ type DeployHandlerOptions = DbtCompileOptions & {
 
 type DeployArgs = DeployHandlerOptions & {
     projectUuid: string;
+    complete?: boolean;
 };
 
 const logDeployWarnings = (
@@ -276,6 +277,7 @@ const deployBatched = async (
                     body: JSON.stringify({
                         explores: batch,
                         batchNumber: batchIndex,
+                        complete: options.complete === true,
                     }),
                 }) as Promise<{ batchNumber: number; exploreCount: number }>,
             batchIndex + 1,
@@ -441,7 +443,7 @@ export const deploy = async (
             const deployResponse = await lightdashApi<ApiDeployExploresResults>(
                 {
                     method: 'PUT',
-                    url: `/api/v1/projects/${options.projectUuid}/explores`,
+                    url: `/api/v1/projects/${options.projectUuid}/explores?complete=${options.complete === true}`,
                     body: deployPayload,
                 },
             );
@@ -696,7 +698,7 @@ export const deployHandler = async (originalOptions: DeployHandlerOptions) => {
             );
     }
 
-    const explores = await compile(options);
+    const { explores, isProjectComplete } = await compileProject(options);
 
     let projectUuid: string;
 
@@ -726,7 +728,11 @@ export const deployHandler = async (originalOptions: DeployHandlerOptions) => {
         );
     }
 
-    await deploy(explores, { ...options, projectUuid });
+    await deploy(explores, {
+        ...options,
+        projectUuid,
+        complete: isProjectComplete,
+    });
 
     const serverUrl = config.context?.serverUrl?.replace(/\/$/, '');
     let displayUrl = options.create

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -18,7 +18,7 @@ import { getDbtContext } from '../dbt/context';
 import GlobalState from '../globalState';
 import { CliProjectType, detectProjectType } from '../lightdash/projectType';
 import * as styles from '../styles';
-import { compile } from './compile';
+import { compileProject } from './compile';
 import { createProject } from './createProject';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
 import { DbtCompileOptions } from './dbt/compile';
@@ -334,10 +334,11 @@ export const previewHandler = async (
         },
     });
     try {
-        const explores = await compile(options);
+        const { explores, isProjectComplete } = await compileProject(options);
         await deploy(explores, {
             ...options,
             projectUuid: project.projectUuid,
+            complete: isProjectComplete,
         });
 
         await setPreviewProject(project.projectUuid, name);
@@ -407,9 +408,11 @@ export const previewHandler = async (
                     watcher!.unwatch(manifestFilePath);
                     // Deploying will change manifest.json too, so we need to stop watching the file until it is deployed
                     if (project) {
-                        await deploy(await compile(options), {
+                        const compileResult = await compileProject(options);
+                        await deploy(compileResult.explores, {
                             ...options,
                             projectUuid: project.projectUuid,
+                            complete: compileResult.isProjectComplete,
                         });
                     }
 
@@ -519,10 +522,11 @@ export const startPreviewHandler = async (
                 options.disableTimestampConversion,
                 previewProject.projectUuid,
             );
-        const explores = await compile(options);
+        const { explores, isProjectComplete } = await compileProject(options);
         await deploy(explores, {
             ...options,
             projectUuid: previewProject.projectUuid,
+            complete: isProjectComplete,
         });
         const url = await projectUrl(previewProject);
         console.error(`Project updated on ${url}`);
@@ -611,10 +615,11 @@ export const startPreviewHandler = async (
             );
         }
 
-        const explores = await compile(options);
+        const { explores, isProjectComplete } = await compileProject(options);
         await deploy(explores, {
             ...options,
             projectUuid: project.projectUuid,
+            complete: isProjectComplete,
         });
         const url = await projectUrl(project);
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -723,6 +723,7 @@ export type ApiStartDeploySessionResponse = {
 export type ApiAddDeployBatchRequest = {
     explores: (Explore | ExploreError)[];
     batchNumber: number;
+    complete?: boolean;
 };
 
 export type ApiAddDeployBatchResponse = {


### PR DESCRIPTION
## What changed

- detect whether a CLI compile represents the complete project before combining external manifests
- carry an explicit completeness assertion through standard and batched deploys
- update cached explores additively unless the server receives that assertion, while preserving virtual views
- retain replace-all behavior for complete CLI and server-side compiles
- cover seed, combined-manifest, legacy batch, additive, replacement, and transport behavior

## Verification

- full common, CLI, and backend test suites
- common, CLI, and backend typechecks
- touched-path lint and formatting checks
- API generation

Linear: SPK-1043
