### PR TITLE
fix: pass custom model names through to OpenAI-compatible gateways

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5125,7 +5125,7 @@ export class AiAgentService extends BaseService {
                 modelName: prompt.modelConfig?.modelName,
             });
 
-        if (!supportsCompaction || contextWindowTokens === null) {
+        if (!supportsCompaction) {
             Logger.debug(
                 `${compactionLogContext} skipped reason=unsupported-model provider=${prompt.modelConfig?.modelProvider ?? 'default'} model=${prompt.modelConfig?.modelName ?? 'default'}`,
             );

--- a/packages/backend/src/ee/services/ai/models/index.test.ts
+++ b/packages/backend/src/ee/services/ai/models/index.test.ts
@@ -11,6 +11,8 @@ import { lightdashConfigMock } from '../../../../config/lightdashConfig.mock';
 import {
     applyStreamingCapability,
     filterModelsForOrg,
+    getAvailableModels,
+    getCompactionModelMetadata,
     getDefaultModel,
     getFastModelForAccessibleKey,
     getModel,
@@ -281,13 +283,114 @@ describe('getModel', () => {
     });
 });
 
+describe('custom OpenAI-compatible gateway models', () => {
+    const gatewayConfig = (
+        openaiOverrides: Partial<
+            NonNullable<typeof baseCopilotConfig.providers.openai>
+        > & { baseUrl?: string },
+    ) => ({
+        ...baseCopilotConfig,
+        providers: {
+            openai: {
+                ...baseCopilotConfig.providers.openai!,
+                baseUrl: 'https://litellm.example.com',
+                ...openaiOverrides,
+            },
+        },
+    });
+
+    const customModelName = 'bedrock/eu.anthropic.claude-sonnet-4-6';
+
+    it('surfaces a non-preset OPENAI_MODEL_NAME as a selectable pass-through model', () => {
+        const models = getAvailableModels(
+            gatewayConfig({ modelName: customModelName }),
+        );
+
+        expect(models[0]).toMatchObject({
+            provider: 'openai',
+            name: customModelName,
+            modelId: customModelName,
+            contextWindowTokens: null,
+        });
+        // presets remain available alongside the configured model
+        expect(models.map((m) => m.name)).toContain('gpt-5.5');
+    });
+
+    it('resolves OPENAI_AVAILABLE_MODELS entries to presets or pass-through models', () => {
+        const models = getAvailableModels(
+            gatewayConfig({
+                modelName: customModelName,
+                availableModels: ['gpt-5.5', customModelName],
+            }),
+        );
+
+        expect(models).toHaveLength(2);
+        expect(models.find((m) => m.name === 'gpt-5.5')?.modelId).toBe(
+            'gpt-5.5-2026-04-23',
+        );
+        expect(models.find((m) => m.name === customModelName)?.modelId).toBe(
+            customModelName,
+        );
+    });
+
+    it('keeps dropping unknown names when no custom base URL is configured', () => {
+        const withoutBaseUrl = getAvailableModels(
+            gatewayConfig({
+                baseUrl: undefined,
+                modelName: customModelName,
+                availableModels: [customModelName, 'gpt-5.5'],
+            }),
+        );
+
+        expect(withoutBaseUrl.map((m) => m.name)).toEqual(['gpt-5.5']);
+    });
+
+    it('sends the configured custom model name to the endpoint', () => {
+        const { model } = getModel(
+            gatewayConfig({ modelName: customModelName }),
+        );
+
+        expect(model.modelId).toBe(customModelName);
+    });
+
+    it('resolves a custom model requested by name (e.g. from an agent setting)', () => {
+        const { model } = getModel(
+            gatewayConfig({
+                availableModels: [customModelName, 'gpt-5.5'],
+            }),
+            { modelName: customModelName },
+        );
+
+        expect(model.modelId).toBe(customModelName);
+    });
+
+    it('disables compaction for custom models with unknown context windows', () => {
+        expect(
+            getCompactionModelMetadata(
+                gatewayConfig({ modelName: customModelName }),
+            ),
+        ).toEqual({
+            supportsCompaction: false,
+            contextWindowTokens: null,
+        });
+    });
+
+    it('keeps compaction metadata for preset models on a custom gateway', () => {
+        expect(
+            getCompactionModelMetadata(gatewayConfig({ modelName: 'gpt-5.5' })),
+        ).toEqual({
+            supportsCompaction: true,
+            contextWindowTokens: 265000,
+        });
+    });
+});
+
 describe('filterModelsForOrg', () => {
     const preset = (
         overrides: Pick<
             ModelPreset<'openai' | 'anthropic' | 'bedrock'>,
             'name' | 'provider' | 'modelId'
-        > &
-            Partial<ModelPreset<'openai' | 'anthropic' | 'bedrock'>>,
+        > & { hiddenUnlessKeyAccess?: boolean },
     ): ModelPreset<'openai' | 'anthropic' | 'bedrock'> => ({
         displayName: overrides.name,
         description: 'test preset',

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -17,6 +17,7 @@ import { getBedrockModel } from './bedrock';
 import { getOpenaiGptmodel } from './openai-gpt';
 import { getOpenRouterModel } from './openrouter';
 import {
+    customGatewayPreset,
     keyGrantsModel,
     matchesPreset,
     MODEL_PRESETS,
@@ -152,17 +153,38 @@ export const getAvailableModels = (
 
         const providerPresets = MODEL_PRESETS[provider];
 
-        // Filter by availableModels if specified, otherwise include all
-        const filteredPresets =
-            availableModels && availableModels.length > 0
-                ? providerPresets.filter((preset) =>
-                      availableModels.some((model) =>
-                          matchesPreset(preset, model),
-                      ),
-                  )
-                : providerPresets;
+        const allowCustomModels =
+            provider === 'openai' && !!providers.openai?.baseUrl;
 
-        return filteredPresets;
+        // Filter by availableModels if specified, otherwise include all
+        if (availableModels && availableModels.length > 0) {
+            const matchedPresets = providerPresets.filter((preset) =>
+                availableModels.some((model) => matchesPreset(preset, model)),
+            );
+            const customPresets = allowCustomModels
+                ? availableModels
+                      .filter(
+                          (model) =>
+                              !providerPresets.some((preset) =>
+                                  matchesPreset(preset, model),
+                              ),
+                      )
+                      .map(customGatewayPreset)
+                : [];
+            return [...matchedPresets, ...customPresets];
+        }
+
+        // Surface the configured default model first so preset fallbacks
+        // resolve to it rather than to an arbitrary preset the gateway may
+        // not serve
+        if (
+            allowCustomModels &&
+            !providerPresets.some((preset) => matchesPreset(preset, modelName))
+        ) {
+            return [customGatewayPreset(modelName), ...providerPresets];
+        }
+
+        return providerPresets;
     });
 };
 
@@ -468,10 +490,9 @@ export const getCompactionModelMetadata = (
         modelName?: string;
         provider?: typeof config.defaultProvider;
     },
-): {
-    supportsCompaction: boolean;
-    contextWindowTokens: number | null;
-} => {
+):
+    | { supportsCompaction: true; contextWindowTokens: number }
+    | { supportsCompaction: false; contextWindowTokens: null } => {
     const provider = options?.provider ?? config.defaultProvider;
 
     if (provider === 'azure' || provider === 'openrouter') {
@@ -483,8 +504,13 @@ export const getCompactionModelMetadata = (
 
     const { preset } = getModelPreset(provider, config, options?.modelName);
 
-    return {
-        supportsCompaction: true,
-        contextWindowTokens: preset.contextWindowTokens,
-    };
+    return preset.contextWindowTokens !== null
+        ? {
+              supportsCompaction: true,
+              contextWindowTokens: preset.contextWindowTokens,
+          }
+        : {
+              supportsCompaction: false,
+              contextWindowTokens: null,
+          };
 };

--- a/packages/backend/src/ee/services/ai/models/presets.ts
+++ b/packages/backend/src/ee/services/ai/models/presets.ts
@@ -11,7 +11,6 @@ export type ModelPreset<P extends ModelPresetProvider> = {
     modelId: string;
     displayName: string;
     description: string;
-    contextWindowTokens: number;
     supportsReasoning: boolean;
     // How the provider exposes extended reasoning. 'budget' uses the original
     // `thinking.type: 'enabled'` + `budgetTokens` API; 'adaptive' uses the newer
@@ -23,7 +22,11 @@ export type ModelPreset<P extends ModelPresetProvider> = {
     deprecated?: boolean;
     callOptions: CallSettings;
     providerOptions: ProviderOptionsMap[P] | undefined;
-};
+} & (
+    | { custom?: false; contextWindowTokens: number }
+    // Pass-through gateway models are the only ones whose window is unknown
+    | { custom: true; contextWindowTokens: null }
+);
 
 export const MODEL_PRESETS: {
     openai: ModelPreset<'openai'>[];
@@ -333,6 +336,24 @@ export const MODEL_PRESETS: {
         },
     ],
 };
+
+// Pass-through preset for model names served by an OpenAI-compatible gateway
+// (e.g. LiteLLM's "bedrock/eu.anthropic.claude-sonnet-4-6") that don't exist
+// in the preset table. The name is sent to the endpoint verbatim.
+export function customGatewayPreset(modelName: string): ModelPreset<'openai'> {
+    return {
+        name: modelName,
+        provider: 'openai',
+        modelId: modelName,
+        displayName: modelName,
+        description: 'Custom model served by the configured OpenAI endpoint',
+        custom: true,
+        contextWindowTokens: null,
+        supportsReasoning: false,
+        callOptions: {},
+        providerOptions: undefined,
+    };
+}
 
 export function matchesPreset(
     preset: ModelPreset<ModelPresetProvider>,


### PR DESCRIPTION
Self-hosted deployments pointing `OPENAI_BASE_URL` at an OpenAI-compatible gateway (e.g. LiteLLM) couldn't use the gateway's model names: a non-preset `OPENAI_MODEL_NAME` was silently replaced by the first hardcoded preset, `OPENAI_AVAILABLE_MODELS` containing non-preset names made model resolution throw, and the model picker showed presets the gateway may not serve while hiding the model actually configured. With a custom base URL set, configured names now pass through to the endpoint verbatim and show up in the picker; compaction is disabled for such models since their context window is unknown, and a deployment that unknowingly relied on the silent preset substitution will now send its configured name instead.

Closes: PROD-5879
Closes: #21024