### PR TITLE
feat(roles): add role-set APIs with legacy compatibility

### DIFF
--- a/packages/api-tests/tests/roles.test.ts
+++ b/packages/api-tests/tests/roles.test.ts
@@ -479,6 +479,155 @@ describe('Roles API Tests', () => {
         });
     });
 
+    describe('Role sets (multiple roles)', () => {
+        type RoleSet = { systemRole: string | null; customRoleUuids: string[] };
+        const editorUuid = SEED_ORG_1_EDITOR.user_uuid;
+        const orgSetUrl = `${orgRolesApiUrl}/${testOrgUuid}/roles/assignments/user/${editorUuid}/set`;
+        const projectSetUrl = `${projectRolesApiUrl}/${SEED_PROJECT.project_uuid}/roles/assignments/user/${editorUuid}/set`;
+
+        afterEach(async () => {
+            // Restore the seeded editor's single org role and drop project access
+            await admin.post(
+                `${orgRolesApiUrl}/${testOrgUuid}/roles/assignments/user/${editorUuid}`,
+                { roleId: 'editor' },
+                { failOnStatusCode: false },
+            );
+            await admin.delete(
+                `${projectRolesApiUrl}/${SEED_PROJECT.project_uuid}/roles/assignments/user/${editorUuid}`,
+                { failOnStatusCode: false },
+            );
+        });
+
+        const createOrgRole = async () => {
+            const resp = await admin.post<Body<RoleResult>>(
+                `${orgRolesApiUrl}/${testOrgUuid}/roles`,
+                {
+                    name: `Extra org role ${Date.now()}`,
+                    level: 'organization',
+                    scopes: ['view:Organization'],
+                },
+            );
+            rolesToCleanup.push(resp.body.results.roleUuid);
+            return resp.body.results.roleUuid;
+        };
+
+        it('replaces and reads an organization role set, exposing hasMultipleRoles on legacy reads', async () => {
+            const roleUuid = await createOrgRole();
+
+            const before = await admin.get<Body<RoleSet>>(orgSetUrl);
+            expect(before.status).toBe(200);
+            expect(before.body.results).toEqual({
+                systemRole: 'editor',
+                customRoleUuids: [],
+            });
+
+            const put = await admin.put<Body<RoleSet>>(orgSetUrl, {
+                systemRole: 'editor',
+                customRoleUuids: [roleUuid, roleUuid],
+            });
+            expect(put.status).toBe(200);
+            expect(put.body.results).toEqual({
+                systemRole: 'editor',
+                customRoleUuids: [roleUuid],
+            });
+
+            const listing = await admin.get<
+                Body<(AssignmentResult & { hasMultipleRoles?: boolean })[]>
+            >(`${orgRolesApiUrl}/${testOrgUuid}/roles/assignments`);
+            const editorRow = listing.body.results.find(
+                (a) => a.assigneeId === editorUuid,
+            );
+            expect(editorRow).toMatchObject({
+                roleId: 'editor',
+                hasMultipleRoles: true,
+            });
+
+            // Legacy singular write replaces the whole set
+            await admin.post(
+                `${orgRolesApiUrl}/${testOrgUuid}/roles/assignments/user/${editorUuid}`,
+                { roleId: 'editor' },
+            );
+            const after = await admin.get<Body<RoleSet>>(orgSetUrl);
+            expect(after.body.results).toEqual({
+                systemRole: 'editor',
+                customRoleUuids: [],
+            });
+        });
+
+        it('rejects empty, wrong-level and cross-tenant sets', async () => {
+            const empty = await admin.put<ErrorBody>(
+                orgSetUrl,
+                { systemRole: null, customRoleUuids: [] },
+                { failOnStatusCode: false },
+            );
+            expect(empty.status).toBe(400);
+
+            const projectRole = await admin.post<Body<RoleResult>>(
+                `${orgRolesApiUrl}/${testOrgUuid}/roles`,
+                {
+                    name: `Project-level role ${Date.now()}`,
+                    level: 'project',
+                    scopes: ['view:Dashboard'],
+                },
+            );
+            rolesToCleanup.push(projectRole.body.results.roleUuid);
+            const wrongLevel = await admin.put<ErrorBody>(
+                orgSetUrl,
+                {
+                    systemRole: null,
+                    customRoleUuids: [projectRole.body.results.roleUuid],
+                },
+                { failOnStatusCode: false },
+            );
+            expect(wrongLevel.status).toBe(400);
+
+            const unknown = await admin.put<ErrorBody>(
+                orgSetUrl,
+                {
+                    systemRole: null,
+                    customRoleUuids: ['00000000-0000-4000-8000-000000000000'],
+                },
+                { failOnStatusCode: false },
+            );
+            expect(unknown.status).toBe(404);
+        });
+
+        it('replaces and reads a project role set for a user', async () => {
+            const projectRole = await admin.post<Body<RoleResult>>(
+                `${orgRolesApiUrl}/${testOrgUuid}/roles`,
+                {
+                    name: `Extra project role ${Date.now()}`,
+                    level: 'project',
+                    scopes: ['view:Dashboard'],
+                },
+            );
+            rolesToCleanup.push(projectRole.body.results.roleUuid);
+
+            const put = await admin.put<Body<RoleSet>>(projectSetUrl, {
+                systemRole: 'viewer',
+                customRoleUuids: [projectRole.body.results.roleUuid],
+            });
+            expect(put.status).toBe(200);
+            expect(put.body.results).toEqual({
+                systemRole: 'viewer',
+                customRoleUuids: [projectRole.body.results.roleUuid],
+            });
+
+            const get = await admin.get<Body<RoleSet>>(projectSetUrl);
+            expect(get.body.results).toEqual(put.body.results);
+        });
+
+        it('forbids non-admins from replacing role sets', async () => {
+            const { client: editor } = await loginWithPermissions('editor', []);
+            const resp = await editor.put<ErrorBody>(
+                orgSetUrl,
+                { systemRole: 'admin', customRoleUuids: [] },
+                { failOnStatusCode: false },
+            );
+            expect(resp.status).toBe(403);
+        });
+    });
+
     describe('Project Access Management', () => {
         afterEach(async () => {
             // Clean up project access to avoid polluting other tests

--- a/packages/backend/src/contentAsCode/fieldCoverage/user.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/user.test.ts
@@ -12,6 +12,7 @@ describeContentAsCodeSchemaContract({
         'isInviteExpired',
         'isPending',
         'lastName',
+        'hasMultipleRoles',
         'organizationUuid',
         'roleUuid',
         'userCreatedAt',

--- a/packages/backend/src/controllers/OrganizationRolesController.ts
+++ b/packages/backend/src/controllers/OrganizationRolesController.ts
@@ -1,10 +1,12 @@
 import {
     ApiErrorPayload,
     ApiGetRolesResponse,
+    ApiOrganizationRoleSetResponse,
     ApiRoleAssignmentListResponse,
     ApiRoleAssignmentResponse,
     ApiRoleWithScopesResponse,
     CreateRole,
+    OrganizationRoleSet,
     type UUID,
 } from '@lightdash/common';
 import {
@@ -14,6 +16,7 @@ import {
     OperationId,
     Path,
     Post,
+    Put,
     Query,
     Request,
     Response,
@@ -162,6 +165,60 @@ export class OrganizationRolesController extends BaseController {
             status: 'ok',
             results: assignment,
         };
+    }
+
+    /**
+     * Get the complete role set (system role plus custom roles) a user holds in the organization.
+     * Requires the `multiple-roles` feature.
+     * @summary Get organization role set for user
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/assignments/user/{userId}/set')
+    @OperationId('GetOrganizationUserRoleSet')
+    async getOrganizationUserRoleSet(
+        @Request() req: express.Request,
+        @Path() orgUuid: UUID,
+        @Path() userId: UUID,
+    ): Promise<ApiOrganizationRoleSetResponse> {
+        const results = await this.getRolesService().getOrganizationUserRoleSet(
+            req.account!,
+            orgUuid,
+            userId,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Atomically replace the complete role set a user holds in the organization.
+     * At most one system role plus any number of custom roles; the set must not be empty.
+     * Requires the `multiple-roles` feature.
+     * @summary Replace organization role set for user
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Put('/assignments/user/{userId}/set')
+    @OperationId('ReplaceOrganizationUserRoleSet')
+    async replaceOrganizationUserRoleSet(
+        @Request() req: express.Request,
+        @Path() orgUuid: UUID,
+        @Path() userId: UUID,
+        @Body() body: OrganizationRoleSet,
+    ): Promise<ApiOrganizationRoleSetResponse> {
+        const results =
+            await this.getRolesService().replaceOrganizationUserRoleSet(
+                req.account!,
+                orgUuid,
+                userId,
+                body,
+            );
+        this.setStatus(200);
+        return { status: 'ok', results };
     }
 
     /**

--- a/packages/backend/src/controllers/ProjectRolesController.ts
+++ b/packages/backend/src/controllers/ProjectRolesController.ts
@@ -1,10 +1,12 @@
 import {
     ApiErrorPayload,
+    ApiProjectRoleSetResponse,
     ApiRoleAssignmentListResponse,
     ApiRoleAssignmentResponse,
     ApiUnassignRoleFromUserResponse,
     CreateGroupRoleAssignmentRequest,
     CreateUserRoleAssignmentRequest,
+    ProjectRoleSet,
     UpdateRoleAssignmentRequest,
     UpsertUserRoleAssignmentRequest,
     type UUID,
@@ -18,6 +20,7 @@ import {
     Patch,
     Path,
     Post,
+    Put,
     Request,
     Response,
     Route,
@@ -116,6 +119,112 @@ export class ProjectRolesController extends BaseController {
             status: 'ok',
             results: assignment,
         };
+    }
+
+    /**
+     * Get the complete role set a user holds directly on the project.
+     * Requires the `multiple-roles` feature.
+     * @summary Get project role set for user
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/assignments/user/{userId}/set')
+    @OperationId('GetProjectUserRoleSet')
+    async getProjectUserRoleSet(
+        @Request() req: express.Request,
+        @Path() projectId: string,
+        @Path() userId: UUID,
+    ): Promise<ApiProjectRoleSetResponse> {
+        const results = await this.getRolesService().getProjectUserRoleSet(
+            req.account!,
+            projectId,
+            userId,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Atomically replace the complete role set a user holds directly on the project.
+     * At most one system role plus any number of custom roles; the set must not be empty.
+     * Requires the `multiple-roles` feature.
+     * @summary Replace project role set for user
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Put('/assignments/user/{userId}/set')
+    @OperationId('ReplaceProjectUserRoleSet')
+    async replaceProjectUserRoleSet(
+        @Request() req: express.Request,
+        @Path() projectId: string,
+        @Path() userId: UUID,
+        @Body() body: ProjectRoleSet,
+    ): Promise<ApiProjectRoleSetResponse> {
+        const results = await this.getRolesService().replaceProjectUserRoleSet(
+            req.account!,
+            projectId,
+            userId,
+            body,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Get the complete role set a group holds on the project.
+     * Requires the `multiple-roles` feature.
+     * @summary Get project role set for group
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/assignments/group/{groupId}/set')
+    @OperationId('GetProjectGroupRoleSet')
+    async getProjectGroupRoleSet(
+        @Request() req: express.Request,
+        @Path() projectId: string,
+        @Path() groupId: UUID,
+    ): Promise<ApiProjectRoleSetResponse> {
+        const results = await this.getRolesService().getProjectGroupRoleSet(
+            req.account!,
+            projectId,
+            groupId,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Atomically replace the complete role set a group holds on the project.
+     * At most one system role plus any number of custom roles; the set must not be empty.
+     * Requires the `multiple-roles` feature.
+     * @summary Replace project role set for group
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Put('/assignments/group/{groupId}/set')
+    @OperationId('ReplaceProjectGroupRoleSet')
+    async replaceProjectGroupRoleSet(
+        @Request() req: express.Request,
+        @Path() projectId: string,
+        @Path() groupId: UUID,
+        @Body() body: ProjectRoleSet,
+    ): Promise<ApiProjectRoleSetResponse> {
+        const results = await this.getRolesService().replaceProjectGroupRoleSet(
+            req.account!,
+            projectId,
+            groupId,
+            body,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results };
     }
 
     /**

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -16,6 +16,7 @@ import { GroupMembershipTableName } from '../database/entities/groupMemberships'
 import { GroupTableName } from '../database/entities/groups';
 import { InviteLinkTableName } from '../database/entities/inviteLinks';
 import { OpenIdIdentitiesTableName } from '../database/entities/openIdIdentities';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
 import {
     DbOrganizationMembership,
     DbOrganizationMembershipIn,
@@ -47,12 +48,13 @@ type DbOrganizationMemberProfile = {
     organization_uuid: string;
     role: OrganizationMemberRole;
     role_uuid: string | null;
+    has_extra_roles: boolean;
     expires_at?: Date;
     avatar_gradient: string | null;
     avatar_content_hash: string | null;
 };
 
-const SelectColumns = [
+const selectColumns = (db: Knex) => [
     `${UserTableName}.user_uuid`,
     `${UserTableName}.user_id`,
     `${UserTableName}.first_name`,
@@ -67,6 +69,14 @@ const SelectColumns = [
     `${UserTableName}.updated_at as user_updated_at`,
     `${UserTableName}.avatar_gradient`,
     `${UserAvatarsTableName}.content_hash as avatar_content_hash`,
+    db.raw(
+        `EXISTS (SELECT 1 FROM ?? AS x WHERE x.organization_id = ??.organization_id AND x.user_id = ??.user_id) AS has_extra_roles`,
+        [
+            OrganizationMembershipCustomRolesTableName,
+            OrganizationMembershipsTableName,
+            OrganizationMembershipsTableName,
+        ],
+    ),
 ];
 
 export class OrganizationMemberProfileModel {
@@ -127,6 +137,7 @@ export class OrganizationMemberProfileModel {
             organizationUuid: member.organization_uuid,
             role: member.role,
             roleUuid: member.role_uuid || undefined,
+            hasMultipleRoles: member.has_extra_roles,
             isActive: member.is_active,
             isInviteExpired,
             isPending,
@@ -163,7 +174,9 @@ export class OrganizationMemberProfileModel {
                 `${OrganizationTableName}.organization_uuid`,
                 organizationUuid,
             )
-            .select<DbOrganizationMemberProfile[]>(SelectColumns);
+            .select<DbOrganizationMemberProfile[]>(
+                selectColumns(this.database),
+            );
 
         // Apply exact match filter if provided
         if (exactMatchFilter) {
@@ -259,7 +272,7 @@ export class OrganizationMemberProfileModel {
                 `${OrganizationTableName}.organization_uuid`,
                 organizationUuid,
             )
-            .select<DbOrganizationMemberProfile[]>(SelectColumns)
+            .select<DbOrganizationMemberProfile[]>(selectColumns(this.database))
             .orderBy(`${EmailTableName}.email`, 'asc');
 
         const usersHaveAuthenticationRows =
@@ -319,7 +332,7 @@ export class OrganizationMemberProfileModel {
                 `${EmailTableName}.email`,
                 normalizedEmails,
             ])
-            .select<DbOrganizationMemberProfile[]>(SelectColumns)
+            .select<DbOrganizationMemberProfile[]>(selectColumns(this.database))
             .orderBy(`${EmailTableName}.email`, 'asc')
             .orderBy(`${UserTableName}.user_uuid`, 'asc');
 
@@ -532,7 +545,9 @@ export class OrganizationMemberProfileModel {
                 organizationUuid,
             )
             .andWhere('role', 'admin')
-            .select<DbOrganizationMemberProfile[]>(SelectColumns);
+            .select<DbOrganizationMemberProfile[]>(
+                selectColumns(this.database),
+            );
         const usersHaveAuthenticationRows =
             await UserModel.findIfUsersHaveAuthentication(this.database, {
                 userUuids: members.map((m) => m.user_uuid),
@@ -611,7 +626,9 @@ export class OrganizationMemberProfileModel {
                 `${OrganizationTableName}.organization_uuid`,
                 organizationUuid,
             )
-            .select<DbOrganizationMemberProfile[]>(SelectColumns);
+            .select<DbOrganizationMemberProfile[]>(
+                selectColumns(this.database),
+            );
 
         if (!dbMember) {
             throw new NotFoundError('No matching member found in organization');
@@ -642,7 +659,9 @@ export class OrganizationMemberProfileModel {
                 `${OrganizationTableName}.organization_uuid`,
                 organizationUuid,
             )
-            .select<DbOrganizationMemberProfile[]>(SelectColumns);
+            .select<DbOrganizationMemberProfile[]>(
+                selectColumns(this.database),
+            );
 
         if (!dbMember) {
             throw new NotFoundError('No matching member found in organization');

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1910,7 +1910,16 @@ export class ProjectModel {
                 'project_memberships.project_id',
                 'projects.project_id',
             )
-            .select<QueryResult[]>()
+            .select<(QueryResult & { has_extra_roles: boolean })[]>(
+                'project_memberships.*',
+                'users.*',
+                'emails.*',
+                'projects.*',
+                this.database.raw(
+                    `EXISTS (SELECT 1 FROM ?? AS x WHERE x.project_id = project_memberships.project_id AND x.user_id = project_memberships.user_id) AS has_extra_roles`,
+                    [ProjectMembershipCustomRolesTableName],
+                ),
+            )
             .where('project_uuid', projectUuid)
             .andWhere('is_primary', true);
 
@@ -1922,6 +1931,7 @@ export class ProjectModel {
             projectUuid,
             lastName: membership.last_name,
             roleUuid: membership.role_uuid || undefined,
+            hasMultipleRoles: membership.has_extra_roles,
         }));
     }
 

--- a/packages/backend/src/models/RolesModel.ts
+++ b/packages/backend/src/models/RolesModel.ts
@@ -70,6 +70,7 @@ type DbOrganizationRoleAssignment = {
     organizationId: string;
     createdAt: Date;
     ownerType: string | null;
+    hasExtraRoles: boolean;
 };
 
 export class RolesModel {
@@ -736,6 +737,14 @@ export class RolesModel {
                 `${ProjectMembershipsTableName}.role as role`,
                 `${UserTableName}.first_name as firstName`,
                 `${UserTableName}.last_name as lastName`,
+                (tx || this.database).raw(
+                    `EXISTS (SELECT 1 FROM ?? AS x WHERE x.project_id = ??.project_id AND x.user_id = ??.user_id) AS "hasExtraRoles"`,
+                    [
+                        ProjectMembershipCustomRolesTableName,
+                        ProjectMembershipsTableName,
+                        ProjectMembershipsTableName,
+                    ],
+                ),
             )
             .where(`${ProjectTableName}.project_uuid`, projectUuid);
 
@@ -746,6 +755,7 @@ export class RolesModel {
             roleName: ac.roleName || ac.role,
             firstName: ac.firstName,
             lastName: ac.lastName,
+            hasMultipleRoles: ac.hasExtraRoles,
         }));
     }
 
@@ -776,6 +786,10 @@ export class RolesModel {
                 `${RolesTableName}.name as roleName`,
                 `project_group_access.role as role`,
                 `${GroupTableName}.name as groupName`,
+                (tx || this.database).raw(
+                    `EXISTS (SELECT 1 FROM ?? AS x WHERE x.project_uuid = project_group_access.project_uuid AND x.group_uuid = project_group_access.group_uuid) AS "hasExtraRoles"`,
+                    [ProjectGroupAccessCustomRolesTableName],
+                ),
             )
             .where(`${ProjectTableName}.project_uuid`, projectUuid);
 
@@ -785,6 +799,7 @@ export class RolesModel {
             roleUuid: ac.roleUuid || ac.role,
             roleName: ac.roleName || ac.role,
             groupName: ac.groupName,
+            hasMultipleRoles: ac.hasExtraRoles,
         }));
     }
 
@@ -925,6 +940,7 @@ export class RolesModel {
                 organizationId: assignment.organizationId,
                 createdAt: assignment.createdAt,
                 updatedAt: assignment.createdAt, // Use createdAt since updatedAt doesn't exist
+                hasMultipleRoles: assignment.hasExtraRoles,
             }),
         );
         return formattedUserAssignments;
@@ -965,6 +981,10 @@ export class RolesModel {
                 ),
                 'organizations.organization_uuid as organizationId',
                 'organization_memberships.created_at as createdAt',
+                (tx || this.database).raw(
+                    `EXISTS (SELECT 1 FROM ?? AS x WHERE x.organization_id = organization_memberships.organization_id AND x.user_id = organization_memberships.user_id) AS "hasExtraRoles"`,
+                    [OrganizationMembershipCustomRolesTableName],
+                ),
             )
             .where('organizations.organization_uuid', orgUuid);
 

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -1269,6 +1269,7 @@ export class RolesService extends BaseService {
                 assigneeType: 'user',
                 assigneeId: userAccess.userUuid,
                 assigneeName: `${userAccess.firstName} ${userAccess.lastName}`,
+                hasMultipleRoles: userAccess.hasMultipleRoles,
                 projectId: userAccess.projectUuid,
                 createdAt: new Date(), // TODO: Get actual dates from DB
                 updatedAt: new Date(),
@@ -1286,6 +1287,7 @@ export class RolesService extends BaseService {
                 assigneeType: 'group',
                 assigneeId: groupAccess.groupUuid,
                 assigneeName: groupAccess.groupName,
+                hasMultipleRoles: groupAccess.hasMultipleRoles,
                 projectId: groupAccess.projectUuid,
                 createdAt: new Date(), // TODO: Get actual dates from DB
                 updatedAt: new Date(),

--- a/packages/common/src/types/organizationMemberProfile.ts
+++ b/packages/common/src/types/organizationMemberProfile.ts
@@ -51,6 +51,8 @@ export type OrganizationMemberProfile = {
      */
     role: OrganizationMemberRole;
     roleUuid: string | undefined;
+    /** True when the member holds extra custom roles beyond `role`/`roleUuid` (see role sets). */
+    hasMultipleRoles?: boolean;
     /**
      * Whether the user can login
      */

--- a/packages/common/src/types/projectMemberProfile.ts
+++ b/packages/common/src/types/projectMemberProfile.ts
@@ -5,6 +5,8 @@ export type ProjectMemberProfile = {
     projectUuid: string;
     role: ProjectMemberRole;
     roleUuid: string | undefined;
+    /** True when the member holds extra custom roles beyond `role`/`roleUuid` (see role sets). */
+    hasMultipleRoles?: boolean;
     email: string;
     firstName: string;
     lastName: string;

--- a/packages/common/src/types/roles.ts
+++ b/packages/common/src/types/roles.ts
@@ -26,6 +26,7 @@ export type ProjectAccess = {
     roleName: string;
     firstName: string;
     lastName: string;
+    hasMultipleRoles?: boolean;
 };
 
 export type GroupProjectAccess = {
@@ -34,6 +35,7 @@ export type GroupProjectAccess = {
     roleUuid: string;
     roleName: string;
     groupName: string;
+    hasMultipleRoles?: boolean;
 };
 
 export type Role = {
@@ -139,6 +141,18 @@ export type RoleAssignment = {
     projectId?: string; // for project-level assignments
     createdAt: Date;
     updatedAt: Date;
+    /** True when the assignee holds extra custom roles beyond `roleId` (see role sets). */
+    hasMultipleRoles?: boolean;
+};
+
+export type ApiOrganizationRoleSetResponse = {
+    status: 'ok';
+    results: OrganizationRoleSet;
+};
+
+export type ApiProjectRoleSetResponse = {
+    status: 'ok';
+    results: ProjectRoleSet;
 };
 
 export type CreateRoleAssignmentRequest = {


### PR DESCRIPTION
## Summary

PR 2 of 3 in Stack B for [PROD-9762](https://linear.app/lightdash/issue/PROD-9762). Exposes role sets over HTTP: `GET`/`PUT …/set` for organization users, project users and project groups (v2, gated by the `multiple-roles` flag via the service layer from the previous PR), and adds `hasMultipleRoles` to the legacy singular reads so a client showing the slot can tell when there is more.

Stacks on top of [#27515](https://github.com/lightdash/lightdash/pull/27515) (guards + audit in `RolesService`).

Closes: https://linear.app/lightdash/issue/PROD-10215

## API shape

```
GET  /api/v2/orgs/{orgUuid}/roles/assignments/user/{userId}/set
PUT  /api/v2/orgs/{orgUuid}/roles/assignments/user/{userId}/set        body: OrganizationRoleSet
GET  /api/v2/projects/{projectId}/roles/assignments/user/{userId}/set
PUT  /api/v2/projects/{projectId}/roles/assignments/user/{userId}/set  body: ProjectRoleSet
GET  /api/v2/projects/{projectId}/roles/assignments/group/{groupId}/set
PUT  /api/v2/projects/{projectId}/roles/assignments/group/{groupId}/set

OrganizationRoleSet = { systemRole: OrganizationMemberRole | null, customRoleUuids: string[] }
ProjectRoleSet      = { systemRole: ProjectMemberRole | null,      customRoleUuids: string[] }
```

- `PUT` is atomic and non-empty; identical roles dedupe; the response is the canonical persisted set.
- Legacy singular reads keep `role` / `roleUuid` (the slot) and gain optional `hasMultipleRoles`: `OrganizationMemberProfile` (`/api/v1/org/users`), `ProjectMemberProfile` (`/api/v1/projects/{p}/access`), `RoleAssignment` (org + project `…/roles/assignments`), `ProjectAccess` / `GroupProjectAccess`. Optional so existing clients and fixtures are untouched.
- Legacy singular writes are unchanged and replace the whole set (from Stack A).
- Errors: flag off / unlicensed → 403; empty, unknown system role, wrong level → 400; unknown / other-org custom role → 404; escalation → 403.

## Test plan

- [x] Live on the dev instance (curl, PAT): GET/PUT org set round-trip incl. dedupe; `hasMultipleRoles: true` on `/api/v2/orgs/{o}/roles/assignments` and `/api/v1/org/users`; empty → 400; wrong-level → 400; legacy `POST …/assignments/user/{u}` collapses the set; flag off → 403; project user + group sets round-trip; `hasMultipleRoles` on project assignments and `/api/v1/projects/{p}/access`
- [x] `packages/api-tests/tests/roles.test.ts` (+4, run locally against the dev instance: 40 pass): round-trip + legacy read + singular collapse; empty/wrong-level/unknown → 400/400/404; project set; non-admin → 403. Previews enable all commercial flags, so these run in CI.
- [x] Backend suites: `RolesService`, `RolesModel`, `OrganizationMemberProfileModel`, `ProjectModel`, controllers — 264 pass
- [x] `pnpm generate-api` (swagger shows the 3 paths × GET/PUT and the `OrganizationRoleSet`/`ProjectRoleSet` schemas; generated files left for CI); `pnpm -F common|frontend typecheck`, `pnpm -F backend typecheck` (only pre-existing `bedrock.ts` error), lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)