### PR TITLE
feat(roles): compose authorization from complete role sets

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -144,6 +144,10 @@ import {
     OrganizationEmailDomainsTableName,
 } from '../database/entities/organizationEmailDomains';
 import {
+    OrganizationMembershipCustomRolesTable,
+    OrganizationMembershipCustomRolesTableName,
+} from '../database/entities/organizationMembershipCustomRoles';
+import {
     OrganizationMembershipsTable,
     OrganizationMembershipsTableName,
 } from '../database/entities/organizationMemberships';
@@ -205,6 +209,14 @@ import {
     ProjectGroupAccessTable,
     ProjectGroupAccessTableName,
 } from '../database/entities/projectGroupAccess';
+import {
+    ProjectGroupAccessCustomRolesTable,
+    ProjectGroupAccessCustomRolesTableName,
+} from '../database/entities/projectGroupAccessCustomRoles';
+import {
+    ProjectMembershipCustomRolesTable,
+    ProjectMembershipCustomRolesTableName,
+} from '../database/entities/projectMembershipCustomRoles';
 import {
     ProjectMembershipsTable,
     ProjectMembershipsTableName,
@@ -575,6 +587,7 @@ declare module 'knex/types/tables' {
         [OnboardingTableName]: OnboardingTable;
         [OpenIdIdentitiesTableName]: OpenIdIdentitiesTable;
         [OrganizationMembershipsTableName]: OrganizationMembershipsTable;
+        [OrganizationMembershipCustomRolesTableName]: OrganizationMembershipCustomRolesTable;
         [PasswordResetTableName]: PasswordResetTable;
         [PasswordLoginTableName]: PasswordLoginTable;
         [CachedExploresTableName]: CachedExploresTable;
@@ -584,7 +597,9 @@ declare module 'knex/types/tables' {
         [JobStepsTableName]: JobStepsTable;
         [PersonalAccessTokenTableName]: PersonalAccessTokenTable;
         [ProjectMembershipsTableName]: ProjectMembershipsTable;
+        [ProjectMembershipCustomRolesTableName]: ProjectMembershipCustomRolesTable;
         [ProjectGroupAccessTableName]: ProjectGroupAccessTable;
+        [ProjectGroupAccessCustomRolesTableName]: ProjectGroupAccessCustomRolesTable;
         [ShareTableName]: ShareTable;
         [SpaceUserAccessTableName]: SpaceUserAccessTable;
         [SlackAuthTokensTableName]: SlackAuthTokensTable;

--- a/packages/backend/src/database/entities/organizationMembershipCustomRoles.ts
+++ b/packages/backend/src/database/entities/organizationMembershipCustomRoles.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+// Extra custom roles unioned on top of an organization membership's primary `role`/`role_uuid` slot.
+export const OrganizationMembershipCustomRolesTableName =
+    'organization_membership_custom_roles';
+
+export type DbOrganizationMembershipCustomRole = {
+    organization_id: number;
+    user_id: number;
+    role_uuid: string;
+    created_at: Date;
+};
+
+export type DbOrganizationMembershipCustomRoleIn = Pick<
+    DbOrganizationMembershipCustomRole,
+    'organization_id' | 'user_id' | 'role_uuid'
+>;
+
+export type OrganizationMembershipCustomRolesTable = Knex.CompositeTableType<
+    DbOrganizationMembershipCustomRole,
+    DbOrganizationMembershipCustomRoleIn,
+    never
+>;

--- a/packages/backend/src/database/entities/projectGroupAccessCustomRoles.ts
+++ b/packages/backend/src/database/entities/projectGroupAccessCustomRoles.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+// Extra custom roles unioned on top of a project group access row's primary `role`/`role_uuid` slot.
+export const ProjectGroupAccessCustomRolesTableName =
+    'project_group_access_custom_roles';
+
+export type DbProjectGroupAccessCustomRole = {
+    project_uuid: string;
+    group_uuid: string;
+    role_uuid: string;
+    created_at: Date;
+};
+
+export type DbProjectGroupAccessCustomRoleIn = Pick<
+    DbProjectGroupAccessCustomRole,
+    'project_uuid' | 'group_uuid' | 'role_uuid'
+>;
+
+export type ProjectGroupAccessCustomRolesTable = Knex.CompositeTableType<
+    DbProjectGroupAccessCustomRole,
+    DbProjectGroupAccessCustomRoleIn,
+    never
+>;

--- a/packages/backend/src/database/entities/projectMembershipCustomRoles.ts
+++ b/packages/backend/src/database/entities/projectMembershipCustomRoles.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+// Extra custom roles unioned on top of a direct project membership's primary `role`/`role_uuid` slot.
+export const ProjectMembershipCustomRolesTableName =
+    'project_membership_custom_roles';
+
+export type DbProjectMembershipCustomRole = {
+    project_id: number;
+    user_id: number;
+    role_uuid: string;
+    created_at: Date;
+};
+
+export type DbProjectMembershipCustomRoleIn = Pick<
+    DbProjectMembershipCustomRole,
+    'project_id' | 'user_id' | 'role_uuid'
+>;
+
+export type ProjectMembershipCustomRolesTable = Knex.CompositeTableType<
+    DbProjectMembershipCustomRole,
+    DbProjectMembershipCustomRoleIn,
+    never
+>;

--- a/packages/backend/src/database/migrations/20260817151500_add_custom_role_join_tables.ts
+++ b/packages/backend/src/database/migrations/20260817151500_add_custom_role_join_tables.ts
@@ -1,0 +1,120 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds three empty join tables for additional custom-role assignments; existing role columns and writes are unchanged',
+} as const;
+
+const RolesTableName = 'roles';
+const OrganizationMembershipsTableName = 'organization_memberships';
+const ProjectMembershipsTableName = 'project_memberships';
+const ProjectGroupAccessTableName = 'project_group_access';
+
+const OrganizationMembershipCustomRolesTableName =
+    'organization_membership_custom_roles';
+const ProjectMembershipCustomRolesTableName = 'project_membership_custom_roles';
+const ProjectGroupAccessCustomRolesTableName =
+    'project_group_access_custom_roles';
+
+const LockTimeout = '5s';
+
+// Extra custom roles unioned on top of a membership's primary `role`/`role_uuid`
+// slot. Rows cascade with the parent membership; referenced roles can't be deleted.
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+
+    if (
+        !(await knex.schema.hasTable(
+            OrganizationMembershipCustomRolesTableName,
+        ))
+    ) {
+        await knex.schema.createTable(
+            OrganizationMembershipCustomRolesTableName,
+            (table) => {
+                table.integer('organization_id').notNullable();
+                table.integer('user_id').notNullable();
+                table
+                    .uuid('role_uuid')
+                    .notNullable()
+                    .references('role_uuid')
+                    .inTable(RolesTableName)
+                    .onDelete('RESTRICT')
+                    .index();
+                table
+                    .timestamp('created_at')
+                    .notNullable()
+                    .defaultTo(knex.fn.now());
+                table.primary(['organization_id', 'user_id', 'role_uuid']);
+                table
+                    .foreign(['organization_id', 'user_id'])
+                    .references(['organization_id', 'user_id'])
+                    .inTable(OrganizationMembershipsTableName)
+                    .onDelete('CASCADE');
+            },
+        );
+    }
+
+    if (!(await knex.schema.hasTable(ProjectMembershipCustomRolesTableName))) {
+        await knex.schema.createTable(
+            ProjectMembershipCustomRolesTableName,
+            (table) => {
+                table.integer('project_id').notNullable();
+                table.integer('user_id').notNullable();
+                table
+                    .uuid('role_uuid')
+                    .notNullable()
+                    .references('role_uuid')
+                    .inTable(RolesTableName)
+                    .onDelete('RESTRICT')
+                    .index();
+                table
+                    .timestamp('created_at')
+                    .notNullable()
+                    .defaultTo(knex.fn.now());
+                table.primary(['project_id', 'user_id', 'role_uuid']);
+                // project_memberships primary key is (user_id, project_id)
+                table
+                    .foreign(['user_id', 'project_id'])
+                    .references(['user_id', 'project_id'])
+                    .inTable(ProjectMembershipsTableName)
+                    .onDelete('CASCADE');
+            },
+        );
+    }
+
+    if (!(await knex.schema.hasTable(ProjectGroupAccessCustomRolesTableName))) {
+        await knex.schema.createTable(
+            ProjectGroupAccessCustomRolesTableName,
+            (table) => {
+                table.uuid('project_uuid').notNullable();
+                table.uuid('group_uuid').notNullable();
+                table
+                    .uuid('role_uuid')
+                    .notNullable()
+                    .references('role_uuid')
+                    .inTable(RolesTableName)
+                    .onDelete('RESTRICT')
+                    .index();
+                table
+                    .timestamp('created_at')
+                    .notNullable()
+                    .defaultTo(knex.fn.now());
+                table.primary(['project_uuid', 'group_uuid', 'role_uuid']);
+                table
+                    .foreign(['project_uuid', 'group_uuid'])
+                    .references(['project_uuid', 'group_uuid'])
+                    .inTable(ProjectGroupAccessTableName)
+                    .onDelete('CASCADE');
+            },
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+    await knex.schema.dropTableIfExists(ProjectGroupAccessCustomRolesTableName);
+    await knex.schema.dropTableIfExists(ProjectMembershipCustomRolesTableName);
+    await knex.schema.dropTableIfExists(
+        OrganizationMembershipCustomRolesTableName,
+    );
+}

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.test.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.test.ts
@@ -1,0 +1,122 @@
+import { CommercialFeatureFlags } from '@lightdash/common';
+import { Knex } from 'knex';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { LightdashConfig } from '../../config/parseConfig';
+import {
+    FeatureFlagOverridesTableName,
+    FeatureFlagsTableName,
+} from '../../database/entities/featureFlags';
+import { CommercialFeatureFlagModel } from './CommercialFeatureFlagModel';
+
+vi.mock('../../models/FeatureFlagModel/flagCheckAggregator', () => ({
+    record: vi.fn(),
+}));
+
+const user = {
+    userUuid: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    organizationUuid: 'org-uuid',
+};
+
+// Fake Knex serving `feature_flags` rows by flag_id; no overrides.
+const buildFakeDatabase = (flagDefaults: Record<string, boolean>): Knex => {
+    const makeBuilder = (table: string) => {
+        let flagId: string | undefined;
+        const builder = {
+            where(column: string, value?: string) {
+                if (column === 'flag_id') flagId = value;
+                return builder;
+            },
+            whereNull: () => builder,
+            first() {
+                if (table === FeatureFlagsTableName && flagId !== undefined) {
+                    return Promise.resolve(
+                        flagId in flagDefaults
+                            ? {
+                                  flag_id: flagId,
+                                  default_enabled: flagDefaults[flagId],
+                              }
+                            : undefined,
+                    );
+                }
+                if (table === FeatureFlagOverridesTableName) {
+                    return Promise.resolve(undefined);
+                }
+                return Promise.resolve(undefined);
+            },
+        };
+        return builder;
+    };
+    return ((table: string) => makeBuilder(table)) as unknown as Knex;
+};
+
+const buildModel = (
+    flagDefaults: Record<string, boolean>,
+    customRolesConfigEnabled = false,
+) =>
+    new CommercialFeatureFlagModel({
+        database: buildFakeDatabase(flagDefaults),
+        lightdashConfig: {
+            ...lightdashConfigMock,
+            enabledFeatureFlags: new Set<string>(),
+            disabledFeatureFlags: new Set<string>(),
+            customRoles: { enabled: customRolesConfigEnabled },
+        } as unknown as LightdashConfig,
+    });
+
+describe('CommercialFeatureFlagModel – multiple-roles', () => {
+    const featureFlagId = CommercialFeatureFlags.MultipleRoles;
+
+    it('is disabled by default (no DB row)', async () => {
+        const model = buildModel({});
+        expect(await model.get({ user, featureFlagId })).toEqual({
+            id: featureFlagId,
+            enabled: false,
+        });
+    });
+
+    it('is disabled without a user', async () => {
+        const model = buildModel({ [featureFlagId]: true }, true);
+        expect(await model.get({ featureFlagId })).toEqual({
+            id: featureFlagId,
+            enabled: false,
+        });
+    });
+
+    it('stays disabled when enabled in DB but custom roles are unavailable', async () => {
+        const model = buildModel({ [featureFlagId]: true });
+        expect(await model.get({ user, featureFlagId })).toEqual({
+            id: featureFlagId,
+            enabled: false,
+        });
+    });
+
+    it('is enabled when enabled in DB and custom roles are enabled by config', async () => {
+        const model = buildModel({ [featureFlagId]: true }, true);
+        expect(await model.get({ user, featureFlagId })).toEqual({
+            id: featureFlagId,
+            enabled: true,
+        });
+    });
+
+    it('is enabled when enabled in DB and the CustomRoles flag is enabled', async () => {
+        const model = buildModel({
+            [featureFlagId]: true,
+            [CommercialFeatureFlags.CustomRoles]: true,
+        });
+        expect(await model.get({ user, featureFlagId })).toEqual({
+            id: featureFlagId,
+            enabled: true,
+        });
+    });
+
+    it('stays disabled when custom roles are available but the flag is off', async () => {
+        const model = buildModel(
+            { [CommercialFeatureFlags.CustomRoles]: true },
+            true,
+        );
+        expect(await model.get({ user, featureFlagId })).toEqual({
+            id: featureFlagId,
+            enabled: false,
+        });
+    });
+});

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -16,7 +16,35 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
                 this.getAiCopilotFlag.bind(this),
             [CommercialFeatureFlags.HomepageBuilder]:
                 this.getHomepageBuilderFlag.bind(this),
+            [CommercialFeatureFlags.MultipleRoles]:
+                this.getMultipleRolesFlag.bind(this),
         };
+    }
+
+    // Default-off; enabled per-org via DB-backed overrides, and only when
+    // custom roles are available (env config or the CustomRoles flag).
+    // Gates management surfaces only — persisted extra roles are always
+    // effective at runtime, mirroring custom roles.
+    private async getMultipleRolesFlag({
+        featureFlagId,
+        user,
+    }: FeatureFlagLogicArgs) {
+        if (!user) {
+            return { id: featureFlagId, enabled: false };
+        }
+        const dbResult = await this.tryGetFromDatabase({ user, featureFlagId });
+        if (!dbResult?.enabled) {
+            return { id: featureFlagId, enabled: false };
+        }
+        const customRolesEnabled =
+            this.lightdashConfig.customRoles.enabled ||
+            (
+                await this.get(
+                    { user, featureFlagId: CommercialFeatureFlags.CustomRoles },
+                    { recordCheck: false },
+                )
+            ).enabled;
+        return { id: featureFlagId, enabled: customRolesEnabled };
     }
 
     // Default-off; enabled per-org via DB-backed overrides.

--- a/packages/backend/src/ee/models/ServiceAccountModel.ts
+++ b/packages/backend/src/ee/models/ServiceAccountModel.ts
@@ -14,6 +14,7 @@ import {
 import * as crypto from 'crypto';
 import { Knex } from 'knex';
 import { LightdashConfig } from '../../config/parseConfig';
+import { OrganizationMembershipCustomRolesTableName } from '../../database/entities/organizationMembershipCustomRoles';
 import { OrganizationMembershipsTableName } from '../../database/entities/organizationMemberships';
 import { RolesTableName } from '../../database/entities/roles';
 import { DbUser, UserTableName } from '../../database/entities/users';
@@ -396,6 +397,18 @@ export class ServiceAccountModel {
                             )
                             .select('user_id'),
                     );
+                // A singular write replaces the whole role set, so extras go too.
+                await trx(OrganizationMembershipCustomRolesTableName)
+                    .whereIn(
+                        'user_id',
+                        trx('users')
+                            .where(
+                                'user_uuid',
+                                existing.service_account_user_uuid,
+                            )
+                            .select('user_id'),
+                    )
+                    .delete();
             }
 
             const updatedServiceAccounts = await trx(ServiceAccountsTableName)

