### PR TITLE
feat(autopilot): require flag-first escalation before individual soft-deletes of never-viewed content

### DIFF
--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -2968,21 +2968,30 @@ chartConfig:
         targetUuid: string,
         targetName: string,
         policy: ManagedAgentPolicy,
+        options: {
+            // Individual soft-deletes require a prior flag for ALL content.
+            // Bulk deletion of charts on deleted models keeps the viewed-only
+            // gate: that content is provably dead, and flag-first there would
+            // defeat the automatable cleanup.
+            flagFirstAlways: boolean;
+        },
     ): Promise<string | null> {
-        const lastViewed =
-            targetType === ManagedAgentTargetType.CHART
-                ? (
-                      await this.analyticsModel.getLastViewedAtForCharts([
-                          targetUuid,
-                      ])
-                  ).get(targetUuid)
-                : (
-                      await this.analyticsModel.getLastViewedAtForDashboards([
-                          targetUuid,
-                      ])
-                  ).get(targetUuid);
-        if (!lastViewed) {
-            return null;
+        if (!options.flagFirstAlways) {
+            const lastViewed =
+                targetType === ManagedAgentTargetType.CHART
+                    ? (
+                          await this.analyticsModel.getLastViewedAtForCharts([
+                              targetUuid,
+                          ])
+                      ).get(targetUuid)
+                    : (
+                          await this.analyticsModel.getLastViewedAtForDashboards(
+                              [targetUuid],
+                          )
+                      ).get(targetUuid);
+            if (!lastViewed) {
+                return null;
+            }
         }
         const flaggedAt =
             await this.managedAgentModel.findLatestActiveFlagCreatedAt(
@@ -2991,7 +3000,7 @@ chartConfig:
             );
         if (!flaggedAt) {
             return JSON.stringify({
-                error: `"${targetName}" has views, so it must be flagged first and stay flagged for ${policy.escalationHours}+ hours before soft-deleting. Use flag_content instead.`,
+                error: `"${targetName}" must be flagged first and stay flagged for ${policy.escalationHours}+ hours before soft-deleting. Use flag_content instead.`,
                 blocked: true,
             });
         }
@@ -3018,6 +3027,7 @@ chartConfig:
         policy: ManagedAgentPolicy;
         actorUuid: string;
         attemptedAction: 'fix' | 'flag' | 'soft-delete';
+        flagFirstAlways: boolean;
     }): Promise<string | null> {
         const {
             actor,
@@ -3029,6 +3039,7 @@ chartConfig:
             policy,
             actorUuid,
             attemptedAction,
+            flagFirstAlways,
         } = args;
 
         const deleteProtectionBlock = await this.checkTargetProtectionGuard(
@@ -3077,6 +3088,7 @@ chartConfig:
             chartUuid,
             chartName,
             policy,
+            { flagFirstAlways },
         );
         if (chartEscalationBlock) {
             return chartEscalationBlock;
@@ -3150,6 +3162,7 @@ chartConfig:
                 policy,
                 actorUuid,
                 attemptedAction: 'soft-delete',
+                flagFirstAlways: true,
             });
             if (chartBlock) {
                 return chartBlock;
@@ -3196,6 +3209,7 @@ chartConfig:
                 targetUuid,
                 targetName,
                 policy,
+                { flagFirstAlways: true },
             );
             if (dashEscalationBlock) {
                 return dashEscalationBlock;
@@ -3312,6 +3326,7 @@ chartConfig:
                     policy,
                     actorUuid,
                     attemptedAction: 'soft-delete',
+                    flagFirstAlways: false,
                 });
                 if (chartBlock) {
                     let blockReason = chartBlock;

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -122,7 +122,7 @@ export const buildManagedAgentSystemPrompt = (
             case 'flag':
                 return `${intro}\n- Any reason → flag_content\n- Content YOU created (slug starts with "agent-") → NEVER flag\nInclude last_viewed_at, views_count, and created_at in the description.`;
             case 'cleanup':
-                return `${intro}\n- reason "never_viewed" → soft_delete_content\n- reason "not_viewed_recently" → flag_content\n- Content YOU created (slug starts with "agent-") → NEVER flag or delete\n- Max 25 individual soft-deletes per run. When the cap is reached, flag the remaining candidates and report the backlog in your summary instead of deleting\nInclude last_viewed_at, views_count, and created_at in the description.`;
+                return `${intro}\n- First sighting of a stale item (any reason) → flag_content; NEVER delete on first sight\n- Items you flagged more than ${escalationHours} hours ago that were not reversed or dismissed → soft_delete_content\n- Content YOU created (slug starts with "agent-") → NEVER flag or delete\n- Max 25 individual soft-deletes per run. When the cap is reached, flag the remaining candidates and report the backlog in your summary instead of deleting\nInclude last_viewed_at, views_count, and created_at in the description.`;
             default:
                 return assertUnreachable(
                     aggression,
@@ -402,7 +402,7 @@ export const managedAgentConfig: AgentCreateParams = {
         },
         {
             description:
-                'Soft-delete a chart or dashboard. The content can be restored by an admin. Do NOT use for content created in the last 30 days. Do NOT use for agent-created content (slug starts with agent-). Do NOT use if the chart is the only chart on a dashboard. At most 25 individual soft-deletes are allowed per run; further calls are blocked, so flag the remainder instead.',
+                'Soft-delete a chart or dashboard. The content can be restored by an admin. Only usable on content that was flagged more than the escalation window ago and not dismissed; unflagged content is blocked, so flag_content it first. Do NOT use for content created in the last 30 days. Do NOT use for agent-created content (slug starts with agent-). Do NOT use if the chart is the only chart on a dashboard. At most 25 individual soft-deletes are allowed per run; further calls are blocked, so flag the remainder instead.',
             input_schema: {
                 properties: {
                     description: {


### PR DESCRIPTION
Linear: [PROD-8489](https://linear.app/lightdash/issue/PROD-8489/bulk-remove-content-that-depends-on-a-deleted-model-autopilot)
Stacked on #27530. Completes the stale-sweep hardening with #27529.

## Problem

The flag-first escalation guard (flag, wait `escalationHours`, then delete) only applied to content with at least one recorded view. Never-viewed content could be soft-deleted on first sight, which is how a first `cleanup` run swept a low-traffic project in one pass.

## Changes

- `soft_delete_content` now requires flag-first escalation for ALL content: the escalation guard takes a `flagFirstAlways` option, and the individual-delete path (charts and dashboards) passes it. First run flags; a later run deletes anything still flagged past the window. The guard's block message no longer references views.
- `bulk_delete_broken_content` keeps the previous viewed-only gate on purpose: it only ever targets charts whose model was deleted — provably dead content — and flag-first there would defeat the automatable cleanup PROD-8489 asks for. The distinction is documented at the option site.
- Prompt and tool description updated so the agent plans the two-phase cycle: flag on first sighting, delete only items flagged more than `escalationHours` ago and not dismissed.

## Regression analysis

- Viewed content behaves exactly as before (guard already applied).
- Never-viewed content changes from delete-on-first-sight to flag-then-delete across two runs; combined with #27529 (must exceed the staleness window) and #27530 (25 per run cap), a first run on a low-traffic project now flags instead of sweeping.
- The bulk deleted-model path is unchanged relative to #27527.
- `escalationHours: 0` still means no waiting period, but an active flag is now always required first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wN2cB2mCApBBwDqn2J76Q
