### PR TITLE
fix: validate dbt source access tokens

### DIFF
--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.test.ts
@@ -1,0 +1,42 @@
+import {
+    SupportedDbtVersions,
+    WarehouseTypes,
+    type CreateWarehouseCredentials,
+} from '@lightdash/common';
+import { warehouseClientMock } from '../utils/QueryBuilder/MetricQueryBuilder.mock';
+import { DbtGithubProjectAdapter } from './dbtGithubProjectAdapter';
+
+describe('DbtGithubProjectAdapter', () => {
+    it('uses a tokenless repository URL when no token is provided', async () => {
+        const adapter = new DbtGithubProjectAdapter({
+            warehouseClient: warehouseClientMock,
+            githubPersonalAccessToken: '',
+            githubRepository: 'org/repo',
+            githubBranch: 'main',
+            projectDirectorySubPath: '/',
+            warehouseCredentials: {
+                type: WarehouseTypes.POSTGRES,
+                host: 'localhost',
+                port: 5432,
+                user: 'postgres',
+                password: 'password',
+                dbname: 'postgres',
+                schema: 'public',
+            } as CreateWarehouseCredentials,
+            targetName: undefined,
+            environment: undefined,
+            environmentVariableAllowlist: [],
+            cachedWarehouse: {
+                warehouseCatalog: {},
+                onWarehouseCatalogChange: vi.fn(),
+            },
+            dbtVersion: SupportedDbtVersions.V1_7,
+        });
+
+        expect(adapter.remoteRepositoryUrl).toBe(
+            'https://github.com/org/repo.git',
+        );
+
+        await adapter.destroy();
+    });
+});

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
@@ -50,9 +50,10 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
             throw new Error(error);
         }
 
