### PR TITLE
feat(permissions): add preview-scoped data app scopes for CLI users

### DIFF
--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -8,6 +8,7 @@ import {
     type ExternalConnectionListItem,
     type ExternalConnectionSample,
     type ExternalConnectionSampleRequest,
+    type ProjectType,
     type UpdateExternalConnection,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
@@ -420,6 +421,42 @@ export class ExternalConnectionModel {
                 'organizations.organization_uuid',
             );
         return row?.organization_uuid ?? null;
+    }
+
+    async findProjectAbilityContext(projectUuid: string): Promise<{
+        organizationUuid: string;
+        projectType: ProjectType;
+        projectCreatedByUserUuid: string | null;
+        upstreamProjectUuid: string | null;
+    } | null> {
+        const row = await this.database('projects')
+            .innerJoin(
+                'organizations',
+                'organizations.organization_id',
+                'projects.organization_id',
+            )
+            .where('projects.project_uuid', projectUuid)
+            .first<
+                | {
+                      organization_uuid: string;
+                      project_type: ProjectType;
+                      created_by_user_uuid: string | null;
+                      copied_from_project_uuid: string | null;
+                  }
+                | undefined
+            >(
+                'organizations.organization_uuid',
+                'projects.project_type',
+                'projects.created_by_user_uuid',
+                'projects.copied_from_project_uuid',
+            );
+        if (!row) return null;
+        return {
+            organizationUuid: row.organization_uuid,
+            projectType: row.project_type,
+            projectCreatedByUserUuid: row.created_by_user_uuid,
+            upstreamProjectUuid: row.copied_from_project_uuid,
+        };
     }
 
     /** Strips the secret — returns the READ shape only. */

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppPreviewScope.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppPreviewScope.test.ts
@@ -1,0 +1,241 @@
+import { Ability, AbilityBuilder } from '@casl/ability';
+import {
+    buildAbilityFromScopes,
+    ForbiddenError,
+    ProjectType,
+    type MemberAbility,
+    type SessionUser,
+} from '@lightdash/common';
+import { AppGenerateService } from './AppGenerateService';
+
+vi.mock('e2b', () => ({
+    Sandbox: class {},
+    CommandExitError: class extends Error {},
+    ALL_TRAFFIC: '*',
+}));
+vi.mock('ai', () => ({
+    generateObject: vi.fn(),
+}));
+
+const ORG_UUID = 'org-1';
+const USER_UUID = 'user-1';
+const PRODUCTION_PROJECT_UUID = 'production-1';
+const OWN_PREVIEW_UUID = 'preview-own';
+const OTHERS_PREVIEW_UUID = 'preview-others';
+
+const PROJECTS = {
+    [PRODUCTION_PROJECT_UUID]: {
+        organizationUuid: ORG_UUID,
+        projectUuid: PRODUCTION_PROJECT_UUID,
+        name: 'Production',
+        type: ProjectType.DEFAULT,
+        createdByUserUuid: USER_UUID,
+        upstreamProjectUuid: undefined,
+    },
+    [OWN_PREVIEW_UUID]: {
+        organizationUuid: ORG_UUID,
+        projectUuid: OWN_PREVIEW_UUID,
+        name: 'Own preview',
+        type: ProjectType.PREVIEW,
+        createdByUserUuid: USER_UUID,
+        upstreamProjectUuid: PRODUCTION_PROJECT_UUID,
+    },
+    [OTHERS_PREVIEW_UUID]: {
+        organizationUuid: ORG_UUID,
+        projectUuid: OTHERS_PREVIEW_UUID,
+        name: "Someone else's preview",
+        type: ProjectType.PREVIEW,
+        createdByUserUuid: 'another-user',
+        upstreamProjectUuid: PRODUCTION_PROJECT_UUID,
+    },
+};
+
+const buildPreviewOnlyUser = (scopes: string[]): SessionUser => {
+    const builder = new AbilityBuilder<MemberAbility>(Ability);
+    buildAbilityFromScopes(
+        {
+            userUuid: USER_UUID,
+            projectUuid: PRODUCTION_PROJECT_UUID,
+            scopes,
+            isEnterprise: true,
+        },
+        builder,
+    );
+    return {
+        userUuid: USER_UUID,
+        organizationUuid: ORG_UUID,
+        ability: builder.build(),
+    } as unknown as SessionUser;
+};
+
+type AssertFn = (
+    user: SessionUser,
+    action: 'view' | 'create' | 'manage',
+    projectUuid: string,
+    errorMessage: string,
+    extraContext?: Record<string, unknown>,
+) => Promise<void>;
+
+const buildService = () =>
+    new AppGenerateService({
+        lightdashConfig: {} as never,
+        analytics: {} as never,
+        analyticsModel: {} as never,
+        catalogModel: {} as never,
+        appModel: {
+            listAppsByProject: vi.fn().mockResolvedValue([
+                {
+                    app_id: 'app-1',
+                    name: 'Preview app',
+                    slug: 'preview-app',
+                },
+            ]),
+        } as never,
+        featureFlagModel: {
+            get: vi.fn().mockResolvedValue({ enabled: true }),
+        } as never,
+        organizationDesignModel: {} as never,
+        pinnedListModel: {} as never,
+        projectModel: {
+            getSummary: vi
+                .fn()
+                .mockImplementation(async (projectUuid: string) => {
+                    const project =
+                        PROJECTS[projectUuid as keyof typeof PROJECTS];
+                    if (!project) throw new Error('unknown project');
+                    return project;
+                }),
+        } as never,
+        projectParametersModel: {} as never,
+        spaceModel: {} as never,
+        savedChartModel: {} as never,
+        schedulerClient: {} as never,
+        savedChartService: {} as never,
+        spacePermissionService: {} as never,
+        coderService: {} as never,
+        dashboardService: {} as never,
+        projectService: {} as never,
+        promoteService: {} as never,
+        externalConnectionModel: {} as never,
+        sandboxRegistryModel: {} as never,
+        orgAiCopilotConfigResolver: {} as never,
+    });
+
+const buildAssert = (): AssertFn => {
+    const service = buildService();
+    return (
+        service as unknown as { assertDataAppAbility: AssertFn }
+    ).assertDataAppAbility.bind(service);
+};
+
+describe('DataApp preview scopes', () => {
+    const previewOnlyScopes = [
+        'view:Project',
+        'view:DataApp',
+        'create:Project@preview',
+        'create:DataApp@preview',
+        'manage:DataApp@preview',
+    ];
+
+    it('allows creating and iterating on apps in a preview the user created', async () => {
+        const assertDataAppAbility = buildAssert();
+        const user = buildPreviewOnlyUser(previewOnlyScopes);
+
+        await expect(
+            assertDataAppAbility(user, 'create', OWN_PREVIEW_UUID, 'denied'),
+        ).resolves.toBeUndefined();
+        await expect(
+            assertDataAppAbility(user, 'manage', OWN_PREVIEW_UUID, 'denied', {
+                createdByUserUuid: USER_UUID,
+            }),
+        ).resolves.toBeUndefined();
+    });
+
+    it('allows viewing apps in a preview the user created', async () => {
+        const service = buildService();
+        const user = buildPreviewOnlyUser(previewOnlyScopes);
+
+        await expect(
+            service.canViewApp(user, {
+                organization_uuid: ORG_UUID,
+                project_uuid: OWN_PREVIEW_UUID,
+                space_uuid: null,
+                created_by_user_uuid: 'another-user',
+            }),
+        ).resolves.toBe(true);
+    });
+
+    it('allows listing apps in a preview the user created', async () => {
+        const service = buildService();
+        const user = buildPreviewOnlyUser(previewOnlyScopes);
+
+        await expect(
+            service.listAppsForProject(user, OWN_PREVIEW_UUID),
+        ).resolves.toEqual([
+            {
+                appUuid: 'app-1',
+                name: 'Preview app',
+                slug: 'preview-app',
+            },
+        ]);
+    });
+
+    it('refuses uploads to production and to previews created by someone else', async () => {
+        const assertDataAppAbility = buildAssert();
+        const user = buildPreviewOnlyUser(previewOnlyScopes);
+
+        await expect(
+            assertDataAppAbility(
+                user,
+                'create',
+                PRODUCTION_PROJECT_UUID,
+                'denied',
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        await expect(
+            assertDataAppAbility(user, 'create', OTHERS_PREVIEW_UUID, 'denied'),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('explains that the role is preview-only when it is', async () => {
+        const assertDataAppAbility = buildAssert();
+        const user = buildPreviewOnlyUser(previewOnlyScopes);
+
+        await expect(
+            assertDataAppAbility(
+                user,
+                'create',
+                PRODUCTION_PROJECT_UUID,
+                'Insufficient permissions to create data apps',
+            ),
+        ).rejects.toThrow(/only allows data apps in preview projects/);
+    });
+
+    it('keeps the generic message for roles with no preview-only grant', async () => {
+        const assertDataAppAbility = buildAssert();
+        const user = buildPreviewOnlyUser(['view:Project']);
+
+        await expect(
+            assertDataAppAbility(
+                user,
+                'create',
+                PRODUCTION_PROJECT_UUID,
+                'Insufficient permissions to create data apps',
+            ),
+        ).rejects.toThrow(/^Insufficient permissions to create data apps$/);
+    });
+
+    it('leaves create:DataApp reaching production as before', async () => {
+        const assertDataAppAbility = buildAssert();
+        const user = buildPreviewOnlyUser(['view:Project', 'create:DataApp']);
+
+        await expect(
+            assertDataAppAbility(
+                user,
+                'create',
+                PRODUCTION_PROJECT_UUID,
+                'denied',
+            ),
+        ).resolves.toBeUndefined();
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppPreviewScope.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppPreviewScope.test.ts
@@ -74,7 +74,7 @@ type AssertFn = (
     projectUuid: string,
     errorMessage: string,
     extraContext?: Record<string, unknown>,
-) => Promise<void>;
+) => Promise<{ projectUuid: string }>;
 
 const buildService = () =>
     new AppGenerateService({
@@ -143,12 +143,12 @@ describe('DataApp preview scopes', () => {
 
         await expect(
             assertDataAppAbility(user, 'create', OWN_PREVIEW_UUID, 'denied'),
-        ).resolves.toBeUndefined();
+        ).resolves.toMatchObject({ projectUuid: OWN_PREVIEW_UUID });
         await expect(
             assertDataAppAbility(user, 'manage', OWN_PREVIEW_UUID, 'denied', {
                 createdByUserUuid: USER_UUID,
             }),
-        ).resolves.toBeUndefined();
+        ).resolves.toMatchObject({ projectUuid: OWN_PREVIEW_UUID });
     });
 
     it('allows viewing apps in a preview the user created', async () => {
@@ -236,6 +236,6 @@ describe('DataApp preview scopes', () => {
                 PRODUCTION_PROJECT_UUID,
                 'denied',
             ),
-        ).resolves.toBeUndefined();
+        ).resolves.toMatchObject({ projectUuid: PRODUCTION_PROJECT_UUID });
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppPreviewScope.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppPreviewScope.test.ts
@@ -208,7 +208,10 @@ describe('DataApp preview scopes', () => {
                 PRODUCTION_PROJECT_UUID,
                 'Insufficient permissions to create data apps',
             ),
-        ).rejects.toThrow(/only allows data apps in preview projects/);
+        ).rejects.toMatchObject({
+            message:
+                'Insufficient permissions to create data apps. Your role only allows data apps in preview projects you created, and this is not one.',
+        });
     });
 
     it('keeps the generic message for roles with no preview-only grant', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -10,7 +10,7 @@ import {
     S3ServiceException,
     type ObjectIdentifier,
 } from '@aws-sdk/client-s3';
-import { subject } from '@casl/ability';
+import { subject, type Ability } from '@casl/ability';
 import {
     AlreadyExistsError,
     APP_VERSION_CANCELLED_BY_USER,
@@ -42,6 +42,7 @@ import {
     MissingConfigError,
     NotFoundError,
     ParameterError,
+    ProjectType,
     QueryExecutionContext,
     resolveDefaultVisibleDataAppClaudeModel,
     sanitizeAppPackageJsonScripts,
@@ -137,6 +138,7 @@ import {
     type DbAppActivityRow,
     type DbAppVersion,
 } from '../../../database/entities/apps';
+import { type CaslAuditWrapper } from '../../../logging/caslAuditWrapper';
 import { AnalyticsModel } from '../../../models/AnalyticsModel';
 import { AppModel } from '../../../models/AppModel';
 import { CatalogModel } from '../../../models/CatalogModel/CatalogModel';
@@ -191,6 +193,7 @@ import {
 import {
     assertCanViewEmbeddedApp,
     assertCanViewApp as assertUserCanViewApp,
+    type DataAppProjectContext,
 } from './appAuthz';
 import { getBundleServableChecker } from './appBundleStorage';
 import {
@@ -553,42 +556,70 @@ export class AppGenerateService extends BaseService {
         this.orgAiCopilotConfigResolver = orgAiCopilotConfigResolver;
     }
 
-    /**
-     * Resolve the organization UUID for a project. Used to derive the CASL
-     * subject's `organizationUuid` from the resource (the project itself)
-     * rather than the user — so cross-org access attempts are denied by
-     * CASL instead of relying only on upstream project scoping.
-     */
-    private async getProjectOrgUuid(projectUuid: string): Promise<string> {
+    private async getDataAppProjectContext(
+        projectUuid: string,
+    ): Promise<DataAppProjectContext> {
         const summary = await this.projectModel.getSummary(projectUuid);
-        return summary.organizationUuid;
+        return {
+            organizationUuid: summary.organizationUuid,
+            projectUuid,
+            projectType: summary.type,
+            projectCreatedByUserUuid: summary.createdByUserUuid,
+            upstreamProjectUuid: summary.upstreamProjectUuid ?? null,
+        };
+    }
+
+    private static isPreviewOnlyDataAppGrant(
+        rules: CaslAuditWrapper<Ability>['rules'],
+        action: 'view' | 'create' | 'manage',
+    ): boolean {
+        const dataAppRules = rules.filter(
+            (rule) =>
+                rule.subject === 'DataApp' &&
+                !rule.inverted &&
+                (rule.action === action || rule.action === 'manage'),
+        );
+        return (
+            dataAppRules.length > 0 &&
+            dataAppRules.every(
+                (rule) =>
+                    (rule.conditions as Record<string, unknown> | undefined)
+                        ?.projectType === ProjectType.PREVIEW,
+            )
+        );
     }
 
     /**
      * Run a CASL check on `DataApp`, throwing `ForbiddenError` if denied.
-     * Callers must pass the resource-derived organizationUuid so that the
-     * check is a genuine cross-org guard, not a tautology on the user's own
-     * org.
      */
-    private assertDataAppAbility(
+    private async assertDataAppAbility(
         user: SessionUser,
         action: 'view' | 'create' | 'manage',
-        organizationUuid: string,
         projectUuid: string,
         errorMessage: string,
         extraContext: Record<string, unknown> = {},
-    ): void {
+    ): Promise<void> {
+        const projectContext = await this.getDataAppProjectContext(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
                 action,
                 subject('DataApp', {
-                    organizationUuid,
-                    projectUuid,
+                    ...projectContext,
                     ...extraContext,
                 }),
             )
         ) {
+            if (
+                AppGenerateService.isPreviewOnlyDataAppGrant(
+                    auditedAbility.rules,
+                    action,
+                )
+            ) {
+                throw new ForbiddenError(
+                    `${errorMessage}. Your role only allows data apps in preview projects you created, and this is not one.`,
+                );
+            }
             throw new ForbiddenError(errorMessage);
         }
     }
@@ -646,6 +677,8 @@ export class AppGenerateService extends BaseService {
                         userUuid,
                         spaceUuid,
                     ),
+                getProjectContext: (projectUuid) =>
+                    this.getDataAppProjectContext(projectUuid),
             },
             user,
             app,
@@ -677,10 +710,9 @@ export class AppGenerateService extends BaseService {
                   app.space_uuid,
               )
             : {};
-        this.assertDataAppAbility(
+        await this.assertDataAppAbility(
             user,
             'manage',
-            app.organization_uuid,
             app.project_uuid,
             errorMessage,
             {
@@ -1087,19 +1119,22 @@ export class AppGenerateService extends BaseService {
         > & {
             organization_uuid: string;
         },
+        projectContext?: DataAppProjectContext,
     ): Promise<boolean> {
-        const spaceContext = app.space_uuid
-            ? await this.spacePermissionService.getSpaceAccessContext(
-                  user.userUuid,
-                  app.space_uuid,
-              )
-            : {};
+        const [spaceContext, resolvedProjectContext] = await Promise.all([
+            app.space_uuid
+                ? this.spacePermissionService.getSpaceAccessContext(
+                      user.userUuid,
+                      app.space_uuid,
+                  )
+                : Promise.resolve({}),
+            projectContext ?? this.getDataAppProjectContext(app.project_uuid),
+        ]);
         const auditedAbility = this.createAuditedAbility(user);
         return auditedAbility.can(
             'view',
             subject('DataApp', {
-                organizationUuid: app.organization_uuid,
-                projectUuid: app.project_uuid,
+                ...resolvedProjectContext,
                 ...spaceContext,
                 createdByUserUuid: app.created_by_user_uuid,
             }),
@@ -1122,16 +1157,21 @@ export class AppGenerateService extends BaseService {
         projectUuid: string,
         apps: T[],
     ): Promise<T[]> {
+        const projectContext = await this.getDataAppProjectContext(projectUuid);
         const checks = await Promise.all(
             apps.map((app) =>
-                this.canViewApp(user, {
-                    organization_uuid: organizationUuid,
-                    project_uuid: projectUuid,
-                    space_uuid: app.spaceUuid,
-                    // A null createdBy can never match the self rule — coerce
-                    // to a sentinel that won't equal any real userUuid.
-                    created_by_user_uuid: app.createdBy?.userUuid ?? '',
-                }),
+                this.canViewApp(
+                    user,
+                    {
+                        organization_uuid: organizationUuid,
+                        project_uuid: projectUuid,
+                        space_uuid: app.spaceUuid,
+                        // A null createdBy can never match the self rule — coerce
+                        // to a sentinel that won't equal any real userUuid.
+                        created_by_user_uuid: app.createdBy?.userUuid ?? '',
+                    },
+                    projectContext,
+                ),
             ),
         );
         return apps.filter((_, i) => checks[i]);
@@ -1493,11 +1533,9 @@ export class AppGenerateService extends BaseService {
                 'Insufficient permissions to upload app files',
             );
         } else {
-            const organizationUuid = await this.getProjectOrgUuid(projectUuid);
-            this.assertDataAppAbility(
+            await this.assertDataAppAbility(
                 user,
                 'create',
-                organizationUuid,
                 projectUuid,
                 'Insufficient permissions to upload app files',
             );
@@ -3679,7 +3717,9 @@ export class AppGenerateService extends BaseService {
             // fail with EPERM. Same reason as in writeCatalogAndPrompt.
             await sandbox.commands.run(
                 'rm -f /tmp/prompt.txt 2>/dev/null; true',
-                { timeoutMs: 10_000 },
+                {
+                    timeoutMs: 10_000,
+                },
             );
             await sandbox.files.write('/tmp/prompt.txt', `${fixPrompt}\n`);
 
@@ -5201,11 +5241,11 @@ export class AppGenerateService extends BaseService {
         fileIds?: string[],
     ): Promise<{ questions: string[] }> {
         await this.assertDataAppsEnabled(user);
-        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
-        this.assertDataAppAbility(
+        const { organizationUuid } =
+            await this.getDataAppProjectContext(projectUuid);
+        await this.assertDataAppAbility(
             user,
             'create',
-            organizationUuid,
             projectUuid,
             'Insufficient permissions to create data apps',
         );
@@ -5526,11 +5566,11 @@ export class AppGenerateService extends BaseService {
         const { creationExperience, designUuidInput, externalConnections } =
             options;
         await this.assertDataAppsEnabled(user);
-        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
-        this.assertDataAppAbility(
+        const { organizationUuid } =
+            await this.getDataAppProjectContext(projectUuid);
+        await this.assertDataAppAbility(
             user,
             'create',
-            organizationUuid,
             projectUuid,
             'Insufficient permissions to create data apps',
         );
@@ -5548,10 +5588,9 @@ export class AppGenerateService extends BaseService {
                     user.userUuid,
                     spaceUuid,
                 );
-            this.assertDataAppAbility(
+            await this.assertDataAppAbility(
                 user,
                 'manage',
-                organizationUuid,
                 projectUuid,
                 'Insufficient permissions to create a data app in this space',
                 spaceContext,
@@ -5777,7 +5816,7 @@ export class AppGenerateService extends BaseService {
         // 403 rather than a model-visibility error. Scoped to the project's
         // organization (not the caller's) to match generateApp.
         const claudeModel = await this.resolveClaudeModel(
-            await this.getProjectOrgUuid(projectUuid),
+            (await this.getDataAppProjectContext(projectUuid)).organizationUuid,
             claudeModelInput,
         );
 
@@ -6689,10 +6728,9 @@ export class AppGenerateService extends BaseService {
 
         // Authoring rights on the upstream project itself — viewers of the
         // preview must not be able to write into production.
-        this.assertDataAppAbility(
+        await this.assertDataAppAbility(
             user,
             'create',
-            upstreamOrganizationUuid,
             upstreamProjectUuid,
             'Insufficient permissions to promote into the upstream project',
         );
@@ -7017,10 +7055,9 @@ export class AppGenerateService extends BaseService {
         // The duplicate lands as a personal app in the same project. We need
         // `create:DataApp` on the project itself — viewers who can read a
         // shared app but can't author new ones must not be able to fork it.
-        this.assertDataAppAbility(
+        await this.assertDataAppAbility(
             user,
             'create',
-            sourceApp.organization_uuid,
             projectUuid,
             'Insufficient permissions to duplicate this data app',
         );
@@ -7660,15 +7697,9 @@ export class AppGenerateService extends BaseService {
         projectUuid: string,
     ): Promise<EmbedProjectApp[]> {
         await this.assertDataAppsEnabled(user);
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const projectContext = await this.getDataAppProjectContext(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('DataApp', { organizationUuid, projectUuid }),
-            )
-        ) {
+        if (auditedAbility.cannot('view', subject('DataApp', projectContext))) {
             throw new ForbiddenError('Insufficient permissions');
         }
         const apps = await this.appModel.listAppsByProject(projectUuid);
@@ -8323,10 +8354,9 @@ export class AppGenerateService extends BaseService {
             });
         } else {
             await this.assertDataAppsEnabled(user);
-            this.assertDataAppAbility(
+            await this.assertDataAppAbility(
                 user,
                 'manage',
-                app.organization_uuid,
                 projectUuid,
                 'Insufficient permissions to restore data apps',
             );
@@ -8369,10 +8399,9 @@ export class AppGenerateService extends BaseService {
             });
         } else {
             await this.assertDataAppsEnabled(user);
-            this.assertDataAppAbility(
+            await this.assertDataAppAbility(
                 user,
                 'manage',
-                app.organization_uuid,
                 projectUuid,
                 'Insufficient permissions to delete data apps',
             );
@@ -8540,10 +8569,9 @@ export class AppGenerateService extends BaseService {
                     user.userUuid,
                     targetSpaceUuid,
                 );
-            this.assertDataAppAbility(
+            await this.assertDataAppAbility(
                 user,
                 'manage',
-                app.organization_uuid,
                 projectUuid,
                 "You don't have access to the space this data app is being moved to",
                 targetSpaceContext,
@@ -9507,19 +9535,21 @@ export class AppGenerateService extends BaseService {
 
         const app = await this.appModel.findApp(payload.appUuid, projectUuid);
         if (!app || app.organization_uuid !== organizationUuid) return empty();
-        const spaceContext = app.space_uuid
-            ? await this.spacePermissionService.getSpaceAccessContext(
-                  account.user.id,
-                  app.space_uuid,
-              )
-            : {};
+        const [spaceContext, projectContext] = await Promise.all([
+            app.space_uuid
+                ? this.spacePermissionService.getSpaceAccessContext(
+                      account.user.id,
+                      app.space_uuid,
+                  )
+                : Promise.resolve({}),
+            this.getDataAppProjectContext(projectUuid),
+        ]);
         const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'view',
                 subject('DataApp', {
-                    organizationUuid,
-                    projectUuid,
+                    ...projectContext,
                     ...spaceContext,
                     createdByUserUuid: app.created_by_user_uuid,
                 }),
@@ -9811,11 +9841,11 @@ export class AppGenerateService extends BaseService {
         designUuid: string | null,
     ): Promise<DataAppContext> {
         await this.assertDataAppsEnabled(user);
-        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
-        this.assertDataAppAbility(
+        const { organizationUuid } =
+            await this.getDataAppProjectContext(projectUuid);
+        await this.assertDataAppAbility(
             user,
             'create',
-            organizationUuid,
             projectUuid,
             'Insufficient permissions to create data apps',
         );
@@ -10092,7 +10122,8 @@ export class AppGenerateService extends BaseService {
             );
         }
 
-        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
+        const { organizationUuid } =
+            await this.getDataAppProjectContext(projectUuid);
 
         // Resolve manifest external-connection links up front so a broken
         // bundle rejects before creating anything.
@@ -10443,10 +10474,9 @@ export class AppGenerateService extends BaseService {
                         user.userUuid,
                         manifestSpaceUuid,
                     );
-                this.assertDataAppAbility(
+                await this.assertDataAppAbility(
                     user,
                     'manage',
-                    organizationUuid,
                     projectUuid,
                     'Insufficient permissions to move this data app into the manifest space',
                     spaceContext,
@@ -10476,10 +10506,9 @@ export class AppGenerateService extends BaseService {
                     : undefined,
             );
         } else {
-            this.assertDataAppAbility(
+            await this.assertDataAppAbility(
                 user,
                 'create',
-                organizationUuid,
                 projectUuid,
                 'Insufficient permissions to create data apps',
             );
@@ -10499,10 +10528,9 @@ export class AppGenerateService extends BaseService {
                         user.userUuid,
                         targetSpaceUuid,
                     );
-                this.assertDataAppAbility(
+                await this.assertDataAppAbility(
                     user,
                     'manage',
-                    organizationUuid,
                     projectUuid,
                     'Insufficient permissions to create a data app in this space',
                     spaceContext,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -10,7 +10,7 @@ import {
     S3ServiceException,
     type ObjectIdentifier,
 } from '@aws-sdk/client-s3';
-import { subject } from '@casl/ability';
+import { subject, type Ability } from '@casl/ability';
 import {
     AlreadyExistsError,
     APP_VERSION_CANCELLED_BY_USER,
@@ -138,6 +138,7 @@ import {
     type DbAppActivityRow,
     type DbAppVersion,
 } from '../../../database/entities/apps';
+import { type CaslAuditWrapper } from '../../../logging/caslAuditWrapper';
 import { AnalyticsModel } from '../../../models/AnalyticsModel';
 import { AppModel } from '../../../models/AppModel';
 import { CatalogModel } from '../../../models/CatalogModel/CatalogModel';
@@ -568,6 +569,30 @@ export class AppGenerateService extends BaseService {
         };
     }
 
+    private static isPreviewOnlyDataAppGrant(
+        rules: CaslAuditWrapper<Ability>['rules'],
+        action: 'view' | 'create' | 'manage',
+    ): boolean {
+        const dataAppRules = rules.filter(
+            (rule) =>
+                rule.subject === 'DataApp' &&
+                !rule.inverted &&
+                (rule.action === action || rule.action === 'manage'),
+        );
+        return (
+            dataAppRules.length > 0 &&
+            dataAppRules.every((rule) => {
+                const { conditions } = rule;
+                return (
+                    typeof conditions === 'object' &&
+                    conditions !== null &&
+                    'projectType' in conditions &&
+                    conditions.projectType === ProjectType.PREVIEW
+                );
+            })
+        );
+    }
+
     /**
      * Run a CASL check on `DataApp`, throwing `ForbiddenError` if denied.
      */
@@ -589,16 +614,12 @@ export class AppGenerateService extends BaseService {
                 }),
             )
         ) {
-            const wouldAllowInOwnPreview = auditedAbility.can(
-                action,
-                subject('DataApp', {
-                    ...projectContext,
-                    ...extraContext,
-                    projectType: ProjectType.PREVIEW,
-                    projectCreatedByUserUuid: user.userUuid,
-                }),
-            );
-            if (wouldAllowInOwnPreview) {
+            if (
+                AppGenerateService.isPreviewOnlyDataAppGrant(
+                    auditedAbility.rules,
+                    action,
+                )
+            ) {
                 throw new ForbiddenError(
                     `${errorMessage}. Your role only allows data apps in preview projects you created, and this is not one.`,
                 );

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -598,7 +598,7 @@ export class AppGenerateService extends BaseService {
         projectUuid: string,
         errorMessage: string,
         extraContext: Record<string, unknown> = {},
-    ): Promise<void> {
+    ): Promise<DataAppProjectContext> {
         const projectContext = await this.getDataAppProjectContext(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -622,6 +622,7 @@ export class AppGenerateService extends BaseService {
             }
             throw new ForbiddenError(errorMessage);
         }
+        return projectContext;
     }
 
     /**
@@ -703,14 +704,14 @@ export class AppGenerateService extends BaseService {
         },
         errorMessage: string,
         extraContext: Record<string, unknown> = {},
-    ): Promise<void> {
+    ): Promise<DataAppProjectContext> {
         const spaceContext = app.space_uuid
             ? await this.spacePermissionService.getSpaceAccessContext(
                   user.userUuid,
                   app.space_uuid,
               )
             : {};
-        await this.assertDataAppAbility(
+        return this.assertDataAppAbility(
             user,
             'manage',
             app.project_uuid,
@@ -5241,9 +5242,7 @@ export class AppGenerateService extends BaseService {
         fileIds?: string[],
     ): Promise<{ questions: string[] }> {
         await this.assertDataAppsEnabled(user);
-        const { organizationUuid } =
-            await this.getDataAppProjectContext(projectUuid);
-        await this.assertDataAppAbility(
+        const { organizationUuid } = await this.assertDataAppAbility(
             user,
             'create',
             projectUuid,
@@ -5566,9 +5565,7 @@ export class AppGenerateService extends BaseService {
         const { creationExperience, designUuidInput, externalConnections } =
             options;
         await this.assertDataAppsEnabled(user);
-        const { organizationUuid } =
-            await this.getDataAppProjectContext(projectUuid);
-        await this.assertDataAppAbility(
+        const { organizationUuid } = await this.assertDataAppAbility(
             user,
             'create',
             projectUuid,
@@ -5793,7 +5790,7 @@ export class AppGenerateService extends BaseService {
         AppGenerateService.validateFileIds(fileIds);
 
         const app = await this.appModel.getApp(appUuid, projectUuid);
-        await this.assertCanManageApp(
+        const { organizationUuid } = await this.assertCanManageApp(
             user,
             app,
             'Insufficient permissions to modify data apps',
@@ -5816,7 +5813,7 @@ export class AppGenerateService extends BaseService {
         // 403 rather than a model-visibility error. Scoped to the project's
         // organization (not the caller's) to match generateApp.
         const claudeModel = await this.resolveClaudeModel(
-            (await this.getDataAppProjectContext(projectUuid)).organizationUuid,
+            organizationUuid,
             claudeModelInput,
         );
 
@@ -9841,9 +9838,7 @@ export class AppGenerateService extends BaseService {
         designUuid: string | null,
     ): Promise<DataAppContext> {
         await this.assertDataAppsEnabled(user);
-        const { organizationUuid } =
-            await this.getDataAppProjectContext(projectUuid);
-        await this.assertDataAppAbility(
+        const { organizationUuid } = await this.assertDataAppAbility(
             user,
             'create',
             projectUuid,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -10,7 +10,7 @@ import {
     S3ServiceException,
     type ObjectIdentifier,
 } from '@aws-sdk/client-s3';
-import { subject, type Ability } from '@casl/ability';
+import { subject } from '@casl/ability';
 import {
     AlreadyExistsError,
     APP_VERSION_CANCELLED_BY_USER,
@@ -138,7 +138,6 @@ import {
     type DbAppActivityRow,
     type DbAppVersion,
 } from '../../../database/entities/apps';
-import { type CaslAuditWrapper } from '../../../logging/caslAuditWrapper';
 import { AnalyticsModel } from '../../../models/AnalyticsModel';
 import { AppModel } from '../../../models/AppModel';
 import { CatalogModel } from '../../../models/CatalogModel/CatalogModel';
@@ -569,26 +568,6 @@ export class AppGenerateService extends BaseService {
         };
     }
 
-    private static isPreviewOnlyDataAppGrant(
-        rules: CaslAuditWrapper<Ability>['rules'],
-        action: 'view' | 'create' | 'manage',
-    ): boolean {
-        const dataAppRules = rules.filter(
-            (rule) =>
-                rule.subject === 'DataApp' &&
-                !rule.inverted &&
-                (rule.action === action || rule.action === 'manage'),
-        );
-        return (
-            dataAppRules.length > 0 &&
-            dataAppRules.every(
-                (rule) =>
-                    (rule.conditions as Record<string, unknown> | undefined)
-                        ?.projectType === ProjectType.PREVIEW,
-            )
-        );
-    }
-
     /**
      * Run a CASL check on `DataApp`, throwing `ForbiddenError` if denied.
      */
@@ -610,12 +589,16 @@ export class AppGenerateService extends BaseService {
                 }),
             )
         ) {
-            if (
-                AppGenerateService.isPreviewOnlyDataAppGrant(
-                    auditedAbility.rules,
-                    action,
-                )
-            ) {
+            const wouldAllowInOwnPreview = auditedAbility.can(
+                action,
+                subject('DataApp', {
+                    ...projectContext,
+                    ...extraContext,
+                    projectType: ProjectType.PREVIEW,
+                    projectCreatedByUserUuid: user.userUuid,
+                }),
+            );
+            if (wouldAllowInOwnPreview) {
                 throw new ForbiddenError(
                     `${errorMessage}. Your role only allows data apps in preview projects you created, and this is not one.`,
                 );

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError, ParameterError } from '@lightdash/common';
+import { ForbiddenError, ParameterError, ProjectType } from '@lightdash/common';
 import { AppGenerateService } from './AppGenerateService';
 
 vi.mock('e2b', () => ({
@@ -76,7 +76,14 @@ function buildService(opts: { canManage?: boolean } = {}) {
         featureFlagModel: featureFlagModel as never,
         organizationDesignModel: {} as never,
         pinnedListModel: {} as never,
-        projectModel: {} as never,
+        projectModel: {
+            getSummary: vi.fn().mockResolvedValue({
+                organizationUuid: USER_ORG_UUID,
+                projectUuid: PROJECT_UUID,
+                type: ProjectType.DEFAULT,
+                createdByUserUuid: USER_UUID,
+            }),
+        } as never,
         projectParametersModel: {} as never,
         spaceModel: {} as never,
         savedChartModel: {} as never,
@@ -99,6 +106,7 @@ function buildService(opts: { canManage?: boolean } = {}) {
     ).mockReturnValue({
         can: () => canManage,
         cannot: () => !canManage,
+        rules: [],
     });
 
     return { service, appModel, schedulerClient, analytics };

--- a/packages/backend/src/ee/services/AppGenerateService/appAuthz.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appAuthz.ts
@@ -2,6 +2,7 @@ import { subject, type Ability } from '@casl/ability';
 import {
     ForbiddenError,
     type AnonymousAccount,
+    type ProjectType,
     type SessionUser,
 } from '@lightdash/common';
 import { type CaslAuditWrapper } from '../../../logging/caslAuditWrapper';
@@ -14,12 +15,21 @@ export type AppViewAuthzApp = {
     organization_uuid: string;
 };
 
+export type DataAppProjectContext = {
+    organizationUuid: string;
+    projectUuid: string;
+    projectType: ProjectType;
+    projectCreatedByUserUuid: string | null;
+    upstreamProjectUuid: string | null;
+};
+
 export type AppViewAuthzDeps = {
     auditedAbility: CaslAuditWrapper<Ability>;
     getSpaceAccessContext: (
         userUuid: string,
         spaceUuid: string,
     ) => Promise<Record<string, unknown>>;
+    getProjectContext: (projectUuid: string) => Promise<DataAppProjectContext>;
 };
 
 async function userCanViewApp(
@@ -27,14 +37,16 @@ async function userCanViewApp(
     user: SessionUser,
     app: AppViewAuthzApp,
 ): Promise<boolean> {
-    const spaceContext = app.space_uuid
-        ? await deps.getSpaceAccessContext(user.userUuid, app.space_uuid)
-        : {};
+    const [spaceContext, projectContext] = await Promise.all([
+        app.space_uuid
+            ? deps.getSpaceAccessContext(user.userUuid, app.space_uuid)
+            : Promise.resolve({}),
+        deps.getProjectContext(app.project_uuid),
+    ]);
     return deps.auditedAbility.can(
         'view',
         subject('DataApp', {
-            organizationUuid: app.organization_uuid,
-            projectUuid: app.project_uuid,
+            ...projectContext,
             ...spaceContext,
             createdByUserUuid: app.created_by_user_uuid,
         }),

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -1,6 +1,7 @@
 import {
     ForbiddenError,
     ParameterError,
+    ProjectType,
     type ExternalConnection,
 } from '@lightdash/common';
 import { fromJwt } from '../../../auth/account';
@@ -120,6 +121,12 @@ function buildService(opts: {
         resolveAppAlias: vi.fn().mockResolvedValue(opts.connection),
         getDecryptedSecret: vi.fn().mockResolvedValue(opts.secret ?? null),
         incrementRateCounter: vi.fn().mockResolvedValue(opts.rateCount ?? 1),
+        findProjectAbilityContext: vi.fn().mockResolvedValue({
+            organizationUuid: 'org-1',
+            projectType: ProjectType.DEFAULT,
+            projectCreatedByUserUuid: null,
+            upstreamProjectUuid: null,
+        }),
     };
     const googleTokenProvider = {
         getAccessToken: vi

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -4,6 +4,7 @@ import {
     MissingConfigError,
     NotFoundError,
     ParameterError,
+    ProjectType,
     type ExternalConnection,
     type ExternalConnectionConfigProposal,
     type ExternalConnectionListItem,
@@ -126,6 +127,12 @@ function buildService(opts: {
                 opts.connection !== undefined ? opts.connection : connection,
             ),
         getProjectOrganizationUuid: vi.fn().mockResolvedValue(orgUuid),
+        findProjectAbilityContext: vi.fn().mockResolvedValue({
+            organizationUuid: orgUuid,
+            projectType: ProjectType.DEFAULT,
+            projectCreatedByUserUuid: null,
+            upstreamProjectUuid: null,
+        }),
         list: vi.fn().mockResolvedValue(opts.connections ?? [listedConnection]),
         getDecryptedSecret: vi.fn().mockResolvedValue(opts.secret ?? 's3cr3t'),
         update:

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -42,6 +42,7 @@ import { type OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolve
 import {
     assertCanViewApp,
     assertCanViewEmbeddedApp,
+    type DataAppProjectContext,
 } from '../AppGenerateService/appAuthz';
 import { getExternalConnectionSubject } from './externalConnectionAuthz';
 import {
@@ -129,6 +130,19 @@ export class ExternalConnectionService extends BaseService {
         }
     }
 
+    private async getDataAppProjectContext(
+        projectUuid: string,
+    ): Promise<DataAppProjectContext> {
+        const context =
+            await this.externalConnectionModel.findProjectAbilityContext(
+                projectUuid,
+            );
+        if (!context) {
+            throw new NotFoundError('Project not found');
+        }
+        return { ...context, projectUuid };
+    }
+
     /**
      * Loads the app row and asserts the caller can `manage` the DataApp,
      * mirroring AppGenerateService's assertCanManageApp pattern (space
@@ -155,14 +169,16 @@ export class ExternalConnectionService extends BaseService {
                   app.space_uuid,
               )
             : {};
+        const projectContext = await this.getDataAppProjectContext(
+            app.project_uuid,
+        );
 
         const ability = this.createAuditedAbility(account);
         if (
             ability.cannot(
                 'manage',
                 subject('DataApp', {
-                    organizationUuid: app.organization_uuid,
-                    projectUuid: app.project_uuid,
+                    ...projectContext,
                     createdByUserUuid: app.created_by_user_uuid,
                     ...spaceContext,
                 }),
@@ -612,6 +628,8 @@ export class ExternalConnectionService extends BaseService {
                             userUuid,
                             spaceUuid,
                         ),
+                    getProjectContext: (appProjectUuid) =>
+                        this.getDataAppProjectContext(appProjectUuid),
                 },
                 user,
                 app,

--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -195,6 +195,19 @@ export const getContentAsCodeUploadPermissions = async (
             },
         ],
     };
+    const dataAppSubject = subject('DataApp', {
+        ...baseSubject,
+        upstreamProjectUuid: project.upstreamProjectUuid,
+        projectType: project.type,
+        projectCreatedByUserUuid: project.createdByUserUuid,
+        inheritsFromOrgOrProject: true,
+        access: [
+            {
+                userUuid: user.userUuid,
+                role: SpaceMemberRole.ADMIN,
+            },
+        ],
+    });
     const canManageScheduledDeliveries = ability.can(
         'manage',
         subject('ScheduledDeliveries', {
@@ -227,14 +240,8 @@ export const getContentAsCodeUploadPermissions = async (
             (canManageScheduledDeliveries || canCreateScheduledDeliveries) &&
             ability.can('manage', subject('GoogleSheets', { ...baseSubject })),
         dataApps:
-            ability.can(
-                'create',
-                subject('DataApp', { ...accessibleResourceSubject }),
-            ) ||
-            ability.can(
-                'manage',
-                subject('DataApp', { ...accessibleResourceSubject }),
-            ),
+            ability.can('create', dataAppSubject) ||
+            ability.can('manage', dataAppSubject),
         externalConnections: ability.can(
             'manage',
             subject('ExternalConnection', { ...baseSubject }),

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -3328,7 +3328,7 @@ export const uploadHandler = async (
             output.startItem('Data apps');
             GlobalState.log(
                 styles.warning(
-                    `Skipping data apps: create:DataApp or manage:DataApp permission is required. Dashboard tiles will resolve only if their apps already exist in this project.`,
+                    `Skipping data apps: create:DataApp or manage:DataApp permission is required for this project (the create:DataApp@preview and manage:DataApp@preview scopes only cover preview projects you created). Dashboard tiles will resolve only if their apps already exist in this project.`,
                 ),
             );
             output.completeItem('permission denied', 'warning');

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -389,6 +389,16 @@ export const applyOrganizationMemberStaticAbilities: Record<
             type: ProjectType.PREVIEW,
             createdByUserUuid: member.userUuid,
         });
+        can('create', 'DataApp', {
+            organizationUuid: member.organizationUuid,
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: member.userUuid,
+        });
+        can('manage', 'DataApp', {
+            organizationUuid: member.organizationUuid,
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: member.userUuid,
+        });
         can('view', 'JobStatus', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -323,6 +323,16 @@ export const projectMemberAbilities: Record<
             type: ProjectType.PREVIEW,
             createdByUserUuid: member.userUuid,
         });
+        can('create', 'DataApp', {
+            projectUuid: member.projectUuid,
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: member.userUuid,
+        });
+        can('manage', 'DataApp', {
+            projectUuid: member.projectUuid,
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: member.userUuid,
+        });
         can('view', 'JobStatus', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -130,6 +130,8 @@ const BASE_ROLE_SCOPES = {
         'manage:SavedChart@self',
         'manage:Space@self',
         'manage:Explore@self',
+        'create:DataApp@preview',
+        'manage:DataApp@preview',
         'view:JobStatus', // All jobs in project
         'view:SourceCode',
         'manage:SourceCode',
@@ -278,6 +280,8 @@ export const getNonEnterpriseScopesForRole = (
         'manage:DataApp',
         'manage:DataApp@space',
         'create:DataApp',
+        'create:DataApp@preview',
+        'manage:DataApp@preview',
         'view:DataApp@self',
         'manage:DataApp@self',
         'view:ExternalConnection',

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -2903,4 +2903,183 @@ describe('scopeAbilityBuilder', () => {
             expect(ability.rules.length).toBe(0);
         });
     });
+    describe('data app preview scopes', () => {
+        const buildDataAppAbility = (scopes: string[]) => {
+            const builder = new AbilityBuilder<MemberAbility>(Ability);
+            buildAbilityFromScopes({ ...baseContext, scopes }, builder);
+            return builder.build();
+        };
+
+        const ownPreviewFromDirectProject = {
+            organizationUuid: 'org-123',
+            projectUuid: 'project-123',
+            upstreamProjectUuid: 'upstream-project',
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: 'user1',
+        };
+        const ownPreviewFromUpstreamProject = {
+            organizationUuid: 'org-123',
+            projectUuid: 'preview-123',
+            upstreamProjectUuid: 'project-123',
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: 'user1',
+        };
+        const ownProduction = {
+            organizationUuid: 'org-123',
+            projectUuid: 'project-123',
+            upstreamProjectUuid: null,
+            projectType: ProjectType.DEFAULT,
+            projectCreatedByUserUuid: 'user1',
+        };
+        const othersPreview = {
+            organizationUuid: 'org-123',
+            projectUuid: 'preview-123',
+            upstreamProjectUuid: 'project-123',
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: 'another-user',
+        };
+
+        it('create:DataApp@preview only reaches previews the user created', () => {
+            const ability = buildDataAppAbility(['create:DataApp@preview']);
+
+            expect(
+                ability.can(
+                    'create',
+                    subject('DataApp', ownPreviewFromDirectProject),
+                ),
+            ).toBe(true);
+            expect(
+                ability.can(
+                    'create',
+                    subject('DataApp', ownPreviewFromUpstreamProject),
+                ),
+            ).toBe(true);
+
+            expect(
+                ability.can('create', subject('DataApp', ownProduction)),
+            ).toBe(false);
+            expect(
+                ability.can('create', subject('DataApp', othersPreview)),
+            ).toBe(false);
+        });
+
+        it('manage:DataApp@preview lets the user iterate on apps inside their own preview', () => {
+            const ability = buildDataAppAbility(['manage:DataApp@preview']);
+
+            expect(
+                ability.can(
+                    'manage',
+                    subject('DataApp', {
+                        ...ownPreviewFromDirectProject,
+                        createdByUserUuid: 'user1',
+                    }),
+                ),
+            ).toBe(true);
+
+            expect(
+                ability.can(
+                    'manage',
+                    subject('DataApp', {
+                        ...ownProduction,
+                        createdByUserUuid: 'user1',
+                    }),
+                ),
+            ).toBe(false);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('DataApp', {
+                        ...othersPreview,
+                        createdByUserUuid: 'user1',
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('keeps project ownership separate from app ownership', () => {
+            const ability = buildDataAppAbility(['manage:DataApp@self']);
+
+            expect(
+                ability.can(
+                    'manage',
+                    subject('DataApp', ownPreviewFromDirectProject),
+                ),
+            ).toBe(false);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('DataApp', {
+                        ...ownPreviewFromDirectProject,
+                        createdByUserUuid: 'user1',
+                    }),
+                ),
+            ).toBe(true);
+        });
+
+        it('the preview scopes do not grant the production create/manage rules', () => {
+            const ability = buildDataAppAbility([
+                'create:DataApp@preview',
+                'manage:DataApp@preview',
+            ]);
+
+            expect(
+                ability.can(
+                    'create',
+                    subject('DataApp', {
+                        organizationUuid: 'org-123',
+                        projectUuid: 'project-123',
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('create:DataApp still covers production and previews alike', () => {
+            const ability = buildDataAppAbility(['create:DataApp']);
+
+            expect(
+                ability.can('create', subject('DataApp', ownProduction)),
+            ).toBe(true);
+            expect(
+                ability.can(
+                    'create',
+                    subject('DataApp', ownPreviewFromDirectProject),
+                ),
+            ).toBe(true);
+        });
+
+        it('grants nothing for org-level assignments outside the user own previews', () => {
+            const builder = new AbilityBuilder<MemberAbility>(Ability);
+            buildAbilityFromScopes(
+                {
+                    ...baseContextWithOrg,
+                    scopes: ['create:DataApp@preview'],
+                },
+                builder,
+            );
+            const ability = builder.build();
+
+            expect(
+                ability.can(
+                    'create',
+                    subject('DataApp', {
+                        organizationUuid: 'org-123',
+                        projectUuid: 'preview-123',
+                        projectType: ProjectType.PREVIEW,
+                        projectCreatedByUserUuid: 'user1',
+                    }),
+                ),
+            ).toBe(true);
+            expect(
+                ability.can(
+                    'create',
+                    subject('DataApp', {
+                        organizationUuid: 'org-123',
+                        projectUuid: 'preview-123',
+                        projectType: ProjectType.PREVIEW,
+                        projectCreatedByUserUuid: 'another-user',
+                    }),
+                ),
+            ).toBe(false);
+        });
+    });
 });

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -1444,10 +1444,6 @@ const scopes: Scope[] = [
             { name: 'view:Project' },
             { name: 'create:Project@preview' },
             {
-                name: 'manage:Explore@self',
-                description: 'Run apps that query data in your preview',
-            },
-            {
                 name: 'view:ExternalConnection',
                 description: 'Link external connections while building',
             },

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -56,14 +56,30 @@ const isSelfPreview = (context: ScopeContext) =>
         context.projectCreatedByUserUuid === context.userUuid,
     );
 
-const ownPreviewProjectConditions = (context: ScopeContext) => {
+const PROJECT_PREVIEW_FIELDS = {
+    type: 'type',
+    createdByUserUuid: 'createdByUserUuid',
+} as const;
+
+const DATA_APP_PREVIEW_FIELDS = {
+    type: 'projectType',
+    createdByUserUuid: 'projectCreatedByUserUuid',
+} as const;
+
+const ownPreviewProjectConditions = (
+    context: ScopeContext,
+    fields: {
+        type: string;
+        createdByUserUuid: string;
+    } = PROJECT_PREVIEW_FIELDS,
+) => {
     if (context.organizationUuid) {
         return [
             {
                 // Org assignments can reach any preview created by this principal.
                 organizationUuid: context.organizationUuid,
-                createdByUserUuid: context.userUuid || false,
-                type: ProjectType.PREVIEW,
+                [fields.createdByUserUuid]: context.userUuid || false,
+                [fields.type]: ProjectType.PREVIEW,
             },
         ];
     }
@@ -74,17 +90,20 @@ const ownPreviewProjectConditions = (context: ScopeContext) => {
         {
             // Direct preview assignment: the grant is on the preview itself.
             projectUuid: context.projectUuid,
-            createdByUserUuid: context.userUuid,
-            type: ProjectType.PREVIEW,
+            [fields.createdByUserUuid]: context.userUuid,
+            [fields.type]: ProjectType.PREVIEW,
         },
         {
             // Upstream assignment: the grant is on the source project.
             upstreamProjectUuid: context.projectUuid,
-            createdByUserUuid: context.userUuid,
-            type: ProjectType.PREVIEW,
+            [fields.createdByUserUuid]: context.userUuid,
+            [fields.type]: ProjectType.PREVIEW,
         },
     ];
 };
+
+const ownPreviewDataAppConditions = (context: ScopeContext) =>
+    ownPreviewProjectConditions(context, DATA_APP_PREVIEW_FIELDS);
 
 /**
  * Project-wide grant inside the user's own preview. For subjects with no space
@@ -1415,6 +1434,45 @@ const scopes: Scope[] = [
             },
         ],
         getConditions: addDefaultUuidCondition,
+    },
+    {
+        name: 'create:DataApp@preview',
+        description: 'Create data apps in preview projects created by the user',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        dependencies: [
+            { name: 'view:Project' },
+            { name: 'create:Project@preview' },
+            {
+                name: 'manage:Explore@self',
+                description: 'Run apps that query data in your preview',
+            },
+            {
+                name: 'view:ExternalConnection',
+                description: 'Link external connections while building',
+            },
+            {
+                name: 'manage:DataApp@preview',
+                description: 'Open and iterate on the apps you upload',
+            },
+        ],
+        getConditions: ownPreviewDataAppConditions,
+    },
+    {
+        name: 'manage:DataApp@preview',
+        description:
+            'Edit and delete data apps in preview projects created by the user',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        dependencies: [
+            { name: 'view:Project' },
+            { name: 'create:Project@preview' },
+            {
+                name: 'create:DataApp@preview',
+                description: 'Create the apps you iterate on',
+            },
+        ],
+        getConditions: ownPreviewDataAppConditions,
     },
     {
         name: 'view:DataApp@self',


### PR DESCRIPTION
Closes: lightdash/lightdash#26915
Linear: GLITCH-656

Supersedes #26922. That PR was closed while still a draft. GitHub does not allow a reopen after a force-push, so this is the same branch raised again, rebased on current main.


### Description:

`create:DataApp` is all-or-nothing per project, so any role that lets someone build a data app in a preview also lets them upload one straight to production. This adds the missing preview-scoped variant, matching the pattern `manage:ContentAsCode@self` / `manage:DeployProject@self` already use.

* **New scopes** `create:DataApp@preview` and `manage:DataApp@preview`, conditioned on the existing own-preview project rules (both the direct-preview and upstream-project assignment shapes). `@self` is already taken on this subject with different semantics (apps the user created, anywhere), hence `@preview` — as with `create:Project@preview`. Both are added because iterating on an already-uploaded app needs `manage`, so the split mirrors the existing `create:DataApp` / `manage:DataApp` vocabulary.
* **The** `DataApp` **ability subject now carries the project's** `type`**, creator and upstream project**, so those conditions can be evaluated. They travel as `projectType` / `projectCreatedByUserUuid` / `upstreamProjectUuid`, prefixed because plain `createdByUserUuid` on this subject already means the *app's* creator (used by `manage:DataApp@self` and the space/creator checks) — the two must not collide. `assertDataAppAbility` resolves them from the project rather than taking a caller-supplied org uuid, so the cross-org guard is unchanged.
* **Clearer refusal**: when a role's only data app grant is preview-scoped and it targets a project it can't reach, the 403 now says so instead of the generic "Insufficient permissions to upload app files". The CLI's pre-flight skip message mentions the preview scope too.
* Both scopes are wired into the developer tier (redundant there, but surfaced so an admin-cloned custom role can drop production data app rights and keep preview authoring) with mirroring rules in the system-role builders. No `scoped_roles` migration needed — these are new scope names, no existing rows change.

The custom roles UI derives from `scopes.ts`, so the new scopes and their dependencies appear automatically.

**Query permissions are granted separately.** A data app reads data, so its role also needs an Explore grant. The dependency list does not name one. `manage:Explore@self` was listed at first and then removed: it only emits a rule when the role carries project context, so an organisation-level role would show a satisfied dependency and then fail at query time. Dependencies are advisory metadata in any case - the roles API does not enforce them - so an admin must grant an Explore scope that suits the assignment level.

Not covered here: the in-app UI still gates data app buttons on the production scopes. That matches how every other `@self` preview scope behaves today (the frontend doesn't pass project preview attributes into any subject), so it's left as a separate change.

**Testing:** new scope-condition tests in `scopeAbilityBuilder.test.ts` and a service-level test (`AppGenerateService.dataAppPreviewScope.test.ts`) covering a preview-only role creating/iterating in its own preview, being refused on production and on someone else's preview, and `create:DataApp` continuing to reach production. Ran the `common` authorization suite, the `AppGenerateService` + `ExternalConnectionService` suites, and typecheck/lint/format for `common`, `backend` and `cli`. One pre-existing unrelated failure (`readDesignForDownload` timeout) reproduces on `main`.

### Update since the first raise

* Rebased on current `main`. The branch was 513 commits behind. Four files conflicted: `AppGenerateService.ts`, `appAuthz.ts`, `ExternalConnectionService.ts` and its test. Main's embedded-app authorization, anonymous-account auth and JWT embedded-app path are all preserved. The project context applies only to registered-user DataApp authorization.
* A review pass found and fixed four defects in the original commit:
  * The CLI pre-flight check spread the generic resource subject into the DataApp subject. That supplied the project creator as plain `createdByUserUuid`, which can satisfy `manage:DataApp@self`. It now uses `projectCreatedByUserUuid`.
  * The preview-only 403 message matched unrelated DataApp actions. It now considers only the requested action and `manage`.
  * The list, search and custom-SQL provenance paths did not carry the preview project attributes. They do now, and the project context resolves once per bulk filter.
  * The external-connection project lookup returned an implicit `undefined`. It returns `null`.
* Verified after the rebase: `common`, `backend` and `cli` typecheck; full package tests (7,113 + 3,558 + 553 passed); lint on the touched paths.
* Removed `manage:Explore@self` from the `create:DataApp@preview` dependency list. Verified against a running EE instance: with an organisation-level assignment the two new data app scopes emit rules and `manage:Explore@self` emits none, so listing it promised a permission the role did not get. See the note above.
* Reviewed by an automated security scan of the diff, which reported nothing introduced by this change.

