### PR TITLE
refactor(merge-query): execute merges through one endpoint

### DIFF
--- a/docs/ai-agent-merge-query-parity.md
+++ b/docs/ai-agent-merge-query-parity.md
@@ -1,0 +1,77 @@
+# AI agent merge-query parity
+
+## Goal
+
+Let agents answer questions that need measures from multiple explores without
+falling back to raw SQL. Preserve the existing agent workflow: query execution
+produces governed data and `generateVisualization` turns that data intent into
+an artifact.
+
+## Product contract
+
+Add merge support to both semantic query tools:
+
+- `runQuery` can execute a merge and return rows without creating a chart.
+- `generateVisualization` can execute the same merge and create a chart.
+- Existing single-explore inputs remain unchanged.
+- A merge uses two or more independently valid metric queries, shared join-key
+  parts, a join type, and optional post-merge calculations.
+- The agent must discover and validate fields in every source explore. It must
+  not invent cross-explore field IDs or use raw SQL to reproduce a supported
+  merge.
+
+## Interface
+
+Model query intent as a discriminated union inside the tools:
+
+```ts
+type SemanticQueryIntent =
+    | { type: 'metric'; query: AiMetricQueryWithFilters }
+    | { type: 'merge'; query: MergeQuery; parameters?: ParametersValuesMap };
+```
+
+Keep visualization config outside this union. Both tools share query
+validation and execution; `generateVisualization` additionally validates and
+persists presentation. Merge execution calls
+`AsyncQueryService.executeAsyncMergeQuery` with the runtime's existing account,
+project, query context, and an interactive mode. No HTTP loopback and no
+compile-preview call.
+
+Add an internal `runAsyncMergeQuery` dependency beside `runAsyncQuery`. It
+awaits the ordinary async result, returns the same `{queryUuid, rows, fields,
+cacheMetadata}` shape, applies agent result expiration, and turns a `refused`
+outcome into actionable tool feedback preserving source-scoped errors.
+
+## Visualization
+
+The generated chart addresses the merged result field IDs returned by compile
+metadata. Initial parity should support table and Cartesian charts without
+pivoting. Pivot support follows only after the tool schema can express merged
+field roles unambiguously; execution already accepts optional chart state, so
+this does not require another endpoint.
+
+Artifacts persist the discriminated semantic intent, not derived pivot
+configuration or compiled SQL. Existing artifact migration continues to treat
+an absent discriminator as a metric query.
+
+## Safety and observability
+
+- Reuse each source explore's access checks, required filters, parameters, and
+  custom-metric validation.
+- Apply the existing agent query limit to the final merged result.
+- Count a merge as one warehouse query for retry caps and `onWarehouseQuery`.
+- Record the runtime's AI query context and expose the resulting query UUID in
+  Deep Research exactly as metric queries do.
+- Keep the frontend feature flag independent from agent availability; gate the
+  new tool input explicitly until evals pass.
+
+## Acceptance tests
+
+1. `runQuery` joins two seeded explores and returns source-correct values.
+2. `generateVisualization` creates a table and a Cartesian artifact from the
+   same merge intent.
+3. Invalid join grain/type, inaccessible explores, missing parameters, and
+   fan-out return actionable tool errors and start no query.
+4. Agent limits affect only the final merge; source CTEs remain complete.
+5. One tool call causes one merge compilation and one warehouse execution.
+6. Existing single-explore tool snapshots and saved artifacts remain stable.

--- a/docs/ai-agent-merge-query-parity.md
+++ b/docs/ai-agent-merge-query-parity.md
@@ -14,8 +14,9 @@ Add merge support to both semantic query tools:
 - `runQuery` can execute a merge and return rows without creating a chart.
 - `generateVisualization` can execute the same merge and create a chart.
 - Existing single-explore inputs remain unchanged.
-- A merge uses two or more independently valid metric queries, shared join-key
-  parts, a join type, and optional post-merge calculations.
+- Initial parity supports exactly two independently valid metric queries,
+  matching the current validator and Explorer. The input remains N-shaped for
+  a separately verified multi-source follow-up.
 - The agent must discover and validate fields in every source explore. It must
   not invent cross-explore field IDs or use raw SQL to reproduce a supported
   merge.

--- a/docs/merge-queries.md
+++ b/docs/merge-queries.md
@@ -8,9 +8,21 @@ stage, caching and downloads all behave as for any other query. Date-spine
 filling is intentionally a follow-up capability layered on this core.
 
 The `merge-queries` feature flag is consumed by the frontend only: it shows or
-hides the explorer entry point. The API endpoints
-(`POST /projects/{uuid}/mergeQuery/compile|run`) are always available — they
-are additive and permission-checked, so orgs without the flag are unaffected.
+hides the explorer entry point. The API endpoints are always available and
+permission-checked, so orgs without the flag are unaffected.
+
+- `POST /api/v2/projects/{uuid}/query/merge-query` validates and starts a merge
+  in one request. It is the primary execution endpoint.
+- `POST /api/v1/projects/{uuid}/mergeQuery/compile` remains the SQL-preview and
+  continuous-validation endpoint. Execution never calls it first.
+- `POST /api/v1/projects/{uuid}/mergeQuery/run` remains a compatibility adapter
+  for existing clients.
+
+The execution request carries source intent (`mergeQuery`, parameters, export
+mode, and optional chart state). Derived pivot SQL is server-owned. Its outcome
+is either `started` with a query UUID or `refused` with validation errors; the
+two states cannot overlap. The effective export limit is established before
+the sole compilation.
 
 ## Verification
 

--- a/packages/api-tests/tests/mergeQuery.test.ts
+++ b/packages/api-tests/tests/mergeQuery.test.ts
@@ -1,4 +1,8 @@
-import { SEED_PROJECT } from '@lightdash/common';
+import {
+    QueryExecutionContext,
+    SEED_PROJECT,
+    type ApiExecuteAsyncMergeQueryResults,
+} from '@lightdash/common';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { ApiClient, Body } from '../helpers/api-client';
 import { login } from '../helpers/auth';
@@ -123,16 +127,24 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
         expect(resp.body.results.coreSql).not.toMatch(/ORDER BY/i);
     });
 
