### PR TITLE
fix: validate space share targets are organization members

### DIFF
--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -277,6 +277,26 @@ export class OrganizationMemberProfileModel {
         );
     }
 
+    /** Returns the subset of the given user uuids that are members of the organization. */
+    async findOrganizationMemberUuids(
+        organizationUuid: string,
+        userUuids: string[],
+    ): Promise<string[]> {
+        if (userUuids.length === 0) return [];
+
+        const members = await this.queryBuilder()
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .whereIn(`${UserTableName}.user_uuid`, userUuids)
+            .select<Pick<DbOrganizationMemberProfile, 'user_uuid'>[]>(
+                `${UserTableName}.user_uuid`,
+            );
+
+        return members.map((member) => member.user_uuid);
+    }
+
     async findOrganizationMembersByEmails(
         organizationUuid: string,
         emails: string[],

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1096,6 +1096,8 @@ export class ServiceRepository
                     projectModel: this.models.getProjectModel(),
                     spaceModel: this.models.getSpaceModel(),
                     organizationModel: this.models.getOrganizationModel(),
+                    organizationMemberProfileModel:
+                        this.models.getOrganizationMemberProfileModel(),
                     pinnedListModel: this.models.getPinnedListModel(),
                     spacePermissionService: this.getSpacePermissionService(),
                     savedChartService: this.getSavedChartService(),

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -1700,9 +1700,6 @@ describe('SpaceService - space share target validation', () => {
                 SpaceMemberRole.VIEWER,
             );
 
-            expect(
-                mockOrganizationMemberProfileModel.findOrganizationMemberUuids,
-            ).toHaveBeenCalledWith('test-org-uuid', ['target-user-uuid']);
             expect(mockSpaceModel.addSpaceAccess).toHaveBeenCalledWith(
                 'test-space-uuid',
                 'target-user-uuid',
@@ -1757,12 +1754,6 @@ describe('SpaceService - space share target validation', () => {
                 ),
             ).rejects.toThrowError(NotFoundError);
 
-            expect(
-                mockOrganizationMemberProfileModel.findOrganizationMemberUuids,
-            ).toHaveBeenCalledWith('test-org-uuid', [
-                'member-user-uuid',
-                'other-org-user-uuid',
-            ]);
             expect(mockSpaceModel.createSpace).not.toHaveBeenCalled();
         });
     });

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { PinnedListModel } from '../../models/PinnedListModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -40,6 +41,8 @@ describe('SpaceService', () => {
             projectModel: {} as ProjectModel,
             spaceModel: {} as SpaceModel,
             organizationModel: {} as OrganizationModel,
+            organizationMemberProfileModel:
+                {} as OrganizationMemberProfileModel,
             pinnedListModel: {} as PinnedListModel,
             spacePermissionService: {
                 getSpaceAccessContext: mockGetSpaceAccessContext,
@@ -74,6 +77,8 @@ describe('SpaceService', () => {
                 projectModel: {} as ProjectModel,
                 spaceModel: spaceModel as unknown as SpaceModel,
                 organizationModel: {} as OrganizationModel,
+                organizationMemberProfileModel:
+                    {} as OrganizationMemberProfileModel,
                 pinnedListModel: {} as PinnedListModel,
                 spacePermissionService:
                     spacePermissionService as unknown as SpacePermissionService,
@@ -968,6 +973,8 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
             projectModel: {} as ProjectModel,
             spaceModel: mockSpaceModel as unknown as SpaceModel,
             organizationModel: {} as OrganizationModel,
+            organizationMemberProfileModel:
+                {} as OrganizationMemberProfileModel,
             pinnedListModel: {} as PinnedListModel,
             spacePermissionService:
                 mockSpacePermissionService as unknown as SpacePermissionService,
@@ -1628,5 +1635,131 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
                 role: SpaceMemberRole.ADMIN,
             }),
         );
