### PR TITLE
fix(frontend): delay null filter option until values load

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.test.tsx
@@ -6,6 +6,7 @@ import {
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useFieldValues } from '../../../../hooks/useFieldValues';
 import { renderWithProviders } from '../../../../testing/testUtils';
 import FilterStringAutoComplete from './FilterStringAutoComplete';
 
@@ -51,9 +52,21 @@ const mockField: FilterableItem = {
 const createValues = (count: number) =>
     Array.from({ length: count }, (_, i) => `value-${i}`);
 
+const createFieldValuesMock = (isInitialLoading = false) =>
+    ({
+        isInitialLoading,
+        results: [],
+        refreshedAt: new Date(),
+        refetch: vi.fn(),
+        reset: vi.fn(),
+        error: null,
+        isError: false,
+    }) as unknown as ReturnType<typeof useFieldValues>;
+
 describe('FilterStringAutoComplete', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.mocked(useFieldValues).mockReturnValue(createFieldValuesMock());
     });
 
     describe('truncation behavior', () => {
@@ -258,6 +271,94 @@ describe('FilterStringAutoComplete', () => {
 
             expect(onIncludeNullChange).toHaveBeenCalledWith(true);
             expect(onChange).not.toHaveBeenCalled();
+        });
+
+        it('hides the unselected null option while field values are initially loading', async () => {
+            vi.mocked(useFieldValues).mockReturnValue(
+                createFieldValuesMock(true),
+            );
+
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+            renderWithProviders(
+                <FilterStringAutoComplete
+                    filterId="test-filter"
+                    field={mockField}
+                    values={[]}
+                    suggestions={[]}
+                    onChange={vi.fn()}
+                    showNullOption
+                    includeNull={false}
+                    onIncludeNullChange={vi.fn()}
+                />,
+            );
+
+            await user.click(screen.getByRole('textbox'));
+
+            expect(screen.getByText('Loading...')).toBeInTheDocument();
+            expect(
+                screen.queryByRole('option', {
+                    name: '(null)',
+                    hidden: true,
+                }),
+            ).not.toBeInTheDocument();
+        });
+
+        it('preserves a selected null value while field values are initially loading', () => {
+            vi.mocked(useFieldValues).mockReturnValue(
+                createFieldValuesMock(true),
+            );
+
+            renderWithProviders(
+                <FilterStringAutoComplete
+                    filterId="test-filter"
+                    field={mockField}
+                    values={[]}
+                    suggestions={[]}
+                    onChange={vi.fn()}
+                    showNullOption
+                    includeNull
+                    onIncludeNullChange={vi.fn()}
+                />,
+            );
+
+            expect(
+                screen.getByRole('button', { name: 'Remove (null)' }),
+            ).toBeInTheDocument();
+        });
+
+        it('shows the null option after the initial field value request settles with an error', async () => {
+            vi.mocked(useFieldValues).mockReturnValue({
+                ...createFieldValuesMock(),
+                isError: true,
+                error: {
+                    error: { message: 'Unable to load field values' },
+                },
+            } as ReturnType<typeof useFieldValues>);
+
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+            renderWithProviders(
+                <FilterStringAutoComplete
+                    filterId="test-filter"
+                    field={mockField}
+                    values={[]}
+                    suggestions={[]}
+                    onChange={vi.fn()}
+                    showNullOption
+                    includeNull={false}
+                    onIncludeNullChange={vi.fn()}
+                />,
+            );
+
+            await user.click(screen.getByRole('textbox'));
+
+            expect(
+                screen.getByRole('option', {
+                    name: '(null)',
+                    hidden: true,
+                }),
+            ).toBeInTheDocument();
         });
 
         it('preserves dropdown lifecycle callbacks', async () => {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -288,13 +288,16 @@ const FilterStringAutoComplete: FC<Props> = ({
             value,
             label: resultLabels.get(value) ?? formatDisplayValue(value),
         }));
-        return showNull
+        const showNullInData =
+            showNull && (!isInitialLoading || includeNull === true);
+
+        return showNullInData
             ? [
                   ...valueData,
                   { value: NULL_VALUE_TOKEN, label: NULL_VALUE_LABEL },
               ]
             : valueData;
-    }, [results, values, showNull]);
+    }, [includeNull, isInitialLoading, results, showNull, values]);
 
     const isSummaryMode =
         !singleValue && values.length > SUMMARY_MODE_THRESHOLD;


### PR DESCRIPTION
Closes: PROD-9741
Closes: #27003

## Requirements

- Do not show the static `(null)` value before the initial warehouse-backed autocomplete request settles.
- Show `(null)` alongside the settled values.
- Preserve an already-selected null value while loading, including saved filters.
- Leave other operators and filter/query payloads unchanged.

## Implementation

The string autocomplete now includes the null sentinel during initial loading only when it is already selected. Once the initial request settles, the option is included exactly as before. Focused tests cover the loading, selected-null, loaded-empty, settled-error, and toggle paths.

## Pre-fix reproduction

1. Start the seeded local app and sign in as `demo@lightdash.com`.
2. Open Jaffle Shop Explore and add a string dimension filter with the `is` operator.
3. Delay the field-value search response by 5 seconds to make the warehouse timing deterministic.
4. Open the value dropdown while the request is pending.
5. Observe the loader and a dropdown containing only `(null)`; the real values appear later.

Observed with the Currency dimension: the loading dropdown contained exactly one visible option, `(null)`.

## Post-fix validation

Repeat the same steps with the same 5-second field-value delay:

- While Promo code was pending, the dropdown showed `Loading...` and no null option.
- After Order source resolved, `mobile_app`, `phone`, `website`, and `(null)` appeared together.
- A selected `(null)` pill remains rendered while field values load.

## Automated checks

- `pnpm -F frontend exec vitest run src/components/common/Filters/FilterInputs/FilterStringAutoComplete.test.tsx` — 15/15 passed
- Focused `oxfmt --check` — passed
- Focused `oxlint` — 0 warnings/errors
- `pnpm -F frontend typecheck` — passed
- `git diff --check` — passed

## Compatibility and security

This is a display-timing-only change. Saved filters, `includeNull`, selected values, filter/query API payloads, empty/error states, feature-flag behavior, and non-`is` operators remain compatible. It does not alter authentication, authorization, permissions, tenant isolation, sensitive data, HTML rendering, or input parsing. No migration, generated artifact, generated API/schema change, dependency, feature flag, or rollout step is required.

## Screenshots

Before and after screenshots use seeded Jaffle Shop data only and contain no secrets or customer data. They will be attached to the PR conversation.

## Remaining risk

Low. The guard affects only whether an unselected static option is present while `isInitialLoading` is true.
