### PR TITLE
feat(autopilot): bulk delete charts on deleted models with guardrails

### DIFF
--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -65,6 +65,7 @@ import {
     getManagedAgentToolResultLimit,
     getValidationRootCauseTableName,
     MANAGED_AGENT_BROKEN_CONTENT_GROUP_ITEM_LIMIT,
+    MANAGED_AGENT_BULK_DELETE_RUN_LIMIT,
     MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT,
     summarizeManagedAgentBrokenContent,
 } from './toolResults';
@@ -2009,6 +2010,14 @@ export class ManagedAgentService extends BaseService {
                     runUuid,
                     input,
                 );
+            case 'bulk_delete_broken_content':
+                return this.handleBulkDeleteBrokenContent(
+                    actor,
+                    projectUuid,
+                    sessionId,
+                    runUuid,
+                    input,
+                );
             case 'log_insight':
                 return this.handleLogInsight(
                     actor,
@@ -2995,6 +3004,86 @@ chartConfig:
         return null;
     }
 
+    // Full chart soft-delete guard chain shared by soft_delete_content and
+    // bulk_delete_broken_content. Returns a blocked JSON payload, or null
+    // after a successful soft delete.
+    private async guardAndSoftDeleteChart(args: {
+        actor: SessionUser;
+        projectUuid: string;
+        sessionId: string;
+        runUuid: string;
+        chartUuid: string;
+        chartName: string;
+        policy: ManagedAgentPolicy;
+        actorUuid: string;
+        attemptedAction: 'fix' | 'flag' | 'soft-delete';
+    }): Promise<string | null> {
+        const {
+            actor,
+            projectUuid,
+            sessionId,
+            runUuid,
+            chartUuid,
+            chartName,
+            policy,
+            actorUuid,
+            attemptedAction,
+        } = args;
+
+        const deleteProtectionBlock = await this.checkTargetProtectionGuard(
+            projectUuid,
+            ManagedAgentTargetType.CHART,
+            chartUuid,
+            chartName,
+            { actor, sessionId, runUuid, attemptedAction },
+        );
+        if (deleteProtectionBlock) {
+            return deleteProtectionBlock;
+        }
+
+        const protectCutoff = new Date();
+        protectCutoff.setDate(
+            protectCutoff.getDate() - policy.protectRecentDays,
+        );
+
+        const chart = await this.savedChartModel.get(chartUuid);
+        ManagedAgentService.assertProjectOwnership(
+            chart.projectUuid,
+            projectUuid,
+            'Chart',
+            chartUuid,
+        );
+        await this.assertActorCanDeleteChart(actor, chart);
+        // Hard guardrail: never delete agent-created charts
+        if (chart.slug?.startsWith('agent-')) {
+            return JSON.stringify({
+                error: `Chart "${chartName}" was created by the agent (slug: ${chart.slug}). Cannot soft-delete own content.`,
+                blocked: true,
+            });
+        }
+        // Hard guardrail: never delete recently created or edited charts
+        const chartModifiedAt =
+            await this.managedAgentModel.getChartLastModifiedAt(chartUuid);
+        if (chartModifiedAt && chartModifiedAt > protectCutoff) {
+            return JSON.stringify({
+                error: `Chart "${chartName}" was created or last edited on ${chartModifiedAt.toISOString().split('T')[0]}, less than ${policy.protectRecentDays} days ago. Cannot soft-delete recently touched content.`,
+                blocked: true,
+            });
+        }
+        const chartEscalationBlock = await this.checkEscalationGuard(
+            projectUuid,
+            ManagedAgentTargetType.CHART,
+            chartUuid,
+            chartName,
+            policy,
+        );
+        if (chartEscalationBlock) {
+            return chartEscalationBlock;
+        }
+        await this.savedChartModel.softDelete(chartUuid, actorUuid);
+        return null;
+    }
+
     private async handleSoftDelete(
         actor: SessionUser,
         projectUuid: string,
@@ -3031,60 +3120,38 @@ chartConfig:
             });
         }
 
