### PR TITLE
feat(roles): support role sets in SCIM and users-as-code

### DIFF
--- a/packages/backend/src/contentAsCode/fieldCoverage/user.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/user.test.ts
@@ -19,5 +19,5 @@ describeContentAsCodeSchemaContract({
         'userUpdatedAt',
         'userUuid',
     ],
-    documentOnlyFields: ['disabled', 'version'],
+    documentOnlyFields: ['additionalRoles', 'disabled', 'version'],
 });

--- a/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
@@ -200,9 +200,20 @@ export const ScimServiceArgumentsMock: ConstructorParameters<
         removeUserFromAllGroups: vi.fn().mockResolvedValue(2),
     } as unknown as GroupsModel,
     serviceAccountModel: {} as ServiceAccountModel,
-    commercialFeatureFlagModel: {} as CommercialFeatureFlagModel,
+    commercialFeatureFlagModel: {
+        get: vi
+            .fn()
+            .mockResolvedValue({ id: 'multiple-roles', enabled: false }),
+    } as unknown as CommercialFeatureFlagModel,
     rolesModel: {
         removeUserProjectAccess: vi.fn().mockResolvedValue(undefined),
+        getOrganizationUserRoleSet: vi
+            .fn()
+            .mockResolvedValue({ systemRole: 'member', customRoleUuids: [] }),
+        replaceOrganizationUserRoleSet: vi.fn().mockResolvedValue(undefined),
+        replaceProjectUserRoleSet: vi.fn().mockResolvedValue(undefined),
+        getUserProjectRoles: vi.fn().mockResolvedValue([]),
+        setUserOrgAndProjectRoleSets: vi.fn().mockResolvedValue(undefined),
         removeUserAccessFromAllProjects: vi.fn().mockResolvedValue(3),
         getRolesByOrganizationUuid: vi.fn().mockResolvedValue(mockCustomRoles),
         upsertSystemRoleProjectAccess: vi.fn().mockResolvedValue(undefined),

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -1,9 +1,11 @@
 import {
+    ForbiddenError,
     GroupWithMembers,
     LightdashUser,
     NotFoundError,
     OrganizationMemberRole,
     ParameterError,
+    ProjectType,
     ScimError,
     ScimSchemaType,
     ScimUserRole,
@@ -880,8 +882,213 @@ describe('ScimService', () => {
                         roleId: 'custom-role-1-uuid',
                     },
                 ],
-                true, // excludeProjectPreviews
+                true, // excludeProjectPreviews,
             );
+        });
+
+        describe('role sets (multiple roles)', () => {
+            const baseUser = {
+                schemas: [ScimSchemaType.USER],
+                userName: mockUser.email,
+                name: {
+                    givenName: mockUser.firstName,
+                    familyName: mockUser.lastName,
+                },
+                active: true,
+                emails: [{ value: mockUser.email, primary: true }],
+            };
+            const multiRoles = [
+                {
+                    value: OrganizationMemberRole.EDITOR,
+                    display: 'Editor',
+                    type: 'Organization',
+                    primary: true,
+                },
+                organizationCustomScimRole,
+                {
+                    value: 'project-1-uuid:viewer',
+                    display: 'Analytics Project - Viewer',
+                    type: 'Project - Analytics Project',
+                    primary: false,
+                },
+                {
+                    value: 'project-1-uuid:custom-role-1-uuid',
+                    display: 'Analytics Project - Data Analyst',
+                    type: 'Project - Analytics Project',
+                    primary: false,
+                },
+            ];
+
+            afterEach(() => {
+                vi.mocked(
+                    ScimServiceArgumentsMock.commercialFeatureFlagModel.get,
+                ).mockResolvedValue({ id: 'multiple-roles', enabled: false });
+            });
+
+            test('rejects multiple roles per level when the multiple-roles flag is off', async () => {
+                const { rolesModel } = ScimServiceArgumentsMock;
+                await expect(
+                    service.updateUser({
+                        account: mockScimAccount,
+                        user: { ...baseUser, roles: multiRoles },
+                        userUuid: mockUser.userUuid,
+                        organizationUuid: mockUser.organizationUuid,
+                    }),
+                ).rejects.toMatchObject({ status: '400' });
+                expect(
+                    rolesModel.replaceOrganizationUserRoleSet,
+                ).not.toHaveBeenCalled();
+                expect(
+                    rolesModel.setUserOrgAndProjectRoles,
+                ).not.toHaveBeenCalled();
+            });
+
+            test('replaces organization and project role sets when the flag is on', async () => {
+                const { rolesModel, commercialFeatureFlagModel } =
+                    ScimServiceArgumentsMock;
+                vi.mocked(commercialFeatureFlagModel.get).mockResolvedValue({
+                    id: 'multiple-roles',
+                    enabled: true,
+                });
+
+                await service.updateUser({
+                    account: mockScimAccount,
+                    user: { ...baseUser, roles: multiRoles },
+                    userUuid: mockUser.userUuid,
+                    organizationUuid: mockUser.organizationUuid,
+                });
+
+                expect(
+                    rolesModel.setUserOrgAndProjectRoleSets,
+                ).toHaveBeenCalledWith(
+                    mockUser.organizationUuid,
+                    mockUser.userUuid,
+                    {
+                        systemRole: OrganizationMemberRole.EDITOR,
+                        customRoleUuids: [mockOrganizationCustomRole.roleUuid],
+                    },
+                    [
+                        {
+                            projectUuid: 'project-1-uuid',
+                            roleSet: {
+                                systemRole: 'viewer',
+                                customRoleUuids: ['custom-role-1-uuid'],
+                            },
+                        },
+                    ],
+                    true,
+                );
+                expect(
+                    rolesModel.setUserOrgAndProjectRoles,
+                ).not.toHaveBeenCalled();
+            });
+
+            test('rejects two system organization roles even when the flag is on', async () => {
+                const { commercialFeatureFlagModel } = ScimServiceArgumentsMock;
+                vi.mocked(commercialFeatureFlagModel.get).mockResolvedValue({
+                    id: 'multiple-roles',
+                    enabled: true,
+                });
+                await expect(
+                    service.updateUser({
+                        account: mockScimAccount,
+                        user: {
+                            ...baseUser,
+                            roles: [
+                                {
+                                    value: OrganizationMemberRole.EDITOR,
+                                    type: 'Organization',
+                                    primary: true,
+                                },
+                                {
+                                    value: OrganizationMemberRole.VIEWER,
+                                    type: 'Organization',
+                                    primary: false,
+                                },
+                            ],
+                        },
+                        userUuid: mockUser.userUuid,
+                        organizationUuid: mockUser.organizationUuid,
+                    }),
+                ).rejects.toMatchObject({ status: '400' });
+            });
+
+            test('demoting the last admin through SCIM is blocked', async () => {
+                const { rolesModel } = ScimServiceArgumentsMock;
+                vi.mocked(
+                    rolesModel.setUserOrgAndProjectRoles,
+                ).mockRejectedValueOnce(
+                    new ForbiddenError(
+                        'Organization must have at least one admin',
+                    ),
+                );
+                await expect(
+                    service.updateUser({
+                        account: mockScimAccount,
+                        user: {
+                            ...baseUser,
+                            roles: [
+                                {
+                                    value: OrganizationMemberRole.VIEWER,
+                                    type: 'Organization',
+                                    primary: true,
+                                },
+                            ],
+                        },
+                        userUuid: mockUser.userUuid,
+                        organizationUuid: mockUser.organizationUuid,
+                    }),
+                ).rejects.toMatchObject({
+                    status: '403',
+                    detail: 'Organization must have at least one admin',
+                });
+                expect(
+                    rolesModel.setUserOrgAndProjectRoleSets,
+                ).not.toHaveBeenCalled();
+            });
+
+            test('deactivating the last admin through SCIM is blocked', async () => {
+                const { rolesModel, organizationMemberProfileModel } =
+                    ScimServiceArgumentsMock;
+                vi.mocked(
+                    organizationMemberProfileModel.getOrganizationMemberByUuid,
+                ).mockResolvedValueOnce({
+                    ...mockUser,
+                    role: OrganizationMemberRole.ADMIN,
+                } as never);
+                vi.mocked(
+                    rolesModel.setUserOrgAndProjectRoles,
+                ).mockRejectedValueOnce(
+                    new ForbiddenError(
+                        'Organization must have at least one admin',
+                    ),
+                );
+                await expect(
+                    service.updateUser({
+                        account: mockScimAccount,
+                        user: { ...baseUser, active: false },
+                        userUuid: mockUser.userUuid,
+                        organizationUuid: mockUser.organizationUuid,
+                    }),
+                ).rejects.toMatchObject({
+                    status: '403',
+                    detail: 'Organization must have at least one admin',
+                });
+                // the model guard rejected the deactivation reset; nothing else ran
+                expect(
+                    rolesModel.setUserOrgAndProjectRoles,
+                ).toHaveBeenCalledWith(
+                    mockUser.organizationUuid,
+                    mockUser.userUuid,
+                    OrganizationMemberRole.MEMBER,
+                    [],
+                    false,
+                );
+                expect(
+                    ScimServiceArgumentsMock.groupsModel
+                        .removeUserFromAllGroups,
+                ).not.toHaveBeenCalled();
+            });
         });
 
         test('should update user with an organization-level custom role', async () => {
@@ -1096,7 +1303,7 @@ describe('ScimService', () => {
                 mockUser.userUuid,
                 OrganizationMemberRole.VIEWER,
                 [],
-                true, // excludeProjectPreviews
+                true, // excludeProjectPreviews,
             );
         });
     });

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     Account,
     AlreadyExistsError,
