### PR TITLE
fix: stop the release-safety tooling from treating tests as migrations

### DIFF
--- a/scripts/ai-migration-review.ts
+++ b/scripts/ai-migration-review.ts
@@ -39,13 +39,13 @@
  */
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
+import { isMigrationPath } from './release-safety-migrations';
 
 const MODEL = 'claude-opus-4-8';
 const MIGRATION_DIRS = [
     'packages/backend/src/database/migrations',
     'packages/backend/src/ee/database/migrations',
 ];
-const MIGRATION_FILENAME_RE = /^\d{14}_.+\.(ts|js)$/;
 const MAX_FILE_CHARS = 8000;
 const MAX_TOOL_CALLS = 40;
 const MAX_GREP_LINES = 80;
@@ -105,7 +105,7 @@ export function addedMigrationPaths(
         const parts = line.split('\t');
         if (parts[0].charAt(0) !== 'A') continue;
         const p = parts[parts.length - 1];
-        if (MIGRATION_FILENAME_RE.test(p.split('/').pop() as string)) paths.push(p);
+        if (isMigrationPath(p)) paths.push(p);
     }
     return paths.sort();
 }

--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -121,6 +121,16 @@ test('detectMigrations counts only added timestamped files and splits EE', () =>
     ]);
 });
 
