### PR TITLE
feat(validation): add grouped-by-root-cause validation summary API

### DIFF
--- a/packages/backend/src/controllers/v2/ValidationController.ts
+++ b/packages/backend/src/controllers/v2/ValidationController.ts
@@ -2,6 +2,7 @@ import {
     ApiErrorPayload,
     ApiPaginatedValidateResponse,
     ApiSingleValidationResponse,
+    ApiValidationSummaryResponse,
     assertRegisteredAccount,
     ValidationErrorType,
     ValidationSourceType,
@@ -42,6 +43,7 @@ export class ValidationControllerV2 extends BaseController {
      * @param sortDirection sort direction
      * @param sourceTypes comma-separated list of source types to filter by
      * @param errorTypes comma-separated list of error types to filter by
+     * @param tableName filter to errors caused by this model/table
      * @param includeChartConfigWarnings whether to include chart configuration warnings
      * @param fromSettings boolean for analytics tracking
      */
@@ -59,6 +61,7 @@ export class ValidationControllerV2 extends BaseController {
         @Query() sortDirection?: 'asc' | 'desc',
         @Query() sourceTypes?: string,
         @Query() errorTypes?: string,
+        @Query() tableName?: string,
         @Query() includeChartConfigWarnings?: boolean,
         @Query() fromSettings?: boolean,
     ): Promise<ApiPaginatedValidateResponse> {
@@ -97,10 +100,36 @@ export class ValidationControllerV2 extends BaseController {
                     sortDirection,
                     sourceTypes: parsedSourceTypes,
                     errorTypes: parsedErrorTypes,
+                    tableName,
                     includeChartConfigWarnings,
                     fromSettings,
                 },
             ),
+        };
+    }
+
+    /**
+     * Get validation errors grouped by root cause (e.g. all errors caused by
+     * one deleted model), with counts and a capped list of affected content.
+     * @summary Get validation summary
+     * @param projectUuid the projectId for the validation
+     * @param req express request
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('summary')
+    @OperationId('GetValidationSummary')
+    async summary(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiValidationSummaryResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getValidationService()
+                .getValidationSummary(toSessionUser(req.account), projectUuid),
         };
     }
 

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -989,6 +989,7 @@ export class ValidationModel {
             sortDirection?: 'asc' | 'desc';
             sourceTypes?: ValidationSourceType[];
             errorTypes?: ValidationErrorType[];
+            tableName?: string;
             includeChartConfigWarnings?: boolean;
             allowedSpaceUuids?: string[] | 'all';
             allowedAppUuids?: string[] | 'all';
@@ -1001,6 +1002,7 @@ export class ValidationModel {
             sortDirection = 'desc',
             sourceTypes,
             errorTypes,
+            tableName,
             includeChartConfigWarnings = false,
             allowedSpaceUuids = 'all',
             allowedAppUuids = 'all',
@@ -1297,6 +1299,9 @@ export class ValidationModel {
                     }
                     if (errorTypes && errorTypes.length > 0) {
                         void qb.whereIn('error_type', errorTypes);
+                    }
+                    if (tableName) {
+                        void qb.where('table_name', tableName);
                     }
                     if (!includeChartConfigWarnings) {
                         void qb.whereNot((inner) => {

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -3,6 +3,7 @@ import {
     AbilityAction,
     AnyType,
     FilterOperator,
+    ForbiddenError,
     OrganizationMemberRole,
     TableCalculationTemplateType,
     TableSelectionType,
@@ -1155,5 +1156,230 @@ describe('ValidationService - Table Calculation Templates', () => {
     it('Should handle empty table calculations array', () => {
         const result = ValidationService.getTableCalculationFieldIds([]);
         expect(result).toEqual([]);
+    });
+});
+
+describe('ValidationService.groupValidationsByRootCause', () => {
+    const baseChartError = {
+        validationId: null,
+        createdAt: new Date(),
+        projectUuid: 'projectUuid',
+        source: ValidationSourceType.Chart as const,
+    };
+
+    const chartModelError = (
+        chartUuid: string | undefined,
+        name: string,
+        views: number,
+    ) => ({
+        ...baseChartError,
+        validationUuid: `validation-${chartUuid ?? name}`,
+        name,
+        error: "Model error: the model 'orders' no longer exists",
+        errorType: ValidationErrorType.Model,
+        chartUuid,
+        chartViews: views,
+        tableName: 'orders',
+    });
+
+    it('groups chart model errors from the same deleted model together', () => {
+        const summary = ValidationService.groupValidationsByRootCause([
+            chartModelError('chart-1', 'Chart one', 5),
+            chartModelError('chart-2', 'Chart two', 10),
+            {
+                ...baseChartError,
+                validationUuid: 'validation-3',
+                name: 'Chart three',
+                error: "Dimension error: the field 'customers_id' no longer exists",
+                errorType: ValidationErrorType.Dimension,
+                fieldName: 'customers_id',
+                tableName: 'customers',
+                chartUuid: 'chart-3',
+                chartViews: 1,
+            },
+        ]);
+
+        expect(summary.totalErrors).toBe(3);
+        expect(summary.totalAffectedItems).toBe(3);
+        expect(summary.groups).toHaveLength(2);
+
+        const [modelGroup, fieldGroup] = summary.groups;
+        expect(modelGroup).toMatchObject({
+            errorType: ValidationErrorType.Model,
+            tableName: 'orders',
+            fieldName: null,
+            errorCount: 2,
+            affectedCharts: 2,
+            hasMoreAffectedContent: false,
+        });
+        // Content sorted by views desc
+        expect(modelGroup!.affectedContent.map((c) => c.uuid)).toEqual([
+            'chart-2',
+            'chart-1',
+        ]);
+        expect(fieldGroup).toMatchObject({
+            errorType: ValidationErrorType.Dimension,
+            tableName: 'customers',
+            fieldName: 'customers_id',
+            errorCount: 1,
+        });
+    });
+
+    it('dedupes content within a group and counts errors per content', () => {
+        const duplicatedError = {
+            ...baseChartError,
+            name: 'Chart one',
+            error: "Dimension error: the field 'orders_status' no longer exists",
+            errorType: ValidationErrorType.Dimension,
+            fieldName: 'orders_status',
+            tableName: 'orders',
+            chartUuid: 'chart-1',
+            chartViews: 3,
+        };
+        const summary = ValidationService.groupValidationsByRootCause([
+            { ...duplicatedError, validationUuid: 'validation-a' },
+            { ...duplicatedError, validationUuid: 'validation-b' },
+        ]);
+
+        expect(summary.groups).toHaveLength(1);
+        expect(summary.groups[0]!.errorCount).toBe(2);
+        expect(summary.groups[0]!.affectedCharts).toBe(1);
+        expect(summary.groups[0]!.affectedContent).toHaveLength(1);
+        expect(summary.groups[0]!.affectedContent[0]!.errorCount).toBe(2);
+        expect(summary.totalAffectedItems).toBe(1);
+    });
+
+    it('excludes chart configuration warnings and keeps masked private content in counts', () => {
+        const summary = ValidationService.groupValidationsByRootCause([
+            chartModelError('chart-1', 'Chart one', 0),
+            chartModelError(undefined, 'Private content', 0),
+            {
+                ...baseChartError,
+                validationUuid: 'validation-warning',
+                name: 'Chart one',
+                error: 'dimension is not used in the chart configuration',
+                errorType: ValidationErrorType.ChartConfiguration,
+                fieldName: 'orders_status',
+                chartUuid: 'chart-1',
+                chartViews: 0,
+            },
+        ]);
+
+        expect(summary.totalErrors).toBe(2);
+        expect(summary.groups).toHaveLength(1);
+        expect(summary.groups[0]!.affectedCharts).toBe(2);
+        expect(summary.groups[0]!.affectedContent.map((c) => c.uuid)).toContain(
+            null,
+        );
+    });
+
+    it('groups table and dashboard errors by their model', () => {
+        const summary = ValidationService.groupValidationsByRootCause([
+            {
+                validationId: null,
+                createdAt: new Date(),
+                projectUuid: 'projectUuid',
+                validationUuid: 'validation-table',
+                source: ValidationSourceType.Table,
+                name: 'orders',
+                error: 'Compile error',
+                errorType: ValidationErrorType.Model,
+            },
+            {
+                validationId: null,
+                createdAt: new Date(),
+                projectUuid: 'projectUuid',
+                validationUuid: 'validation-dashboard',
+                source: ValidationSourceType.Dashboard,
+                name: 'My dashboard',
+                error: "Table 'orders' no longer exists",
+                errorType: ValidationErrorType.Filter,
+                fieldName: 'orders_status',
+                tableName: 'orders',
+                dashboardUuid: 'dashboard-1',
+                dashboardViews: 7,
+            },
+        ]);
+
+        expect(summary.groups).toHaveLength(2);
+        expect(summary.groups[0]).toMatchObject({
+            errorType: ValidationErrorType.Model,
+            tableName: 'orders',
+            affectedTables: 1,
+        });
+        expect(summary.groups[1]).toMatchObject({
+            errorType: ValidationErrorType.Filter,
+            tableName: 'orders',
+            fieldName: 'orders_status',
+            affectedDashboards: 1,
+        });
+    });
+});
+
+describe('ValidationService.getValidationSummary', () => {
+    const validationService = new ValidationService({
+        analytics: analyticsMock,
+        validationModel: validationModel as unknown as ValidationModel,
+        projectModel: projectModel as unknown as ProjectModel,
+        appModel: appModel as unknown as AppModel,
+        savedChartModel: savedChartModel as unknown as SavedChartModel,
+        dashboardModel: dashboardModel as unknown as DashboardModel,
+        lightdashConfig: config,
+        spaceModel: spaceModel as unknown as SpaceModel,
+        schedulerClient: {} as SchedulerClient,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
+        featureFlagModel: {} as FeatureFlagModel,
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns grouped summary from stored validations', async () => {
+        (validationModel.get as import('vitest').Mock).mockImplementationOnce(
+            async () => [
+                {
+                    validationId: null,
+                    createdAt: new Date(),
+                    projectUuid: 'projectUuid',
+                    validationUuid: 'validation-1',
+                    source: ValidationSourceType.Chart,
+                    name: 'Chart one',
+                    error: "Model error: the model 'orders' no longer exists",
+                    errorType: ValidationErrorType.Model,
+                    chartUuid: 'chart-1',
+                    chartViews: 2,
+                    tableName: 'orders',
+                },
+            ],
+        );
+
+        const summary = await validationService.getValidationSummary(
+            user,
+            'projectUuid',
+        );
+
+        expect(summary.totalErrors).toBe(1);
+        expect(summary.groups).toHaveLength(1);
+        expect(summary.groups[0]).toMatchObject({
+            tableName: 'orders',
+            errorType: ValidationErrorType.Model,
+            affectedCharts: 1,
+        });
+    });
+
+    it('throws ForbiddenError without manage Validation ability', async () => {
+        const restrictedUser = {
+            ...user,
+            ability: new Ability<[AbilityAction, AnyType]>([]),
+        };
+
+        await expect(
+            validationService.getValidationSummary(
+                restrictedUser,
+                'projectUuid',
+            ),
+        ).rejects.toThrowError(ForbiddenError);
     });
 });

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -39,7 +39,10 @@ import {
     TableCalculation,
     TableSelectionType,
     UnexpectedServerError,
+    ValidationAffectedContent,
+    ValidationErrorGroup,
     ValidationErrorType,
+    ValidationGroupedSummary,
     ValidationResponse,
     ValidationSourceType,
     ValidationTarget,
@@ -57,6 +60,8 @@ import { ValidationModel } from '../../models/ValidationModel/ValidationModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { BaseService } from '../BaseService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+
+const VALIDATION_SUMMARY_AFFECTED_CONTENT_LIMIT = 20;
 
 type ValidationServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -1403,6 +1408,224 @@ export class ValidationService extends BaseService {
             .map((app) => app.app_id);
     }
 
+    // Filter out orphaned validations (content was deleted)
+    private static filterOrphanedValidations(
+        validations: ValidationResponse[],
+    ): ValidationResponse[] {
+        return validations.filter((validation) => {
+            // Table validations are project-level. Data app rows have already
+            // been joined against a non-deleted app by the model.
+            if (
+                !isDashboardValidationError(validation) &&
+                !isChartValidationError(validation)
+            ) {
+                return true;
+            }
+
+            const hasChartUuid =
+                isChartValidationError(validation) && validation.chartUuid;
+            const hasDashboardUuid =
+                isDashboardValidationError(validation) &&
+                validation.dashboardUuid;
+
+            return hasChartUuid || hasDashboardUuid;
+        });
+    }
+
+    static groupValidationsByRootCause(
+        validations: ValidationResponse[],
+    ): ValidationGroupedSummary {
+        type MutableGroup = Omit<
+            ValidationErrorGroup,
+            'affectedContent' | 'hasMoreAffectedContent'
+        > & {
+            contentByKey: Map<string, ValidationAffectedContent>;
+        };
+
+        const getContent = (
+            validation: ValidationResponse,
+        ): Omit<ValidationAffectedContent, 'errorCount'> => {
+            if (isChartValidationError(validation)) {
+                return {
+                    uuid: validation.chartUuid ?? null,
+                    name: validation.name,
+                    source: ValidationSourceType.Chart,
+                    views: validation.chartViews ?? 0,
+                };
+            }
+            if (isDashboardValidationError(validation)) {
+                return {
+                    uuid: validation.dashboardUuid ?? null,
+                    name: validation.name,
+                    source: ValidationSourceType.Dashboard,
+                    views: validation.dashboardViews ?? 0,
+                };
+            }
+            if (isDataAppValidationError(validation)) {
+                return {
+                    uuid: validation.appUuid ?? null,
+                    name: validation.name,
+                    source: ValidationSourceType.DataApp,
+                    views: 0,
+                };
+            }
+            return {
+                uuid: null,
+                name: validation.name ?? 'Unknown table',
+                source: ValidationSourceType.Table,
+                views: 0,
+            };
+        };
+
+        const groups = new Map<string, MutableGroup>();
+        const allContentKeys = new Set<string>();
+        let totalErrors = 0;
+
+        validations.forEach((validation) => {
+            // Advisory chart configuration warnings are not broken content
+            if (
+                validation.errorType === ValidationErrorType.ChartConfiguration
+            ) {
+                return;
+            }
+            totalErrors += 1;
+
+            let tableName: string | null = null;
+            let fieldName: string | null = null;
+            if (isChartValidationError(validation)) {
+                tableName = validation.tableName ?? null;
+                fieldName = validation.fieldName ?? null;
+            } else if (isDashboardValidationError(validation)) {
+                tableName = validation.tableName ?? null;
+                fieldName = validation.fieldName ?? null;
+            } else if (isDataAppValidationError(validation)) {
+                tableName = validation.modelName ?? null;
+                fieldName = validation.fieldName ?? null;
+            } else {
+                // Table validations: `name` is the model name
+                tableName = validation.name ?? null;
+            }
+            const groupKey = `${validation.errorType}:${tableName ?? ''}:${
+                fieldName ?? ''
+            }`;
+
+            const content = getContent(validation);
+            const contentKey = `${content.source}:${
+                content.uuid ?? content.name
+            }`;
+            allContentKeys.add(contentKey);
+
+            const group = groups.get(groupKey) ?? {
+                groupKey,
+                errorType: validation.errorType,
+                tableName,
+                fieldName,
+                errorCount: 0,
+                affectedCharts: 0,
+                affectedDashboards: 0,
+                affectedTables: 0,
+                affectedDataApps: 0,
+                sampleError: validation.error,
+                contentByKey: new Map<string, ValidationAffectedContent>(),
+            };
+            group.errorCount += 1;
+
+            const existingContent = group.contentByKey.get(contentKey);
+            if (existingContent) {
+                existingContent.errorCount += 1;
+            } else {
+                group.contentByKey.set(contentKey, {
+                    ...content,
+                    errorCount: 1,
+                });
+                switch (content.source) {
+                    case ValidationSourceType.Chart:
+                        group.affectedCharts += 1;
+                        break;
+                    case ValidationSourceType.Dashboard:
+                        group.affectedDashboards += 1;
+                        break;
+                    case ValidationSourceType.Table:
+                        group.affectedTables += 1;
+                        break;
+                    case ValidationSourceType.DataApp:
+                        group.affectedDataApps += 1;
+                        break;
+                    default:
+                        assertUnreachable(
+                            content.source,
+                            'Unknown validation source',
+                        );
+                }
+            }
+            groups.set(groupKey, group);
+        });
+
+        const sortedGroups = [...groups.values()]
+            .sort((a, b) => {
+                // Deleted/broken models first — they are bulk-actionable
+                const aIsModel = a.errorType === ValidationErrorType.Model;
+                const bIsModel = b.errorType === ValidationErrorType.Model;
+                if (aIsModel !== bIsModel) return aIsModel ? -1 : 1;
+                if (a.errorCount !== b.errorCount)
+                    return b.errorCount - a.errorCount;
+                return a.groupKey.localeCompare(b.groupKey);
+            })
+            .map(({ contentByKey, ...group }) => {
+                const affectedContent = [...contentByKey.values()].sort(
+                    (a, b) => b.views - a.views,
+                );
+                return {
+                    ...group,
+                    affectedContent: affectedContent.slice(
+                        0,
+                        VALIDATION_SUMMARY_AFFECTED_CONTENT_LIMIT,
+                    ),
+                    hasMoreAffectedContent:
+                        affectedContent.length >
+                        VALIDATION_SUMMARY_AFFECTED_CONTENT_LIMIT,
+                };
+            });
+
+        return {
+            totalErrors,
+            totalAffectedItems: allContentKeys.size,
+            groups: sortedGroups,
+        };
+    }
+
+    async getValidationSummary(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ValidationGroupedSummary> {
+        const { organizationUuid } = user;
+        const auditedAbility = this.createAuditedAbility(user);
+
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Validation', {
+                    organizationUuid: organizationUuid!,
+                    projectUuid,
+                    metadata: { summary: true },
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const allValidations = await this.validationModel.get(projectUuid);
+        const validations =
+            ValidationService.filterOrphanedValidations(allValidations);
+        const maskedValidations = await this.hidePrivateContent(
+            user,
+            projectUuid,
+            validations,
+        );
+
+        return ValidationService.groupValidationsByRootCause(maskedValidations);
+    }
+
     async get(
         user: SessionUser,
         projectUuid: string,
@@ -1430,26 +1653,8 @@ export class ValidationService extends BaseService {
             jobId,
         );
 
-        // Filter out orphaned validations (content was deleted)
-        const validations = allValidations.filter((validation) => {
-            // Table validations are project-level. Data app rows have already
-            // been joined against a non-deleted app by the model.
-            if (
-                !isDashboardValidationError(validation) &&
-                !isChartValidationError(validation)
-            ) {
-                return true;
-            }
-
-            // Filter out chart/dashboard validations where content no longer exists
-            const hasChartUuid =
-                isChartValidationError(validation) && validation.chartUuid;
-            const hasDashboardUuid =
-                isDashboardValidationError(validation) &&
-                validation.dashboardUuid;
-
-            return hasChartUuid || hasDashboardUuid;
-        });
+        const validations =
+            ValidationService.filterOrphanedValidations(allValidations);
 
         if (fromSettings) {
             const contentIds = validations.map(
@@ -1542,6 +1747,7 @@ export class ValidationService extends BaseService {
             sortDirection?: 'asc' | 'desc';
             sourceTypes?: ValidationSourceType[];
             errorTypes?: ValidationErrorType[];
+            tableName?: string;
             includeChartConfigWarnings?: boolean;
             fromSettings?: boolean;
             jobId?: string;
@@ -1598,6 +1804,7 @@ export class ValidationService extends BaseService {
                 sortDirection: options?.sortDirection,
                 sourceTypes: options?.sourceTypes,
                 errorTypes: options?.errorTypes,
+                tableName: options?.tableName,
                 includeChartConfigWarnings: options?.includeChartConfigWarnings,
                 allowedSpaceUuids,
                 allowedAppUuids,

--- a/packages/common/src/types/validation.ts
+++ b/packages/common/src/types/validation.ts
@@ -145,6 +145,37 @@ export type ValidationSummary = Pick<
     'error' | 'createdAt' | 'validationUuid' | 'validationId'
 >;
 
+export type ValidationAffectedContent = {
+    uuid: string | null; // null when content is private or deleted for this user
+    name: string;
+    source: ValidationSourceType;
+    views: number;
+    errorCount: number;
+};
+
+export type ValidationErrorGroup = {
+    groupKey: string;
+    errorType: ValidationErrorType;
+    tableName: string | null; // root-cause model, when known
+    fieldName: string | null; // set for field-level groups
+    errorCount: number;
+    affectedCharts: number;
+    affectedDashboards: number;
+    affectedTables: number;
+    affectedDataApps: number;
+    sampleError: string;
+    affectedContent: ValidationAffectedContent[]; // capped, see hasMoreAffectedContent
+    hasMoreAffectedContent: boolean;
+};
+
+export type ValidationGroupedSummary = {
+    totalErrors: number;
+    totalAffectedItems: number;
+    groups: ValidationErrorGroup[];
+};
+
+export type ApiValidationSummaryResponse = ApiSuccess<ValidationGroupedSummary>;
+
 export enum ValidationErrorType {
     Chart = 'chart',
     Sorting = 'sorting',


### PR DESCRIPTION
Linear: [PROD-8487](https://linear.app/lightdash/issue/PROD-8487/autopilot-surface-a-summary-of-all-validation-errors-not-only-a)
Part of #24712. Stacked on #27522.

## Changes

- New endpoint `GET /api/v2/projects/{projectUuid}/validate/summary` returning validation errors grouped by root cause: one group per (error type, model, field) with complete counts (`errorCount`, affected charts/dashboards/tables/data apps), a sample error, and a capped (20) list of affected content sorted by views. Model-level groups sort first since they are bulk-actionable; groups are never truncated.
- Grouping lives in a pure static `ValidationService.groupValidationsByRootCause`, applied after the same orphan filtering and private-content masking as the existing list endpoints, so non-admins see complete counts but masked names/uuids. Chart configuration warnings are excluded (advisory, not broken content).
- The v2 list endpoint gains a `tableName` filter (applied on the combined CTE, where `table_name` is selected by every subquery) so a summary group can drive a filtered list view.
- The route is declared before the `{validationIdOrUuid}` wildcard so `/summary` resolves correctly (verified in generated routes).

## Regression analysis

- The list endpoint's behavior is unchanged when `tableName` is not passed; the new filter only adds a `WHERE` clause.
- Rows written before #27522's migration lack `table_name` and land in a null-keyed group until the next validation run; documented as expected, self-heals.
- The shared orphan filter was extracted from `get()` into a private helper with identical logic; `get()` output is unchanged.
- `pnpm generate-api` validated the new route and types (generated files not committed, per repo policy).

Tests: pure grouping tests (dedupe per content, per-content error counts, config-warning exclusion, masked-content counting, table/dashboard grouping) plus service tests for the happy path and the `manage Validation` permission gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wN2cB2mCApBBwDqn2J76Q
