### PR TITLE
fix: preserve distinct keys in period comparisons

### DIFF
--- a/packages/common/src/types/periodOverPeriodComparison.test.ts
+++ b/packages/common/src/types/periodOverPeriodComparison.test.ts
@@ -1,4 +1,6 @@
+import { MetricType, type Metric } from './field';
 import {
+    buildPopAdditionalMetric,
     getPopComparisonConfigKey,
     hashPopComparisonConfigKeyToSuffix,
 } from './periodOverPeriodComparison';
@@ -95,5 +97,26 @@ describe('periodOverPeriodComparison helpers', () => {
             periodOffset: 1,
         });
         expect(withPipe).not.toEqual(normal);
+    });
+
+    test('generated PoP metrics preserve sum_distinct keys', () => {
+        const { additionalMetric } = buildPopAdditionalMetric({
+            metric: {
+                table: 'orders',
+                name: 'deduplicated_revenue',
+                label: 'Deduplicated revenue',
+                type: MetricType.SUM_DISTINCT,
+                sql: '${TABLE}.revenue',
+                distinctKeys: ['orders.order_id', 'orders.payment_id'],
+            } as Metric,
+            timeDimensionId: 'orders_order_date_month',
+            granularity: TimeFrames.MONTH,
+            periodOffset: 1,
+        });
+
+        expect(additionalMetric.distinctKeys).toEqual([
+            'orders.order_id',
+            'orders.payment_id',
+        ]);
     });
 });

--- a/packages/common/src/types/periodOverPeriodComparison.ts
+++ b/packages/common/src/types/periodOverPeriodComparison.ts
@@ -160,6 +160,7 @@ export const buildPopAdditionalMetric = ({
         | 'compact'
         | 'format'
         | 'formatOptions'
+        | 'distinctKeys'
     >;
     timeDimensionId: string;
     granularity: TimeFrames;
@@ -190,6 +191,7 @@ export const buildPopAdditionalMetric = ({
         compact: metric.compact,
         format: metric.format,
         formatOptions: metric.formatOptions,
+        distinctKeys: metric.distinctKeys,
         generationType: 'periodOverPeriod',
         baseMetricId,
         timeDimensionId,


### PR DESCRIPTION
## Summary

Period-over-period metrics copy their aggregation type and SQL from the base metric, but did not copy `distinctKeys`. For `sum_distinct`, the generated metric therefore failed compilation before the query could run.

This change copies the existing `distinctKeys` array into the generated PoP additional metric and adds a focused regression test covering multiple keys.

## Requirements

- A `sum_distinct` metric with one or more `distinct_keys` can use a previous-period comparison.
- Generated PoP metrics preserve all distinct keys from the base metric.
- Existing metric types, saved content, compiler validation, and formatting behavior remain unchanged.

## Pre-fix reproduction

On the parent commit, sign in to the seeded Jaffle Shop and submit the metric shape generated by Explorer before this fix:

```bash
API_URL=http://localhost:8100
PROJECT_UUID=3675b69e-8324-4110-bdca-059031aa8da3
COOKIE_JAR=/tmp/lightdash-prod-8687-cookie.txt

curl -sS -c "$COOKIE_JAR" -X POST "$API_URL/api/v1/login" \
  -H 'Content-Type: application/json' \
  -d '{"email":"demo@lightdash.com","password":"demo_password!"}' >/dev/null

jq -nc '{invalidateCache:true,query:{exploreName:"customers",dimensions:["customers_created_month"],metrics:["customers_total_order_amount_deduped","customers_total_order_amount_deduped__pop__month_1__prod8687"],filters:{},sorts:[],limit:500,tableCalculations:[],additionalMetrics:[{uuid:"00000000-0000-4000-8000-000000008687",table:"customers",name:"total_order_amount_deduped__pop__month_1__prod8687",label:"Previous month",type:"sum_distinct",sql:"${orders.amount}",hidden:true,generationType:"periodOverPeriod",baseMetricId:"customers_total_order_amount_deduped",timeDimensionId:"customers_created_month",granularity:"MONTH",periodOffset:1}],metricOverrides:{},customDimensions:[]}}' | \
curl -sS -b "$COOKIE_JAR" -X POST "$API_URL/api/v2/projects/$PROJECT_UUID/query/metric-query" \
  -H 'Content-Type: application/json' --data-binary @- | jq
```

Observed response:

```text
CompileError: Metric "total_order_amount_deduped__pop__month_1__prod8687" of type "sum_distinct" requires a "distinct_keys" property
```

The focused test also failed before the implementation lines were applied: generated `additionalMetric.distinctKeys` was `undefined` instead of the two base keys.

## Post-fix validation

- Repeated the public API scenario using the shape now generated by Explorer, adding `distinctKeys: ["orders.order_id"]`: query accepted, status `ready`, 24 rows returned, and 16 rows contained a previous-period value.
- Ran an existing seeded saved chart: status `ready`, one result row returned, including its table calculation.
- Verified malformed direct API input that omits `distinctKeys` is still rejected with the same 400 `CompileError`.
- Regression test: 133 test files passed; 3,553 tests passed and 1 skipped.
- `pnpm -F common format`
- `pnpm -F common lint`
- `pnpm -F common typecheck`
- `pnpm -F frontend typecheck`
- `pnpm -F backend typecheck` (after rebuilding `common` and `warehouses`)
- `git diff --check`

## Compatibility, security, and rollout

- Backward compatible: `distinctKeys` is an existing optional field. Saved metric/query formats and API shapes do not change.
- Non-distinct metrics continue to serialize without the optional property when it is undefined.
- No permission, authentication, authorization, tenant-isolation, input-execution, or sensitive-data behavior changes.
- No migration, feature flag, dependency, generated artifact, or generated API update is required.
- Screenshots are not applicable: this is a query-generation fix with no visual UI change. API request/result evidence is provided above.

Residual risk is low and limited to generated PoP metric serialization.

Closes: PROD-8687
Closes: #25160
