### PR TITLE
fix(merge-query): complete feature parity

### DIFF
--- a/packages/api-tests/tests/mergeQuery.test.ts
+++ b/packages/api-tests/tests/mergeQuery.test.ts
@@ -74,11 +74,22 @@ type QueryResultsBody = Body<{
     totalResults: number;
 }>;
 
-type MergeTestContext = { client: ApiClient; projectUuid: string };
+// hasSubscriptionsModel: whether the warehouse dataset carries a current
+// build of the jaffle `subscriptions` model. The staging datasets reliably
+// mirror only the core models (customers/orders/payments) — BigQuery never
+// built `subscriptions` and Trino's build predates the mrr columns — so the
+// parameterized merge compiles everywhere but executes only where the model
+// exists.
+type MergeTestContext = {
+    client: ApiClient;
+    projectUuid: string;
+    hasSubscriptionsModel: boolean;
+};
 
 function registerMergeQueryTests(getContext: () => MergeTestContext) {
     let admin: ApiClient;
     let projectUuid: string;
+    let hasSubscriptionsModel: boolean;
 
     async function pollQueryResults(
         client: ApiClient,
@@ -107,7 +118,7 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
     // The merge-queries flag gates only the frontend entry point; the API
     // endpoints are always available.
     beforeAll(() => {
-        ({ client: admin, projectUuid } = getContext());
+        ({ client: admin, projectUuid, hasSubscriptionsModel } = getContext());
     });
 
     it('compiles the merge for the project warehouse without errors', async () => {
@@ -364,9 +375,6 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
         expect(await rowCountFor('inner')).toBe(intersection.length);
     }, 90_000);
 
-    // The date-spine fill, generated natively on the project warehouse: every
-    // period between the first and last key exists as a row, so the pages
-    // come back gap-free in key order.
     // The jaffle subscriptions explore's customers join carries a Lightdash
     // parameter, so selecting orders_status through it forces the
     // parameterized join in. The single-query path refuses to run without a
@@ -452,6 +460,10 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
         expect(supplied.body.results.usedParametersValues).toEqual(
             expect.objectContaining({ 'customers.customer_name': 'Ken' }),
         );
+
+        // Executing reads the subscriptions model on the warehouse, which
+        // only some staging datasets have built; compiling above does not.
+        if (!hasSubscriptionsModel) return;
 
         const runResp = await admin.post<
             Body<ApiExecuteAsyncMergeQueryResults>
@@ -555,6 +567,10 @@ const mergeWarehouseEntries = getAvailableWarehouseConfigs({
     includeDatabricks: false,
 });
 
+// Staging datasets with a current build of the `subscriptions` model; see
+// MergeTestContext.hasSubscriptionsModel.
+const WAREHOUSES_WITH_SUBSCRIPTIONS = new Set(['snowflake']);
+
 describe('Merge queries on the project warehouse', () => {
     // Postgres: reuse the already-seeded project (no create/refresh needed).
     describe('postgres (seed project)', () => {
@@ -567,6 +583,7 @@ describe('Merge queries on the project warehouse', () => {
         registerMergeQueryTests(() => ({
             client: admin,
             projectUuid: SEED_PROJECT.project_uuid,
+            hasSubscriptionsModel: true,
         }));
     });
 
@@ -596,6 +613,7 @@ describe('Merge queries on the project warehouse', () => {
             registerMergeQueryTests(() => ({
                 client: admin,
                 projectUuid,
+                hasSubscriptionsModel: WAREHOUSES_WITH_SUBSCRIPTIONS.has(name),
             }));
         });
     }

--- a/packages/api-tests/tests/mergeQuery.test.ts
+++ b/packages/api-tests/tests/mergeQuery.test.ts
@@ -1,6 +1,8 @@
 import {
+    FilterOperator,
     QueryExecutionContext,
     SEED_PROJECT,
+    type ApiCompiledMergeQueryResults,
     type ApiExecuteAsyncMergeQueryResults,
 } from '@lightdash/common';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -256,6 +258,78 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
         });
     }, 60_000);
 
+    it('applies each source filter before aggregation and merging', async () => {
+        const completedOnly = {
+            dimensions: {
+                id: 'merge-status-filter-group',
+                and: [
+                    {
+                        id: 'merge-status-filter',
+                        target: { fieldId: 'orders_status' },
+                        operator: FilterOperator.EQUALS,
+                        values: ['completed'],
+                    },
+                ],
+            },
+        };
+        const filteredOrders = {
+            ...ordersByMonth,
+            filters: completedOnly,
+        };
+        const filteredPayments = {
+            ...paymentsByMonth,
+            filters: completedOnly,
+        };
+        const filteredMerge = {
+            ...mergeQuery,
+            sources: [
+                { id: 'orders', metricQuery: filteredOrders },
+                { id: 'payments', metricQuery: filteredPayments },
+            ],
+        };
+
+        const [ordersRows, paymentsRows, runResp] = await Promise.all([
+            runSourceQuery(filteredOrders),
+            runSourceQuery(filteredPayments),
+            admin.post<Body<{ queryUuid: string }>>(
+                `/api/v1/projects/${projectUuid}/mergeQuery/run`,
+                { mergeQuery: filteredMerge },
+            ),
+        ]);
+        const ordersByKey = new Map(
+            ordersRows.map((row) => [
+                monthOf(row.orders_order_date_month),
+                row.orders_total_order_amount,
+            ]),
+        );
+        const paymentsByKey = new Map(
+            paymentsRows.map((row) => [
+                monthOf(row.orders_order_date_month),
+                row.payments_unique_payment_count,
+            ]),
+        );
+        const results = await pollQueryResults(
+            admin,
+            runResp.body.results.queryUuid,
+        );
+
+        expect(results.totalResults).toBe(
+            new Set([...ordersByKey.keys(), ...paymentsByKey.keys()]).size,
+        );
+        results.rows.forEach((row) => {
+            const key = monthOf(
+                (row[KEY_FIELD_ID] as { value: { raw: unknown } }).value.raw,
+            );
+            expect(
+                (row[ORDERS_FIELD_ID] as { value: { raw: unknown } }).value.raw,
+            ).toEqual(ordersByKey.get(key) ?? null);
+            expect(
+                (row[PAYMENTS_FIELD_ID] as { value: { raw: unknown } }).value
+                    .raw,
+            ).toEqual(paymentsByKey.get(key) ?? null);
+        });
+    }, 60_000);
+
     it('keeps the key sets each join type promises', async () => {
         const [ordersRows, paymentsRows] = await Promise.all([
             runSourceQuery(ordersByMonth),
@@ -298,7 +372,7 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
     // parameterized join in. The single-query path refuses to run without a
     // value; the merge must refuse the same way instead of shipping a
     // literal `${ld.parameters...}` placeholder to the warehouse.
-    it('refuses a merge whose source is missing a parameter value, by name', async () => {
+    it('refuses a missing parameter and applies a supplied value', async () => {
         const parameterized = {
             sources: [
                 {
@@ -349,10 +423,7 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
             limit: 500,
         };
 
-        type CompileBody = Body<{
-            sql: string | null;
-            errors: { kind: string; sourceId: string | null }[];
-        }>;
+        type CompileBody = Body<ApiCompiledMergeQueryResults>;
         const refused = await admin.post<CompileBody>(
             `/api/v1/projects/${projectUuid}/mergeQuery/compile`,
             { mergeQuery: parameterized },
@@ -375,7 +446,38 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
         );
         expect(supplied.body.results.errors).toEqual([]);
         expect(supplied.body.results.sql).not.toContain('${ld.parameters');
-    });
+        expect(supplied.body.results.parameterReferences).toContain(
+            'customers.customer_name',
+        );
+        expect(supplied.body.results.usedParametersValues).toEqual(
+            expect.objectContaining({ 'customers.customer_name': 'Ken' }),
+        );
+
+        const runResp = await admin.post<
+            Body<ApiExecuteAsyncMergeQueryResults>
+        >(`/api/v2/projects/${projectUuid}/query/merge-query`, {
+            mergeQuery: parameterized,
+            parameters: { 'customers.customer_name': 'Ken' },
+            context: QueryExecutionContext.EXPLORE,
+        });
+        expect(runResp.body.results.outcome).toBe('started');
+        expect(runResp.body.results.parameterReferences).toContain(
+            'customers.customer_name',
+        );
+        if (runResp.body.results.outcome !== 'started') {
+            throw new Error(
+                `Parameterized merge was refused: ${JSON.stringify(runResp.body.results.errors)}`,
+            );
+        }
+        expect(runResp.body.results.query.usedParametersValues).toEqual(
+            expect.objectContaining({ 'customers.customer_name': 'Ken' }),
+        );
+        const results = await pollQueryResults(
+            admin,
+            runResp.body.results.query.queryUuid,
+        );
+        expect(results.totalResults).toBeGreaterThan(0);
+    }, 60_000);
 
     it('runs a pivoted merge through the standard pivot stage', async () => {
         // Widen the key with the order status, shared by both explores, and

--- a/packages/api-tests/tests/savedChart.test.ts
+++ b/packages/api-tests/tests/savedChart.test.ts
@@ -2,10 +2,13 @@ import {
     CreateChartInDashboard,
     CreateChartInSpace,
     Dashboard,
+    FilterOperator,
+    MergeJoinType,
     SavedChart,
     SEED_ORG_1_EDITOR,
     SEED_PROJECT,
     SpaceMemberRole,
+    type SavedMergeQuery,
 } from '@lightdash/common';
 import { login, loginAsEditor } from '../helpers/auth';
 import { chartMock, dashboardMock } from '../helpers/mocks';
@@ -157,6 +160,118 @@ describe('Saved chart space selection', () => {
             columns: ['orders_status'],
             rows: ['orders_average_order_size'],
         });
+    });
+
+    it('Should persist and edit a merged chart without losing filters or parameters', async () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+        const completedOnly = {
+            dimensions: {
+                id: 'completed-orders',
+                and: [
+                    {
+                        id: 'completed-orders-filter',
+                        target: { fieldId: 'orders_status' },
+                        operator: FilterOperator.EQUALS,
+                        values: ['completed'],
+                    },
+                ],
+            },
+        };
+        const additionalMetricQuery = {
+            exploreName: 'payments',
+            dimensions: ['orders_status'],
+            metrics: ['payments_unique_payment_count'],
+            filters: completedOnly,
+            sorts: [],
+            limit: 500,
+            tableCalculations: [],
+            additionalMetrics: [],
+        };
+        const merge: SavedMergeQuery = {
+            primarySourceId: 'a',
+            sources: [
+                { id: 'a', kind: 'chart' },
+                {
+                    id: 'b',
+                    kind: 'query',
+                    metricQuery: additionalMetricQuery,
+                },
+            ],
+            joinKey: [
+                {
+                    name: 'status',
+                    fieldIdBySourceId: {
+                        a: 'orders_status',
+                        b: 'orders_status',
+                    },
+                },
+            ],
+            joinType: MergeJoinType.FULL,
+            tableCalculations: [],
+        };
+        const parameters = { 'customers.customer_name': 'Ken' };
+        const createResponse = await admin.post<{ results: SavedChart }>(
+            `${apiUrl}/projects/${projectUuid}/saved`,
+            {
+                ...chartMock,
+                name: uniqueName('Merged chart persistence'),
+                metricQuery: {
+                    ...chartMock.metricQuery,
+                    filters: completedOnly,
+                },
+                merge,
+                parameters,
+                dashboardUuid: null,
+                spaceUuid: undefined,
+            } satisfies CreateChartInSpace,
+        );
+        expect(createResponse.status).toBe(200);
+        createdChartUuids.push(createResponse.body.results.uuid);
+
+        const getCreated = await admin.get<{ results: SavedChart }>(
+            `${apiUrl}/saved/${createResponse.body.results.uuid}`,
+        );
+        expect(getCreated.body.results.merge).toEqual(merge);
+        expect(getCreated.body.results.metricQuery.filters).toEqual(
+            completedOnly,
+        );
+        expect(getCreated.body.results.parameters).toEqual(parameters);
+
+        const editedMerge: SavedMergeQuery = {
+            ...merge,
+            joinType: MergeJoinType.LEFT,
+            sources: [
+                merge.sources[0],
+                {
+                    id: 'b',
+                    kind: 'query',
+                    metricQuery: {
+                        ...additionalMetricQuery,
+                        filters: {},
+                    },
+                },
+            ],
+        };
+        const editResponse = await admin.post(
+            `${apiUrl}/saved/${createResponse.body.results.uuid}/version`,
+            {
+                ...chartMock,
+                metricQuery: {
+                    ...chartMock.metricQuery,
+                    filters: completedOnly,
+                },
+                merge: editedMerge,
+                parameters,
+            },
+        );
+        expect(editResponse.status).toBe(200);
+
+        const getEdited = await admin.get<{ results: SavedChart }>(
+            `${apiUrl}/saved/${createResponse.body.results.uuid}`,
+        );
+        expect(getEdited.body.results.merge).toEqual(editedMerge);
+        expect(getEdited.body.results.merge?.joinType).toBe(MergeJoinType.LEFT);
+        expect(getEdited.body.results.parameters).toEqual(parameters);
     });
 
     it('Should create a chart belonging to a dashboard', async () => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5516,6 +5516,15 @@ export class ProjectService extends BaseService {
             ),
             tableCalculations: mergeQuery.tableCalculations,
             nullPlaceholderByKeyName,
+            stringJoinKeyNames: mergeQuery.joinKey.flatMap((part) => {
+                const meta = Object.entries(part.fieldIdBySourceId)
+                    .map(
+                        ([sourceId, fieldId]) =>
+                            fieldTypes[sourceId]?.[fieldId],
+                    )
+                    .find((candidate) => candidate !== undefined);
+                return meta?.type === DimensionType.STRING ? [part.name] : [];
+            }),
             // Each query is bounded, but reaching the bound is reported rather
             // than trimmed: a join over a trimmed side returns numbers that
             // look complete and are not.

--- a/packages/backend/src/utils/QueryBuilder/MergeQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MergeQueryBuilder.test.ts
@@ -710,6 +710,8 @@ describe('per-dialect compile snapshots', () => {
             joinKeyNames: [keyName],
             joinType,
             warehouseSqlBuilder,
+            stringJoinKeyNames:
+                keyMeta.type === DimensionType.STRING ? [keyName] : [],
             nullPlaceholderByKeyName: {
                 [keyName]: getMergeNullPlaceholder(
                     keyMeta,
@@ -741,12 +743,20 @@ describe('per-dialect compile snapshots', () => {
     });
 
     it.each(adapters)('compiles a string-keyed merge on %s', (adapter) => {
-        expect(
-            compile(adapter, 'status', {
-                type: DimensionType.STRING,
-                timeInterval: null,
-            }),
-        ).toMatchSnapshot();
+        const sql = compile(adapter, 'status', {
+            type: DimensionType.STRING,
+            timeInterval: null,
+        });
+        const stringType = [
+            SupportedDbtAdapter.BIGQUERY,
+            SupportedDbtAdapter.DATABRICKS,
+        ].includes(adapter as SupportedDbtAdapter)
+            ? 'STRING'
+            : 'VARCHAR';
+
+        expect(sql).toMatchSnapshot();
+        expect(sql).toContain('CAST(merge_0_a.');
+        expect(sql).toContain(` AS ${stringType})`);
     });
 
     it('uses a DATETIME placeholder for a naive timestamp key on bigquery', () => {

--- a/packages/backend/src/utils/QueryBuilder/MergeQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MergeQueryBuilder.ts
@@ -5,6 +5,7 @@ import {
     MERGE_TRUNCATED_COLUMN,
     mergeCalculationReferencePattern,
     MergeJoinType,
+    SupportedDbtAdapter,
     type MergeFieldMeta,
     type MergeQueryColumns,
     type MergeTableCalculation,
@@ -138,6 +139,8 @@ export class MergeQueryBuilder {
 
     private readonly nullPlaceholderByKeyName: Record<string, string>;
 
+    private readonly stringJoinKeyNames: Set<string>;
+
     private readonly tableCalculations: MergeTableCalculation[];
 
     private readonly sourceRowCap: number | undefined;
@@ -152,6 +155,7 @@ export class MergeQueryBuilder {
         limit,
         tableCalculations,
         nullPlaceholderByKeyName,
+        stringJoinKeyNames,
         sourceRowCap,
         sorts,
     }: {
@@ -175,6 +179,9 @@ export class MergeQueryBuilder {
          * keys match each other; omitting it leaves them unmatched.
          */
         nullPlaceholderByKeyName?: Record<string, string>;
+        /** Keys modeled as strings. Cast source values before coalescing so a
+         * physically numeric column is compatible with the string sentinel. */
+        stringJoinKeyNames?: string[];
     }) {
         this.sources = sources;
         this.joinKeyNames = joinKeyNames;
@@ -182,6 +189,7 @@ export class MergeQueryBuilder {
         this.warehouseSqlBuilder = warehouseSqlBuilder;
         this.limit = limit;
         this.nullPlaceholderByKeyName = nullPlaceholderByKeyName ?? {};
+        this.stringJoinKeyNames = new Set(stringJoinKeyNames ?? []);
         this.tableCalculations = tableCalculations ?? [];
         this.sourceRowCap = sourceRowCap;
         this.sorts = sorts ?? [];
@@ -268,19 +276,52 @@ export class MergeQueryBuilder {
                     return `${this.joinKeyColumnFor(0, keyName)} AS ${alias}`;
                 }
                 const columns = this.sources.map((_, index) =>
-                    this.joinKeyColumnFor(index, keyName),
+                    this.getComparableJoinKeyColumn(index, keyName),
                 );
                 return `COALESCE(${columns.join(', ')}) AS ${alias}`;
             }
             case MergeJoinType.LEFT:
             case MergeJoinType.INNER:
-                return `${this.joinKeyColumnFor(0, keyName)} AS ${alias}`;
+                return `${this.getComparableJoinKeyColumn(0, keyName)} AS ${alias}`;
             default:
                 return assertUnreachable(
                     this.joinType,
                     `Unknown merge join type ${this.joinType}`,
                 );
         }
+    }
+
+    private getComparableJoinKeyColumn(
+        sourceIndex: number,
+        keyName: string,
+    ): string {
+        const column = this.joinKeyColumnFor(sourceIndex, keyName);
+        if (!this.stringJoinKeyNames.has(keyName)) return column;
+
+        const adapter = this.warehouseSqlBuilder.getAdapterType();
+        const stringType = (() => {
+            switch (adapter) {
+                case SupportedDbtAdapter.BIGQUERY:
+                case SupportedDbtAdapter.DATABRICKS:
+                case SupportedDbtAdapter.SPARK:
+                    return 'STRING';
+                case SupportedDbtAdapter.CLICKHOUSE:
+                    return 'String';
+                case SupportedDbtAdapter.POSTGRES:
+                case SupportedDbtAdapter.REDSHIFT:
+                case SupportedDbtAdapter.SNOWFLAKE:
+                case SupportedDbtAdapter.DUCKDB:
+                case SupportedDbtAdapter.TRINO:
+                case SupportedDbtAdapter.ATHENA:
+                    return 'VARCHAR';
+                default:
+                    return assertUnreachable(
+                        adapter,
+                        'Unknown warehouse adapter',
+                    );
+            }
+        })();
+        return `CAST(${column} AS ${stringType})`;
     }
 
     private getJoinKeyword(): string {
@@ -310,21 +351,26 @@ export class MergeQueryBuilder {
      * FULL OUTER JOIN whose condition is not merge- or hash-joinable, which
      * both `(a = b OR (a IS NULL AND b IS NULL))` and `IS NOT DISTINCT FROM`
      * are. Using it only for LEFT and INNER would silently change what a null
-     * key means when the user toggles the include mode. The cost is that null
-     * keys never match: under a FULL join each source contributes its own
-     * null-key row instead of one merged row.
+     * key means when the user toggles the include mode. Callers that want null
+     * keys to match supply a typed placeholder; the separate null-ness
+     * equality keeps that sentinel collision-safe and hash-joinable.
      */
     private getJoinCondition(sourceIndex: number): string {
         return this.joinKeyNames
             .map((keyName) => {
                 const previous = this.sources
                     .slice(0, sourceIndex)
-                    .map((_, index) => this.joinKeyColumnFor(index, keyName));
+                    .map((_, index) =>
+                        this.getComparableJoinKeyColumn(index, keyName),
+                    );
                 const left =
                     this.joinType === MergeJoinType.FULL && previous.length > 1
                         ? `COALESCE(${previous.join(', ')})`
                         : previous[0];
-                const right = this.joinKeyColumnFor(sourceIndex, keyName);
+                const right = this.getComparableJoinKeyColumn(
+                    sourceIndex,
+                    keyName,
+                );
                 const placeholder = this.nullPlaceholderByKeyName[keyName];
                 if (placeholder === undefined) {
                     return `${left} = ${right}`;

--- a/packages/backend/src/utils/QueryBuilder/__snapshots__/MergeQueryBuilder.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/__snapshots__/MergeQueryBuilder.test.ts.snap
@@ -187,11 +187,11 @@ SELECT status, 1 AS new_organic FROM followers GROUP BY 1
 merge_1_b AS (
 SELECT status, 2 AS total_followers FROM follower_snapshots GROUP BY 1
 )
-SELECT COALESCE(merge_0_a.\`status\`, merge_1_b.\`status\`) AS \`status\`,
+SELECT COALESCE(CAST(merge_0_a.\`status\` AS STRING), CAST(merge_1_b.\`status\` AS STRING)) AS \`status\`,
        merge_0_a.\`new_organic\` AS \`c0_0\`,
        merge_1_b.\`total_followers\` AS \`c1_0\`
 FROM merge_0_a
-FULL OUTER JOIN merge_1_b ON (merge_0_a.\`status\` IS NULL) = (merge_1_b.\`status\` IS NULL) AND COALESCE(merge_0_a.\`status\`, '') = COALESCE(merge_1_b.\`status\`, '')
+FULL OUTER JOIN merge_1_b ON (CAST(merge_0_a.\`status\` AS STRING) IS NULL) = (CAST(merge_1_b.\`status\` AS STRING) IS NULL) AND COALESCE(CAST(merge_0_a.\`status\` AS STRING), '') = COALESCE(CAST(merge_1_b.\`status\` AS STRING), '')
 ORDER BY \`status\`"
 `;
 
@@ -202,11 +202,11 @@ SELECT status, 1 AS new_organic FROM followers GROUP BY 1
 merge_1_b AS (
 SELECT status, 2 AS total_followers FROM follower_snapshots GROUP BY 1
 )
-SELECT COALESCE(merge_0_a.\`status\`, merge_1_b.\`status\`) AS \`status\`,
+SELECT COALESCE(CAST(merge_0_a.\`status\` AS STRING), CAST(merge_1_b.\`status\` AS STRING)) AS \`status\`,
        merge_0_a.\`new_organic\` AS \`c0_0\`,
        merge_1_b.\`total_followers\` AS \`c1_0\`
 FROM merge_0_a
-FULL OUTER JOIN merge_1_b ON (merge_0_a.\`status\` IS NULL) = (merge_1_b.\`status\` IS NULL) AND COALESCE(merge_0_a.\`status\`, '') = COALESCE(merge_1_b.\`status\`, '')
+FULL OUTER JOIN merge_1_b ON (CAST(merge_0_a.\`status\` AS STRING) IS NULL) = (CAST(merge_1_b.\`status\` AS STRING) IS NULL) AND COALESCE(CAST(merge_0_a.\`status\` AS STRING), '') = COALESCE(CAST(merge_1_b.\`status\` AS STRING), '')
 ORDER BY \`status\`"
 `;
 
@@ -217,11 +217,11 @@ SELECT status, 1 AS new_organic FROM followers GROUP BY 1
 merge_1_b AS (
 SELECT status, 2 AS total_followers FROM follower_snapshots GROUP BY 1
 )
-SELECT COALESCE(merge_0_a."status", merge_1_b."status") AS "status",
+SELECT COALESCE(CAST(merge_0_a."status" AS VARCHAR), CAST(merge_1_b."status" AS VARCHAR)) AS "status",
        merge_0_a."new_organic" AS "c0_0",
        merge_1_b."total_followers" AS "c1_0"
 FROM merge_0_a
-FULL OUTER JOIN merge_1_b ON (merge_0_a."status" IS NULL) = (merge_1_b."status" IS NULL) AND COALESCE(merge_0_a."status", '') = COALESCE(merge_1_b."status", '')
+FULL OUTER JOIN merge_1_b ON (CAST(merge_0_a."status" AS VARCHAR) IS NULL) = (CAST(merge_1_b."status" AS VARCHAR) IS NULL) AND COALESCE(CAST(merge_0_a."status" AS VARCHAR), '') = COALESCE(CAST(merge_1_b."status" AS VARCHAR), '')
 ORDER BY "status""
 `;
 
@@ -232,11 +232,11 @@ SELECT status, 1 AS new_organic FROM followers GROUP BY 1
 merge_1_b AS (
 SELECT status, 2 AS total_followers FROM follower_snapshots GROUP BY 1
 )
-SELECT COALESCE(merge_0_a."status", merge_1_b."status") AS "status",
+SELECT COALESCE(CAST(merge_0_a."status" AS VARCHAR), CAST(merge_1_b."status" AS VARCHAR)) AS "status",
        merge_0_a."new_organic" AS "c0_0",
        merge_1_b."total_followers" AS "c1_0"
 FROM merge_0_a
-FULL OUTER JOIN merge_1_b ON (merge_0_a."status" IS NULL) = (merge_1_b."status" IS NULL) AND COALESCE(merge_0_a."status", '') = COALESCE(merge_1_b."status", '')
+FULL OUTER JOIN merge_1_b ON (CAST(merge_0_a."status" AS VARCHAR) IS NULL) = (CAST(merge_1_b."status" AS VARCHAR) IS NULL) AND COALESCE(CAST(merge_0_a."status" AS VARCHAR), '') = COALESCE(CAST(merge_1_b."status" AS VARCHAR), '')
 ORDER BY "status""
 `;
 
@@ -247,11 +247,11 @@ SELECT status, 1 AS new_organic FROM followers GROUP BY 1
 merge_1_b AS (
 SELECT status, 2 AS total_followers FROM follower_snapshots GROUP BY 1
 )
-SELECT COALESCE(merge_0_a."status", merge_1_b."status") AS "status",
+SELECT COALESCE(CAST(merge_0_a."status" AS VARCHAR), CAST(merge_1_b."status" AS VARCHAR)) AS "status",
        merge_0_a."new_organic" AS "c0_0",
        merge_1_b."total_followers" AS "c1_0"
 FROM merge_0_a
-FULL OUTER JOIN merge_1_b ON (merge_0_a."status" IS NULL) = (merge_1_b."status" IS NULL) AND COALESCE(merge_0_a."status", '') = COALESCE(merge_1_b."status", '')
+FULL OUTER JOIN merge_1_b ON (CAST(merge_0_a."status" AS VARCHAR) IS NULL) = (CAST(merge_1_b."status" AS VARCHAR) IS NULL) AND COALESCE(CAST(merge_0_a."status" AS VARCHAR), '') = COALESCE(CAST(merge_1_b."status" AS VARCHAR), '')
 ORDER BY "status""
 `;
 
@@ -262,10 +262,10 @@ SELECT status, 1 AS new_organic FROM followers GROUP BY 1
 merge_1_b AS (
 SELECT status, 2 AS total_followers FROM follower_snapshots GROUP BY 1
 )
-SELECT COALESCE(merge_0_a."status", merge_1_b."status") AS "status",
+SELECT COALESCE(CAST(merge_0_a."status" AS VARCHAR), CAST(merge_1_b."status" AS VARCHAR)) AS "status",
        merge_0_a."new_organic" AS "c0_0",
        merge_1_b."total_followers" AS "c1_0"
 FROM merge_0_a
-FULL OUTER JOIN merge_1_b ON (merge_0_a."status" IS NULL) = (merge_1_b."status" IS NULL) AND COALESCE(merge_0_a."status", '') = COALESCE(merge_1_b."status", '')
+FULL OUTER JOIN merge_1_b ON (CAST(merge_0_a."status" AS VARCHAR) IS NULL) = (CAST(merge_1_b."status" AS VARCHAR) IS NULL) AND COALESCE(CAST(merge_0_a."status" AS VARCHAR), '') = COALESCE(CAST(merge_1_b."status" AS VARCHAR), '')
 ORDER BY "status""
 `;

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -122,6 +122,31 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
         // A configured merge is the explorer's result, so the table reads it
         // instead of the query it was built from.
         if (mergeResults) {
+            const unpivotedRunError = merge?.unpivotedRunError;
+            const unpivotedRunErrors = merge?.unpivotedRunErrors ?? [];
+            if (unpivotedRunError || unpivotedRunErrors.length > 0) {
+                return {
+                    rows: [],
+                    totalResults: 0,
+                    isFetchingRows: false,
+                    fetchMoreRows: () => {},
+                    status: 'error' as const,
+                    apiError:
+                        unpivotedRunError ??
+                        ({
+                            status: 'error',
+                            error: {
+                                name: 'Error',
+                                statusCode: 400,
+                                message: unpivotedRunErrors
+                                    .map((error) => error.message)
+                                    .join(' '),
+                                data: {},
+                            },
+                        } as const),
+                    queryStatus: undefined,
+                };
+            }
             const rawResults =
                 mergeResults.unpivotedResults ?? mergeResults.results;
             return {
@@ -248,6 +273,8 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
         merge?.wasRestored,
         merge?.runError,
         merge?.runErrors,
+        merge?.unpivotedRunError,
+        merge?.unpivotedRunErrors,
         unpivotedQuery,
         hasPivotConfig,
         unpivotedEnabled,

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -15,6 +15,7 @@ import {
     useExplorerSelector,
 } from '../../../features/explorer/store';
 import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
+import { resolveMergeColumnOrder } from '../../../features/mergeQuery/utils/resolveMergeColumnOrder';
 import { useColumnTotalsEnabledByDefault } from '../../../hooks/useAsyncCalculateTotal';
 import { useColumns } from '../../../hooks/useColumns';
 import { useExplore } from '../../../hooks/useExplore';
@@ -84,7 +85,8 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
             ? chartConfig.config.columns
             : undefined;
 
-    const mergeResults = useMergeSafe()?.mergeResults ?? null;
+    const merge = useMergeSafe();
+    const mergeResults = merge?.mergeResults ?? null;
 
     // Get query state from new hook
     const {
@@ -104,6 +106,9 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
     const dimensions = query.data?.metricQuery?.dimensions ?? [];
     const metrics = query.data?.metricQuery?.metrics ?? [];
     const explorerColumnOrder = useExplorerSelector(selectColumnOrder);
+    const resultsColumnOrder = mergeResults
+        ? resolveMergeColumnOrder(mergeResults.columnOrder, explorerColumnOrder)
+        : explorerColumnOrder;
     const columnLimit =
         chartConfig.type === 'cartesian' && chartConfig.config
             ? chartConfig.config.columnLimit
@@ -117,18 +122,57 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
         // A configured merge is the explorer's result, so the table reads it
         // instead of the query it was built from.
         if (mergeResults) {
+            const rawResults =
+                mergeResults.unpivotedResults ?? mergeResults.results;
             return {
-                rows: mergeResults.results.rows,
-                totalResults: mergeResults.results.totalResults,
-                isFetchingRows:
-                    mergeResults.results.isFetchingRows &&
-                    !mergeResults.results.error,
-                fetchMoreRows: mergeResults.results.fetchMoreRows,
-                status: mergeResults.results.error
+                rows: rawResults.rows,
+                totalResults: rawResults.totalResults,
+                isFetchingRows: rawResults.isFetchingRows && !rawResults.error,
+                fetchMoreRows: rawResults.fetchMoreRows,
+                status: rawResults.error
                     ? ('error' as const)
                     : ('success' as const),
-                apiError: mergeResults.results.error ?? undefined,
-                queryStatus: mergeResults.results.queryStatus,
+                apiError: rawResults.error ?? undefined,
+                queryStatus: rawResults.queryStatus,
+            };
+        }
+
+        if (
+            merge?.isMerging &&
+            (merge.runError || merge.runErrors.length > 0)
+        ) {
+            return {
+                rows: [],
+                totalResults: 0,
+                isFetchingRows: false,
+                fetchMoreRows: () => {},
+                status: 'error' as const,
+                apiError:
+                    merge.runError ??
+                    ({
+                        status: 'error',
+                        error: {
+                            name: 'Error',
+                            statusCode: 400,
+                            message: merge.runErrors
+                                .map((error) => error.message)
+                                .join(' '),
+                            data: {},
+                        },
+                    } as const),
+                queryStatus: undefined,
+            };
+        }
+
+        if (merge?.isMerging && (merge.isRunning || merge.wasRestored)) {
+            return {
+                rows: [],
+                totalResults: undefined,
+                isFetchingRows: true,
+                fetchMoreRows: () => {},
+                status: 'loading' as const,
+                apiError: undefined,
+                queryStatus: undefined,
             };
         }
 
@@ -199,6 +243,11 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
         return result;
     }, [
         mergeResults,
+        merge?.isMerging,
+        merge?.isRunning,
+        merge?.wasRestored,
+        merge?.runError,
+        merge?.runErrors,
         unpivotedQuery,
         hasPivotConfig,
         unpivotedEnabled,
@@ -223,6 +272,22 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
             return null;
         }
 
+        if (mergeResults) {
+            return {
+                rows: mergeResults.results.rows,
+                totalResults: mergeResults.results.totalResults,
+                isFetchingRows:
+                    mergeResults.results.isFetchingRows &&
+                    !mergeResults.results.error,
+                fetchMoreRows: mergeResults.results.fetchMoreRows,
+                status: mergeResults.results.error
+                    ? ('error' as const)
+                    : ('success' as const),
+                apiError: mergeResults.results.error ?? undefined,
+                pivotDetails: mergeResults.results.pivotDetails,
+            };
+        }
+
         const finalStatus = getQueryStatus(query, queryResults);
         return {
             rows: queryResults.rows,
@@ -233,7 +298,7 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
             apiError: query.error ?? queryResults.error,
             pivotDetails: queryResults.pivotDetails,
         };
-    }, [canShowGroupedResults, query, queryResults]);
+    }, [canShowGroupedResults, mergeResults, query, queryResults]);
 
     const handleColumnOrderChange = useCallback(
         (order: string[]) => {
@@ -311,7 +376,9 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
     // pivot headers / row index; metrics drop out of data columns. Both ship
     // to the pivot reducer worker so the user's "Hide column" toggle takes
     // effect without waiting for a new query.
-    const queryDimensions = query.data?.metricQuery?.dimensions;
+    const queryDimensions =
+        mergeResults?.metricQuery.dimensions ??
+        query.data?.metricQuery?.dimensions;
     const { hiddenDimensionFieldIds, hiddenMetricFieldIds } = useMemo(() => {
         if (!columnProperties) {
             return {
@@ -341,9 +408,9 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
     // Only process when user is actually viewing grouped results
     const pivotTableQuery = usePivotTableData({
         enabled: canShowGroupedResults && viewMode === ResultsViewMode.GROUPED,
-        rows: queryResults.rows,
-        pivotDetails: queryResults.pivotDetails,
-        columnOrder: explorerColumnOrder,
+        rows: groupedResultsData?.rows ?? [],
+        pivotDetails: groupedResultsData?.pivotDetails,
+        columnOrder: resultsColumnOrder,
         getField,
         getFieldLabel,
         columnLimit,
@@ -504,7 +571,7 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
                         isFetchingRows={isFetchingRows}
                         fetchMoreRows={fetchMoreRows}
                         columns={columns}
-                        columnOrder={explorerColumnOrder}
+                        columnOrder={resultsColumnOrder}
                         onColumnOrderChange={handleColumnOrderChange}
                         cellContextMenu={cellContextMenu}
                         headerContextMenu={

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -22,6 +22,7 @@ import {
     useExplorerSelector,
 } from '../../../features/explorer/store';
 import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
+import { resolveMergeColumnOrder } from '../../../features/mergeQuery/utils/resolveMergeColumnOrder';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
@@ -73,7 +74,9 @@ const ResultsCard: FC = memo(() => {
     const merge = useMergeSafe();
     const mergeResults = merge?.mergeResults;
 
-    const mergedTotalResults = mergeResults?.results.totalResults;
+    const mergedTotalResults =
+        mergeResults?.unpivotedResults?.totalResults ??
+        mergeResults?.results.totalResults;
     const totalResults = mergeResults
         ? (mergedTotalResults ?? mergeResults.metricQuery.limit)
         : queryResults.totalResults;
@@ -120,7 +123,9 @@ const ResultsCard: FC = memo(() => {
         [getDownloadQueryUuid, merge, mergeResults],
     );
 
-    const exportColumnOrder = mergeResults?.columnOrder ?? columnOrder;
+    const exportColumnOrder = mergeResults
+        ? resolveMergeColumnOrder(mergeResults.columnOrder, columnOrder)
+        : columnOrder;
 
     return (
         <CollapsableCard

--- a/packages/frontend/src/components/Explorer/ResultsCard/useGroupedResultsAvailability.test.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/useGroupedResultsAvailability.test.tsx
@@ -1,0 +1,80 @@
+import { renderHook } from '@testing-library/react';
+import { useGroupedResultsAvailability } from './useGroupedResultsAvailability';
+
+const state = vi.hoisted(() => ({
+    queryResults: {
+        rows: [] as unknown[],
+        pivotDetails: { totalColumnCount: 999 },
+    },
+    merge: {
+        isMerging: true,
+        wasRestored: false,
+        isRunning: false,
+        runError: null as unknown,
+        runErrors: [] as unknown[],
+        mergeResults: {
+            results: {
+                rows: [{}] as unknown[],
+                pivotDetails: { totalColumnCount: 2 },
+            },
+        } as unknown,
+    },
+}));
+
+vi.mock('../../../features/explorer/store', () => ({
+    selectPivotConfig: 'pivot-config',
+    selectChartConfig: 'chart-config',
+    useExplorerSelector: (selector: string) =>
+        selector === 'pivot-config'
+            ? { columns: ['merge_status'] }
+            : { type: 'cartesian' },
+}));
+
+vi.mock('../../../features/mergeQuery/context/useMerge', () => ({
+    useMergeSafe: () => state.merge,
+}));
+
+vi.mock('../../../hooks/useExplorerQuery', () => ({
+    useExplorerQuery: () => ({ queryResults: state.queryResults }),
+}));
+
+vi.mock('../../../providers/App/useApp', () => ({
+    default: () => ({
+        health: { data: { pivotTable: { maxColumnLimit: 10 } } },
+    }),
+}));
+
+describe('useGroupedResultsAvailability', () => {
+    afterEach(() => {
+        state.merge.wasRestored = false;
+        state.merge.isRunning = false;
+        state.merge.runError = null;
+        state.merge.runErrors = [];
+        state.merge.mergeResults = {
+            results: {
+                rows: [{}],
+                pivotDetails: { totalColumnCount: 2 },
+            },
+        };
+        state.queryResults.rows = [];
+    });
+
+    it('uses merged rows and pivot metadata instead of the primary query', () => {
+        const { result } = renderHook(() => useGroupedResultsAvailability());
+
+        expect(result.current.hasNoResults).toBe(false);
+        expect(result.current.exceedsColumnLimit).toBe(false);
+        expect(result.current.isGroupedDisabled).toBe(false);
+    });
+
+    it('does not expose stale primary grouped results while a saved merge restores', () => {
+        state.merge.mergeResults = null;
+        state.merge.wasRestored = true;
+        state.queryResults.rows = [{}];
+
+        const { result } = renderHook(() => useGroupedResultsAvailability());
+
+        expect(result.current.hasNoResults).toBe(true);
+        expect(result.current.isGroupedDisabled).toBe(true);
+    });
+});

--- a/packages/frontend/src/components/Explorer/ResultsCard/useGroupedResultsAvailability.ts
+++ b/packages/frontend/src/components/Explorer/ResultsCard/useGroupedResultsAvailability.ts
@@ -3,6 +3,7 @@ import {
     selectPivotConfig,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import useApp from '../../../providers/App/useApp';
 
@@ -18,14 +19,25 @@ export function useGroupedResultsAvailability() {
     const pivotConfig = useExplorerSelector(selectPivotConfig);
     const chartConfig = useExplorerSelector(selectChartConfig);
     const { queryResults } = useExplorerQuery();
+    const merge = useMergeSafe();
+    const mergeResults = merge?.mergeResults;
+    const activeResults = mergeResults?.results ?? queryResults;
 
     const hasPivotColumns = !!pivotConfig?.columns?.length;
     const isTableViz = chartConfig.type === 'table';
-    const hasNoResults = queryResults.rows.length === 0;
+    const mergeIsPendingOrFailed =
+        !!merge?.isMerging &&
+        !mergeResults &&
+        (merge.wasRestored ||
+            merge.isRunning ||
+            !!merge.runError ||
+            merge.runErrors.length > 0);
+    const hasNoResults =
+        mergeIsPendingOrFailed || activeResults.rows.length === 0;
 
     // Check if pivot column limit is exceeded
     const maxColumnLimit = health.data?.pivotTable?.maxColumnLimit;
-    const totalColumnCount = queryResults.pivotDetails?.totalColumnCount;
+    const totalColumnCount = activeResults.pivotDetails?.totalColumnCount;
     const exceedsColumnLimit =
         maxColumnLimit !== undefined &&
         totalColumnCount !== undefined &&

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -42,6 +42,7 @@ import {
     useExplorerSelector,
 } from '../../../features/explorer/store';
 import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
+import { resolveMergeColumnOrder } from '../../../features/mergeQuery/utils/resolveMergeColumnOrder';
 import { useColorPalettes } from '../../../hooks/appearance/useOrganizationAppearance';
 import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColorPalette';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
@@ -160,9 +161,19 @@ const VisualizationCard: FC<Props> = memo((props) => {
         !mergeResults &&
         !merge.runError &&
         merge.runErrors.length === 0;
+    const suppressPrimaryResults =
+        awaitingRestoredMerge ||
+        (!!merge?.isMerging &&
+            !mergeResults &&
+            (merge.isRunning ||
+                !!merge.runError ||
+                merge.runErrors.length > 0));
     const isLoadingQueryResults = mergeResults
         ? mergeResults.results.isFetchingRows
-        : awaitingRestoredMerge || isLoading || queryResults.isFetchingRows;
+        : !!merge?.isRunning ||
+          awaitingRestoredMerge ||
+          isLoading ||
+          queryResults.isFetchingRows;
 
     const resultsData = useMemo(() => {
         if (mergeResults) {
@@ -177,7 +188,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
         // chart config validates its layout against whatever fields it is
         // given, and primary-source fields would fail the saved merged layout and
         // rebuild it from defaults — silently discarding the saved config.
-        if (awaitingRestoredMerge) {
+        if (suppressPrimaryResults) {
             return {
                 ...queryResults,
                 rows: [],
@@ -192,12 +203,18 @@ const VisualizationCard: FC<Props> = memo((props) => {
             fields: query.data?.fields,
             resolvedTimezone: query.data?.resolvedTimezone ?? undefined,
         };
-    }, [query.data, queryResults, mergeResults, awaitingRestoredMerge]);
+    }, [query.data, queryResults, mergeResults, suppressPrimaryResults]);
 
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
-    const visualizationMetricQuery = awaitingRestoredMerge
+    const visualizationMetricQuery = suppressPrimaryResults
         ? undefined
         : (mergeResults?.metricQuery ?? unsavedChartVersion.metricQuery);
+    const visualizationColumnOrder = mergeResults
+        ? resolveMergeColumnOrder(
+              mergeResults.columnOrder,
+              unsavedChartVersion.tableConfig.columnOrder,
+          )
+        : unsavedChartVersion.tableConfig.columnOrder;
 
     const handleSetPivotFields = useCallback(
         (fields: FieldId[] = []) => {
@@ -315,6 +332,18 @@ const VisualizationCard: FC<Props> = memo((props) => {
     const apiErrorDetail = useMemo(() => {
         const queryError = query.error?.error ?? queryResults.error?.error;
 
+        if (merge?.runError) return merge.runError.error;
+        if (merge?.runErrors.length) {
+            return {
+                message: merge.runErrors
+                    .map((error) => error.message)
+                    .join(' '),
+                name: 'Error',
+                statusCode: 400,
+                data: {},
+            } satisfies ApiErrorDetail;
+        }
+
         return !missingRequiredParameters?.length
             ? queryError
             : // Mimicking an API Error Detail so it can be used in the EmptyState component
@@ -328,6 +357,8 @@ const VisualizationCard: FC<Props> = memo((props) => {
         query.error?.error,
         queryResults.error?.error,
         missingRequiredParameters,
+        merge?.runError,
+        merge?.runErrors,
     ]);
 
     const dirtyPivotConfiguration = useMemo(() => {
@@ -398,10 +429,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
                 resultsData={resultsData}
                 apiErrorDetail={apiErrorDetail}
                 isLoading={isLoadingQueryResults}
-                columnOrder={
-                    mergeResults?.columnOrder ??
-                    unsavedChartVersion.tableConfig.columnOrder
-                }
+                columnOrder={visualizationColumnOrder}
                 onSeriesContextMenu={onSeriesContextMenu}
                 savedChartUuid={isEditMode ? undefined : savedChart?.uuid}
                 onChartConfigChange={handleSetChartConfig}
@@ -410,7 +438,10 @@ const VisualizationCard: FC<Props> = memo((props) => {
                 onPivotRowsChange={handleSetPivotRows}
                 colorPalette={colorPalette}
                 tableCalculationsMetadata={tableCalculationsMetadata}
-                parameters={query.data?.usedParametersValues}
+                parameters={
+                    mergeResults?.usedParametersValues ??
+                    query.data?.usedParametersValues
+                }
                 containerWidth={containerWidth}
                 containerHeight={containerHeight}
                 isDashboard={false}

--- a/packages/frontend/src/features/mergeQuery/components/MergeRelationshipCard.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeRelationshipCard.tsx
@@ -16,6 +16,7 @@ const MergeRelationshipCardContent: FC = () => {
         additionalExploreLabel,
         additionalSourceId,
         isIncomplete,
+        setupStep,
     } = useMergeSetup();
     const merge = useMergeSafe();
     const [isOpen, setIsOpen] = useState(true);
@@ -40,9 +41,7 @@ const MergeRelationshipCardContent: FC = () => {
             );
         })
         .join(' AND ');
-    const badgeLabel = isIncomplete
-        ? 'Needs a matching field'
-        : `${relationshipSummary} · ${joinTypeLabel}`;
+    const badgeLabel = setupStep ?? `${relationshipSummary} · ${joinTypeLabel}`;
 
     return (
         <CollapsableCard

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.test.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.test.tsx
@@ -1,0 +1,245 @@
+import {
+    ChartType,
+    DimensionType,
+    FieldType,
+    MergeJoinType,
+    MetricType,
+    type ApiExecuteAsyncMergeQueryResults,
+    type ItemsMap,
+    type MergeQuery,
+    type SavedChartDAO,
+} from '@lightdash/common';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { MergeProvider } from './MergeContext';
+import { useMerge } from './useMerge';
+
+const setSearchParams = vi.fn();
+const { executeMergeQuery } = vi.hoisted(() => ({
+    executeMergeQuery: vi.fn(),
+}));
+
+vi.mock('react-router', () => ({
+    useParams: () => ({ projectUuid: 'project-uuid' }),
+    useSearchParams: () => [new URLSearchParams(), setSearchParams],
+}));
+
+vi.mock('../../../hooks/useQueryResults', () => ({
+    useInfiniteQueryResults: () => ({
+        data: undefined,
+        error: null,
+        isFetching: false,
+    }),
+}));
+
+vi.mock('../hooks/useMergeQuery', () => ({ executeMergeQuery }));
+
+const mergeQuery: MergeQuery = {
+    sources: [],
+    joinKey: [],
+    joinType: MergeJoinType.FULL,
+    tableCalculations: [],
+    limit: 500,
+};
+
+const fields: ItemsMap = {
+    merge_month: {
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.DATE,
+        name: 'month',
+        label: 'Month',
+        table: 'merge',
+        tableLabel: 'Merged result',
+        sql: '${TABLE}.month',
+        hidden: false,
+    },
+    merge_status: {
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.STRING,
+        name: 'status',
+        label: 'Status',
+        table: 'merge',
+        tableLabel: 'Merged result',
+        sql: '${TABLE}.status',
+        hidden: false,
+    },
+    orders_total: {
+        fieldType: FieldType.METRIC,
+        type: MetricType.SUM,
+        name: 'total',
+        label: 'Total',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.total',
+        hidden: false,
+    },
+};
+
+const startedResult = (
+    queryUuid: string,
+): ApiExecuteAsyncMergeQueryResults => ({
+    outcome: 'started',
+    parameterReferences: [],
+    fieldOrigins: {},
+    query: {
+        queryUuid,
+        cacheMetadata: { cacheHit: false },
+        parameterReferences: [],
+        usedParametersValues: {},
+        resolvedTimezone: null,
+        metricQuery: {
+            exploreName: 'merge',
+            dimensions: ['merge_month', 'merge_status'],
+            metrics: ['orders_total'],
+            filters: {},
+            sorts: [],
+            limit: 500,
+            tableCalculations: [],
+            additionalMetrics: [],
+        },
+        fields,
+        warnings: [],
+    },
+});
+
+const wrapper = ({ children }: PropsWithChildren) => (
+    <MergeProvider>{children}</MergeProvider>
+);
+
+describe('MergeProvider', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('publishes join type changes immediately', () => {
+        const { result } = renderHook(() => useMerge(), { wrapper });
+
+        expect(result.current.joinType).toBe(MergeJoinType.FULL);
+
+        act(() => result.current.setJoinType(MergeJoinType.LEFT));
+
+        expect(result.current.joinType).toBe(MergeJoinType.LEFT);
+    });
+
+    it('adds, deselects, and removes source fields without orphaning join state', () => {
+        const { result } = renderHook(() => useMerge(), { wrapper });
+
+        act(() => result.current.addSource('b'));
+        act(() => result.current.setSourceExplore('b', 'payments'));
+        act(() => {
+            result.current.toggleSourceField('b', 'orders_status', true);
+            result.current.toggleSourceField(
+                'b',
+                'payments_unique_payment_count',
+                false,
+            );
+            result.current.setJoinField(0, 'b', 'orders_status');
+        });
+
+        expect(result.current.additionalSources[0]).toMatchObject({
+            id: 'b',
+            exploreName: 'payments',
+            dimensions: ['orders_status'],
+            metrics: ['payments_unique_payment_count'],
+        });
+        expect(result.current.joinParts[0].fieldIdBySourceId.b).toBe(
+            'orders_status',
+        );
+
+        act(() =>
+            result.current.toggleSourceField(
+                'b',
+                'payments_unique_payment_count',
+                false,
+            ),
+        );
+        expect(result.current.additionalSources[0].metrics).toEqual([]);
+
+        act(() => result.current.removeSource('b'));
+        expect(result.current.isMerging).toBe(false);
+        expect(result.current.additionalSources).toEqual([]);
+        expect(
+            result.current.joinParts[0].fieldIdBySourceId,
+        ).not.toHaveProperty('b');
+    });
+
+    it('keeps the parameter values used by the merged run', async () => {
+        executeMergeQuery.mockResolvedValueOnce({
+            outcome: 'started',
+            parameterReferences: ['customers.customer_name'],
+            fieldOrigins: {},
+            query: {
+                queryUuid: 'merge-query-uuid',
+                cacheMetadata: { cacheHit: false },
+                parameterReferences: ['customers.customer_name'],
+                usedParametersValues: {
+                    'customers.customer_name': 'Ken',
+                },
+                resolvedTimezone: null,
+                metricQuery: {
+                    exploreName: 'orders',
+                    dimensions: [],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    tableCalculations: [],
+                    additionalMetrics: [],
+                },
+                fields: {},
+                warnings: [],
+            },
+        } satisfies ApiExecuteAsyncMergeQueryResults);
+        const { result } = renderHook(() => useMerge(), { wrapper });
+
+        act(() =>
+            result.current.run(mergeQuery, {
+                'customers.customer_name': 'Ken',
+            }),
+        );
+
+        await waitFor(() =>
+            expect(result.current.mergeResults?.usedParametersValues).toEqual({
+                'customers.customer_name': 'Ken',
+            }),
+        );
+        expect(executeMergeQuery).toHaveBeenCalledWith(
+            'project-uuid',
+            mergeQuery,
+            { 'customers.customer_name': 'Ken' },
+            undefined,
+        );
+    });
+
+    it('starts an unpivoted run for the raw Results table', async () => {
+        executeMergeQuery
+            .mockResolvedValueOnce(startedResult('pivoted-query'))
+            .mockResolvedValueOnce(startedResult('raw-query'));
+        const { result } = renderHook(() => useMerge(), { wrapper });
+        const savedChart = {
+            chartConfig: { type: ChartType.TABLE },
+            pivotConfig: { columns: ['merge_status'] },
+        } satisfies Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>;
+
+        act(() => result.current.run(mergeQuery, undefined, savedChart));
+
+        await waitFor(() =>
+            expect(
+                result.current.mergeResults?.unpivotedResults,
+            ).not.toBeNull(),
+        );
+        expect(executeMergeQuery).toHaveBeenNthCalledWith(
+            1,
+            'project-uuid',
+            mergeQuery,
+            undefined,
+            savedChart,
+        );
+        expect(executeMergeQuery).toHaveBeenNthCalledWith(
+            2,
+            'project-uuid',
+            mergeQuery,
+            undefined,
+        );
+    });
+});

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.test.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.test.tsx
@@ -4,6 +4,8 @@ import {
     FieldType,
     MergeJoinType,
     MetricType,
+    MergeQueryErrorKind,
+    type ApiError,
     type ApiExecuteAsyncMergeQueryResults,
     type ItemsMap,
     type MergeQuery,
@@ -241,5 +243,69 @@ describe('MergeProvider', () => {
             mergeQuery,
             undefined,
         );
+    });
+
+    it('keeps the pivoted chart when the raw Results query is refused', async () => {
+        executeMergeQuery
+            .mockResolvedValueOnce(startedResult('pivoted-query'))
+            .mockResolvedValueOnce({
+                outcome: 'refused',
+                errors: [
+                    {
+                        kind: MergeQueryErrorKind.UNRESOLVED_COLUMN_TYPE,
+                        sourceId: null,
+                        fieldIds: ['merge_status'],
+                        message: 'Could not compile raw results',
+                    },
+                ],
+                parameterReferences: [],
+                fieldOrigins: {},
+            });
+        const { result } = renderHook(() => useMerge(), { wrapper });
+        const savedChart = {
+            chartConfig: { type: ChartType.TABLE },
+            pivotConfig: { columns: ['merge_status'] },
+        } satisfies Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>;
+
+        act(() => result.current.run(mergeQuery, undefined, savedChart));
+
+        await waitFor(() =>
+            expect(result.current.mergeResults?.queryUuid).toBe(
+                'pivoted-query',
+            ),
+        );
+        expect(result.current.mergeResults?.unpivotedResults).toBeNull();
+        expect(result.current.runErrors).toEqual([]);
+        expect(result.current.unpivotedRunErrors).toHaveLength(1);
+    });
+
+    it('keeps the pivoted chart when the raw Results request fails', async () => {
+        const rawResultsError: ApiError = {
+            status: 'error',
+            error: {
+                name: 'NetworkError',
+                statusCode: 500,
+                message: 'Could not start raw results',
+                data: {},
+            },
+        };
+        executeMergeQuery
+            .mockResolvedValueOnce(startedResult('pivoted-query'))
+            .mockRejectedValueOnce(rawResultsError);
+        const { result } = renderHook(() => useMerge(), { wrapper });
+        const savedChart = {
+            chartConfig: { type: ChartType.TABLE },
+            pivotConfig: { columns: ['merge_status'] },
+        } satisfies Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>;
+
+        act(() => result.current.run(mergeQuery, undefined, savedChart));
+
+        await waitFor(() =>
+            expect(result.current.mergeResults?.queryUuid).toBe(
+                'pivoted-query',
+            ),
+        );
+        expect(result.current.runError).toBeNull();
+        expect(result.current.unpivotedRunError).toBe(rawResultsError);
     });
 });

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -1,4 +1,5 @@
 import {
+    derivePivotConfigurationFromChart,
     MergeJoinType,
     type ApiCompiledMergeQueryResults,
     type ApiError,
@@ -93,6 +94,7 @@ export const MergeProvider: FC<
         isRunning: boolean;
         errors: MergeQueryError[];
         started: ApiExecuteAsyncMetricQueryResults | null;
+        unpivotedStarted: ApiExecuteAsyncMetricQueryResults | null;
         error: ApiError | null;
         parameterReferences: string[];
         fieldOrigins: ApiCompiledMergeQueryResults['fieldOrigins'];
@@ -100,6 +102,7 @@ export const MergeProvider: FC<
         isRunning: false,
         errors: [],
         started: null,
+        unpivotedStarted: null,
         error: null,
         parameterReferences: [],
         fieldOrigins: {},
@@ -151,6 +154,7 @@ export const MergeProvider: FC<
             isRunning: false,
             errors: [],
             started: null,
+            unpivotedStarted: null,
             error: null,
             parameterReferences: [],
             fieldOrigins: {},
@@ -315,27 +319,58 @@ export const MergeProvider: FC<
                 isRunning: true,
                 errors: [],
                 started: null,
+                unpivotedStarted: null,
                 error: null,
                 parameterReferences: current.parameterReferences,
                 fieldOrigins: current.fieldOrigins,
             }));
             executeMergeQuery(projectUuid, mergeQuery, parameters, savedChart)
-                .then((result) => {
+                .then(async (result) => {
                     if (activeRun.current !== runId) return;
                     if (result.outcome === 'refused') {
                         setRunState({
                             isRunning: false,
                             errors: result.errors,
                             started: null,
+                            unpivotedStarted: null,
                             error: null,
                             parameterReferences: result.parameterReferences,
                             fieldOrigins: result.fieldOrigins,
                         });
                     } else {
+                        const pivotConfiguration = savedChart
+                            ? derivePivotConfigurationFromChart(
+                                  savedChart,
+                                  result.query.metricQuery,
+                                  result.query.fields,
+                              )
+                            : undefined;
+                        const unpivoted = pivotConfiguration
+                            ? await executeMergeQuery(
+                                  projectUuid,
+                                  mergeQuery,
+                                  parameters,
+                              )
+                            : null;
+                        if (activeRun.current !== runId) return;
+                        if (unpivoted?.outcome === 'refused') {
+                            setRunState({
+                                isRunning: false,
+                                errors: unpivoted.errors,
+                                started: null,
+                                unpivotedStarted: null,
+                                error: null,
+                                parameterReferences:
+                                    unpivoted.parameterReferences,
+                                fieldOrigins: unpivoted.fieldOrigins,
+                            });
+                            return;
+                        }
                         setRunState({
                             isRunning: false,
                             errors: [],
                             started: result.query,
+                            unpivotedStarted: unpivoted?.query ?? null,
                             error: null,
                             parameterReferences: result.parameterReferences,
                             fieldOrigins: result.fieldOrigins,
@@ -348,6 +383,7 @@ export const MergeProvider: FC<
                         isRunning: false,
                         errors: [],
                         started: null,
+                        unpivotedStarted: null,
                         error,
                         parameterReferences: current.parameterReferences,
                         fieldOrigins: current.fieldOrigins,
@@ -380,8 +416,12 @@ export const MergeProvider: FC<
         [projectUuid],
     );
 
-    const { started } = runState;
+    const { started, unpivotedStarted } = runState;
     const results = useInfiniteQueryResults(projectUuid, started?.queryUuid);
+    const unpivotedResults = useInfiniteQueryResults(
+        projectUuid,
+        unpivotedStarted?.queryUuid,
+    );
 
     const mergeResults = useMemo(
         () =>
@@ -398,10 +438,20 @@ export const MergeProvider: FC<
                           ...started.metricQuery.metrics,
                       ],
                       fieldOrigins: runState.fieldOrigins,
+                      usedParametersValues: started.usedParametersValues,
                       results,
+                      unpivotedResults: unpivotedStarted
+                          ? unpivotedResults
+                          : null,
                   }
                 : null,
-        [started, results, runState.fieldOrigins],
+        [
+            started,
+            unpivotedStarted,
+            results,
+            unpivotedResults,
+            runState.fieldOrigins,
+        ],
     );
 
     const value = useMemo(

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -390,8 +390,7 @@ export const MergeProvider: FC<
                                 error: null,
                                 unpivotedErrors: unpivoted.errors,
                                 unpivotedError: null,
-                                parameterReferences:
-                                    result.parameterReferences,
+                                parameterReferences: result.parameterReferences,
                                 fieldOrigins: result.fieldOrigins,
                             });
                             return;

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -96,6 +96,8 @@ export const MergeProvider: FC<
         started: ApiExecuteAsyncMetricQueryResults | null;
         unpivotedStarted: ApiExecuteAsyncMetricQueryResults | null;
         error: ApiError | null;
+        unpivotedErrors: MergeQueryError[];
+        unpivotedError: ApiError | null;
         parameterReferences: string[];
         fieldOrigins: ApiCompiledMergeQueryResults['fieldOrigins'];
     }>({
@@ -104,6 +106,8 @@ export const MergeProvider: FC<
         started: null,
         unpivotedStarted: null,
         error: null,
+        unpivotedErrors: [],
+        unpivotedError: null,
         parameterReferences: [],
         fieldOrigins: {},
     });
@@ -156,6 +160,8 @@ export const MergeProvider: FC<
             started: null,
             unpivotedStarted: null,
             error: null,
+            unpivotedErrors: [],
+            unpivotedError: null,
             parameterReferences: [],
             fieldOrigins: {},
         });
@@ -321,6 +327,8 @@ export const MergeProvider: FC<
                 started: null,
                 unpivotedStarted: null,
                 error: null,
+                unpivotedErrors: [],
+                unpivotedError: null,
                 parameterReferences: current.parameterReferences,
                 fieldOrigins: current.fieldOrigins,
             }));
@@ -334,6 +342,8 @@ export const MergeProvider: FC<
                             started: null,
                             unpivotedStarted: null,
                             error: null,
+                            unpivotedErrors: [],
+                            unpivotedError: null,
                             parameterReferences: result.parameterReferences,
                             fieldOrigins: result.fieldOrigins,
                         });
@@ -345,24 +355,44 @@ export const MergeProvider: FC<
                                   result.query.fields,
                               )
                             : undefined;
-                        const unpivoted = pivotConfiguration
-                            ? await executeMergeQuery(
-                                  projectUuid,
-                                  mergeQuery,
-                                  parameters,
-                              )
-                            : null;
+                        let unpivoted = null;
+                        if (pivotConfiguration) {
+                            try {
+                                unpivoted = await executeMergeQuery(
+                                    projectUuid,
+                                    mergeQuery,
+                                    parameters,
+                                );
+                            } catch (error) {
+                                if (activeRun.current !== runId) return;
+                                setRunState({
+                                    isRunning: false,
+                                    errors: [],
+                                    started: result.query,
+                                    unpivotedStarted: null,
+                                    error: null,
+                                    unpivotedErrors: [],
+                                    unpivotedError: error as ApiError,
+                                    parameterReferences:
+                                        result.parameterReferences,
+                                    fieldOrigins: result.fieldOrigins,
+                                });
+                                return;
+                            }
+                        }
                         if (activeRun.current !== runId) return;
                         if (unpivoted?.outcome === 'refused') {
                             setRunState({
                                 isRunning: false,
-                                errors: unpivoted.errors,
-                                started: null,
+                                errors: [],
+                                started: result.query,
                                 unpivotedStarted: null,
                                 error: null,
+                                unpivotedErrors: unpivoted.errors,
+                                unpivotedError: null,
                                 parameterReferences:
-                                    unpivoted.parameterReferences,
-                                fieldOrigins: unpivoted.fieldOrigins,
+                                    result.parameterReferences,
+                                fieldOrigins: result.fieldOrigins,
                             });
                             return;
                         }
@@ -372,6 +402,8 @@ export const MergeProvider: FC<
                             started: result.query,
                             unpivotedStarted: unpivoted?.query ?? null,
                             error: null,
+                            unpivotedErrors: [],
+                            unpivotedError: null,
                             parameterReferences: result.parameterReferences,
                             fieldOrigins: result.fieldOrigins,
                         });
@@ -385,6 +417,8 @@ export const MergeProvider: FC<
                         started: null,
                         unpivotedStarted: null,
                         error,
+                        unpivotedErrors: [],
+                        unpivotedError: null,
                         parameterReferences: current.parameterReferences,
                         fieldOrigins: current.fieldOrigins,
                     }));
@@ -464,6 +498,8 @@ export const MergeProvider: FC<
             isRunning: runState.isRunning,
             runErrors: runState.errors,
             runError: runState.error,
+            unpivotedRunErrors: runState.unpivotedErrors,
+            unpivotedRunError: runState.unpivotedError,
             parameterReferences: runState.parameterReferences,
             mergeResults,
             focus,
@@ -490,6 +526,8 @@ export const MergeProvider: FC<
             runState.isRunning,
             runState.errors,
             runState.error,
+            runState.unpivotedErrors,
+            runState.unpivotedError,
             runState.parameterReferences,
             mergeResults,
             focus,

--- a/packages/frontend/src/features/mergeQuery/context/context.ts
+++ b/packages/frontend/src/features/mergeQuery/context/context.ts
@@ -79,6 +79,10 @@ export type MergeContextValue = {
     runErrors: MergeQueryError[];
     /** Transport or server failure of the last run, if any. */
     runError: ApiError | null;
+    /** Why the auxiliary raw-results query was refused. */
+    unpivotedRunErrors: MergeQueryError[];
+    /** Transport or server failure of the auxiliary raw-results query. */
+    unpivotedRunError: ApiError | null;
     /** User parameters referenced by either source query. */
     parameterReferences: string[];
     /** The merged run, or null when none has succeeded yet. */

--- a/packages/frontend/src/features/mergeQuery/context/context.ts
+++ b/packages/frontend/src/features/mergeQuery/context/context.ts
@@ -47,7 +47,11 @@ export type MergeResults = {
     /** Field ids in the order the merged statement returns them. */
     columnOrder: string[];
     fieldOrigins: MergeFieldOrigins;
+    /** Parameter values embedded in this merged run. */
+    usedParametersValues: ParametersValuesMap;
     results: InfiniteQueryResults;
+    /** Raw rows for the Results tab when the chart run is pivoted. */
+    unpivotedResults: InfiniteQueryResults | null;
 };
 
 export type MergeContextValue = {

--- a/packages/frontend/src/features/mergeQuery/utils/resolveMergeColumnOrder.test.ts
+++ b/packages/frontend/src/features/mergeQuery/utils/resolveMergeColumnOrder.test.ts
@@ -1,0 +1,30 @@
+import { resolveMergeColumnOrder } from './resolveMergeColumnOrder';
+
+describe('resolveMergeColumnOrder', () => {
+    it('keeps saved order, removes deselected fields, and appends new fields', () => {
+        expect(
+            resolveMergeColumnOrder(
+                ['merge_month', 'orders_total', 'payments_count'],
+                ['removed_field', 'payments_count', 'merge_month'],
+            ),
+        ).toEqual(['payments_count', 'merge_month', 'orders_total']);
+    });
+
+    it('uses query order before a merged order has been saved', () => {
+        expect(
+            resolveMergeColumnOrder(
+                ['merge_month', 'orders_total'],
+                ['orders_month', 'orders_total_unmerged'],
+            ),
+        ).toEqual(['merge_month', 'orders_total']);
+    });
+
+    it('deduplicates malformed saved order', () => {
+        expect(
+            resolveMergeColumnOrder(
+                ['merge_month'],
+                ['merge_month', 'merge_month'],
+            ),
+        ).toEqual(['merge_month']);
+    });
+});

--- a/packages/frontend/src/features/mergeQuery/utils/resolveMergeColumnOrder.ts
+++ b/packages/frontend/src/features/mergeQuery/utils/resolveMergeColumnOrder.ts
@@ -1,0 +1,21 @@
+/**
+ * Keeps saved user order for fields still present, drops removed fields, and
+ * appends newly selected fields in query order.
+ */
+export const resolveMergeColumnOrder = (
+    queryOrder: string[],
+    savedOrder: string[],
+): string[] => {
+    const available = new Set(queryOrder);
+    const seen = new Set<string>();
+    const resolved: string[] = [];
+
+    [...savedOrder, ...queryOrder].forEach((fieldId) => {
+        if (available.has(fieldId) && !seen.has(fieldId)) {
+            seen.add(fieldId);
+            resolved.push(fieldId);
+        }
+    });
+
+    return resolved;
+};


### PR DESCRIPTION
## What changed

- keep merged chart and results data aligned while fields, filters, pivots, and parameters change
- make grouped, pivoted, and raw Results views merge-aware
- reconcile saved merged-column order as fields are added or removed
- preserve merge filters, parameters, and relationship settings across save/reload/edit
- cast string-modeled join keys before null-safe coalescing across warehouse dialects
- show the actual setup blocker when a merged source has no metric

## Why

A parity sweep found that the UI's suggested customer-id merge failed on Postgres when semantically string join keys were backed by integer columns. The empty-string null sentinel was coerced to integer. The sweep also found stale primary-query data and saved-chart/result-state gaps during merge transitions.

## Impact

Suggested merges now execute correctly, Results and chart views track merge changes, and saved merged charts retain their full configuration.

## Validation

- backend MergeQueryBuilder: 59 tests
- Postgres merge API suite: 7 tests
- saved-chart API suite: 9 tests
- focused frontend merge tests: 9 tests
- backend/frontend/API typechecks
- formatting, lint, and diff checks
- manual browser sweep: fields, add/remove, inner/left/full joins, filters, bar/table visualization, Results, save/reopen/edit, SQL

BigQuery dialect compilation is covered by snapshots. Its live project refresh was blocked by an unrelated `dbt deps` environment failure.