-        const remoteRepositoryUrl = `https://lightdash:${githubPersonalAccessToken}@${
-            hostDomain || DEFAULT_GITHUB_HOST_DOMAIN
-        }/${githubRepository}.git`;
+        const githubHostDomain = hostDomain || DEFAULT_GITHUB_HOST_DOMAIN;
+        const remoteRepositoryUrl = githubPersonalAccessToken
+            ? `https://lightdash:${githubPersonalAccessToken}@${githubHostDomain}/${githubRepository}.git`
+            : `https://${githubHostDomain}/${githubRepository}.git`;
         super({
             warehouseClient,
             remoteRepositoryUrl,

--- a/packages/backend/src/services/ProjectDbtSourcesService.test.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.test.ts
@@ -556,6 +556,34 @@ describe('ProjectDbtSourcesService', () => {
             );
         });
 
+        it('rejects an invalid GitHub token before updating the source', async () => {
+            projectDbtSourcesModel.getSource.mockResolvedValue({
+                projectDbtSourceUuid: sourceUuid,
+                projectUuid,
+                dbtConnection: githubConnection,
+            } as never);
+            const service = getService();
+
+            await expect(
+                service.updateProjectDbtSource(
+                    adminAccount,
+                    projectUuid,
+                    sourceUuid,
+                    {
+                        dbtConnection: {
+                            ...githubConnection,
+                            authorization_method: 'personal_access_token',
+                            personal_access_token: 'invalid',
+                        } as never,
+                    },
+                ),
+            ).rejects.toThrow(
+                'GitHub token should start with "github_pat_", "ghp_", "gho_", "ghs_", or "ghu_"',
+            );
+
+            expect(projectDbtSourcesModel.updateSource).not.toHaveBeenCalled();
+        });
+
         it('rejects a source uuid that belongs to a different project', async () => {
             projectDbtSourcesModel.getSource.mockResolvedValue({
                 projectDbtSourceUuid: sourceUuid,

--- a/packages/backend/src/services/ProjectDbtSourcesService.test.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.test.ts
@@ -240,6 +240,25 @@ describe('ProjectDbtSourcesService', () => {
             expect(projectDbtSourcesModel.createSource).not.toHaveBeenCalled();
         });
 
+        it('rejects an invalid GitHub token before creating the source', async () => {
+            const service = getService();
+
+            await expect(
+                service.createProjectDbtSource(adminAccount, projectUuid, {
+                    name: 'private_source',
+                    dbtConnection: {
+                        ...githubConnection,
+                        authorization_method: 'personal_access_token',
+                        personal_access_token: 'invalid',
+                    } as never,
+                }),
+            ).rejects.toThrow(
+                'GitHub token should start with "github_pat_", "ghp_", "gho_", "ghs_", or "ghu_"',
+            );
+
+            expect(projectDbtSourcesModel.createSource).not.toHaveBeenCalled();
+        });
+
         it('creates a GitHub source at precedence = max(existing) + 1', async () => {
             projectDbtSourcesModel.getSources.mockResolvedValue([
                 { precedence: 1 } as never,
@@ -376,6 +395,34 @@ describe('ProjectDbtSourcesService', () => {
                     { dbtConnection: { type: DbtProjectType.GITLAB } as never },
                 ),
             ).rejects.toThrow(ParameterError);
+
+            expect(projectDbtSourcesModel.updateSource).not.toHaveBeenCalled();
+        });
+
+        it('rejects an invalid GitHub token before updating the source', async () => {
+            projectDbtSourcesModel.getSource.mockResolvedValue({
+                projectDbtSourceUuid: sourceUuid,
+                projectUuid,
+                dbtConnection: githubConnection,
+            } as never);
+            const service = getService();
+
+            await expect(
+                service.updateProjectDbtSource(
+                    adminAccount,
+                    projectUuid,
+                    sourceUuid,
+                    {
+                        dbtConnection: {
+                            ...githubConnection,
+                            authorization_method: 'personal_access_token',
+                            personal_access_token: 'invalid',
+                        } as never,
+                    },
+                ),
+            ).rejects.toThrow(
+                'GitHub token should start with "github_pat_", "ghp_", "gho_", "ghs_", or "ghu_"',
+            );
 
             expect(projectDbtSourcesModel.updateSource).not.toHaveBeenCalled();
         });

--- a/packages/backend/src/services/ProjectDbtSourcesService.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.ts
@@ -13,8 +13,8 @@ import {
     ProjectDbtSourceWithConnection,
     sensitiveDbtCredentialsFieldNames,
     UnexpectedServerError,
-    validateProjectDbtSourceName,
     validateGithubToken,
+    validateProjectDbtSourceName,
     type Account,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';

--- a/packages/backend/src/services/ProjectDbtSourcesService.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.ts
@@ -18,6 +18,7 @@ import {
     UnexpectedServerError,
     validateWarehouseLocation,
     validateProjectDbtSourceName,
+    validateGithubToken,
     type Account,
     type WarehouseLocation,
 } from '@lightdash/common';
@@ -155,6 +156,23 @@ export class ProjectDbtSourcesService extends BaseService {
         return location;
     }
 
+    private static validateGithubPersonalAccessToken(
+        dbtConnection: DbtProjectConfig,
+    ): void {
+        if (
+            dbtConnection.type !== DbtProjectType.GITHUB ||
+            !dbtConnection.personal_access_token
+        ) {
+            return;
+        }
+        const [isValid, error] = validateGithubToken(
+            dbtConnection.personal_access_token,
+        );
+        if (!isValid) {
+            throw new ParameterError(error);
+        }
+    }
+
     private async checkProjectAccess(
         account: Account,
         projectUuid: string,
@@ -223,6 +241,9 @@ export class ProjectDbtSourcesService extends BaseService {
                 'Additional dbt sources currently support GitHub connections only',
             );
         }
+        ProjectDbtSourcesService.validateGithubPersonalAccessToken(
+            data.dbtConnection,
+        );
         ProjectDbtSourcesService.validateDbtEnvironmentVariables(
             data.dbtConnection,
         );
@@ -344,6 +365,9 @@ export class ProjectDbtSourcesService extends BaseService {
             );
         }
         if (data.dbtConnection) {
+            ProjectDbtSourcesService.validateGithubPersonalAccessToken(
+                data.dbtConnection,
+            );
             ProjectDbtSourcesService.validateDbtEnvironmentVariables(
                 data.dbtConnection,
             );

--- a/packages/backend/src/services/ProjectDbtSourcesService.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.ts
@@ -14,6 +14,7 @@ import {
     sensitiveDbtCredentialsFieldNames,
     UnexpectedServerError,
     validateProjectDbtSourceName,
+    validateGithubToken,
     type Account,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
@@ -130,6 +131,23 @@ export class ProjectDbtSourcesService extends BaseService {
         });
     }
 
+    private static validateGithubPersonalAccessToken(
+        dbtConnection: DbtProjectConfig,
+    ): void {
+        if (
+            dbtConnection.type !== DbtProjectType.GITHUB ||
+            !dbtConnection.personal_access_token
+        ) {
+            return;
+        }
+        const [isValid, error] = validateGithubToken(
+            dbtConnection.personal_access_token,
+        );
+        if (!isValid) {
+            throw new ParameterError(error);
+        }
+    }
+
     private async checkProjectAccess(
         account: Account,
         projectUuid: string,
@@ -195,6 +213,9 @@ export class ProjectDbtSourcesService extends BaseService {
                 'Additional dbt sources currently support GitHub connections only',
             );
         }
+        ProjectDbtSourcesService.validateGithubPersonalAccessToken(
+            data.dbtConnection,
+        );
         ProjectDbtSourcesService.validateDbtEnvironmentVariables(
             data.dbtConnection,
         );
@@ -310,6 +331,9 @@ export class ProjectDbtSourcesService extends BaseService {
             );
         }
         if (data.dbtConnection) {
+            ProjectDbtSourcesService.validateGithubPersonalAccessToken(
+                data.dbtConnection,
+            );
             ProjectDbtSourcesService.validateDbtEnvironmentVariables(
                 data.dbtConnection,
             );

--- a/packages/common/src/utils/github.test.ts
+++ b/packages/common/src/utils/github.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { validateGithubToken } from './github';
+
+describe('validateGithubToken', () => {
+    it.each([
+        'ghp_token',
+        'github_pat_token',
+        'gho_token',
+        'ghs_token',
+        'ghu_token',
+    ])('accepts the GitHub token family %s', (token) => {
+        expect(validateGithubToken(token)).toEqual([true, undefined]);
+    });
+
+    it('allows an empty token for public repositories', () => {
+        expect(validateGithubToken('')).toEqual([true, undefined]);
+    });
+
+    it('names every supported prefix when rejecting a token', () => {
+        expect(validateGithubToken('invalid')).toEqual([
+            false,
+            'GitHub token should start with "github_pat_", "ghp_", "gho_", "ghs_", or "ghu_"',
+        ]);
+    });
+});

--- a/packages/common/src/utils/github.ts
+++ b/packages/common/src/utils/github.ts
@@ -1,13 +1,16 @@
 export const isGithubToken = (value: string) =>
-    !!value.match(/^(github_pat_|ghp_|ghs_)/);
+    /^(github_pat_|ghp_|gho_|ghs_|ghu_)/.test(value);
 
 export const validateGithubToken = (
     value: string,
 ): [boolean, string | undefined] => {
+    if (value === '') {
+        return [true, undefined];
+    }
     if (!isGithubToken(value)) {
         return [
             false,
-            `GitHub token should start with "github_pat_" or "ghp_"`,
+            `GitHub token should start with "github_pat_", "ghp_", "gho_", "ghs_", or "ghu_"`,
         ];
     }
     return [true, undefined];

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
@@ -12,6 +12,7 @@ import {
     Avatar,
     Tooltip,
 } from '@mantine/core';
+import { useInterval } from '@mantine/hooks';
 import { IconCheck, IconRefresh } from '@tabler/icons-react';
 import React, { useEffect, type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -51,18 +52,20 @@ const GithubLoginForm: FC<{ disabled: boolean }> = ({ disabled }) => {
         }
     }, [config?.installationId, form]);
 
-    useEffect(() => {
-        if (
-            repos &&
-            repos.length > 0 &&
-            form.values.dbt.type === DbtProjectType.GITHUB &&
-            form.values.dbt.repository === ''
-        ) {
-            form.setFieldValue('dbt.repository', repos[0].fullName);
-        }
-    }, [repos, form]);
-
     const { showToastSuccess } = useToaster();
+    const installationPolling = useInterval(() => {
+        void refetch()
+            .then((status) => {
+                if (status.status === 'success' && status.data.installationId) {
+                    showToastSuccess({
+                        title: 'Successfully connected to GitHub',
+                    });
+                    installationPolling.stop();
+                    void refetchRepos();
+                }
+            })
+            .catch(() => {});
+    }, 2000);
 
     const repositoryField = form.getInputProps('dbt.repository');
 
@@ -77,6 +80,7 @@ const GithubLoginForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                             required
                             w="90%"
                             label="Repository"
+                            placeholder="Select a repository"
                             disabled={disabled}
                             data={repos.map((repo) => ({
                                 value: repo.fullName,
@@ -158,24 +162,7 @@ const GithubLoginForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                         '_blank',
                         'popup=true,width=600,height=700',
                     );
-                    // Poll the API to check if the installation is successful
-                    const interval = setInterval(() => {
-                        refetch()
-                            .then((s) => {
-                                if (
-                                    s.status === 'success' &&
-                                    s.data.installationId
-                                ) {
-                                    showToastSuccess({
-                                        title: 'Successfully connected to GitHub',
-                                    });
-
-                                    clearInterval(interval);
-                                    void refetchRepos();
-                                }
-                            })
-                            .catch(() => {});
-                    }, 2000);
+                    installationPolling.start();
                 }}
             >
                 Sign in with GitHub
@@ -203,9 +190,10 @@ const GithubLoginForm: FC<{ disabled: boolean }> = ({ disabled }) => {
 const GithubPersonalAccessTokenForm: FC<{ disabled: boolean }> = ({
     disabled,
 }) => {
-    const { savedProject } = useProjectFormContext();
+    const { savedProject, isDbtSource } = useProjectFormContext();
     const form = useFormContext();
     const requireSecrets: boolean =
+        !isDbtSource &&
         savedProject?.dbtConnection.type !== DbtProjectType.GITHUB;
 
     return (
@@ -214,19 +202,24 @@ const GithubPersonalAccessTokenForm: FC<{ disabled: boolean }> = ({
                 name="dbt.personal_access_token"
                 label="Personal access token"
                 description={
-                    <p>
-                        This is used to access your repo.
-                        <Anchor
-                            inherit
-                            target="_blank"
-                            href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#github"
-                            rel="noreferrer"
-                        >
-                            {' '}
-                            Click to open documentation
-                        </Anchor>
-                        .
-                    </p>
+                    <>
+                        {isDbtSource && (
+                            <p>Required for private repositories</p>
+                        )}
+                        <p>
+                            This is used to access your repo.
+                            <Anchor
+                                inherit
+                                target="_blank"
+                                href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#github"
+                                rel="noreferrer"
+                            >
+                                {' '}
+                                Click to open documentation
+                            </Anchor>
+                            .
+                        </p>
+                    </>
                 }
                 required={requireSecrets}
                 {...form.getInputProps('dbt.personal_access_token')}

--- a/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.test.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.test.tsx
@@ -238,4 +238,39 @@ describe('DbtSourcesPanel', () => {
             expect.objectContaining({ method: 'PATCH' }),
         );
     });
+
+    it('marks the access token as optional for public repositories', async () => {
+        const { dialog, user } = await openAddSourceModal();
+
+        await user.click(
+            within(dialog).getByRole('textbox', {
+                name: 'Authorization method',
+            }),
+        );
+        await user.click(
+            await screen.findByRole('option', {
+                name: 'Personal Access Token',
+            }),
+        );
+
+        expect(
+            within(dialog).getByLabelText(/Personal access token/),
+        ).not.toBeRequired();
+        expect(
+            within(dialog).getByText('Required for private repositories'),
+        ).toBeInTheDocument();
+    });
+
+    it('starts app authentication with no repository selected', async () => {
+        const { dialog } = await openAddSourceModal();
+        const repository = await within(dialog).findByRole('textbox', {
+            name: 'Repository',
+        });
+
+        expect(repository).toHaveValue('');
+        expect(repository).toHaveAttribute(
+            'placeholder',
+            'Select a repository',
+        );
+    });
 });


### PR DESCRIPTION
Linear: SPK-1053\n\n### Description\n- allow tokenless clones for public repositories\n- validate supplied GitHub token families when sources are saved\n- make source access tokens optional in the UI and clean up installation polling