+    });
+});
+
+describe('SpaceService - space share target validation', () => {
+    const mockUser = createTestUser({
+        organizationRole: OrganizationMemberRole.ADMIN,
+    });
+
+    const mockSpaceModel = {
+        getSpaceSummary: vi.fn(),
+        addSpaceAccess: vi.fn(),
+        createSpace: vi.fn(),
+    };
+    const mockOrganizationMemberProfileModel = {
+        findOrganizationMemberUuids: vi.fn(),
+    };
+    const mockSpacePermissionService = {
+        can: vi.fn(),
+    };
+    const mockProjectModel = {
+        getSummary: vi.fn(),
+    };
+
+    let service: SpaceService;
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+
+        service = new SpaceService({
+            analytics: analyticsMock,
+            lightdashConfig: lightdashConfigMock,
+            projectModel: mockProjectModel as unknown as ProjectModel,
+            spaceModel: mockSpaceModel as unknown as SpaceModel,
+            organizationModel: {} as OrganizationModel,
+            organizationMemberProfileModel:
+                mockOrganizationMemberProfileModel as unknown as OrganizationMemberProfileModel,
+            pinnedListModel: {} as PinnedListModel,
+            spacePermissionService:
+                mockSpacePermissionService as unknown as SpacePermissionService,
+            savedChartService: {} as SavedChartService,
+            dashboardService: {} as DashboardService,
+            appGenerateService: undefined,
+        });
+
+        mockSpacePermissionService.can.mockResolvedValue(true);
+        mockSpaceModel.getSpaceSummary.mockResolvedValue({
+            uuid: 'test-space-uuid',
+            organizationUuid: 'test-org-uuid',
+            projectUuid: 'test-project-uuid',
+        });
+    });
+
+    describe('addSpaceUserAccess', () => {
+        it('adds access when the target user is a member of the organization', async () => {
+            mockOrganizationMemberProfileModel.findOrganizationMemberUuids.mockResolvedValue(
+                ['target-user-uuid'],
+            );
+
+            await service.addSpaceUserAccess(
+                mockUser as unknown as SessionUser,
+                'test-space-uuid',
+                'target-user-uuid',
+                SpaceMemberRole.VIEWER,
+            );
+
+            expect(
+                mockOrganizationMemberProfileModel.findOrganizationMemberUuids,
+            ).toHaveBeenCalledWith('test-org-uuid', ['target-user-uuid']);
+            expect(mockSpaceModel.addSpaceAccess).toHaveBeenCalledWith(
+                'test-space-uuid',
+                'target-user-uuid',
+                SpaceMemberRole.VIEWER,
+            );
+        });
+
+        it('rejects a target user outside the organization without writing access', async () => {
+            mockOrganizationMemberProfileModel.findOrganizationMemberUuids.mockResolvedValue(
+                [],
+            );
+
+            await expect(
+                service.addSpaceUserAccess(
+                    mockUser as unknown as SessionUser,
+                    'test-space-uuid',
+                    'other-org-user-uuid',
+                    SpaceMemberRole.VIEWER,
+                ),
+            ).rejects.toThrowError(NotFoundError);
+
+            expect(mockSpaceModel.addSpaceAccess).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('createSpace', () => {
+        it('rejects initial access entries for users outside the organization without creating the space', async () => {
+            mockProjectModel.getSummary.mockResolvedValue({
+                organizationUuid: 'test-org-uuid',
+            });
+            mockOrganizationMemberProfileModel.findOrganizationMemberUuids.mockResolvedValue(
+                ['member-user-uuid'],
+            );
+
+            await expect(
+                service.createSpace('test-project-uuid', mockUser as unknown as SessionUser, {
+                    name: 'New space',
+                    access: [
+                        {
+                            userUuid: 'member-user-uuid',
+                            role: SpaceMemberRole.VIEWER,
+                        },
+                        {
+                            userUuid: 'other-org-user-uuid',
+                            role: SpaceMemberRole.VIEWER,
+                        },
+                    ],
+                }),
+            ).rejects.toThrowError(NotFoundError);
+
+            expect(
+                mockOrganizationMemberProfileModel.findOrganizationMemberUuids,
+            ).toHaveBeenCalledWith('test-org-uuid', [
+                'member-user-uuid',
+                'other-org-user-uuid',
+            ]);
+            expect(mockSpaceModel.createSpace).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -1738,19 +1738,23 @@ describe('SpaceService - space share target validation', () => {
             );
 
             await expect(
-                service.createSpace('test-project-uuid', mockUser as unknown as SessionUser, {
-                    name: 'New space',
-                    access: [
-                        {
-                            userUuid: 'member-user-uuid',
-                            role: SpaceMemberRole.VIEWER,
-                        },
-                        {
-                            userUuid: 'other-org-user-uuid',
-                            role: SpaceMemberRole.VIEWER,
-                        },
-                    ],
-                }),
+                service.createSpace(
+                    'test-project-uuid',
+                    mockUser as unknown as SessionUser,
+                    {
+                        name: 'New space',
+                        access: [
+                            {
+                                userUuid: 'member-user-uuid',
+                                role: SpaceMemberRole.VIEWER,
+                            },
+                            {
+                                userUuid: 'other-org-user-uuid',
+                                role: SpaceMemberRole.VIEWER,
+                            },
+                        ],
+                    },
+                ),
             ).rejects.toThrowError(NotFoundError);
 
             expect(

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -23,6 +23,7 @@ import { Knex } from 'knex';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
 import type { AppGenerateService } from '../../ee/services/AppGenerateService/AppGenerateService';
+import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { PinnedListModel } from '../../models/PinnedListModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -42,6 +43,7 @@ type SpaceServiceArguments = {
     projectModel: ProjectModel;
     spaceModel: SpaceModel;
     organizationModel: OrganizationModel;
+    organizationMemberProfileModel: OrganizationMemberProfileModel;
     pinnedListModel: PinnedListModel;
     spacePermissionService: SpacePermissionService;
     savedChartService: SavedChartService;
@@ -91,6 +93,8 @@ export class SpaceService
 
     private readonly organizationModel: OrganizationModel;
 
+    private readonly organizationMemberProfileModel: OrganizationMemberProfileModel;
+
     private readonly pinnedListModel: PinnedListModel;
 
     private readonly spacePermissionService: SpacePermissionService;
@@ -108,6 +112,7 @@ export class SpaceService
         this.projectModel = args.projectModel;
         this.spaceModel = args.spaceModel;
         this.organizationModel = args.organizationModel;
+        this.organizationMemberProfileModel = args.organizationMemberProfileModel;
         this.pinnedListModel = args.pinnedListModel;
         this.spacePermissionService = args.spacePermissionService;
         this.savedChartService = args.savedChartService;
@@ -262,6 +267,29 @@ export class SpaceService
         });
     }
 
+    /**
+     * Space access rows for users outside the space's organization never grant
+     * access (no CASL rule matches them) but would linger as dangling state and
+     * show up in access lists — reject them at the boundary instead.
+     */
+    private async validateSpaceShareTargetUsers(
+        organizationUuid: string,
+        userUuids: string[],
+    ): Promise<void> {
+        const uniqueUserUuids = [...new Set(userUuids)];
+        const memberUuids = new Set(
+            await this.organizationMemberProfileModel.findOrganizationMemberUuids(
+                organizationUuid,
+                uniqueUserUuids,
+            ),
+        );
+        if (uniqueUserUuids.some((userUuid) => !memberUuids.has(userUuid))) {
+            throw new NotFoundError(
+                'Cannot share space: user is not a member of this organization',
+            );
+        }
+    }
+
     async createSpace(
         projectUuid: string,
         user: SessionUser,
@@ -292,6 +320,13 @@ export class SpaceService
             if (parentSpace.projectUuid !== projectUuid) {
                 throw new NotFoundError('Parent space not found');
             }
+        }
+
+        if (space.access && space.access.length > 0) {
+            await this.validateSpaceShareTargetUsers(
+                organizationUuid,
+                space.access.map((access) => access.userUuid),
+            );
         }
 
         let inheritParentPermissions: boolean;
@@ -915,6 +950,11 @@ export class SpaceService
         ) {
             throw new ForbiddenError();
         }
+
+        const space = await this.spaceModel.getSpaceSummary(spaceUuid);
+        await this.validateSpaceShareTargetUsers(space.organizationUuid, [
+            shareWithUserUuid,
+        ]);
 
         await this.spaceModel.addSpaceAccess(
             spaceUuid,

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -112,7 +112,8 @@ export class SpaceService
         this.projectModel = args.projectModel;
         this.spaceModel = args.spaceModel;
         this.organizationModel = args.organizationModel;
-        this.organizationMemberProfileModel = args.organizationMemberProfileModel;
+        this.organizationMemberProfileModel =
+            args.organizationMemberProfileModel;
         this.pinnedListModel = args.pinnedListModel;
         this.spacePermissionService = args.spacePermissionService;
         this.savedChartService = args.savedChartService;


### PR DESCRIPTION
### Description:

Adds validation to prevent sharing spaces with users who are not members of the space's organization. This prevents dangling access entries that would never grant actual access due to CASL authorization rules.

**Changes:**

1. **OrganizationMemberProfileModel**: Added `findOrganizationMemberUuids()` method to query which of a given set of user UUIDs are members of a specific organization.

2. **SpaceService**: 
   - Added `organizationMemberProfileModel` dependency
   - Introduced `validateSpaceShareTargetUsers()` private method that checks all target users are organization members, throwing `NotFoundError` if any are not
   - Applied validation in `createSpace()` when initial access entries are provided
   - Applied validation in `addSpaceUserAccess()` before granting access to a user

3. **ServiceRepository**: Wired `organizationMemberProfileModel` into `SpaceService` constructor

4. **Tests**: Added comprehensive test suite covering:
   - Successful access grant when user is an organization member
   - Rejection when attempting to share with non-member users
   - Rejection of space creation with mixed member/non-member access entries (without creating the space)

The validation occurs at the service boundary, preventing invalid state from being persisted while providing clear error messaging to callers.

https://claude.ai/code/session_01JHFpavLsAK4MPRE7XoE4mc