### PR TITLE
feat(validator): grouped error summary and bulk delete of broken content

### DIFF
--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -351,6 +351,7 @@ import {
     type ApiDashboardValidationResponse,
     type ApiPaginatedValidateResponse,
     type ApiSingleValidationResponse,
+    type ApiValidationSummaryResponse,
     type ValidationResponse,
 } from './validation';
 import {
@@ -1201,6 +1202,7 @@ type ApiResults =
     | SchedulerWithLogs
     | ValidationResponse[]
     | ApiPaginatedValidateResponse['results']
+    | ApiValidationSummaryResponse['results']
     | ApiRoadmapResponse['results']
     | ChartHistory
     | ChartVersion

--- a/packages/frontend/src/components/SettingsValidator/BulkDeleteContentModal.tsx
+++ b/packages/frontend/src/components/SettingsValidator/BulkDeleteContentModal.tsx
@@ -1,0 +1,106 @@
+import { ContentType } from '@lightdash/common';
+import { List, ScrollArea, Text } from '@mantine/core';
+import { IconTrash } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { type FC } from 'react';
+import { useContentBulkAction } from '../../hooks/useContent';
+import useApp from '../../providers/App/useApp';
+import Callout from '../common/Callout';
+import MantineModal from '../common/MantineModal';
+import {
+    toBulkDeletePayload,
+    type ValidationContentItem,
+} from './utils/deletableContent';
+
+type Props = {
+    projectUuid: string;
+    items: ValidationContentItem[];
+    opened: boolean;
+    onClose: () => void;
+    onDeleted?: () => void;
+};
+
+export const BulkDeleteContentModal: FC<Props> = ({
+    projectUuid,
+    items,
+    opened,
+    onClose,
+    onDeleted,
+}) => {
+    const { health } = useApp();
+    const isSoftDeleteEnabled = health.data?.softDelete.enabled ?? false;
+    const queryClient = useQueryClient();
+
+    const { mutate: contentBulkAction, isLoading } = useContentBulkAction(
+        projectUuid,
+        {
+            onSuccess: async () => {
+                await queryClient.invalidateQueries(['validation']);
+                await queryClient.invalidateQueries(['paginatedValidation']);
+                await queryClient.invalidateQueries(['validationSummary']);
+                onDeleted?.();
+                onClose();
+            },
+        },
+    );
+
+    const chartCount = items.filter(
+        (item) => item.contentType === ContentType.CHART,
+    ).length;
+    const dashboardCount = items.length - chartCount;
+
+    const summaryParts = [
+        chartCount > 0 && `${chartCount} chart${chartCount === 1 ? '' : 's'}`,
+        dashboardCount > 0 &&
+            `${dashboardCount} dashboard${dashboardCount === 1 ? '' : 's'}`,
+    ].filter(Boolean);
+
+    return (
+        <MantineModal
+            size="lg"
+            title="Delete broken content"
+            icon={IconTrash}
+            opened={opened}
+            onClose={onClose}
+            variant="delete"
+            confirmLabel={`Delete ${items.length} item${
+                items.length === 1 ? '' : 's'
+            }`}
+            confirmLoading={isLoading}
+            confirmDisabled={items.length === 0}
+            onConfirm={() =>
+                contentBulkAction({
+                    content: toBulkDeletePayload(items),
+                    action: { type: 'delete' },
+                })
+            }
+        >
+            <Callout
+                variant="warning"
+                title={`This will delete ${summaryParts.join(' and ')} from this project.`}
+            >
+                {isSoftDeleteEnabled ? (
+                    <Text fz="xs">
+                        Deleted content can be restored from recently deleted.
+                    </Text>
+                ) : (
+                    <Text fz="xs">This cannot be undone.</Text>
+                )}
+            </Callout>
+            <ScrollArea.Autosize mah={300} scrollbars="y">
+                <List size="xs">
+                    {items.map((item) => (
+                        <List.Item key={`${item.contentType}-${item.uuid}`}>
+                            {item.name}
+                            <Text span c="dimmed" fz="xs">
+                                {' '}
+                                ({item.contentType}, {item.views} view
+                                {item.views === 1 ? '' : 's'})
+                            </Text>
+                        </List.Item>
+                    ))}
+                </List>
+            </ScrollArea.Autosize>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/components/SettingsValidator/ValidationSummarySection.module.css
+++ b/packages/frontend/src/components/SettingsValidator/ValidationSummarySection.module.css
@@ -1,0 +1,18 @@
+.groupCard {
+    flex-shrink: 0;
+    cursor: pointer;
+}
+
+.groupCardActive {
+    flex-shrink: 0;
+    cursor: pointer;
+    border-color: var(--mantine-color-indigo-5);
+    background-color: var(--mantine-color-indigo-light);
+}
+
+.title {
+    max-width: 260px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/packages/frontend/src/components/SettingsValidator/ValidationSummarySection.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidationSummarySection.tsx
@@ -1,0 +1,163 @@
+import {
+    friendlyName,
+    ValidationErrorType,
+    type ValidationErrorGroup,
+    type ValidationGroupedSummary,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Badge,
+    Group,
+    Paper,
+    ScrollArea,
+    Stack,
+    Text,
+    Tooltip,
+    UnstyledButton,
+} from '@mantine/core';
+import { IconTrash } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../common/MantineIcon';
+import classes from './ValidationSummarySection.module.css';
+
+const getGroupTitle = (group: ValidationErrorGroup): string => {
+    if (group.errorType === ValidationErrorType.Model && group.tableName) {
+        return group.sampleError.includes('failed to compile')
+            ? `Model ${group.tableName} failed to compile`
+            : `Model ${group.tableName} no longer exists`;
+    }
+    if (group.fieldName) {
+        return `${friendlyName(group.errorType)}: ${group.fieldName}`;
+    }
+    if (group.tableName) {
+        return `${friendlyName(group.errorType)}: ${group.tableName}`;
+    }
+    return `${friendlyName(group.errorType)} errors`;
+};
+
+const getAffectedLabel = (group: ValidationErrorGroup): string => {
+    const parts = [
+        group.affectedCharts > 0 &&
+            `${group.affectedCharts} chart${
+                group.affectedCharts === 1 ? '' : 's'
+            }`,
+        group.affectedDashboards > 0 &&
+            `${group.affectedDashboards} dashboard${
+                group.affectedDashboards === 1 ? '' : 's'
+            }`,
+        group.affectedTables > 0 &&
+            `${group.affectedTables} table${
+                group.affectedTables === 1 ? '' : 's'
+            }`,
+        group.affectedDataApps > 0 &&
+            `${group.affectedDataApps} data app${
+                group.affectedDataApps === 1 ? '' : 's'
+            }`,
+    ].filter(Boolean);
+    return parts.join(', ');
+};
+
+type Props = {
+    summary: ValidationGroupedSummary;
+    activeGroupKey: string | null;
+    onToggleGroup: (group: ValidationErrorGroup) => void;
+    onDeleteGroup: (group: ValidationErrorGroup) => void;
+};
+
+export const ValidationSummarySection: FC<Props> = ({
+    summary,
+    activeGroupKey,
+    onToggleGroup,
+    onDeleteGroup,
+}) => {
+    if (summary.groups.length === 0) return null;
+
+    return (
+        <Stack gap="xs">
+            <Text fz="xs" fw={600} c="ldGray.7">
+                {summary.totalErrors} error
+                {summary.totalErrors === 1 ? '' : 's'} across{' '}
+                {summary.totalAffectedItems} item
+                {summary.totalAffectedItems === 1 ? '' : 's'}, grouped by cause
+            </Text>
+            <ScrollArea scrollbars="x" offsetScrollbars>
+                <Group gap="xs" wrap="nowrap">
+                    {summary.groups.map((group) => {
+                        const isActive = group.groupKey === activeGroupKey;
+                        const isDeletableModelGroup =
+                            group.errorType === ValidationErrorType.Model &&
+                            group.tableName !== null &&
+                            group.affectedCharts + group.affectedDashboards > 0;
+
+                        return (
+                            <Paper
+                                key={group.groupKey}
+                                withBorder
+                                px="sm"
+                                py={6}
+                                className={
+                                    isActive
+                                        ? classes.groupCardActive
+                                        : classes.groupCard
+                                }
+                            >
+                                <Group gap="xs" wrap="nowrap">
+                                    <UnstyledButton
+                                        onClick={() => onToggleGroup(group)}
+                                    >
+                                        <Group gap="xs" wrap="nowrap">
+                                            <Badge
+                                                variant="light"
+                                                color={
+                                                    group.errorType ===
+                                                    ValidationErrorType.Model
+                                                        ? 'red'
+                                                        : 'orange'
+                                                }
+                                                size="sm"
+                                            >
+                                                {group.errorCount}
+                                            </Badge>
+                                            <Stack gap={0}>
+                                                <Text
+                                                    fz="xs"
+                                                    fw={600}
+                                                    className={classes.title}
+                                                >
+                                                    {getGroupTitle(group)}
+                                                </Text>
+                                                <Text fz={10} c="ldGray.6">
+                                                    {getAffectedLabel(group)}
+                                                </Text>
+                                            </Stack>
+                                        </Group>
+                                    </UnstyledButton>
+                                    {isDeletableModelGroup && (
+                                        <Tooltip
+                                            withinPortal
+                                            label="Delete all content referencing this model"
+                                        >
+                                            <ActionIcon
+                                                variant="subtle"
+                                                color="red"
+                                                size="sm"
+                                                onClick={() =>
+                                                    onDeleteGroup(group)
+                                                }
+                                            >
+                                                <MantineIcon
+                                                    icon={IconTrash}
+                                                    size="sm"
+                                                />
+                                            </ActionIcon>
+                                        </Tooltip>
+                                    )}
+                                </Group>
+                            </Paper>
+                        );
+                    })}
+                </Group>
+            </ScrollArea>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/ValidatorTableTopToolbar.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/ValidatorTableTopToolbar.tsx
@@ -14,7 +14,12 @@ import {
     TextInput,
     Tooltip,
 } from '@mantine/core';
-import { IconArrowBack, IconFilter, IconSearch } from '@tabler/icons-react';
+import {
+    IconArrowBack,
+    IconFilter,
+    IconSearch,
+    IconTrash,
+} from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import classes from './ValidatorTableTopToolbar.module.css';
@@ -36,6 +41,9 @@ type ValidatorTableTopToolbarProps = {
     totalResults: number;
     lastValidatedAt: Date | null;
     isFetching: boolean;
+    selectedCount: number;
+    onDeleteSelected: () => void;
+    onClearSelection: () => void;
 };
 
 export const ValidatorTableTopToolbar: FC<ValidatorTableTopToolbarProps> = ({
@@ -47,6 +55,9 @@ export const ValidatorTableTopToolbar: FC<ValidatorTableTopToolbarProps> = ({
     setShowConfigWarnings,
     totalResults,
     lastValidatedAt,
+    selectedCount,
+    onDeleteSelected,
+    onClearSelection,
 }) => {
     const hasActiveFilters =
         sourceTypeFilter.length > 0 || showConfigWarnings || searchQuery !== '';
@@ -189,6 +200,29 @@ export const ValidatorTableTopToolbar: FC<ValidatorTableTopToolbarProps> = ({
             </Group>
 
             <Group gap="md" wrap="nowrap">
+                {selectedCount > 0 && (
+                    <Group gap="xs" wrap="nowrap">
+                        <Button
+                            size="compact-xs"
+                            color="red"
+                            variant="light"
+                            leftSection={
+                                <MantineIcon icon={IconTrash} size="sm" />
+                            }
+                            onClick={onDeleteSelected}
+                        >
+                            Delete content ({selectedCount})
+                        </Button>
+                        <Button
+                            size="compact-xs"
+                            variant="subtle"
+                            color="gray"
+                            onClick={onClearSelection}
+                        >
+                            Clear
+                        </Button>
+                    </Group>
+                )}
                 {lastValidatedAt && (
                     <Text fw={500} fz="xs" c="ldGray.6">
                         Last validated: {formatTime(lastValidatedAt)}

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -24,7 +24,7 @@ import {
     IconTable,
     IconX,
 } from '@tabler/icons-react';
-import { useMemo, useRef, type FC } from 'react';
+import { useCallback, useMemo, useRef, type FC } from 'react';
 import { useInfiniteScroll } from '../../../hooks/useInfiniteScroll';
 import { useDeleteValidation } from '../../../hooks/validation/useValidation';
 import {
@@ -35,6 +35,11 @@ import {
 } from '../../common/ContentTable';
 import MantineIcon from '../../common/MantineIcon';
 import { ChartIcon, IconBox } from '../../common/ResourceIcon';
+import {
+    dedupeContentItems,
+    getDeletableContentItem,
+    type ValidationContentItem,
+} from '../utils/deletableContent';
 import { getLinkToResource } from '../utils/utils';
 import { ErrorMessage } from './ErrorMessage';
 import classes from './ValidatorTable.module.css';
@@ -116,6 +121,9 @@ export type ValidatorTableProps = {
     setShowConfigWarnings: (show: boolean) => void;
     lastValidatedAt: Date | null;
     flush?: boolean;
+    rowSelection: Record<string, boolean>;
+    setRowSelection: (selection: Record<string, boolean>) => void;
+    onBulkDelete: (items: ValidationContentItem[]) => void;
 };
 
 export const ValidatorTable: FC<ValidatorTableProps> = ({
@@ -137,6 +145,9 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
     setShowConfigWarnings,
     lastValidatedAt,
     flush = false,
+    rowSelection,
+    setRowSelection,
+    onBulkDelete,
 }) => {
     const rowVirtualizerInstanceRef =
         useRef<ContentTableVirtualizer<HTMLDivElement, HTMLTableRowElement>>(
@@ -154,6 +165,27 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
     }, [data, pinnedValidation]);
 
     const totalFetched = data.length;
+
+    const selectedCount = useMemo(
+        () => Object.values(rowSelection).filter(Boolean).length,
+        [rowSelection],
+    );
+
+    const handleDeleteSelected = useCallback(() => {
+        const items = dedupeContentItems(
+            tableData.flatMap((validationError) => {
+                if (!rowSelection[validationError.validationUuid]) return [];
+                const item = getDeletableContentItem(validationError);
+                return item ? [item] : [];
+            }),
+        );
+        if (items.length > 0) onBulkDelete(items);
+    }, [tableData, rowSelection, onBulkDelete]);
+
+    const handleClearSelection = useCallback(
+        () => setRowSelection({}),
+        [setRowSelection],
+    );
 
     const { containerRef: tableContainerRef, onScroll } = useInfiniteScroll({
         fetchNextPage,
@@ -320,7 +352,20 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
         enableTopToolbar: true,
         enableBottomToolbar: false,
         enableRowActions: false,
+        enableRowSelection: (row) =>
+            getDeletableContentItem(row.original) !== null,
         getRowId: (row) => row.validationUuid,
+        state: {
+            isLoading,
+            showAlertBanner: isError,
+            showProgressBars: isFetching,
+            density: 'md',
+            rowSelection,
+        },
+        onRowSelectionChange: (updater) =>
+            setRowSelection(
+                typeof updater === 'function' ? updater(rowSelection) : updater,
+            ),
         renderTopToolbar: () => (
             <ValidatorTableTopToolbar
                 searchQuery={searchQuery}
@@ -332,6 +377,9 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
                 totalResults={totalDBRowCount}
                 lastValidatedAt={lastValidatedAt}
                 isFetching={isFetching || isLoading}
+                selectedCount={selectedCount}
+                onDeleteSelected={handleDeleteSelected}
+                onClearSelection={handleClearSelection}
             />
         ),
         mantinePaperProps: {
@@ -368,12 +416,6 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
         },
         rowVirtualizerInstanceRef,
         rowVirtualizerProps: { estimateSize: () => 44, overscan: 10 },
-        state: {
-            isLoading,
-            showAlertBanner: isError,
-            showProgressBars: isFetching,
-            density: 'md',
-        },
     });
 
     return <ContentTable table={table} />;

--- a/packages/frontend/src/components/SettingsValidator/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/index.tsx
@@ -2,24 +2,34 @@ import {
     isChartValidationError,
     isFixableDashboardValidationError,
     ValidationErrorType,
+    ValidationSourceType,
     type ValidationErrorChartResponse,
     type ValidationErrorDashboardResponse,
-    type ValidationSourceType,
+    type ValidationErrorGroup,
 } from '@lightdash/common';
-import { Button, Group, Loader, Paper, Text } from '@mantine/core';
+import { Button, Group, Loader, Paper, Stack, Text } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconCheck } from '@tabler/icons-react';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import useSearchParams from '../../hooks/useSearchParams';
 import {
+    useAllValidations,
     usePaginatedValidation,
     usePinnedValidation,
     useValidationMutation,
+    useValidationSummary,
 } from '../../hooks/validation/useValidation';
 import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
 import { SettingsPage } from '../common/Settings/SettingsPage';
+import { BulkDeleteContentModal } from './BulkDeleteContentModal';
+import {
+    dedupeContentItems,
+    getDeletableContentItem,
+    type ValidationContentItem,
+} from './utils/deletableContent';
+import { ValidationSummarySection } from './ValidationSummarySection';
 import { ValidatorTable } from './ValidatorTable';
 import { ChartConfigurationErrorModal } from './ValidatorTable/ChartConfigurationErrorModal';
 import { FixDashboardFilterModal } from './ValidatorTable/FixDashboardFilterModal';
@@ -52,12 +62,19 @@ export const SettingsValidator: FC<{
         void navigate({ pathname }, { replace: true });
     }, [navigate, pathname]);
 
+    const { data: summary } = useValidationSummary(projectUuid, user);
+    const [activeGroup, setActiveGroup] = useState<ValidationErrorGroup | null>(
+        null,
+    );
+
     const { data, isLoading, isFetching, isError, fetchNextPage } =
         usePaginatedValidation(projectUuid, user, {
             pageSize: 20,
             searchQuery: debouncedSearch || undefined,
             sourceTypes:
                 sourceTypeFilter.length > 0 ? sourceTypeFilter : undefined,
+            errorTypes: activeGroup ? [activeGroup.errorType] : undefined,
+            tableName: activeGroup?.tableName ?? undefined,
             includeChartConfigWarnings: showConfigWarnings,
         });
 
@@ -73,6 +90,57 @@ export const SettingsValidator: FC<{
         useState<ValidationErrorChartResponse>();
     const [selectedDashboardError, setSelectedDashboardError] =
         useState<ValidationErrorDashboardResponse>();
+
+    // Bulk delete: from table row selection or from a summary group
+    const [rowSelection, setRowSelection] = useState<Record<string, boolean>>(
+        {},
+    );
+    const [selectionDeleteItems, setSelectionDeleteItems] = useState<
+        ValidationContentItem[] | null
+    >(null);
+    const [deleteGroup, setDeleteGroup] = useState<ValidationErrorGroup | null>(
+        null,
+    );
+    const { data: allValidations } = useAllValidations(
+        projectUuid,
+        deleteGroup !== null,
+    );
+
+    // Group delete targets charts referencing the model. Dashboards usually
+    // have other healthy tiles, so they stay for manual review.
+    const groupDeleteItems = useMemo(() => {
+        if (!deleteGroup || !allValidations) return null;
+        return dedupeContentItems(
+            allValidations.flatMap((validation) => {
+                if (
+                    validation.source !== ValidationSourceType.Chart ||
+                    !isChartValidationError(validation) ||
+                    validation.tableName !== deleteGroup.tableName
+                ) {
+                    return [];
+                }
+                const item = getDeletableContentItem(validation);
+                return item ? [item] : [];
+            }),
+        );
+    }, [deleteGroup, allValidations]);
+
+    const deleteModalItems = selectionDeleteItems ?? groupDeleteItems;
+
+    const closeDeleteModal = useCallback(() => {
+        setSelectionDeleteItems(null);
+        setDeleteGroup(null);
+    }, []);
+
+    // Selection references loaded rows, so clear it when the result set changes
+    useEffect(() => {
+        setRowSelection({});
+    }, [
+        debouncedSearch,
+        sourceTypeFilter,
+        showConfigWarnings,
+        activeGroup?.groupKey,
+    ]);
 
     const flatData = useMemo(
         () => data?.pages.flatMap((page) => page.data) ?? [],
@@ -123,58 +191,88 @@ export const SettingsValidator: FC<{
                     setSelectedConfigError(undefined);
                 }}
             />
-            {isLoading ? (
-                <Paper withBorder shadow="sm">
-                    <Group justify="center" gap="xs" p="md">
-                        <Loader color="gray" />
-                    </Group>
-                </Paper>
-            ) : flatData.length > 0 || pinnedValidation || hasActiveFilters ? (
-                <ValidatorTable
-                    data={deduplicatedData}
-                    projectUuid={projectUuid}
-                    onSelectValidationError={(validationError) => {
-                        if (isChartValidationError(validationError)) {
-                            if (
-                                validationError.errorType ===
-                                ValidationErrorType.ChartConfiguration
-                            ) {
-                                setSelectedConfigError(validationError);
-                            } else {
-                                setSelectedValidationError(validationError);
-                            }
-                        } else if (
-                            isFixableDashboardValidationError(validationError)
-                        ) {
-                            setSelectedDashboardError(validationError);
+            <BulkDeleteContentModal
+                projectUuid={projectUuid}
+                items={deleteModalItems ?? []}
+                opened={deleteModalItems !== null}
+                onClose={closeDeleteModal}
+                onDeleted={() => setRowSelection({})}
+            />
+            <Stack gap="sm">
+                {summary && (
+                    <ValidationSummarySection
+                        summary={summary}
+                        activeGroupKey={activeGroup?.groupKey ?? null}
+                        onToggleGroup={(group) =>
+                            setActiveGroup((current) =>
+                                current?.groupKey === group.groupKey
+                                    ? null
+                                    : group,
+                            )
                         }
-                    }}
-                    isFetching={isFetching}
-                    isLoading={isLoading}
-                    isError={isError}
-                    totalDBRowCount={totalDBRowCount}
-                    fetchNextPage={fetchNextPage}
-                    pinnedValidation={pinnedValidation}
-                    onUnpin={handleUnpin}
-                    searchQuery={searchQuery}
-                    setSearchQuery={setSearchQuery}
-                    sourceTypeFilter={sourceTypeFilter}
-                    setSourceTypeFilter={setSourceTypeFilter}
-                    showConfigWarnings={showConfigWarnings}
-                    setShowConfigWarnings={setShowConfigWarnings}
-                    lastValidatedAt={lastValidatedAt}
-                    flush={flush}
-                />
-            ) : (
-                <Paper withBorder shadow="sm">
-                    <Group justify="center" gap="xs" p="md">
-                        <MantineIcon icon={IconCheck} color="green" />
-                        <Text fw={500} c="ldGray.7">
-                            No validation errors found
-                        </Text>
-                    </Group>
-                </Paper>
-            )}
+                        onDeleteGroup={setDeleteGroup}
+                    />
+                )}
+                {isLoading ? (
+                    <Paper withBorder shadow="sm">
+                        <Group justify="center" gap="xs" p="md">
+                            <Loader color="gray" />
+                        </Group>
+                    </Paper>
+                ) : flatData.length > 0 ||
+                  pinnedValidation ||
+                  hasActiveFilters ? (
+                    <ValidatorTable
+                        data={deduplicatedData}
+                        projectUuid={projectUuid}
+                        onSelectValidationError={(validationError) => {
+                            if (isChartValidationError(validationError)) {
+                                if (
+                                    validationError.errorType ===
+                                    ValidationErrorType.ChartConfiguration
+                                ) {
+                                    setSelectedConfigError(validationError);
+                                } else {
+                                    setSelectedValidationError(validationError);
+                                }
+                            } else if (
+                                isFixableDashboardValidationError(
+                                    validationError,
+                                )
+                            ) {
+                                setSelectedDashboardError(validationError);
+                            }
+                        }}
+                        isFetching={isFetching}
+                        isLoading={isLoading}
+                        isError={isError}
+                        totalDBRowCount={totalDBRowCount}
+                        fetchNextPage={fetchNextPage}
+                        pinnedValidation={pinnedValidation}
+                        onUnpin={handleUnpin}
+                        searchQuery={searchQuery}
+                        setSearchQuery={setSearchQuery}
+                        sourceTypeFilter={sourceTypeFilter}
+                        setSourceTypeFilter={setSourceTypeFilter}
+                        showConfigWarnings={showConfigWarnings}
+                        setShowConfigWarnings={setShowConfigWarnings}
+                        lastValidatedAt={lastValidatedAt}
+                        flush={flush}
+                        rowSelection={rowSelection}
+                        setRowSelection={setRowSelection}
+                        onBulkDelete={setSelectionDeleteItems}
+                    />
+                ) : (
+                    <Paper withBorder shadow="sm">
+                        <Group justify="center" gap="xs" p="md">
+                            <MantineIcon icon={IconCheck} color="green" />
+                            <Text fw={500} c="ldGray.7">
+                                No validation errors found
+                            </Text>
+                        </Group>
+                    </Paper>
+                )}
+            </Stack>
         </>
     );
 

--- a/packages/frontend/src/components/SettingsValidator/utils/deletableContent.ts
+++ b/packages/frontend/src/components/SettingsValidator/utils/deletableContent.ts
@@ -1,0 +1,69 @@
+import {
+    ChartSourceType,
+    ContentType,
+    isChartValidationError,
+    isDashboardValidationError,
+    type ApiContentBulkActionBody,
+    type ContentActionDelete,
+    type ValidationResponse,
+} from '@lightdash/common';
+
+export type ValidationContentItem = {
+    uuid: string;
+    contentType: ContentType.CHART | ContentType.DASHBOARD;
+    name: string;
+    views: number;
+};
+
+// Table and data-app validations, and private/deleted rows, cannot be deleted
+// from the Validator
+export const getDeletableContentItem = (
+    validationError: ValidationResponse,
+): ValidationContentItem | null => {
+    if (isChartValidationError(validationError) && validationError.chartUuid) {
+        return {
+            uuid: validationError.chartUuid,
+            contentType: ContentType.CHART,
+            name: validationError.name,
+            views: validationError.chartViews ?? 0,
+        };
+    }
+    if (
+        isDashboardValidationError(validationError) &&
+        validationError.dashboardUuid
+    ) {
+        return {
+            uuid: validationError.dashboardUuid,
+            contentType: ContentType.DASHBOARD,
+            name: validationError.name,
+            views: validationError.dashboardViews ?? 0,
+        };
+    }
+    return null;
+};
+
+export const dedupeContentItems = (
+    items: ValidationContentItem[],
+): ValidationContentItem[] => {
+    const byKey = new Map<string, ValidationContentItem>();
+    items.forEach((item) => {
+        byKey.set(`${item.contentType}:${item.uuid}`, item);
+    });
+    return [...byKey.values()];
+};
+
+export const toBulkDeletePayload = (
+    items: ValidationContentItem[],
+): ApiContentBulkActionBody<ContentActionDelete>['content'] =>
+    items.map((item) =>
+        item.contentType === ContentType.CHART
+            ? {
+                  uuid: item.uuid,
+                  contentType: ContentType.CHART,
+                  source: ChartSourceType.DBT_EXPLORE,
+              }
+            : {
+                  uuid: item.uuid,
+                  contentType: ContentType.DASHBOARD,
+              },
+    );

--- a/packages/frontend/src/hooks/validation/useValidation.ts
+++ b/packages/frontend/src/hooks/validation/useValidation.ts
@@ -3,10 +3,12 @@ import {
     type ApiError,
     type ApiJobScheduledResponse,
     type ApiPaginatedValidateResponse,
+    type ApiValidationSummaryResponse,
     type Explore,
     type ExploreError,
     type KnexPaginatedData,
     type ValidationErrorType,
+    type ValidationGroupedSummary,
     type ValidationResponse,
     type ValidationSourceType,
     type ValidationTarget,
@@ -122,6 +124,47 @@ export const useValidation = (
     });
 };
 
+const getValidationSummary = async (
+    projectUuid: string,
+): Promise<ValidationGroupedSummary> =>
+    lightdashApi<ApiValidationSummaryResponse['results']>({
+        url: `/projects/${projectUuid}/validate/summary`,
+        method: 'GET',
+        body: undefined,
+        version: 'v2',
+    });
+
+export const useValidationSummary = (
+    projectUuid: string,
+    user: UseQueryResult<UserWithAbility, ApiError>,
+) => {
+    const organizationUuid = user.data?.organizationUuid;
+    const canManageValidation = user.data?.ability.can(
+        'manage',
+        subject('Validation', {
+            organizationUuid,
+            projectUuid,
+        }),
+    );
+
+    return useQuery<ValidationGroupedSummary, ApiError>({
+        queryKey: ['validationSummary', projectUuid],
+        queryFn: () => getValidationSummary(projectUuid),
+        enabled: canManageValidation,
+        retry: (_, error) => error.error.statusCode !== 403,
+    });
+};
+
+// Full unpaginated validation list, fetched on demand (e.g. to resolve every
+// content item affected by one root cause before a bulk delete)
+export const useAllValidations = (projectUuid: string, enabled: boolean) =>
+    useQuery<ValidationResponse[], ApiError>({
+        queryKey: ['validation', 'all', projectUuid],
+        queryFn: () => getValidation(projectUuid, false),
+        enabled,
+        staleTime: 0,
+    });
+
 const getPaginatedValidation = async (
     projectUuid: string,
     page: number,
@@ -132,6 +175,7 @@ const getPaginatedValidation = async (
         sortDirection?: 'asc' | 'desc';
         sourceTypes?: ValidationSourceType[];
         errorTypes?: ValidationErrorType[];
+        tableName?: string;
         includeChartConfigWarnings?: boolean;
         fromSettings?: boolean;
     },
@@ -149,6 +193,7 @@ const getPaginatedValidation = async (
         params.set('sourceTypes', options.sourceTypes.join(','));
     if (options?.errorTypes?.length)
         params.set('errorTypes', options.errorTypes.join(','));
+    if (options?.tableName) params.set('tableName', options.tableName);
     if (options?.includeChartConfigWarnings != null)
         params.set(
             'includeChartConfigWarnings',
@@ -175,6 +220,7 @@ export const usePaginatedValidation = (
         sortDirection?: 'asc' | 'desc';
         sourceTypes?: ValidationSourceType[];
         errorTypes?: ValidationErrorType[];
+        tableName?: string;
         includeChartConfigWarnings?: boolean;
     },
 ) => {
@@ -199,6 +245,7 @@ export const usePaginatedValidation = (
             options?.sortDirection,
             options?.sourceTypes,
             options?.errorTypes,
+            options?.tableName,
             options?.includeChartConfigWarnings,
         ],
         queryFn: async ({ pageParam = 1 }) =>
@@ -208,6 +255,7 @@ export const usePaginatedValidation = (
                 sortDirection: options?.sortDirection,
                 sourceTypes: options?.sourceTypes,
                 errorTypes: options?.errorTypes,
+                tableName: options?.tableName,
                 includeChartConfigWarnings: options?.includeChartConfigWarnings,
                 fromSettings: true,
             }),
@@ -259,6 +307,9 @@ export const useValidationMutation = (
                     });
                     await queryClient.invalidateQueries({
                         queryKey: ['paginatedValidation'],
+                    });
+                    await queryClient.invalidateQueries({
+                        queryKey: ['validationSummary'],
                     });
                     showToastSuccess({ title: 'Validation completed' });
                 })
@@ -336,6 +387,7 @@ export const useDeleteValidation = (projectUuid: string) => {
             onSuccess: async () => {
                 await queryClient.invalidateQueries(['validation']);
                 await queryClient.invalidateQueries(['paginatedValidation']);
+                await queryClient.invalidateQueries(['validationSummary']);
                 showToastSuccess({
                     title: 'Validation dismissed',
                 });


### PR DESCRIPTION
Linear: [PROD-8489](https://linear.app/lightdash/issue/PROD-8489/bulk-remove-content-that-depends-on-a-deleted-model-autopilot) and [PROD-8487](https://linear.app/lightdash/issue/PROD-8487/autopilot-surface-a-summary-of-all-validation-errors-not-only-a)
Part of #24712 and #24714. Stacked on #27524.

## Changes

Validator page UX for bulk triage:

- A grouped summary strip above the table (`useValidationSummary` on the new v2 summary endpoint): one chip per root cause with error count and affected-content breakdown; deleted or failed-compile model groups sort first. Clicking a chip filters the table via the `errorTypes` and new `tableName` list params; clicking again clears the filter.
- Row selection on the Validator table (only rows mapping to deletable content: charts and dashboards with visible uuids). A "Delete content (N)" toolbar action opens a confirmation modal listing the deduped content with views, then calls the new `bulk-action/delete` endpoint. Toast and recently-deleted navigation come from the pre-existing `useContentBulkAction` handling.
- Model groups get a shortcut that deletes every chart referencing the deleted model: the full validation list is fetched on demand and filtered by structural `tableName`, so the target set is exact and listed in the modal before anything happens. Dashboards are excluded from the shortcut on purpose (they usually have other healthy tiles); they can still be selected and deleted row by row.
- Selection clears when filters change (it references loaded rows) and after a successful delete. Successful deletes invalidate the validation, paginated, and summary queries.
- Bulk dismiss is deliberately not included: dismissals do not survive `replaceProjectValidations` (full delete-and-reinsert per run), so it would set a false expectation. Persistent dismissals need a keyed table and are a separate follow-up.

## Regression analysis

- With no group selected and no rows selected, the table renders exactly as before apart from the selection checkbox column.
- The rename/fix flow is untouched; only Model groups get the delete shortcut.
- The summary strip renders only when the summary query returns data; a 403 or error leaves the page as it was.
- `ApiValidationSummaryResponse['results']` was added to the common `ApiResults` union for `lightdashApi` typing; additive only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wN2cB2mCApBBwDqn2J76Q
