### PR TITLE
fix: keep deleted scheduler filters restorable instead of resurrecting them

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.test.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.test.tsx
@@ -1,0 +1,212 @@
+import {
+    DimensionType,
+    FieldType,
+    FilterOperator,
+    type DashboardFilterRule,
+    type FilterableDimension,
+} from '@lightdash/common';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import { SchedulerFormFiltersTab } from './SchedulerFormFiltersTab';
+
+const statusField: FilterableDimension = {
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name: 'status',
+    label: 'Status',
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '${TABLE}.status',
+    hidden: false,
+};
+
+const paymentField: FilterableDimension = {
+    ...statusField,
+    name: 'payment_method',
+    label: 'Payment method',
+};
+
+const statusFilter: DashboardFilterRule = {
+    id: 'filter-status',
+    target: { fieldId: 'orders_status', tableName: 'orders' },
+    operator: FilterOperator.EQUALS,
+    values: ['completed'],
+    tileTargets: {},
+    label: undefined,
+};
+
+const paymentFilter: DashboardFilterRule = {
+    id: 'filter-payment',
+    target: { fieldId: 'orders_payment_method', tableName: 'orders' },
+    operator: FilterOperator.EQUALS,
+    values: ['credit_card'],
+    tileTargets: {},
+    label: undefined,
+};
+
+const dashboardContext = {
+    isLoadingDashboardFilters: false,
+    allFilters: {
+        dimensions: [statusFilter, paymentFilter],
+        metrics: [],
+        tableCalculations: [],
+    },
+    allFilterableFieldsMap: {
+        orders_status: statusField,
+        orders_payment_method: paymentField,
+    },
+};
+
+vi.mock('../../../../providers/Dashboard/useDashboardContext', () => ({
+    default: (selector: (context: unknown) => unknown) =>
+        selector(dashboardContext),
+}));
+
+vi.mock(
+    '../../../../providers/Dashboard/useDashboardTileStatusContext',
+    () => ({
+        default: (selector: (context: unknown) => unknown) =>
+            selector({ tileNamesById: {} }),
+    }),
+);
+
+vi.mock('../../../../hooks/useProject', () => ({
+    useProject: () => ({
+        data: { projectUuid: 'project-uuid', warehouseConnection: undefined },
+        isInitialLoading: false,
+    }),
+}));
+
+const Harness = ({
+    initialFilters,
+    isEditMode = false,
+    savedFilters = [],
+    onDraftChange,
+}: {
+    initialFilters: DashboardFilterRule[] | undefined;
+    isEditMode?: boolean;
+    savedFilters?: DashboardFilterRule[];
+    onDraftChange?: (filters: DashboardFilterRule[]) => void;
+}) => {
+    const [draftFilters, setDraftFilters] = useState(initialFilters);
+    return (
+        <SchedulerFormFiltersTab
+            draftFilters={draftFilters}
+            savedFilters={savedFilters}
+            isEditMode={isEditMode}
+            onChange={(filters) => {
+                setDraftFilters(filters);
+                onDraftChange?.(filters);
+            }}
+            unmetRequirements={[]}
+            filtersWithUnmetRequirements={[]}
+        />
+    );
+};
+
+describe('SchedulerFormFiltersTab', () => {
+    it('seeds the draft with current dashboard filters on first render', async () => {
+        const onDraftChange = vi.fn();
+        renderWithProviders(
+            <Harness
+                initialFilters={undefined}
+                onDraftChange={onDraftChange}
+            />,
+        );
+
+        await waitFor(() =>
+            expect(onDraftChange).toHaveBeenCalledWith([
+                statusFilter,
+                paymentFilter,
+            ]),
+        );
+        expect(screen.getByText('Status')).toBeInTheDocument();
+        expect(screen.getByText('Payment method')).toBeInTheDocument();
+    });
+
+    it('keeps a deleted filter visible as "uses dashboard default" instead of dropping it', async () => {
+        renderWithProviders(
+            <Harness initialFilters={[statusFilter, paymentFilter]} />,
+        );
+
+        const removeButtons = screen.getAllByRole('button', {
+            name: 'Remove filter',
+        });
+        expect(removeButtons).toHaveLength(2);
+        await userEvent.click(removeButtons[0]);
+
+        // Row stays, now restorable
+        expect(screen.getByText('Status')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Re-add filter' }),
+        ).toBeInTheDocument();
+    });
+
+    it('does not resurrect deleted filters when the last one is removed', async () => {
+        const onDraftChange = vi.fn();
+        renderWithProviders(
+            <Harness
+                initialFilters={[statusFilter, paymentFilter]}
+                onDraftChange={onDraftChange}
+            />,
+        );
+
+        await userEvent.click(
+            screen.getAllByRole('button', { name: 'Remove filter' })[0],
+        );
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Remove filter' }),
+        );
+
+        // The regression: emptying the draft re-seeded every dashboard filter
+        await waitFor(() => expect(onDraftChange).toHaveBeenLastCalledWith([]));
+        expect(
+            screen.queryAllByRole('button', { name: 'Remove filter' }),
+        ).toHaveLength(0);
+        expect(
+            screen.getAllByRole('button', { name: 'Re-add filter' }),
+        ).toHaveLength(2);
+    });
+
+    it('restores a deleted filter with the dashboard default value', async () => {
+        const onDraftChange = vi.fn();
+        renderWithProviders(
+            <Harness
+                initialFilters={[paymentFilter]}
+                onDraftChange={onDraftChange}
+            />,
+        );
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Re-add filter' }),
+        );
+
+        expect(onDraftChange).toHaveBeenLastCalledWith([
+            paymentFilter,
+            statusFilter,
+        ]);
+        expect(
+            screen.getAllByRole('button', { name: 'Remove filter' }),
+        ).toHaveLength(2);
+    });
+
+    it('shows non-overridden dashboard filters as restorable in edit mode', () => {
+        renderWithProviders(
+            <Harness
+                initialFilters={[statusFilter]}
+                savedFilters={[statusFilter]}
+                isEditMode
+            />,
+        );
+
+        // paymentFilter was deleted when the scheduler was created; it must
+        // still be visible and restorable when editing
+        expect(screen.getByText('Payment method')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Re-add filter' }),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
@@ -25,6 +25,7 @@ import {
     IconAlertTriangle,
     IconCheck,
     IconPencil,
+    IconPlus,
     IconRotate2,
     IconTrash,
 } from '@tabler/icons-react';
@@ -315,7 +316,7 @@ const RemovedFilterItem: FC<RemovedFilterItemProps> = ({
                     aria-label="Re-add filter"
                     onClick={onRestore}
                 >
-                    <MantineIcon icon={IconRotate2} />
+                    <MantineIcon icon={IconPlus} />
                 </ActionIcon>
             </Tooltip>
         </Group>

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
@@ -81,6 +81,7 @@ type SchedulerFilterItemProps = {
     onRevert: () => void;
     hasChanged: boolean;
     onRemove?: () => void;
+    removeTooltip?: string;
     tilesWithFilter?: string[];
 };
 
@@ -92,6 +93,7 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
     onRevert,
     hasChanged,
     onRemove,
+    removeTooltip = 'Remove filter',
     tilesWithFilter,
 }) => {
     const { itemsMap } =
@@ -135,7 +137,11 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
                 </Paper>
                 {onRemove && (
                     <Tooltip label="Remove invalid filter" fz="xs">
-                        <ActionIcon size="xs" onClick={onRemove}>
+                        <ActionIcon
+                            size="xs"
+                            aria-label="Remove invalid filter"
+                            onClick={onRemove}
+                        >
                             <MantineIcon icon={IconTrash} />
                         </ActionIcon>
                     </Tooltip>
@@ -210,9 +216,15 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
                         />
                     </ActionIcon>
                     {onRemove && (
-                        <ActionIcon size="xs" onClick={onRemove}>
-                            <MantineIcon icon={IconTrash} />
-                        </ActionIcon>
+                        <Tooltip label={removeTooltip} fz="xs">
+                            <ActionIcon
+                                size="xs"
+                                aria-label="Remove filter"
+                                onClick={onRemove}
+                            >
+                                <MantineIcon icon={IconTrash} />
+                            </ActionIcon>
+                        </Tooltip>
                     )}
                 </Group>
             </Group>
@@ -261,6 +273,52 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
                 </Flex>
             )}
         </Stack>
+    );
+};
+
+type RemovedFilterItemProps = {
+    dashboardFilter: DashboardFilterRule;
+    onRestore: () => void;
+};
+
+const RemovedFilterItem: FC<RemovedFilterItemProps> = ({
+    dashboardFilter,
+    onRestore,
+}) => {
+    const { itemsMap } =
+        useFiltersContext<Record<string, FilterableDimension>>();
+    const field = itemsMap[dashboardFilter.target.fieldId];
+
+    if (!field) return null;
+
+    return (
+        <Group gap="xs" wrap="nowrap" align="flex-start">
+            <Group gap="xs" opacity={0.5} style={{ flex: 1, minWidth: 0 }}>
+                <FieldIcon item={field} />
+                <FieldLabel
+                    item={{
+                        ...field,
+                        label: dashboardFilter.label ?? field.label,
+                    }}
+                    hideTableName
+                />
+                <Text fz="xs" c="ldGray.6" span>
+                    Uses dashboard default
+                </Text>
+            </Group>
+            <Tooltip
+                label="Re-add filter to override it for this delivery"
+                fz="xs"
+            >
+                <ActionIcon
+                    size="xs"
+                    aria-label="Re-add filter"
+                    onClick={onRestore}
+                >
+                    <MantineIcon icon={IconRotate2} />
+                </ActionIcon>
+            </Tooltip>
+        </Group>
     );
 };
 
@@ -374,18 +432,20 @@ export const SchedulerFormFiltersTab: FC<SchedulerFiltersProps> = ({
             };
         }, [savedFilters, currentDashboardFilters.dimensions]);
 
-    // Initialize form with live filters if no saved filters exist
+    // Seed the form with live filters exactly once (undefined = never seeded).
+    // Checking for an empty array instead would re-seed after the user removes
+    // the last filter, resurrecting every deleted filter.
     useEffect(() => {
         if (
             !isEditMode &&
-            draftFilters?.length === 0 &&
-            currentDashboardFilters.dimensions.length > 0
+            draftFilters === undefined &&
+            !isLoadingDashboardFilters
         ) {
             onChange(currentDashboardFilters.dimensions);
         }
     }, [
         currentDashboardFilters.dimensions,
-        savedFilters,
+        isLoadingDashboardFilters,
         onChange,
         draftFilters,
         isEditMode,
@@ -421,6 +481,13 @@ export const SchedulerFormFiltersTab: FC<SchedulerFiltersProps> = ({
         [onChange, draftFilters],
     );
 
+    const handleRestoreFilter = useCallback(
+        (dashboardFilter: DashboardFilterRule) => {
+            onChange([...(draftFilters ?? []), dashboardFilter]);
+        },
+        [onChange, draftFilters],
+    );
+
     if (isInitialLoading || isLoadingDashboardFilters || !project) {
         return (
             <Center component={Stack} h={100}>
@@ -450,7 +517,8 @@ export const SchedulerFormFiltersTab: FC<SchedulerFiltersProps> = ({
             startOfWeek={project.warehouseConnection?.startOfWeek ?? undefined}
             dashboardFilters={currentDashboardFilters}
         >
-            {(draftFilters?.length ?? 0) + savedFiltersNotInDashboard?.length >
+            {currentDashboardFilters.dimensions.length +
+                savedFiltersNotInDashboard.length >
             0 ? (
                 <Stack mb="sm">
                     {hasUnmetSingles && (
@@ -464,51 +532,64 @@ export const SchedulerFormFiltersTab: FC<SchedulerFiltersProps> = ({
                             requirement group
                         </Text>
                     )}
-                    {draftFilters?.map((filter) => {
-                        const originalFilter = isEditMode
-                            ? savedFiltersInDashboard?.find(
-                                  (sf) => sf.id === filter.id,
-                              )
-                            : currentDashboardFilters.dimensions.find(
-                                  (d) => d.id === filter.id,
-                              );
+                    {currentDashboardFilters.dimensions.map(
+                        (dashboardFilterRule) => {
+                            const draftFilter = draftFilters?.find(
+                                (f) => f.id === dashboardFilterRule.id,
+                            );
 
-                        if (!originalFilter) {
-                            return null;
-                        }
+                            if (!draftFilter) {
+                                return (
+                                    <RemovedFilterItem
+                                        key={dashboardFilterRule.id}
+                                        dashboardFilter={dashboardFilterRule}
+                                        onRestore={() =>
+                                            handleRestoreFilter(
+                                                dashboardFilterRule,
+                                            )
+                                        }
+                                    />
+                                );
+                            }
 
-                        return (
-                            <FilterItem
-                                key={filter.id}
-                                dashboardFilter={originalFilter}
-                                schedulerFilter={filter}
-                                isMissingRequiredValue={isMissingRequiredValue(
-                                    originalFilter,
-                                )}
-                                onChange={(updatedFilter) =>
-                                    handleUpdateSchedulerFilter(
-                                        updatedFilter,
+                            const originalFilter = isEditMode
+                                ? (savedFiltersInDashboard?.find(
+                                      (sf) => sf.id === draftFilter.id,
+                                  ) ?? dashboardFilterRule)
+                                : dashboardFilterRule;
+
+                            return (
+                                <FilterItem
+                                    key={draftFilter.id}
+                                    dashboardFilter={originalFilter}
+                                    schedulerFilter={draftFilter}
+                                    isMissingRequiredValue={isMissingRequiredValue(
                                         originalFilter,
-                                    )
-                                }
-                                onRevert={() =>
-                                    handleUpdateSchedulerFilter(
+                                    )}
+                                    onChange={(updatedFilter) =>
+                                        handleUpdateSchedulerFilter(
+                                            updatedFilter,
+                                            originalFilter,
+                                        )
+                                    }
+                                    onRevert={() =>
+                                        handleUpdateSchedulerFilter(
+                                            originalFilter,
+                                            originalFilter,
+                                        )
+                                    }
+                                    hasChanged={hasFilterChanged(
+                                        draftFilter,
                                         originalFilter,
-                                        originalFilter,
-                                    )
-                                }
-                                hasChanged={
-                                    originalFilter
-                                        ? hasFilterChanged(
-                                              filter,
-                                              originalFilter,
-                                          )
-                                        : false
-                                }
-                                onRemove={() => handleRemoveFilter(filter.id)}
-                            />
-                        );
-                    })}
+                                    )}
+                                    onRemove={() =>
+                                        handleRemoveFilter(draftFilter.id)
+                                    }
+                                    removeTooltip="Remove filter — the delivery will use the dashboard default"
+                                />
+                            );
+                        },
+                    )}
                     {savedFiltersNotInDashboard.length > 0 && (
                         <Text fz="xs" color="ldGray.6" mt="xs">
                             The following filters are applied to this scheduled

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
@@ -25,7 +25,7 @@ import {
     IconAlertTriangle,
     IconCheck,
     IconPencil,
-    IconPlus,
+    IconFilterPlus,
     IconRotate2,
     IconTrash,
 } from '@tabler/icons-react';
@@ -316,7 +316,7 @@ const RemovedFilterItem: FC<RemovedFilterItemProps> = ({
                     aria-label="Re-add filter"
                     onClick={onRestore}
                 >
-                    <MantineIcon icon={IconPlus} />
+                    <MantineIcon icon={IconFilterPlus} />
                 </ActionIcon>
             </Tooltip>
         </Group>

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -91,7 +91,8 @@ export const DEFAULT_VALUES: SchedulerFormValues = {
     slackTargets: [],
     msTeamsTargets: [],
     googleChatTargets: [],
-    dashboardFilters: [],
+    // undefined = not yet seeded from live dashboard filters; [] = user removed them all
+    dashboardFilters: undefined,
     chartFilters: undefined,
     parameters: undefined,
     customViewportWidth: undefined,

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
@@ -178,8 +178,7 @@ export const useSchedulerFormModal = ({
                 },
             },
             dashboardFilters: (value, values) => {
-                if (!value) {
-                    // Dashboard filters are undefined/null for charts
+                if (!isDashboard) {
                     return null;
                 }
                 const { unmetRequirements, filtersWithUnmetRequirements } =
@@ -220,7 +219,7 @@ export const useSchedulerFormModal = ({
                     ? 'Instructions are required'
                     : null,
         }),
-        [dashboard?.filters, filterableTiles],
+        [isDashboard, dashboard?.filters, filterableTiles],
     );
 
     const form = useSchedulerForm({


### PR DESCRIPTION
## Problem

In the scheduled delivery form, deleting a filter removed it from the list with no way to get it back — and deleting the *last* remaining filter silently resurrected every previously deleted filter.

Root cause: the effect that seeds the form with the dashboard's current filter values used `draftFilters.length === 0` as its "not initialized yet" signal, so emptying the list re-triggered the seed. On a dashboard with one exclusive filter per tab (2 filters total), deleting the second filter visibly re-added the first.

## Changes

* Seed the scheduler filter overrides exactly once: `dashboardFilters: undefined` now means "never seeded" while `[]` means "user removed every override". The sentinel lives in form state, so it survives the section unmount/remount that happens when switching between Setup and Data & format.
* Deleting a filter no longer drops the row. It stays visible semi-transparent as "Uses dashboard default" with an active reset icon that re-adds it — mirroring the existing parameters reset UX. This matches the actual delivery semantics: a filter absent from the scheduler overrides still applies at delivery time with its dashboard default value (`applyDimensionOverrides`).
* In edit mode, dashboard filters that were deleted when the delivery was created are now also shown as restorable — previously they were invisible and impossible to re-add.
* The required-filters validator now gates on resource type instead of treating an undefined filter list as "this is a chart".
* Added accessible labels to the filter row action icons and a component regression test suite.

## How to test

1. Open a dashboard with 2+ filters → `...` → Scheduled deliveries → New delivery → Data & format.
2. Delete a filter: the row dims to "Uses dashboard default" with a reset icon.
3. Delete all filters: nothing resurrects; every row stays restorable (also after switching to Setup and back).
4. Reset icon re-adds the filter with the dashboard value.
5. Edit an existing delivery that was saved without some filters: those filters now appear as restorable rows.

Closes: lightdash/lightdash#27460<br>Closes: lightdash/lightdash#27460