### PR TITLE
feat(content): add delete and bulk-delete content actions

### DIFF
--- a/packages/backend/src/controllers/v2/ContentController.ts
+++ b/packages/backend/src/controllers/v2/ContentController.ts
@@ -1,6 +1,7 @@
 import {
     ApiContentActionBody,
     ApiContentBulkActionBody,
+    ApiContentBulkDeleteResponse,
     ApiContentResponse,
     ApiDeletedContentResponse,
     ApiErrorPayload,
@@ -8,6 +9,7 @@ import {
     ApiRestoreContentBody,
     ApiSuccessEmpty,
     assertRegisteredAccount,
+    ContentActionDelete,
     ContentActionMove,
     ContentType,
     ParameterError,
@@ -152,6 +154,69 @@ export class ContentController extends BaseController {
             );
 
         return { status: 'ok', results: undefined };
+    }
+
+    /**
+     * Delete a single item (Chart, Dashboard, Space). Soft-deletes when the
+     * instance has soft delete enabled, otherwise deletes permanently.
+     * @summary Delete content
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/:projectUuid/delete')
+    @OperationId('Delete content')
+    @Tags('Content', 'Delete content')
+    async deleteContent(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Body() body: ApiContentActionBody<ContentActionDelete>,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+
+        if (body.action.type !== 'delete') {
+            throw new ParameterError('Invalid action type');
+        }
+
+        await this.services
+            .getContentService()
+            .delete(toSessionUser(req.account), projectUuid, body.item);
+
+        return { status: 'ok', results: undefined };
+    }
+
+    /**
+     * Delete multiple items (Charts, Dashboards, Spaces). Items the caller
+     * cannot delete are skipped and reported in the response.
+     * @summary Bulk delete content
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/bulk-action/:projectUuid/delete')
+    @OperationId('Bulk delete content')
+    @Tags('Content', 'Bulk action', 'Delete content')
+    async bulkDeleteContent(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Body() body: ApiContentBulkActionBody<ContentActionDelete>,
+    ): Promise<ApiContentBulkDeleteResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+
+        if (body.action.type !== 'delete') {
+            throw new ParameterError('Invalid action type');
+        }
+
+        return {
+            status: 'ok',
+            results: await this.services
+                .getContentService()
+                .bulkDelete(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    body.content,
+                ),
+        };
     }
 
     /**

--- a/packages/backend/src/services/ContentService/ContentService.test.ts
+++ b/packages/backend/src/services/ContentService/ContentService.test.ts
@@ -13,6 +13,7 @@ import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import type { ContentModel } from '../../models/ContentModel/ContentModel';
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import type { SpaceModel } from '../../models/SpaceModel';
+import type { ValidationModel } from '../../models/ValidationModel/ValidationModel';
 import type { DashboardService } from '../DashboardService/DashboardService';
 import type { SavedChartService } from '../SavedChartsService/SavedChartService';
 import type { SavedSqlService } from '../SavedSqlService/SavedSqlService';
@@ -84,18 +85,26 @@ const createService = ({
     const savedChartService = {
         restore: vi.fn().mockResolvedValue(undefined),
         permanentDelete: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
     };
     const savedSqlService = {
         restore: vi.fn().mockResolvedValue(undefined),
         permanentDelete: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
     };
     const dashboardService = {
         restore: vi.fn().mockResolvedValue(undefined),
         permanentDelete: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
     };
     const spaceService = {
         restore: vi.fn().mockResolvedValue(undefined),
         permanentDelete: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+    };
+    const validationModel = {
+        deleteChartValidations: vi.fn().mockResolvedValue(undefined),
+        deleteDashboardValidations: vi.fn().mockResolvedValue(undefined),
     };
 
     return {
@@ -110,6 +119,7 @@ const createService = ({
                 savedChartService as unknown as SavedChartService,
             savedSqlService: savedSqlService as unknown as SavedSqlService,
             spacePermissionService,
+            validationModel: validationModel as unknown as ValidationModel,
             appMoveService: undefined,
             appGenerateService: undefined,
         }),
@@ -118,6 +128,7 @@ const createService = ({
         savedSqlService,
         dashboardService,
         spaceService,
+        validationModel,
     };
 };
 
@@ -406,6 +417,113 @@ describe('ContentService.find', () => {
                 expect.any(Object),
             );
         });
+    });
+});
+
+describe('ContentService.bulkDelete', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('dispatches deletes per content type and clears validation rows', async () => {
+        const deps = createService();
+        const user = createUser();
+
+        const results = await deps.service.bulkDelete(user, projectUuid, [
+            {
+                uuid: 'chart-uuid',
+                contentType: ContentType.CHART,
+                source: ChartSourceType.DBT_EXPLORE,
+            },
+            {
+                uuid: 'sql-chart-uuid',
+                contentType: ContentType.CHART,
+                source: ChartSourceType.SQL,
+            },
+            { uuid: 'dashboard-uuid', contentType: ContentType.DASHBOARD },
+            { uuid: 'space-uuid', contentType: ContentType.SPACE },
+        ]);
+
+        expect(results).toEqual({ deletedCount: 4, skipped: [] });
+        expect(deps.savedChartService.delete).toHaveBeenCalledWith(
+            user,
+            'chart-uuid',
+            { projectUuid },
+        );
+        expect(
+            deps.validationModel.deleteChartValidations,
+        ).toHaveBeenCalledWith('chart-uuid', projectUuid);
+        expect(deps.savedSqlService.delete).toHaveBeenCalledWith(
+            user,
+            'sql-chart-uuid',
+        );
+        expect(deps.dashboardService.delete).toHaveBeenCalledWith(
+            user,
+            'dashboard-uuid',
+            { projectUuid },
+        );
+        expect(
+            deps.validationModel.deleteDashboardValidations,
+        ).toHaveBeenCalledWith('dashboard-uuid', projectUuid);
+        expect(deps.spaceService.delete).toHaveBeenCalledWith(
+            user,
+            'space-uuid',
+        );
+    });
+
+    it('reports partial success when some items cannot be deleted', async () => {
+        const deps = createService();
+        deps.savedChartService.delete.mockRejectedValueOnce(
+            new ForbiddenError(),
+        );
+        const user = createUser();
+
+        const results = await deps.service.bulkDelete(user, projectUuid, [
+            {
+                uuid: 'forbidden-chart-uuid',
+                contentType: ContentType.CHART,
+                source: ChartSourceType.DBT_EXPLORE,
+            },
+            { uuid: 'dashboard-uuid', contentType: ContentType.DASHBOARD },
+            { uuid: 'app-uuid', contentType: ContentType.DATA_APP },
+        ]);
+
+        expect(results.deletedCount).toBe(1);
+        expect(results.skipped).toHaveLength(2);
+        expect(results.skipped[0]).toMatchObject({
+            uuid: 'forbidden-chart-uuid',
+            contentType: ContentType.CHART,
+        });
+        expect(results.skipped[1]).toMatchObject({
+            uuid: 'app-uuid',
+            contentType: ContentType.DATA_APP,
+        });
+        // Failed chart delete must not clear its validation rows
+        expect(
+            deps.validationModel.deleteChartValidations,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('rejects a project the user cannot view', async () => {
+        const deps = createService();
+        deps.projectModel.getSummary.mockResolvedValue({
+            organizationUuid: 'another-organization-uuid',
+            name: 'Another project',
+        });
+
+        await expect(
+            deps.service.bulkDelete(
+                createOrganizationAdminUser(),
+                projectUuid,
+                [
+                    {
+                        uuid: 'dashboard-uuid',
+                        contentType: ContentType.DASHBOARD,
+                    },
+                ],
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        expect(deps.dashboardService.delete).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -5,12 +5,15 @@ import {
     assertUnreachable,
     BulkActionable,
     ChartSourceType,
+    ContentActionDelete,
     ContentActionMove,
+    ContentBulkDeleteResults,
     ContentType,
     DeletedContentFilters,
     DeletedContentItem,
     DeletedContentWithDescendants,
     ForbiddenError,
+    getErrorMessage,
     KnexPaginateArgs,
     KnexPaginatedData,
     NotFoundError,
@@ -30,6 +33,7 @@ import {
 } from '../../models/ContentModel/ContentModelTypes';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SpaceModel } from '../../models/SpaceModel';
+import { ValidationModel } from '../../models/ValidationModel/ValidationModel';
 import { wrapSentryTransaction } from '../../utils';
 import { BaseService } from '../BaseService';
 import { DashboardService } from '../DashboardService/DashboardService';
@@ -48,6 +52,7 @@ type ContentServiceArguments = {
     savedChartService: SavedChartService;
     savedSqlService: SavedSqlService;
     spacePermissionService: SpacePermissionService;
+    validationModel: ValidationModel;
     appMoveService: BulkActionable<Knex> | undefined;
     appGenerateService: AppGenerateService | undefined;
 };
@@ -71,6 +76,8 @@ export class ContentService extends BaseService {
 
     spacePermissionService: SpacePermissionService;
 
+    validationModel: ValidationModel;
+
     appMoveService: BulkActionable<Knex> | undefined;
 
     appGenerateService: AppGenerateService | undefined;
@@ -88,6 +95,7 @@ export class ContentService extends BaseService {
         this.savedChartService = args.savedChartService;
         this.savedSqlService = args.savedSqlService;
         this.spacePermissionService = args.spacePermissionService;
+        this.validationModel = args.validationModel;
         this.appMoveService = args.appMoveService;
         this.appGenerateService = args.appGenerateService;
     }
@@ -439,6 +447,134 @@ export class ContentService extends BaseService {
             default:
                 return assertUnreachable(item, 'Unknown content type');
         }
+    }
+
+    private async assertProjectViewAccess(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        if (user.organizationUuid === undefined) {
+            throw new NotFoundError('Organization not found');
+        }
+
+        const { organizationUuid, name: projectName } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    metadata: { projectUuid, projectName },
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
+    // Per-item permission checks, analytics, soft/permanent-delete branching
+    // and cascades all live in each service's delete()
+    private async deleteContentItem(
+        user: SessionUser,
+        projectUuid: string,
+        item: ApiContentActionBody<ContentActionDelete>['item'],
+    ): Promise<void> {
+        switch (item.contentType) {
+            case ContentType.CHART:
+                switch (item.source) {
+                    case ChartSourceType.DBT_EXPLORE:
+                        await this.savedChartService.delete(user, item.uuid, {
+                            projectUuid,
+                        });
+                        // Clear the chart's validation errors so the Validator
+                        // list updates without waiting for the next run
+                        await this.validationModel.deleteChartValidations(
+                            item.uuid,
+                            projectUuid,
+                        );
+                        return;
+                    case ChartSourceType.SQL:
+                        await this.savedSqlService.delete(user, item.uuid);
+                        return;
+                    default:
+                        return assertUnreachable(
+                            item.source,
+                            `Unknown chart source in content delete: ${item.source}`,
+                        );
+                }
+            case ContentType.DASHBOARD:
+                await this.dashboardService.delete(user, item.uuid, {
+                    projectUuid,
+                });
+                await this.validationModel.deleteDashboardValidations(
+                    item.uuid,
+                    projectUuid,
+                );
+                return;
+            case ContentType.SPACE:
+                await this.spaceService.delete(user, item.uuid);
+                return;
+            case ContentType.DATA_APP:
+                throw new ParameterError(
+                    'Data apps cannot be deleted via content actions',
+                );
+            default:
+                return assertUnreachable(item, 'Unknown content type');
+        }
+    }
+
+    async delete(
+        user: SessionUser,
+        projectUuid: string,
+        item: ApiContentActionBody<ContentActionDelete>['item'],
+    ): Promise<void> {
+        await this.assertProjectViewAccess(user, projectUuid);
+        await this.deleteContentItem(user, projectUuid, item);
+    }
+
+    async bulkDelete(
+        user: SessionUser,
+        projectUuid: string,
+        content: ApiContentBulkActionBody<ContentActionDelete>['content'],
+    ): Promise<ContentBulkDeleteResults> {
+        await this.assertProjectViewAccess(user, projectUuid);
+
+        const skipped: ContentBulkDeleteResults['skipped'] = [];
+        let deletedCount = 0;
+
+        // Sequential on purpose: deletes cascade (spaces delete their charts
+        // and dashboards), so parallel deletes over overlapping trees race
+        for (const item of content) {
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await this.deleteContentItem(user, projectUuid, item);
+                deletedCount += 1;
+            } catch (error: unknown) {
+                skipped.push({
+                    uuid: item.uuid,
+                    contentType: item.contentType,
+                    reason:
+                        error instanceof ForbiddenError
+                            ? 'You do not have permission to delete this content'
+                            : getErrorMessage(error),
+                });
+            }
+        }
+
+        this.analytics.track({
+            event: 'content.bulk_delete',
+            userId: user.userUuid,
+            properties: {
+                projectId: projectUuid,
+                contentCount: content.length,
+                deletedCount,
+                skippedCount: skipped.length,
+            },
+        });
+
+        return { deletedCount, skipped };
     }
 
     /**

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1368,6 +1368,7 @@ export class ServiceRepository
                     savedChartService: this.getSavedChartService(),
                     savedSqlService: this.getSavedSqlService(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    validationModel: this.models.getValidationModel(),
                     // Only wired when EE license is active. Core builds get
                     // undefined and fail DATA_APP moves with a clear error.
                     appMoveService: this.providers.appGenerateService

--- a/packages/common/src/types/content.ts
+++ b/packages/common/src/types/content.ts
@@ -187,6 +187,22 @@ export type ApiContentBulkActionBody<T extends ContentAction = ContentAction> =
         action: T;
     };
 
+export type ContentBulkDeleteSkippedItem = {
+    uuid: string;
+    contentType: ContentType;
+    reason: string;
+};
+
+export type ContentBulkDeleteResults = {
+    deletedCount: number;
+    skipped: ContentBulkDeleteSkippedItem[];
+};
+
+export type ApiContentBulkDeleteResponse = {
+    status: 'ok';
+    results: ContentBulkDeleteResults;
+};
+
 export interface BulkActionable<Tx extends unknown> {
     moveToSpace: (
         user: SessionUser,


### PR DESCRIPTION
Linear: [PROD-8489](https://linear.app/lightdash/issue/PROD-8489/bulk-remove-content-that-depends-on-a-deleted-model-autopilot)
Part of #24714. Stacked on #27523.

## Changes

Implements the delete content actions the frontend was already wired for (`useContentAction`/`useContentBulkAction` build `/content/{projectUuid}/delete` and `/content/bulk-action/{projectUuid}/delete` and carry `case 'delete'` toasts; `ContentActionDelete` was typed in common but had no backend).

- `POST /api/v2/content/{projectUuid}/delete` and `POST /api/v2/content/bulk-action/{projectUuid}/delete` on `ContentController`.
- `ContentService.delete`/`bulkDelete` dispatch per content type to the existing `SoftDeletableService.delete()` implementations, which already handle CASL checks, analytics, soft vs permanent branching on `lightdashConfig.softDelete.enabled`, and cascades. Data apps are rejected explicitly.
- Bulk delete runs sequentially (cascades over overlapping trees would race in parallel) with partial-success semantics: forbidden or failed items are skipped and reported as `{deletedCount, skipped[]}` rather than failing the batch.
- Deleting a dbt chart or dashboard also clears its validation rows so the Validator list updates immediately; today soft-deleted content's validations linger until the next run.

## Regression analysis

- No existing endpoint changes; `bulk-action/move` is untouched. The new routes reuse the same project-view guard pattern as `bulkMove`.
- Per-item permission checks are the services' own (`bypassPermissions` is never passed), so a bulk request grants nothing a single delete would not.
- `ContentService` gains a `ValidationModel` dependency, wired in `ServiceRepository`; validation cleanup only runs after a successful delete.
- `pnpm generate-api` validated the new routes (generated files not committed, per repo policy).

Tests: `ContentService.test.ts` covers per-type dispatch with validation cleanup, partial success (forbidden chart and data app skipped, cleanup not run for failures), and cross-organization project rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wN2cB2mCApBBwDqn2J76Q
