### PR TITLE
fix: remove legacy AI agent memory flag

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -666,7 +666,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     organizationModel: models.getOrganizationModel(),
                     commercialFeatureFlagModel:
                         models.getFeatureFlagModel() as CommercialFeatureFlagModel,
-                    featureFlagService: repository.getFeatureFlagService(),
                     lightdashConfig: context.lightdashConfig,
                     orgAiCopilotConfigResolver: new OrgAiCopilotConfigResolver({
                         lightdashConfig: context.lightdashConfig,

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -1,6 +1,5 @@
 import {
     CommercialFeatureFlags,
-    FeatureFlags,
     ProjectType,
     SEED_ORG_1,
     SEED_ORG_1_ADMIN,
@@ -19,6 +18,7 @@ import {
     type DbFeatureFlag,
     type FeatureFlagsTable,
 } from '../../database/entities/featureFlags';
+import { OrganizationTableName } from '../../database/entities/organizations';
 import {
     ProjectTableName,
     type DbProject,
@@ -68,6 +68,12 @@ describe('AiAgentMemoryModel integration', () => {
             .merge({ default_enabled: enabled });
     };
 
+    const setOrgMemoryEnabled = async (enabled: boolean) => {
+        await database(OrganizationTableName)
+            .where('organization_uuid', SEED_ORG_1.organization_uuid)
+            .update({ ai_agent_memory_enabled: enabled });
+    };
+
     beforeAll(async () => {
         database = getTestContext().db;
         model = getTestContext()
@@ -80,8 +86,6 @@ describe('AiAgentMemoryModel integration', () => {
         const testDatabaseUrl = new URL(lightdashConfig.database.connectionUri);
         testDatabaseUrl.pathname = `${testDatabaseUrl.pathname}_test`;
         lightdashConfig.database.connectionUri = testDatabaseUrl.toString();
-        lightdashConfig.enabledFeatureFlags.delete(FeatureFlags.AiAgentMemory);
-        lightdashConfig.disabledFeatureFlags.delete(FeatureFlags.AiAgentMemory);
         const featureFlagModel = new CommercialFeatureFlagModel({
             database,
             lightdashConfig,
@@ -105,10 +109,7 @@ describe('AiAgentMemoryModel integration', () => {
             featureFlagModel,
         });
         await schedulerClient.graphileUtils;
-        const flagIds = [
-            FeatureFlags.AiAgentMemory,
-            CommercialFeatureFlags.AiCopilot,
-        ];
+        const flagIds = [CommercialFeatureFlags.AiCopilot];
         const storedFlags = await Promise.all(
             flagIds.map((flagId) =>
                 database<FeatureFlagsTable>(FeatureFlagsTableName)
@@ -122,10 +123,11 @@ describe('AiAgentMemoryModel integration', () => {
         await Promise.all(
             flagIds.map((flagId) => setFeatureFlag(flagId, true)),
         );
+        await setOrgMemoryEnabled(true);
     });
 
     afterEach(async () => {
-        await setFeatureFlag(FeatureFlags.AiAgentMemory, true);
+        await setOrgMemoryEnabled(true);
         if (consolidationRunUuids.size > 0) {
             await database(AiAgentMemoryConsolidationRunTableName)
                 .whereIn('ai_agent_memory_consolidation_run_uuid', [
@@ -287,13 +289,13 @@ describe('AiAgentMemoryModel integration', () => {
             userModel: { findSessionUserAndOrgByUuid: vi.fn() } as never,
             featureFlagService,
             aiOrganizationSettingsService: {
-                isAiAgentMemoryEnabled: async (user) =>
-                    (
-                        await featureFlagService.get({
-                            user,
-                            featureFlagId: FeatureFlags.AiAgentMemory,
-                        })
-                    ).enabled,
+                isAiAgentMemoryEnabled: async ({ organizationUuid }) => {
+                    const org = await database(OrganizationTableName)
+                        .select('ai_agent_memory_enabled')
+                        .where('organization_uuid', organizationUuid)
+                        .first();
+                    return org?.ai_agent_memory_enabled ?? false;
+                },
                 isAiAgentReviewsEnabled: vi.fn().mockResolvedValue(true),
             },
             schedulerClient,
@@ -1478,7 +1480,7 @@ describe('AiAgentMemoryModel integration', () => {
         expect(distillCall).toHaveBeenCalledOnce();
     });
 
-    it('uses the stored flag to gate real scheduler enqueueing', async () => {
+    it('uses the stored org setting to gate real scheduler enqueueing', async () => {
         const now = new Date('2026-07-22T12:00:00Z');
         const threadUuid = await createThread();
         await createPrompt(threadUuid, new Date('2026-07-22T05:00:00Z'));
@@ -1486,7 +1488,7 @@ describe('AiAgentMemoryModel integration', () => {
         const service = buildService(distillCall);
         const jobKey = `ai-agent-memory-distill:${threadUuid}`;
 
-        await setFeatureFlag(FeatureFlags.AiAgentMemory, false);
+        await setOrgMemoryEnabled(false);
         await expect(service.sweep(now)).resolves.toBe(0);
         const graphileClient = await schedulerClient.graphileUtils;
         await expect(
@@ -1499,7 +1501,7 @@ describe('AiAgentMemoryModel integration', () => {
             }),
         ).resolves.toBeUndefined();
 
-        await setFeatureFlag(FeatureFlags.AiAgentMemory, true);
+        await setOrgMemoryEnabled(true);
         await expect(service.sweep(now)).resolves.toBeGreaterThanOrEqual(1);
         const job = await graphileClient.withPgClient(async (client) => {
             const result = await client.query(

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
@@ -2,7 +2,6 @@ import { Ability, AbilityBuilder } from '@casl/ability';
 import {
     AI_AGENT_MEMORY_PROMOTION_MIN_CITED_COUNT,
     CommercialFeatureFlags,
-    FeatureFlags,
     SEED_ORG_1,
     SEED_PROJECT,
     type AiAgentMemoryConsolidationOperation,
@@ -59,6 +58,12 @@ describe('AI agent memory consolidation integration', () => {
     const createdUserUuids: string[] = [];
     const createdThreadUuids: string[] = [];
 
+    const setOrgMemoryEnabled = async (enabled: boolean) => {
+        await database('organizations')
+            .where('organization_uuid', SEED_ORG_1.organization_uuid)
+            .update({ ai_agent_memory_enabled: enabled });
+    };
+
     const setFeatureFlag = async (flagId: string, enabled: boolean) => {
         await database<FeatureFlagsTable>(FeatureFlagsTableName)
             .insert({ flag_id: flagId, default_enabled: enabled })
@@ -87,8 +92,6 @@ describe('AI agent memory consolidation integration', () => {
             .app.getModels()
             .getAiAgentMemoryModel<AiAgentMemoryModel>();
         const lightdashConfig = parseConfig();
-        lightdashConfig.enabledFeatureFlags.delete(FeatureFlags.AiAgentMemory);
-        lightdashConfig.disabledFeatureFlags.delete(FeatureFlags.AiAgentMemory);
         const featureFlagModel = new CommercialFeatureFlagModel({
             database,
             lightdashConfig,
@@ -112,10 +115,7 @@ describe('AI agent memory consolidation integration', () => {
             featureFlagModel,
         });
 
-        const flagIds = [
-            FeatureFlags.AiAgentMemory,
-            CommercialFeatureFlags.AiCopilot,
-        ];
+        const flagIds = [CommercialFeatureFlags.AiCopilot];
         const storedFlags = await Promise.all(
             flagIds.map((flagId) =>
                 database<FeatureFlagsTable>(FeatureFlagsTableName)
@@ -129,6 +129,7 @@ describe('AI agent memory consolidation integration', () => {
         await Promise.all(
             flagIds.map((flagId) => setFeatureFlag(flagId, true)),
         );
+        await setOrgMemoryEnabled(true);
 
         ownerUuid = await createUser('Owner');
         otherOwnerUuid = await createUser('Other');
@@ -168,7 +169,7 @@ describe('AI agent memory consolidation integration', () => {
     });
 
     afterEach(async () => {
-        await setFeatureFlag(FeatureFlags.AiAgentMemory, true);
+        await setOrgMemoryEnabled(true);
         await database(AiAgentMemoryConsolidationRunTableName)
             .whereIn('user_uuid', createdUserUuids)
             .delete();
@@ -319,13 +320,13 @@ describe('AI agent memory consolidation integration', () => {
             },
             featureFlagService,
             aiOrganizationSettingsService: {
-                isAiAgentMemoryEnabled: async (user) =>
-                    (
-                        await featureFlagService.get({
-                            user,
-                            featureFlagId: FeatureFlags.AiAgentMemory,
-                        })
-                    ).enabled,
+                isAiAgentMemoryEnabled: async ({ organizationUuid }) => {
+                    const org = await database('organizations')
+                        .select('ai_agent_memory_enabled')
+                        .where('organization_uuid', organizationUuid)
+                        .first();
+                    return org?.ai_agent_memory_enabled ?? false;
+                },
                 isAiAgentReviewsEnabled: vi
                     .fn()
                     .mockResolvedValue(reviewsEnabled),
@@ -1828,13 +1829,13 @@ describe('AI agent memory consolidation integration', () => {
         expect(runs[2]!.input_hash).toBe(runs[1]!.input_hash);
     });
 
-    it('records nothing for a manual run in a flag-off organization', async () => {
+    it('records nothing for a manual run in a memory-off organization', async () => {
         const slugs = await seedPartition({
             userUuid: ownerUuid,
             count: FLOOR,
             prefix: 'manualflag',
         });
-        await setFeatureFlag(FeatureFlags.AiAgentMemory, false);
+        await setOrgMemoryEnabled(false);
         const call = cannedCall([
             { type: 'retire', slug: slugs[0]!, reason: 'Its explore is gone.' },
         ]);
@@ -1957,13 +1958,13 @@ describe('AI agent memory consolidation integration', () => {
         ]);
     });
 
-    it('does nothing for an organization whose memory flag is off', async () => {
+    it('does nothing for an organization whose memory setting is off', async () => {
         await seedPartition({
             userUuid: ownerUuid,
             count: FLOOR,
             prefix: 'flagoff',
         });
-        await setFeatureFlag(FeatureFlags.AiAgentMemory, false);
+        await setOrgMemoryEnabled(false);
         const enqueue = stubSchedulerClient();
         const call = cannedCall([]);
         const service = buildService(call, {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -2,7 +2,6 @@ import { Ability, AbilityBuilder } from '@casl/ability';
 import {
     CommercialFeatureFlags,
     DimensionType,
-    FeatureFlags,
     FieldType,
     ForbiddenError,
     NotFoundError,
@@ -156,8 +155,7 @@ describe('AiAgentMemoryService', () => {
             id: featureFlagId,
             enabled:
                 user.organizationUuid === enabledOrganization &&
-                (featureFlagId === FeatureFlags.AiAgentMemory ||
-                    featureFlagId === CommercialFeatureFlags.AiCopilot),
+                featureFlagId === CommercialFeatureFlags.AiCopilot,
         }));
         const findByProjectAndSlug = vi.fn();
         const findByProjectAndUuid = vi.fn();
@@ -275,14 +273,11 @@ describe('AiAgentMemoryService', () => {
             userModel: { findSessionUserAndOrgByUuid } as AnyType,
             featureFlagService: { get: getFlag } as AnyType,
             aiOrganizationSettingsService: {
-                isAiAgentMemoryEnabled: async (user) =>
+                isAiAgentMemoryEnabled: async (user: {
+                    organizationUuid?: string;
+                }) =>
                     memorySettingEnabled &&
-                    (
-                        await getFlag({
-                            user,
-                            featureFlagId: FeatureFlags.AiAgentMemory,
-                        })
-                    ).enabled,
+                    user.organizationUuid === enabledOrganization,
                 isAiAgentReviewsEnabled: vi.fn().mockResolvedValue(true),
             },
             schedulerClient: {

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.test.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.test.ts
@@ -284,9 +284,6 @@ describe('upsertSettings model validation', () => {
             commercialFeatureFlagModel: {
                 get: async () => ({ enabled: true }),
             },
-            featureFlagService: {
-                get: async () => ({ enabled: false }),
-            },
             lightdashConfig: ANTHROPIC_ONLY_CONFIG,
             orgAiCopilotConfigResolver: {
                 // Writing modelVisibility is gated on the BYO-keys flag.
@@ -480,54 +477,35 @@ describe('upsertSettings model validation', () => {
 });
 
 describe('isAiAgentMemoryEnabled', () => {
-    const buildService = (
-        settingEnabled: boolean | null,
-        flagEnabled: boolean,
-    ) => {
-        const getFlag = vi.fn().mockResolvedValue({ enabled: flagEnabled });
-        const service = new AiOrganizationSettingsService({
+    const buildService = (settingEnabled: boolean | null) =>
+        new AiOrganizationSettingsService({
             organizationModel: {
                 getAiAgentMemoryEnabled: vi
                     .fn()
                     .mockResolvedValue(settingEnabled),
             },
-            featureFlagService: {
-                get: getFlag,
-            },
         } as never);
-        return { getFlag, service };
-    };
 
     it.each([
-        [null, false, false],
-        [null, true, true],
-        [false, true, false],
-        [true, false, true],
-        [true, true, true],
-    ])(
-        'resolves persisted=%s with flag=%s as %s',
-        async (settingEnabled, flagEnabled, expected) => {
-            await expect(
-                buildService(
-                    settingEnabled,
-                    flagEnabled,
-                ).service.isAiAgentMemoryEnabled({
-                    organizationUuid: 'org-uuid',
-                    userUuid: 'user-uuid',
-                }),
-            ).resolves.toBe(expected);
-        },
-    );
+        [null, false],
+        [false, false],
+        [true, true],
+    ])('resolves persisted=%s as %s', async (settingEnabled, expected) => {
+        await expect(
+            buildService(settingEnabled).isAiAgentMemoryEnabled({
+                organizationUuid: 'org-uuid',
+                userUuid: 'user-uuid',
+            }),
+        ).resolves.toBe(expected);
+    });
 
-    it('does not read the flag after an explicit choice', async () => {
-        const { getFlag, service } = buildService(false, true);
-
-        await service.isAiAgentMemoryEnabled({
-            organizationUuid: 'org-uuid',
-            userUuid: 'user-uuid',
-        });
-
-        expect(getFlag).not.toHaveBeenCalled();
+    it('is disabled for a user without an organization', async () => {
+        await expect(
+            buildService(true).isAiAgentMemoryEnabled({
+                organizationUuid: undefined,
+                userUuid: 'user-uuid',
+            }),
+        ).resolves.toBe(false);
     });
 });
 

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -6,7 +6,6 @@ import {
     BYO_AI_PROVIDERS,
     CommercialFeatureFlags,
     ComputedAiOrganizationSettings,
-    FeatureFlags,
     ForbiddenError,
     getVisibleDataAppClaudeModels,
     LightdashUser,
@@ -23,7 +22,6 @@ import {
 import { LightdashConfig } from '../../config/parseConfig';
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { BaseService } from '../../services/BaseService';
-import { FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
 import { CommercialFeatureFlagModel } from '../models/CommercialFeatureFlagModel';
 import {
@@ -137,7 +135,6 @@ type AiOrganizationSettingsServiceDependencies = {
     aiOrganizationSettingsModel: AiOrganizationSettingsModel;
     organizationModel: OrganizationModel;
     commercialFeatureFlagModel: CommercialFeatureFlagModel;
-    featureFlagService: FeatureFlagService;
     lightdashConfig: LightdashConfig;
     orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
 };
@@ -148,8 +145,6 @@ export class AiOrganizationSettingsService extends BaseService {
     private readonly organizationModel: OrganizationModel;
 
     private readonly commercialFeatureFlagModel: CommercialFeatureFlagModel;
-
-    private readonly featureFlagService: FeatureFlagService;
 
     private readonly lightdashConfig: LightdashConfig;
 
@@ -165,7 +160,6 @@ export class AiOrganizationSettingsService extends BaseService {
         this.organizationModel = dependencies.organizationModel;
         this.commercialFeatureFlagModel =
             dependencies.commercialFeatureFlagModel;
-        this.featureFlagService = dependencies.featureFlagService;
         this.lightdashConfig = dependencies.lightdashConfig;
         this.orgAiCopilotConfigResolver =
             dependencies.orgAiCopilotConfigResolver;
@@ -320,12 +314,7 @@ export class AiOrganizationSettingsService extends BaseService {
             await this.organizationModel.getAiAgentMemoryEnabled(
                 user.organizationUuid,
             );
-        if (settingEnabled !== null) return settingEnabled;
-        const flag = await this.featureFlagService.get({
-            user,
-            featureFlagId: FeatureFlags.AiAgentMemory,
-        });
-        return flag.enabled;
+        return settingEnabled ?? false;
     }
 
     private async resolveSettings(

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -133,9 +133,6 @@ export enum FeatureFlags {
      */
     AiDeepResearch = 'ai-deep-research',
 
-    /** Enable project-scoped AI agent memory runtime. */
-    AiAgentMemory = 'ai-agent-memory',
-
     /**
      * Enable the Hexbin (H3 hexagonal binning) layer type for Map charts.
      * Gates the option in the Map Type segmented control. Existing charts

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -48,7 +48,6 @@ export const AiGeneralSettingsPage = () => {
         FeatureFlags.OrgAiProviderApiKeys,
     );
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
-    const aiAgentMemoryFlag = useServerFeatureFlag(FeatureFlags.AiAgentMemory);
 
     const aiRouterQuery = useAiRouterConfig();
     const isRouterEnabled = aiRouterQuery.data?.enabled ?? false;
@@ -62,10 +61,7 @@ export const AiGeneralSettingsPage = () => {
     const reviewsPausedByByok = settings?.aiAgentReviewsPausedByByok ?? false;
     const reviewsEffectivelyOn =
         Boolean(settings?.aiAgentReviewsEnabled) && !reviewsPausedByByok;
-    const aiAgentMemoryEnabled = resolveAiAgentMemoryEnabled(
-        settings,
-        aiAgentMemoryFlag.data,
-    );
+    const aiAgentMemoryEnabled = resolveAiAgentMemoryEnabled(settings);
     const {
         fallbackModelLabel: systemDefaultModelLabel,
         selectedModel: selectedDefaultModel,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiOrganizationSettings.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiOrganizationSettings.ts
@@ -1,5 +1,4 @@
 import {
-    FeatureFlags,
     type ApiAiOrganizationRuntimeSettingsResponse,
     type ApiAiOrganizationSettingsResponse,
     type ApiError,
@@ -16,7 +15,6 @@ import {
 } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
 import useToaster from '../../../../hooks/toaster/useToaster';
-import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 
 export const resolveAiAgentMemoryEnabled = (
     settings:
@@ -25,8 +23,7 @@ export const resolveAiAgentMemoryEnabled = (
               'aiAgentMemoryEnabled'
           >
         | undefined,
-    featureFlag: { enabled: boolean } | undefined,
-): boolean => settings?.aiAgentMemoryEnabled ?? featureFlag?.enabled ?? false;
+): boolean => settings?.aiAgentMemoryEnabled ?? false;
 
 const getAiOrganizationSettings = async () => {
     return lightdashApi<ApiAiOrganizationRuntimeSettingsResponse['results']>({
@@ -88,10 +85,7 @@ export const useAiOrganizationAdminSettings = (
 
 export const useAiAgentMemoryEnabled = (): boolean => {
     const { data: settings } = useAiOrganizationSettings();
-    const { data: featureFlag } = useServerFeatureFlag(
-        FeatureFlags.AiAgentMemory,
-    );
-    return resolveAiAgentMemoryEnabled(settings, featureFlag);
+    return resolveAiAgentMemoryEnabled(settings);
 };
 
 const updateAiOrganizationSettings = async (


### PR DESCRIPTION
## Summary

- remove the ai-agent-memory feature flag and its backend/frontend fallback checks
- use organizations.ai_agent_memory_enabled as the only runtime setting
- treat NULL settings as disabled; preserve explicit true/false values
- keep new organizations enabled through the existing column default
- leave legacy flag rows untouched; application code ignores them

## Behavior change

Existing organizations with a NULL memory setting become disabled, regardless of legacy env, preview, user, organization, or default flag state.

## Validation

- backend focused tests: 123 passed
- common, backend, frontend typechecks
- formatting and diff checks

Closes: ZAP-773