### PR TITLE
feat: add chart slug history foundation

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -256,6 +256,10 @@ import {
     SavedChartVersionsTableName,
 } from '../database/entities/savedCharts';
 import {
+    SavedChartSlugMappingsTableName,
+    SavedChartSlugMappingTable,
+} from '../database/entities/savedChartSlugMappings';
+import {
     SavedSqlTable,
     SavedSqlTableName,
     SavedSqlVersionsTable,
@@ -549,6 +553,7 @@ declare module 'knex/types/tables' {
         [ProjectTableName]: ProjectTable;
         [ProjectDbtSourcesTableName]: ProjectDbtSourcesTable;
         [SavedChartsTableName]: SavedChartTable;
+        [SavedChartSlugMappingsTableName]: SavedChartSlugMappingTable;
         [SavedChartVersionsTableName]: SavedChartVersionsTable;
         [SavedChartVersionFieldsTableName]: SavedChartVersionFieldsTable;
         [SavedChartVersionSortsTableName]: SavedChartVersionSortsTable;

--- a/packages/backend/src/database/entities/savedChartSlugMappings.ts
+++ b/packages/backend/src/database/entities/savedChartSlugMappings.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+export const SavedChartSlugMappingsTableName = 'saved_query_slug_mappings';
+
+export type DbSavedChartSlugMapping = {
+    saved_query_slug_mapping_uuid: string;
+    project_uuid: string;
+    saved_query_uuid: string;
+    slug: string;
+    created_at: Date;
+};
+
+export type SavedChartSlugMappingTable = Knex.CompositeTableType<
+    DbSavedChartSlugMapping,
+    Pick<DbSavedChartSlugMapping, 'project_uuid' | 'saved_query_uuid' | 'slug'>,
+    never
+>;

--- a/packages/backend/src/database/migrations/20260817100000_add_saved_query_slug_mappings.ts
+++ b/packages/backend/src/database/migrations/20260817100000_add_saved_query_slug_mappings.ts
@@ -1,0 +1,49 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds an empty chart slug history table without changing existing chart writes',
+} as const;
+
+const SavedQueriesTableName = 'saved_queries';
+const SavedQuerySlugMappingsTableName = 'saved_query_slug_mappings';
+const ProjectsTableName = 'projects';
+const LockTimeout = '5s';
+const MappingProjectSlugUnique =
+    'saved_query_slug_mappings_project_uuid_slug_unique';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+    if (await knex.schema.hasTable(SavedQuerySlugMappingsTableName)) return;
+
+    await knex.schema.createTable(SavedQuerySlugMappingsTableName, (table) => {
+        table
+            .uuid('saved_query_slug_mapping_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable(ProjectsTableName)
+            .onDelete('CASCADE')
+            .index();
+        table
+            .uuid('saved_query_uuid')
+            .notNullable()
+            .references('saved_query_uuid')
+            .inTable(SavedQueriesTableName)
+            .onDelete('CASCADE')
+            .index();
+        table.string('slug', 255).notNullable();
+        table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+        table.unique(['project_uuid', 'slug'], {
+            indexName: MappingProjectSlugUnique,
+        });
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+    await knex.schema.dropTableIfExists(SavedQuerySlugMappingsTableName);
+}

--- a/packages/backend/src/models/SavedChartModel.test.ts
+++ b/packages/backend/src/models/SavedChartModel.test.ts
@@ -8,6 +8,7 @@ import {
     DashboardTileChartTableName,
 } from '../database/entities/dashboards';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
+import { SavedChartSlugMappingsTableName } from '../database/entities/savedChartSlugMappings';
 import { SpaceTableName } from '../database/entities/spaces';
 import { createSavedChart, SavedChartModel } from './SavedChartModel';
 import { chartSummary } from './SavedChartModel.mock';
@@ -61,6 +62,7 @@ describe('createSavedChart', () => {
         const spaceUuid = '33333333-3333-4333-8333-333333333333';
 
         tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
         tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
         tracker.on
             .insert(SavedChartsTableName)
@@ -100,6 +102,7 @@ describe('createSavedChart', () => {
         const dashboardUuid = '44444444-4444-4444-8444-444444444444';
 
         tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
         tracker.on
             .select(DashboardsTableName)
             .responseOnce([{ dashboard_uuid: dashboardUuid }]);
@@ -144,6 +147,7 @@ describe('createSavedChart', () => {
             .select(SavedChartsTableName)
             .responseOnce([{ slug: 'orders' }]);
         tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
         tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
         tracker.on
             .insert(SavedChartsTableName)
@@ -203,6 +207,36 @@ describe('createSavedChart', () => {
         expect(tracker.history.insert).toHaveLength(0);
     });
 
+    test('returns an active chart that owns a forced historical slug', async () => {
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([
+            {
+                saved_query_uuid: 'existing-chart-uuid',
+                deleted_at: null,
+            },
+        ]);
+
+        const result = await createSavedChart(
+            database,
+            '22222222-2222-4222-8222-222222222222',
+            '11111111-1111-4111-8111-111111111111',
+            {
+                ...chartInput,
+                spaceUuid: '33333333-3333-4333-8333-333333333333',
+                dashboardUuid: null,
+                forceSlug: true,
+            },
+        );
+
+        expect(result).toBe('existing-chart-uuid');
+        expect(tracker.history.insert).toHaveLength(0);
+        expect(
+            tracker.history.select.some((query) =>
+                query.sql.includes(SavedChartSlugMappingsTableName),
+            ),
+        ).toBe(true);
+    });
+
     test('rejects a forced slug owned by a deleted chart', async () => {
         tracker.on.select(SavedChartsTableName).responseOnce([
             {
@@ -258,10 +292,12 @@ describe('createSavedChart', () => {
         const spaceUuid = '33333333-3333-4333-8333-333333333333';
 
         tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
         tracker.on
             .select(SavedChartsTableName)
             .responseOnce([{ saved_query_id: 10 }]);
         tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
         tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
         tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
         tracker.on
@@ -294,6 +330,7 @@ describe('createSavedChart', () => {
 
     test('resolves a forced-slug race to the chart committed by the other writer', async () => {
         tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
         tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
         tracker.on.select(SavedChartsTableName).responseOnce([
             {
@@ -324,6 +361,7 @@ describe('createSavedChart', () => {
     test('reconciles a forced slug after the final retry loses a race', async () => {
         for (let attempt = 0; attempt < 3; attempt += 1) {
             tracker.on.select(SavedChartsTableName).responseOnce([]);
+            tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
             tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
             tracker.on
                 .insert(SavedChartsTableName)
@@ -338,6 +376,11 @@ describe('createSavedChart', () => {
                       ]
                     : [],
             );
+            if (attempt < 2) {
+                tracker.on
+                    .select(SavedChartSlugMappingsTableName)
+                    .responseOnce([]);
+            }
         }
 
         const result = await createSavedChart(
@@ -354,6 +397,54 @@ describe('createSavedChart', () => {
 
         expect(result).toBe('final-racing-chart-uuid');
         expect(tracker.history.insert).toHaveLength(3);
+    });
+});
+
+describe('get', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new SavedChartModel({
+        database,
+        lightdashConfig: lightdashConfigMock,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    test('looks up non-UUID chart identifiers by canonical and historical slug', async () => {
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+
+        await expect(
+            model.get('old-orders', undefined, { projectUuid }),
+        ).rejects.toThrow('Saved query not found');
+
+        const [query] = tracker.history.select;
+        expect(query.sql).toContain(`"${SavedChartsTableName}"."slug" in`);
+        expect(query.sql).toContain(SavedChartSlugMappingsTableName);
+        expect(query.sql).toContain('exists');
+        expect(
+            query.bindings.filter((value) => value === 'old-orders'),
+        ).toHaveLength(2);
+        expect(query.bindings).toContain(projectUuid);
+    });
+
+    test('returns aliases for downloaded chart UUIDs', async () => {
+        tracker.on
+            .select(SavedChartSlugMappingsTableName)
+            .responseOnce([{ slug: 'old-orders' }, { slug: 'older-orders' }]);
+
+        const aliases = await model.getSlugAliasesForUuids(['chart-uuid']);
+
+        expect(aliases).toEqual(['old-orders', 'older-orders']);
+        const [query] = tracker.history.select;
+        expect(query.sql).toContain(SavedChartSlugMappingsTableName);
+        expect(query.bindings).toContain('chart-uuid');
     });
 });
 

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -94,6 +94,7 @@ import {
     SavedChartVersionFieldsTableName,
     SavedChartVersionsTableName,
 } from '../database/entities/savedCharts';
+import { SavedChartSlugMappingsTableName } from '../database/entities/savedChartSlugMappings';
 import { SchedulerTableName } from '../database/entities/scheduler';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
@@ -446,8 +447,8 @@ const getSavedChartSlugOwner = async (
     database: Knex,
     projectUuid: string,
     slug: string,
-): Promise<SavedChartSlugOwner | undefined> =>
-    database(SavedChartsTableName)
+): Promise<SavedChartSlugOwner | undefined> => {
+    const canonicalOwner = await database(SavedChartsTableName)
         .where(`${SavedChartsTableName}.project_uuid`, projectUuid)
         .where(`${SavedChartsTableName}.slug`, slug)
         .select(
@@ -455,6 +456,22 @@ const getSavedChartSlugOwner = async (
             `${SavedChartsTableName}.deleted_at`,
         )
         .first();
+    if (canonicalOwner) return canonicalOwner;
+
+    return database(SavedChartSlugMappingsTableName)
+        .innerJoin(
+            SavedChartsTableName,
+            `${SavedChartsTableName}.saved_query_uuid`,
+            `${SavedChartSlugMappingsTableName}.saved_query_uuid`,
+        )
+        .where(`${SavedChartSlugMappingsTableName}.project_uuid`, projectUuid)
+        .where(`${SavedChartSlugMappingsTableName}.slug`, slug)
+        .select(
+            `${SavedChartsTableName}.saved_query_uuid`,
+            `${SavedChartsTableName}.deleted_at`,
+        )
+        .first();
+};
 
 const resolveForcedChartSlug = async (
     database: Knex,
@@ -1549,13 +1566,49 @@ export class SavedChartModel {
             savedChartUuidOrSlug,
         );
 
-        // Fallback for uuid-shaped slugs
-        const lookupBySlug = buildProbe().where(
+        // Fallback for uuid-shaped canonical slugs
+        const lookupByCanonicalSlug = buildProbe().where(
             `${SavedChartsTableName}.slug`,
             savedChartUuidOrSlug,
         );
 
-        void queryBuilder.unionAll([lookupByUuid, lookupBySlug], true);
+        // Fallback for uuid-shaped historical slugs
+        const lookupByHistoricalSlug = buildProbe()
+            .innerJoin(
+                SavedChartSlugMappingsTableName,
+                `${SavedChartSlugMappingsTableName}.saved_query_uuid`,
+                `${SavedChartsTableName}.saved_query_uuid`,
+            )
+            .where(
+                `${SavedChartSlugMappingsTableName}.slug`,
+                savedChartUuidOrSlug,
+            );
+
+        void queryBuilder.unionAll(
+            [lookupByUuid, lookupByCanonicalSlug, lookupByHistoricalSlug],
+            true,
+        );
+    }
+
+    private applyChartSlugFilter(
+        queryBuilder: Knex.QueryBuilder,
+        slugs: string[],
+    ): void {
+        void queryBuilder.where((slugQuery) => {
+            void slugQuery
+                .whereIn(`${SavedChartsTableName}.slug`, slugs)
+                .orWhereExists(
+                    this.database(SavedChartSlugMappingsTableName)
+                        .select(this.database.raw('1'))
+                        .whereRaw(
+                            `${SavedChartSlugMappingsTableName}.saved_query_uuid = ${SavedChartsTableName}.saved_query_uuid`,
+                        )
+                        .whereIn(
+                            `${SavedChartSlugMappingsTableName}.slug`,
+                            slugs,
+                        ),
+                );
+        });
     }
 
     async get(
@@ -1707,10 +1760,9 @@ export class SavedChartModel {
                             `${SavedChartsTableName}.saved_query_id = ANY(ARRAY(SELECT saved_query_id FROM chart_lookup))`,
                         );
                 } else {
-                    void chartQuery.where(
-                        `${SavedChartsTableName}.slug`,
+                    this.applyChartSlugFilter(chartQuery, [
                         savedChartUuidOrSlug,
-                    );
+                    ]);
                 }
 
                 if (options?.projectUuid) {
@@ -2258,6 +2310,17 @@ export class SavedChartModel {
         return charts.map((chart) => chart.slug);
     }
 
+    async getSlugAliasesForUuids(uuids: string[]): Promise<string[]> {
+        if (uuids.length === 0) return [];
+        const aliases = await this.database(SavedChartSlugMappingsTableName)
+            .whereIn(
+                `${SavedChartSlugMappingsTableName}.saved_query_uuid`,
+                uuids,
+            )
+            .select(`${SavedChartSlugMappingsTableName}.slug`);
+        return aliases.map((alias) => alias.slug);
+    }
+
     async find(filters: {
         projectUuid?: string;
         spaceUuids?: string[];
@@ -2350,16 +2413,10 @@ export class SavedChartModel {
                     );
                 }
                 if (filters.slug) {
-                    void query.where(
-                        `${SavedChartsTableName}.slug`,
-                        filters.slug,
-                    );
+                    this.applyChartSlugFilter(query, [filters.slug]);
                 }
                 if (filters.slugs) {
-                    void query.whereIn(
-                        `${SavedChartsTableName}.slug`,
-                        filters.slugs,
-                    );
+                    this.applyChartSlugFilter(query, filters.slugs);
                 }
 
                 if (filters.exploreName) {

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -12,6 +12,18 @@ import { CoderService } from './CoderService';
 import { withTileWarnings } from './dashboardReferences';
 
 describe('CoderService', () => {
+    describe('getMissingIds', () => {
+        it('recognizes requested chart aliases as downloaded content', () => {
+            expect(
+                CoderService.getMissingIds(
+                    ['old-orders'],
+                    [{ uuid: 'chart-uuid', slug: 'orders' }],
+                    ['old-orders'],
+                ),
+            ).toEqual([]);
+        });
+    });
+
     describe('transformChart', () => {
         it('identifies the chart when its space is missing', () => {
             expect(() =>

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -1916,13 +1916,15 @@ export class CoderService extends BaseService {
     static getMissingIds(
         ids: string[] | undefined,
         items: Pick<SavedChartDAO | DashboardDAO, 'slug' | 'uuid'>[],
+        aliases: string[] = [],
     ) {
+        const aliasSet = new Set(aliases);
         return ids
             ? ids.reduce<string[]>((acc, id) => {
                   const exists = items.some(
                       (item) => id === item.uuid || id === item.slug,
                   );
-                  if (!exists) {
+                  if (!exists && !aliasSet.has(id)) {
                       acc.push(id);
                   }
                   return acc;
@@ -2195,11 +2197,13 @@ export class CoderService extends BaseService {
             await this.dashboardModel.getSlugsForUuids(dashboardUuids);
 
         const chartUuids = charts.map((chart) => chart.uuid);
-        const chartVerificationMap =
-            await this.contentVerificationModel.getByContentUuids(
+        const [chartVerificationMap, chartAliases] = await Promise.all([
+            this.contentVerificationModel.getByContentUuids(
                 ContentType.CHART,
                 chartUuids,
-            );
+            ),
+            this.savedChartModel.getSlugAliasesForUuids(chartUuids),
+        ]);
 
         const transformedCharts = charts.map((chart) =>
             CoderService.transformChart(
@@ -2210,7 +2214,11 @@ export class CoderService extends BaseService {
             ),
         );
 
-        const missingIds = CoderService.getMissingIds(chartIds, charts);
+        const missingIds = CoderService.getMissingIds(
+            chartIds,
+            charts,
+            chartAliases,
+        );
 
         return {
             charts: transformedCharts,
@@ -2922,6 +2930,7 @@ export class CoderService extends BaseService {
             chart: {
                 ...promotedChart.chart,
                 ...chartWithDefaults,
+                slug: chart.slug,
                 projectUuid,
                 organizationUuid: project.organizationUuid,
             },

--- a/packages/backend/src/utils/SlugUtils.test.ts
+++ b/packages/backend/src/utils/SlugUtils.test.ts
@@ -3,6 +3,7 @@ import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { AppsTableName } from '../database/entities/apps';
 import { DashboardsTableName } from '../database/entities/dashboards';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
+import { SavedChartSlugMappingsTableName } from '../database/entities/savedChartSlugMappings';
 import { SavedSqlTableName } from '../database/entities/savedSql';
 import { SpaceTableName } from '../database/entities/spaces';
 import { generateUniqueSlugScopedToProject } from './SlugUtils';
@@ -21,6 +22,7 @@ describe('generateUniqueSlugScopedToProject', () => {
 
     it('uses the saved chart project UUID directly', async () => {
         tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
 
         const slug = await generateUniqueSlugScopedToProject(
             database,
@@ -38,6 +40,7 @@ describe('generateUniqueSlugScopedToProject', () => {
     it('preserves a unique long chart slug', async () => {
         const longName = 'a'.repeat(300);
         tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
 
         const slug = await generateUniqueSlugScopedToProject(
             database,
@@ -58,6 +61,7 @@ describe('generateUniqueSlugScopedToProject', () => {
             .select(SavedChartsTableName)
             .responseOnce([{ saved_query_id: 2 }]);
         tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
 
         const slug = await generateUniqueSlugScopedToProject(
             database,
@@ -68,7 +72,7 @@ describe('generateUniqueSlugScopedToProject', () => {
 
         expect(slug).toHaveLength(255);
         expect(slug.endsWith('-2')).toBe(true);
-        expect(tracker.history.select).toHaveLength(3);
+        expect(tracker.history.select).toHaveLength(4);
         expect(tracker.history.select[1].sql).toContain('"slug" = $2');
         expect(tracker.history.select[1].bindings).toContain(
             `${'a'.repeat(253)}-1`,
@@ -80,6 +84,7 @@ describe('generateUniqueSlugScopedToProject', () => {
             .select(SavedChartsTableName)
             .responseOnce([{ saved_query_id: 1 }]);
         tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
 
         const slug = await generateUniqueSlugScopedToProject(
             database,
@@ -89,6 +94,30 @@ describe('generateUniqueSlugScopedToProject', () => {
         );
 
         expect(slug).toBe(`${'a'.repeat(253)}-1`);
+    });
+
+    it('skips historical chart slugs', async () => {
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on
+            .select(SavedChartSlugMappingsTableName)
+            .responseOnce([{ slug: 'orders' }]);
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
+
+        const slug = await generateUniqueSlugScopedToProject(
+            database,
+            '22222222-2222-4222-8222-222222222222',
+            SavedChartsTableName,
+            'Orders',
+        );
+
+        expect(slug).toBe('orders-1');
+        const historyQueries = tracker.history.select.filter((query) =>
+            query.sql.includes(SavedChartSlugMappingsTableName),
+        );
+        expect(historyQueries).toHaveLength(2);
+        expect(historyQueries[0].bindings).toContain('orders');
+        expect(historyQueries[1].bindings).toContain('orders-1');
     });
 
     it('uses direct project ownership and exact probes for dashboards', async () => {

--- a/packages/backend/src/utils/SlugUtils.ts
+++ b/packages/backend/src/utils/SlugUtils.ts
@@ -3,6 +3,7 @@ import { Knex } from 'knex';
 import { AppsTableName } from '../database/entities/apps';
 import { DashboardsTableName } from '../database/entities/dashboards';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
+import { SavedChartSlugMappingsTableName } from '../database/entities/savedChartSlugMappings';
 import { SavedSqlTableName } from '../database/entities/savedSql';
 import { SpaceTableName } from '../database/entities/spaces';
 
@@ -106,7 +107,22 @@ export async function generateUniqueSlugScopedToProject(
             .where(ownerColumn, projectOwner)
             .where(`${tableName}.slug`, candidate)
             .first();
-        if (!existing) return candidate;
+        let isReserved = existing !== undefined;
+
+        if (!isReserved && tableName === SavedChartsTableName) {
+            // eslint-disable-next-line no-await-in-loop
+            const historical = await trx(SavedChartSlugMappingsTableName)
+                .select(`${SavedChartSlugMappingsTableName}.slug`)
+                .where(
+                    `${SavedChartSlugMappingsTableName}.project_uuid`,
+                    projectOwner,
+                )
+                .where(`${SavedChartSlugMappingsTableName}.slug`, candidate)
+                .first();
+            isReserved = historical !== undefined;
+        }
+
+        if (!isReserved) return candidate;
         increment += 1;
     }
 }


### PR DESCRIPTION
## Summary

- add an empty, project-scoped chart slug history table with no backfill, triggers, or database functions
- keep `saved_queries.slug` as the sole canonical slug and reserve aliases with `UNIQUE (project_uuid, slug)`
- resolve charts through either their current slug or service-managed aliases
- make content-as-code uploads through an alias preserve the current canonical slug
- make CLI downloads through an alias emit canonical YAML without reporting the alias as missing
- make generated chart slugs avoid both current and aliased slugs

## Validation

- applied the simplified migration and verified the alias table starts empty with no trigger functions or canonical-state column
- verified current and old slugs resolve to the same chart
- uploaded through an alias: no duplicate, no slug change, and no content changes
- downloaded through an alias: canonical slug returned and `missingIds` remained empty
- `pnpm -F backend exec vitest run --config vitest.config.ts src/utils/SlugUtils.test.ts src/models/SavedChartModel.test.ts src/services/CoderService/CoderService.test.ts` — 77 passed
- `pnpm -F backend typecheck`
- targeted backend lint, formatting, and migration-safety checks

Closes: SPK-1069