### PR TITLE
fix(merge-query): reserve the merge pseudo-table name as a source id

### DIFF
--- a/packages/common/src/types/mergeQuery.test.ts
+++ b/packages/common/src/types/mergeQuery.test.ts
@@ -178,6 +178,29 @@ describe('validateMergeQuery', () => {
             );
         });
 
+        it('rejects "merge" as a source id', () => {
+            const errors = validateMergeQuery(
+                mergeQuery({
+                    sources: [{ ...queryA(), id: 'merge' }, queryB()],
+                    joinKey: [
+                        {
+                            name: 'date_day',
+                            fieldIdBySourceId: {
+                                merge: 'followers_created_date',
+                                b: 'follower_snapshots_date',
+                            },
+                        },
+                    ],
+                }),
+            );
+
+            expect(errors.map((error) => error.kind)).toEqual(
+                expect.arrayContaining([
+                    MergeQueryErrorKind.RESERVED_SOURCE_ID,
+                ]),
+            );
+        });
+
         it('rejects an empty join key', () => {
             const errors = validateMergeQuery(mergeQuery({ joinKey: [] }));
 

--- a/packages/common/src/types/mergeQuery.ts
+++ b/packages/common/src/types/mergeQuery.ts
@@ -147,6 +147,12 @@ export enum MergeQueryErrorKind {
      */
     TOO_MANY_SOURCES = 'too_many_sources',
     DUPLICATE_SOURCE_ID = 'duplicate_source_id',
+    /**
+     * A source named after the merged result's own pseudo-table. Value
+     * columns are `<sourceId>_<fieldId>` and join keys `merge_<keyName>`,
+     * so a source id of "merge" makes the two namespaces collide silently.
+     */
+    RESERVED_SOURCE_ID = 'reserved_source_id',
     EMPTY_JOIN_KEY = 'empty_join_key',
     JOIN_KEY_COVERAGE = 'join_key_coverage',
     UNKNOWN_SOURCE_IN_JOIN_KEY = 'unknown_source_in_join_key',
@@ -236,6 +242,13 @@ export const getUnaccountedDimensions = (
  * Every reason this merge would produce a wrong or unbuildable result. Empty
  * means the merge is safe to compile.
  */
+/**
+ * Table merged columns that belong to no single source are attributed to:
+ * join keys, which are shared by every source, and calculations over the
+ * merged result.
+ */
+export const MERGE_TABLE_NAME = 'merge';
+
 export const validateMergeQuery = (
     mergeQuery: MergeQuery,
     /**
@@ -278,6 +291,17 @@ export const validateMergeQuery = (
             fieldIds: [],
             message: `More than one query uses the id "${id}".`,
         });
+    });
+
+    sources.forEach((source) => {
+        if (source.id === MERGE_TABLE_NAME) {
+            errors.push({
+                kind: MergeQueryErrorKind.RESERVED_SOURCE_ID,
+                sourceId: source.id,
+                fieldIds: [],
+                message: `"${MERGE_TABLE_NAME}" is reserved for the merged result's own columns. Use a different query id.`,
+            });
+        }
     });
 
     if (joinKey.length === 0) {
@@ -508,13 +532,6 @@ export const MERGE_TRUNCATED_COLUMN = '__merge_truncated';
 
 /** Internal marker that distinguishes the empty-result guard row from data. */
 export const MERGE_ROW_PRESENT_COLUMN = '__merge_row_present';
-
-/**
- * Table merged columns that belong to no single source are attributed to:
- * join keys, which are shared by every source, and calculations over the
- * merged result.
- */
-export const MERGE_TABLE_NAME = 'merge';
 
 /** Label for the pseudo-table a source's merged fields belong to. */
 export const getMergeSourceTableLabel = (sourceIndex: number): string =>


### PR DESCRIPTION
## Problem

The merge engine attributes join-key columns to a synthetic pseudo-table named `merge`, so key field ids are `merge_<keyName>`. Value columns are namespaced as `<sourceId>_<fieldId>`. Source ids are caller-chosen (API consumers, and the AI agent picks them freely), and nothing reserved the name `merge` — a source id of `merge` puts its value columns (`merge_<fieldId>`) into the same namespace as the join-key columns. A collision there is silent field-id ambiguity in the merged result, not an error.

## Fix

`validateMergeQuery` now refuses a source id of `merge` with a dedicated `RESERVED_SOURCE_ID` error kind, alongside the existing duplicate-id check. `MERGE_TABLE_NAME` moved above `validateMergeQuery` in the same file to satisfy declaration-before-use lint; no behavior change from the move.

## Regression analysis

- The explorer UI always uses fixed source ids (`a`/`b`), so no existing UI flow can hit the new refusal.
- The new enum member is additive; no consumer switches exhaustively on `MergeQueryErrorKind`, and API responses only gain a possible new `kind` value in an existing error array.
- Any persisted merge that somehow used `merge` as a source id would previously have produced ambiguous columns; it now refuses with an actionable message instead.

## Testing

- New unit test: `validateMergeQuery` rejects `merge` as a source id.
- Full `@lightdash/common` suite passes (3569 tests), plus lint and typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHZFSRrjgJDahQA6M4oGvW