### PR TITLE
feat(autopilot): cap individual soft-deletes per run and clear validation rows on delete

### DIFF
--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -1176,6 +1176,19 @@ export class ManagedAgentModel {
         return result ? Number(result.count) : 0;
     }
 
+    // Bulk deletions (metadata.bulk = true) have their own per-call cap, so
+    // they are excluded from the individual soft-delete run cap
+    async countNonBulkSoftDeletesForRun(runUuid: string): Promise<number> {
+        const [row] = await this.database(ManagedAgentActionsTableName)
+            .where({
+                managed_agent_run_uuid: runUuid,
+                action_type: ManagedAgentActionType.SOFT_DELETED,
+            })
+            .whereRaw(`COALESCE(metadata->>'bulk', '') <> 'true'`)
+            .count<{ count: string }[]>('* as count');
+        return Number(row?.count ?? 0);
+    }
+
     async getActionCountsByTypeForRun(
         runUuid: string,
     ): Promise<Record<string, number>> {

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -66,6 +66,7 @@ import {
     getValidationRootCauseTableName,
     MANAGED_AGENT_BROKEN_CONTENT_GROUP_ITEM_LIMIT,
     MANAGED_AGENT_BULK_DELETE_RUN_LIMIT,
+    MANAGED_AGENT_SOFT_DELETE_RUN_LIMIT,
     MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT,
     summarizeManagedAgentBrokenContent,
 } from './toolResults';
@@ -3081,6 +3082,12 @@ chartConfig:
             return chartEscalationBlock;
         }
         await this.savedChartModel.softDelete(chartUuid, actorUuid);
+        // Clear the chart's validation errors so the Validator updates
+        // without waiting for the next validation run
+        await this.validationModel.deleteChartValidations(
+            chartUuid,
+            projectUuid,
+        );
         return null;
     }
 
@@ -3116,6 +3123,17 @@ chartConfig:
         if (policy.aggression !== 'cleanup') {
             return JSON.stringify({
                 error: `Soft-delete is disabled by project policy (cleanup mode: ${policy.aggression}). Flag or log an insight instead.`,
+                blocked: true,
+            });
+        }
+
+        // Per-run blast-radius cap so a first run on a low-traffic project
+        // cannot sweep everything in one pass
+        const deletedThisRun =
+            await this.managedAgentModel.countNonBulkSoftDeletesForRun(runUuid);
+        if (deletedThisRun >= MANAGED_AGENT_SOFT_DELETE_RUN_LIMIT) {
+            return JSON.stringify({
+                error: `Soft-delete run cap reached (${MANAGED_AGENT_SOFT_DELETE_RUN_LIMIT} per run). Flag remaining candidates instead and mention the backlog in your summary; the next run can continue the cleanup.`,
                 blocked: true,
             });
         }
@@ -3183,6 +3201,12 @@ chartConfig:
                 return dashEscalationBlock;
             }
             await this.dashboardModel.softDelete(targetUuid, actorUuid);
+            // Clear the dashboard's validation errors so the Validator
+            // updates without waiting for the next validation run
+            await this.validationModel.deleteDashboardValidations(
+                targetUuid,
+                projectUuid,
+            );
         } else {
             throw new Error(
                 `soft_delete_content only supports chart and dashboard, got: ${targetType}`,

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -122,7 +122,7 @@ export const buildManagedAgentSystemPrompt = (
             case 'flag':
                 return `${intro}\n- Any reason → flag_content\n- Content YOU created (slug starts with "agent-") → NEVER flag\nInclude last_viewed_at, views_count, and created_at in the description.`;
             case 'cleanup':
-                return `${intro}\n- reason "never_viewed" → soft_delete_content\n- reason "not_viewed_recently" → flag_content\n- Content YOU created (slug starts with "agent-") → NEVER flag or delete\nInclude last_viewed_at, views_count, and created_at in the description.`;
+                return `${intro}\n- reason "never_viewed" → soft_delete_content\n- reason "not_viewed_recently" → flag_content\n- Content YOU created (slug starts with "agent-") → NEVER flag or delete\n- Max 25 individual soft-deletes per run. When the cap is reached, flag the remaining candidates and report the backlog in your summary instead of deleting\nInclude last_viewed_at, views_count, and created_at in the description.`;
             default:
                 return assertUnreachable(
                     aggression,
@@ -402,7 +402,7 @@ export const managedAgentConfig: AgentCreateParams = {
         },
         {
             description:
-                'Soft-delete a chart or dashboard. The content can be restored by an admin. Do NOT use for content created in the last 30 days. Do NOT use for agent-created content (slug starts with agent-). Do NOT use if the chart is the only chart on a dashboard.',
+                'Soft-delete a chart or dashboard. The content can be restored by an admin. Do NOT use for content created in the last 30 days. Do NOT use for agent-created content (slug starts with agent-). Do NOT use if the chart is the only chart on a dashboard. At most 25 individual soft-deletes are allowed per run; further calls are blocked, so flag the remainder instead.',
             input_schema: {
                 properties: {
                     description: {

--- a/packages/backend/src/ee/services/ManagedAgentService/toolResults.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/toolResults.ts
@@ -9,6 +9,7 @@ export const MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT = 100;
 export const MANAGED_AGENT_BROKEN_CONTENT_ERROR_LIMIT = 10;
 export const MANAGED_AGENT_BROKEN_CONTENT_GROUP_ITEM_LIMIT = 10;
 export const MANAGED_AGENT_BULK_DELETE_RUN_LIMIT = 25;
+export const MANAGED_AGENT_SOFT_DELETE_RUN_LIMIT = 25;
 
 // Root-cause model of a validation row. Guard order matters: table responses
 // are structurally assignable from the others, so they are the fallback.


### PR DESCRIPTION
Linear: [PROD-8489](https://linear.app/lightdash/issue/PROD-8489/bulk-remove-content-that-depends-on-a-deleted-model-autopilot)
Follow-up to the stack, prompted by watching a live run. Companion to #27529.

## Problem

A live Autopilot run on a low-traffic project soft-deleted 54 charts and 9 dashboards in one pass: the stale-content path has no per-run bound, unlike the new `bulk_delete_broken_content` tool (25 per call). Separately, Autopilot deletions left the deleted content's validation rows behind until the next validation run, so the Validator kept listing content that no longer existed.

## Changes

- `soft_delete_content` now enforces a per-run cap of 25 individual soft-deletions (counted from the run's recorded actions, excluding `bulk: true` ones, which carry their own per-call cap). At the cap the tool returns a blocked payload telling the agent to flag the remainder and report the backlog; the stale-step prompt and tool description state the cap so the agent plans around it.
- Autopilot deletions (single and bulk, charts and dashboards) now clear the target's validation rows immediately, matching the behavior of the UI bulk delete added earlier in the stack.

## Regression analysis

- Runs deleting fewer than 25 individual items behave identically; the cap only converts the tail of a mass sweep into flags plus a reported backlog, and the next run continues.
- Bulk deletions are excluded from the count on purpose: they are already bounded per call and target provably-dead content (deleted models).
- Validation-row clearing only runs after a successful soft delete; rows would have been dropped at the next validation run anyway, this just removes the stale window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wN2cB2mCApBBwDqn2J76Q
