### PR TITLE
fix: stop the upgrade-safety comment from inventing a database change

### DIFF
--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -147,6 +147,68 @@ test('failed REST generation replaces a false-safe headline', () => {
     assert.match(body, /REST API check didn’t run/);
 });
 
+const unknownMarker = (overrides: Partial<Marker> = {}): Marker =>
+    baseMarker({
+        compatibility: {
+            rollingUpdateSafe: 'unknown',
+            recommendedStrategy: 'Recreate',
+        },
+        ...overrides,
+    });
+
+test('an unknown verdict with no migrations never claims a database change', () => {
+    const marker = unknownMarker();
+    marker.api.rest = { checked: false, breaking: 'unknown', changes: [] };
+    const body = renderPrComment(marker, { draft: true, restStatus: 'failed' });
+    assert.doesNotMatch(body, /This changes the database/);
+    assert.match(body, /No database changes here/);
+    assert.match(body, /didn’t complete/);
+    assert.match(body, /Database changes \| none/);
+    // The REST check didn't run, so the comment must not claim the API is clean
+    // either — only that the database is.
+    assert.doesNotMatch(body, /changes the database or the API/);
+    // The code-aware review only runs on a migration or an API break, so marking
+    // this PR ready for review would not clear it.
+    assert.doesNotMatch(body, /Mark the PR ready for review/);
+});
+
+test('an unknown verdict with an indeterminate migration state says so', () => {
+    const marker = unknownMarker();
+    marker.migrations.present = 'unknown';
+    const body = renderPrComment(marker, { draft: true });
+    assert.doesNotMatch(body, /This changes the database/);
+    assert.match(body, /We couldn’t tell what this release changes/);
+});
+
+test('an unknown verdict with migrations still names the database', () => {
+    const body = renderPrComment(
+        unknownMarker({
+            migrations: {
+                present: true,
+                count: 1,
+                coreCount: 1,
+                eeCount: 0,
+                files: [],
+            },
+        }),
+        { draft: true },
+    );
+    assert.match(body, /This changes the database/);
+    assert.match(body, /Mark the PR ready for review/);
+});
+
+test('an unknown verdict driven by an API break still names the API', () => {
+    const marker = unknownMarker();
+    marker.api.rest = {
+        checked: true,
+        breaking: true,
+        changes: ['GET /legacy removed'],
+    };
+    const body = renderPrComment(marker, { draft: false });
+    assert.match(body, /This changes the API/);
+    assert.doesNotMatch(body, /This changes the database/);
+});
+
 test('raw v2 JSON is embedded for machines', () => {
     const body = renderPrComment(baseMarker());
     assert.match(body, /Technical details \(raw JSON\)/);

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -110,15 +110,26 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         );
     } else if (rollingUpdateSafe === 'unknown') {
         head.push('❓ **Couldn’t confirm it’s safe.** Treat it as needing care on upgrade until checked.');
-        // An API break with no migration lands here too, so name what actually
-        // changed — telling the author "this changes the database" when it doesn't
-        // sends them looking for a migration that isn't there.
-        const subject = apiDriven ? 'This changes the API' : 'This changes the database';
-        head.push(
-            opts.draft
-                ? `${subject}. Mark the PR ready for review and an automated, code-aware check will look at whether the old version still uses what changed — it may clear it as safe.`
-                : `${subject} and we couldn’t automatically confirm the old version keeps working through the upgrade.`,
-        );
+        // Name what actually drove the verdict. An API break with no migration
+        // lands here, and so does a PR that changes neither — a check that
+        // couldn't run leaves the verdict unknown on its own. Telling that second
+        // author "this changes the database" sends them looking for a migration
+        // that isn't there, and the code-aware review they're pointed at only
+        // runs on a migration or an API break, so it would never clear them.
+        if (apiDriven || migrationsPresent === true) {
+            const subject = apiDriven ? 'This changes the API' : 'This changes the database';
+            head.push(
+                opts.draft
+                    ? `${subject}. Mark the PR ready for review and an automated, code-aware check will look at whether the old version still uses what changed — it may clear it as safe.`
+                    : `${subject} and we couldn’t automatically confirm the old version keeps working through the upgrade.`,
+            );
+        } else {
+            head.push(
+                migrationsPresent === false
+                    ? 'No database changes here. One of the checks below didn’t complete, so we can’t confirm this either way — the table says which one.'
+                    : 'We couldn’t tell what this release changes, because one of the checks below didn’t complete — the table says which one.',
+            );
+        }
     } else if (clearedAsSafeDrop) {
         head.push(SAFE_HEADLINE);
         head.push('This removes something from the database, but the app already stopped using it in an earlier release, so the old version keeps working fine through the upgrade.');


### PR DESCRIPTION
## What this change does

The upgrade-safety PR comment no longer says "This changes the database" on a pull request that has no migrations.

The unknown-verdict sentence chose between two causes: an API break, or a database change. A verdict that is unknown because a check did not run matches neither, so it fell through to the database wording. The table in the same comment said `Database changes | none`, so the comment contradicted itself.

The sentence now names only what the evidence supports:

- An API break with no migration keeps "This changes the API".
- A migration keeps "This changes the database".
- Neither gets a new sentence that points at the check that did not complete.

In that third case the comment also drops the "mark the PR ready for review" invitation. The code-aware review runs only when a migration or an API break is present (`gen-release-safety.ts`), so marking such a pull request ready would never clear it.

The wording stays inside what is known. The database result is a real determination, so the comment states it. The REST result is not, so the comment does not claim the API is clean. The existing "The REST API check didn't run" line still carries that part.

## Why

Seen on a draft pull request with no migrations, where the OpenAPI specs could not be generated. The author reads "This changes the database", looks for a migration that is not there, and learns to discount the check. The signal is the product, so a false statement in it costs more than the line is worth.

## Before and after

The same marker, replayed through the renderer:

```
- ❓ Couldn’t confirm it’s safe. Treat it as needing care on upgrade until checked.
- This changes the database. Mark the PR ready for review and an automated,
  code-aware check will look at whether the old version still uses what changed.       <- before
- No database changes here. One of the checks below didn’t complete, so we can’t
  confirm this either way — the table says which one.                                  <- after
- ⚠️ The REST API check didn’t run — its OpenAPI specs couldn’t be generated.
```

## Tests

`scripts/release-safety-pr-comment.test.ts` gets four cases: no migrations with a failed REST check, an indeterminate migration state, a migration (regression guard), and an API break (regression guard). The two new negative cases fail on the old renderer and pass on the new one. 16 tests pass.

Linear: SPK-1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRsTpr8ZFVdmfXX3Hm8fNL