### PR TITLE
feat(autopilot): make flag_content idempotent and skip deleted targets

### DIFF
--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -2926,6 +2926,42 @@ chartConfig:
             );
         }
 
+        // Flags on deleted content are pointless: refuse instead of
+        // recording an action nobody can act on
+        if (
+            targetType === ManagedAgentTargetType.CHART ||
+            targetType === ManagedAgentTargetType.DASHBOARD
+        ) {
+            try {
+                if (targetType === ManagedAgentTargetType.CHART) {
+                    await this.savedChartModel.get(targetUuid);
+                } else {
+                    await this.dashboardModel.getByIdOrSlug(targetUuid);
+                }
+            } catch {
+                return JSON.stringify({
+                    skipped: true,
+                    note: `"${targetName}" no longer exists (deleted); no flag was created.`,
+                });
+            }
+        }
+
+        // Idempotency: re-flagging an actively flagged target would reset the
+        // escalation clock and duplicate the activity feed, so report the
+        // existing flag instead of creating a new action
+        const existingFlaggedAt =
+            await this.managedAgentModel.findLatestActiveFlagCreatedAt(
+                projectUuid,
+                targetUuid,
+            );
+        if (existingFlaggedAt) {
+            return JSON.stringify({
+                already_flagged: true,
+                flagged_at: existingFlaggedAt.toISOString(),
+                note: 'This target already carries an active flag; no new action was created. Once the flag is older than the escalation window it becomes eligible for soft_delete_content.',
+            });
+        }
+
         // Block flagging agent-created charts as stale
         if (
             flagType === ManagedAgentActionType.FLAGGED_STALE &&
@@ -2959,9 +2995,10 @@ chartConfig:
         return JSON.stringify({ action_uuid: action.actionUuid });
     }
 
-    // Code-enforced escalation: content with views may only be deleted after
-    // carrying an unreversed flag for the policy's escalation window.
-    // Never-viewed content may be deleted directly (recency guard still applies).
+    // Code-enforced escalation: content may only be deleted after carrying an
+    // unreversed flag for the policy's escalation window. Callers that target
+    // provably dead content (bulk deleted-model cleanup) opt out of the
+    // flag-first requirement for never-viewed items via flagFirstAlways=false.
     private async checkEscalationGuard(
         projectUuid: string,
         targetType: ManagedAgentTargetType,

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -356,7 +356,7 @@ export const managedAgentConfig: AgentCreateParams = {
         },
         {
             description:
-                'Flag a chart, dashboard, or project in the action log. Does NOT delete or modify the content, only records an observation. Use for stale content, broken content, or old preview projects.',
+                'Flag a chart, dashboard, or project in the action log. Does NOT delete or modify the content, only records an observation. Use for stale content, broken content, or old preview projects. Idempotent: flagging an already-flagged target returns the existing flag without creating a duplicate, and deleted targets are skipped — so never re-flag a list you have already processed this run.',
             input_schema: {
                 properties: {
                     description: {


### PR DESCRIPTION
Linear: [PROD-8489](https://linear.app/lightdash/issue/PROD-8489/bulk-remove-content-that-depends-on-a-deleted-model-autopilot)
Stacked on #27531. Motivated by a second live run under the new guardrails.

## Problem

Observed in a live run: the agent flagged its entire stale list twice (118 `flagged_stale` actions across 59 distinct targets), re-flagged broken content (27 across 18), and flagged nine charts it had already bulk-deleted — despite prompt instructions not to repeat itself. Duplicate flags are worse than noise: the escalation guard reads the *latest* active flag, so an agent that re-flags every run resets the escalation clock each time and the flag-then-delete cycle introduced in #27531 never reaches the delete phase.

## Changes

`flag_content` is now idempotent and target-aware, enforced server-side instead of relying on prompt compliance:

- If the target already carries an active (unreversed) flag, the tool returns `{already_flagged, flagged_at}` without creating a new action — preserving the original escalation timestamp and keeping the activity feed one-row-per-finding.
- If the target chart or dashboard no longer exists (soft-deleted or removed), the tool returns a skip note instead of recording a flag nobody can act on. This replaces the previous allow-on-missing behavior.
- Tool description updated so the agent knows re-flagging is a no-op.
- Also corrects the escalation-guard comment left stale by #27531.

## Regression analysis

- First-time flags behave identically.
- Duplicate flags previously created extra actions; both the run's action counts and the escalation clock now stay stable. Nothing consumed duplicate flags as a signal (the guard reads one row).
- The deleted-target skip changes behavior for hard-deleted-mid-run content from "flag anyway" to "skip with a note"; a flag on nonexistent content had no consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wN2cB2mCApBBwDqn2J76Q
