### PR TITLE
fix: keep stored AI agent memories readable when memory generation is disabled

### DIFF
--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -627,16 +627,21 @@ describe('AiAgentAdminService review access', () => {
 });
 
 describe('AiAgentAdminService.getAllMemories', () => {
-    it('rejects when AI agent memory is disabled', async () => {
+    it('lists stored memories even when AI agent memory is disabled', async () => {
+        const findAdminMemoriesPaginated = vi
+            .fn()
+            .mockResolvedValue({ data: { memories: [] } });
         const service = makeService({
+            aiAgentMemoryModel: { findAdminMemoriesPaginated },
             aiOrganizationSettingsService: {
                 isAiAgentMemoryEnabled: vi.fn().mockResolvedValue(false),
             },
         });
 
-        await expect(service.getAllMemories(makeAdminUser())).rejects.toThrow(
-            'AI agent memory is not enabled',
-        );
+        await expect(service.getAllMemories(makeAdminUser())).resolves.toEqual({
+            data: { memories: [] },
+        });
+        expect(findAdminMemoriesPaginated).toHaveBeenCalled();
     });
 
     it('rejects principals without manage access to any project', async () => {

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -772,14 +772,9 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        if (
-            !(await this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(
-                user,
-            ))
-        ) {
-            throw new ForbiddenError('AI agent memory is not enabled');
-        }
 
+        // Deliberately not gated on the org memory setting: admins must be
+        // able to review/retire stored memories after disabling generation.
         const scope = await this.resolveReadScope(user, organizationUuid);
         const { filters: scopedFilters, empty } =
             AiAgentAdminService.restrictFiltersToScope(scope, filters);

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -149,6 +149,7 @@ describe('AiAgentMemoryService', () => {
 
     const build = ({
         enabledOrganization = 'org-enabled',
+        memorySettingEnabled = true,
         consolidationDryRun = false,
     } = {}) => {
         const getFlag = vi.fn(async ({ user, featureFlagId }) => ({
@@ -274,13 +275,11 @@ describe('AiAgentMemoryService', () => {
             userModel: { findSessionUserAndOrgByUuid } as AnyType,
             featureFlagService: { get: getFlag } as AnyType,
             aiOrganizationSettingsService: {
-                isAiAgentMemoryEnabled: async (user) =>
-                    (
-                        await getFlag({
-                            user,
-                            featureFlagId: FeatureFlags.AiAgentMemory,
-                        })
-                    ).enabled,
+                isAiAgentMemoryEnabled: async (user: {
+                    organizationUuid?: string;
+                }) =>
+                    memorySettingEnabled &&
+                    user.organizationUuid === enabledOrganization,
                 isAiAgentReviewsEnabled: vi.fn().mockResolvedValue(true),
             },
             schedulerClient: {
@@ -490,6 +489,73 @@ describe('AiAgentMemoryService', () => {
             memoryUuid: 'memory-1',
             status: 'retired',
         });
+    });
+
+    it('keeps stored memories readable and retirable when the org memory setting is off', async () => {
+        const {
+            service,
+            findByProjectAndSlug,
+            findByProjectAndUuid,
+            findUserMemoriesPaginated,
+            updateStatus,
+        } = build({ memorySettingEnabled: false });
+        findByProjectAndSlug.mockResolvedValue({
+            memory: memoryRow({ user_uuid: 'current-user' }),
+            sources: [lineageSource()],
+            replacement: null,
+        });
+        findByProjectAndUuid.mockResolvedValue(
+            memoryRow({ user_uuid: 'current-user' }),
+        );
+        const user = buildUser(true);
+
+        await expect(
+            service.getMemory(user, 'project-enabled', 'net-revenue-ab12cd34'),
+        ).resolves.toMatchObject({ slug: 'net-revenue-ab12cd34' });
+        await expect(
+            service.listMyMemories(user, 'project-enabled', {
+                page: 1,
+                pageSize: 50,
+            }),
+        ).resolves.toBeDefined();
+        expect(findUserMemoriesPaginated).toHaveBeenCalled();
+        await expect(
+            service.updateMemoryStatus(
+                user,
+                'project-enabled',
+                'memory-1',
+                'retired',
+            ),
+        ).resolves.toBeUndefined();
+        expect(updateStatus).toHaveBeenCalledWith({
+            memoryUuid: 'memory-1',
+            status: 'retired',
+        });
+    });
+
+    it('rejects promotion and manual distill when the org memory setting is off', async () => {
+        const { service, findByProjectAndUuid, aiAgentMemoryDistill } = build({
+            memorySettingEnabled: false,
+        });
+        findByProjectAndUuid.mockResolvedValue(
+            memoryRow({ user_uuid: 'current-user' }),
+        );
+
+        await expect(
+            service.promoteMemory(
+                buildUser(true),
+                'project-enabled',
+                'memory-1',
+            ),
+        ).rejects.toThrow(NotFoundError);
+        await expect(
+            service.triggerThreadDistill(
+                buildUser(true, { canManageAgents: true }),
+                'project-enabled',
+                'thread-enabled',
+            ),
+        ).rejects.toThrow(NotFoundError);
+        expect(aiAgentMemoryDistill).not.toHaveBeenCalled();
     });
 
     it('does not reactivate a memory when its source has a newer active memory', async () => {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -547,11 +547,18 @@ export class AiAgentMemoryService extends BaseService {
         }
     }
 
-    /** Shared gate for every memory read: project access + both feature flags. */
+    /**
+     * Shared gate for every memory endpoint: project access + copilot flag.
+     * `requireMemoryEnabled` additionally gates on the org memory setting —
+     * generation-adjacent paths (promotion, manual distill) pass true; pure
+     * read/manage paths pass false so stored memories stay reachable after an
+     * org disables memory generation.
+     */
     private async getMemoryAccessContext(
         user: SessionUser,
         projectUuid: string,
         notFoundMessage: string,
+        options: { requireMemoryEnabled: boolean },
     ): Promise<string> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
@@ -571,7 +578,10 @@ export class AiAgentMemoryService extends BaseService {
             }),
             this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(user),
         ]);
-        if (!copilot.enabled || !memoryEnabled) {
+        if (
+            !copilot.enabled ||
+            (options.requireMemoryEnabled && !memoryEnabled)
+        ) {
             throw new NotFoundError(notFoundMessage);
         }
 
@@ -609,6 +619,7 @@ export class AiAgentMemoryService extends BaseService {
             user,
             projectUuid,
             `Memory not found: ${slug}`,
+            { requireMemoryEnabled: false },
         );
 
         const result = await this.aiAgentMemoryModel.findByProjectAndSlug({
@@ -736,6 +747,7 @@ export class AiAgentMemoryService extends BaseService {
             user,
             projectUuid,
             `Memory not found: ${memoryUuid}`,
+            { requireMemoryEnabled: true },
         );
         const memory = await this.requireReadableMemory(
             user,
@@ -906,6 +918,7 @@ export class AiAgentMemoryService extends BaseService {
             user,
             projectUuid,
             `Memories not found for project: ${projectUuid}`,
+            { requireMemoryEnabled: false },
         );
 
         return this.aiAgentMemoryModel.findUserMemoriesPaginated({
@@ -926,6 +939,7 @@ export class AiAgentMemoryService extends BaseService {
             user,
             projectUuid,
             `Memory not found: ${memoryUuid}`,
+            { requireMemoryEnabled: false },
         );
         const memory = await this.requireReadableMemory(
             user,
@@ -1015,6 +1029,7 @@ export class AiAgentMemoryService extends BaseService {
             user,
             projectUuid,
             notFoundMessage,
+            { requireMemoryEnabled: true },
         );
 
         if (

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -549,16 +549,13 @@ export class AiAgentMemoryService extends BaseService {
 
     /**
      * Shared gate for every memory endpoint: project access + copilot flag.
-     * `requireMemoryEnabled` additionally gates on the org memory setting —
-     * generation-adjacent paths (promotion, manual distill) pass true; pure
-     * read/manage paths pass false so stored memories stay reachable after an
-     * org disables memory generation.
+     * Deliberately not the org memory setting, so stored memories stay
+     * reachable after an org disables memory generation.
      */
     private async getMemoryAccessContext(
         user: SessionUser,
         projectUuid: string,
         notFoundMessage: string,
-        options: { requireMemoryEnabled: boolean },
     ): Promise<string> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
@@ -571,21 +568,33 @@ export class AiAgentMemoryService extends BaseService {
             throw new ForbiddenError('Cannot view project');
         }
 
-        const [copilot, memoryEnabled] = await Promise.all([
-            this.featureFlagService.get({
-                user,
-                featureFlagId: CommercialFeatureFlags.AiCopilot,
-            }),
-            this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(user),
-        ]);
-        if (
-            !copilot.enabled ||
-            (options.requireMemoryEnabled && !memoryEnabled)
-        ) {
+        const copilot = await this.featureFlagService.get({
+            user,
+            featureFlagId: CommercialFeatureFlags.AiCopilot,
+        });
+        if (!copilot.enabled) {
             throw new NotFoundError(notFoundMessage);
         }
 
         return organizationUuid;
+    }
+
+    /**
+     * Extra gate for generation-adjacent paths (promotion, manual distill):
+     * the org memory setting. The background-job equivalent is `isEnabled`,
+     * which folds the same setting in with the copilot flag.
+     */
+    private async assertMemoryGenerationEnabled(
+        user: SessionUser,
+        notFoundMessage: string,
+    ): Promise<void> {
+        if (
+            !(await this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(
+                user,
+            ))
+        ) {
+            throw new NotFoundError(notFoundMessage);
+        }
     }
 
     private async requireReadableMemory(
@@ -619,7 +628,6 @@ export class AiAgentMemoryService extends BaseService {
             user,
             projectUuid,
             `Memory not found: ${slug}`,
-            { requireMemoryEnabled: false },
         );
 
         const result = await this.aiAgentMemoryModel.findByProjectAndSlug({
@@ -743,12 +751,13 @@ export class AiAgentMemoryService extends BaseService {
         reason?: string,
     ): Promise<MemoryReviewItemUpsert> {
         const nominationReason = reason?.trim() || null;
+        const notFoundMessage = `Memory not found: ${memoryUuid}`;
         const organizationUuid = await this.getMemoryAccessContext(
             user,
             projectUuid,
-            `Memory not found: ${memoryUuid}`,
-            { requireMemoryEnabled: true },
+            notFoundMessage,
         );
+        await this.assertMemoryGenerationEnabled(user, notFoundMessage);
         const memory = await this.requireReadableMemory(
             user,
             organizationUuid,
@@ -918,7 +927,6 @@ export class AiAgentMemoryService extends BaseService {
             user,
             projectUuid,
             `Memories not found for project: ${projectUuid}`,
-            { requireMemoryEnabled: false },
         );
 
         return this.aiAgentMemoryModel.findUserMemoriesPaginated({
@@ -939,7 +947,6 @@ export class AiAgentMemoryService extends BaseService {
             user,
             projectUuid,
             `Memory not found: ${memoryUuid}`,
-            { requireMemoryEnabled: false },
         );
         const memory = await this.requireReadableMemory(
             user,
@@ -1029,8 +1036,8 @@ export class AiAgentMemoryService extends BaseService {
             user,
             projectUuid,
             notFoundMessage,
-            { requireMemoryEnabled: true },
         );
+        await this.assertMemoryGenerationEnabled(user, notFoundMessage);
 
         if (
             this.createAuditedAbility(user).cannot(

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
@@ -14,7 +14,6 @@ import { IconArrowRight } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useParams } from 'react-router';
 import { useAiAgentMemory } from '../../hooks/useAiAgentMemory';
-import { useAiAgentMemoryEnabled } from '../../hooks/useAiOrganizationSettings';
 import { MemoryDetailsModal } from '../MemoryDetails/MemoryDetails';
 import styles from './MemoryCitation.module.css';
 
@@ -31,22 +30,13 @@ export const MemoryCitation = ({
     const [detailsOpened, { open: openDetails, close: closeDetails }] =
         useDisclosure(false);
     const { projectUuid, agentUuid } = useParams();
-    const memoryEnabled = useAiAgentMemoryEnabled();
     const slug = id?.replace(/^user-content-/, '');
     const memoryQuery = useAiAgentMemory({
         projectUuid,
         agentUuid,
         slug,
-        enabled: memoryEnabled && hasOpened,
+        enabled: hasOpened,
     });
-
-    if (!memoryEnabled) {
-        return (
-            <span className={styles.marker} aria-hidden="true">
-                {memoryIndex ?? '·'}
-            </span>
-        );
-    }
 
     return (
         <>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/useMessageMemorySources.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/useMessageMemorySources.ts
@@ -1,10 +1,9 @@
 import { useMemo } from 'react';
-import { useAiAgentMemoryEnabled } from '../../hooks/useAiOrganizationSettings';
 import { parseMemoryCitationSlugs } from './parseMemoryCitationSlugs';
 
-/** Cited memory slugs for a message, empty when the feature is off. */
-export const useMessageMemorySources = (markdown: string): string[] => {
-    const memoryEnabled = useAiAgentMemoryEnabled();
-    const slugs = useMemo(() => parseMemoryCitationSlugs(markdown), [markdown]);
-    return memoryEnabled ? slugs : [];
-};
+/**
+ * Cited memory slugs for a message. Not gated on the org memory setting:
+ * stored memories stay readable after generation is disabled.
+ */
+export const useMessageMemorySources = (markdown: string): string[] =>
+    useMemo(() => parseMemoryCitationSlugs(markdown), [markdown]);

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -254,11 +254,7 @@ const AgentPage = () => {
                                 : undefined
                         }
                         isSharing={isCreatingShare}
-                        onOpenMemories={
-                            memoryEnabled
-                                ? () => setIsMemoriesModalOpen(true)
-                                : undefined
-                        }
+                        onOpenMemories={() => setIsMemoriesModalOpen(true)}
                         onMinimize={() => handleMinimize()}
                         settingsHref={
                             canManageAgents

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -46,7 +46,6 @@ import { useAiAgentModelSelection } from '../../features/aiCopilot/hooks/useAiAg
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentRouterFlow } from '../../features/aiCopilot/hooks/useAiAgentRouterFlow';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
-import { useAiAgentMemoryEnabled } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
 import { usePinnedContext } from '../../features/aiCopilot/hooks/usePinnedContext';
 import {
     useCreateAgentThreadMutation,
@@ -76,7 +75,6 @@ const AgentsRouterPage = () => {
 
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
     const [isMemoriesModalOpen, setIsMemoriesModalOpen] = useState(false);
-    const memoryEnabled = useAiAgentMemoryEnabled();
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     const chartUuid = searchParams.get('chartUuid');
@@ -301,22 +299,20 @@ const AgentsRouterPage = () => {
         >
             <Box className={classes.routerView}>
                 <Group gap={4} className={classes.routerActions}>
-                    {memoryEnabled && (
-                        <UnstyledButton
-                            type="button"
-                            className={classes.memoriesButton}
-                            onClick={() => setIsMemoriesModalOpen(true)}
-                        >
-                            <Group gap={6} wrap="nowrap" align="center">
-                                <MantineIcon
-                                    icon={IconNotebook}
-                                    size="sm"
-                                    color="ldGray.6"
-                                />
-                                <Text size="xs">Memories</Text>
-                            </Group>
-                        </UnstyledButton>
-                    )}
+                    <UnstyledButton
+                        type="button"
+                        className={classes.memoriesButton}
+                        onClick={() => setIsMemoriesModalOpen(true)}
+                    >
+                        <Group gap={6} wrap="nowrap" align="center">
+                            <MantineIcon
+                                icon={IconNotebook}
+                                size="sm"
+                                color="ldGray.6"
+                            />
+                            <Text size="xs">Memories</Text>
+                        </Group>
+                    </UnstyledButton>
                     {canManageAgents && (
                         <AgentSettingsSelector
                             agents={agents ?? []}

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -1,10 +1,7 @@
 import { subject } from '@casl/ability';
 import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
 import { useIsGitProject } from '../../components/Explorer/WriteBackModal/hooks';
-import {
-    resolveAiAgentMemoryEnabled,
-    useAiOrganizationSettings,
-} from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
+import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 import useApp from '../../providers/App/useApp';
 import { useOrganization } from '../organization/useOrganization';
 import { useActiveProjectUuid } from '../useActiveProject';
@@ -38,13 +35,9 @@ export const useSettingsContext = (): SettingsContext => {
     const shouldShowAiAgentReviews =
         aiOrganizationSettingsQuery.data?.aiAgentReviewsEnabled === true;
 
-    const { data: aiAgentMemoryFlag } = useServerFeatureFlag(
-        FeatureFlags.AiAgentMemory,
-    );
-    const shouldShowAiAgentMemories = resolveAiAgentMemoryEnabled(
-        aiOrganizationSettingsQuery.data,
-        aiAgentMemoryFlag,
-    );
+    // Not gated on the org memory setting: admins must still reach stored
+    // memories after disabling generation.
+    const shouldShowAiAgentMemories = isAiCopilotEnabledOrTrial;
 
     const { data: serviceAccountsFlag } = useServerFeatureFlag(
         CommercialFeatureFlags.ServiceAccounts,


### PR DESCRIPTION
## Summary

Disabling the org setting **Enable AI agent memories** now stops memory *generation* only — stored memories stay reachable so admins and owners can review and retire what was already learned, and old threads keep their citations.

Independent of #27465 (flag retirement) — rebased onto `main`; works with the feature-flag fallback still in place.

## Changes

Backend:
- `AiAgentMemoryService`: split the gate in two — `getMemoryAccessContext` now checks only copilot flag + project access (used by every memory endpoint: `getMemory` / `listMyMemories` / `updateMemoryStatus` / `prepareMemoryPromotion` / `triggerThreadDistill`), and a separate `assertMemoryGenerationEnabled` guard checks the org memory setting for generation-adjacent paths only (`prepareMemoryPromotion` / `triggerThreadDistill`).
- `AiAgentAdminService.getAllMemories`: dropped the memory-enabled `ForbiddenError` gate (was a 403 once the setting is off); org + admin read-scope checks remain.
- Generation paths untouched: distill enqueue + job runtime re-check, consolidation partitions, promotion, manual distill all still gate on the setting.

Frontend:
- `MemoryCitation` renders the interactive hover card regardless of the setting (was an inert span).
- `useMessageMemorySources` un-gated so the sources section renders in old threads.
- Admin **Memories** settings page + nav entry now shown whenever AI settings are (copilot enabled), not only when memory is on.
- "My memories" button always available on agent pages; the first-run memory tour stays gated on the setting.

## Verified locally

With the org setting off: admin memories list returns 200 with data; my-memories list, get-by-slug, retire + reactivate all work; promote and manual distill return 404. Unit tests cover both directions.

Fixes ZAP-854

🤖 Generated with [Claude Code](https://claude.com/claude-code)