-    it('runs a merge as one statement and pages joined rows back', async () => {
-        const runResp = await admin.post<Body<{ queryUuid: string }>>(
-            `/api/v1/projects/${projectUuid}/mergeQuery/run`,
-            { mergeQuery },
-        );
+    it('runs a merge through one v2 request and pages joined rows back', async () => {
+        const runResp = await admin.post<
+            Body<ApiExecuteAsyncMergeQueryResults>
+        >(`/api/v2/projects/${projectUuid}/query/merge-query`, {
+            mergeQuery,
+            context: QueryExecutionContext.EXPLORE,
+        });
         expect(runResp.status).toBe(200);
+        expect(runResp.body.results.outcome).toBe('started');
+        if (runResp.body.results.outcome !== 'started') {
+            throw new Error(
+                `Merge was refused: ${JSON.stringify(runResp.body.results.errors)}`,
+            );
+        }
 
         const results = await pollQueryResults(
             admin,
-            runResp.body.results.queryUuid,
+            runResp.body.results.query.queryUuid,
         );
 
         expect(results.totalResults).toBeGreaterThan(0);

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -592,22 +592,27 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
         results: ApiExecuteAsyncMetricQueryResults;
     }> {
         this.setStatus(200);
-        return {
-            status: 'ok',
-            results: await this.services
-                .getAsyncQueryService()
-                .executeAsyncMergeQuery({
-                    account: req.account!,
-                    projectUuid,
-                    mergeQuery: body.mergeQuery,
-                    pivotConfiguration: body.pivotConfiguration,
-                    csvLimit: body.csvLimit,
-                    parameters: body.parameters,
-                    context:
-                        getContextFromHeader(req) ??
-                        QueryExecutionContext.EXPLORE,
-                }),
-        };
+        const result = await this.services
+            .getAsyncQueryService()
+            .executeAsyncMergeQuery({
+                account: req.account!,
+                projectUuid,
+                mergeQuery: body.mergeQuery,
+                pivotConfiguration: body.pivotConfiguration,
+                csvLimit: body.csvLimit,
+                parameters: body.parameters,
+                context:
+                    getContextFromHeader(req) ?? QueryExecutionContext.EXPLORE,
+            });
+        if (!result.started) {
+            throw new ParameterError(
+                `This merge cannot be run: ${result.errors
+                    .map((error) => error.message)
+                    .join(' ')}`,
+                { errors: result.errors },
+            );
+        }
+        return { status: 'ok', results: result.started };
     }
 
     /**

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -598,13 +598,21 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
                 account: req.account!,
                 projectUuid,
                 mergeQuery: body.mergeQuery,
-                pivotConfiguration: body.pivotConfiguration,
-                csvLimit: body.csvLimit,
                 parameters: body.parameters,
+                mode:
+                    body.csvLimit === undefined
+                        ? { type: 'interactive' }
+                        : { type: 'export', limit: body.csvLimit },
+                presentation: body.pivotConfiguration
+                    ? {
+                          type: 'resolvedPivot',
+                          configuration: body.pivotConfiguration,
+                      }
+                    : undefined,
                 context:
                     getContextFromHeader(req) ?? QueryExecutionContext.EXPLORE,
             });
-        if (!result.started) {
+        if (result.outcome === 'refused') {
             throw new ParameterError(
                 `This merge cannot be run: ${result.errors
                     .map((error) => error.message)
@@ -612,7 +620,7 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
                 { errors: result.errors },
             );
         }
-        return { status: 'ok', results: result.started };
+        return { status: 'ok', results: result.query };
     }
 
     /**

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -594,7 +594,7 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
         this.setStatus(200);
         const result = await this.services
             .getAsyncQueryService()
-            .executeAsyncMergeQuery({
+            .executeLegacyAsyncMergeQuery({
                 account: req.account!,
                 projectUuid,
                 mergeQuery: body.mergeQuery,
@@ -603,12 +603,7 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
                     body.csvLimit === undefined
                         ? { type: 'interactive' }
                         : { type: 'export', limit: body.csvLimit },
-                presentation: body.pivotConfiguration
-                    ? {
-                          type: 'resolvedPivot',
-                          configuration: body.pivotConfiguration,
-                      }
-                    : undefined,
+                pivotConfiguration: body.pivotConfiguration,
                 context:
                     getContextFromHeader(req) ?? QueryExecutionContext.EXPLORE,
             });

--- a/packages/backend/src/controllers/v2/QueryController.test.ts
+++ b/packages/backend/src/controllers/v2/QueryController.test.ts
@@ -1,12 +1,18 @@
-import { LightdashAppPreviewTokenHeader } from '@lightdash/common';
+import {
+    ChartType,
+    LightdashAppPreviewTokenHeader,
+    MergeJoinType,
+    QueryExecutionContext,
+    type ApiExecuteAsyncMergeQueryRequest,
+} from '@lightdash/common';
 import express from 'express';
 import { QueryController } from './QueryController';
 
 describe('QueryController', () => {
     it('forwards merge execution to the one-call service interface', async () => {
         const executeAsyncMergeQuery = vi.fn().mockResolvedValue({
-            errors: [],
-            started: { queryUuid: 'query-uuid' },
+            outcome: 'started',
+            query: { queryUuid: 'query-uuid' },
         });
         const controller = new QueryController({
             getAsyncQueryService: () => ({
@@ -19,24 +25,31 @@ describe('QueryController', () => {
             headers: {},
             header: vi.fn(),
         } as unknown as express.Request;
-        const body = {
-            mergeQuery: { sources: [] },
-            chartConfig: { type: 'table', config: {} },
-            pivotConfig: { columns: ['customer_id'] },
+        const body: ApiExecuteAsyncMergeQueryRequest = {
+            mergeQuery: {
+                sources: [],
+                joinKey: [],
+                joinType: MergeJoinType.FULL,
+                limit: 500,
+                tableCalculations: [],
+            },
+            context: QueryExecutionContext.EXPLORE,
+            mode: { type: 'export', limit: 42 },
+            chart: {
+                chartConfig: { type: ChartType.TABLE, config: {} },
+                pivotConfig: { columns: ['customer_id'], rows: [] },
+            },
         };
 
-        await controller.executeAsyncMergeQuery(
-            body as never,
-            'project-uuid',
-            req,
-        );
+        await controller.executeAsyncMergeQuery(body, 'project-uuid', req);
 
         expect(executeAsyncMergeQuery).toHaveBeenCalledWith(
             expect.objectContaining({
                 projectUuid: 'project-uuid',
                 mergeQuery: body.mergeQuery,
-                chartConfig: body.chartConfig,
-                pivotConfig: body.pivotConfig,
+                context: QueryExecutionContext.EXPLORE,
+                mode: body.mode,
+                presentation: { type: 'chart', ...body.chart },
             }),
         );
     });

--- a/packages/backend/src/controllers/v2/QueryController.test.ts
+++ b/packages/backend/src/controllers/v2/QueryController.test.ts
@@ -49,7 +49,7 @@ describe('QueryController', () => {
                 mergeQuery: body.mergeQuery,
                 context: QueryExecutionContext.EXPLORE,
                 mode: body.mode,
-                presentation: { type: 'chart', ...body.chart },
+                chart: body.chart,
             }),
         );
     });

--- a/packages/backend/src/controllers/v2/QueryController.test.ts
+++ b/packages/backend/src/controllers/v2/QueryController.test.ts
@@ -3,6 +3,44 @@ import express from 'express';
 import { QueryController } from './QueryController';
 
 describe('QueryController', () => {
+    it('forwards merge execution to the one-call service interface', async () => {
+        const executeAsyncMergeQuery = vi.fn().mockResolvedValue({
+            errors: [],
+            started: { queryUuid: 'query-uuid' },
+        });
+        const controller = new QueryController({
+            getAsyncQueryService: () => ({
+                executeAsyncMergeQuery,
+            }),
+        } as unknown as ConstructorParameters<typeof QueryController>[0]);
+        controller.setStatus = vi.fn();
+        const req = {
+            account: {},
+            headers: {},
+            header: vi.fn(),
+        } as unknown as express.Request;
+        const body = {
+            mergeQuery: { sources: [] },
+            chartConfig: { type: 'table', config: {} },
+            pivotConfig: { columns: ['customer_id'] },
+        };
+
+        await controller.executeAsyncMergeQuery(
+            body as never,
+            'project-uuid',
+            req,
+        );
+
+        expect(executeAsyncMergeQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                projectUuid: 'project-uuid',
+                mergeQuery: body.mergeQuery,
+                chartConfig: body.chartConfig,
+                pivotConfig: body.pivotConfig,
+            }),
+        );
+    });
+
     it('forwards the signed Data App preview token to metric-query execution', async () => {
         const executeAsyncMetricQuery = vi.fn().mockResolvedValue({
             queryUuid: 'query-uuid',

--- a/packages/backend/src/controllers/v2/QueryController.test.ts
+++ b/packages/backend/src/controllers/v2/QueryController.test.ts
@@ -21,7 +21,7 @@ describe('QueryController', () => {
         } as unknown as ConstructorParameters<typeof QueryController>[0]);
         controller.setStatus = vi.fn();
         const req = {
-            account: {},
+            account: { user: { type: 'registered' } },
             headers: {},
             header: vi.fn(),
         } as unknown as express.Request;

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -199,9 +199,7 @@ export class QueryController extends BaseController {
                 invalidateCache: body.invalidateCache,
                 parameters: body.parameters,
                 mode: body.mode ?? { type: 'interactive' },
-                presentation: body.chart
-                    ? { type: 'chart', ...body.chart }
-                    : undefined,
+                chart: body.chart,
             });
 
         return { status: 'ok', results };

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -21,6 +21,8 @@ import {
     type ApiDownloadAsyncQueryResults,
     type ApiDownloadAsyncQueryResultsAsCsv,
     type ApiDownloadAsyncQueryResultsAsXlsx,
+    type ApiExecuteAsyncMergeQueryRequest,
+    type ApiExecuteAsyncMergeQueryResults,
     type ApiExecuteAsyncMetricQueryResults,
     type ApiJobScheduledResponse,
     type ExecuteAsyncCalculateTotalRequestParams,
@@ -167,6 +169,41 @@ export class QueryController extends BaseController {
             status: 'ok',
             results,
         };
+    }
+
+    /**
+     * Validates and executes a merge as one asynchronous query request.
+     * @summary Execute merge query
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/merge-query')
+    @OperationId('executeAsyncMergeQuery')
+    async executeAsyncMergeQuery(
+        @Body() body: ApiExecuteAsyncMergeQueryRequest,
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccess<ApiExecuteAsyncMergeQueryResults>> {
+        this.setStatus(200);
+        const results = await this.services
+            .getAsyncQueryService()
+            .executeAsyncMergeQuery({
+                account: req.account!,
+                projectUuid,
+                mergeQuery: body.mergeQuery,
+                context:
+                    body.context ??
+                    getContextFromHeader(req) ??
+                    QueryExecutionContext.API,
+                invalidateCache: body.invalidateCache,
+                parameters: body.parameters,
+                csvLimit: body.csvLimit,
+                chartConfig: body.chartConfig,
+                pivotConfig: body.pivotConfig,
+                pivotConfiguration: body.pivotConfiguration,
+            });
+
+        return { status: 'ok', results };
     }
 
     /**

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -34,6 +34,7 @@ import {
     type ExecuteAsyncSqlChartRequestParams,
     type ExecuteAsyncUnderlyingDataRequestParams,
     type MetricQuery,
+    type UUID,
 } from '@lightdash/common';
 import {
     Body,
@@ -181,7 +182,7 @@ export class QueryController extends BaseController {
     @OperationId('executeAsyncMergeQuery')
     async executeAsyncMergeQuery(
         @Body() body: ApiExecuteAsyncMergeQueryRequest,
-        @Path() projectUuid: string,
+        @Path() projectUuid: UUID,
         @Request() req: express.Request,
     ): Promise<ApiSuccess<ApiExecuteAsyncMergeQueryResults>> {
         this.setStatus(200);
@@ -197,10 +198,10 @@ export class QueryController extends BaseController {
                     QueryExecutionContext.API,
                 invalidateCache: body.invalidateCache,
                 parameters: body.parameters,
-                csvLimit: body.csvLimit,
-                chartConfig: body.chartConfig,
-                pivotConfig: body.pivotConfig,
-                pivotConfiguration: body.pivotConfiguration,
+                mode: body.mode ?? { type: 'interactive' },
+                presentation: body.chart
+                    ? { type: 'chart', ...body.chart }
+                    : undefined,
             });
 
         return { status: 'ok', results };

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -8,6 +8,7 @@ import {
     ApiGetAsyncQueryResults,
     ApiSuccess,
     ApiSuccessEmpty,
+    assertRegisteredAccount,
     DownloadAsyncQueryResultsRequestParams,
     ExecuteAsyncSqlQueryRequestParams,
     ForbiddenError,
@@ -185,11 +186,12 @@ export class QueryController extends BaseController {
         @Path() projectUuid: UUID,
         @Request() req: express.Request,
     ): Promise<ApiSuccess<ApiExecuteAsyncMergeQueryResults>> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const results = await this.services
             .getAsyncQueryService()
             .executeAsyncMergeQuery({
-                account: req.account!,
+                account: req.account,
                 projectUuid,
                 mergeQuery: body.mergeQuery,
                 context:

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -9,8 +9,10 @@ import {
     ExecuteAsyncQueryRequestParams,
     ExploreType,
     FeatureFlags,
+    FieldType,
     FilterOperator,
     ForbiddenError,
+    MetricType,
     NotFoundError,
     OrganizationAccessStatus,
     PersistentDownloadFileAccessMode,
@@ -408,6 +410,108 @@ type JwtDashboardQueryContextTestService = {
 };
 
 describe('AsyncQueryService', () => {
+    describe('executeAsyncMergeQuery', () => {
+        const mergeQuery = {
+            sources: [],
+            joinKey: [],
+            joinType: 'full',
+            tableCalculations: [],
+            limit: 500,
+        } as never;
+
+        test('passes the validated compilation into execution', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const compiledMerge = {
+                sql: 'select 1',
+                coreSql: 'select 1',
+                typedColumns: [],
+                terminalWrapper: {},
+                fieldIdByColumn: {
+                    join_key: 'merge_join_key_0',
+                    orders_count: 'a_orders_count',
+                },
+                itemsMap: {
+                    merge_join_key_0: {
+                        fieldType: FieldType.DIMENSION,
+                        type: DimensionType.STRING,
+                    },
+                    a_orders_count: {
+                        fieldType: FieldType.METRIC,
+                        type: MetricType.COUNT,
+                    },
+                },
+                fieldOrigins: {},
+                parameterReferences: [],
+                errors: [],
+            } as never;
+            const compile = vi
+                .spyOn(service, 'compileMergeQuery')
+                .mockResolvedValue(compiledMerge);
+            const execute = vi
+                .spyOn(service as AnyType, 'executeCompiledAsyncMergeQuery')
+                .mockResolvedValue({ queryUuid: 'query-uuid' } as never);
+
+            const result = await service.executeAsyncMergeQuery({
+                account: sessionAccount,
+                projectUuid,
+                mergeQuery,
+                context: QueryExecutionContext.EXPLORE,
+                chartConfig: { type: ChartType.TABLE, config: {} },
+                pivotConfig: {
+                    columns: ['merge_join_key_0'],
+                    rows: [],
+                },
+            });
+
+            expect(compile).toHaveBeenCalledTimes(1);
+            expect(execute).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    precompiledMerge: compiledMerge,
+                    pivotConfiguration: expect.objectContaining({
+                        groupByColumns: [{ reference: 'merge_join_key_0' }],
+                        valuesColumns: [
+                            {
+                                aggregation: 'any',
+                                reference: 'a_orders_count',
+                            },
+                        ],
+                    }),
+                }),
+            );
+            expect(result.started).toMatchObject({ queryUuid: 'query-uuid' });
+        });
+
+        test('returns validation errors without starting execution', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            vi.spyOn(service, 'compileMergeQuery').mockResolvedValue({
+                coreSql: null,
+                typedColumns: null,
+                terminalWrapper: null,
+                errors: [{ message: 'Fan-out' }],
+                parameterReferences: ['date'],
+                fieldOrigins: {},
+            } as never);
+            const execute = vi.spyOn(
+                service as AnyType,
+                'executeCompiledAsyncMergeQuery',
+            );
+
+            const result = await service.executeAsyncMergeQuery({
+                account: sessionAccount,
+                projectUuid,
+                mergeQuery,
+                context: QueryExecutionContext.EXPLORE,
+            });
+
+            expect(execute).not.toHaveBeenCalled();
+            expect(result).toMatchObject({
+                started: null,
+                parameterReferences: ['date'],
+                errors: [{ message: 'Fan-out' }],
+            });
+        });
+    });
+
     describe('getJwtDashboardQueryContext', () => {
         const buildDashboardEmbedAccount = () =>
             ({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -419,68 +419,6 @@ describe('AsyncQueryService', () => {
             limit: 500,
         } as never;
 
-        test('passes the validated compilation into execution', async () => {
-            const service = getMockedAsyncQueryService(lightdashConfigMock);
-            const compiledMerge = {
-                sql: 'select 1',
-                coreSql: 'select 1',
-                typedColumns: [],
-                terminalWrapper: {},
-                fieldIdByColumn: {
-                    join_key: 'merge_join_key_0',
-                    orders_count: 'a_orders_count',
-                },
-                itemsMap: {
-                    merge_join_key_0: {
-                        fieldType: FieldType.DIMENSION,
-                        type: DimensionType.STRING,
-                    },
-                    a_orders_count: {
-                        fieldType: FieldType.METRIC,
-                        type: MetricType.COUNT,
-                    },
-                },
-                fieldOrigins: {},
-                parameterReferences: [],
-                errors: [],
-            } as never;
-            const compile = vi
-                .spyOn(service, 'compileMergeQuery')
-                .mockResolvedValue(compiledMerge);
-            const execute = vi
-                .spyOn(service as AnyType, 'executeCompiledAsyncMergeQuery')
-                .mockResolvedValue({ queryUuid: 'query-uuid' } as never);
-
-            const result = await service.executeAsyncMergeQuery({
-                account: sessionAccount,
-                projectUuid,
-                mergeQuery,
-                context: QueryExecutionContext.EXPLORE,
-                chartConfig: { type: ChartType.TABLE, config: {} },
-                pivotConfig: {
-                    columns: ['merge_join_key_0'],
-                    rows: [],
-                },
-            });
-
-            expect(compile).toHaveBeenCalledTimes(1);
-            expect(execute).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    precompiledMerge: compiledMerge,
-                    pivotConfiguration: expect.objectContaining({
-                        groupByColumns: [{ reference: 'merge_join_key_0' }],
-                        valuesColumns: [
-                            {
-                                aggregation: 'any',
-                                reference: 'a_orders_count',
-                            },
-                        ],
-                    }),
-                }),
-            );
-            expect(result.started).toMatchObject({ queryUuid: 'query-uuid' });
-        });
-
         test('returns validation errors without starting execution', async () => {
             const service = getMockedAsyncQueryService(lightdashConfigMock);
             vi.spyOn(service, 'compileMergeQuery').mockResolvedValue({
@@ -491,21 +429,17 @@ describe('AsyncQueryService', () => {
                 parameterReferences: ['date'],
                 fieldOrigins: {},
             } as never);
-            const execute = vi.spyOn(
-                service as AnyType,
-                'executeCompiledAsyncMergeQuery',
-            );
-
             const result = await service.executeAsyncMergeQuery({
                 account: sessionAccount,
                 projectUuid,
                 mergeQuery,
                 context: QueryExecutionContext.EXPLORE,
+                mode: { type: 'interactive' },
             });
 
-            expect(execute).not.toHaveBeenCalled();
+            expect(service.compileMergeQuery).toHaveBeenCalledTimes(1);
             expect(result).toMatchObject({
-                started: null,
+                outcome: 'refused',
                 parameterReferences: ['date'],
                 errors: [{ message: 'Fan-out' }],
             });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -59,7 +59,6 @@ import {
     isCustomBinDimension,
     isCustomDimension,
     isDateItem,
-    isDimension,
     isExploreError,
     isField,
     isJwtUser,
@@ -69,7 +68,6 @@ import {
     ItemsMap,
     KnexPaginateArgs,
     KnexPaginatedData,
-    MERGE_TABLE_NAME,
     MergeQuery,
     MetricQuery,
     MissingConfigError,
@@ -167,7 +165,10 @@ import {
     streamJsonlData,
 } from '../../utils/FileDownloadUtils/FileDownloadUtils';
 import { updateExploreWithDateZoom } from '../../utils/QueryBuilder/dateZoom';
-import { MergeQueryComposer } from '../../utils/QueryBuilder/MergeQueryComposer';
+import {
+    buildMergeResultMetricQuery,
+    MergeQueryComposer,
+} from '../../utils/QueryBuilder/MergeQueryComposer';
 import { consumeMergeResultMetadata } from '../../utils/QueryBuilder/mergeQueryResults';
 import { safeReplaceParametersWithSqlBuilder } from '../../utils/QueryBuilder/parameters';
 import { PivotQueryBuilder } from '../../utils/QueryBuilder/PivotQueryBuilder';
@@ -210,6 +211,7 @@ import {
 import { getValidatedDashboardSorts } from './dashboardSorts';
 import { getPivotedColumns } from './getPivotedColumns';
 import { getUnpivotedColumns } from './getUnpivotedColumns';
+import { applyMergeExecutionMode } from './mergeQueryExecution';
 import {
     NoOpPreAggregateStrategy,
     type PreAggregateExecutionResolution,
@@ -231,7 +233,6 @@ import {
     type ExecuteAsyncSavedChartQueryArgs,
     type ExecuteAsyncSqlChartArgs,
     type ExecuteAsyncUnderlyingDataQueryArgs,
-    type ExecuteCompiledAsyncMergeQueryArgs,
     type GetAsyncQueryResultsArgs,
     type PollingOptions,
     type PreAggregateExecutionEngine,
@@ -241,6 +242,31 @@ import {
     type ScheduleDownloadAsyncQueryResultsArgs,
     type UnboundedRerunFromQueryHistoryResult,
 } from './types';
+
+type RunnableCompiledMergeQuery = ApiCompiledMergeQueryResults & {
+    coreSql: string;
+    typedColumns: NonNullable<ApiCompiledMergeQueryResults['typedColumns']>;
+    terminalWrapper: NonNullable<
+        ApiCompiledMergeQueryResults['terminalWrapper']
+    >;
+};
+
+const isRunnableCompiledMergeQuery = (
+    compiled: ApiCompiledMergeQueryResults,
+): compiled is RunnableCompiledMergeQuery =>
+    compiled.errors.length === 0 &&
+    compiled.coreSql !== null &&
+    compiled.typedColumns !== null &&
+    compiled.terminalWrapper !== null;
+
+type ExecuteCompiledAsyncMergeQueryArgs = Omit<
+    ExecuteAsyncMergeQueryArgs,
+    'mode' | 'presentation'
+> & {
+    organizationUuid: string;
+    compiledMerge: RunnableCompiledMergeQuery;
+    pivotConfiguration?: PivotConfiguration;
+};
 
 // NULL pivot keys collide with the unsuffixed base column when joined
 // (`[null].join('_') === ''`). Wrapped in `<>` so it strips cleanly via
@@ -5145,13 +5171,6 @@ export class AsyncQueryService extends ProjectService {
             dashboardFilters,
         };
 
-        const { maxLimit, csvCellsLimit } =
-            await resolveOrganizationExportLimits(
-                this.organizationSettingsModel,
-                this.lightdashConfig.query,
-                savedChartOrganizationUuid,
-            );
-
         if (savedChart.merge) {
             const mergeQuery = buildMergeQueryFromSaved(
                 metricQuery,
@@ -5161,50 +5180,42 @@ export class AsyncQueryService extends ProjectService {
                 ...savedChartParameters,
                 ...parameters,
             };
-            const precompiledMerge = await this.compileMergeQuery({
-                account,
-                projectUuid,
-                mergeQuery,
-                parameters: combinedParameters,
-            });
-            let pivotConfiguration: PivotConfiguration | undefined;
-            if (pivotResults) {
-                const columnOrder = Object.values(
-                    precompiledMerge.fieldIdByColumn,
-                );
-                const dimensions = columnOrder.filter((fieldId) =>
-                    isDimension(precompiledMerge.itemsMap[fieldId]),
-                );
-                const mergedMetricQuery: MetricQuery = {
-                    exploreName: MERGE_TABLE_NAME,
-                    dimensions,
-                    metrics: columnOrder.filter(
-                        (fieldId) => !dimensions.includes(fieldId),
-                    ),
-                    filters: {},
-                    sorts: [],
-                    limit: mergeQuery.limit,
-                    tableCalculations: [],
-                };
-                pivotConfiguration = derivePivotConfigurationFromChart(
-                    savedChart,
-                    mergedMetricQuery,
-                    precompiledMerge.itemsMap,
-                );
-            }
-
-            return this.executeCompiledAsyncMergeQuery({
+            const outcome = await this.executeAsyncMergeQuery({
                 account,
                 projectUuid,
                 mergeQuery,
                 context,
                 invalidateCache,
                 parameters: combinedParameters,
-                pivotConfiguration,
-                csvLimit: limit,
-                precompiledMerge,
+                mode:
+                    limit === undefined
+                        ? { type: 'interactive' }
+                        : { type: 'export', limit },
+                presentation: pivotResults
+                    ? {
+                          type: 'chart',
+                          chartConfig: savedChart.chartConfig,
+                          pivotConfig: savedChart.pivotConfig,
+                      }
+                    : undefined,
             });
+            if (outcome.outcome === 'refused') {
+                throw new ParameterError(
+                    `This saved merge cannot be run: ${outcome.errors
+                        .map((error) => error.message)
+                        .join(' ')}`,
+                    { errors: outcome.errors },
+                );
+            }
+            return outcome.query;
         }
+
+        const { maxLimit, csvCellsLimit } =
+            await resolveOrganizationExportLimits(
+                this.organizationSettingsModel,
+                this.lightdashConfig.query,
+                savedChartOrganizationUuid,
+            );
 
         const limitedMetricQuery = applyMetricQueryLimit(
             metricQuery,
@@ -6264,70 +6275,75 @@ export class AsyncQueryService extends ProjectService {
         context,
         invalidateCache,
         parameters,
-        csvLimit,
-        chartConfig,
-        pivotConfig,
-        pivotConfiguration: suppliedPivotConfiguration,
+        mode,
+        presentation,
     }: ExecuteAsyncMergeQueryArgs): Promise<ApiExecuteAsyncMergeQueryResults> {
+        assertIsAccountWithOrg(account);
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const effectiveMergeQuery =
+            mode.type === 'export'
+                ? applyMergeExecutionMode({
+                      mergeQuery,
+                      mode,
+                      csvCellsLimit: (
+                          await resolveOrganizationExportLimits(
+                              this.organizationSettingsModel,
+                              this.lightdashConfig.query,
+                              organizationUuid,
+                          )
+                      ).csvCellsLimit,
+                  })
+                : mergeQuery;
         const compiledMerge = await this.compileMergeQuery({
             account,
             projectUuid,
-            mergeQuery,
+            mergeQuery: effectiveMergeQuery,
             parameters,
         });
-        if (
-            compiledMerge.coreSql === null ||
-            compiledMerge.typedColumns === null ||
-            compiledMerge.terminalWrapper === null
-        ) {
+        if (!isRunnableCompiledMergeQuery(compiledMerge)) {
             return {
+                outcome: 'refused',
                 errors: compiledMerge.errors,
-                started: null,
                 parameterReferences: compiledMerge.parameterReferences,
                 fieldOrigins: compiledMerge.fieldOrigins,
             };
         }
 
         const columnOrder = Object.values(compiledMerge.fieldIdByColumn);
-        const dimensions = columnOrder.filter((fieldId) =>
-            isDimension(compiledMerge.itemsMap[fieldId]),
-        );
-        const metricQuery: MetricQuery = {
-            exploreName: MERGE_TABLE_NAME,
-            dimensions,
-            metrics: columnOrder.filter(
-                (fieldId) => !dimensions.includes(fieldId),
-            ),
-            filters: {},
-            sorts: [],
-            limit: mergeQuery.limit,
-            tableCalculations: [],
-        };
-        const pivotConfiguration =
-            suppliedPivotConfiguration ??
-            (chartConfig
-                ? derivePivotConfigurationFromChart(
-                      { chartConfig, pivotConfig },
-                      metricQuery,
-                      compiledMerge.itemsMap,
-                  )
-                : undefined);
+        const pivotConfiguration = (() => {
+            if (presentation?.type === 'resolvedPivot') {
+                return presentation.configuration;
+            }
+            if (presentation?.type === 'chart') {
+                return derivePivotConfigurationFromChart(
+                    presentation,
+                    buildMergeResultMetricQuery({
+                        itemsMap: compiledMerge.itemsMap,
+                        columnOrder,
+                        limit: effectiveMergeQuery.limit,
+                    }),
+                    compiledMerge.itemsMap,
+                );
+            }
+            return undefined;
+        })();
 
-        const started = await this.executeCompiledAsyncMergeQuery({
+        const query = await this.executeCompiledAsyncMergeQuery({
             account,
             projectUuid,
-            mergeQuery,
+            organizationUuid,
+            mergeQuery: effectiveMergeQuery,
             context,
             invalidateCache,
             parameters,
-            csvLimit,
             pivotConfiguration,
-            precompiledMerge: compiledMerge,
+            compiledMerge,
         });
 
         return {
-            errors: [],
-            started,
+            outcome: 'started',
+            query,
             parameterReferences: compiledMerge.parameterReferences,
             fieldOrigins: compiledMerge.fieldOrigins,
         };
@@ -6350,75 +6366,9 @@ export class AsyncQueryService extends ProjectService {
         invalidateCache,
         pivotConfiguration,
         parameters,
-        csvLimit,
-        precompiledMerge,
+        organizationUuid,
+        compiledMerge,
     }: ExecuteCompiledAsyncMergeQueryArgs): Promise<ApiExecuteAsyncMetricQueryResults> {
-        assertIsAccountWithOrg(account);
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
-
-        let effectiveMergeQuery = mergeQuery;
-        let compiledMerge = precompiledMerge;
-        if (
-            compiledMerge.coreSql === null ||
-            compiledMerge.typedColumns === null ||
-            compiledMerge.terminalWrapper === null
-        ) {
-            throw new ParameterError(
-                `This merge cannot be run: ${compiledMerge.errors
-                    .map((error) => error.message)
-                    .join(' ')}`,
-                { errors: compiledMerge.errors },
-            );
-        }
-
-        if (csvLimit !== undefined) {
-            const { csvCellsLimit } = await resolveOrganizationExportLimits(
-                this.organizationSettingsModel,
-                this.lightdashConfig.query,
-                organizationUuid,
-            );
-            const columnCount = Object.keys(
-                compiledMerge.fieldIdByColumn,
-            ).length;
-            const cellLimitedRows = Math.floor(
-                csvCellsLimit / Math.max(columnCount, 1),
-            );
-            const exportLimit =
-                csvLimit === null
-                    ? cellLimitedRows
-                    : Math.min(csvLimit, cellLimitedRows);
-            effectiveMergeQuery = {
-                ...mergeQuery,
-                limit: exportLimit,
-                sources: mergeQuery.sources.map((source) => ({
-                    ...source,
-                    metricQuery: {
-                        ...source.metricQuery,
-                        limit: exportLimit,
-                    },
-                })),
-            };
-            compiledMerge = await this.compileMergeQuery({
-                account,
-                projectUuid,
-                mergeQuery: effectiveMergeQuery,
-                parameters,
-            });
-            if (
-                compiledMerge.coreSql === null ||
-                compiledMerge.typedColumns === null ||
-                compiledMerge.terminalWrapper === null
-            ) {
-                throw new ParameterError(
-                    `This merge cannot be exported: ${compiledMerge.errors
-                        .map((error) => error.message)
-                        .join(' ')}`,
-                    { errors: compiledMerge.errors },
-                );
-            }
-        }
-
         // Only for composing SQL — quoting and the pivot stage need the
         // dialect. The async runtime opens its own connection to execute.
         const [warehouseCredentials, userAccessControls] = await Promise.all([
@@ -6443,7 +6393,7 @@ export class AsyncQueryService extends ProjectService {
                 itemsMap: compiledMerge.itemsMap,
                 typedColumns: compiledMerge.typedColumns,
                 columnOrder: Object.values(compiledMerge.fieldIdByColumn),
-                limit: effectiveMergeQuery.limit,
+                limit: mergeQuery.limit,
                 warehouseClient,
                 pivotConfiguration,
             });
@@ -6465,7 +6415,7 @@ export class AsyncQueryService extends ProjectService {
         const requestParameters: ExecuteAsyncMergeQueryRequestParams = {
             context,
             invalidateCache,
-            mergeQuery: effectiveMergeQuery,
+            mergeQuery,
             parameters,
             pivotConfiguration,
         };

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -115,6 +115,7 @@ import {
     type ExecuteAsyncQueryRequestParams,
     type ExecuteAsyncSavedChartRequestParams,
     type ExecuteAsyncUnderlyingDataRequestParams,
+    type MergeQueryChart,
     type Organization,
     type ParameterDefinitions,
     type ParametersValuesMap,
@@ -261,11 +262,20 @@ const isRunnableCompiledMergeQuery = (
 
 type ExecuteCompiledAsyncMergeQueryArgs = Omit<
     ExecuteAsyncMergeQueryArgs,
-    'mode' | 'presentation'
+    'mode' | 'chart'
 > & {
     organizationUuid: string;
     compiledMerge: RunnableCompiledMergeQuery;
     pivotConfiguration?: PivotConfiguration;
+};
+
+type ExecuteMergeQueryInternalArgs = Omit<
+    ExecuteAsyncMergeQueryArgs,
+    'chart'
+> & {
+    pivotInput?:
+        | { type: 'chart'; chart: MergeQueryChart }
+        | { type: 'resolved'; configuration: PivotConfiguration };
 };
 
 // NULL pivot keys collide with the unsuffixed base column when joined
@@ -5191,9 +5201,8 @@ export class AsyncQueryService extends ProjectService {
                     limit === undefined
                         ? { type: 'interactive' }
                         : { type: 'export', limit },
-                presentation: pivotResults
+                chart: pivotResults
                     ? {
-                          type: 'chart',
                           chartConfig: savedChart.chartConfig,
                           pivotConfig: savedChart.pivotConfig,
                       }
@@ -6268,7 +6277,32 @@ export class AsyncQueryService extends ProjectService {
      * errors to the source that caused them. A valid compilation is passed
      * into execution and never repeated.
      */
-    async executeAsyncMergeQuery({
+    async executeAsyncMergeQuery(
+        args: ExecuteAsyncMergeQueryArgs,
+    ): Promise<ApiExecuteAsyncMergeQueryResults> {
+        const { chart, ...execution } = args;
+        return this.executeAsyncMergeQueryInternal({
+            ...execution,
+            pivotInput: chart ? { type: 'chart', chart } : undefined,
+        });
+    }
+
+    /** Compatibility seam for the v1 endpoint's already-derived pivot. */
+    async executeLegacyAsyncMergeQuery({
+        pivotConfiguration,
+        ...execution
+    }: Omit<ExecuteAsyncMergeQueryArgs, 'chart'> & {
+        pivotConfiguration?: PivotConfiguration;
+    }): Promise<ApiExecuteAsyncMergeQueryResults> {
+        return this.executeAsyncMergeQueryInternal({
+            ...execution,
+            pivotInput: pivotConfiguration
+                ? { type: 'resolved', configuration: pivotConfiguration }
+                : undefined,
+        });
+    }
+
+    private async executeAsyncMergeQueryInternal({
         account,
         projectUuid,
         mergeQuery,
@@ -6276,8 +6310,8 @@ export class AsyncQueryService extends ProjectService {
         invalidateCache,
         parameters,
         mode,
-        presentation,
-    }: ExecuteAsyncMergeQueryArgs): Promise<ApiExecuteAsyncMergeQueryResults> {
+        pivotInput,
+    }: ExecuteMergeQueryInternalArgs): Promise<ApiExecuteAsyncMergeQueryResults> {
         assertIsAccountWithOrg(account);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
@@ -6312,12 +6346,12 @@ export class AsyncQueryService extends ProjectService {
 
         const columnOrder = Object.values(compiledMerge.fieldIdByColumn);
         const pivotConfiguration = (() => {
-            if (presentation?.type === 'resolvedPivot') {
-                return presentation.configuration;
+            if (pivotInput?.type === 'resolved') {
+                return pivotInput.configuration;
             }
-            if (presentation?.type === 'chart') {
+            if (pivotInput?.type === 'chart') {
                 return derivePivotConfigurationFromChart(
-                    presentation,
+                    pivotInput.chart,
                     buildMergeResultMetricQuery({
                         itemsMap: compiledMerge.itemsMap,
                         columnOrder,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -97,10 +97,12 @@ import {
     UnexpectedServerError,
     UserAccessControls,
     WarehouseClient,
+    type ApiCompiledMergeQueryResults,
     type ApiDownloadAsyncQueryResults,
     type ApiDownloadAsyncQueryResultsAsCsv,
     type ApiDownloadAsyncQueryResultsAsXlsx,
     type ApiExecuteAsyncFieldValueSearchResults,
+    type ApiExecuteAsyncMergeQueryResults,
     type ApiExecuteAsyncMetricQueryResults,
     type ApiGetAsyncQueryResults,
     type CacheMetadata,
@@ -229,6 +231,7 @@ import {
     type ExecuteAsyncSavedChartQueryArgs,
     type ExecuteAsyncSqlChartArgs,
     type ExecuteAsyncUnderlyingDataQueryArgs,
+    type ExecuteCompiledAsyncMergeQueryArgs,
     type GetAsyncQueryResultsArgs,
     type PollingOptions,
     type PreAggregateExecutionEngine,
@@ -5158,17 +5161,19 @@ export class AsyncQueryService extends ProjectService {
                 ...savedChartParameters,
                 ...parameters,
             };
+            const precompiledMerge = await this.compileMergeQuery({
+                account,
+                projectUuid,
+                mergeQuery,
+                parameters: combinedParameters,
+            });
             let pivotConfiguration: PivotConfiguration | undefined;
             if (pivotResults) {
-                const compiled = await this.compileMergeQuery({
-                    account,
-                    projectUuid,
-                    mergeQuery,
-                    parameters: combinedParameters,
-                });
-                const columnOrder = Object.values(compiled.fieldIdByColumn);
+                const columnOrder = Object.values(
+                    precompiledMerge.fieldIdByColumn,
+                );
                 const dimensions = columnOrder.filter((fieldId) =>
-                    isDimension(compiled.itemsMap[fieldId]),
+                    isDimension(precompiledMerge.itemsMap[fieldId]),
                 );
                 const mergedMetricQuery: MetricQuery = {
                     exploreName: MERGE_TABLE_NAME,
@@ -5184,11 +5189,11 @@ export class AsyncQueryService extends ProjectService {
                 pivotConfiguration = derivePivotConfigurationFromChart(
                     savedChart,
                     mergedMetricQuery,
-                    compiled.itemsMap,
+                    precompiledMerge.itemsMap,
                 );
             }
 
-            return this.executeAsyncMergeQuery({
+            return this.executeCompiledAsyncMergeQuery({
                 account,
                 projectUuid,
                 mergeQuery,
@@ -5197,6 +5202,7 @@ export class AsyncQueryService extends ProjectService {
                 parameters: combinedParameters,
                 pivotConfiguration,
                 csvLimit: limit,
+                precompiledMerge,
             });
         }
 
@@ -6245,6 +6251,89 @@ export class AsyncQueryService extends ProjectService {
     }
 
     /**
+     * Validates, prepares and starts a merge through one interface.
+     *
+     * Validation is data rather than an HTTP failure so the editor can attach
+     * errors to the source that caused them. A valid compilation is passed
+     * into execution and never repeated.
+     */
+    async executeAsyncMergeQuery({
+        account,
+        projectUuid,
+        mergeQuery,
+        context,
+        invalidateCache,
+        parameters,
+        csvLimit,
+        chartConfig,
+        pivotConfig,
+        pivotConfiguration: suppliedPivotConfiguration,
+    }: ExecuteAsyncMergeQueryArgs): Promise<ApiExecuteAsyncMergeQueryResults> {
+        const compiledMerge = await this.compileMergeQuery({
+            account,
+            projectUuid,
+            mergeQuery,
+            parameters,
+        });
+        if (
+            compiledMerge.coreSql === null ||
+            compiledMerge.typedColumns === null ||
+            compiledMerge.terminalWrapper === null
+        ) {
+            return {
+                errors: compiledMerge.errors,
+                started: null,
+                parameterReferences: compiledMerge.parameterReferences,
+                fieldOrigins: compiledMerge.fieldOrigins,
+            };
+        }
+
+        const columnOrder = Object.values(compiledMerge.fieldIdByColumn);
+        const dimensions = columnOrder.filter((fieldId) =>
+            isDimension(compiledMerge.itemsMap[fieldId]),
+        );
+        const metricQuery: MetricQuery = {
+            exploreName: MERGE_TABLE_NAME,
+            dimensions,
+            metrics: columnOrder.filter(
+                (fieldId) => !dimensions.includes(fieldId),
+            ),
+            filters: {},
+            sorts: [],
+            limit: mergeQuery.limit,
+            tableCalculations: [],
+        };
+        const pivotConfiguration =
+            suppliedPivotConfiguration ??
+            (chartConfig
+                ? derivePivotConfigurationFromChart(
+                      { chartConfig, pivotConfig },
+                      metricQuery,
+                      compiledMerge.itemsMap,
+                  )
+                : undefined);
+
+        const started = await this.executeCompiledAsyncMergeQuery({
+            account,
+            projectUuid,
+            mergeQuery,
+            context,
+            invalidateCache,
+            parameters,
+            csvLimit,
+            pivotConfiguration,
+            precompiledMerge: compiledMerge,
+        });
+
+        return {
+            errors: [],
+            started,
+            parameterReferences: compiledMerge.parameterReferences,
+            fieldOrigins: compiledMerge.fieldOrigins,
+        };
+    }
+
+    /**
      * Runs a merge as one statement on the org's own warehouse.
      *
      * The compile is the merge: both sides become CTEs of one statement in
@@ -6253,7 +6342,7 @@ export class AsyncQueryService extends ProjectService {
      * downloads all behave as for any other query. Nothing materialises to
      * S3 and nothing runs anywhere but the project warehouse.
      */
-    async executeAsyncMergeQuery({
+    private async executeCompiledAsyncMergeQuery({
         account,
         projectUuid,
         mergeQuery,
@@ -6262,18 +6351,14 @@ export class AsyncQueryService extends ProjectService {
         pivotConfiguration,
         parameters,
         csvLimit,
-    }: ExecuteAsyncMergeQueryArgs): Promise<ApiExecuteAsyncMetricQueryResults> {
+        precompiledMerge,
+    }: ExecuteCompiledAsyncMergeQueryArgs): Promise<ApiExecuteAsyncMetricQueryResults> {
         assertIsAccountWithOrg(account);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
         let effectiveMergeQuery = mergeQuery;
-        let compiledMerge = await this.compileMergeQuery({
-            account,
-            projectUuid,
-            mergeQuery: effectiveMergeQuery,
-            parameters,
-        });
+        let compiledMerge = precompiledMerge;
         if (
             compiledMerge.coreSql === null ||
             compiledMerge.typedColumns === null ||

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -212,7 +212,7 @@ import {
 import { getValidatedDashboardSorts } from './dashboardSorts';
 import { getPivotedColumns } from './getPivotedColumns';
 import { getUnpivotedColumns } from './getUnpivotedColumns';
-import { applyMergeExecutionMode } from './mergeQueryExecution';
+import { applyMergeExportLimit } from './mergeQueryExecution';
 import {
     NoOpPreAggregateStrategy,
     type PreAggregateExecutionResolution,
@@ -6317,9 +6317,9 @@ export class AsyncQueryService extends ProjectService {
             await this.projectModel.getSummary(projectUuid);
         const effectiveMergeQuery =
             mode.type === 'export'
-                ? applyMergeExecutionMode({
+                ? applyMergeExportLimit({
                       mergeQuery,
-                      mode,
+                      requestedRows: mode.limit,
                       csvCellsLimit: (
                           await resolveOrganizationExportLimits(
                               this.organizationSettingsModel,
@@ -6428,6 +6428,8 @@ export class AsyncQueryService extends ProjectService {
                 typedColumns: compiledMerge.typedColumns,
                 columnOrder: Object.values(compiledMerge.fieldIdByColumn),
                 limit: mergeQuery.limit,
+                parameterReferences: compiledMerge.parameterReferences,
+                usedParametersValues: compiledMerge.usedParametersValues,
                 warehouseClient,
                 pivotConfiguration,
             });

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
@@ -1,0 +1,99 @@
+import {
+    MergeJoinType,
+    type MergeQuery,
+    type MetricQuery,
+} from '@lightdash/common';
+import {
+    applyMergeExecutionMode,
+    getMergeResultColumnCount,
+} from './mergeQueryExecution';
+
+const sourceQuery = (metrics: string[], calculations: string[] = []) =>
+    ({
+        exploreName: 'orders',
+        dimensions: ['orders_month'],
+        metrics,
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: calculations.map((name) => ({
+            name,
+            displayName: name,
+            sql: '1',
+        })),
+    }) satisfies MetricQuery;
+
+const mergeQuery: MergeQuery = {
+    sources: [
+        { id: 'orders', metricQuery: sourceQuery(['orders_count']) },
+        {
+            id: 'payments',
+            metricQuery: sourceQuery(
+                ['payments_sum', 'payments_count'],
+                ['payments_average'],
+            ),
+        },
+    ],
+    joinKey: [
+        {
+            name: 'month',
+            fieldIdBySourceId: {
+                orders: 'orders_month',
+                payments: 'orders_month',
+            },
+        },
+    ],
+    joinType: MergeJoinType.FULL,
+    tableCalculations: [{ name: 'ratio', displayName: 'Ratio', sql: '1' }],
+    limit: 500,
+};
+
+describe('merge query execution', () => {
+    test('counts every column in the merged result', () => {
+        expect(getMergeResultColumnCount(mergeQuery)).toBe(6);
+    });
+
+    test('leaves interactive queries unchanged', () => {
+        expect(
+            applyMergeExecutionMode({
+                mergeQuery,
+                mode: { type: 'interactive' },
+                csvCellsLimit: 60,
+            }),
+        ).toBe(mergeQuery);
+    });
+
+    test('applies requested and cell-based export limits once to the merge', () => {
+        expect(
+            applyMergeExecutionMode({
+                mergeQuery,
+                mode: { type: 'export', limit: 8 },
+                csvCellsLimit: 60,
+            }).limit,
+        ).toBe(8);
+        expect(
+            applyMergeExecutionMode({
+                mergeQuery,
+                mode: { type: 'export', limit: null },
+                csvCellsLimit: 60,
+            }).limit,
+        ).toBe(10);
+        expect(mergeQuery.sources[0].metricQuery.limit).toBe(500);
+    });
+
+    test('leaves structural validation to compilation', () => {
+        expect(
+            applyMergeExecutionMode({
+                mergeQuery: {
+                    sources: [],
+                    joinKey: [],
+                    joinType: MergeJoinType.FULL,
+                    tableCalculations: [],
+                    limit: 500,
+                },
+                mode: { type: 'export', limit: null },
+                csvCellsLimit: 60,
+            }).limit,
+        ).toBe(60);
+    });
+});

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
@@ -4,8 +4,8 @@ import {
     type MetricQuery,
 } from '@lightdash/common';
 import {
-    applyMergeExecutionMode,
-    getMergeResultColumnCount,
+    applyMergeExportLimit,
+    getMergeOutputColumnCount,
 } from './mergeQueryExecution';
 
 const sourceQuery = (metrics: string[], calculations: string[] = []) =>
@@ -50,31 +50,21 @@ const mergeQuery: MergeQuery = {
 
 describe('merge query execution', () => {
     test('counts every column in the merged result', () => {
-        expect(getMergeResultColumnCount(mergeQuery)).toBe(6);
-    });
-
-    test('leaves interactive queries unchanged', () => {
-        expect(
-            applyMergeExecutionMode({
-                mergeQuery,
-                mode: { type: 'interactive' },
-                csvCellsLimit: 60,
-            }),
-        ).toBe(mergeQuery);
+        expect(getMergeOutputColumnCount(mergeQuery)).toBe(6);
     });
 
     test('applies requested and cell-based export limits once to the merge', () => {
         expect(
-            applyMergeExecutionMode({
+            applyMergeExportLimit({
                 mergeQuery,
-                mode: { type: 'export', limit: 8 },
+                requestedRows: 8,
                 csvCellsLimit: 60,
             }).limit,
         ).toBe(8);
         expect(
-            applyMergeExecutionMode({
+            applyMergeExportLimit({
                 mergeQuery,
-                mode: { type: 'export', limit: null },
+                requestedRows: null,
                 csvCellsLimit: 60,
             }).limit,
         ).toBe(10);
@@ -83,7 +73,7 @@ describe('merge query execution', () => {
 
     test('leaves structural validation to compilation', () => {
         expect(
-            applyMergeExecutionMode({
+            applyMergeExportLimit({
                 mergeQuery: {
                     sources: [],
                     joinKey: [],
@@ -91,7 +81,7 @@ describe('merge query execution', () => {
                     tableCalculations: [],
                     limit: 500,
                 },
-                mode: { type: 'export', limit: null },
+                requestedRows: null,
                 csvCellsLimit: 60,
             }).limit,
         ).toBe(60);

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
@@ -1,6 +1,6 @@
-import type { MergeQuery, MergeQueryExecutionMode } from '@lightdash/common';
+import type { MergeQuery } from '@lightdash/common';
 
-export const getMergeResultColumnCount = (mergeQuery: MergeQuery): number =>
+export const getMergeOutputColumnCount = (mergeQuery: MergeQuery): number =>
     mergeQuery.joinKey.length +
     mergeQuery.tableCalculations.length +
     mergeQuery.sources.reduce(
@@ -13,26 +13,24 @@ export const getMergeResultColumnCount = (mergeQuery: MergeQuery): number =>
 
 /** Resolve the final merged row limit before compilation. Source CTE limits
  * stay untouched because merge compilation deliberately removes them. */
-export const applyMergeExecutionMode = ({
+export const applyMergeExportLimit = ({
     mergeQuery,
-    mode,
+    requestedRows,
     csvCellsLimit,
 }: {
     mergeQuery: MergeQuery;
-    mode: MergeQueryExecutionMode;
+    requestedRows: number | null;
     csvCellsLimit: number;
 }): MergeQuery => {
-    if (mode.type === 'interactive') return mergeQuery;
-
     // Structural validation remains the compiler's job so invalid exports
     // receive the same structured refusal as interactive runs.
-    const columnCount = Math.max(getMergeResultColumnCount(mergeQuery), 1);
+    const columnCount = Math.max(getMergeOutputColumnCount(mergeQuery), 1);
     const cellLimitedRows = Math.floor(csvCellsLimit / columnCount);
     return {
         ...mergeQuery,
         limit:
-            mode.limit === null
+            requestedRows === null
                 ? cellLimitedRows
-                : Math.min(mode.limit, cellLimitedRows),
+                : Math.min(requestedRows, cellLimitedRows),
     };
 };

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
@@ -1,0 +1,38 @@
+import type { MergeQuery, MergeQueryExecutionMode } from '@lightdash/common';
+
+export const getMergeResultColumnCount = (mergeQuery: MergeQuery): number =>
+    mergeQuery.joinKey.length +
+    mergeQuery.tableCalculations.length +
+    mergeQuery.sources.reduce(
+        (count, source) =>
+            count +
+            source.metricQuery.metrics.length +
+            source.metricQuery.tableCalculations.length,
+        0,
+    );
+
+/** Resolve the final merged row limit before compilation. Source CTE limits
+ * stay untouched because merge compilation deliberately removes them. */
+export const applyMergeExecutionMode = ({
+    mergeQuery,
+    mode,
+    csvCellsLimit,
+}: {
+    mergeQuery: MergeQuery;
+    mode: MergeQueryExecutionMode;
+    csvCellsLimit: number;
+}): MergeQuery => {
+    if (mode.type === 'interactive') return mergeQuery;
+
+    // Structural validation remains the compiler's job so invalid exports
+    // receive the same structured refusal as interactive runs.
+    const columnCount = Math.max(getMergeResultColumnCount(mergeQuery), 1);
+    const cellLimitedRows = Math.floor(csvCellsLimit / columnCount);
+    return {
+        ...mergeQuery,
+        limit:
+            mode.limit === null
+                ? cellLimitedRows
+                : Math.min(mode.limit, cellLimitedRows),
+    };
+};

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -1,8 +1,9 @@
 import {
     Account,
-    ApiCompiledMergeQueryResults,
     DownloadFileType,
     MergeQuery,
+    MergeQueryChart,
+    MergeQueryExecutionMode,
     MetricQuery,
     PersistentDownloadFileAccessMode,
     PivotConfig,
@@ -175,19 +176,10 @@ export type ExecuteAsyncSqlQueryArgs = CommonAsyncQueryArgs & {
 
 export type ExecuteAsyncMergeQueryArgs = CommonAsyncQueryArgs & {
     mergeQuery: MergeQuery;
-    csvLimit?: number | null;
-    /** Legacy callers may already have derived the standard pivot stage. */
-    pivotConfiguration?: PivotConfiguration;
-} & Partial<Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>>;
-
-export type ExecuteCompiledAsyncMergeQueryArgs = Omit<
-    ExecuteAsyncMergeQueryArgs,
-    'chartConfig' | 'pivotConfig' | 'pivotConfiguration'
-> & {
-    /** Standard pivot stage over the merged rows. */
-    pivotConfiguration?: PivotConfiguration;
-    /** Server-owned compilation reused by execution. */
-    precompiledMerge: ApiCompiledMergeQueryResults;
+    mode: MergeQueryExecutionMode;
+    presentation?:
+        | ({ type: 'chart' } & MergeQueryChart)
+        | { type: 'resolvedPivot'; configuration: PivotConfiguration };
 };
 
 export type ExecuteAsyncDashboardSqlChartCommonArgs = CommonAsyncQueryArgs & {

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -177,9 +177,7 @@ export type ExecuteAsyncSqlQueryArgs = CommonAsyncQueryArgs & {
 export type ExecuteAsyncMergeQueryArgs = CommonAsyncQueryArgs & {
     mergeQuery: MergeQuery;
     mode: MergeQueryExecutionMode;
-    presentation?:
-        | ({ type: 'chart' } & MergeQueryChart)
-        | { type: 'resolvedPivot'; configuration: PivotConfiguration };
+    chart?: MergeQueryChart;
 };
 
 export type ExecuteAsyncDashboardSqlChartCommonArgs = CommonAsyncQueryArgs & {

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -1,5 +1,6 @@
 import {
     Account,
+    ApiCompiledMergeQueryResults,
     DownloadFileType,
     MergeQuery,
     MetricQuery,
@@ -174,9 +175,19 @@ export type ExecuteAsyncSqlQueryArgs = CommonAsyncQueryArgs & {
 
 export type ExecuteAsyncMergeQueryArgs = CommonAsyncQueryArgs & {
     mergeQuery: MergeQuery;
+    csvLimit?: number | null;
+    /** Legacy callers may already have derived the standard pivot stage. */
+    pivotConfiguration?: PivotConfiguration;
+} & Partial<Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>>;
+
+export type ExecuteCompiledAsyncMergeQueryArgs = Omit<
+    ExecuteAsyncMergeQueryArgs,
+    'chartConfig' | 'pivotConfig' | 'pivotConfiguration'
+> & {
     /** Standard pivot stage over the merged rows. */
     pivotConfiguration?: PivotConfiguration;
-    csvLimit?: number | null;
+    /** Server-owned compilation reused by execution. */
+    precompiledMerge: ApiCompiledMergeQueryResults;
 };
 
 export type ExecuteAsyncDashboardSqlChartCommonArgs = CommonAsyncQueryArgs & {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5356,6 +5356,7 @@ export class ProjectService extends BaseService {
                 itemsMap: {},
                 fieldOrigins: {},
                 parameterReferences: [],
+                usedParametersValues: {},
                 fieldIdByColumn: {},
                 errors,
             };
@@ -5430,6 +5431,7 @@ export class ProjectService extends BaseService {
                     valueColumns,
                     missingParameters,
                     parameterReferences,
+                    usedParametersValues: compiled.usedParameters,
                     originBySourceColumn: Object.fromEntries(
                         valueColumns.map((column) => [
                             column,
@@ -5457,6 +5459,10 @@ export class ProjectService extends BaseService {
         const parameterReferences = Array.from(
             new Set(sources.flatMap((source) => source.parameterReferences)),
         );
+        const usedParametersValues = Object.assign(
+            {},
+            ...sources.map((source) => source.usedParametersValues),
+        );
         if (parameterErrors.length > 0) {
             return {
                 sql: null,
@@ -5468,6 +5474,7 @@ export class ProjectService extends BaseService {
                 itemsMap: {},
                 fieldOrigins: {},
                 parameterReferences,
+                usedParametersValues,
                 fieldIdByColumn: {},
                 errors: parameterErrors,
             };
@@ -5566,6 +5573,7 @@ export class ProjectService extends BaseService {
                 itemsMap: {},
                 fieldOrigins: {},
                 parameterReferences,
+                usedParametersValues,
                 fieldIdByColumn: {},
                 errors: referenceErrors,
             };
@@ -5904,6 +5912,7 @@ export class ProjectService extends BaseService {
                 itemsMap: {},
                 fieldOrigins: {},
                 parameterReferences,
+                usedParametersValues,
                 fieldIdByColumn: {},
                 errors: typeErrors,
             };
@@ -5927,6 +5936,7 @@ export class ProjectService extends BaseService {
             itemsMap,
             fieldOrigins,
             parameterReferences,
+            usedParametersValues,
             fieldIdByColumn,
             errors: [],
         };

--- a/packages/backend/src/utils/QueryBuilder/MergeQueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MergeQueryComposer.test.ts
@@ -1,6 +1,7 @@
 import {
     DimensionType,
     FieldType,
+    MERGE_TABLE_NAME,
     MetricType,
     SupportedDbtAdapter,
     VizAggregationOptions,
@@ -9,7 +10,7 @@ import {
     type ItemsMap,
     type WarehouseClient,
 } from '@lightdash/common';
-import { MERGE_EXPLORE_NAME, MergeQueryComposer } from './MergeQueryComposer';
+import { MergeQueryComposer } from './MergeQueryComposer';
 
 const mockWarehouseClient = {
     getFieldQuoteChar: () => '"',
@@ -82,6 +83,11 @@ const typedColumns = [
     },
 ];
 
+const parameterMetadata = {
+    parameterReferences: ['date_parameter'],
+    usedParametersValues: { date_parameter: '2024-01-01' },
+};
+
 const compose = () =>
     new MergeQueryComposer({
         coreSql: 'SELECT 1',
@@ -94,6 +100,7 @@ const compose = () =>
         typedColumns,
         columnOrder: ['merge_k0', 'a_followers_count'],
         limit: 500,
+        ...parameterMetadata,
         warehouseClient: mockWarehouseClient,
     });
 
@@ -104,6 +111,13 @@ describe('MergeQueryComposer', () => {
 
     it('reports the merged items map as the query fields', () => {
         expect(compose().getFields()).toEqual(itemsMap);
+    });
+
+    it('reports the parameters embedded during source compilation', () => {
+        expect(compose().getParameterReferences()).toEqual(['date_parameter']);
+        expect(compose().getUsedParameters()).toEqual(
+            parameterMetadata.usedParametersValues,
+        );
     });
 
     // Everything downstream looks fields up by id, so a composer whose fields
@@ -119,7 +133,7 @@ describe('MergeQueryComposer', () => {
     // of the join and quietly return that side's numbers.
     it('names a sentinel explore rather than either source', () => {
         expect(compose().getMetricQuery().exploreName).toEqual(
-            MERGE_EXPLORE_NAME,
+            MERGE_TABLE_NAME,
         );
     });
 
@@ -146,6 +160,7 @@ describe('MergeQueryComposer', () => {
             typedColumns,
             columnOrder: ['merge_k0', 'merge_k1', 'a_followers_count'],
             limit: 500,
+            ...parameterMetadata,
             warehouseClient: mockWarehouseClient,
             pivotConfiguration: {
                 indexColumn: { reference: 'merge_k0', type: VizIndexType.TIME },
@@ -180,6 +195,7 @@ describe('MergeQueryComposer', () => {
             typedColumns,
             columnOrder: ['merge_k0', 'merge_k1', 'a_followers_count'],
             limit: 500,
+            ...parameterMetadata,
             warehouseClient: mockWarehouseClient,
             pivotConfiguration: {
                 indexColumn: { reference: 'merge_k0', type: VizIndexType.TIME },

--- a/packages/backend/src/utils/QueryBuilder/MergeQueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/MergeQueryComposer.ts
@@ -36,6 +36,35 @@ export type MergeQueryComposerArguments = {
 };
 
 /**
+ * Describes the merged result for result ordering and chart configuration.
+ * It is a metadata carrier, never a query that can be compiled on its own.
+ */
+export const buildMergeResultMetricQuery = ({
+    itemsMap,
+    columnOrder,
+    limit,
+}: {
+    itemsMap: ItemsMap;
+    columnOrder: string[];
+    limit: number;
+}): MetricQuery => {
+    const dimensions = columnOrder.filter((fieldId) => {
+        const item = itemsMap[fieldId];
+        return item !== undefined && isDimension(item);
+    });
+
+    return {
+        exploreName: MERGE_EXPLORE_NAME,
+        dimensions,
+        metrics: columnOrder.filter((fieldId) => !dimensions.includes(fieldId)),
+        filters: {},
+        sorts: [],
+        limit,
+        tableCalculations: [],
+    };
+};
+
+/**
  * QueryComposer for merged queries.
  *
  * A merge compiles two metric queries into one statement, so there is no
@@ -70,11 +99,11 @@ export class MergeQueryComposer extends QueryComposer {
 
         super(
             {
-                metricQuery: MergeQueryComposer.buildMetricQuery(
+                metricQuery: buildMergeResultMetricQuery({
                     itemsMap,
                     columnOrder,
                     limit,
-                ),
+                }),
                 pivotConfiguration,
             },
             {
@@ -116,34 +145,6 @@ export class MergeQueryComposer extends QueryComposer {
             // present. The source-cap assertion must remain outermost.
             ...(isPivoted ? { orderBy: [], limit: null } : {}),
         });
-    }
-
-    /**
-     * Describes the merged result for column ordering and the chart config.
-     * Filters and sorts stay empty: the real filters live on the source
-     * queries, and echoing them here invites a consumer to apply them twice.
-     */
-    private static buildMetricQuery(
-        itemsMap: ItemsMap,
-        columnOrder: string[],
-        limit: number,
-    ): MetricQuery {
-        const dimensions = columnOrder.filter((fieldId) => {
-            const item = itemsMap[fieldId];
-            return item !== undefined && isDimension(item);
-        });
-
-        return {
-            exploreName: MERGE_EXPLORE_NAME,
-            dimensions,
-            metrics: columnOrder.filter(
-                (fieldId) => !dimensions.includes(fieldId),
-            ),
-            filters: {},
-            sorts: [],
-            limit,
-            tableCalculations: [],
-        };
     }
 
     /**

--- a/packages/backend/src/utils/QueryBuilder/MergeQueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/MergeQueryComposer.ts
@@ -1,20 +1,19 @@
 import {
     createVirtualView,
     isDimension,
+    MERGE_TABLE_NAME,
     type Explore,
     type ItemsMap,
     type MergeTerminalWrapper,
     type MergeTypedColumn,
     type MetricQuery,
+    type ParametersValuesMap,
     type PivotConfiguration,
     type WarehouseClient,
 } from '@lightdash/common';
 import { applyMergeTerminalWrapper } from './MergeQueryBuilder';
 import { type CompiledQuery } from './MetricQueryBuilder';
 import { QueryComposer } from './QueryComposer';
-
-/** Explore name a merged result reports. Deliberately not either source's. */
-export const MERGE_EXPLORE_NAME = 'merge';
 
 export type MergeQueryComposerArguments = {
     /** Composable merge SQL, before presentation pivot and terminal checks. */
@@ -27,6 +26,8 @@ export type MergeQueryComposerArguments = {
     /** Field ids the merged result carries, in the order it returns them. */
     columnOrder: string[];
     limit: number;
+    parameterReferences: string[];
+    usedParametersValues: ParametersValuesMap;
     warehouseClient: WarehouseClient;
     /**
      * Standard pivot stage over the merged rows. Every merged dimension is a
@@ -54,7 +55,7 @@ export const buildMergeResultMetricQuery = ({
     });
 
     return {
-        exploreName: MERGE_EXPLORE_NAME,
+        exploreName: MERGE_TABLE_NAME,
         dimensions,
         metrics: columnOrder.filter((fieldId) => !dimensions.includes(fieldId)),
         filters: {},
@@ -85,6 +86,10 @@ export class MergeQueryComposer extends QueryComposer {
 
     private readonly terminalWrapper: MergeTerminalWrapper;
 
+    private readonly parameterReferences: Set<string>;
+
+    private readonly usedParametersValues: ParametersValuesMap;
+
     constructor(args: MergeQueryComposerArguments) {
         const {
             coreSql,
@@ -93,6 +98,8 @@ export class MergeQueryComposer extends QueryComposer {
             typedColumns,
             columnOrder,
             limit,
+            parameterReferences,
+            usedParametersValues,
             warehouseClient,
             pivotConfiguration,
         } = args;
@@ -123,6 +130,8 @@ export class MergeQueryComposer extends QueryComposer {
         this.mergedSql = coreSql;
         this.mergedItemsMap = itemsMap;
         this.terminalWrapper = terminalWrapper;
+        this.parameterReferences = new Set(parameterReferences);
+        this.usedParametersValues = usedParametersValues;
     }
 
     /** The merged statement is already compiled; nothing recompiles it. */
@@ -131,9 +140,9 @@ export class MergeQueryComposer extends QueryComposer {
             query: this.mergedSql,
             fields: this.mergedItemsMap,
             warnings: [],
-            parameterReferences: new Set(),
+            parameterReferences: this.parameterReferences,
             missingParameterReferences: new Set(),
-            usedParameters: {},
+            usedParameters: this.usedParametersValues,
             compilationErrors: [],
         };
     }
@@ -159,7 +168,7 @@ export class MergeQueryComposer extends QueryComposer {
         warehouseClient: WarehouseClient,
     ): Explore {
         return createVirtualView(
-            MERGE_EXPLORE_NAME,
+            MERGE_TABLE_NAME,
             sql,
             typedColumns.map(({ reference, type }) => ({ reference, type })),
             warehouseClient,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -877,22 +877,38 @@ export type ApiExecuteAsyncMetricQueryResults =
         warnings: QueryWarning[];
     };
 
-export type ApiExecuteAsyncMergeQueryResults = {
-    /** Validation errors that prevented execution. Empty when started is set. */
-    errors: MergeQueryError[];
-    started: ApiExecuteAsyncMetricQueryResults | null;
+type ApiExecuteAsyncMergeQueryMetadata = {
     parameterReferences: string[];
     fieldOrigins: MergeFieldOrigins;
 };
 
-/** One-call merge execution request. Chart state stays optional for exports without pivoting. */
-export type ApiExecuteAsyncMergeQueryRequest =
-    ExecuteAsyncMergeQueryRequestParams & {
-        chartConfig?: ChartConfig;
-        pivotConfig?: SavedChart['pivotConfig'];
-        /** Export row limit. Null means all rows within the organization's cell cap. */
-        csvLimit?: number | null;
-    };
+export type ApiExecuteAsyncMergeQueryResults =
+    | (ApiExecuteAsyncMergeQueryMetadata & {
+          outcome: 'started';
+          query: ApiExecuteAsyncMetricQueryResults;
+      })
+    | (ApiExecuteAsyncMergeQueryMetadata & {
+          outcome: 'refused';
+          errors: MergeQueryError[];
+      });
+
+export type MergeQueryExecutionMode =
+    | { type: 'interactive' }
+    | { type: 'export'; limit: number | null };
+
+export type MergeQueryChart = {
+    chartConfig: ChartConfig;
+    pivotConfig?: SavedChart['pivotConfig'];
+};
+
+/** One-call merge execution request. Derived pivot SQL remains server-owned. */
+export type ApiExecuteAsyncMergeQueryRequest = Omit<
+    ExecuteAsyncMergeQueryRequestParams,
+    'pivotConfiguration' | 'usePreAggregateCache'
+> & {
+    mode?: MergeQueryExecutionMode;
+    chart?: MergeQueryChart;
+};
 
 export type ApiExecuteAsyncDashboardChartQueryResults =
     ApiExecuteAsyncQueryResultsCommon & {

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -111,6 +111,7 @@ import {
     type ApiGetComments,
 } from './api/comments';
 import { type Email } from './api/email';
+import type { ExecuteAsyncMergeQueryRequestParams } from './api/paginatedQuery';
 import {
     type ApiGetProjectParametersListResults,
     type ApiGetProjectParametersResults,
@@ -200,7 +201,11 @@ import type {
     ApiGroupListResponse,
 } from './groups';
 import { type ApiImpersonationOrganizationSettingsResponse } from './impersonationOrganizationSettings';
-import { type ApiCompiledMergeQueryResults } from './mergeQuery';
+import {
+    type ApiCompiledMergeQueryResults,
+    type MergeFieldOrigins,
+    type MergeQueryError,
+} from './mergeQuery';
 import { type MetricQuery, type QueryWarning } from './metricQuery';
 import type {
     ApiMetricsExplorerQueryResults,
@@ -287,6 +292,7 @@ import {
 import {
     type ApiCalculateSubtotalsResponse,
     type ApiCalculateTotalResponse,
+    type ChartConfig,
     type ChartHistory,
     type ChartVersion,
     type SavedChart,
@@ -871,6 +877,23 @@ export type ApiExecuteAsyncMetricQueryResults =
         warnings: QueryWarning[];
     };
 
+export type ApiExecuteAsyncMergeQueryResults = {
+    /** Validation errors that prevented execution. Empty when started is set. */
+    errors: MergeQueryError[];
+    started: ApiExecuteAsyncMetricQueryResults | null;
+    parameterReferences: string[];
+    fieldOrigins: MergeFieldOrigins;
+};
+
+/** One-call merge execution request. Chart state stays optional for exports without pivoting. */
+export type ApiExecuteAsyncMergeQueryRequest =
+    ExecuteAsyncMergeQueryRequestParams & {
+        chartConfig?: ChartConfig;
+        pivotConfig?: SavedChart['pivotConfig'];
+        /** Export row limit. Null means all rows within the organization's cell cap. */
+        csvLimit?: number | null;
+    };
+
 export type ApiExecuteAsyncDashboardChartQueryResults =
     ApiExecuteAsyncQueryResultsCommon & {
         metricQuery: MetricQuery;
@@ -1087,6 +1110,7 @@ type ApiResults =
     | ApiSqlQueryResults
     | ApiCompiledQueryResults
     | ApiCompiledMergeQueryResults
+    | ApiExecuteAsyncMergeQueryResults
     | ApiFormulaValidationResults
     | ApiExploresResults
     | ApiExploreResults

--- a/packages/common/src/types/mergeQuery.ts
+++ b/packages/common/src/types/mergeQuery.ts
@@ -487,6 +487,8 @@ export type ApiCompiledMergeQueryResults = {
     fieldOrigins: MergeFieldOrigins;
     /** User parameters referenced by any source query. */
     parameterReferences: string[];
+    /** Resolved parameter values embedded in the compiled source queries. */
+    usedParametersValues: ParametersValuesMap;
     /**
      * Field id for each column the statement returns. Warehouse aliases are
      * short and positional so they cannot breach an identifier length limit;

--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.module.css
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.module.css
@@ -34,7 +34,7 @@
     border: 1px solid var(--mantine-color-ldGray-3);
     border-top: none;
     border-radius: 0 0 6px 6px;
-    padding: 10px;
+    padding: 8px 10px;
     background: var(--mantine-color-body);
 }
 
@@ -50,13 +50,178 @@
 .pair {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 6px;
 }
 
-.pairHeader {
+.pairFields {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 24px minmax(0, 1fr) 28px;
+    gap: 8px;
+    align-items: end;
+}
+
+.fieldSide,
+.sourceLabel {
+    min-width: 0;
+}
+
+.sourceDot {
+    width: 7px;
+    height: 7px;
+    flex: none;
+    border-radius: 50%;
+}
+
+.sourceDot[data-side='primary'] {
+    background: var(--mantine-color-blue-6);
+}
+
+.sourceDot[data-side='additional'] {
+    background: var(--mantine-color-orange-6);
+}
+
+.operator {
+    display: flex;
+    height: 30px;
+    align-items: center;
+    justify-content: center;
+    color: var(--mantine-color-ldGray-7);
+}
+
+.removeKey,
+.removeKeySpacer {
+    align-self: end;
+    width: 28px;
+    height: 30px;
+}
+
+.andDivider {
     display: flex;
     align-items: center;
+    gap: 8px;
+}
+
+.andDivider::before,
+.andDivider::after {
+    height: 1px;
+    flex: 1;
+    background: var(--mantine-color-ldGray-2);
+    content: '';
+}
+
+.suggestion {
+    display: flex;
+    align-items: baseline;
     justify-content: space-between;
+    gap: 12px;
+    padding: 6px 8px;
+    border-radius: 6px;
+    background: var(--mantine-color-ldGray-0);
+}
+
+.joinTypeGrid {
+    padding: 3px;
+    border: 1px solid var(--mantine-color-ldGray-3);
+    border-radius: 8px;
+    background: var(--mantine-color-ldGray-0);
+}
+
+.joinTypeCard {
+    min-width: 0;
+    background: transparent;
+    transition:
+        transform 120ms cubic-bezier(0.23, 1, 0.32, 1),
+        background-color 120ms ease;
+}
+
+.joinTypeCard[data-checked] {
+    background: var(--mantine-color-body);
+    box-shadow:
+        0 1px 2px rgb(0 0 0 / 8%),
+        0 0 0 1px var(--mantine-color-ldGray-3);
+}
+
+.joinTypeCard:focus-visible {
+    outline: 2px solid var(--mantine-color-blue-6);
+    outline-offset: 2px;
+}
+
+.joinTypeCard:active {
+    transform: scale(0.98);
+}
+
+.joinTypeDiagram {
+    width: 36px;
+    height: 21px;
+    flex: none;
+    overflow: visible;
+}
+
+.primaryRegion {
+    fill: var(--mantine-color-blue-5);
+    fill-opacity: 0.55;
+}
+
+.additionalRegion {
+    fill: var(--mantine-color-orange-5);
+    fill-opacity: 0.55;
+}
+
+.overlapRegion {
+    fill: var(--mantine-color-violet-5);
+    fill-opacity: 0.7;
+}
+
+.primaryOutline,
+.additionalOutline {
+    fill: none;
+    stroke-width: 1.5;
+}
+
+.primaryOutline {
+    stroke: var(--mantine-color-blue-7);
+}
+
+.additionalOutline {
+    stroke: var(--mantine-color-orange-7);
+}
+
+@media (max-width: 48em) {
+    .pairFields {
+        grid-template-columns: minmax(0, 1fr) 24px;
+    }
+
+    .fieldSide {
+        grid-column: 1 / -1;
+    }
+
+    .operator {
+        grid-column: 1 / -1;
+        height: 18px;
+    }
+
+    .removeKey,
+    .removeKeySpacer {
+        grid-column: 2;
+        grid-row: 1;
+        justify-self: end;
+    }
+
+    .suggestion {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 4px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .joinTypeCard {
+        transition: none;
+    }
+
+    .joinTypeCard:active {
+        transform: none;
+    }
 }
 
 .note {

--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.test.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.test.tsx
@@ -1,0 +1,306 @@
+import { MergeJoinType } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ChangeEvent } from 'react';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { PRIMARY_SOURCE_ID } from '../constants';
+import { MergeJoinBar } from './MergeJoinBar';
+import { MergeReadOnlyBar } from './MergeReadOnlyBar';
+
+type TestItem = {
+    table: string;
+    name: string;
+    label: string;
+};
+
+const state = vi.hoisted(() => ({
+    dispatch: vi.fn(),
+    setJoinField: vi.fn(),
+    addJoinPart: vi.fn(),
+    removeJoinPart: vi.fn(),
+    setJoinType: vi.fn(),
+    toggleSourceField: vi.fn(),
+    merge: {
+        isMerging: true,
+        readOnly: false,
+        additionalSources: [
+            {
+                id: 'b',
+                exploreName: 'customers',
+                dimensions: [],
+                metrics: [],
+            },
+        ],
+        joinType: 'full',
+        mergeResults: undefined,
+        runErrors: [],
+    },
+    setup: {
+        effectiveParts: [
+            {
+                fieldIdBySourceId: {
+                    a: 'orders_customer_id',
+                    b: 'customers_id',
+                },
+            },
+        ] as Array<{
+            fieldIdBySourceId: Record<string, string | null>;
+        }>,
+        labelFor: (fieldId: string) =>
+            ({
+                orders_customer_id: 'Customer ID',
+                orders_account_id: 'Account ID',
+                customers_id: 'ID',
+                customers_account_key: 'Account key',
+            })[fieldId] ?? fieldId,
+        fanOut: [],
+        joinKeyErrors: [],
+        joinFieldLabel: 'join fields',
+        primaryJoinItems: [] as TestItem[],
+        additionalJoinItems: [] as TestItem[],
+        availablePrimaryJoinItems: [] as TestItem[],
+        availableAdditionalJoinItems: [] as TestItem[],
+        suggestedAvailablePair: null as Record<string, string> | null,
+        primaryExploreLabel: 'Orders',
+        additionalExploreLabel: 'Customers',
+        additionalSourceId: 'b',
+        isIncomplete: false,
+        blockingReason: null,
+    },
+}));
+
+vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({ data: { enabled: true } }),
+}));
+
+vi.mock('../../explorer/store', () => ({
+    explorerActions: {
+        toggleDimension: (fieldId: string) => ({
+            type: 'toggleDimension',
+            payload: fieldId,
+        }),
+    },
+    selectTableName: vi.fn(),
+    useExplorerDispatch: () => state.dispatch,
+    useExplorerSelector: () => 'orders',
+}));
+
+vi.mock('../context/useMerge', () => ({
+    useMergeSafe: () => ({
+        ...state.merge,
+        setJoinField: state.setJoinField,
+        addJoinPart: state.addJoinPart,
+        removeJoinPart: state.removeJoinPart,
+        setJoinType: state.setJoinType,
+        toggleSourceField: state.toggleSourceField,
+    }),
+}));
+
+vi.mock('../hooks/useMergeSetup', () => ({
+    useMergeSetup: () => state.setup,
+}));
+
+vi.mock('../../../components/common/FieldSelect', () => ({
+    default: ({
+        'aria-label': ariaLabel,
+        item,
+        items,
+        onChange,
+    }: {
+        'aria-label': string;
+        item?: TestItem;
+        items: TestItem[];
+        onChange: (item: TestItem | undefined) => void;
+    }) => {
+        const itemId = (candidate: TestItem) =>
+            `${candidate.table}_${candidate.name}`;
+        return (
+            <select
+                aria-label={ariaLabel}
+                value={item ? itemId(item) : ''}
+                onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+                    onChange(
+                        items.find(
+                            (candidate) =>
+                                itemId(candidate) === event.target.value,
+                        ),
+                    )
+                }
+            >
+                <option value="">Choose a field</option>
+                {items.map((candidate) => (
+                    <option key={itemId(candidate)} value={itemId(candidate)}>
+                        {candidate.label}
+                    </option>
+                ))}
+            </select>
+        );
+    },
+}));
+
+const primaryItems: TestItem[] = [
+    { table: 'orders', name: 'customer_id', label: 'Customer ID' },
+    { table: 'orders', name: 'account_id', label: 'Account ID' },
+];
+const additionalItems: TestItem[] = [
+    { table: 'customers', name: 'id', label: 'ID' },
+    { table: 'customers', name: 'account_key', label: 'Account key' },
+];
+
+const resetState = () => {
+    state.merge.readOnly = false;
+    state.merge.joinType = MergeJoinType.FULL;
+    state.setup.effectiveParts = [
+        {
+            fieldIdBySourceId: {
+                [PRIMARY_SOURCE_ID]: 'orders_customer_id',
+                b: 'customers_id',
+            },
+        },
+    ];
+    state.setup.primaryJoinItems = [primaryItems[0]];
+    state.setup.additionalJoinItems = [additionalItems[0]];
+    state.setup.availablePrimaryJoinItems = primaryItems;
+    state.setup.availableAdditionalJoinItems = additionalItems;
+    state.setup.suggestedAvailablePair = null;
+    state.setup.isIncomplete = false;
+};
+
+describe('MergeJoinBar', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        resetState();
+    });
+
+    it('shows source-qualified fields and updates the correct side', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<MergeJoinBar guided />);
+
+        expect(screen.getByText('Orders')).toBeInTheDocument();
+        expect(screen.getByText('Customers')).toBeInTheDocument();
+        expect(screen.getByText('=')).toBeInTheDocument();
+
+        await user.selectOptions(
+            screen.getByRole('combobox', { name: 'Orders join field' }),
+            'orders_account_id',
+        );
+        await user.selectOptions(
+            screen.getByRole('combobox', { name: 'Customers join field' }),
+            'customers_account_key',
+        );
+
+        expect(state.setJoinField).toHaveBeenCalledWith(
+            0,
+            PRIMARY_SOURCE_ID,
+            'orders_account_id',
+        );
+        expect(state.setJoinField).toHaveBeenCalledWith(
+            0,
+            'b',
+            'customers_account_key',
+        );
+    });
+
+    it('shows AND between clauses and keeps remove actions visible', async () => {
+        const user = userEvent.setup();
+        state.setup.effectiveParts = [
+            ...state.setup.effectiveParts,
+            {
+                fieldIdBySourceId: {
+                    [PRIMARY_SOURCE_ID]: 'orders_account_id',
+                    b: 'customers_account_key',
+                },
+            },
+        ];
+
+        renderWithProviders(<MergeJoinBar guided />);
+
+        expect(screen.getByText('AND')).toBeInTheDocument();
+        await user.click(
+            screen.getByRole('button', {
+                name: 'Remove join condition 2',
+            }),
+        );
+        expect(state.removeJoinPart).toHaveBeenCalledWith(1);
+    });
+
+    it('applies a source-qualified suggested pair', async () => {
+        const user = userEvent.setup();
+        state.setup.effectiveParts = [
+            {
+                fieldIdBySourceId: {
+                    [PRIMARY_SOURCE_ID]: null,
+                    b: null,
+                },
+            },
+        ];
+        state.setup.isIncomplete = true;
+        state.setup.suggestedAvailablePair = {
+            [PRIMARY_SOURCE_ID]: 'orders_customer_id',
+            b: 'customers_id',
+        };
+
+        renderWithProviders(<MergeJoinBar guided />);
+
+        expect(
+            screen.getByText('Orders · Customer ID = Customers · ID', {
+                exact: false,
+            }),
+        ).toBeInTheDocument();
+        await user.click(
+            screen.getByRole('button', { name: 'Use suggestion' }),
+        );
+
+        expect(state.setJoinField).toHaveBeenCalledWith(
+            0,
+            PRIMARY_SOURCE_ID,
+            'orders_customer_id',
+        );
+        expect(state.setJoinField).toHaveBeenCalledWith(0, 'b', 'customers_id');
+    });
+
+    it('supports clicking and arrow-key navigation between join types', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<MergeJoinBar guided />);
+
+        const fullOuter = screen.getByRole('radio', {
+            name: /Full outer:/,
+        });
+        expect(fullOuter).toBeChecked();
+
+        await user.click(screen.getByRole('radio', { name: /Left:/ }));
+        expect(state.setJoinType).toHaveBeenCalledWith(MergeJoinType.LEFT);
+
+        fullOuter.focus();
+        await user.keyboard('{ArrowRight}');
+        expect(state.setJoinType).toHaveBeenCalledWith(MergeJoinType.INNER);
+    });
+
+    it('keeps both source and field names in the collapsed summary', () => {
+        renderWithProviders(<MergeJoinBar />);
+
+        expect(
+            screen.getByText('Orders · Customer ID = Customers · ID', {
+                exact: false,
+            }),
+        ).toBeInTheDocument();
+    });
+});
+
+describe('MergeReadOnlyBar', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        resetState();
+        state.merge.readOnly = true;
+    });
+
+    it('shows both source-qualified fields', () => {
+        renderWithProviders(<MergeReadOnlyBar />);
+
+        expect(
+            screen.getByText('Orders · Customer ID = Customers · ID', {
+                exact: false,
+            }),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
@@ -4,9 +4,10 @@ import {
     Anchor,
     Box,
     Group,
-    SegmentedControl,
+    Radio,
+    SimpleGrid,
+    Stack,
     Text,
-    Tooltip,
 } from '@mantine/core';
 import {
     IconAlertTriangle,
@@ -14,7 +15,7 @@ import {
     IconPlus,
     IconX,
 } from '@tabler/icons-react';
-import { useState, type FC, type ReactNode } from 'react';
+import { useId, useState, type FC, type ReactNode } from 'react';
 import FieldSelect from '../../../components/common/FieldSelect';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
@@ -28,6 +29,7 @@ import { EMPTY_MERGE, PRIMARY_SOURCE_ID } from '../constants';
 import { useMergeSafe } from '../context/useMerge';
 import { useMergeSetup } from '../hooks/useMergeSetup';
 import styles from './MergeJoinBar.module.css';
+import { getJoinClauseLabel } from './mergeJoinLabels';
 
 /** Guidance as a line of text. A coloured box for every hint is a lot to read. */
 const Note: FC<{ tone: 'muted' | 'warn'; children: ReactNode }> = ({
@@ -44,6 +46,110 @@ const Note: FC<{ tone: 'muted' | 'warn'; children: ReactNode }> = ({
             {children}
         </Text>
     </Box>
+);
+
+type JoinTypeOption = {
+    value: MergeJoinType;
+    label: string;
+    help: string;
+};
+
+const SourceLabel: FC<{ side: 'primary' | 'additional'; label: string }> = ({
+    side,
+    label,
+}) => (
+    <Group gap={6} wrap="nowrap" className={styles.sourceLabel}>
+        <Box className={styles.sourceDot} data-side={side} />
+        <Text size="xs" fw={600} truncate title={label}>
+            {label}
+        </Text>
+    </Group>
+);
+
+const JoinTypeDiagram: FC<{ type: MergeJoinType }> = ({ type }) => {
+    const clipId = useId();
+
+    return (
+        <svg aria-hidden className={styles.joinTypeDiagram} viewBox="0 0 48 28">
+            <defs>
+                <clipPath id={clipId}>
+                    <circle cx="18" cy="14" r="10" />
+                </clipPath>
+            </defs>
+            {type === MergeJoinType.LEFT ? (
+                <circle
+                    className={styles.primaryRegion}
+                    cx="18"
+                    cy="14"
+                    r="10"
+                />
+            ) : null}
+            {type === MergeJoinType.FULL ? (
+                <>
+                    <circle
+                        className={styles.primaryRegion}
+                        cx="18"
+                        cy="14"
+                        r="10"
+                    />
+                    <circle
+                        className={styles.additionalRegion}
+                        cx="30"
+                        cy="14"
+                        r="10"
+                    />
+                </>
+            ) : null}
+            {type === MergeJoinType.INNER ? (
+                <circle
+                    className={styles.overlapRegion}
+                    cx="30"
+                    cy="14"
+                    r="10"
+                    clipPath={`url(#${clipId})`}
+                />
+            ) : null}
+            <circle className={styles.primaryOutline} cx="18" cy="14" r="10" />
+            <circle
+                className={styles.additionalOutline}
+                cx="30"
+                cy="14"
+                r="10"
+            />
+        </svg>
+    );
+};
+
+const JoinTypePicker: FC<{
+    value: MergeJoinType;
+    options: JoinTypeOption[];
+    onChange: (value: MergeJoinType) => void;
+}> = ({ value, options, onChange }) => (
+    <Radio.Group
+        aria-label="Join type"
+        value={value}
+        onChange={(nextValue) => onChange(nextValue as MergeJoinType)}
+    >
+        <SimpleGrid className={styles.joinTypeGrid} cols={3} spacing={4}>
+            {options.map((option) => (
+                <Radio.Card
+                    className={styles.joinTypeCard}
+                    key={option.value}
+                    value={option.value}
+                    radius="sm"
+                    withBorder={false}
+                    aria-label={`${option.label}: ${option.help}`}
+                >
+                    <Group justify="center" gap={6} wrap="nowrap" p={6}>
+                        <JoinTypeDiagram type={option.value} />
+                        <Text size="xs" fw={600} ta="center" truncate>
+                            {option.label}
+                        </Text>
+                    </Group>
+                </Radio.Card>
+            ))}
+        </SimpleGrid>
+    </Radio.Group>
 );
 
 /**
@@ -108,21 +214,21 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
 
     const thisQuery = primaryExploreLabel || 'this query';
     const otherQuery = additionalExploreLabel || 'the other query';
-    const keepOptions = [
+    const keepOptions: JoinTypeOption[] = [
         {
-            value: MergeJoinType.FULL,
-            label: 'All rows',
-            help: `Full outer join · Every ${joinFieldLabel} from either query. Where one side has no match, its columns are blank.`,
+            value: MergeJoinType.INNER,
+            label: 'Inner',
+            help: `Inner join · Only the ${joinFieldLabel} values in both ${thisQuery} and ${otherQuery}. Everything unmatched is dropped.`,
         },
         {
             value: MergeJoinType.LEFT,
-            label: thisQuery,
+            label: 'Left',
             help: `Left join · Only the ${joinFieldLabel} values in ${thisQuery}. Anything found solely in ${otherQuery} is dropped.`,
         },
         {
-            value: MergeJoinType.INNER,
-            label: 'Matches',
-            help: `Inner join · Only the ${joinFieldLabel} values in both ${thisQuery} and ${otherQuery}. Everything unmatched is dropped.`,
+            value: MergeJoinType.FULL,
+            label: 'Full outer',
+            help: `Full outer join · Every ${joinFieldLabel} from either query. Where one side has no match, its columns are blank.`,
         },
     ];
     const activeKeep =
@@ -140,13 +246,22 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
             <b>
                 {effectiveParts
                     .map((part) => {
-                        const fieldId =
+                        const primaryFieldId =
                             part.fieldIdBySourceId[PRIMARY_SOURCE_ID];
-                        return fieldId ? labelFor(fieldId) : '?';
+                        const additionalFieldId =
+                            part.fieldIdBySourceId[additionalSourceId];
+                        return getJoinClauseLabel(
+                            thisQuery,
+                            primaryFieldId ? labelFor(primaryFieldId) : '?',
+                            otherQuery,
+                            additionalFieldId
+                                ? labelFor(additionalFieldId)
+                                : '?',
+                        );
                     })
-                    .join(' + ')}
+                    .join(' AND ')}
             </b>{' '}
-            · keep <b>{activeKeep.label}</b>
+            · <b>{activeKeep.label}</b>
         </>
     );
 
@@ -176,33 +291,24 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
 
                 {expanded && (
                     <Box className={styles.editor} data-guided={guided}>
+                        <Text size="xs" fw={600}>
+                            Join conditions
+                        </Text>
                         {effectiveParts.map((part, index) => (
                             // eslint-disable-next-line react/no-array-index-key
                             <Box className={styles.pair} key={index}>
-                                <Box className={styles.pairHeader}>
-                                    <Text span size="xs" c="dimmed">
-                                        {primaryExploreLabel} matches{' '}
-                                        {additionalExploreLabel ??
-                                            'the second query'}{' '}
-                                        on
-                                    </Text>
-                                    {effectiveParts.length > 1 && (
-                                        <ActionIcon
-                                            variant="subtle"
-                                            color="gray"
+                                {index > 0 ? (
+                                    <Box className={styles.andDivider}>
+                                        <Text
+                                            span
                                             size="xs"
-                                            onClick={() =>
-                                                removeJoinPart(index)
-                                            }
-                                            aria-label="Remove this key"
+                                            c="dimmed"
+                                            fw={600}
                                         >
-                                            <MantineIcon
-                                                icon={IconX}
-                                                size={12}
-                                            />
-                                        </ActionIcon>
-                                    )}
-                                </Box>
+                                            AND
+                                        </Text>
+                                    </Box>
+                                ) : null}
                                 {index === 0 &&
                                     !part.fieldIdBySourceId[
                                         PRIMARY_SOURCE_ID
@@ -211,149 +317,216 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
                                         additionalSourceId
                                     ] &&
                                     suggestedAvailablePair && (
-                                        <Anchor
-                                            component="button"
-                                            type="button"
+                                        <Box className={styles.suggestion}>
+                                            <Text size="xs" c="dimmed">
+                                                Suggested:{' '}
+                                                <Text
+                                                    span
+                                                    inherit
+                                                    fw={600}
+                                                    c="gray.7"
+                                                >
+                                                    {getJoinClauseLabel(
+                                                        thisQuery,
+                                                        labelFor(
+                                                            suggestedAvailablePair[
+                                                                PRIMARY_SOURCE_ID
+                                                            ],
+                                                        ),
+                                                        otherQuery,
+                                                        labelFor(
+                                                            suggestedAvailablePair[
+                                                                additionalSourceId
+                                                            ],
+                                                        ),
+                                                    )}
+                                                </Text>
+                                            </Text>
+                                            <Anchor
+                                                component="button"
+                                                type="button"
+                                                size="xs"
+                                                fw={600}
+                                                onClick={() => {
+                                                    const primaryField =
+                                                        suggestedAvailablePair[
+                                                            PRIMARY_SOURCE_ID
+                                                        ];
+                                                    const additionalField =
+                                                        suggestedAvailablePair[
+                                                            additionalSourceId
+                                                        ];
+                                                    if (
+                                                        !primaryField ||
+                                                        !additionalField
+                                                    )
+                                                        return;
+                                                    if (
+                                                        !primaryJoinItems.some(
+                                                            (item) =>
+                                                                getItemId(
+                                                                    item,
+                                                                ) ===
+                                                                primaryField,
+                                                        )
+                                                    ) {
+                                                        dispatch(
+                                                            explorerActions.toggleDimension(
+                                                                primaryField,
+                                                            ),
+                                                        );
+                                                    }
+                                                    if (
+                                                        !additionalJoinItems.some(
+                                                            (item) =>
+                                                                getItemId(
+                                                                    item,
+                                                                ) ===
+                                                                additionalField,
+                                                        )
+                                                    ) {
+                                                        toggleSourceField(
+                                                            additionalSourceId,
+                                                            additionalField,
+                                                            true,
+                                                        );
+                                                    }
+                                                    setJoinField(
+                                                        index,
+                                                        PRIMARY_SOURCE_ID,
+                                                        primaryField,
+                                                    );
+                                                    setJoinField(
+                                                        index,
+                                                        additionalSourceId,
+                                                        additionalField,
+                                                    );
+                                                }}
+                                            >
+                                                Use suggestion
+                                            </Anchor>
+                                        </Box>
+                                    )}
+                                <Box className={styles.pairFields}>
+                                    <Stack gap={4} className={styles.fieldSide}>
+                                        <SourceLabel
+                                            side="primary"
+                                            label={thisQuery}
+                                        />
+                                        <FieldSelect
+                                            aria-label={`${thisQuery} join field`}
                                             size="xs"
-                                            ta="left"
-                                            onClick={() => {
-                                                const primaryField =
-                                                    suggestedAvailablePair[
+                                            placeholder="Choose or add a field"
+                                            hasGrouping
+                                            items={availablePrimaryJoinItems}
+                                            item={availablePrimaryJoinItems.find(
+                                                (candidate) =>
+                                                    getItemId(candidate) ===
+                                                    part.fieldIdBySourceId[
                                                         PRIMARY_SOURCE_ID
-                                                    ];
-                                                const additionalField =
-                                                    suggestedAvailablePair[
-                                                        additionalSourceId
-                                                    ];
+                                                    ],
+                                            )}
+                                            onChange={(value) => {
+                                                const fieldId = value
+                                                    ? getItemId(value)
+                                                    : null;
                                                 if (
-                                                    !primaryField ||
-                                                    !additionalField
-                                                )
-                                                    return;
-                                                if (
+                                                    fieldId &&
                                                     !primaryJoinItems.some(
                                                         (item) =>
                                                             getItemId(item) ===
-                                                            primaryField,
+                                                            fieldId,
                                                     )
                                                 ) {
                                                     dispatch(
                                                         explorerActions.toggleDimension(
-                                                            primaryField,
+                                                            fieldId,
                                                         ),
-                                                    );
-                                                }
-                                                if (
-                                                    !additionalJoinItems.some(
-                                                        (item) =>
-                                                            getItemId(item) ===
-                                                            additionalField,
-                                                    )
-                                                ) {
-                                                    toggleSourceField(
-                                                        additionalSourceId,
-                                                        additionalField,
-                                                        true,
                                                     );
                                                 }
                                                 setJoinField(
                                                     index,
                                                     PRIMARY_SOURCE_ID,
-                                                    primaryField,
+                                                    fieldId,
                                                 );
+                                            }}
+                                        />
+                                    </Stack>
+                                    <Text
+                                        className={styles.operator}
+                                        aria-hidden
+                                        size="sm"
+                                        fw={600}
+                                    >
+                                        =
+                                    </Text>
+                                    <Stack gap={4} className={styles.fieldSide}>
+                                        <SourceLabel
+                                            side="additional"
+                                            label={otherQuery}
+                                        />
+                                        <FieldSelect
+                                            aria-label={`${otherQuery} join field`}
+                                            size="xs"
+                                            placeholder="Choose or add a field"
+                                            hasGrouping
+                                            items={availableAdditionalJoinItems}
+                                            item={availableAdditionalJoinItems.find(
+                                                (candidate) =>
+                                                    getItemId(candidate) ===
+                                                    part.fieldIdBySourceId[
+                                                        additionalSourceId
+                                                    ],
+                                            )}
+                                            onChange={(value) => {
+                                                const fieldId = value
+                                                    ? getItemId(value)
+                                                    : null;
+                                                if (
+                                                    fieldId &&
+                                                    !additionalJoinItems.some(
+                                                        (item) =>
+                                                            getItemId(item) ===
+                                                            fieldId,
+                                                    )
+                                                ) {
+                                                    toggleSourceField(
+                                                        additionalSourceId,
+                                                        fieldId,
+                                                        true,
+                                                    );
+                                                }
                                                 setJoinField(
                                                     index,
                                                     additionalSourceId,
-                                                    additionalField,
+                                                    fieldId,
                                                 );
                                             }}
+                                        />
+                                    </Stack>
+                                    {effectiveParts.length > 1 ? (
+                                        <ActionIcon
+                                            className={styles.removeKey}
+                                            variant="subtle"
+                                            color="gray"
+                                            size="sm"
+                                            onClick={() =>
+                                                removeJoinPart(index)
+                                            }
+                                            aria-label={`Remove join condition ${index + 1}`}
                                         >
-                                            Suggested:{' '}
-                                            {labelFor(
-                                                suggestedAvailablePair[
-                                                    PRIMARY_SOURCE_ID
-                                                ],
-                                            )}{' '}
-                                            ↔{' '}
-                                            {labelFor(
-                                                suggestedAvailablePair[
-                                                    additionalSourceId
-                                                ],
-                                            )}
-                                        </Anchor>
+                                            <MantineIcon
+                                                icon={IconX}
+                                                size={14}
+                                            />
+                                        </ActionIcon>
+                                    ) : (
+                                        <Box
+                                            aria-hidden
+                                            className={styles.removeKeySpacer}
+                                        />
                                     )}
-                                <FieldSelect
-                                    size="xs"
-                                    placeholder="choose or add a field"
-                                    hasGrouping
-                                    items={availablePrimaryJoinItems}
-                                    item={availablePrimaryJoinItems.find(
-                                        (candidate) =>
-                                            getItemId(candidate) ===
-                                            part.fieldIdBySourceId[
-                                                PRIMARY_SOURCE_ID
-                                            ],
-                                    )}
-                                    onChange={(value) => {
-                                        const fieldId = value
-                                            ? getItemId(value)
-                                            : null;
-                                        if (
-                                            fieldId &&
-                                            !primaryJoinItems.some(
-                                                (item) =>
-                                                    getItemId(item) === fieldId,
-                                            )
-                                        ) {
-                                            dispatch(
-                                                explorerActions.toggleDimension(
-                                                    fieldId,
-                                                ),
-                                            );
-                                        }
-                                        setJoinField(
-                                            index,
-                                            PRIMARY_SOURCE_ID,
-                                            fieldId,
-                                        );
-                                    }}
-                                />
-                                <FieldSelect
-                                    size="xs"
-                                    placeholder="choose or add a field"
-                                    hasGrouping
-                                    items={availableAdditionalJoinItems}
-                                    item={availableAdditionalJoinItems.find(
-                                        (candidate) =>
-                                            getItemId(candidate) ===
-                                            part.fieldIdBySourceId[
-                                                additionalSourceId
-                                            ],
-                                    )}
-                                    onChange={(value) => {
-                                        const fieldId = value
-                                            ? getItemId(value)
-                                            : null;
-                                        if (
-                                            fieldId &&
-                                            !additionalJoinItems.some(
-                                                (item) =>
-                                                    getItemId(item) === fieldId,
-                                            )
-                                        ) {
-                                            toggleSourceField(
-                                                additionalSourceId,
-                                                fieldId,
-                                                true,
-                                            );
-                                        }
-                                        setJoinField(
-                                            index,
-                                            additionalSourceId,
-                                            fieldId,
-                                        );
-                                    }}
-                                />
+                                </Box>
                             </Box>
                         ))}
 
@@ -366,40 +539,20 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
                         >
                             <Group gap={4} wrap="nowrap">
                                 <MantineIcon icon={IconPlus} size={12} />
-                                match on another field
+                                Add join condition
                             </Group>
                         </Anchor>
 
-                        <Group gap="xs" wrap="nowrap" mt={4}>
-                            <Text size="xs" c="dimmed">
-                                Keep
+                        <Stack gap={4} mt={2}>
+                            <Text size="xs" fw={600}>
+                                Join type
                             </Text>
-                            <SegmentedControl
-                                size="xs"
-                                radius="md"
+                            <JoinTypePicker
                                 value={joinType}
-                                onChange={(value) =>
-                                    setJoinType(value as MergeJoinType)
-                                }
-                                data={keepOptions.map((option) => ({
-                                    value: option.value,
-                                    label: (
-                                        <Tooltip
-                                            label={option.help}
-                                            withinPortal
-                                            position="bottom"
-                                            openDelay={250}
-                                            multiline
-                                            w={260}
-                                        >
-                                            <Text span size="xs">
-                                                {option.label}
-                                            </Text>
-                                        </Tooltip>
-                                    ),
-                                }))}
+                                options={keepOptions}
+                                onChange={setJoinType}
                             />
-                        </Group>
+                        </Stack>
 
                         {/* What the current choice does, in the terms of this
                         merge, so the trade-off reads without hovering. */}

--- a/packages/frontend/src/features/mergeQuery/components/MergeReadOnlyBar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeReadOnlyBar.tsx
@@ -6,6 +6,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { PRIMARY_SOURCE_ID } from '../constants';
 import { useMergeSafe } from '../context/useMerge';
 import { useMergeSetup } from '../hooks/useMergeSetup';
+import { getJoinClauseLabel } from './mergeJoinLabels';
 
 /**
  * One line for the saved-chart view: what this chart is merged with and on
@@ -37,11 +38,14 @@ export const MergeReadOnlyBar: FC = () => {
                 ? labelFor(additionalFieldId)
                 : '?';
 
-            return primaryField === additionalField
-                ? primaryField
-                : `${primaryField} ↔ ${additionalField}`;
+            return getJoinClauseLabel(
+                primaryExploreLabel ?? 'First data',
+                primaryField,
+                additionalExploreLabel ?? 'Combined data',
+                additionalField,
+            );
         })
-        .join(' + ');
+        .join(' AND ');
     const keepLabel =
         merge.joinType === MergeJoinType.LEFT
             ? `Keep ${primaryExploreLabel}`

--- a/packages/frontend/src/features/mergeQuery/components/MergeRelationshipCard.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeRelationshipCard.tsx
@@ -1,14 +1,48 @@
+import { MergeJoinType } from '@lightdash/common';
 import { Badge, Box } from '@mantine/core';
 import { useState, type FC } from 'react';
 import CollapsableCard from '../../../components/common/CollapsableCard/CollapsableCard';
+import { PRIMARY_SOURCE_ID } from '../constants';
 import { useMergeSafe } from '../context/useMerge';
 import { useMergeSetup } from '../hooks/useMergeSetup';
 import { MergeJoinBar } from './MergeJoinBar';
+import { getJoinClauseLabel } from './mergeJoinLabels';
 
 const MergeRelationshipCardContent: FC = () => {
-    const { primaryExploreLabel, additionalExploreLabel, isIncomplete } =
-        useMergeSetup();
+    const {
+        effectiveParts,
+        labelFor,
+        primaryExploreLabel,
+        additionalExploreLabel,
+        additionalSourceId,
+        isIncomplete,
+    } = useMergeSetup();
+    const merge = useMergeSafe();
     const [isOpen, setIsOpen] = useState(true);
+    const primaryLabel = primaryExploreLabel ?? 'First data';
+    const additionalLabel = additionalExploreLabel ?? 'Combined data';
+    const joinTypeLabel =
+        merge?.joinType === MergeJoinType.LEFT
+            ? 'Left'
+            : merge?.joinType === MergeJoinType.INNER
+              ? 'Inner'
+              : 'Full outer';
+    const relationshipSummary = effectiveParts
+        .map((part) => {
+            const primaryFieldId = part.fieldIdBySourceId[PRIMARY_SOURCE_ID];
+            const additionalFieldId =
+                part.fieldIdBySourceId[additionalSourceId];
+            return getJoinClauseLabel(
+                primaryLabel,
+                primaryFieldId ? labelFor(primaryFieldId) : '?',
+                additionalLabel,
+                additionalFieldId ? labelFor(additionalFieldId) : '?',
+            );
+        })
+        .join(' AND ');
+    const badgeLabel = isIncomplete
+        ? 'Needs a matching field'
+        : `${relationshipSummary} · ${joinTypeLabel}`;
 
     return (
         <CollapsableCard
@@ -16,12 +50,16 @@ const MergeRelationshipCardContent: FC = () => {
             isOpen={isOpen}
             onToggle={setIsOpen}
             headerElement={
-                <Badge variant="light" color={isIncomplete ? 'orange' : 'gray'}>
-                    {isIncomplete
-                        ? 'Needs a matching field'
-                        : `${primaryExploreLabel ?? 'First data'} + ${
-                              additionalExploreLabel ?? 'combined data'
-                          }`}
+                <Badge
+                    variant="light"
+                    color={isIncomplete ? 'orange' : 'gray'}
+                    maw="min(70vw, 720px)"
+                    title={badgeLabel}
+                    styles={{
+                        label: { overflow: 'hidden', textOverflow: 'ellipsis' },
+                    }}
+                >
+                    {badgeLabel}
                 </Badge>
             }
         >

--- a/packages/frontend/src/features/mergeQuery/components/mergeJoinLabels.ts
+++ b/packages/frontend/src/features/mergeQuery/components/mergeJoinLabels.ts
@@ -1,0 +1,7 @@
+export const getJoinClauseLabel = (
+    primarySourceLabel: string,
+    primaryFieldLabel: string,
+    additionalSourceLabel: string,
+    additionalFieldLabel: string,
+) =>
+    `${primarySourceLabel} · ${primaryFieldLabel} = ${additionalSourceLabel} · ${additionalFieldLabel}`;

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -322,14 +322,25 @@ export const MergeProvider: FC<
             executeMergeQuery(projectUuid, mergeQuery, parameters, savedChart)
                 .then((result) => {
                     if (activeRun.current !== runId) return;
-                    setRunState({
-                        isRunning: false,
-                        errors: result.errors,
-                        started: result.started,
-                        error: null,
-                        parameterReferences: result.parameterReferences,
-                        fieldOrigins: result.fieldOrigins,
-                    });
+                    if (result.outcome === 'refused') {
+                        setRunState({
+                            isRunning: false,
+                            errors: result.errors,
+                            started: null,
+                            error: null,
+                            parameterReferences: result.parameterReferences,
+                            fieldOrigins: result.fieldOrigins,
+                        });
+                    } else {
+                        setRunState({
+                            isRunning: false,
+                            errors: [],
+                            started: result.query,
+                            error: null,
+                            parameterReferences: result.parameterReferences,
+                            fieldOrigins: result.fieldOrigins,
+                        });
+                    }
                 })
                 .catch((error: ApiError) => {
                     if (activeRun.current !== runId) return;
@@ -359,12 +370,12 @@ export const MergeProvider: FC<
                 exportPivotedResults ? savedChart : undefined,
                 limit,
             );
-            if (!result.started) {
+            if (result.outcome === 'refused') {
                 throw new Error(
                     result.errors.map((error) => error.message).join(' '),
                 );
             }
-            return result.started.queryUuid;
+            return result.query.queryUuid;
         },
         [projectUuid],
     );

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.test.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.test.ts
@@ -1,4 +1,8 @@
-import { ChartType, MergeJoinType } from '@lightdash/common';
+import {
+    ChartType,
+    MergeJoinType,
+    QueryExecutionContext,
+} from '@lightdash/common';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { lightdashApi } from '../../../api';
 import { executeMergeQuery } from './useMergeQuery';
@@ -12,8 +16,8 @@ describe('executeMergeQuery', () => {
 
     it('starts a merge with one v2 request', async () => {
         api.mockResolvedValueOnce({
-            errors: [],
-            started: { queryUuid: 'query-uuid' },
+            outcome: 'started',
+            query: { queryUuid: 'query-uuid' },
             fieldOrigins: {},
             parameterReferences: ['date_dim_parameter'],
         } as never);
@@ -50,15 +54,18 @@ describe('executeMergeQuery', () => {
         expect(
             JSON.parse((api.mock.calls[0][0].body as string) ?? '{}'),
         ).toMatchObject({
-            chartConfig: {
-                type: ChartType.TABLE,
-                config: {},
+            context: QueryExecutionContext.EXPLORE,
+            mode: { type: 'export', limit: 42 },
+            chart: {
+                chartConfig: {
+                    type: ChartType.TABLE,
+                    config: {},
+                },
+                pivotConfig: {
+                    columns: ['merge_join_key_0'],
+                    rows: [],
+                },
             },
-            pivotConfig: {
-                columns: ['merge_join_key_0'],
-                rows: [],
-            },
-            csvLimit: 42,
         });
         expect(result.parameterReferences).toEqual(['date_dim_parameter']);
         expect(api).toHaveBeenCalledTimes(1);
@@ -66,7 +73,7 @@ describe('executeMergeQuery', () => {
 
     it('returns parameter references when compilation is refused', async () => {
         api.mockResolvedValueOnce({
-            started: null,
+            outcome: 'refused',
             fieldOrigins: {},
             parameterReferences: ['customers.customer_name'],
             errors: [{ message: 'Missing customer name' }],
@@ -81,7 +88,7 @@ describe('executeMergeQuery', () => {
         });
 
         expect(result).toMatchObject({
-            started: null,
+            outcome: 'refused',
             parameterReferences: ['customers.customer_name'],
         });
         expect(api).toHaveBeenCalledTimes(1);

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.test.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.test.ts
@@ -1,10 +1,4 @@
-import {
-    ChartType,
-    DimensionType,
-    FieldType,
-    MergeJoinType,
-    MetricType,
-} from '@lightdash/common';
+import { ChartType, MergeJoinType } from '@lightdash/common';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { lightdashApi } from '../../../api';
 import { executeMergeQuery } from './useMergeQuery';
@@ -16,45 +10,13 @@ const api = vi.mocked(lightdashApi);
 describe('executeMergeQuery', () => {
     beforeEach(() => api.mockReset());
 
-    it('runs a merged table with its pivot configuration', async () => {
+    it('starts a merge with one v2 request', async () => {
         api.mockResolvedValueOnce({
-            sql: 'select 1',
-            coreSql: 'select 1',
-            typedColumns: [],
-            terminalWrapper: {},
-            columns: {},
-            fields: [],
-            itemsMap: {
-                merge_join_key_0: {
-                    fieldType: FieldType.DIMENSION,
-                    type: DimensionType.STRING,
-                    name: 'join_key_0',
-                    label: 'Customer',
-                    table: 'merge',
-                    tableLabel: 'Merged',
-                    sql: '',
-                    hidden: false,
-                },
-                a_orders_count: {
-                    fieldType: FieldType.METRIC,
-                    type: MetricType.COUNT,
-                    name: 'orders_count',
-                    label: 'Orders',
-                    table: 'a',
-                    tableLabel: 'Orders',
-                    sql: '',
-                    hidden: false,
-                },
-            },
+            errors: [],
+            started: { queryUuid: 'query-uuid' },
             fieldOrigins: {},
             parameterReferences: ['date_dim_parameter'],
-            fieldIdByColumn: {
-                join_key_0: 'merge_join_key_0',
-                orders_count: 'a_orders_count',
-            },
-            errors: [],
         } as never);
-        api.mockResolvedValueOnce({ queryUuid: 'query-uuid' } as never);
 
         const result = await executeMergeQuery(
             'project-uuid',
@@ -79,24 +41,33 @@ describe('executeMergeQuery', () => {
             42,
         );
 
+        expect(api).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/projects/project-uuid/query/merge-query',
+                version: 'v2',
+            }),
+        );
         expect(
-            JSON.parse((api.mock.calls[1][0].body as string) ?? '{}'),
+            JSON.parse((api.mock.calls[0][0].body as string) ?? '{}'),
         ).toMatchObject({
-            pivotConfiguration: {
-                groupByColumns: [{ reference: 'merge_join_key_0' }],
-                valuesColumns: [
-                    { reference: 'a_orders_count', aggregation: 'any' },
-                ],
+            chartConfig: {
+                type: ChartType.TABLE,
+                config: {},
+            },
+            pivotConfig: {
+                columns: ['merge_join_key_0'],
+                rows: [],
             },
             csvLimit: 42,
         });
         expect(result.parameterReferences).toEqual(['date_dim_parameter']);
-        expect(api).toHaveBeenCalledTimes(2);
+        expect(api).toHaveBeenCalledTimes(1);
     });
 
     it('returns parameter references when compilation is refused', async () => {
         api.mockResolvedValueOnce({
-            sql: null,
+            started: null,
+            fieldOrigins: {},
             parameterReferences: ['customers.customer_name'],
             errors: [{ message: 'Missing customer name' }],
         } as never);

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
@@ -1,14 +1,10 @@
 import {
-    derivePivotConfigurationFromChart,
-    isDimension,
-    MERGE_TABLE_NAME,
     type ApiCompiledMergeQueryResults,
-    type ApiExecuteAsyncMetricQueryResults,
+    type ApiExecuteAsyncMergeQueryRequest,
+    type ApiExecuteAsyncMergeQueryResults,
     type CompileMergeQueryRequest,
     type MergeQuery,
     type ParametersValuesMap,
-    type PivotConfiguration,
-    type RunMergeQueryRequest,
     type SavedChartDAO,
 } from '@lightdash/common';
 import { lightdashApi } from '../../../api';
@@ -29,41 +25,31 @@ export const compileMergeQuery = (
         } satisfies CompileMergeQueryRequest),
     });
 
-export type MergeQueryRun = {
-    /** Errors that stopped the merge running. Empty when `started` is set. */
-    errors: CompiledMergeQuery['errors'];
-    /** The query to page results from, or null when the merge was refused. */
-    started: ApiExecuteAsyncMetricQueryResults | null;
-    parameterReferences: string[];
-    fieldOrigins: ApiCompiledMergeQueryResults['fieldOrigins'];
-};
+export type MergeQueryRun = ApiExecuteAsyncMergeQueryResults;
 
 const runMergeQuery = (
     projectUuid: string,
     mergeQuery: MergeQuery,
     parameters: ParametersValuesMap | undefined,
-    pivotConfiguration: PivotConfiguration | undefined,
+    savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'> | undefined,
     csvLimit?: number | null,
 ) =>
-    lightdashApi<ApiExecuteAsyncMetricQueryResults>({
-        url: `/projects/${projectUuid}/mergeQuery/run`,
+    lightdashApi<ApiExecuteAsyncMergeQueryResults>({
+        url: `/projects/${projectUuid}/query/merge-query`,
+        version: 'v2',
         method: 'POST',
         body: JSON.stringify({
             mergeQuery,
             parameters,
-            pivotConfiguration,
+            chartConfig: savedChart?.chartConfig,
+            pivotConfig: savedChart?.pivotConfig,
             csvLimit,
-        } satisfies RunMergeQueryRequest),
+        } satisfies ApiExecuteAsyncMergeQueryRequest),
     });
 
 /**
- * Compiles a merge, then runs it as an ordinary async query.
- *
- * Compiling first is what lets a refusal be shown against the query row that
- * caused it: a merge that would produce wrong numbers is a result to render,
- * not a failure to throw. A plain async function rather than a mutation —
- * the caller owns the state, and there is no cache identity for a run that
- * only ever belongs to the screen that started it.
+ * Starts a merge through the async query interface. Validation failures are
+ * returned as data so the caller can render them against their source rows.
  */
 export const executeMergeQuery = async (
     projectUuid: string,
@@ -72,51 +58,11 @@ export const executeMergeQuery = async (
     savedChart?: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>,
     csvLimit?: number | null,
 ): Promise<MergeQueryRun> => {
-    const compiled = await compileMergeQuery(
+    return runMergeQuery(
         projectUuid,
         mergeQuery,
         parameters,
+        savedChart,
+        csvLimit,
     );
-    if (!compiled.sql) {
-        return {
-            errors: compiled.errors,
-            started: null,
-            parameterReferences: compiled.parameterReferences,
-            fieldOrigins: compiled.fieldOrigins,
-        };
-    }
-
-    const columnOrder = Object.values(compiled.fieldIdByColumn);
-    const dimensions = columnOrder.filter((fieldId) =>
-        isDimension(compiled.itemsMap[fieldId]),
-    );
-    const metricQuery = {
-        exploreName: MERGE_TABLE_NAME,
-        dimensions,
-        metrics: columnOrder.filter((fieldId) => !dimensions.includes(fieldId)),
-        filters: {},
-        sorts: [],
-        limit: mergeQuery.limit,
-        tableCalculations: [],
-    };
-    const pivotConfiguration = savedChart
-        ? derivePivotConfigurationFromChart(
-              savedChart,
-              metricQuery,
-              compiled.itemsMap,
-          )
-        : undefined;
-
-    return {
-        errors: [],
-        parameterReferences: compiled.parameterReferences,
-        fieldOrigins: compiled.fieldOrigins,
-        started: await runMergeQuery(
-            projectUuid,
-            mergeQuery,
-            parameters,
-            pivotConfiguration,
-            csvLimit,
-        ),
-    };
 };

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
@@ -5,6 +5,7 @@ import {
     type CompileMergeQueryRequest,
     type MergeQuery,
     type ParametersValuesMap,
+    QueryExecutionContext,
     type SavedChartDAO,
 } from '@lightdash/common';
 import { lightdashApi } from '../../../api';
@@ -41,9 +42,12 @@ const runMergeQuery = (
         body: JSON.stringify({
             mergeQuery,
             parameters,
-            chartConfig: savedChart?.chartConfig,
-            pivotConfig: savedChart?.pivotConfig,
-            csvLimit,
+            context: QueryExecutionContext.EXPLORE,
+            mode:
+                csvLimit === undefined
+                    ? { type: 'interactive' }
+                    : { type: 'export', limit: csvLimit },
+            chart: savedChart,
         } satisfies ApiExecuteAsyncMergeQueryRequest),
     });
 


### PR DESCRIPTION
## What changed

- adds `POST /api/v2/projects/{projectUuid}/query/merge-query`
- makes Explorer merge execution one HTTP request and explicitly records `exploreView` context
- uses discriminated execution modes and outcomes, so invalid states are unrepresentable
- keeps derived pivot configuration server-owned; legacy resolved pivots stay in the v1 adapter
- resolves export limits before the sole compilation, including saved-chart pivot exports
- preserves nested merge parameter metadata through the async result
- centralizes merged-result metadata and removes private-method test coupling
- retains compile preview and the legacy run endpoint
- documents the follow-up AI agent merge-query parity design

## Why

Explorer previously called compile and then run, while run compiled the same merge again. Exports and saved-chart pivots could compile twice too. The new v2 path establishes effective query intent first, compiles exactly once, then reuses the ordinary async query runtime.

`MergeQuery` stays distinct from `MetricQuery`; callers still share v2 polling, paging, formatting, caching, pivoting, and downloads.

## Validation

- branch based exactly on latest `origin/main` (`0597d82319`)
- common, backend, frontend, and API-test typechecks
- common, backend, frontend, and API-test lint/format
- generated API contract
- 78 targeted backend tests; final controller tests 2/2
- 2 frontend merge-query tests
- live v2 API test against the seeded Postgres project
- browser QA with demo user: ordinary chart rendered; freshly-built two-source merge chart rendered both series

Local BigQuery parity setup also ran because credentials were present; its unrelated project refresh failed before merge execution.