### PR TITLE
feat: add chart slug rename API

### DIFF
--- a/examples/api/content-slug-rename.http
+++ b/examples/api/content-slug-rename.http
@@ -1,0 +1,26 @@
+@apiHost = http://localhost:8080
+@projectUuid = 3675b69e-8324-4110-bdca-059031aa8da3
+@fromSlug = how-much-revenue-do-we-have-per-payment-method
+@toSlug = my-amazing-chart
+
+### Login
+# Run this first. The HTTP client should retain the session cookie for the
+# requests below.
+POST {{apiHost}}/api/v1/login
+Content-Type: application/json
+
+{
+    "email": "demo@lightdash.com",
+    "password": "demo_password!"
+}
+
+
+### Rename the chart
+POST {{apiHost}}/api/v1/projects/{{projectUuid}}/slugs/rename
+Content-Type: application/json
+
+{
+    "resourceType": "chart",
+    "from": "{{fromSlug}}",
+    "to": "{{toSlug}}"
+}

--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -24,9 +24,11 @@ import {
     type ApiSpaceAsCodeUpsertResponse,
     type ApiSqlChartAsCodeListResponse,
     type ApiSqlChartAsCodeUpsertResponse,
+    type ApiSuccessEmpty,
     type ApiVirtualViewAsCodeListResponse,
     type ApiVirtualViewAsCodeUpsertResponse,
     type ChartAsCode,
+    type ContentSlugRenameRequest,
     type DashboardAsCode,
     type ExternalConnectionAsCode,
     type GoogleSheetsSyncAsCode,
@@ -94,6 +96,28 @@ type ExternalConnectionCoder = {
 @Route('/api/v1/projects/{projectUuid}')
 @Response<ApiErrorPayload>('default', 'Error')
 export class ProjectCoderController extends BaseController {
+    /**
+     * Rename a project-scoped content slug
+     * @summary Rename content slug
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_WRITE_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Post('/slugs/rename')
+    @OperationId('renameContentSlug')
+    async renameContentSlug(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Body() body: ContentSlugRenameRequest,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        await this.services
+            .getCoderService()
+            .renameContentSlug(toSessionUser(req.account), projectUuid, body);
+        return { status: 'ok', results: undefined };
+    }
+
     /**
      * Get charts in code representation
      * @summary List charts as code

--- a/packages/backend/src/models/SavedChartModel.test.ts
+++ b/packages/backend/src/models/SavedChartModel.test.ts
@@ -400,6 +400,161 @@ describe('createSavedChart', () => {
     });
 });
 
+describe('renameSlug', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new SavedChartModel({
+        database,
+        lightdashConfig: lightdashConfigMock,
+    });
+    const projectUuid = '22222222-2222-4222-8222-222222222222';
+    const chartUuid = '11111111-1111-4111-8111-111111111111';
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    beforeEach(() => {
+        tracker.on.select('pg_advisory_xact_lock').response({});
+        vi.spyOn(database, 'transaction').mockImplementation(((
+            callback: AnyType,
+        ) => callback(database)) as AnyType);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        tracker.reset();
+    });
+
+    test('renames the canonical slug and records the previous slug as an alias', async () => {
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ saved_query_uuid: chartUuid, deleted_at: null }]);
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ slug: 'old-orders' }]);
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
+        tracker.on
+            .insert(SavedChartSlugMappingsTableName)
+            .responseOnce([{ saved_query_uuid: chartUuid }]);
+        tracker.on.update(SavedChartsTableName).responseOnce(1);
+
+        await model.renameSlug({
+            projectUuid,
+            savedChartUuid: chartUuid,
+            from: 'old-orders',
+            to: 'new-orders',
+        });
+
+        const aliasInsert = tracker.history.insert.find((query) =>
+            query.sql.includes(SavedChartSlugMappingsTableName),
+        );
+        expect(aliasInsert?.bindings).toEqual(
+            expect.arrayContaining([projectUuid, chartUuid, 'old-orders']),
+        );
+        const [chartUpdate] = tracker.history.update;
+        expect(chartUpdate.bindings).toEqual(
+            expect.arrayContaining([
+                'new-orders',
+                projectUuid,
+                chartUuid,
+                'old-orders',
+            ]),
+        );
+    });
+
+    test('treats an alias-to-current replay as idempotent', async () => {
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on
+            .select(SavedChartSlugMappingsTableName)
+            .responseOnce([{ saved_query_uuid: chartUuid, deleted_at: null }]);
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ slug: 'new-orders' }]);
+
+        await model.renameSlug({
+            projectUuid,
+            savedChartUuid: chartUuid,
+            from: 'old-orders',
+            to: 'new-orders',
+        });
+
+        expect(tracker.history.insert).toHaveLength(0);
+        expect(tracker.history.update).toHaveLength(0);
+        expect(tracker.history.delete).toHaveLength(0);
+    });
+
+    test('rejects a target slug owned by another chart before writing', async () => {
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ saved_query_uuid: chartUuid, deleted_at: null }]);
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ slug: 'old-orders' }]);
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([
+                { saved_query_uuid: 'another-chart-uuid', deleted_at: null },
+            ]);
+
+        await expect(
+            model.renameSlug({
+                projectUuid,
+                savedChartUuid: chartUuid,
+                from: 'old-orders',
+                to: 'existing-orders',
+            }),
+        ).rejects.toThrow(
+            'Chart slug "existing-orders" is already in use in this project',
+        );
+
+        expect(tracker.history.insert).toHaveLength(0);
+        expect(tracker.history.update).toHaveLength(0);
+        expect(tracker.history.delete).toHaveLength(0);
+    });
+
+    test('renames back to an alias owned by the same chart', async () => {
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ saved_query_uuid: chartUuid, deleted_at: null }]);
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ slug: 'new-orders' }]);
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on
+            .select(SavedChartSlugMappingsTableName)
+            .responseOnce([{ saved_query_uuid: chartUuid, deleted_at: null }]);
+        tracker.on.delete(SavedChartSlugMappingsTableName).responseOnce(1);
+        tracker.on
+            .insert(SavedChartSlugMappingsTableName)
+            .responseOnce([{ saved_query_uuid: chartUuid }]);
+        tracker.on.update(SavedChartsTableName).responseOnce(1);
+
+        await model.renameSlug({
+            projectUuid,
+            savedChartUuid: chartUuid,
+            from: 'new-orders',
+            to: 'old-orders',
+        });
+
+        expect(tracker.history.delete).toHaveLength(1);
+        const [aliasInsert] = tracker.history.insert;
+        expect(aliasInsert.bindings).toEqual(
+            expect.arrayContaining([projectUuid, chartUuid, 'new-orders']),
+        );
+        const [chartUpdate] = tracker.history.update;
+        expect(chartUpdate.bindings).toEqual(
+            expect.arrayContaining([
+                'old-orders',
+                projectUuid,
+                chartUuid,
+                'new-orders',
+            ]),
+        );
+    });
+});
+
 describe('get', () => {
     const database = knex({ client: MockClient, dialect: 'pg' });
     const model = new SavedChartModel({

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1099,6 +1099,103 @@ export class SavedChartModel {
         return this.get(savedChartUuid);
     }
 
+    async renameSlug({
+        projectUuid,
+        savedChartUuid,
+        from,
+        to,
+    }: {
+        projectUuid: string;
+        savedChartUuid: string;
+        from: string;
+        to: string;
+    }): Promise<void> {
+        return this.database.transaction(async (trx) => {
+            const slugsToLock = [...new Set([from, to])].sort();
+            for (const slug of slugsToLock) {
+                // eslint-disable-next-line no-await-in-loop
+                await acquireProjectSlugLock(trx, projectUuid, slug);
+            }
+
+            const sourceOwner = await getSavedChartSlugOwner(
+                trx,
+                projectUuid,
+                from,
+            );
+            if (
+                !sourceOwner ||
+                sourceOwner.deleted_at ||
+                sourceOwner.saved_query_uuid !== savedChartUuid
+            ) {
+                throw new NotFoundError(`Chart slug "${from}" not found`);
+            }
+
+            const chart = await trx(SavedChartsTableName)
+                .where(`${SavedChartsTableName}.project_uuid`, projectUuid)
+                .where(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    savedChartUuid,
+                )
+                .whereNull(`${SavedChartsTableName}.deleted_at`)
+                .select(`${SavedChartsTableName}.slug`)
+                .first();
+            if (!chart) {
+                throw new NotFoundError(`Chart slug "${from}" not found`);
+            }
+
+            if (chart.slug === to) {
+                return;
+            }
+
+            if (chart.slug !== from) {
+                throw new ConflictError(
+                    `Chart slug "${from}" is a historical alias. Use the current slug "${chart.slug}" as the source`,
+                );
+            }
+
+            const targetOwner = await getSavedChartSlugOwner(
+                trx,
+                projectUuid,
+                to,
+            );
+            if (
+                targetOwner &&
+                targetOwner.saved_query_uuid !== savedChartUuid
+            ) {
+                throw new ConflictError(
+                    `Chart slug "${to}" is already in use in this project`,
+                );
+            }
+
+            const targetIsAlias = targetOwner !== undefined;
+            if (targetIsAlias) {
+                await trx(SavedChartSlugMappingsTableName)
+                    .where('project_uuid', projectUuid)
+                    .where('saved_query_uuid', savedChartUuid)
+                    .where('slug', to)
+                    .delete();
+            }
+
+            await trx(SavedChartSlugMappingsTableName).insert({
+                project_uuid: projectUuid,
+                saved_query_uuid: savedChartUuid,
+                slug: chart.slug,
+            });
+
+            const updated = await trx(SavedChartsTableName)
+                .where('project_uuid', projectUuid)
+                .where('saved_query_uuid', savedChartUuid)
+                .where('slug', chart.slug)
+                .whereNull('deleted_at')
+                .update({ slug: to });
+            if (updated !== 1) {
+                throw new ConflictError(
+                    `Chart slug "${chart.slug}" changed while it was being renamed`,
+                );
+            }
+        });
+    }
+
     async updateMultiple(
         projectUuid: string,
         data: UpdateMultipleSavedChart[],
@@ -2319,6 +2416,26 @@ export class SavedChartModel {
             )
             .select(`${SavedChartSlugMappingsTableName}.slug`);
         return aliases.map((alias) => alias.slug);
+    }
+
+    async getSlugAliasMappingsForUuids(
+        projectUuid: string,
+        uuids: string[],
+    ): Promise<Array<{ slug: string; savedChartUuid: string }>> {
+        if (uuids.length === 0) return [];
+        return this.database(SavedChartSlugMappingsTableName)
+            .where(
+                `${SavedChartSlugMappingsTableName}.project_uuid`,
+                projectUuid,
+            )
+            .whereIn(
+                `${SavedChartSlugMappingsTableName}.saved_query_uuid`,
+                uuids,
+            )
+            .select({
+                slug: `${SavedChartSlugMappingsTableName}.slug`,
+                savedChartUuid: `${SavedChartSlugMappingsTableName}.saved_query_uuid`,
+            });
     }
 
     async find(filters: {

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -1250,6 +1250,7 @@ describe('CoderService', () => {
                     find: vi.fn(async () => [
                         { uuid: 'chart-uuid', slug: 'revenue-chart' },
                     ]),
+                    getSlugAliasMappingsForUuids: vi.fn(async () => []),
                 } as AnyType,
                 savedSqlModel: { find: vi.fn(async () => []) } as AnyType,
                 appModel: {
@@ -1301,6 +1302,60 @@ describe('CoderService', () => {
             expect(tiles[1].properties).toMatchObject({
                 appUuid: 'target-app-uuid',
                 appSlug: 'revenue-explorer',
+            });
+        });
+
+        it('resolves a historical chart slug to the existing chart UUID', async () => {
+            const service = new CoderService({
+                analytics: {} as AnyType,
+                contentVerificationModel: {} as AnyType,
+                dashboardModel: {} as AnyType,
+                lightdashConfig: {} as AnyType,
+                projectModel: {} as AnyType,
+                promoteService: {} as AnyType,
+                savedChartModel: {
+                    find: vi.fn(async () => [
+                        { uuid: 'chart-uuid', slug: 'new-revenue-chart' },
+                    ]),
+                    getSlugAliasMappingsForUuids: vi.fn(async () => [
+                        {
+                            slug: 'old-revenue-chart',
+                            savedChartUuid: 'chart-uuid',
+                        },
+                    ]),
+                } as AnyType,
+                savedSqlModel: { find: vi.fn(async () => []) } as AnyType,
+                appModel: {
+                    findAppsBySlugs: vi.fn(async () => []),
+                    findAppsByUuids: vi.fn(async () => []),
+                } as AnyType,
+                schedulerModel: {} as AnyType,
+                schedulerService: {} as AnyType,
+                savedChartService: {} as AnyType,
+                dashboardService: {} as AnyType,
+                schedulerClient: {} as AnyType,
+                spaceModel: {} as AnyType,
+                spacePermissionService: {} as AnyType,
+                groupsModel: {} as AnyType,
+                organizationMemberProfileModel: {} as AnyType,
+                userModel: {} as AnyType,
+            });
+
+            const { tiles, warnings } =
+                await service.convertTileWithSlugsToUuids('project-uuid', [
+                    {
+                        type: DashboardTileTypes.SAVED_CHART,
+                        properties: {
+                            chartSlug: 'old-revenue-chart',
+                            chartName: 'Revenue',
+                        },
+                    },
+                ] as AnyType);
+
+            expect(warnings).toEqual([]);
+            expect(tiles[0].properties).toMatchObject({
+                chartSlug: 'old-revenue-chart',
+                savedChartUuid: 'chart-uuid',
             });
         });
 

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -22,6 +22,7 @@ import {
     ChartScheduledDeliveryAsCode,
     ChartSummary,
     ContentAsCodeType,
+    ContentSlugRenameRequest,
     ContentType,
     CreateSavedChart,
     CreateSchedulerTarget,
@@ -45,6 +46,7 @@ import {
     ExploreType,
     ForbiddenError,
     friendlyName,
+    generateSlug,
     getContentAsCodePathFromLtreePath,
     getLtreePathFromContentAsCodePath,
     getParameterReferences,
@@ -60,6 +62,7 @@ import {
     isSlackTarget,
     NotFoundError,
     NotificationFrequency,
+    NotImplementedError,
     OrganizationMemberRole,
     ParameterError,
     Project,
@@ -1850,6 +1853,11 @@ export class CoderService extends BaseService {
                 projectUuid,
             }),
         ]);
+        const chartAliasMappings =
+            await this.savedChartModel.getSlugAliasMappingsForUuids(
+                projectUuid,
+                charts.map((chart) => chart.uuid),
+            );
 
         // Create a unified map of slug -> { uuid, isSql } for both chart types
         const chartSlugToInfo = new Map<
@@ -1858,6 +1866,12 @@ export class CoderService extends BaseService {
         >();
         charts.forEach((chart) =>
             chartSlugToInfo.set(chart.slug, { uuid: chart.uuid, isSql: false }),
+        );
+        chartAliasMappings.forEach(({ slug, savedChartUuid }) =>
+            chartSlugToInfo.set(slug, {
+                uuid: savedChartUuid,
+                isSql: false,
+            }),
         );
         sqlChartRows.forEach((row) =>
             chartSlugToInfo.set(row.slug, {
@@ -2972,6 +2986,86 @@ export class CoderService extends BaseService {
         );
 
         return promotionChanges;
+    }
+
+    async renameContentSlug(
+        user: SessionUser,
+        projectUuid: string,
+        request: ContentSlugRenameRequest,
+    ): Promise<void> {
+        const { resourceType, from, to } = request;
+        if (!from || from.length > 255) {
+            throw new ParameterError(
+                'The source slug must contain between 1 and 255 characters',
+            );
+        }
+        if (!to || to.length > 255 || generateSlug(to) !== to) {
+            throw new ParameterError(
+                'The target slug must contain between 1 and 255 lowercase letters, numbers, or hyphen-separated words',
+            );
+        }
+
+        const project = await this.projectModel.get(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        const { canUploadAnyContent } =
+            CoderService.checkContentAsCodeWriteAccess({
+                auditedAbility,
+                project,
+                slug: from,
+            });
+
+        switch (resourceType) {
+            case ContentType.CHART: {
+                const chart = await this.savedChartModel.get(from, undefined, {
+                    projectUuid,
+                });
+                if (!canUploadAnyContent) {
+                    const { inheritsFromOrgOrProject, access } =
+                        await this.spacePermissionService.getSpaceAccessContext(
+                            user.userUuid,
+                            chart.spaceUuid,
+                        );
+                    if (
+                        auditedAbility.cannot(
+                            'update',
+                            subject('SavedChart', {
+                                organizationUuid: project.organizationUuid,
+                                projectUuid,
+                                inheritsFromOrgOrProject,
+                                access,
+                                metadata: {
+                                    savedChartUuid: chart.uuid,
+                                    savedChartName: chart.name,
+                                },
+                            }),
+                        )
+                    ) {
+                        throw new ForbiddenError(
+                            `You don't have access to rename chart "${from}"`,
+                        );
+                    }
+                }
+
+                await this.savedChartModel.renameSlug({
+                    projectUuid,
+                    savedChartUuid: chart.uuid,
+                    from,
+                    to,
+                });
+                return;
+            }
+            case ContentType.DASHBOARD:
+            case ContentType.SPACE:
+            case ContentType.DATA_APP:
+                throw new NotImplementedError(
+                    `Slug renaming is not supported for resource type "${resourceType}" yet`,
+                );
+            default:
+                return assertUnreachable(
+                    resourceType,
+                    'Unknown content slug resource type',
+                );
+        }
     }
 
     async upsertSqlChart(

--- a/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
@@ -77,6 +77,7 @@ const buildService = () =>
         } as AnyType,
         savedChartModel: {
             find: vi.fn(async () => []),
+            getSlugAliasMappingsForUuids: vi.fn(async () => []),
             get: vi.fn(),
             create: vi.fn(),
         } as AnyType,

--- a/packages/backend/src/utils/SlugUtils.test.ts
+++ b/packages/backend/src/utils/SlugUtils.test.ts
@@ -16,6 +16,10 @@ describe('generateUniqueSlugScopedToProject', () => {
         tracker = getTracker();
     });
 
+    beforeEach(() => {
+        tracker.on.select('pg_advisory_xact_lock').response({});
+    });
+
     afterEach(() => {
         tracker.reset();
     });
@@ -31,9 +35,13 @@ describe('generateUniqueSlugScopedToProject', () => {
             'Orders',
         );
 
-        const [query] = tracker.history.select;
-        expect(query.sql).toContain(`"${SavedChartsTableName}"."project_uuid"`);
-        expect(query.sql).not.toContain('join');
+        const query = tracker.history.select.find(({ sql }) =>
+            sql.includes(SavedChartsTableName),
+        );
+        expect(query?.sql).toContain(
+            `"${SavedChartsTableName}"."project_uuid"`,
+        );
+        expect(query?.sql).not.toContain('join');
         expect(slug).toBe('orders');
     });
 
@@ -72,11 +80,12 @@ describe('generateUniqueSlugScopedToProject', () => {
 
         expect(slug).toHaveLength(255);
         expect(slug.endsWith('-2')).toBe(true);
-        expect(tracker.history.select).toHaveLength(4);
-        expect(tracker.history.select[1].sql).toContain('"slug" = $2');
-        expect(tracker.history.select[1].bindings).toContain(
-            `${'a'.repeat(253)}-1`,
+        const slugQueries = tracker.history.select.filter(
+            ({ sql }) => !sql.includes('pg_advisory_xact_lock'),
         );
+        expect(slugQueries).toHaveLength(4);
+        expect(slugQueries[1].sql).toContain('"slug" = $2');
+        expect(slugQueries[1].bindings).toContain(`${'a'.repeat(253)}-1`);
     });
 
     it('detects collisions for long names with the same bounded prefix', async () => {

--- a/packages/backend/src/utils/SlugUtils.ts
+++ b/packages/backend/src/utils/SlugUtils.ts
@@ -95,6 +95,16 @@ export async function generateUniqueSlugScopedToProject(
     let increment = 0;
     for (;;) {
         const candidate = getSlugCandidate(tableName, baseSlug, increment);
+        if (tableName === SavedChartsTableName) {
+            // Alias and canonical rows cannot share a database constraint, so
+            // all chart writers lock the exact candidate before checking both.
+            // eslint-disable-next-line no-await-in-loop
+            await acquireProjectSlugLock(
+                trx,
+                projectOwner as string,
+                candidate,
+            );
+        }
         const ownerColumn =
             tableName === SpaceTableName
                 ? `${SpaceTableName}.project_id`

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -113,6 +113,7 @@ export * from './types/coder';
 export * from './types/comments';
 export * from './types/conditionalFormatting';
 export * from './types/content';
+export * from './types/contentSlug';
 export * from './types/contentVerification';
 export * from './types/dashboard';
 export * from './types/emailWhitelabel';

--- a/packages/common/src/types/contentSlug.ts
+++ b/packages/common/src/types/contentSlug.ts
@@ -1,0 +1,7 @@
+import { type ContentType } from './content';
+
+export type ContentSlugRenameRequest = {
+    resourceType: ContentType;
+    from: string;
+    to: string;
+};


### PR DESCRIPTION
## What

Adds a generic slug rename endpoint, with charts as the first supported resource:

```http
POST /api/v1/projects/{projectUuid}/slugs/rename
```

The endpoint reuses the existing content-as-code controller, authorization, and service path. The request contains `resourceType`, `from`, and `to`; a successful rename returns the standard empty success response.

When a chart is renamed, the new slug becomes canonical and the previous slug remains a transparent alias. Existing links continue to work, and uploads using an old slug update the same chart instead of creating a duplicate. The rename and alias update happen in one transaction, with both slugs locked to preserve project-level uniqueness during concurrent renames or uploads.

Dashboard tiles in Lightdash reference charts by UUID, so they remain valid without rewriting dashboard versions. Content-as-code uploads also resolve historical chart slugs to the existing chart UUID, while downloads emit the current canonical slug. Alias handling is entirely backend-side, so existing CLI versions remain compatible.

Dashboard and space slug renames, local YAML changes, dry-run behavior, and preview-project alias cloning are intentionally out of scope.

## Validation

- `pnpm -F common build`
- `pnpm -F backend typecheck`
- 28 focused `SavedChartModel` tests pass, including canonical rename, idempotent replay, target collision, and rename-back through an owned alias
- 168 focused stack-level backend tests pass (1 skipped)
- generated and validated the API routes without committing generated artifacts
- exercised rename, old-link resolution, stale dashboard YAML upload, content-as-code download, idempotent replay, rename-back, collisions, unsupported resource types, and concurrent requests against the local API
- verified a dashboard uploaded with a historical chart slug remained linked to the existing chart and downloaded with the canonical slug
- verified `POST /slugs/rename` returns `{"status":"ok"}` and the removed `/content-slugs/rename` route returns 404

Closes: SPK-1071
Relates: #14578