--- a/packages/backend/src/models/GroupsModel.test.ts
+++ b/packages/backend/src/models/GroupsModel.test.ts
@@ -5,6 +5,7 @@ import { GroupMembershipTableName } from '../database/entities/groupMemberships'
 import { GroupTableName } from '../database/entities/groups';
 import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectGroupAccessCustomRolesTableName } from '../database/entities/projectGroupAccessCustomRoles';
 import { GroupsModel } from './GroupsModel';
 
 describe('GroupsModel', () => {
@@ -21,6 +22,7 @@ describe('GroupsModel', () => {
     });
 
     it('only updates allowed project access fields', async () => {
+        tracker.on.delete(ProjectGroupAccessCustomRolesTableName).response(0);
         tracker.on.update(ProjectGroupAccessTableName).responseOnce([
             {
                 project_id: 1,
@@ -46,9 +48,15 @@ describe('GroupsModel', () => {
         expect(query.sql).toContain(ProjectGroupAccessTableName);
         expect(query.sql).toContain('set "role" = $1 where');
         expect(query.bindings).not.toContain('attacker-project-uuid');
+        // singular write clears extra custom roles
+        expect(tracker.history.delete).toHaveLength(1);
+        expect(tracker.history.delete[0].sql).toContain(
+            ProjectGroupAccessCustomRolesTableName,
+        );
     });
 
     it('preserves null role_uuid when unsetting custom project access role', async () => {
+        tracker.on.delete(ProjectGroupAccessCustomRolesTableName).response(0);
         tracker.on.update(ProjectGroupAccessTableName).responseOnce([
             {
                 project_id: 1,

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -40,6 +40,7 @@ import {
 } from '../database/entities/projectGroupAccess';
 import { DbUser, UserTableName } from '../database/entities/users';
 import KnexPaginate from '../database/pagination';
+import { clearGroupExtraRoles } from './roleSetUtils';
 import { getColumnMatchRegexQuery } from './SearchModel/utils/search';
 
 export class GroupsModel {
@@ -845,13 +846,16 @@ export class GroupsModel {
                 : {}),
         };
 
-        const query = this.database(ProjectGroupAccessTableName)
-            .update(updateFields)
-            .where('project_uuid', projectUuid)
-            .andWhere('group_uuid', groupUuid)
-            .returning('*');
-
-        const rows = await query;
+        const rows = await this.database.transaction(async (trx) => {
+            const updated = await trx(ProjectGroupAccessTableName)
+                .update(updateFields)
+                .where('project_uuid', projectUuid)
+                .andWhere('group_uuid', groupUuid)
+                .returning('*');
+            // A singular write replaces the whole role set, so extras go too.
+            await clearGroupExtraRoles(trx, projectUuid, groupUuid);
+            return updated;
+        });
 
         if (rows.length === 0) {
             throw new UnexpectedDatabaseError(

--- a/packages/backend/src/models/OrganizationMemberProfileModel.test.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.test.ts
@@ -1,6 +1,7 @@
 import { OrganizationMemberRole } from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import { UserTableName } from '../database/entities/users';
 import { OrganizationMemberProfileModel } from './OrganizationMemberProfileModel';
@@ -76,6 +77,31 @@ describe('OrganizationMemberProfileModel', () => {
             expect(memberQuery.sql).toContain('"users"."is_internal"');
             expect(memberQuery.bindings).toContain('organization-uuid');
             expect(memberQuery.bindings).toContainEqual(['member@example.com']);
+        });
+    });
+
+    describe('updateOrganizationMember', () => {
+        it('clears extra custom roles when the system role is written', async () => {
+            tracker.on
+                .any(/UPDATE organization_memberships/)
+                .response({ rows: [{ organization_id: 3, user_id: 7 }] });
+            tracker.on
+                .delete(OrganizationMembershipCustomRolesTableName)
+                .response(0);
+            const getMember = vi
+                .spyOn(model, 'getOrganizationMemberByUuid')
+                .mockResolvedValue({} as never);
+
+            await model.updateOrganizationMember('org-uuid', 'user-uuid', {
+                role: OrganizationMemberRole.EDITOR,
+            });
+
+            const [clear] = tracker.history.delete;
+            expect(clear.sql).toContain(
+                OrganizationMembershipCustomRolesTableName,
+            );
+            expect(clear.bindings).toEqual([3, 7]);
+            getMember.mockRestore();
         });
     });
 });

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -29,6 +29,7 @@ import { UserAvatarsTableName } from '../database/entities/userAvatars';
 import { UserOAuthGrantsTableName } from '../database/entities/userOAuthGrants';
 import { DbUser, UserTableName } from '../database/entities/users';
 import KnexPaginate from '../database/pagination';
+import { clearOrganizationExtraRoles } from './roleSetUtils';
 import { getColumnMatchRegexQuery } from './SearchModel/utils/search';
 import { UserModel } from './UserModel';
 
@@ -650,20 +651,35 @@ export class OrganizationMemberProfileModel {
                 userUuid,
                 role: data.role,
             };
-            await this.database.raw<
-                (DbOrganizationMemberProfile & DbOrganization & DbUser)[]
-            >(
-                `
+            // A singular write replaces the whole role set, so extras go too.
+            await this.database.transaction(async (trx) => {
+                const { rows } = await trx.raw<{
+                    rows: Pick<
+                        DbOrganizationMembership,
+                        'organization_id' | 'user_id'
+                    >[];
+                }>(
+                    `
                     UPDATE organization_memberships AS m
                     SET role = :role FROM organizations AS o, users AS u
                     WHERE o.organization_id = m.organization_id
                       AND u.user_id = m.user_id
                       AND user_uuid = :userUuid
                       AND organization_uuid = :organizationUuid
-                        RETURNING *
+                        RETURNING m.organization_id, m.user_id
                 `,
-                sqlParams,
-            );
+                    sqlParams,
+                );
+                await Promise.all(
+                    rows.map((row) =>
+                        clearOrganizationExtraRoles(
+                            trx,
+                            row.organization_id,
+                            row.user_id,
+                        ),
+                    ),
+                );
+            });
         }
         return this.getOrganizationMemberByUuid(organizationUuid, userUuid);
     }

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -31,8 +31,11 @@ import { getTracker, MockClient, RawQuery, Tracker } from 'knex-mock-client';
 import { FunctionQueryMatcher } from 'knex-mock-client/types/mock-client';
 import isEqual from 'lodash/isEqual';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { OrganizationMembershipCustomRolesTableName } from '../../database/entities/organizationMembershipCustomRoles';
 import { OrganizationMembershipsTableName } from '../../database/entities/organizationMemberships';
 import { ProjectGroupAccessTableName } from '../../database/entities/projectGroupAccess';
+import { ProjectGroupAccessCustomRolesTableName } from '../../database/entities/projectGroupAccessCustomRoles';
+import { ProjectMembershipCustomRolesTableName } from '../../database/entities/projectMembershipCustomRoles';
 import { ProjectMembershipsTableName } from '../../database/entities/projectMemberships';
 import {
     CachedExploresTableName,
@@ -239,6 +242,18 @@ describe('ProjectModel', () => {
         ]);
         tracker.on.insert(matchSql(ProjectMembershipsTableName)).response([]);
         tracker.on.insert(matchSql(ProjectGroupAccessTableName)).response([]);
+        tracker.on
+            .delete(matchSql(ProjectMembershipCustomRolesTableName))
+            .response(0);
+        tracker.on
+            .delete(matchSql(ProjectGroupAccessCustomRolesTableName))
+            .response(0);
+        tracker.on
+            .insert(matchSql(ProjectMembershipCustomRolesTableName))
+            .response([]);
+        tracker.on
+            .insert(matchSql(ProjectGroupAccessCustomRolesTableName))
+            .response([]);
 
         const copyAccess = () =>
             model.copyProjectAccess(upstreamProjectUuid, previewProjectUuid);
@@ -251,18 +266,56 @@ describe('ProjectModel', () => {
         await expect(copyAccess()).resolves.toEqual(expectedResult);
         await expect(copyAccess()).resolves.toEqual(expectedResult);
 
-        expect(tracker.history.insert).toHaveLength(4);
-        expect(tracker.history.insert[0].bindings).toEqual(
+        const membershipInserts = tracker.history.insert.filter(({ sql }) =>
+            sql.includes(`"${ProjectMembershipsTableName}"`),
+        );
+        const groupInserts = tracker.history.insert.filter(({ sql }) =>
+            sql.includes(`"${ProjectGroupAccessTableName}"`),
+        );
+        const extraRoleInserts = tracker.history.insert.filter(
+            ({ sql }) =>
+                sql.includes(ProjectMembershipCustomRolesTableName) ||
+                sql.includes(ProjectGroupAccessCustomRolesTableName),
+        );
+        expect(membershipInserts).toHaveLength(2);
+        expect(groupInserts).toHaveLength(2);
+        expect(extraRoleInserts).toHaveLength(4);
+        expect(membershipInserts[0].bindings).toEqual(
             expect.arrayContaining([1, 2, ProjectMemberRole.EDITOR]),
         );
-        expect(tracker.history.insert[0].bindings).not.toContain(3);
-        expect(tracker.history.insert[0].sql).toContain('on conflict');
-        expect(tracker.history.insert[1].sql).toContain('on conflict');
+        expect(membershipInserts[0].bindings).not.toContain(3);
+        expect(membershipInserts[0].sql).toContain('on conflict');
+        expect(groupInserts[0].sql).toContain('on conflict');
+        // extra custom roles are copied from upstream (1) into preview (2) for the eligible user only
+        expect(extraRoleInserts[0].bindings).toEqual(
+            expect.arrayContaining([2, 1, [1]]),
+        );
         const groupAccessQuery = tracker.history.select.find(({ sql }) =>
             sql.includes(ProjectGroupAccessTableName),
         );
         expect(groupAccessQuery?.sql).toContain('groups');
         expect(groupAccessQuery?.bindings).toContain(10);
+    });
+
+    test('updateProjectAccess clears extra custom roles for every updated membership', async () => {
+        tracker.on
+            .any(/UPDATE project_memberships/)
+            .response({ rows: [{ project_id: 5, user_id: 7 }] });
+        tracker.on
+            .delete(({ sql }: RawQuery) =>
+                sql.includes(ProjectMembershipCustomRolesTableName),
+            )
+            .response(0);
+
+        await model.updateProjectAccess(
+            projectUuid,
+            'user-uuid',
+            ProjectMemberRole.EDITOR,
+        );
+
+        const [clear] = tracker.history.delete;
+        expect(clear.sql).toContain(ProjectMembershipCustomRolesTableName);
+        expect(clear.bindings).toEqual([5, 7]);
     });
 
     describe('should convert outdated metric filters in explores', () => {
@@ -1148,6 +1201,9 @@ describe('ProjectModel', () => {
             tracker.on
                 .update(matchSql(OrganizationMembershipsTableName))
                 .response([]);
+            tracker.on
+                .delete(matchSql(OrganizationMembershipCustomRolesTableName))
+                .response(0);
 
             await model.setServiceAccountProjectAccess(
                 SA_UUID,
@@ -1162,6 +1218,11 @@ describe('ProjectModel', () => {
             expect(tracker.history.update[1].bindings).toContain(
                 OrganizationMemberRole.MEMBER,
             );
+            // singular org-role write also clears extra custom roles
+            const extrasClear = tracker.history.delete.find(({ sql }) =>
+                sql.includes(OrganizationMembershipCustomRolesTableName),
+            );
+            expect(extrasClear).toBeDefined();
         });
     });
 });

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -80,6 +80,7 @@ import {
 } from '../../database/entities/dashboards';
 import { GroupMembershipTableName } from '../../database/entities/groupMemberships';
 import { GroupTableName } from '../../database/entities/groups';
+import { OrganizationMembershipCustomRolesTableName } from '../../database/entities/organizationMembershipCustomRoles';
 import { OrganizationMembershipsTableName } from '../../database/entities/organizationMemberships';
 import {
     DbOrganization,
@@ -87,6 +88,8 @@ import {
 } from '../../database/entities/organizations';
 import { PinnedListTableName } from '../../database/entities/pinnedList';
 import { ProjectGroupAccessTableName } from '../../database/entities/projectGroupAccess';
+import { ProjectGroupAccessCustomRolesTableName } from '../../database/entities/projectGroupAccessCustomRoles';
+import { ProjectMembershipCustomRolesTableName } from '../../database/entities/projectMembershipCustomRoles';
 import {
     DbProjectMembership,
     ProjectMembershipsTableName,
@@ -140,6 +143,7 @@ import {
     acquireProjectSlugLock,
     generateUniqueSlugScopedToProject,
 } from '../../utils/SlugUtils';
+import { clearProjectExtraRoles } from '../roleSetUtils';
 import { omitProjectUuid, replaceProjectUuid } from './previewContent';
 import Transaction = Knex.Transaction;
 
@@ -2038,6 +2042,27 @@ export class ProjectModel {
                     )
                     .onConflict(['user_id', 'project_id'])
                     .merge(['role', 'role_uuid']);
+                // Extra custom roles follow their membership into the preview.
+                const eligibleUserIds = eligibleProjectAccesses.map(
+                    ({ user_id }) => user_id,
+                );
+                await trx(ProjectMembershipCustomRolesTableName)
+                    .where('project_id', previewProject.project_id)
+                    .whereIn('user_id', eligibleUserIds)
+                    .delete();
+                await trx.raw(
+                    `INSERT INTO ?? (project_id, user_id, role_uuid)
+                     SELECT ?, user_id, role_uuid FROM ??
+                     WHERE project_id = ? AND user_id = ANY(?)
+                     ON CONFLICT DO NOTHING`,
+                    [
+                        ProjectMembershipCustomRolesTableName,
+                        previewProject.project_id,
+                        ProjectMembershipCustomRolesTableName,
+                        upstreamProject.project_id,
+                        eligibleUserIds,
+                    ],
+                );
             }
             if (groupAccesses.length > 0) {
                 await trx(ProjectGroupAccessTableName)
@@ -2053,6 +2078,26 @@ export class ProjectModel {
                     )
                     .onConflict(['project_uuid', 'group_uuid'])
                     .merge(['role', 'role_uuid']);
+                const groupUuids = groupAccesses.map(
+                    ({ group_uuid }) => group_uuid,
+                );
+                await trx(ProjectGroupAccessCustomRolesTableName)
+                    .where('project_uuid', previewProjectUuid)
+                    .whereIn('group_uuid', groupUuids)
+                    .delete();
+                await trx.raw(
+                    `INSERT INTO ?? (project_uuid, group_uuid, role_uuid)
+                     SELECT ?, group_uuid, role_uuid FROM ??
+                     WHERE project_uuid = ? AND group_uuid = ANY(?)
+                     ON CONFLICT DO NOTHING`,
+                    [
+                        ProjectGroupAccessCustomRolesTableName,
+                        previewProjectUuid,
+                        ProjectGroupAccessCustomRolesTableName,
+                        upstreamProjectUuid,
+                        groupUuids,
+                    ],
+                );
             }
 
             return {
@@ -2122,18 +2167,28 @@ export class ProjectModel {
     ): Promise<void> {
         // Clear role_uuid when switching to a system role so that stale FK
         // references don't prevent custom role deletion later (see #20690).
-        await this.database.raw<(DbProjectMembership & DbProject & DbUser)[]>(
-            `
+        // A singular write replaces the whole role set, so extras go too.
+        await this.database.transaction(async (trx) => {
+            const { rows } = await trx.raw<{
+                rows: Pick<DbProjectMembership, 'project_id' | 'user_id'>[];
+            }>(
+                `
                 UPDATE project_memberships AS m
                 SET role = :role, role_uuid = NULL FROM projects AS p, users AS u
                 WHERE p.project_id = m.project_id
                   AND u.user_id = m.user_id
                   AND user_uuid = :userUuid
                   AND p.project_uuid = :projectUuid
-                    RETURNING *
+                    RETURNING m.project_id, m.user_id
             `,
-            { projectUuid, userUuid, role },
-        );
+                { projectUuid, userUuid, role },
+            );
+            await Promise.all(
+                rows.map((row) =>
+                    clearProjectExtraRoles(trx, row.project_id, row.user_id),
+                ),
+            );
+        });
     }
 
     async updateMetadata(
@@ -2557,6 +2612,10 @@ export class ProjectModel {
                         role: OrganizationMemberRole.MEMBER,
                         role_uuid: null,
                     });
+                // A singular write replaces the whole role set, so extras go too.
+                await trx(OrganizationMembershipCustomRolesTableName)
+                    .where('user_id', sa.user_id)
+                    .delete();
             }
         });
     }

--- a/packages/backend/src/models/RolesModel.test.ts
+++ b/packages/backend/src/models/RolesModel.test.ts
@@ -1,7 +1,17 @@
-import { AlreadyExistsError, NotFoundError } from '@lightdash/common';
+import {
+    AlreadyExistsError,
+    NotFoundError,
+    OrganizationMemberRole,
+    ParameterError,
+    ProjectMemberRole,
+} from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { DatabaseError } from 'pg';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { ProjectMembershipCustomRolesTableName } from '../database/entities/projectMembershipCustomRoles';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
 import { RolesTableName } from '../database/entities/roles';
 import { RolesModel } from './RolesModel';
 
@@ -94,6 +104,219 @@ describe('RolesModel', () => {
             await expect(
                 model.updateRole('missing-uuid', { description: 'x' }),
             ).rejects.toThrow(NotFoundError);
+        });
+    });
+
+    describe('getOrganizationUserRoleSet', () => {
+        beforeEach(() => {
+            tracker.on.select('users').response([{ user_id: 7 }]);
+            tracker.on
+                .select('organizations')
+                .response([{ organization_id: 3 }]);
+        });
+
+        it('returns the system role plus extras when the slot has no custom role', async () => {
+            tracker.on
+                .select(OrganizationMembershipsTableName)
+                .response([
+                    { role: OrganizationMemberRole.EDITOR, role_uuid: null },
+                ]);
+            tracker.on
+                .select(OrganizationMembershipCustomRolesTableName)
+                .response([{ role_uuid: 'extra-1' }, { role_uuid: 'extra-2' }]);
+
+            await expect(
+                model.getOrganizationUserRoleSet('org-uuid', 'user-uuid'),
+            ).resolves.toEqual({
+                systemRole: OrganizationMemberRole.EDITOR,
+                customRoleUuids: ['extra-1', 'extra-2'],
+            });
+        });
+
+        it('never surfaces the member placeholder when the slot holds a custom role', async () => {
+            tracker.on
+                .select(OrganizationMembershipsTableName)
+                .response([
+                    { role: OrganizationMemberRole.MEMBER, role_uuid: 'slot' },
+                ]);
+            tracker.on
+                .select(OrganizationMembershipCustomRolesTableName)
+                .response([{ role_uuid: 'extra-1' }]);
+
+            await expect(
+                model.getOrganizationUserRoleSet('org-uuid', 'user-uuid'),
+            ).resolves.toEqual({
+                systemRole: null,
+                customRoleUuids: ['slot', 'extra-1'],
+            });
+        });
+
+        it('throws NotFoundError when the user is not a member', async () => {
+            tracker.on.select(OrganizationMembershipsTableName).response([]);
+
+            await expect(
+                model.getOrganizationUserRoleSet('org-uuid', 'user-uuid'),
+            ).rejects.toThrow(NotFoundError);
+        });
+    });
+
+    describe('replaceOrganizationUserRoleSet', () => {
+        it('rejects an empty set before touching the database', async () => {
+            await expect(
+                model.replaceOrganizationUserRoleSet('org-uuid', 'user-uuid', {
+                    systemRole: null,
+                    customRoleUuids: [],
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(tracker.history.all).toHaveLength(0);
+        });
+    });
+
+    describe('singular writers replace the whole role set', () => {
+        beforeEach(() => {
+            tracker.on.select('users').response([{ user_id: 7 }]);
+            tracker.on
+                .select('organizations')
+                .response([{ organization_id: 3 }]);
+            tracker.on.select('projects').response([{ project_id: 5 }]);
+        });
+
+        it('upsertOrganizationUserRoleAssignment clears org extras in the same transaction', async () => {
+            tracker.on.update(OrganizationMembershipsTableName).response(1);
+            tracker.on
+                .delete(OrganizationMembershipCustomRolesTableName)
+                .response(0);
+
+            await model.upsertOrganizationUserRoleAssignment(
+                'org-uuid',
+                'user-uuid',
+                OrganizationMemberRole.EDITOR,
+            );
+
+            const [clear] = tracker.history.delete;
+            expect(clear.sql).toContain(
+                OrganizationMembershipCustomRolesTableName,
+            );
+            expect(clear.bindings).toEqual([3, 7]);
+        });
+
+        it('upsertSystemRoleProjectAccess clears project extras', async () => {
+            tracker.on.insert(ProjectMembershipsTableName).response([]);
+            tracker.on
+                .delete(ProjectMembershipCustomRolesTableName)
+                .response(0);
+
+            await model.upsertSystemRoleProjectAccess(
+                'project-uuid',
+                'user-uuid',
+                ProjectMemberRole.VIEWER,
+            );
+
+            const [clear] = tracker.history.delete;
+            expect(clear.sql).toContain(ProjectMembershipCustomRolesTableName);
+            expect(clear.bindings).toEqual([5, 7]);
+        });
+    });
+
+    describe('replaceOrganizationUserRoleSet validation', () => {
+        const ORG_ROLE = '11111111-1111-4111-a111-111111111111';
+
+        it('rejects malformed custom role ids before querying roles', async () => {
+            await expect(
+                model.replaceOrganizationUserRoleSet('org-uuid', 'user-uuid', {
+                    systemRole: null,
+                    customRoleUuids: ['admin'],
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(tracker.history.select).toHaveLength(0);
+        });
+
+        it('rejects a custom role that is missing or belongs to another organization', async () => {
+            tracker.on.select(RolesTableName).response([]);
+
+            await expect(
+                model.replaceOrganizationUserRoleSet('org-uuid', 'user-uuid', {
+                    systemRole: null,
+                    customRoleUuids: [ORG_ROLE],
+                }),
+            ).rejects.toThrow(NotFoundError);
+            expect(tracker.history.update).toHaveLength(0);
+        });
+
+        it('rejects a project-level custom role at organization level', async () => {
+            tracker.on
+                .select(RolesTableName)
+                .response([{ role_uuid: ORG_ROLE, level: 'project' }]);
+
+            await expect(
+                model.replaceOrganizationUserRoleSet('org-uuid', 'user-uuid', {
+                    systemRole: null,
+                    customRoleUuids: [ORG_ROLE],
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(tracker.history.update).toHaveLength(0);
+        });
+
+        it('throws NotFoundError when the user is not a member (no extras written)', async () => {
+            tracker.on
+                .select(RolesTableName)
+                .response([{ role_uuid: ORG_ROLE, level: 'organization' }]);
+            tracker.on.select('users').response([{ user_id: 7 }]);
+            tracker.on
+                .select('organizations')
+                .response([{ organization_id: 3 }]);
+            tracker.on.update(OrganizationMembershipsTableName).response(0);
+
+            await expect(
+                model.replaceOrganizationUserRoleSet('org-uuid', 'user-uuid', {
+                    systemRole: OrganizationMemberRole.VIEWER,
+                    customRoleUuids: [ORG_ROLE],
+                }),
+            ).rejects.toThrow(NotFoundError);
+            expect(tracker.history.insert).toHaveLength(0);
+        });
+
+        it('writes slot then replaces extras for a custom-only set', async () => {
+            const SECOND = '22222222-2222-4222-a222-222222222222';
+            tracker.on.select(RolesTableName).response([
+                { role_uuid: ORG_ROLE, level: 'organization' },
+                { role_uuid: SECOND, level: 'organization' },
+            ]);
+            tracker.on.select('users').response([{ user_id: 7 }]);
+            tracker.on
+                .select('organizations')
+                .response([{ organization_id: 3 }]);
+            tracker.on.update(OrganizationMembershipsTableName).response(1);
+            tracker.on
+                .delete(OrganizationMembershipCustomRolesTableName)
+                .response(0);
+            tracker.on
+                .insert(OrganizationMembershipCustomRolesTableName)
+                .response([]);
+
+            await model.replaceOrganizationUserRoleSet(
+                'org-uuid',
+                'user-uuid',
+                {
+                    systemRole: null,
+                    customRoleUuids: [ORG_ROLE, SECOND, ORG_ROLE],
+                },
+            );
+
+            const [slot] = tracker.history.update;
+            // custom-only: first custom role in the slot with the member placeholder
+            expect(slot.bindings).toEqual(
+                expect.arrayContaining([
+                    OrganizationMemberRole.MEMBER,
+                    ORG_ROLE,
+                ]),
+            );
+            expect(tracker.history.delete).toHaveLength(1);
+            const [extras] = tracker.history.insert;
+            expect(extras.bindings).toEqual(
+                expect.arrayContaining([3, 7, SECOND]),
+            );
+            expect(extras.bindings).not.toContain(ORG_ROLE);
         });
     });
 });

--- a/packages/backend/src/models/RolesModel.ts
+++ b/packages/backend/src/models/RolesModel.ts
@@ -6,20 +6,28 @@ import {
     isSystemRole,
     NotFoundError,
     OrganizationMemberRole,
+    OrganizationRoleSet,
+    ParameterError,
     Project,
     ProjectAccess,
     ProjectMemberProfile,
     ProjectMemberRole,
+    ProjectRoleSet,
     ProjectType,
     Role,
     RoleAssignee,
     RoleAssignment,
+    RoleLevel,
     RoleWithScopes,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { validate as isValidUuid } from 'uuid';
 import { GroupTableName } from '../database/entities/groups';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectGroupAccessCustomRolesTableName } from '../database/entities/projectGroupAccessCustomRoles';
+import { ProjectMembershipCustomRolesTableName } from '../database/entities/projectMembershipCustomRoles';
 import {
     DbProjectMembership,
     ProjectMembershipsTableName,
@@ -34,6 +42,17 @@ import {
 } from '../database/entities/roles';
 import { UserTableName } from '../database/entities/users';
 import { isUniqueConstraintViolation } from '../database/errors';
+import {
+    clearGroupExtraRoles,
+    clearOrganizationExtraRoles,
+    clearProjectExtraRoles,
+    joinRoleSet,
+    normalizeRoleSet,
+    ORGANIZATION_PLACEHOLDER_ROLE,
+    PROJECT_PLACEHOLDER_ROLE,
+    replaceExtraRoles,
+    splitRoleSet,
+} from './roleSetUtils';
 
 type DbRoleWithScopes = DbRole & {
     scopes: string;
@@ -333,7 +352,24 @@ export class RolesModel {
                 'service_accounts.service_account_user_uuid',
                 `${UserTableName}.user_uuid`,
             )
-            .where(`${OrganizationMembershipsTableName}.role_uuid`, roleUuid)
+            .where((qb) =>
+                qb
+                    .where(
+                        `${OrganizationMembershipsTableName}.role_uuid`,
+                        roleUuid,
+                    )
+                    .orWhereIn(
+                        [
+                            `${OrganizationMembershipsTableName}.organization_id`,
+                            `${OrganizationMembershipsTableName}.user_id`,
+                        ],
+                        this.database(
+                            OrganizationMembershipCustomRolesTableName,
+                        )
+                            .select('organization_id', 'user_id')
+                            .where('role_uuid', roleUuid),
+                    ),
+            )
             .select<
                 Array<{
                     userUuid: string;
@@ -361,7 +397,19 @@ export class RolesModel {
                 `${ProjectMembershipsTableName}.project_id`,
                 `${ProjectTableName}.project_id`,
             )
-            .where(`${ProjectMembershipsTableName}.role_uuid`, roleUuid)
+            .where((qb) =>
+                qb
+                    .where(`${ProjectMembershipsTableName}.role_uuid`, roleUuid)
+                    .orWhereIn(
+                        [
+                            `${ProjectMembershipsTableName}.project_id`,
+                            `${ProjectMembershipsTableName}.user_id`,
+                        ],
+                        this.database(ProjectMembershipCustomRolesTableName)
+                            .select('project_id', 'user_id')
+                            .where('role_uuid', roleUuid),
+                    ),
+            )
             .select<
                 Array<{
                     userUuid: string;
@@ -391,7 +439,19 @@ export class RolesModel {
                 `${ProjectGroupAccessTableName}.project_uuid`,
                 `${ProjectTableName}.project_uuid`,
             )
-            .where(`${ProjectGroupAccessTableName}.role_uuid`, roleUuid)
+            .where((qb) =>
+                qb
+                    .where(`${ProjectGroupAccessTableName}.role_uuid`, roleUuid)
+                    .orWhereIn(
+                        [
+                            `${ProjectGroupAccessTableName}.project_uuid`,
+                            `${ProjectGroupAccessTableName}.group_uuid`,
+                        ],
+                        this.database(ProjectGroupAccessCustomRolesTableName)
+                            .select('project_uuid', 'group_uuid')
+                            .where('role_uuid', roleUuid),
+                    ),
+            )
             .select<
                 Array<{
                     groupUuid: string;
@@ -485,10 +545,13 @@ export class RolesModel {
             );
         }
 
-        await (tx || this.database)(ProjectMembershipsTableName)
-            .where('user_id', userId)
-            .where('project_id', project.project_id)
-            .update({ role_uuid: null });
+        await this.runInTransaction(async (trx) => {
+            await trx(ProjectMembershipsTableName)
+                .where('user_id', userId)
+                .where('project_id', project.project_id)
+                .update({ role_uuid: null });
+            await clearProjectExtraRoles(trx, project.project_id, userId);
+        }, tx);
     }
 
     private async getUserProjectRoles(
@@ -564,15 +627,18 @@ export class RolesModel {
         role: ProjectMemberRole,
         tx?: Knex.Transaction,
     ): Promise<void> {
-        await (tx || this.database)('project_group_access')
-            .insert({
-                group_uuid: groupUuid,
-                project_uuid: projectUuid,
-                role,
-                role_uuid: null,
-            })
-            .onConflict(['group_uuid', 'project_uuid'])
-            .merge(['role', 'role_uuid']);
+        await this.runInTransaction(async (trx) => {
+            await trx('project_group_access')
+                .insert({
+                    group_uuid: groupUuid,
+                    project_uuid: projectUuid,
+                    role,
+                    role_uuid: null,
+                })
+                .onConflict(['group_uuid', 'project_uuid'])
+                .merge(['role', 'role_uuid']);
+            await clearGroupExtraRoles(trx, projectUuid, groupUuid);
+        }, tx);
     }
 
     async upsertCustomRoleGroupAccess(
@@ -581,15 +647,18 @@ export class RolesModel {
         roleUuid: string,
         tx?: Knex.Transaction,
     ): Promise<void> {
-        await (tx || this.database)('project_group_access')
-            .insert({
-                group_uuid: groupUuid,
-                project_uuid: projectUuid,
-                role_uuid: roleUuid,
-                role: ProjectMemberRole.VIEWER,
-            })
-            .onConflict(['group_uuid', 'project_uuid'])
-            .merge(['role_uuid', 'role']);
+        await this.runInTransaction(async (trx) => {
+            await trx('project_group_access')
+                .insert({
+                    group_uuid: groupUuid,
+                    project_uuid: projectUuid,
+                    role_uuid: roleUuid,
+                    role: ProjectMemberRole.VIEWER,
+                })
+                .onConflict(['group_uuid', 'project_uuid'])
+                .merge(['role_uuid', 'role']);
+            await clearGroupExtraRoles(trx, projectUuid, groupUuid);
+        }, tx);
     }
 
     async assignRoleToGroup(
@@ -598,29 +667,30 @@ export class RolesModel {
         projectUuid: string,
         tx?: Knex.Transaction,
     ): Promise<void> {
-        const existingAccess = await (tx || this.database)(
-            'project_group_access',
-        )
-            .where('group_uuid', groupUuid)
-            .where('project_uuid', projectUuid)
-            .first();
-
-        if (existingAccess) {
-            await (tx || this.database)('project_group_access')
+        await this.runInTransaction(async (trx) => {
+            const existingAccess = await trx('project_group_access')
                 .where('group_uuid', groupUuid)
                 .where('project_uuid', projectUuid)
-                .update({
+                .first();
+
+            if (existingAccess) {
+                await trx('project_group_access')
+                    .where('group_uuid', groupUuid)
+                    .where('project_uuid', projectUuid)
+                    .update({
+                        role_uuid: roleUuid,
+                        role: ProjectMemberRole.VIEWER,
+                    });
+            } else {
+                await trx('project_group_access').insert({
+                    group_uuid: groupUuid,
+                    project_uuid: projectUuid,
                     role_uuid: roleUuid,
-                    role: ProjectMemberRole.VIEWER,
+                    role: 'viewer' as ProjectMemberRole, // Default role when using custom role_uuid
                 });
-        } else {
-            await (tx || this.database)('project_group_access').insert({
-                group_uuid: groupUuid,
-                project_uuid: projectUuid,
-                role_uuid: roleUuid,
-                role: 'viewer' as ProjectMemberRole, // Default role when using custom role_uuid
-            });
-        }
+            }
+            await clearGroupExtraRoles(trx, projectUuid, groupUuid);
+        }, tx);
     }
 
     async unassignRoleFromGroup(
@@ -724,15 +794,18 @@ export class RolesModel {
         const userId = await this.getUserId(userUuid, tx);
         const projectId = await this.getProjectId(projectUuid, tx);
 
-        await (tx || this.database)(ProjectMembershipsTableName)
-            .insert({
-                project_id: projectId,
-                user_id: userId,
-                role,
-                role_uuid: null,
-            })
-            .onConflict(['project_id', 'user_id'])
-            .merge(['role', 'role_uuid']);
+        await this.runInTransaction(async (trx) => {
+            await trx(ProjectMembershipsTableName)
+                .insert({
+                    project_id: projectId,
+                    user_id: userId,
+                    role,
+                    role_uuid: null,
+                })
+                .onConflict(['project_id', 'user_id'])
+                .merge(['role', 'role_uuid']);
+            await clearProjectExtraRoles(trx, projectId, userId);
+        }, tx);
     }
 
     async upsertCustomRoleProjectAccess(
@@ -744,15 +817,18 @@ export class RolesModel {
         const userId = await this.getUserId(userUuid, tx);
         const projectId = await this.getProjectId(projectUuid, tx);
 
-        await (tx || this.database)(ProjectMembershipsTableName)
-            .insert({
-                project_id: projectId,
-                user_id: userId,
-                role_uuid: roleUuid,
-                role: ProjectMemberRole.VIEWER,
-            })
-            .onConflict(['project_id', 'user_id'])
-            .merge(['role_uuid', 'role']);
+        await this.runInTransaction(async (trx) => {
+            await trx(ProjectMembershipsTableName)
+                .insert({
+                    project_id: projectId,
+                    user_id: userId,
+                    role_uuid: roleUuid,
+                    role: ProjectMemberRole.VIEWER,
+                })
+                .onConflict(['project_id', 'user_id'])
+                .merge(['role_uuid', 'role']);
+            await clearProjectExtraRoles(trx, projectId, userId);
+        }, tx);
     }
 
     async removeUserAccessFromAllProjects(
@@ -903,17 +979,357 @@ export class RolesModel {
 
         const isSystemOrganizationRole = isOrganizationMemberRole(roleId);
 
-        await (tx || this.database)(OrganizationMembershipsTableName)
-            .where({
-                organization_id: orgId,
-                user_id: userId,
-            })
-            .update({
-                role: isSystemOrganizationRole
-                    ? roleId
-                    : OrganizationMemberRole.MEMBER,
-                role_uuid: isSystemOrganizationRole ? null : roleId,
-            });
+        await this.runInTransaction(async (trx) => {
+            await trx(OrganizationMembershipsTableName)
+                .where({
+                    organization_id: orgId,
+                    user_id: userId,
+                })
+                .update({
+                    role: isSystemOrganizationRole
+                        ? roleId
+                        : OrganizationMemberRole.MEMBER,
+                    role_uuid: isSystemOrganizationRole ? null : roleId,
+                });
+            await clearOrganizationExtraRoles(trx, orgId, userId);
+        }, tx);
+    }
+
+    private async getProjectOrganizationUuid(
+        projectUuid: string,
+        tx?: Knex.Transaction,
+    ): Promise<string> {
+        const row = await (tx || this.database)(ProjectTableName)
+            .join(
+                'organizations',
+                `${ProjectTableName}.organization_id`,
+                'organizations.organization_id',
+            )
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .first<{ organization_uuid: string }>(
+                'organizations.organization_uuid',
+            );
+        if (!row) {
+            throw new NotFoundError(
+                `Project with uuid ${projectUuid} not found`,
+            );
+        }
+        return row.organization_uuid;
+    }
+
+    private async assertGroupInOrganization(
+        groupUuid: string,
+        orgUuid: string,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        const row = await (tx || this.database)(GroupTableName)
+            .join(
+                'organizations',
+                `${GroupTableName}.organization_id`,
+                'organizations.organization_id',
+            )
+            .where(`${GroupTableName}.group_uuid`, groupUuid)
+            .first<{ organization_uuid: string }>(
+                'organizations.organization_uuid',
+            );
+        if (!row || row.organization_uuid !== orgUuid) {
+            throw new NotFoundError(`Group with uuid ${groupUuid} not found`);
+        }
+    }
+
+    private async getOrganizationMemberUserId(
+        orgUuid: string,
+        userUuid: string,
+        tx?: Knex.Transaction,
+    ): Promise<number> {
+        const row = await (tx || this.database)(UserTableName)
+            .join(
+                OrganizationMembershipsTableName,
+                `${OrganizationMembershipsTableName}.user_id`,
+                `${UserTableName}.user_id`,
+            )
+            .join(
+                'organizations',
+                'organizations.organization_id',
+                `${OrganizationMembershipsTableName}.organization_id`,
+            )
+            .where(`${UserTableName}.user_uuid`, userUuid)
+            .where('organizations.organization_uuid', orgUuid)
+            .first<{ user_id: number }>(`${UserTableName}.user_id`);
+        if (!row) {
+            throw new NotFoundError(
+                `User ${userUuid} is not a member of the project's organization`,
+            );
+        }
+        return row.user_id;
+    }
+
+    /**
+     * Ensures every custom role exists, belongs to the organization and has
+     * the expected level. Missing or foreign roles are reported as not found.
+     */
+    private async validateCustomRoles(
+        orgUuid: string,
+        customRoleUuids: string[],
+        level: RoleLevel,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        if (customRoleUuids.length === 0) {
+            return;
+        }
+        const malformed = customRoleUuids.filter((u) => !isValidUuid(u));
+        if (malformed.length > 0) {
+            throw new ParameterError(
+                `Invalid custom role id(s): ${malformed.join(', ')}`,
+            );
+        }
+        const rows = await (tx || this.database)(RolesTableName)
+            .select<Pick<DbRole, 'role_uuid' | 'level'>[]>('role_uuid', 'level')
+            .where('organization_uuid', orgUuid)
+            .where('owner_type', 'user')
+            .whereIn('role_uuid', customRoleUuids);
+        const byUuid = new Map(rows.map((r) => [r.role_uuid, r.level]));
+        const missing = customRoleUuids.filter((u) => !byUuid.has(u));
+        if (missing.length > 0) {
+            throw new NotFoundError(
+                `Custom role(s) not found in organization: ${missing.join(', ')}`,
+            );
+        }
+        const wrongLevel = customRoleUuids.filter(
+            (u) => byUuid.get(u) !== level,
+        );
+        if (wrongLevel.length > 0) {
+            throw new ParameterError(
+                `Custom role(s) are not ${level}-level roles: ${wrongLevel.join(', ')}`,
+            );
+        }
+    }
+
+    async getOrganizationUserRoleSet(
+        orgUuid: string,
+        userUuid: string,
+        tx?: Knex.Transaction,
+    ): Promise<OrganizationRoleSet> {
+        const userId = await this.getUserId(userUuid, tx);
+        const orgId = await this.getOrganizationId(orgUuid, tx);
+        const membership = await (tx || this.database)(
+            OrganizationMembershipsTableName,
+        )
+            .where({ organization_id: orgId, user_id: userId })
+            .first('role', 'role_uuid');
+        if (!membership) {
+            throw new NotFoundError(
+                `User ${userUuid} is not a member of organization ${orgUuid}`,
+            );
+        }
+        const extras = await (tx || this.database)(
+            OrganizationMembershipCustomRolesTableName,
+        )
+            .where({ organization_id: orgId, user_id: userId })
+            .orderBy([{ column: 'created_at' }, { column: 'role_uuid' }])
+            .pluck('role_uuid');
+        return joinRoleSet(
+            { role: membership.role, roleUuid: membership.role_uuid ?? null },
+            extras,
+        );
+    }
+
+    async getProjectUserRoleSet(
+        projectUuid: string,
+        userUuid: string,
+        tx?: Knex.Transaction,
+    ): Promise<ProjectRoleSet> {
+        const userId = await this.getUserId(userUuid, tx);
+        const projectId = await this.getProjectId(projectUuid, tx);
+        const membership = await (tx || this.database)(
+            ProjectMembershipsTableName,
+        )
+            .where({ project_id: projectId, user_id: userId })
+            .first('role', 'role_uuid');
+        if (!membership) {
+            throw new NotFoundError(
+                `User ${userUuid} has no direct access to project ${projectUuid}`,
+            );
+        }
+        const extras = await (tx || this.database)(
+            ProjectMembershipCustomRolesTableName,
+        )
+            .where({ project_id: projectId, user_id: userId })
+            .orderBy([{ column: 'created_at' }, { column: 'role_uuid' }])
+            .pluck('role_uuid');
+        return joinRoleSet(
+            {
+                role: membership.role ?? PROJECT_PLACEHOLDER_ROLE,
+                roleUuid: membership.role_uuid ?? null,
+            },
+            extras,
+        );
+    }
+
+    async getProjectGroupRoleSet(
+        projectUuid: string,
+        groupUuid: string,
+        tx?: Knex.Transaction,
+    ): Promise<ProjectRoleSet> {
+        const access = await (tx || this.database)(ProjectGroupAccessTableName)
+            .where({ project_uuid: projectUuid, group_uuid: groupUuid })
+            .first('role', 'role_uuid');
+        if (!access) {
+            throw new NotFoundError(
+                `Group ${groupUuid} has no access to project ${projectUuid}`,
+            );
+        }
+        const extras = await (tx || this.database)(
+            ProjectGroupAccessCustomRolesTableName,
+        )
+            .where({ project_uuid: projectUuid, group_uuid: groupUuid })
+            .orderBy([{ column: 'created_at' }, { column: 'role_uuid' }])
+            .pluck('role_uuid');
+        return joinRoleSet(
+            { role: access.role, roleUuid: access.role_uuid ?? null },
+            extras,
+        );
+    }
+
+    /** Atomically replaces the user's organization role set (membership must exist). */
+    async replaceOrganizationUserRoleSet(
+        orgUuid: string,
+        userUuid: string,
+        roleSet: OrganizationRoleSet,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        const set = normalizeRoleSet(roleSet);
+        const runner = async (trx: Knex.Transaction) => {
+            await this.validateCustomRoles(
+                orgUuid,
+                set.customRoleUuids,
+                'organization',
+                trx,
+            );
+            const userId = await this.getUserId(userUuid, trx);
+            const orgId = await this.getOrganizationId(orgUuid, trx);
+            const { slot, extraRoleUuids } = splitRoleSet(
+                set,
+                ORGANIZATION_PLACEHOLDER_ROLE,
+            );
+            const updated = await trx(OrganizationMembershipsTableName)
+                .where({ organization_id: orgId, user_id: userId })
+                .update({ role: slot.role, role_uuid: slot.roleUuid });
+            if (updated === 0) {
+                throw new NotFoundError(
+                    `User ${userUuid} is not a member of organization ${orgUuid}`,
+                );
+            }
+            await replaceExtraRoles(
+                trx,
+                OrganizationMembershipCustomRolesTableName,
+                { organization_id: orgId, user_id: userId },
+                extraRoleUuids,
+            );
+        };
+        await this.runInTransaction(runner, tx);
+    }
+
+    /** Atomically replaces the user's direct project role set, creating access if needed. */
+    async replaceProjectUserRoleSet(
+        projectUuid: string,
+        userUuid: string,
+        roleSet: ProjectRoleSet,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        const set = normalizeRoleSet(roleSet);
+        const runner = async (trx: Knex.Transaction) => {
+            const orgUuid = await this.getProjectOrganizationUuid(
+                projectUuid,
+                trx,
+            );
+            await this.validateCustomRoles(
+                orgUuid,
+                set.customRoleUuids,
+                'project',
+                trx,
+            );
+            const userId = await this.getOrganizationMemberUserId(
+                orgUuid,
+                userUuid,
+                trx,
+            );
+            const projectId = await this.getProjectId(projectUuid, trx);
+            const { slot, extraRoleUuids } = splitRoleSet(
+                set,
+                PROJECT_PLACEHOLDER_ROLE,
+            );
+            await trx(ProjectMembershipsTableName)
+                .insert({
+                    project_id: projectId,
+                    user_id: userId,
+                    role: slot.role,
+                    role_uuid: slot.roleUuid,
+                })
+                .onConflict(['project_id', 'user_id'])
+                .merge(['role', 'role_uuid']);
+            await replaceExtraRoles(
+                trx,
+                ProjectMembershipCustomRolesTableName,
+                { project_id: projectId, user_id: userId },
+                extraRoleUuids,
+            );
+        };
+        await this.runInTransaction(runner, tx);
+    }
+
+    /** Atomically replaces the group's project role set, creating access if needed. */
+    async replaceProjectGroupRoleSet(
+        projectUuid: string,
+        groupUuid: string,
+        roleSet: ProjectRoleSet,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        const set = normalizeRoleSet(roleSet);
+        const runner = async (trx: Knex.Transaction) => {
+            const orgUuid = await this.getProjectOrganizationUuid(
+                projectUuid,
+                trx,
+            );
+            await this.assertGroupInOrganization(groupUuid, orgUuid, trx);
+            await this.validateCustomRoles(
+                orgUuid,
+                set.customRoleUuids,
+                'project',
+                trx,
+            );
+            const { slot, extraRoleUuids } = splitRoleSet(
+                set,
+                PROJECT_PLACEHOLDER_ROLE,
+            );
+            await trx(ProjectGroupAccessTableName)
+                .insert({
+                    project_uuid: projectUuid,
+                    group_uuid: groupUuid,
+                    role: slot.role,
+                    role_uuid: slot.roleUuid,
+                })
+                .onConflict(['project_uuid', 'group_uuid'])
+                .merge(['role', 'role_uuid']);
+            await replaceExtraRoles(
+                trx,
+                ProjectGroupAccessCustomRolesTableName,
+                { project_uuid: projectUuid, group_uuid: groupUuid },
+                extraRoleUuids,
+            );
+        };
+        await this.runInTransaction(runner, tx);
+    }
+
+    private async runInTransaction(
+        runner: (trx: Knex.Transaction) => Promise<void>,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        if (tx) {
+            await runner(tx);
+        } else {
+            await this.database.transaction(runner);
+        }
     }
 
     async getOrganizationAdmins(

--- a/packages/backend/src/models/SpacePermissionModel.ts
+++ b/packages/backend/src/models/SpacePermissionModel.ts
@@ -19,9 +19,12 @@ import { Knex } from 'knex';
 import { EmailTableName } from '../database/entities/emails';
 import { GroupMembershipTableName } from '../database/entities/groupMemberships';
 import { GroupTableName } from '../database/entities/groups';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectGroupAccessCustomRolesTableName } from '../database/entities/projectGroupAccessCustomRoles';
+import { ProjectMembershipCustomRolesTableName } from '../database/entities/projectMembershipCustomRoles';
 import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
 import { ProjectTableName } from '../database/entities/projects';
 import { ScopedRolesTableName } from '../database/entities/roles';
@@ -63,6 +66,26 @@ const parseUserMetadataRow = (
             : null,
 });
 
+/** `uuid[]` of extra custom roles for the parent row, ordered deterministically. */
+const extraRoleUuidsSubquery = (
+    trx: Knex,
+    extrasTable: string,
+    parentTable: string,
+    keys: [string, string],
+) =>
+    trx.raw(
+        `COALESCE((SELECT array_agg(x.role_uuid ORDER BY x.created_at, x.role_uuid) FROM ?? AS x WHERE x.?? = ??.?? AND x.?? = ??.??), '{}')`,
+        [
+            extrasTable,
+            keys[0],
+            parentTable,
+            keys[0],
+            keys[1],
+            parentTable,
+            keys[1],
+        ],
+    );
+
 export type RawSpaceUserAccess = {
     userUuid: string;
     email: string | null;
@@ -88,6 +111,8 @@ export type RawSpaceDirectAccess = {
  */
 export type ProjectSpaceAccessWithCustomRole = ProjectSpaceAccess & {
     roleUuid: string | null;
+    /** Extra custom roles unioned on top of `role`/`roleUuid`. */
+    extraRoleUuids: string[];
 };
 
 /**
@@ -96,6 +121,8 @@ export type ProjectSpaceAccessWithCustomRole = ProjectSpaceAccess & {
  */
 export type OrganizationSpaceAccessWithCustomRole = OrganizationSpaceAccess & {
     roleUuid: string | null;
+    /** Extra custom roles unioned on top of `role`/`roleUuid`. */
+    extraRoleUuids: string[];
 };
 
 export class SpacePermissionModel {
@@ -440,6 +467,12 @@ export class SpacePermissionModel {
                             spaceUuid: `${SpaceTableName}.space_uuid`,
                             role: `${ProjectMembershipsTableName}.role`,
                             roleUuid: `${ProjectMembershipsTableName}.role_uuid`,
+                            extraRoleUuids: extraRoleUuidsSubquery(
+                                trx,
+                                ProjectMembershipCustomRolesTableName,
+                                ProjectMembershipsTableName,
+                                ['project_id', 'user_id'],
+                            ),
                             from: trx.raw(
                                 `'${ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP}'`,
                             ),
@@ -481,6 +514,12 @@ export class SpacePermissionModel {
                                     spaceUuid: `${SpaceTableName}.space_uuid`,
                                     role: `${ProjectGroupAccessTableName}.role`,
                                     roleUuid: `${ProjectGroupAccessTableName}.role_uuid`,
+                                    extraRoleUuids: extraRoleUuidsSubquery(
+                                        trx,
+                                        ProjectGroupAccessCustomRolesTableName,
+                                        ProjectGroupAccessTableName,
+                                        ['project_uuid', 'group_uuid'],
+                                    ),
                                     from: trx.raw(
                                         `'${ProjectSpaceAccessOrigin.GROUP_MEMBERSHIP}'`,
                                     ),
@@ -591,6 +630,12 @@ export class SpacePermissionModel {
                             spaceUuid: `${SpaceTableName}.space_uuid`,
                             role: `${OrganizationMembershipsTableName}.role`,
                             roleUuid: `${OrganizationMembershipsTableName}.role_uuid`,
+                            extraRoleUuids: extraRoleUuidsSubquery(
+                                trx,
+                                OrganizationMembershipCustomRolesTableName,
+                                OrganizationMembershipsTableName,
+                                ['organization_id', 'user_id'],
+                            ),
                         })
                         .innerJoin(
                             ProjectTableName,

--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -46,6 +46,11 @@ type TestableUserModel = {
         userUuid: string,
         trx?: Knex,
     ) => Promise<never[]>;
+    getOrganizationExtraRoleUuids: (
+        userId: number,
+        organizationId: number,
+        trx?: Knex,
+    ) => Promise<string[]>;
     findServiceAccountByUserUuid: (
         userUuid: string,
         options?: { trx?: Knex },
@@ -124,6 +129,7 @@ const createUserModel = (): TestableUserModel => {
     model.hasAuthentication = vi.fn(async () => true);
     model.getUserProjectRoles = vi.fn(async () => []);
     model.getUserGroupProjectRoles = vi.fn(async () => []);
+    model.getOrganizationExtraRoleUuids = vi.fn(async () => []);
     model.findServiceAccountByUserUuid = vi.fn(async (userUuid) => ({
         uuid: 'service-account',
         description: 'Service account',
@@ -401,6 +407,114 @@ describe('UserModel', () => {
         expectCollapsedDashboardProjectRule(abilityBuilder.rules);
     });
 
+    describe('extra custom roles (role sets)', () => {
+        const humanDetails: DbUserDetails = {
+            ...userDetails,
+            user_uuid: 'human-user',
+            is_internal: false,
+            role: OrganizationMemberRole.VIEWER,
+            role_uuid: undefined,
+        };
+
+        const createHumanModel = () => {
+            const model = new UserModel({
+                database: vi.fn() as unknown as Knex,
+                lightdashConfig: {
+                    ...lightdashConfig,
+                    customRoles: { enabled: true },
+                } as LightdashConfig,
+                featureFlagModel,
+            }) as unknown as TestableUserModel;
+            model.hasAuthentication = vi.fn(async () => true);
+            model.getUserProjectRoles = vi.fn(async () => [
+                {
+                    projectUuid: 'project-1',
+                    role: ProjectMemberRole.VIEWER,
+                    userUuid: humanDetails.user_uuid,
+                    roleUuid: undefined,
+                    extraRoleUuids: ['project-extra'],
+                },
+            ]) as unknown as TestableUserModel['getUserProjectRoles'];
+            model.getUserGroupProjectRoles = vi.fn(async () => []);
+            model.getOrganizationExtraRoleUuids = vi.fn(async () => [
+                'org-extra',
+            ]);
+            model.customRoleScopes = vi.fn(async () => ({
+                'org-extra': ['manage:Organization'],
+                'project-extra': ['manage:SqlRunner'],
+            }));
+            model.findServiceAccountByUserUuid = vi.fn(async () => undefined);
+            model.applyServiceAccountProjectMemberships = vi.fn(async () => {});
+            return model;
+        };
+
+        it('unions org and project extra roles into a human user ability', async () => {
+            const model = createHumanModel();
+
+            const { abilityBuilder } =
+                await model.generateUserAbilityBuilder(humanDetails);
+            const ability = abilityBuilder.build();
+
+            expect(model.customRoleScopes).toHaveBeenCalledWith(
+                expect.arrayContaining(['org-extra', 'project-extra']),
+                expect.anything(),
+            );
+            // base viewer ability kept
+            expect(
+                ability.can(
+                    'view',
+                    subject('OrganizationMemberProfile', {
+                        organizationUuid: humanDetails.organization_uuid,
+                    }),
+                ),
+            ).toBe(true);
+            // extra org role adds manage:Organization (a viewer cannot)
+            expect(
+                ability.can(
+                    'manage',
+                    subject('Organization', {
+                        organizationUuid: humanDetails.organization_uuid,
+                    }),
+                ),
+            ).toBe(true);
+            // extra project role adds manage:SqlRunner in that project only
+            expect(
+                ability.can(
+                    'manage',
+                    subject('SqlRunner', { projectUuid: 'project-1' }),
+                ),
+            ).toBe(true);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('SqlRunner', { projectUuid: 'project-2' }),
+                ),
+            ).toBe(false);
+        });
+
+        it('applies org extra roles to a legacy-scopes service account', async () => {
+            const model = createUserModel();
+            model.getOrganizationExtraRoleUuids = vi.fn(async () => [
+                'org-extra',
+            ]);
+            model.customRoleScopes = vi.fn(async () => ({
+                'org-extra': ['manage:Organization'],
+            }));
+
+            const { abilityBuilder } =
+                await model.generateUserAbilityBuilder(userDetails);
+
+            expect(
+                abilityBuilder.build().can(
+                    'manage',
+                    subject('Organization', {
+                        organizationUuid: userDetails.organization_uuid,
+                    }),
+                ),
+            ).toBe(true);
+        });
+    });
+
     it('uses one transaction executor for every ability source', async () => {
         const model = createUserModel();
         const trx = vi.fn() as unknown as Knex;
@@ -419,6 +533,11 @@ describe('UserModel', () => {
             userDetails.user_id,
             userDetails.organization_id,
             userDetails.user_uuid,
+            trx,
+        );
+        expect(model.getOrganizationExtraRoleUuids).toHaveBeenCalledWith(
+            userDetails.user_id,
+            userDetails.organization_id,
             trx,
         );
         expect(model.findServiceAccountByUserUuid).toHaveBeenCalledWith(

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -47,6 +47,7 @@ import {
     EmailTableName,
 } from '../database/entities/emails';
 import { OpenIdIdentitiesTableName } from '../database/entities/openIdIdentities';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import {
     DbOrganization,
@@ -58,6 +59,8 @@ import {
     PasswordLoginTableName,
 } from '../database/entities/passwordLogins';
 import { DbPersonalAccessToken } from '../database/entities/personalAccessTokens';
+import { ProjectGroupAccessCustomRolesTableName } from '../database/entities/projectGroupAccessCustomRoles';
+import { ProjectMembershipCustomRolesTableName } from '../database/entities/projectMembershipCustomRoles';
 import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
 import { ProjectTableName } from '../database/entities/projects';
 import { ScopedRolesTableName } from '../database/entities/roles';
@@ -692,6 +695,7 @@ export class UserModel {
         { trx = this.database }: { trx?: Knex } = {},
     ): Promise<ProjectAbilityProfile[]> {
         type Row = {
+            project_id: number;
             project_uuid: string;
             role: ProjectMemberRole | null;
             role_uuid: string | null;
@@ -706,6 +710,7 @@ export class UserModel {
             )
             .leftJoin('users', 'project_memberships.user_id', 'users.user_id')
             .select<Row[]>([
+                `${ProjectTableName}.project_id`,
                 `${ProjectTableName}.project_uuid`,
                 'project_memberships.role',
                 'project_memberships.role_uuid',
@@ -714,6 +719,12 @@ export class UserModel {
             ])
             .where('users.user_uuid', userUuid);
 
+        const extraRoleUuidsByProjectId = await this.getProjectExtraRoleUuids(
+            projectMemberships.map((m) => m.project_id),
+            userUuid,
+            trx,
+        );
+
         return projectMemberships.map((membership) => ({
             projectUuid: membership.project_uuid,
             role: membership.role || ProjectMemberRole.VIEWER,
@@ -721,7 +732,61 @@ export class UserModel {
             roleUuid: membership.role_uuid || undefined,
             projectType: membership.project_type,
             projectCreatedByUserUuid: membership.created_by_user_uuid,
+            extraRoleUuids:
+                extraRoleUuidsByProjectId.get(membership.project_id) ?? [],
         }));
+    }
+
+    /** Extra custom roles per project for one user's direct memberships. */
+    private async getProjectExtraRoleUuids(
+        projectIds: number[],
+        userUuid: string,
+        trx: Knex = this.database,
+    ): Promise<Map<number, string[]>> {
+        if (projectIds.length === 0) {
+            return new Map();
+        }
+        const rows = await trx(ProjectMembershipCustomRolesTableName)
+            .join(
+                'users',
+                `${ProjectMembershipCustomRolesTableName}.user_id`,
+                'users.user_id',
+            )
+            .where('users.user_uuid', userUuid)
+            .whereIn(
+                `${ProjectMembershipCustomRolesTableName}.project_id`,
+                projectIds,
+            )
+            .select<{ project_id: number; role_uuid: string }[]>(
+                `${ProjectMembershipCustomRolesTableName}.project_id`,
+                `${ProjectMembershipCustomRolesTableName}.role_uuid`,
+            )
+            .orderBy([
+                {
+                    column: `${ProjectMembershipCustomRolesTableName}.created_at`,
+                },
+                {
+                    column: `${ProjectMembershipCustomRolesTableName}.role_uuid`,
+                },
+            ]);
+        return rows.reduce<Map<number, string[]>>((acc, row) => {
+            acc.set(row.project_id, [
+                ...(acc.get(row.project_id) ?? []),
+                row.role_uuid,
+            ]);
+            return acc;
+        }, new Map());
+    }
+
+    private async getOrganizationExtraRoleUuids(
+        userId: number,
+        organizationId: number,
+        trx: Knex = this.database,
+    ): Promise<string[]> {
+        return trx(OrganizationMembershipCustomRolesTableName)
+            .where({ organization_id: organizationId, user_id: userId })
+            .orderBy([{ column: 'created_at' }, { column: 'role_uuid' }])
+            .pluck('role_uuid');
     }
 
     private async getUserGroupProjectRoles(
@@ -746,12 +811,44 @@ export class UserModel {
             .andWhere('group_memberships.user_id', userId)
             .select(
                 'projects.project_uuid',
+                'project_group_access.group_uuid',
                 'project_group_access.role',
                 'project_group_access.role_uuid',
                 'projects.project_type',
                 'projects.created_by_user_uuid',
             );
         const projectMemberships = await query;
+        const extraRows: {
+            project_uuid: string;
+            group_uuid: string;
+            role_uuid: string;
+        }[] =
+            projectMemberships.length === 0
+                ? []
+                : await trx(ProjectGroupAccessCustomRolesTableName)
+                      .innerJoin(
+                          'group_memberships',
+                          'group_memberships.group_uuid',
+                          `${ProjectGroupAccessCustomRolesTableName}.group_uuid`,
+                      )
+                      .where(
+                          'group_memberships.organization_id',
+                          organizationId,
+                      )
+                      .andWhere('group_memberships.user_id', userId)
+                      .select(
+                          `${ProjectGroupAccessCustomRolesTableName}.project_uuid`,
+                          `${ProjectGroupAccessCustomRolesTableName}.group_uuid`,
+                          `${ProjectGroupAccessCustomRolesTableName}.role_uuid`,
+                      );
+        const extrasByAccess = extraRows.reduce<Map<string, string[]>>(
+            (acc, row) => {
+                const key = `${row.project_uuid}:${row.group_uuid}`;
+                acc.set(key, [...(acc.get(key) ?? []), row.role_uuid]);
+                return acc;
+            },
+            new Map(),
+        );
         return projectMemberships.map((membership) => ({
             projectUuid: membership.project_uuid,
             role: membership.role,
@@ -759,6 +856,10 @@ export class UserModel {
             roleUuid: membership.role_uuid || undefined,
             projectType: membership.project_type,
             projectCreatedByUserUuid: membership.created_by_user_uuid,
+            extraRoleUuids:
+                extrasByAccess.get(
+                    `${membership.project_uuid}:${membership.group_uuid}`,
+                ) ?? [],
         }));
     }
 
@@ -796,17 +897,26 @@ export class UserModel {
         abilityBuilder: AbilityBuilder<MemberAbility>;
         lightdashUser: LightdashUser;
     }> {
-        const [hasAuthentication, projectRoles, groupProjectRoles] =
-            await Promise.all([
-                this.hasAuthentication(user.user_uuid, trx),
-                this.getUserProjectRoles(user.user_uuid, { trx }),
-                this.getUserGroupProjectRoles(
-                    user.user_id,
-                    user.organization_id,
-                    user.user_uuid,
-                    trx,
-                ),
-            ]);
+        const [
+            hasAuthentication,
+            projectRoles,
+            groupProjectRoles,
+            orgExtraRoleUuids,
+        ] = await Promise.all([
+            this.hasAuthentication(user.user_uuid, trx),
+            this.getUserProjectRoles(user.user_uuid, { trx }),
+            this.getUserGroupProjectRoles(
+                user.user_id,
+                user.organization_id,
+                user.user_uuid,
+                trx,
+            ),
+            this.getOrganizationExtraRoleUuids(
+                user.user_id,
+                user.organization_id,
+                trx,
+            ),
+        ]);
         const lightdashUser = mapDbUserDetailsToLightdashUser(
             user,
             hasAuthentication,
@@ -832,6 +942,38 @@ export class UserModel {
             // silently neutered role-driven SAs whenever an admin toggled
             // the flag off, every CI workflow on those tokens would 403
             // overnight.
+            const applyOrgExtraRoles = async (
+                builder: AbilityBuilder<MemberAbility>,
+            ) => {
+                if (orgExtraRoleUuids.length === 0) {
+                    return;
+                }
+                const extraScopes = await this.customRoleScopes(
+                    orgExtraRoleUuids,
+                    trx,
+                );
+                orgExtraRoleUuids.forEach((roleUuid) => {
+                    const scopes = extraScopes[roleUuid];
+                    if (!scopes) {
+                        return;
+                    }
+                    buildAbilityFromScopes(
+                        {
+                            organizationUuid: user.organization_uuid as string,
+                            userUuid: user.user_uuid,
+                            scopes,
+                            isEnterprise:
+                                this.lightdashConfig.license.licenseKey !==
+                                undefined,
+                            organizationRole: user.role,
+                            permissionsConfig: {
+                                pat: this.lightdashConfig.auth.pat,
+                            },
+                        },
+                        builder,
+                    );
+                });
+            };
             if (user.role_uuid) {
                 const customRoleScopes = await this.customRoleScopes(
                     [user.role_uuid],
@@ -864,6 +1006,7 @@ export class UserModel {
                             )}`,
                         );
                     }
+                    await applyOrgExtraRoles(builder);
                     await this.applyServiceAccountProjectMemberships(
                         user.user_id,
                         user.user_uuid,
@@ -893,6 +1036,7 @@ export class UserModel {
                     userUuid: user.user_uuid,
                     builder,
                 });
+                await applyOrgExtraRoles(builder);
                 await this.applyServiceAccountProjectMemberships(
                     user.user_id,
                     user.user_uuid,
@@ -912,8 +1056,15 @@ export class UserModel {
         // runtime (getUserAbilityBuilder reads customRoleScopes[user.roleUuid]).
         const customRoleUuids = [
             lightdashUser.roleUuid,
-            ...projectRoles.map((role) => role.roleUuid),
-            ...groupProjectRoles.map((role) => role.roleUuid),
+            ...orgExtraRoleUuids,
+            ...projectRoles.flatMap((role) => [
+                role.roleUuid,
+                ...(role.extraRoleUuids ?? []),
+            ]),
+            ...groupProjectRoles.flatMap((role) => [
+                role.roleUuid,
+                ...(role.extraRoleUuids ?? []),
+            ]),
         ].filter((roleUuid): roleUuid is string => Boolean(roleUuid));
         const [customRoleScopes, customRolesFlag] = await Promise.all([
             this.customRoleScopes(customRoleUuids, trx),
@@ -928,6 +1079,7 @@ export class UserModel {
         const { builder: abilityBuilder, invalidScopes } =
             getUserAbilityBuilder({
                 user: lightdashUser,
+                orgExtraRoleUuids,
                 projectProfiles: [...projectRoles, ...groupProjectRoles],
                 permissionsConfig: {
                     pat: this.lightdashConfig.auth.pat,
@@ -975,6 +1127,7 @@ export class UserModel {
         trx: Knex = this.database,
     ): Promise<void> {
         type Row = {
+            project_id: number;
             project_uuid: string;
             role: ProjectMemberRole;
             role_uuid: string | null;
@@ -988,6 +1141,7 @@ export class UserModel {
                 `${ProjectTableName}.project_id`,
             )
             .select<Row[]>(
+                `${ProjectTableName}.project_id`,
                 `${ProjectTableName}.project_uuid`,
                 `${ProjectMembershipsTableName}.role`,
                 `${ProjectMembershipsTableName}.role_uuid`,
@@ -995,13 +1149,21 @@ export class UserModel {
                 `${ProjectTableName}.created_by_user_uuid`,
             )
             .where(`${ProjectMembershipsTableName}.user_id`, userId);
+        const extraRoleUuidsByProjectId = await this.getProjectExtraRoleUuids(
+            rows.map((r) => r.project_id),
+            userUuid,
+            trx,
+        );
 
         // Bulk-load scopes for any custom-role grants. Matches the human
         // path's philosophy (UserModel.generateUserAbilityBuilder): once a
         // role is bound in the DB the runtime must respect it, regardless
         // of the customRoles.enabled feature flag (which gates UI only).
         const customRoleUuids = rows
-            .map((r) => r.role_uuid)
+            .flatMap((r) => [
+                r.role_uuid,
+                ...(extraRoleUuidsByProjectId.get(r.project_id) ?? []),
+            ])
             .filter((u): u is string => u !== null);
         const customRoleScopes =
             customRoleUuids.length > 0
@@ -1012,10 +1174,7 @@ export class UserModel {
 
         const aggregatedInvalidScopes = new Set<string>();
         for (const row of rows) {
-            const scopes = row.role_uuid
-                ? customRoleScopes[row.role_uuid]
-                : undefined;
-            if (scopes) {
+            const applyScopes = (scopes: string[]) => {
                 const invalid = buildAbilityFromScopes(
                     {
                         projectUuid: row.project_uuid,
@@ -1031,6 +1190,12 @@ export class UserModel {
                     builder,
                 );
                 invalid.forEach((s) => aggregatedInvalidScopes.add(s));
+            };
+            const scopes = row.role_uuid
+                ? customRoleScopes[row.role_uuid]
+                : undefined;
+            if (scopes) {
+                applyScopes(scopes);
             } else {
                 projectMemberAbilities[row.role](
                     {
@@ -1041,6 +1206,15 @@ export class UserModel {
                     builder,
                 );
             }
+            // Extra custom roles are unioned on top of the slot.
+            (extraRoleUuidsByProjectId.get(row.project_id) ?? []).forEach(
+                (roleUuid) => {
+                    const extraScopes = customRoleScopes[roleUuid];
+                    if (extraScopes) {
+                        applyScopes(extraScopes);
+                    }
+                },
+            );
         }
         if (aggregatedInvalidScopes.size > 0) {
             Logger.warn(

--- a/packages/backend/src/models/roleSetUtils.test.ts
+++ b/packages/backend/src/models/roleSetUtils.test.ts
@@ -1,0 +1,119 @@
+import {
+    OrganizationMemberRole,
+    ParameterError,
+    ProjectMemberRole,
+} from '@lightdash/common';
+import {
+    joinRoleSet,
+    normalizeRoleSet,
+    ORGANIZATION_PLACEHOLDER_ROLE,
+    PROJECT_PLACEHOLDER_ROLE,
+    splitRoleSet,
+} from './roleSetUtils';
+
+describe('roleSetUtils', () => {
+    describe('normalizeRoleSet', () => {
+        it('dedupes custom roles keeping first occurrence order', () => {
+            expect(
+                normalizeRoleSet({
+                    systemRole: null,
+                    customRoleUuids: ['b', 'a', 'b', 'c', 'a'],
+                }),
+            ).toEqual({ systemRole: null, customRoleUuids: ['b', 'a', 'c'] });
+        });
+
+        it('rejects an empty set', () => {
+            expect(() =>
+                normalizeRoleSet({ systemRole: null, customRoleUuids: [] }),
+            ).toThrow(ParameterError);
+        });
+
+        it('accepts a system-only set', () => {
+            expect(
+                normalizeRoleSet({
+                    systemRole: OrganizationMemberRole.VIEWER,
+                    customRoleUuids: [],
+                }),
+            ).toEqual({
+                systemRole: OrganizationMemberRole.VIEWER,
+                customRoleUuids: [],
+            });
+        });
+    });
+
+    describe('splitRoleSet', () => {
+        it('puts the system role in the slot and all custom roles in extras', () => {
+            expect(
+                splitRoleSet(
+                    {
+                        systemRole: OrganizationMemberRole.EDITOR,
+                        customRoleUuids: ['a', 'b'],
+                    },
+                    ORGANIZATION_PLACEHOLDER_ROLE,
+                ),
+            ).toEqual({
+                slot: { role: OrganizationMemberRole.EDITOR, roleUuid: null },
+                extraRoleUuids: ['a', 'b'],
+            });
+        });
+
+        it('puts the first custom role in the slot with the placeholder when custom-only', () => {
+            expect(
+                splitRoleSet(
+                    { systemRole: null, customRoleUuids: ['a', 'b'] },
+                    PROJECT_PLACEHOLDER_ROLE,
+                ),
+            ).toEqual({
+                slot: { role: ProjectMemberRole.VIEWER, roleUuid: 'a' },
+                extraRoleUuids: ['b'],
+            });
+        });
+    });
+
+    describe('joinRoleSet', () => {
+        it('reports the system role when the slot has no custom role', () => {
+            expect(
+                joinRoleSet(
+                    { role: ProjectMemberRole.EDITOR, roleUuid: null },
+                    ['x'],
+                ),
+            ).toEqual({
+                systemRole: ProjectMemberRole.EDITOR,
+                customRoleUuids: ['x'],
+            });
+        });
+
+        it('never surfaces the placeholder as a system role', () => {
+            expect(
+                joinRoleSet({ role: ProjectMemberRole.VIEWER, roleUuid: 'a' }, [
+                    'b',
+                ]),
+            ).toEqual({ systemRole: null, customRoleUuids: ['a', 'b'] });
+        });
+
+        it('round-trips split → join for every shape', () => {
+            const shapes = [
+                {
+                    systemRole: OrganizationMemberRole.ADMIN,
+                    customRoleUuids: [],
+                },
+                {
+                    systemRole: OrganizationMemberRole.MEMBER,
+                    customRoleUuids: ['a'],
+                },
+                { systemRole: null, customRoleUuids: ['a'] },
+                { systemRole: null, customRoleUuids: ['a', 'b', 'c'] },
+            ] as const;
+            shapes.forEach((shape) => {
+                const { slot, extraRoleUuids } = splitRoleSet(
+                    { ...shape, customRoleUuids: [...shape.customRoleUuids] },
+                    ORGANIZATION_PLACEHOLDER_ROLE,
+                );
+                expect(joinRoleSet(slot, extraRoleUuids)).toEqual({
+                    systemRole: shape.systemRole,
+                    customRoleUuids: [...shape.customRoleUuids],
+                });
+            });
+        });
+    });
+});

--- a/packages/backend/src/models/roleSetUtils.ts
+++ b/packages/backend/src/models/roleSetUtils.ts
@@ -1,0 +1,114 @@
+import {
+    OrganizationMemberRole,
+    OrganizationRoleSet,
+    ParameterError,
+    ProjectMemberRole,
+    ProjectRoleSet,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
+import { ProjectGroupAccessCustomRolesTableName } from '../database/entities/projectGroupAccessCustomRoles';
+import { ProjectMembershipCustomRolesTableName } from '../database/entities/projectMembershipCustomRoles';
+
+type RoleSet = OrganizationRoleSet | ProjectRoleSet;
+
+/** Dedupes custom roles (first occurrence wins) and rejects empty sets. */
+export const normalizeRoleSet = <T extends RoleSet>(set: T): T => {
+    const customRoleUuids = [...new Set(set.customRoleUuids)];
+    if (set.systemRole === null && customRoleUuids.length === 0) {
+        throw new ParameterError('A role set must contain at least one role');
+    }
+    return { ...set, customRoleUuids };
+};
+
+/**
+ * Splits a set into the primary slot (`role`/`role_uuid` columns) and the extra
+ * custom roles stored in the join tables. A custom-only set puts its first
+ * custom role in the slot with the level's placeholder system role.
+ */
+export const splitRoleSet = <TRole extends string>(
+    set: { systemRole: TRole | null; customRoleUuids: string[] },
+    placeholder: TRole,
+): {
+    slot: { role: TRole; roleUuid: string | null };
+    extraRoleUuids: string[];
+} => {
+    if (set.systemRole !== null) {
+        return {
+            slot: { role: set.systemRole, roleUuid: null },
+            extraRoleUuids: set.customRoleUuids,
+        };
+    }
+    const [first, ...rest] = set.customRoleUuids;
+    return {
+        slot: { role: placeholder, roleUuid: first },
+        extraRoleUuids: rest,
+    };
+};
+
+/** Rebuilds a set from a slot row plus its extras (placeholder never surfaces). */
+export const joinRoleSet = <TRole extends string>(
+    slot: { role: TRole; roleUuid: string | null },
+    extraRoleUuids: string[],
+): { systemRole: TRole | null; customRoleUuids: string[] } => ({
+    systemRole: slot.roleUuid ? null : slot.role,
+    customRoleUuids: slot.roleUuid
+        ? [slot.roleUuid, ...extraRoleUuids.filter((u) => u !== slot.roleUuid)]
+        : [...extraRoleUuids],
+});
+
+export const ORGANIZATION_PLACEHOLDER_ROLE = OrganizationMemberRole.MEMBER;
+export const PROJECT_PLACEHOLDER_ROLE = ProjectMemberRole.VIEWER;
+
+export const clearOrganizationExtraRoles = async (
+    db: Knex,
+    organizationId: number,
+    userId: number,
+): Promise<void> => {
+    await db(OrganizationMembershipCustomRolesTableName)
+        .where({ organization_id: organizationId, user_id: userId })
+        .delete();
+};
+
+export const clearProjectExtraRoles = async (
+    db: Knex,
+    projectId: number,
+    userId: number,
+): Promise<void> => {
+    await db(ProjectMembershipCustomRolesTableName)
+        .where({ project_id: projectId, user_id: userId })
+        .delete();
+};
+
+export const clearGroupExtraRoles = async (
+    db: Knex,
+    projectUuid: string,
+    groupUuid: string,
+): Promise<void> => {
+    await db(ProjectGroupAccessCustomRolesTableName)
+        .where({ project_uuid: projectUuid, group_uuid: groupUuid })
+        .delete();
+};
+
+/** Replaces the extra custom roles of one parent row (delete + insert) inside `db`. */
+export const replaceExtraRoles = async (
+    db: Knex,
+    table:
+        | typeof OrganizationMembershipCustomRolesTableName
+        | typeof ProjectMembershipCustomRolesTableName
+        | typeof ProjectGroupAccessCustomRolesTableName,
+    parentKey: Record<string, number | string>,
+    extraRoleUuids: string[],
+): Promise<void> => {
+    // Untyped table handle: the three join tables share the (parent key + role_uuid) shape.
+    const rows = db<Record<string, number | string>>(table);
+    await rows.clone().where(parentKey).delete();
+    if (extraRoleUuids.length > 0) {
+        await rows.clone().insert(
+            extraRoleUuids.map((roleUuid) => ({
+                ...parentKey,
+                role_uuid: roleUuid,
+            })),
+        );
+    }
+};

--- a/packages/backend/src/services/RolesService/RolesService.test.ts
+++ b/packages/backend/src/services/RolesService/RolesService.test.ts
@@ -17,6 +17,7 @@ import {
     UserAsCodeLifecycleStatus,
     type MemberAbility,
 } from '@lightdash/common';
+import { DatabaseError } from 'pg';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -665,6 +666,35 @@ describe('RolesService', () => {
                 ),
             ).resolves.toBeUndefined();
             expect(mockRolesModel.addScopesToRole).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('deleteRole', () => {
+        const dbError = (code: string) => {
+            const error = new DatabaseError('violates foreign key', 0, 'error');
+            error.code = code;
+            return error;
+        };
+
+        it.each(['23503', '23001'])(
+            'maps SQLSTATE %s from an assigned role to a ParameterError',
+            async (code) => {
+                mockRolesModel.getRoleByUuid.mockResolvedValue(mockCustomRole);
+                mockRolesModel.deleteRole.mockRejectedValueOnce(dbError(code));
+
+                await expect(
+                    service.deleteRole(mockAccount, mockCustomRole.roleUuid),
+                ).rejects.toThrow('Role cannot be deleted if assigned');
+            },
+        );
+
+        it('rethrows unrelated database errors', async () => {
+            mockRolesModel.getRoleByUuid.mockResolvedValue(mockCustomRole);
+            mockRolesModel.deleteRole.mockRejectedValueOnce(dbError('42P01'));
+
+            await expect(
+                service.deleteRole(mockAccount, mockCustomRole.roleUuid),
+            ).rejects.toBeInstanceOf(DatabaseError);
         });
     });
 

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -1578,10 +1578,12 @@ export class RolesService extends BaseService {
                 },
             });
         } catch (error) {
-            const foreignKeyViolation = '23503';
+            // 23503 = foreign_key_violation, 23001 = restrict_violation
+            // (raised by the ON DELETE RESTRICT role_uuid foreign keys)
+            const foreignKeyViolations = ['23503', '23001'];
             if (
                 error instanceof DatabaseError &&
-                error.code === foreignKeyViolation
+                foreignKeyViolations.includes(error.code ?? '')
             ) {
                 this.logger.error('Role deletion blocked by FK constraint', {
                     roleUuid,

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -198,6 +198,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid: 'root-space',
                         role: 'editor' as ProjectMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                 ],
@@ -209,6 +210,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid: 'root-space',
                         role: 'member' as OrganizationMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                     },
                 ],
             });
@@ -263,6 +265,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid: 'root-space',
                         role: 'viewer' as ProjectMemberRole,
                         roleUuid: customRoleUuid,
+                        extraRoleUuids: [],
                         from: ProjectSpaceAccessOrigin.GROUP_MEMBERSHIP,
                     },
                 ],
@@ -274,6 +277,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid: 'root-space',
                         role: 'member' as OrganizationMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                     },
                 ],
             });
@@ -305,6 +309,68 @@ describe('SpacePermissionService', () => {
             ]);
         });
 
+        test('extra custom roles are unioned with the system role for inherited space access', async () => {
+            const spaceUuid = 'root-space';
+            const extraRoleUuid = 'extra-role-uuid';
+
+            mockPermissionModel.getInheritanceChains.mockResolvedValue({
+                'root-space': {
+                    chain: [
+                        {
+                            spaceUuid: 'root-space',
+                            spaceName: 'Root',
+                            inheritParentPermissions: true,
+                        },
+                    ],
+                    inheritsFromOrgOrProject: true,
+                },
+            });
+            mockPermissionModel.getDirectSpaceAccess.mockResolvedValue({});
+            // System viewer slot + an extra custom role granting manage:Space
+            mockPermissionModel.getProjectSpaceAccess.mockResolvedValue({
+                'root-space': [
+                    {
+                        userUuid,
+                        spaceUuid: 'root-space',
+                        role: 'viewer' as ProjectMemberRole,
+                        roleUuid: null,
+                        extraRoleUuids: [extraRoleUuid],
+                        from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
+                    },
+                ],
+            });
+            mockPermissionModel.getOrganizationSpaceAccess.mockResolvedValue({
+                'root-space': [
+                    {
+                        userUuid,
+                        spaceUuid: 'root-space',
+                        role: 'member' as OrganizationMemberRole,
+                        roleUuid: null,
+                        extraRoleUuids: [],
+                    },
+                ],
+            });
+            mockPermissionModel.getSpaceInfo.mockResolvedValue({
+                [spaceUuid]: { projectUuid, organizationUuid },
+            });
+            mockPermissionModel.getRoleScopes.mockResolvedValue({
+                [extraRoleUuid]: ['manage:Space'],
+            });
+
+            const result = await service.getAllSpaceAccessContext(spaceUuid);
+
+            expect(mockPermissionModel.getRoleScopes).toHaveBeenCalledWith(
+                [extraRoleUuid],
+                { trx: undefined },
+            );
+            expect(result.access).toEqual([
+                expect.objectContaining({
+                    userUuid,
+                    role: SpaceMemberRole.ADMIN,
+                }),
+            ]);
+        });
+
         test('org-level custom-role holders get the space role derived from their scopes, not the member placeholder', async () => {
             const spaceUuid = 'root-space';
             const orgCustomRoleUuid = 'org-custom-role-uuid';
@@ -332,6 +398,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid: 'root-space',
                         role: 'member' as OrganizationMemberRole,
                         roleUuid: orgCustomRoleUuid,
+                        extraRoleUuids: [],
                     },
                 ],
             });
@@ -404,6 +471,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid: 'private-space',
                         role: 'viewer' as ProjectMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                 ],
@@ -415,6 +483,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid: 'private-space',
                         role: 'member' as OrganizationMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                     },
                 ],
             });
@@ -459,6 +528,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid: 'private-space',
                         role: 'admin' as ProjectMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                 ],
@@ -470,6 +540,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid: 'private-space',
                         role: 'admin' as OrganizationMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                     },
                 ],
             });
@@ -612,6 +683,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid: 'root-space',
                         role: 'editor' as ProjectMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                 ],
@@ -815,6 +887,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid,
                         role: 'admin' as ProjectMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                     {
@@ -822,6 +895,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid,
                         role: 'admin' as ProjectMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                     {
@@ -829,6 +903,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid,
                         role: 'editor' as ProjectMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                 ],
@@ -840,18 +915,21 @@ describe('SpacePermissionService', () => {
                         spaceUuid,
                         role: 'admin' as OrganizationMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                     },
                     {
                         userUuid: 'dual-admin',
                         spaceUuid,
                         role: 'admin' as OrganizationMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                     },
                     {
                         userUuid: 'org-member',
                         spaceUuid,
                         role: 'member' as OrganizationMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                     },
                 ],
             });
@@ -1276,6 +1354,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid,
                         role: 'viewer' as ProjectMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                     {
@@ -1283,6 +1362,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid,
                         role: 'admin' as ProjectMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                 ],
@@ -1294,6 +1374,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid,
                         role: 'admin' as OrganizationMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                     },
                 ],
             });
@@ -1439,6 +1520,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid,
                         role: 'viewer' as ProjectMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                     {
@@ -1446,6 +1528,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid,
                         role: 'viewer' as ProjectMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                 ],
@@ -1514,6 +1597,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid: 'parent-space',
                         role: 'viewer' as ProjectMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                 ],
@@ -1595,6 +1679,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid,
                         role: 'viewer' as OrganizationMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                     },
                 ],
             });
@@ -1640,6 +1725,7 @@ describe('SpacePermissionService', () => {
                         spaceUuid,
                         role: 'viewer' as OrganizationMemberRole,
                         roleUuid: null,
+                        extraRoleUuids: [],
                     },
                 ],
             });

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -1,8 +1,8 @@
 import { subject } from '@casl/ability';
 import {
     getHighestSpaceRole,
-    getOrganizationRoleForSpaceAccess,
-    getProjectRoleForSpaceAccess,
+    getOrganizationRoleForRoleSetSpaceAccess,
+    getProjectRoleForRoleSetSpaceAccess,
     NotFoundError,
     OrganizationMemberRole,
     ProjectMemberRole,
@@ -278,14 +278,19 @@ export class SpacePermissionService extends BaseService {
         projectAccessMap: Record<string, ProjectSpaceAccess[]>;
         organizationAccessMap: Record<string, OrganizationSpaceAccess[]>;
     }> {
+        const heldCustomRoleUuids = (access: {
+            roleUuid: string | null;
+            extraRoleUuids: string[];
+        }) => [
+            ...(access.roleUuid ? [access.roleUuid] : []),
+            ...access.extraRoleUuids,
+        ];
         const customRoleUuids = [
             ...new Set(
                 [
                     ...Object.values(projectAccessMap).flat(),
                     ...Object.values(organizationAccessMap).flat(),
-                ].flatMap((access) =>
-                    access.roleUuid ? [access.roleUuid] : [],
-                ),
+                ].flatMap(heldCustomRoleUuids),
             ),
         ];
         if (customRoleUuids.length === 0) {
@@ -296,21 +301,35 @@ export class SpacePermissionService extends BaseService {
             customRoleUuids,
             { trx },
         );
+        const unionScopes = (roleUuids: string[]) =>
+            roleUuids.flatMap((roleUuid) => scopesByRole[roleUuid] ?? []);
 
         return {
             projectAccessMap: Object.fromEntries(
                 Object.entries(projectAccessMap).map(
                     ([spaceUuid, accessList]) => [
                         spaceUuid,
-                        accessList.map(({ roleUuid, ...access }) =>
-                            roleUuid
-                                ? {
-                                      ...access,
-                                      role: getProjectRoleForSpaceAccess(
-                                          scopesByRole[roleUuid] ?? [],
-                                      ),
-                                  }
-                                : access,
+                        accessList.map(
+                            ({ roleUuid, extraRoleUuids, ...access }) => {
+                                const held = heldCustomRoleUuids({
+                                    roleUuid,
+                                    extraRoleUuids,
+                                });
+                                return held.length > 0
+                                    ? {
+                                          ...access,
+                                          role: getProjectRoleForRoleSetSpaceAccess(
+                                              {
+                                                  systemRole: roleUuid
+                                                      ? null
+                                                      : access.role,
+                                                  customRoleScopes:
+                                                      unionScopes(held),
+                                              },
+                                          ),
+                                      }
+                                    : access;
+                            },
                         ),
                     ],
                 ),
@@ -319,15 +338,27 @@ export class SpacePermissionService extends BaseService {
                 Object.entries(organizationAccessMap).map(
                     ([spaceUuid, accessList]) => [
                         spaceUuid,
-                        accessList.map(({ roleUuid, ...access }) =>
-                            roleUuid
-                                ? {
-                                      ...access,
-                                      role: getOrganizationRoleForSpaceAccess(
-                                          scopesByRole[roleUuid] ?? [],
-                                      ),
-                                  }
-                                : access,
+                        accessList.map(
+                            ({ roleUuid, extraRoleUuids, ...access }) => {
+                                const held = heldCustomRoleUuids({
+                                    roleUuid,
+                                    extraRoleUuids,
+                                });
+                                return held.length > 0
+                                    ? {
+                                          ...access,
+                                          role: getOrganizationRoleForRoleSetSpaceAccess(
+                                              {
+                                                  systemRole: roleUuid
+                                                      ? null
+                                                      : access.role,
+                                                  customRoleScopes:
+                                                      unionScopes(held),
+                                              },
+                                          ),
+                                      }
+                                    : access;
+                            },
                         ),
                     ],
                 ),

--- a/packages/common/src/authorization/AGENTS.md
+++ b/packages/common/src/authorization/AGENTS.md
@@ -22,14 +22,20 @@ This folder is the main authorization surface for Lightdash. TypeScript files ar
 
 A user's ability is the union of two independent layers:
 
-| Layer        | Source                     | Builder                                                                                                                                                                                      |
-| ------------ | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Organization | `organization_memberships` | `organizationMemberAbility.ts` when `role_uuid` is null (system role); `buildAbilityFromScopes` when `role_uuid` is set — org-level custom roles, for both human users and service accounts. |
-| Project      | `project_memberships`      | `projectMemberAbility.ts` when `role_uuid` is null; `buildAbilityFromScopes` when `role_uuid` is set.                                                                                        |
+| Layer        | Source                                                                | Builder                                                                                                                                                                                                                                                 |
+| ------------ | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Organization | `organization_memberships` (+ `organization_membership_custom_roles`) | `organizationMemberAbility.ts` when `role_uuid` is null (system role); `buildAbilityFromScopes` when `role_uuid` is set — org-level custom roles, for both human users and service accounts. Extra custom roles from the join table are unioned on top. |
+| Project      | `project_memberships` / `project_group_access` (+ `*_custom_roles`)   | `projectMemberAbility.ts` when `role_uuid` is null; `buildAbilityFromScopes` when `role_uuid` is set. Extra custom roles from the join tables are unioned on top.                                                                                       |
 
 CASL rules are additive. Project permissions cannot revoke organization permissions. If the org layer grants a permission, a narrower project custom role cannot remove it.
 
 Org-level custom roles are a supported human-user surface. Assigning one (`upsertOrganizationUserRoleAssignment` with a custom `roleId`) sets `organization_memberships.role_uuid` and stores `role = 'member'`; the role's `level` must be `'organization'` (validated at assign time, alongside an org-ownership check). At runtime, when `role_uuid` is set and custom roles are enabled, the org layer is built from that role's scopes and **replaces** the system-role org abilities — it does not add on top of `member`. So an org-level custom role must be self-contained: it has to list every org scope its users need (including basic `view:*`), because the system-role defaults do not apply underneath it. This mirrors project custom roles, which replace the project system role rather than extending it. SCIM still assigns system org roles only (`setUserOrgAndProjectRoles`).
+
+## Role Sets (Multiple Roles Per Level)
+
+A membership holds a **role set**: at most one system role plus any number of custom roles (`OrganizationRoleSet` / `ProjectRoleSet` in `types/roles.ts`). Storage keeps the primary slot (`role` / `role_uuid`, semantics above unchanged) and stores the _additional_ custom roles in `organization_membership_custom_roles`, `project_membership_custom_roles`, `project_group_access_custom_roles`. `RolesModel.replace*RoleSet` writes a set atomically; every singular writer replaces the whole set (extras cleared).
+
+At runtime the extra roles are unioned on top of the slot (`getUserAbilityBuilder` — `orgExtraRoleUuids`, `ProjectAbilityProfile.extraRoleUuids`), so a system base is never narrowed and a custom-only set (slot = custom role + placeholder, no extras or more customs) is the only way to build a restrictive profile. Inherited space access is derived from the union too (`getProjectRoleForRoleSetSpaceAccess` / `getOrganizationRoleForRoleSetSpaceAccess`: system role or scope-derived role, whichever is higher). Never emit `cannot` rules; `collapseAbilityRules` depends on the rule set staying purely additive.
 
 ## Custom Roles Are Part Of The Contract
 

--- a/packages/common/src/authorization/getUserAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/getUserAbilityBuilder.test.ts
@@ -428,3 +428,174 @@ describe('getUserAbilityBuilder — org-level role resolution', () => {
         });
     });
 });
+
+describe('getUserAbilityBuilder — role sets (extra custom roles)', () => {
+    const EXTRA_ROLE_UUID = '22222222-2222-4222-a222-222222222222';
+    const PROJECT_UUID = 'project-uuid';
+    const PROJECT_EXTRA_ROLE_UUID = '33333333-3333-4333-a333-333333333333';
+
+    it('unions an extra org custom role on top of a system role', () => {
+        const { builder } = getUserAbilityBuilder({
+            user: {
+                role: OrganizationMemberRole.VIEWER,
+                organizationUuid: ORG_UUID,
+                userUuid: USER_UUID,
+                roleUuid: undefined,
+            },
+            orgExtraRoleUuids: [EXTRA_ROLE_UUID],
+            projectProfiles: [],
+            permissionsConfig: PERMISSIONS_CONFIG,
+            customRoleScopes: { [EXTRA_ROLE_UUID]: ['view:Roadmap'] },
+            customRolesEnabled: true,
+            isEnterprise: true,
+        });
+        const ability = builder.build();
+        // Base viewer abilities are kept…
+        expect(
+            ability.can(
+                'view',
+                subject('Dashboard', {
+                    organizationUuid: ORG_UUID,
+                    inheritsFromOrgOrProject: true,
+                }),
+            ),
+        ).toBe(true);
+        // …and the extra role adds on top (viewer alone cannot view the roadmap)
+        expect(
+            ability.can(
+                'view',
+                subject('Roadmap', { organizationUuid: ORG_UUID }),
+            ),
+        ).toBe(true);
+        expect(
+            buildExpected(OrganizationMemberRole.VIEWER).some(
+                (r) => r.subject === 'Roadmap',
+            ),
+        ).toBe(false);
+    });
+
+    it('unions an extra org custom role on top of a custom-only slot', () => {
+        const { builder } = getUserAbilityBuilder({
+            user: {
+                role: OrganizationMemberRole.MEMBER, // placeholder
+                organizationUuid: ORG_UUID,
+                userUuid: USER_UUID,
+                roleUuid: CUSTOM_ROLE_UUID,
+            },
+            orgExtraRoleUuids: [EXTRA_ROLE_UUID],
+            projectProfiles: [],
+            permissionsConfig: PERMISSIONS_CONFIG,
+            customRoleScopes: {
+                [CUSTOM_ROLE_UUID]: ['view:Dashboard'],
+                [EXTRA_ROLE_UUID]: ['view:Roadmap'],
+            },
+            customRolesEnabled: true,
+            isEnterprise: true,
+        });
+        const ability = builder.build();
+        expect(ability.rules.some((r) => r.subject === 'Dashboard')).toBe(true);
+        expect(ability.rules.some((r) => r.subject === 'Roadmap')).toBe(true);
+        // still no admin/system abilities leaking in
+        expect(ability.rules.some((r) => r.subject === 'InviteLink')).toBe(
+            false,
+        );
+    });
+
+    it('ignores extra roles when custom roles are disabled or scopes are missing', () => {
+        const disabled = getUserAbilityBuilder({
+            user: {
+                role: OrganizationMemberRole.VIEWER,
+                organizationUuid: ORG_UUID,
+                userUuid: USER_UUID,
+                roleUuid: undefined,
+            },
+            orgExtraRoleUuids: [EXTRA_ROLE_UUID],
+            projectProfiles: [],
+            permissionsConfig: PERMISSIONS_CONFIG,
+            customRoleScopes: { [EXTRA_ROLE_UUID]: ['view:Roadmap'] },
+            customRolesEnabled: false,
+        });
+        ruleSetEqual(
+            disabled.builder.build().rules,
+            buildExpected(OrganizationMemberRole.VIEWER),
+        );
+
+        const missing = getUserAbilityBuilder({
+            user: {
+                role: OrganizationMemberRole.VIEWER,
+                organizationUuid: ORG_UUID,
+                userUuid: USER_UUID,
+                roleUuid: undefined,
+            },
+            orgExtraRoleUuids: [EXTRA_ROLE_UUID],
+            projectProfiles: [],
+            permissionsConfig: PERMISSIONS_CONFIG,
+            customRoleScopes: {},
+            customRolesEnabled: true,
+        });
+        ruleSetEqual(
+            missing.builder.build().rules,
+            buildExpected(OrganizationMemberRole.VIEWER),
+        );
+    });
+
+    it('unions extra project custom roles on top of a project system role', () => {
+        const { builder } = getUserAbilityBuilder({
+            user: {
+                role: OrganizationMemberRole.MEMBER,
+                organizationUuid: ORG_UUID,
+                userUuid: USER_UUID,
+                roleUuid: undefined,
+            },
+            projectProfiles: [
+                {
+                    projectUuid: PROJECT_UUID,
+                    role: ProjectMemberRole.VIEWER,
+                    userUuid: USER_UUID,
+                    roleUuid: undefined,
+                    projectType: ProjectType.DEFAULT,
+                    extraRoleUuids: [PROJECT_EXTRA_ROLE_UUID],
+                },
+            ],
+            permissionsConfig: PERMISSIONS_CONFIG,
+            customRoleScopes: {
+                [PROJECT_EXTRA_ROLE_UUID]: ['manage:SqlRunner'],
+            },
+            customRolesEnabled: true,
+        });
+        const ability = builder.build();
+        expect(
+            ability.can(
+                'view',
+                subject('Dashboard', {
+                    projectUuid: PROJECT_UUID,
+                    inheritsFromOrgOrProject: true,
+                }),
+            ),
+        ).toBe(true);
+        expect(
+            ability.can(
+                'manage',
+                subject('SqlRunner', { projectUuid: PROJECT_UUID }),
+            ),
+        ).toBe(true);
+    });
+
+    it('rules stay collapsible (no inverted rules) with extras present', () => {
+        const { builder } = getUserAbilityBuilder({
+            user: {
+                role: OrganizationMemberRole.VIEWER,
+                organizationUuid: ORG_UUID,
+                userUuid: USER_UUID,
+                roleUuid: undefined,
+            },
+            orgExtraRoleUuids: [EXTRA_ROLE_UUID],
+            projectProfiles: [],
+            permissionsConfig: PERMISSIONS_CONFIG,
+            customRoleScopes: { [EXTRA_ROLE_UUID]: ['view:Roadmap'] },
+            customRolesEnabled: true,
+            isEnterprise: true,
+        });
+        expect(builder.rules.some((r) => r.inverted)).toBe(false);
+    });
+});

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -22,6 +22,8 @@ export type ProjectAbilityProfile = Pick<
 > & {
     projectType?: ProjectType;
     projectCreatedByUserUuid?: string | null;
+    /** Additional custom roles unioned on top of `role`/`roleUuid`. */
+    extraRoleUuids?: string[];
 };
 
 type UserAbilityBuilderArgs = {
@@ -29,6 +31,8 @@ type UserAbilityBuilderArgs = {
         LightdashUser,
         'role' | 'organizationUuid' | 'userUuid' | 'roleUuid'
     >;
+    /** Additional organization custom roles unioned on top of the user's slot. */
+    orgExtraRoleUuids?: string[];
     projectProfiles: ProjectAbilityProfile[];
     permissionsConfig: OrganizationMemberAbilitiesArgs['permissionsConfig'];
     customRoleScopes?: Record<Role['roleUuid'], RoleWithScopes['scopes']>;
@@ -45,6 +49,7 @@ export type UserAbilityBuilderResult = {
 
 export const getUserAbilityBuilder = ({
     user,
+    orgExtraRoleUuids = [],
     projectProfiles,
     permissionsConfig,
     customRoleScopes,
@@ -53,6 +58,27 @@ export const getUserAbilityBuilder = ({
 }: UserAbilityBuilderArgs): UserAbilityBuilderResult => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
     const invalidScopes: string[] = [];
+    // Extra custom roles are unioned on top of the slot; unknown uuids are
+    // skipped (logged) rather than granting anything.
+    const applyExtraRoles = (
+        extraRoleUuids: string[],
+        apply: (scopes: string[]) => string[],
+    ) => {
+        if (!customRolesEnabled) {
+            return;
+        }
+        extraRoleUuids.forEach((roleUuid) => {
+            const scopes = customRoleScopes?.[roleUuid];
+            if (!scopes) {
+                // eslint-disable-next-line no-console
+                console.error(
+                    `Custom role with uuid ${roleUuid} was not found`,
+                );
+                return;
+            }
+            invalidScopes.push(...apply(scopes));
+        });
+    };
     if (user.role && user.organizationUuid) {
         // Org-level custom role: if the user's organization_memberships row
         // points at a role_uuid AND custom roles are enabled AND we have the
@@ -89,6 +115,19 @@ export const getUserAbilityBuilder = ({
                 permissionsConfig,
             });
         }
+        applyExtraRoles(orgExtraRoleUuids, (scopes) =>
+            buildAbilityFromScopes(
+                {
+                    organizationUuid: user.organizationUuid as string,
+                    userUuid: user.userUuid,
+                    scopes,
+                    isEnterprise,
+                    organizationRole: user.role,
+                    permissionsConfig,
+                },
+                builder,
+            ),
+        );
 
         projectProfiles.forEach((projectProfile) => {
             if (projectProfile.roleUuid && customRolesEnabled) {
@@ -129,6 +168,22 @@ export const getUserAbilityBuilder = ({
                     builder,
                 );
             }
+            applyExtraRoles(projectProfile.extraRoleUuids ?? [], (scopes) =>
+                buildAbilityFromScopes(
+                    {
+                        projectUuid: projectProfile.projectUuid,
+                        projectType: projectProfile.projectType,
+                        projectCreatedByUserUuid:
+                            projectProfile.projectCreatedByUserUuid,
+                        userUuid: user.userUuid,
+                        scopes,
+                        isEnterprise,
+                        organizationRole: user.role,
+                        permissionsConfig,
+                    },
+                    builder,
+                ),
+            );
         });
     }
     // Collapse per-project rules into `{ $in: [...] }` so the rule set (and the

--- a/packages/common/src/authorization/space/customRoleProjectRole.test.ts
+++ b/packages/common/src/authorization/space/customRoleProjectRole.test.ts
@@ -1,3 +1,4 @@
+import { OrganizationMemberRole } from '../../types/organizationMemberProfile';
 import { ProjectMemberRole } from '../../types/projectMemberRole';
 import {
     convertOrganizationRoleToProjectRole,
@@ -5,7 +6,9 @@ import {
 } from '../../utils/projectMemberRole';
 import { PROJECT_ROLE_TO_SCOPES_MAP } from '../roleToScopeMapping';
 import {
+    getOrganizationRoleForRoleSetSpaceAccess,
     getOrganizationRoleForSpaceAccess,
+    getProjectRoleForRoleSetSpaceAccess,
     getProjectRoleForSpaceAccess,
 } from './customRoleProjectRole';
 
@@ -35,4 +38,51 @@ describe('getOrganizationRoleForSpaceAccess', () => {
             ).toEqual(getProjectRoleForSpaceAccess(scopes));
         },
     );
+});
+
+describe('role-set space access derivation', () => {
+    it('keeps the system role when extras add nothing higher', () => {
+        expect(
+            getProjectRoleForRoleSetSpaceAccess({
+                systemRole: ProjectMemberRole.EDITOR,
+                customRoleScopes: ['view:Dashboard'],
+            }),
+        ).toBe(ProjectMemberRole.EDITOR);
+    });
+    it('raises to the derived role when extras grant more', () => {
+        expect(
+            getProjectRoleForRoleSetSpaceAccess({
+                systemRole: ProjectMemberRole.VIEWER,
+                customRoleScopes: ['manage:Space'],
+            }),
+        ).toBe(ProjectMemberRole.ADMIN);
+    });
+    it('derives from scopes alone for custom-only sets', () => {
+        expect(
+            getProjectRoleForRoleSetSpaceAccess({
+                systemRole: null,
+                customRoleScopes: ['manage:Space@public'],
+            }),
+        ).toBe(ProjectMemberRole.EDITOR);
+        expect(
+            getOrganizationRoleForRoleSetSpaceAccess({
+                systemRole: null,
+                customRoleScopes: [],
+            }),
+        ).toBe(OrganizationMemberRole.VIEWER);
+    });
+    it('never lowers an organization system role', () => {
+        expect(
+            getOrganizationRoleForRoleSetSpaceAccess({
+                systemRole: OrganizationMemberRole.DEVELOPER,
+                customRoleScopes: ['manage:Space@public'],
+            }),
+        ).toBe(OrganizationMemberRole.DEVELOPER);
+        expect(
+            getOrganizationRoleForRoleSetSpaceAccess({
+                systemRole: OrganizationMemberRole.MEMBER,
+                customRoleScopes: ['manage:Space'],
+            }),
+        ).toBe(OrganizationMemberRole.ADMIN);
+    });
 });

--- a/packages/common/src/authorization/space/customRoleProjectRole.ts
+++ b/packages/common/src/authorization/space/customRoleProjectRole.ts
@@ -1,5 +1,9 @@
 import { OrganizationMemberRole } from '../../types/organizationMemberProfile';
-import { ProjectMemberRole } from '../../types/projectMemberRole';
+import {
+    ProjectMemberRole,
+    ProjectRoleOrder,
+} from '../../types/projectMemberRole';
+import { convertOrganizationRoleToProjectRole } from '../../utils/projectMemberRole';
 
 /**
  * Project-role equivalent of a custom role for space-access resolution.
@@ -40,4 +44,63 @@ export const getOrganizationRoleForSpaceAccess = (
         default:
             return OrganizationMemberRole.VIEWER;
     }
+};
+
+/**
+ * Space-access role for a complete project role set: the system role (if any)
+ * or the role derived from the union of all held custom-role scopes,
+ * whichever is higher. Roles are additive, so a system base is never lowered.
+ */
+export const getProjectRoleForRoleSetSpaceAccess = ({
+    systemRole,
+    customRoleScopes,
+}: {
+    systemRole: ProjectMemberRole | null;
+    customRoleScopes: string[];
+}): ProjectMemberRole => {
+    const derived =
+        customRoleScopes.length > 0
+            ? getProjectRoleForSpaceAccess(customRoleScopes)
+            : null;
+    if (systemRole === null) {
+        return derived ?? ProjectMemberRole.VIEWER;
+    }
+    if (derived === null) {
+        return systemRole;
+    }
+    return ProjectRoleOrder[derived] > ProjectRoleOrder[systemRole]
+        ? derived
+        : systemRole;
+};
+
+export const getOrganizationRoleForRoleSetSpaceAccess = ({
+    systemRole,
+    customRoleScopes,
+}: {
+    systemRole: OrganizationMemberRole | null;
+    customRoleScopes: string[];
+}): OrganizationMemberRole => {
+    const derived =
+        customRoleScopes.length > 0
+            ? getOrganizationRoleForSpaceAccess(customRoleScopes)
+            : null;
+    if (systemRole === null) {
+        return derived ?? OrganizationMemberRole.VIEWER;
+    }
+    if (derived === null) {
+        return systemRole;
+    }
+    // Compare through the project-role order; `member` maps to no project role.
+    const systemProjectRole = convertOrganizationRoleToProjectRole(systemRole);
+    const derivedProjectRole = convertOrganizationRoleToProjectRole(derived);
+    if (systemProjectRole === undefined) {
+        return derived;
+    }
+    if (derivedProjectRole === undefined) {
+        return systemRole;
+    }
+    return ProjectRoleOrder[derivedProjectRole] >
+        ProjectRoleOrder[systemProjectRole]
+        ? derived
+        : systemRole;
 };

--- a/packages/common/src/ee/commercialFeatureFlags.ts
+++ b/packages/common/src/ee/commercialFeatureFlags.ts
@@ -5,5 +5,7 @@ export enum CommercialFeatureFlags {
     ServiceAccounts = 'service-accounts',
     OrganizationWarehouseCredentials = 'organization-warehouse-credentials',
     CustomRoles = 'custom-roles',
+    /** Multiple roles per organization/project (requires CustomRoles). Gates management surfaces only. */
+    MultipleRoles = 'multiple-roles',
     HomepageBuilder = 'homepage-builder',
 }

--- a/packages/common/src/types/roles.ts
+++ b/packages/common/src/types/roles.ts
@@ -1,7 +1,23 @@
 import type { ApiSuccessEmpty } from './api/success';
+import type { OrganizationMemberRole } from './organizationMemberProfile';
+import type { ProjectMemberRole } from './projectMemberRole';
 import type { PromotionAction } from './promotion';
 
 export type RoleLevel = 'project' | 'organization';
+
+/**
+ * Complete set of roles held at one level: at most one system role plus any
+ * number of custom roles. Permissions are the union of all held roles.
+ */
+export type OrganizationRoleSet = {
+    systemRole: OrganizationMemberRole | null;
+    customRoleUuids: string[];
+};
+
+export type ProjectRoleSet = {
+    systemRole: ProjectMemberRole | null;
+    customRoleUuids: string[];
+};
 
 export type ProjectAccess = {
     projectUuid: string;


### PR DESCRIPTION
## Summary

PR 3 of 3 for [PROD-9762](https://linear.app/lightdash/issue/PROD-9762) (Stack A). Makes extra custom roles **effective at runtime**: abilities are the union of the primary role slot and every extra role held at the organization and project level (direct and group-derived), and inherited space access is derived from that union. Nothing exposes multi-role writes yet, so this changes no user's permissions until Stack B lands — but a role set persisted through `RolesModel` is now honoured under the same rule as custom roles today.

Stacks on top of PR 2 ([#27502](https://github.com/lightdash/lightdash/pull/27502)) which added role-set reads/writes to `RolesModel`.

Closes: https://linear.app/lightdash/issue/PROD-10213

## Changes

**Common**
- `getUserAbilityBuilder` accepts `orgExtraRoleUuids` and `ProjectAbilityProfile.extraRoleUuids`; each extra role's scopes are applied with `buildAbilityFromScopes` on top of the slot (system or custom). Gated by `customRolesEnabled` like the slot; unknown uuids are skipped, never granted.
- `getProjectRoleForRoleSetSpaceAccess` / `getOrganizationRoleForRoleSetSpaceAccess`: system role or scope-derived role, whichever is higher — a base is never lowered.
- `authorization/AGENTS.md`: documents role sets alongside the existing slot/placeholder rules.

**Backend**
- `UserModel`: loads org extras, direct-project extras and group-project extras (three small queries), feeds them into the existing `customRoleScopes` bulk load and the builder; service-account paths apply org and project extras too.
- `SpacePermissionModel`: `getProjectSpaceAccess` / `getOrganizationSpaceAccess` rows carry `extraRoleUuids` (correlated `array_agg` over the join tables).
- `SpacePermissionService.resolveCustomRoleAccess`: derives the inherited role from the union of slot + extras (this is where PROD-8976 / PROD-8956 previously broke for custom-role users).

## Composition

```
org:      slot(system | custom)  ∪  extras[]        → org abilities
project:  slot(system | custom)  ∪  extras[]        → project abilities   (per direct membership and per group access)
space:    higher(systemRole, roleFromScopes(∪ custom scopes))
```

## Test plan

- [x] `getUserAbilityBuilder.test.ts` (+5): system+extra, custom-only+extra, disabled/missing extras ignored (rules identical to system role), project extras on top of a project system role, no inverted rules
- [x] `customRoleProjectRole.test.ts` (+4): keep system role, raise to derived, custom-only, never lower org role
- [x] `SpacePermissionService.test.ts` (+1): viewer slot + extra `manage:Space` → `SpaceMemberRole.ADMIN` on inherited spaces
- [x] Real dev DB, restored afterwards: an `editor` given an extra org role (`manage:Organization`, `view:Roadmap`) can `manage Organization` and `view Roadmap` while keeping base abilities; `role` on the session user still reports the slot; a `viewer` + extra project role with `manage:Space` can `manage Space` in that project; `SpacePermissionModel` rows return the extras
- [x] `pnpm -F common exec vitest run src/authorization` (640 pass); backend suites `UserModel`, `SpaceService`, `UserService`, `ProjectService`, `RolesService`, `ServiceAccountService`, controllers — all pass
- [x] `pnpm -F common typecheck`, `pnpm -F backend typecheck` (only pre-existing `bedrock.ts` error), `pnpm -F common|backend lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)