### PR TITLE
fix: show a failed gate in the upgrade-safety headline

### DIFF
--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -78,6 +78,24 @@ test('a declaration gate failure renders remediation for an otherwise green mark
     assert.match(body, /API or type break/);
 });
 
+test('a failed gate never leaves a green headline above a red check', () => {
+    for (const opts of [{ declarationGateFailed: true }, { gateFailed: true }]) {
+        const body = renderPrComment(baseMarker(), opts);
+        assert.doesNotMatch(body, /✅ \*\*Safe to upgrade normally/);
+        assert.match(body, /A required check failed/);
+        // The verdict itself is unchanged, and the reader is told so.
+        assert.match(body, /The upgrade itself looks safe/);
+        assert.match(body, /How to unblock this pull request/);
+    }
+});
+
+test('a green marker with no failed gate keeps its safe headline', () => {
+    const body = renderPrComment(baseMarker());
+    assert.match(body, /✅ \*\*Safe to upgrade normally/);
+    assert.doesNotMatch(body, /A required check failed/);
+    assert.doesNotMatch(body, /How to unblock this pull request/);
+});
+
 test('migration and enterprise counts use the v2 split', () => {
     const body = renderPrComment(
         baseMarker({

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -91,7 +91,12 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
     const clearedAsSafeDrop = lintFlagged && rollingUpdateSafe === true;
     // The risk comes from an API change (no DB migration) rather than the schema.
     const apiDriven = (restBreaking || mcpBreaking) && migrationsPresent !== true;
-    const needsUnblock = rollingUpdateSafe !== true || opts.declarationGateFailed === true;
+    // Any failed gate needs remediation text, or the downgraded headline below
+    // names a problem the comment never explains.
+    const needsUnblock =
+        rollingUpdateSafe !== true ||
+        opts.declarationGateFailed === true ||
+        opts.gateFailed === true;
 
     // ---- the answer, in one line + a plain "why" ----------------------------
     const head: string[] = [];
@@ -155,6 +160,18 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
             head[safe] = '❓ **Couldn’t confirm it’s safe.** Part of the check didn’t run.';
         }
         head.push('⚠️ **The REST API check didn’t run** — its OpenAPI specs couldn’t be generated, so a change that breaks scripts or integrations wouldn’t have been spotted here.');
+    }
+
+    // A failed gate is not a verdict about the upgrade: the declaration gate can
+    // fail while the marker is green, and that separation is deliberate. The
+    // headline is still the line people read, and "Safe to upgrade normally" above
+    // a red required check reads as a contradiction — the author trusts one of the
+    // two and ignores the other. Keep both facts, and lead with the blocking one.
+    if (opts.gateFailed === true || opts.declarationGateFailed === true) {
+        const safe = head.indexOf(SAFE_HEADLINE);
+        if (safe >= 0) {
+            head[safe] = '⚠️ **A required check failed.** The upgrade itself looks safe — this is about the check, not the release.';
+        }
     }
 
     // ---- what we looked at (plain, no internal tool names) ------------------


### PR DESCRIPTION
## What this change does

The upgrade-safety comment no longer says "Safe to upgrade normally" while its own required check is red.

Seen on a pull request whose release-safety gate failed:

```
- ✅ Safe to upgrade normally. No downtime needed.
- This changes the database, and the old version keeps working with those changes through the upgrade.
...
**How to unblock this pull request**
This required check must pass before merge.
```

Safe and unblock-me in one comment.

## Cause

The headline reads `rollingUpdateSafe` alone. The gate signals arrive separately as `declarationGateFailed` and `gateFailed`, and they reached only the remediation block and the hidden stamp. The marker was `rollingUpdateSafe: true`, because the failure was a declaration-gate failure and the linter's raw verdict was passed as `--no-linter-breaking`.

The verdict and the gate are independent by design, and that stays. A green marker with a red gate is a real state. The comment just has to say so.

## What it looks like now

The same marker, replayed with the flags that run produced:

```
- ⚠️ A required check failed. The upgrade itself looks safe — this is about the check, not the release.
- This changes the database, and the old version keeps working with those changes through the upgrade.
```

The reader keeps the verdict and learns which fact blocks the merge. The existing "How to unblock this pull request" block explains what to fix.

A failed gate now also always renders that block. Before, `gateFailed` on its own did not, so the new headline could have named a problem the comment never explained.

## Tests

- A failed gate, from either signal, never leaves the safe headline, states the verdict is still green, and renders the remediation block.
- A green marker with no failed gate keeps its safe headline and renders no remediation block.

The new negative case fails on the old renderer. 18 tests pass.

Linear: SPK-1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRsTpr8ZFVdmfXX3Hm8fNL