### PR TITLE
feat(roles): read and write role sets in RolesModel

### DIFF
--- a/packages/backend/src/ee/models/ServiceAccountModel.ts
+++ b/packages/backend/src/ee/models/ServiceAccountModel.ts
@@ -14,6 +14,7 @@ import {
 import * as crypto from 'crypto';
 import { Knex } from 'knex';
 import { LightdashConfig } from '../../config/parseConfig';
+import { OrganizationMembershipCustomRolesTableName } from '../../database/entities/organizationMembershipCustomRoles';
 import { OrganizationMembershipsTableName } from '../../database/entities/organizationMemberships';
 import { RolesTableName } from '../../database/entities/roles';
 import { DbUser, UserTableName } from '../../database/entities/users';
@@ -396,6 +397,18 @@ export class ServiceAccountModel {
                             )
                             .select('user_id'),
                     );
+                // A singular write replaces the whole role set, so extras go too.
+                await trx(OrganizationMembershipCustomRolesTableName)
+                    .whereIn(
+                        'user_id',
+                        trx('users')
+                            .where(
+                                'user_uuid',
+                                existing.service_account_user_uuid,
+                            )
+                            .select('user_id'),
+                    )
+                    .delete();
             }
 
             const updatedServiceAccounts = await trx(ServiceAccountsTableName)

