### PR TITLE
fix(cli): save rename changelogs outside binary bundle

### DIFF
--- a/packages/cli/src/handlers/renameHandler.test.ts
+++ b/packages/cli/src/handlers/renameHandler.test.ts
@@ -1,4 +1,10 @@
-import { RenameType, SchedulerJobStatus } from '@lightdash/common';
+import {
+    RenameChange,
+    RenameType,
+    SchedulerJobStatus,
+} from '@lightdash/common';
+import fs from 'fs';
+import path from 'path';
 import { LightdashAnalytics } from '../analytics/analytics';
 import { getConfig } from '../config';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
@@ -24,7 +30,14 @@ const baseOptions: RenameOptions = {
     validate: true,
 };
 
-const emptyResults = {
+type RenameResults = {
+    charts: RenameChange[];
+    dashboards: RenameChange[];
+    alerts: RenameChange[];
+    dashboardSchedulers: RenameChange[];
+};
+
+const emptyResults: RenameResults = {
     charts: [],
     dashboards: [],
     alerts: [],
@@ -37,7 +50,10 @@ const VALIDATION_JOB_ID = 'validation-job-id';
 describe('renameHandler follow-up validation', () => {
     let errorOutput: string[];
 
-    const mockApi = (failingJobId: string | null) => {
+    const mockApi = (
+        failingJobId: string | null,
+        results: RenameResults = emptyResults,
+    ) => {
         vi.mocked(lightdashApi).mockImplementation(async ({ method, url }) => {
             if (method === 'POST' && url.endsWith('/rename')) {
                 return { jobId: RENAME_JOB_ID };
@@ -54,7 +70,7 @@ describe('renameHandler follow-up validation', () => {
             if (url.includes('/schedulers/job/')) {
                 return {
                     status: SchedulerJobStatus.COMPLETED,
-                    details: { results: emptyResults },
+                    details: { results },
                 };
             }
             if (url.includes('/validate?jobId=')) {
@@ -163,6 +179,55 @@ describe('renameHandler follow-up validation', () => {
         const output = errorOutput.join('\n');
         expect(output).not.toContain('failed');
         expect(output).not.toContain('unexpected error');
+        expect(trackedEvents()).toEqual([
+            {
+                event: 'rename.completed',
+                properties: expect.objectContaining({
+                    validationStatus: 'skipped',
+                }),
+            },
+        ]);
+    });
+
+    test('saves rename changes in the current working directory', async () => {
+        const results = {
+            ...emptyResults,
+            charts: [{ uuid: 'chart-uuid', name: 'renamed chart' }],
+        };
+        mockApi(null, results);
+        const writeFileSync = vi
+            .spyOn(fs, 'writeFileSync')
+            .mockImplementation(() => undefined);
+
+        await renameHandler({ ...baseOptions, validate: false });
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            path.join(
+                process.cwd(),
+                `rename old_name to new_name ${
+                    new Date().toISOString().split('T')[0]
+                }.json`,
+            ),
+            JSON.stringify(results, null, 2),
+            'utf-8',
+        );
+    });
+
+    test('reports a changelog write failure without reporting the committed rename as failed', async () => {
+        mockApi(null, {
+            ...emptyResults,
+            charts: [{ uuid: 'chart-uuid', name: 'renamed chart' }],
+        });
+        vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+            throw new Error('read-only bundle');
+        });
+
+        await renameHandler({ ...baseOptions, validate: false });
+
+        const output = errorOutput.join('\n');
+        expect(output).toContain('Rename completed');
+        expect(output).toContain('read-only bundle');
+        expect(output).not.toContain('Unable to rename');
         expect(trackedEvents()).toEqual([
             {
                 event: 'rename.completed',

--- a/packages/cli/src/handlers/renameHandler.ts
+++ b/packages/cli/src/handlers/renameHandler.ts
@@ -210,17 +210,29 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
         } else if (hasResults) {
             const currentDate = new Date().toISOString().split('T')[0];
             const filePath = path.join(
-                __dirname,
+                process.cwd(),
                 `rename ${options.from} to ${options.to} ${currentDate}.json`,
             );
-            fs.writeFileSync(
-                filePath,
-                JSON.stringify(results, null, 2),
-                'utf-8',
-            );
-            console.info(
-                `Rename changes saved to: ${styles.success(` ${filePath}`)}`,
-            );
+            try {
+                fs.writeFileSync(
+                    filePath,
+                    JSON.stringify(results, null, 2),
+                    'utf-8',
+                );
+                console.info(
+                    `Rename changes saved to: ${styles.success(
+                        ` ${filePath}`,
+                    )}`,
+                );
+            } catch (e: unknown) {
+                console.error(
+                    styles.warning(
+                        `Rename completed, but the changes could not be saved to ${filePath}: ${getErrorMessage(
+                            e,
+                        )}`,
+                    ),
+                );
+            }
         }
 
         let validationStatus: 'skipped' | 'passed' | 'failed' = 'skipped';


### PR DESCRIPTION
## Summary

The packaged CLI resolves `__dirname` inside its read-only `/snapshot/bundle` filesystem. After a successful server-side rename, writing the local changelog there failed and the outer handler reported the committed rename as unsuccessful.

This change writes the changelog in the caller's current working directory and handles changelog I/O failures at that boundary. A failed local write now warns that the rename completed, then continues through follow-up validation and completed analytics.

## Requirements

- Save non-dry-run rename changelogs somewhere writable by the CLI caller.
- Never classify a local changelog-write failure as a failed server-side rename.
- Preserve dry-run behavior, rename results, validation, and completed analytics.

## Pre-fix reproduction

Build the macOS arm64 package from `origin/main`:

```sh
pnpm -F common build
pnpm -F warehouses build
pnpm -F cli build
pnpm -F cli bundle
cd packages/cli
npx @yao-pkg/pkg bundle/index.js --config pkg.config.json --targets node24-macos-arm64 --output bin/lightdash --compress Brotli
```

Start this disposable API stub in one terminal:

```sh
node -e 'const http=require("http");const project="11111111-1111-4111-8111-111111111111";const results={charts:[{uuid:"chart-uuid",name:"renamed chart"}],dashboards:[],alerts:[],dashboardSchedulers:[]};http.createServer((req,res)=>{res.setHeader("content-type","application/json");let payload;if(req.url.startsWith("/api/v1/health")){payload={status:"ok",results:{version:"1.163.2"}};}else if(req.url==="/api/v1/projects/"+project){payload={status:"ok",results:{name:"repro project"}};}else if(req.url==="/api/v1/projects/"+project+"/rename"&&req.method==="POST"){payload={status:"ok",results:{jobId:"rename-job"}};}else if(req.url==="/api/v1/schedulers/job/rename-job/status"){payload={status:"ok",results:{status:"completed",details:{results}}};}else{res.statusCode=404;payload={status:"error",error:{name:"Not Found",message:req.method+" "+req.url,statusCode:404,data:{}}};}res.end(JSON.stringify(payload));}).listen(47999,"127.0.0.1");'
```

Run the binary from a disposable directory in a second terminal:

```sh
run_dir=$(mktemp -d /tmp/prod-8099.XXXXXX)
cd "$run_dir"
LIGHTDASH_URL=http://127.0.0.1:47999 LIGHTDASH_API_KEY=ldpat_repro LIGHTDASH_PROJECT=11111111-1111-4111-8111-111111111111 /absolute/path/to/packages/cli/bin/lightdash rename --project 11111111-1111-4111-8111-111111111111 --type model --from old_name --to new_name --assume-yes --list
```

Before this change, the public output reported one updated chart and then:

```text
Unable to rename, unexpected error: Error: ENOENT: no such file or directory, open '/snapshot/bundle/rename old_name to new_name 2026-08-17.json'
```

The command exited 0 even though it told the caller the successful rename failed.

## Post-fix validation

Using the same build, stub, and CLI command on this branch reports one updated chart and:

```text
Rename changes saved to: /private/tmp/prod-8099.../rename old_name to new_name 2026-08-17.json
```

The JSON exists in the caller's working directory and contains the returned charts, dashboards, alerts, and dashboard schedulers. Running the same binary from a `chmod 555` temporary directory produces:

```text
Rename completed, but the changes could not be saved ... EACCES: permission denied
```

It does not print `Unable to rename` and exits 0, preserving the committed rename result.

## Automated checks

- `pnpm -F cli exec vitest run --config vitest.config.ts src/handlers/renameHandler.test.ts` — 7 passed
- `pnpm -F cli test` — 48 files, 555 tests passed
- `pnpm -F cli format` — passed
- `pnpm -F cli lint` — passed
- `pnpm -F cli typecheck` — passed
- `pnpm -F cli build` and packaged arm64 binary build — passed
- `git diff --check` — passed

## Compatibility, security, and rollout

- Existing rename requests, dry runs, result JSON, validation, and analytics remain unchanged.
- The changelog moves from the executable/module directory to the caller's working directory. This fixes binary/Homebrew builds and is the only intentional compatibility change.
- Rename values are already restricted to lowercase letters and underscores, so the generated filename cannot traverse directories.
- No authentication, authorization, permission, tenant, sensitive-data, migration, dependency, feature-flag, API/schema, or generated-artifact change.
- No rollout steps are required. Residual risk is limited to callers choosing a non-writable working directory, which now produces an explicit non-fatal warning.
- Screenshots are not applicable because this is a non-visual CLI change; terminal evidence is included above.

Closes: PROD-8099
