### PR TITLE
feat(autopilot): render agent reasoning as markdown and cap message tooltips

### DIFF
--- a/packages/frontend/src/components/common/TruncatedText/index.test.tsx
+++ b/packages/frontend/src/components/common/TruncatedText/index.test.tsx
@@ -1,0 +1,38 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import TruncatedText from '.';
+
+// jsdom has no layout, so the truncation detection never fires on its own.
+vi.mock('../../../hooks/useIsTruncated', () => ({
+    useIsTruncated: () => ({ ref: { current: null }, isTruncated: true }),
+}));
+
+const LONG_TEXT = 'a'.repeat(50);
+
+describe('TruncatedText', () => {
+    it('shows the full text in the tooltip by default', async () => {
+        renderWithProviders(
+            <TruncatedText maxWidth={100}>{LONG_TEXT}</TruncatedText>,
+        );
+
+        await userEvent.hover(screen.getByText(LONG_TEXT));
+
+        expect(await screen.findByRole('tooltip')).toHaveTextContent(LONG_TEXT);
+    });
+
+    it('caps the tooltip label at tooltipMaxLength', async () => {
+        renderWithProviders(
+            <TruncatedText maxWidth={100} tooltipMaxLength={10}>
+                {LONG_TEXT}
+            </TruncatedText>,
+        );
+
+        await userEvent.hover(screen.getByText(LONG_TEXT));
+
+        expect(await screen.findByRole('tooltip')).toHaveTextContent(
+            `${'a'.repeat(10)}…`,
+        );
+    });
+});

--- a/packages/frontend/src/components/common/TruncatedText/index.test.tsx
+++ b/packages/frontend/src/components/common/TruncatedText/index.test.tsx
@@ -1,8 +1,8 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { renderWithProviders } from '../../../testing/testUtils';
 import TruncatedText from '.';
+import { renderWithProviders } from '../../../testing/testUtils';
 
 // jsdom has no layout, so the truncation detection never fires on its own.
 vi.mock('../../../hooks/useIsTruncated', () => ({

--- a/packages/frontend/src/components/common/TruncatedText/index.tsx
+++ b/packages/frontend/src/components/common/TruncatedText/index.tsx
@@ -9,7 +9,12 @@ interface TruncatedTextProps extends Omit<TextProps, 'truncate'> {
      *  TruncatedText is nested inside another block-level text element to
      *  avoid invalid HTML (<p> inside <p>). */
     inline?: boolean;
+    /** Caps the tooltip label at this many characters and wraps it, so long
+     *  values don't stretch the tooltip across the page. */
+    tooltipMaxLength?: number;
 }
+
+const TOOLTIP_MAX_WIDTH = 420;
 
 /**
  * Renders text truncated with an ellipsis at the given maxWidth.
@@ -19,15 +24,23 @@ const TruncatedText: FC<TruncatedTextProps> = ({
     children,
     maxWidth,
     inline,
+    tooltipMaxLength,
     ...textProps
 }) => {
     const { ref, isTruncated } = useIsTruncated<HTMLParagraphElement>();
+    const isCapped = tooltipMaxLength !== undefined;
+    const label =
+        isCapped && children.length > tooltipMaxLength
+            ? `${children.slice(0, tooltipMaxLength).trimEnd()}…`
+            : children;
 
     return (
         <Tooltip
-            label={children}
+            label={label}
             disabled={!isTruncated}
             withinPortal
+            multiline={isCapped}
+            maw={isCapped ? TOOLTIP_MAX_WIDTH : undefined}
             zIndex={getDefaultZIndex('max')}
         >
             <Text

--- a/packages/frontend/src/components/common/TruncatedText/index.tsx
+++ b/packages/frontend/src/components/common/TruncatedText/index.tsx
@@ -14,7 +14,7 @@ interface TruncatedTextProps extends Omit<TextProps, 'truncate'> {
     tooltipMaxLength?: number;
 }
 
-const TOOLTIP_MAX_WIDTH = 420;
+const TOOLTIP_MAX_WIDTH = 400;
 
 /**
  * Renders text truncated with an ellipsis at the given maxWidth.

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -761,3 +761,21 @@
         transition: none;
     }
 }
+
+/* Agent reasoning markdown in the detail sidebar: match the dimmed 12px
+   metadata typography, and keep code fences (chart-as-code YAML) inside the
+   panel width. */
+.reasoningMarkdown {
+    --ai-markdown-font-size: 12px;
+    --ai-markdown-padding-left: 0;
+    min-width: 0;
+}
+
+.reasoningMarkdown p,
+.reasoningMarkdown li {
+    color: var(--mantine-color-dimmed);
+}
+
+.reasoningMarkdown pre {
+    max-width: 100%;
+}

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -74,6 +74,7 @@ import {
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useParams } from 'react-router';
 import { lightdashApi } from '../../../api';
+import { AiMarkdown } from '../../../components/common/AiMarkdown';
 import { CategoryBadge } from '../../../components/common/CategoryBadge';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { NumberInput } from '../../../components/common/NumberInput';
@@ -131,6 +132,10 @@ const runHeartbeat = async (projectUuid: string) =>
         method: 'POST',
         body: undefined,
     });
+
+// Messages can be several paragraphs of agent reasoning; the hover tooltip only
+// needs a preview, the sidebar renders the full markdown.
+const MESSAGE_TOOLTIP_MAX_LENGTH = 280;
 
 const SCHEDULE_OPTIONS = [
     { value: ManagedAgentScheduleOption.EVERY_6_HOURS, label: 'Every 6 hours' },
@@ -1231,9 +1236,9 @@ const DetailSidebar: FC<{
                 {/* Agent reasoning */}
                 <Stack gap={4}>
                     <MetadataLabel label="Agent reasoning" />
-                    <Text fz="xs" lh={1.7} c="dimmed">
+                    <AiMarkdown className={classes.reasoningMarkdown}>
                         {action.description}
-                    </Text>
+                    </AiMarkdown>
                 </Stack>
             </Stack>
         </Stack>
@@ -1897,7 +1902,12 @@ const ActionRow: FC<{
                 </Group>
             </Table.Td>
             <Table.Td className={classes.messageCell}>
-                <TruncatedText maxWidth={9999} fz="xs" c="dimmed">
+                <TruncatedText
+                    maxWidth={9999}
+                    tooltipMaxLength={MESSAGE_TOOLTIP_MAX_LENGTH}
+                    fz="xs"
+                    c="dimmed"
+                >
                     {action.description}
                 </TruncatedText>
             </Table.Td>


### PR DESCRIPTION
### Description:

Two small Autopilot activity-page fixes:

- **Agent reasoning** in the detail sidebar now renders through the shared `AiMarkdown` (Streamdown) renderer instead of a plain `Text`, so bold text, lists and fenced YAML code blocks display properly rather than as raw markdown. A CSS-module class keeps the dimmed 12px metadata typography and keeps code fences inside the panel width.
- **Message-column tooltips** are capped at 280 characters (with an ellipsis) and wrap at 420px, so a long reasoning message no longer stretches a tooltip across the page. This is a new opt-in `tooltipMaxLength` prop on the shared `TruncatedText`; existing callers are unchanged.

Verified with typecheck, oxlint, and a new unit test covering the tooltip cap; also confirmed in jsdom that a fenced yaml block renders as a code block through `AiMarkdown`. No screenshots — this sandbox has no running app/database to drive the page.
