### PR TITLE
feat: the CLI fetches the served merged manifest for previews

### DIFF
--- a/packages/cli/src/dbt/manifest.test.ts
+++ b/packages/cli/src/dbt/manifest.test.ts
@@ -64,6 +64,10 @@ describe('loadCombineManifest', () => {
         });
         mockedFetch.mockResolvedValue({
             ok: true,
+            headers: {
+                get: (name: string) =>
+                    name === 'content-type' ? 'application/json' : null,
+            },
             text: async () => JSON.stringify(manifest),
         });
 
@@ -83,6 +87,9 @@ describe('loadCombineManifest', () => {
             ok: false,
             status: 404,
             statusText: 'Not Found',
+            headers: {
+                get: () => 'application/json',
+            },
             text: async () => '',
         });
 
@@ -90,6 +97,105 @@ describe('loadCombineManifest', () => {
             loadCombineManifest('https://example.com/manifest.json'),
         ).rejects.toThrow(
             'Could not load manifest from https://example.com/manifest.json',
+        );
+    });
+
+    test('reports the Lightdash dev app fallback as a missing manifest', async () => {
+        mockedFetch.mockResolvedValue({
+            ok: false,
+            status: 500,
+            statusText: 'Internal Server Error',
+            headers: {
+                get: (name: string) => {
+                    if (name === 'content-type') {
+                        return 'application/json; charset=utf-8';
+                    }
+                    if (name === 'lightdash-version') return '1.163.2';
+                    return null;
+                },
+            },
+            text: async () =>
+                JSON.stringify({
+                    status: 'error',
+                    error: {
+                        statusCode: 500,
+                        name: 'UnexpectedServerError',
+                        message: 'Something went wrong.',
+                        data: {},
+                    },
+                }),
+        });
+
+        const promise = loadCombineManifest(
+            'http://localhost:8080/charter5-does-not-exist/manifest.json',
+        );
+
+        await expect(promise).rejects.toThrow('Manifest not found');
+        await expect(promise).rejects.not.toThrow('500 Internal Server Error');
+    });
+
+    test('reports the Lightdash production html fallback as a missing manifest', async () => {
+        mockedFetch.mockResolvedValue({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            headers: {
+                get: (name: string) => {
+                    if (name === 'content-type') {
+                        return 'text/html; charset=utf-8';
+                    }
+                    if (name === 'lightdash-version') return '1.163.2';
+                    return null;
+                },
+            },
+            text: async () =>
+                '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
+        });
+
+        await expect(
+            loadCombineManifest(
+                'https://lightdash.example.com/missing/manifest.json',
+            ),
+        ).rejects.toThrow('Manifest not found');
+    });
+
+    test.each([
+        [
+            'a Lightdash API error',
+            'https://lightdash.example.com/api/v1/missing/manifest.json',
+            '1.163.2',
+        ],
+        [
+            'an unmarked external error',
+            'https://example.com/missing/manifest.json',
+            null,
+        ],
+    ])('preserves %s', async (_description, url, lightdashVersion) => {
+        mockedFetch.mockResolvedValue({
+            ok: false,
+            status: 500,
+            statusText: 'Internal Server Error',
+            headers: {
+                get: (name: string) => {
+                    if (name === 'content-type') return 'application/json';
+                    if (name === 'lightdash-version') return lightdashVersion;
+                    return null;
+                },
+            },
+            text: async () =>
+                JSON.stringify({
+                    status: 'error',
+                    error: {
+                        statusCode: 500,
+                        name: 'UnexpectedServerError',
+                        message: 'Something went wrong.',
+                        data: {},
+                    },
+                }),
+        });
+
+        await expect(loadCombineManifest(url)).rejects.toThrow(
+            '500 Internal Server Error',
         );
     });
 

--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -1,4 +1,9 @@
-import { DbtManifest, getErrorMessage, ParseError } from '@lightdash/common';
+import {
+    DbtManifest,
+    getErrorMessage,
+    isApiError,
+    ParseError,
+} from '@lightdash/common';
 import { promises as fs } from 'fs';
 import fetch from 'node-fetch';
 import * as path from 'path';
@@ -48,14 +53,65 @@ export const isHttpUrl = (value: string): boolean => {
     }
 };
 
