### PR TITLE
fix: keep stored AI agent memories reachable after disabling memory generation

### DIFF
--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -627,16 +627,21 @@ describe('AiAgentAdminService review access', () => {
 });
 
 describe('AiAgentAdminService.getAllMemories', () => {
-    it('rejects when AI agent memory is disabled', async () => {
+    it('lists memories even when AI agent memory is disabled', async () => {
+        const findAdminMemoriesPaginated = vi
+            .fn()
+            .mockResolvedValue({ data: { memories: [] } });
         const service = makeService({
+            aiAgentMemoryModel: { findAdminMemoriesPaginated },
             aiOrganizationSettingsService: {
                 isAiAgentMemoryEnabled: vi.fn().mockResolvedValue(false),
             },
         });
 
-        await expect(service.getAllMemories(makeAdminUser())).rejects.toThrow(
-            'AI agent memory is not enabled',
-        );
+        await expect(service.getAllMemories(makeAdminUser())).resolves.toEqual({
+            data: { memories: [] },
+        });
+        expect(findAdminMemoriesPaginated).toHaveBeenCalled();
     });
 
     it('rejects principals without manage access to any project', async () => {

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -772,14 +772,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        if (
-            !(await this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(
-                user,
-            ))
-        ) {
-            throw new ForbiddenError('AI agent memory is not enabled');
-        }
-
+        // No memory-enabled gate: stored memories stay reviewable when disabled
         const scope = await this.resolveReadScope(user, organizationUuid);
         const { filters: scopedFilters, empty } =
             AiAgentAdminService.restrictFiltersToScope(scope, filters);

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -150,6 +150,7 @@ describe('AiAgentMemoryService', () => {
     const build = ({
         enabledOrganization = 'org-enabled',
         consolidationDryRun = false,
+        memorySettingEnabled = true,
     } = {}) => {
         const getFlag = vi.fn(async ({ user, featureFlagId }) => ({
             id: featureFlagId,
@@ -275,6 +276,7 @@ describe('AiAgentMemoryService', () => {
             featureFlagService: { get: getFlag } as AnyType,
             aiOrganizationSettingsService: {
                 isAiAgentMemoryEnabled: async (user) =>
+                    memorySettingEnabled &&
                     (
                         await getFlag({
                             user,
@@ -2348,7 +2350,7 @@ describe('AiAgentMemoryService', () => {
         ).toHaveBeenCalledOnce();
     });
 
-    it('returns not found without reading rows when the flag is off', async () => {
+    it('returns not found without reading rows when copilot is off', async () => {
         const { service, findByProjectAndSlug } = build({
             enabledOrganization: 'none',
         });
@@ -2358,6 +2360,78 @@ describe('AiAgentMemoryService', () => {
             service.getMemory(user, 'project-enabled', 'net-revenue'),
         ).rejects.toThrow('Memory not found: net-revenue');
         expect(findByProjectAndSlug).not.toHaveBeenCalled();
+    });
+
+    it('still returns a memory after the org disables the memory setting', async () => {
+        const { service, findByProjectAndSlug } = build({
+            memorySettingEnabled: false,
+        });
+        findByProjectAndSlug.mockResolvedValue({
+            memory: memoryRow({ user_uuid: 'current-user' }),
+            sources: [lineageSource()],
+            replacement: null,
+        });
+
+        await expect(
+            service.getMemory(
+                buildUser(true),
+                'project-enabled',
+                'net-revenue-ab12cd34',
+            ),
+        ).resolves.toMatchObject({ uuid: 'memory-1' });
+    });
+
+    it('still lets the owner retire a memory after the org disables the memory setting', async () => {
+        const { service, findByProjectAndUuid, updateStatus } = build({
+            memorySettingEnabled: false,
+        });
+        findByProjectAndUuid.mockResolvedValue(
+            memoryRow({ user_uuid: 'current-user' }),
+        );
+
+        await expect(
+            service.updateMemoryStatus(
+                buildUser(true),
+                'project-enabled',
+                'memory-1',
+                'retired',
+            ),
+        ).resolves.toBeUndefined();
+        expect(updateStatus).toHaveBeenCalledWith({
+            memoryUuid: 'memory-1',
+            status: 'retired',
+        });
+    });
+
+    it('refuses a promotion when the memory setting is off', async () => {
+        const { service, findByProjectAndUuid } = build({
+            memorySettingEnabled: false,
+        });
+
+        await expect(
+            service.promoteMemory(
+                buildUser(true),
+                'project-enabled',
+                'memory-1',
+            ),
+        ).rejects.toThrow('Memory not found: memory-1');
+        expect(findByProjectAndUuid).not.toHaveBeenCalled();
+    });
+
+    it('refuses a manual distill when the memory setting is off', async () => {
+        const { service, findThreadForDistill, aiAgentMemoryDistill } = build({
+            memorySettingEnabled: false,
+        });
+
+        await expect(
+            service.triggerThreadDistill(
+                buildUser(true, { canManageAgents: true }),
+                'project-enabled',
+                'thread-enabled',
+            ),
+        ).rejects.toThrow('Thread not found: thread-enabled');
+        expect(findThreadForDistill).not.toHaveBeenCalled();
+        expect(aiAgentMemoryDistill).not.toHaveBeenCalled();
     });
 
     it('rejects users who cannot view the project before checking flags', async () => {
@@ -2411,7 +2485,21 @@ describe('AiAgentMemoryService', () => {
         ]);
     });
 
-    it('returns not found for the memory list when the flag is off', async () => {
+    it('still lists memories after the org disables the memory setting', async () => {
+        const { service, findUserMemoriesPaginated } = build({
+            memorySettingEnabled: false,
+        });
+        const user = buildUser(true);
+
+        await service.listMyMemories(user, 'project-enabled', {
+            page: 1,
+            pageSize: 50,
+        });
+
+        expect(findUserMemoriesPaginated).toHaveBeenCalled();
+    });
+
+    it('returns not found for the memory list when copilot is off', async () => {
         const { service, findUserMemoriesPaginated } = build({
             enabledOrganization: 'none',
         });

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -547,8 +547,9 @@ export class AiAgentMemoryService extends BaseService {
         }
     }
 
-    /** Shared gate for every memory read: project access + both feature flags. */
-    private async getMemoryAccessContext(
+    /** Read gate: project access + copilot flag. Stored memories stay readable
+     * after the org disables memory generation. */
+    private async getMemoryReadContext(
         user: SessionUser,
         projectUuid: string,
         notFoundMessage: string,
@@ -564,17 +565,36 @@ export class AiAgentMemoryService extends BaseService {
             throw new ForbiddenError('Cannot view project');
         }
 
-        const [copilot, memoryEnabled] = await Promise.all([
-            this.featureFlagService.get({
-                user,
-                featureFlagId: CommercialFeatureFlags.AiCopilot,
-            }),
-            this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(user),
-        ]);
-        if (!copilot.enabled || !memoryEnabled) {
+        const copilot = await this.featureFlagService.get({
+            user,
+            featureFlagId: CommercialFeatureFlags.AiCopilot,
+        });
+        if (!copilot.enabled) {
             throw new NotFoundError(notFoundMessage);
         }
 
+        return organizationUuid;
+    }
+
+    /** Gate for generation paths (promotion, distill): read gate + the
+     * memory setting. */
+    private async getMemoryGenerationContext(
+        user: SessionUser,
+        projectUuid: string,
+        notFoundMessage: string,
+    ): Promise<string> {
+        const organizationUuid = await this.getMemoryReadContext(
+            user,
+            projectUuid,
+            notFoundMessage,
+        );
+        if (
+            !(await this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(
+                user,
+            ))
+        ) {
+            throw new NotFoundError(notFoundMessage);
+        }
         return organizationUuid;
     }
 
@@ -605,7 +625,7 @@ export class AiAgentMemoryService extends BaseService {
         projectUuid: string,
         slug: string,
     ): Promise<AiAgentMemory> {
-        const organizationUuid = await this.getMemoryAccessContext(
+        const organizationUuid = await this.getMemoryReadContext(
             user,
             projectUuid,
             `Memory not found: ${slug}`,
@@ -732,7 +752,7 @@ export class AiAgentMemoryService extends BaseService {
         reason?: string,
     ): Promise<MemoryReviewItemUpsert> {
         const nominationReason = reason?.trim() || null;
-        const organizationUuid = await this.getMemoryAccessContext(
+        const organizationUuid = await this.getMemoryGenerationContext(
             user,
             projectUuid,
             `Memory not found: ${memoryUuid}`,
@@ -902,7 +922,7 @@ export class AiAgentMemoryService extends BaseService {
         projectUuid: string,
         paginateArgs: KnexPaginateArgs,
     ): Promise<KnexPaginatedData<AiAgentUserMemoriesSummary>> {
-        const organizationUuid = await this.getMemoryAccessContext(
+        const organizationUuid = await this.getMemoryReadContext(
             user,
             projectUuid,
             `Memories not found for project: ${projectUuid}`,
@@ -922,7 +942,7 @@ export class AiAgentMemoryService extends BaseService {
         memoryUuid: string,
         status: AiAgentMemoryEditableStatus,
     ): Promise<void> {
-        const organizationUuid = await this.getMemoryAccessContext(
+        const organizationUuid = await this.getMemoryReadContext(
             user,
             projectUuid,
             `Memory not found: ${memoryUuid}`,
@@ -1011,7 +1031,7 @@ export class AiAgentMemoryService extends BaseService {
         threadUuid: UUID,
     ): Promise<{ jobId: string }> {
         const notFoundMessage = `Thread not found: ${threadUuid}`;
-        const organizationUuid = await this.getMemoryAccessContext(
+        const organizationUuid = await this.getMemoryGenerationContext(
             user,
             projectUuid,
             notFoundMessage,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
@@ -14,7 +14,6 @@ import { IconArrowRight } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useParams } from 'react-router';
 import { useAiAgentMemory } from '../../hooks/useAiAgentMemory';
-import { useAiAgentMemoryEnabled } from '../../hooks/useAiOrganizationSettings';
 import { MemoryDetailsModal } from '../MemoryDetails/MemoryDetails';
 import styles from './MemoryCitation.module.css';
 
@@ -31,22 +30,14 @@ export const MemoryCitation = ({
     const [detailsOpened, { open: openDetails, close: closeDetails }] =
         useDisclosure(false);
     const { projectUuid, agentUuid } = useParams();
-    const memoryEnabled = useAiAgentMemoryEnabled();
     const slug = id?.replace(/^user-content-/, '');
+    // Citations in old threads keep resolving after memories are disabled
     const memoryQuery = useAiAgentMemory({
         projectUuid,
         agentUuid,
         slug,
-        enabled: memoryEnabled && hasOpened,
+        enabled: hasOpened,
     });
-
-    if (!memoryEnabled) {
-        return (
-            <span className={styles.marker} aria-hidden="true">
-                {memoryIndex ?? '·'}
-            </span>
-        );
-    }
 
     return (
         <>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/useMessageMemorySources.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/useMessageMemorySources.ts
@@ -1,10 +1,6 @@
 import { useMemo } from 'react';
-import { useAiAgentMemoryEnabled } from '../../hooks/useAiOrganizationSettings';
 import { parseMemoryCitationSlugs } from './parseMemoryCitationSlugs';
 
-/** Cited memory slugs for a message, empty when the feature is off. */
-export const useMessageMemorySources = (markdown: string): string[] => {
-    const memoryEnabled = useAiAgentMemoryEnabled();
-    const slugs = useMemo(() => parseMemoryCitationSlugs(markdown), [markdown]);
-    return memoryEnabled ? slugs : [];
-};
+/** Cited memory slugs for a message; stays visible after memories are disabled. */
+export const useMessageMemorySources = (markdown: string): string[] =>
+    useMemo(() => parseMemoryCitationSlugs(markdown), [markdown]);

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -71,7 +71,6 @@ export type SettingsContext = {
     isServiceAccountsEnabled: boolean;
     isAiCopilotEnabledOrTrial: boolean;
     shouldShowAiAgentReviews: boolean;
-    shouldShowAiAgentMemories: boolean;
     // Org-level AI settings access (router config, org settings, review queue).
     canManageOrgAiAgent: boolean;
     // True when the user can manage org AI settings OR has AI agent access in at

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -1,10 +1,7 @@
 import { subject } from '@casl/ability';
 import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
 import { useIsGitProject } from '../../components/Explorer/WriteBackModal/hooks';
-import {
-    resolveAiAgentMemoryEnabled,
-    useAiOrganizationSettings,
-} from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
+import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 import useApp from '../../providers/App/useApp';
 import { useOrganization } from '../organization/useOrganization';
 import { useActiveProjectUuid } from '../useActiveProject';
@@ -37,14 +34,6 @@ export const useSettingsContext = (): SettingsContext => {
 
     const shouldShowAiAgentReviews =
         aiOrganizationSettingsQuery.data?.aiAgentReviewsEnabled === true;
-
-    const { data: aiAgentMemoryFlag } = useServerFeatureFlag(
-        FeatureFlags.AiAgentMemory,
-    );
-    const shouldShowAiAgentMemories = resolveAiAgentMemoryEnabled(
-        aiOrganizationSettingsQuery.data,
-        aiAgentMemoryFlag,
-    );
 
     const { data: serviceAccountsFlag } = useServerFeatureFlag(
         CommercialFeatureFlags.ServiceAccounts,
@@ -201,7 +190,6 @@ export const useSettingsContext = (): SettingsContext => {
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
-        shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         isAiOrganizationSettingsLoading:

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -84,7 +84,6 @@ export const useSettingsNavigation = (
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
-        shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         embeddingEnabled,
@@ -529,16 +528,14 @@ export const useSettingsNavigation = (
                 });
             }
 
-            if (shouldShowAiAgentMemories) {
-                aiChildren.push({
-                    label: 'Memories',
-                    to: '/generalSettings/ai/memories',
-                    icon: IconNotebook,
-                    keywords: ['memory', 'memories', 'learned', 'knowledge'],
-                    children: [],
-                    exact: true,
-                });
-            }
+            aiChildren.push({
+                label: 'Memories',
+                to: '/generalSettings/ai/memories',
+                icon: IconNotebook,
+                keywords: ['memory', 'memories', 'learned', 'knowledge'],
+                children: [],
+                exact: true,
+            });
 
             if (
                 canAccessDeepResearchSettings({
@@ -987,7 +984,6 @@ export const useSettingsNavigation = (
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
-        shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         isEmbeddingEnabled,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -156,7 +156,6 @@ const Settings: FC = () => {
         isDataAppsFlagLoading,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
-        shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         isAiOrganizationSettingsLoading,
@@ -702,16 +701,14 @@ const Settings: FC = () => {
                     </AiSettingsProviders>
                 ),
             });
-            if (shouldShowAiAgentMemories) {
-                allowedRoutes.push({
-                    path: '/ai/memories',
-                    element: (
-                        <AiSettingsProviders>
-                            <AiMemoriesSettingsPage />
-                        </AiSettingsProviders>
-                    ),
-                });
-            }
+            allowedRoutes.push({
+                path: '/ai/memories',
+                element: (
+                    <AiSettingsProviders>
+                        <AiMemoriesSettingsPage />
+                    </AiSettingsProviders>
+                ),
+            });
             if (shouldShowAiAgentReviews) {
                 allowedRoutes.push({
                     path: '/ai/issues',
@@ -785,7 +782,6 @@ const Settings: FC = () => {
         isLeaveOrganizationEnabled,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
-        shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
     ]);


### PR DESCRIPTION
Disabling the org setting **Enable AI agent memories** is meant to stop memory *generation*, but it also blocked every stored-memory surface: admin list returned 403, "My memories"/citations/sources disappeared, and a customer who disabled the setting could no longer review or retire what was already learned.

## Changes

**Backend** — split the shared memory gate into two explicit methods:
- `getMemoryReadContext` (project access + copilot flag only): used by `getMemory`, `listMyMemories`, `updateMemoryStatus` — stored memories stay readable and retirable after generation is disabled.
- `getMemoryGenerationContext` (read gate + memory setting): used by `prepareMemoryPromotion`, `triggerThreadDistill` — generation paths stay rejected while disabled.
- `AiAgentAdminService.getAllMemories`: dropped the memory-enabled gate (org + read-scope checks remain).
- All other generation paths (distill enqueue, job runtime re-check, consolidation partitions, prompt injection) untouched and still gated.

**Frontend**
- `MemoryCitation` / `useMessageMemorySources`: citations in existing threads always resolve — interactive markers, hover cards, details modal, sources section — instead of rendering inert.
- Settings → AI → Memories nav entry + route un-gated so admins can manage stored memories; removed the now-unused `shouldShowAiAgentMemories` from `SettingsContext`.
- "Memories"/"My memories" buttons and the first-run memory tour remain gated on the resolved enabled value (setting, falling back to the rollout flag) — orgs with memories off (or never rolled out) don't see memory entry points.

## Testing

- Unit tests: reads/retire work with the setting off, promotion + manual distill rejected, admin list works when disabled, copilot-off still 404s.
- E2E via browser against a local stack: with the setting off, citation hover/modal/sources still resolve in an old thread, admin Memories page lists and archives, Memories buttons hidden; distill POST returns 404; toggling back restores the buttons.

Closes: ZAP-854

🤖 Generated with [Claude Code](https://claude.com/claude-code)
