### PR TITLE
fix: show "View full error" in error toasts only when the message is cropped

### DIFF
--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -13,7 +13,7 @@ import {
     useComputedColorScheme,
 } from '@mantine/core';
 import { modals } from '@mantine/modals';
-import { IconCheck, IconCopy, IconSpeakerphone } from '@tabler/icons-react';
+import { IconCheck, IconCopy } from '@tabler/icons-react';
 import { defaultContext } from '@tanstack/react-query';
 import { useContext, useLayoutEffect, useRef, useState } from 'react';
 import MantineIcon from '../../components/common/MantineIcon';
@@ -56,7 +56,10 @@ const ErrorMessage = ({
         clone.style.setProperty('overflow', 'visible');
         clone.style.setProperty('position', 'absolute');
         clone.style.setProperty('visibility', 'hidden');
-        clone.style.setProperty('width', `${el.clientWidth}px`);
+        clone.style.setProperty(
+            'width',
+            `${el.getBoundingClientRect().width}px`,
+        );
         el.parentElement?.appendChild(clone);
         setIsClamped(clone.scrollHeight > el.clientHeight + 1);
         clone.remove();
@@ -126,6 +129,23 @@ export const CopyErrorButton = ({
                     />
                 </ActionIcon>
             </Tooltip>
+        )}
+    </CopyButton>
+);
+
+const CopyErrorIdButton = ({ value }: { value: string }) => (
+    <CopyButton value={value}>
+        {({ copied, copy }) => (
+            <Button
+                size="compact-xs"
+                variant="subtle"
+                leftSection={
+                    <MantineIcon icon={copied ? IconCheck : IconCopy} />
+                }
+                onClick={copy}
+            >
+                {copied ? 'Copied' : 'Copy error'}
+            </Button>
         )}
     </CopyButton>
 );
@@ -274,10 +294,6 @@ const ApiErrorDisplayWithHealth = ({
                     <Group gap="xs">
                         <Button
                             size="compact-xs"
-                            variant="default"
-                            leftSection={
-                                <MantineIcon icon={IconSpeakerphone} />
-                            }
                             onClick={() => {
                                 modals.open({
                                     title: 'Share with Lightdash Support',
@@ -288,11 +304,10 @@ const ApiErrorDisplayWithHealth = ({
                                 });
                             }}
                         >
-                            <Text fz="xs">Notify support</Text>
+                            Notify support
                         </Button>
-                        <CopyErrorButton
+                        <CopyErrorIdButton
                             value={errorClipboardValue(apiError)}
-                            color="ldGray.6"
                         />
                     </Group>
                 </Stack>

--- a/packages/frontend/src/stories/Toaster.stories.tsx
+++ b/packages/frontend/src/stories/Toaster.stories.tsx
@@ -1,3 +1,4 @@
+import { LightdashMode, type HealthState } from '@lightdash/common';
 import {
     Box,
     Button,
@@ -20,7 +21,8 @@ import {
     IconReload,
     type Icon,
 } from '@tabler/icons-react';
-import { useRef, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useRef, useState, type ReactNode } from 'react';
 import MantineIcon from '../components/common/MantineIcon';
 import ApiErrorDisplay from '../hooks/toaster/ApiErrorDisplay';
 import MultipleToastBody from '../hooks/toaster/MultipleToastBody';
@@ -484,6 +486,24 @@ const StaticJobProgressBody = () => (
     </Box>
 );
 
+const NotifySupportHealthProvider = ({ children }: { children: ReactNode }) => {
+    const [queryClient] = useState(() => {
+        const client = new QueryClient({
+            defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+        });
+        client.setQueryData(['health'], {
+            mode: LightdashMode.DEV,
+            siteUrl: 'http://localhost:3000',
+        } as unknown as HealthState);
+        return client;
+    });
+    return (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+};
+
 const InlineGalleryDemo = () => (
     <Stack gap="xl" p="xl" w={860}>
         <Box component="section">
@@ -628,6 +648,51 @@ const InlineGalleryDemo = () => (
                     </StaticToast>
                 </Box>
             </Group>
+        </Box>
+
+        <Box component="section">
+            <Title order={4} mb="md">
+                Error (notify support)
+            </Title>
+            <NotifySupportHealthProvider>
+                <Group align="flex-start" gap="md">
+                    <Box w={400}>
+                        <StaticToast
+                            variant="error"
+                            title="Failed to create issue"
+                        >
+                            <Box className={toastStyles.subtitle}>
+                                <ApiErrorDisplay
+                                    apiError={{
+                                        name: 'ApiError',
+                                        message: 'Something went wrong.',
+                                        statusCode: 500,
+                                        sentryEventId: 'a1b2c3d4e5',
+                                        sentryTraceId: 'f6a7b8c9d0',
+                                        data: {},
+                                    }}
+                                />
+                            </Box>
+                        </StaticToast>
+                    </Box>
+                    <Box w={400}>
+                        <StaticToast variant="error" title="Query failed">
+                            <Box className={toastStyles.subtitle}>
+                                <ApiErrorDisplay
+                                    apiError={{
+                                        name: 'ApiError',
+                                        message: LONG_SQL_ERROR_MESSAGE,
+                                        statusCode: 400,
+                                        sentryEventId: 'c3d4e5f6a7',
+                                        sentryTraceId: 'b8c9d0e1f2',
+                                        data: {},
+                                    }}
+                                />
+                            </Box>
+                        </StaticToast>
+                    </Box>
+                </Group>
+            </NotifySupportHealthProvider>
         </Box>
 
         <Box component="section">


### PR DESCRIPTION
Short error messages in the notify-support error toast always showed a "View full error" link that revealed nothing: the clamp detection measured the message at its integer-rounded width, so shrink-to-fit text wrapped one word early and reported a false clamp for almost any message. While here, the support actions are restyled per design feedback (primary "Notify support", ghost "Copy error") and the toaster Storybook gallery gains a notify-support section to iterate on.

closes PROD-10155