### PR TITLE
fix(autopilot): lay out markdown code blocks line by line

### DIFF
--- a/packages/frontend/src/components/common/AiMarkdown/AiMarkdown.module.css
+++ b/packages/frontend/src/components/common/AiMarkdown/AiMarkdown.module.css
@@ -116,6 +116,54 @@
     line-height: 1.5;
 }
 
+/* Streamdown styles its code blocks with Tailwind utilities on
+ *   [data-streamdown='code-block'] > header + body > pre > code > span-per-line
+ * and we don't ship Tailwind, so all of them are inert: the card is unstyled
+ * and the per-line `block` class is dropped, collapsing the whole snippet onto
+ * one very long line. Restyle the structure here. */
+.aiMarkdown [data-streamdown='code-block'] {
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 8px;
+    background-color: var(--mantine-color-ldGray-0);
+}
+
+.aiMarkdown [data-streamdown='code-block-header'] {
+    padding: 5px 12px;
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11px;
+    line-height: 1.4;
+    color: var(--mantine-color-ldGray-6);
+}
+
+/* Fenced blocks with no language would otherwise get an empty header strip. */
+.aiMarkdown [data-streamdown='code-block-header'][data-language=''] {
+    display: none;
+}
+
+.aiMarkdown [data-streamdown='code-block-body'] {
+    min-width: 0;
+}
+
+.aiMarkdown [data-streamdown='code-block'] pre {
+    border-radius: 0;
+    background-color: transparent;
+    /* Wrap rather than scroll: these blocks live in narrow panels. */
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    tab-size: 2;
+}
+
+/* One span per source line — `display: block` restores the line breaks, and the
+ * hanging indent keeps a wrapped line from reading as a new YAML key. */
+.aiMarkdown [data-streamdown='code-block'] pre code > span {
+    display: block;
+    padding-left: 2ch;
+    text-indent: -2ch;
+}
+
 .aiMarkdown pre code {
     font-family: var(--mantine-font-family-monospace);
     background: transparent;

--- a/packages/frontend/src/components/common/AiMarkdown/AiMarkdown.test.tsx
+++ b/packages/frontend/src/components/common/AiMarkdown/AiMarkdown.test.tsx
@@ -1,0 +1,98 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { AiMarkdown } from './AiMarkdown';
+import styles from './AiMarkdown.module.css';
+
+const YAML_LINES = [
+    'dimensions:',
+    '  - name: order_date_with_a_rather_long_identifier',
+    '    type: timestamp',
+    'metrics:',
+    '  - name: total_revenue',
+];
+
+const YAML_MARKDOWN = ['```yaml', ...YAML_LINES, '```'].join('\n');
+
+// Vitest resolves CSS modules to hashed class names but doesn't apply them, so
+// load the stylesheet by hand to assert against computed styles.
+beforeAll(() => {
+    const css = fs.readFileSync(
+        path.resolve(__dirname, 'AiMarkdown.module.css'),
+        'utf8',
+    );
+    const style = document.createElement('style');
+    style.textContent = css.replaceAll('.aiMarkdown', `.${styles.aiMarkdown}`);
+    document.head.appendChild(style);
+});
+
+const getCodeBlock = (container: HTMLElement) => {
+    const codeBlock = container.querySelector<HTMLElement>(
+        '[data-streamdown="code-block"]',
+    );
+    if (!codeBlock) throw new Error('No code block rendered');
+    return codeBlock;
+};
+
+// Streamdown renders one span per source line and styles code blocks with
+// Tailwind utilities we don't ship — including the `block` that separates those
+// lines. AiMarkdown.module.css restyles the structure by data attribute
+// instead; if a streamdown upgrade moves it, every line collapses onto one very
+// long line that has to be scrolled horizontally, so pin it here.
+describe('AiMarkdown code blocks', () => {
+    it('renders a fenced block as one span per source line', () => {
+        const { container } = renderWithProviders(
+            <AiMarkdown>{YAML_MARKDOWN}</AiMarkdown>,
+        );
+
+        const lines =
+            getCodeBlock(container).querySelectorAll('pre code > span');
+
+        expect(Array.from(lines).map((line) => line.textContent)).toStrictEqual(
+            YAML_LINES,
+        );
+    });
+
+    it('lays each line out as its own block, wrapping instead of scrolling', () => {
+        const { container } = renderWithProviders(
+            <AiMarkdown>{YAML_MARKDOWN}</AiMarkdown>,
+        );
+        const codeBlock = getCodeBlock(container);
+
+        const line = codeBlock.querySelector('pre code > span')!;
+        expect(getComputedStyle(line).display).toBe('block');
+        // Hanging indent so a wrapped line doesn't read as a new YAML key.
+        expect(getComputedStyle(line).textIndent).toBe('-2ch');
+
+        expect(
+            getComputedStyle(codeBlock.querySelector('pre')!).whiteSpace,
+        ).toBe('pre-wrap');
+    });
+
+    it('labels the block with its language', () => {
+        const { container } = renderWithProviders(
+            <AiMarkdown>{YAML_MARKDOWN}</AiMarkdown>,
+        );
+
+        const header = getCodeBlock(container).querySelector(
+            '[data-streamdown="code-block-header"]',
+        )!;
+
+        expect(header).toHaveAttribute('data-language', 'yaml');
+        expect(header).toHaveTextContent('yaml');
+        expect(getComputedStyle(header).display).not.toBe('none');
+    });
+
+    it('hides the header strip for an unlabelled block', () => {
+        const { container } = renderWithProviders(
+            <AiMarkdown>{'```\nplain text\n```'}</AiMarkdown>,
+        );
+
+        const header = getCodeBlock(container).querySelector(
+            '[data-streamdown="code-block-header"]',
+        )!;
+
+        expect(getComputedStyle(header).display).toBe('none');
+    });
+});

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -776,6 +776,10 @@
     color: var(--mantine-color-dimmed);
 }
 
-.reasoningMarkdown pre {
+.reasoningMarkdown [data-streamdown='code-block'] {
     max-width: 100%;
+}
+
+.reasoningMarkdown [data-streamdown='code-block'] pre {
+    font-size: 11px;
 }


### PR DESCRIPTION
### Description:

Follow-up to #27506: fenced YAML in Agent reasoning rendered as one endless line you had to scroll horizontally.

Streamdown renders one `<span>` per source line and styles code blocks entirely with Tailwind utilities — including the `block` class that separates those lines. We don't ship Tailwind, so all of it was inert: the lines stayed inline and collapsed into a single line (`"dimensions:  - name: x    type: timestampmetrics:"`), and the surrounding card/header were unstyled.

`AiMarkdown.module.css` now styles that structure by data attribute: a card border, a dimmed monospace language header (hidden when the fence has no language), one block per line with a hanging indent, and `pre-wrap` so long YAML wraps inside narrow panels instead of scrolling. This is in the shared renderer, so agent chat, deep research and data-app markdown get the same fix.

Verified with typecheck, lint, and unit tests that load the stylesheet into jsdom and assert the computed styles against Streamdown's real DOM (so a streamdown upgrade that moves the structure fails loudly rather than silently re-breaking the layout). No screenshot — this sandbox has no browser or running app.
