### PR TITLE
feat(cli): default to batched deploy with old-server fallback

### DIFF
--- a/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
+++ b/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
@@ -400,6 +400,7 @@ describe('compile warehouse column validation', () => {
                 projectUuid: 'projectUuid',
                 ignoreErrors: true,
                 validateWarehouseColumns: true,
+                batchedDeploy: false,
             });
 
             const deployRequest = vi

--- a/packages/cli/src/handlers/deploy.test.ts
+++ b/packages/cli/src/handlers/deploy.test.ts
@@ -1,5 +1,6 @@
 import {
     DeploySessionStatus,
+    LightdashError,
     SupportedDbtAdapter,
     type Explore,
 } from '@lightdash/common';
@@ -66,7 +67,7 @@ describe('deploy completeness transport', () => {
         { complete: false, expected: 'false' },
         { complete: undefined, expected: 'false' },
     ])(
-        'sends complete=$expected on the default upload',
+        'sends complete=$expected when batched deploy is disabled',
         async ({ complete, expected }) => {
             vi.mocked(lightdashApi).mockImplementation(async ({ url }) => {
                 if (url.includes('/explores?')) {
@@ -84,6 +85,7 @@ describe('deploy completeness transport', () => {
             await deploy([compiledExplore], {
                 ...deployOptions,
                 complete,
+                batchedDeploy: false,
             });
 
             expect(lightdashApi).toHaveBeenCalledWith(
@@ -96,7 +98,7 @@ describe('deploy completeness transport', () => {
         },
     );
 
-    test('includes the completeness assertion in every batch body', async () => {
+    test('uses batched deploy by default and includes the completeness assertion in every batch body', async () => {
         vi.mocked(lightdashApi).mockImplementation(async ({ url }) => {
             if (url.endsWith('/deploy')) {
                 return {
@@ -122,7 +124,6 @@ describe('deploy completeness transport', () => {
         await deploy([compiledExplore], {
             ...deployOptions,
             complete: false,
-            useBatchedDeploy: true,
         });
 
         expect(lightdashApi).toHaveBeenCalledWith({
@@ -134,5 +135,62 @@ describe('deploy completeness transport', () => {
                 complete: false,
             }),
         });
+    });
+
+    test('falls back to the legacy deploy when session creation returns 404', async () => {
+        vi.mocked(lightdashApi).mockImplementation(async ({ url }) => {
+            if (url.endsWith('/deploy')) {
+                throw new LightdashError({
+                    message: 'Not found',
+                    name: 'NotFoundError',
+                    statusCode: 404,
+                    data: {},
+                });
+            }
+            if (url.includes('/explores?')) {
+                return {
+                    exploreCount: 1,
+                    warnings: {
+                        warningCount: 0,
+                        exploresWithWarnings: [],
+                    },
+                } as never;
+            }
+            return null as never;
+        });
+
+        await deploy([compiledExplore], deployOptions);
+
+        expect(lightdashApi).toHaveBeenCalledWith({
+            method: 'PUT',
+            url: '/api/v1/projects/project-uuid/explores?complete=false',
+            body: JSON.stringify([compiledExplore]),
+        });
+    });
+
+    test('propagates non-404 session creation errors', async () => {
+        const serverError = new LightdashError({
+            message: 'Server unavailable',
+            name: 'InternalServerError',
+            statusCode: 500,
+            data: {},
+        });
+        vi.mocked(lightdashApi).mockImplementation(async ({ url }) => {
+            if (url.endsWith('/deploy')) {
+                throw serverError;
+            }
+            return null as never;
+        });
+
+        await expect(deploy([compiledExplore], deployOptions)).rejects.toBe(
+            serverError,
+        );
+
+        expect(lightdashApi).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'PUT',
+                url: expect.stringContaining('/explores?'),
+            }),
+        );
     });
 });

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -61,7 +61,7 @@ type DeployHandlerOptions = DbtCompileOptions & {
     warehouseCredentials?: boolean;
     organizationCredentials?: string;
     assumeYes?: boolean;
-    useBatchedDeploy?: boolean;
+    batchedDeploy?: boolean;
     batchSize?: string;
     parallelBatches?: string;
     gzip?: boolean;
@@ -213,7 +213,7 @@ const retryBatchUpload = async <T>(
 const deployBatched = async (
     explores: (Explore | ExploreError)[],
     options: DeployArgs,
-): Promise<void> => {
+): Promise<boolean> => {
     const batchSize = parseInt(options.batchSize || '50', 10);
     if (Number.isNaN(batchSize) || batchSize < 1 || batchSize > 1000) {
         throw new Error(
@@ -241,14 +241,27 @@ const deployBatched = async (
 
     // Start deploy session
     GlobalState.log(`Starting deploy session...`);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const startSessionResponse = (await lightdashApi<any>({
-        method: 'POST',
-        url: `/api/v2/projects/${options.projectUuid}/deploy`,
-        body: JSON.stringify({}),
-    })) as { deploySessionUuid: string };
+    let sessionUuid: string;
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const startSessionResponse = (await lightdashApi<any>({
+            method: 'POST',
+            url: `/api/v2/projects/${options.projectUuid}/deploy`,
+            body: JSON.stringify({}),
+        })) as { deploySessionUuid: string };
+        sessionUuid = startSessionResponse.deploySessionUuid;
+    } catch (error) {
+        if (error instanceof LightdashError && error.statusCode === 404) {
+            GlobalState.log(
+                styles.info(
+                    'Batched deploy is not supported by this server; falling back to legacy deploy',
+                ),
+            );
+            return false;
+        }
+        throw error;
+    }
 
-    const sessionUuid = startSessionResponse.deploySessionUuid;
     GlobalState.log(styles.success(`Deploy session created: ${sessionUuid}`));
 
     // Split explores into batches
@@ -342,6 +355,7 @@ const deployBatched = async (
             durationMs: Date.now() - deployStartTime,
         },
     });
+    return true;
 };
 
 export const deploy = async (
@@ -433,10 +447,10 @@ export const deploy = async (
         );
     }
 
-    // Use batched deploy if enabled
-    if (options.useBatchedDeploy) {
-        await deployBatched(deployableExplores, options);
-    } else {
+    const shouldUseLegacyDeploy =
+        options.batchedDeploy === false ||
+        !(await deployBatched(deployableExplores, options));
+    if (shouldUseLegacyDeploy) {
         const deployStartTime = Date.now();
         const deployPayload = JSON.stringify(deployableExplores);
         try {

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -42,7 +42,7 @@ type PreviewHandlerOptions = DbtCompileOptions & {
     organizationCredentials?: string;
     assumeYes?: boolean;
     warehouseCredentials?: boolean;
-    useBatchedDeploy?: boolean;
+    batchedDeploy?: boolean;
     batchSize?: string;
     parallelBatches?: string;
     expiresIn?: string;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -604,10 +604,10 @@ program
         '--organization-credentials <name>',
         'Use organization warehouse credentials with the specified name (Enterprise Edition feature)',
     )
+    .option('--no-batched-deploy', 'Use the legacy single-request deploy')
     .option(
         '--use-batched-deploy',
-        'Use the new batched deploy feature to upload explores in batches',
-        false,
+        'Use batched deploy to upload explores in batches',
     )
     .option(
         '--batch-size <number>',
@@ -743,10 +743,10 @@ program
         'Create preview without warehouse credentials. Copies credentials from upstream project.',
     )
     .option('-y, --assume-yes', 'assume yes to prompts', false)
+    .option('--no-batched-deploy', 'Use the legacy single-request deploy')
     .option(
         '--use-batched-deploy',
-        'Use the new batched deploy feature to upload explores in batches',
-        false,
+        'Use batched deploy to upload explores in batches',
     )
     .option(
         '--batch-size <number>',
@@ -1293,10 +1293,10 @@ program
         parseDisableTimestampConversionOption,
     )
     .option('-y, --assume-yes', 'assume yes to prompts', false)
+    .option('--no-batched-deploy', 'Use the legacy single-request deploy')
     .option(
         '--use-batched-deploy',
-        'Use batched deploy for large projects (sends explores in batches)',
-        false,
+        'Use batched deploy to upload explores in batches',
     )
     .option(
         '--batch-size <number>',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -605,10 +605,10 @@ program
         '--organization-credentials <name>',
         'Use organization warehouse credentials with the specified name (Enterprise Edition feature)',
     )
+    .option('--no-batched-deploy', 'Use the legacy single-request deploy')
     .option(
         '--use-batched-deploy',
-        'Use the new batched deploy feature to upload explores in batches',
-        false,
+        'Use batched deploy to upload explores in batches',
     )
     .option(
         '--batch-size <number>',
@@ -744,10 +744,10 @@ program
         'Create preview without warehouse credentials. Copies credentials from upstream project.',
     )
     .option('-y, --assume-yes', 'assume yes to prompts', false)
+    .option('--no-batched-deploy', 'Use the legacy single-request deploy')
     .option(
         '--use-batched-deploy',
-        'Use the new batched deploy feature to upload explores in batches',
-        false,
+        'Use batched deploy to upload explores in batches',
     )
     .option(
         '--batch-size <number>',
@@ -1294,10 +1294,10 @@ program
         parseDisableTimestampConversionOption,
     )
     .option('-y, --assume-yes', 'assume yes to prompts', false)
+    .option('--no-batched-deploy', 'Use the legacy single-request deploy')
     .option(
         '--use-batched-deploy',
-        'Use batched deploy for large projects (sends explores in batches)',
-        false,
+        'Use batched deploy to upload explores in batches',
     )
     .option(
         '--batch-size <number>',


### PR DESCRIPTION
Batched deploy becomes the default for `lightdash deploy`, `lightdash preview`, and `lightdash start-preview`.

## Why

The default deploy sends all compiled explores in one PUT. A large project can make this payload larger than the server's payload limit. The upload then fails after a fully successful local compile. With multiple dbt sources, the server-manifest combine sets the preview size from the full project, not from the analyst's repository. An analyst with a small repository can hit the limit and cannot prevent it.

Batched deploy already exists behind `--use-batched-deploy` and uses a staged deploy session: create session, upload batches with retry, finalize. A failure in the middle leaves an unfinalized session. It does not leave a partial catalog.

## Changes

- Batched deploy is the default. `--no-batched-deploy` selects the legacy single-request path.
- `--use-batched-deploy` stays as a no-op for compatibility with documented workflows.
- If the server does not have the deploy-session endpoint (404 on session create), the CLI logs a notice and falls back to the legacy path. Other errors still propagate.

## Tests

Default-on, explicit opt-out, 404 fallback, and non-404 error propagation in `packages/cli/src/handlers/deploy.test.ts`. CLI typecheck, tests (577), and lint pass.

Linear: SPK-1106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kyg5Qw8v4vLKfKb7Bh9gcj