### PR TITLE
feat(validation): record broken model structurally and collapse deleted-model chart errors

### DIFF
--- a/packages/backend/src/database/entities/validation.ts
+++ b/packages/backend/src/database/entities/validation.ts
@@ -18,6 +18,7 @@ export type DbValidationTable = {
     chart_name: string | null;
     field_name: string | null;
     model_name: string | null;
+    table_name: string | null;
     saved_chart_uuid: string | null;
     dashboard_uuid: string | null;
     app_uuid: string | null;

--- a/packages/backend/src/database/migrations/20260817100000_add_table_name_to_validations.ts
+++ b/packages/backend/src/database/migrations/20260817100000_add_table_name_to_validations.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+const ValidationTableName = 'validations';
+
+// Adding a nullable column with no default is a catalog-only change in
+// Postgres: instant regardless of table size. No index on purpose — every
+// read of this table is already scoped by the indexed project_uuid, and
+// per-project row counts are small (the table is fully rewritten per
+// validation run), so table_name works as a residual filter.
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ValidationTableName, (table) => {
+        table.text('table_name').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ValidationTableName, (table) => {
+        table.dropColumn('table_name');
+    });
+}

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -55,6 +55,7 @@ type NormalizedValidationRow = {
     field_name: string | null;
     chart_name: string | null;
     model_name: string | null;
+    table_name: string | null;
     saved_chart_uuid: string | null;
     dashboard_uuid: string | null;
     app_uuid: string | null;
@@ -129,22 +130,28 @@ export class ValidationModel {
                         source: validation.source ?? null,
                         ...(isTableValidationError(validation) && {
                             model_name: validation.modelName,
+                            table_name: validation.modelName,
                         }),
                         ...(isChartValidationError(validation) && {
                             saved_chart_uuid: validation.chartUuid,
                             field_name: validation.fieldName,
                             chart_name: validation.chartName ?? null,
+                            table_name: validation.tableName ?? null,
                         }),
                         ...(isDashboardValidationError(validation) && {
                             dashboard_uuid: validation.dashboardUuid,
                             field_name: validation.fieldName ?? null,
                             chart_name: validation.chartName ?? null,
+                            // model_name is (historically) the dashboard's
+                            // display-name fallback, not a model reference
                             model_name: validation.name,
+                            table_name: validation.tableName ?? null,
                         }),
                         ...(isDataAppValidationError(validation) && {
                             app_uuid: validation.appUuid,
                             field_name: validation.fieldName ?? null,
                             model_name: validation.modelName ?? null,
+                            table_name: validation.modelName ?? null,
                         }),
                     })),
                 );
@@ -458,6 +465,7 @@ export class ValidationModel {
                     ChartKind.VERTICAL_BAR,
                 errorType: validationError.error_type,
                 fieldName: validationError.field_name ?? undefined,
+                tableName: validationError.table_name ?? undefined,
                 source: ValidationSourceType.Chart,
             }));
 
@@ -560,7 +568,8 @@ export class ValidationModel {
                     fieldName: validationError.field_name ?? undefined,
                     chartName: validationError.chart_name ?? undefined,
                     source: ValidationSourceType.Dashboard,
-                    tableName: parsedError.tableName,
+                    tableName:
+                        validationError.table_name ?? parsedError.tableName,
                     dashboardFilterErrorType:
                         parsedError.dashboardFilterErrorType,
                 };
@@ -684,6 +693,7 @@ export class ValidationModel {
                 errorType: row.error_type,
                 source: ValidationSourceType.Chart,
                 fieldName: row.field_name ?? undefined,
+                tableName: row.table_name ?? undefined,
                 chartUuid: row.saved_chart_uuid!,
                 chartViews: row.views_count ?? 0,
                 chartKind:
@@ -721,7 +731,7 @@ export class ValidationModel {
                 lastUpdatedAt: row.last_updated_at ?? undefined,
                 spaceUuid: row.space_uuid ?? undefined,
                 chartName: row.chart_name ?? undefined,
-                tableName: parsedError.tableName,
+                tableName: row.table_name ?? parsedError.tableName,
                 dashboardFilterErrorType: parsedError.dashboardFilterErrorType,
             };
         }
