### PR TITLE
fix: render JSON-like strings literally

### DIFF
--- a/packages/frontend/src/hooks/useColumns.test.tsx
+++ b/packages/frontend/src/hooks/useColumns.test.tsx
@@ -3,6 +3,7 @@ import {
     FieldType,
     MetricType,
     TableCalculationType,
+    type RawResultRow,
     type ResultRow,
     type ResultValue,
 } from '@lightdash/common';
@@ -16,6 +17,7 @@ import {
     getJsonCellValue,
     getFormattedValueCell,
     getJsonLikeString,
+    getValueCell,
 } from './useColumns';
 
 /* eslint-disable testing-library/no-container */
@@ -84,6 +86,55 @@ describe('JSON cell inspection', () => {
         expect(getJsonLikeString('not json')).toBeUndefined();
         expect(getJsonLikeString('"json string"')).toBeUndefined();
         expect(getJsonLikeString(' true ')).toBeUndefined();
+    });
+
+    test('renders JSON-like result strings as their literal value', () => {
+        const context = createMockCellContext({
+            columnId: 'array_like_string',
+            value: {
+                raw: '[5,5]',
+                formatted: '[5,5]',
+            },
+        });
+
+        const result = getFormattedValueCell(context, undefined, {
+            enableJsonViewer: true,
+        });
+        renderWithMantine(result as React.ReactElement);
+
+        expect(screen.getByText('[5,5]')).toBeInTheDocument();
+    });
+
+    test('renders JSON-like SQL Runner strings as their literal value', () => {
+        const context = {
+            getValue: () => '[5,5]',
+            column: { id: 'array_like_string', columnDef: {} },
+            table: { options: { meta: {} } },
+        } as CellContext<RawResultRow, string>;
+
+        const result = getValueCell(context, undefined, {
+            enableJsonViewer: true,
+        });
+        renderWithMantine(result as React.ReactElement);
+
+        expect(screen.getByText('[5,5]')).toBeInTheDocument();
+    });
+
+    test('keeps collapsed previews for structured result values', () => {
+        const context = createMockCellContext({
+            columnId: 'array_value',
+            value: {
+                raw: [5, 5],
+                formatted: '[object Object]',
+            } as ResultValue,
+        });
+
+        const result = getFormattedValueCell(context, undefined, {
+            enableJsonViewer: true,
+        });
+        renderWithMantine(result as React.ReactElement);
+
+        expect(screen.getByText('[...] 2')).toBeInTheDocument();
     });
 });
 

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -138,10 +138,7 @@ const getResultJsonCellValue = (
 ) => {
     if (!cellValue) return;
 
-    const rawJsonValue = getJsonCellValue(cellValue.value.raw);
-    if (rawJsonValue) return rawJsonValue;
-
-    return getJsonLikeString(cellValue.value.raw);
+    return getJsonCellValue(cellValue.value.raw);
 };
 
 const isBarDisplay = (
@@ -467,7 +464,7 @@ export const getValueCell = (
     }
 
     if (options?.enableJsonViewer) {
-        const jsonValue = getJsonCellValue(value) ?? getJsonLikeString(value);
+        const jsonValue = getJsonCellValue(value);
         if (jsonValue) {
             return <JsonCellPreview value={jsonValue} />;
         }


### PR DESCRIPTION
## Summary

- render JSON-looking string values literally in Explore and SQL Runner result cells
- keep collapsed JSON previews for raw object and array values
- preserve **View JSON** for valid serialized JSON strings
- add focused regression coverage for both result-table paths and structured values

## Why

PR #24221 reused JSON-string detection in the inline cell renderer. That made any string containing valid object or array syntax render as a collapsed JSON preview, so a literal value such as `[5,5]` appeared as `[...] 2`.

This change separates inline preview behavior from the existing JSON inspection affordance: only structured raw values are collapsed, while JSON-formatted strings still remain inspectable through **View JSON**.

Closes #27481.

## Validation

- `pnpm -F frontend test -- src/hooks/useColumns.test.tsx` — 339 test files / 2,579 tests passed
- `pnpm -F frontend typecheck`
- targeted Oxlint and Oxfmt checks for the changed files
- `git diff --check`
- browser verification on the local development app:
  - SQL Runner renders `'[5,5]'::text` as `[5,5]`
  - a real `json_build_array(5,5)` value still renders as `[...] 2`
  - the serialized string still offers **View JSON** and opens the JSON tree
  - Explore renders the seeded string-typed JSON dimension literally while retaining **View JSON**, **Show only**, and **Exclude**
