### PR TITLE
fix: show the candidate explores when a saved chart points at a split name

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -148,6 +148,79 @@ describe('ProjectModel', () => {
         expect(result).toEqual(expectedTablesConfiguration);
         expect(tracker.history.select).toHaveLength(1);
     });
+    describe('getExploreFromCache', () => {
+        const createQualifiedExplore = (name: string) => ({
+            ...exploreWithMetricFilters,
+            name,
+            label: name,
+            baseTable: name,
+            tables: {
+                [name]: {
+                    ...exploreWithMetricFilters.tables.payments,
+                    name,
+                    originalName: 'orders',
+                },
+            },
+        });
+
+        test('returns a structured error when an explore was split', async () => {
+            const sourceAExplore = createQualifiedExplore('sourceA__orders');
+            const sourceBExplore = createQualifiedExplore('sourceB__orders');
+            const findExploresFromCache = vi
+                .spyOn(model, 'findExploresFromCache')
+                .mockResolvedValueOnce({})
+                .mockResolvedValueOnce({
+                    [sourceAExplore.name]: sourceAExplore,
+                    [sourceBExplore.name]: sourceBExplore,
+                });
+
+            await expect(
+                model.getExploreFromCache(projectUuid, 'orders'),
+            ).rejects.toMatchObject({
+                name: 'ExploreSplitError',
+                statusCode: 404,
+                data: {
+                    exploreName: 'orders',
+                    candidateExploreNames: [
+                        'sourceA__orders',
+                        'sourceB__orders',
+                    ],
+                },
+            });
+            expect(findExploresFromCache).toHaveBeenCalledTimes(2);
+        });
+
+        test('keeps the plain not found error when no split candidates exist', async () => {
+            const findExploresFromCache = vi
+                .spyOn(model, 'findExploresFromCache')
+                .mockResolvedValueOnce({})
+                .mockResolvedValueOnce({
+                    payments: exploreWithMetricFilters,
+                });
+
+            await expect(
+                model.getExploreFromCache(projectUuid, 'orders'),
+            ).rejects.toEqual(
+                new NotFoundError('Explore "orders" does not exist.'),
+            );
+            expect(findExploresFromCache).toHaveBeenCalledTimes(2);
+        });
+
+        test('keeps the plain not found error for one original-name match', async () => {
+            const sourceAExplore = createQualifiedExplore('sourceA__orders');
+            vi.spyOn(model, 'findExploresFromCache')
+                .mockResolvedValueOnce({})
+                .mockResolvedValueOnce({
+                    [sourceAExplore.name]: sourceAExplore,
+                });
+
+            await expect(
+                model.getExploreFromCache(projectUuid, 'orders'),
+            ).rejects.toEqual(
+                new NotFoundError('Explore "orders" does not exist.'),
+            );
+        });
+    });
     test('should update project tables configuration', async () => {
         tracker.on
             .update(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -171,12 +171,16 @@ describe('ProjectModel', () => {
         test('returns a structured error when an explore was split', async () => {
             const sourceAExplore = createQualifiedExplore('sourceA__orders');
             const sourceBExplore = createQualifiedExplore('sourceB__orders');
+            const bystanderExplore = createQualifiedExplore(
+                'orders_with_custom_dims',
+            );
             const findExploresFromCache = vi
                 .spyOn(model, 'findExploresFromCache')
                 .mockResolvedValueOnce({})
                 .mockResolvedValueOnce({
                     [sourceAExplore.name]: sourceAExplore,
                     [sourceBExplore.name]: sourceBExplore,
+                    [bystanderExplore.name]: bystanderExplore,
                 });
 
             await expect(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -153,6 +153,79 @@ describe('ProjectModel', () => {
         expect(result).toEqual(expectedTablesConfiguration);
         expect(tracker.history.select).toHaveLength(1);
     });
+    describe('getExploreFromCache', () => {
+        const createQualifiedExplore = (name: string) => ({
+            ...exploreWithMetricFilters,
+            name,
+            label: name,
+            baseTable: name,
+            tables: {
+                [name]: {
+                    ...exploreWithMetricFilters.tables.payments,
+                    name,
+                    originalName: 'orders',
+                },
+            },
+        });
+
+        test('returns a structured error when an explore was split', async () => {
+            const sourceAExplore = createQualifiedExplore('sourceA__orders');
+            const sourceBExplore = createQualifiedExplore('sourceB__orders');
+            const findExploresFromCache = vi
+                .spyOn(model, 'findExploresFromCache')
+                .mockResolvedValueOnce({})
+                .mockResolvedValueOnce({
+                    [sourceAExplore.name]: sourceAExplore,
+                    [sourceBExplore.name]: sourceBExplore,
+                });
+
+            await expect(
+                model.getExploreFromCache(projectUuid, 'orders'),
+            ).rejects.toMatchObject({
+                name: 'ExploreSplitError',
+                statusCode: 404,
+                data: {
+                    exploreName: 'orders',
+                    candidateExploreNames: [
+                        'sourceA__orders',
+                        'sourceB__orders',
+                    ],
+                },
+            });
+            expect(findExploresFromCache).toHaveBeenCalledTimes(2);
+        });
+
+        test('keeps the plain not found error when no split candidates exist', async () => {
+            const findExploresFromCache = vi
+                .spyOn(model, 'findExploresFromCache')
+                .mockResolvedValueOnce({})
+                .mockResolvedValueOnce({
+                    payments: exploreWithMetricFilters,
+                });
+
+            await expect(
+                model.getExploreFromCache(projectUuid, 'orders'),
+            ).rejects.toEqual(
+                new NotFoundError('Explore "orders" does not exist.'),
+            );
+            expect(findExploresFromCache).toHaveBeenCalledTimes(2);
+        });
+
+        test('keeps the plain not found error for one original-name match', async () => {
+            const sourceAExplore = createQualifiedExplore('sourceA__orders');
+            vi.spyOn(model, 'findExploresFromCache')
+                .mockResolvedValueOnce({})
+                .mockResolvedValueOnce({
+                    [sourceAExplore.name]: sourceAExplore,
+                });
+
+            await expect(
+                model.getExploreFromCache(projectUuid, 'orders'),
+            ).rejects.toEqual(
+                new NotFoundError('Explore "orders" does not exist.'),
+            );
+        });
+    });
     test('should update project tables configuration', async () => {
         tracker.on
             .update(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -186,7 +186,7 @@ describe('ProjectModel', () => {
             await expect(
                 model.getExploreFromCache(projectUuid, 'orders'),
             ).rejects.toMatchObject({
-                name: 'ExploreSplitError',
+                name: 'NotFoundError',
                 statusCode: 404,
                 data: {
                     exploreName: 'orders',

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -166,12 +166,16 @@ describe('ProjectModel', () => {
         test('returns a structured error when an explore was split', async () => {
             const sourceAExplore = createQualifiedExplore('sourceA__orders');
             const sourceBExplore = createQualifiedExplore('sourceB__orders');
+            const bystanderExplore = createQualifiedExplore(
+                'orders_with_custom_dims',
+            );
             const findExploresFromCache = vi
                 .spyOn(model, 'findExploresFromCache')
                 .mockResolvedValueOnce({})
                 .mockResolvedValueOnce({
                     [sourceAExplore.name]: sourceAExplore,
                     [sourceBExplore.name]: sourceBExplore,
+                    [bystanderExplore.name]: bystanderExplore,
                 });
 
             await expect(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -181,7 +181,7 @@ describe('ProjectModel', () => {
             await expect(
                 model.getExploreFromCache(projectUuid, 'orders'),
             ).rejects.toMatchObject({
-                name: 'ExploreSplitError',
+                name: 'NotFoundError',
                 statusCode: 404,
                 data: {
                     exploreName: 'orders',

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -16,8 +16,10 @@ import {
     DuckdbConnectionType,
     Explore,
     ExploreError,
+    ExploreSplitError,
     ExploreType,
     generateSlug,
+    getExploreSplitCandidates,
     getLtreePathFromSlug,
     GroupType,
     IdContentMapping,
@@ -1593,9 +1595,30 @@ export class ProjectModel {
         );
         const cachedExplore = cachedExplores[exploreName];
         if (cachedExplore === undefined) {
+            const candidateExploreNames = await this.findExploreSplitCandidates(
+                projectUuid,
+                exploreName,
+            );
+            if (candidateExploreNames.length >= 2) {
+                throw new ExploreSplitError(exploreName, candidateExploreNames);
+            }
             throw new NotFoundError(`Explore "${exploreName}" does not exist.`);
         }
         return cachedExplore;
+    }
+
+    async findExploreSplitCandidates(
+        projectUuid: string,
+        exploreName: string,
+    ): Promise<string[]> {
+        const allCachedExplores = await this.findExploresFromCache(
+            projectUuid,
+            'name',
+        );
+        return getExploreSplitCandidates(
+            exploreName,
+            Object.values(allCachedExplores),
+        );
     }
 
     async findExploreByTableName(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -16,9 +16,11 @@ import {
     DuckdbConnectionType,
     Explore,
     ExploreError,
+    ExploreSplitError,
     ExploreType,
     ExternalSourceScope,
     generateSlug,
+    getExploreSplitCandidates,
     getLtreePathFromSlug,
     GroupType,
     IdContentMapping,
@@ -1709,9 +1711,30 @@ export class ProjectModel {
         );
         const cachedExplore = cachedExplores[exploreName];
         if (cachedExplore === undefined) {
+            const candidateExploreNames = await this.findExploreSplitCandidates(
+                projectUuid,
+                exploreName,
+            );
+            if (candidateExploreNames.length >= 2) {
+                throw new ExploreSplitError(exploreName, candidateExploreNames);
+            }
             throw new NotFoundError(`Explore "${exploreName}" does not exist.`);
         }
         return cachedExplore;
+    }
+
+    async findExploreSplitCandidates(
+        projectUuid: string,
+        exploreName: string,
+    ): Promise<string[]> {
+        const allCachedExplores = await this.findExploresFromCache(
+            projectUuid,
+            'name',
+        );
+        return getExploreSplitCandidates(
+            exploreName,
+            Object.values(allCachedExplores),
+        );
     }
 
     async findExploreByTableName(

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -205,6 +205,9 @@ const projectModel = {
         queryTimezone: null,
     })),
     findExploresFromCache: vi.fn(async () => allExplores),
+    findExploreSplitCandidates: vi.fn<
+        ProjectModel['findExploreSplitCandidates']
+    >(async () => []),
     getAllExploreSummaries: vi.fn(async () =>
         allExplores.map(exploreToSummaryWithAttributes),
     ),
@@ -2789,6 +2792,43 @@ describe('ProjectService', () => {
     });
 
     describe('getExplore', () => {
+        test('returns split candidates when the requested explore name was qualified', async () => {
+            vi.mocked(projectModel.findExploresFromCache).mockResolvedValueOnce(
+                [],
+            );
+            vi.mocked(
+                projectModel.findExploreSplitCandidates,
+            ).mockResolvedValueOnce(['sourceA__orders', 'sourceB__orders']);
+
+            await expect(
+                service.getExplore(account, projectUuid, 'orders'),
+            ).rejects.toMatchObject({
+                name: 'ExploreSplitError',
+                data: {
+                    exploreName: 'orders',
+                    candidateExploreNames: [
+                        'sourceA__orders',
+                        'sourceB__orders',
+                    ],
+                },
+            });
+        });
+
+        test('keeps the plain not found error when the explore was not split', async () => {
+            vi.mocked(projectModel.findExploresFromCache).mockResolvedValueOnce(
+                [],
+            );
+            vi.mocked(
+                projectModel.findExploreSplitCandidates,
+            ).mockResolvedValueOnce([]);
+
+            await expect(
+                service.getExplore(account, projectUuid, 'orders'),
+            ).rejects.toEqual(
+                new NotFoundError('Explore "orders" does not exist.'),
+            );
+        });
+
         test('should allow developer users to get a pre-aggregate explore', async () => {
             const serviceWithPreAggregatesEnabled = getMockedProjectService({
                 ...lightdashConfigMock,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -2803,7 +2803,7 @@ describe('ProjectService', () => {
             await expect(
                 service.getExplore(account, projectUuid, 'orders'),
             ).rejects.toMatchObject({
-                name: 'ExploreSplitError',
+                name: 'NotFoundError',
                 data: {
                     exploreName: 'orders',
                     candidateExploreNames: [

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -208,6 +208,9 @@ const projectModel = {
         queryTimezone: null,
     })),
     findExploresFromCache: vi.fn(async () => allExplores),
+    findExploreSplitCandidates: vi.fn<
+        ProjectModel['findExploreSplitCandidates']
+    >(async () => []),
     getAllExploreSummaries: vi.fn(async () =>
         allExplores.map(exploreToSummaryWithAttributes),
     ),
@@ -2902,6 +2905,43 @@ describe('ProjectService', () => {
     });
 
     describe('getExplore', () => {
+        test('returns split candidates when the requested explore name was qualified', async () => {
+            vi.mocked(projectModel.findExploresFromCache).mockResolvedValueOnce(
+                [],
+            );
+            vi.mocked(
+                projectModel.findExploreSplitCandidates,
+            ).mockResolvedValueOnce(['sourceA__orders', 'sourceB__orders']);
+
+            await expect(
+                service.getExplore(account, projectUuid, 'orders'),
+            ).rejects.toMatchObject({
+                name: 'ExploreSplitError',
+                data: {
+                    exploreName: 'orders',
+                    candidateExploreNames: [
+                        'sourceA__orders',
+                        'sourceB__orders',
+                    ],
+                },
+            });
+        });
+
+        test('keeps the plain not found error when the explore was not split', async () => {
+            vi.mocked(projectModel.findExploresFromCache).mockResolvedValueOnce(
+                [],
+            );
+            vi.mocked(
+                projectModel.findExploreSplitCandidates,
+            ).mockResolvedValueOnce([]);
+
+            await expect(
+                service.getExplore(account, projectUuid, 'orders'),
+            ).rejects.toEqual(
+                new NotFoundError('Explore "orders" does not exist.'),
+            );
+        });
+
         test('should allow developer users to get a pre-aggregate explore', async () => {
             const serviceWithPreAggregatesEnabled = getMockedProjectService({
                 ...lightdashConfigMock,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -2916,7 +2916,7 @@ describe('ProjectService', () => {
             await expect(
                 service.getExplore(account, projectUuid, 'orders'),
             ).rejects.toMatchObject({
-                name: 'ExploreSplitError',
+                name: 'NotFoundError',
                 data: {
                     exploreName: 'orders',
                     candidateExploreNames: [

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -75,6 +75,7 @@ import {
     EnsurePlaygroundProjectResults,
     Explore,
     ExploreError,
+    ExploreSplitError,
     ExploreType,
     FeatureFlags,
     Field,
@@ -8839,6 +8840,17 @@ export class ProjectService extends BaseService {
                 const explore = exploresMap[exploreName];
 
                 if (!explore) {
+                    const candidateExploreNames =
+                        await this.projectModel.findExploreSplitCandidates(
+                            projectUuid,
+                            exploreName,
+                        );
+                    if (candidateExploreNames.length >= 2) {
+                        throw new ExploreSplitError(
+                            exploreName,
+                            candidateExploreNames,
+                        );
+                    }
                     throw new NotFoundError(
                         `Explore "${exploreName}" does not exist.`,
                     );

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -75,6 +75,7 @@ import {
     EnsurePlaygroundProjectResults,
     Explore,
     ExploreError,
+    ExploreSplitError,
     ExploreType,
     FeatureFlags,
     Field,
@@ -8576,6 +8577,17 @@ export class ProjectService extends BaseService {
                 const explore = exploresMap[exploreName];
 
                 if (!explore) {
+                    const candidateExploreNames =
+                        await this.projectModel.findExploreSplitCandidates(
+                            projectUuid,
+                            exploreName,
+                        );
+                    if (candidateExploreNames.length >= 2) {
+                        throw new ExploreSplitError(
+                            exploreName,
+                            candidateExploreNames,
+                        );
+                    }
                     throw new NotFoundError(
                         `Explore "${exploreName}" does not exist.`,
                     );

--- a/packages/backend/src/services/RenameService/RenameService.test.ts
+++ b/packages/backend/src/services/RenameService/RenameService.test.ts
@@ -1,0 +1,118 @@
+import { Ability } from '@casl/ability';
+import {
+    OrganizationMemberRole,
+    RenameType,
+    RequestMethod,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SchedulerModel } from '../../models/SchedulerModel';
+import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { chartMocked } from './rename.mock';
+import { RenameService } from './RenameService';
+
+const chart = {
+    ...chartMocked,
+    tableName: 'orders',
+    metricQuery: {
+        ...chartMocked.metricQuery,
+        exploreName: 'orders',
+        dimensions: [],
+        metrics: ['orders_amount'],
+        sorts: [],
+        tableCalculations: [],
+        additionalMetrics: [],
+        customDimensions: [],
+    },
+    tableConfig: {
+        ...chartMocked.tableConfig,
+        columnOrder: ['orders_amount'],
+    },
+};
+
+const savedChartModel = {
+    get: vi.fn(async () => chart),
+    createVersion: vi.fn<SavedChartModel['createVersion']>(async () => chart),
+};
+const projectModel = {
+    getExploreFromCache: vi.fn(async () => ({})),
+};
+const spacePermissionService = {
+    getSpaceAccessContext: vi.fn(async () => ({
+        inheritsFromOrgOrProject: true,
+        access: [],
+    })),
+};
+
+const user: SessionUser = {
+    userUuid: 'user-uuid',
+    email: 'user@example.com',
+    firstName: 'Test',
+    lastName: 'User',
+    organizationUuid: chart.organizationUuid,
+    organizationName: 'Test organization',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    avatarUrl: null,
+    avatarGradient: null,
+    timezone: null,
+    isSetupComplete: true,
+    userId: 1,
+    role: OrganizationMemberRole.EDITOR,
+    ability: new Ability<PossibleAbilities>([
+        { subject: 'SavedChart', action: 'update' },
+    ]),
+    isActive: true,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+};
+
+const service = new RenameService({
+    lightdashConfig: lightdashConfigMock,
+    analytics: analyticsMock,
+    projectModel: projectModel as unknown as ProjectModel,
+    savedChartModel: savedChartModel as unknown as SavedChartModel,
+    dashboardModel: {} as unknown as DashboardModel,
+    schedulerClient: {} as unknown as SchedulerClient,
+    schedulerModel: {} as unknown as SchedulerModel,
+    spacePermissionService:
+        spacePermissionService as unknown as SpacePermissionService,
+});
+
+describe('RenameService', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('persists a chart repointed to a qualified explore', async () => {
+        await service.renameChart({
+            user,
+            projectUuid: chart.projectUuid,
+            chartUuid: chart.uuid,
+            from: 'orders',
+            to: 'sourceA__orders',
+            type: RenameType.MODEL,
+            context: RequestMethod.WEB_APP,
+        });
+
+        expect(savedChartModel.createVersion).toHaveBeenCalledOnce();
+        const persistedChart = vi.mocked(savedChartModel.createVersion).mock
+            .calls[0]![1];
+        expect(persistedChart.tableName).toBe('sourceA__orders');
+        expect(persistedChart.metricQuery.exploreName).toBe('sourceA__orders');
+        expect(persistedChart.metricQuery.metrics).toEqual([
+            'sourceA__orders_amount',
+        ]);
+        expect(persistedChart.tableConfig.columnOrder).toEqual([
+            'sourceA__orders_amount',
+        ]);
+    });
+});

--- a/packages/backend/src/services/RenameService/rename.test.ts
+++ b/packages/backend/src/services/RenameService/rename.test.ts
@@ -966,6 +966,49 @@ describe('renameChartConfigType', () => {
 });
 
 describe('renameSavedChart', () => {
+    test('should repoint a split explore and its field references', () => {
+        const { updatedChart, hasChanges } = renameSavedChart({
+            type: RenameType.MODEL,
+            chart: {
+                ...chartMocked,
+                tableName: 'orders',
+                metricQuery: {
+                    ...chartMocked.metricQuery,
+                    exploreName: 'orders',
+                    dimensions: [],
+                    metrics: ['orders_amount'],
+                    sorts: [],
+                    tableCalculations: [],
+                    additionalMetrics: [],
+                    customDimensions: [],
+                },
+                tableConfig: {
+                    ...chartMocked.tableConfig,
+                    columnOrder: ['orders_amount'],
+                },
+            },
+            nameChanges: {
+                from: 'orders',
+                to: 'sourceA__orders',
+                fromReference: 'orders',
+                toReference: 'sourceA__orders',
+                fromFieldName: undefined,
+                toFieldName: undefined,
+            },
+            validate: false,
+        });
+
+        expect(hasChanges).toBe(true);
+        expect(updatedChart.tableName).toBe('sourceA__orders');
+        expect(updatedChart.metricQuery.exploreName).toBe('sourceA__orders');
+        expect(updatedChart.metricQuery.metrics).toEqual([
+            'sourceA__orders_amount',
+        ]);
+        expect(updatedChart.tableConfig.columnOrder).toEqual([
+            'sourceA__orders_amount',
+        ]);
+    });
+
     test('should rename mocked saved chart field', () => {
         const { updatedChart, hasChanges } = renameSavedChart({
             type: RenameType.FIELD,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
@@ -193,7 +193,7 @@ describe('SavedChartService - Content Verification', () => {
                 { projectUuid: 'project-uuid' },
             ),
         ).rejects.toMatchObject({
-            name: 'ExploreSplitError',
+            name: 'NotFoundError',
             data: {
                 exploreName: 'test_table',
                 candidateExploreNames: [

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
@@ -4,7 +4,9 @@ import {
     ContentType,
     CustomDimensionType,
     DimensionType,
+    ExploreSplitError,
     ForbiddenError,
+    NotFoundError,
     OrganizationMemberRole,
     PossibleAbilities,
 } from '@lightdash/common';
@@ -138,6 +140,12 @@ const projectModel = {
         projectUuid: 'project-uuid',
     })),
 };
+const analyticsModel = {
+    addChartViewEvent: vi.fn(async () => undefined),
+};
+const spaceModel = {
+    getSpaceSummary: vi.fn(async () => ({ uuid: 'space-uuid' })),
+};
 
 vi.spyOn(analyticsMock, 'track');
 
@@ -147,8 +155,8 @@ describe('SavedChartService - Content Verification', () => {
         lightdashConfig: lightdashConfigMock,
         projectModel: projectModel as unknown as ProjectModel,
         savedChartModel: savedChartModel as unknown as SavedChartModel,
-        spaceModel: {} as unknown as SpaceModel,
-        analyticsModel: {} as unknown as AnalyticsModel,
+        spaceModel: spaceModel as unknown as SpaceModel,
+        analyticsModel: analyticsModel as unknown as AnalyticsModel,
         pinnedListModel: {} as unknown as PinnedListModel,
         schedulerModel: {} as unknown as SchedulerModel,
         schedulerService: {} as unknown as SchedulerService,
@@ -168,6 +176,49 @@ describe('SavedChartService - Content Verification', () => {
 
     afterEach(() => {
         vi.clearAllMocks();
+    });
+
+    it('returns split candidates when a saved chart uses an original explore name', async () => {
+        vi.mocked(projectModel.getExploreFromCache).mockRejectedValueOnce(
+            new ExploreSplitError('test_table', [
+                'sourceA__test_table',
+                'sourceB__test_table',
+            ]),
+        );
+
+        await expect(
+            service.get(
+                'chart-uuid',
+                fromSession(adminUser, 'session-cookie'),
+                { projectUuid: 'project-uuid' },
+            ),
+        ).rejects.toMatchObject({
+            name: 'ExploreSplitError',
+            data: {
+                exploreName: 'test_table',
+                candidateExploreNames: [
+                    'sourceA__test_table',
+                    'sourceB__test_table',
+                ],
+            },
+        });
+    });
+
+    it('keeps saved chart loading unchanged for a plain missing explore', async () => {
+        vi.mocked(projectModel.getExploreFromCache).mockRejectedValueOnce(
+            new NotFoundError('Explore "test_table" does not exist.'),
+        );
+
+        await expect(
+            service.get(
+                'chart-uuid',
+                fromSession(adminUser, 'session-cookie'),
+                { projectUuid: 'project-uuid' },
+            ),
+        ).resolves.toMatchObject({
+            uuid: 'chart-uuid',
+            tableName: 'test_table',
+        });
     });
 
     it('duplicates a chart from its original slug base', async () => {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -16,6 +16,7 @@ import {
     CreateSchedulerAndTargetsWithoutIds,
     DeletedContentFilters,
     DeletedDbtChartContentSummary,
+    ExploreSplitError,
     ExploreType,
     ForbiddenError,
     generateSlug,
@@ -1370,6 +1371,16 @@ export class SavedChartService
 
         const { access, inheritsFromOrgOrProject } =
             await this.checkPermissions(account, space, savedChart);
+
+        try {
+            await this.projectModel.getExploreFromCache(
+                savedChart.projectUuid,
+                savedChart.tableName,
+            );
+        } catch (error) {
+            if (error instanceof ExploreSplitError) throw error;
+            if (!(error instanceof NotFoundError)) throw error;
+        }
 
         void this.analyticsModel
             .addChartViewEvent(

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -16,6 +16,7 @@ import {
     CreateSchedulerAndTargetsWithoutIds,
     DeletedContentFilters,
     DeletedDbtChartContentSummary,
+    ExploreSplitError,
     ExploreType,
     ForbiddenError,
     generateSlug,
@@ -1374,6 +1375,16 @@ export class SavedChartService
 
         const { access, inheritsFromOrgOrProject } =
             await this.checkPermissions(account, space, savedChart);
+
+        try {
+            await this.projectModel.getExploreFromCache(
+                savedChart.projectUuid,
+                savedChart.tableName,
+            );
+        } catch (error) {
+            if (error instanceof ExploreSplitError) throw error;
+            if (!(error instanceof NotFoundError)) throw error;
+        }
 
         void this.analyticsModel
             .addChartViewEvent(

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -178,6 +178,116 @@ describe('validation', () => {
             await validationService.generateValidation('projectUuid'),
         ).toEqual([]);
     });
+    it('Should report a split explore for a chart using the original name', async () => {
+        const sourceAExplore = {
+            ...explore,
+            name: 'sourceA__orders',
+            label: 'sourceA__orders',
+            baseTable: 'sourceA__orders',
+            tables: {
+                sourceA__orders: {
+                    ...explore.tables.table,
+                    name: 'sourceA__orders',
+                    originalName: 'orders',
+                },
+            },
+        };
+        const sourceBExplore = {
+            ...sourceAExplore,
+            name: 'sourceB__orders',
+            label: 'sourceB__orders',
+            baseTable: 'sourceB__orders',
+            tables: {
+                sourceB__orders: {
+                    ...sourceAExplore.tables.sourceA__orders,
+                    name: 'sourceB__orders',
+                },
+            },
+        };
+        vi.mocked(projectModel.findExploresFromCache).mockResolvedValueOnce({
+            [sourceAExplore.name]: sourceAExplore,
+            [sourceBExplore.name]: sourceBExplore,
+        });
+        vi.mocked(
+            savedChartModel.findChartsForValidation,
+        ).mockResolvedValueOnce([
+            {
+                ...chartForValidation,
+                tableName: 'orders',
+                filters: {},
+                dimensions: ['orders_amount'],
+                metrics: [],
+                sorts: [],
+                customMetrics: [],
+                tableCalculations: [],
+                customMetricsBaseDimensions: [],
+                customMetricsFilters: [],
+            },
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            undefined,
+            new Set([ValidationTarget.CHARTS]),
+        );
+
+        expect(errors).toEqual([
+            expect.objectContaining({
+                chartUuid: 'chartUuid',
+                error: 'Explore "orders" was split into "sourceA__orders" and "sourceB__orders". Pick one.',
+                errorType: 'explore split',
+                source: ValidationSourceType.Chart,
+            }),
+        ]);
+    });
+
+    it('keeps existing chart errors when an original name has one match', async () => {
+        const sourceAExplore = {
+            ...explore,
+            name: 'sourceA__orders',
+            label: 'sourceA__orders',
+            baseTable: 'sourceA__orders',
+            tables: {
+                sourceA__orders: {
+                    ...explore.tables.table,
+                    name: 'sourceA__orders',
+                    originalName: 'orders',
+                },
+            },
+        };
+        vi.mocked(projectModel.findExploresFromCache).mockResolvedValueOnce({
+            [sourceAExplore.name]: sourceAExplore,
+        });
+        vi.mocked(
+            savedChartModel.findChartsForValidation,
+        ).mockResolvedValueOnce([
+            {
+                ...chartForValidation,
+                tableName: 'orders',
+                filters: {},
+                dimensions: ['orders_amount'],
+                metrics: [],
+                sorts: [],
+                customMetrics: [],
+                tableCalculations: [],
+                customMetricsBaseDimensions: [],
+                customMetricsFilters: [],
+            },
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            undefined,
+            new Set([ValidationTarget.CHARTS]),
+        );
+
+        expect(errors).toEqual([
+            expect.objectContaining({
+                error: "Dimension error: the field 'orders_amount' no longer exists",
+                errorType: ValidationErrorType.Dimension,
+            }),
+        ]);
+    });
     it('Should validate project with dimension errors', async () => {
         (
             projectModel.findExploresFromCache as import('vitest').Mock

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -177,6 +177,116 @@ describe('validation', () => {
             await validationService.generateValidation('projectUuid'),
         ).toEqual([]);
     });
+    it('Should report a split explore for a chart using the original name', async () => {
+        const sourceAExplore = {
+            ...explore,
+            name: 'sourceA__orders',
+            label: 'sourceA__orders',
+            baseTable: 'sourceA__orders',
+            tables: {
+                sourceA__orders: {
+                    ...explore.tables.table,
+                    name: 'sourceA__orders',
+                    originalName: 'orders',
+                },
+            },
+        };
+        const sourceBExplore = {
+            ...sourceAExplore,
+            name: 'sourceB__orders',
+            label: 'sourceB__orders',
+            baseTable: 'sourceB__orders',
+            tables: {
+                sourceB__orders: {
+                    ...sourceAExplore.tables.sourceA__orders,
+                    name: 'sourceB__orders',
+                },
+            },
+        };
+        vi.mocked(projectModel.findExploresFromCache).mockResolvedValueOnce({
+            [sourceAExplore.name]: sourceAExplore,
+            [sourceBExplore.name]: sourceBExplore,
+        });
+        vi.mocked(
+            savedChartModel.findChartsForValidation,
+        ).mockResolvedValueOnce([
+            {
+                ...chartForValidation,
+                tableName: 'orders',
+                filters: {},
+                dimensions: ['orders_amount'],
+                metrics: [],
+                sorts: [],
+                customMetrics: [],
+                tableCalculations: [],
+                customMetricsBaseDimensions: [],
+                customMetricsFilters: [],
+            },
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            undefined,
+            new Set([ValidationTarget.CHARTS]),
+        );
+
+        expect(errors).toEqual([
+            expect.objectContaining({
+                chartUuid: 'chartUuid',
+                error: 'Explore "orders" was split into "sourceA__orders" and "sourceB__orders". Pick one.',
+                errorType: 'explore split',
+                source: ValidationSourceType.Chart,
+            }),
+        ]);
+    });
+
+    it('keeps existing chart errors when an original name has one match', async () => {
+        const sourceAExplore = {
+            ...explore,
+            name: 'sourceA__orders',
+            label: 'sourceA__orders',
+            baseTable: 'sourceA__orders',
+            tables: {
+                sourceA__orders: {
+                    ...explore.tables.table,
+                    name: 'sourceA__orders',
+                    originalName: 'orders',
+                },
+            },
+        };
+        vi.mocked(projectModel.findExploresFromCache).mockResolvedValueOnce({
+            [sourceAExplore.name]: sourceAExplore,
+        });
+        vi.mocked(
+            savedChartModel.findChartsForValidation,
+        ).mockResolvedValueOnce([
+            {
+                ...chartForValidation,
+                tableName: 'orders',
+                filters: {},
+                dimensions: ['orders_amount'],
+                metrics: [],
+                sorts: [],
+                customMetrics: [],
+                tableCalculations: [],
+                customMetricsBaseDimensions: [],
+                customMetricsFilters: [],
+            },
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            undefined,
+            new Set([ValidationTarget.CHARTS]),
+        );
+
+        expect(errors).toEqual([
+            expect.objectContaining({
+                error: "Dimension error: the field 'orders_amount' no longer exists",
+                errorType: ValidationErrorType.Dimension,
+            }),
+        ]);
+    });
     it('Should validate project with dimension errors', async () => {
         (
             projectModel.findExploresFromCache as import('vitest').Mock

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -13,9 +13,11 @@ import {
     DashboardTileTarget,
     Explore,
     ExploreError,
+    ExploreSplitError,
     ExploreType,
     FeatureFlags,
     ForbiddenError,
+    getExploreSplitCandidates,
     getFilterRules,
     getItemId,
     getUnusedDimensions,
@@ -405,6 +407,7 @@ export class ValidationService extends BaseService {
         exploreErrorNames: Set<string>,
         selectedExplores?: (Explore | ExploreError)[],
         chartUuid?: string,
+        allExplores: (Explore | ExploreError)[] = selectedExplores ?? [],
     ): Promise<CreateChartValidation[]> {
         const charts = await this.savedChartModel.findChartsForValidation(
             projectUuid,
@@ -443,6 +446,27 @@ export class ValidationService extends BaseService {
                     chartConfig,
                     pivotDimensions,
                 }) => {
+                    const splitCandidates = getExploreSplitCandidates(
+                        tableName,
+                        allExplores,
+                    );
+                    if (splitCandidates.length >= 2) {
+                        const splitError = new ExploreSplitError(
+                            tableName,
+                            splitCandidates,
+                        );
+                        return [
+                            {
+                                chartUuid: uuid,
+                                name,
+                                projectUuid,
+                                source: ValidationSourceType.Chart,
+                                chartName: name,
+                                errorType: ValidationErrorType.ExploreSplit,
+                                error: splitError.message,
+                            },
+                        ];
+                    }
                     const availableDimensionIds =
                         exploreFields[tableName]?.dimensionIds || [];
                     const availableCustomDimensionIds = [
@@ -1149,6 +1173,8 @@ export class ValidationService extends BaseService {
                       exploreFields,
                       ValidationService.buildExploreErrorNames(explores ?? []),
                       onlyValidateExploresInArgs ? compiledExplores : undefined,
+                      undefined,
+                      explores,
                   )
                 : [];
 

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -13,9 +13,11 @@ import {
     DashboardTileTarget,
     Explore,
     ExploreError,
+    ExploreSplitError,
     ExploreType,
     FeatureFlags,
     ForbiddenError,
+    getExploreSplitCandidates,
     getFilterRules,
     getItemId,
     getUnusedDimensions,
@@ -380,6 +382,7 @@ export class ValidationService extends BaseService {
         >,
         selectedExplores?: (Explore | ExploreError)[],
         chartUuid?: string,
+        allExplores: (Explore | ExploreError)[] = selectedExplores ?? [],
     ): Promise<CreateChartValidation[]> {
         const charts = await this.savedChartModel.findChartsForValidation(
             projectUuid,
@@ -418,6 +421,27 @@ export class ValidationService extends BaseService {
                     chartConfig,
                     pivotDimensions,
                 }) => {
+                    const splitCandidates = getExploreSplitCandidates(
+                        tableName,
+                        allExplores,
+                    );
+                    if (splitCandidates.length >= 2) {
+                        const splitError = new ExploreSplitError(
+                            tableName,
+                            splitCandidates,
+                        );
+                        return [
+                            {
+                                chartUuid: uuid,
+                                name,
+                                projectUuid,
+                                source: ValidationSourceType.Chart,
+                                chartName: name,
+                                errorType: ValidationErrorType.ExploreSplit,
+                                error: splitError.message,
+                            },
+                        ];
+                    }
                     const availableDimensionIds =
                         exploreFields[tableName]?.dimensionIds || [];
                     const availableCustomDimensionIds = [
@@ -1099,6 +1123,8 @@ export class ValidationService extends BaseService {
                       projectUuid,
                       exploreFields,
                       onlyValidateExploresInArgs ? compiledExplores : undefined,
+                      undefined,
+                      explores,
                   )
                 : [];
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -1393,7 +1393,7 @@ export type ApiErrorDetail = {
     name: string;
     statusCode: number;
     message: string;
-    data: { [key: string]: string };
+    data: { [key: string]: AnyType };
     sentryTraceId?: string;
     sentryEventId?: string;
 };

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -1501,7 +1501,7 @@ export type ApiErrorDetail = {
     name: string;
     statusCode: number;
     message: string;
-    data: { [key: string]: string };
+    data: { [key: string]: AnyType };
     sentryTraceId?: string;
     sentryEventId?: string;
 };

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -325,7 +325,6 @@ export class ExploreSplitError extends NotFoundError {
             `Explore "${exploreName}" was split into ${candidateList}. Pick one.`,
             { exploreName, candidateExploreNames },
         );
-        this.name = 'ExploreSplitError';
     }
 }
 

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -303,13 +303,29 @@ export class DbtError extends LightdashError {
 }
 
 export class NotFoundError extends LightdashError {
-    constructor(message: string) {
+    constructor(message: string, data: Record<string, AnyType> = {}) {
         super({
             message,
             name: 'NotFoundError',
             statusCode: 404,
-            data: {},
+            data,
         });
+    }
+}
+
+export class ExploreSplitError extends NotFoundError {
+    constructor(exploreName: string, candidateExploreNames: string[]) {
+        const quotedCandidates = candidateExploreNames.map(
+            (candidate) => `"${candidate}"`,
+        );
+        const candidateList = `${quotedCandidates
+            .slice(0, -1)
+            .join(', ')} and ${quotedCandidates.at(-1)}`;
+        super(
+            `Explore "${exploreName}" was split into ${candidateList}. Pick one.`,
+            { exploreName, candidateExploreNames },
+        );
+        this.name = 'ExploreSplitError';
     }
 }
 

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -148,6 +148,19 @@ export const isExploreError = (
     explore: Explore | ExploreError,
 ): explore is ExploreError => 'errors' in explore;
 
+export const getExploreSplitCandidates = (
+    exploreName: string,
+    explores: (Explore | ExploreError)[],
+): string[] => {
+    const candidates = explores.flatMap((explore) => {
+        if (isExploreError(explore)) return [];
+        const baseTable = explore.tables[explore.baseTable];
+        return baseTable?.originalName === exploreName ? [explore.name] : [];
+    });
+
+    return [...new Set(candidates)].sort();
+};
+
 type SummaryExploreFields =
     | 'name'
     | 'label'

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -176,7 +176,15 @@ export const getExploreSplitCandidates = (
     const candidates = explores.flatMap((explore) => {
         if (isExploreError(explore)) return [];
         const baseTable = explore.tables[explore.baseTable];
-        return baseTable?.originalName === exploreName ? [explore.name] : [];
+        const separatorIndex = explore.name.indexOf('__');
+        const originalExploreName =
+            separatorIndex === -1
+                ? undefined
+                : explore.name.slice(separatorIndex + 2);
+        return baseTable?.originalName === exploreName &&
+            originalExploreName === exploreName
+            ? [explore.name]
+            : [];
     });
 
     return [...new Set(candidates)].sort();

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -155,7 +155,15 @@ export const getExploreSplitCandidates = (
     const candidates = explores.flatMap((explore) => {
         if (isExploreError(explore)) return [];
         const baseTable = explore.tables[explore.baseTable];
-        return baseTable?.originalName === exploreName ? [explore.name] : [];
+        const separatorIndex = explore.name.indexOf('__');
+        const originalExploreName =
+            separatorIndex === -1
+                ? undefined
+                : explore.name.slice(separatorIndex + 2);
+        return baseTable?.originalName === exploreName &&
+            originalExploreName === exploreName
+            ? [explore.name]
+            : [];
     });
 
     return [...new Set(candidates)].sort();

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -169,6 +169,19 @@ export const isExploreError = (
     explore: Explore | ExploreError,
 ): explore is ExploreError => 'errors' in explore;
 
+export const getExploreSplitCandidates = (
+    exploreName: string,
+    explores: (Explore | ExploreError)[],
+): string[] => {
+    const candidates = explores.flatMap((explore) => {
+        if (isExploreError(explore)) return [];
+        const baseTable = explore.tables[explore.baseTable];
+        return baseTable?.originalName === exploreName ? [explore.name] : [];
+    });
+
+    return [...new Set(candidates)].sort();
+};
+
 type SummaryExploreFields =
     | 'name'
     | 'label'

--- a/packages/common/src/types/validation.ts
+++ b/packages/common/src/types/validation.ts
@@ -186,6 +186,7 @@ export enum ValidationErrorType {
     Dimension = 'dimension',
     CustomMetric = 'custom metric',
     ChartConfiguration = 'chart configuration',
+    ExploreSplit = 'explore split',
 }
 
 export enum DashboardFilterValidationErrorType {

--- a/packages/common/src/types/validation.ts
+++ b/packages/common/src/types/validation.ts
@@ -151,6 +151,7 @@ export enum ValidationErrorType {
     Dimension = 'dimension',
     CustomMetric = 'custom metric',
     ChartConfiguration = 'chart configuration',
+    ExploreSplit = 'explore split',
 }
 
 export enum DashboardFilterValidationErrorType {

--- a/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
@@ -405,7 +405,7 @@ const DbtSourcesPanel: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                         w={300}
                         withinPortal
                         position="right"
-                        label="Merge models from other git-backed dbt projects. They're combined with this project's dbt connection on every deploy and preview — if a name clashes between sources, the deploy fails until you rename or remove the duplicate."
+                        label="Merge models from other git-backed dbt projects. They're combined with this project's dbt connection on every deploy. If a model or metric name exists in more than one source, each one is renamed to <source>__<name>."
                     >
                         <ActionIcon
                             variant="subtle"

--- a/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
@@ -368,7 +368,7 @@ const DbtSourcesPanel: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                         w={300}
                         withinPortal
                         position="right"
-                        label="Merge models from other git-backed dbt projects. They're combined with this project's dbt connection on every deploy and preview — if a name clashes between sources, the deploy fails until you rename or remove the duplicate."
+                        label="Merge models from other git-backed dbt projects. They're combined with this project's dbt connection on every deploy. If a model or metric name exists in more than one source, each one is renamed to <source>__<name>."
                     >
                         <ActionIcon
                             variant="subtle"

--- a/packages/frontend/src/components/common/ErrorState/ErrorState.test.tsx
+++ b/packages/frontend/src/components/common/ErrorState/ErrorState.test.tsx
@@ -8,7 +8,7 @@ describe('ErrorState', () => {
             <MantineProvider>
                 <ErrorState
                     error={{
-                        name: 'ExploreSplitError',
+                        name: 'NotFoundError',
                         statusCode: 404,
                         message:
                             'Explore "orders" was split. Pick a replacement.',

--- a/packages/frontend/src/components/common/ErrorState/ErrorState.test.tsx
+++ b/packages/frontend/src/components/common/ErrorState/ErrorState.test.tsx
@@ -1,0 +1,31 @@
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import ErrorState from '.';
+
+describe('ErrorState', () => {
+    test('renders every candidate for a split explore', () => {
+        render(
+            <MantineProvider>
+                <ErrorState
+                    error={{
+                        name: 'ExploreSplitError',
+                        statusCode: 404,
+                        message:
+                            'Explore "orders" was split. Pick a replacement.',
+                        data: {
+                            exploreName: 'orders',
+                            candidateExploreNames: [
+                                'sourceA__orders',
+                                'sourceB__orders',
+                            ],
+                        },
+                    }}
+                />
+            </MantineProvider>,
+        );
+
+        expect(screen.getByText('Explore was split')).toBeInTheDocument();
+        expect(screen.getByText('sourceA__orders')).toBeInTheDocument();
+        expect(screen.getByText('sourceB__orders')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/common/ErrorState/index.tsx
+++ b/packages/frontend/src/components/common/ErrorState/index.tsx
@@ -11,6 +11,7 @@ import React, {
     type FC,
     type ReactNode,
 } from 'react';
+import { getCandidateExploreNames } from '../../../utils/exploreSplitError';
 import CodeBlock from '../CodeBlock/CodeBlock';
 import SuboptimalState from '../SuboptimalState/SuboptimalState';
 
@@ -50,14 +51,26 @@ const ErrorState: FC<{
                     )}
                 </>
             );
-            const candidateExploreNames = Array.isArray(
-                error.data?.candidateExploreNames,
-            )
-                ? error.data.candidateExploreNames.filter(
-                      (candidate): candidate is string =>
-                          typeof candidate === 'string',
-                  )
-                : [];
+            const candidateExploreNames = getCandidateExploreNames(error.data);
+            const isExploreSplitError =
+                error.statusCode === 404 &&
+                typeof error.data?.exploreName === 'string' &&
+                candidateExploreNames.length >= 2;
+            if (isExploreSplitError) {
+                return {
+                    icon: IconMoodPuzzled,
+                    title: 'Explore was split',
+                    description: (
+                        <Stack gap="xs" align="center">
+                            <Text maw={400}>{error.message}</Text>
+                            {candidateExploreNames.map((candidate) => (
+                                <Code key={candidate}>{candidate}</Code>
+                            ))}
+                        </Stack>
+                    ),
+                    action,
+                };
+            }
             switch (error.name) {
                 case 'ForbiddenError':
                     return {
@@ -76,20 +89,6 @@ const ErrorState: FC<{
                         icon: IconMoodPuzzled,
                         title: 'Not found',
                         description,
-                    };
-                case 'ExploreSplitError':
-                    return {
-                        icon: IconMoodPuzzled,
-                        title: 'Explore was split',
-                        description: (
-                            <Stack gap="xs" align="center">
-                                <Text maw={400}>{error.message}</Text>
-                                {candidateExploreNames.map((candidate) => (
-                                    <Code key={candidate}>{candidate}</Code>
-                                ))}
-                            </Stack>
-                        ),
-                        action,
                     };
                 default:
                     return {

--- a/packages/frontend/src/components/common/ErrorState/index.tsx
+++ b/packages/frontend/src/components/common/ErrorState/index.tsx
@@ -1,11 +1,16 @@
 import { type ApiErrorDetail } from '@lightdash/common';
-import { Text } from '@mantine/core';
+import { Code, Stack, Text } from '@mantine/core';
 import {
     IconAlertCircle,
     IconLock,
     IconMoodPuzzled,
 } from '@tabler/icons-react';
-import React, { useMemo, type ComponentProps, type FC } from 'react';
+import React, {
+    useMemo,
+    type ComponentProps,
+    type FC,
+    type ReactNode,
+} from 'react';
 import CodeBlock from '../CodeBlock/CodeBlock';
 import SuboptimalState from '../SuboptimalState/SuboptimalState';
 
@@ -18,7 +23,8 @@ const DEFAULT_ERROR_PROPS: ComponentProps<typeof SuboptimalState> = {
 const ErrorState: FC<{
     error?: ApiErrorDetail | null;
     hasMarginTop?: boolean;
-}> = ({ error, hasMarginTop = true }) => {
+    action?: ReactNode;
+}> = ({ error, hasMarginTop = true, action }) => {
     const props = useMemo<ComponentProps<typeof SuboptimalState>>(() => {
         if (!error) {
             return DEFAULT_ERROR_PROPS;
@@ -44,6 +50,14 @@ const ErrorState: FC<{
                     )}
                 </>
             );
+            const candidateExploreNames = Array.isArray(
+                error.data?.candidateExploreNames,
+            )
+                ? error.data.candidateExploreNames.filter(
+                      (candidate): candidate is string =>
+                          typeof candidate === 'string',
+                  )
+                : [];
             switch (error.name) {
                 case 'ForbiddenError':
                     return {
@@ -63,6 +77,20 @@ const ErrorState: FC<{
                         title: 'Not found',
                         description,
                     };
+                case 'ExploreSplitError':
+                    return {
+                        icon: IconMoodPuzzled,
+                        title: 'Explore was split',
+                        description: (
+                            <Stack gap="xs" align="center">
+                                <Text maw={400}>{error.message}</Text>
+                                {candidateExploreNames.map((candidate) => (
+                                    <Code key={candidate}>{candidate}</Code>
+                                ))}
+                            </Stack>
+                        ),
+                        action,
+                    };
                 default:
                     return {
                         ...DEFAULT_ERROR_PROPS,
@@ -72,7 +100,7 @@ const ErrorState: FC<{
         } catch {
             return DEFAULT_ERROR_PROPS;
         }
-    }, [error]);
+    }, [action, error]);
 
     return (
         <SuboptimalState mt={hasMarginTop ? '20px' : undefined} {...props} />

--- a/packages/frontend/src/components/common/modal/ChangeChartExploreModal.test.tsx
+++ b/packages/frontend/src/components/common/modal/ChangeChartExploreModal.test.tsx
@@ -1,0 +1,73 @@
+import { MantineProvider } from '@mantine/core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useExplores } from '../../../hooks/useExplores';
+import useApp from '../../../providers/App/useApp';
+import ChangeChartExploreModal from './ChangeChartExploreModal';
+
+vi.mock('../../../hooks/useExplores', () => ({
+    useExplores: vi.fn(),
+}));
+
+vi.mock('../../../providers/App/useApp', () => ({
+    default: vi.fn(),
+}));
+
+vi.mock('../../../hooks/toaster/useToaster', () => ({
+    default: () => ({
+        showToastSuccess: vi.fn(),
+        showToastError: vi.fn(),
+        showToastInfo: vi.fn(),
+    }),
+}));
+
+describe('ChangeChartExploreModal', () => {
+    test('offers only the exact split candidates', () => {
+        vi.mocked(useApp).mockReturnValue({
+            user: {
+                data: {
+                    ability: { can: vi.fn(() => false) },
+                    organizationUuid: 'organization-uuid',
+                },
+            },
+        } as never);
+        vi.mocked(useExplores).mockReturnValue({
+            data: [
+                { name: 'sourceA__orders', label: 'Source A orders' },
+                { name: 'sourceB__orders', label: 'Source B orders' },
+                {
+                    name: 'orders_with_custom_dims',
+                    label: 'Orders with custom dimensions',
+                },
+            ],
+            isLoading: false,
+        } as never);
+
+        render(
+            <QueryClientProvider client={new QueryClient()}>
+                <MantineProvider env="test">
+                    <ChangeChartExploreModal
+                        opened
+                        onClose={vi.fn()}
+                        projectUuid="project-uuid"
+                        chartUuid="chart-uuid"
+                        currentExploreName="orders"
+                        hasUnsavedChanges={false}
+                        candidateExploreNames={[
+                            'sourceA__orders',
+                            'sourceB__orders',
+                        ]}
+                    />
+                </MantineProvider>
+            </QueryClientProvider>,
+        );
+
+        fireEvent.click(screen.getByPlaceholderText('Select an explore'));
+
+        expect(screen.getByText('Source A orders')).toBeInTheDocument();
+        expect(screen.getByText('Source B orders')).toBeInTheDocument();
+        expect(
+            screen.queryByText('Orders with custom dimensions'),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/common/modal/ChangeChartExploreModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChangeChartExploreModal.tsx
@@ -61,6 +61,7 @@ interface ChangeChartExploreModalProps extends Pick<
     chartUuid: string;
     currentExploreName: string;
     hasUnsavedChanges: boolean;
+    candidateExploreNames?: string[];
 }
 
 const FORM_ID = 'change-chart-explore-form';
@@ -72,6 +73,7 @@ const ChangeChartExploreModal: FC<ChangeChartExploreModalProps> = ({
     chartUuid,
     currentExploreName,
     hasUnsavedChanges,
+    candidateExploreNames,
 }) => {
     const queryClient = useQueryClient();
     const { user } = useApp();
@@ -94,17 +96,22 @@ const ChangeChartExploreModal: FC<ChangeChartExploreModalProps> = ({
         true,
     );
 
-    const exploreOptions = useMemo(
-        () =>
-            (explores ?? [])
-                .filter((e) => !isSummaryExploreError(e))
-                .map((e) => ({
-                    value: e.name,
-                    label: e.label ?? e.name,
-                }))
-                .sort((a, b) => a.label.localeCompare(b.label)),
-        [explores],
-    );
+    const exploreOptions = useMemo(() => {
+        const candidateSet = candidateExploreNames
+            ? new Set(candidateExploreNames)
+            : undefined;
+        return (explores ?? [])
+            .reduce<{ value: string; label: string }[]>((acc, e) => {
+                if (
+                    !isSummaryExploreError(e) &&
+                    (candidateSet === undefined || candidateSet.has(e.name))
+                ) {
+                    acc.push({ value: e.name, label: e.label ?? e.name });
+                }
+                return acc;
+            }, [])
+            .sort((a, b) => a.label.localeCompare(b.label));
+    }, [candidateExploreNames, explores]);
 
     const { mutateAsync: rename, isLoading: isRenaming } = useMutation<
         ApiJobScheduledResponse['results'],

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -1,7 +1,10 @@
+import { Button } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import { lazy, memo, Suspense, useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
 import { useParams } from 'react-router';
 import ErrorState from '../components/common/ErrorState';
+import ChangeChartExploreModal from '../components/common/modal/ChangeChartExploreModal';
 import Page from '../components/common/Page/Page';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import Explorer from '../components/Explorer';
@@ -65,6 +68,8 @@ const SavedExplorer = () => {
         uuidOrSlug: savedQueryUuid,
         projectUuid,
     });
+    const [isChangeExploreModalOpen, changeExploreModalHandlers] =
+        useDisclosure(false);
 
     useEffect(() => {
         // If the saved explore is part of a dashboard, set the dashboard chart info
@@ -108,7 +113,45 @@ const SavedExplorer = () => {
 
     // Check for error first
     if (error) {
-        return <ErrorState error={error.error} />;
+        const exploreName = error.error.data?.exploreName;
+        const candidateExploreNames = Array.isArray(
+            error.error.data?.candidateExploreNames,
+        )
+            ? error.error.data.candidateExploreNames.filter(
+                  (candidate): candidate is string =>
+                      typeof candidate === 'string',
+              )
+            : [];
+        const isSplitExploreError =
+            error.error.name === 'ExploreSplitError' &&
+            typeof exploreName === 'string' &&
+            candidateExploreNames.length >= 2;
+
+        return (
+            <>
+                <ErrorState
+                    error={error.error}
+                    action={
+                        isSplitExploreError ? (
+                            <Button onClick={changeExploreModalHandlers.open}>
+                                Change explore
+                            </Button>
+                        ) : undefined
+                    }
+                />
+                {isSplitExploreError && projectUuid && savedQueryUuid && (
+                    <ChangeChartExploreModal
+                        opened={isChangeExploreModalOpen}
+                        onClose={changeExploreModalHandlers.close}
+                        projectUuid={projectUuid}
+                        chartUuid={savedQueryUuid}
+                        currentExploreName={exploreName}
+                        candidateExploreNames={candidateExploreNames}
+                        hasUnsavedChanges={false}
+                    />
+                )}
+            </>
+        );
     }
 
     // Early return if no data yet

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -21,6 +21,7 @@ import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
 import { useSavedQuery } from '../hooks/useSavedQuery';
 import useApp from '../providers/App/useApp';
 import { ExplorerSection } from '../providers/Explorer/types';
+import { getCandidateExploreNames } from '../utils/exploreSplitError';
 
 const LazyExplorePanel = lazy(
     () => import('../components/Explorer/ExplorePanel'),
@@ -114,16 +115,11 @@ const SavedExplorer = () => {
     // Check for error first
     if (error) {
         const exploreName = error.error.data?.exploreName;
-        const candidateExploreNames = Array.isArray(
-            error.error.data?.candidateExploreNames,
-        )
-            ? error.error.data.candidateExploreNames.filter(
-                  (candidate): candidate is string =>
-                      typeof candidate === 'string',
-              )
-            : [];
+        const candidateExploreNames = getCandidateExploreNames(
+            error.error.data,
+        );
         const isSplitExploreError =
-            error.error.name === 'ExploreSplitError' &&
+            error.error.statusCode === 404 &&
             typeof exploreName === 'string' &&
             candidateExploreNames.length >= 2;
 

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -1,7 +1,10 @@
+import { Button } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import { lazy, memo, Suspense, useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
 import { useParams } from 'react-router';
 import ErrorState from '../components/common/ErrorState';
+import ChangeChartExploreModal from '../components/common/modal/ChangeChartExploreModal';
 import Page from '../components/common/Page/Page';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import Explorer from '../components/Explorer';
@@ -71,6 +74,8 @@ const SavedExplorer = () => {
         uuidOrSlug: savedQueryUuid,
         projectUuid,
     });
+    const [isChangeExploreModalOpen, changeExploreModalHandlers] =
+        useDisclosure(false);
 
     useEffect(() => {
         // If the saved explore is part of a dashboard, set the dashboard chart info
@@ -115,7 +120,45 @@ const SavedExplorer = () => {
 
     // Check for error first
     if (error) {
-        return <ErrorState error={error.error} />;
+        const exploreName = error.error.data?.exploreName;
+        const candidateExploreNames = Array.isArray(
+            error.error.data?.candidateExploreNames,
+        )
+            ? error.error.data.candidateExploreNames.filter(
+                  (candidate): candidate is string =>
+                      typeof candidate === 'string',
+              )
+            : [];
+        const isSplitExploreError =
+            error.error.name === 'ExploreSplitError' &&
+            typeof exploreName === 'string' &&
+            candidateExploreNames.length >= 2;
+
+        return (
+            <>
+                <ErrorState
+                    error={error.error}
+                    action={
+                        isSplitExploreError ? (
+                            <Button onClick={changeExploreModalHandlers.open}>
+                                Change explore
+                            </Button>
+                        ) : undefined
+                    }
+                />
+                {isSplitExploreError && projectUuid && savedQueryUuid && (
+                    <ChangeChartExploreModal
+                        opened={isChangeExploreModalOpen}
+                        onClose={changeExploreModalHandlers.close}
+                        projectUuid={projectUuid}
+                        chartUuid={savedQueryUuid}
+                        currentExploreName={exploreName}
+                        candidateExploreNames={candidateExploreNames}
+                        hasUnsavedChanges={false}
+                    />
+                )}
+            </>
+        );
     }
 
     // Early return if no data yet

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -23,6 +23,7 @@ import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useSavedQuery } from '../hooks/useSavedQuery';
 import useApp from '../providers/App/useApp';
 import { ExplorerSection } from '../providers/Explorer/types';
+import { getCandidateExploreNames } from '../utils/exploreSplitError';
 
 const LazyExplorePanel = lazy(
     () => import('../components/Explorer/ExplorePanel'),
@@ -121,16 +122,11 @@ const SavedExplorer = () => {
     // Check for error first
     if (error) {
         const exploreName = error.error.data?.exploreName;
-        const candidateExploreNames = Array.isArray(
-            error.error.data?.candidateExploreNames,
-        )
-            ? error.error.data.candidateExploreNames.filter(
-                  (candidate): candidate is string =>
-                      typeof candidate === 'string',
-              )
-            : [];
+        const candidateExploreNames = getCandidateExploreNames(
+            error.error.data,
+        );
         const isSplitExploreError =
-            error.error.name === 'ExploreSplitError' &&
+            error.error.statusCode === 404 &&
             typeof exploreName === 'string' &&
             candidateExploreNames.length >= 2;
 

--- a/packages/frontend/src/utils/exploreSplitError.test.ts
+++ b/packages/frontend/src/utils/exploreSplitError.test.ts
@@ -1,0 +1,22 @@
+import { getCandidateExploreNames } from './exploreSplitError';
+
+describe('getCandidateExploreNames', () => {
+    test('keeps only serialized string candidates', () => {
+        expect(
+            getCandidateExploreNames({
+                candidateExploreNames: [
+                    'sourceA__orders',
+                    null,
+                    'sourceB__orders',
+                    42,
+                ],
+            }),
+        ).toEqual(['sourceA__orders', 'sourceB__orders']);
+    });
+
+    test('returns no candidates for an invalid serialized value', () => {
+        expect(
+            getCandidateExploreNames({ candidateExploreNames: 'orders' }),
+        ).toEqual([]);
+    });
+});

--- a/packages/frontend/src/utils/exploreSplitError.ts
+++ b/packages/frontend/src/utils/exploreSplitError.ts
@@ -1,0 +1,10 @@
+import { type ApiErrorDetail } from '@lightdash/common';
+
+export const getCandidateExploreNames = (
+    data: ApiErrorDetail['data'],
+): string[] =>
+    Array.isArray(data?.candidateExploreNames)
+        ? data.candidateExploreNames.filter(
+              (candidate): candidate is string => typeof candidate === 'string',
+          )
+        : [];


### PR DESCRIPTION
## What this change does

After #27444, a name collision splits an explore into two renamed explores, and the old bare name stops to exist. Saved content that points at the old name must fail with a clear message and a repair path. This change adds that.

- A new error type, `ExploreSplitError`, extends the not-found error. It carries the old name and the candidate names.
- Chart loading, explore resolution, and query execution detect the split case. They find the candidates through the stored original name of each renamed explore. Zero or one match keeps the normal not-found behaviour.
- The validation sweep after a deploy also detects the split case. A broken chart gets a specific error that names both candidates, distinct from the generic error.
- The error screen shows the message and a "pick one" action. The action opens the existing "change explore" modal, limited to the candidate explores.
- The modal uses the existing chart rename mechanism. The rename rewrites the explore name and all field references.
- The change does not select a candidate for the user, and it does not keep the old name as an alias. A wrong silent guess is the failure this policy removes.

## Why

A silent break becomes a mystifying break without this change. The user must see what happened and get a repair path. See the SPK-1029 resolution comment for the policy.

## Tests

- A chart that points at a name with two candidates gets the split error with both candidates. A name with no candidates gets the normal error.
- The validation sweep flags the split chart with the specific error type.
- The rename rewrites the explore name and the field references. The tests assert on the saved configuration.
- One-source projects show no change in behaviour.
- The error screen test covers the split state.
- Common: 3,558 tests pass. Backend: 7,128 tests pass. Frontend: 2,571 tests pass. Typecheck and lint pass.

Linear: SPK-1038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kyg5Qw8v4vLKfKb7Bh9gcj
