### PR TITLE
feat(roles): add custom-role join tables and multiple-roles flag

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -144,6 +144,10 @@ import {
     OrganizationEmailDomainsTableName,
 } from '../database/entities/organizationEmailDomains';
 import {
+    OrganizationMembershipCustomRolesTable,
+    OrganizationMembershipCustomRolesTableName,
+} from '../database/entities/organizationMembershipCustomRoles';
+import {
     OrganizationMembershipsTable,
     OrganizationMembershipsTableName,
 } from '../database/entities/organizationMemberships';
@@ -205,6 +209,14 @@ import {
     ProjectGroupAccessTable,
     ProjectGroupAccessTableName,
 } from '../database/entities/projectGroupAccess';
+import {
+    ProjectGroupAccessCustomRolesTable,
+    ProjectGroupAccessCustomRolesTableName,
+} from '../database/entities/projectGroupAccessCustomRoles';
+import {
+    ProjectMembershipCustomRolesTable,
+    ProjectMembershipCustomRolesTableName,
+} from '../database/entities/projectMembershipCustomRoles';
 import {
     ProjectMembershipsTable,
     ProjectMembershipsTableName,
@@ -575,6 +587,7 @@ declare module 'knex/types/tables' {
         [OnboardingTableName]: OnboardingTable;
         [OpenIdIdentitiesTableName]: OpenIdIdentitiesTable;
         [OrganizationMembershipsTableName]: OrganizationMembershipsTable;
+        [OrganizationMembershipCustomRolesTableName]: OrganizationMembershipCustomRolesTable;
         [PasswordResetTableName]: PasswordResetTable;
         [PasswordLoginTableName]: PasswordLoginTable;
         [CachedExploresTableName]: CachedExploresTable;
@@ -584,7 +597,9 @@ declare module 'knex/types/tables' {
         [JobStepsTableName]: JobStepsTable;
         [PersonalAccessTokenTableName]: PersonalAccessTokenTable;
         [ProjectMembershipsTableName]: ProjectMembershipsTable;
+        [ProjectMembershipCustomRolesTableName]: ProjectMembershipCustomRolesTable;
         [ProjectGroupAccessTableName]: ProjectGroupAccessTable;
+        [ProjectGroupAccessCustomRolesTableName]: ProjectGroupAccessCustomRolesTable;
         [ShareTableName]: ShareTable;
         [SpaceUserAccessTableName]: SpaceUserAccessTable;
         [SlackAuthTokensTableName]: SlackAuthTokensTable;

--- a/packages/backend/src/database/entities/organizationMembershipCustomRoles.ts
+++ b/packages/backend/src/database/entities/organizationMembershipCustomRoles.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+// Extra custom roles unioned on top of an organization membership's primary `role`/`role_uuid` slot.
+export const OrganizationMembershipCustomRolesTableName =
+    'organization_membership_custom_roles';
+
+export type DbOrganizationMembershipCustomRole = {
+    organization_id: number;
+    user_id: number;
+    role_uuid: string;
+    created_at: Date;
+};
+
+export type DbOrganizationMembershipCustomRoleIn = Pick<
+    DbOrganizationMembershipCustomRole,
+    'organization_id' | 'user_id' | 'role_uuid'
+>;
+
+export type OrganizationMembershipCustomRolesTable = Knex.CompositeTableType<
+    DbOrganizationMembershipCustomRole,
+    DbOrganizationMembershipCustomRoleIn,
+    never
+>;

--- a/packages/backend/src/database/entities/projectGroupAccessCustomRoles.ts
+++ b/packages/backend/src/database/entities/projectGroupAccessCustomRoles.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+// Extra custom roles unioned on top of a project group access row's primary `role`/`role_uuid` slot.
+export const ProjectGroupAccessCustomRolesTableName =
+    'project_group_access_custom_roles';
+
+export type DbProjectGroupAccessCustomRole = {
+    project_uuid: string;
+    group_uuid: string;
+    role_uuid: string;
+    created_at: Date;
+};
+
+export type DbProjectGroupAccessCustomRoleIn = Pick<
+    DbProjectGroupAccessCustomRole,
+    'project_uuid' | 'group_uuid' | 'role_uuid'
+>;
+
+export type ProjectGroupAccessCustomRolesTable = Knex.CompositeTableType<
+    DbProjectGroupAccessCustomRole,
+    DbProjectGroupAccessCustomRoleIn,
+    never
+>;

--- a/packages/backend/src/database/entities/projectMembershipCustomRoles.ts
+++ b/packages/backend/src/database/entities/projectMembershipCustomRoles.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+// Extra custom roles unioned on top of a direct project membership's primary `role`/`role_uuid` slot.
+export const ProjectMembershipCustomRolesTableName =
+    'project_membership_custom_roles';
+
+export type DbProjectMembershipCustomRole = {
+    project_id: number;
+    user_id: number;
+    role_uuid: string;
+    created_at: Date;
+};
+
+export type DbProjectMembershipCustomRoleIn = Pick<
+    DbProjectMembershipCustomRole,
+    'project_id' | 'user_id' | 'role_uuid'
+>;
+
+export type ProjectMembershipCustomRolesTable = Knex.CompositeTableType<
+    DbProjectMembershipCustomRole,
+    DbProjectMembershipCustomRoleIn,
+    never
+>;

--- a/packages/backend/src/database/migrations/20260817151500_add_custom_role_join_tables.ts
+++ b/packages/backend/src/database/migrations/20260817151500_add_custom_role_join_tables.ts
@@ -1,0 +1,120 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds three empty join tables for additional custom-role assignments; existing role columns and writes are unchanged',
+} as const;
+
+const RolesTableName = 'roles';
+const OrganizationMembershipsTableName = 'organization_memberships';
+const ProjectMembershipsTableName = 'project_memberships';
+const ProjectGroupAccessTableName = 'project_group_access';
+
+const OrganizationMembershipCustomRolesTableName =
+    'organization_membership_custom_roles';
+const ProjectMembershipCustomRolesTableName = 'project_membership_custom_roles';
+const ProjectGroupAccessCustomRolesTableName =
+    'project_group_access_custom_roles';
+
+const LockTimeout = '5s';
+
+// Extra custom roles unioned on top of a membership's primary `role`/`role_uuid`
+// slot. Rows cascade with the parent membership; referenced roles can't be deleted.
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+
+    if (
+        !(await knex.schema.hasTable(
+            OrganizationMembershipCustomRolesTableName,
+        ))
+    ) {
+        await knex.schema.createTable(
+            OrganizationMembershipCustomRolesTableName,
+            (table) => {
+                table.integer('organization_id').notNullable();
+                table.integer('user_id').notNullable();
+                table
+                    .uuid('role_uuid')
+                    .notNullable()
+                    .references('role_uuid')
+                    .inTable(RolesTableName)
+                    .onDelete('RESTRICT')
+                    .index();
+                table
+                    .timestamp('created_at')
+                    .notNullable()
+                    .defaultTo(knex.fn.now());
+                table.primary(['organization_id', 'user_id', 'role_uuid']);
+                table
+                    .foreign(['organization_id', 'user_id'])
+                    .references(['organization_id', 'user_id'])
+                    .inTable(OrganizationMembershipsTableName)
+                    .onDelete('CASCADE');
+            },
+        );
+    }
+
+    if (!(await knex.schema.hasTable(ProjectMembershipCustomRolesTableName))) {
+        await knex.schema.createTable(
+            ProjectMembershipCustomRolesTableName,
+            (table) => {
+                table.integer('project_id').notNullable();
+                table.integer('user_id').notNullable();
+                table
+                    .uuid('role_uuid')
+                    .notNullable()
+                    .references('role_uuid')
+                    .inTable(RolesTableName)
+                    .onDelete('RESTRICT')
+                    .index();
+                table
+                    .timestamp('created_at')
+                    .notNullable()
+                    .defaultTo(knex.fn.now());
+                table.primary(['project_id', 'user_id', 'role_uuid']);
+                // project_memberships primary key is (user_id, project_id)
+                table
+                    .foreign(['user_id', 'project_id'])
+                    .references(['user_id', 'project_id'])
+                    .inTable(ProjectMembershipsTableName)
+                    .onDelete('CASCADE');
+            },
+        );
+    }
+
+    if (!(await knex.schema.hasTable(ProjectGroupAccessCustomRolesTableName))) {
+        await knex.schema.createTable(
+            ProjectGroupAccessCustomRolesTableName,
+            (table) => {
+                table.uuid('project_uuid').notNullable();
+                table.uuid('group_uuid').notNullable();
+                table
+                    .uuid('role_uuid')
+                    .notNullable()
+                    .references('role_uuid')
+                    .inTable(RolesTableName)
+                    .onDelete('RESTRICT')
+                    .index();
+                table
+                    .timestamp('created_at')
+                    .notNullable()
+                    .defaultTo(knex.fn.now());
+                table.primary(['project_uuid', 'group_uuid', 'role_uuid']);
+                table
+                    .foreign(['project_uuid', 'group_uuid'])
+                    .references(['project_uuid', 'group_uuid'])
+                    .inTable(ProjectGroupAccessTableName)
+                    .onDelete('CASCADE');
+            },
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+    await knex.schema.dropTableIfExists(ProjectGroupAccessCustomRolesTableName);
+    await knex.schema.dropTableIfExists(ProjectMembershipCustomRolesTableName);
+    await knex.schema.dropTableIfExists(
+        OrganizationMembershipCustomRolesTableName,
+    );
+}

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.test.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.test.ts
@@ -1,0 +1,122 @@
+import { CommercialFeatureFlags } from '@lightdash/common';
+import { Knex } from 'knex';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { LightdashConfig } from '../../config/parseConfig';
+import {
+    FeatureFlagOverridesTableName,
+    FeatureFlagsTableName,
+} from '../../database/entities/featureFlags';
+import { CommercialFeatureFlagModel } from './CommercialFeatureFlagModel';
+
+vi.mock('../../models/FeatureFlagModel/flagCheckAggregator', () => ({
+    record: vi.fn(),
+}));
+
+const user = {
+    userUuid: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    organizationUuid: 'org-uuid',
+};
+
+// Fake Knex serving `feature_flags` rows by flag_id; no overrides.
+const buildFakeDatabase = (flagDefaults: Record<string, boolean>): Knex => {
+    const makeBuilder = (table: string) => {
+        let flagId: string | undefined;
+        const builder = {
+            where(column: string, value?: string) {
+                if (column === 'flag_id') flagId = value;
+                return builder;
+            },
+            whereNull: () => builder,
+            first() {
+                if (table === FeatureFlagsTableName && flagId !== undefined) {
+                    return Promise.resolve(
+                        flagId in flagDefaults
+                            ? {
+                                  flag_id: flagId,
+                                  default_enabled: flagDefaults[flagId],
+                              }
+                            : undefined,
+                    );
+                }
+                if (table === FeatureFlagOverridesTableName) {
+                    return Promise.resolve(undefined);
+                }
+                return Promise.resolve(undefined);
+            },
+        };
+        return builder;
+    };
+    return ((table: string) => makeBuilder(table)) as unknown as Knex;
+};
+
+const buildModel = (
+    flagDefaults: Record<string, boolean>,
+    customRolesConfigEnabled = false,
+) =>
+    new CommercialFeatureFlagModel({
+        database: buildFakeDatabase(flagDefaults),
+        lightdashConfig: {
+            ...lightdashConfigMock,
+            enabledFeatureFlags: new Set<string>(),
+            disabledFeatureFlags: new Set<string>(),
+            customRoles: { enabled: customRolesConfigEnabled },
+        } as unknown as LightdashConfig,
+    });
+
+describe('CommercialFeatureFlagModel – multiple-roles', () => {
+    const featureFlagId = CommercialFeatureFlags.MultipleRoles;
+
+    it('is disabled by default (no DB row)', async () => {
+        const model = buildModel({});
+        expect(await model.get({ user, featureFlagId })).toEqual({
+            id: featureFlagId,
+            enabled: false,
+        });
+    });
+
+    it('is disabled without a user', async () => {
+        const model = buildModel({ [featureFlagId]: true }, true);
+        expect(await model.get({ featureFlagId })).toEqual({
+            id: featureFlagId,
+            enabled: false,
+        });
+    });
+
+    it('stays disabled when enabled in DB but custom roles are unavailable', async () => {
+        const model = buildModel({ [featureFlagId]: true });
+        expect(await model.get({ user, featureFlagId })).toEqual({
+            id: featureFlagId,
+            enabled: false,
+        });
+    });
+
+    it('is enabled when enabled in DB and custom roles are enabled by config', async () => {
+        const model = buildModel({ [featureFlagId]: true }, true);
+        expect(await model.get({ user, featureFlagId })).toEqual({
+            id: featureFlagId,
+            enabled: true,
+        });
+    });
+
+    it('is enabled when enabled in DB and the CustomRoles flag is enabled', async () => {
+        const model = buildModel({
+            [featureFlagId]: true,
+            [CommercialFeatureFlags.CustomRoles]: true,
+        });
+        expect(await model.get({ user, featureFlagId })).toEqual({
+            id: featureFlagId,
+            enabled: true,
+        });
+    });
+
+    it('stays disabled when custom roles are available but the flag is off', async () => {
+        const model = buildModel(
+            { [CommercialFeatureFlags.CustomRoles]: true },
+            true,
+        );
+        expect(await model.get({ user, featureFlagId })).toEqual({
+            id: featureFlagId,
+            enabled: false,
+        });
+    });
+});

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -16,7 +16,35 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
                 this.getAiCopilotFlag.bind(this),
             [CommercialFeatureFlags.HomepageBuilder]:
                 this.getHomepageBuilderFlag.bind(this),
+            [CommercialFeatureFlags.MultipleRoles]:
+                this.getMultipleRolesFlag.bind(this),
         };
+    }
+
+    // Default-off; enabled per-org via DB-backed overrides, and only when
+    // custom roles are available (env config or the CustomRoles flag).
+    // Gates management surfaces only — persisted extra roles are always
+    // effective at runtime, mirroring custom roles.
+    private async getMultipleRolesFlag({
+        featureFlagId,
+        user,
+    }: FeatureFlagLogicArgs) {
+        if (!user) {
+            return { id: featureFlagId, enabled: false };
+        }
+        const dbResult = await this.tryGetFromDatabase({ user, featureFlagId });
+        if (!dbResult?.enabled) {
+            return { id: featureFlagId, enabled: false };
+        }
+        const customRolesEnabled =
+            this.lightdashConfig.customRoles.enabled ||
+            (
+                await this.get(
+                    { user, featureFlagId: CommercialFeatureFlags.CustomRoles },
+                    { recordCheck: false },
+                )
+            ).enabled;
+        return { id: featureFlagId, enabled: customRolesEnabled };
     }
 
     // Default-off; enabled per-org via DB-backed overrides.

--- a/packages/common/src/ee/commercialFeatureFlags.ts
+++ b/packages/common/src/ee/commercialFeatureFlags.ts
@@ -5,5 +5,7 @@ export enum CommercialFeatureFlags {
     ServiceAccounts = 'service-accounts',
     OrganizationWarehouseCredentials = 'organization-warehouse-credentials',
     CustomRoles = 'custom-roles',
+    /** Multiple roles per organization/project (requires CustomRoles). Gates management surfaces only. */
+    MultipleRoles = 'multiple-roles',
     HomepageBuilder = 'homepage-builder',
 }


### PR DESCRIPTION
## Summary

PR 1 of 3 for [PROD-9762](https://linear.app/lightdash/issue/PROD-9762) (Stack A). Adds the storage and the flag for holding multiple roles per organization/project: three empty join tables for *additional* custom roles, and the default-off `multiple-roles` commercial flag. No runtime behaviour changes — nothing reads or writes the new tables yet.

Closes: https://linear.app/lightdash/issue/PROD-10212

## Changes

**Migration** (`20260817151500_add_custom_role_join_tables.ts`, expand-only, transactional, `lock_timeout 5s`, idempotent)

```
organization_memberships (org_id, user_id, role, role_uuid)   ← primary slot, unchanged
   └─ organization_membership_custom_roles (org_id, user_id, role_uuid)   PK triple
project_memberships (user_id, project_id, role, role_uuid)   ← primary slot, unchanged
   └─ project_membership_custom_roles (project_id, user_id, role_uuid)    PK triple
project_group_access (project_uuid, group_uuid, role, role_uuid) ← primary slot, unchanged
   └─ project_group_access_custom_roles (project_uuid, group_uuid, role_uuid) PK triple
```

- Each child row → parent membership row `ON DELETE CASCADE`; `role_uuid` → `roles` `ON DELETE RESTRICT` (same as today's `role_uuid`), indexed.
- Existing `role` / `role_uuid` columns keep their semantics; later PRs union extra roles on top of them.

**Backend**
- `CommercialFeatureFlags.MultipleRoles = 'multiple-roles'`; `CommercialFeatureFlagModel.getMultipleRolesFlag`: enabled only when the DB flag is on for the org/user **and** custom roles are available (`customRoles.enabled` config or the `custom-roles` flag). Gates management surfaces only.
- Entities + `knex-tables.d.ts` registration for the three tables.

## Test plan

- [x] `pnpm -F backend migrate` / `rollback-last` / `migrate` on the populated dev DB; `\d` shows PKs, cascade FK, RESTRICT FK, `role_uuid` index
- [x] Constraint behaviour (rolled-back txn): duplicate row → unique violation; deleting a referenced role → RESTRICT violation; deleting the membership → child rows removed
- [x] `CommercialFeatureFlagModel.test.ts` — 6 cases (default off, no user, DB on but no custom roles, config-enabled, flag-enabled, flag off)
- [x] `pnpm -F common typecheck`, `pnpm -F backend typecheck` (only pre-existing `bedrock.ts` error on `main`), `pnpm -F backend lint`
- [x] `scripts/gen-release-safety.ts` SQL linter: no breaking shapes (same footprint as `20260817100000_add_saved_query_slug_mappings.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)