### PR TITLE
fix: viz dialog tables must scroll horizontally (generation contract)

### DIFF
--- a/sandboxes/data-apps/template/.claude/skills/reusable-visualization/SKILL.md
+++ b/sandboxes/data-apps/template/.claude/skills/reusable-visualization/SKILL.md
@@ -123,6 +123,14 @@ container itself — pad the cells, not the scroller. A sticky header pins to th
 container's content edge, so any container padding becomes a strip that rows
 visibly scroll through above the header.
 
+The table must scroll BOTH ways: `overflow: auto` on ONE wrapper directly around the
+`<table>`, and every element between that wrapper and the dialog body a plain block
+that can shrink (`min-width: 0`; no `display: table`, no `w-max`/`width:
+max-content`). A wrapper that sizes to the table's intrinsic width makes the
+overflow container's horizontal scroll dead — the table looks clipped and viewers
+cannot reach the right-hand columns. Verify by scrolling right in the rendered
+dialog with more columns than fit.
+
 ## The declaration
 
 Alongside the component you emit one structured declaration — as **structured output, not a


### PR DESCRIPTION
Relates: GLITCH-589

### Description:

A viewer reported that a viz's underlying-data dialog could not be scrolled horizontally — wide tables looked clipped with the right-hand columns unreachable. Root cause (diagnosed on a live viz): the generated markup put `display: table` on a wrapper between the `overflow: auto` scroll container and the `<table>`, so the wrapper sized to the table's intrinsic width and the container's horizontal scroll went dead. Vertical scrolling still worked, which made it look like a partial table.

The dialog markup is generated app code, so the durable fix is the generation contract: the `reusable-visualization` skill's underlying-data section now requires `overflow: auto` on ONE wrapper directly around the `<table>`, every intermediate element a shrinkable plain block (`min-width: 0`, no `display: table` / `width: max-content`), and a rendered-dialog scroll-right check with more columns than fit.

Same lever as the earlier dense-table/sticky-header guidance in this section: skill text only, no host or SDK changes. Applies to newly generated/rebuilt vizs once a template image containing this text is published; existing vizs need a rebuild (or a one-off builder iteration) to pick it up.