### PR TITLE
fix: remove the quotes from GitHub App values in dev-reconcile

### DIFF
--- a/scripts/dev-reconcile.sh
+++ b/scripts/dev-reconcile.sh
@@ -51,8 +51,18 @@ if [ -z "$RUNNING_SECRET" ]; then
 fi
 [ -n "$RUNNING_SECRET" ] || { echo "FAIL: reconcile -- could not determine LIGHTDASH_SECRET" >&2; exit 1; }
 
-GITHUB_APP_ID="$(grep '^GITHUB_APP_ID=' "$ENV_FILE" | head -1 | cut -d= -f2-)"
-GITHUB_PRIVATE_KEY="$(grep '^GITHUB_PRIVATE_KEY=' "$ENV_FILE" | head -1 | cut -d= -f2-)"
+# Dequote for the same reason as LIGHTDASH_SECRET above: dotenv strips surrounding
+# quotes at load, and 1Password pulls may write quoted values. A quoted app id ends up
+# in the JWT 'iss' claim verbatim and GitHub rejects every call with
+# 401 "'Issuer' claim ('iss') must be an Integer".
+dequote() {
+    local v="$1"
+    v="${v%\"}"; v="${v#\"}"
+    v="${v%\'}"; v="${v#\'}"
+    printf '%s' "$v"
+}
+GITHUB_APP_ID="$(dequote "$(grep '^GITHUB_APP_ID=' "$ENV_FILE" | head -1 | cut -d= -f2-)")"
+GITHUB_PRIVATE_KEY="$(dequote "$(grep '^GITHUB_PRIVATE_KEY=' "$ENV_FILE" | head -1 | cut -d= -f2-)")"
 
 # The dev GitHub App is shared and has many installations, so the reconcile must
 # target YOUR account. Resolve from $GH_ACCOUNT, then the per-engineer local config.


### PR DESCRIPTION
## What this change does

`dev-reconcile.sh` reads the GitHub App environment values with `cut`, which keeps the surrounding quotes from the env file. The quoted App ID goes into the GitHub App JWT `iss` claim, and GitHub returns 401. This change applies the script's existing dequote treatment to the GitHub App values.

Development tooling only. No runtime code changes.

## Tests

A controlled comparison against the GitHub API: the quoted value gets 401 (`'iss' must be an Integer`); the dequoted value gets 200 with installations returned.

Linear: SPK-1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kyg5Qw8v4vLKfKb7Bh9gcj
