### PR TITLE
fix: close add source modal after creation

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.test.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.test.tsx
@@ -138,7 +138,7 @@ describe('DbtSourcesPanel', () => {
 
         expect(
             within(dialog).getByText(
-                "Connect another git-backed dbt project. Its models are merged with the primary source on every deploy, using the project's warehouse and dbt version.",
+                "Connect another git-backed dbt project. Its models are merged with this project's dbt connection on every deploy.",
             ),
         ).toBeInTheDocument();
     });

--- a/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.test.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.test.tsx
@@ -1,7 +1,16 @@
 import { DbtProjectType } from '@lightdash/common';
+import { QueryClient } from '@tanstack/react-query';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+    type Mock,
+} from 'vitest';
 import { lightdashApi } from '../../api';
 import { renderWithProviders } from '../../testing/testUtils';
 import DbtSourcesPanel from './DbtSourcesPanel';
@@ -42,13 +51,32 @@ const connection = {
     host_domain: 'github.com',
 };
 
-const routeApi = (sourceName = source.name) => {
+const routeApi = (sourceName?: string) => {
     mockApi.mockImplementation(
         ({ url, method }: { url: string; method: string }) => {
             if (url === '/projects/project-uuid/dbt-sources') {
-                return Promise.resolve([{ ...source, name: sourceName }]);
+                if (method === 'POST') {
+                    return Promise.resolve({
+                        projectDbtSourceUuid: 'source-uuid',
+                        name: 'marketing',
+                        isPrimary: false,
+                        hasCredentialError: false,
+                        type: DbtProjectType.GITHUB,
+                        repository: 'org/repo',
+                        branch: 'main',
+                        projectSubPath: '/',
+                    });
+                }
+                return Promise.resolve(
+                    sourceName === undefined
+                        ? []
+                        : [{ ...source, name: sourceName }],
+                );
             }
-            if (url === '/projects/project-uuid/dbt-sources/source-uuid') {
+            if (
+                url === '/projects/project-uuid/dbt-sources/source-uuid' &&
+                sourceName !== undefined
+            ) {
                 if (method === 'GET') {
                     return Promise.resolve({
                         ...source,
@@ -59,11 +87,28 @@ const routeApi = (sourceName = source.name) => {
                 return Promise.resolve({ ...source, name: sourceName });
             }
             if (url === '/github/config') {
-                return Promise.resolve({ enabled: false });
+                return Promise.resolve({
+                    enabled: true,
+                    installationId: 'installation-id',
+                });
+            }
+            if (url === '/github/repos/list') {
+                return Promise.resolve([{ fullName: 'org/repo' }]);
             }
             return Promise.resolve(undefined);
         },
     );
+};
+
+const openAddSourceModal = async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DbtSourcesPanel projectUuid="project-uuid" />);
+    await user.click(await screen.findByRole('button', { name: 'Add source' }));
+    await screen.findByText('Add a dbt source');
+    return {
+        dialog: await screen.findByRole('dialog'),
+        user,
+    };
 };
 
 const openEditSourceModal = async (sourceName: string) => {
@@ -81,10 +126,57 @@ const openEditSourceModal = async (sourceName: string) => {
 describe('DbtSourcesPanel', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        routeApi();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('describes additional sources as merged on every deploy', async () => {
+        const { dialog } = await openAddSourceModal();
+
+        expect(
+            within(dialog).getByText(
+                "Connect another git-backed dbt project. Its models are merged with the primary source on every deploy, using the project's warehouse and dbt version.",
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('closes after a source is created without waiting for list invalidation', async () => {
+        vi.spyOn(QueryClient.prototype, 'invalidateQueries').mockReturnValue(
+            new Promise(() => {}),
+        );
+        const { dialog, user } = await openAddSourceModal();
+
+        await user.type(
+            within(dialog).getByRole('textbox', { name: /Name/ }),
+            'marketing',
+        );
+        await waitFor(() =>
+            expect(mockApi).toHaveBeenCalledWith(
+                expect.objectContaining({ url: '/github/repos/list' }),
+            ),
+        );
+        await user.click(
+            within(dialog).getByRole('button', { name: 'Add source' }),
+        );
+
+        await waitFor(() =>
+            expect(mockApi).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    url: '/projects/project-uuid/dbt-sources',
+                    method: 'POST',
+                }),
+            ),
+        );
+        await waitFor(() =>
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
+        );
     });
 
     it('updates a legacy source connection without resubmitting its invalid name', async () => {
-        routeApi();
+        routeApi(source.name);
         const { dialog, user } = await openEditSourceModal(source.name);
         const repository = within(dialog).getByRole('textbox', {
             name: 'Repository',

--- a/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
@@ -210,7 +210,7 @@ const AddDbtSourceModal: FC<{
         >
             <DbtSourceFields
                 form={form}
-                intro="Connect another git-backed dbt project. Its models are merged with the primary source on every deploy, using the project's warehouse and dbt version."
+                intro="Connect another git-backed dbt project. Its models are merged with this project's dbt connection on every deploy."
             />
         </MantineModal>
     );

--- a/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
@@ -162,7 +162,6 @@ const AddDbtSourceModal: FC<{
     opened: boolean;
     onClose: () => void;
 }> = ({ projectUuid, opened, onClose }) => {
-    const createMutation = useCreateProjectDbtSourceMutation(projectUuid);
     const form = useForm({
         initialValues: {
             name: '',
@@ -185,17 +184,17 @@ const AddDbtSourceModal: FC<{
         form.reset();
         onClose();
     };
+    const createMutation = useCreateProjectDbtSourceMutation(projectUuid, {
+        onSuccess: handleClose,
+    });
 
     const handleSubmit = () => {
         const { hasErrors } = form.validate();
         if (hasErrors) return;
-        createMutation.mutate(
-            {
-                name: form.values.name.trim(),
-                dbtConnection: form.values.dbt,
-            },
-            { onSuccess: handleClose },
-        );
+        createMutation.mutate({
+            name: form.values.name.trim(),
+            dbtConnection: form.values.dbt,
+        });
     };
 
     return (
@@ -211,7 +210,7 @@ const AddDbtSourceModal: FC<{
         >
             <DbtSourceFields
                 form={form}
-                intro="Connect another git-backed dbt project. Its models are merged with the primary source on every deploy and preview, using the project's warehouse and dbt version."
+                intro="Connect another git-backed dbt project. Its models are merged with the primary source on every deploy, using the project's warehouse and dbt version."
             />
         </MantineModal>
     );

--- a/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
@@ -191,7 +191,6 @@ const AddDbtSourceModal: FC<{
     opened: boolean;
     onClose: () => void;
 }> = ({ projectUuid, opened, onClose }) => {
-    const createMutation = useCreateProjectDbtSourceMutation(projectUuid);
     const form = useForm({
         initialValues: {
             name: '',
@@ -215,6 +214,9 @@ const AddDbtSourceModal: FC<{
         form.reset();
         onClose();
     };
+    const createMutation = useCreateProjectDbtSourceMutation(projectUuid, {
+        onSuccess: handleClose,
+    });
 
     const handleSubmit = () => {
         const { hasErrors } = form.validate();

--- a/packages/frontend/src/hooks/useProjectDbtSources.ts
+++ b/packages/frontend/src/hooks/useProjectDbtSources.ts
@@ -64,7 +64,10 @@ export const useProjectDbtSources = (projectUuid?: string) =>
         enabled: !!projectUuid,
     });
 
-export const useCreateProjectDbtSourceMutation = (projectUuid: string) => {
+export const useCreateProjectDbtSourceMutation = (
+    projectUuid: string,
+    options?: { onSuccess?: (source: ProjectDbtSourceSummary) => void },
+) => {
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<
@@ -73,7 +76,8 @@ export const useCreateProjectDbtSourceMutation = (projectUuid: string) => {
         ApiCreateProjectDbtSource
     >((data) => createProjectDbtSource(projectUuid, data), {
         mutationKey: ['create_project_dbt_source', projectUuid],
-        onSuccess: async () => {
+        onSuccess: async (source) => {
+            options?.onSuccess?.(source);
             await queryClient.invalidateQueries([
                 'project_dbt_sources',
                 projectUuid,


### PR DESCRIPTION
Linear: SPK-1052\n\n### Description\n- close the add-source modal immediately after a successful creation\n- align the deploy copy with actual behavior\n- cover the invalidation race with a component regression test