### PR TITLE
fix: treat empty OPENAI_BASE_URL as unset

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 export const DEFAULT_OPENAI_MODEL_NAME = 'gpt-5.4';
+export const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
 export const DEFAULT_OPENAI_FAST_MODEL_NAME = 'gpt-5.6-luna';
 export const DEFAULT_ANTHROPIC_MODEL_NAME = 'claude-sonnet-4-6';
 export const DEFAULT_DEFAULT_AI_PROVIDER = 'openai';

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1266,7 +1266,7 @@ export const getAiConfig = () => ({
                   embeddingModelName:
                       process.env.OPENAI_EMBEDDING_MODEL ||
                       DEFAULT_OPENAI_EMBEDDING_MODEL,
-                  baseUrl: process.env.OPENAI_BASE_URL,
+                  baseUrl: process.env.OPENAI_BASE_URL?.trim() || undefined,
                   availableModels: getArrayFromCommaSeparatedList(
                       'OPENAI_AVAILABLE_MODELS',
                   ),

--- a/packages/backend/src/ee/services/ai/models/openai-embedding.ts
+++ b/packages/backend/src/ee/services/ai/models/openai-embedding.ts
@@ -1,5 +1,6 @@
 import { createOpenAI } from '@ai-sdk/openai';
 import { EmbeddingModel } from 'ai';
+import { DEFAULT_OPENAI_BASE_URL } from '../../../../config/aiConfigSchema';
 import { LightdashConfig } from '../../../../config/parseConfig';
 
 export const getOpenAIEmbeddingModel = (
@@ -9,7 +10,7 @@ export const getOpenAIEmbeddingModel = (
 ): EmbeddingModel => {
     const openai = createOpenAI({
         apiKey: config.apiKey,
-        ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
+        baseURL: config.baseUrl || DEFAULT_OPENAI_BASE_URL,
         headers: config.customHeaders,
     });
 

--- a/packages/backend/src/ee/services/ai/models/openai-gpt.ts
+++ b/packages/backend/src/ee/services/ai/models/openai-gpt.ts
@@ -1,4 +1,5 @@
 import { createOpenAI } from '@ai-sdk/openai';
+import { DEFAULT_OPENAI_BASE_URL } from '../../../../config/aiConfigSchema';
 import { LightdashConfig } from '../../../../config/parseConfig';
 import { ModelPreset } from './presets';
 import { AiModel } from './types';
@@ -14,7 +15,7 @@ export const getOpenaiGptmodel = (
 ): AiModel<typeof PROVIDER> => {
     const openai = createOpenAI({
         apiKey: config.apiKey,
-        ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
+        baseURL: config.baseUrl || DEFAULT_OPENAI_BASE_URL,
         headers: config.customHeaders,
     });
     const { supportsReasoning, modelId } = preset;


### PR DESCRIPTION
Self-hosted deployments that set `OPENAI_BASE_URL=""` got a 500 from every AI Analyst request: omitting the `baseURL` option for a falsy config value makes the AI SDK read `OPENAI_BASE_URL` from the environment itself, and it accepts the empty string, so every request URL became a bare path like `/responses`.

Closes: lightdash/lightdash#23847<br>Closes: lightdash/lightdash#23847