### PR TITLE
style(merge-query): use neutral source treatment

### DIFF
--- a/packages/frontend/src/features/mergeQuery/components/MergeColumnProvenance.module.css
+++ b/packages/frontend/src/features/mergeQuery/components/MergeColumnProvenance.module.css
@@ -13,21 +13,5 @@
 .source {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
     vertical-align: middle;
-}
-
-.dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 2px;
-    flex: none;
-}
-
-.dot[data-side='a'] {
-    background: var(--mantine-color-blue-6);
-}
-
-.dot[data-side='b'] {
-    background: var(--mantine-color-orange-6);
 }

--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.module.css
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.module.css
@@ -65,21 +65,6 @@
     min-width: 0;
 }
 
-.sourceDot {
-    width: 7px;
-    height: 7px;
-    flex: none;
-    border-radius: 50%;
-}
-
-.sourceDot[data-side='primary'] {
-    background: var(--mantine-color-blue-6);
-}
-
-.sourceDot[data-side='additional'] {
-    background: var(--mantine-color-orange-6);
-}
-
 .operator {
     display: flex;
     height: 30px;
@@ -157,33 +142,15 @@
     overflow: visible;
 }
 
-.primaryRegion {
-    fill: var(--mantine-color-blue-5);
-    fill-opacity: 0.55;
+.retainedRegion {
+    fill: var(--mantine-color-ldGray-6);
+    fill-opacity: 0.42;
 }
 
-.additionalRegion {
-    fill: var(--mantine-color-orange-5);
-    fill-opacity: 0.55;
-}
-
-.overlapRegion {
-    fill: var(--mantine-color-violet-5);
-    fill-opacity: 0.7;
-}
-
-.primaryOutline,
-.additionalOutline {
+.circleOutline {
     fill: none;
+    stroke: var(--mantine-color-ldGray-6);
     stroke-width: 1.5;
-}
-
-.primaryOutline {
-    stroke: var(--mantine-color-blue-7);
-}
-
-.additionalOutline {
-    stroke: var(--mantine-color-orange-7);
 }
 
 @media (max-width: 48em) {

--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
@@ -54,12 +54,8 @@ type JoinTypeOption = {
     help: string;
 };
 
-const SourceLabel: FC<{ side: 'primary' | 'additional'; label: string }> = ({
-    side,
-    label,
-}) => (
+const SourceLabel: FC<{ label: string }> = ({ label }) => (
     <Group gap={6} wrap="nowrap" className={styles.sourceLabel}>
-        <Box className={styles.sourceDot} data-side={side} />
         <Text size="xs" fw={600} truncate title={label}>
             {label}
         </Text>
@@ -78,7 +74,7 @@ const JoinTypeDiagram: FC<{ type: MergeJoinType }> = ({ type }) => {
             </defs>
             {type === MergeJoinType.LEFT ? (
                 <circle
-                    className={styles.primaryRegion}
+                    className={styles.retainedRegion}
                     cx="18"
                     cy="14"
                     r="10"
@@ -87,13 +83,13 @@ const JoinTypeDiagram: FC<{ type: MergeJoinType }> = ({ type }) => {
             {type === MergeJoinType.FULL ? (
                 <>
                     <circle
-                        className={styles.primaryRegion}
+                        className={styles.retainedRegion}
                         cx="18"
                         cy="14"
                         r="10"
                     />
                     <circle
-                        className={styles.additionalRegion}
+                        className={styles.retainedRegion}
                         cx="30"
                         cy="14"
                         r="10"
@@ -102,20 +98,15 @@ const JoinTypeDiagram: FC<{ type: MergeJoinType }> = ({ type }) => {
             ) : null}
             {type === MergeJoinType.INNER ? (
                 <circle
-                    className={styles.overlapRegion}
+                    className={styles.retainedRegion}
                     cx="30"
                     cy="14"
                     r="10"
                     clipPath={`url(#${clipId})`}
                 />
             ) : null}
-            <circle className={styles.primaryOutline} cx="18" cy="14" r="10" />
-            <circle
-                className={styles.additionalOutline}
-                cx="30"
-                cy="14"
-                r="10"
-            />
+            <circle className={styles.circleOutline} cx="18" cy="14" r="10" />
+            <circle className={styles.circleOutline} cx="30" cy="14" r="10" />
         </svg>
     );
 };
@@ -409,10 +400,7 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
                                     )}
                                 <Box className={styles.pairFields}>
                                     <Stack gap={4} className={styles.fieldSide}>
-                                        <SourceLabel
-                                            side="primary"
-                                            label={thisQuery}
-                                        />
+                                        <SourceLabel label={thisQuery} />
                                         <FieldSelect
                                             aria-label={`${thisQuery} join field`}
                                             size="xs"
@@ -461,10 +449,7 @@ export const MergeJoinBar: FC<{ guided?: boolean }> = ({ guided = false }) => {
                                         =
                                     </Text>
                                     <Stack gap={4} className={styles.fieldSide}>
-                                        <SourceLabel
-                                            side="additional"
-                                            label={otherQuery}
-                                        />
+                                        <SourceLabel label={otherQuery} />
                                         <FieldSelect
                                             aria-label={`${otherQuery} join field`}
                                             size="xs"

--- a/packages/frontend/src/features/mergeQuery/components/MergeQuerySidebar.module.css
+++ b/packages/frontend/src/features/mergeQuery/components/MergeQuerySidebar.module.css
@@ -47,7 +47,7 @@
 
 .headerButton {
     display: grid;
-    grid-template-columns: 8px minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
     gap: 9px;
     min-width: 0;
@@ -59,20 +59,6 @@
 .headerCopy {
     min-width: 0;
     line-height: 1.15;
-}
-
-.dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 2px;
-}
-
-.dot[data-side='a'] {
-    background: var(--mantine-color-blue-6);
-}
-
-.dot[data-side='b'] {
-    background: var(--mantine-color-orange-6);
 }
 
 .remove {

--- a/packages/frontend/src/features/mergeQuery/components/MergeQuerySidebar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeQuerySidebar.tsx
@@ -47,10 +47,6 @@ const DatasetHeader: FC<{
 }> = ({ sourceRole, label, count, open, onClick, onRemove }) => (
     <Box className={styles.header} data-open={open}>
         <UnstyledButton className={styles.headerButton} onClick={onClick}>
-            <Box
-                className={styles.dot}
-                data-side={sourceRole === 'primary' ? 'a' : 'b'}
-            />
             <Box className={styles.headerCopy}>
                 <Text size="sm" fw={600} truncate title={label}>
                     {label}

--- a/packages/frontend/src/features/mergeQuery/components/MergeReadOnlyBar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeReadOnlyBar.tsx
@@ -60,30 +60,18 @@ export const MergeReadOnlyBar: FC = () => {
                 <ThemeIcon variant="light" color="gray" radius="md" size="md">
                     <MantineIcon
                         icon={IconArrowMerge}
-                        color="blue.7"
+                        color="gray.7"
                         size={14}
                     />
                 </ThemeIcon>
                 <Box style={{ flex: 1, minWidth: 0 }}>
                     <Group gap={6} wrap="nowrap">
-                        <Box
-                            w={7}
-                            h={7}
-                            bg="blue.6"
-                            style={{ borderRadius: '50%', flexShrink: 0 }}
-                        />
                         <Text size="sm" fw={600} truncate>
                             {primaryExploreLabel}
                         </Text>
                         <Text size="xs" c="dimmed">
                             +
                         </Text>
-                        <Box
-                            w={7}
-                            h={7}
-                            bg="orange.6"
-                            style={{ borderRadius: '50%', flexShrink: 0 }}
-                        />
                         <Text size="sm" fw={600} truncate>
                             {additionalExploreLabel}
                         </Text>

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -717,14 +717,6 @@ export const useColumns = (): TableColumn[] => {
                                                         provenanceStyles.source
                                                     }
                                                 >
-                                                    <span
-                                                        className={
-                                                            provenanceStyles.dot
-                                                        }
-                                                        data-side={
-                                                            mergeOrigin.sourceId
-                                                        }
-                                                    />
                                                     {item.tableLabel}
                                                 </span>
                                             ) : (


### PR DESCRIPTION
## What changed

- remove source-color dots from merge setup, saved summaries, and result headers
- use one neutral treatment for retained regions in join diagrams
- keep source names visible wherever provenance matters

## Why

Explicit source labels already communicate where fields come from. A second color-coded provenance system added visual noise without adding meaning.

## Impact

Merge configuration and results are calmer and more compact while remaining understandable without color.

## Validation

- 40 focused frontend tests passed
- frontend typecheck passed
- frontend lint passed
- verified the merge flow locally from field selection through merged results