### PR TITLE
feat(autopilot): grouped, complete broken-content summary tool

### DIFF
--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -19,6 +19,7 @@ import {
     ProjectType,
     ServiceAccountScope,
     ValidationErrorType,
+    ValidationSourceType,
     type ChartConfig,
     type ManagedAgentAction,
     type ManagedAgentActionFilters,
@@ -50,6 +51,7 @@ import type { ValidationModel } from '../../../models/ValidationModel/Validation
 import { SchedulerClient } from '../../../scheduler/SchedulerClient';
 import { BaseService } from '../../../services/BaseService';
 import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
+import { ValidationService } from '../../../services/ValidationService/ValidationService';
 import {
     ManagedAgentClient,
     type ManagedAgentSessionConfig,
@@ -61,6 +63,9 @@ import {
     buildManagedAgentToolListResult,
     formatManagedAgentToolListResult,
     getManagedAgentToolResultLimit,
+    getValidationRootCauseTableName,
+    MANAGED_AGENT_BROKEN_CONTENT_GROUP_ITEM_LIMIT,
+    MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT,
     summarizeManagedAgentBrokenContent,
 } from './toolResults';
 
@@ -1983,7 +1988,7 @@ export class ManagedAgentService extends BaseService {
                     'dashboards',
                 );
             case 'get_broken_content':
-                return this.handleGetBrokenContent(actor, projectUuid);
+                return this.handleGetBrokenContent(actor, projectUuid, input);
             case 'get_preview_projects':
                 return this.handleGetPreviewProjects(actor, projectUuid);
             case 'get_popular_content':
@@ -2143,23 +2148,15 @@ export class ManagedAgentService extends BaseService {
         );
     }
 
-    private async handleGetBrokenContent(
+    private async mapVisibleBrokenContentRows(
         actor: SessionUser,
         projectUuid: string,
-    ): Promise<string> {
-        const validations: ValidationResponse[] = (
-            await this.validationModel.get(projectUuid)
-        ).filter(
-            // Exclude advisory "unused field" warnings so Autopilot does not
-            // remove valid fields or table calculations that are merely flagged
-            // as unused. These are the only validations using ChartConfiguration.
-            (validation) =>
-                validation.errorType !== ValidationErrorType.ChartConfiguration,
-        );
+        validations: ValidationResponse[],
+    ) {
         const { canViewChartUuid, canViewDashboardUuid } =
             this.createContentVisibilityChecker(actor, projectUuid);
 
-        const visibleValidations = (
+        return (
             await Promise.all(
                 validations.map(async (validation) => {
                     if ('chartUuid' in validation && validation.chartUuid) {
@@ -2201,9 +2198,118 @@ export class ManagedAgentService extends BaseService {
                 }),
             )
         ).filter((validation) => validation !== null);
-        return formatManagedAgentToolListResult(
-            summarizeManagedAgentBrokenContent(visibleValidations),
+    }
+
+    private async handleGetBrokenContent(
+        actor: SessionUser,
+        projectUuid: string,
+        input: Record<string, unknown>,
+    ): Promise<string> {
+        const validations: ValidationResponse[] = (
+            await this.validationModel.get(projectUuid)
+        ).filter(
+            // Exclude advisory "unused field" warnings so Autopilot does not
+            // remove valid fields or table calculations that are merely flagged
+            // as unused. These are the only validations using ChartConfiguration.
+            (validation) =>
+                validation.errorType !== ValidationErrorType.ChartConfiguration,
         );
+
+        // Detail mode: full item list for one root-cause model. Scoping by
+        // model keeps every item reachable without raising the global cap.
+        const tableNameFilter =
+            typeof input.table_name === 'string' && input.table_name.length > 0
+                ? input.table_name
+                : undefined;
+        if (tableNameFilter) {
+            const matching = validations.filter(
+                (validation) =>
+                    getValidationRootCauseTableName(validation) ===
+                    tableNameFilter,
+            );
+            const visibleValidations = await this.mapVisibleBrokenContentRows(
+                actor,
+                projectUuid,
+                matching,
+            );
+            return formatManagedAgentToolListResult(
+                summarizeManagedAgentBrokenContent(visibleValidations),
+                getManagedAgentToolResultLimit(
+                    input.limit,
+                    MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT,
+                ),
+            );
+        }
+
+        // Summary mode: EVERY root-cause group with complete counts (never
+        // truncated), plus a capped sample of affected content per group
+        const summary =
+            ValidationService.groupValidationsByRootCause(validations);
+        const { canViewChartUuid, canViewDashboardUuid } =
+            this.createContentVisibilityChecker(actor, projectUuid);
+
+        const groups = await Promise.all(
+            summary.groups.map(async (group) => {
+                const visibleContent = (
+                    await Promise.all(
+                        group.affectedContent.map(async (content) => {
+                            if (content.uuid === null) return null;
+                            if (
+                                content.source === ValidationSourceType.Chart &&
+                                !(await canViewChartUuid(content.uuid))
+                            ) {
+                                return null;
+                            }
+                            if (
+                                content.source ===
+                                    ValidationSourceType.Dashboard &&
+                                !(await canViewDashboardUuid(content.uuid))
+                            ) {
+                                return null;
+                            }
+                            return {
+                                uuid: content.uuid,
+                                name: content.name,
+                                source: content.source,
+                                views: content.views,
+                                error_count: content.errorCount,
+                            };
+                        }),
+                    )
+                ).filter((content) => content !== null);
+
+                const items = visibleContent.slice(
+                    0,
+                    MANAGED_AGENT_BROKEN_CONTENT_GROUP_ITEM_LIMIT,
+                );
+                const totalItems =
+                    group.affectedCharts +
+                    group.affectedDashboards +
+                    group.affectedTables +
+                    group.affectedDataApps;
+                return {
+                    group_key: group.groupKey,
+                    error_type: group.errorType,
+                    table_name: group.tableName,
+                    field_name: group.fieldName,
+                    error_count: group.errorCount,
+                    affected_charts: group.affectedCharts,
+                    affected_dashboards: group.affectedDashboards,
+                    affected_tables: group.affectedTables,
+                    affected_data_apps: group.affectedDataApps,
+                    sample_error: group.sampleError,
+                    items,
+                    items_truncated: items.length < totalItems,
+                };
+            }),
+        );
+
+        return JSON.stringify({
+            total_errors: summary.totalErrors,
+            total_affected_items: summary.totalAffectedItems,
+            groups,
+            note: 'This is the COMPLETE set of validation error groups. To list every affected item for one group, call get_broken_content again with table_name set to that group. Counts include content outside your visibility scope; items only list content you can act on.',
+        });
     }
 
     private async handleGetPreviewProjects(

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -183,9 +183,10 @@ ${previewStep}
 ${staleStep}
 
 ### 3. Broken Content
-Call get_broken_content. For each broken chart:
-- Call get_chart_details to understand the current state
-- If the fix is clear (removed field has an obvious replacement, or invalid fields can be dropped without changing the chart's purpose), use fix_broken_chart
+Call get_broken_content. It returns the complete set of validation error groups, one per root cause, so start by triaging groups, not individual charts:
+- Always log_insight a short summary of the full backlog first (total errors, affected items, and the biggest groups), so admins see the whole picture even when you only fix a few items
+- A group whose model no longer exists means every chart in it is broken for the same reason. Call get_broken_content with that table_name to list all affected content
+- For renamed or replaced fields, fix charts individually: call get_chart_details to understand the current state, then use fix_broken_chart when the fix is clear (removed field has an obvious replacement, or invalid fields can be dropped without changing the chart's purpose)
 - If the fix is ambiguous or would change what the chart shows, ${brokenFallback}
 - Reference the "Developing in Lightdash" skill for valid metricQuery and chartConfig structure
 
@@ -311,9 +312,20 @@ export const managedAgentConfig: AgentCreateParams = {
         },
         {
             description:
-                'Get charts and dashboards with validation errors (e.g., referencing fields that no longer exist). Returns uuid, name, type, and the specific errors.',
+                'Get validation errors grouped by root cause (e.g. one group per deleted model). Without arguments, returns the COMPLETE set of groups with counts and a capped sample of affected content per group. Pass table_name to list every broken item caused by that model.',
             input_schema: {
-                properties: {},
+                properties: {
+                    limit: {
+                        description:
+                            'Max items to return in table_name detail mode',
+                        type: 'number',
+                    },
+                    table_name: {
+                        description:
+                            'Root-cause model name from a summary group; switches to detail mode listing all affected content for that model',
+                        type: 'string',
+                    },
+                },
                 required: [],
                 type: 'object',
             },

--- a/packages/backend/src/ee/services/ManagedAgentService/toolResults.test.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/toolResults.test.ts
@@ -1,0 +1,103 @@
+import {
+    ValidationErrorType,
+    ValidationSourceType,
+    type ValidationResponse,
+} from '@lightdash/common';
+import {
+    getValidationRootCauseTableName,
+    summarizeManagedAgentBrokenContent,
+} from './toolResults';
+
+const base = {
+    validationId: null,
+    createdAt: new Date(),
+    projectUuid: 'project-uuid',
+};
+
+describe('getValidationRootCauseTableName', () => {
+    it('reads tableName from chart validations', () => {
+        const validation: ValidationResponse = {
+            ...base,
+            validationUuid: 'v1',
+            source: ValidationSourceType.Chart,
+            name: 'Chart',
+            error: "Model error: the model 'orders' no longer exists",
+            errorType: ValidationErrorType.Model,
+            chartUuid: 'chart-1',
+            chartViews: 0,
+            tableName: 'orders',
+        };
+        expect(getValidationRootCauseTableName(validation)).toBe('orders');
+    });
+
+    it('reads tableName from dashboard validations', () => {
+        const validation: ValidationResponse = {
+            ...base,
+            validationUuid: 'v2',
+            source: ValidationSourceType.Dashboard,
+            name: 'Dashboard',
+            error: "Table 'orders' no longer exists",
+            errorType: ValidationErrorType.Filter,
+            dashboardUuid: 'dashboard-1',
+            dashboardViews: 0,
+            tableName: 'orders',
+        };
+        expect(getValidationRootCauseTableName(validation)).toBe('orders');
+    });
+
+    it('reads the model name from table validations', () => {
+        const validation: ValidationResponse = {
+            ...base,
+            validationUuid: 'v3',
+            source: ValidationSourceType.Table,
+            name: 'orders',
+            error: 'Compile error',
+            errorType: ValidationErrorType.Model,
+        };
+        expect(getValidationRootCauseTableName(validation)).toBe('orders');
+    });
+
+    it('returns null when the row has no structural model reference', () => {
+        const validation: ValidationResponse = {
+            ...base,
+            validationUuid: 'v4',
+            source: ValidationSourceType.Chart,
+            name: 'Chart',
+            error: "Dimension error: the field 'x' no longer exists",
+            errorType: ValidationErrorType.Dimension,
+            chartUuid: 'chart-1',
+            chartViews: 0,
+        };
+        expect(getValidationRootCauseTableName(validation)).toBeNull();
+    });
+});
+
+describe('summarizeManagedAgentBrokenContent', () => {
+    it('groups rows by content uuid with per-content error counts', () => {
+        const rows = [
+            {
+                uuid: 'chart-1',
+                name: 'Chart one',
+                type: 'chart' as const,
+                error: 'error a',
+                error_type: ValidationErrorType.Dimension,
+                source: ValidationSourceType.Chart,
+            },
+            {
+                uuid: 'chart-1',
+                name: 'Chart one',
+                type: 'chart' as const,
+                error: 'error b',
+                error_type: ValidationErrorType.Metric,
+                source: ValidationSourceType.Chart,
+            },
+        ];
+        const summary = summarizeManagedAgentBrokenContent(rows);
+        expect(summary).toHaveLength(1);
+        expect(summary[0]).toMatchObject({
+            uuid: 'chart-1',
+            error_count: 2,
+            errors_truncated: false,
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ManagedAgentService/toolResults.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/toolResults.ts
@@ -1,7 +1,30 @@
-import type { ValidationResponse } from '@lightdash/common';
+import {
+    isChartValidationError,
+    isDashboardValidationError,
+    isDataAppValidationError,
+    type ValidationResponse,
+} from '@lightdash/common';
 
 export const MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT = 100;
 export const MANAGED_AGENT_BROKEN_CONTENT_ERROR_LIMIT = 10;
+export const MANAGED_AGENT_BROKEN_CONTENT_GROUP_ITEM_LIMIT = 10;
+
+// Root-cause model of a validation row. Guard order matters: table responses
+// are structurally assignable from the others, so they are the fallback.
+export const getValidationRootCauseTableName = (
+    validation: ValidationResponse,
+): string | null => {
+    if (isChartValidationError(validation)) {
+        return validation.tableName ?? null;
+    }
+    if (isDashboardValidationError(validation)) {
+        return validation.tableName ?? null;
+    }
+    if (isDataAppValidationError(validation)) {
+        return validation.modelName ?? null;
+    }
+    return validation.name ?? null;
+};
 
 export const getManagedAgentToolResultLimit = (
     requestedLimit: unknown,


### PR DESCRIPTION
Linear: [PROD-8487](https://linear.app/lightdash/issue/PROD-8487/autopilot-surface-a-summary-of-all-validation-errors-not-only-a)
Closes #24712. Stacked on #27525.

## Problem

Autopilot's `get_broken_content` returned an arbitrary first-100 slice of validation rows (insertion order, no ranking), grouped by content uuid, and dropped the field/model information needed to reason about root causes. With a large backlog the agent saw a fraction of it and could not tell that fifty charts were broken by one deleted model.

## Changes

- `get_broken_content` without arguments now returns the complete set of root-cause groups (reusing `ValidationService.groupValidationsByRootCause` from #27523): every group with full counts, never truncated, plus a per-group sample of affected content (10) filtered by the existing content-visibility checker. Counts include content outside the agent's visibility scope; only listed items are actionable, and the payload says so.
- A new optional `table_name` input switches to detail mode: the full item list for one root-cause model, in the previous per-content shape, with the existing limit semantics. Scoping by model makes every item reachable without raising the global 100-item cap.
- Prompt checklist step 3 now triages by root cause: log an insight summarizing the whole backlog first, drill into deleted-model groups by `table_name`, and keep per-chart fixes for renamed/replaced fields.
- `getValidationRootCauseTableName` in `toolResults.ts` resolves the structural model reference per source type (with guard ordering documented, since table responses are structurally assignable from the others).

## Regression analysis

- Detail mode preserves the exact previous output shape (`items/total_count/truncated`), so the agent's existing handling of per-content entries still applies.
- Chart-configuration warnings remain excluded, as before.
- Visibility filtering is unchanged for items; only counts became complete, which is the point of the ticket.
- Summary completeness for legacy rows requires one validation run after #27522's migration deploys (rows written before it lack `table_name` and group under null).

Tests: `toolResults.test.ts` covers the root-cause resolver per source type and the per-content summarizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wN2cB2mCApBBwDqn2J76Q