+const isGenericUnexpectedServerError = (responseText: string): boolean => {
+    try {
+        const response = JSON.parse(responseText) as unknown;
+        if (!isApiError(response)) return false;
+        const { error } = response;
+        return (
+            error.statusCode === 500 &&
+            error.name === 'UnexpectedServerError' &&
+            error.message === 'Something went wrong.'
+        );
+    } catch {
+        return false;
+    }
+};
+
+const isLightdashFrontendFallback = (
+    url: string,
+    response: Awaited<ReturnType<typeof fetch>>,
+    responseText: string,
+): boolean => {
+    const { pathname } = new URL(url);
+    const isFrontendPath = pathname !== '/api' && !pathname.startsWith('/api/');
+    const isLightdashResponse =
+        response.headers.get('lightdash-version') !== null;
+    const isHtmlResponse =
+        response.headers.get('content-type')?.includes('text/html') === true ||
+        /^\s*(?:<!doctype html|<html)/i.test(responseText);
+
+    return (
+        isFrontendPath &&
+        isLightdashResponse &&
+        (isHtmlResponse || isGenericUnexpectedServerError(responseText))
+    );
+};
+
 const loadManifestFromUrl = async (url: string): Promise<DbtManifest> => {
     globalState.debug(`> Loading dbt manifest from ${url}`);
     try {
         const response = await fetch(url);
+        const responseText = await response.text();
+        const isFrontendFallback = isLightdashFrontendFallback(
+            url,
+            response,
+            responseText,
+        );
         if (!response.ok) {
+            if (isFrontendFallback) {
+                throw new Error(
+                    'Manifest not found: the URL resolves to a Lightdash app route instead of a dbt manifest',
+                );
+            }
             throw new Error(`${response.status} ${response.statusText}`);
         }
-        const manifest = JSON.parse(await response.text()) as DbtManifest;
+        if (isFrontendFallback) {
+            throw new Error(
+                'Manifest not found: the URL resolves to a Lightdash app route instead of a dbt manifest',
+            );
+        }
+        const manifest = JSON.parse(responseText) as DbtManifest;
         return manifest;
     } catch (err: unknown) {
         const msg = getErrorMessage(err);

--- a/packages/cli/src/dbt/validation.test.ts
+++ b/packages/cli/src/dbt/validation.test.ts
@@ -1,12 +1,14 @@
 import {
     DbtManifestVersion,
     InlineErrorType,
+    ManifestValidator,
     type DbtRawModelNode,
 } from '@lightdash/common';
 import { validateDbtModel } from './validation';
 
 const makeModel = (name: string): DbtRawModelNode =>
     ({
+        unique_id: `model.test.${name}`,
         name,
         resource_type: 'model',
         database: 'database',
@@ -15,6 +17,44 @@ const makeModel = (name: string): DbtRawModelNode =>
     }) as unknown as DbtRawModelNode;
 
 describe('validateDbtModel', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test('directs served manifest validation failures to a project redeploy', async () => {
+        const validationMessage =
+            'Model "served_orders" from dbt source "server": Field at model root must have required property \'original_file_path\'. Update this field in your dbt model, then deploy again.';
+        const invalidValidator = Object.assign(vi.fn().mockReturnValue(false), {
+            errors: [],
+        }) as unknown as ReturnType<typeof ManifestValidator.getValidator>;
+        vi.spyOn(ManifestValidator, 'getValidator').mockReturnValue(
+            invalidValidator,
+        );
+        vi.spyOn(ManifestValidator, 'formatAjvErrors').mockReturnValue(
+            validationMessage,
+        );
+        const servedModel = makeModel('served_orders');
+        const localModel = makeModel('local_orders');
+
+        const result = await validateDbtModel(
+            'postgres',
+            DbtManifestVersion.V11,
+            [servedModel, localModel],
+            new Set([servedModel.unique_id]),
+        );
+
+        const servedMessage = result.invalid[0].errors[0].message;
+        const localMessage = result.invalid[1].errors[0].message;
+        expect(servedMessage).toContain('The served manifest is outdated.');
+        expect(servedMessage).toContain(
+            'Redeploy the Lightdash project, then try again.',
+        );
+        expect(servedMessage).not.toContain(
+            'Update this field in your dbt model',
+        );
+        expect(localMessage).toContain('Update this field in your dbt model');
+    });
+
     test('keeps valid v12 models when column config metadata is invalid', async () => {
         const validModel = makeModel('valid_orders');
         const invalidModel = {

--- a/packages/cli/src/dbt/validation.ts
+++ b/packages/cli/src/dbt/validation.ts
@@ -17,10 +17,23 @@ type DbtModelsGroupedByState = {
     invalid: ExploreError[];
     skipped: DbtRawModelNode[];
 };
+
+const formatServedManifestValidationError = (message: string): string => {
+    const details = message
+        .replace(
+            / (?:Remove or update it|Update this field) in your dbt model, then deploy again\./g,
+            '',
+        )
+        .trimEnd();
+    const separator = /[.!?]$/.test(details) ? ' ' : '. ';
+    return `${details}${separator}The served manifest is outdated. Redeploy the Lightdash project, then try again.`;
+};
+
 export const validateDbtModel = async (
     adapterType: string,
     manifestVersion: DbtManifestVersion,
     models: DbtRawModelNode[],
+    servedModelIds: ReadonlySet<string> = new Set(),
 ): Promise<DbtModelsGroupedByState> => {
     GlobalState.debug(`> Validating ${models.length} models from dbt manifest`);
 
@@ -37,7 +50,9 @@ export const validateDbtModel = async (
             if (!isValid) {
                 error = {
                     type: InlineErrorType.METADATA_PARSE_ERROR,
-                    message: errorMessage,
+                    message: servedModelIds.has(model.unique_id)
+                        ? formatServedManifestValidationError(errorMessage)
+                        : errorMessage,
                 };
             } else if (isValid && Object.values(model.columns).length <= 0) {
                 error = {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -97,6 +97,50 @@ export const stripWarehouseColumnErrors = (
         : exploreWithoutWarnings;
 };
 
+type SourceAnnotatedDbtNode = DbtManifest['nodes'][string] & {
+    lightdash_source_name?: unknown;
+};
+
+const getManifestModelIds = (manifest: DbtManifest): string[] =>
+    Object.entries(manifest.nodes)
+        .filter(([, node]) => node.resource_type === 'model')
+        .map(([uniqueId]) => uniqueId);
+
+const getCompiledManifestModelIds = (manifest: DbtManifest): string[] =>
+    Object.entries(manifest.nodes)
+        .filter(
+            ([, node]) =>
+                node.resource_type === 'model' &&
+                (node as SourceAnnotatedDbtNode & { compiled?: boolean })
+                    .compiled === true,
+        )
+        .map(([uniqueId]) => uniqueId);
+
+const combinePreviewManifests = (
+    localManifest: DbtManifest,
+    externalManifest: DbtManifest,
+) => {
+    const { manifest, addedModelIds } = combineManifests(
+        localManifest,
+        externalManifest,
+    );
+    const nodes = { ...manifest.nodes };
+
+    Object.keys(localManifest.nodes).forEach((uniqueId) => {
+        const externalNode = externalManifest.nodes[uniqueId] as
+            | SourceAnnotatedDbtNode
+            | undefined;
+        if (typeof externalNode?.lightdash_source_name === 'string') {
+            nodes[uniqueId] = {
+                ...nodes[uniqueId],
+                lightdash_source_name: externalNode.lightdash_source_name,
+            } as DbtManifest['nodes'][string];
+        }
+    });
+
+    return { manifest: { ...manifest, nodes }, addedModelIds };
+};
+
 const getDisplayableDiagnostics = (
     explore: Explore,
     allowPartialCompilation: boolean,
@@ -400,6 +444,7 @@ export const compileProject = async (
         let effectiveCompiledModelIds = compiledModelIds;
         let additionalManifest: DbtManifest | undefined;
         let combineSource: string | undefined;
+        let isAutomaticServerManifest = false;
         if (options.combineManifest) {
             additionalManifest = await loadCombineManifest(
                 options.combineManifest,
@@ -417,6 +462,7 @@ export const compileProject = async (
                 });
                 additionalManifest = (await response.json()) as DbtManifest;
                 combineSource = 'manifest from the server';
+                isAutomaticServerManifest = true;
             } catch (error) {
                 if (
                     !(error instanceof LightdashError) ||
@@ -431,25 +477,48 @@ export const compileProject = async (
             }
         }
         if (additionalManifest && combineSource) {
-            const { manifest: merged, addedModelIds } = combineManifests(
-                manifest,
-                additionalManifest,
+            const localModelIds = new Set(getManifestModelIds(manifest));
+            const externalModelIds = getManifestModelIds(additionalManifest);
+            const localSourceExists = externalModelIds.some((uniqueId) =>
+                localModelIds.has(uniqueId),
             );
-            manifest = merged;
-            if (
-                effectiveCompiledModelIds !== undefined &&
-                addedModelIds.length > 0
-            ) {
-                effectiveCompiledModelIds = [
-                    ...effectiveCompiledModelIds,
-                    ...addedModelIds,
-                ];
+
+            if (isAutomaticServerManifest && !localSourceExists) {
+                console.info(
+                    styles.info(
+                        `Skipped combining ${combineSource}: the local dbt project is not a source of this Lightdash project`,
+                    ),
+                );
+            } else {
+                const compiledExternalModelIds =
+                    getCompiledManifestModelIds(additionalManifest);
+                const { manifest: merged, addedModelIds } =
+                    combinePreviewManifests(manifest, additionalManifest);
+                manifest = merged;
+                if (
+                    effectiveCompiledModelIds !== undefined &&
+                    addedModelIds.length > 0
+                ) {
+                    effectiveCompiledModelIds = [
+                        ...effectiveCompiledModelIds,
+                        ...addedModelIds,
+                    ];
+                }
+
+                let combineResult: string;
+                if (addedModelIds.length > 0) {
+                    combineResult = `added ${addedModelIds.length} model(s) not present in the preview manifest`;
+                } else if (compiledExternalModelIds.length === 0) {
+                    combineResult =
+                        'added 0 model(s) because the manifest contains no compiled models';
+                } else {
+                    combineResult =
+                        'added 0 model(s) because all compiled models already exist in the preview manifest';
+                }
+                console.info(
+                    styles.info(`Combined ${combineSource}: ${combineResult}`),
+                );
             }
-            console.info(
-                styles.info(
-                    `Combined ${combineSource}: added ${addedModelIds.length} model(s) not present in the preview manifest`,
-                ),
-            );
         }
         const manifestVersion = getDbtManifestVersion(manifest);
         const manifestModels = getModelsFromManifest(manifest);

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -418,6 +418,7 @@ export const compileProject = async (
             getCompiledModels(projectManifestModels, compiledModelIds)
                 .length === projectManifestModels.length;
         let effectiveCompiledModelIds = compiledModelIds;
+        const servedModelIds = new Set<string>();
         let additionalManifest: DbtManifest | undefined;
         let combineSource: string | undefined;
         let isAutomaticServerManifest = false;
@@ -477,6 +478,11 @@ export const compileProject = async (
                 const { manifest: merged, addedModelIds } =
                     combinePreviewManifests(manifest, additionalManifest);
                 manifest = merged;
+                if (isAutomaticServerManifest) {
+                    addedModelIds.forEach((modelId) => {
+                        servedModelIds.add(modelId);
+                    });
+                }
                 if (
                     effectiveCompiledModelIds !== undefined &&
                     addedModelIds.length > 0
@@ -527,6 +533,7 @@ export const compileProject = async (
                 adapterType,
                 manifestVersion,
                 modelsForValidation,
+                servedModelIds,
             );
 
         if (failedExplores.length > 0) {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -101,6 +101,12 @@ type SourceAnnotatedDbtNode = DbtManifest['nodes'][string] & {
     lightdash_source_name?: unknown;
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isServedDbtManifest = (value: unknown): value is DbtManifest =>
+    isRecord(value) && isRecord(value.nodes) && isRecord(value.metadata);
+
 const getManifestModelIds = (manifest: DbtManifest): string[] =>
     Object.entries(manifest.nodes)
         .filter(([, node]) => node.resource_type === 'model')
@@ -432,12 +438,19 @@ export const compileProject = async (
             options.combineManifestProjectUuid
         ) {
             try {
+                const manifestEndpoint = `/api/v1/projects/${options.combineManifestProjectUuid}/dbt/manifest`;
                 const response = await lightdashRawApi({
                     method: 'GET',
-                    url: `/api/v1/projects/${options.combineManifestProjectUuid}/dbt/manifest`,
+                    url: manifestEndpoint,
                     body: undefined,
                 });
-                additionalManifest = (await response.json()) as DbtManifest;
+                const servedManifest: unknown = await response.json();
+                if (!isServedDbtManifest(servedManifest)) {
+                    throw new Error(
+                        `${manifestEndpoint} returned an invalid manifest: expected an object with metadata and a nodes record`,
+                    );
+                }
+                additionalManifest = servedManifest;
                 combineSource = 'manifest from the server';
                 isAutomaticServerManifest = true;
             } catch (error) {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -442,6 +442,7 @@ export const compileProject = async (
             getCompiledModels(projectManifestModels, compiledModelIds)
                 .length === projectManifestModels.length;
         let effectiveCompiledModelIds = compiledModelIds;
+        const servedModelIds = new Set<string>();
         let additionalManifest: DbtManifest | undefined;
         let combineSource: string | undefined;
         let isAutomaticServerManifest = false;
@@ -501,6 +502,11 @@ export const compileProject = async (
                 const { manifest: merged, addedModelIds } =
                     combinePreviewManifests(manifest, additionalManifest);
                 manifest = merged;
+                if (isAutomaticServerManifest) {
+                    addedModelIds.forEach((modelId) => {
+                        servedModelIds.add(modelId);
+                    });
+                }
                 if (
                     effectiveCompiledModelIds !== undefined &&
                     addedModelIds.length > 0
@@ -551,6 +557,7 @@ export const compileProject = async (
                 adapterType,
                 manifestVersion,
                 modelsForValidation,
+                servedModelIds,
             );
 
         if (failedExplores.length > 0) {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -15,6 +15,7 @@ import {
     InlineErrorType,
     isExploreError,
     isSupportedDbtAdapter,
+    LightdashError,
     LightdashProjectConfig,
     ParseError,
     preAggregatePostProcessor,
@@ -41,6 +42,7 @@ import { readAndLoadLightdashProjectConfig } from '../lightdash-config';
 import { loadLightdashModels } from '../lightdash/loader';
 import { detectProjectType } from '../lightdash/projectType';
 import * as styles from '../styles';
+import { lightdashRawApi } from './dbt/apiClient';
 import { DbtCompileOptions, maybeCompileModelsAndJoins } from './dbt/compile';
 import { tryGetDbtVersion } from './dbt/getDbtVersion';
 import getWarehouseClient from './dbt/getWarehouseClient';
@@ -57,6 +59,8 @@ export type CompileHandlerOptions = DbtCompileOptions & {
     disableTimestampConversion?: boolean;
     validateWarehouseColumns?: boolean;
     partialCompilation?: boolean;
+    combineManifestProjectUuid?: string;
+    combine?: boolean;
 };
 
 export type CompileProjectResult = {
@@ -370,13 +374,42 @@ export const compileProject = async (
             getCompiledModels(projectManifestModels, compiledModelIds)
                 .length === projectManifestModels.length;
         let effectiveCompiledModelIds = compiledModelIds;
+        let additionalManifest: DbtManifest | undefined;
+        let combineSource: string | undefined;
         if (options.combineManifest) {
-            const externalManifest = await loadCombineManifest(
+            additionalManifest = await loadCombineManifest(
                 options.combineManifest,
             );
+            combineSource = `external manifest from ${options.combineManifest}`;
+        } else if (
+            options.combine !== false &&
+            options.combineManifestProjectUuid
+        ) {
+            try {
+                const response = await lightdashRawApi({
+                    method: 'GET',
+                    url: `/api/v1/projects/${options.combineManifestProjectUuid}/dbt/manifest`,
+                    body: undefined,
+                });
+                additionalManifest = (await response.json()) as DbtManifest;
+                combineSource = 'manifest from the server';
+            } catch (error) {
+                if (
+                    !(error instanceof LightdashError) ||
+                    error.statusCode !== 404
+                ) {
+                    console.error(
+                        styles.warning(
+                            `Could not fetch the server manifest; continuing with the preview manifest: ${getErrorMessage(error)}`,
+                        ),
+                    );
+                }
+            }
+        }
+        if (additionalManifest && combineSource) {
             const { manifest: merged, addedModelIds } = combineManifests(
                 manifest,
-                externalManifest,
+                additionalManifest,
             );
             manifest = merged;
             if (
@@ -390,7 +423,7 @@ export const compileProject = async (
             }
             console.info(
                 styles.info(
-                    `Combined external manifest from ${options.combineManifest}: added ${addedModelIds.length} model(s) not present in the preview manifest`,
+                    `Combined ${combineSource}: added ${addedModelIds.length} model(s) not present in the preview manifest`,
                 ),
             );
         }

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -101,6 +101,12 @@ type SourceAnnotatedDbtNode = DbtManifest['nodes'][string] & {
     lightdash_source_name?: unknown;
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isServedDbtManifest = (value: unknown): value is DbtManifest =>
+    isRecord(value) && isRecord(value.nodes) && isRecord(value.metadata);
+
 const getManifestModelIds = (manifest: DbtManifest): string[] =>
     Object.entries(manifest.nodes)
         .filter(([, node]) => node.resource_type === 'model')
@@ -456,12 +462,19 @@ export const compileProject = async (
             options.combineManifestProjectUuid
         ) {
             try {
+                const manifestEndpoint = `/api/v1/projects/${options.combineManifestProjectUuid}/dbt/manifest`;
                 const response = await lightdashRawApi({
                     method: 'GET',
-                    url: `/api/v1/projects/${options.combineManifestProjectUuid}/dbt/manifest`,
+                    url: manifestEndpoint,
                     body: undefined,
                 });
-                additionalManifest = (await response.json()) as DbtManifest;
+                const servedManifest: unknown = await response.json();
+                if (!isServedDbtManifest(servedManifest)) {
+                    throw new Error(
+                        `${manifestEndpoint} returned an invalid manifest: expected an object with metadata and a nodes record`,
+                    );
+                }
+                additionalManifest = servedManifest;
                 combineSource = 'manifest from the server';
                 isAutomaticServerManifest = true;
             } catch (error) {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -14,6 +14,7 @@ import {
     InlineErrorType,
     isExploreError,
     isSupportedDbtAdapter,
+    LightdashError,
     LightdashProjectConfig,
     ParseError,
     preAggregatePostProcessor,
@@ -41,6 +42,7 @@ import { readAndLoadLightdashProjectConfig } from '../lightdash-config';
 import { loadLightdashModels } from '../lightdash/loader';
 import { detectProjectType } from '../lightdash/projectType';
 import * as styles from '../styles';
+import { lightdashRawApi } from './dbt/apiClient';
 import { DbtCompileOptions, maybeCompileModelsAndJoins } from './dbt/compile';
 import { tryGetDbtVersion } from './dbt/getDbtVersion';
 import getWarehouseClient from './dbt/getWarehouseClient';
@@ -57,6 +59,8 @@ export type CompileHandlerOptions = DbtCompileOptions & {
     disableTimestampConversion?: boolean;
     validateWarehouseColumns?: boolean;
     partialCompilation?: boolean;
+    combineManifestProjectUuid?: string;
+    combine?: boolean;
 };
 
 export type CompileProjectResult = {
@@ -394,13 +398,42 @@ export const compileProject = async (
             getCompiledModels(projectManifestModels, compiledModelIds)
                 .length === projectManifestModels.length;
         let effectiveCompiledModelIds = compiledModelIds;
+        let additionalManifest: DbtManifest | undefined;
+        let combineSource: string | undefined;
         if (options.combineManifest) {
-            const externalManifest = await loadCombineManifest(
+            additionalManifest = await loadCombineManifest(
                 options.combineManifest,
             );
+            combineSource = `external manifest from ${options.combineManifest}`;
+        } else if (
+            options.combine !== false &&
+            options.combineManifestProjectUuid
+        ) {
+            try {
+                const response = await lightdashRawApi({
+                    method: 'GET',
+                    url: `/api/v1/projects/${options.combineManifestProjectUuid}/dbt/manifest`,
+                    body: undefined,
+                });
+                additionalManifest = (await response.json()) as DbtManifest;
+                combineSource = 'manifest from the server';
+            } catch (error) {
+                if (
+                    !(error instanceof LightdashError) ||
+                    error.statusCode !== 404
+                ) {
+                    console.error(
+                        styles.warning(
+                            `Could not fetch the server manifest; continuing with the preview manifest: ${getErrorMessage(error)}`,
+                        ),
+                    );
+                }
+            }
+        }
+        if (additionalManifest && combineSource) {
             const { manifest: merged, addedModelIds } = combineManifests(
                 manifest,
-                externalManifest,
+                additionalManifest,
             );
             manifest = merged;
             if (
@@ -414,7 +447,7 @@ export const compileProject = async (
             }
             console.info(
                 styles.info(
-                    `Combined external manifest from ${options.combineManifest}: added ${addedModelIds.length} model(s) not present in the preview manifest`,
+                    `Combined ${combineSource}: added ${addedModelIds.length} model(s) not present in the preview manifest`,
                 ),
             );
         }

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -441,9 +441,15 @@ export const compileProject = async (
                 isAutomaticServerManifest = true;
             } catch (error) {
                 if (
-                    !(error instanceof LightdashError) ||
-                    error.statusCode !== 404
+                    error instanceof LightdashError &&
+                    error.statusCode === 404
                 ) {
+                    console.info(
+                        styles.info(
+                            'No server manifest found; continuing with the preview manifest',
+                        ),
+                    );
+                } else {
                     console.error(
                         styles.warning(
                             `Could not fetch the server manifest; continuing with the preview manifest: ${getErrorMessage(error)}`,

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -465,9 +465,15 @@ export const compileProject = async (
                 isAutomaticServerManifest = true;
             } catch (error) {
                 if (
-                    !(error instanceof LightdashError) ||
-                    error.statusCode !== 404
+                    error instanceof LightdashError &&
+                    error.statusCode === 404
                 ) {
+                    console.info(
+                        styles.info(
+                            'No server manifest found; continuing with the preview manifest',
+                        ),
+                    );
+                } else {
                     console.error(
                         styles.warning(
                             `Could not fetch the server manifest; continuing with the preview manifest: ${getErrorMessage(error)}`,

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -97,6 +97,50 @@ export const stripWarehouseColumnErrors = (
         : exploreWithoutWarnings;
 };
 
+type SourceAnnotatedDbtNode = DbtManifest['nodes'][string] & {
+    lightdash_source_name?: unknown;
+};
+
+const getManifestModelIds = (manifest: DbtManifest): string[] =>
+    Object.entries(manifest.nodes)
+        .filter(([, node]) => node.resource_type === 'model')
+        .map(([uniqueId]) => uniqueId);
+
+const getCompiledManifestModelIds = (manifest: DbtManifest): string[] =>
+    Object.entries(manifest.nodes)
+        .filter(
+            ([, node]) =>
+                node.resource_type === 'model' &&
+                (node as SourceAnnotatedDbtNode & { compiled?: boolean })
+                    .compiled === true,
+        )
+        .map(([uniqueId]) => uniqueId);
+
+const combinePreviewManifests = (
+    localManifest: DbtManifest,
+    externalManifest: DbtManifest,
+) => {
+    const { manifest, addedModelIds } = combineManifests(
+        localManifest,
+        externalManifest,
+    );
+    const nodes = { ...manifest.nodes };
+
+    Object.keys(localManifest.nodes).forEach((uniqueId) => {
+        const externalNode = externalManifest.nodes[uniqueId] as
+            | SourceAnnotatedDbtNode
+            | undefined;
+        if (typeof externalNode?.lightdash_source_name === 'string') {
+            nodes[uniqueId] = {
+                ...nodes[uniqueId],
+                lightdash_source_name: externalNode.lightdash_source_name,
+            } as DbtManifest['nodes'][string];
+        }
+    });
+
+    return { manifest: { ...manifest, nodes }, addedModelIds };
+};
+
 const getDisplayableDiagnostics = (
     explore: Explore,
     allowPartialCompilation: boolean,
@@ -376,6 +420,7 @@ export const compileProject = async (
         let effectiveCompiledModelIds = compiledModelIds;
         let additionalManifest: DbtManifest | undefined;
         let combineSource: string | undefined;
+        let isAutomaticServerManifest = false;
         if (options.combineManifest) {
             additionalManifest = await loadCombineManifest(
                 options.combineManifest,
@@ -393,6 +438,7 @@ export const compileProject = async (
                 });
                 additionalManifest = (await response.json()) as DbtManifest;
                 combineSource = 'manifest from the server';
+                isAutomaticServerManifest = true;
             } catch (error) {
                 if (
                     !(error instanceof LightdashError) ||
@@ -407,25 +453,48 @@ export const compileProject = async (
             }
         }
         if (additionalManifest && combineSource) {
-            const { manifest: merged, addedModelIds } = combineManifests(
-                manifest,
-                additionalManifest,
+            const localModelIds = new Set(getManifestModelIds(manifest));
+            const externalModelIds = getManifestModelIds(additionalManifest);
+            const localSourceExists = externalModelIds.some((uniqueId) =>
+                localModelIds.has(uniqueId),
             );
-            manifest = merged;
-            if (
-                effectiveCompiledModelIds !== undefined &&
-                addedModelIds.length > 0
-            ) {
-                effectiveCompiledModelIds = [
-                    ...effectiveCompiledModelIds,
-                    ...addedModelIds,
-                ];
+
+            if (isAutomaticServerManifest && !localSourceExists) {
+                console.info(
+                    styles.info(
+                        `Skipped combining ${combineSource}: the local dbt project is not a source of this Lightdash project`,
+                    ),
+                );
+            } else {
+                const compiledExternalModelIds =
+                    getCompiledManifestModelIds(additionalManifest);
+                const { manifest: merged, addedModelIds } =
+                    combinePreviewManifests(manifest, additionalManifest);
+                manifest = merged;
+                if (
+                    effectiveCompiledModelIds !== undefined &&
+                    addedModelIds.length > 0
+                ) {
+                    effectiveCompiledModelIds = [
+                        ...effectiveCompiledModelIds,
+                        ...addedModelIds,
+                    ];
+                }
+
+                let combineResult: string;
+                if (addedModelIds.length > 0) {
+                    combineResult = `added ${addedModelIds.length} model(s) not present in the preview manifest`;
+                } else if (compiledExternalModelIds.length === 0) {
+                    combineResult =
+                        'added 0 model(s) because the manifest contains no compiled models';
+                } else {
+                    combineResult =
+                        'added 0 model(s) because all compiled models already exist in the preview manifest';
+                }
+                console.info(
+                    styles.info(`Combined ${combineSource}: ${combineResult}`),
+                );
             }
-            console.info(
-                styles.info(
-                    `Combined ${combineSource}: added ${addedModelIds.length} model(s) not present in the preview manifest`,
-                ),
-            );
         }
         const manifestVersion = getDbtManifestVersion(manifest);
         const manifestModels = getModelsFromManifest(manifest);

--- a/packages/cli/src/handlers/compileProject.test.ts
+++ b/packages/cli/src/handlers/compileProject.test.ts
@@ -1,6 +1,7 @@
 import {
     DimensionType,
     LightdashError,
+    projectMergedManifest,
     SupportedDbtVersions,
     type DbtManifest,
     type DbtModelNode,
@@ -41,6 +42,7 @@ const dbtNode = (
     uniqueId: string,
     resourceType: 'model' | 'seed',
     compiled: boolean,
+    extra: Record<string, unknown> = {},
 ) => ({
     unique_id: uniqueId,
     name: uniqueId.split('.').at(-1) ?? uniqueId,
@@ -72,6 +74,7 @@ const dbtNode = (
     relation_name: `"db"."public"."${uniqueId}"`,
     config: { materialized: 'table' },
     compiled,
+    ...extra,
 });
 
 const manifest = (
@@ -234,23 +237,53 @@ describe('compileProject completeness', () => {
         });
 
         expect(result.isProjectComplete).toBe(true);
+        expect(result.explores.map((explore) => explore.name)).toEqual([
+            'orders',
+            'compiled',
+        ]);
         expect(lightdashRawApi).not.toHaveBeenCalled();
         expect(console.info).toHaveBeenCalledWith(
             expect.stringContaining('Combined external manifest from'),
         );
     });
 
-    test('includes models from the served project manifest', async () => {
+    test('projects, merges, and compiles served-only models while preserving local precedence and source identity', async () => {
         const projectManifest = manifest({
-            'model.test.orders': dbtNode('model.test.orders', 'model', true),
+            'model.test.orders': dbtNode('model.test.orders', 'model', true, {
+                description: 'Local orders description',
+            }),
         });
-        const servedManifest = manifest({
-            'model.test.customers': dbtNode(
-                'model.test.customers',
-                'model',
-                true,
-            ),
-        });
+        const servedManifest = projectMergedManifest(
+            manifest({
+                'model.test.orders': dbtNode(
+                    'model.test.orders',
+                    'model',
+                    true,
+                    {
+                        description: 'Served orders description',
+                        lightdash_source_name: 'local_source',
+                    },
+                ),
+                'model.served.customers': dbtNode(
+                    'model.served.customers',
+                    'model',
+                    true,
+                    {
+                        package_name: 'served',
+                        lightdash_source_name: 'served_source',
+                    },
+                ),
+                'model.served.customer_helper': dbtNode(
+                    'model.served.customer_helper',
+                    'model',
+                    false,
+                    {
+                        package_name: 'served',
+                        lightdash_source_name: 'served_source',
+                    },
+                ),
+            }),
+        );
         vi.mocked(loadManifest).mockResolvedValue(projectManifest);
         vi.mocked(lightdashRawApi).mockResolvedValue(
             new Response(JSON.stringify(servedManifest)),
@@ -276,7 +309,112 @@ describe('compileProject completeness', () => {
             body: undefined,
         });
         expect(console.info).toHaveBeenCalledWith(
-            expect.stringContaining('Combined manifest from the server'),
+            expect.stringMatching(/added [1-9]\d* model\(s\)/),
+        );
+
+        const modelsForValidation =
+            vi.mocked(validateDbtModel).mock.calls[0][2];
+        const localModel = modelsForValidation.find(
+            (model) => model.unique_id === 'model.test.orders',
+        ) as DbtModelNode & { lightdash_source_name?: string };
+        expect(localModel.description).toBe('Local orders description');
+        expect(localModel.lightdash_source_name).toBe('local_source');
+        expect(
+            modelsForValidation.map((model) => model.unique_id),
+        ).not.toContain('model.served.customer_helper');
+    });
+
+    test('skips automatic combination when the local dbt project is not a served source', async () => {
+        const projectManifest = manifest({
+            'model.local.orders': dbtNode('model.local.orders', 'model', true),
+        });
+        const servedManifest = manifest({
+            'model.served.customers': dbtNode(
+                'model.served.customers',
+                'model',
+                true,
+            ),
+        });
+        vi.mocked(loadManifest).mockResolvedValue(projectManifest);
+        vi.mocked(lightdashRawApi).mockResolvedValue(
+            new Response(JSON.stringify(servedManifest)),
+        );
+        vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+            compiledModelIds: ['model.local.orders'],
+            originallySelectedModelIds: undefined,
+        });
+
+        const result = await compileProject({
+            ...compileOptions(tempDir),
+            combineManifestProjectUuid: 'project-uuid',
+        });
+
+        expect(result.explores.map((explore) => explore.name)).toEqual([
+            'orders',
+        ]);
+        expect(console.info).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'the local dbt project is not a source of this Lightdash project',
+            ),
+        );
+    });
+
+    test('explains when a matching served manifest has no compiled models', async () => {
+        const projectManifest = manifest({
+            'model.test.orders': dbtNode('model.test.orders', 'model', true),
+        });
+        const servedManifest = manifest({
+            'model.test.orders': dbtNode('model.test.orders', 'model', false),
+            'model.served.helper': dbtNode(
+                'model.served.helper',
+                'model',
+                false,
+            ),
+        });
+        vi.mocked(loadManifest).mockResolvedValue(projectManifest);
+        vi.mocked(lightdashRawApi).mockResolvedValue(
+            new Response(JSON.stringify(servedManifest)),
+        );
+        vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+            compiledModelIds: ['model.test.orders'],
+            originallySelectedModelIds: undefined,
+        });
+
+        await compileProject({
+            ...compileOptions(tempDir),
+            combineManifestProjectUuid: 'project-uuid',
+        });
+
+        expect(console.info).toHaveBeenCalledWith(
+            expect.stringContaining('contains no compiled models'),
+        );
+    });
+
+    test('explains when all compiled served models already overlap locally', async () => {
+        const projectManifest = manifest({
+            'model.test.orders': dbtNode('model.test.orders', 'model', true),
+        });
+        const servedManifest = manifest({
+            'model.test.orders': dbtNode('model.test.orders', 'model', true),
+        });
+        vi.mocked(loadManifest).mockResolvedValue(projectManifest);
+        vi.mocked(lightdashRawApi).mockResolvedValue(
+            new Response(JSON.stringify(servedManifest)),
+        );
+        vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+            compiledModelIds: ['model.test.orders'],
+            originallySelectedModelIds: undefined,
+        });
+
+        await compileProject({
+            ...compileOptions(tempDir),
+            combineManifestProjectUuid: 'project-uuid',
+        });
+
+        expect(console.info).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'all compiled models already exist in the preview manifest',
+            ),
         );
     });
 

--- a/packages/cli/src/handlers/compileProject.test.ts
+++ b/packages/cli/src/handlers/compileProject.test.ts
@@ -463,6 +463,47 @@ describe('compileProject completeness', () => {
     });
 
     test.each([
+        ['a null response', null],
+        ['an array of nodes', { metadata: {}, nodes: [] }],
+        ['array metadata', { metadata: [], nodes: {} }],
+        ['missing metadata', { nodes: {} }],
+    ])(
+        'rejects %s from the server manifest endpoint and keeps the local manifest',
+        async (_description, invalidManifest) => {
+            vi.mocked(loadManifest).mockResolvedValue(
+                manifest({
+                    'model.test.orders': dbtNode(
+                        'model.test.orders',
+                        'model',
+                        true,
+                    ),
+                }),
+            );
+            vi.mocked(lightdashRawApi).mockResolvedValue(
+                new Response(JSON.stringify(invalidManifest)),
+            );
+            vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+                compiledModelIds: ['model.test.orders'],
+                originallySelectedModelIds: undefined,
+            });
+
+            const result = await compileProject({
+                ...compileOptions(tempDir),
+                combineManifestProjectUuid: 'project-uuid',
+            });
+
+            expect(result.explores.map((explore) => explore.name)).toEqual([
+                'orders',
+            ]);
+            expect(console.error).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    '/api/v1/projects/project-uuid/dbt/manifest returned an invalid manifest',
+                ),
+            );
+        },
+    );
+
+    test.each([
         [
             'an authorization error',
             new LightdashError({

--- a/packages/cli/src/handlers/compileProject.test.ts
+++ b/packages/cli/src/handlers/compileProject.test.ts
@@ -322,6 +322,9 @@ describe('compileProject completeness', () => {
         expect(
             modelsForValidation.map((model) => model.unique_id),
         ).not.toContain('model.served.customer_helper');
+        expect(vi.mocked(validateDbtModel).mock.calls[0][3]).toEqual(
+            new Set(['model.served.customers']),
+        );
     });
 
     test('skips automatic combination when the local dbt project is not a served source', async () => {

--- a/packages/cli/src/handlers/compileProject.test.ts
+++ b/packages/cli/src/handlers/compileProject.test.ts
@@ -1,10 +1,12 @@
 import {
     DimensionType,
+    LightdashError,
     SupportedDbtVersions,
     type DbtManifest,
     type DbtModelNode,
 } from '@lightdash/common';
 import fs from 'fs/promises';
+import { Response } from 'node-fetch';
 import os from 'os';
 import path from 'path';
 import { getDbtContext } from '../dbt/context';
@@ -12,6 +14,7 @@ import { loadCombineManifest, loadManifest } from '../dbt/manifest';
 import { validateDbtModel } from '../dbt/validation';
 import { loadLightdashModels } from '../lightdash/loader';
 import { compileProject, type CompileHandlerOptions } from './compile';
+import { lightdashRawApi } from './dbt/apiClient';
 import { maybeCompileModelsAndJoins } from './dbt/compile';
 import { tryGetDbtVersion } from './dbt/getDbtVersion';
 
@@ -29,6 +32,10 @@ vi.mock('../dbt/validation');
 vi.mock('../lightdash/loader');
 vi.mock('./dbt/compile');
 vi.mock('./dbt/getDbtVersion');
+vi.mock('./dbt/apiClient', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('./dbt/apiClient')>()),
+    lightdashRawApi: vi.fn(),
+}));
 
 const dbtNode = (
     uniqueId: string,
@@ -149,6 +156,7 @@ describe('compileProject completeness', () => {
             }),
         );
         vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        vi.spyOn(console, 'info').mockImplementation(() => undefined);
     });
 
     afterEach(async () => {
@@ -222,8 +230,180 @@ describe('compileProject completeness', () => {
         const result = await compileProject({
             ...compileOptions(tempDir),
             combineManifest: 'external-manifest.json',
+            combineManifestProjectUuid: 'project-uuid',
         });
 
         expect(result.isProjectComplete).toBe(true);
+        expect(lightdashRawApi).not.toHaveBeenCalled();
+        expect(console.info).toHaveBeenCalledWith(
+            expect.stringContaining('Combined external manifest from'),
+        );
+    });
+
+    test('includes models from the served project manifest', async () => {
+        const projectManifest = manifest({
+            'model.test.orders': dbtNode('model.test.orders', 'model', true),
+        });
+        const servedManifest = manifest({
+            'model.test.customers': dbtNode(
+                'model.test.customers',
+                'model',
+                true,
+            ),
+        });
+        vi.mocked(loadManifest).mockResolvedValue(projectManifest);
+        vi.mocked(lightdashRawApi).mockResolvedValue(
+            new Response(JSON.stringify(servedManifest)),
+        );
+        vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+            compiledModelIds: ['model.test.orders'],
+            originallySelectedModelIds: undefined,
+        });
+
+        const result = await compileProject({
+            ...compileOptions(tempDir),
+            combineManifestProjectUuid: 'project-uuid',
+        });
+
+        expect(result.explores.map((explore) => explore.name)).toEqual([
+            'orders',
+            'customers',
+        ]);
+        expect(result.isProjectComplete).toBe(true);
+        expect(lightdashRawApi).toHaveBeenCalledWith({
+            method: 'GET',
+            url: '/api/v1/projects/project-uuid/dbt/manifest',
+            body: undefined,
+        });
+        expect(console.info).toHaveBeenCalledWith(
+            expect.stringContaining('Combined manifest from the server'),
+        );
+    });
+
+    test('keeps the local manifest without warning when no served manifest exists', async () => {
+        vi.mocked(loadManifest).mockResolvedValue(
+            manifest({
+                'model.test.orders': dbtNode(
+                    'model.test.orders',
+                    'model',
+                    true,
+                ),
+            }),
+        );
+        vi.mocked(lightdashRawApi).mockRejectedValue(
+            new LightdashError({
+                message: 'Manifest not found',
+                name: 'NotFoundError',
+                statusCode: 404,
+                data: {},
+            }),
+        );
+        vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+            compiledModelIds: ['model.test.orders'],
+            originallySelectedModelIds: undefined,
+        });
+
+        const result = await compileProject({
+            ...compileOptions(tempDir),
+            combineManifestProjectUuid: 'project-uuid',
+        });
+
+        expect(result.explores.map((explore) => explore.name)).toEqual([
+            'orders',
+        ]);
+        expect(console.error).not.toHaveBeenCalledWith(
+            expect.stringContaining('Could not fetch the server manifest'),
+        );
+    });
+
+    test.each([
+        [
+            'an authorization error',
+            new LightdashError({
+                message: 'Not authorized',
+                name: 'AuthorizationError',
+                statusCode: 401,
+                data: {},
+            }),
+        ],
+        [
+            'a server error',
+            new LightdashError({
+                message: 'Server unavailable',
+                name: 'InternalServerError',
+                statusCode: 500,
+                data: {},
+            }),
+        ],
+        [
+            'a permission error',
+            new LightdashError({
+                message: 'Forbidden',
+                name: 'ForbiddenError',
+                statusCode: 403,
+                data: {},
+            }),
+        ],
+        ['a network error', new Error('Connection refused')],
+    ])(
+        'warns once and keeps the local manifest after %s',
+        async (_description, error) => {
+            vi.mocked(loadManifest).mockResolvedValue(
+                manifest({
+                    'model.test.orders': dbtNode(
+                        'model.test.orders',
+                        'model',
+                        true,
+                    ),
+                }),
+            );
+            vi.mocked(lightdashRawApi).mockRejectedValue(error);
+            vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+                compiledModelIds: ['model.test.orders'],
+                originallySelectedModelIds: undefined,
+            });
+
+            const result = await compileProject({
+                ...compileOptions(tempDir),
+                combineManifestProjectUuid: 'project-uuid',
+            });
+
+            expect(result.explores.map((explore) => explore.name)).toEqual([
+                'orders',
+            ]);
+            expect(
+                vi
+                    .mocked(console.error)
+                    .mock.calls.filter(([message]) =>
+                        String(message).includes(
+                            'Could not fetch the server manifest',
+                        ),
+                    ),
+            ).toHaveLength(1);
+        },
+    );
+
+    test('does not fetch a served manifest when manifest combining is disabled', async () => {
+        vi.mocked(loadManifest).mockResolvedValue(
+            manifest({
+                'model.test.orders': dbtNode(
+                    'model.test.orders',
+                    'model',
+                    true,
+                ),
+            }),
+        );
+        vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+            compiledModelIds: ['model.test.orders'],
+            originallySelectedModelIds: undefined,
+        });
+
+        await compileProject({
+            ...compileOptions(tempDir),
+            combine: false,
+            combineManifestProjectUuid: 'project-uuid',
+        });
+
+        expect(lightdashRawApi).not.toHaveBeenCalled();
     });
 });

--- a/packages/cli/src/handlers/compileProject.test.ts
+++ b/packages/cli/src/handlers/compileProject.test.ts
@@ -418,7 +418,7 @@ describe('compileProject completeness', () => {
         );
     });
 
-    test('keeps the local manifest without warning when no served manifest exists', async () => {
+    test('notices when no served manifest exists and keeps the local manifest', async () => {
         vi.mocked(loadManifest).mockResolvedValue(
             manifest({
                 'model.test.orders': dbtNode(
@@ -451,6 +451,11 @@ describe('compileProject completeness', () => {
         ]);
         expect(console.error).not.toHaveBeenCalledWith(
             expect.stringContaining('Could not fetch the server manifest'),
+        );
+        expect(console.info).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'No server manifest found; continuing with the preview manifest',
+            ),
         );
     });
 

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -49,6 +49,8 @@ type PreviewHandlerOptions = DbtCompileOptions & {
     disableTimestampConversion?: boolean;
     validateWarehouseColumns: boolean;
     partialCompilation?: boolean;
+    combine?: boolean;
+    combineManifestProjectUuid?: string;
 };
 
 type StopPreviewHandlerOptions = {
@@ -207,6 +209,7 @@ export const previewHandler = async (
     let contentCopySkipReason: string | undefined;
 
     const config = await getConfig();
+    options.combineManifestProjectUuid = config.context?.project;
 
     // Validate upstream project before attempting to copy permissions or content
     let upstreamProjectValid = false;
@@ -483,6 +486,7 @@ export const startPreviewHandler = async (
 
     const projectName = options.name;
     const config = await getConfig();
+    options.combineManifestProjectUuid = config.context?.project;
 
     // Log current source project info if copying content
     if (!options.skipCopyContent && config.context?.project) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -579,6 +579,10 @@ program
         'Path or http(s) URL to an additional dbt manifest.json. Models present in this file but missing from the preview manifest are merged in so the preview shows the full project. The preview-generated manifest always wins on conflicts.',
     )
     .option(
+        '--no-combine',
+        'Skip combining the preview manifest with the manifest served by Lightdash',
+    )
+    .option(
         '--table-configuration <prod|all>',
         `If set to 'prod' it will copy the table configuration from prod project`,
         'all',
@@ -715,6 +719,10 @@ program
     .option(
         '--combine-manifest <path-or-url>',
         'Path or http(s) URL to an additional dbt manifest.json. Models present in this file but missing from the preview manifest are merged in so the preview shows the full project. The preview-generated manifest always wins on conflicts.',
+    )
+    .option(
+        '--no-combine',
+        'Skip combining the preview manifest with the manifest served by Lightdash',
     )
     .option(
         '--table-configuration <prod|all>',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -578,6 +578,10 @@ program
         'Path or http(s) URL to an additional dbt manifest.json. Models present in this file but missing from the preview manifest are merged in so the preview shows the full project. The preview-generated manifest always wins on conflicts.',
     )
     .option(
+        '--no-combine',
+        'Skip combining the preview manifest with the manifest served by Lightdash',
+    )
+    .option(
         '--table-configuration <prod|all>',
         `If set to 'prod' it will copy the table configuration from prod project`,
         'all',
@@ -714,6 +718,10 @@ program
     .option(
         '--combine-manifest <path-or-url>',
         'Path or http(s) URL to an additional dbt manifest.json. Models present in this file but missing from the preview manifest are merged in so the preview shows the full project. The preview-generated manifest always wins on conflicts.',
+    )
+    .option(
+        '--no-combine',
+        'Skip combining the preview manifest with the manifest served by Lightdash',
     )
     .option(
         '--table-configuration <prod|all>',


### PR DESCRIPTION
## What this change does

`lightdash preview` fetches the selected project's merged manifest through the CLI's authenticated client and combines it with the local dbt manifest.

- The automatic fetch uses `GET /api/v1/projects/{projectUuid}/dbt/manifest`; explicit `--combine-manifest` still takes precedence.
- Successful combinations report how many models were added, including a reason when zero can be explained.
- A missing server manifest prints one informational line and continues with the preview manifest.
- Other fetch failures warn once and continue. Bogus Lightdash app-route manifest URLs produce a clean manifest-not-found error.
- `--no-combine` disables automatic fetching, and unrelated local dbt projects explain why server combination was skipped.

## Why

The CLI already knows the server, project, and authentication context, so preview users should not need to host or pass a merged manifest URL.

## Tests

- Automatic fetch, gzip decoding, explicit URL precedence, opt-out, stranger projects, zero-model explanations, 404 notice, and fetch failures are covered.
- CLI: 570 tests across 48 files pass. Typecheck and touched-path lint pass.

Linear: SPK-1044
