### PR TITLE
feat: add chart slug update CLI

### DIFF
--- a/packages/cli/src/handlers/slugUpdate.test.ts
+++ b/packages/cli/src/handlers/slugUpdate.test.ts
@@ -1,0 +1,356 @@
+import { ContentType, LightdashError } from '@lightdash/common';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { parse } from 'yaml';
+import * as apiClient from './dbt/apiClient';
+import {
+    applyLocalChartSlugUpdate,
+    executeChartSlugUpdate,
+    getLocalSlugUpdateFileChanges,
+    planLocalChartSlugUpdate,
+    requestSlugUpdate,
+} from './slugUpdate';
+
+const temporaryDirectories: string[] = [];
+
+const createTemporaryContent = async (): Promise<string> => {
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'slug-update-'));
+    temporaryDirectories.push(root);
+    await Promise.all(
+        ['charts', 'dashboards', 'alerts'].map((folder) =>
+            fs.mkdir(path.join(root, folder), { recursive: true }),
+        ),
+    );
+    return root;
+};
+
+afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(
+        temporaryDirectories
+            .splice(0)
+            .map((directory) =>
+                fs.rm(directory, { recursive: true, force: true }),
+            ),
+    );
+});
+
+describe('local chart slug updates', () => {
+    test('updates chart files, language maps, references, filenames, and metadata', async () => {
+        const root = await createTemporaryContent();
+        const chartFile = path.join(root, 'charts', 'copy-of-orders.yml');
+        const languageMapFile = path.join(
+            root,
+            'charts',
+            'copy-of-orders.language.map.yml',
+        );
+        const dashboardFile = path.join(root, 'dashboards', 'overview.yml');
+        const alertFile = path.join(root, 'alerts', 'orders-alert.yml');
+        const unrelatedFile = path.join(root, 'dashboards', 'unrelated.yml');
+        const unrelatedSource =
+            '# Keep this file byte-identical\ncontentType: dashboard\nslug: unrelated\ntiles: []\n';
+
+        await Promise.all([
+            fs.writeFile(
+                chartFile,
+                '# Chart comment\ncontentType: chart\nslug: copy-of-orders\nname: Orders\nmetricQuery: {}\n',
+            ),
+            fs.writeFile(
+                languageMapFile,
+                'chart:\n  copy-of-orders:\n    name: Orders\n',
+            ),
+            fs.writeFile(
+                dashboardFile,
+                [
+                    'contentType: dashboard',
+                    'slug: overview',
+                    'tiles:',
+                    '  - type: saved_chart',
+                    '    tileSlug: copy-of-orders',
+                    '    properties:',
+                    '      chartSlug: copy-of-orders',
+                    '  - type: sql_chart',
+                    '    properties:',
+                    '      chartSlug: copy-of-orders',
+                    '',
+                ].join('\n'),
+            ),
+            fs.writeFile(
+                alertFile,
+                'contentType: alert\nslug: orders-alert\nresource:\n  type: chart\n  slug: copy-of-orders\n',
+            ),
+            fs.writeFile(unrelatedFile, unrelatedSource),
+            fs.writeFile(
+                path.join(root, '.lightdash-metadata.json'),
+                JSON.stringify({
+                    version: 1,
+                    charts: { 'copy-of-orders': 'timestamp' },
+                    dashboards: { overview: 'dashboard-timestamp' },
+                }),
+            ),
+        ]);
+
+        const plan = await planLocalChartSlugUpdate(
+            root,
+            'copy-of-orders',
+            'orders',
+        );
+        expect(plan.referencesUpdated).toBe(4);
+        expect(plan.fileMoves).toHaveLength(2);
+        expect(getLocalSlugUpdateFileChanges(plan, root)).toEqual([
+            { source: '.lightdash-metadata.json' },
+            { source: path.join('alerts', 'orders-alert.yml') },
+            {
+                source: path.join('charts', 'copy-of-orders.language.map.yml'),
+                target: path.join('charts', 'orders.language.map.yml'),
+            },
+            {
+                source: path.join('charts', 'copy-of-orders.yml'),
+                target: path.join('charts', 'orders.yml'),
+            },
+            { source: path.join('dashboards', 'overview.yml') },
+        ]);
+        await applyLocalChartSlugUpdate(plan);
+
+        await expect(fs.access(chartFile)).rejects.toThrow();
+        await expect(fs.access(languageMapFile)).rejects.toThrow();
+
+        const renamedChart = parse(
+            await fs.readFile(path.join(root, 'charts', 'orders.yml'), 'utf8'),
+        );
+        expect(renamedChart.slug).toBe('orders');
+        expect(
+            await fs.readFile(path.join(root, 'charts', 'orders.yml'), 'utf8'),
+        ).toContain('# Chart comment');
+
+        const languageMap = parse(
+            await fs.readFile(
+                path.join(root, 'charts', 'orders.language.map.yml'),
+                'utf8',
+            ),
+        );
+        expect(languageMap.chart.orders.name).toBe('Orders');
+        expect(languageMap.chart['copy-of-orders']).toBeUndefined();
+
+        const dashboard = parse(await fs.readFile(dashboardFile, 'utf8'));
+        expect(dashboard.tiles[0]).toMatchObject({
+            tileSlug: 'copy-of-orders',
+            properties: { chartSlug: 'orders' },
+        });
+        expect(dashboard.tiles[1].properties.chartSlug).toBe('copy-of-orders');
+        expect(parse(await fs.readFile(alertFile, 'utf8')).resource.slug).toBe(
+            'orders',
+        );
+        expect(await fs.readFile(unrelatedFile, 'utf8')).toBe(unrelatedSource);
+
+        const metadata = JSON.parse(
+            await fs.readFile(
+                path.join(root, '.lightdash-metadata.json'),
+                'utf8',
+            ),
+        );
+        expect(metadata).toEqual({
+            version: 1,
+            charts: { orders: 'timestamp' },
+            dashboards: { overview: 'dashboard-timestamp' },
+        });
+    });
+
+    test('is idempotent after local files have already been updated', async () => {
+        const root = await createTemporaryContent();
+        await fs.writeFile(
+            path.join(root, 'charts', 'copy-of-orders.yml'),
+            'contentType: chart\nslug: copy-of-orders\nname: Orders\nmetricQuery: {}\n',
+        );
+
+        await applyLocalChartSlugUpdate(
+            await planLocalChartSlugUpdate(root, 'copy-of-orders', 'orders'),
+        );
+        const secondPlan = await planLocalChartSlugUpdate(
+            root,
+            'copy-of-orders',
+            'orders',
+        );
+
+        expect(secondPlan).toEqual({
+            fileUpdates: [],
+            fileMoves: [],
+            metadata: undefined,
+            referencesUpdated: 0,
+        });
+    });
+
+    test('planning a dry run does not change local files or call the API', async () => {
+        const root = await createTemporaryContent();
+        const chartFile = path.join(root, 'charts', 'copy-of-orders.yml');
+        const source =
+            'contentType: chart\nslug: copy-of-orders\nname: Orders\nmetricQuery: {}\n';
+        await fs.writeFile(chartFile, source);
+        const api = vi.spyOn(apiClient, 'lightdashApi');
+
+        const plan = await planLocalChartSlugUpdate(
+            root,
+            'copy-of-orders',
+            'orders',
+        );
+
+        expect(getLocalSlugUpdateFileChanges(plan, root)).toEqual([
+            {
+                source: path.join('charts', 'copy-of-orders.yml'),
+                target: path.join('charts', 'orders.yml'),
+            },
+        ]);
+        expect(api).not.toHaveBeenCalled();
+        expect(await fs.readFile(chartFile, 'utf8')).toBe(source);
+        await expect(
+            fs.access(path.join(root, 'charts', 'orders.yml')),
+        ).rejects.toThrow();
+    });
+
+    test('rejects a local target collision before changing files', async () => {
+        const root = await createTemporaryContent();
+        const sourceFile = path.join(root, 'charts', 'copy-of-orders.yml');
+        await Promise.all([
+            fs.writeFile(
+                sourceFile,
+                'contentType: chart\nslug: copy-of-orders\nname: Orders\nmetricQuery: {}\n',
+            ),
+            fs.writeFile(
+                path.join(root, 'charts', 'orders.yml'),
+                'contentType: chart\nslug: another-chart\nname: Another\nmetricQuery: {}\n',
+            ),
+        ]);
+
+        await expect(
+            planLocalChartSlugUpdate(root, 'copy-of-orders', 'orders'),
+        ).rejects.toThrow('already exists');
+        expect(await fs.readFile(sourceFile, 'utf8')).toContain(
+            'slug: copy-of-orders',
+        );
+    });
+
+    test('rejects malformed target slugs before constructing file paths', async () => {
+        const root = await createTemporaryContent();
+        const chartFile = path.join(root, 'charts', 'copy-of-orders.yml');
+        const source =
+            'contentType: chart\nslug: copy-of-orders\nname: Orders\nmetricQuery: {}\n';
+        await fs.writeFile(chartFile, source);
+
+        await expect(
+            planLocalChartSlugUpdate(root, 'copy-of-orders', '../../orders'),
+        ).rejects.toThrow('target slug must contain');
+        expect(await fs.readFile(chartFile, 'utf8')).toBe(source);
+    });
+
+    test('does not change local files when the server rejects the rename', async () => {
+        const root = await createTemporaryContent();
+        const chartFile = path.join(root, 'charts', 'copy-of-orders.yml');
+        const source =
+            'contentType: chart\nslug: copy-of-orders\nname: Orders\nmetricQuery: {}\n';
+        await fs.writeFile(chartFile, source);
+        vi.spyOn(apiClient, 'lightdashApi').mockRejectedValue(
+            new LightdashError({
+                message: 'Slug already in use',
+                name: 'ConflictError',
+                statusCode: 409,
+                data: {},
+            }),
+        );
+
+        await expect(
+            executeChartSlugUpdate(
+                'project-uuid',
+                root,
+                'copy-of-orders',
+                'orders',
+            ),
+        ).rejects.toThrow('Slug already in use');
+
+        expect(await fs.readFile(chartFile, 'utf8')).toBe(source);
+        await expect(
+            fs.access(path.join(root, 'charts', 'orders.yml')),
+        ).rejects.toThrow();
+        expect(
+            (await fs.readdir(path.join(root, 'charts'))).some((file) =>
+                file.includes('.slug-update-'),
+            ),
+        ).toBe(false);
+    });
+
+    test('reserves the new slug on the server before changing local files', async () => {
+        const root = await createTemporaryContent();
+        const chartFile = path.join(root, 'charts', 'copy-of-orders.yml');
+        await fs.writeFile(
+            chartFile,
+            'contentType: chart\nslug: copy-of-orders\nname: Orders\nmetricQuery: {}\n',
+        );
+        vi.spyOn(apiClient, 'lightdashApi').mockImplementation(async () => {
+            expect(await fs.readFile(chartFile, 'utf8')).toContain(
+                'slug: copy-of-orders',
+            );
+            await expect(
+                fs.access(path.join(root, 'charts', 'orders.yml')),
+            ).rejects.toThrow();
+            return undefined;
+        });
+
+        await executeChartSlugUpdate(
+            'project-uuid',
+            root,
+            'copy-of-orders',
+            'orders',
+        );
+
+        await expect(fs.access(chartFile)).rejects.toThrow();
+        expect(
+            await fs.readFile(path.join(root, 'charts', 'orders.yml'), 'utf8'),
+        ).toContain('slug: orders');
+    });
+});
+
+describe('content slug rename API', () => {
+    test('calls the generic rename endpoint once', async () => {
+        const api = vi
+            .spyOn(apiClient, 'lightdashApi')
+            .mockResolvedValue(undefined);
+
+        await requestSlugUpdate('project-uuid', {
+            resourceType: ContentType.CHART,
+            from: 'old-chart',
+            to: 'new-chart',
+        });
+
+        expect(api).toHaveBeenCalledExactlyOnceWith({
+            method: 'POST',
+            url: '/api/v1/projects/project-uuid/slugs/rename',
+            body: JSON.stringify({
+                resourceType: ContentType.CHART,
+                from: 'old-chart',
+                to: 'new-chart',
+            }),
+        });
+    });
+
+    test('explains when the connected server does not support slug-update', async () => {
+        vi.spyOn(apiClient, 'lightdashApi').mockRejectedValue(
+            new LightdashError({
+                message: 'API endpoint not found',
+                name: 'NotFoundError',
+                statusCode: 404,
+                data: {},
+            }),
+        );
+
+        await expect(
+            requestSlugUpdate('project-uuid', {
+                resourceType: ContentType.CHART,
+                from: 'old-chart',
+                to: 'new-chart',
+            }),
+        ).rejects.toThrow(
+            'This Lightdash server does not support slug-update yet',
+        );
+    });
+});