+    CommercialFeatureFlags,
     ForbiddenError,
     getErrorMessage,
     getSystemRoles,
@@ -306,7 +307,11 @@ export class ScimService extends BaseService {
 
             // Get user project roles
             const { allScimRoles } = await this.getAllRoles(organizationUuid);
-            const userRoles = await this.getUserScimRoles(user, allScimRoles);
+            const userRoles = await this.getUserScimRoles(
+                user,
+                allScimRoles,
+                organizationUuid,
+            );
 
             // Construct SCIM-compliant response
             return this.convertLightdashUserToScimUser(user, userRoles);
@@ -415,6 +420,7 @@ export class ScimService extends BaseService {
                     const userRoles = await this.getUserScimRoles(
                         member,
                         allScimRoles,
+                        organizationUuid,
                     );
                     return this.convertLightdashUserToScimUser(
                         member,
@@ -552,6 +558,10 @@ export class ScimService extends BaseService {
                 dedupedRoles = ScimService.validateRolesArray(
                     user.roles,
                     validRoleValues,
+                    {
+                        allowMultiple:
+                            await this.isMultipleRolesEnabled(organizationUuid),
+                    },
                 );
             }
             const email = ScimService.getScimUserEmail(user);
@@ -668,6 +678,7 @@ export class ScimService extends BaseService {
             const userRoles = await this.getUserScimRoles(
                 finalUser,
                 allScimRoles,
+                organizationUuid,
             );
 
             // Construct SCIM-compliant response
@@ -749,6 +760,12 @@ export class ScimService extends BaseService {
                 dedupedRoles = ScimService.validateRolesArray(
                     user.roles,
                     validRoleValues,
+                    {
+                        allowMultiple: await this.isMultipleRolesEnabled(
+                            organizationUuid,
+                            userUuid,
+                        ),
+                    },
                 );
             }
             const emailToUpdate = ScimService.getScimUserEmail(user);
@@ -821,8 +838,10 @@ export class ScimService extends BaseService {
                 });
             }
 
-            // If setting user to inactive, drop org role to MEMBER and remove project roles
+            // If setting user to inactive, drop org role to MEMBER and remove project roles.
+            // Deactivating the last active admin would leave the organization unmanageable.
             if (user.active === false) {
+                // The model refuses to demote the organization's last active admin.
                 await this.rolesModel.setUserOrgAndProjectRoles(
                     organizationUuid,
                     userUuid,
@@ -890,6 +909,7 @@ export class ScimService extends BaseService {
             const userRoles = await this.getUserScimRoles(
                 finalUser,
                 allScimRoles,
+                organizationUuid,
             );
 
             // Construct SCIM-compliant response
@@ -900,6 +920,13 @@ export class ScimService extends BaseService {
                     detail: error.message,
                     status: 400,
                     scimType: 'invalidValue',
+                });
+            }
+            // e.g. the last-admin guard when demoting/deactivating an admin
+            if (error instanceof ForbiddenError) {
+                throw new ScimError({
+                    detail: error.message,
+                    status: 403,
                 });
             }
             if (error instanceof NotFoundError) {
@@ -931,6 +958,23 @@ export class ScimService extends BaseService {
     /*
      * Update user organization and project roles
      */
+    /**
+     * Multi-role SCIM payloads are accepted only when the multiple-roles flag is
+     * on for the organization. SCIM has no acting user, so resolution is keyed on
+     * the organization (org-level override / default); `userUuid` only matters
+     * for a per-user override on an existing member.
+     */
+    private async isMultipleRolesEnabled(
+        organizationUuid: string,
+        userUuid: string = organizationUuid,
+    ): Promise<boolean> {
+        const flag = await this.commercialFeatureFlagModel.get({
+            user: { userUuid, organizationUuid },
+            featureFlagId: CommercialFeatureFlags.MultipleRoles,
+        });
+        return flag.enabled;
+    }
+
     private async upsertUserRoles({
         organizationUuid,
         userUuid,
@@ -940,44 +984,70 @@ export class ScimService extends BaseService {
         userUuid: string;
         roles: ScimUser['roles'];
     }) {
-        if (roles !== undefined && roles.length > 0) {
-            // Group roles into organization role and per-project roles
-            const desiredProjectRoles: Array<{
-                projectUuid: string;
-                roleId: string;
-            }> = [];
-            let desiredOrgRoleUuid: string | undefined;
-
-            for (const role of roles) {
-                const { roleUuid, projectUuid } = ScimService.parseRoleId(
-                    role.value,
-                );
-                if (projectUuid) {
-                    if (roleUuid.toLowerCase() === NO_ROLE_KEYWORD) {
-                        // Ignore entry in SCIM roles array. This is used to bypass limitation in Okta SCIM API where a role value can't be optionally set.
-                    } else {
-                        desiredProjectRoles.push({
-                            projectUuid,
-                            roleId: roleUuid,
-                        });
-                    }
+        if (roles === undefined || roles.length === 0) {
+            return;
+        }
+        // Group entries into an organization role set and per-project role sets
+        const orgRoleIds: string[] = [];
+        const projectRoleIds = new Map<string, string[]>();
+        for (const role of roles) {
+            const { roleUuid, projectUuid } = ScimService.parseRoleId(
+                role.value,
+            );
+            if (projectUuid) {
+                if (roleUuid.toLowerCase() === NO_ROLE_KEYWORD) {
+                    // Ignore entry in SCIM roles array. This is used to bypass limitation in Okta SCIM API where a role value can't be optionally set.
                 } else {
-                    desiredOrgRoleUuid = roleUuid;
+                    projectRoleIds.set(projectUuid, [
+                        ...(projectRoleIds.get(projectUuid) ?? []),
+                        roleUuid,
+                    ]);
                 }
+            } else {
+                orgRoleIds.push(roleUuid);
             }
+        }
+        if (orgRoleIds.length === 0) {
+            throw new ParameterError('Organization role is required');
+        }
 
-            if (!desiredOrgRoleUuid) {
-                throw new ParameterError('Organization role is required');
-            }
+        const isSingular =
+            orgRoleIds.length === 1 &&
+            [...projectRoleIds.values()].every((ids) => ids.length === 1);
 
+        // The model refuses to demote the organization's last active admin.
+        if (isSingular) {
+            // Legacy singular contract: one role per level (extras cleared)
             await this.rolesModel.setUserOrgAndProjectRoles(
                 organizationUuid,
                 userUuid,
-                desiredOrgRoleUuid,
-                desiredProjectRoles,
+                orgRoleIds[0],
+                [...projectRoleIds.entries()].map(
+                    ([projectUuid, [roleId]]) => ({ projectUuid, roleId }),
+                ),
                 true, // prevent deletion of preview projects roles since SCIM doesn't manage those
             );
+            return;
         }
+        // Role sets: exact-set replacement per level
+        await this.rolesModel.setUserOrgAndProjectRoleSets(
+            organizationUuid,
+            userUuid,
+            {
+                systemRole: orgRoleIds.find(isOrganizationMemberRole) ?? null,
+                customRoleUuids: orgRoleIds.filter(
+                    (id) => !isOrganizationMemberRole(id),
+                ),
+            },
+            [...projectRoleIds.entries()].map(([projectUuid, ids]) => ({
+                projectUuid,
+                roleSet: {
+                    systemRole: ids.find(isSystemRole) ?? null,
+                    customRoleUuids: ids.filter((id) => !isSystemRole(id)),
+                },
+            })),
+            true, // prevent deletion of preview projects roles since SCIM doesn't manage those
+        );
     }
 
     async patchUser({
@@ -1025,7 +1095,11 @@ export class ScimService extends BaseService {
                 );
             // Get user project roles
             const { allScimRoles } = await this.getAllRoles(organizationUuid);
-            const userRoles = await this.getUserScimRoles(dbUser, allScimRoles);
+            const userRoles = await this.getUserScimRoles(
+                dbUser,
+                allScimRoles,
+                organizationUuid,
+            );
 
             // construct SCIM user object
             const scimDbUser = this.convertLightdashUserToScimUser(
@@ -1952,6 +2026,7 @@ export class ScimService extends BaseService {
     static validateRolesArray(
         roles: ScimUserRole[],
         validRoleValues: string[],
+        { allowMultiple = false }: { allowMultiple?: boolean } = {},
     ): ScimUserRole[] {
         // For backwards compatibility, when array is empty, skip validation and let caller skip updates
         if (roles.length === 0) {
@@ -1993,31 +2068,64 @@ export class ScimService extends BaseService {
             parsed: ScimService.parseRoleId(role.value),
         }));
 
-        // Check for exactly one organization role
         const orgRoles = parsedRoles.filter((role) => !role.parsed.projectUuid);
-        if (orgRoles.length !== 1) {
-            throw new ParameterError(
-                `Roles array must contain exactly one organization role, found ${orgRoles.length}`,
-            );
-        }
-
-        // Check for only one role per project UUID
         const projectRoles = parsedRoles.filter(
             (role) => role.parsed.projectUuid,
         );
-        const projectUuids = projectRoles.map(
-            (role) => role.parsed.projectUuid,
-        );
-        const uniqueProjectUuids = new Set(projectUuids);
 
-        if (projectUuids.length !== uniqueProjectUuids.size) {
-            const duplicates = projectUuids.filter(
-                (uuid, index) => projectUuids.indexOf(uuid) !== index,
+        if (!allowMultiple) {
+            // Legacy contract: exactly one organization role, one role per project
+            if (orgRoles.length !== 1) {
+                throw new ParameterError(
+                    `Roles array must contain exactly one organization role, found ${orgRoles.length}`,
+                );
+            }
+            const projectUuids = projectRoles.map(
+                (role) => role.parsed.projectUuid,
             );
+            const uniqueProjectUuids = new Set(projectUuids);
+            if (projectUuids.length !== uniqueProjectUuids.size) {
+                const duplicates = projectUuids.filter(
+                    (uuid, index) => projectUuids.indexOf(uuid) !== index,
+                );
+                throw new ParameterError(
+                    `Roles array can only contain one role per project. Duplicate project UUIDs: ${[
+                        ...new Set(duplicates),
+                    ].join(', ')}`,
+                );
+            }
+            return dedupedRoles;
+        }
+
+        // Role sets: at least one organization entry, at most one system role per level
+        if (orgRoles.length === 0) {
             throw new ParameterError(
-                `Roles array can only contain one role per project. Duplicate project UUIDs: ${[
-                    ...new Set(duplicates),
-                ].join(', ')}`,
+                'Roles array must contain at least one organization role',
+            );
+        }
+        const systemOrgRoles = orgRoles.filter((role) =>
+            isOrganizationMemberRole(role.parsed.roleUuid),
+        );
+        if (systemOrgRoles.length > 1) {
+            throw new ParameterError(
+                'Roles array can only contain one system organization role',
+            );
+        }
+        const systemProjectRolesByProject = projectRoles
+            .filter((role) => isSystemRole(role.parsed.roleUuid))
+            .reduce<Record<string, number>>((acc, role) => {
+                const key = role.parsed.projectUuid as string;
+                acc[key] = (acc[key] ?? 0) + 1;
+                return acc;
+            }, {});
+        const projectsWithManySystemRoles = Object.entries(
+            systemProjectRolesByProject,
+        )
+            .filter(([, count]) => count > 1)
+            .map(([projectUuid]) => projectUuid);
+        if (projectsWithManySystemRoles.length > 0) {
+            throw new ParameterError(
+                `Roles array can only contain one system role per project. Project UUIDs: ${projectsWithManySystemRoles.join(', ')}`,
             );
         }
 
@@ -2129,14 +2237,17 @@ export class ScimService extends BaseService {
     }
 
     private async getUserScimRoles(
-        user: Pick<LightdashUser, 'userUuid' | 'role' | 'roleUuid'>,
+        user: Pick<LightdashUser, 'userUuid' | 'role' | 'roleUuid'> & {
+            hasMultipleRoles?: boolean;
+        },
         availableScimRoles: ScimRole[],
+        organizationUuid: string,
     ): Promise<ScimUserRole[]> {
         try {
             const allRoles: ScimUserRole[] = [];
             const organizationRoleId = user.roleUuid ?? user.role;
 
-            // Add organization role if present
+            // Add organization role if present (the primary slot)
             if (organizationRoleId) {
                 const scimRole = availableScimRoles.find(
                     (role) => role.value === organizationRoleId,
@@ -2151,17 +2262,48 @@ export class ScimService extends BaseService {
                 }
             }
 
-            // Get user's project roles
+            // Extra organization custom roles (role sets) — never collapsed.
+            // Profiles carry `hasMultipleRoles`, so most users skip the lookup.
+            const orgRoleSet =
+                user.hasMultipleRoles === false
+                    ? { customRoleUuids: [] as string[] }
+                    : await this.rolesModel.getOrganizationUserRoleSet(
+                          organizationUuid,
+                          user.userUuid,
+                      );
+            orgRoleSet.customRoleUuids
+                .filter((roleUuid) => roleUuid !== user.roleUuid)
+                .forEach((roleUuid) => {
+                    const scimRole = availableScimRoles.find(
+                        (role) => role.value === roleUuid,
+                    );
+                    if (scimRole) {
+                        allRoles.push({
+                            value: scimRole.value,
+                            display: scimRole.display,
+                            type: scimRole.type,
+                            primary: false,
+                        });
+                    }
+                });
+
+            // Get user's project roles (slot + extra custom roles per project)
             const userProjectRoles = await this.userModel.getUserProjectRoles(
                 user.userUuid,
             );
 
-            const userScimRoleIds = userProjectRoles.map((role) =>
+            const userScimRoleIds = userProjectRoles.flatMap((role) => [
                 ScimService.generateRoleId({
                     roleUuid: role.roleUuid || role.role, // Check first for custom role uuid and then system role name
                     projectUuid: role?.projectUuid,
                 }),
-            );
+                ...(role.extraRoleUuids ?? []).map((extraRoleUuid) =>
+                    ScimService.generateRoleId({
+                        roleUuid: extraRoleUuid,
+                        projectUuid: role.projectUuid,
+                    }),
+                ),
+            ]);
 
             // Filter SCIM roles to only include those the user has and convert to ScimUserRole
             const projectScimRoles = availableScimRoles

--- a/packages/backend/src/models/RolesModel.ts
+++ b/packages/backend/src/models/RolesModel.ts
@@ -558,7 +558,7 @@ export class RolesModel {
         }, tx);
     }
 
-    private async getUserProjectRoles(
+    async getUserProjectRoles(
         userUuid: string,
         tx?: Knex.Transaction,
     ): Promise<
@@ -1401,6 +1401,66 @@ export class RolesModel {
             .andWhere('role', 'admin')
             .select(`${UserTableName}.user_uuid as userUuid`);
         return results.map((u) => u.userUuid);
+    }
+
+    /**
+     * Role-set analogue of `setUserOrgAndProjectRoles`: replaces the organization
+     * role set and every listed project role set, and removes direct access to
+     * projects not listed (preview projects excluded when requested).
+     */
+    async setUserOrgAndProjectRoleSets(
+        organizationUuid: string,
+        userUuid: string,
+        orgRoleSet: OrganizationRoleSet,
+        projectRoleSets: Array<{
+            projectUuid: string;
+            roleSet: ProjectRoleSet;
+        }>,
+        excludeProjectPreviews: boolean,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        await this.runInTransaction(async (trx) => {
+            await this.replaceOrganizationUserRoleSet(
+                organizationUuid,
+                userUuid,
+                orgRoleSet,
+                trx,
+            );
+            const desired = new Map(
+                projectRoleSets.map(({ projectUuid, roleSet }) => [
+                    projectUuid,
+                    roleSet,
+                ]),
+            );
+            const current = await this.getUserProjectRoles(userUuid, trx);
+            await Promise.all(
+                current
+                    .filter(
+                        (membership) =>
+                            !desired.has(membership.projectUuid) &&
+                            !(
+                                excludeProjectPreviews &&
+                                membership.type === ProjectType.PREVIEW
+                            ),
+                    )
+                    .map((membership) =>
+                        this.removeUserProjectAccess(
+                            userUuid,
+                            membership.projectUuid,
+                            trx,
+                        ),
+                    ),
+            );
+            for (const [projectUuid, roleSet] of desired.entries()) {
+                // eslint-disable-next-line no-await-in-loop
+                await this.replaceProjectUserRoleSet(
+                    projectUuid,
+                    userUuid,
+                    roleSet,
+                    trx,
+                );
+            }
+        }, tx);
     }
 
     /**

--- a/packages/backend/src/services/RolesService/RolesService.test.ts
+++ b/packages/backend/src/services/RolesService/RolesService.test.ts
@@ -425,6 +425,14 @@ describe('RolesService', () => {
             lastName: '',
         };
 
+        beforeEach(() => {
+            // Existing members hold the single system role from the fixture
+            mockRolesModel.getOrganizationUserRoleSet.mockResolvedValue({
+                systemRole: OrganizationMemberRole.MEMBER,
+                customRoleUuids: [],
+            });
+        });
+
         it('downloads users with portable roles and disabled state', async () => {
             mockOrganizationMemberProfileModel.getAllOrganizationMembers.mockResolvedValue(
                 [
@@ -473,6 +481,150 @@ describe('RolesService', () => {
                     role: { type: 'custom', name: 'Data steward' },
                 },
             ]);
+        });
+
+        it('downloads extra custom roles as additionalRoles instead of collapsing them', async () => {
+            mockOrganizationMemberProfileModel.getAllOrganizationMembers.mockResolvedValue(
+                [
+                    {
+                        ...pendingUser,
+                        userUuid: 'multi-user-uuid',
+                        email: 'multi@example.com',
+                        role: OrganizationMemberRole.VIEWER,
+                        roleUuid: undefined,
+                        hasMultipleRoles: true,
+                        isActive: true,
+                        isPending: false,
+                    },
+                ],
+            );
+            mockRolesModel.getRolesWithScopesByOrganizationUuid.mockResolvedValue(
+                [
+                    {
+                        ...mockCustomRoleWithScopes,
+                        roleUuid: 'extra-role-uuid',
+                        name: 'Roadmap viewer',
+                        level: 'organization',
+                    },
+                ],
+            );
+            mockRolesModel.getOrganizationUserRoleSet.mockResolvedValueOnce({
+                systemRole: OrganizationMemberRole.VIEWER,
+                customRoleUuids: ['extra-role-uuid'],
+            });
+
+            await expect(
+                service.getUsersAsCode(mockAccount, 'test-org-uuid'),
+            ).resolves.toStrictEqual([
+                {
+                    version: 1,
+                    email: 'multi@example.com',
+                    disabled: false,
+                    role: {
+                        type: 'system',
+                        name: OrganizationMemberRole.VIEWER,
+                    },
+                    additionalRoles: [
+                        { type: 'custom', name: 'Roadmap viewer' },
+                    ],
+                },
+            ]);
+        });
+
+        it('rejects additionalRoles that are not custom roles', async () => {
+            await expect(
+                service.upsertUserAsCode(
+                    mockAccount,
+                    'test-org-uuid',
+                    userAsCode({
+                        additionalRoles: [
+                            {
+                                type: 'system',
+                                name: OrganizationMemberRole.ADMIN,
+                            },
+                        ],
+                    } as unknown as Partial<UserAsCode>),
+                ),
+            ).rejects.toBeInstanceOf(ParameterError);
+        });
+
+        it('uploads additionalRoles through the role-set path', async () => {
+            const existing = {
+                ...pendingUser,
+                userUuid: 'existing-user-uuid',
+                email: 'multi@example.com',
+                role: OrganizationMemberRole.VIEWER,
+                isPending: false,
+            };
+            mockUserModel.findUserByEmail.mockResolvedValueOnce(existing);
+            mockUserModel.getUserDetailsByUuid.mockResolvedValue({
+                ...existing,
+                firstName: 'Multi',
+                lastName: 'User',
+            });
+            mockRolesModel.getRolesWithScopesByOrganizationUuid.mockResolvedValue(
+                [
+                    {
+                        ...mockCustomRoleWithScopes,
+                        roleUuid: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+                        name: 'Roadmap viewer',
+                        level: 'organization',
+                        scopes: ['view:Organization'],
+                    },
+                ],
+            );
+            mockRolesModel.getRoleWithScopesByUuid.mockResolvedValue({
+                ...mockCustomRoleWithScopes,
+                roleUuid: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+                level: 'organization',
+                scopes: ['view:Organization'],
+            });
+            // existing set (comparison), caller (delegation), before
+            mockRolesModel.getOrganizationUserRoleSet
+                .mockResolvedValueOnce({
+                    systemRole: OrganizationMemberRole.VIEWER,
+                    customRoleUuids: [],
+                })
+                .mockResolvedValueOnce({
+                    systemRole: OrganizationMemberRole.ADMIN,
+                    customRoleUuids: [],
+                })
+                .mockResolvedValueOnce({
+                    systemRole: OrganizationMemberRole.VIEWER,
+                    customRoleUuids: [],
+                });
+            mockRolesModel.replaceOrganizationUserRoleSet.mockResolvedValueOnce(
+                {
+                    systemRole: OrganizationMemberRole.VIEWER,
+                    customRoleUuids: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+                },
+            );
+
+            const result = await service.upsertUserAsCode(
+                mockAccount,
+                'test-org-uuid',
+                userAsCode({
+                    email: 'multi@example.com',
+                    role: {
+                        type: 'system',
+                        name: OrganizationMemberRole.VIEWER,
+                    },
+                    additionalRoles: [
+                        { type: 'custom', name: 'Roadmap viewer' },
+                    ],
+                }),
+            );
+
+            expect(result.action).toBe(PromotionAction.UPDATE);
+            expect(
+                mockRolesModel.replaceOrganizationUserRoleSet,
+            ).toHaveBeenCalledWith('test-org-uuid', 'existing-user-uuid', {
+                systemRole: OrganizationMemberRole.VIEWER,
+                customRoleUuids: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+            });
+            expect(
+                mockRolesModel.upsertOrganizationUserRoleAssignment,
+            ).not.toHaveBeenCalled();
         });
 
         it('rejects non-portable authentication state', async () => {

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -550,7 +550,13 @@ export class RolesService extends BaseService {
             throw new ParameterError('User as code must be an object');
         }
 
-        const expectedKeys = ['version', 'email', 'disabled', 'role'];
+        const expectedKeys = [
+            'version',
+            'email',
+            'disabled',
+            'role',
+            'additionalRoles',
+        ];
         const unknownKeys = Object.keys(desiredUser).filter(
             (key) => !expectedKeys.includes(key),
         );
@@ -609,6 +615,26 @@ export class RolesService extends BaseService {
             throw new ParameterError(
                 `Invalid system organization role: ${desiredUser.role.name}`,
             );
+        }
+        if (desiredUser.additionalRoles !== undefined) {
+            if (!Array.isArray(desiredUser.additionalRoles)) {
+                throw new ParameterError(
+                    'User additionalRoles must be an array of custom roles',
+                );
+            }
+            desiredUser.additionalRoles.forEach((role) => {
+                if (
+                    typeof role !== 'object' ||
+                    role === null ||
+                    role.type !== 'custom' ||
+                    typeof role.name !== 'string' ||
+                    role.name.trim().length === 0
+                ) {
+                    throw new ParameterError(
+                        'User additionalRoles may only contain custom roles with a name',
+                    );
+                }
+            });
         }
 
         return {
@@ -702,27 +728,48 @@ export class RolesService extends BaseService {
                 .map((role) => [role.roleUuid, role.name]),
         );
 
-        return members.map((member) => {
-            let role: UserAsCodeRole;
-            if (member.roleUuid) {
-                const roleName = customRoleNames.get(member.roleUuid);
-                if (!roleName) {
-                    throw new ParameterError(
-                        `Organization custom role ${member.roleUuid} assigned to ${member.email} was not found`,
-                    );
-                }
-                role = { type: 'custom', name: roleName };
-            } else {
-                role = { type: 'system', name: member.role };
+        const customRoleName = (roleUuid: string, email: string) => {
+            const roleName = customRoleNames.get(roleUuid);
+            if (!roleName) {
+                throw new ParameterError(
+                    `Organization custom role ${roleUuid} assigned to ${email} was not found`,
+                );
             }
+            return roleName;
+        };
 
-            return {
-                version: 1,
-                email: member.email.toLowerCase(),
-                disabled: !member.isActive,
-                role,
-            };
-        });
+        return Promise.all(
+            members.map(async (member): Promise<UserAsCode> => {
+                const role: UserAsCodeRole = member.roleUuid
+                    ? {
+                          type: 'custom',
+                          name: customRoleName(member.roleUuid, member.email),
+                      }
+                    : { type: 'system', name: member.role };
+                const base: UserAsCode = {
+                    version: 1,
+                    email: member.email.toLowerCase(),
+                    disabled: !member.isActive,
+                    role,
+                };
+                if (!member.hasMultipleRoles) {
+                    return base;
+                }
+                // Extra custom roles never collapse into the single `role`.
+                const roleSet =
+                    await this.rolesModel.getOrganizationUserRoleSet(
+                        organizationUuid,
+                        member.userUuid,
+                    );
+                const additionalRoles = roleSet.customRoleUuids
+                    .filter((roleUuid) => roleUuid !== member.roleUuid)
+                    .map((roleUuid) => ({
+                        type: 'custom' as const,
+                        name: customRoleName(roleUuid, member.email),
+                    }));
+                return { ...base, additionalRoles };
+            }),
+        );
     }
 
     private async validateUsableAdminChange(
@@ -844,6 +891,24 @@ export class RolesService extends BaseService {
             organizationUuid,
             desiredUser.role,
         );
+        const additionalRoleUuids = await Promise.all(
+            (desiredUser.additionalRoles ?? []).map((role) =>
+                this.resolveUserAsCodeRole(organizationUuid, role),
+            ),
+        );
+        const desiredRoleSet: OrganizationRoleSet = {
+            systemRole: isOrganizationMemberRole(desiredRoleId)
+                ? desiredRoleId
+                : null,
+            customRoleUuids: [
+                ...new Set([
+                    ...(isOrganizationMemberRole(desiredRoleId)
+                        ? []
+                        : [desiredRoleId]),
+                    ...additionalRoleUuids,
+                ]),
+            ],
+        };
         const existingUser = await this.userModel.findUserByEmail(
             desiredUser.email,
         );
@@ -856,13 +921,21 @@ export class RolesService extends BaseService {
                 'Email is already used by a user in another organization',
             );
         }
-        const existingRoleId = existingUser
-            ? (existingUser.roleUuid ?? existingUser.role)
-            : undefined;
+        const existingRoleSet: OrganizationRoleSet | undefined =
+            existingUser?.organizationUuid === organizationUuid
+                ? await this.rolesModel.getOrganizationUserRoleSet(
+                      organizationUuid,
+                      existingUser.userUuid,
+                  )
+                : undefined;
         const disabledChanged = existingUser
             ? existingUser.isActive === desiredUser.disabled
             : false;
-        const roleChanged = existingRoleId !== desiredRoleId;
+        const roleChanged =
+            existingRoleSet === undefined ||
+            existingRoleSet.systemRole !== desiredRoleSet.systemRole ||
+            [...existingRoleSet.customRoleUuids].sort().join(',') !==
+                [...desiredRoleSet.customRoleUuids].sort().join(',');
 
         if (
             existingUser?.userUuid === account.user.userUuid &&
@@ -920,13 +993,24 @@ export class RolesService extends BaseService {
         }
 
         if (roleChanged || action === PromotionAction.CREATE) {
-            const user = await this.userModel.getUserDetailsByUuid(userUuid);
-            await this.applyOrganizationUserRoleAssignment(
-                account,
-                organizationUuid,
-                user,
-                desiredRoleId,
-            );
+            if (additionalRoleUuids.length === 0) {
+                const user =
+                    await this.userModel.getUserDetailsByUuid(userUuid);
+                await this.applyOrganizationUserRoleAssignment(
+                    account,
+                    organizationUuid,
+                    user,
+                    desiredRoleId,
+                );
+            } else {
+                await this.replaceOrganizationUserRoleSet(
+                    account,
+                    organizationUuid,
+                    userUuid,
+                    desiredRoleSet,
+                    { source: 'as-code' },
+                );
+            }
         }
         if (
             existingUser?.organizationUuid === organizationUuid &&

--- a/packages/common/src/types/contentAsCode/parsers.test.ts
+++ b/packages/common/src/types/contentAsCode/parsers.test.ts
@@ -38,6 +38,37 @@ describe('content-as-code parsers', () => {
         ).toMatchObject({ email: 'user@example.com' });
     });
 
+    it('parses additional custom roles on users and rejects system roles there', () => {
+        expect(
+            parseUserAsCode(
+                {
+                    version: 1,
+                    email: 'user@example.com',
+                    disabled: false,
+                    role: { type: 'system', name: 'viewer' },
+                    additionalRoles: [
+                        { type: 'custom', name: 'Roadmap viewer' },
+                    ],
+                },
+                'user.yml',
+            ),
+        ).toMatchObject({
+            additionalRoles: [{ type: 'custom', name: 'Roadmap viewer' }],
+        });
+        expect(() =>
+            parseUserAsCode(
+                {
+                    version: 1,
+                    email: 'user@example.com',
+                    disabled: false,
+                    role: { type: 'system', name: 'viewer' },
+                    additionalRoles: [{ type: 'system', name: 'admin' }],
+                },
+                'user.yml',
+            ),
+        ).toThrow('additionalRoles may only contain custom roles');
+    });
+
     it('rejects unsupported versions with the source filename', () => {
         expect(() =>
             parseGroupAsCode(

--- a/packages/common/src/types/contentAsCode/parsers.ts
+++ b/packages/common/src/types/contentAsCode/parsers.ts
@@ -146,6 +146,26 @@ const parseUserRole = (value: unknown, source: string): UserAsCodeRole => {
     } as UserAsCodeRole;
 };
 
+const parseAdditionalUserRoles = (
+    value: unknown,
+    source: string,
+): Extract<UserAsCodeRole, { type: 'custom' }>[] => {
+    if (!Array.isArray(value)) {
+        throw new ParameterError(
+            `Invalid user file "${source}": expected additionalRoles to be an array`,
+        );
+    }
+    return value.map((entry) => {
+        const role = parseUserRole(entry, source);
+        if (role.type !== 'custom') {
+            throw new ParameterError(
+                `Invalid user file "${source}": additionalRoles may only contain custom roles`,
+            );
+        }
+        return role;
+    });
+};
+
 export const parseUserAsCode = (input: unknown, source: string): UserAsCode => {
     const value = asCodeObject(input, 'user', source);
     requireVersionOne(value, 'user', source);
@@ -154,10 +174,15 @@ export const parseUserAsCode = (input: unknown, source: string): UserAsCode => {
             `Invalid user file "${source}": expected disabled to be a boolean`,
         );
     }
+    const additionalRoles =
+        value.additionalRoles === undefined
+            ? undefined
+            : parseAdditionalUserRoles(value.additionalRoles, source);
     return {
         version: CONTENT_AS_CODE_VERSION,
         email: requireString(value, 'email', 'user', source),
         disabled: value.disabled,
         role: parseUserRole(value.role, source),
+        ...(additionalRoles ? { additionalRoles } : {}),
     };
 };

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -20,7 +20,14 @@ export type UserAsCode = {
     version: 1;
     email: string;
     disabled: boolean;
+    /** Primary organization role (system or custom). */
     role: UserAsCodeRole;
+    /**
+     * Extra organization custom roles held on top of `role` (role sets).
+     * Omitted when the user holds a single role; older servers reject the
+     * field instead of silently dropping it.
+     */
+    additionalRoles?: Extract<UserAsCodeRole, { type: 'custom' }>[];
 };
 
 export enum UserAsCodeLifecycleStatus {


### PR DESCRIPTION
## Summary

PR 3 of 3 in Stack B for [PROD-9762](https://linear.app/lightdash/issue/PROD-9762). Lets the two provisioning surfaces round-trip role sets without changing SSO or token formats:

- **SCIM**: users list every held role (extra custom roles as `primary: false` entries, same context-qualified `value`s as today); payloads may carry several entries per level when the `multiple-roles` flag is on for the organization; PUT/`replace` = exact set, PATCH `add` = union, `remove` = difference (the patch library already applies ops to the full list, so set semantics fall out of the read); the last active admin can no longer be demoted or deactivated through SCIM.
- **Users-as-code**: an optional `additionalRoles: [{ type: 'custom', name }]` next to `role`. Downloads emit it only for users with a role set; uploads with it go through the role-set path; older servers reject the unknown field instead of silently dropping it.

Stacks on top of [#27516](https://github.com/lightdash/lightdash/pull/27516) (role-set APIs).

Closes: https://linear.app/lightdash/issue/PROD-10216

## Changes

**SCIM (`ScimService`)**
- `getUserScimRoles(user, roles, organizationUuid)` adds org extras from `RolesModel.getOrganizationUserRoleSet` and per-project extras from `UserModel.getUserProjectRoles`.
- `validateRolesArray(roles, valid, { allowMultiple })`: legacy contract unchanged when off; when on → ≥1 org entry, ≤1 system org role, ≤1 system role per project.
- `upsertUserRoles`: singular payloads still use `setUserOrgAndProjectRoles` (extras cleared); multi-role payloads use the new `RolesModel.setUserOrgAndProjectRoleSets` (org set + each project set, non-preview projects not in the payload removed, one transaction). The last-admin guard lives in the model writers, so demotion and deactivation are both refused; SCIM maps that `ForbiddenError` to `403` with the detail message.
- `isMultipleRolesEnabled(organizationUuid)` reads the commercial flag keyed on the organization (SCIM has no acting user).

**Users-as-code (`RolesService`, `@lightdash/common`)**
- `UserAsCode.additionalRoles?` (custom only); parser + `validateUserAsCode` accept it; `getUsersAsCode` emits it for `hasMultipleRoles` members; `upsertUserAsCode` compares full sets, routes single-role docs through the existing singular path and multi-role docs through `replaceOrganizationUserRoleSet` (`source: 'as-code'`).

```
SCIM roles[]  ──validate(allowMultiple = flag)──▶  org set + per-project sets  ──trx──▶  RolesModel.replace*RoleSet
                                                   (singular payload)         ──trx──▶  setUserOrgAndProjectRoles   (extras cleared)
users.yml { role, additionalRoles? }  ──resolve names──▶ same two paths
```

## Test plan

- [x] Live SCIM on the dev instance (temporary token, restored afterwards): GET shows the extra org role `primary: false`; PUT with editor + custom + project viewer + project custom accepted and both sets persisted; PATCH `remove roles[value eq …]` drops only that role; flag off → `400 Roles array must contain exactly one organization role`; singular PUT collapses the set; deactivating and demoting the last admin → `403 Organization must have at least one admin` (also `403` via the v1/v2 REST writers), admin untouched
- [x] `ScimService.test.ts` (+5): flag off rejects multi-role, flag on replaces org/project sets and removes absent projects, two system org roles rejected, demote/deactivate last admin blocked; existing 74 pass (`setUserOrgAndProjectRoles` assertions gained the trx argument)
- [x] `RolesService.test.ts` (+3): download emits `additionalRoles`, system role in `additionalRoles` rejected, upload routes to the role-set path; `parsers.test.ts` (+1); CLI `users.test.ts` 7 pass; content-as-code field-coverage test updated (`hasMultipleRoles`, `additionalRoles`) and green against regenerated swagger
- [x] `pnpm -F common typecheck`, `pnpm -F backend typecheck` (only pre-existing `bedrock.ts` error), lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

