### PR TITLE
fix: prompt caching not working on Bedrock

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
@@ -125,6 +125,7 @@ export const getDiscoverFieldsSystemPrompt = (args: {
         content,
         providerOptions: {
             anthropic: { cacheControl: { type: 'ephemeral' } },
+            bedrock: { cachePoint: { type: 'default' } },
         },
     };
 };

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -356,6 +356,7 @@ export const getSystemPromptV2 = (args: {
         content: finalContent,
         providerOptions: {
             anthropic: { cacheControl: { type: 'ephemeral' } },
+            bedrock: { cachePoint: { type: 'default' } },
         },
     };
 };


### PR DESCRIPTION
Agent system prompts only set Anthropic's `cacheControl` cache marker, which the Bedrock provider silently ignores, so self-hosted deployments using Bedrock paid full input tokens on every agent message (verified locally: a 255k-token prompt ran with zero cache reads/writes; with the Bedrock marker the same flow writes ~60k tokens once and reads them back on every subsequent call).

Closes: ZAP-441