### PR TITLE
fix(ai): render streamdown link buttons as inline links, not native buttons

### DIFF
--- a/packages/frontend/src/components/common/AiMarkdown/AiMarkdown.tsx
+++ b/packages/frontend/src/components/common/AiMarkdown/AiMarkdown.tsx
@@ -31,6 +31,19 @@ type AiMarkdownProps = {
 
 const BASE_REMARK_PLUGINS = [remarkGfm, remarkEmoji];
 
+// Streamdown's default link renderer is a <button> that opens an inline
+// "open external link?" confirmation, both styled with Tailwind classes we
+// don't ship — so links degrade to native button chrome. Render plain
+// anchors by default; consumers with richer behavior (e.g. agent chat's
+// ContentLink pills) override `components.a`.
+const DEFAULT_COMPONENTS: StreamdownProps['components'] = {
+    a: ({ node: _node, children, ...props }) => (
+        <a {...props} target="_blank" rel="noreferrer noopener">
+            {children}
+        </a>
+    ),
+};
+
 type SanitizeSchema = {
     tagNames?: string[];
     attributes?: Record<string, unknown>;
@@ -95,6 +108,10 @@ export const AiMarkdown: FC<AiMarkdownProps> = ({
                 : rehypePlugins,
         [allowedTags, rehypePlugins],
     );
+    const mergedComponents = useMemo(
+        () => ({ ...DEFAULT_COMPONENTS, ...components }),
+        [components],
+    );
 
     return (
         <Box
@@ -111,7 +128,7 @@ export const AiMarkdown: FC<AiMarkdownProps> = ({
                     remarkPlugins={mergedRemarkPlugins}
                     rehypePlugins={mergedRehypePlugins}
                     plugins={plugins}
-                    components={components}
+                    components={mergedComponents}
                     allowedTags={allowedTags}
                 >
                     {children}


### PR DESCRIPTION
## Problem

Streamdown's default link renderer is a `<button data-streamdown="link">` that opens an inline "open external link?" confirmation. Both are styled with Tailwind utility classes Lightdash does not ship, so in every `AiMarkdown` surface that does not override the link component (Autopilot agent reasoning, deep research reports, memory details, evidence excerpts, homepage markdown blocks), autolinked emails and URLs degrade to native browser button chrome, and clicking one injects an unstyled confirmation flow into the prose.

Observed on the Autopilot activity page: an inactive-users insight rendered `demo2@lightdash.com` as a grey bordered button, and clicking it dumped raw "Open external link? / Copy link / Open link" buttons mid-sentence.

## Change

`AiMarkdown` now supplies a default `components.a` that renders a plain `<a target="_blank" rel="noreferrer noopener">`, picking up the existing `.aiMarkdown a` indigo underline styling. Consumers that pass their own `a` override (the agent chat's `ContentLink` pills) still win via the merge order.

## Regression analysis

- Agent chat is unaffected: `AgentChatAssistantBubble` passes `components.a` explicitly, which overrides the new default.
- No CSS changes; the anchor styling rule already existed and now simply applies.
- The Streamdown click-confirmation gate is intentionally bypassed, matching the precedent already set by the chat surfaces, and `rel="noreferrer noopener"` covers the opener risk.
- Verified live on the Autopilot activity page: the reasoning sidebar renders emails as inline mailto links with no `data-streamdown="link"` buttons in the DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wN2cB2mCApBBwDqn2J76Q
