### PR TITLE
fix(autopilot): never-viewed content must exceed the staleness window before counting as stale

### DIFF
--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -723,6 +723,7 @@ export class ManagedAgentModel {
             projectUuid,
             memberUuidList,
             inactiveDays,
+            inactiveDays,
             limit,
         ]);
 

--- a/packages/backend/src/ee/models/ManagedAgentModelSql.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModelSql.ts
@@ -24,7 +24,8 @@ export type UnusedAgentRoutingSignal =
 
 /**
  * Parameters: member_uuids, project_uuid, member_uuids, project_uuid,
- * member_uuids, project_uuid, member_uuids, inactive_days, limit
+ * member_uuids, project_uuid, member_uuids, inactive_days, inactive_days,
+ * limit
  */
 export const inactiveUsersSql = () => `
 WITH activity AS (
@@ -68,7 +69,12 @@ WHERE u.user_uuid = ANY(string_to_array(?, ',')::uuid[])
   AND u.is_active = true
   AND u.is_internal = false
   AND (
-    latest.timestamp IS NULL
+    -- Never-active users only count as inactive once their account has
+    -- existed for the full window; a user invited yesterday is not inactive
+    (
+      latest.timestamp IS NULL
+      AND u.created_at < now() - make_interval(days => ?)
+    )
     OR latest.timestamp < now() - make_interval(days => ?)
   )
 ORDER BY latest.timestamp ASC NULLS FIRST

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -762,8 +762,8 @@ const aggressionDisabledTools: Record<
 const buildPolicyToolDescriptions = (
     policy: ManagedAgentPolicy,
 ): Record<string, string> => ({
-    get_stale_charts: `Get charts that are stale per project policy: not viewed in ${policy.stalenessChartDays}+ days (or never viewed), and not created or edited in the last ${policy.protectRecentDays} days. Returns uuid, name, space, last_viewed_at, views_count, created_by, and a reason field.`,
-    get_stale_dashboards: `Get dashboards that are stale per project policy: not viewed in ${policy.stalenessDashboardDays}+ days (or never viewed), and not created or edited in the last ${policy.protectRecentDays} days. Returns uuid, name, space, last_viewed_at, views_count, created_by, and a reason field.`,
+    get_stale_charts: `Get charts that are stale per project policy: not viewed in ${policy.stalenessChartDays}+ days (or never viewed and created ${policy.stalenessChartDays}+ days ago), and not created or edited in the last ${policy.protectRecentDays} days. Returns uuid, name, space, last_viewed_at, views_count, created_by, and a reason field.`,
+    get_stale_dashboards: `Get dashboards that are stale per project policy: not viewed in ${policy.stalenessDashboardDays}+ days (or never viewed and created ${policy.stalenessDashboardDays}+ days ago), and not created or edited in the last ${policy.protectRecentDays} days. Returns uuid, name, space, last_viewed_at, views_count, created_by, and a reason field.`,
     get_preview_projects: `Get preview projects older than ${policy.previewProjectDays} days per project policy. Returns uuid, name, created_at, and the project they were copied from.`,
     get_slow_queries: `Get the slowest warehouse queries in the project from the last 30 days (threshold: ${policy.slowQueryThresholdMs} ms per project policy). Returns the chart or dashboard name, execution time in ms, query context, and when it ran. Use this to flag charts or dashboards with consistently slow queries so admins can optimize them.`,
 });

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -427,11 +427,13 @@ export class AnalyticsModel {
                     this.database.raw(chartsQuery, [
                         projectUuid,
                         options.stalenessChartDays,
+                        options.stalenessChartDays,
                         options.protectRecentDays,
                         options.limit,
                     ]),
                     this.database.raw(dashboardsQuery, [
                         projectUuid,
+                        options.stalenessDashboardDays,
                         options.stalenessDashboardDays,
                         options.protectRecentDays,
                         options.limit,

--- a/packages/backend/src/models/AnalyticsModelSql.ts
+++ b/packages/backend/src/models/AnalyticsModelSql.ts
@@ -264,7 +264,7 @@ WHERE rank = 1;
 `;
 
 /**
- * Parameters: project_uuid, staleness_days, protect_recent_days, limit
+ * Parameters: project_uuid, staleness_days, staleness_days, protect_recent_days, limit
  */
 export const unusedChartsSql = () => `
 SELECT
@@ -313,7 +313,12 @@ GROUP BY
 HAVING
   (
     MAX(cv.timestamp) < now() - make_interval(days => ?)
-    OR MAX(cv.timestamp) IS NULL
+    -- Never-viewed content only counts as stale once it has existed for the
+    -- full staleness window; the protect window alone is not enough
+    OR (
+      MAX(cv.timestamp) IS NULL
+      AND sq.created_at < now() - make_interval(days => ?)
+    )
   )
   AND GREATEST(
     sq.created_at,
@@ -327,7 +332,7 @@ LIMIT ?;
 `;
 
 /**
- * Parameters: project_uuid, staleness_days, protect_recent_days, limit
+ * Parameters: project_uuid, staleness_days, staleness_days, protect_recent_days, limit
  */
 export const unusedDashboardsSql = () => `
 SELECT
@@ -383,7 +388,12 @@ GROUP BY
 HAVING
   (
     MAX(adv.timestamp) < now() - make_interval(days => ?)
-    OR MAX(adv.timestamp) IS NULL
+    -- Never-viewed content only counts as stale once it has existed for the
+    -- full staleness window; the protect window alone is not enough
+    OR (
+      MAX(adv.timestamp) IS NULL
+      AND d.created_at < now() - make_interval(days => ?)
+    )
   )
   AND GREATEST(
     d.created_at,


### PR DESCRIPTION
## Problem

The Autopilot policy says "Stale charts after N days" (default 90), but the stale-content query treated any **never-viewed** chart or dashboard as stale the moment it cleared the 30-day protect window: the `HAVING` clause was `viewed < now() - staleness_days OR never_viewed`, with only the protect-recent check applying to the never-viewed branch. Observed live: a first `cleanup` run on a low-traffic project soft-deleted 76-day-old never-viewed content under a 90-day policy — effectively sweeping the whole project while the settings promised a 90-day grace.

## Changes

Two instances of the same bug class ("never-X short-circuits the policy window") are fixed:

- **Stale content**: never-viewed content only qualifies as stale once it has *existed* for the full staleness window (`created_at < now() - staleness_days`), for both charts and dashboards. The staleness parameter is bound twice; the protect-recent-edit check is unchanged. The `get_stale_charts`/`get_stale_dashboards` tool descriptions now state the rule precisely so the agent's reasoning matches the query.
- **Inactive users**: a user with no recorded activity only counts as inactive once their account has existed for the full window — previously a user invited yesterday was reported as "never active, consider a seat review". (Reporting-only path, but wrong advice.) The unused-agents query already handled this correctly and is unchanged.

An audit of the remaining policy thresholds (preview projects, slow queries, orphaned content, unused agents) found no further instances.

## Regression analysis

- Content with at least one view is selected exactly as before.
- Never-viewed content older than the staleness window is selected exactly as before; the only change is that never-viewed content younger than the window no longer appears, which is the settings' stated contract.
- Query shape/params verified by typecheck and the existing model tests; parameter comments updated alongside the extra binding.

Related follow-up (separate PR on the validation stack): a per-run cap on stale soft-deletions, mirroring the 25-per-call cap on `bulk_delete_broken_content`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wN2cB2mCApBBwDqn2J76Q
