### PR TITLE
docs(docker-dev): delete the api-routes-watch PM2 process on stop

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -784,7 +784,7 @@ If PM2 shows `MISMATCH`, delete this instance's processes first:
 # One name per call — `pm2 delete a b c` aborts at the first name it cannot
 # find (e.g. sdk-test on an instance that never ran SDK test mode), leaving
 # every later name running.
-for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
+for suffix in api api-routes-watch scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
   pm2 delete "${LD_INSTANCE_ID}-${suffix}" 2>/dev/null || true
 done
 ```
@@ -926,7 +926,7 @@ For permanent worktree removal, use `destroy` instead.
 # One name per call — `pm2 delete a b c` aborts at the first name it cannot
 # find (e.g. sdk-test on an instance that never ran SDK test mode), leaving
 # every later name running.
-for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
+for suffix in api api-routes-watch scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
   pm2 delete "${LD_INSTANCE_ID}-${suffix}" 2>/dev/null || true
 done
 
@@ -943,7 +943,7 @@ Permanently remove this instance's services, PostgreSQL volumes, and port slot. 
 
 ```bash
 # One name per call — see the note under `stop`.
-for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
+for suffix in api api-routes-watch scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
   pm2 delete "${LD_INSTANCE_ID}-${suffix}" 2>/dev/null || true
 done
 
@@ -972,7 +972,7 @@ for f in ~/.lightdash/dev-instances/*.json; do
   [ -f "$f" ] || continue
   INST_ID=$(python3 -c "import json; print(json.load(open('$f'))['instanceId'])")
   # One name per call — see the note under `stop`.
-  for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
+  for suffix in api api-routes-watch scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
     pm2 delete "${INST_ID}-${suffix}" 2>/dev/null || true
   done
 done


### PR DESCRIPTION
Linear: SPK-1113

### Description:

`/docker-dev stop` reports success and leaves one process running.

The runbook deletes PM2 processes by exact name:

```bash
for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test maple; do
  pm2 delete "${LD_INSTANCE_ID}-${suffix}" 2>/dev/null || true
done
```

That list names eight processes. `ecosystem.config.js` defines nine. It does not name `api-routes-watch` (`ecosystem.config.js:132`).

A `pm2 delete` on a name that does not exist is already tolerated with `|| true`, so an incomplete list looks exactly like a complete one. Nothing fails and nothing warns. The `<instance>-api-routes-watch` process stays online after the documented stop, and it survives worktree removal, so it keeps running from a directory that no longer exists.

This change adds the missing suffix to all four lists that carry it: Start PM2, `stop`, `destroy` and `stop-all`. The order matches `ecosystem.config.js` so the two lists can be compared by eye.

**How it was found:** after running the documented `stop` loop on a worktree instance, `pm2 list` still showed `<instance>-api-routes-watch` online with 47 minutes uptime. Deleting it by name worked, which confirms the loop simply never named it.

**Not covered here:** the list duplicates data that already lives in `ecosystem.config.js`, so it goes stale whenever a process is added. Deriving the names from PM2 at run time — for example deleting every process whose name starts with `${LD_INSTANCE_ID}-` — would remove the duplication, but it needs care around prefix matching between instances. Noted on the ticket as follow-up.

**Testing:** documentation only, no runtime code. Verified the four edited lists against the nine `name:` entries in `ecosystem.config.js`, and confirmed each edit sits in the intended section.
