### PR TITLE
fix(pre-aggregates): prefer specific miss reason over metric-not-in-pre-aggregate

### DIFF
--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -1130,6 +1130,51 @@ describe('findMatch', () => {
         });
     });
 
+    it('reports a specific miss over metric-not-in-pre-aggregate from unrelated defs', () => {
+        const base = baseExplore();
+        const explore = {
+            ...base,
+            tables: {
+                ...base.tables,
+                orders: {
+                    ...base.tables.orders,
+                    metrics: {
+                        ...base.tables.orders.metrics,
+                        running_total_amount: makeMetric({
+                            name: 'running_total_amount',
+                            type: MetricType.RUNNING_TOTAL,
+                        }),
+                    },
+                },
+            },
+            preAggregates: [
+                {
+                    name: 'additive_only',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                },
+                {
+                    name: 'orders_running',
+                    dimensions: ['status'],
+                    metrics: ['running_total_amount'],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_running_total_amount'],
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.NON_ADDITIVE_METRIC,
+            fieldId: 'orders_running_total_amount',
+        });
+    });
+
     it('allows type:number metrics when they are explicitly included in the pre-aggregate definition', () => {
         const explore = {
             ...baseExplore(),

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -1119,6 +1119,9 @@ export const findMatch = (
 
     const matchedDefs: PreAggregateDef[] = [];
     let firstMiss: PreAggregateMatchMiss | null = null;
+    // A miss from a def that covers the queried metrics is more actionable
+    // than "metric not in pre-aggregate" from an unrelated def.
+    let firstSpecificMiss: PreAggregateMatchMiss | null = null;
 
     explore.preAggregates.forEach((preAggregateDef) => {
         const miss = getMissForDef({
@@ -1139,19 +1142,26 @@ export const findMatch = (
         if (!firstMiss) {
             firstMiss = miss;
         }
+        if (
+            !firstSpecificMiss &&
+            miss.reason !== PreAggregateMissReason.METRIC_NOT_IN_PRE_AGGREGATE
+        ) {
+            firstSpecificMiss = miss;
+        }
     });
 
     if (matchedDefs.length === 0) {
         return {
             hit: false,
             preAggregateName: null,
-            miss: firstMiss ?? {
-                reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
-                fieldId:
-                    metricQuery.dimensions[0] ??
-                    metricQuery.metrics[0] ??
-                    'unknown',
-            },
+            miss: firstSpecificMiss ??
+                firstMiss ?? {
+                    reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
+                    fieldId:
+                        metricQuery.dimensions[0] ??
+                        metricQuery.metrics[0] ??
+                        'unknown',
+                },
         };
     }
 


### PR DESCRIPTION
When no pre-aggregate matches, `findMatch` reported the first miss encountered — often a generic `metric_not_in_pre_aggregate` from an unrelated definition — even when another definition covering the queried metric produced a more actionable reason (non-additive metric, missing dimension, granularity, filters).

Now the first miss with a reason other than `metric_not_in_pre_aggregate` is preferred, falling back to the first miss as before.

Split out of #27406 as the bottom of the stack.

## Test plan

- Unit test: two defs, one unrelated (generic miss) and one covering a non-additive metric — the specific `non_additive_metric` miss is reported.

Relates: ZAP-847