--- a/packages/backend/src/models/GroupsModel.test.ts
+++ b/packages/backend/src/models/GroupsModel.test.ts
@@ -5,6 +5,7 @@ import { GroupMembershipTableName } from '../database/entities/groupMemberships'
 import { GroupTableName } from '../database/entities/groups';
 import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectGroupAccessCustomRolesTableName } from '../database/entities/projectGroupAccessCustomRoles';
 import { GroupsModel } from './GroupsModel';
 
 describe('GroupsModel', () => {
@@ -21,6 +22,7 @@ describe('GroupsModel', () => {
     });
 
     it('only updates allowed project access fields', async () => {
+        tracker.on.delete(ProjectGroupAccessCustomRolesTableName).response(0);
         tracker.on.update(ProjectGroupAccessTableName).responseOnce([
             {
                 project_id: 1,
@@ -46,9 +48,15 @@ describe('GroupsModel', () => {
         expect(query.sql).toContain(ProjectGroupAccessTableName);
         expect(query.sql).toContain('set "role" = $1 where');
         expect(query.bindings).not.toContain('attacker-project-uuid');
+        // singular write clears extra custom roles
+        expect(tracker.history.delete).toHaveLength(1);
+        expect(tracker.history.delete[0].sql).toContain(
+            ProjectGroupAccessCustomRolesTableName,
+        );
     });
 
     it('preserves null role_uuid when unsetting custom project access role', async () => {
+        tracker.on.delete(ProjectGroupAccessCustomRolesTableName).response(0);
         tracker.on.update(ProjectGroupAccessTableName).responseOnce([
             {
                 project_id: 1,

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -40,6 +40,7 @@ import {
 } from '../database/entities/projectGroupAccess';
 import { DbUser, UserTableName } from '../database/entities/users';
 import KnexPaginate from '../database/pagination';
+import { clearGroupExtraRoles } from './roleSetUtils';
 import { getColumnMatchRegexQuery } from './SearchModel/utils/search';
 
 export class GroupsModel {
@@ -845,13 +846,16 @@ export class GroupsModel {
                 : {}),
         };
 
-        const query = this.database(ProjectGroupAccessTableName)
-            .update(updateFields)
-            .where('project_uuid', projectUuid)
-            .andWhere('group_uuid', groupUuid)
-            .returning('*');
-
-        const rows = await query;
+        const rows = await this.database.transaction(async (trx) => {
+            const updated = await trx(ProjectGroupAccessTableName)
+                .update(updateFields)
+                .where('project_uuid', projectUuid)
+                .andWhere('group_uuid', groupUuid)
+                .returning('*');
+            // A singular write replaces the whole role set, so extras go too.
+            await clearGroupExtraRoles(trx, projectUuid, groupUuid);
+            return updated;
+        });
 
         if (rows.length === 0) {
             throw new UnexpectedDatabaseError(

--- a/packages/backend/src/models/OrganizationMemberProfileModel.test.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.test.ts
@@ -1,6 +1,7 @@
 import { OrganizationMemberRole } from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import { UserTableName } from '../database/entities/users';
 import { OrganizationMemberProfileModel } from './OrganizationMemberProfileModel';
@@ -76,6 +77,31 @@ describe('OrganizationMemberProfileModel', () => {
             expect(memberQuery.sql).toContain('"users"."is_internal"');
             expect(memberQuery.bindings).toContain('organization-uuid');
             expect(memberQuery.bindings).toContainEqual(['member@example.com']);
+        });
+    });
+
+    describe('updateOrganizationMember', () => {
+        it('clears extra custom roles when the system role is written', async () => {
+            tracker.on
+                .any(/UPDATE organization_memberships/)
+                .response({ rows: [{ organization_id: 3, user_id: 7 }] });
+            tracker.on
+                .delete(OrganizationMembershipCustomRolesTableName)
+                .response(0);
+            const getMember = vi
+                .spyOn(model, 'getOrganizationMemberByUuid')
+                .mockResolvedValue({} as never);
+
+            await model.updateOrganizationMember('org-uuid', 'user-uuid', {
+                role: OrganizationMemberRole.EDITOR,
+            });
+
+            const [clear] = tracker.history.delete;
+            expect(clear.sql).toContain(
+                OrganizationMembershipCustomRolesTableName,
+            );
+            expect(clear.bindings).toEqual([3, 7]);
+            getMember.mockRestore();
         });
     });
 });

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -29,6 +29,7 @@ import { UserAvatarsTableName } from '../database/entities/userAvatars';
 import { UserOAuthGrantsTableName } from '../database/entities/userOAuthGrants';
 import { DbUser, UserTableName } from '../database/entities/users';
 import KnexPaginate from '../database/pagination';
+import { clearOrganizationExtraRoles } from './roleSetUtils';
 import { getColumnMatchRegexQuery } from './SearchModel/utils/search';
 import { UserModel } from './UserModel';
 
@@ -650,20 +651,35 @@ export class OrganizationMemberProfileModel {
                 userUuid,
                 role: data.role,
             };
-            await this.database.raw<
-                (DbOrganizationMemberProfile & DbOrganization & DbUser)[]
-            >(
-                `
+            // A singular write replaces the whole role set, so extras go too.
+            await this.database.transaction(async (trx) => {
+                const { rows } = await trx.raw<{
+                    rows: Pick<
+                        DbOrganizationMembership,
+                        'organization_id' | 'user_id'
+                    >[];
+                }>(
+                    `
                     UPDATE organization_memberships AS m
                     SET role = :role FROM organizations AS o, users AS u
                     WHERE o.organization_id = m.organization_id
                       AND u.user_id = m.user_id
                       AND user_uuid = :userUuid
                       AND organization_uuid = :organizationUuid
-                        RETURNING *
+                        RETURNING m.organization_id, m.user_id
                 `,
-                sqlParams,
-            );
+                    sqlParams,
+                );
+                await Promise.all(
+                    rows.map((row) =>
+                        clearOrganizationExtraRoles(
+                            trx,
+                            row.organization_id,
+                            row.user_id,
+                        ),
+                    ),
+                );
+            });
         }
         return this.getOrganizationMemberByUuid(organizationUuid, userUuid);
     }

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -31,8 +31,11 @@ import { getTracker, MockClient, RawQuery, Tracker } from 'knex-mock-client';
 import { FunctionQueryMatcher } from 'knex-mock-client/types/mock-client';
 import isEqual from 'lodash/isEqual';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { OrganizationMembershipCustomRolesTableName } from '../../database/entities/organizationMembershipCustomRoles';
 import { OrganizationMembershipsTableName } from '../../database/entities/organizationMemberships';
 import { ProjectGroupAccessTableName } from '../../database/entities/projectGroupAccess';
+import { ProjectGroupAccessCustomRolesTableName } from '../../database/entities/projectGroupAccessCustomRoles';
+import { ProjectMembershipCustomRolesTableName } from '../../database/entities/projectMembershipCustomRoles';
 import { ProjectMembershipsTableName } from '../../database/entities/projectMemberships';
 import {
     CachedExploresTableName,
@@ -239,6 +242,18 @@ describe('ProjectModel', () => {
         ]);
         tracker.on.insert(matchSql(ProjectMembershipsTableName)).response([]);
         tracker.on.insert(matchSql(ProjectGroupAccessTableName)).response([]);
+        tracker.on
+            .delete(matchSql(ProjectMembershipCustomRolesTableName))
+            .response(0);
+        tracker.on
+            .delete(matchSql(ProjectGroupAccessCustomRolesTableName))
+            .response(0);
+        tracker.on
+            .insert(matchSql(ProjectMembershipCustomRolesTableName))
+            .response([]);
+        tracker.on
+            .insert(matchSql(ProjectGroupAccessCustomRolesTableName))
+            .response([]);
 
         const copyAccess = () =>
             model.copyProjectAccess(upstreamProjectUuid, previewProjectUuid);
@@ -251,18 +266,56 @@ describe('ProjectModel', () => {
         await expect(copyAccess()).resolves.toEqual(expectedResult);
         await expect(copyAccess()).resolves.toEqual(expectedResult);
 
-        expect(tracker.history.insert).toHaveLength(4);
-        expect(tracker.history.insert[0].bindings).toEqual(
+        const membershipInserts = tracker.history.insert.filter(({ sql }) =>
+            sql.includes(`"${ProjectMembershipsTableName}"`),
+        );
+        const groupInserts = tracker.history.insert.filter(({ sql }) =>
+            sql.includes(`"${ProjectGroupAccessTableName}"`),
+        );
+        const extraRoleInserts = tracker.history.insert.filter(
+            ({ sql }) =>
+                sql.includes(ProjectMembershipCustomRolesTableName) ||
+                sql.includes(ProjectGroupAccessCustomRolesTableName),
+        );
+        expect(membershipInserts).toHaveLength(2);
+        expect(groupInserts).toHaveLength(2);
+        expect(extraRoleInserts).toHaveLength(4);
+        expect(membershipInserts[0].bindings).toEqual(
             expect.arrayContaining([1, 2, ProjectMemberRole.EDITOR]),
         );
-        expect(tracker.history.insert[0].bindings).not.toContain(3);
-        expect(tracker.history.insert[0].sql).toContain('on conflict');
-        expect(tracker.history.insert[1].sql).toContain('on conflict');
+        expect(membershipInserts[0].bindings).not.toContain(3);
+        expect(membershipInserts[0].sql).toContain('on conflict');
+        expect(groupInserts[0].sql).toContain('on conflict');
+        // extra custom roles are copied from upstream (1) into preview (2) for the eligible user only
+        expect(extraRoleInserts[0].bindings).toEqual(
+            expect.arrayContaining([2, 1, [1]]),
+        );
         const groupAccessQuery = tracker.history.select.find(({ sql }) =>
             sql.includes(ProjectGroupAccessTableName),
         );
         expect(groupAccessQuery?.sql).toContain('groups');
         expect(groupAccessQuery?.bindings).toContain(10);
+    });
+
+    test('updateProjectAccess clears extra custom roles for every updated membership', async () => {
+        tracker.on
+            .any(/UPDATE project_memberships/)
+            .response({ rows: [{ project_id: 5, user_id: 7 }] });
+        tracker.on
+            .delete(({ sql }: RawQuery) =>
+                sql.includes(ProjectMembershipCustomRolesTableName),
+            )
+            .response(0);
+
+        await model.updateProjectAccess(
+            projectUuid,
+            'user-uuid',
+            ProjectMemberRole.EDITOR,
+        );
+
+        const [clear] = tracker.history.delete;
+        expect(clear.sql).toContain(ProjectMembershipCustomRolesTableName);
+        expect(clear.bindings).toEqual([5, 7]);
     });
 
     describe('should convert outdated metric filters in explores', () => {
@@ -1148,6 +1201,9 @@ describe('ProjectModel', () => {
             tracker.on
                 .update(matchSql(OrganizationMembershipsTableName))
                 .response([]);
+            tracker.on
+                .delete(matchSql(OrganizationMembershipCustomRolesTableName))
+                .response(0);
 
             await model.setServiceAccountProjectAccess(
                 SA_UUID,
@@ -1162,6 +1218,11 @@ describe('ProjectModel', () => {
             expect(tracker.history.update[1].bindings).toContain(
                 OrganizationMemberRole.MEMBER,
             );
+            // singular org-role write also clears extra custom roles
+            const extrasClear = tracker.history.delete.find(({ sql }) =>
+                sql.includes(OrganizationMembershipCustomRolesTableName),
+            );
+            expect(extrasClear).toBeDefined();
         });
     });
 });

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -80,6 +80,7 @@ import {
 } from '../../database/entities/dashboards';
 import { GroupMembershipTableName } from '../../database/entities/groupMemberships';
 import { GroupTableName } from '../../database/entities/groups';
+import { OrganizationMembershipCustomRolesTableName } from '../../database/entities/organizationMembershipCustomRoles';
 import { OrganizationMembershipsTableName } from '../../database/entities/organizationMemberships';
 import {
     DbOrganization,
@@ -87,6 +88,8 @@ import {
 } from '../../database/entities/organizations';
 import { PinnedListTableName } from '../../database/entities/pinnedList';
 import { ProjectGroupAccessTableName } from '../../database/entities/projectGroupAccess';
+import { ProjectGroupAccessCustomRolesTableName } from '../../database/entities/projectGroupAccessCustomRoles';
+import { ProjectMembershipCustomRolesTableName } from '../../database/entities/projectMembershipCustomRoles';
 import {
     DbProjectMembership,
     ProjectMembershipsTableName,
@@ -140,6 +143,7 @@ import {
     acquireProjectSlugLock,
     generateUniqueSlugScopedToProject,
 } from '../../utils/SlugUtils';
+import { clearProjectExtraRoles } from '../roleSetUtils';
 import { omitProjectUuid, replaceProjectUuid } from './previewContent';
 import Transaction = Knex.Transaction;
 
@@ -2038,6 +2042,27 @@ export class ProjectModel {
                     )
                     .onConflict(['user_id', 'project_id'])
                     .merge(['role', 'role_uuid']);
+                // Extra custom roles follow their membership into the preview.
+                const eligibleUserIds = eligibleProjectAccesses.map(
+                    ({ user_id }) => user_id,
+                );
+                await trx(ProjectMembershipCustomRolesTableName)
+                    .where('project_id', previewProject.project_id)
+                    .whereIn('user_id', eligibleUserIds)
+                    .delete();
+                await trx.raw(
+                    `INSERT INTO ?? (project_id, user_id, role_uuid)
+                     SELECT ?, user_id, role_uuid FROM ??
+                     WHERE project_id = ? AND user_id = ANY(?)
+                     ON CONFLICT DO NOTHING`,
+                    [
+                        ProjectMembershipCustomRolesTableName,
+                        previewProject.project_id,
+                        ProjectMembershipCustomRolesTableName,
+                        upstreamProject.project_id,
+                        eligibleUserIds,
+                    ],
+                );
             }
             if (groupAccesses.length > 0) {
                 await trx(ProjectGroupAccessTableName)
@@ -2053,6 +2078,26 @@ export class ProjectModel {
                     )
                     .onConflict(['project_uuid', 'group_uuid'])
                     .merge(['role', 'role_uuid']);
+                const groupUuids = groupAccesses.map(
+                    ({ group_uuid }) => group_uuid,
+                );
+                await trx(ProjectGroupAccessCustomRolesTableName)
+                    .where('project_uuid', previewProjectUuid)
+                    .whereIn('group_uuid', groupUuids)
+                    .delete();
+                await trx.raw(
+                    `INSERT INTO ?? (project_uuid, group_uuid, role_uuid)
+                     SELECT ?, group_uuid, role_uuid FROM ??
+                     WHERE project_uuid = ? AND group_uuid = ANY(?)
+                     ON CONFLICT DO NOTHING`,
+                    [
+                        ProjectGroupAccessCustomRolesTableName,
+                        previewProjectUuid,
+                        ProjectGroupAccessCustomRolesTableName,
+                        upstreamProjectUuid,
+                        groupUuids,
+                    ],
+                );
             }
 
             return {
@@ -2122,18 +2167,28 @@ export class ProjectModel {
     ): Promise<void> {
         // Clear role_uuid when switching to a system role so that stale FK
         // references don't prevent custom role deletion later (see #20690).
-        await this.database.raw<(DbProjectMembership & DbProject & DbUser)[]>(
-            `
+        // A singular write replaces the whole role set, so extras go too.
+        await this.database.transaction(async (trx) => {
+            const { rows } = await trx.raw<{
+                rows: Pick<DbProjectMembership, 'project_id' | 'user_id'>[];
+            }>(
+                `
                 UPDATE project_memberships AS m
                 SET role = :role, role_uuid = NULL FROM projects AS p, users AS u
                 WHERE p.project_id = m.project_id
                   AND u.user_id = m.user_id
                   AND user_uuid = :userUuid
                   AND p.project_uuid = :projectUuid
-                    RETURNING *
+                    RETURNING m.project_id, m.user_id
             `,
-            { projectUuid, userUuid, role },
-        );
+                { projectUuid, userUuid, role },
+            );
+            await Promise.all(
+                rows.map((row) =>
+                    clearProjectExtraRoles(trx, row.project_id, row.user_id),
+                ),
+            );
+        });
     }
 
     async updateMetadata(
@@ -2557,6 +2612,10 @@ export class ProjectModel {
                         role: OrganizationMemberRole.MEMBER,
                         role_uuid: null,
                     });
+                // A singular write replaces the whole role set, so extras go too.
+                await trx(OrganizationMembershipCustomRolesTableName)
+                    .where('user_id', sa.user_id)
+                    .delete();
             }
         });
     }

--- a/packages/backend/src/models/RolesModel.test.ts
+++ b/packages/backend/src/models/RolesModel.test.ts
@@ -1,7 +1,17 @@
-import { AlreadyExistsError, NotFoundError } from '@lightdash/common';
+import {
+    AlreadyExistsError,
+    NotFoundError,
+    OrganizationMemberRole,
+    ParameterError,
+    ProjectMemberRole,
+} from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { DatabaseError } from 'pg';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { ProjectMembershipCustomRolesTableName } from '../database/entities/projectMembershipCustomRoles';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
 import { RolesTableName } from '../database/entities/roles';
 import { RolesModel } from './RolesModel';
 
@@ -94,6 +104,219 @@ describe('RolesModel', () => {
             await expect(
                 model.updateRole('missing-uuid', { description: 'x' }),
             ).rejects.toThrow(NotFoundError);
+        });
+    });
+
+    describe('getOrganizationUserRoleSet', () => {
+        beforeEach(() => {
+            tracker.on.select('users').response([{ user_id: 7 }]);
+            tracker.on
+                .select('organizations')
+                .response([{ organization_id: 3 }]);
+        });
+
+        it('returns the system role plus extras when the slot has no custom role', async () => {
+            tracker.on
+                .select(OrganizationMembershipsTableName)
+                .response([
+                    { role: OrganizationMemberRole.EDITOR, role_uuid: null },
+                ]);
+            tracker.on
+                .select(OrganizationMembershipCustomRolesTableName)
+                .response([{ role_uuid: 'extra-1' }, { role_uuid: 'extra-2' }]);
+
+            await expect(
+                model.getOrganizationUserRoleSet('org-uuid', 'user-uuid'),
+            ).resolves.toEqual({
+                systemRole: OrganizationMemberRole.EDITOR,
+                customRoleUuids: ['extra-1', 'extra-2'],
+            });
+        });
+
+        it('never surfaces the member placeholder when the slot holds a custom role', async () => {
+            tracker.on
+                .select(OrganizationMembershipsTableName)
+                .response([
+                    { role: OrganizationMemberRole.MEMBER, role_uuid: 'slot' },
+                ]);
+            tracker.on
+                .select(OrganizationMembershipCustomRolesTableName)
+                .response([{ role_uuid: 'extra-1' }]);
+
+            await expect(
+                model.getOrganizationUserRoleSet('org-uuid', 'user-uuid'),
+            ).resolves.toEqual({
+                systemRole: null,
+                customRoleUuids: ['slot', 'extra-1'],
+            });
+        });
+
+        it('throws NotFoundError when the user is not a member', async () => {
+            tracker.on.select(OrganizationMembershipsTableName).response([]);
+
+            await expect(
+                model.getOrganizationUserRoleSet('org-uuid', 'user-uuid'),
+            ).rejects.toThrow(NotFoundError);
+        });
+    });
+
+    describe('replaceOrganizationUserRoleSet', () => {
+        it('rejects an empty set before touching the database', async () => {
+            await expect(
+                model.replaceOrganizationUserRoleSet('org-uuid', 'user-uuid', {
+                    systemRole: null,
+                    customRoleUuids: [],
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(tracker.history.all).toHaveLength(0);
+        });
+    });
+
+    describe('singular writers replace the whole role set', () => {
+        beforeEach(() => {
+            tracker.on.select('users').response([{ user_id: 7 }]);
+            tracker.on
+                .select('organizations')
+                .response([{ organization_id: 3 }]);
+            tracker.on.select('projects').response([{ project_id: 5 }]);
+        });
+
+        it('upsertOrganizationUserRoleAssignment clears org extras in the same transaction', async () => {
+            tracker.on.update(OrganizationMembershipsTableName).response(1);
+            tracker.on
+                .delete(OrganizationMembershipCustomRolesTableName)
+                .response(0);
+
+            await model.upsertOrganizationUserRoleAssignment(
+                'org-uuid',
+                'user-uuid',
+                OrganizationMemberRole.EDITOR,
+            );
+
+            const [clear] = tracker.history.delete;
+            expect(clear.sql).toContain(
+                OrganizationMembershipCustomRolesTableName,
+            );
+            expect(clear.bindings).toEqual([3, 7]);
+        });
+
+        it('upsertSystemRoleProjectAccess clears project extras', async () => {
+            tracker.on.insert(ProjectMembershipsTableName).response([]);
+            tracker.on
+                .delete(ProjectMembershipCustomRolesTableName)
+                .response(0);
+
+            await model.upsertSystemRoleProjectAccess(
+                'project-uuid',
+                'user-uuid',
+                ProjectMemberRole.VIEWER,
+            );
+
+            const [clear] = tracker.history.delete;
+            expect(clear.sql).toContain(ProjectMembershipCustomRolesTableName);
+            expect(clear.bindings).toEqual([5, 7]);
+        });
+    });
+
+    describe('replaceOrganizationUserRoleSet validation', () => {
+        const ORG_ROLE = '11111111-1111-4111-a111-111111111111';
+
+        it('rejects malformed custom role ids before querying roles', async () => {
+            await expect(
+                model.replaceOrganizationUserRoleSet('org-uuid', 'user-uuid', {
+                    systemRole: null,
+                    customRoleUuids: ['admin'],
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(tracker.history.select).toHaveLength(0);
+        });
+
+        it('rejects a custom role that is missing or belongs to another organization', async () => {
+            tracker.on.select(RolesTableName).response([]);
+
+            await expect(
+                model.replaceOrganizationUserRoleSet('org-uuid', 'user-uuid', {
+                    systemRole: null,
+                    customRoleUuids: [ORG_ROLE],
+                }),
+            ).rejects.toThrow(NotFoundError);
+            expect(tracker.history.update).toHaveLength(0);
+        });
+
+        it('rejects a project-level custom role at organization level', async () => {
+            tracker.on
+                .select(RolesTableName)
+                .response([{ role_uuid: ORG_ROLE, level: 'project' }]);
+
+            await expect(
+                model.replaceOrganizationUserRoleSet('org-uuid', 'user-uuid', {
+                    systemRole: null,
+                    customRoleUuids: [ORG_ROLE],
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(tracker.history.update).toHaveLength(0);
+        });
+
+        it('throws NotFoundError when the user is not a member (no extras written)', async () => {
+            tracker.on
+                .select(RolesTableName)
+                .response([{ role_uuid: ORG_ROLE, level: 'organization' }]);
+            tracker.on.select('users').response([{ user_id: 7 }]);
+            tracker.on
+                .select('organizations')
+                .response([{ organization_id: 3 }]);
+            tracker.on.update(OrganizationMembershipsTableName).response(0);
+
+            await expect(
+                model.replaceOrganizationUserRoleSet('org-uuid', 'user-uuid', {
+                    systemRole: OrganizationMemberRole.VIEWER,
+                    customRoleUuids: [ORG_ROLE],
+                }),
+            ).rejects.toThrow(NotFoundError);
+            expect(tracker.history.insert).toHaveLength(0);
+        });
+
+        it('writes slot then replaces extras for a custom-only set', async () => {
+            const SECOND = '22222222-2222-4222-a222-222222222222';
+            tracker.on.select(RolesTableName).response([
+                { role_uuid: ORG_ROLE, level: 'organization' },
+                { role_uuid: SECOND, level: 'organization' },
+            ]);
+            tracker.on.select('users').response([{ user_id: 7 }]);
+            tracker.on
+                .select('organizations')
+                .response([{ organization_id: 3 }]);
+            tracker.on.update(OrganizationMembershipsTableName).response(1);
+            tracker.on
+                .delete(OrganizationMembershipCustomRolesTableName)
+                .response(0);
+            tracker.on
+                .insert(OrganizationMembershipCustomRolesTableName)
+                .response([]);
+
+            await model.replaceOrganizationUserRoleSet(
+                'org-uuid',
+                'user-uuid',
+                {
+                    systemRole: null,
+                    customRoleUuids: [ORG_ROLE, SECOND, ORG_ROLE],
+                },
+            );
+
+            const [slot] = tracker.history.update;
+            // custom-only: first custom role in the slot with the member placeholder
+            expect(slot.bindings).toEqual(
+                expect.arrayContaining([
+                    OrganizationMemberRole.MEMBER,
+                    ORG_ROLE,
+                ]),
+            );
+            expect(tracker.history.delete).toHaveLength(1);
+            const [extras] = tracker.history.insert;
+            expect(extras.bindings).toEqual(
+                expect.arrayContaining([3, 7, SECOND]),
+            );
+            expect(extras.bindings).not.toContain(ORG_ROLE);
         });
     });
 });

--- a/packages/backend/src/models/RolesModel.ts
+++ b/packages/backend/src/models/RolesModel.ts
@@ -6,20 +6,28 @@ import {
     isSystemRole,
     NotFoundError,
     OrganizationMemberRole,
+    OrganizationRoleSet,
+    ParameterError,
     Project,
     ProjectAccess,
     ProjectMemberProfile,
     ProjectMemberRole,
+    ProjectRoleSet,
     ProjectType,
     Role,
     RoleAssignee,
     RoleAssignment,
+    RoleLevel,
     RoleWithScopes,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { validate as isValidUuid } from 'uuid';
 import { GroupTableName } from '../database/entities/groups';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectGroupAccessCustomRolesTableName } from '../database/entities/projectGroupAccessCustomRoles';
+import { ProjectMembershipCustomRolesTableName } from '../database/entities/projectMembershipCustomRoles';
 import {
     DbProjectMembership,
     ProjectMembershipsTableName,
@@ -34,6 +42,17 @@ import {
 } from '../database/entities/roles';
 import { UserTableName } from '../database/entities/users';
 import { isUniqueConstraintViolation } from '../database/errors';
+import {
+    clearGroupExtraRoles,
+    clearOrganizationExtraRoles,
+    clearProjectExtraRoles,
+    joinRoleSet,
+    normalizeRoleSet,
+    ORGANIZATION_PLACEHOLDER_ROLE,
+    PROJECT_PLACEHOLDER_ROLE,
+    replaceExtraRoles,
+    splitRoleSet,
+} from './roleSetUtils';
 
 type DbRoleWithScopes = DbRole & {
     scopes: string;
@@ -333,7 +352,24 @@ export class RolesModel {
                 'service_accounts.service_account_user_uuid',
                 `${UserTableName}.user_uuid`,
             )
-            .where(`${OrganizationMembershipsTableName}.role_uuid`, roleUuid)
+            .where((qb) =>
+                qb
+                    .where(
+                        `${OrganizationMembershipsTableName}.role_uuid`,
+                        roleUuid,
+                    )
+                    .orWhereIn(
+                        [
+                            `${OrganizationMembershipsTableName}.organization_id`,
+                            `${OrganizationMembershipsTableName}.user_id`,
+                        ],
+                        this.database(
+                            OrganizationMembershipCustomRolesTableName,
+                        )
+                            .select('organization_id', 'user_id')
+                            .where('role_uuid', roleUuid),
+                    ),
+            )
             .select<
                 Array<{
                     userUuid: string;
@@ -361,7 +397,19 @@ export class RolesModel {
                 `${ProjectMembershipsTableName}.project_id`,
                 `${ProjectTableName}.project_id`,
             )
-            .where(`${ProjectMembershipsTableName}.role_uuid`, roleUuid)
+            .where((qb) =>
+                qb
+                    .where(`${ProjectMembershipsTableName}.role_uuid`, roleUuid)
+                    .orWhereIn(
+                        [
+                            `${ProjectMembershipsTableName}.project_id`,
+                            `${ProjectMembershipsTableName}.user_id`,
+                        ],
+                        this.database(ProjectMembershipCustomRolesTableName)
+                            .select('project_id', 'user_id')
+                            .where('role_uuid', roleUuid),
+                    ),
+            )
             .select<
                 Array<{
                     userUuid: string;
@@ -391,7 +439,19 @@ export class RolesModel {
                 `${ProjectGroupAccessTableName}.project_uuid`,
                 `${ProjectTableName}.project_uuid`,
             )
-            .where(`${ProjectGroupAccessTableName}.role_uuid`, roleUuid)
+            .where((qb) =>
+                qb
+                    .where(`${ProjectGroupAccessTableName}.role_uuid`, roleUuid)
+                    .orWhereIn(
+                        [
+                            `${ProjectGroupAccessTableName}.project_uuid`,
+                            `${ProjectGroupAccessTableName}.group_uuid`,
+                        ],
+                        this.database(ProjectGroupAccessCustomRolesTableName)
+                            .select('project_uuid', 'group_uuid')
+                            .where('role_uuid', roleUuid),
+                    ),
+            )
             .select<
                 Array<{
                     groupUuid: string;
@@ -485,10 +545,13 @@ export class RolesModel {
             );
         }
 
-        await (tx || this.database)(ProjectMembershipsTableName)
-            .where('user_id', userId)
-            .where('project_id', project.project_id)
-            .update({ role_uuid: null });
+        await this.runInTransaction(async (trx) => {
+            await trx(ProjectMembershipsTableName)
+                .where('user_id', userId)
+                .where('project_id', project.project_id)
+                .update({ role_uuid: null });
+            await clearProjectExtraRoles(trx, project.project_id, userId);
+        }, tx);
     }
 
     private async getUserProjectRoles(
@@ -564,15 +627,18 @@ export class RolesModel {
         role: ProjectMemberRole,
         tx?: Knex.Transaction,
     ): Promise<void> {
-        await (tx || this.database)('project_group_access')
-            .insert({
-                group_uuid: groupUuid,
-                project_uuid: projectUuid,
-                role,
-                role_uuid: null,
-            })
-            .onConflict(['group_uuid', 'project_uuid'])
-            .merge(['role', 'role_uuid']);
+        await this.runInTransaction(async (trx) => {
+            await trx('project_group_access')
+                .insert({
+                    group_uuid: groupUuid,
+                    project_uuid: projectUuid,
+                    role,
+                    role_uuid: null,
+                })
+                .onConflict(['group_uuid', 'project_uuid'])
+                .merge(['role', 'role_uuid']);
+            await clearGroupExtraRoles(trx, projectUuid, groupUuid);
+        }, tx);
     }
 
     async upsertCustomRoleGroupAccess(
@@ -581,15 +647,18 @@ export class RolesModel {
         roleUuid: string,
         tx?: Knex.Transaction,
     ): Promise<void> {
-        await (tx || this.database)('project_group_access')
-            .insert({
-                group_uuid: groupUuid,
-                project_uuid: projectUuid,
-                role_uuid: roleUuid,
-                role: ProjectMemberRole.VIEWER,
-            })
-            .onConflict(['group_uuid', 'project_uuid'])
-            .merge(['role_uuid', 'role']);
+        await this.runInTransaction(async (trx) => {
+            await trx('project_group_access')
+                .insert({
+                    group_uuid: groupUuid,
+                    project_uuid: projectUuid,
+                    role_uuid: roleUuid,
+                    role: ProjectMemberRole.VIEWER,
+                })
+                .onConflict(['group_uuid', 'project_uuid'])
+                .merge(['role_uuid', 'role']);
+            await clearGroupExtraRoles(trx, projectUuid, groupUuid);
+        }, tx);
     }
 
     async assignRoleToGroup(
@@ -598,29 +667,30 @@ export class RolesModel {
         projectUuid: string,
         tx?: Knex.Transaction,
     ): Promise<void> {
-        const existingAccess = await (tx || this.database)(
-            'project_group_access',
-        )
-            .where('group_uuid', groupUuid)
-            .where('project_uuid', projectUuid)
-            .first();
-
-        if (existingAccess) {
-            await (tx || this.database)('project_group_access')
+        await this.runInTransaction(async (trx) => {
+            const existingAccess = await trx('project_group_access')
                 .where('group_uuid', groupUuid)
                 .where('project_uuid', projectUuid)
-                .update({
+                .first();
+
+            if (existingAccess) {
+                await trx('project_group_access')
+                    .where('group_uuid', groupUuid)
+                    .where('project_uuid', projectUuid)
+                    .update({
+                        role_uuid: roleUuid,
+                        role: ProjectMemberRole.VIEWER,
+                    });
+            } else {
+                await trx('project_group_access').insert({
+                    group_uuid: groupUuid,
+                    project_uuid: projectUuid,
                     role_uuid: roleUuid,
-                    role: ProjectMemberRole.VIEWER,
+                    role: 'viewer' as ProjectMemberRole, // Default role when using custom role_uuid
                 });
-        } else {
-            await (tx || this.database)('project_group_access').insert({
-                group_uuid: groupUuid,
-                project_uuid: projectUuid,
-                role_uuid: roleUuid,
-                role: 'viewer' as ProjectMemberRole, // Default role when using custom role_uuid
-            });
-        }
+            }
+            await clearGroupExtraRoles(trx, projectUuid, groupUuid);
+        }, tx);
     }
 
     async unassignRoleFromGroup(
@@ -724,15 +794,18 @@ export class RolesModel {
         const userId = await this.getUserId(userUuid, tx);
         const projectId = await this.getProjectId(projectUuid, tx);
 
-        await (tx || this.database)(ProjectMembershipsTableName)
-            .insert({
-                project_id: projectId,
-                user_id: userId,
-                role,
-                role_uuid: null,
-            })
-            .onConflict(['project_id', 'user_id'])
-            .merge(['role', 'role_uuid']);
+        await this.runInTransaction(async (trx) => {
+            await trx(ProjectMembershipsTableName)
+                .insert({
+                    project_id: projectId,
+                    user_id: userId,
+                    role,
+                    role_uuid: null,
+                })
+                .onConflict(['project_id', 'user_id'])
+                .merge(['role', 'role_uuid']);
+            await clearProjectExtraRoles(trx, projectId, userId);
+        }, tx);
     }
 
     async upsertCustomRoleProjectAccess(
@@ -744,15 +817,18 @@ export class RolesModel {
         const userId = await this.getUserId(userUuid, tx);
         const projectId = await this.getProjectId(projectUuid, tx);
 
-        await (tx || this.database)(ProjectMembershipsTableName)
-            .insert({
-                project_id: projectId,
-                user_id: userId,
-                role_uuid: roleUuid,
-                role: ProjectMemberRole.VIEWER,
-            })
-            .onConflict(['project_id', 'user_id'])
-            .merge(['role_uuid', 'role']);
+        await this.runInTransaction(async (trx) => {
+            await trx(ProjectMembershipsTableName)
+                .insert({
+                    project_id: projectId,
+                    user_id: userId,
+                    role_uuid: roleUuid,
+                    role: ProjectMemberRole.VIEWER,
+                })
+                .onConflict(['project_id', 'user_id'])
+                .merge(['role_uuid', 'role']);
+            await clearProjectExtraRoles(trx, projectId, userId);
+        }, tx);
     }
 
     async removeUserAccessFromAllProjects(
@@ -903,17 +979,357 @@ export class RolesModel {
 
         const isSystemOrganizationRole = isOrganizationMemberRole(roleId);
 
-        await (tx || this.database)(OrganizationMembershipsTableName)
-            .where({
-                organization_id: orgId,
-                user_id: userId,
-            })
-            .update({
-                role: isSystemOrganizationRole
-                    ? roleId
-                    : OrganizationMemberRole.MEMBER,
-                role_uuid: isSystemOrganizationRole ? null : roleId,
-            });
+        await this.runInTransaction(async (trx) => {
+            await trx(OrganizationMembershipsTableName)
+                .where({
+                    organization_id: orgId,
+                    user_id: userId,
+                })
+                .update({
+                    role: isSystemOrganizationRole
+                        ? roleId
+                        : OrganizationMemberRole.MEMBER,
+                    role_uuid: isSystemOrganizationRole ? null : roleId,
+                });
+            await clearOrganizationExtraRoles(trx, orgId, userId);
+        }, tx);
+    }
+
+    private async getProjectOrganizationUuid(
+        projectUuid: string,
+        tx?: Knex.Transaction,
+    ): Promise<string> {
+        const row = await (tx || this.database)(ProjectTableName)
+            .join(
+                'organizations',
+                `${ProjectTableName}.organization_id`,
+                'organizations.organization_id',
+            )
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .first<{ organization_uuid: string }>(
+                'organizations.organization_uuid',
+            );
+        if (!row) {
+            throw new NotFoundError(
+                `Project with uuid ${projectUuid} not found`,
+            );
+        }
+        return row.organization_uuid;
+    }
+
+    private async assertGroupInOrganization(
+        groupUuid: string,
+        orgUuid: string,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        const row = await (tx || this.database)(GroupTableName)
+            .join(
+                'organizations',
+                `${GroupTableName}.organization_id`,
+                'organizations.organization_id',
+            )
+            .where(`${GroupTableName}.group_uuid`, groupUuid)
+            .first<{ organization_uuid: string }>(
+                'organizations.organization_uuid',
+            );
+        if (!row || row.organization_uuid !== orgUuid) {
+            throw new NotFoundError(`Group with uuid ${groupUuid} not found`);
+        }
+    }
+
+    private async getOrganizationMemberUserId(
+        orgUuid: string,
+        userUuid: string,
+        tx?: Knex.Transaction,
+    ): Promise<number> {
+        const row = await (tx || this.database)(UserTableName)
+            .join(
+                OrganizationMembershipsTableName,
+                `${OrganizationMembershipsTableName}.user_id`,
+                `${UserTableName}.user_id`,
+            )
+            .join(
+                'organizations',
+                'organizations.organization_id',
+                `${OrganizationMembershipsTableName}.organization_id`,
+            )
+            .where(`${UserTableName}.user_uuid`, userUuid)
+            .where('organizations.organization_uuid', orgUuid)
+            .first<{ user_id: number }>(`${UserTableName}.user_id`);
+        if (!row) {
+            throw new NotFoundError(
+                `User ${userUuid} is not a member of the project's organization`,
+            );
+        }
+        return row.user_id;
+    }
+
+    /**
+     * Ensures every custom role exists, belongs to the organization and has
+     * the expected level. Missing or foreign roles are reported as not found.
+     */
+    private async validateCustomRoles(
+        orgUuid: string,
+        customRoleUuids: string[],
+        level: RoleLevel,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        if (customRoleUuids.length === 0) {
+            return;
+        }
+        const malformed = customRoleUuids.filter((u) => !isValidUuid(u));
+        if (malformed.length > 0) {
+            throw new ParameterError(
+                `Invalid custom role id(s): ${malformed.join(', ')}`,
+            );
+        }
+        const rows = await (tx || this.database)(RolesTableName)
+            .select<Pick<DbRole, 'role_uuid' | 'level'>[]>('role_uuid', 'level')
+            .where('organization_uuid', orgUuid)
+            .where('owner_type', 'user')
+            .whereIn('role_uuid', customRoleUuids);
+        const byUuid = new Map(rows.map((r) => [r.role_uuid, r.level]));
+        const missing = customRoleUuids.filter((u) => !byUuid.has(u));
+        if (missing.length > 0) {
+            throw new NotFoundError(
+                `Custom role(s) not found in organization: ${missing.join(', ')}`,
+            );
+        }
+        const wrongLevel = customRoleUuids.filter(
+            (u) => byUuid.get(u) !== level,
+        );
+        if (wrongLevel.length > 0) {
+            throw new ParameterError(
+                `Custom role(s) are not ${level}-level roles: ${wrongLevel.join(', ')}`,
+            );
+        }
+    }
+
+    async getOrganizationUserRoleSet(
+        orgUuid: string,
+        userUuid: string,
+        tx?: Knex.Transaction,
+    ): Promise<OrganizationRoleSet> {
+        const userId = await this.getUserId(userUuid, tx);
+        const orgId = await this.getOrganizationId(orgUuid, tx);
+        const membership = await (tx || this.database)(
+            OrganizationMembershipsTableName,
+        )
+            .where({ organization_id: orgId, user_id: userId })
+            .first('role', 'role_uuid');
+        if (!membership) {
+            throw new NotFoundError(
+                `User ${userUuid} is not a member of organization ${orgUuid}`,
+            );
+        }
+        const extras = await (tx || this.database)(
+            OrganizationMembershipCustomRolesTableName,
+        )
+            .where({ organization_id: orgId, user_id: userId })
+            .orderBy([{ column: 'created_at' }, { column: 'role_uuid' }])
+            .pluck('role_uuid');
+        return joinRoleSet(
+            { role: membership.role, roleUuid: membership.role_uuid ?? null },
+            extras,
+        );
+    }
+
+    async getProjectUserRoleSet(
+        projectUuid: string,
+        userUuid: string,
+        tx?: Knex.Transaction,
+    ): Promise<ProjectRoleSet> {
+        const userId = await this.getUserId(userUuid, tx);
+        const projectId = await this.getProjectId(projectUuid, tx);
+        const membership = await (tx || this.database)(
+            ProjectMembershipsTableName,
+        )
+            .where({ project_id: projectId, user_id: userId })
+            .first('role', 'role_uuid');
+        if (!membership) {
+            throw new NotFoundError(
+                `User ${userUuid} has no direct access to project ${projectUuid}`,
+            );
+        }
+        const extras = await (tx || this.database)(
+            ProjectMembershipCustomRolesTableName,
+        )
+            .where({ project_id: projectId, user_id: userId })
+            .orderBy([{ column: 'created_at' }, { column: 'role_uuid' }])
+            .pluck('role_uuid');
+        return joinRoleSet(
+            {
+                role: membership.role ?? PROJECT_PLACEHOLDER_ROLE,
+                roleUuid: membership.role_uuid ?? null,
+            },
+            extras,
+        );
+    }
+
+    async getProjectGroupRoleSet(
+        projectUuid: string,
+        groupUuid: string,
+        tx?: Knex.Transaction,
+    ): Promise<ProjectRoleSet> {
+        const access = await (tx || this.database)(ProjectGroupAccessTableName)
+            .where({ project_uuid: projectUuid, group_uuid: groupUuid })
+            .first('role', 'role_uuid');
+        if (!access) {
+            throw new NotFoundError(
+                `Group ${groupUuid} has no access to project ${projectUuid}`,
+            );
+        }
+        const extras = await (tx || this.database)(
+            ProjectGroupAccessCustomRolesTableName,
+        )
+            .where({ project_uuid: projectUuid, group_uuid: groupUuid })
+            .orderBy([{ column: 'created_at' }, { column: 'role_uuid' }])
+            .pluck('role_uuid');
+        return joinRoleSet(
+            { role: access.role, roleUuid: access.role_uuid ?? null },
+            extras,
+        );
+    }
+
+    /** Atomically replaces the user's organization role set (membership must exist). */
+    async replaceOrganizationUserRoleSet(
+        orgUuid: string,
+        userUuid: string,
+        roleSet: OrganizationRoleSet,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        const set = normalizeRoleSet(roleSet);
+        const runner = async (trx: Knex.Transaction) => {
+            await this.validateCustomRoles(
+                orgUuid,
+                set.customRoleUuids,
+                'organization',
+                trx,
+            );
+            const userId = await this.getUserId(userUuid, trx);
+            const orgId = await this.getOrganizationId(orgUuid, trx);
+            const { slot, extraRoleUuids } = splitRoleSet(
+                set,
+                ORGANIZATION_PLACEHOLDER_ROLE,
+            );
+            const updated = await trx(OrganizationMembershipsTableName)
+                .where({ organization_id: orgId, user_id: userId })
+                .update({ role: slot.role, role_uuid: slot.roleUuid });
+            if (updated === 0) {
+                throw new NotFoundError(
+                    `User ${userUuid} is not a member of organization ${orgUuid}`,
+                );
+            }
+            await replaceExtraRoles(
+                trx,
+                OrganizationMembershipCustomRolesTableName,
+                { organization_id: orgId, user_id: userId },
+                extraRoleUuids,
+            );
+        };
+        await this.runInTransaction(runner, tx);
+    }
+
+    /** Atomically replaces the user's direct project role set, creating access if needed. */
+    async replaceProjectUserRoleSet(
+        projectUuid: string,
+        userUuid: string,
+        roleSet: ProjectRoleSet,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        const set = normalizeRoleSet(roleSet);
+        const runner = async (trx: Knex.Transaction) => {
+            const orgUuid = await this.getProjectOrganizationUuid(
+                projectUuid,
+                trx,
+            );
+            await this.validateCustomRoles(
+                orgUuid,
+                set.customRoleUuids,
+                'project',
+                trx,
+            );
+            const userId = await this.getOrganizationMemberUserId(
+                orgUuid,
+                userUuid,
+                trx,
+            );
+            const projectId = await this.getProjectId(projectUuid, trx);
+            const { slot, extraRoleUuids } = splitRoleSet(
+                set,
+                PROJECT_PLACEHOLDER_ROLE,
+            );
+            await trx(ProjectMembershipsTableName)
+                .insert({
+                    project_id: projectId,
+                    user_id: userId,
+                    role: slot.role,
+                    role_uuid: slot.roleUuid,
+                })
+                .onConflict(['project_id', 'user_id'])
+                .merge(['role', 'role_uuid']);
+            await replaceExtraRoles(
+                trx,
+                ProjectMembershipCustomRolesTableName,
+                { project_id: projectId, user_id: userId },
+                extraRoleUuids,
+            );
+        };
+        await this.runInTransaction(runner, tx);
+    }
+
+    /** Atomically replaces the group's project role set, creating access if needed. */
+    async replaceProjectGroupRoleSet(
+        projectUuid: string,
+        groupUuid: string,
+        roleSet: ProjectRoleSet,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        const set = normalizeRoleSet(roleSet);
+        const runner = async (trx: Knex.Transaction) => {
+            const orgUuid = await this.getProjectOrganizationUuid(
+                projectUuid,
+                trx,
+            );
+            await this.assertGroupInOrganization(groupUuid, orgUuid, trx);
+            await this.validateCustomRoles(
+                orgUuid,
+                set.customRoleUuids,
+                'project',
+                trx,
+            );
+            const { slot, extraRoleUuids } = splitRoleSet(
+                set,
+                PROJECT_PLACEHOLDER_ROLE,
+            );
+            await trx(ProjectGroupAccessTableName)
+                .insert({
+                    project_uuid: projectUuid,
+                    group_uuid: groupUuid,
+                    role: slot.role,
+                    role_uuid: slot.roleUuid,
+                })
+                .onConflict(['project_uuid', 'group_uuid'])
+                .merge(['role', 'role_uuid']);
+            await replaceExtraRoles(
+                trx,
+                ProjectGroupAccessCustomRolesTableName,
+                { project_uuid: projectUuid, group_uuid: groupUuid },
+                extraRoleUuids,
+            );
+        };
+        await this.runInTransaction(runner, tx);
+    }
+
+    private async runInTransaction(
+        runner: (trx: Knex.Transaction) => Promise<void>,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        if (tx) {
+            await runner(tx);
+        } else {
+            await this.database.transaction(runner);
+        }
     }
 
     async getOrganizationAdmins(

--- a/packages/backend/src/models/roleSetUtils.test.ts
+++ b/packages/backend/src/models/roleSetUtils.test.ts
@@ -1,0 +1,119 @@
+import {
+    OrganizationMemberRole,
+    ParameterError,
+    ProjectMemberRole,
+} from '@lightdash/common';
+import {
+    joinRoleSet,
+    normalizeRoleSet,
+    ORGANIZATION_PLACEHOLDER_ROLE,
+    PROJECT_PLACEHOLDER_ROLE,
+    splitRoleSet,
+} from './roleSetUtils';
+
+describe('roleSetUtils', () => {
+    describe('normalizeRoleSet', () => {
+        it('dedupes custom roles keeping first occurrence order', () => {
+            expect(
+                normalizeRoleSet({
+                    systemRole: null,
+                    customRoleUuids: ['b', 'a', 'b', 'c', 'a'],
+                }),
+            ).toEqual({ systemRole: null, customRoleUuids: ['b', 'a', 'c'] });
+        });
+
+        it('rejects an empty set', () => {
+            expect(() =>
+                normalizeRoleSet({ systemRole: null, customRoleUuids: [] }),
+            ).toThrow(ParameterError);
+        });
+
+        it('accepts a system-only set', () => {
+            expect(
+                normalizeRoleSet({
+                    systemRole: OrganizationMemberRole.VIEWER,
+                    customRoleUuids: [],
+                }),
+            ).toEqual({
+                systemRole: OrganizationMemberRole.VIEWER,
+                customRoleUuids: [],
+            });
+        });
+    });
+
+    describe('splitRoleSet', () => {
+        it('puts the system role in the slot and all custom roles in extras', () => {
+            expect(
+                splitRoleSet(
+                    {
+                        systemRole: OrganizationMemberRole.EDITOR,
+                        customRoleUuids: ['a', 'b'],
+                    },
+                    ORGANIZATION_PLACEHOLDER_ROLE,
+                ),
+            ).toEqual({
+                slot: { role: OrganizationMemberRole.EDITOR, roleUuid: null },
+                extraRoleUuids: ['a', 'b'],
+            });
+        });
+
+        it('puts the first custom role in the slot with the placeholder when custom-only', () => {
+            expect(
+                splitRoleSet(
+                    { systemRole: null, customRoleUuids: ['a', 'b'] },
+                    PROJECT_PLACEHOLDER_ROLE,
+                ),
+            ).toEqual({
+                slot: { role: ProjectMemberRole.VIEWER, roleUuid: 'a' },
+                extraRoleUuids: ['b'],
+            });
+        });
+    });
+
+    describe('joinRoleSet', () => {
+        it('reports the system role when the slot has no custom role', () => {
+            expect(
+                joinRoleSet(
+                    { role: ProjectMemberRole.EDITOR, roleUuid: null },
+                    ['x'],
+                ),
+            ).toEqual({
+                systemRole: ProjectMemberRole.EDITOR,
+                customRoleUuids: ['x'],
+            });
+        });
+
+        it('never surfaces the placeholder as a system role', () => {
+            expect(
+                joinRoleSet({ role: ProjectMemberRole.VIEWER, roleUuid: 'a' }, [
+                    'b',
+                ]),
+            ).toEqual({ systemRole: null, customRoleUuids: ['a', 'b'] });
+        });
+
+        it('round-trips split → join for every shape', () => {
+            const shapes = [
+                {
+                    systemRole: OrganizationMemberRole.ADMIN,
+                    customRoleUuids: [],
+                },
+                {
+                    systemRole: OrganizationMemberRole.MEMBER,
+                    customRoleUuids: ['a'],
+                },
+                { systemRole: null, customRoleUuids: ['a'] },
+                { systemRole: null, customRoleUuids: ['a', 'b', 'c'] },
+            ] as const;
+            shapes.forEach((shape) => {
+                const { slot, extraRoleUuids } = splitRoleSet(
+                    { ...shape, customRoleUuids: [...shape.customRoleUuids] },
+                    ORGANIZATION_PLACEHOLDER_ROLE,
+                );
+                expect(joinRoleSet(slot, extraRoleUuids)).toEqual({
+                    systemRole: shape.systemRole,
+                    customRoleUuids: [...shape.customRoleUuids],
+                });
+            });
+        });
+    });
+});

--- a/packages/backend/src/models/roleSetUtils.ts
+++ b/packages/backend/src/models/roleSetUtils.ts
@@ -1,0 +1,114 @@
+import {
+    OrganizationMemberRole,
+    OrganizationRoleSet,
+    ParameterError,
+    ProjectMemberRole,
+    ProjectRoleSet,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
+import { ProjectGroupAccessCustomRolesTableName } from '../database/entities/projectGroupAccessCustomRoles';
+import { ProjectMembershipCustomRolesTableName } from '../database/entities/projectMembershipCustomRoles';
+
+type RoleSet = OrganizationRoleSet | ProjectRoleSet;
+
+/** Dedupes custom roles (first occurrence wins) and rejects empty sets. */
+export const normalizeRoleSet = <T extends RoleSet>(set: T): T => {
+    const customRoleUuids = [...new Set(set.customRoleUuids)];
+    if (set.systemRole === null && customRoleUuids.length === 0) {
+        throw new ParameterError('A role set must contain at least one role');
+    }
+    return { ...set, customRoleUuids };
+};
+
+/**
+ * Splits a set into the primary slot (`role`/`role_uuid` columns) and the extra
+ * custom roles stored in the join tables. A custom-only set puts its first
+ * custom role in the slot with the level's placeholder system role.
+ */
+export const splitRoleSet = <TRole extends string>(
+    set: { systemRole: TRole | null; customRoleUuids: string[] },
+    placeholder: TRole,
+): {
+    slot: { role: TRole; roleUuid: string | null };
+    extraRoleUuids: string[];
+} => {
+    if (set.systemRole !== null) {
+        return {
+            slot: { role: set.systemRole, roleUuid: null },
+            extraRoleUuids: set.customRoleUuids,
+        };
+    }
+    const [first, ...rest] = set.customRoleUuids;
+    return {
+        slot: { role: placeholder, roleUuid: first },
+        extraRoleUuids: rest,
+    };
+};
+
+/** Rebuilds a set from a slot row plus its extras (placeholder never surfaces). */
+export const joinRoleSet = <TRole extends string>(
+    slot: { role: TRole; roleUuid: string | null },
+    extraRoleUuids: string[],
+): { systemRole: TRole | null; customRoleUuids: string[] } => ({
+    systemRole: slot.roleUuid ? null : slot.role,
+    customRoleUuids: slot.roleUuid
+        ? [slot.roleUuid, ...extraRoleUuids.filter((u) => u !== slot.roleUuid)]
+        : [...extraRoleUuids],
+});
+
+export const ORGANIZATION_PLACEHOLDER_ROLE = OrganizationMemberRole.MEMBER;
+export const PROJECT_PLACEHOLDER_ROLE = ProjectMemberRole.VIEWER;
+
+export const clearOrganizationExtraRoles = async (
+    db: Knex,
+    organizationId: number,
+    userId: number,
+): Promise<void> => {
+    await db(OrganizationMembershipCustomRolesTableName)
+        .where({ organization_id: organizationId, user_id: userId })
+        .delete();
+};
+
+export const clearProjectExtraRoles = async (
+    db: Knex,
+    projectId: number,
+    userId: number,
+): Promise<void> => {
+    await db(ProjectMembershipCustomRolesTableName)
+        .where({ project_id: projectId, user_id: userId })
+        .delete();
+};
+
+export const clearGroupExtraRoles = async (
+    db: Knex,
+    projectUuid: string,
+    groupUuid: string,
+): Promise<void> => {
+    await db(ProjectGroupAccessCustomRolesTableName)
+        .where({ project_uuid: projectUuid, group_uuid: groupUuid })
+        .delete();
+};
+
+/** Replaces the extra custom roles of one parent row (delete + insert) inside `db`. */
+export const replaceExtraRoles = async (
+    db: Knex,
+    table:
+        | typeof OrganizationMembershipCustomRolesTableName
+        | typeof ProjectMembershipCustomRolesTableName
+        | typeof ProjectGroupAccessCustomRolesTableName,
+    parentKey: Record<string, number | string>,
+    extraRoleUuids: string[],
+): Promise<void> => {
+    // Untyped table handle: the three join tables share the (parent key + role_uuid) shape.
+    const rows = db<Record<string, number | string>>(table);
+    await rows.clone().where(parentKey).delete();
+    if (extraRoleUuids.length > 0) {
+        await rows.clone().insert(
+            extraRoleUuids.map((roleUuid) => ({
+                ...parentKey,
+                role_uuid: roleUuid,
+            })),
+        );
+    }
+};

--- a/packages/backend/src/services/RolesService/RolesService.test.ts
+++ b/packages/backend/src/services/RolesService/RolesService.test.ts
@@ -17,6 +17,7 @@ import {
     UserAsCodeLifecycleStatus,
     type MemberAbility,
 } from '@lightdash/common';
+import { DatabaseError } from 'pg';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -665,6 +666,35 @@ describe('RolesService', () => {
                 ),
             ).resolves.toBeUndefined();
             expect(mockRolesModel.addScopesToRole).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('deleteRole', () => {
+        const dbError = (code: string) => {
+            const error = new DatabaseError('violates foreign key', 0, 'error');
+            error.code = code;
+            return error;
+        };
+
+        it.each(['23503', '23001'])(
+            'maps SQLSTATE %s from an assigned role to a ParameterError',
+            async (code) => {
+                mockRolesModel.getRoleByUuid.mockResolvedValue(mockCustomRole);
+                mockRolesModel.deleteRole.mockRejectedValueOnce(dbError(code));
+
+                await expect(
+                    service.deleteRole(mockAccount, mockCustomRole.roleUuid),
+                ).rejects.toThrow('Role cannot be deleted if assigned');
+            },
+        );
+
+        it('rethrows unrelated database errors', async () => {
+            mockRolesModel.getRoleByUuid.mockResolvedValue(mockCustomRole);
+            mockRolesModel.deleteRole.mockRejectedValueOnce(dbError('42P01'));
+
+            await expect(
+                service.deleteRole(mockAccount, mockCustomRole.roleUuid),
+            ).rejects.toBeInstanceOf(DatabaseError);
         });
     });
 

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -1578,10 +1578,12 @@ export class RolesService extends BaseService {
                 },
             });
         } catch (error) {
-            const foreignKeyViolation = '23503';
+            // 23503 = foreign_key_violation, 23001 = restrict_violation
+            // (raised by the ON DELETE RESTRICT role_uuid foreign keys)
+            const foreignKeyViolations = ['23503', '23001'];
             if (
                 error instanceof DatabaseError &&
-                error.code === foreignKeyViolation
+                foreignKeyViolations.includes(error.code ?? '')
             ) {
                 this.logger.error('Role deletion blocked by FK constraint', {
                     roleUuid,

--- a/packages/common/src/types/roles.ts
+++ b/packages/common/src/types/roles.ts
@@ -1,7 +1,23 @@
 import type { ApiSuccessEmpty } from './api/success';
+import type { OrganizationMemberRole } from './organizationMemberProfile';
+import type { ProjectMemberRole } from './projectMemberRole';
 import type { PromotionAction } from './promotion';
 
 export type RoleLevel = 'project' | 'organization';
+
+/**
+ * Complete set of roles held at one level: at most one system role plus any
+ * number of custom roles. Permissions are the union of all held roles.
+ */
+export type OrganizationRoleSet = {
+    systemRole: OrganizationMemberRole | null;
+    customRoleUuids: string[];
+};
+
+export type ProjectRoleSet = {
+    systemRole: ProjectMemberRole | null;
+    customRoleUuids: string[];
+};
 
 export type ProjectAccess = {
     projectUuid: string;


### PR DESCRIPTION
## Summary

PR 2 of 3 for [PROD-9762](https://linear.app/lightdash/issue/PROD-9762) (Stack A). Gives `RolesModel` a **role-set** view — at most one system role plus any number of custom roles — over the existing primary slot (`role`/`role_uuid`) and the join tables added in PR 1. No call site exposes multi-role writes yet; behaviour of every existing singular path is unchanged except that it now also clears extra roles (which nothing creates yet).

Stacks on top of PR 1 ([#27500](https://github.com/lightdash/lightdash/pull/27500)) which added the join tables and the `multiple-roles` flag.

Closes: https://linear.app/lightdash/issue/PROD-10208

## Changes

**Types** — `OrganizationRoleSet` / `ProjectRoleSet` (`{ systemRole | null, customRoleUuids[] }`) in `@lightdash/common`.

**Backend**
- `roleSetUtils.ts`: `normalizeRoleSet` (dedupe, reject empty), `splitRoleSet` / `joinRoleSet` (slot ⇄ extras), `clear*ExtraRoles`.
- `RolesModel.get{OrganizationUser,ProjectUser,ProjectGroup}RoleSet` and `replace…RoleSet` (atomic: validate → write slot → replace extras). Custom roles must exist in the *project's/group's* organization (derived inside the model, not trusted from the caller) and match the level.
- Singular writers replace the whole set: `RolesModel.upsert*`, `assignRoleToGroup`, `unassignCustomRoleFromUser`, `ProjectModel.updateProjectAccess`, `OrganizationMemberProfileModel.updateOrganizationMember`, `GroupsModel.updateProjectAccess`, `ServiceAccountModel.update`.
- `getRoleAssignees` and preview-project access copy include extra roles.
- `RolesService.deleteRole` also maps SQLSTATE `23001` (`restrict_violation`, what the existing `ON DELETE RESTRICT` FKs actually raise) to "Role cannot be deleted if assigned".

## Slot semantics

```
set {system: editor, custom: [A,B]}  →  slot role=editor, role_uuid=NULL   extras [A,B]
set {system: null,   custom: [A,B]}  →  slot role=member*, role_uuid=A     extras [B]     (*viewer at project level)
join(slot, extras) never reports the placeholder as a system role
```

## Test plan

- [x] `roleSetUtils.test.ts` (8) — dedupe/empty/split/join round-trips; `RolesModel.test.ts` (+4) — set reads, placeholder hidden, not-a-member, empty set rejected before any query
- [x] Real dev DB (transaction rolled back): system+custom, custom-only, singular write clears extras, empty / wrong-level / unknown / foreign-org role rejected, project user + group sets, deterministic ordering, unknown group rejected
- [x] Real dev DB (committed then restored): `getRoleAssignees` returns org user / project user / project group for a role held only as an extra; `deleteRole` blocked (`23001`)
- [x] Preview-copy `INSERT … SELECT … = ANY(?)` statements execute; `ProjectModel.test.ts` copy test extended (extras copied for eligible user only)
- [x] Affected suites: `RolesModel`, `GroupsModel`, `ProjectModel`, `RolesService`, `ee/models`, `ScimService`, `ServiceAccountService`, `OrganizationMemberProfileModel` — 22 files, 397 pass
- [x] `pnpm -F common typecheck`, `pnpm -F backend typecheck` (only pre-existing `bedrock.ts` error), `pnpm -F backend lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)