### PR TITLE
fix: warn when synced tables have errors

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -3139,7 +3139,14 @@ describe('ProjectService', () => {
                 },
                 'refreshTablesAndProjectConfig',
             ).mockResolvedValueOnce({
-                explores: [],
+                explores: [
+                    validExplore,
+                    {
+                        name: 'invalid_orders',
+                        label: 'Invalid orders',
+                        errors: [],
+                    },
+                ],
                 lightdashProjectConfig: {
                     spotlight: {
                         categories: {
@@ -3191,7 +3198,11 @@ describe('ProjectService', () => {
             );
             expect(jobModel.update).toHaveBeenCalledWith(compileJobUuid, {
                 jobStatus: JobStatusType.DONE,
-                jobResults: { indexCatalogJobUuid: { jobId: 'catalog-job-1' } },
+                jobResults: {
+                    indexCatalogJobUuid: { jobId: 'catalog-job-1' },
+                    errorCount: 1,
+                    total: 2,
+                },
             });
         });
 
@@ -3220,6 +3231,85 @@ describe('ProjectService', () => {
             ).rejects.toThrowError(ForbiddenError);
 
             expect(tagsModel.replaceYamlTags).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('testAndCompileProject', () => {
+        test('records explore errors for settings-page deploys', async () => {
+            const compileJobUuid = 'settings-compile-job-uuid';
+            const invalidExplore = {
+                name: 'invalid_orders',
+                label: 'Invalid orders',
+                errors: [],
+            };
+            const adapter = {
+                compileAllExplores: vi.fn(async () => [
+                    validExplore,
+                    invalidExplore,
+                ]),
+                getLightdashProjectConfig: vi.fn(async () => ({
+                    spotlight: { categories: {} },
+                    parameters: {},
+                    table_groups: {},
+                })),
+                destroy: vi.fn(async () => undefined),
+            } as unknown as ProjectAdapter;
+            const sshTunnel = {
+                disconnect: vi.fn(async () => undefined),
+            };
+
+            projectModel.getWithSensitiveFields.mockResolvedValueOnce({
+                ...projectWithSensitiveFields,
+                warehouseConnection: warehouseClientMock.credentials,
+            });
+
+            vi.spyOn(
+                service as unknown as {
+                    testProjectAdapter: () => Promise<unknown>;
+                },
+                'testProjectAdapter',
+            ).mockResolvedValueOnce({
+                adapter,
+                sshTunnel,
+                warehouseCredentials: warehouseClientMock.credentials,
+                cachedWarehouse: {
+                    warehouseCatalog: undefined,
+                    onWarehouseCatalogChange: vi.fn(),
+                },
+                dbtVersionOption: DefaultSupportedDbtVersion,
+            });
+            vi.spyOn(
+                service as unknown as {
+                    getProjectContextFromAdapter: () => Promise<undefined>;
+                },
+                'getProjectContextFromAdapter',
+            ).mockResolvedValueOnce(undefined);
+            vi.spyOn(
+                service,
+                'saveExploresToCacheAndIndexCatalog',
+            ).mockResolvedValueOnce('catalog-job-1');
+
+            await service.testAndCompileProject(
+                {
+                    ...user,
+                    organizationUuid: 'organizationUuid',
+                    organizationName: 'Organization',
+                    organizationCreatedAt: new Date(),
+                },
+                projectUuid,
+                RequestMethod.WEB_APP,
+                compileJobUuid,
+                'project_connection_form',
+            );
+
+            expect(jobModel.update).toHaveBeenCalledWith(compileJobUuid, {
+                jobStatus: JobStatusType.DONE,
+                jobResults: {
+                    indexCatalogJobUuid: 'catalog-job-1',
+                    errorCount: 1,
+                    total: 2,
+                },
+            });
         });
     });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -3026,7 +3026,14 @@ describe('ProjectService', () => {
                 },
                 'refreshTablesAndProjectConfig',
             ).mockResolvedValueOnce({
-                explores: [],
+                explores: [
+                    validExplore,
+                    {
+                        name: 'invalid_orders',
+                        label: 'Invalid orders',
+                        errors: [],
+                    },
+                ],
                 lightdashProjectConfig: {
                     spotlight: {
                         categories: {
@@ -3078,7 +3085,11 @@ describe('ProjectService', () => {
             );
             expect(jobModel.update).toHaveBeenCalledWith(compileJobUuid, {
                 jobStatus: JobStatusType.DONE,
-                jobResults: { indexCatalogJobUuid: { jobId: 'catalog-job-1' } },
+                jobResults: {
+                    indexCatalogJobUuid: { jobId: 'catalog-job-1' },
+                    errorCount: 1,
+                    total: 2,
+                },
             });
         });
 
@@ -3107,6 +3118,85 @@ describe('ProjectService', () => {
             ).rejects.toThrowError(ForbiddenError);
 
             expect(tagsModel.replaceYamlTags).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('testAndCompileProject', () => {
+        test('records explore errors for settings-page deploys', async () => {
+            const compileJobUuid = 'settings-compile-job-uuid';
+            const invalidExplore = {
+                name: 'invalid_orders',
+                label: 'Invalid orders',
+                errors: [],
+            };
+            const adapter = {
+                compileAllExplores: vi.fn(async () => [
+                    validExplore,
+                    invalidExplore,
+                ]),
+                getLightdashProjectConfig: vi.fn(async () => ({
+                    spotlight: { categories: {} },
+                    parameters: {},
+                    table_groups: {},
+                })),
+                destroy: vi.fn(async () => undefined),
+            } as unknown as ProjectAdapter;
+            const sshTunnel = {
+                disconnect: vi.fn(async () => undefined),
+            };
+
+            projectModel.getWithSensitiveFields.mockResolvedValueOnce({
+                ...projectWithSensitiveFields,
+                warehouseConnection: warehouseClientMock.credentials,
+            });
+
+            vi.spyOn(
+                service as unknown as {
+                    testProjectAdapter: () => Promise<unknown>;
+                },
+                'testProjectAdapter',
+            ).mockResolvedValueOnce({
+                adapter,
+                sshTunnel,
+                warehouseCredentials: warehouseClientMock.credentials,
+                cachedWarehouse: {
+                    warehouseCatalog: undefined,
+                    onWarehouseCatalogChange: vi.fn(),
+                },
+                dbtVersionOption: DefaultSupportedDbtVersion,
+            });
+            vi.spyOn(
+                service as unknown as {
+                    getProjectContextFromAdapter: () => Promise<undefined>;
+                },
+                'getProjectContextFromAdapter',
+            ).mockResolvedValueOnce(undefined);
+            vi.spyOn(
+                service,
+                'saveExploresToCacheAndIndexCatalog',
+            ).mockResolvedValueOnce('catalog-job-1');
+
+            await service.testAndCompileProject(
+                {
+                    ...user,
+                    organizationUuid: 'organizationUuid',
+                    organizationName: 'Organization',
+                    organizationCreatedAt: new Date(),
+                },
+                projectUuid,
+                RequestMethod.WEB_APP,
+                compileJobUuid,
+                'project_connection_form',
+            );
+
+            expect(jobModel.update).toHaveBeenCalledWith(compileJobUuid, {
+                jobStatus: JobStatusType.DONE,
+                jobResults: {
+                    indexCatalogJobUuid: 'catalog-job-1',
+                    errorCount: 1,
+                    total: 2,
+                },
+            });
         });
     });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3784,7 +3784,7 @@ export class ProjectService extends BaseService {
             // Source git clones built only to read manifests for the merge.
             const manifestFetchAdapters: ProjectAdapter[] = [];
             if (updatedProject.dbtConnection.type !== DbtProjectType.NONE) {
-                await this.jobModel.tryJobStep(
+                const compileResult = await this.jobModel.tryJobStep(
                     job.jobUuid,
                     JobStepType.COMPILING,
                     async () => {
@@ -3871,18 +3871,26 @@ export class ProjectService extends BaseService {
                             );
                             timings.parameters.end = performance.now();
                             timings.cacheExplores.start = performance.now();
-                            await this.saveExploresToCacheAndIndexCatalog({
-                                userUuid: user.userUuid,
-                                projectUuid,
-                                explores,
-                                compilationSource,
-                                jobUuid: job.jobUuid,
-                                requestMethod: method,
-                                projectConfigDefaults:
-                                    lightdashProjectConfig.defaults,
-                                complete: true,
-                            });
+                            const indexCatalogJobUuid =
+                                await this.saveExploresToCacheAndIndexCatalog({
+                                    userUuid: user.userUuid,
+                                    projectUuid,
+                                    explores,
+                                    compilationSource,
+                                    jobUuid: job.jobUuid,
+                                    requestMethod: method,
+                                    projectConfigDefaults:
+                                        lightdashProjectConfig.defaults,
+                                    complete: true,
+                                });
                             timings.cacheExplores.end = performance.now();
+
+                            return {
+                                indexCatalogJobUuid,
+                                errorCount:
+                                    explores.filter(isExploreError).length,
+                                total: explores.length,
+                            };
                         } finally {
                             await compileAdapter.destroy();
                             await sshTunnel.disconnect();
@@ -3903,14 +3911,18 @@ export class ProjectService extends BaseService {
                         }
                     },
                 );
+                await this.jobModel.update(job.jobUuid, {
+                    jobStatus: JobStatusType.DONE,
+                    jobResults: compileResult,
+                });
+            } else {
+                await this.jobModel.update(job.jobUuid, {
+                    jobStatus: JobStatusType.DONE,
+                    jobResults: {
+                        projectUuid,
+                    },
+                });
             }
-
-            await this.jobModel.update(job.jobUuid, {
-                jobStatus: JobStatusType.DONE,
-                jobResults: {
-                    projectUuid,
-                },
-            });
             const projectWithWarehouse = {
                 ...updatedProject,
                 warehouseConnection: updatedProject.warehouseConnection,
@@ -8561,7 +8573,7 @@ export class ProjectService extends BaseService {
                 await this.jobModel.update(job.jobUuid, {
                     jobStatus: JobStatusType.RUNNING,
                 });
-                const indexCatalogJobUuid = await this.jobModel.tryJobStep(
+                const compileResult = await this.jobModel.tryJobStep(
                     job.jobUuid,
                     JobStepType.COMPILING,
                     async () => {
@@ -8615,28 +8627,31 @@ export class ProjectService extends BaseService {
                         );
                         timings.parameters.end = performance.now();
                         timings.cacheExplores.start = performance.now();
-                        const result = this.saveExploresToCacheAndIndexCatalog({
-                            userUuid: user.userUuid,
-                            projectUuid,
-                            explores,
-                            compilationSource: 'refresh_dbt',
-                            jobUuid: job.jobUuid,
-                            requestMethod,
-                            projectConfigDefaults:
-                                lightdashProjectConfig.defaults,
-                            complete: true,
-                        });
+                        const indexCatalogJobUuid =
+                            await this.saveExploresToCacheAndIndexCatalog({
+                                userUuid: user.userUuid,
+                                projectUuid,
+                                explores,
+                                compilationSource: 'refresh_dbt',
+                                jobUuid: job.jobUuid,
+                                requestMethod,
+                                projectConfigDefaults:
+                                    lightdashProjectConfig.defaults,
+                                complete: true,
+                            });
                         timings.cacheExplores.end = performance.now();
 
-                        return result;
+                        return {
+                            indexCatalogJobUuid,
+                            errorCount: explores.filter(isExploreError).length,
+                            total: explores.length,
+                        };
                     },
                 );
 
                 await this.jobModel.update(job.jobUuid, {
                     jobStatus: JobStatusType.DONE,
-                    jobResults: {
-                        indexCatalogJobUuid,
-                    },
+                    jobResults: compileResult,
                 });
             } catch (e) {
                 await this.jobModel.update(job.jobUuid, {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3776,7 +3776,7 @@ export class ProjectService extends BaseService {
             // Source git clones built only to read manifests for the merge.
             const manifestFetchAdapters: ProjectAdapter[] = [];
             if (updatedProject.dbtConnection.type !== DbtProjectType.NONE) {
-                await this.jobModel.tryJobStep(
+                const compileResult = await this.jobModel.tryJobStep(
                     job.jobUuid,
                     JobStepType.COMPILING,
                     async () => {
@@ -3863,18 +3863,26 @@ export class ProjectService extends BaseService {
                             );
                             timings.parameters.end = performance.now();
                             timings.cacheExplores.start = performance.now();
-                            await this.saveExploresToCacheAndIndexCatalog({
-                                userUuid: user.userUuid,
-                                projectUuid,
-                                explores,
-                                compilationSource,
-                                jobUuid: job.jobUuid,
-                                requestMethod: method,
-                                projectConfigDefaults:
-                                    lightdashProjectConfig.defaults,
-                                complete: true,
-                            });
+                            const indexCatalogJobUuid =
+                                await this.saveExploresToCacheAndIndexCatalog({
+                                    userUuid: user.userUuid,
+                                    projectUuid,
+                                    explores,
+                                    compilationSource,
+                                    jobUuid: job.jobUuid,
+                                    requestMethod: method,
+                                    projectConfigDefaults:
+                                        lightdashProjectConfig.defaults,
+                                    complete: true,
+                                });
                             timings.cacheExplores.end = performance.now();
+
+                            return {
+                                indexCatalogJobUuid,
+                                errorCount:
+                                    explores.filter(isExploreError).length,
+                                total: explores.length,
+                            };
                         } finally {
                             await compileAdapter.destroy();
                             await sshTunnel.disconnect();
@@ -3895,14 +3903,18 @@ export class ProjectService extends BaseService {
                         }
                     },
                 );
+                await this.jobModel.update(job.jobUuid, {
+                    jobStatus: JobStatusType.DONE,
+                    jobResults: compileResult,
+                });
+            } else {
+                await this.jobModel.update(job.jobUuid, {
+                    jobStatus: JobStatusType.DONE,
+                    jobResults: {
+                        projectUuid,
+                    },
+                });
             }
-
-            await this.jobModel.update(job.jobUuid, {
-                jobStatus: JobStatusType.DONE,
-                jobResults: {
-                    projectUuid,
-                },
-            });
             const projectWithWarehouse = {
                 ...updatedProject,
                 warehouseConnection: updatedProject.warehouseConnection,
@@ -8297,7 +8309,7 @@ export class ProjectService extends BaseService {
                 await this.jobModel.update(job.jobUuid, {
                     jobStatus: JobStatusType.RUNNING,
                 });
-                const indexCatalogJobUuid = await this.jobModel.tryJobStep(
+                const compileResult = await this.jobModel.tryJobStep(
                     job.jobUuid,
                     JobStepType.COMPILING,
                     async () => {
@@ -8351,28 +8363,31 @@ export class ProjectService extends BaseService {
                         );
                         timings.parameters.end = performance.now();
                         timings.cacheExplores.start = performance.now();
-                        const result = this.saveExploresToCacheAndIndexCatalog({
-                            userUuid: user.userUuid,
-                            projectUuid,
-                            explores,
-                            compilationSource: 'refresh_dbt',
-                            jobUuid: job.jobUuid,
-                            requestMethod,
-                            projectConfigDefaults:
-                                lightdashProjectConfig.defaults,
-                            complete: true,
-                        });
+                        const indexCatalogJobUuid =
+                            await this.saveExploresToCacheAndIndexCatalog({
+                                userUuid: user.userUuid,
+                                projectUuid,
+                                explores,
+                                compilationSource: 'refresh_dbt',
+                                jobUuid: job.jobUuid,
+                                requestMethod,
+                                projectConfigDefaults:
+                                    lightdashProjectConfig.defaults,
+                                complete: true,
+                            });
                         timings.cacheExplores.end = performance.now();
 
-                        return result;
+                        return {
+                            indexCatalogJobUuid,
+                            errorCount: explores.filter(isExploreError).length,
+                            total: explores.length,
+                        };
                     },
                 );
 
                 await this.jobModel.update(job.jobUuid, {
                     jobStatus: JobStatusType.DONE,
-                    jobResults: {
-                        indexCatalogJobUuid,
-                    },
+                    jobResults: compileResult,
                 });
             } catch (e) {
                 await this.jobModel.update(job.jobUuid, {

--- a/packages/common/src/types/job.ts
+++ b/packages/common/src/types/job.ts
@@ -55,6 +55,8 @@ type CompileJob = BaseJob & {
     jobType: JobType.COMPILE_PROJECT;
     jobResults?: {
         indexCatalogJobUuid: string;
+        errorCount?: number;
+        total?: number;
     };
 };
 

--- a/packages/frontend/src/hooks/useRefreshServer.test.ts
+++ b/packages/frontend/src/hooks/useRefreshServer.test.ts
@@ -1,0 +1,34 @@
+import { JobStatusType, JobType, type Job } from '@lightdash/common';
+import { getJobCompletionToast } from './useRefreshServer';
+
+const compileJob = (errorCount: number, total: number): Job => ({
+    jobUuid: 'job-uuid',
+    projectUuid: 'project-uuid',
+    userUuid: 'user-uuid',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    jobStatus: JobStatusType.DONE,
+    jobType: JobType.COMPILE_PROJECT,
+    steps: [],
+    jobResults: {
+        indexCatalogJobUuid: 'catalog-job-uuid',
+        errorCount,
+        total,
+    },
+});
+
+describe('getJobCompletionToast', () => {
+    test('warns when a successful sync contains explore errors', () => {
+        expect(getJobCompletionToast(compileJob(2, 10))).toEqual({
+            variant: 'warning',
+            title: 'Synced: 2 of 10 tables have errors',
+        });
+    });
+
+    test('keeps the successful sync message when every explore is valid', () => {
+        expect(getJobCompletionToast(compileJob(0, 10))).toEqual({
+            variant: 'success',
+            title: 'Successfully synced dbt project!',
+        });
+    });
+});

--- a/packages/frontend/src/hooks/useRefreshServer.ts
+++ b/packages/frontend/src/hooks/useRefreshServer.ts
@@ -58,6 +58,27 @@ export const jobStatusLabel = (status: JobStatusType, jobType?: JobType) => {
     }
 };
 
+export const getJobCompletionToast = (
+    job: Job,
+): { variant: 'success' | 'warning'; title: string } => {
+    if (
+        job.jobType === JobType.COMPILE_PROJECT &&
+        job.jobResults?.errorCount !== undefined &&
+        job.jobResults.errorCount > 0 &&
+        job.jobResults.total !== undefined
+    ) {
+        return {
+            variant: 'warning',
+            title: `Synced: ${job.jobResults.errorCount} of ${job.jobResults.total} tables have errors`,
+        };
+    }
+
+    return {
+        variant: 'success',
+        title: jobStatusLabel(job.jobStatus, job.jobType),
+    };
+};
+
 export const runningStepsInfo = (steps: JobStep[]) => {
     const runningStep = steps.find((step) => {
         return step.stepStatus === 'RUNNING';

--- a/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
+++ b/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
@@ -10,12 +10,15 @@ import { useQueryClient } from '@tanstack/react-query';
 import {
     useCallback,
     useEffect,
+    useMemo,
     useState,
     type FC,
     type SetStateAction,
 } from 'react';
+import { useNavigate } from 'react-router';
 import useToaster from '../../hooks/toaster/useToaster';
 import {
+    getJobCompletionToast,
     jobStatusLabel,
     runningStepsInfo,
     TOAST_KEY_FOR_REFRESH_JOB,
@@ -28,7 +31,13 @@ const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
     const [activeJobId, setActiveJobIdState] = useState<string | undefined>();
     const [isQuietJob, setIsQuietJob] = useState(false);
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastApiError, showToastInfo } = useToaster();
+    const navigate = useNavigate();
+    const {
+        showToastSuccess,
+        showToastApiError,
+        showToastInfo,
+        showToastWarning,
+    } = useToaster();
 
     const setActiveJobId = useCallback(
         (jobId: SetStateAction<string | undefined>) => {
@@ -61,10 +70,28 @@ const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
                     }
                     await queryClient.invalidateQueries(['parameters']);
                     if (isQuietJob) break;
-                    showToastSuccess({
-                        key: TOAST_KEY_FOR_REFRESH_JOB,
-                        title: toastTitle,
-                    });
+                    const completionToast = getJobCompletionToast(job);
+                    if (completionToast.variant === 'warning') {
+                        showToastWarning({
+                            key: TOAST_KEY_FOR_REFRESH_JOB,
+                            title: completionToast.title,
+                            action: job.projectUuid
+                                ? {
+                                      children: 'View errors',
+                                      icon: IconArrowRight,
+                                      onClick: () =>
+                                          navigate(
+                                              `/generalSettings/projectManagement/${job.projectUuid}/validator`,
+                                          ),
+                                  }
+                                : undefined,
+                        });
+                    } else {
+                        showToastSuccess({
+                            key: TOAST_KEY_FOR_REFRESH_JOB,
+                            title: completionToast.title,
+                        });
+                    }
                     break;
                 case 'RUNNING':
                     if (isQuietJob) break;
@@ -93,9 +120,11 @@ const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
         [
             showToastInfo,
             showToastSuccess,
+            showToastWarning,
             queryClient,
             isJobsDrawerOpen,
             isQuietJob,
+            navigate,
         ],
     );
 
@@ -131,22 +160,27 @@ const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
     }, [activeJob, activeJobId, toastJobStatus, isJobsDrawerOpen, queryClient]);
 
     const activeJobIsRunning = activeJob && activeJob?.jobStatus === 'RUNNING';
-
-    return (
-        <Context.Provider
-            value={{
-                isJobsDrawerOpen,
-                setIsJobsDrawerOpen,
-                activeJobId,
-                setActiveJobId,
-                setQuietActiveJobId,
-                activeJob,
-                activeJobIsRunning,
-            }}
-        >
-            {children}
-        </Context.Provider>
+    const contextValue = useMemo(
+        () => ({
+            isJobsDrawerOpen,
+            setIsJobsDrawerOpen,
+            activeJobId,
+            setActiveJobId,
+            setQuietActiveJobId,
+            activeJob,
+            activeJobIsRunning,
+        }),
+        [
+            activeJob,
+            activeJobId,
+            activeJobIsRunning,
+            isJobsDrawerOpen,
+            setActiveJobId,
+            setQuietActiveJobId,
+        ],
     );
+
+    return <Context.Provider value={contextValue}>{children}</Context.Provider>;
 };
 
 export default ActiveJobProvider;


### PR DESCRIPTION
Linear: SPK-1055\n\n### Description\n- include explore error counts in successful compile job results\n- warn when synced tables contain errors without failing the deploy\n- link the warning to the project validator