### PR TITLE
fix: creating an AI agent issue with related content failed with a 500

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -30,6 +30,12 @@ import type {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 
+type JsonbWrites<T, K extends keyof T> = Omit<T, K> & {
+    [P in K]: null extends T[P]
+        ? Knex.Raw<NonNullable<T[P]>> | null
+        : Knex.Raw<T[P]>;
+};
+
 export const AiAgentReviewClassifierRunTableName = 'ai_agent_review_run';
 
 export type DbAiAgentReviewClassifierRun = {
@@ -55,29 +61,32 @@ export type DbAiAgentReviewClassifierRun = {
 
 export type AiAgentReviewClassifierRunTable = Knex.CompositeTableType<
     DbAiAgentReviewClassifierRun,
-    Pick<
-        DbAiAgentReviewClassifierRun,
-        | 'organization_uuid'
-        | 'review_agent_version'
-        | 'judge_prompt_hash'
-        | 'run_scope'
-    > &
-        Partial<
-            Pick<
-                DbAiAgentReviewClassifierRun,
-                | 'agent_config_snapshot_hash'
-                | 'agent_config_snapshot'
-                | 'agent_config_snapshot_agent_updated_at'
-                | 'status'
-                | 'total_turns'
-                | 'processed_turns'
-                | 'signal_count'
-                | 'finding_count'
-                | 'review_item_count'
-                | 'error_message'
-                | 'completed_at'
-            >
-        >,
+    JsonbWrites<
+        Pick<
+            DbAiAgentReviewClassifierRun,
+            | 'organization_uuid'
+            | 'review_agent_version'
+            | 'judge_prompt_hash'
+            | 'run_scope'
+        > &
+            Partial<
+                Pick<
+                    DbAiAgentReviewClassifierRun,
+                    | 'agent_config_snapshot_hash'
+                    | 'agent_config_snapshot'
+                    | 'agent_config_snapshot_agent_updated_at'
+                    | 'status'
+                    | 'total_turns'
+                    | 'processed_turns'
+                    | 'signal_count'
+                    | 'finding_count'
+                    | 'review_item_count'
+                    | 'error_message'
+                    | 'completed_at'
+                >
+            >,
+        'run_scope' | 'agent_config_snapshot'
+    >,
     Partial<
         Pick<
             DbAiAgentReviewClassifierRun,
@@ -132,14 +141,48 @@ export type DbAiAgentTurnSignal = {
 
 export type AiAgentTurnSignalTable = Knex.CompositeTableType<
     DbAiAgentTurnSignal,
-    Omit<
-        DbAiAgentTurnSignal,
-        | 'ai_agent_review_turn_signal_uuid'
-        | 'created_at'
-        | 'promoted_to_finding'
-        | 'promotion_reason'
-        | 'fingerprint'
-        | 'primary_root_cause'
+    JsonbWrites<
+        Omit<
+            DbAiAgentTurnSignal,
+            | 'ai_agent_review_turn_signal_uuid'
+            | 'created_at'
+            | 'promoted_to_finding'
+            | 'promotion_reason'
+            | 'fingerprint'
+            | 'primary_root_cause'
+            | 'secondary_root_causes'
+            | 'subcategories'
+            | 'fix_targets'
+            | 'target_refs'
+            | 'evidence_excerpts'
+            | 'recommendation'
+            | 'project_context_entry'
+            | 'owner_type'
+            | 'review_item_title'
+            | 'review_item_description'
+        > &
+            Partial<
+                Pick<
+                    DbAiAgentTurnSignal,
+                    | 'promoted_to_finding'
+                    | 'promotion_reason'
+                    | 'fingerprint'
+                    | 'primary_root_cause'
+                    | 'secondary_root_causes'
+                    | 'subcategories'
+                    | 'fix_targets'
+                    | 'target_refs'
+                    | 'evidence_excerpts'
+                    | 'recommendation'
+                    | 'project_context_entry'
+                    | 'owner_type'
+                    | 'review_item_title'
+                    | 'review_item_description'
+                >
+            >,
+        | 'source_ref'
+        | 'implicit_signal_sources'
+        | 'tool_evidence_refs'
         | 'secondary_root_causes'
         | 'subcategories'
         | 'fix_targets'
@@ -147,29 +190,9 @@ export type AiAgentTurnSignalTable = Knex.CompositeTableType<
         | 'evidence_excerpts'
         | 'recommendation'
         | 'project_context_entry'
-        | 'owner_type'
-        | 'review_item_title'
-        | 'review_item_description'
-    > &
-        Partial<
-            Pick<
-                DbAiAgentTurnSignal,
-                | 'promoted_to_finding'
-                | 'promotion_reason'
-                | 'fingerprint'
-                | 'primary_root_cause'
-                | 'secondary_root_causes'
-                | 'subcategories'
-                | 'fix_targets'
-                | 'target_refs'
-                | 'evidence_excerpts'
-                | 'recommendation'
-                | 'project_context_entry'
-                | 'owner_type'
-                | 'review_item_title'
-                | 'review_item_description'
-            >
-        >,
+        | 'runtime_context_snapshot'
+        | 'model_metadata'
+    >,
     Partial<
         Pick<DbAiAgentTurnSignal, 'promoted_to_finding' | 'promotion_reason'>
     >
@@ -268,26 +291,32 @@ export type DbAiAgentReviewItem = {
 
 export type AiAgentReviewItemTable = Knex.CompositeTableType<
     DbAiAgentReviewItem,
-    Pick<
-        DbAiAgentReviewItem,
-        'fingerprint' | 'organization_uuid' | 'project_uuid' | 'agent_uuid'
-    > &
+    JsonbWrites<
+        Pick<
+            DbAiAgentReviewItem,
+            'fingerprint' | 'organization_uuid' | 'project_uuid' | 'agent_uuid'
+        > &
+            Partial<
+                Omit<
+                    DbAiAgentReviewItem,
+                    | 'created_at'
+                    | 'updated_at'
+                    | 'fingerprint'
+                    | 'organization_uuid'
+                    | 'project_uuid'
+                    | 'agent_uuid'
+                >
+            >,
+        'target_refs' | 'project_context_entry'
+    >,
+    JsonbWrites<
         Partial<
             Omit<
                 DbAiAgentReviewItem,
-                | 'created_at'
-                | 'updated_at'
-                | 'fingerprint'
-                | 'organization_uuid'
-                | 'project_uuid'
-                | 'agent_uuid'
+                'ai_agent_review_item_uuid' | 'fingerprint' | 'created_at'
             >
         >,
-    Partial<
-        Omit<
-            DbAiAgentReviewItem,
-            'ai_agent_review_item_uuid' | 'fingerprint' | 'created_at'
-        >
+        'target_refs' | 'project_context_entry'
     >
 >;
 

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -560,7 +560,7 @@ export class AiAgentReviewClassifierModel {
         this.database = database;
     }
 
-    private jsonb(value: unknown): Knex.Raw {
+    private jsonb<T>(value: T): Knex.Raw<T> {
         return this.database.raw('?::jsonb', [JSON.stringify(value)]);
     }
 
@@ -728,10 +728,10 @@ export class AiAgentReviewClassifierModel {
                 organization_uuid: args.organizationUuid,
                 review_agent_version: args.reviewAgentVersion,
                 judge_prompt_hash: args.judgePromptHash,
-                run_scope: this.jsonb(args.runScope) as never,
+                run_scope: this.jsonb(args.runScope),
                 agent_config_snapshot_hash: args.agentConfigSnapshotHash,
                 agent_config_snapshot: args.agentConfigSnapshot
-                    ? (this.jsonb(args.agentConfigSnapshot) as never)
+                    ? this.jsonb(args.agentConfigSnapshot)
                     : null,
                 agent_config_snapshot_agent_updated_at:
                     args.agentConfigSnapshotAgentUpdatedAt,
@@ -1660,7 +1660,9 @@ export class AiAgentReviewClassifierModel {
                 primary_root_cause: args.primaryRootCause,
                 priority: args.priority,
                 target_refs:
-                    args.targetRefs.length > 0 ? args.targetRefs : null,
+                    args.targetRefs.length > 0
+                        ? this.jsonb(args.targetRefs)
+                        : null,
                 status: 'open',
                 assigned_to_user_uuid: args.assignedToUserUuid,
                 created_by_user_uuid: args.createdByUserUuid,
@@ -1751,9 +1753,7 @@ export class AiAgentReviewClassifierModel {
             primary_root_cause: 'project_context' as const,
             priority: 'none' as const,
             target_refs: null,
-            project_context_entry: JSON.stringify(
-                args.projectContextEntry,
-            ) as never,
+            project_context_entry: this.jsonb(args.projectContextEntry),
             nomination_reason: args.nominationReason,
             status: 'open' as const,
             dismissed_reason: null,
@@ -2806,49 +2806,45 @@ export class AiAgentReviewClassifierModel {
                     project_uuid: turnSignal.subject.projectUuid,
                     agent_uuid: turnSignal.subject.agentUuid,
                     interaction_source: turnSignal.interactionSource,
-                    source_ref: this.jsonb(turnSignal.sourceRef) as never,
+                    source_ref: this.jsonb(turnSignal.sourceRef),
                     signal: turnSignal.signal,
                     implicit_signal_sources: this.jsonb(
                         turnSignal.implicitSignalSources,
-                    ) as never,
+                    ),
                     confidence: turnSignal.confidence,
                     promoted_to_finding: turnSignal.promotedToFinding,
                     promotion_reason: turnSignal.promotionReason,
-                    tool_evidence_refs: this.jsonb(
-                        turnSignal.toolEvidenceRefs,
-                    ) as never,
+                    tool_evidence_refs: this.jsonb(turnSignal.toolEvidenceRefs),
                     fingerprint: finding?.reviewItem.fingerprint,
                     primary_root_cause: finding?.primaryRootCause,
                     secondary_root_causes: finding
-                        ? (this.jsonb(finding.secondaryRootCauses) as never)
+                        ? this.jsonb(finding.secondaryRootCauses)
                         : null,
                     subcategories: finding
-                        ? (this.jsonb(finding.subcategories) as never)
+                        ? this.jsonb(finding.subcategories)
                         : null,
                     fix_targets: finding
-                        ? (this.jsonb(finding.fixTargets) as never)
+                        ? this.jsonb(finding.fixTargets)
                         : null,
                     target_refs: finding
-                        ? (this.jsonb(finding.targetRefs) as never)
+                        ? this.jsonb(finding.targetRefs)
                         : null,
                     evidence_excerpts: finding
-                        ? (this.jsonb(finding.evidenceExcerpts) as never)
+                        ? this.jsonb(finding.evidenceExcerpts)
                         : null,
-                    recommendation: finding
-                        ? (this.jsonb(finding.recommendation) as never)
+                    recommendation: finding?.recommendation
+                        ? this.jsonb(finding.recommendation)
                         : null,
-                    project_context_entry: finding
-                        ? (this.jsonb(finding.projectContextEntry) as never)
+                    project_context_entry: finding?.projectContextEntry
+                        ? this.jsonb(finding.projectContextEntry)
                         : null,
                     owner_type: finding?.reviewItem.ownerType,
                     review_item_title: finding?.reviewItem.title,
                     review_item_description: finding?.reviewItem.description,
                     runtime_context_snapshot: this.jsonb(
                         turnSignal.runtimeContextSnapshot,
-                    ) as never,
-                    model_metadata: this.jsonb(
-                        turnSignal.modelMetadata,
-                    ) as never,
+                    ),
+                    model_metadata: this.jsonb(turnSignal.modelMetadata),
                 })
                 .returning('ai_agent_review_turn_signal_uuid');
 


### PR DESCRIPTION
Creating an issue from the AI admin board with target refs attached (related explores or content) always failed with an unexpected server error. Bare JS values bound to jsonb columns are serialized by the pg driver as Postgres array literals, which Postgres rejects as invalid json; the jsonb write columns are now typed so the compiler enforces the raw jsonb binding.