### PR TITLE
feat: preserve chart slug aliases in previews

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -42,6 +42,7 @@ import {
     CachedExploreTableName,
     ProjectTableName,
 } from '../../database/entities/projects';
+import { SavedChartSlugMappingsTableName } from '../../database/entities/savedChartSlugMappings';
 import {
     SpaceTableName,
     SpaceUserAccessTableName,
@@ -316,6 +317,51 @@ describe('ProjectModel', () => {
         const [clear] = tracker.history.delete;
         expect(clear.sql).toContain(ProjectMembershipCustomRolesTableName);
         expect(clear.bindings).toEqual([5, 7]);
+    });
+
+    test('copies chart aliases to the mapped preview chart UUIDs only', async () => {
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([
+            { saved_query_uuid: 'source-chart-1', slug: 'old-chart-1' },
+            { saved_query_uuid: 'source-chart-2', slug: 'old-chart-2' },
+        ]);
+        tracker.on.insert(SavedChartSlugMappingsTableName).responseOnce([]);
+
+        await model.copyChartSlugMappingsToPreview(
+            database,
+            'source-project',
+            'preview-project',
+            [
+                {
+                    sourceChartUuid: 'source-chart-1',
+                    previewChartUuid: 'preview-chart-1',
+                },
+                {
+                    sourceChartUuid: 'source-chart-2',
+                    previewChartUuid: 'preview-chart-2',
+                },
+            ],
+        );
+
+        const [selectQuery] = tracker.history.select;
+        expect(selectQuery.bindings).toEqual(
+            expect.arrayContaining([
+                'source-project',
+                'source-chart-1',
+                'source-chart-2',
+            ]),
+        );
+        const [insertQuery] = tracker.history.insert;
+        expect(insertQuery.bindings).toEqual(
+            expect.arrayContaining([
+                'preview-project',
+                'preview-chart-1',
+                'old-chart-1',
+                'preview-chart-2',
+                'old-chart-2',
+            ]),
+        );
+        expect(insertQuery.bindings).not.toContain('source-chart-1');
+        expect(insertQuery.bindings).not.toContain('source-chart-2');
     });
 
     describe('should convert outdated metric filters in explores', () => {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -110,6 +110,7 @@ import {
     SavedChartCustomSqlDimensionsTableName,
     SavedChartsTableName,
 } from '../../database/entities/savedCharts';
+import { SavedChartSlugMappingsTableName } from '../../database/entities/savedChartSlugMappings';
 import {
     DbSavedSql,
     InsertSql,
@@ -208,6 +209,11 @@ type RawSummaryRow = {
         | null;
     baseTableAnyAttributes: Explore['tables'][string]['anyAttributes'] | null;
     aiHint: Explore['aiHint'] | null;
+};
+
+type PreviewChartUuidMapping = {
+    sourceChartUuid: string;
+    previewChartUuid: string;
 };
 
 export class ProjectModel {
@@ -2887,6 +2893,52 @@ export class ProjectModel {
         return swapped;
     }
 
+    async copyChartSlugMappingsToPreview(
+        trx: Knex,
+        sourceProjectUuid: string,
+        previewProjectUuid: string,
+        chartUuidMapping: PreviewChartUuidMapping[],
+    ): Promise<void> {
+        if (chartUuidMapping.length === 0) return;
+
+        const aliases = await trx(SavedChartSlugMappingsTableName)
+            .where('project_uuid', sourceProjectUuid)
+            .whereIn(
+                'saved_query_uuid',
+                chartUuidMapping.map(({ sourceChartUuid }) => sourceChartUuid),
+            )
+            .select('saved_query_uuid', 'slug');
+        if (aliases.length === 0) return;
+
+        const previewChartUuidBySource = new Map(
+            chartUuidMapping.map(({ sourceChartUuid, previewChartUuid }) => [
+                sourceChartUuid,
+                previewChartUuid,
+            ]),
+        );
+        const previewAliases = aliases.map((alias) => {
+            const previewChartUuid = previewChartUuidBySource.get(
+                alias.saved_query_uuid,
+            );
+            if (!previewChartUuid) {
+                throw new UnexpectedServerError(
+                    `Missing preview chart mapping for ${alias.saved_query_uuid}`,
+                );
+            }
+            return {
+                project_uuid: previewProjectUuid,
+                saved_query_uuid: previewChartUuid,
+                slug: alias.slug,
+            };
+        });
+
+        await trx.batchInsert(
+            SavedChartSlugMappingsTableName,
+            previewAliases,
+            INSERT_BATCH_SIZE,
+        );
+    }
+
     async duplicateContent(
         projectUuid: string,
         previewProjectUuid: string,
@@ -3343,6 +3395,25 @@ export class ProjectModel {
                 id: c.saved_query_id,
                 newId: newChartsInDashboards[i].saved_query_id,
             }));
+
+            const chartUuidMapping = [
+                ...charts.map((chart, index) => ({
+                    sourceChartUuid: chart.saved_query_uuid,
+                    previewChartUuid: newCharts[index].saved_query_uuid,
+                })),
+                ...chartsInDashboards.map((chart, index) => ({
+                    sourceChartUuid: chart.saved_query_uuid,
+                    previewChartUuid:
+                        newChartsInDashboards[index].saved_query_uuid,
+                })),
+            ];
+
+            await this.copyChartSlugMappingsToPreview(
+                trx,
+                projectUuid,
+                previewProjectUuid,
+                chartUuidMapping,
+            );
 
             const chartMapping = [
                 ...chartInSpacesMapping,


### PR DESCRIPTION
## What

Copies historical chart slugs when content is cloned into a preview project. Each alias is remapped from the source chart UUID to the copied preview chart UUID and remains scoped to the preview project.

Normal chart duplication remains unchanged and receives no aliases. Preview cleanup continues to remove mappings through the existing project and chart foreign-key cascades.

Promoting canonical slug changes made inside a preview is intentionally excluded from this PR and tracked separately in SPK-1120. That behavior was prototyped and validated before being extracted to keep this change focused.

Stacked on #27486, which provides persistent chart aliases and the canonical rename operation.

## Validation

- `pnpm -F backend exec vitest run --config vitest.config.ts src/models/ProjectModel/ProjectModel.test.ts` (42 passed, 1 skipped)
- created a local preview from a project with historical aliases and verified every alias was remapped to the copied chart UUID
- uploaded chart YAML through a historical alias and verified it updated the copied chart without changing its canonical slug or creating a duplicate
- verified a normal chart duplicate received a fresh slug and zero aliases
- deleted the preview and verified its alias rows were removed while production mappings remained unchanged

## Compatibility and safety

No migration, API, or promotion behavior changes are included. Alias copying runs inside the existing preview-content transaction, so a mapping collision rolls back the content copy. All source and destination lookups are project-scoped.

Closes: SPK-1072
Relates: SPK-1120
Relates: #14578