@@ -834,6 +844,7 @@ export class ValidationModel {
                 `${ValidationTableName}.field_name`,
                 `${ValidationTableName}.chart_name`,
                 `${ValidationTableName}.model_name`,
+                `${ValidationTableName}.table_name`,
                 `${ValidationTableName}.saved_chart_uuid`,
                 `${ValidationTableName}.dashboard_uuid`,
                 `${ValidationTableName}.app_uuid`,
@@ -889,6 +900,7 @@ export class ValidationModel {
                 `${ValidationTableName}.field_name`,
                 `${ValidationTableName}.chart_name`,
                 `${ValidationTableName}.model_name`,
+                `${ValidationTableName}.table_name`,
                 `${ValidationTableName}.saved_chart_uuid`,
                 `${ValidationTableName}.dashboard_uuid`,
                 `${ValidationTableName}.app_uuid`,
@@ -924,6 +936,7 @@ export class ValidationModel {
                 `${ValidationTableName}.field_name`,
                 `${ValidationTableName}.chart_name`,
                 `${ValidationTableName}.model_name`,
+                `${ValidationTableName}.table_name`,
                 `${ValidationTableName}.saved_chart_uuid`,
                 `${ValidationTableName}.dashboard_uuid`,
                 `${ValidationTableName}.app_uuid`,
@@ -1048,6 +1061,7 @@ export class ValidationModel {
                 `${ValidationTableName}.field_name`,
                 `${ValidationTableName}.chart_name`,
                 `${ValidationTableName}.model_name`,
+                `${ValidationTableName}.table_name`,
                 `${ValidationTableName}.saved_chart_uuid`,
                 `${ValidationTableName}.dashboard_uuid`,
                 `${ValidationTableName}.app_uuid`,
@@ -1124,6 +1138,7 @@ export class ValidationModel {
                 `${ValidationTableName}.field_name`,
                 `${ValidationTableName}.chart_name`,
                 `${ValidationTableName}.model_name`,
+                `${ValidationTableName}.table_name`,
                 `${ValidationTableName}.saved_chart_uuid`,
                 `${ValidationTableName}.dashboard_uuid`,
                 `${ValidationTableName}.app_uuid`,
@@ -1177,6 +1192,7 @@ export class ValidationModel {
                 `${ValidationTableName}.field_name`,
                 `${ValidationTableName}.chart_name`,
                 `${ValidationTableName}.model_name`,
+                `${ValidationTableName}.table_name`,
                 `${ValidationTableName}.saved_chart_uuid`,
                 `${ValidationTableName}.dashboard_uuid`,
                 `${ValidationTableName}.app_uuid`,
@@ -1228,6 +1244,7 @@ export class ValidationModel {
                 `${ValidationTableName}.field_name`,
                 `${ValidationTableName}.chart_name`,
                 `${ValidationTableName}.model_name`,
+                `${ValidationTableName}.table_name`,
                 `${ValidationTableName}.saved_chart_uuid`,
                 `${ValidationTableName}.dashboard_uuid`,
                 `${ValidationTableName}.app_uuid`,

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -190,6 +190,7 @@ describe('validation', () => {
             error: "Dimension error: the field 'table_dimension' no longer exists",
             errorType: 'dimension',
             fieldName: 'table_dimension',
+            tableName: 'table',
             name: 'Test chart',
             projectUuid: 'projectUuid',
             chartUuid: 'chartUuid',
@@ -221,6 +222,7 @@ describe('validation', () => {
             error: "Metric error: the field 'table_metric' no longer exists",
             errorType: 'metric',
             fieldName: 'table_metric',
+            tableName: 'table',
             name: 'Test chart',
             projectUuid: 'projectUuid',
             chartUuid: 'chartUuid',
@@ -234,6 +236,57 @@ describe('validation', () => {
             "The chart 'Test chart' is broken on this dashboard.",
         ];
         expect(errors.map((error) => error.error)).toEqual(expectedErrors);
+    });
+
+    it('Should collapse chart field errors into a single model error when the explore was deleted', async () => {
+        (
+            projectModel.findExploresFromCache as import('vitest').Mock
+        ).mockImplementationOnce(async () => []);
+
+        const errors =
+            await validationService.generateValidation('projectUuid');
+        const chartErrors = errors.filter(
+            (e) => e.source === ValidationSourceType.Chart,
+        );
+
+        expect(chartErrors).toHaveLength(1);
+        expect({ ...chartErrors[0], createdAt: undefined }).toEqual({
+            createdAt: undefined,
+            error: "Model error: the model 'table' no longer exists",
+            errorType: ValidationErrorType.Model,
+            tableName: 'table',
+            name: 'Test chart',
+            projectUuid: 'projectUuid',
+            chartUuid: 'chartUuid',
+            source: ValidationSourceType.Chart,
+            chartName: 'Test chart',
+        });
+
+        // The model error is blocking, so dashboards still flag the broken chart
+        expect(
+            errors
+                .filter((e) => e.source === ValidationSourceType.Dashboard)
+                .map((e) => e.error),
+        ).toContain("The chart 'Test chart' is broken on this dashboard.");
+    });
+
+    it('Should report a compile failure when the chart explore failed to compile', async () => {
+        (
+            projectModel.findExploresFromCache as import('vitest').Mock
+        ).mockImplementationOnce(async () => [exploreError]);
+
+        const errors =
+            await validationService.generateValidation('projectUuid');
+        const chartErrors = errors.filter(
+            (e) => e.source === ValidationSourceType.Chart,
+        );
+
+        expect(chartErrors).toHaveLength(1);
+        expect(chartErrors[0]).toMatchObject({
+            error: "Model error: the model 'table' failed to compile",
+            errorType: ValidationErrorType.Model,
+            tableName: 'table',
+        });
     });
 
     it('Should create table validation errors from CLI warehouse diagnostics without probing the warehouse', async () => {

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -145,6 +145,24 @@ export class ValidationService extends BaseService {
         return existingFields;
     }
 
+    // Explores that exist but failed to compile — indexed by name and
+    // baseTable (charts reference either), so a broken-but-present model is
+    // reported as a compile failure, not falsely as deleted.
+    private static buildExploreErrorNames(
+        compiledExplores: (Explore | ExploreError)[],
+    ): Set<string> {
+        return new Set(
+            compiledExplores.flatMap((explore) =>
+                isExploreError(explore)
+                    ? [
+                          explore.name,
+                          ...(explore.baseTable ? [explore.baseTable] : []),
+                      ]
+                    : [],
+            ),
+        );
+    }
+
     private static buildExistingTableNames(
         compiledExplores: (Explore | ExploreError)[],
     ): Set<string> {
@@ -378,6 +396,7 @@ export class ValidationService extends BaseService {
             string,
             { dimensionIds: string[]; metricIds: string[] }
         >,
+        exploreErrorNames: Set<string>,
         selectedExplores?: (Explore | ExploreError)[],
         chartUuid?: string,
     ): Promise<CreateChartValidation[]> {
@@ -441,7 +460,25 @@ export class ValidationService extends BaseService {
                         projectUuid,
                         source: ValidationSourceType.Chart,
                         chartName: name,
+                        tableName,
                     };
+
+                    // When the whole explore is gone (deleted or failed to
+                    // compile), every field check would fail — collapse the
+                    // noise into a single model-level error so cleanup can
+                    // group all affected charts by model.
+                    if (exploreFields[tableName] === undefined) {
+                        return [
+                            {
+                                ...commonValidation,
+                                errorType: ValidationErrorType.Model,
+                                error: exploreErrorNames.has(tableName)
+                                    ? `Model error: the model '${tableName}' failed to compile`
+                                    : `Model error: the model '${tableName}' no longer exists`,
+                            },
+                        ];
+                    }
+
                     const containsFieldId = ({
                         acc,
                         fieldIds,
@@ -677,13 +714,14 @@ export class ValidationService extends BaseService {
                         error,
                         errorType,
                         fieldName,
+                        tableName,
                     }: {
                         acc: CreateDashboardValidation[];
                         fieldIds: Set<string>;
                         fieldId: string;
                     } & Pick<
                         CreateDashboardValidation,
-                        'error' | 'errorType' | 'fieldName'
+                        'error' | 'errorType' | 'fieldName' | 'tableName'
                     >) => {
                         if (!fieldIds?.has(fieldId)) {
                             return [
@@ -693,6 +731,7 @@ export class ValidationService extends BaseService {
                                     errorType,
                                     error,
                                     fieldName,
+                                    tableName,
                                 },
                             ];
                         }
@@ -709,6 +748,7 @@ export class ValidationService extends BaseService {
                                 errorType: ValidationErrorType.Filter,
                                 error: `Filter error: the field '${fieldId}' does not match table '${tableName}'`,
                                 fieldName: fieldId,
+                                tableName,
                             };
                         }
                         return undefined;
@@ -730,6 +770,7 @@ export class ValidationService extends BaseService {
                                 errorType: ValidationErrorType.Filter,
                                 error: `Table '${tableName}' no longer exists`,
                                 fieldName: fieldId,
+                                tableName,
                             };
                         }
                         return undefined;
@@ -782,6 +823,7 @@ export class ValidationService extends BaseService {
                                     : `Filter error: the field '${filter.target.fieldId}' no longer exists`,
                                 errorType: ValidationErrorType.Filter,
                                 fieldName: filter.target.fieldId,
+                                tableName,
                             });
                         } catch (e) {
                             console.error(
@@ -839,6 +881,7 @@ export class ValidationService extends BaseService {
                                         : `Filter error: the field '${tileTarget.fieldId}' no longer exists`,
                                     errorType: ValidationErrorType.Filter,
                                     fieldName: tileTarget.fieldId,
+                                    tableName,
                                 });
                             }
                             return acc;
@@ -1098,6 +1141,7 @@ export class ValidationService extends BaseService {
                 ? await this.validateCharts(
                       projectUuid,
                       exploreFields,
+                      ValidationService.buildExploreErrorNames(explores ?? []),
                       onlyValidateExploresInArgs ? compiledExplores : undefined,
                   )
                 : [];
@@ -1712,6 +1756,7 @@ export class ValidationService extends BaseService {
         const validationErrors = await this.validateCharts(
             projectUuid,
             exploreFields,
+            ValidationService.buildExploreErrorNames(compiledExplores),
             compiledExplores,
             chartUuid,
         );

--- a/packages/common/src/types/validation.ts
+++ b/packages/common/src/types/validation.ts
@@ -22,6 +22,7 @@ export type ValidationErrorChartResponse = ValidationResponseBase & {
     chartUuid: string | undefined; // NOTE: can be undefined if private content
     chartKind?: ChartKind;
     fieldName?: string;
+    tableName?: string; // The model/explore the broken field or chart belongs to
     lastUpdatedBy?: string;
     lastUpdatedAt?: Date;
     chartViews: number;
@@ -73,6 +74,7 @@ export type CreateChartValidation = Pick<
     | 'error'
     | 'errorType'
     | 'fieldName'
+    | 'tableName'
     | 'name'
     | 'projectUuid'
     | 'chartUuid'
@@ -85,6 +87,7 @@ export type CreateDashboardValidation = Pick<
     | 'error'
     | 'errorType'
     | 'fieldName'
+    | 'tableName'
     | 'name'
     | 'projectUuid'
     | 'dashboardUuid'

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.tsx
@@ -35,6 +35,17 @@ const ErrorMessageByType: FC<{
                 </Text>
             );
         }
+        // Model-level errors: the whole model is gone or failed to compile
+        if (validationError.errorType === ValidationErrorType.Model) {
+            return (
+                <Text fz={11}>
+                    Model <CustomMark>{validationError.tableName}</CustomMark>{' '}
+                    {validationError.error.includes('failed to compile')
+                        ? 'failed to compile'
+                        : 'no longer exists'}
+                </Text>
+            );
+        }
         return (
             <Text fz={11}>
                 <CustomMark>{validationError.fieldName}</CustomMark> no longer

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/FixValidationErrorModal.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/FixValidationErrorModal.tsx
@@ -2,6 +2,7 @@ import {
     assertUnreachable,
     isChartValidationError,
     RenameType,
+    ValidationErrorType,
     type ApiRenameResponse,
     type ValidationErrorChartResponse,
     type ValidationResponse,
@@ -61,10 +62,18 @@ export const FixValidationErrorModal: FC<Props> = ({
         projectUuid: validationError?.projectUuid,
     });
     const { data: explores } = useExplores(validationError?.projectUuid, true);
-    const [oldName, setOldName] = useState<string | undefined>();
+    // Model-level errors (whole explore deleted or failed to compile) have no
+    // fieldName to rename — default those straight to model rename.
+    const isModelError =
+        validationError?.errorType === ValidationErrorType.Model;
+    const [oldName, setOldName] = useState<string | undefined>(() =>
+        isModelError ? validationError?.tableName : undefined,
+    );
     const [newName, setNewName] = useState('');
     const [fixAll, setFixAll] = useState(false);
-    const [renameType, setRenameType] = useState<RenameType>(RenameType.FIELD);
+    const [renameType, setRenameType] = useState<RenameType>(() =>
+        isModelError ? RenameType.MODEL : RenameType.FIELD,
+    );
     const [previewData, setPreviewData] = useState<
         ApiRenameResponse['results'] | null
     >(null);
@@ -107,7 +116,8 @@ export const FixValidationErrorModal: FC<Props> = ({
             return allValidationErrors.filter(
                 (e) =>
                     isChartValidationError(e) &&
-                    (e.fieldName || '').startsWith(`${tableName}_`),
+                    (e.tableName === tableName ||
+                        (e.fieldName || '').startsWith(`${tableName}_`)),
             ).length;
         } else {
             return assertUnreachable(
@@ -121,12 +131,18 @@ export const FixValidationErrorModal: FC<Props> = ({
 
     const fieldBaseTableNameCandidate = useMemo(
         () =>
+            validationError?.tableName ??
             resolveModelNameFromField(
                 fieldName ?? '',
                 savedQuery?.tableName,
                 explores?.map((e) => e.name),
             ),
-        [fieldName, savedQuery?.tableName, explores],
+        [
+            validationError?.tableName,
+            fieldName,
+            savedQuery?.tableName,
+            explores,
+        ],
     );
 
     if (!validationError) {

--- a/packages/frontend/src/components/SettingsValidator/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/index.tsx
@@ -103,6 +103,7 @@ export const SettingsValidator: FC<{
     const content = (
         <>
             <FixValidationErrorModal
+                key={selectedValidationError?.validationUuid}
                 validationError={selectedValidationError}
                 allValidationErrors={flatData}
                 onClose={() => {


### PR DESCRIPTION
Linear: [PROD-8487](https://linear.app/lightdash/issue/PROD-8487/autopilot-surface-a-summary-of-all-validation-errors-not-only-a) and [PROD-8489](https://linear.app/lightdash/issue/PROD-8489/bulk-remove-content-that-depends-on-a-deleted-model-autopilot)
Closes #24712 groundwork, first PR of the stack.

## Problem

Validation rows do not structurally record which model broke them. A deleted model produces one row per broken field per chart (a 20-chart, 6-field model yields ~120 rows with no shared key), the missing model is only recoverable by string-prefix inference on the frontend, and dashboards overload `validations.model_name` with the dashboard's display name.

## Changes

- New nullable `validations.table_name` column. Deliberately no index and no data mutation: a nullable ADD COLUMN with no default is a catalog-only change in Postgres (instant at any table size), and every read is already scoped by the indexed `project_uuid` with small per-project row counts, so `table_name` works as a residual filter. `replaceProjectValidations` is delete-and-reinsert, so the column self-populates on the next validation run. `model_name` semantics are untouched (it feeds the deleted-dashboard display fallback).
- Chart validations now record `tableName` structurally, and when the whole explore is gone the per-field noise collapses into a single chart-level `Model` error, distinguishing "no longer exists" (deleted) from "failed to compile" (`ExploreError`, matched by name or base table).
- Dashboard filter errors record the offending table structurally; the regex parser in `ValidationModel.parseDashboardFilterError` remains as a fallback for rows written before this change.
- Table and data-app validations mirror their model name into `table_name` so every source shares one grouping key.
- Validator UI: the Fix modal defaults to model rename for the new Model-type errors, prefers the structural `tableName` over prefix inference, and counts occurrences by `tableName` as well as field prefix. `ErrorMessage` renders the new error type. The modal is remounted per validation error (`key`) so its initial mode tracks the selected error.

## Regression analysis

- Collapsing per-field rows into one Model error intentionally lowers total error counts for deleted models everywhere counts surface (Validator badge, notification bell). Field-level errors on existing models are unchanged.
- The dashboard-name fallback (`COALESCE(dashboards.name, validations.model_name, ...)`) is untouched; `table_name` is a new column, not a repurposing.
- `buildExploreErrorNames` marks base tables of failed explores as compile failures only when no compiled explore covers that key, so a healthy canonical explore is never misreported.
- `distinctOn`/`orderBy` clauses in `ValidationModel` are unchanged; `table_name` was only added to select lists and mappers.
- `pnpm generate-api` validated the TSOA changes (generated files intentionally not committed, per repo policy).

Tests: `ValidationService.test.ts` covers the collapse (deleted vs failed-compile), `tableName` on field- and dashboard-level errors, and the two pre-existing assertions were extended with the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wN2cB2mCApBBwDqn2J76Q