-        const deleteProtectionBlock = await this.checkTargetProtectionGuard(
-            projectUuid,
-            targetType,
-            targetUuid,
-            targetName,
-            { actor, sessionId, runUuid, attemptedAction: 'soft-delete' },
-        );
-        if (deleteProtectionBlock) {
-            return deleteProtectionBlock;
-        }
-
-        const protectCutoff = new Date();
-        protectCutoff.setDate(
-            protectCutoff.getDate() - policy.protectRecentDays,
-        );
-
         // Verify entity exists, belongs to this project, and apply guardrails
         if (targetType === ManagedAgentTargetType.CHART) {
-            const chart = await this.savedChartModel.get(targetUuid);
-            ManagedAgentService.assertProjectOwnership(
-                chart.projectUuid,
+            const chartBlock = await this.guardAndSoftDeleteChart({
+                actor,
                 projectUuid,
-                'Chart',
-                targetUuid,
-            );
-            await this.assertActorCanDeleteChart(actor, chart);
-            // Hard guardrail: never delete agent-created charts
-            if (chart.slug?.startsWith('agent-')) {
-                return JSON.stringify({
-                    error: `Chart "${targetName}" was created by the agent (slug: ${chart.slug}). Cannot soft-delete own content.`,
-                    blocked: true,
-                });
+                sessionId,
+                runUuid,
+                chartUuid: targetUuid,
+                chartName: targetName,
+                policy,
+                actorUuid,
+                attemptedAction: 'soft-delete',
+            });
+            if (chartBlock) {
+                return chartBlock;
             }
-            // Hard guardrail: never delete recently created or edited charts
-            const chartModifiedAt =
-                await this.managedAgentModel.getChartLastModifiedAt(targetUuid);
-            if (chartModifiedAt && chartModifiedAt > protectCutoff) {
-                return JSON.stringify({
-                    error: `Chart "${targetName}" was created or last edited on ${chartModifiedAt.toISOString().split('T')[0]}, less than ${policy.protectRecentDays} days ago. Cannot soft-delete recently touched content.`,
-                    blocked: true,
-                });
-            }
-            const chartEscalationBlock = await this.checkEscalationGuard(
+        } else if (targetType === ManagedAgentTargetType.DASHBOARD) {
+            const deleteProtectionBlock = await this.checkTargetProtectionGuard(
                 projectUuid,
                 targetType,
                 targetUuid,
                 targetName,
-                policy,
+                { actor, sessionId, runUuid, attemptedAction: 'soft-delete' },
             );
-            if (chartEscalationBlock) {
-                return chartEscalationBlock;
+            if (deleteProtectionBlock) {
+                return deleteProtectionBlock;
             }
-            await this.savedChartModel.softDelete(targetUuid, actorUuid);
-        } else if (targetType === ManagedAgentTargetType.DASHBOARD) {
+
+            const protectCutoff = new Date();
+            protectCutoff.setDate(
+                protectCutoff.getDate() - policy.protectRecentDays,
+            );
             const dashboard =
                 await this.dashboardModel.getByIdOrSlug(targetUuid);
             ManagedAgentService.assertProjectOwnership(
@@ -3137,6 +3204,148 @@ chartConfig:
         return JSON.stringify({
             action_uuid: action.actionUuid,
             recoverable: true,
+        });
+    }
+
+    private async handleBulkDeleteBrokenContent(
+        actor: SessionUser,
+        projectUuid: string,
+        sessionId: string,
+        runUuid: string,
+        input: Record<string, unknown>,
+    ): Promise<string> {
+        const tableName = input.table_name as string;
+        const reason = input.reason as string;
+        if (!tableName || !reason) {
+            throw new Error('table_name and reason are required');
+        }
+
+        await this.assertActorCanManageProject(actor, projectUuid);
+        const settings = await this.managedAgentModel.getSettings(projectUuid);
+        const actorUuid = settings?.enabledByUserUuid ?? projectUuid;
+        const policy = settings?.policy ?? DEFAULT_MANAGED_AGENT_POLICY;
+
+        // Hard guardrail: aggression below 'cleanup' never deletes
+        if (policy.aggression !== 'cleanup') {
+            return JSON.stringify({
+                error: `Bulk delete is disabled by project policy (cleanup mode: ${policy.aggression}). Flag or log an insight instead.`,
+                blocked: true,
+            });
+        }
+
+        // Candidates: charts whose whole model is gone. Dashboards referencing
+        // the model are never bulk-deleted; they usually have healthy tiles
+        const validations = await this.validationModel.get(projectUuid);
+        const candidates = new Map<string, string>();
+        validations.forEach((validation) => {
+            if (
+                validation.source === ValidationSourceType.Chart &&
+                validation.errorType === ValidationErrorType.Model &&
+                'chartUuid' in validation &&
+                validation.chartUuid &&
+                getValidationRootCauseTableName(validation) === tableName
+            ) {
+                candidates.set(validation.chartUuid, validation.name);
+            }
+        });
+
+        if (candidates.size === 0) {
+            return JSON.stringify({
+                error: `No charts with a model-level validation error were found for model '${tableName}'. Run get_broken_content to see current groups.`,
+            });
+        }
+
+        const entries = [...candidates.entries()];
+        const toProcess = entries.slice(0, MANAGED_AGENT_BULK_DELETE_RUN_LIMIT);
+        const remaining = entries.length - toProcess.length;
+
+        const deleted: { uuid: string; name: string; action_uuid: string }[] =
+            [];
+        const blocked: { uuid: string; name: string; reason: string }[] = [];
+
+        // Sequential on purpose: each delete runs the full guard chain and
+        // writes an action row
+        for (const [chartUuid, chartName] of toProcess) {
+            // eslint-disable-next-line no-await-in-loop
+            const chart = await this.savedChartModel.get(chartUuid);
+            // Defense against stale validation rows: the chart must still
+            // reference the deleted model
+            if (chart.tableName !== tableName) {
+                blocked.push({
+                    uuid: chartUuid,
+                    name: chartName,
+                    reason: `Chart no longer references model '${tableName}'`,
+                });
+            } else {
+                // eslint-disable-next-line no-await-in-loop
+                const chartBlock = await this.guardAndSoftDeleteChart({
+                    actor,
+                    projectUuid,
+                    sessionId,
+                    runUuid,
+                    chartUuid,
+                    chartName,
+                    policy,
+                    actorUuid,
+                    attemptedAction: 'soft-delete',
+                });
+                if (chartBlock) {
+                    let blockReason = chartBlock;
+                    try {
+                        const parsed: unknown = JSON.parse(chartBlock);
+                        if (
+                            parsed !== null &&
+                            typeof parsed === 'object' &&
+                            'error' in parsed &&
+                            typeof parsed.error === 'string'
+                        ) {
+                            blockReason = parsed.error;
+                        }
+                    } catch {
+                        // keep the raw payload as the reason
+                    }
+                    blocked.push({
+                        uuid: chartUuid,
+                        name: chartName,
+                        reason: blockReason,
+                    });
+                } else {
+                    // eslint-disable-next-line no-await-in-loop
+                    const action = await this.managedAgentModel.createAction({
+                        projectUuid,
+                        sessionId,
+                        managedAgentRunUuid: runUuid,
+                        actionType: ManagedAgentActionType.SOFT_DELETED,
+                        targetType: ManagedAgentTargetType.CHART,
+                        targetUuid: chartUuid,
+                        targetName: chartName,
+                        description: reason,
+                        metadata: {
+                            bulk: true,
+                            table_name: tableName,
+                            reason,
+                        },
+                    });
+                    this.trackActionCreated(actor, runUuid, action);
+                    deleted.push({
+                        uuid: chartUuid,
+                        name: chartName,
+                        action_uuid: action.actionUuid,
+                    });
+                }
+            }
+        }
+
+        return JSON.stringify({
+            deleted_count: deleted.length,
+            deleted,
+            blocked,
+            remaining,
+            recoverable: true,
+            note:
+                remaining > 0
+                    ? `Run cap reached: ${remaining} more broken charts remain for model '${tableName}'. They will be picked up on the next run.`
+                    : undefined,
         });
     }
 

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -185,7 +185,7 @@ ${staleStep}
 ### 3. Broken Content
 Call get_broken_content. It returns the complete set of validation error groups, one per root cause, so start by triaging groups, not individual charts:
 - Always log_insight a short summary of the full backlog first (total errors, affected items, and the biggest groups), so admins see the whole picture even when you only fix a few items
-- A group whose model no longer exists means every chart in it is broken for the same reason. Call get_broken_content with that table_name to list all affected content
+- A group whose model no longer exists means every chart in it is broken for the same reason. Call get_broken_content with that table_name to list all affected content. When bulk_delete_broken_content is available, use it to clean up all charts on that deleted model in one call; flag affected dashboards instead of deleting them
 - For renamed or replaced fields, fix charts individually: call get_chart_details to understand the current state, then use fix_broken_chart when the fix is clear (removed field has an obvious replacement, or invalid fields can be dropped without changing the chart's purpose)
 - If the fix is ambiguous or would change what the chart shows, ${brokenFallback}
 - Reference the "Developing in Lightdash" skill for valid metricQuery and chartConfig structure
@@ -438,6 +438,28 @@ export const managedAgentConfig: AgentCreateParams = {
                 type: 'object',
             },
             name: 'soft_delete_content',
+            type: 'custom',
+        },
+        {
+            description:
+                'Soft-delete every chart whose underlying model was deleted, in one call. Only use when get_broken_content shows a model-level group (the whole model no longer exists). Charts are individually recoverable; dashboards referencing the model are never deleted by this tool, flag them instead. Deletes at most 25 charts per call and reports the remainder. Per-chart guardrails still apply and skipped charts are reported with reasons.',
+            input_schema: {
+                properties: {
+                    reason: {
+                        description:
+                            'Human-readable explanation of WHY this cleanup is safe (e.g. which model was removed and when)',
+                        type: 'string',
+                    },
+                    table_name: {
+                        description:
+                            'The deleted model name, exactly as returned by get_broken_content',
+                        type: 'string',
+                    },
+                },
+                required: ['table_name', 'reason'],
+                type: 'object',
+            },
+            name: 'bulk_delete_broken_content',
             type: 'custom',
         },
         {
@@ -766,8 +788,12 @@ const aggressionDisabledTools: Record<
     ManagedAgentPolicy['aggression'],
     string[]
 > = {
-    observe: ['flag_content', 'soft_delete_content'],
-    flag: ['soft_delete_content'],
+    observe: [
+        'flag_content',
+        'soft_delete_content',
+        'bulk_delete_broken_content',
+    ],
+    flag: ['soft_delete_content', 'bulk_delete_broken_content'],
     cleanup: [],
 };
 
@@ -784,6 +810,7 @@ const managedAgentCapabilityTools = {
     createContent: ['create_content_from_code'],
     modifyExistingContent: [
         'soft_delete_content',
+        'bulk_delete_broken_content',
         'fix_broken_chart',
         'reverse_own_action',
     ],

--- a/packages/backend/src/ee/services/ManagedAgentService/toolResults.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/toolResults.ts
@@ -8,6 +8,7 @@ import {
 export const MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT = 100;
 export const MANAGED_AGENT_BROKEN_CONTENT_ERROR_LIMIT = 10;
 export const MANAGED_AGENT_BROKEN_CONTENT_GROUP_ITEM_LIMIT = 10;
+export const MANAGED_AGENT_BULK_DELETE_RUN_LIMIT = 25;
 
 // Root-cause model of a validation row. Guard order matters: table responses
 // are structurally assignable from the others, so they are the fallback.


### PR DESCRIPTION
Linear: [PROD-8489](https://linear.app/lightdash/issue/PROD-8489/bulk-remove-content-that-depends-on-a-deleted-model-autopilot)
Closes #24714. Stacked on #27526.

## Changes

New Autopilot tool `bulk_delete_broken_content({ table_name, reason })`: soft-deletes every chart whose model was deleted, in one call.

- Candidates are charts with a model-level validation error whose structural `table_name` matches, cross-checked against the chart's current base table (defense against stale validation rows). Dashboards referencing the model are never deleted by this tool; the prompt directs the agent to flag them instead, since they usually have other healthy tiles.
- The full per-chart guard chain from `soft_delete_content` applies to every candidate: target protections (blocked attempts recorded as BLOCKED actions), project ownership, actor delete permission, the agent-created-content guard, the recent-content window, and the flag-first escalation guard. The chart branch of `handleSoftDelete` was extracted into a shared `guardAndSoftDeleteChart` helper rather than duplicated; the dashboard branch is unchanged.
- Capped at 25 deletions per call; the response reports `deleted`, `blocked` (with per-chart reasons), and `remaining` so the agent reports backlog instead of churning.
- Each deletion is its own `soft_deleted` action with `{bulk: true, table_name, reason}` metadata, so per-item `reverse_own_action` restore and the existing activity page rendering work without changes.
- Gated like deletion generally: removed from the toolset under `observe` and `flag` aggression, part of the `modifyExistingContent` capability, and hard-blocked at runtime when aggression is below `cleanup`.

## Regression analysis

- `soft_delete_content` behavior is unchanged: the extracted helper runs the same checks in the same order for charts (protection guard moved inside the type branches; dashboards run it at the start of their branch, equivalent to the previous pre-branch call).
- The tool only ever targets charts whose whole model is gone (`errorType = model`), never field-level breakage, so a rename scenario cannot trigger it.
- Deletions use the same `savedChartModel.softDelete` with the enabling admin as actor, matching the single-delete path.

Tests: existing ManagedAgentService and config suites pass; guard behavior is exercised through the shared helper used by `soft_delete_content`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wN2cB2mCApBBwDqn2J76Q
