### PR TITLE
feat(roles): secure and audit role-set mutations

### DIFF
--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.test.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.test.ts
@@ -80,6 +80,10 @@ const buildMocks = (): Mocks => ({
             level: 'project',
             scopes: ['view:Dashboard'],
         }),
+        getOrganizationUserRoleSet: vi.fn().mockResolvedValue({
+            systemRole: null,
+            customRoleUuids: [],
+        }),
     } as AnyType,
     analytics: { track: vi.fn() } as AnyType,
     commercialFeatureFlagModel: {} as AnyType,

--- a/packages/backend/src/models/OrganizationMemberProfileModel.test.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.test.ts
@@ -82,9 +82,15 @@ describe('OrganizationMemberProfileModel', () => {
 
     describe('updateOrganizationMember', () => {
         it('clears extra custom roles when the system role is written', async () => {
-            tracker.on
-                .any(/UPDATE organization_memberships/)
-                .response({ rows: [{ organization_id: 3, user_id: 7 }] });
+            tracker.on.select(OrganizationMembershipsTableName).response([
+                {
+                    organization_id: 3,
+                    user_id: 7,
+                    role: OrganizationMemberRole.VIEWER,
+                    role_uuid: null,
+                },
+            ]);
+            tracker.on.update(OrganizationMembershipsTableName).response(1);
             tracker.on
                 .delete(OrganizationMembershipCustomRolesTableName)
                 .response(0);

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -29,7 +29,10 @@ import { UserAvatarsTableName } from '../database/entities/userAvatars';
 import { UserOAuthGrantsTableName } from '../database/entities/userOAuthGrants';
 import { DbUser, UserTableName } from '../database/entities/users';
 import KnexPaginate from '../database/pagination';
-import { clearOrganizationExtraRoles } from './roleSetUtils';
+import {
+    assertAdminDemotionAllowed,
+    clearOrganizationExtraRoles,
+} from './roleSetUtils';
 import { getColumnMatchRegexQuery } from './SearchModel/utils/search';
 import { UserModel } from './UserModel';
 
@@ -666,38 +669,54 @@ export class OrganizationMemberProfileModel {
         data: OrganizationMemberProfileUpdate,
     ): Promise<OrganizationMemberProfile> {
         if (data.role) {
-            const sqlParams = {
-                organizationUuid,
-                userUuid,
-                role: data.role,
-            };
-            // A singular write replaces the whole role set, so extras go too.
+            const { role } = data;
+            // A singular write replaces the whole role set (extras cleared) and
+            // may not demote the organization's last active admin.
             await this.database.transaction(async (trx) => {
-                const { rows } = await trx.raw<{
-                    rows: Pick<
-                        DbOrganizationMembership,
-                        'organization_id' | 'user_id'
-                    >[];
-                }>(
-                    `
-                    UPDATE organization_memberships AS m
-                    SET role = :role FROM organizations AS o, users AS u
-                    WHERE o.organization_id = m.organization_id
-                      AND u.user_id = m.user_id
-                      AND user_uuid = :userUuid
-                      AND organization_uuid = :organizationUuid
-                        RETURNING m.organization_id, m.user_id
-                `,
-                    sqlParams,
+                const membership = await trx(OrganizationMembershipsTableName)
+                    .join(
+                        OrganizationTableName,
+                        `${OrganizationTableName}.organization_id`,
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                    )
+                    .join(
+                        UserTableName,
+                        `${UserTableName}.user_id`,
+                        `${OrganizationMembershipsTableName}.user_id`,
+                    )
+                    .where(
+                        `${OrganizationTableName}.organization_uuid`,
+                        organizationUuid,
+                    )
+                    .where(`${UserTableName}.user_uuid`, userUuid)
+                    .first<
+                        Pick<
+                            DbOrganizationMembership,
+                            'organization_id' | 'user_id'
+                        >
+                    >(
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                        `${OrganizationMembershipsTableName}.user_id`,
+                    );
+                if (!membership) {
+                    return;
+                }
+                await assertAdminDemotionAllowed(
+                    trx,
+                    membership.organization_id,
+                    membership.user_id,
+                    role,
                 );
-                await Promise.all(
-                    rows.map((row) =>
-                        clearOrganizationExtraRoles(
-                            trx,
-                            row.organization_id,
-                            row.user_id,
-                        ),
-                    ),
+                await trx(OrganizationMembershipsTableName)
+                    .where({
+                        organization_id: membership.organization_id,
+                        user_id: membership.user_id,
+                    })
+                    .update({ role });
+                await clearOrganizationExtraRoles(
+                    trx,
+                    membership.organization_id,
+                    membership.user_id,
                 );
             });
         }

--- a/packages/backend/src/models/RolesModel.test.ts
+++ b/packages/backend/src/models/RolesModel.test.ts
@@ -182,6 +182,11 @@ describe('RolesModel', () => {
         });
 
         it('upsertOrganizationUserRoleAssignment clears org extras in the same transaction', async () => {
+            tracker.on
+                .select(OrganizationMembershipsTableName)
+                .response([
+                    { role: OrganizationMemberRole.EDITOR, role_uuid: null },
+                ]);
             tracker.on.update(OrganizationMembershipsTableName).response(1);
             tracker.on
                 .delete(OrganizationMembershipCustomRolesTableName)
@@ -265,6 +270,7 @@ describe('RolesModel', () => {
             tracker.on
                 .select('organizations')
                 .response([{ organization_id: 3 }]);
+            tracker.on.select(OrganizationMembershipsTableName).response([]);
             tracker.on.update(OrganizationMembershipsTableName).response(0);
 
             await expect(
@@ -286,6 +292,15 @@ describe('RolesModel', () => {
             tracker.on
                 .select('organizations')
                 .response([{ organization_id: 3 }]);
+            tracker.on.select(OrganizationMembershipsTableName).response([
+                {
+                    role: OrganizationMemberRole.MEMBER,
+                    role_uuid: ORG_ROLE,
+                },
+            ]);
+            tracker.on
+                .select(OrganizationMembershipCustomRolesTableName)
+                .response([{ role_uuid: SECOND }]);
             tracker.on.update(OrganizationMembershipsTableName).response(1);
             tracker.on
                 .delete(OrganizationMembershipCustomRolesTableName)
@@ -294,7 +309,7 @@ describe('RolesModel', () => {
                 .insert(OrganizationMembershipCustomRolesTableName)
                 .response([]);
 
-            await model.replaceOrganizationUserRoleSet(
+            const result = await model.replaceOrganizationUserRoleSet(
                 'org-uuid',
                 'user-uuid',
                 {
@@ -302,6 +317,10 @@ describe('RolesModel', () => {
                     customRoleUuids: [ORG_ROLE, SECOND, ORG_ROLE],
                 },
             );
+            expect(result).toEqual({
+                systemRole: null,
+                customRoleUuids: [ORG_ROLE, SECOND],
+            });
 
             const [slot] = tracker.history.update;
             // custom-only: first custom role in the slot with the member placeholder
@@ -317,6 +336,55 @@ describe('RolesModel', () => {
                 expect.arrayContaining([3, 7, SECOND]),
             );
             expect(extras.bindings).not.toContain(ORG_ROLE);
+        });
+    });
+
+    describe('assertAnotherActiveAdmin', () => {
+        beforeEach(() => {
+            tracker.on
+                .select(({ sql }) =>
+                    sql.startsWith(
+                        'select "organization_id" from "organizations"',
+                    ),
+                )
+                .response([{ organization_id: 3 }]);
+            tracker.on
+                .select(({ sql }) =>
+                    sql.startsWith('select "user_id" from "users"'),
+                )
+                .response([{ user_id: 7 }]);
+        });
+
+        it('locks admin rows and throws when the excluded user is the only active admin', async () => {
+            tracker.on
+                .select(({ sql }) => sql.includes('for update'))
+                .response([{ user_id: 7 }]);
+
+            await expect(
+                database.transaction((trx) =>
+                    model.assertAnotherActiveAdmin(
+                        'org-uuid',
+                        'only-admin',
+                        trx,
+                    ),
+                ),
+            ).rejects.toThrow('Organization must have at least one admin');
+            const lockQuery = tracker.history.select.find(({ sql }) =>
+                sql.includes('for update'),
+            );
+            expect(lockQuery?.sql).toContain(OrganizationMembershipsTableName);
+        });
+
+        it('passes when another active admin remains', async () => {
+            tracker.on
+                .select(({ sql }) => sql.includes('for update'))
+                .response([{ user_id: 7 }, { user_id: 8 }]);
+
+            await expect(
+                database.transaction((trx) =>
+                    model.assertAnotherActiveAdmin('org-uuid', 'a', trx),
+                ),
+            ).resolves.toBeUndefined();
         });
     });
 });

--- a/packages/backend/src/models/RolesModel.ts
+++ b/packages/backend/src/models/RolesModel.ts
@@ -1,5 +1,6 @@
 import {
     AlreadyExistsError,
+    ForbiddenError,
     getSystemRoles,
     GroupProjectAccess,
     isOrganizationMemberRole,
@@ -43,6 +44,8 @@ import {
 import { UserTableName } from '../database/entities/users';
 import { isUniqueConstraintViolation } from '../database/errors';
 import {
+    assertAdminDemotionAllowed,
+    assertAnotherActiveAdminInOrganization,
     clearGroupExtraRoles,
     clearOrganizationExtraRoles,
     clearProjectExtraRoles,
@@ -980,6 +983,12 @@ export class RolesModel {
         const isSystemOrganizationRole = isOrganizationMemberRole(roleId);
 
         await this.runInTransaction(async (trx) => {
+            await assertAdminDemotionAllowed(
+                trx,
+                orgId,
+                userId,
+                isSystemOrganizationRole ? roleId : null,
+            );
             await trx(OrganizationMembershipsTableName)
                 .where({
                     organization_id: orgId,
@@ -1197,7 +1206,7 @@ export class RolesModel {
         userUuid: string,
         roleSet: OrganizationRoleSet,
         tx?: Knex.Transaction,
-    ): Promise<void> {
+    ): Promise<OrganizationRoleSet> {
         const set = normalizeRoleSet(roleSet);
         const runner = async (trx: Knex.Transaction) => {
             await this.validateCustomRoles(
@@ -1208,6 +1217,12 @@ export class RolesModel {
             );
             const userId = await this.getUserId(userUuid, trx);
             const orgId = await this.getOrganizationId(orgUuid, trx);
+            await assertAdminDemotionAllowed(
+                trx,
+                orgId,
+                userId,
+                set.systemRole,
+            );
             const { slot, extraRoleUuids } = splitRoleSet(
                 set,
                 ORGANIZATION_PLACEHOLDER_ROLE,
@@ -1226,8 +1241,9 @@ export class RolesModel {
                 { organization_id: orgId, user_id: userId },
                 extraRoleUuids,
             );
+            return this.getOrganizationUserRoleSet(orgUuid, userUuid, trx);
         };
-        await this.runInTransaction(runner, tx);
+        return this.runInTransaction(runner, tx);
     }
 
     /** Atomically replaces the user's direct project role set, creating access if needed. */
@@ -1236,7 +1252,7 @@ export class RolesModel {
         userUuid: string,
         roleSet: ProjectRoleSet,
         tx?: Knex.Transaction,
-    ): Promise<void> {
+    ): Promise<ProjectRoleSet> {
         const set = normalizeRoleSet(roleSet);
         const runner = async (trx: Knex.Transaction) => {
             const orgUuid = await this.getProjectOrganizationUuid(
@@ -1274,8 +1290,9 @@ export class RolesModel {
                 { project_id: projectId, user_id: userId },
                 extraRoleUuids,
             );
+            return this.getProjectUserRoleSet(projectUuid, userUuid, trx);
         };
-        await this.runInTransaction(runner, tx);
+        return this.runInTransaction(runner, tx);
     }
 
     /** Atomically replaces the group's project role set, creating access if needed. */
@@ -1284,7 +1301,7 @@ export class RolesModel {
         groupUuid: string,
         roleSet: ProjectRoleSet,
         tx?: Knex.Transaction,
-    ): Promise<void> {
+    ): Promise<ProjectRoleSet> {
         const set = normalizeRoleSet(roleSet);
         const runner = async (trx: Knex.Transaction) => {
             const orgUuid = await this.getProjectOrganizationUuid(
@@ -1317,19 +1334,34 @@ export class RolesModel {
                 { project_uuid: projectUuid, group_uuid: groupUuid },
                 extraRoleUuids,
             );
+            return this.getProjectGroupRoleSet(projectUuid, groupUuid, trx);
         };
-        await this.runInTransaction(runner, tx);
+        return this.runInTransaction(runner, tx);
     }
 
-    private async runInTransaction(
-        runner: (trx: Knex.Transaction) => Promise<void>,
+    private async runInTransaction<T>(
+        runner: (trx: Knex.Transaction) => Promise<T>,
         tx?: Knex.Transaction,
-    ): Promise<void> {
+    ): Promise<T> {
         if (tx) {
-            await runner(tx);
-        } else {
-            await this.database.transaction(runner);
+            return runner(tx);
         }
+        return this.database.transaction(runner);
+    }
+
+    /**
+     * Locks the organization's current admin rows and throws unless another
+     * active admin (other than `excludingUserUuid`) remains. Call inside the
+     * transaction that demotes/removes the user so concurrent demotions serialize.
+     */
+    async assertAnotherActiveAdmin(
+        orgUuid: string,
+        excludingUserUuid: string,
+        trx: Knex.Transaction,
+    ): Promise<void> {
+        const orgId = await this.getOrganizationId(orgUuid, trx);
+        const userId = await this.getUserId(excludingUserUuid, trx);
+        await assertAnotherActiveAdminInOrganization(trx, orgId, userId);
     }
 
     async getOrganizationAdmins(

--- a/packages/backend/src/models/roleSetUtils.ts
+++ b/packages/backend/src/models/roleSetUtils.ts
@@ -1,4 +1,5 @@
 import {
+    ForbiddenError,
     OrganizationMemberRole,
     OrganizationRoleSet,
     ParameterError,
@@ -7,8 +8,10 @@ import {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import { ProjectGroupAccessCustomRolesTableName } from '../database/entities/projectGroupAccessCustomRoles';
 import { ProjectMembershipCustomRolesTableName } from '../database/entities/projectMembershipCustomRoles';
+import { UserTableName } from '../database/entities/users';
 
 type RoleSet = OrganizationRoleSet | ProjectRoleSet;
 
@@ -109,6 +112,68 @@ export const replaceExtraRoles = async (
                 ...parentKey,
                 role_uuid: roleUuid,
             })),
+        );
+    }
+};
+
+/**
+ * Locks the organization's current admin rows and throws unless another active
+ * admin (other than `excludingUserId`) remains. Run inside the transaction that
+ * demotes/removes the user so concurrent demotions serialize.
+ */
+export const assertAnotherActiveAdminInOrganization = async (
+    trx: Knex.Transaction,
+    organizationId: number,
+    excludingUserId: number,
+): Promise<void> => {
+    const admins = await trx(OrganizationMembershipsTableName)
+        .join(
+            UserTableName,
+            `${OrganizationMembershipsTableName}.user_id`,
+            `${UserTableName}.user_id`,
+        )
+        .where(
+            `${OrganizationMembershipsTableName}.organization_id`,
+            organizationId,
+        )
+        .where(
+            `${OrganizationMembershipsTableName}.role`,
+            OrganizationMemberRole.ADMIN,
+        )
+        .where(`${UserTableName}.is_active`, true)
+        .forUpdate(OrganizationMembershipsTableName)
+        .select<{ user_id: number }[]>(
+            `${OrganizationMembershipsTableName}.user_id`,
+        );
+    if (admins.every((admin) => admin.user_id === excludingUserId)) {
+        throw new ForbiddenError('Organization must have at least one admin');
+    }
+};
+
+/**
+ * Guards a demotion: when the membership currently holds the system `admin`
+ * slot and the new slot is not `admin`, another active admin must remain.
+ */
+export const assertAdminDemotionAllowed = async (
+    trx: Knex.Transaction,
+    organizationId: number,
+    userId: number,
+    newSystemRole: string | null,
+): Promise<void> => {
+    if (newSystemRole === OrganizationMemberRole.ADMIN) {
+        return;
+    }
+    const current = await trx(OrganizationMembershipsTableName)
+        .where({ organization_id: organizationId, user_id: userId })
+        .first('role', 'role_uuid');
+    if (
+        current?.role === OrganizationMemberRole.ADMIN &&
+        current.role_uuid === null
+    ) {
+        await assertAnotherActiveAdminInOrganization(
+            trx,
+            organizationId,
+            userId,
         );
     }
 };

--- a/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
@@ -64,6 +64,13 @@ const organizationMemberProfileModel = {
 };
 const rolesModel = {
     getRoleWithScopesByUuid: vi.fn(),
+    getOrganizationUserRoleSet: vi
+        .fn()
+        .mockResolvedValue({ systemRole: 'admin', customRoleUuids: [] }),
+    assertAnotherActiveAdmin: vi.fn(),
+    db: {
+        transaction: vi.fn(async (cb: (trx: unknown) => unknown) => cb({})),
+    },
 };
 
 describe('organization service', () => {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -766,16 +766,6 @@ export class OrganizationService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
-        // Race condition between check and delete
-        const [admin, ...remainingAdmins] =
-            await this.organizationMemberProfileModel.getOrganizationAdmins(
-                organizationUuid,
-            );
-        if (remainingAdmins.length === 0 && admin.userUuid === memberUserUuid) {
-            throw new ForbiddenError(
-                'Organization must have at least one admin',
-            );
-        }
         if (data.role !== undefined) {
             await validateOrganizationScopesCanBeGranted({
                 user: authenticatedUser,
@@ -808,6 +798,7 @@ export class OrganizationService extends BaseService {
             });
         }
 
+        // The model refuses to demote the organization's last active admin.
         return this.organizationMemberProfileModel.updateOrganizationMember(
             organizationUuid,
             memberUserUuid,

--- a/packages/backend/src/services/RolesService/RolesService.mock.ts
+++ b/packages/backend/src/services/RolesService/RolesService.mock.ts
@@ -122,6 +122,13 @@ type MockRolesModel = {
     removeScopesFromRole: MockFn;
     getOrganizationRoleAssignments: MockFn;
     getOrganizationAdmins: MockFn;
+    getOrganizationUserRoleSet: MockFn;
+    getProjectUserRoleSet: MockFn;
+    getProjectGroupRoleSet: MockFn;
+    replaceOrganizationUserRoleSet: MockFn;
+    replaceProjectUserRoleSet: MockFn;
+    replaceProjectGroupRoleSet: MockFn;
+    assertAnotherActiveAdmin: MockFn;
     upsertOrganizationUserRoleAssignment: MockFn;
     upsertSystemRoleProjectAccess: MockFn;
     upsertCustomRoleProjectAccess: MockFn;
@@ -150,6 +157,15 @@ export const mockRolesModel: MockRolesModel = {
     removeScopesFromRole: vi.fn(),
     getOrganizationRoleAssignments: vi.fn(),
     getOrganizationAdmins: vi.fn(),
+    getOrganizationUserRoleSet: vi
+        .fn()
+        .mockResolvedValue({ systemRole: 'admin', customRoleUuids: [] }),
+    getProjectUserRoleSet: vi.fn(),
+    getProjectGroupRoleSet: vi.fn(),
+    replaceOrganizationUserRoleSet: vi.fn(),
+    replaceProjectUserRoleSet: vi.fn(),
+    replaceProjectGroupRoleSet: vi.fn(),
+    assertAnotherActiveAdmin: vi.fn(),
     upsertOrganizationUserRoleAssignment: vi.fn(),
     upsertSystemRoleProjectAccess: vi.fn(),
     upsertCustomRoleProjectAccess: vi.fn(),
@@ -230,6 +246,10 @@ export const mockInviteLinkModel: Record<string, MockFn> = {
     hasValidInviteLink: vi.fn(),
     upsert: vi.fn(),
     deleteByCode: vi.fn(),
+};
+
+export const mockFeatureFlagModel: Record<string, MockFn> = {
+    get: vi.fn().mockResolvedValue({ id: 'multiple-roles', enabled: true }),
 };
 
 export const mockOrganizationMemberProfileModel: Record<string, MockFn> = {

--- a/packages/backend/src/services/RolesService/RolesService.test.ts
+++ b/packages/backend/src/services/RolesService/RolesService.test.ts
@@ -21,6 +21,7 @@ import { DatabaseError } from 'pg';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import { LightdashConfig } from '../../config/parseConfig';
+import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { GroupsModel } from '../../models/GroupsModel';
 import { InviteLinkModel } from '../../models/InviteLinkModel';
 import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
@@ -39,6 +40,7 @@ import {
     mockCustomRole,
     mockCustomRoleWithScopes,
     mockEmailClient,
+    mockFeatureFlagModel,
     mockGroupsModel,
     mockInviteLinkModel,
     mockNewRole,
@@ -91,6 +93,8 @@ describe('RolesService', () => {
             inviteLinkModel: mockInviteLinkModel as unknown as InviteLinkModel,
             organizationMemberProfileModel:
                 mockOrganizationMemberProfileModel as unknown as OrganizationMemberProfileModel,
+            featureFlagModel:
+                mockFeatureFlagModel as unknown as FeatureFlagModel,
         });
     const service = buildService();
     beforeEach(() => {
@@ -666,6 +670,327 @@ describe('RolesService', () => {
                 ),
             ).resolves.toBeUndefined();
             expect(mockRolesModel.addScopesToRole).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('role sets', () => {
+        const orgUuid = 'test-org-uuid';
+        const projectUuid = 'test-project-uuid';
+        const CUSTOM_ORG = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        const CUSTOM_PROJECT = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+        const orgRoleWithScopes = {
+            ...mockCustomRole,
+            roleUuid: CUSTOM_ORG,
+            level: 'organization' as const,
+            scopes: ['view:Organization'],
+        };
+        const projectRoleWithScopes = {
+            ...mockCustomRole,
+            roleUuid: CUSTOM_PROJECT,
+            level: 'project' as const,
+            scopes: ['manage:Project'],
+        };
+
+        beforeEach(() => {
+            mockFeatureFlagModel.get.mockResolvedValue({
+                id: 'multiple-roles',
+                enabled: true,
+            });
+            mockRolesModel.getOrganizationUserRoleSet.mockResolvedValue({
+                systemRole: OrganizationMemberRole.VIEWER,
+                customRoleUuids: [],
+            });
+            mockRolesModel.getProjectUserRoleSet.mockResolvedValue({
+                systemRole: null,
+                customRoleUuids: [],
+            });
+            mockRolesModel.getProjectGroupRoleSet.mockResolvedValue({
+                systemRole: null,
+                customRoleUuids: [],
+            });
+            mockRolesModel.getProjectAccessByUserUuid.mockResolvedValue([]);
+            mockRolesModel.getRoleWithScopesByUuid.mockImplementation(
+                async (roleUuid: unknown) => {
+                    if (roleUuid === CUSTOM_ORG) return orgRoleWithScopes;
+                    if (roleUuid === CUSTOM_PROJECT)
+                        return projectRoleWithScopes;
+                    return {
+                        ...mockCustomRole,
+                        roleUuid,
+                        scopes: ['view:Organization'],
+                    };
+                },
+            );
+        });
+
+        it('rejects role-set writes when the multiple-roles flag is off', async () => {
+            mockFeatureFlagModel.get.mockResolvedValue({
+                id: 'multiple-roles',
+                enabled: false,
+            });
+            await expect(
+                service.replaceOrganizationUserRoleSet(
+                    mockAccount,
+                    orgUuid,
+                    'u',
+                    {
+                        systemRole: OrganizationMemberRole.VIEWER,
+                        customRoleUuids: [],
+                    },
+                ),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(
+                mockRolesModel.replaceOrganizationUserRoleSet,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('rejects an empty set', async () => {
+            await expect(
+                service.replaceOrganizationUserRoleSet(
+                    mockAccount,
+                    orgUuid,
+                    'u',
+                    {
+                        systemRole: null,
+                        customRoleUuids: [],
+                    },
+                ),
+            ).rejects.toBeInstanceOf(ParameterError);
+        });
+
+        it('rejects a custom role from another organization', async () => {
+            mockRolesModel.getRoleWithScopesByUuid.mockResolvedValueOnce({
+                ...orgRoleWithScopes,
+                organizationUuid: 'other-org',
+            });
+            await expect(
+                service.replaceOrganizationUserRoleSet(
+                    mockAccount,
+                    orgUuid,
+                    'u',
+                    {
+                        systemRole: null,
+                        customRoleUuids: [CUSTOM_ORG],
+                    },
+                ),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+        });
+
+        it('rejects a project-level custom role at organization level', async () => {
+            await expect(
+                service.replaceOrganizationUserRoleSet(
+                    mockAccount,
+                    orgUuid,
+                    'u',
+                    {
+                        systemRole: null,
+                        customRoleUuids: [CUSTOM_PROJECT],
+                    },
+                ),
+            ).rejects.toBeInstanceOf(ParameterError);
+        });
+
+        it('rejects a set whose scope union exceeds the caller permissions', async () => {
+            mockRolesModel.getRoleWithScopesByUuid.mockResolvedValue({
+                ...orgRoleWithScopes,
+                roleUuid: 'limited-org-manager-role',
+                scopes: ['manage:Organization'],
+            });
+            await expect(
+                service.replaceOrganizationUserRoleSet(
+                    limitedOrganizationManagerAccount(),
+                    orgUuid,
+                    'u',
+                    {
+                        systemRole: OrganizationMemberRole.ADMIN,
+                        customRoleUuids: [],
+                    },
+                ),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(
+                mockRolesModel.replaceOrganizationUserRoleSet,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('replaces the set inside a transaction and audits the change', async () => {
+            mockRolesModel.getOrganizationUserRoleSet
+                .mockResolvedValueOnce({
+                    systemRole: OrganizationMemberRole.ADMIN,
+                    customRoleUuids: [],
+                }) // caller (delegation)
+                .mockResolvedValueOnce({
+                    systemRole: OrganizationMemberRole.VIEWER,
+                    customRoleUuids: [],
+                }); // before
+            mockRolesModel.replaceOrganizationUserRoleSet.mockResolvedValueOnce(
+                {
+                    systemRole: OrganizationMemberRole.VIEWER,
+                    customRoleUuids: [CUSTOM_ORG],
+                },
+            );
+
+            const result = await service.replaceOrganizationUserRoleSet(
+                mockAccount,
+                orgUuid,
+                'target-user',
+                {
+                    systemRole: OrganizationMemberRole.VIEWER,
+                    customRoleUuids: [CUSTOM_ORG],
+                },
+            );
+
+            expect(
+                mockRolesModel.replaceOrganizationUserRoleSet,
+            ).toHaveBeenCalledWith(orgUuid, 'target-user', {
+                systemRole: OrganizationMemberRole.VIEWER,
+                customRoleUuids: [CUSTOM_ORG],
+            });
+            expect(result).toEqual({
+                systemRole: OrganizationMemberRole.VIEWER,
+                customRoleUuids: [CUSTOM_ORG],
+            });
+            expect(mockAnalytics.track).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    event: 'organization_role_set.replaced',
+                    properties: expect.objectContaining({
+                        organizationUuid: orgUuid,
+                        userUuid: 'target-user',
+                        source: 'api',
+                        addedCount: 1,
+                        removedCount: 0,
+                    }),
+                }),
+            );
+        });
+
+        it('surfaces the model last-admin guard and does not audit a rejected replace', async () => {
+            mockRolesModel.getOrganizationUserRoleSet
+                .mockResolvedValueOnce({
+                    systemRole: OrganizationMemberRole.ADMIN,
+                    customRoleUuids: [],
+                })
+                .mockResolvedValueOnce({
+                    systemRole: OrganizationMemberRole.ADMIN,
+                    customRoleUuids: [],
+                });
+            mockRolesModel.replaceOrganizationUserRoleSet.mockRejectedValueOnce(
+                new ForbiddenError('Organization must have at least one admin'),
+            );
+
+            await expect(
+                service.replaceOrganizationUserRoleSet(
+                    mockAccount,
+                    orgUuid,
+                    'target-user',
+                    {
+                        systemRole: OrganizationMemberRole.EDITOR,
+                        customRoleUuids: [],
+                    },
+                ),
+            ).rejects.toThrow('at least one admin');
+            expect(mockAnalytics.track).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    event: 'organization_role_set.replaced',
+                }),
+            );
+        });
+
+        it('rejects a project set whose scopes exceed the caller ability', async () => {
+            // caller ability lacks manage:SqlRunner
+            mockRolesModel.getRoleWithScopesByUuid.mockResolvedValueOnce({
+                ...projectRoleWithScopes,
+                scopes: ['manage:SqlRunner'],
+            });
+            await expect(
+                service.replaceProjectUserRoleSet(
+                    mockAccount,
+                    projectUuid,
+                    'u',
+                    {
+                        systemRole: null,
+                        customRoleUuids: [CUSTOM_PROJECT],
+                    },
+                ),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(
+                mockRolesModel.replaceProjectUserRoleSet,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('rejects a project set for a user outside the project organization', async () => {
+            mockUserModel.getUserDetailsByUuid.mockResolvedValueOnce({
+                firstName: 'Other',
+                lastName: 'Org',
+                organizationUuid: 'other-org',
+            });
+            await expect(
+                service.replaceProjectUserRoleSet(
+                    mockAccount,
+                    projectUuid,
+                    'u',
+                    {
+                        systemRole: null,
+                        customRoleUuids: [CUSTOM_PROJECT],
+                    },
+                ),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(
+                mockRolesModel.replaceProjectUserRoleSet,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('rejects a project group set for a group outside the project organization', async () => {
+            mockGroupsModel.getGroup.mockResolvedValueOnce({
+                groupUuid: 'g',
+                name: 'G',
+                organizationUuid: 'other-org',
+            });
+            await expect(
+                service.replaceProjectGroupRoleSet(
+                    mockAccount,
+                    projectUuid,
+                    'g',
+                    {
+                        systemRole: null,
+                        customRoleUuids: [CUSTOM_PROJECT],
+                    },
+                ),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(
+                mockRolesModel.replaceProjectGroupRoleSet,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('replaces a project group set and audits it', async () => {
+            mockRolesModel.getProjectGroupRoleSet.mockResolvedValueOnce({
+                systemRole: ProjectMemberRole.VIEWER,
+                customRoleUuids: [],
+            });
+            mockRolesModel.replaceProjectGroupRoleSet.mockResolvedValueOnce({
+                systemRole: null,
+                customRoleUuids: [CUSTOM_PROJECT],
+            });
+
+            // custom-only set: manage:Project is covered by the caller's ability
+            const result = await service.replaceProjectGroupRoleSet(
+                mockAccount,
+                projectUuid,
+                'test-group-uuid',
+                { systemRole: null, customRoleUuids: [CUSTOM_PROJECT] },
+            );
+
+            expect(
+                mockRolesModel.replaceProjectGroupRoleSet,
+            ).toHaveBeenCalledWith(projectUuid, 'test-group-uuid', {
+                systemRole: null,
+                customRoleUuids: [CUSTOM_PROJECT],
+            });
+            expect(result.customRoleUuids).toEqual([CUSTOM_PROJECT]);
+            expect(mockAnalytics.track).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    event: 'project_group_role_set.replaced',
+                }),
+            );
         });
     });
 

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -5,18 +5,22 @@ import {
     ApiCustomRoleAsCodeUpsertResponse,
     ApiUserAsCodeUpsertResponse,
     assertRegisteredAccount,
+    CommercialFeatureFlags,
     CreateRole,
     CustomRoleAsCode,
     ForbiddenError,
     getAllScopeMap,
+    getAllScopesForRole,
     InviteLinkPurpose,
     isOrganizationMemberRole,
     isScopeAssignableAtLevel,
     isSystemRole,
     NotFoundError,
     OrganizationMemberRole,
+    OrganizationRoleSet,
     ParameterError,
     ProjectMemberRole,
+    ProjectRoleSet,
     PromotionAction,
     Role,
     RoleAssignee,
@@ -39,7 +43,13 @@ import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { toSessionUser } from '../../auth/account';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import { LightdashConfig } from '../../config/parseConfig';
-import { CaslAuditWrapper } from '../../logging/caslAuditWrapper';
+import { createAuditLogEvent } from '../../logging/auditLog';
+import {
+    CaslAuditWrapper,
+    createActorFromAccount,
+} from '../../logging/caslAuditWrapper';
+import { logAuditEvent } from '../../logging/winston';
+import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { GroupsModel } from '../../models/GroupsModel';
 import { InviteLinkModel } from '../../models/InviteLinkModel';
 import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
@@ -51,6 +61,7 @@ import { wrapSentryTransaction } from '../../utils';
 import {
     getOrganizationSystemRoleScopes,
     validateOrganizationScopesCanBeGranted,
+    validateProjectScopesCanBeGranted,
 } from '../../utils/organizationRolePermissions';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
 import { BaseService } from '../BaseService';
@@ -69,7 +80,11 @@ type RolesServiceArguments = {
     adminNotificationService: AdminNotificationService;
     inviteLinkModel: InviteLinkModel;
     organizationMemberProfileModel: OrganizationMemberProfileModel;
+    featureFlagModel: FeatureFlagModel;
 };
+
+/** Where a role-set mutation originated; recorded in the audit event. */
+export type RoleSetMutationSource = 'api' | 'scim' | 'as-code';
 
 export class RolesService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
@@ -96,6 +111,8 @@ export class RolesService extends BaseService {
 
     private readonly organizationMemberProfileModel: OrganizationMemberProfileModel;
 
+    private readonly featureFlagModel: FeatureFlagModel;
+
     constructor({
         lightdashConfig,
         licenseService,
@@ -109,6 +126,7 @@ export class RolesService extends BaseService {
         adminNotificationService,
         inviteLinkModel,
         organizationMemberProfileModel,
+        featureFlagModel,
     }: RolesServiceArguments) {
         super({ serviceName: 'RolesService' });
         this.lightdashConfig = lightdashConfig;
@@ -123,6 +141,7 @@ export class RolesService extends BaseService {
         this.adminNotificationService = adminNotificationService;
         this.inviteLinkModel = inviteLinkModel;
         this.organizationMemberProfileModel = organizationMemberProfileModel;
+        this.featureFlagModel = featureFlagModel;
     }
 
     /**
@@ -1150,6 +1169,7 @@ export class RolesService extends BaseService {
             rolesModel: this.rolesModel,
         });
 
+        // The model refuses to demote the organization's last active admin.
         await this.rolesModel.upsertOrganizationUserRoleAssignment(
             orgUuid,
             user.userUuid,
@@ -1214,17 +1234,6 @@ export class RolesService extends BaseService {
         );
 
         const user = await this.userModel.getUserDetailsByUuid(userUuid);
-        if (user.role === OrganizationMemberRole.ADMIN) {
-            // If user is currently an admin, we need to check if there are more admins
-            // because every org should have at least one admin
-            const adminUuids =
-                await this.rolesModel.getOrganizationAdmins(orgUuid);
-            if (adminUuids.length === 1) {
-                throw new ParameterError(
-                    'Organization must have at least one admin',
-                );
-            }
-        }
 
         return this.applyOrganizationUserRoleAssignment(
             account,
@@ -1541,6 +1550,380 @@ export class RolesService extends BaseService {
             createdAt: new Date(),
             updatedAt: new Date(),
         };
+    }
+
+    // =====================================
+    // ROLE SETS (multiple roles per level)
+    // =====================================
+
+    private async assertRoleSetsEnabled(account: Account): Promise<void> {
+        this.assertCustomRolesLicensed();
+        assertRegisteredAccount(account);
+        const flag = await this.featureFlagModel.get({
+            user: {
+                userUuid: account.user.userUuid,
+                organizationUuid: account.organization.organizationUuid,
+            },
+            featureFlagId: CommercialFeatureFlags.MultipleRoles,
+        });
+        if (!flag.enabled) {
+            throw new ForbiddenError('Multiple roles are not enabled');
+        }
+    }
+
+    private static assertNonEmptyRoleSet(roleSet: {
+        systemRole: string | null;
+        customRoleUuids: string[];
+    }): void {
+        if (
+            roleSet.systemRole === null &&
+            roleSet.customRoleUuids.length === 0
+        ) {
+            throw new ParameterError(
+                'A role set must contain at least one role',
+            );
+        }
+    }
+
+    /** Loads the custom roles of a set and checks tenancy, level and non-empty scopes. */
+    private async loadCustomRolesForSet(
+        organizationUuid: string,
+        customRoleUuids: string[],
+        level: RoleLevel,
+    ): Promise<RoleWithScopes[]> {
+        const roles = await Promise.all(
+            [...new Set(customRoleUuids)].map((roleUuid) =>
+                this.rolesModel.getRoleWithScopesByUuid(roleUuid),
+            ),
+        );
+        roles.forEach((role) => {
+            if (role.organizationUuid !== organizationUuid) {
+                throw new ForbiddenError();
+            }
+            RolesService.validateCustomRoleLevel(role, level);
+            if (role.scopes.length === 0) {
+                throw new ParameterError(
+                    'Custom role must have at least one scope',
+                );
+            }
+        });
+        return roles;
+    }
+
+    private static roleSetChanges(
+        before: { systemRole: string | null; customRoleUuids: string[] },
+        after: { systemRole: string | null; customRoleUuids: string[] },
+    ) {
+        const toIds = (set: typeof before) => [
+            ...(set.systemRole ? [set.systemRole] : []),
+            ...set.customRoleUuids,
+        ];
+        const beforeIds = new Set(toIds(before));
+        const afterIds = new Set(toIds(after));
+        return {
+            added: [...afterIds].filter((id) => !beforeIds.has(id)),
+            removed: [...beforeIds].filter((id) => !afterIds.has(id)),
+        };
+    }
+
+    private auditRoleSetChange({
+        account,
+        action,
+        organizationUuid,
+        projectUuid,
+        source,
+        target,
+        before,
+        after,
+    }: {
+        account: Account;
+        action: string;
+        organizationUuid: string;
+        projectUuid?: string;
+        source: RoleSetMutationSource;
+        target: { userUuid?: string; groupUuid?: string };
+        before: OrganizationRoleSet | ProjectRoleSet;
+        after: OrganizationRoleSet | ProjectRoleSet;
+    }): void {
+        const { added, removed } = RolesService.roleSetChanges(before, after);
+        try {
+            logAuditEvent(
+                createAuditLogEvent(
+                    createActorFromAccount(account),
+                    action,
+                    {
+                        type: 'RoleSet',
+                        organizationUuid,
+                        projectUuid,
+                        metadata: {
+                            ...target,
+                            source,
+                            before,
+                            after,
+                            added,
+                            removed,
+                        },
+                    },
+                    {},
+                    'allowed',
+                ),
+            );
+        } catch (error) {
+            this.logger.warn('Failed to write role-set audit event', { error });
+        }
+        this.analytics.track({
+            event: action,
+            userId: account.user?.id,
+            properties: {
+                organizationUuid,
+                projectUuid,
+                ...target,
+                source,
+                addedCount: added.length,
+                removedCount: removed.length,
+                systemRole: after.systemRole,
+                customRoleCount: after.customRoleUuids.length,
+            },
+        });
+    }
+
+    async getOrganizationUserRoleSet(
+        account: Account,
+        orgUuid: string,
+        userUuid: string,
+    ): Promise<OrganizationRoleSet> {
+        await this.assertRoleSetsEnabled(account);
+        RolesService.validateOrganizationAccess(
+            account,
+            this.createAuditedAbility(account),
+            orgUuid,
+        );
+        return this.rolesModel.getOrganizationUserRoleSet(orgUuid, userUuid);
+    }
+
+    async replaceOrganizationUserRoleSet(
+        account: Account,
+        orgUuid: string,
+        userUuid: string,
+        roleSet: OrganizationRoleSet,
+        { source = 'api' }: { source?: RoleSetMutationSource } = {},
+    ): Promise<OrganizationRoleSet> {
+        await this.assertRoleSetsEnabled(account);
+        RolesService.validateOrganizationAccess(
+            account,
+            this.createAuditedAbility(account),
+            orgUuid,
+        );
+        RolesService.assertNonEmptyRoleSet(roleSet);
+        if (
+            roleSet.systemRole !== null &&
+            !isOrganizationMemberRole(roleSet.systemRole)
+        ) {
+            throw new ParameterError(`Unknown organization role`);
+        }
+        const user = await this.userModel.getUserDetailsByUuid(userUuid);
+        if (user.organizationUuid !== orgUuid) {
+            throw new ForbiddenError();
+        }
+        const customRoles = await this.loadCustomRolesForSet(
+            orgUuid,
+            roleSet.customRoleUuids,
+            'organization',
+        );
+
+        assertRegisteredAccount(account);
+        await validateOrganizationScopesCanBeGranted({
+            user: toSessionUser(account),
+            organizationUuid: orgUuid,
+            grantedScopes: [
+                ...(roleSet.systemRole
+                    ? getOrganizationSystemRoleScopes(roleSet.systemRole, {
+                          includePersonalAccessToken:
+                              this.lightdashConfig.auth?.pat?.enabled ===
+                                  true &&
+                              this.lightdashConfig.auth.pat.allowedOrgRoles.includes(
+                                  roleSet.systemRole,
+                              ),
+                      })
+                    : []),
+                ...customRoles.flatMap((role) => role.scopes),
+            ],
+            rolesModel: this.rolesModel,
+        });
+
+        const before = await this.rolesModel.getOrganizationUserRoleSet(
+            orgUuid,
+            userUuid,
+        );
+        // The model refuses to demote the organization's last active admin.
+        const after = await this.rolesModel.replaceOrganizationUserRoleSet(
+            orgUuid,
+            userUuid,
+            roleSet,
+        );
+        this.auditRoleSetChange({
+            account,
+            action: 'organization_role_set.replaced',
+            organizationUuid: orgUuid,
+            source,
+            target: { userUuid },
+            before,
+            after,
+        });
+        if (before.systemRole !== after.systemRole) {
+            this.adminNotificationService
+                .notifyOrgAdminRoleChange(
+                    account,
+                    userUuid,
+                    orgUuid,
+                    before.systemRole ?? OrganizationMemberRole.MEMBER,
+                    after.systemRole ?? OrganizationMemberRole.MEMBER,
+                )
+                .catch((err) => {
+                    this.logger.error(
+                        'Failed to send org admin role change notification',
+                        { error: err },
+                    );
+                });
+        }
+        return after;
+    }
+
+    async getProjectUserRoleSet(
+        account: Account,
+        projectUuid: string,
+        userUuid: string,
+    ): Promise<ProjectRoleSet> {
+        await this.assertRoleSetsEnabled(account);
+        await this.validateProjectAccess(account, projectUuid);
+        return this.rolesModel.getProjectUserRoleSet(projectUuid, userUuid);
+    }
+
+    private async validateProjectRoleSetRequest(
+        account: Account,
+        projectUuid: string,
+        roleSet: ProjectRoleSet,
+    ): Promise<{ organizationUuid: string }> {
+        await this.assertRoleSetsEnabled(account);
+        RolesService.assertNonEmptyRoleSet(roleSet);
+        const project = await this.projectModel.getSummary(projectUuid);
+        await this.validateProjectAccess(account, projectUuid);
+        if (roleSet.systemRole !== null && !isSystemRole(roleSet.systemRole)) {
+            throw new ParameterError(`Unknown project role`);
+        }
+        const customRoles = await this.loadCustomRolesForSet(
+            project.organizationUuid,
+            roleSet.customRoleUuids,
+            'project',
+        );
+        assertRegisteredAccount(account);
+        validateProjectScopesCanBeGranted({
+            user: toSessionUser(account),
+            grantedScopes: [
+                ...(roleSet.systemRole
+                    ? getAllScopesForRole(roleSet.systemRole)
+                    : []),
+                ...customRoles.flatMap((role) => role.scopes),
+            ],
+        });
+        return { organizationUuid: project.organizationUuid };
+    }
+
+    async replaceProjectUserRoleSet(
+        account: Account,
+        projectUuid: string,
+        userUuid: string,
+        roleSet: ProjectRoleSet,
+        { source = 'api' }: { source?: RoleSetMutationSource } = {},
+    ): Promise<ProjectRoleSet> {
+        const { organizationUuid } = await this.validateProjectRoleSetRequest(
+            account,
+            projectUuid,
+            roleSet,
+        );
+        const user = await this.userModel.getUserDetailsByUuid(userUuid);
+        if (user.organizationUuid !== organizationUuid) {
+            throw new ForbiddenError();
+        }
+        const existing = await this.rolesModel.getProjectAccessByUserUuid(
+            userUuid,
+            projectUuid,
+        );
+        const before: ProjectRoleSet =
+            existing.length > 0
+                ? await this.rolesModel.getProjectUserRoleSet(
+                      projectUuid,
+                      userUuid,
+                  )
+                : { systemRole: null, customRoleUuids: [] };
+        const after = await this.rolesModel.replaceProjectUserRoleSet(
+            projectUuid,
+            userUuid,
+            roleSet,
+        );
+        this.auditRoleSetChange({
+            account,
+            action: 'project_role_set.replaced',
+            organizationUuid,
+            projectUuid,
+            source,
+            target: { userUuid },
+            before,
+            after,
+        });
+        return after;
+    }
+
+    async getProjectGroupRoleSet(
+        account: Account,
+        projectUuid: string,
+        groupUuid: string,
+    ): Promise<ProjectRoleSet> {
+        await this.assertRoleSetsEnabled(account);
+        await this.validateProjectAccess(account, projectUuid);
+        return this.rolesModel.getProjectGroupRoleSet(projectUuid, groupUuid);
+    }
+
+    async replaceProjectGroupRoleSet(
+        account: Account,
+        projectUuid: string,
+        groupUuid: string,
+        roleSet: ProjectRoleSet,
+        { source = 'api' }: { source?: RoleSetMutationSource } = {},
+    ): Promise<ProjectRoleSet> {
+        const { organizationUuid } = await this.validateProjectRoleSetRequest(
+            account,
+            projectUuid,
+            roleSet,
+        );
+        const group = await this.groupsModel.getGroup(groupUuid);
+        if (group.organizationUuid !== organizationUuid) {
+            throw new ForbiddenError();
+        }
+        const before: ProjectRoleSet = await this.rolesModel
+            .getProjectGroupRoleSet(projectUuid, groupUuid)
+            .catch((error) => {
+                if (error instanceof NotFoundError) {
+                    return { systemRole: null, customRoleUuids: [] };
+                }
+                throw error;
+            });
+        const after = await this.rolesModel.replaceProjectGroupRoleSet(
+            projectUuid,
+            groupUuid,
+            roleSet,
+        );
+        this.auditRoleSetChange({
+            account,
+            action: 'project_group_role_set.replaced',
+            organizationUuid,
+            projectUuid,
+            source,
+            target: { groupUuid },
+            before,
+            after,
+        });
+        return after;
     }
 
     async getRoleAssignees(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1590,6 +1590,7 @@ export class ServiceRepository
                     inviteLinkModel: this.models.getInviteLinkModel(),
                     organizationMemberProfileModel:
                         this.models.getOrganizationMemberProfileModel(),
+                    featureFlagModel: this.models.getFeatureFlagModel(),
                 }),
         );
     }

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -224,7 +224,20 @@ type UserServiceTestOverrides = {
         PasswordResetLinkModel,
         'getByCode' | 'deleteByCode'
     >;
-    rolesModel?: Pick<RolesModel, 'getRoleWithScopesByUuid'>;
+    rolesModel?: Partial<
+        Pick<
+            RolesModel,
+            'getRoleWithScopesByUuid' | 'getOrganizationUserRoleSet'
+        >
+    >;
+};
+
+// Delegation checks read the caller's extra custom roles; default to none.
+const rolesModelWithoutExtraRoles = {
+    getOrganizationUserRoleSet: vi.fn(async () => ({
+        systemRole: null,
+        customRoleUuids: [],
+    })),
 };
 
 const createUserService = (
@@ -275,7 +288,10 @@ const createUserService = (
             } as unknown as FeatureFlagModel),
         userAvatarModel: {} as UserAvatarModel,
         userOnboardingModel: {} as UserOnboardingModel,
-        rolesModel: (overrides.rolesModel as RolesModel) ?? ({} as RolesModel),
+        rolesModel: {
+            ...rolesModelWithoutExtraRoles,
+            ...overrides.rolesModel,
+        } as unknown as RolesModel,
     });
 
 vi.spyOn(analyticsMock, 'track');
@@ -3574,8 +3590,8 @@ describe('UserService', () => {
                 );
             });
 
-            // rolesModel is left unstubbed here: a system-role caller must be
-            // measured from its own role, without a custom-role lookup.
+            // getRoleWithScopesByUuid is left unstubbed here: a system-role
+            // caller must be measured from its own role, without a custom-role lookup.
             test('allows an organization admin to invite an admin', async () => {
                 const adminUser = {
                     ...sessionUser,

--- a/packages/backend/src/utils/organizationRolePermissions.test.ts
+++ b/packages/backend/src/utils/organizationRolePermissions.test.ts
@@ -37,13 +37,21 @@ const customRoleCaller = ({
     } as never;
 };
 
-const rolesModelWithScopes = (scopes: string[]) =>
+const rolesModelWithScopes = (
+    scopes: string[],
+    extraRoleUuids: string[] = [],
+) =>
     ({
         getRoleWithScopesByUuid: vi.fn().mockResolvedValue({
             roleUuid: CUSTOM_ROLE,
             organizationUuid: ORG,
             level: 'organization',
             scopes,
+        }),
+        // Callers may hold extra custom roles on top of their session slot
+        getOrganizationUserRoleSet: vi.fn().mockResolvedValue({
+            systemRole: null,
+            customRoleUuids: extraRoleUuids,
         }),
     }) as unknown as RolesModel;
 

--- a/packages/backend/src/utils/organizationRolePermissions.ts
+++ b/packages/backend/src/utils/organizationRolePermissions.ts
@@ -1,6 +1,7 @@
 import {
     ForbiddenError,
     getOrganizationMemberRolePermissions,
+    getPermissionsFromAbilityRules,
     getUncoveredPermissions,
     OrganizationMemberRole,
     type SessionUser,
@@ -35,22 +36,36 @@ const getCallerOrganizationScopes = async (
         'PersonalAccessToken',
     );
 
-    if (!user.roleUuid) {
-        return getOrganizationSystemRoleScopes(user.role, {
-            includePersonalAccessToken: canManagePersonalAccessToken,
-        });
-    }
-
-    // The caller's runtime ability is built from this role's scopes whatever
-    // its level, so the scopes are the caller's footprint either way.
-    const role = await rolesModel.getRoleWithScopesByUuid(user.roleUuid);
-    if (role.organizationUuid !== organizationUuid) {
+    // The caller's runtime ability is the union of the slot (system role or
+    // custom role from the session) and any extra custom roles they hold.
+    const roleSet = await rolesModel.getOrganizationUserRoleSet(
+        organizationUuid,
+        user.userUuid,
+    );
+    const customRoleUuids = [
+        ...new Set([
+            ...(user.roleUuid ? [user.roleUuid] : []),
+            ...roleSet.customRoleUuids,
+        ]),
+    ];
+    const customRoles = await Promise.all(
+        customRoleUuids.map((roleUuid) =>
+            rolesModel.getRoleWithScopesByUuid(roleUuid),
+        ),
+    );
+    if (
+        customRoles.some((role) => role.organizationUuid !== organizationUuid)
+    ) {
         throw new ForbiddenError('You do not have permission');
     }
 
+    const scopes = [
+        ...(user.roleUuid ? [] : getOrganizationSystemRoleScopes(user.role)),
+        ...customRoles.flatMap((role) => role.scopes),
+    ];
     return canManagePersonalAccessToken
-        ? [...role.scopes, 'manage:PersonalAccessToken']
-        : role.scopes;
+        ? [...scopes, 'manage:PersonalAccessToken']
+        : scopes;
 };
 
 export const validateOrganizationScopesCanBeGranted = async ({
@@ -74,6 +89,29 @@ export const validateOrganizationScopesCanBeGranted = async ({
         callerScopes,
     );
 
+    if (uncoveredScopes.length > 0) {
+        throw new ForbiddenError('Cannot grant permissions exceeding your own');
+    }
+};
+
+/**
+ * Project-level delegation: every granted scope must be covered by a permission
+ * the caller's own ability already holds. Callers reaching project role writes
+ * already need `manage` on the project, so this is a floor against granting
+ * scopes the caller does not have anywhere.
+ */
+export const validateProjectScopesCanBeGranted = ({
+    user,
+    grantedScopes,
+}: {
+    user: SessionUser;
+    grantedScopes: string[];
+}): void => {
+    const callerScopes = getPermissionsFromAbilityRules(user.ability.rules);
+    const uncoveredScopes = getUncoveredPermissions(
+        grantedScopes,
+        callerScopes,
+    );
     if (uncoveredScopes.length > 0) {
         throw new ForbiddenError('Cannot grant permissions exceeding your own');
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -43,6 +43,7 @@ import { timeFrameConfigs } from './utils/timeFrames';
 import type { PivotValuesColumn } from './visualizations/types';
 
 dayjs.extend(utc);
+export { getPermissionsFromAbilityRules } from './authorization/abilityPermissions';
 export * from './authorization/buildAccountHelpers';
 export { collapseAbilityRules } from './authorization/collapseAbilityRules';
 export {


### PR DESCRIPTION
## Summary

PR 1 of 3 in Stack B for [PROD-9762](https://linear.app/lightdash/issue/PROD-9762) (Stack A — storage, model, authorization — is merged). Adds the **service layer** for role sets: `RolesService.get*/replace*RoleSet` for organization users, project users and project groups, with every guard a public writer will need. No HTTP endpoints yet (next PR), so nothing user-facing changes.

Closes: https://linear.app/lightdash/issue/PROD-10214

## Changes

**Guards on every role-set mutation**
- Gate: `CommercialFeatureFlags.MultipleRoles` (default off, requires custom roles/licence) via the injected `FeatureFlagModel`.
- Access: existing `validateOrganizationAccess` / `validateProjectAccess`; user must belong to the project's organization, group must belong to the organization.
- Set validity: non-empty; system role must be a valid org/project role; each custom role must exist, belong to the organization, match `roles.level` and have ≥1 scope.
- Delegation on the **union**: org sets use `validateOrganizationScopesCanBeGranted`; the caller's own footprint now includes their extra custom roles (`getCallerOrganizationScopes`); project sets use the new `validateProjectScopesCanBeGranted` (union vs. the caller's ability permissions).
- Last admin: enforced **inside the model writers** (`assertAdminDemotionAllowed` in `roleSetUtils.ts`, used by `RolesModel.upsertOrganizationUserRoleAssignment` / `replaceOrganizationUserRoleSet` / `setUserOrgAndProjectRoles` and `OrganizationMemberProfileModel.updateOrganizationMember`): the org's admin rows are locked `FOR UPDATE` in the same transaction as the demotion, so every writer is guarded by construction and services no longer open transactions themselves. `OrganizationService.updateMember`'s "race condition between check and delete" comment is retired.
- Audit: structured `logAuditEvent` (`RoleSet` resource; `source`, `before`, `after`, `added`, `removed`) plus analytics `*_role_set.replaced` events; org system-role changes still notify admins.

```
replace*RoleSet(account, …, set, { source })
  flag → access → tenancy → set validity → delegation(union) ─┐
                                                              ▼
  RolesModel.replace*RoleSet  [trx: last-admin guard (org) → slot → extras → read back]  → audit → return set
```

## Test plan

- [x] `RolesService.test.ts` (+11): flag off, empty set, cross-tenant custom role, wrong level, org escalation, project escalation, user/group outside org, last-admin guard blocks demotion, replace + audit for org and group
- [x] `RolesModel.test.ts` (+2): guard throws for the only active admin and emits `FOR UPDATE`; passes with another admin
- [x] Real dev DB race (restored): T1 demotes admin A while T2 concurrently demotes admin B → T2 blocks on the row locks and is rejected after T1 commits; exactly one admin remains
- [x] `OrganizationService`, `UserService`, `ScimService`, `RolesModel`, `OrganizationMemberProfileModel` suites — 316 pass
- [x] `pnpm -F common typecheck`, `pnpm -F backend typecheck` (only pre-existing `bedrock.ts` error), lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

