### PR TITLE
feat: authenticate private dbt packages with a per-run git config file

### DIFF
--- a/packages/backend/src/dbt/dbtCliClient.test.ts
+++ b/packages/backend/src/dbt/dbtCliClient.test.ts
@@ -112,6 +112,7 @@ describe('DbtCliClient environment', () => {
     const cliArgs = {
         ...cliArgsWithoutVersion,
         dbtVersion: SupportedDbtVersions.V1_10,
+        gitPackageHost: 'github.com',
     };
 
     beforeEach(() => {
@@ -125,6 +126,25 @@ describe('DbtCliClient environment', () => {
     afterEach(() => {
         vi.unstubAllEnvs();
     });
+
+    const dbtErrorLog = (message: string) =>
+        JSON.stringify({
+            code: 'E006',
+            info: {
+                category: '',
+                code: 'E006',
+                extra: {},
+                invocation_id: 'invocation-id',
+                level: 'error',
+                log_version: 2,
+                msg: message,
+                name: 'MainReportVersion',
+                pid: 1,
+                thread_name: 'MainThread',
+                ts: '2026-08-16T00:00:00.000Z',
+                type: 'log_line',
+            },
+        });
 
     it('does not extend the backend environment', async () => {
         await new DbtCliClient(cliArgs).installDeps();
@@ -232,5 +252,81 @@ describe('DbtCliClient environment', () => {
             recursive: true,
             force: true,
         });
+    });
+
+    it('names an inaccessible package repository without exposing credentials', async () => {
+        execaMock.mockImplementationOnce(async () => {
+            throw {
+                all: dbtErrorLog(
+                    "Git Error: remote: Repository not found. fatal: repository 'https://installation-token@github.com/lightdash/private-dbt-package.git/' not found",
+                ),
+            };
+        });
+
+        const error = await new DbtCliClient({
+            ...cliArgs,
+            dbtSourceName: 'finance',
+            gitPackageTokenProvider: async () => 'installation-token',
+        })
+            .installDeps()
+            .catch((caught: unknown) => caught);
+
+        expect(error).toBeInstanceOf(DbtError);
+        expect(error).toHaveProperty(
+            'message',
+            'Could not download the dbt package "private-dbt-package" from https://github.com/lightdash/private-dbt-package for source "finance": access was denied. Check that the Lightdash GitHub App has access to that repository.',
+        );
+        expect(JSON.stringify(error)).not.toContain('installation-token');
+    });
+
+    it('preserves the original dependency error when no token provider was used', async () => {
+        execaMock.mockImplementationOnce(async () => {
+            throw {
+                all: dbtErrorLog('Dependency installation failed'),
+            };
+        });
+
+        const error = await new DbtCliClient({
+            ...cliArgs,
+            dbtSourceName: 'finance',
+        })
+            .installDeps()
+            .catch((caught: unknown) => caught);
+
+        expect(error).toBeInstanceOf(DbtError);
+        expect(error).toHaveProperty(
+            'message',
+            'Failed to run "dbt1.10 deps" with dbt version "v1.10"',
+        );
+        expect(error).toHaveProperty(
+            'logs.0.info.msg',
+            'Dependency installation failed',
+        );
+    });
+
+    it('preserves a token-backed dependency error that is not an authentication failure', async () => {
+        execaMock.mockImplementationOnce(async () => {
+            throw {
+                all: dbtErrorLog('packages.yml could not be parsed'),
+            };
+        });
+
+        const error = await new DbtCliClient({
+            ...cliArgs,
+            dbtSourceName: 'finance',
+            gitPackageTokenProvider: async () => 'installation-token',
+        })
+            .installDeps()
+            .catch((caught: unknown) => caught);
+
+        expect(error).toBeInstanceOf(DbtError);
+        expect(error).toHaveProperty(
+            'message',
+            'Failed to run "dbt1.10 deps" with dbt version "v1.10"',
+        );
+        expect(error).toHaveProperty(
+            'logs.0.info.msg',
+            'packages.yml could not be parsed',
+        );
     });
 });

--- a/packages/backend/src/dbt/dbtCliClient.test.ts
+++ b/packages/backend/src/dbt/dbtCliClient.test.ts
@@ -15,6 +15,7 @@ import {
 const execaMock = execa as unknown as import('vitest').Mock;
 
 vi.mock('fs/promises', () => ({
+    chmod: vi.fn(),
     readFile: vi.fn(),
     writeFile: vi.fn(),
     mkdtemp: vi.fn(),
@@ -168,6 +169,68 @@ describe('DbtCliClient environment', () => {
 
         expect((options as { env: Record<string, string> }).env).toMatchObject({
             DBT_TARGET_PATH: '/tmp/dbt_target_test',
+        });
+    });
+
+    it('removes the per-run git config after installing dependencies', async () => {
+        const token = 'github-installation-token';
+        const tokenProvider = vi.fn<() => Promise<string>>();
+        vi.mocked(tokenProvider).mockResolvedValue(token);
+        vi.mocked(fs.mkdtemp)
+            .mockResolvedValueOnce('/tmp/dbt_git_config_test' as never)
+            .mockResolvedValueOnce('/tmp/dbt_target_test' as never);
+        execaMock.mockImplementationOnce(
+            async (
+                _command: string,
+                _args: string[],
+                options: { env: Record<string, string> },
+            ) => {
+                expect(options.env).toMatchObject({
+                    GIT_CONFIG_GLOBAL: '/tmp/dbt_git_config_test/config',
+                    GIT_CONFIG_NOSYSTEM: '1',
+                    GIT_TERMINAL_PROMPT: '0',
+                    GIT_ASKPASS: '',
+                    SSH_ASKPASS: '',
+                });
+                expect(Object.values(options.env)).not.toContain(token);
+                expect(fs.rm).not.toHaveBeenCalledWith(
+                    '/tmp/dbt_git_config_test',
+                    expect.anything(),
+                );
+                return cliMockImplementation.success();
+            },
+        );
+
+        await new DbtCliClient({
+            ...cliArgs,
+            gitPackageTokenProvider: tokenProvider,
+        }).installDeps();
+
+        expect(tokenProvider).toHaveBeenCalledOnce();
+        expect(fs.rm).toHaveBeenCalledWith('/tmp/dbt_git_config_test', {
+            recursive: true,
+            force: true,
+        });
+    });
+
+    it('removes the per-run git config when installing dependencies fails', async () => {
+        const tokenProvider = vi.fn<() => Promise<string>>();
+        vi.mocked(tokenProvider).mockResolvedValue('github-installation-token');
+        vi.mocked(fs.mkdtemp)
+            .mockResolvedValueOnce('/tmp/dbt_git_config_test' as never)
+            .mockResolvedValueOnce('/tmp/dbt_target_test' as never);
+        execaMock.mockImplementationOnce(cliMockImplementation.error);
+
+        await expect(
+            new DbtCliClient({
+                ...cliArgs,
+                gitPackageTokenProvider: tokenProvider,
+            }).installDeps(),
+        ).rejects.toThrowError(DbtError);
+
+        expect(fs.rm).toHaveBeenCalledWith('/tmp/dbt_git_config_test', {
+            recursive: true,
+            force: true,
         });
     });
 });

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -38,6 +38,8 @@ type DbtCliArgs = {
     dbtVersion: SupportedDbtVersions;
     selector?: string;
     gitPackageTokenProvider?: () => Promise<string>;
+    gitPackageHost?: string;
+    dbtSourceName?: string;
 };
 
 enum DbtCommands {
@@ -73,6 +75,10 @@ export class DbtCliClient implements DbtClient {
 
     gitPackageTokenProvider?: () => Promise<string>;
 
+    gitPackageHost?: string;
+
+    dbtSourceName: string;
+
     constructor({
         dbtProjectDirectory,
         dbtProfilesDirectory,
@@ -83,6 +89,8 @@ export class DbtCliClient implements DbtClient {
         dbtVersion,
         selector,
         gitPackageTokenProvider,
+        gitPackageHost,
+        dbtSourceName = 'dbt_project',
     }: DbtCliArgs) {
         this.dbtProjectDirectory = dbtProjectDirectory;
         this.dbtProfilesDirectory = dbtProfilesDirectory;
@@ -94,6 +102,8 @@ export class DbtCliClient implements DbtClient {
         this.dbtVersion = dbtVersion;
         this.selector = selector;
         this.gitPackageTokenProvider = gitPackageTokenProvider;
+        this.gitPackageHost = gitPackageHost;
+        this.dbtSourceName = dbtSourceName;
     }
 
     getSelector(): string | undefined {
@@ -170,6 +180,7 @@ export class DbtCliClient implements DbtClient {
 
     private async _runDbtCommandWithGitConfig(
         gitConfigPath: string | undefined,
+        secretsToRedact: string[],
         ...command: string[]
     ): Promise<{
         logs: DbtLog[];
@@ -214,15 +225,23 @@ export class DbtCliClient implements DbtClient {
                     gitConfigPath,
                 }),
             });
+            const sanitizedOutput = secretsToRedact.reduce(
+                (output, secret) => output?.replaceAll(secret, '*****'),
+                dbtProcess.all,
+            );
             return {
-                logs: DbtCliClient.parseDbtJsonLogs(dbtProcess.all),
+                logs: DbtCliClient.parseDbtJsonLogs(sanitizedOutput),
                 stdout: dbtProcess.stdout,
             };
         } catch (e) {
+            const sanitizedError = secretsToRedact.reduce(
+                (message, secret) => message.replaceAll(secret, '*****'),
+                getErrorMessage(e),
+            );
             Logger.error(
                 `Error running dbt command with version ${
                     this.dbtVersion
-                }: ${getErrorMessage(e)}`,
+                }: ${sanitizedError}`,
             );
             // TODO parse ExecaError
             const execaError = e as Partial<ExecaError>;
@@ -231,16 +250,19 @@ export class DbtCliClient implements DbtClient {
                 'all' in execaError &&
                 typeof execaError.all === 'string'
             ) {
-                const missingVariablesHint = getMissingEnvironmentVariableHint(
+                const sanitizedOutput = secretsToRedact.reduce(
+                    (output, secret) => output.replaceAll(secret, '*****'),
                     execaError.all,
                 );
+                const missingVariablesHint =
+                    getMissingEnvironmentVariableHint(sanitizedOutput);
                 throw new DbtError(
                     `Failed to run "${dbtExec} ${command.join(
                         ' ',
                     )}" with dbt version "${this.dbtVersion}"${
                         missingVariablesHint ? `. ${missingVariablesHint}` : ''
                     }`,
-                    DbtCliClient.parseDbtJsonLogs(execaError.all),
+                    DbtCliClient.parseDbtJsonLogs(sanitizedOutput),
                 );
             }
             throw e;
@@ -251,7 +273,7 @@ export class DbtCliClient implements DbtClient {
         logs: DbtLog[];
         stdout: string;
     }> {
-        return this._runDbtCommandWithGitConfig(undefined, ...command);
+        return this._runDbtCommandWithGitConfig(undefined, [], ...command);
     }
 
     async installDeps(): Promise<void> {
@@ -262,21 +284,60 @@ export class DbtCliClient implements DbtClient {
             },
             async () => {
                 const startTime = Date.now();
-                if (this.gitPackageTokenProvider) {
-                    const token = await this.gitPackageTokenProvider();
-                    await withDbtGitConfig(
-                        {
-                            token,
-                            repositoryDirectory: this.dbtProjectDirectory,
-                        },
-                        (gitConfigPath) =>
-                            this._runDbtCommandWithGitConfig(
-                                gitConfigPath,
-                                'deps',
-                            ),
-                    );
-                } else {
-                    await this._runDbtCommand('deps');
+                let usedGitPackageToken = false;
+                try {
+                    if (this.gitPackageTokenProvider) {
+                        const token = await this.gitPackageTokenProvider();
+                        if (!this.gitPackageHost) {
+                            throw new Error(
+                                'Git package host is required when a token provider is configured',
+                            );
+                        }
+                        usedGitPackageToken = true;
+                        await withDbtGitConfig(
+                            {
+                                token,
+                                host: this.gitPackageHost,
+                                repositoryDirectory: this.dbtProjectDirectory,
+                            },
+                            (gitConfigPath) =>
+                                this._runDbtCommandWithGitConfig(
+                                    gitConfigPath,
+                                    [token],
+                                    'deps',
+                                ),
+                        );
+                    } else {
+                        await this._runDbtCommand('deps');
+                    }
+                } catch (error) {
+                    if (usedGitPackageToken && error instanceof DbtError) {
+                        const messages =
+                            error.logs?.map((log) => log.info.msg).join('\n') ??
+                            '';
+                        const repositoryMatch = messages.match(
+                            /github\.com[/:]([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?(?:\/|['"\s]|$)/i,
+                        );
+                        const accessWasDenied =
+                            /repository not found|authentication failed|permission denied|access denied|could not read username|terminal prompts disabled/i.test(
+                                messages,
+                            );
+                        if (!accessWasDenied) {
+                            throw error;
+                        }
+                        if (repositoryMatch) {
+                            const [, owner, repository] = repositoryMatch;
+                            throw new DbtError(
+                                `Could not download the dbt package "${repository}" from https://github.com/${owner}/${repository} for source "${this.dbtSourceName}": access was denied. Check that the Lightdash GitHub App has access to that repository.`,
+                                error.logs,
+                            );
+                        }
+                        throw new DbtError(
+                            `Could not download dbt packages for source "${this.dbtSourceName}". Check that the Lightdash GitHub App has access to every package repository.`,
+                            error.logs,
+                        );
+                    }
+                    throw error;
                 }
                 Logger.info(
                     `dbt deps completed in ${Date.now() - startTime}ms`,

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -22,6 +22,7 @@ import path from 'path';
 import Logger from '../logging/logger';
 import { traceSpan } from '../tracing/tracing';
 import { DbtClient } from '../types';
+import { withDbtGitConfig } from './dbtGitConfig';
 import {
     getDbtProcessEnvironment,
     getMissingEnvironmentVariableHint,
@@ -36,6 +37,7 @@ type DbtCliArgs = {
     target?: string;
     dbtVersion: SupportedDbtVersions;
     selector?: string;
+    gitPackageTokenProvider?: () => Promise<string>;
 };
 
 enum DbtCommands {
@@ -69,6 +71,8 @@ export class DbtCliClient implements DbtClient {
 
     selector?: string;
 
+    gitPackageTokenProvider?: () => Promise<string>;
+
     constructor({
         dbtProjectDirectory,
         dbtProfilesDirectory,
@@ -78,6 +82,7 @@ export class DbtCliClient implements DbtClient {
         target,
         dbtVersion,
         selector,
+        gitPackageTokenProvider,
     }: DbtCliArgs) {
         this.dbtProjectDirectory = dbtProjectDirectory;
         this.dbtProfilesDirectory = dbtProfilesDirectory;
@@ -88,6 +93,7 @@ export class DbtCliClient implements DbtClient {
         this.targetDirectory = undefined;
         this.dbtVersion = dbtVersion;
         this.selector = selector;
+        this.gitPackageTokenProvider = gitPackageTokenProvider;
     }
 
     getSelector(): string | undefined {
@@ -162,7 +168,10 @@ export class DbtCliClient implements DbtClient {
         }
     }
 
-    private async _runDbtCommand(...command: string[]): Promise<{
+    private async _runDbtCommandWithGitConfig(
+        gitConfigPath: string | undefined,
+        ...command: string[]
+    ): Promise<{
         logs: DbtLog[];
         stdout: string;
     }> {
@@ -202,6 +211,7 @@ export class DbtCliClient implements DbtClient {
                         this.environmentVariableAllowlist,
                     projectEnvironment: this.environment,
                     targetPath,
+                    gitConfigPath,
                 }),
             });
             return {
@@ -237,6 +247,13 @@ export class DbtCliClient implements DbtClient {
         }
     }
 
+    private async _runDbtCommand(...command: string[]): Promise<{
+        logs: DbtLog[];
+        stdout: string;
+    }> {
+        return this._runDbtCommandWithGitConfig(undefined, ...command);
+    }
+
     async installDeps(): Promise<void> {
         return traceSpan(
             {
@@ -245,7 +262,22 @@ export class DbtCliClient implements DbtClient {
             },
             async () => {
                 const startTime = Date.now();
-                await this._runDbtCommand('deps');
+                if (this.gitPackageTokenProvider) {
+                    const token = await this.gitPackageTokenProvider();
+                    await withDbtGitConfig(
+                        {
+                            token,
+                            repositoryDirectory: this.dbtProjectDirectory,
+                        },
+                        (gitConfigPath) =>
+                            this._runDbtCommandWithGitConfig(
+                                gitConfigPath,
+                                'deps',
+                            ),
+                    );
+                } else {
+                    await this._runDbtCommand('deps');
+                }
                 Logger.info(
                     `dbt deps completed in ${Date.now() - startTime}ms`,
                 );

--- a/packages/backend/src/dbt/dbtGitConfig.test.ts
+++ b/packages/backend/src/dbt/dbtGitConfig.test.ts
@@ -1,0 +1,47 @@
+import * as fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { withDbtGitConfig } from './dbtGitConfig';
+
+describe('withDbtGitConfig', () => {
+    let repositoryDirectory: string;
+
+    beforeEach(async () => {
+        repositoryDirectory = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'dbt_repository_'),
+        );
+    });
+
+    afterEach(async () => {
+        await fs.rm(repositoryDirectory, { recursive: true, force: true });
+    });
+
+    it('provides an isolated config that authenticates every GitHub URL form', async () => {
+        const token = 'github-installation-token';
+
+        await withDbtGitConfig(
+            {
+                token,
+                repositoryDirectory,
+            },
+            async (configPath) => {
+                const configDirectory = path.dirname(configPath);
+                const config = await fs.readFile(configPath, 'utf8');
+                const directoryStats = await fs.stat(configDirectory);
+
+                expect(config).toEqual(
+                    `[url "https://x-access-token:${token}@github.com/"]\n` +
+                        `    insteadOf = https://github.com/\n` +
+                        `    insteadOf = git@github.com:\n` +
+                        `    insteadOf = ssh://git@github.com/\n` +
+                        `[credential]\n` +
+                        `    helper =\n`,
+                );
+                expect(directoryStats.mode % 0o1000).toBe(0o700);
+                expect(
+                    path.relative(repositoryDirectory, configDirectory),
+                ).toMatch(/^\.\./);
+            },
+        );
+    });
+});

--- a/packages/backend/src/dbt/dbtGitConfig.test.ts
+++ b/packages/backend/src/dbt/dbtGitConfig.test.ts
@@ -1,3 +1,4 @@
+import execa from 'execa';
 import * as fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -22,6 +23,7 @@ describe('withDbtGitConfig', () => {
         await withDbtGitConfig(
             {
                 token,
+                host: 'github.com',
                 repositoryDirectory,
             },
             async (configPath) => {
@@ -41,6 +43,46 @@ describe('withDbtGitConfig', () => {
                 expect(
                     path.relative(repositoryDirectory, configDirectory),
                 ).toMatch(/^\.\./);
+            },
+        );
+    });
+
+    it('does not rewrite userinfo-bearing DBT_ENV_SECRET package URLs', async () => {
+        const token = 'github-installation-token';
+        const host = 'github.example.com';
+
+        await withDbtGitConfig(
+            {
+                token,
+                host,
+                repositoryDirectory,
+            },
+            async (configPath) => {
+                const env = {
+                    ...process.env,
+                    GIT_CONFIG_GLOBAL: configPath,
+                    GIT_CONFIG_NOSYSTEM: '1',
+                };
+                const ordinaryUrl = `https://${host}/org/package.git`;
+                const dbtEnvironmentSecretUrl = `https://dbt-environment-secret@${host}/org/package.git`;
+
+                const ordinaryResult = await execa(
+                    'git',
+                    ['ls-remote', '--get-url', ordinaryUrl],
+                    { env },
+                );
+                const dbtEnvironmentSecretResult = await execa(
+                    'git',
+                    ['ls-remote', '--get-url', dbtEnvironmentSecretUrl],
+                    { env },
+                );
+
+                expect(ordinaryResult.stdout).toBe(
+                    `https://x-access-token:${token}@${host}/org/package.git`,
+                );
+                expect(dbtEnvironmentSecretResult.stdout).toBe(
+                    dbtEnvironmentSecretUrl,
+                );
             },
         );
     });

--- a/packages/backend/src/dbt/dbtGitConfig.ts
+++ b/packages/backend/src/dbt/dbtGitConfig.ts
@@ -4,6 +4,7 @@ import path from 'path';
 
 type DbtGitConfigArgs = {
     token: string;
+    host: string;
     repositoryDirectory: string;
 };
 
@@ -20,7 +21,7 @@ const isWithinDirectory = (parent: string, child: string): boolean => {
 };
 
 export const withDbtGitConfig = async <T>(
-    { token, repositoryDirectory }: DbtGitConfigArgs,
+    { token, host, repositoryDirectory }: DbtGitConfigArgs,
     run: (configPath: string) => Promise<T>,
 ): Promise<T> => {
     const configDirectory = await fs.mkdtemp(
@@ -38,10 +39,10 @@ export const withDbtGitConfig = async <T>(
         const configPath = path.join(configDirectory, 'config');
         await fs.writeFile(
             configPath,
-            `[url "https://x-access-token:${token}@github.com/"]\n` +
-                `    insteadOf = https://github.com/\n` +
-                `    insteadOf = git@github.com:\n` +
-                `    insteadOf = ssh://git@github.com/\n` +
+            `[url "https://x-access-token:${token}@${host}/"]\n` +
+                `    insteadOf = https://${host}/\n` +
+                `    insteadOf = git@${host}:\n` +
+                `    insteadOf = ssh://git@${host}/\n` +
                 `[credential]\n` +
                 `    helper =\n`,
             { mode: 0o600 },

--- a/packages/backend/src/dbt/dbtGitConfig.ts
+++ b/packages/backend/src/dbt/dbtGitConfig.ts
@@ -1,0 +1,54 @@
+import * as fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+type DbtGitConfigArgs = {
+    token: string;
+    repositoryDirectory: string;
+};
+
+const isWithinDirectory = (parent: string, child: string): boolean => {
+    const relativePath = path.relative(
+        path.resolve(parent),
+        path.resolve(child),
+    );
+    return (
+        relativePath === '' ||
+        (!relativePath.startsWith(`..${path.sep}`) &&
+            !path.isAbsolute(relativePath))
+    );
+};
+
+export const withDbtGitConfig = async <T>(
+    { token, repositoryDirectory }: DbtGitConfigArgs,
+    run: (configPath: string) => Promise<T>,
+): Promise<T> => {
+    const configDirectory = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'dbt_git_config_'),
+    );
+
+    try {
+        if (isWithinDirectory(repositoryDirectory, configDirectory)) {
+            throw new Error(
+                'dbt git config directory must be outside the repo',
+            );
+        }
+
+        await fs.chmod(configDirectory, 0o700);
+        const configPath = path.join(configDirectory, 'config');
+        await fs.writeFile(
+            configPath,
+            `[url "https://x-access-token:${token}@github.com/"]\n` +
+                `    insteadOf = https://github.com/\n` +
+                `    insteadOf = git@github.com:\n` +
+                `    insteadOf = ssh://git@github.com/\n` +
+                `[credential]\n` +
+                `    helper =\n`,
+            { mode: 0o600 },
+        );
+
+        return await run(configPath);
+    } finally {
+        await fs.rm(configDirectory, { recursive: true, force: true });
+    }
+};

--- a/packages/backend/src/dbt/dbtProcessEnvironment.test.ts
+++ b/packages/backend/src/dbt/dbtProcessEnvironment.test.ts
@@ -1,3 +1,4 @@
+import { buildSafeDbtEnvironmentVariables } from '@lightdash/common';
 import {
     getDbtProcessEnvironment,
     getMissingEnvironmentVariableHint,
@@ -24,6 +25,11 @@ const processEnvironment: NodeJS.ProcessEnv = {
     ALLOW_DBT_COMMANDS_ACCESS_TO_ENV_VARS:
         'UTILS_PII_SALT,OTHER_ALLOWED_VARIABLE',
     EMPTY_VARIABLE: undefined,
+    GIT_CONFIG_GLOBAL: '/tmp/backend-global-git-config',
+    GIT_CONFIG_NOSYSTEM: '0',
+    GIT_TERMINAL_PROMPT: '1',
+    GIT_ASKPASS: '/tmp/backend-askpass',
+    SSH_ASKPASS: '/tmp/backend-ssh-askpass',
 };
 
 const buildEnvironment = (projectEnvironment: Record<string, string> = {}) =>
@@ -124,6 +130,97 @@ describe('getDbtProcessEnvironment', () => {
         expect(environment.DBT_PARTIAL_PARSE).toEqual('false');
         expect(environment.DBT_SEND_ANONYMOUS_USAGE_STATS).toEqual('false');
         expect(environment.DBT_TARGET_PATH).toEqual('/tmp/dbt_target_test');
+    });
+
+    it('adds the per-run git configuration without exposing its token', () => {
+        const environment = getDbtProcessEnvironment({
+            processEnvironment,
+            environmentVariableAllowlist: [],
+            projectEnvironment: {},
+            targetPath: '/tmp/dbt_target_test',
+            gitConfigPath: '/tmp/dbt_git_config/config',
+        });
+
+        expect(environment).toMatchObject({
+            GIT_CONFIG_GLOBAL: '/tmp/dbt_git_config/config',
+            GIT_CONFIG_NOSYSTEM: '1',
+            GIT_TERMINAL_PROMPT: '0',
+            GIT_ASKPASS: '',
+            SSH_ASKPASS: '',
+        });
+        expect(Object.values(environment)).not.toContain(
+            'github-installation-token',
+        );
+    });
+
+    it('does not add git configuration variables without a config path', () => {
+        const environment = buildEnvironment();
+
+        expect(environment).not.toHaveProperty('GIT_CONFIG_GLOBAL');
+        expect(environment).not.toHaveProperty('GIT_CONFIG_NOSYSTEM');
+        expect(environment).not.toHaveProperty('GIT_TERMINAL_PROMPT');
+        expect(environment).not.toHaveProperty('GIT_ASKPASS');
+        expect(environment).not.toHaveProperty('SSH_ASKPASS');
+    });
+
+    it('does not let project variables override the per-run git configuration', () => {
+        const environment = getDbtProcessEnvironment({
+            processEnvironment,
+            environmentVariableAllowlist: [],
+            projectEnvironment: {
+                GIT_CONFIG_GLOBAL: '/tmp/attacker',
+                GIT_CONFIG_NOSYSTEM: '0',
+                GIT_TERMINAL_PROMPT: '1',
+                GIT_ASKPASS: '/tmp/attacker-askpass',
+                SSH_ASKPASS: '/tmp/attacker-ssh-askpass',
+            },
+            targetPath: '/tmp/dbt_target_test',
+            gitConfigPath: '/tmp/dbt_git_config/config',
+        });
+
+        expect(environment).toMatchObject({
+            GIT_CONFIG_GLOBAL: '/tmp/dbt_git_config/config',
+            GIT_CONFIG_NOSYSTEM: '1',
+            GIT_TERMINAL_PROMPT: '0',
+            GIT_ASKPASS: '',
+            SSH_ASKPASS: '',
+        });
+    });
+
+    it('strips git configuration stored in project environment variables', () => {
+        const { environment: projectEnvironment, blockedKeys } =
+            buildSafeDbtEnvironmentVariables([
+                { key: 'ENV', value: 'production' },
+                { key: 'GIT_CONFIG_GLOBAL', value: '/tmp/attacker' },
+                { key: 'GIT_ASKPASS', value: '/tmp/attacker-askpass' },
+                { key: 'SSH_ASKPASS', value: '/tmp/attacker-ssh-askpass' },
+            ]);
+        const environment = getDbtProcessEnvironment({
+            processEnvironment,
+            environmentVariableAllowlist: [],
+            projectEnvironment,
+            targetPath: '/tmp/dbt_target_test',
+            gitConfigPath: '/tmp/dbt_git_config/config',
+        });
+
+        expect(blockedKeys).toEqual([
+            'GIT_CONFIG_GLOBAL',
+            'GIT_ASKPASS',
+            'SSH_ASKPASS',
+        ]);
+        expect(environment).toMatchObject({
+            ENV: 'production',
+            GIT_CONFIG_GLOBAL: '/tmp/dbt_git_config/config',
+            GIT_ASKPASS: '',
+            SSH_ASKPASS: '',
+        });
+        expect(Object.values(environment)).not.toContain('/tmp/attacker');
+        expect(Object.values(environment)).not.toContain(
+            '/tmp/attacker-askpass',
+        );
+        expect(Object.values(environment)).not.toContain(
+            '/tmp/attacker-ssh-askpass',
+        );
     });
 
     it('does not let a project redirect the runtime plumbing', () => {

--- a/packages/backend/src/dbt/dbtProcessEnvironment.ts
+++ b/packages/backend/src/dbt/dbtProcessEnvironment.ts
@@ -85,6 +85,7 @@ type DbtProcessEnvironmentArgs = {
     environmentVariableAllowlist: string[];
     projectEnvironment: Record<string, string>;
     targetPath: string;
+    gitConfigPath?: string;
 };
 
 const inheritKeys = (
@@ -101,6 +102,7 @@ export const getDbtProcessEnvironment = ({
     environmentVariableAllowlist,
     projectEnvironment,
     targetPath,
+    gitConfigPath,
 }: DbtProcessEnvironmentArgs): Record<string, string> => ({
     // Ambient cloud credentials sit below the project, because profiles.ts
     // injects the warehouse's own AWS_* keys through projectEnvironment and
@@ -115,6 +117,15 @@ export const getDbtProcessEnvironment = ({
     // proxy and CA settings decide where dbt deps fetches from, so a project
     // cannot redirect either.
     ...inheritKeys(processEnvironment, RUNTIME_ENVIRONMENT_VARIABLE_KEYS),
+    ...(gitConfigPath
+        ? {
+              GIT_CONFIG_GLOBAL: gitConfigPath,
+              GIT_CONFIG_NOSYSTEM: '1',
+              GIT_TERMINAL_PROMPT: '0',
+              GIT_ASKPASS: '',
+              SSH_ASKPASS: '',
+          }
+        : {}),
     DBT_PARTIAL_PARSE: 'false', // Disable dbt from storing manifest and doing partial parses. https://docs.getdbt.com/reference/parsing#partial-parsing
     DBT_SEND_ANONYMOUS_USAGE_STATS: 'false', // Disable sending usage stats. https://docs.getdbt.com/reference/global-configs/usage-stats
     DBT_TARGET_PATH: targetPath,

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -37,6 +37,8 @@ export type DbtGitProjectAdapterArgs = {
     selector?: string;
     analytics?: LightdashAnalytics;
     gitPackageTokenProvider?: () => Promise<string>;
+    gitPackageHost?: string;
+    dbtSourceName?: string;
 };
 
 const stripTokensFromUrls = (raw: string) => {
@@ -106,6 +108,8 @@ export class DbtGitProjectAdapter
         selector,
         analytics,
         gitPackageTokenProvider,
+        gitPackageHost,
+        dbtSourceName,
     }: DbtGitProjectAdapterArgs) {
         const localRepositoryDir = fs.mkdtempSync('/tmp/git_');
         const projectDir = path.join(
@@ -124,6 +128,8 @@ export class DbtGitProjectAdapter
             selector,
             analytics,
             gitPackageTokenProvider,
+            gitPackageHost,
+            dbtSourceName,
         });
         this.projectDirectorySubPath = projectDirectorySubPath;
         this.localRepositoryDir = localRepositoryDir;

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -36,6 +36,7 @@ export type DbtGitProjectAdapterArgs = {
     dbtVersion: SupportedDbtVersions;
     selector?: string;
     analytics?: LightdashAnalytics;
+    gitPackageTokenProvider?: () => Promise<string>;
 };
 
 const stripTokensFromUrls = (raw: string) => {
@@ -104,6 +105,7 @@ export class DbtGitProjectAdapter
         dbtVersion,
         selector,
         analytics,
+        gitPackageTokenProvider,
     }: DbtGitProjectAdapterArgs) {
         const localRepositoryDir = fs.mkdtempSync('/tmp/git_');
         const projectDir = path.join(
@@ -121,6 +123,7 @@ export class DbtGitProjectAdapter
             dbtVersion,
             selector,
             analytics,
+            gitPackageTokenProvider,
         });
         this.projectDirectorySubPath = projectDirectorySubPath;
         this.localRepositoryDir = localRepositoryDir;

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.test.ts
@@ -1,0 +1,144 @@
+import {
+    SupportedDbtVersions,
+    WarehouseTypes,
+    type CreateWarehouseCredentials,
+    type WarehouseClient,
+} from '@lightdash/common';
+import execa from 'execa';
+import * as fs from 'fs/promises';
+import { getInstallationToken } from '../clients/github/Github';
+import type { CachedWarehouse } from '../types';
+import { DbtGithubProjectAdapter } from './dbtGithubProjectAdapter';
+
+vi.mock('execa');
+vi.mock('../clients/github/Github', () => ({
+    getInstallationToken: vi.fn(),
+}));
+
+const execaMock = execa as unknown as import('vitest').Mock;
+
+const warehouseCredentials: CreateWarehouseCredentials = {
+    type: WarehouseTypes.POSTGRES,
+    host: 'db.example.com',
+    port: 5432,
+    user: 'user',
+    password: 'password',
+    dbname: 'database',
+    schema: 'public',
+};
+
+const cachedWarehouse: CachedWarehouse = {
+    warehouseCatalog: undefined,
+    onWarehouseCatalogChange: vi.fn(),
+};
+
+describe('DbtGithubProjectAdapter package authentication', () => {
+    let adapter: DbtGithubProjectAdapter | undefined;
+
+    afterEach(async () => {
+        await adapter?.destroy();
+        vi.resetAllMocks();
+    });
+
+    it('mints an installation token for each dependency run without exposing it in the environment', async () => {
+        const firstToken = 'first-github-installation-token';
+        const secondToken = 'second-github-installation-token';
+        vi.mocked(getInstallationToken)
+            .mockResolvedValueOnce(firstToken)
+            .mockResolvedValueOnce(secondToken);
+        const observedTokens: string[] = [];
+        const configPaths: string[] = [];
+        execaMock.mockImplementation(
+            async (
+                _command: string,
+                _args: string[],
+                options: { env: Record<string, string> },
+            ) => {
+                const configPath = options.env.GIT_CONFIG_GLOBAL;
+                const config = await fs.readFile(configPath, 'utf8');
+                let token: string | undefined;
+                if (config.includes(firstToken)) {
+                    token = firstToken;
+                } else if (config.includes(secondToken)) {
+                    token = secondToken;
+                }
+
+                expect(Object.values(options.env)).not.toContain(token);
+                expect(token).toBeDefined();
+                observedTokens.push(token!);
+                configPaths.push(configPath);
+                return {
+                    all: 'success message',
+                    stdout: '',
+                } as never;
+            },
+        );
+        adapter = new DbtGithubProjectAdapter({
+            warehouseClient: vi.fn() as unknown as WarehouseClient,
+            githubPersonalAccessToken: 'ghp_clone_token',
+            githubInstallationId: '12345',
+            githubRepository: 'lightdash/private-dbt-package',
+            githubBranch: 'main',
+            projectDirectorySubPath: '',
+            warehouseCredentials,
+            targetName: undefined,
+            environment: undefined,
+            environmentVariableAllowlist: [],
+            cachedWarehouse,
+            dbtVersion: SupportedDbtVersions.V1_10,
+        });
+
+        await adapter.dbtClient.installDeps?.();
+        await adapter.dbtClient.installDeps?.();
+
+        expect(getInstallationToken).toHaveBeenNthCalledWith(1, '12345');
+        expect(getInstallationToken).toHaveBeenNthCalledWith(2, '12345');
+        expect(observedTokens).toEqual([firstToken, secondToken]);
+        expect(configPaths[0]).not.toEqual(configPaths[1]);
+        await expect(fs.access(configPaths[0])).rejects.toThrow();
+        await expect(fs.access(configPaths[1])).rejects.toThrow();
+    });
+
+    it('uses a personal access token through the same isolated config', async () => {
+        const token = 'github_pat_private-package-token';
+        let configPath: string | undefined;
+        execaMock.mockImplementation(
+            async (
+                _command: string,
+                _args: string[],
+                options: { env: Record<string, string> },
+            ) => {
+                configPath = options.env.GIT_CONFIG_GLOBAL;
+                expect(await fs.readFile(configPath, 'utf8')).toContain(
+                    `x-access-token:${token}@github.com/`,
+                );
+                expect(Object.values(options.env)).not.toContain(token);
+                return {
+                    all: 'success message',
+                    stdout: '',
+                } as never;
+            },
+        );
+        adapter = new DbtGithubProjectAdapter({
+            warehouseClient: vi.fn() as unknown as WarehouseClient,
+            githubPersonalAccessToken: token,
+            githubRepository: 'lightdash/private-dbt-package',
+            githubBranch: 'main',
+            projectDirectorySubPath: '',
+            warehouseCredentials,
+            targetName: undefined,
+            environment: undefined,
+            environmentVariableAllowlist: [],
+            cachedWarehouse,
+            dbtVersion: SupportedDbtVersions.V1_10,
+        });
+
+        await adapter.dbtClient.installDeps?.();
+
+        expect(getInstallationToken).not.toHaveBeenCalled();
+        if (!configPath) {
+            throw new Error('dbt deps did not receive a git config path');
+        }
+        await expect(fs.access(configPath)).rejects.toThrow();
+    });
+});

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.test.ts
@@ -141,4 +141,111 @@ describe('DbtGithubProjectAdapter package authentication', () => {
         }
         await expect(fs.access(configPath)).rejects.toThrow();
     });
+
+    it('does not install a git config when no package credential is available', async () => {
+        execaMock.mockImplementation(
+            async (
+                _command: string,
+                _args: string[],
+                options: { env: Record<string, string> },
+            ) => {
+                expect(options.env).not.toHaveProperty('GIT_CONFIG_GLOBAL');
+                expect(options.env).not.toHaveProperty('GIT_CONFIG_NOSYSTEM');
+                return {
+                    all: 'success message',
+                    stdout: '',
+                } as never;
+            },
+        );
+        adapter = new DbtGithubProjectAdapter({
+            warehouseClient: vi.fn() as unknown as WarehouseClient,
+            githubPersonalAccessToken: '',
+            githubRepository: 'lightdash/public-dbt-package',
+            githubBranch: 'main',
+            projectDirectorySubPath: '',
+            warehouseCredentials,
+            targetName: undefined,
+            environment: undefined,
+            environmentVariableAllowlist: [],
+            cachedWarehouse,
+            dbtVersion: SupportedDbtVersions.V1_10,
+        });
+
+        await adapter.dbtClient.installDeps?.();
+
+        expect(getInstallationToken).not.toHaveBeenCalled();
+    });
+
+    it('uses the configured GitHub host for package URL rewrites', async () => {
+        const token = 'github_pat_enterprise-package-token';
+        execaMock.mockImplementation(
+            async (
+                _command: string,
+                _args: string[],
+                options: { env: Record<string, string> },
+            ) => {
+                const config = await fs.readFile(
+                    options.env.GIT_CONFIG_GLOBAL,
+                    'utf8',
+                );
+                expect(config).toContain(
+                    `x-access-token:${token}@github.example.com/`,
+                );
+                expect(config).toContain(
+                    'insteadOf = https://github.example.com/',
+                );
+                expect(config).not.toContain('@github.com/');
+                return {
+                    all: 'success message',
+                    stdout: '',
+                } as never;
+            },
+        );
+        adapter = new DbtGithubProjectAdapter({
+            warehouseClient: vi.fn() as unknown as WarehouseClient,
+            githubPersonalAccessToken: token,
+            githubRepository: 'lightdash/private-dbt-package',
+            githubBranch: 'main',
+            projectDirectorySubPath: '',
+            warehouseCredentials,
+            hostDomain: 'github.example.com',
+            targetName: undefined,
+            environment: undefined,
+            environmentVariableAllowlist: [],
+            cachedWarehouse,
+            dbtVersion: SupportedDbtVersions.V1_10,
+        });
+
+        await adapter.dbtClient.installDeps?.();
+    });
+
+    it('uses the Lightdash source name in dependency access errors', async () => {
+        execaMock.mockRejectedValueOnce({
+            all: JSON.stringify({
+                code: 'E006',
+                info: {
+                    level: 'error',
+                    msg: "Git Error: remote: Repository not found. fatal: repository 'https://github.com/lightdash/private-dbt-package.git/' not found",
+                },
+            }),
+        });
+        adapter = new DbtGithubProjectAdapter({
+            warehouseClient: vi.fn() as unknown as WarehouseClient,
+            githubPersonalAccessToken: 'ghp_clone_token',
+            githubRepository: 'lightdash/analytics-repository',
+            githubBranch: 'main',
+            projectDirectorySubPath: '',
+            warehouseCredentials,
+            targetName: undefined,
+            environment: undefined,
+            environmentVariableAllowlist: [],
+            cachedWarehouse,
+            dbtVersion: SupportedDbtVersions.V1_10,
+            dbtSourceName: 'finance',
+        });
+
+        await expect(adapter.dbtClient.installDeps?.()).rejects.toThrow(
+            'for source "finance": access was denied',
+        );
+    });
 });

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
@@ -6,6 +6,7 @@ import {
 } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
+import { getInstallationToken } from '../clients/github/Github';
 import { CachedWarehouse } from '../types';
 import { DEFAULT_GITHUB_HOST_DOMAIN } from '../utils/credentialDestination';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
@@ -33,6 +34,7 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
         warehouseClient,
         githubBranch,
         githubPersonalAccessToken,
+        githubInstallationId,
         githubRepository,
         projectDirectorySubPath,
         warehouseCredentials,
@@ -67,6 +69,9 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
             dbtVersion,
             selector,
             analytics,
+            gitPackageTokenProvider: githubInstallationId
+                ? () => getInstallationToken(githubInstallationId)
+                : async () => githubPersonalAccessToken,
         });
     }
 }

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
@@ -27,6 +27,7 @@ type DbtGithubProjectAdapterArgs = {
     dbtVersion: SupportedDbtVersions;
     selector?: string;
     analytics?: LightdashAnalytics;
+    dbtSourceName?: string;
 };
 
 export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
@@ -46,15 +47,27 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
         dbtVersion,
         selector,
         analytics,
+        dbtSourceName,
     }: DbtGithubProjectAdapterArgs) {
-        const [isValid, error] = validateGithubToken(githubPersonalAccessToken);
-        if (!isValid) {
-            throw new Error(error);
+        if (githubPersonalAccessToken) {
+            const [isValid, error] = validateGithubToken(
+                githubPersonalAccessToken,
+            );
+            if (!isValid) {
+                throw new Error(error);
+            }
         }
 
         const remoteRepositoryUrl = `https://lightdash:${githubPersonalAccessToken}@${
             hostDomain || DEFAULT_GITHUB_HOST_DOMAIN
         }/${githubRepository}.git`;
+        let gitPackageTokenProvider: (() => Promise<string>) | undefined;
+        if (githubInstallationId) {
+            gitPackageTokenProvider = () =>
+                getInstallationToken(githubInstallationId);
+        } else if (githubPersonalAccessToken) {
+            gitPackageTokenProvider = async () => githubPersonalAccessToken;
+        }
         super({
             warehouseClient,
             remoteRepositoryUrl,
@@ -69,9 +82,9 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
             dbtVersion,
             selector,
             analytics,
-            gitPackageTokenProvider: githubInstallationId
-                ? () => getInstallationToken(githubInstallationId)
-                : async () => githubPersonalAccessToken,
+            gitPackageHost: hostDomain || DEFAULT_GITHUB_HOST_DOMAIN,
+            gitPackageTokenProvider,
+            dbtSourceName,
         });
     }
 }

--- a/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
@@ -29,6 +29,7 @@ type DbtLocalCredentialsProjectAdapterArgs = {
     dbtVersion: SupportedDbtVersions;
     selector?: string;
     analytics?: LightdashAnalytics;
+    gitPackageTokenProvider?: () => Promise<string>;
 };
 
 export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
@@ -45,6 +46,7 @@ export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
         dbtVersion,
         selector,
         analytics,
+        gitPackageTokenProvider,
     }: DbtLocalCredentialsProjectAdapterArgs) {
         const profilesDir = fs.mkdtempSync('/tmp/local_');
         const profilesFilename = path.join(profilesDir, 'profiles.yml');
@@ -89,6 +91,7 @@ export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
             dbtVersion,
             selector,
             analytics,
+            gitPackageTokenProvider,
         });
         this.profilesDir = profilesDir;
     }

--- a/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
@@ -30,6 +30,8 @@ type DbtLocalCredentialsProjectAdapterArgs = {
     selector?: string;
     analytics?: LightdashAnalytics;
     gitPackageTokenProvider?: () => Promise<string>;
+    gitPackageHost?: string;
+    dbtSourceName?: string;
 };
 
 export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
@@ -47,6 +49,8 @@ export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
         selector,
         analytics,
         gitPackageTokenProvider,
+        gitPackageHost,
+        dbtSourceName,
     }: DbtLocalCredentialsProjectAdapterArgs) {
         const profilesDir = fs.mkdtempSync('/tmp/local_');
         const profilesFilename = path.join(profilesDir, 'profiles.yml');
@@ -92,6 +96,8 @@ export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
             selector,
             analytics,
             gitPackageTokenProvider,
+            gitPackageHost,
+            dbtSourceName,
         });
         this.profilesDir = profilesDir;
     }

--- a/packages/backend/src/projectAdapters/dbtLocalProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtLocalProjectAdapter.ts
@@ -17,6 +17,7 @@ type DbtLocalProjectAdapterArgs = {
     dbtVersion: SupportedDbtVersions;
     selector?: string;
     analytics?: LightdashAnalytics;
+    gitPackageTokenProvider?: () => Promise<string>;
 };
 
 export class DbtLocalProjectAdapter extends DbtBaseProjectAdapter {
@@ -32,6 +33,7 @@ export class DbtLocalProjectAdapter extends DbtBaseProjectAdapter {
         cachedWarehouse,
         dbtVersion,
         selector,
+        gitPackageTokenProvider,
     }: DbtLocalProjectAdapterArgs) {
         const dbtClient = new DbtCliClient({
             dbtProjectDirectory: projectDir,
@@ -42,6 +44,7 @@ export class DbtLocalProjectAdapter extends DbtBaseProjectAdapter {
             target,
             dbtVersion,
             selector,
+            gitPackageTokenProvider,
         });
         super(
             dbtClient,

--- a/packages/backend/src/projectAdapters/dbtLocalProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtLocalProjectAdapter.ts
@@ -18,6 +18,8 @@ type DbtLocalProjectAdapterArgs = {
     selector?: string;
     analytics?: LightdashAnalytics;
     gitPackageTokenProvider?: () => Promise<string>;
+    gitPackageHost?: string;
+    dbtSourceName?: string;
 };
 
 export class DbtLocalProjectAdapter extends DbtBaseProjectAdapter {
@@ -34,6 +36,8 @@ export class DbtLocalProjectAdapter extends DbtBaseProjectAdapter {
         dbtVersion,
         selector,
         gitPackageTokenProvider,
+        gitPackageHost,
+        dbtSourceName,
     }: DbtLocalProjectAdapterArgs) {
         const dbtClient = new DbtCliClient({
             dbtProjectDirectory: projectDir,
@@ -45,6 +49,8 @@ export class DbtLocalProjectAdapter extends DbtBaseProjectAdapter {
             dbtVersion,
             selector,
             gitPackageTokenProvider,
+            gitPackageHost,
+            dbtSourceName,
         });
         super(
             dbtClient,

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -106,6 +106,10 @@ export const projectAdapterFromConfig = async (
                 analytics,
                 warehouseClient,
                 githubPersonalAccessToken: githubToken!,
+                githubInstallationId:
+                    config.authorization_method === 'installation_id'
+                        ? config.installation_id
+                        : undefined,
                 githubRepository: config.repository,
                 githubBranch: config.branch,
                 projectDirectorySubPath: config.project_sub_path,

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -31,6 +31,7 @@ export const projectAdapterFromConfig = async (
     // project_context.yml from (the multiple-dbt-sources merge passes the
     // primary source's checkout here). Ignored by every other adapter type.
     manifestProjectDir?: string,
+    dbtSourceName?: string,
 ): Promise<ProjectAdapter> => {
     Logger.debug(
         `Initialize warehouse client of type ${warehouseCredentials.type}`,
@@ -56,6 +57,7 @@ export const projectAdapterFromConfig = async (
                 dbtVersion,
 
                 selector: config.selector,
+                dbtSourceName,
             });
         case DbtProjectType.NONE:
             return new DbtNoneCredentialsProjectAdapter({
@@ -122,6 +124,7 @@ export const projectAdapterFromConfig = async (
                 dbtVersion,
 
                 selector: config.selector,
+                dbtSourceName,
             });
         case DbtProjectType.GITLAB:
             return new DbtGitlabProjectAdapter({

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -4593,6 +4593,33 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
         });
     };
 
+    it('passes the Lightdash source name to additional source adapters', async () => {
+        const projectService = getMockedProjectService(
+            lightdashConfigMock,
+        ) as unknown as ProjectServiceInternals;
+        const buildSourceAdapter = vi
+            .spyOn(projectService, 'buildSourceAdapter')
+            .mockResolvedValue(buildAdapterWithManifest(buildManifest([])));
+
+        await projectService.buildMergedManifestAdapter({
+            projectUuid: 'project-uuid',
+            organizationUuid: 'org-uuid',
+            primary: {
+                ...primary,
+                adapter: buildAdapterWithManifest(buildManifest([])),
+            },
+            sources: [buildSource('finance')],
+            manifestFetchAdapters: [],
+        });
+
+        expect(buildSourceAdapter).toHaveBeenCalledWith(
+            expect.anything(),
+            'finance',
+            'org-uuid',
+            expect.anything(),
+        );
+    });
+
     it('rejects cross-source bare model name collisions before returning a merged adapter', async () => {
         const primaryManifest = buildManifest([
             {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4483,6 +4483,7 @@ export class ProjectService extends BaseService {
      */
     private async buildSourceAdapter(
         dbtConnection: DbtProjectConfig,
+        dbtSourceName: string,
         organizationUuid: string | undefined,
         shared: {
             warehouseCredentials: CreateWarehouseCredentials;
@@ -4502,6 +4503,8 @@ export class ProjectService extends BaseService {
             shared.dbtVersionOption,
             this.lightdashConfig.dbt.environmentVariableAllowlist,
             this.analytics,
+            undefined,
+            dbtSourceName,
         );
     }
 
@@ -4636,6 +4639,7 @@ export class ProjectService extends BaseService {
                 try {
                     sourceAdapter = await this.buildSourceAdapter(
                         source.dbtConnection,
+                        source.name,
                         organizationUuid,
                         shared,
                     );


### PR DESCRIPTION
## What this change does

`dbt deps` can now download private dbt packages from GitHub. Lightdash writes the credential to a git config file that exists only for the duration of the `deps` command.

- A new helper, `withDbtGitConfig`, creates a temporary directory (mode 0700) outside the repository. It writes a git config file (mode 0600) and always removes the directory, also after a failure.
- The config file rewrites three URL forms to `https://x-access-token:<TOKEN>@github.com/`: the HTTPS form, the `git@` form, and the `ssh://` form. A `packages.yml` with SSH URLs works without changes and without an SSH client.
- The config file also resets the git credential helper. Git then cannot store the token after a successful clone.
- The dbt subprocess environment gets `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_NOSYSTEM`, `GIT_TERMINAL_PROMPT=0`, and empty `GIT_ASKPASS`/`SSH_ASKPASS`. The token is only in the file. The environment has only the path.
- Lightdash makes a new GitHub App installation token for each run. A connection with a personal access token uses the same file mechanism.
- The GitLab, Bitbucket, and Azure adapters do not change. They are follow-up work.

## Why

Customers with private dbt packages cannot run `dbt deps` on the server. A token in an environment variable is not safe, because dbt can read environment variables with `env_var()`. The file mechanism keeps the token out of dbt's view. The SPK-1030 resolution comment has the decision. SPK-1041 confirmed the mechanism against a real private repository.

## Tests

- The environment contains the five `GIT_*` keys when a config path is present, and does not contain them when it is absent.
- Hostile `GIT_*` variables from project configuration stay blocked.
- The config file has the correct content, mode, and location.
- The temporary directory is removed after success and after a failure.
- The token does not appear in any environment value.
- Backend: 7,111 tests pass. Typecheck and lint pass.

Linear: SPK-1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kyg5Qw8v4vLKfKb7Bh9gcj