+test('detectMigrations ignores tests colocated with migrations', () => {
+    const result = detectMigrations([
+        change('A', `${core}/20260810000000_core.ts`),
+        change('A', `${core}/__tests__/20260810000000_core.test.ts`),
+        change('A', `${core}/20260810000002_core.spec.ts`),
+    ]);
+    assert.strictEqual(result.count, 1);
+    assert.deepStrictEqual(result.files, ['20260810000000_core.ts']);
+});
+
 test('detectMigrations surfaces deleted history without counting it', () => {
     const result = detectMigrations([
         change('D', `${core}/20200101000000_old.ts`),

--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -121,11 +121,10 @@ test('detectMigrations counts only added timestamped files and splits EE', () =>
     ]);
 });
 
-test('detectMigrations ignores tests colocated with migrations', () => {
+test('detectMigrations ignores migration tests knex never loads', () => {
     const result = detectMigrations([
         change('A', `${core}/20260810000000_core.ts`),
         change('A', `${core}/__tests__/20260810000000_core.test.ts`),
-        change('A', `${core}/20260810000002_core.spec.ts`),
     ]);
     assert.strictEqual(result.count, 1);
     assert.deepStrictEqual(result.files, ['20260810000000_core.ts']);

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -39,7 +39,7 @@ import {
     writeReleaseSafetyIndex,
 } from './release-safety-index';
 import type { MigrationDetail } from './release-safety-migrations';
-import { readMigrationMetadata } from './release-safety-migrations';
+import { isMigrationPath, readMigrationMetadata } from './release-safety-migrations';
 import {
     CarriedFloor,
     carriedUpgradeFloor,
@@ -64,9 +64,6 @@ const EE_MIGRATION_DIR = 'packages/backend/src/ee/database/migrations';
 const DECLARATION_DIRS = ['packages/backend', 'packages/common'] as const;
 const TYPESCRIPT_SOURCE = /^packages\/(backend|common)\/src\/.+\.tsx?$/;
 const TYPESCRIPT_TEST = /(^|\/)__tests__\/|\.(test|spec)\.tsx?$/;
-
-// Knex migration files are timestamped: YYYYMMDDHHMMSS_description.ts
-const MIGRATION_FILENAME_RE = /^\d{14}_.+\.(ts|js)$/;
 
 export interface GitChange {
     /** git --name-status code: A, M, D, R100, C75, ... */
@@ -94,8 +91,7 @@ export function detectMigrations(changes: GitChange[]): MigrationsResult {
     const deletedHistorical: string[] = [];
 
     for (const change of changes) {
-        const base = path.basename(change.path);
-        if (!MIGRATION_FILENAME_RE.test(base)) continue;
+        if (!isMigrationPath(change.path)) continue;
         const code = change.status.charAt(0);
         if (code === 'A') {
             added.push(change.path);
@@ -518,7 +514,7 @@ export async function generateReleaseSafety(
                 .filter(
                     (change) =>
                         change.status.startsWith('A') &&
-                        MIGRATION_FILENAME_RE.test(path.basename(change.path)),
+                        isMigrationPath(change.path),
                 )
                 .map((change) => change.path)
                 .sort();

--- a/scripts/release-safety-migrations.test.ts
+++ b/scripts/release-safety-migrations.test.ts
@@ -30,13 +30,19 @@ test('isMigrationPath accepts a timestamped migration', () => {
     assert.strictEqual(isMigrationPath(`${core}/20260810000000_add_column.js`), true);
 });
 
-test('isMigrationPath rejects a test that carries its migration timestamp', () => {
+test('isMigrationPath rejects a test knex never loads', () => {
     assert.strictEqual(
         isMigrationPath(`${core}/__tests__/20260810000000_add_column.test.ts`),
         false,
     );
-    assert.strictEqual(isMigrationPath(`${core}/20260810000000_add_column.spec.ts`), false);
     assert.strictEqual(isMigrationPath(`${core}/__tests__/helpers.ts`), false);
+});
+
+test('isMigrationPath keeps a timestamped file knex does load, whatever it is called', () => {
+    // Directly in the migration directory, so knex runs it. Skipping it would
+    // hide a file that breaks migrations in production.
+    assert.strictEqual(isMigrationPath(`${core}/20260810000000_add_column.test.ts`), true);
+    assert.strictEqual(isMigrationPath(`${core}/20260810000000_add_column.spec.ts`), true);
 });
 
 test('isMigrationPath rejects an untimestamped file', () => {

--- a/scripts/release-safety-migrations.test.ts
+++ b/scripts/release-safety-migrations.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
     analyzeMigrationSource,
+    isMigrationPath,
     readMigrationMetadata,
 } from './release-safety-migrations';
 
@@ -21,6 +22,27 @@ function test(name: string, fn: () => void): void {
         );
     }
 }
+
+const core = 'packages/backend/src/database/migrations';
+
+test('isMigrationPath accepts a timestamped migration', () => {
+    assert.strictEqual(isMigrationPath(`${core}/20260810000000_add_column.ts`), true);
+    assert.strictEqual(isMigrationPath(`${core}/20260810000000_add_column.js`), true);
+});
+
+test('isMigrationPath rejects a test that carries its migration timestamp', () => {
+    assert.strictEqual(
+        isMigrationPath(`${core}/__tests__/20260810000000_add_column.test.ts`),
+        false,
+    );
+    assert.strictEqual(isMigrationPath(`${core}/20260810000000_add_column.spec.ts`), false);
+    assert.strictEqual(isMigrationPath(`${core}/__tests__/helpers.ts`), false);
+});
+
+test('isMigrationPath rejects an untimestamped file', () => {
+    assert.strictEqual(isMigrationPath(`${core}/README.md`), false);
+    assert.strictEqual(isMigrationPath(`${core}/add_column.ts`), false);
+});
 
 test('analyzer reads core tables and forward heaviness only', () => {
     const result = analyzeMigrationSource(

--- a/scripts/release-safety-migrations.ts
+++ b/scripts/release-safety-migrations.ts
@@ -1,5 +1,28 @@
 import { execFileSync } from 'node:child_process';
 
+/** Knex migration files are timestamped: YYYYMMDDHHMMSS_description.ts */
+const MIGRATION_FILENAME_RE = /^\d{14}_.+\.(ts|js)$/;
+
+/** Same shape the declaration scan uses to spot a test. */
+const TEST_FILE_RE = /(^|\/)__tests__\/|\.(test|spec)\.(ts|js)$/;
+
+/**
+ * PURE. Is this path a migration the release-safety tooling should act on?
+ *
+ * A test that carries its migration's timestamp is not one. It exports no
+ * `up`/`down`, it changes no schema, and the repo already colocates such tests
+ * (`migrations/__tests__/<timestamp>_<name>.test.ts`). Counting one inflates the
+ * shipped marker, feeds a non-migration to the code-aware review, and fails the
+ * linter with advice — "export a down function" — that cannot be followed.
+ *
+ * Callers still scope the diff to the migration directories; this decides what
+ * counts as a migration inside them.
+ */
+export function isMigrationPath(filePath: string): boolean {
+    if (TEST_FILE_RE.test(filePath)) return false;
+    return MIGRATION_FILENAME_RE.test(filePath.split('/').pop() ?? '');
+}
+
 export interface MigrationHeaviness {
     locksTable: boolean | 'unknown';
     rewritesTable: boolean | 'unknown';

--- a/scripts/release-safety-migrations.ts
+++ b/scripts/release-safety-migrations.ts
@@ -3,23 +3,32 @@ import { execFileSync } from 'node:child_process';
 /** Knex migration files are timestamped: YYYYMMDDHHMMSS_description.ts */
 const MIGRATION_FILENAME_RE = /^\d{14}_.+\.(ts|js)$/;
 
-/** Same shape the declaration scan uses to spot a test. */
-const TEST_FILE_RE = /(^|\/)__tests__\/|\.(test|spec)\.(ts|js)$/;
+/**
+ * Knex reads each migration directory non-recursively, so a file under
+ * `__tests__/` is never run as a migration even when it is named after one.
+ */
+const MIGRATION_TEST_PATH_RE = /(^|\/)__tests__\//;
 
 /**
  * PURE. Is this path a migration the release-safety tooling should act on?
  *
- * A test that carries its migration's timestamp is not one. It exports no
- * `up`/`down`, it changes no schema, and the repo already colocates such tests
- * (`migrations/__tests__/<timestamp>_<name>.test.ts`). Counting one inflates the
- * shipped marker, feeds a non-migration to the code-aware review, and fails the
- * linter with advice — "export a down function" — that cannot be followed.
+ * The test for a migration is not one. The repo colocates such tests as
+ * `migrations/__tests__/<timestamp>_<name>.test.ts`, and knex never loads them.
+ * Counting one inflates the shipped marker, feeds a non-migration to the
+ * code-aware review, and fails the linter with advice — "export a down
+ * function" — that cannot be followed.
+ *
+ * The rule is the directory, not the file name. A timestamped file sitting
+ * directly in a migration directory IS loaded by knex, whatever it is called, so
+ * a stray `<timestamp>_<name>.test.ts` there stays in scope: it will run as a
+ * migration in production, and that is exactly what this tooling exists to
+ * catch.
  *
  * Callers still scope the diff to the migration directories; this decides what
  * counts as a migration inside them.
  */
 export function isMigrationPath(filePath: string): boolean {
-    if (TEST_FILE_RE.test(filePath)) return false;
+    if (MIGRATION_TEST_PATH_RE.test(filePath)) return false;
     return MIGRATION_FILENAME_RE.test(filePath.split('/').pop() ?? '');
 }
 

--- a/scripts/sql-migration-lint.test.ts
+++ b/scripts/sql-migration-lint.test.ts
@@ -434,6 +434,19 @@ export async function down(knex) { await knex.raw('DROP INDEX CONCURRENTLY IF EX
     assert.ok(!enforcementRules(source, 'warning').includes('concurrent-index-invalid-retry'));
 });
 
+test('changed migration paths exclude tests colocated with migrations', () => {
+    const root = 'packages/backend/src/database/migrations';
+    const paths = changedMigrationPathsFromNameStatus(
+        [
+            `A\t${root}/20260101000000_added.ts`,
+            `A\t${root}/__tests__/20260101000000_added.test.ts`,
+            `A\t${root}/20260101000005_added.spec.ts`,
+        ].join('\n'),
+        () => true,
+    );
+    assert.deepStrictEqual(paths, [`${root}/20260101000000_added.ts`]);
+});
+
 test('changed migration paths include existing A M R C destinations and exclude deletes', () => {
     const root = 'packages/backend/src/database/migrations';
     const paths = changedMigrationPathsFromNameStatus(

--- a/scripts/sql-migration-lint.test.ts
+++ b/scripts/sql-migration-lint.test.ts
@@ -440,7 +440,6 @@ test('changed migration paths exclude tests colocated with migrations', () => {
         [
             `A\t${root}/20260101000000_added.ts`,
             `A\t${root}/__tests__/20260101000000_added.test.ts`,
-            `A\t${root}/20260101000005_added.spec.ts`,
         ].join('\n'),
         () => true,
     );

--- a/scripts/sql-migration-lint.ts
+++ b/scripts/sql-migration-lint.ts
@@ -42,6 +42,7 @@ import {
     hollowBreakingReasonMessage,
     isSubstantiveBreakingReason,
 } from './breaking-change-gate-policy';
+import { isMigrationPath } from './release-safety-migrations';
 
 export interface SqlLintFinding {
     file: string;
@@ -296,7 +297,6 @@ const MIGRATION_DIRS = [
     'packages/backend/src/database/migrations',
     'packages/backend/src/ee/database/migrations',
 ];
-const MIGRATION_FILENAME_RE = /^\d{14}_.+\.(ts|js)$/;
 
 interface RawCall {
     index: number;
@@ -852,7 +852,7 @@ export function changedMigrationPathsFromNameStatus(
         const path = fields[fields.length - 1];
         if (
             MIGRATION_DIRS.some((directory) => path.startsWith(`${directory}/`)) &&
-            MIGRATION_FILENAME_RE.test(path.split('/').pop() ?? '') &&
+            isMigrationPath(path) &&
             exists(path)
         ) {
             paths.push(path);


### PR DESCRIPTION
## What this change does

A test that knex never loads is no longer treated as a migration.

The filter appears in three scripts and is the same in each: the path sits under a migration directory, at any depth, and the file name matches `/^\d{14}_.+\.(ts|js)$/`. The `.+` matches the `.test` part of the name, so `migrations/__tests__/20260816210000_create_project_merged_manifests.test.ts` passes both halves.

The three copies move to one `isMigrationPath` in `release-safety-migrations.ts`, which excludes a `__tests__/` path segment.

The rule is the directory, not the file name. Knex reads each migration directory non-recursively, so nothing under `__tests__/` is ever run. A timestamped file sitting directly in a migration directory IS loaded by knex whatever it is called, so a stray `<timestamp>_<name>.test.ts` there stays in scope. It would run as a migration in production, and that is the case this tooling exists to catch.

## Why

Three effects, all seen on one pull request:

1. `sql-migration-lint.ts` linted the test and failed the required check with `migration must export a down function`. The advice cannot be followed, because the file is a test.
2. `gen-release-safety.ts` counted the test as a migration. The marker read `count: 2` and listed the test with `heaviness: unknown`. That number ships to self-hosted operators in `release-safety.json`.
3. `ai-migration-review.ts` passed the test to the code-aware review as a migration.

The convention is already in the repository: `migrations/__tests__/20260720223000_unique_onboarding_organization.test.ts` is on main.

## Evidence

The two files from the affected branch, replayed through the scripts in this branch:

```
# linter, before:  checked 2 changed migration(s): 1 error(s), 0 warning(s)   [missing-down]
# linter, after:   checked 1 changed migration(s): 0 error(s), 0 warning(s)   exit 0

# marker, before:  count: 2  (the test listed with heaviness: unknown)
# marker, after:   present: true  count: 1  files: [ '20260816210000_create_project_merged_manifests.ts' ]
```

The real migration in that pair is still linted and still counted.

## Tests

- `release-safety-migrations.test.ts`: `isMigrationPath` accepts a timestamped migration, rejects anything under `__tests__/`, and keeps a timestamped file that sits directly in the directory whatever its name.
- `sql-migration-lint.test.ts`: changed-path selection drops colocated tests and keeps the migration.
- `gen-release-safety.test.ts`: `detectMigrations` counts the migration only.

The full `scripts/*.test.ts` suite passes locally.

Linear: SPK-1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRsTpr8ZFVdmfXX3Hm8fNL