### PR TITLE
fix(cli): preserve source overrides in previews

### DIFF
--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -122,9 +122,73 @@ const getCompiledManifestModelIds = (manifest: DbtManifest): string[] =>
         )
         .map(([uniqueId]) => uniqueId);
 
+const inferLocalSourceName = (
+    localManifest: DbtManifest,
+    servedManifest: DbtManifest,
+): string | undefined => {
+    const sourceNames = new Set(
+        getManifestModelIds(localManifest).flatMap((uniqueId) => {
+            const servedNode = servedManifest.nodes[uniqueId] as
+                | SourceAnnotatedDbtNode
+                | undefined;
+            return servedNode?.resource_type === 'model' &&
+                typeof servedNode.lightdash_source_name === 'string'
+                ? [servedNode.lightdash_source_name]
+                : [];
+        }),
+    );
+
+    if (sourceNames.size > 1) {
+        throw new ParseError(
+            `Cannot automatically combine manifest from the server: overlapping local models match multiple Lightdash sources (${[...sourceNames].sort().join(', ')})`,
+        );
+    }
+
+    return sourceNames.values().next().value;
+};
+
+const withoutModelsFromSource = (
+    manifest: DbtManifest,
+    sourceName: string,
+): DbtManifest => ({
+    ...manifest,
+    nodes: Object.fromEntries(
+        Object.entries(manifest.nodes).filter(([, node]) => {
+            const sourceAnnotatedNode = node as SourceAnnotatedDbtNode;
+            return !(
+                node.resource_type === 'model' &&
+                sourceAnnotatedNode.lightdash_source_name === sourceName
+            );
+        }),
+    ),
+});
+
+const withoutUnselectedOverlappingModels = (
+    localManifest: DbtManifest,
+    servedManifest: DbtManifest,
+    sourceName: string,
+    selectedModelIds: Set<string>,
+): DbtManifest => ({
+    ...localManifest,
+    nodes: Object.fromEntries(
+        Object.entries(localManifest.nodes).filter(([uniqueId, localNode]) => {
+            const servedNode = servedManifest.nodes[uniqueId] as
+                | SourceAnnotatedDbtNode
+                | undefined;
+            return !(
+                localNode.resource_type === 'model' &&
+                !selectedModelIds.has(uniqueId) &&
+                servedNode?.resource_type === 'model' &&
+                servedNode.lightdash_source_name === sourceName
+            );
+        }),
+    ),
+});
+
 const combinePreviewManifests = (
     localManifest: DbtManifest,
     externalManifest: DbtManifest,
+    localSourceName?: string,
 ) => {
     const { manifest, addedModelIds } = combineManifests(
         localManifest,
@@ -132,14 +196,18 @@ const combinePreviewManifests = (
     );
     const nodes = { ...manifest.nodes };
 
-    Object.keys(localManifest.nodes).forEach((uniqueId) => {
+    Object.entries(localManifest.nodes).forEach(([uniqueId, localNode]) => {
         const externalNode = externalManifest.nodes[uniqueId] as
             | SourceAnnotatedDbtNode
             | undefined;
-        if (typeof externalNode?.lightdash_source_name === 'string') {
+        const sourceName =
+            localNode.resource_type === 'model' && localSourceName !== undefined
+                ? localSourceName
+                : externalNode?.lightdash_source_name;
+        if (typeof sourceName === 'string') {
             nodes[uniqueId] = {
                 ...nodes[uniqueId],
-                lightdash_source_name: externalNode.lightdash_source_name,
+                lightdash_source_name: sourceName,
             } as DbtManifest['nodes'][string];
         }
     });
@@ -497,23 +565,49 @@ export const compileProject = async (
             }
         }
         if (additionalManifest && combineSource) {
-            const localModelIds = new Set(getManifestModelIds(manifest));
-            const externalModelIds = getManifestModelIds(additionalManifest);
-            const localSourceExists = externalModelIds.some((uniqueId) =>
-                localModelIds.has(uniqueId),
-            );
+            const localSourceName = isAutomaticServerManifest
+                ? inferLocalSourceName(manifest, additionalManifest)
+                : undefined;
 
-            if (isAutomaticServerManifest && !localSourceExists) {
+            if (isAutomaticServerManifest && localSourceName === undefined) {
                 console.info(
                     styles.info(
                         `Skipped combining ${combineSource}: the local dbt project is not a source of this Lightdash project`,
                     ),
                 );
             } else {
+                const localManifest =
+                    isAutomaticServerManifest &&
+                    !isProjectComplete &&
+                    localSourceName !== undefined
+                        ? withoutUnselectedOverlappingModels(
+                              manifest,
+                              additionalManifest,
+                              localSourceName,
+                              new Set(
+                                  originallySelectedModelIds ??
+                                      compiledModelIds ??
+                                      [],
+                              ),
+                          )
+                        : manifest;
+                const externalManifest =
+                    isAutomaticServerManifest &&
+                    isProjectComplete &&
+                    localSourceName !== undefined
+                        ? withoutModelsFromSource(
+                              additionalManifest,
+                              localSourceName,
+                          )
+                        : additionalManifest;
                 const compiledExternalModelIds =
                     getCompiledManifestModelIds(additionalManifest);
                 const { manifest: merged, addedModelIds } =
-                    combinePreviewManifests(manifest, additionalManifest);
+                    combinePreviewManifests(
+                        localManifest,
+                        externalManifest,
+                        localSourceName,
+                    );
                 manifest = merged;
                 if (isAutomaticServerManifest) {
                     addedModelIds.forEach((modelId) => {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -122,9 +122,73 @@ const getCompiledManifestModelIds = (manifest: DbtManifest): string[] =>
         )
         .map(([uniqueId]) => uniqueId);
 
+const inferLocalSourceName = (
+    localManifest: DbtManifest,
+    servedManifest: DbtManifest,
+): string | undefined => {
+    const sourceNames = new Set(
+        getManifestModelIds(localManifest).flatMap((uniqueId) => {
+            const servedNode = servedManifest.nodes[uniqueId] as
+                | SourceAnnotatedDbtNode
+                | undefined;
+            return servedNode?.resource_type === 'model' &&
+                typeof servedNode.lightdash_source_name === 'string'
+                ? [servedNode.lightdash_source_name]
+                : [];
+        }),
+    );
+
+    if (sourceNames.size > 1) {
+        throw new ParseError(
+            `Cannot automatically combine manifest from the server: overlapping local models match multiple Lightdash sources (${[...sourceNames].sort().join(', ')})`,
+        );
+    }
+
+    return sourceNames.values().next().value;
+};
+
+const withoutModelsFromSource = (
+    manifest: DbtManifest,
+    sourceName: string,
+): DbtManifest => ({
+    ...manifest,
+    nodes: Object.fromEntries(
+        Object.entries(manifest.nodes).filter(([, node]) => {
+            const sourceAnnotatedNode = node as SourceAnnotatedDbtNode;
+            return !(
+                node.resource_type === 'model' &&
+                sourceAnnotatedNode.lightdash_source_name === sourceName
+            );
+        }),
+    ),
+});
+
+const withoutUnselectedOverlappingModels = (
+    localManifest: DbtManifest,
+    servedManifest: DbtManifest,
+    sourceName: string,
+    selectedModelIds: Set<string>,
+): DbtManifest => ({
+    ...localManifest,
+    nodes: Object.fromEntries(
+        Object.entries(localManifest.nodes).filter(([uniqueId, localNode]) => {
+            const servedNode = servedManifest.nodes[uniqueId] as
+                | SourceAnnotatedDbtNode
+                | undefined;
+            return !(
+                localNode.resource_type === 'model' &&
+                !selectedModelIds.has(uniqueId) &&
+                servedNode?.resource_type === 'model' &&
+                servedNode.lightdash_source_name === sourceName
+            );
+        }),
+    ),
+});
+
 const combinePreviewManifests = (
     localManifest: DbtManifest,
     externalManifest: DbtManifest,
+    localSourceName?: string,
 ) => {
     const { manifest, addedModelIds } = combineManifests(
         localManifest,
@@ -132,14 +196,18 @@ const combinePreviewManifests = (
     );
     const nodes = { ...manifest.nodes };
 
-    Object.keys(localManifest.nodes).forEach((uniqueId) => {
+    Object.entries(localManifest.nodes).forEach(([uniqueId, localNode]) => {
         const externalNode = externalManifest.nodes[uniqueId] as
             | SourceAnnotatedDbtNode
             | undefined;
-        if (typeof externalNode?.lightdash_source_name === 'string') {
+        const sourceName =
+            localNode.resource_type === 'model' && localSourceName !== undefined
+                ? localSourceName
+                : externalNode?.lightdash_source_name;
+        if (typeof sourceName === 'string') {
             nodes[uniqueId] = {
                 ...nodes[uniqueId],
-                lightdash_source_name: externalNode.lightdash_source_name,
+                lightdash_source_name: sourceName,
             } as DbtManifest['nodes'][string];
         }
     });
@@ -473,23 +541,49 @@ export const compileProject = async (
             }
         }
         if (additionalManifest && combineSource) {
-            const localModelIds = new Set(getManifestModelIds(manifest));
-            const externalModelIds = getManifestModelIds(additionalManifest);
-            const localSourceExists = externalModelIds.some((uniqueId) =>
-                localModelIds.has(uniqueId),
-            );
+            const localSourceName = isAutomaticServerManifest
+                ? inferLocalSourceName(manifest, additionalManifest)
+                : undefined;
 
-            if (isAutomaticServerManifest && !localSourceExists) {
+            if (isAutomaticServerManifest && localSourceName === undefined) {
                 console.info(
                     styles.info(
                         `Skipped combining ${combineSource}: the local dbt project is not a source of this Lightdash project`,
                     ),
                 );
             } else {
+                const localManifest =
+                    isAutomaticServerManifest &&
+                    !isProjectComplete &&
+                    localSourceName !== undefined
+                        ? withoutUnselectedOverlappingModels(
+                              manifest,
+                              additionalManifest,
+                              localSourceName,
+                              new Set(
+                                  originallySelectedModelIds ??
+                                      compiledModelIds ??
+                                      [],
+                              ),
+                          )
+                        : manifest;
+                const externalManifest =
+                    isAutomaticServerManifest &&
+                    isProjectComplete &&
+                    localSourceName !== undefined
+                        ? withoutModelsFromSource(
+                              additionalManifest,
+                              localSourceName,
+                          )
+                        : additionalManifest;
                 const compiledExternalModelIds =
                     getCompiledManifestModelIds(additionalManifest);
                 const { manifest: merged, addedModelIds } =
-                    combinePreviewManifests(manifest, additionalManifest);
+                    combinePreviewManifests(
+                        localManifest,
+                        externalManifest,
+                        localSourceName,
+                    );
                 manifest = merged;
                 if (isAutomaticServerManifest) {
                     addedModelIds.forEach((modelId) => {

--- a/packages/cli/src/handlers/compileProject.test.ts
+++ b/packages/cli/src/handlers/compileProject.test.ts
@@ -327,6 +327,239 @@ describe('compileProject completeness', () => {
         );
     });
 
+    test('replaces the complete local source while retaining served models from other sources', async () => {
+        const projectManifest = manifest({
+            'model.local.orders': dbtNode('model.local.orders', 'model', true, {
+                description: 'Local orders description',
+            }),
+        });
+        const servedManifest = projectMergedManifest(
+            manifest({
+                'model.local.orders': dbtNode(
+                    'model.local.orders',
+                    'model',
+                    true,
+                    {
+                        description: 'Served orders description',
+                        lightdash_source_name: 'local_source',
+                    },
+                ),
+                'model.local.deleted': dbtNode(
+                    'model.local.deleted',
+                    'model',
+                    true,
+                    {
+                        lightdash_source_name: 'local_source',
+                    },
+                ),
+                'model.other.customers': dbtNode(
+                    'model.other.customers',
+                    'model',
+                    true,
+                    {
+                        lightdash_source_name: 'other_source',
+                    },
+                ),
+            }),
+        );
+        vi.mocked(loadManifest).mockResolvedValue(projectManifest);
+        vi.mocked(lightdashRawApi).mockResolvedValue(
+            new Response(JSON.stringify(servedManifest)),
+        );
+        vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+            compiledModelIds: ['model.local.orders'],
+            originallySelectedModelIds: undefined,
+        });
+
+        const result = await compileProject({
+            ...compileOptions(tempDir),
+            combineManifestProjectUuid: 'project-uuid',
+        });
+
+        expect(result.isProjectComplete).toBe(true);
+        expect(result.explores.map((explore) => explore.name)).toEqual([
+            'orders',
+            'customers',
+        ]);
+        const modelsForValidation =
+            vi.mocked(validateDbtModel).mock.calls[0][2];
+        expect(modelsForValidation).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    unique_id: 'model.local.orders',
+                    description: 'Local orders description',
+                    lightdash_source_name: 'local_source',
+                }),
+                expect.objectContaining({
+                    unique_id: 'model.other.customers',
+                    lightdash_source_name: 'other_source',
+                }),
+            ]),
+        );
+        expect(
+            modelsForValidation.map((model) => model.unique_id),
+        ).not.toContain('model.local.deleted');
+    });
+
+    test('additively combines selective local models with compiled served collision candidates', async () => {
+        const projectManifest = manifest({
+            'model.source_a.orders': dbtNode(
+                'model.source_a.orders',
+                'model',
+                true,
+                {
+                    description: 'Local selected orders',
+                },
+            ),
+            'model.source_a.customers': dbtNode(
+                'model.source_a.customers',
+                'model',
+                true,
+                {
+                    description: 'Local unselected customers',
+                },
+            ),
+        });
+        const servedManifest = projectMergedManifest(
+            manifest({
+                'model.source_a.orders': dbtNode(
+                    'model.source_a.orders',
+                    'model',
+                    true,
+                    {
+                        description: 'Served selected orders',
+                        lightdash_source_name: 'source_a',
+                    },
+                ),
+                'model.source_a.customers': dbtNode(
+                    'model.source_a.customers',
+                    'model',
+                    true,
+                    {
+                        description: 'Served unselected customers',
+                        lightdash_source_name: 'source_a',
+                    },
+                ),
+                'model.source_a.deleted': dbtNode(
+                    'model.source_a.deleted',
+                    'model',
+                    true,
+                    {
+                        lightdash_source_name: 'source_a',
+                    },
+                ),
+                'model.source_b.customers': dbtNode(
+                    'model.source_b.customers',
+                    'model',
+                    true,
+                    {
+                        lightdash_source_name: 'source_b',
+                    },
+                ),
+            }),
+        );
+        vi.mocked(loadManifest).mockResolvedValue(projectManifest);
+        vi.mocked(lightdashRawApi).mockResolvedValue(
+            new Response(JSON.stringify(servedManifest)),
+        );
+        vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+            compiledModelIds: ['model.source_a.orders'],
+            originallySelectedModelIds: ['model.source_a.orders'],
+        });
+
+        const result = await compileProject({
+            ...compileOptions(tempDir),
+            combineManifestProjectUuid: 'project-uuid',
+        });
+
+        expect(result.isProjectComplete).toBe(false);
+        const modelsForValidation =
+            vi.mocked(validateDbtModel).mock.calls[0][2];
+        expect(modelsForValidation).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    unique_id: 'model.source_a.orders',
+                    description: 'Local selected orders',
+                    lightdash_source_name: 'source_a',
+                }),
+                expect.objectContaining({
+                    unique_id: 'model.source_a.customers',
+                    description: 'Served unselected customers',
+                    compiled: true,
+                    lightdash_source_name: 'source_a',
+                }),
+                expect.objectContaining({
+                    unique_id: 'model.source_a.deleted',
+                    lightdash_source_name: 'source_a',
+                }),
+                expect.objectContaining({
+                    unique_id: 'model.source_b.customers',
+                    lightdash_source_name: 'source_b',
+                }),
+            ]),
+        );
+        const unselectedCollisionCandidates = modelsForValidation.filter(
+            (model) => model.name === 'customers',
+        ) as (DbtModelNode & { lightdash_source_name?: string })[];
+        expect(
+            unselectedCollisionCandidates.map((model) => ({
+                uniqueId: model.unique_id,
+                sourceName: model.lightdash_source_name,
+            })),
+        ).toEqual([
+            {
+                uniqueId: 'model.source_a.customers',
+                sourceName: 'source_a',
+            },
+            {
+                uniqueId: 'model.source_b.customers',
+                sourceName: 'source_b',
+            },
+        ]);
+    });
+
+    test('rejects automatic combination when overlaps identify multiple local sources', async () => {
+        const projectManifest = manifest({
+            'model.local.orders': dbtNode('model.local.orders', 'model', true),
+            'model.local.customers': dbtNode(
+                'model.local.customers',
+                'model',
+                true,
+            ),
+        });
+        const servedManifest = manifest({
+            'model.local.orders': dbtNode('model.local.orders', 'model', true, {
+                lightdash_source_name: 'source_a',
+            }),
+            'model.local.customers': dbtNode(
+                'model.local.customers',
+                'model',
+                true,
+                {
+                    lightdash_source_name: 'source_c',
+                },
+            ),
+        });
+        vi.mocked(loadManifest).mockResolvedValue(projectManifest);
+        vi.mocked(lightdashRawApi).mockResolvedValue(
+            new Response(JSON.stringify(servedManifest)),
+        );
+        vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+            compiledModelIds: ['model.local.orders', 'model.local.customers'],
+            originallySelectedModelIds: undefined,
+        });
+
+        await expect(
+            compileProject({
+                ...compileOptions(tempDir),
+                combineManifestProjectUuid: 'project-uuid',
+            }),
+        ).rejects.toThrow(
+            'Cannot automatically combine manifest from the server: overlapping local models match multiple Lightdash sources (source_a, source_c)',
+        );
+        expect(validateDbtModel).not.toHaveBeenCalled();
+    });
+
     test('skips automatic combination when the local dbt project is not a served source', async () => {
         const projectManifest = manifest({
             'model.local.orders': dbtNode('model.local.orders', 'model', true),
@@ -367,7 +600,9 @@ describe('compileProject completeness', () => {
             'model.test.orders': dbtNode('model.test.orders', 'model', true),
         });
         const servedManifest = manifest({
-            'model.test.orders': dbtNode('model.test.orders', 'model', false),
+            'model.test.orders': dbtNode('model.test.orders', 'model', false, {
+                lightdash_source_name: 'local_source',
+            }),
             'model.served.helper': dbtNode(
                 'model.served.helper',
                 'model',
@@ -398,7 +633,9 @@ describe('compileProject completeness', () => {
             'model.test.orders': dbtNode('model.test.orders', 'model', true),
         });
         const servedManifest = manifest({
-            'model.test.orders': dbtNode('model.test.orders', 'model', true),
+            'model.test.orders': dbtNode('model.test.orders', 'model', true, {
+                lightdash_source_name: 'local_source',
+            }),
         });
         vi.mocked(loadManifest).mockResolvedValue(projectManifest);
         vi.mocked(lightdashRawApi).mockResolvedValue(


### PR DESCRIPTION
## What this change does

Automatic server-manifest combination now respects the scope of the local dbt compile.

- A complete compile makes the local source authoritative: stale served nodes for that source are removed, so local deletions stay deleted.
- A selective compile is additive: the full served baseline remains and only selected local nodes override it.
- Unselected overlapping nodes use their served copies, preserving both candidates for downstream source qualification instead of collapsing collision pairs.
- Source identity is inferred from annotated overlaps; ambiguous overlaps fail with a clear error. Explicit `--combine-manifest` behaviour is unchanged.

## Why

A full preview must represent local deletions, while a selective preview must not remove or de-qualify unselected models from either source.

## Tests

- Complete-source replacement, selective additive combination, collision candidate preservation, and ambiguous source identity are covered.
- CLI: 570 tests across 48 files pass. Typecheck and touched-path lint pass.

Linear: SPK-1062