--- a/packages/cli/src/handlers/slugUpdate.ts
+++ b/packages/cli/src/handlers/slugUpdate.ts
@@ -1,0 +1,533 @@
+import {
+    AuthorizationError,
+    ContentType,
+    generateSlug,
+    LightdashError,
+    ParameterError,
+    type ContentSlugRenameRequest,
+} from '@lightdash/common';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { parseDocument } from 'yaml';
+import { getConfig } from '../config';
+import GlobalState from '../globalState';
+import * as styles from '../styles';
+import { getDownloadFolder } from './contentAsCodePaths';
+import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
+import { METADATA_FILENAME, readMetadataFile } from './metadataFile';
+import { logSelectedProject, selectProject } from './selectProject';
+
+type SlugUpdateOptions = {
+    verbose: boolean;
+    project?: string;
+    path?: string;
+    dryRun: boolean;
+    from: string;
+    to: string;
+};
+
+type LocalSlugUpdatePlan = {
+    fileUpdates: Array<{ filePath: string; content: string }>;
+    fileMoves: Array<{ source: string; target: string }>;
+    metadata:
+        | {
+              root: string;
+              charts: Record<string, string>;
+          }
+        | undefined;
+    referencesUpdated: number;
+};
+
+type FileSnapshot = Map<string, Buffer | undefined>;
+
+export type LocalSlugUpdateFileChange = {
+    source: string;
+    target?: string;
+};
+
+const getYamlFiles = async (root: string): Promise<string[]> => {
+    try {
+        const entries = await fs.readdir(root, {
+            recursive: true,
+            withFileTypes: true,
+        });
+        return entries
+            .filter(
+                (entry) =>
+                    entry.isFile() &&
+                    (entry.name.endsWith('.yml') ||
+                        entry.name.endsWith('.yaml')) &&
+                    !entry.name.endsWith('.language.map.yml') &&
+                    !entry.name.endsWith('.language.map.yaml'),
+            )
+            .map((entry) => path.join(entry.parentPath, entry.name));
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return [];
+        }
+        throw error;
+    }
+};
+
+const assertMovesAreSafe = async (
+    moves: LocalSlugUpdatePlan['fileMoves'],
+): Promise<void> => {
+    const sources = new Set(moves.map(({ source }) => source));
+    const targets = new Set<string>();
+
+    for (const { target } of moves) {
+        if (targets.has(target)) {
+            throw new ParameterError(
+                `Multiple content files would be renamed to "${target}"`,
+            );
+        }
+        targets.add(target);
+
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            await fs.access(target);
+            if (!sources.has(target)) {
+                throw new ParameterError(
+                    `Cannot rename content file because "${target}" already exists`,
+                );
+            }
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+                throw error;
+            }
+        }
+    }
+};
+
+export const planLocalChartSlugUpdate = async (
+    customPath: string | undefined,
+    from: string,
+    to: string,
+): Promise<LocalSlugUpdatePlan> => {
+    const root = getDownloadFolder(customPath);
+    const fileUpdates: LocalSlugUpdatePlan['fileUpdates'] = [];
+    const fileMoves: LocalSlugUpdatePlan['fileMoves'] = [];
+    let referencesUpdated = 0;
+
+    if (!from || from.length > 255) {
+        throw new ParameterError(
+            'The source slug must contain between 1 and 255 characters',
+        );
+    }
+    if (!to || to.length > 255 || generateSlug(to) !== to) {
+        throw new ParameterError(
+            'The target slug must contain between 1 and 255 lowercase letters, numbers, or hyphen-separated words',
+        );
+    }
+
+    if (from === to) {
+        return {
+            fileUpdates,
+            fileMoves,
+            metadata: undefined,
+            referencesUpdated,
+        };
+    }
+
+    for (const filePath of await getYamlFiles(root)) {
+        // eslint-disable-next-line no-await-in-loop
+        const source = await fs.readFile(filePath, 'utf8');
+        const document = parseDocument(source);
+        if (document.errors.length > 0) {
+            throw new ParameterError(
+                `Could not parse "${filePath}": ${document.errors
+                    .map(({ message }) => message)
+                    .join('; ')}`,
+            );
+        }
+
+        let changed = false;
+        const parsed = document.toJS() as {
+            slug?: unknown;
+            contentType?: unknown;
+            metricQuery?: unknown;
+            tiles?: Array<{
+                type?: unknown;
+                properties?: { chartSlug?: unknown };
+            }>;
+            resource?: { type?: unknown; slug?: unknown };
+        };
+
+        const isChart =
+            parsed.contentType === ContentType.CHART ||
+            parsed.metricQuery !== undefined;
+        if (isChart && parsed.slug === from) {
+            document.set('slug', to);
+            referencesUpdated += 1;
+            changed = true;
+
+            const extension = path.extname(filePath);
+            if (path.basename(filePath) === `${from}${extension}`) {
+                fileMoves.push({
+                    source: filePath,
+                    target: path.join(
+                        path.dirname(filePath),
+                        `${to}${extension}`,
+                    ),
+                });
+
+                for (const languageMapExtension of ['.yml', '.yaml']) {
+                    const sourceLanguageMap = path.join(
+                        path.dirname(filePath),
+                        `${from}.language.map${languageMapExtension}`,
+                    );
+                    try {
+                        // eslint-disable-next-line no-await-in-loop
+                        await fs.access(sourceLanguageMap);
+
+                        // eslint-disable-next-line no-await-in-loop
+                        const languageMapSource = await fs.readFile(
+                            sourceLanguageMap,
+                            'utf8',
+                        );
+                        const languageMapDocument =
+                            parseDocument(languageMapSource);
+                        if (languageMapDocument.errors.length > 0) {
+                            throw new ParameterError(
+                                `Could not parse "${sourceLanguageMap}": ${languageMapDocument.errors
+                                    .map(({ message }) => message)
+                                    .join('; ')}`,
+                            );
+                        }
+                        const languageMapEntry = languageMapDocument.getIn([
+                            'chart',
+                            from,
+                        ]);
+                        if (languageMapEntry !== undefined) {
+                            if (
+                                languageMapDocument.getIn(['chart', to]) !==
+                                undefined
+                            ) {
+                                throw new ParameterError(
+                                    `Cannot update language map because chart slug "${to}" already exists in "${sourceLanguageMap}"`,
+                                );
+                            }
+                            languageMapDocument.setIn(
+                                ['chart', to],
+                                languageMapEntry,
+                            );
+                            languageMapDocument.deleteIn(['chart', from]);
+                            fileUpdates.push({
+                                filePath: sourceLanguageMap,
+                                content: languageMapDocument.toString(),
+                            });
+                            referencesUpdated += 1;
+                        }
+
+                        fileMoves.push({
+                            source: sourceLanguageMap,
+                            target: path.join(
+                                path.dirname(filePath),
+                                `${to}.language.map${languageMapExtension}`,
+                            ),
+                        });
+                    } catch (error) {
+                        if (
+                            (error as NodeJS.ErrnoException).code !== 'ENOENT'
+                        ) {
+                            throw error;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (Array.isArray(parsed.tiles)) {
+            for (const [index, tile] of parsed.tiles.entries()) {
+                if (
+                    tile.type === 'saved_chart' &&
+                    tile.properties?.chartSlug === from
+                ) {
+                    document.setIn(
+                        ['tiles', index, 'properties', 'chartSlug'],
+                        to,
+                    );
+                    referencesUpdated += 1;
+                    changed = true;
+                }
+            }
+        }
+
+        if (
+            parsed.resource?.type === ContentType.CHART &&
+            parsed.resource.slug === from
+        ) {
+            document.setIn(['resource', 'slug'], to);
+            referencesUpdated += 1;
+            changed = true;
+        }
+
+        if (changed) {
+            fileUpdates.push({ filePath, content: document.toString() });
+        }
+    }
+
+    const metadata = await readMetadataFile(root);
+    let updatedMetadata: LocalSlugUpdatePlan['metadata'];
+    if (from in metadata.charts) {
+        if (to !== from && to in metadata.charts) {
+            throw new ParameterError(
+                `Cannot update local metadata because chart slug "${to}" already exists`,
+            );
+        }
+        const charts = { ...metadata.charts };
+        charts[to] = charts[from];
+        delete charts[from];
+        updatedMetadata = { root, charts };
+    }
+
+    await assertMovesAreSafe(fileMoves);
+    return {
+        fileUpdates,
+        fileMoves,
+        metadata: updatedMetadata,
+        referencesUpdated,
+    };
+};
+
+export const getLocalSlugUpdateFileChanges = (
+    plan: LocalSlugUpdatePlan,
+    customPath: string | undefined,
+): LocalSlugUpdateFileChange[] => {
+    const root = getDownloadFolder(customPath);
+    const movedSources = new Set(plan.fileMoves.map(({ source }) => source));
+    const relative = (filePath: string) => path.relative(root, filePath);
+
+    return [
+        ...plan.fileMoves.map(({ source, target }) => ({
+            source: relative(source),
+            target: relative(target),
+        })),
+        ...plan.fileUpdates
+            .filter(({ filePath }) => !movedSources.has(filePath))
+            .map(({ filePath }) => ({ source: relative(filePath) })),
+        ...(plan.metadata
+            ? [
+                  {
+                      source: relative(
+                          path.join(plan.metadata.root, METADATA_FILENAME),
+                      ),
+                  },
+              ]
+            : []),
+    ].sort((first, second) => first.source.localeCompare(second.source));
+};
+
+const logLocalSlugUpdateFileChanges = (
+    plan: LocalSlugUpdatePlan,
+    customPath: string | undefined,
+    dryRun: boolean,
+) => {
+    const changes = getLocalSlugUpdateFileChanges(plan, customPath);
+    if (changes.length === 0) {
+        console.info(styles.secondary('No local files need updating.'));
+        return;
+    }
+
+    console.info(
+        styles.secondary(
+            dryRun ? 'Local files that would change:' : 'Updated local files:',
+        ),
+    );
+    for (const change of changes) {
+        console.info(
+            styles.secondary(
+                `  ${change.source}${change.target ? ` -> ${change.target}` : ''}`,
+            ),
+        );
+    }
+};
+
+const captureFiles = async (
+    filePaths: Iterable<string>,
+): Promise<FileSnapshot> => {
+    const snapshots: FileSnapshot = new Map();
+    for (const filePath of filePaths) {
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            snapshots.set(filePath, await fs.readFile(filePath));
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+                throw error;
+            }
+            snapshots.set(filePath, undefined);
+        }
+    }
+    return snapshots;
+};
+
+const restoreFiles = async (snapshots: FileSnapshot): Promise<void> => {
+    await Promise.all(
+        [...snapshots].map(([filePath, content]) =>
+            content === undefined
+                ? fs.rm(filePath, { force: true })
+                : fs.writeFile(filePath, content),
+        ),
+    );
+};
+
+export const applyLocalChartSlugUpdate = async (
+    plan: LocalSlugUpdatePlan,
+): Promise<() => Promise<void>> => {
+    const metadataPath = plan.metadata
+        ? path.join(plan.metadata.root, METADATA_FILENAME)
+        : undefined;
+    const affectedPaths = new Set([
+        ...plan.fileUpdates.map(({ filePath }) => filePath),
+        ...plan.fileMoves.flatMap(({ source, target }) => [source, target]),
+        ...(metadataPath ? [metadataPath] : []),
+    ]);
+    const snapshots = await captureFiles(affectedPaths);
+    const stagedMoves: string[] = [];
+
+    try {
+        await Promise.all(
+            plan.fileUpdates.map(({ filePath, content }) =>
+                fs.writeFile(filePath, content),
+            ),
+        );
+
+        for (const [index, move] of plan.fileMoves.entries()) {
+            const temporary = `${move.source}.slug-update-${process.pid}-${index}`;
+            // eslint-disable-next-line no-await-in-loop
+            await fs.rename(move.source, temporary);
+            stagedMoves.push(temporary);
+        }
+        for (const [index, move] of plan.fileMoves.entries()) {
+            // eslint-disable-next-line no-await-in-loop
+            await fs.rename(stagedMoves[index], move.target);
+        }
+
+        if (plan.metadata && metadataPath) {
+            const existing = await readMetadataFile(plan.metadata.root);
+            await fs.writeFile(
+                metadataPath,
+                JSON.stringify(
+                    { ...existing, charts: plan.metadata.charts },
+                    null,
+                    2,
+                ),
+            );
+        }
+    } catch (error) {
+        await Promise.all(
+            stagedMoves.map((temporary) => fs.rm(temporary, { force: true })),
+        );
+        await restoreFiles(snapshots);
+        throw error;
+    }
+
+    return () => restoreFiles(snapshots);
+};
+
+export const requestSlugUpdate = async (
+    projectUuid: string,
+    request: ContentSlugRenameRequest,
+): Promise<void> => {
+    try {
+        await lightdashApi<undefined>({
+            method: 'POST',
+            url: `/api/v1/projects/${projectUuid}/slugs/rename`,
+            body: JSON.stringify(request),
+        });
+    } catch (error) {
+        if (
+            error instanceof LightdashError &&
+            error.statusCode === 404 &&
+            error.message === 'API endpoint not found'
+        ) {
+            throw new ParameterError(
+                'This Lightdash server does not support slug-update yet. Upgrade the server before using this command.',
+            );
+        }
+        throw error;
+    }
+};
+
+export const executeChartSlugUpdate = async (
+    projectUuid: string,
+    customPath: string | undefined,
+    from: string,
+    to: string,
+): Promise<LocalSlugUpdatePlan> => {
+    const localPlan = await planLocalChartSlugUpdate(customPath, from, to);
+    await requestSlugUpdate(projectUuid, {
+        resourceType: ContentType.CHART,
+        from,
+        to,
+    });
+
+    try {
+        await applyLocalChartSlugUpdate(localPlan);
+    } catch (error) {
+        throw new Error(
+            'The chart slug was renamed in Lightdash, but the local files could not be updated. Fix the local file error and rerun the same command; the rename is idempotent.',
+            { cause: error },
+        );
+    }
+
+    return localPlan;
+};
+
+export const slugUpdateHandler = async (
+    options: SlugUpdateOptions,
+): Promise<void> => {
+    GlobalState.setVerbose(options.verbose);
+    await checkLightdashVersion();
+
+    const config = await getConfig();
+    if (!config.context?.apiKey || !config.context.serverUrl) {
+        throw new AuthorizationError(
+            `Not logged in. Run 'lightdash login --help'`,
+        );
+    }
+
+    const selection = await selectProject(config, options.project);
+    if (!selection) {
+        throw new ParameterError(
+            'No project selected. Run lightdash config set-project',
+        );
+    }
+    logSelectedProject(
+        selection,
+        config,
+        options.dryRun
+            ? 'Previewing chart slug update in'
+            : 'Updating chart slug in',
+    );
+
+    if (options.dryRun) {
+        const localPlan = await planLocalChartSlugUpdate(
+            options.path,
+            options.from,
+            options.to,
+        );
+        console.info(
+            styles.success(
+                `Would update chart slug "${options.from}" -> "${options.to}".`,
+            ),
+        );
+        logLocalSlugUpdateFileChanges(localPlan, options.path, true);
+        console.info(styles.secondary('No changes were made.'));
+        return;
+    }
+
+    const localPlan = await executeChartSlugUpdate(
+        selection.projectUuid,
+        options.path,
+        options.from,
+        options.to,
+    );
+
+    console.info(
+        styles.success(
+            `Updated chart slug "${options.from}" -> "${options.to}".`,
+        ),
+    );
+    logLocalSlugUpdateFileChanges(localPlan, options.path, false);
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -52,6 +52,7 @@ import { renameProjectHandler } from './handlers/renameProject';
 import { runChartHandler } from './handlers/runChart';
 import { setProjectHandler, unsetProjectHandler } from './handlers/setProject';
 import { setWarehouseHandler } from './handlers/setWarehouse';
+import { slugUpdateHandler } from './handlers/slugUpdate';
 import { sqlHandler } from './handlers/sql';
 import { registerUpgradeCheckCommand } from './handlers/upgradeCheck';
 import { validateHandler } from './handlers/validate';
@@ -1525,6 +1526,30 @@ program
     .option('--list', 'List all charts and dashboards that are renamed', false)
 
     .action(renameHandler);
+
+program
+    .command('slug-update')
+    .description('Rename a chart slug and update its local references')
+    .option('--verbose', 'show verbose output', false)
+    .option(
+        '-p, --project <project uuid>',
+        'specify a project UUID',
+        parseProjectArgument,
+        undefined,
+    )
+    .option(
+        '--path <path>',
+        'specify the local content-as-code path to update',
+        undefined,
+    )
+    .option(
+        '--dry-run',
+        'preview the chart rename and local file changes without making changes',
+        false,
+    )
+    .requiredOption('--from <slug>', 'current content slug')
+    .requiredOption('--to <slug>', 'new content slug')
+    .action(slugUpdateHandler);
 
 program
     .command('generate-exposures')


### PR DESCRIPTION
![CleanShot 2026-08-18 at 12.54.49.png](https://app.graphite.com/user-attachments/assets/2bfa9a38-6f62-43ec-be28-0852f85e11e7.png)

edge cases

![CleanShot 2026-08-18 at 12.55.20.png](https://app.graphite.com/user-attachments/assets/34511afb-41c1-47f0-a85c-4bb9b906d69c.png)

![CleanShot 2026-08-18 at 12.55.31.png](https://app.graphite.com/user-attachments/assets/6ed2d1f0-9fdc-44d2-861f-3cb2289b151b.png)



## Summary

- add `lightdash slug-update --from <old-slug> --to <new-slug>` as a thin client over the chart slug rename API
- update local chart YAML, saved-chart dashboard references, scheduled-content chart references, chart filenames, language-map keys/files, and content metadata
- list every affected local file after a rename, using relative paths and explicit source-to-target file moves
- add `--dry-run` to preview the intended chart rename and local file changes without calling the rename API or writing files
- keep aliases transparent: repeat runs are no-ops, interrupted local updates can be safely retried, and stale uploads continue to update the same chart

## Validation

- renamed a real local chart and renamed it back through the CLI
- ran a real `--dry-run` against downloaded content and verified the chart file move, dashboard reference, and metadata file were listed without changes
- verified repeated execution made no byte-level file changes
- downloaded through the retired slug and received the current canonical slug
- uploaded stale YAML through the retired slug and confirmed the same chart UUID was updated with no duplicate
- verified local and server-side target collisions leave both files and the canonical slug unchanged
- verified chart and language-map filenames/keys, dashboard references, metadata, and all 12 downloaded YAML files remained consistent
- 9 focused CLI tests pass, including dry-run safety, server-before-local ordering, and unchanged local files after server rejection
- CLI typecheck, build, lint, and formatting checks pass
- stack-level backend typecheck and 168 focused backend tests pass (1 skipped)

## Compatibility and security

- chart-only in this version, so the CLI does not expose a resource type option
- no automatic copy cleanup, migration, API change, or feature flag
- target slugs are validated locally before any destination path is constructed
- the backend reserves the target before local files change, closing the interruption window that could otherwise recreate a duplicate
- dry-run only reads and validates local files; server-side validation still happens when the rename is applied
- SQL chart tiles and unrelated YAML files are left unchanged
- existing CLI download/upload behavior remains compatible; older servers return an actionable upgrade message

Closes: SPK-736
Relates: #14578