### PR TITLE
feat(pgwire): support the PostgreSQL extended query protocol

### DIFF
--- a/packages/backend/src/ee/postgresWire/PgWireServerError.ts
+++ b/packages/backend/src/ee/postgresWire/PgWireServerError.ts
@@ -1,0 +1,11 @@
+/** Sent to the client as an ErrorResponse (`code` is a SQLSTATE) */
+export class PgWireServerError extends Error {
+    constructor(
+        message: string,
+        public readonly code: string = 'XX000',
+        public readonly hint?: string,
+    ) {
+        super(message);
+        this.name = 'PgWireServerError';
+    }
+}

--- a/packages/backend/src/ee/postgresWire/PostgresWireServer.test.ts
+++ b/packages/backend/src/ee/postgresWire/PostgresWireServer.test.ts
@@ -2,14 +2,17 @@ import * as fs from 'fs';
 import * as net from 'net';
 import * as os from 'os';
 import * as path from 'path';
+import { Client, type QueryConfig } from 'pg';
 import * as tls from 'tls';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
     PgWireServerError,
     PostgresWireServer,
     type PgWireHandlers,
+    type PgWireQueryResult,
     type PgWireServerOptions,
 } from './PostgresWireServer';
+import { cstring, int16, int32 } from './wireEncoding';
 
 const FIXTURES = path.join(__dirname, 'testFixtures');
 const CERT_A = path.join(FIXTURES, 'test-cert.pem');
@@ -21,15 +24,6 @@ const PROTOCOL_VERSION = 196608;
 const SSL_REQUEST_CODE = 80877103;
 
 // --- frontend message encoding ---
-
-const int32 = (n: number): Buffer => {
-    const b = Buffer.alloc(4);
-    b.writeInt32BE(n);
-    return b;
-};
-
-const cstring = (s: string): Buffer =>
-    Buffer.concat([Buffer.from(s, 'utf8'), Buffer.from([0])]);
 
 const startupMessage = (params: Record<string, string>): Buffer => {
     const body = Buffer.concat([
@@ -50,6 +44,72 @@ const passwordMessage = (password: string): Buffer =>
     typedMessage('p', cstring(password));
 
 const queryMessage = (sql: string): Buffer => typedMessage('Q', cstring(sql));
+
+const parseMessage = (
+    name: string,
+    sql: string,
+    parameterOids: number[] = [],
+): Buffer =>
+    typedMessage(
+        'P',
+        Buffer.concat([
+            cstring(name),
+            cstring(sql),
+            int16(parameterOids.length),
+            ...parameterOids.map(int32),
+        ]),
+    );
+
+type BindOptions = {
+    portal?: string;
+    statement?: string;
+    parameterFormats?: number[];
+    /** strings are sent as UTF-8; pass a Buffer for exact bytes */
+    parameters?: (string | Buffer | null)[];
+    resultFormats?: number[];
+};
+
+const bindMessage = ({
+    portal = '',
+    statement = '',
+    parameterFormats = [],
+    parameters = [],
+    resultFormats = [],
+}: BindOptions = {}): Buffer =>
+    typedMessage(
+        'B',
+        Buffer.concat([
+            cstring(portal),
+            cstring(statement),
+            int16(parameterFormats.length),
+            ...parameterFormats.map(int16),
+            int16(parameters.length),
+            ...parameters.map((value) => {
+                if (value === null) {
+                    return int32(-1);
+                }
+                const bytes = Buffer.isBuffer(value)
+                    ? value
+                    : Buffer.from(value, 'utf8');
+                return Buffer.concat([int32(bytes.length), bytes]);
+            }),
+            int16(resultFormats.length),
+            ...resultFormats.map(int16),
+        ]),
+    );
+
+const describeMessage = (kind: 'S' | 'P', name = ''): Buffer =>
+    typedMessage('D', Buffer.concat([Buffer.from(kind), cstring(name)]));
+
+const executeMessage = (portal = '', maxRows = 0): Buffer =>
+    typedMessage('E', Buffer.concat([cstring(portal), int32(maxRows)]));
+
+const closeMessage = (kind: 'S' | 'P', name = ''): Buffer =>
+    typedMessage('C', Buffer.concat([Buffer.from(kind), cstring(name)]));
+
+const syncMessage = (): Buffer => typedMessage('S', Buffer.alloc(0));
+
+const flushMessage = (): Buffer => typedMessage('H', Buffer.alloc(0));
 
 // --- backend message reading ---
 
@@ -143,6 +203,17 @@ class MessageReader {
     }
 }
 
+/** Read message types until ReadyForQuery, e.g. "12TDCZ" */
+const readTypesUntilReady = async (reader: MessageReader): Promise<string> => {
+    let types = '';
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        const message = await reader.readMessage();
+        types += message.type;
+        if (message.type === 'Z') return types;
+    }
+};
+
 /** Parse the SQLSTATE code out of an ErrorResponse payload */
 const errorCode = (payload: Buffer): string | null => {
     let offset = 0;
@@ -158,6 +229,86 @@ const errorCode = (payload: Buffer): string | null => {
 
 type TestSession = { user: string };
 
+/** Records what the server asked the handlers, for assertions */
+const handlerCalls: { kind: 'describe' | 'query'; sql: string }[] = [];
+
+/**
+ * Canned statements: `SELECT who` -> one row, `SELECT three` -> three rows,
+ * `SET ...` -> command, `SELECT fail` -> error; anything else echoes the SQL
+ */
+const cannedResult = (session: TestSession, sql: string): PgWireQueryResult => {
+    if (/^SET\b/i.test(sql)) {
+        return { type: 'command', commandTag: 'SET' };
+    }
+    if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'DISCARD ALL') {
+        return { type: 'command', commandTag: sql };
+    }
+    if (sql === 'SELECT fail') {
+        throw new PgWireServerError('canned failure', 'XX001');
+    }
+    if (sql === 'SELECT nul') {
+        throw new PgWireServerError('bad\u0000value', 'XX002', 'hint\u0000too');
+    }
+    if (sql === 'DISCARD PLANS') {
+        return { type: 'command', commandTag: 'DISCARD' };
+    }
+    if (sql === 'SELECT three') {
+        return {
+            type: 'rows',
+            fields: [{ name: 'n', oid: 23 }],
+            rows: [['1'], ['2'], ['3']],
+            commandTag: 'SELECT 3',
+        };
+    }
+    if (sql === 'SELECT numeric') {
+        return {
+            type: 'rows',
+            fields: [{ name: 'n', oid: 1700 }],
+            rows: [['1.5']],
+            commandTag: 'SELECT 1',
+        };
+    }
+    if (sql === 'SELECT typed') {
+        return {
+            type: 'rows',
+            fields: [
+                { name: 'b', oid: 16 },
+                { name: 'i', oid: 20 },
+                { name: 'f', oid: 701 },
+                { name: 'd', oid: 1082 },
+                { name: 'ts', oid: 1114 },
+                { name: 't', oid: 25 },
+            ],
+            rows: [
+                [
+                    't',
+                    '42',
+                    '2.5',
+                    '2000-01-03',
+                    '2000-01-01 00:00:01.5+00',
+                    'x',
+                ],
+                [null, null, null, null, null, null],
+            ],
+            commandTag: 'SELECT 2',
+        };
+    }
+    if (sql === 'SELECT who') {
+        return {
+            type: 'rows',
+            fields: [{ name: 'who', oid: 25 }],
+            rows: [[session.user]],
+            commandTag: 'SELECT 1',
+        };
+    }
+    return {
+        type: 'rows',
+        fields: [{ name: 'sql', oid: 25 }],
+        rows: [[sql]],
+        commandTag: 'SELECT 1',
+    };
+};
+
 const testHandlers: PgWireHandlers<TestSession> = {
     authenticate: async ({ user, password }) => {
         if (password !== 'good-token') {
@@ -168,12 +319,15 @@ const testHandlers: PgWireHandlers<TestSession> = {
         }
         return { user };
     },
-    query: async (session) => ({
-        type: 'rows',
-        fields: [{ name: 'who', oid: 25 }],
-        rows: [[session.user]],
-        commandTag: 'SELECT 1',
-    }),
+    describe: async (session, sql) => {
+        handlerCalls.push({ kind: 'describe', sql });
+        const result = cannedResult(session, sql);
+        return result.type === 'rows' ? result.fields : null;
+    },
+    query: async (session, sql) => {
+        handlerCalls.push({ kind: 'query', sql });
+        return cannedResult(session, sql);
+    },
 };
 
 const connect = async (port: number): Promise<net.Socket> =>
@@ -275,6 +429,19 @@ describe('PostgresWireServer TLS', () => {
         const dataRow = await reader.readMessage();
         expect(dataRow.type).toBe('D');
         expect(dataRow.payload.toString('utf8')).toContain('alice');
+        await reader.readUntil('Z');
+
+        // the extended protocol runs over the upgraded socket too
+        secureSocket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT who'),
+                bindMessage(),
+                describeMessage('P'),
+                executeMessage(),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('12TDCZ');
     });
 
     it('rejects bad credentials over TLS with 28P01', async () => {
@@ -376,5 +543,798 @@ describe('PostgresWireServer TLS', () => {
         expect(secondSecure.getPeerCertificate().subject.CN).toBe(
             'pgwire-test-b',
         );
+    });
+});
+
+describe('PostgresWireServer extended query protocol', () => {
+    const openSockets: net.Socket[] = [];
+    const servers: PostgresWireServer<TestSession>[] = [];
+    const clients: Client[] = [];
+
+    const startServer = async (): Promise<number> => {
+        const server = new PostgresWireServer(testHandlers);
+        servers.push(server);
+        await server.listen(0, '127.0.0.1');
+        const address = server.address();
+        if (!address) throw new Error('server has no address');
+        return address.port;
+    };
+
+    /** Plaintext connection authenticated as alice, positioned after ReadyForQuery */
+    const openSession = async (): Promise<{
+        socket: net.Socket;
+        reader: MessageReader;
+    }> => {
+        const port = await startServer();
+        const socket = await connect(port);
+        openSockets.push(socket);
+        const reader = new MessageReader(socket);
+        socket.write(startupMessage({ user: 'alice', database: 'db' }));
+        await reader.readUntil('R');
+        socket.write(passwordMessage('good-token'));
+        await reader.readUntil('Z');
+        return { socket, reader };
+    };
+
+    /** node-postgres client (uses the extended protocol whenever values are given) */
+    const openClient = async (): Promise<Client> => {
+        const port = await startServer();
+        const client = new Client({
+            host: '127.0.0.1',
+            port,
+            user: 'alice',
+            password: 'good-token',
+            database: 'db',
+            ssl: false,
+        });
+        clients.push(client);
+        await client.connect();
+        return client;
+    };
+
+    const dataRowText = (payload: Buffer): string =>
+        payload.subarray(6).toString('utf8'); // int16 count, int32 length, bytes
+
+    beforeEach(() => {
+        handlerCalls.splice(0);
+    });
+
+    afterEach(async () => {
+        await Promise.all(clients.splice(0).map((client) => client.end()));
+        openSockets.splice(0).forEach((socket) => socket.destroy());
+        await Promise.all(servers.splice(0).map((server) => server.close()));
+    });
+
+    it('runs the pgjdbc-style one-shot flow: Parse, Bind, Describe portal, Execute, Sync', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT who'),
+                bindMessage(),
+                describeMessage('P'),
+                executeMessage(),
+                syncMessage(),
+            ]),
+        );
+        expect(await reader.readMessage()).toMatchObject({ type: '1' });
+        expect(await reader.readMessage()).toMatchObject({ type: '2' });
+        const rowDescription = await reader.readMessage();
+        expect(rowDescription.type).toBe('T');
+        expect(rowDescription.payload.toString('utf8')).toContain('who');
+        const dataRow = await reader.readMessage();
+        expect(dataRow.type).toBe('D');
+        expect(dataRowText(dataRow.payload)).toBe('alice');
+        const complete = await reader.readMessage();
+        expect(complete.type).toBe('C');
+        expect(complete.payload.toString('utf8')).toBe('SELECT 1\0');
+        expect(await reader.readMessage()).toMatchObject({ type: 'Z' });
+        expect(handlerCalls).toEqual([
+            { kind: 'describe', sql: 'SELECT who' },
+            { kind: 'query', sql: 'SELECT who' },
+        ]);
+    });
+
+    it('describes a statement before it is bound with ParameterDescription and RowDescription', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(
+            Buffer.concat([
+                parseMessage(
+                    's1',
+                    'SELECT * FROM t WHERE a = $1 AND b = $2',
+                    [23, 0],
+                ),
+                describeMessage('S', 's1'),
+                syncMessage(),
+            ]),
+        );
+        expect(await reader.readMessage()).toMatchObject({ type: '1' });
+        const parameterDescription = await reader.readMessage();
+        expect(parameterDescription.type).toBe('t');
+        expect(parameterDescription.payload.readInt16BE(0)).toBe(2);
+        expect(parameterDescription.payload.readInt32BE(2)).toBe(23);
+        expect(parameterDescription.payload.readInt32BE(6)).toBe(25); // 0 -> text
+        expect(await reader.readMessage()).toMatchObject({ type: 'T' });
+        expect(await reader.readMessage()).toMatchObject({ type: 'Z' });
+        // described with placeholder literals of the right shape
+        expect(handlerCalls).toEqual([
+            {
+                kind: 'describe',
+                sql: "SELECT * FROM t WHERE a = 1 AND b = ''",
+            },
+        ]);
+
+        socket.write(
+            Buffer.concat([
+                bindMessage({ statement: 's1', parameters: ['7', "O'Brien"] }),
+                executeMessage(),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('2DCZ');
+        expect(handlerCalls.at(-1)).toEqual({
+            kind: 'query',
+            sql: "SELECT * FROM t WHERE a = 7 AND b = 'O''Brien'",
+        });
+    });
+
+    it('answers NoData and a bare CommandComplete for statements without rows', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(
+            Buffer.concat([
+                parseMessage('', "SET application_name = 'x'"),
+                bindMessage(),
+                describeMessage('P'),
+                executeMessage(),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('12nCZ');
+    });
+
+    it('answers EmptyQueryResponse for an empty statement', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(
+            Buffer.concat([
+                parseMessage('', '   '),
+                bindMessage(),
+                describeMessage('P'),
+                executeMessage(),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('12nIZ');
+        expect(handlerCalls).toEqual([]);
+    });
+
+    it('suspends and resumes a portal when Execute limits rows', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT three'),
+                bindMessage({ portal: 'c1' }),
+                executeMessage('c1', 2),
+                flushMessage(),
+            ]),
+        );
+        expect(await reader.readMessage()).toMatchObject({ type: '1' });
+        expect(await reader.readMessage()).toMatchObject({ type: '2' });
+        expect(dataRowText((await reader.readMessage()).payload)).toBe('1');
+        expect(dataRowText((await reader.readMessage()).payload)).toBe('2');
+        expect(await reader.readMessage()).toMatchObject({ type: 's' });
+
+        socket.write(Buffer.concat([executeMessage('c1', 2), syncMessage()]));
+        expect(dataRowText((await reader.readMessage()).payload)).toBe('3');
+        expect(await reader.readMessage()).toMatchObject({ type: 'C' });
+        expect(await reader.readMessage()).toMatchObject({ type: 'Z' });
+        // the query ran once; the second Execute resumed from the cursor
+        expect(handlerCalls.filter((c) => c.kind === 'query')).toHaveLength(1);
+    });
+
+    it('ignores everything after an error until Sync, then recovers', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT fail'),
+                bindMessage(),
+                describeMessage('P'),
+                executeMessage(),
+                closeMessage('P'),
+                queryMessage('SELECT who'), // ignored too, like Postgres
+                syncMessage(),
+            ]),
+        );
+        expect(await reader.readMessage()).toMatchObject({ type: '1' });
+        expect(await reader.readMessage()).toMatchObject({ type: '2' });
+        const error = await reader.readMessage();
+        expect(error.type).toBe('E');
+        expect(errorCode(error.payload)).toBe('XX001');
+        expect(await reader.readMessage()).toMatchObject({ type: 'Z' });
+
+        socket.write(queryMessage('SELECT who'));
+        expect(await readTypesUntilReady(reader)).toBe('TDCZ');
+    });
+
+    it('decodes binary parameters and encodes binary result columns', async () => {
+        const { socket, reader } = await openSession();
+        const int4 = Buffer.alloc(4);
+        int4.writeInt32BE(-7);
+        const float8 = Buffer.alloc(8);
+        float8.writeDoubleBE(2.5);
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT $1, $2, $3, $4', [23, 701, 16, 25]),
+                bindMessage({
+                    parameterFormats: [1, 1, 1, 0],
+                    parameters: [int4, float8, Buffer.from([1]), 'plain'],
+                }),
+                executeMessage(),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('12DCZ');
+        expect(handlerCalls.at(-1)).toEqual({
+            kind: 'query',
+            sql: "SELECT -7, 2.5, TRUE, 'plain'",
+        });
+
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT typed'),
+                bindMessage({ resultFormats: [1] }),
+                describeMessage('P'),
+                executeMessage(),
+                syncMessage(),
+            ]),
+        );
+        expect(await reader.readMessage()).toMatchObject({ type: '1' });
+        expect(await reader.readMessage()).toMatchObject({ type: '2' });
+        const rowDescription = await reader.readMessage();
+        expect(rowDescription.type).toBe('T');
+        // last int16 of the first field entry is its format code
+        expect(rowDescription.payload.readInt16BE(2 + 2 + 18 - 2)).toBe(1);
+        const row = await reader.readMessage();
+        expect(row.type).toBe('D');
+        let offset = 2;
+        const next = (): Buffer => {
+            const length = row.payload.readInt32BE(offset);
+            const value = row.payload.subarray(offset + 4, offset + 4 + length);
+            offset += 4 + length;
+            return value;
+        };
+        expect(next()).toEqual(Buffer.from([1])); // bool
+        expect(next().readBigInt64BE(0)).toBe(42n); // int8
+        expect(next().readDoubleBE(0)).toBe(2.5); // float8
+        expect(next().readInt32BE(0)).toBe(2); // date: days since 2000-01-01
+        expect(next().readBigInt64BE(0)).toBe(1_500_000n); // timestamp: micros since 2000-01-01
+        expect(next().toString('utf8')).toBe('x'); // text
+        const nullRow = await reader.readMessage();
+        expect(nullRow.payload.readInt32BE(2)).toBe(-1);
+        expect(await readTypesUntilReady(reader)).toBe('CZ');
+    });
+
+    it('rejects binary formats for types it cannot encode, and malformed binary parameters', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT numeric'),
+                bindMessage({ resultFormats: [1] }),
+                executeMessage(),
+                syncMessage(),
+            ]),
+        );
+        expect(await reader.readMessage()).toMatchObject({ type: '1' });
+        expect(await reader.readMessage()).toMatchObject({ type: '2' });
+        const resultError = await reader.readMessage();
+        expect(errorCode(resultError.payload)).toBe('0A000');
+        expect(await reader.readMessage()).toMatchObject({ type: 'Z' });
+
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT $1', [23]),
+                bindMessage({
+                    parameterFormats: [1],
+                    parameters: [Buffer.from([0])],
+                }),
+                syncMessage(),
+            ]),
+        );
+        expect(await reader.readMessage()).toMatchObject({ type: '1' });
+        const paramError = await reader.readMessage();
+        expect(errorCode(paramError.payload)).toBe('22P03');
+        expect(await reader.readMessage()).toMatchObject({ type: 'Z' });
+
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT $1', [1700]),
+                bindMessage({
+                    parameterFormats: [1],
+                    parameters: [Buffer.from([0])],
+                }),
+                syncMessage(),
+            ]),
+        );
+        expect(await reader.readMessage()).toMatchObject({ type: '1' });
+        const numericError = await reader.readMessage();
+        expect(errorCode(numericError.payload)).toBe('0A000');
+        expect(await reader.readMessage()).toMatchObject({ type: 'Z' });
+    });
+
+    it('keeps portals alive across Sync inside a transaction and reports the status', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(queryMessage('BEGIN'));
+        const begin = await reader.readMessage();
+        expect(begin.type).toBe('C');
+        const inTransaction = await reader.readMessage();
+        expect(inTransaction.payload.toString('utf8')).toBe('T');
+
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT three'),
+                bindMessage({ portal: 'C_1' }),
+                executeMessage('C_1', 2),
+                syncMessage(),
+                executeMessage('C_1', 2),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('12DDsZ');
+        expect(await readTypesUntilReady(reader)).toBe('DCZ');
+
+        socket.write(queryMessage('COMMIT'));
+        await reader.readUntil('C');
+        const idle = await reader.readMessage();
+        expect(idle.payload.toString('utf8')).toBe('I');
+        socket.write(Buffer.concat([executeMessage('C_1'), syncMessage()]));
+        expect(await readTypesUntilReady(reader)).toBe('EZ');
+    });
+
+    it('reports statement and portal bookkeeping errors with Postgres SQLSTATEs', async () => {
+        const { socket, reader } = await openSession();
+        const expectError = async (
+            frontend: Buffer,
+            code: string,
+        ): Promise<void> => {
+            socket.write(Buffer.concat([frontend, syncMessage()]));
+            const error = await reader.readUntil('E');
+            expect(errorCode(error.payload)).toBe(code);
+            await reader.readUntil('Z');
+        };
+
+        await expectError(bindMessage({ statement: 'missing' }), '26000');
+        await expectError(executeMessage('missing'), '34000');
+        await expectError(describeMessage('S', 'missing'), '26000');
+        await expectError(describeMessage('P', 'missing'), '34000');
+        await expectError(
+            Buffer.concat([
+                parseMessage('', 'SELECT $1', [23]),
+                bindMessage({ parameters: [] }),
+            ]),
+            '08P01',
+        );
+        await expectError(
+            Buffer.concat([
+                parseMessage('dup', 'SELECT who'),
+                parseMessage('dup', 'SELECT who'),
+            ]),
+            '42P05',
+        );
+        await expectError(
+            Buffer.concat([
+                parseMessage('', 'SELECT who'),
+                bindMessage({ portal: 'p' }),
+                bindMessage({ portal: 'p' }),
+            ]),
+            '42P03',
+        );
+    });
+
+    it('closes statements and portals, and clears portals on Sync', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(
+            Buffer.concat([
+                parseMessage('s1', 'SELECT who'),
+                bindMessage({ portal: 'p1', statement: 's1' }),
+                closeMessage('P', 'p1'),
+                closeMessage('P', 'never-existed'),
+                executeMessage('p1'),
+                syncMessage(),
+            ]),
+        );
+        expect(await reader.readMessage()).toMatchObject({ type: '1' });
+        expect(await reader.readMessage()).toMatchObject({ type: '2' });
+        expect(await reader.readMessage()).toMatchObject({ type: '3' });
+        expect(await reader.readMessage()).toMatchObject({ type: '3' });
+        expect(errorCode((await reader.readMessage()).payload)).toBe('34000');
+        expect(await reader.readMessage()).toMatchObject({ type: 'Z' });
+
+        // statement survives Sync, a portal does not
+        socket.write(
+            Buffer.concat([
+                bindMessage({ portal: 'p2', statement: 's1' }),
+                syncMessage(),
+                executeMessage('p2'),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('2Z');
+        expect(await readTypesUntilReady(reader)).toBe('EZ');
+
+        socket.write(
+            Buffer.concat([
+                closeMessage('S', 's1'),
+                bindMessage({ statement: 's1' }),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('3EZ');
+    });
+
+    it('rejects protocol violations in Bind with 08P01 before touching the query', async () => {
+        const { socket, reader } = await openSession();
+        const expectError = async (
+            frontend: Buffer,
+            code: string,
+        ): Promise<void> => {
+            socket.write(Buffer.concat([frontend, syncMessage()]));
+            const error = await reader.readUntil('E');
+            expect(errorCode(error.payload)).toBe(code);
+            await reader.readUntil('Z');
+        };
+        // two parameter formats for three parameters
+        await expectError(
+            Buffer.concat([
+                parseMessage('', 'SELECT $1, $2, $3'),
+                bindMessage({
+                    parameterFormats: [0, 1],
+                    parameters: ['a', 'b', 'c'],
+                }),
+            ]),
+            '08P01',
+        );
+        // format code other than 0/1
+        await expectError(
+            Buffer.concat([
+                parseMessage('', 'SELECT who'),
+                bindMessage({ resultFormats: [2] }),
+            ]),
+            '08P01',
+        );
+        // parameter length below -1
+        const corruptBind = typedMessage(
+            'B',
+            Buffer.concat([
+                cstring(''),
+                cstring(''),
+                int16(0),
+                int16(1),
+                int32(-2),
+                int16(0),
+            ]),
+        );
+        await expectError(
+            Buffer.concat([parseMessage('', 'SELECT $1'), corruptBind]),
+            '08P01',
+        );
+        // more result formats than columns is caught at Describe, before Execute
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT who'),
+                bindMessage({ resultFormats: [0, 0] }),
+                describeMessage('P'),
+                executeMessage(),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('12EZ');
+        expect(handlerCalls.filter((c) => c.kind === 'query')).toEqual([]);
+    });
+
+    it('rejects absurd placeholder numbers with 54023 without allocating for them', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT $4000000000'),
+                syncMessage(),
+            ]),
+        );
+        const error = await reader.readMessage();
+        expect(errorCode(error.payload)).toBe('54023');
+        expect(await reader.readMessage()).toMatchObject({ type: 'Z' });
+    });
+
+    it('refuses statements that grow past 1MB after parameter substitution with 54000', async () => {
+        const { socket, reader } = await openSession();
+        const placeholders = Array.from({ length: 64 }, () => '$1').join(',');
+        socket.write(
+            Buffer.concat([
+                parseMessage('', `SELECT ${placeholders}`),
+                bindMessage({ parameters: ['x'.repeat(20_000)] }),
+                syncMessage(),
+            ]),
+        );
+        expect(await reader.readMessage()).toMatchObject({ type: '1' });
+        const error = await reader.readMessage();
+        expect(errorCode(error.payload)).toBe('54000');
+        expect(await reader.readMessage()).toMatchObject({ type: 'Z' });
+    });
+
+    it('describes statements with more than 32767 parameters (counts are unsigned)', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT $40000'),
+                describeMessage('S'),
+                syncMessage(),
+            ]),
+        );
+        expect(await reader.readMessage()).toMatchObject({ type: '1' });
+        const parameterDescription = await reader.readMessage();
+        expect(parameterDescription.type).toBe('t');
+        expect(parameterDescription.payload.readUInt16BE(0)).toBe(40000);
+        expect(await readTypesUntilReady(reader)).toBe('TZ');
+    });
+
+    it('strips NUL bytes from outbound strings so error fields stay intact', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(queryMessage('SELECT nul'));
+        const error = await reader.readMessage();
+        expect(error.type).toBe('E');
+        expect(error.payload.toString('utf8')).toContain('Mbadvalue\0');
+        expect(error.payload.toString('utf8')).toContain('Hhinttoo\0');
+        await reader.readUntil('Z');
+    });
+
+    it('budgets the SQL held by statements and portals together with 54000', async () => {
+        const { socket, reader } = await openSession();
+        // ~1MB of inlined SQL per portal, kept alive by the transaction
+        const placeholders = Array.from({ length: 100 }, () => '$1').join(',');
+        socket.write(queryMessage('BEGIN'));
+        await reader.readUntil('Z');
+        socket.write(
+            Buffer.concat([
+                parseMessage('big', `SELECT ${placeholders}`),
+                ...Array.from({ length: 17 }, (_, i) =>
+                    bindMessage({
+                        portal: `p${i}`,
+                        statement: 'big',
+                        parameters: ['x'.repeat(10_000)],
+                    }),
+                ),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe(`1${'2'.repeat(16)}EZ`);
+        // closing a portal frees its share
+        socket.write(
+            Buffer.concat([
+                closeMessage('P', 'p0'),
+                bindMessage({
+                    portal: 'p17',
+                    statement: 'big',
+                    parameters: ['x'.repeat(10_000)],
+                }),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('32Z');
+    });
+
+    it('caps named statements and portals per connection with 54000', async () => {
+        const { socket, reader } = await openSession();
+        const batch = Buffer.concat(
+            Array.from({ length: 1000 }, (_, i) =>
+                parseMessage(`s${i}`, 'SELECT who'),
+            ),
+        );
+        socket.write(Buffer.concat([batch, syncMessage()]));
+        expect(await readTypesUntilReady(reader)).toBe(`${'1'.repeat(1000)}Z`);
+
+        socket.write(
+            Buffer.concat([
+                parseMessage('one-too-many', 'SELECT who'),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('EZ');
+        // the unnamed statement is exempt
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT who'),
+                bindMessage({ statement: 's999' }),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('12Z');
+
+        // portals are capped the same way (inside a transaction they survive Sync)
+        socket.write(queryMessage('BEGIN'));
+        await reader.readUntil('Z');
+        socket.write(
+            Buffer.concat([
+                ...Array.from({ length: 1000 }, (_, i) =>
+                    bindMessage({ portal: `p${i}`, statement: 's1' }),
+                ),
+                bindMessage({ portal: 'one-too-many', statement: 's1' }),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe(`${'2'.repeat(1000)}EZ`);
+        socket.write(queryMessage('DISCARD PLANS')); // not ALL: nothing dropped
+        await reader.readUntil('Z');
+        socket.write(
+            Buffer.concat([
+                bindMessage({ portal: 'still-full', statement: 's1' }),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('EZ');
+
+        // DISCARD ALL frees everything
+        socket.write(queryMessage('DISCARD ALL'));
+        await reader.readUntil('Z');
+        socket.write(
+            Buffer.concat([
+                parseMessage('s1', 'SELECT who'), // was taken before DISCARD
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('1Z');
+    });
+
+    it('encodes mixed per-column result formats', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT typed'),
+                bindMessage({ resultFormats: [1, 0, 0, 0, 0, 0] }),
+                executeMessage(),
+                syncMessage(),
+            ]),
+        );
+        expect(await reader.readMessage()).toMatchObject({ type: '1' });
+        expect(await reader.readMessage()).toMatchObject({ type: '2' });
+        const row = await reader.readMessage();
+        expect(row.type).toBe('D');
+        // first column binary bool (1 byte), second column text '42'
+        expect(row.payload.readInt32BE(2)).toBe(1);
+        expect(row.payload[6]).toBe(1);
+        expect(row.payload.readInt32BE(7)).toBe(2);
+        expect(row.payload.subarray(11, 13).toString('utf8')).toBe('42');
+        await reader.readUntil('Z');
+    });
+
+    it('runs two pipelined batches when the first one fails', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT fail'),
+                bindMessage(),
+                executeMessage(),
+                syncMessage(),
+                parseMessage('', 'SELECT who'),
+                bindMessage(),
+                executeMessage(),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('12EZ');
+        expect(await readTypesUntilReady(reader)).toBe('12DCZ');
+    });
+
+    it('re-executing a finished portal completes again without rows', async () => {
+        const { socket, reader } = await openSession();
+        socket.write(queryMessage('BEGIN'));
+        await reader.readUntil('Z');
+        socket.write(
+            Buffer.concat([
+                parseMessage('', 'SELECT three'),
+                bindMessage({ portal: 'p' }),
+                executeMessage('p'),
+                syncMessage(),
+                executeMessage('p'),
+                syncMessage(),
+            ]),
+        );
+        expect(await readTypesUntilReady(reader)).toBe('12DDDCZ');
+        expect(await readTypesUntilReady(reader)).toBe('CZ');
+        expect(
+            handlerCalls.filter(
+                (c) => c.kind === 'query' && c.sql === 'SELECT three',
+            ),
+        ).toHaveLength(1);
+    });
+
+    it('rejects extended messages before authentication', async () => {
+        const port = await startServer();
+        const socket = await connect(port);
+        openSockets.push(socket);
+        const reader = new MessageReader(socket);
+        socket.write(startupMessage({ user: 'alice', database: 'db' }));
+        await reader.readUntil('R');
+        socket.write(parseMessage('', 'SELECT who'));
+        const error = await reader.readMessage();
+        expect(errorCode(error.payload)).toBe('08P01');
+        await reader.waitForClose();
+    });
+
+    it('serves node-postgres parameterised queries', async () => {
+        const client = await openClient();
+        const result = await client.query('SELECT who', []);
+        expect(result.rows).toEqual([{ who: 'alice' }]);
+        expect(result.command).toBe('SELECT');
+
+        const withParams = await client.query(
+            'SELECT * FROM t WHERE a = $1 AND b = $2 AND c = $3',
+            ['x', 42, null],
+        );
+        expect(withParams.rows).toEqual([
+            { sql: "SELECT * FROM t WHERE a = 'x' AND b = '42' AND c = NULL" },
+        ]);
+    });
+
+    it('inlines multibyte text parameters from node-postgres and serves binary rows', async () => {
+        const client = await openClient();
+        const unicode = await client.query('SELECT * FROM t WHERE name = $1', [
+            'héllo 日本 ✓',
+        ]);
+        expect(unicode.rows).toEqual([
+            { sql: "SELECT * FROM t WHERE name = 'héllo 日本 ✓'" },
+        ]);
+
+        // node-postgres supports `binary` but its types don't declare it
+        const binary = await client.query({
+            text: 'SELECT typed',
+            values: [],
+            binary: true,
+        } as unknown as QueryConfig);
+        expect(binary.rows[0]).toMatchObject({
+            b: true,
+            i: '42', // node-postgres keeps int8 as string
+            f: 2.5,
+            t: 'x',
+        });
+        expect(binary.rows[0].d.toISOString().slice(0, 10)).toBe('2000-01-03');
+        expect(binary.rows[1]).toEqual({
+            b: null,
+            i: null,
+            f: null,
+            d: null,
+            ts: null,
+            t: null,
+        });
+    });
+
+    it('serves node-postgres named prepared statements across queries', async () => {
+        const client = await openClient();
+        const first = await client.query({
+            name: 'named',
+            text: 'SELECT who',
+            values: [],
+        });
+        const second = await client.query({
+            name: 'named',
+            text: 'SELECT who',
+            values: [],
+        });
+        expect(first.rows).toEqual([{ who: 'alice' }]);
+        expect(second.rows).toEqual([{ who: 'alice' }]);
+        expect(handlerCalls.filter((c) => c.kind === 'query')).toHaveLength(2);
+    });
+
+    it('surfaces handler errors to node-postgres and keeps the connection usable', async () => {
+        const client = await openClient();
+        await expect(client.query('SELECT fail', [])).rejects.toMatchObject({
+            code: 'XX001',
+            message: 'canned failure',
+        });
+        const after = await client.query('SELECT who', []);
+        expect(after.rows).toEqual([{ who: 'alice' }]);
+    });
+
+    it('still serves simple queries from node-postgres', async () => {
+        const client = await openClient();
+        const result = await client.query('SELECT who');
+        expect(result.rows).toEqual([{ who: 'alice' }]);
+        expect(handlerCalls).toEqual([{ kind: 'query', sql: 'SELECT who' }]);
     });
 });

--- a/packages/backend/src/ee/postgresWire/PostgresWireServer.ts
+++ b/packages/backend/src/ee/postgresWire/PostgresWireServer.ts
@@ -2,12 +2,30 @@ import * as fs from 'fs';
 import * as net from 'net';
 import * as tls from 'tls';
 import Logger from '../../logging/logger';
+import { decodeBinaryParameter, encodeBinaryValue } from './binaryFormat';
+import {
+    countParameters,
+    expandFormats,
+    inlineParameters,
+    isTextFormat,
+    placeholderValues,
+    readBindMessage,
+    readCloseMessage,
+    readDescribeMessage,
+    readExecuteMessage,
+    readParseMessage,
+} from './extendedQuery';
+import { PG_OID, TEXT_FORMAT } from './pgTypes';
+import { PgWireServerError } from './PgWireServerError';
+import { cstring, int16, int32, uint16 } from './wireEncoding';
+
+export { PgWireServerError };
 
 /**
  * A minimal implementation of the Postgres wire protocol (v3) frontend/backend
- * message flow, supporting cleartext password authentication and the simple
- * query protocol. Enough for psql, node-postgres and most drivers that don't
- * force the extended protocol for parameterless queries.
+ * message flow, supporting cleartext password authentication, the simple query
+ * protocol and the extended query protocol (Parse/Bind/Describe/Execute/Sync),
+ * with binary parameters and result columns for the types this server emits.
  *
  * TLS: the pg handshake is StartTLS-style — a plaintext `SSLRequest` precedes
  * the TLS upgrade — so generic TLS-terminating load balancers cannot front
@@ -23,17 +41,10 @@ const SSL_REQUEST_CODE = 80877103;
 const GSSENC_REQUEST_CODE = 80877104;
 const CANCEL_REQUEST_CODE = 80877102;
 const MAX_MESSAGE_LENGTH = 1024 * 1024; // 1MB
-
-export class PgWireServerError extends Error {
-    constructor(
-        message: string,
-        public readonly code: string = 'XX000',
-        public readonly hint?: string,
-    ) {
-        super(message);
-        this.name = 'PgWireServerError';
-    }
-}
+/** Named prepared statements / portals a single connection may hold open */
+const MAX_NAMED_OBJECTS = 1000;
+/** Statement and portal text a single connection may keep, in UTF-16 code units */
+const MAX_RETAINED_SQL_LENGTH = 16 * 1024 * 1024;
 
 export type PgWireResultField = {
     name: string;
@@ -58,8 +69,21 @@ export type PgWireHandlers<TSession> = {
         database: string;
         password: string;
     }) => Promise<TSession>;
-    /** Throw PgWireServerError to return an error to the client */
+    /**
+     * Throw PgWireServerError to return an error to the client. The command
+     * tags `BEGIN`, `COMMIT`, `ROLLBACK` and `DISCARD ALL` are read back by
+     * the server to track the transaction status it reports and the lifetime
+     * of portals and prepared statements.
+     */
     query: (session: TSession, sql: string) => Promise<PgWireQueryResult>;
+    /**
+     * Result columns of `sql` without running it; null when the statement
+     * produces no rows. Answers Describe, so it must agree with `query`.
+     */
+    describe: (
+        session: TSession,
+        sql: string,
+    ) => Promise<PgWireResultField[] | null>;
 };
 
 export type PgWireTlsOptions = {
@@ -140,21 +164,6 @@ class SecureContextProvider {
 
 // --- message encoding helpers ---
 
-const cstring = (s: string): Buffer =>
-    Buffer.concat([Buffer.from(s, 'utf8'), Buffer.from([0])]);
-
-const int16 = (n: number): Buffer => {
-    const b = Buffer.alloc(2);
-    b.writeInt16BE(n);
-    return b;
-};
-
-const int32 = (n: number): Buffer => {
-    const b = Buffer.alloc(4);
-    b.writeInt32BE(n);
-    return b;
-};
-
 const message = (type: string, ...parts: Buffer[]): Buffer => {
     const body = Buffer.concat(parts);
     return Buffer.concat([Buffer.from(type), int32(body.length + 4), body]);
@@ -166,9 +175,18 @@ const parameterStatus = (name: string, value: string) =>
     message('S', cstring(name), cstring(value));
 const backendKeyData = (pid: number, secret: number) =>
     message('K', int32(pid), int32(secret));
-const readyForQuery = () => message('Z', Buffer.from('I'));
+type TransactionStatus = 'I' | 'T';
+const readyForQuery = (status: TransactionStatus) =>
+    message('Z', Buffer.from(status));
 const commandComplete = (tag: string) => message('C', cstring(tag));
 const emptyQueryResponse = () => message('I');
+const parseComplete = () => message('1');
+const bindComplete = () => message('2');
+const closeComplete = () => message('3');
+const noData = () => message('n');
+const portalSuspended = () => message('s');
+const parameterDescription = (oids: number[]) =>
+    message('t', uint16(oids.length), ...oids.map(int32));
 
 const errorResponse = (error: PgWireServerError): Buffer => {
     const parts: Buffer[] = [
@@ -188,9 +206,13 @@ const errorResponse = (error: PgWireServerError): Buffer => {
     return message('E', ...parts);
 };
 
-const rowDescription = (fields: PgWireResultField[]): Buffer => {
-    const parts: Buffer[] = [int16(fields.length)];
-    for (const field of fields) {
+/** `formats` has one code per field, or is empty for all-text */
+const rowDescription = (
+    fields: PgWireResultField[],
+    formats: number[] = [],
+): Buffer => {
+    const parts: Buffer[] = [uint16(fields.length)];
+    fields.forEach((field, index) => {
         parts.push(
             cstring(field.name),
             int32(0), // table oid
@@ -198,22 +220,28 @@ const rowDescription = (fields: PgWireResultField[]): Buffer => {
             int32(field.oid),
             int16(-1), // type length (variable)
             int32(-1), // type modifier
-            int16(0), // text format
+            int16(formats[index] ?? TEXT_FORMAT),
         );
-    }
+    });
     return message('T', ...parts);
 };
 
-const dataRow = (values: (string | null)[]): Buffer => {
-    const parts: Buffer[] = [int16(values.length)];
-    for (const value of values) {
+const dataRow = (
+    values: (string | null)[],
+    fields: PgWireResultField[],
+    formats: number[] = [],
+): Buffer => {
+    const parts: Buffer[] = [uint16(values.length)];
+    values.forEach((value, index) => {
         if (value === null) {
             parts.push(int32(-1));
-        } else {
-            const bytes = Buffer.from(value, 'utf8');
-            parts.push(int32(bytes.length), bytes);
+            return;
         }
-    }
+        const bytes = isTextFormat(formats[index] ?? TEXT_FORMAT)
+            ? Buffer.from(value, 'utf8')
+            : encodeBinaryValue(value, fields[index].oid);
+        parts.push(int32(bytes.length), bytes);
+    });
     return message('D', ...parts);
 };
 
@@ -224,6 +252,39 @@ const toServerError = (e: unknown): PgWireServerError => {
 };
 
 type ConnectionPhase = 'startup' | 'password' | 'ready';
+
+type PreparedStatement = {
+    sql: string;
+    /** highest `$n` in the SQL or the number of declared types, whichever is larger */
+    parameterCount: number;
+    /** only what the client declared (0 = unspecified); undeclared ones are text */
+    declaredParameterOids: number[];
+};
+
+const parameterOidsOf = (statement: PreparedStatement): number[] =>
+    Array.from(
+        { length: statement.parameterCount },
+        (_, index) => statement.declaredParameterOids[index] || PG_OID.text,
+    );
+
+/** Heap a statement or portal keeps alive, in the units of the budget */
+const retainedSize = (object: {
+    sql: string;
+    declaredParameterOids?: number[];
+}): number =>
+    object.sql.length + (object.declaredParameterOids?.length ?? 0) * 4;
+
+type Portal = {
+    /** statement SQL with parameters inlined */
+    sql: string;
+    /** requested column formats as sent in Bind: none, one for all, or one per column */
+    resultFormats: number[];
+    /** set by the first Execute; later Executes resume from `cursor` */
+    result: PgWireQueryResult | null;
+    cursor: number;
+};
+
+const UNNAMED = '';
 
 /** State machine for a single client connection */
 class PgWireConnection<TSession> {
@@ -242,6 +303,19 @@ class PgWireConnection<TSession> {
 
     /** true once the socket has been upgraded to TLS */
     private isSecure = false;
+
+    private statements = new Map<string, PreparedStatement>();
+
+    private portals = new Map<string, Portal>();
+
+    /** after an extended-protocol error, everything up to the next Sync is ignored */
+    private skipUntilSync = false;
+
+    /**
+     * BEGIN/COMMIT are accepted as no-ops by the handlers, but drivers still
+     * expect portals (fetchSize cursors) to survive Sync inside a transaction
+     */
+    private isInTransaction = false;
 
     private readonly onData = (chunk: Buffer): void => {
         try {
@@ -403,7 +477,14 @@ class PgWireConnection<TSession> {
     }
 
     private async handleMessage(type: string, payload: Buffer): Promise<void> {
-        if (this.socket.destroyed) return;
+        if (this.socket.destroyed) {
+            return;
+        }
+        // Like Postgres: after an extended-protocol error only Sync (and
+        // Terminate) are acted upon until the client resynchronises
+        if (this.skipUntilSync && type !== 'S' && type !== 'X') {
+            return;
+        }
         switch (type) {
             case 'p': {
                 if (this.phase !== 'password') return;
@@ -441,26 +522,15 @@ class PgWireConnection<TSession> {
             case 'X': // Terminate
                 this.socket.end();
                 return;
-            case 'P': // extended query protocol not supported
+            case 'P':
             case 'B':
             case 'D':
             case 'E':
             case 'C':
             case 'H':
-            case 'S': {
-                this.socket.write(
-                    errorResponse(
-                        new PgWireServerError(
-                            'the extended query protocol is not supported',
-                            '0A000',
-                            'Use simple queries without bind parameters',
-                        ),
-                    ),
-                );
-                // Sync: let the client recover
-                if (type === 'S') this.socket.write(readyForQuery());
+            case 'S':
+                await this.handleExtendedMessage(type, payload);
                 return;
-            }
             default:
                 this.socket.write(
                     errorResponse(
@@ -509,15 +579,325 @@ class PgWireConnection<TSession> {
                     process.pid,
                     Math.floor(Math.random() * 2 ** 31),
                 ),
-                readyForQuery(),
+                readyForQuery('I'),
             ]),
         );
+    }
+
+    private async handleExtendedMessage(
+        type: string,
+        payload: Buffer,
+    ): Promise<void> {
+        if (this.phase !== 'ready') {
+            this.socket.write(
+                errorResponse(
+                    new PgWireServerError(
+                        'connection not authenticated',
+                        '08P01',
+                    ),
+                ),
+            );
+            this.socket.end();
+            return;
+        }
+        if (type === 'S') {
+            this.sync();
+            return;
+        }
+        try {
+            switch (type) {
+                case 'P':
+                    this.parseStatement(payload);
+                    return;
+                case 'B':
+                    this.bindPortal(payload);
+                    return;
+                case 'D':
+                    await this.describe(payload);
+                    return;
+                case 'E':
+                    await this.execute(payload);
+                    return;
+                case 'C':
+                    this.closeTarget(payload);
+                    return;
+                case 'H': // Flush: every reply is written immediately
+                    return;
+                default:
+                    return;
+            }
+        } catch (e) {
+            this.socket.write(errorResponse(toServerError(e)));
+            this.skipUntilSync = true;
+        }
+    }
+
+    private sync(): void {
+        this.endImplicitTransaction();
+        this.skipUntilSync = false;
+        this.socket.write(readyForQuery(this.transactionStatus()));
+    }
+
+    private transactionStatus(): TransactionStatus {
+        return this.isInTransaction ? 'T' : 'I';
+    }
+
+    /** Outside an explicit transaction every statement is its own; portals end with it */
+    private endImplicitTransaction(): void {
+        if (!this.isInTransaction) {
+            this.portals.clear();
+        }
+    }
+
+    private trackTransaction(commandTag: string): void {
+        if (commandTag === 'BEGIN') {
+            this.isInTransaction = true;
+        } else if (commandTag === 'COMMIT' || commandTag === 'ROLLBACK') {
+            this.isInTransaction = false;
+            this.portals.clear();
+        } else if (commandTag === 'DISCARD ALL') {
+            this.isInTransaction = false;
+            this.portals.clear();
+            this.statements.clear();
+        }
+    }
+
+    private parseStatement(payload: Buffer): void {
+        const { statementName, sql, parameterOids } = readParseMessage(payload);
+        if (statementName !== UNNAMED && this.statements.has(statementName)) {
+            throw new PgWireServerError(
+                `prepared statement "${statementName}" already exists`,
+                '42P05',
+            );
+        }
+        // types the client left undeclared (0) or omitted entirely are text
+        const parameterCount = Math.max(
+            parameterOids.length,
+            countParameters(sql),
+        );
+        this.assertCapacity(
+            this.statements,
+            statementName,
+            'prepared statements',
+        );
+        const statement: PreparedStatement = {
+            sql,
+            parameterCount,
+            declaredParameterOids: parameterOids,
+        };
+        this.assertRetainedSqlBudget(statement, {
+            replacing: this.statements.get(statementName),
+        });
+        this.statements.set(statementName, statement);
+        this.socket.write(parseComplete());
+    }
+
+    private bindPortal(payload: Buffer): void {
+        const bind = readBindMessage(payload);
+        const statement = this.statements.get(bind.statementName);
+        if (!statement) {
+            throw new PgWireServerError(
+                `prepared statement "${bind.statementName}" does not exist`,
+                '26000',
+            );
+        }
+        if (bind.portalName !== UNNAMED && this.portals.has(bind.portalName)) {
+            throw new PgWireServerError(
+                `cursor "${bind.portalName}" already exists`,
+                '42P03',
+            );
+        }
+        if (bind.parameters.length !== statement.parameterCount) {
+            throw new PgWireServerError(
+                `bind message supplies ${bind.parameters.length} parameters, but prepared statement "${bind.statementName}" requires ${statement.parameterCount}`,
+                '08P01',
+            );
+        }
+        const parameterOids = parameterOidsOf(statement);
+        const values = bind.parameters.map((value, index) => {
+            if (value === null) {
+                return null;
+            }
+            return isTextFormat(bind.parameterFormats[index])
+                ? value.toString('utf8')
+                : decodeBinaryParameter(value, parameterOids[index]);
+        });
+        this.assertCapacity(this.portals, bind.portalName, 'portals');
+        const portal: Portal = {
+            sql: inlineParameters(statement.sql, values, parameterOids),
+            resultFormats: bind.resultFormats,
+            result: null,
+            cursor: 0,
+        };
+        this.assertRetainedSqlBudget(portal, {
+            replacing: this.portals.get(bind.portalName),
+        });
+        this.portals.set(bind.portalName, portal);
+        this.socket.write(bindComplete());
+    }
+
+    private async describe(payload: Buffer): Promise<void> {
+        const { kind, name } = readDescribeMessage(payload);
+        if (kind === 'S') {
+            const statement = this.statements.get(name);
+            if (!statement) {
+                throw new PgWireServerError(
+                    `prepared statement "${name}" does not exist`,
+                    '26000',
+                );
+            }
+            const parameterOids = parameterOidsOf(statement);
+            const sql = inlineParameters(
+                statement.sql,
+                placeholderValues(parameterOids),
+                parameterOids,
+            );
+            const fields = await this.describeSql(sql);
+            this.socket.write(
+                Buffer.concat([
+                    parameterDescription(parameterOids),
+                    fields ? rowDescription(fields) : noData(),
+                ]),
+            );
+            return;
+        }
+        const portal = this.getPortal(name);
+        const fields = await this.describeSql(portal.sql);
+        this.socket.write(
+            fields
+                ? rowDescription(
+                      fields,
+                      expandFormats(
+                          portal.resultFormats,
+                          fields.length,
+                          'result column',
+                      ),
+                  )
+                : noData(),
+        );
+    }
+
+    private async describeSql(
+        sql: string,
+    ): Promise<PgWireResultField[] | null> {
+        if (sql.trim().length === 0) {
+            return null;
+        }
+        return this.handlers.describe(this.session as TSession, sql);
+    }
+
+    private async execute(payload: Buffer): Promise<void> {
+        const { portalName, maxRows } = readExecuteMessage(payload);
+        const portal = this.getPortal(portalName);
+        if (portal.sql.trim().length === 0) {
+            this.socket.write(emptyQueryResponse());
+            return;
+        }
+        const result =
+            portal.result ??
+            (await this.handlers.query(this.session as TSession, portal.sql));
+        if (result.type === 'command') {
+            this.portals.set(portalName, { ...portal, result });
+            this.trackTransaction(result.commandTag);
+            this.socket.write(commandComplete(result.commandTag));
+            return;
+        }
+        const formats = expandFormats(
+            portal.resultFormats,
+            result.fields.length,
+            'result column',
+        );
+        const end =
+            maxRows > 0
+                ? Math.min(portal.cursor + maxRows, result.rows.length)
+                : result.rows.length;
+        const isComplete = end >= result.rows.length;
+        // a finished portal keeps its shape (re-Execute is legal) but not its rows
+        this.portals.set(portalName, {
+            ...portal,
+            result: isComplete ? { ...result, rows: [] } : result,
+            cursor: isComplete ? 0 : end,
+        });
+        this.socket.write(
+            Buffer.concat([
+                ...result.rows
+                    .slice(portal.cursor, end)
+                    .map((row) => dataRow(row, result.fields, formats)),
+                isComplete
+                    ? commandComplete(result.commandTag)
+                    : portalSuspended(),
+            ]),
+        );
+    }
+
+    private closeTarget(payload: Buffer): void {
+        const { kind, name } = readCloseMessage(payload);
+        if (kind === 'S') {
+            this.statements.delete(name);
+        } else {
+            this.portals.delete(name);
+        }
+        this.socket.write(closeComplete());
+    }
+
+    /** Statements and portals together may not pin more than the budget */
+    private assertRetainedSqlBudget(
+        incoming: PreparedStatement | Portal,
+        { replacing }: { replacing: PreparedStatement | Portal | undefined },
+    ): void {
+        const kept = [
+            ...this.statements.values(),
+            ...this.portals.values(),
+        ].reduce(
+            (total, object) =>
+                object === replacing ? total : total + retainedSize(object),
+            0,
+        );
+        if (kept + retainedSize(incoming) > MAX_RETAINED_SQL_LENGTH) {
+            throw new PgWireServerError(
+                'too much statement text held open on this connection',
+                '54000',
+                'Close prepared statements and portals you no longer need',
+            );
+        }
+    }
+
+    /** The unnamed object is exempt (there is only ever one); named growth is capped */
+    private assertCapacity(
+        objects: Map<string, unknown>,
+        name: string,
+        subject: 'prepared statements' | 'portals',
+    ): void {
+        if (name === UNNAMED) {
+            return;
+        }
+        if (objects.size >= MAX_NAMED_OBJECTS) {
+            throw new PgWireServerError(
+                `too many ${subject} open on this connection (max ${MAX_NAMED_OBJECTS})`,
+                '54000',
+                `Close ${subject} you no longer need`,
+            );
+        }
+    }
+
+    private getPortal(name: string): Portal {
+        const portal = this.portals.get(name);
+        if (!portal) {
+            throw new PgWireServerError(
+                `portal "${name}" does not exist`,
+                '34000',
+            );
+        }
+        return portal;
     }
 
     private async runQuery(sql: string): Promise<void> {
         if (sql.trim().length === 0) {
             this.socket.write(
-                Buffer.concat([emptyQueryResponse(), readyForQuery()]),
+                Buffer.concat([
+                    emptyQueryResponse(),
+                    readyForQuery(this.transactionStatus()),
+                ]),
             );
             return;
         }
@@ -530,16 +910,21 @@ class PgWireConnection<TSession> {
             if (result.type === 'rows') {
                 buffers.push(rowDescription(result.fields));
                 for (const row of result.rows) {
-                    buffers.push(dataRow(row));
+                    buffers.push(dataRow(row, result.fields));
                 }
             }
-            buffers.push(commandComplete(result.commandTag), readyForQuery());
+            this.trackTransaction(result.commandTag);
+            this.endImplicitTransaction();
+            buffers.push(
+                commandComplete(result.commandTag),
+                readyForQuery(this.transactionStatus()),
+            );
             this.socket.write(Buffer.concat(buffers));
         } catch (e) {
             this.socket.write(
                 Buffer.concat([
                     errorResponse(toServerError(e)),
-                    readyForQuery(),
+                    readyForQuery(this.transactionStatus()),
                 ]),
             );
         }

--- a/packages/backend/src/ee/postgresWire/binaryFormat.test.ts
+++ b/packages/backend/src/ee/postgresWire/binaryFormat.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { decodeBinaryParameter, encodeBinaryValue } from './binaryFormat';
+import { float64, int32, int64 } from './wireEncoding';
+
+describe('decodeBinaryParameter', () => {
+    it('decodes the fixed-width numeric and boolean types to text', () => {
+        expect(decodeBinaryParameter(Buffer.from([1]), 16)).toBe('t');
+        expect(decodeBinaryParameter(Buffer.from([0]), 16)).toBe('f');
+        expect(decodeBinaryParameter(Buffer.from([0xff, 0xfe]), 21)).toBe('-2');
+        expect(decodeBinaryParameter(int32(800), 23)).toBe('800');
+        expect(decodeBinaryParameter(int64(9007199254740993n), 20)).toBe(
+            '9007199254740993',
+        );
+        const float4 = Buffer.alloc(4);
+        float4.writeFloatBE(1.5);
+        expect(decodeBinaryParameter(float4, 700)).toBe('1.5');
+        expect(decodeBinaryParameter(float64(800.5), 701)).toBe('800.5');
+    });
+
+    it('decodes binary date and timestamp parameters to the text the compiler expects', () => {
+        expect(decodeBinaryParameter(int32(0), 1082)).toBe('2000-01-01');
+        expect(decodeBinaryParameter(int32(9556), 1082)).toBe('2026-03-01');
+        expect(decodeBinaryParameter(int32(-1), 1082)).toBe('1999-12-31');
+        expect(decodeBinaryParameter(int64(0n), 1114)).toBe(
+            '2000-01-01 00:00:00.000000',
+        );
+        expect(decodeBinaryParameter(int64(1_500_000n), 1114)).toBe(
+            '2000-01-01 00:00:01.500000',
+        );
+        expect(decodeBinaryParameter(int64(-1n), 1114)).toBe(
+            '1999-12-31 23:59:59.999999',
+        );
+        expect(decodeBinaryParameter(int64(-500_000n), 1114)).toBe(
+            '1999-12-31 23:59:59.500000',
+        );
+    });
+
+    it('rejects out-of-range binary dates and timestamps with 22008', () => {
+        expect(() => decodeBinaryParameter(int32(2 ** 31 - 1), 1082)).toThrow(
+            expect.objectContaining({ code: '22008' }),
+        );
+        expect(() =>
+            decodeBinaryParameter(int64(9223372036854775807n), 1114),
+        ).toThrow(expect.objectContaining({ code: '22008' }));
+    });
+
+    it('passes text-like types through as UTF-8', () => {
+        expect(decodeBinaryParameter(Buffer.from('héllo'), 1043)).toBe('héllo');
+    });
+
+    it('rejects wrong lengths with 22P03 and unknown types with 0A000', () => {
+        expect(() => decodeBinaryParameter(Buffer.from([0]), 23)).toThrow(
+            expect.objectContaining({ code: '22P03' }),
+        );
+        expect(() => decodeBinaryParameter(int32(1), 1700)).toThrow(
+            expect.objectContaining({ code: '0A000' }),
+        );
+    });
+});
+
+describe('encodeBinaryValue', () => {
+    it('encodes bool, int4, int8, float8 from their text form', () => {
+        expect(encodeBinaryValue('t', 16)).toEqual(Buffer.from([1]));
+        expect(encodeBinaryValue('TRUE', 16)).toEqual(Buffer.from([1]));
+        expect(encodeBinaryValue('yes', 16)).toEqual(Buffer.from([1]));
+        expect(encodeBinaryValue('f', 16)).toEqual(Buffer.from([0]));
+        expect(encodeBinaryValue('false', 16)).toEqual(Buffer.from([0]));
+        expect(encodeBinaryValue('7', 23)).toEqual(int32(7));
+        expect(encodeBinaryValue('2397', 20)).toEqual(int64(2397n));
+        expect(encodeBinaryValue('12.0', 20)).toEqual(int64(12n));
+        expect(encodeBinaryValue('889.57', 701)).toEqual(float64(889.57));
+    });
+
+    it('reports out-of-range integers with 22003 and empty text with 22P03', () => {
+        expect(() => encodeBinaryValue('3000000000', 23)).toThrow(
+            expect.objectContaining({ code: '22003' }),
+        );
+        expect(() => encodeBinaryValue('9223372036854775808', 20)).toThrow(
+            expect.objectContaining({ code: '22003' }),
+        );
+        expect(encodeBinaryValue('9223372036854775807', 20)).toEqual(
+            int64(9223372036854775807n),
+        );
+        expect(() => encodeBinaryValue('', 20)).toThrow(
+            expect.objectContaining({ code: '22P03' }),
+        );
+        expect(() => encodeBinaryValue(' ', 701)).toThrow(
+            expect.objectContaining({ code: '22P03' }),
+        );
+    });
+
+    it('encodes date as days and timestamp as microseconds since 2000-01-01', () => {
+        expect(encodeBinaryValue('2000-01-01', 1082)).toEqual(int32(0));
+        const year50 = new Date(0);
+        year50.setUTCFullYear(50, 0, 1); // Date.UTC(50, …) would mean 1950
+        expect(encodeBinaryValue('0050-01-01', 1082)).toEqual(
+            int32((year50.getTime() - Date.UTC(2000, 0, 1)) / 86400000),
+        );
+        expect(encodeBinaryValue('2026-03-01', 1082)).toEqual(int32(9556));
+        expect(encodeBinaryValue('1999-12-31', 1082)).toEqual(int32(-1));
+        expect(encodeBinaryValue('2000-01-01 00:00:00+00', 1114)).toEqual(
+            int64(0n),
+        );
+        expect(encodeBinaryValue('2000-01-01 00:00:01.5+00', 1114)).toEqual(
+            int64(1_500_000n),
+        );
+        expect(
+            encodeBinaryValue('2000-01-01 00:00:00.123456789', 1114),
+        ).toEqual(int64(123_456n));
+        expect(encodeBinaryValue('2026-03-01 12:34:56Z', 1114)).toEqual(
+            int64(
+                BigInt(
+                    Date.UTC(2026, 2, 1, 12, 34, 56) - Date.UTC(2000, 0, 1),
+                ) * 1000n,
+            ),
+        );
+    });
+
+    it('passes text through and rejects types it cannot encode', () => {
+        expect(encodeBinaryValue('abc', 25)).toEqual(Buffer.from('abc'));
+        expect(() => encodeBinaryValue('1.5', 1700)).toThrow(
+            expect.objectContaining({ code: '0A000' }),
+        );
+        expect(() => encodeBinaryValue('not a date', 1082)).toThrow(
+            expect.objectContaining({ code: '22P03' }),
+        );
+        expect(() => encodeBinaryValue('2024-13-45 10:00:00', 1114)).toThrow(
+            expect.objectContaining({ code: '22P03' }),
+        );
+        expect(() => encodeBinaryValue('abc', 20)).toThrow(
+            expect.objectContaining({ code: '22P03' }),
+        );
+    });
+});

--- a/packages/backend/src/ee/postgresWire/binaryFormat.ts
+++ b/packages/backend/src/ee/postgresWire/binaryFormat.ts
@@ -1,0 +1,221 @@
+import { PG_OID, TRUE_LITERALS } from './pgTypes';
+import { PgWireServerError } from './PgWireServerError';
+import { float64, int32, int64 } from './wireEncoding';
+
+/**
+ * Binary wire encodings for the handful of Postgres types this server emits
+ * (TYPE_OIDS in lightdashHandlers) and accepts as bound parameters. Drivers
+ * ask for binary once they know a column's type: pgjdbc after
+ * `prepareThreshold`, psycopg3 for ints by default.
+ *
+ * Reference: src/backend/utils/adt/*send/*recv in the Postgres sources.
+ */
+
+const TEXT_LIKE_OIDS = new Set<number>([
+    PG_OID.name,
+    PG_OID.text,
+    PG_OID.bpchar,
+    PG_OID.varchar,
+]);
+
+const FIXED_BINARY_LENGTHS: Record<number, number> = {
+    [PG_OID.bool]: 1,
+    [PG_OID.int2]: 2,
+    [PG_OID.int4]: 4,
+    [PG_OID.int8]: 8,
+    [PG_OID.float4]: 4,
+    [PG_OID.float8]: 8,
+    [PG_OID.date]: 4,
+    [PG_OID.timestamp]: 8,
+};
+
+const POSTGRES_EPOCH_MS = Date.UTC(2000, 0, 1);
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MICROS_PER_MS = 1000n;
+const INT4_MIN = -(2 ** 31);
+const INT4_MAX = 2 ** 31 - 1;
+const INT8_MIN = -(2n ** 63n);
+const INT8_MAX = 2n ** 63n - 1n;
+
+const unsupported = (verb: 'decode' | 'encode', oid: number) =>
+    new PgWireServerError(
+        `cannot ${verb} type with OID ${oid} in binary format`,
+        '0A000',
+        'Use text format for this type',
+    );
+
+const invalidText = (text: string, oid: number) =>
+    new PgWireServerError(
+        `cannot encode "${text}" as binary type with OID ${oid}`,
+        '22P03',
+    );
+
+const outOfRange = (text: string, oid: number) =>
+    new PgWireServerError(
+        `value "${text}" is out of range for type with OID ${oid}`,
+        '22003',
+    );
+
+const pad = (n: number, width: number): string =>
+    String(n).padStart(width, '0');
+
+const outOfDateRange = () =>
+    new PgWireServerError('date/time field value out of range', '22008');
+
+/** days since 2000-01-01 -> 'YYYY-MM-DD' */
+const decodeDate = (days: number): string => {
+    const date = new Date(POSTGRES_EPOCH_MS + days * MS_PER_DAY);
+    if (Number.isNaN(date.getTime())) {
+        throw outOfDateRange();
+    }
+    return `${pad(date.getUTCFullYear(), 4)}-${pad(date.getUTCMonth() + 1, 2)}-${pad(date.getUTCDate(), 2)}`;
+};
+
+/** BigInt division rounding towards -Infinity, so the remainder is never negative */
+const floorDiv = (n: bigint, d: bigint): bigint =>
+    n >= 0n ? n / d : -((-n + d - 1n) / d);
+
+/** microseconds since 2000-01-01 -> 'YYYY-MM-DD HH:MM:SS.ffffff' */
+const decodeTimestamp = (micros: bigint): string => {
+    const wholeMs = floorDiv(micros, MICROS_PER_MS);
+    const remainderMicros = micros - wholeMs * MICROS_PER_MS;
+    const date = new Date(POSTGRES_EPOCH_MS + Number(wholeMs));
+    if (Number.isNaN(date.getTime())) {
+        throw outOfDateRange();
+    }
+    const fraction = pad(
+        date.getUTCMilliseconds() * 1000 + Number(remainderMicros),
+        6,
+    );
+    return `${decodeDate(Math.floor((date.getTime() - POSTGRES_EPOCH_MS) / MS_PER_DAY))} ${pad(date.getUTCHours(), 2)}:${pad(date.getUTCMinutes(), 2)}:${pad(date.getUTCSeconds(), 2)}.${fraction}`;
+};
+
+/** Binary parameter bytes -> the text form the compiler expects */
+export const decodeBinaryParameter = (bytes: Buffer, oid: number): string => {
+    if (TEXT_LIKE_OIDS.has(oid)) {
+        return bytes.toString('utf8');
+    }
+    const expectedLength = FIXED_BINARY_LENGTHS[oid];
+    if (expectedLength === undefined) {
+        throw unsupported('decode', oid);
+    }
+    if (bytes.length !== expectedLength) {
+        throw new PgWireServerError(
+            `incorrect binary data format in bind parameter: expected ${expectedLength} bytes for type OID ${oid}, got ${bytes.length}`,
+            '22P03',
+        );
+    }
+    switch (oid) {
+        case PG_OID.bool:
+            return bytes[0] !== 0 ? 't' : 'f';
+        case PG_OID.int2:
+            return String(bytes.readInt16BE(0));
+        case PG_OID.int4:
+            return String(bytes.readInt32BE(0));
+        case PG_OID.int8:
+            return bytes.readBigInt64BE(0).toString();
+        case PG_OID.float4:
+            return String(bytes.readFloatBE(0));
+        case PG_OID.float8:
+            return String(bytes.readDoubleBE(0));
+        case PG_OID.date:
+            return decodeDate(bytes.readInt32BE(0));
+        default:
+            return decodeTimestamp(bytes.readBigInt64BE(0));
+    }
+};
+
+const parseInteger = (text: string, oid: number): bigint => {
+    if (text.trim().length === 0) {
+        throw invalidText(text, oid);
+    }
+    try {
+        return BigInt(text);
+    } catch {
+        const asNumber = Number(text);
+        if (!Number.isFinite(asNumber)) {
+            throw invalidText(text, oid);
+        }
+        return BigInt(Math.trunc(asNumber));
+    }
+};
+
+const parseFloat64 = (text: string, oid: number): number => {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) {
+        throw invalidText(text, oid);
+    }
+    const value = Number(trimmed);
+    if (Number.isNaN(value) && trimmed.toLowerCase() !== 'nan') {
+        throw invalidText(text, oid);
+    }
+    return value;
+};
+
+/** 'YYYY-MM-DD' -> days since 2000-01-01 */
+const encodeDate = (text: string): Buffer => {
+    const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(text);
+    if (!match) {
+        throw invalidText(text, PG_OID.date);
+    }
+    const [, year, month, day] = match.map(Number);
+    const date = new Date(0);
+    date.setUTCFullYear(year, month - 1, day); // Date.UTC maps years < 100 to 19xx
+    return int32((date.getTime() - POSTGRES_EPOCH_MS) / MS_PER_DAY);
+};
+
+/** 'YYYY-MM-DD HH:MM:SS[.ffffff][+00]' (always UTC here) -> microseconds since 2000-01-01 */
+const encodeTimestamp = (text: string): Buffer => {
+    const match =
+        /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})(?:\.(\d+))?(?:Z|[+-]00(?::?00)?)?$/.exec(
+            text,
+        );
+    if (!match) {
+        throw invalidText(text, PG_OID.timestamp);
+    }
+    const [, date, time, fraction = ''] = match;
+    const wholeSecondsMs = Date.parse(`${date}T${time}Z`);
+    if (Number.isNaN(wholeSecondsMs)) {
+        throw invalidText(text, PG_OID.timestamp);
+    }
+    const micros = Number(fraction.padEnd(6, '0').slice(0, 6));
+    return int64(
+        BigInt(wholeSecondsMs - POSTGRES_EPOCH_MS) * MICROS_PER_MS +
+            BigInt(micros),
+    );
+};
+
+/** Text-format value (as produced by the handlers) -> binary bytes for `oid` */
+export const encodeBinaryValue = (text: string, oid: number): Buffer => {
+    if (TEXT_LIKE_OIDS.has(oid)) {
+        return Buffer.from(text, 'utf8');
+    }
+    switch (oid) {
+        case PG_OID.bool:
+            return Buffer.from([
+                TRUE_LITERALS.has(text.trim().toLowerCase()) ? 1 : 0,
+            ]);
+        case PG_OID.int4: {
+            const value = parseInteger(text, oid);
+            if (value < BigInt(INT4_MIN) || value > BigInt(INT4_MAX)) {
+                throw outOfRange(text, oid);
+            }
+            return int32(Number(value));
+        }
+        case PG_OID.int8: {
+            const value = parseInteger(text, oid);
+            if (value < INT8_MIN || value > INT8_MAX) {
+                throw outOfRange(text, oid);
+            }
+            return int64(value);
+        }
+        case PG_OID.float8:
+            return float64(parseFloat64(text, oid));
+        case PG_OID.date:
+            return encodeDate(text);
+        case PG_OID.timestamp:
+            return encodeTimestamp(text);
+        default:
+            throw unsupported('encode', oid);
+    }
+};

--- a/packages/backend/src/ee/postgresWire/extendedQuery.test.ts
+++ b/packages/backend/src/ee/postgresWire/extendedQuery.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+import {
+    countParameters,
+    expandFormats,
+    inlineParameters,
+    placeholderValues,
+    readBindMessage,
+    readCloseMessage,
+    readDescribeMessage,
+    readExecuteMessage,
+    readParseMessage,
+} from './extendedQuery';
+import { cstring, int16, int32 } from './wireEncoding';
+
+describe('extended query message decoding', () => {
+    it('reads Parse with parameter type OIDs', () => {
+        const payload = Buffer.concat([
+            cstring('s1'),
+            cstring('SELECT $1, $2'),
+            int16(2),
+            int32(23),
+            int32(0),
+        ]);
+        expect(readParseMessage(payload)).toEqual({
+            statementName: 's1',
+            sql: 'SELECT $1, $2',
+            parameterOids: [23, 0],
+        });
+    });
+
+    it('reads Bind and expands a single format code to every parameter', () => {
+        const payload = Buffer.concat([
+            cstring('p'),
+            cstring('s'),
+            int16(1),
+            int16(0),
+            int16(3),
+            int32(1),
+            Buffer.from('a'),
+            int32(-1),
+            int32(2),
+            Buffer.from('bc'),
+            int16(2),
+            int16(0),
+            int16(1),
+        ]);
+        const bind = readBindMessage(payload);
+        expect(bind.portalName).toBe('p');
+        expect(bind.statementName).toBe('s');
+        expect(bind.parameterFormats).toEqual([0, 0, 0]);
+        expect(bind.parameters.map((p) => p?.toString('utf8') ?? null)).toEqual(
+            ['a', null, 'bc'],
+        );
+        expect(bind.resultFormats).toEqual([0, 1]);
+    });
+
+    it('reads Describe, Close and Execute', () => {
+        expect(
+            readDescribeMessage(
+                Buffer.concat([Buffer.from('S'), cstring('x')]),
+            ),
+        ).toEqual({ kind: 'S', name: 'x' });
+        expect(
+            readCloseMessage(Buffer.concat([Buffer.from('P'), cstring('')])),
+        ).toEqual({ kind: 'P', name: '' });
+        expect(
+            readExecuteMessage(Buffer.concat([cstring('c'), int32(50)])),
+        ).toEqual({ portalName: 'c', maxRows: 50 });
+    });
+
+    it('rejects mismatched format counts, unknown format codes and negative lengths with 08P01', () => {
+        expect(expandFormats([], 3, 'parameter')).toEqual([0, 0, 0]);
+        expect(expandFormats([1], 2, 'result column')).toEqual([1, 1]);
+        expect(expandFormats([1], 0, 'result column')).toEqual([]);
+        expect(expandFormats([0, 1], 2, 'parameter')).toEqual([0, 1]);
+        expect(() => expandFormats([0, 1], 3, 'parameter')).toThrow(
+            expect.objectContaining({ code: '08P01' }),
+        );
+        const bindWith = (formatCode: number, length: number): Buffer =>
+            Buffer.concat([
+                cstring(''),
+                cstring(''),
+                int16(1),
+                int16(formatCode),
+                int16(1),
+                int32(length),
+                int16(0),
+            ]);
+        expect(() => readBindMessage(bindWith(2, -1))).toThrow(
+            expect.objectContaining({ code: '08P01' }),
+        );
+        expect(() => readBindMessage(bindWith(0, -2))).toThrow(
+            expect.objectContaining({ code: '08P01' }),
+        );
+        expect(() =>
+            readParseMessage(
+                Buffer.concat([cstring(''), cstring('SELECT 1'), int16(-1)]),
+            ),
+        ).toThrow(expect.objectContaining({ code: '08P01' }));
+    });
+
+    it('rejects truncated payloads and unknown Describe kinds with 08P01', () => {
+        expect(() => readExecuteMessage(cstring('c'))).toThrow(
+            expect.objectContaining({ code: '08P01' }),
+        );
+        expect(() => readParseMessage(Buffer.from('no terminator'))).toThrow(
+            expect.objectContaining({ code: '08P01' }),
+        );
+        expect(() =>
+            readDescribeMessage(Buffer.concat([Buffer.from('X'), cstring('')])),
+        ).toThrow(expect.objectContaining({ code: '08P01' }));
+    });
+});
+
+describe('inlineParameters', () => {
+    it('inlines text, numeric, boolean and null parameters by OID', () => {
+        expect(
+            inlineParameters(
+                'SELECT $1, $2, $3, $4, $5',
+                ["O'Brien", '42', '3.5e2', 't', null],
+                [25, 23, 701, 16, 25],
+            ),
+        ).toBe("SELECT 'O''Brien', 42, 3.5e2, TRUE, NULL");
+    });
+
+    it('quotes numeric-typed values that are not numeric literals', () => {
+        expect(inlineParameters('SELECT $1', ['12abc'], [23])).toBe(
+            "SELECT '12abc'",
+        );
+    });
+
+    it('quotes untyped (OID 0) numbers as text', () => {
+        expect(inlineParameters('SELECT $1', ['42'], [0])).toBe("SELECT '42'");
+    });
+
+    it('leaves placeholders alone inside strings, identifiers and comments', () => {
+        const sql = [
+            "SELECT '$1', \"$1\", 'it''s $1' -- $1 here",
+            '/* $1 there */ WHERE a = $1',
+        ].join('\n');
+        expect(inlineParameters(sql, ['v'], [25])).toBe(
+            [
+                "SELECT '$1', \"$1\", 'it''s $1' -- $1 here",
+                "/* $1 there */ WHERE a = 'v'",
+            ].join('\n'),
+        );
+    });
+
+    it('distinguishes $10 from $1', () => {
+        const values = Array.from({ length: 10 }, (_, i) => String(i + 1));
+        const oids = values.map(() => 23);
+        expect(inlineParameters('SELECT $10, $1', values, oids)).toBe(
+            'SELECT 10, 1',
+        );
+    });
+
+    it('leaves a $ glued to an identifier alone', () => {
+        expect(inlineParameters('SELECT foo$1, $1', ['v'], [25])).toBe(
+            "SELECT foo$1, 'v'",
+        );
+    });
+
+    it('accepts every Postgres boolean spelling and rejects others with 22P02', () => {
+        expect(
+            inlineParameters(
+                'SELECT $1, $2, $3, $4',
+                ['TRUE', 'yes', 'off', ' 0 '],
+                [16, 16, 16, 16],
+            ),
+        ).toBe('SELECT TRUE, TRUE, FALSE, FALSE');
+        expect(() => inlineParameters('SELECT $1', ['maybe'], [16])).toThrow(
+            expect.objectContaining({ code: '22P02' }),
+        );
+    });
+
+    it('refuses to grow a statement past 1MB with 54000', () => {
+        const sql = Array.from({ length: 1100 }, () => '$1').join(',');
+        expect(() => inlineParameters(sql, ['x'.repeat(1000)], [25])).toThrow(
+            expect.objectContaining({ code: '54000' }),
+        );
+        expect(
+            inlineParameters('SELECT $1', ['x'.repeat(1000)], [25]),
+        ).toHaveLength('SELECT '.length + 1002);
+    });
+
+    it('rejects placeholder numbers above the Postgres limit with 54023', () => {
+        expect(() => countParameters('SELECT $65536')).toThrow(
+            expect.objectContaining({ code: '54023' }),
+        );
+        expect(countParameters('SELECT $65535')).toBe(65535);
+        expect(() => inlineParameters('SELECT $4000000000', [], [])).toThrow(
+            expect.objectContaining({ code: '54023' }),
+        );
+    });
+
+    it('rejects a placeholder without a bound value with 42P02', () => {
+        expect(() => inlineParameters('SELECT $2', ['a'], [25])).toThrow(
+            expect.objectContaining({ code: '42P02' }),
+        );
+    });
+
+    it('produces compilable placeholder values by OID for Describe before Bind', () => {
+        expect(placeholderValues([23, 16, 25, 0])).toEqual([
+            '1',
+            'true',
+            '',
+            '',
+        ]);
+        expect(
+            inlineParameters(
+                'WHERE n > $1 AND b = $2 AND s = $3 LIMIT $4',
+                placeholderValues([23, 16, 25, 20]),
+                [23, 16, 25, 20],
+            ),
+        ).toBe("WHERE n > 1 AND b = TRUE AND s = '' LIMIT 1");
+    });
+});
+
+describe('countParameters', () => {
+    it('returns the highest placeholder index, ignoring quoted and commented ones', () => {
+        expect(countParameters('SELECT 1')).toBe(0);
+        expect(countParameters('SELECT $2, $1')).toBe(2);
+        expect(countParameters("SELECT '$9', $3 -- $8")).toBe(3);
+    });
+});

--- a/packages/backend/src/ee/postgresWire/extendedQuery.ts
+++ b/packages/backend/src/ee/postgresWire/extendedQuery.ts
@@ -1,0 +1,430 @@
+import { assertUnreachable } from '@lightdash/common';
+import {
+    BINARY_FORMAT,
+    FALSE_LITERALS,
+    PG_OID,
+    TEXT_FORMAT,
+    TRUE_LITERALS,
+} from './pgTypes';
+import { PgWireServerError } from './PgWireServerError';
+
+/**
+ * Decoders for the extended query protocol frontend messages (Parse, Bind,
+ * Describe, Execute, Close) and the parameter inlining that turns a bound
+ * statement back into plain SQL for the compiler.
+ *
+ * Message layouts: https://www.postgresql.org/docs/current/protocol-message-formats.html
+ */
+
+/** Postgres' own limit; also what fits the uint16 count in ParameterDescription */
+export const MAX_PARAMETERS = 65535;
+
+/**
+ * A statement with parameters inlined may not exceed what a simple-query
+ * message could carry, so repeating a large value many times cannot amplify
+ * a small request into a huge SQL string.
+ */
+export const MAX_INLINED_SQL_LENGTH = 1024 * 1024;
+
+const NUMERIC_OIDS = new Set<number>([
+    PG_OID.int2,
+    PG_OID.int4,
+    PG_OID.int8,
+    PG_OID.float4,
+    PG_OID.float8,
+    PG_OID.numeric,
+]);
+
+export type ParseMessage = {
+    statementName: string;
+    sql: string;
+    /** 0 = unspecified by the client */
+    parameterOids: number[];
+};
+
+export type BindMessage = {
+    portalName: string;
+    statementName: string;
+    /** one entry per parameter */
+    parameterFormats: number[];
+    /** raw parameter bytes; null for SQL NULL */
+    parameters: (Buffer | null)[];
+    /** as sent: none (all text), one for every column, or one per column */
+    resultFormats: number[];
+};
+
+export type DescribeMessage = { kind: 'S' | 'P'; name: string };
+
+export type CloseMessage = { kind: 'S' | 'P'; name: string };
+
+export type ExecuteMessage = {
+    portalName: string;
+    /** 0 = no limit */
+    maxRows: number;
+};
+
+const protocolViolation = (message: string): PgWireServerError =>
+    new PgWireServerError(message, '08P01');
+
+class PayloadReader {
+    private offset = 0;
+
+    constructor(private readonly payload: Buffer) {}
+
+    cstring(): string {
+        const end = this.payload.indexOf(0, this.offset);
+        if (end === -1) {
+            throw PayloadReader.truncated();
+        }
+        const value = this.payload.toString('utf8', this.offset, end);
+        this.offset = end + 1;
+        return value;
+    }
+
+    byte(): number {
+        this.ensure(1);
+        const value = this.payload[this.offset];
+        this.offset += 1;
+        return value;
+    }
+
+    int16(): number {
+        this.ensure(2);
+        const value = this.payload.readInt16BE(this.offset);
+        this.offset += 2;
+        return value;
+    }
+
+    uint16(): number {
+        this.ensure(2);
+        const value = this.payload.readUInt16BE(this.offset);
+        this.offset += 2;
+        return value;
+    }
+
+    int32(): number {
+        this.ensure(4);
+        const value = this.payload.readInt32BE(this.offset);
+        this.offset += 4;
+        return value;
+    }
+
+    bytes(length: number): Buffer {
+        if (length < 0) {
+            throw protocolViolation(`invalid length ${length} in message`);
+        }
+        this.ensure(length);
+        const value = this.payload.subarray(this.offset, this.offset + length);
+        this.offset += length;
+        return value;
+    }
+
+    private ensure(length: number): void {
+        if (this.offset + length > this.payload.length) {
+            throw PayloadReader.truncated();
+        }
+    }
+
+    private static truncated(): PgWireServerError {
+        return protocolViolation('insufficient data left in message');
+    }
+}
+
+/** Counts on the wire are unsigned (Postgres reads them with pq_getmsgint) */
+const readCount = (reader: PayloadReader): number => reader.uint16();
+
+const readTimes = <T>(count: number, read: () => T): T[] =>
+    Array.from({ length: count }, read);
+
+const readKind = (reader: PayloadReader): 'S' | 'P' => {
+    const kind = String.fromCharCode(reader.byte());
+    if (kind !== 'S' && kind !== 'P') {
+        throw protocolViolation(
+            `invalid DESCRIBE/CLOSE message subtype "${kind}"`,
+        );
+    }
+    return kind;
+};
+
+const readFormatCodes = (reader: PayloadReader, subject: string): number[] =>
+    readTimes(readCount(reader), () => {
+        const code = reader.int16();
+        if (code !== TEXT_FORMAT && code !== BINARY_FORMAT) {
+            throw protocolViolation(
+                `unsupported ${subject} format code ${code}`,
+            );
+        }
+        return code;
+    });
+
+export const readParseMessage = (payload: Buffer): ParseMessage => {
+    const reader = new PayloadReader(payload);
+    const statementName = reader.cstring();
+    const sql = reader.cstring();
+    const parameterOids = readTimes(readCount(reader), () => reader.int32());
+    return { statementName, sql, parameterOids };
+};
+
+/**
+ * Format codes come as 0 entries (all text), 1 entry (applies to every
+ * value) or one entry per value; expand to one entry per value.
+ */
+export const expandFormats = (
+    formats: number[],
+    count: number,
+    subject: 'parameter' | 'result column',
+): number[] => {
+    if (formats.length === 0) {
+        return Array.from({ length: count }, () => TEXT_FORMAT);
+    }
+    if (formats.length === 1) {
+        return Array.from({ length: count }, () => formats[0]);
+    }
+    if (formats.length !== count) {
+        throw protocolViolation(
+            `bind message has ${formats.length} ${subject} formats but ${count} ${subject}s`,
+        );
+    }
+    return formats;
+};
+
+export const readBindMessage = (payload: Buffer): BindMessage => {
+    const reader = new PayloadReader(payload);
+    const portalName = reader.cstring();
+    const statementName = reader.cstring();
+    const rawParameterFormats = readFormatCodes(reader, 'parameter');
+    const parameters = readTimes(readCount(reader), () => {
+        const length = reader.int32();
+        if (length === -1) {
+            return null;
+        }
+        if (length < 0) {
+            throw protocolViolation(`invalid parameter length ${length}`);
+        }
+        return Buffer.from(reader.bytes(length));
+    });
+    const resultFormats = readFormatCodes(reader, 'result column');
+    return {
+        portalName,
+        statementName,
+        parameterFormats: expandFormats(
+            rawParameterFormats,
+            parameters.length,
+            'parameter',
+        ),
+        parameters,
+        resultFormats,
+    };
+};
+
+export const readDescribeMessage = (payload: Buffer): DescribeMessage => {
+    const reader = new PayloadReader(payload);
+    const kind = readKind(reader);
+    return { kind, name: reader.cstring() };
+};
+
+export const readCloseMessage = (payload: Buffer): CloseMessage => {
+    const reader = new PayloadReader(payload);
+    const kind = readKind(reader);
+    return { kind, name: reader.cstring() };
+};
+
+export const readExecuteMessage = (payload: Buffer): ExecuteMessage => {
+    const reader = new PayloadReader(payload);
+    const portalName = reader.cstring();
+    return { portalName, maxRows: reader.int32() };
+};
+
+export const isTextFormat = (format: number): boolean => format === TEXT_FORMAT;
+
+const NUMERIC_LITERAL = /^-?\d+(\.\d+)?([eE][-+]?\d+)?$/;
+
+/** Render one bound text-format parameter as a SQL literal */
+const toSqlLiteral = (value: string | null, oid: number): string => {
+    if (value === null) {
+        return 'NULL';
+    }
+    if (oid === PG_OID.bool) {
+        const spelling = value.trim().toLowerCase();
+        if (TRUE_LITERALS.has(spelling)) {
+            return 'TRUE';
+        }
+        if (FALSE_LITERALS.has(spelling)) {
+            return 'FALSE';
+        }
+        throw new PgWireServerError(
+            `invalid input syntax for type boolean: "${value}"`,
+            '22P02',
+        );
+    }
+    if (NUMERIC_OIDS.has(oid) && NUMERIC_LITERAL.test(value)) {
+        return value;
+    }
+    return `'${value.replace(/'/g, "''")}'`;
+};
+
+/**
+ * Values that stand in for unbound parameters when a statement is described
+ * before it is bound: the result columns don't depend on them, they only
+ * have to compile.
+ */
+export const placeholderValues = (parameterOids: number[]): string[] =>
+    parameterOids.map((oid) => {
+        if (oid === PG_OID.bool) {
+            return 'true';
+        }
+        if (NUMERIC_OIDS.has(oid)) {
+            return '1';
+        }
+        return '';
+    });
+
+type ScanState =
+    | 'sql'
+    | 'string'
+    | 'identifier'
+    | 'lineComment'
+    | 'blockComment';
+
+const IDENTIFIER_CHAR = /[A-Za-z0-9_$]/;
+
+/** `$` starts a placeholder only when it is not glued to an identifier (`foo$1`) */
+const placeholderAt = (sql: string, position: number): string | null => {
+    if (sql[position] !== '$') {
+        return null;
+    }
+    const previous = sql[position - 1];
+    if (previous !== undefined && IDENTIFIER_CHAR.test(previous)) {
+        return null;
+    }
+    const digits = /^\d+/.exec(sql.slice(position + 1));
+    return digits ? digits[0] : null;
+};
+
+/** Length of the token at `position` and the state after it; the tricky cases are two-character delimiters */
+const scanStep = (
+    sql: string,
+    position: number,
+    state: ScanState,
+): { length: number; state: ScanState } => {
+    const char = sql[position];
+    const pair = sql.slice(position, position + 2);
+    switch (state) {
+        case 'sql':
+            if (char === "'") {
+                return { length: 1, state: 'string' };
+            }
+            if (char === '"') {
+                return { length: 1, state: 'identifier' };
+            }
+            if (pair === '--') {
+                return { length: 2, state: 'lineComment' };
+            }
+            if (pair === '/*') {
+                return { length: 2, state: 'blockComment' };
+            }
+            return { length: 1, state };
+        case 'string':
+            // '' inside a string is an escaped quote, not the end
+            if (pair === "''") {
+                return { length: 2, state };
+            }
+            return { length: 1, state: char === "'" ? 'sql' : state };
+        case 'identifier':
+            return { length: 1, state: char === '"' ? 'sql' : state };
+        case 'lineComment':
+            return { length: 1, state: char === '\n' ? 'sql' : state };
+        case 'blockComment':
+            if (pair === '*/') {
+                return { length: 2, state: 'sql' };
+            }
+            return { length: 1, state };
+        default:
+            return assertUnreachable(state, `unknown scan state ${state}`);
+    }
+};
+
+/**
+ * Rewrite every `$n` placeholder outside quoted strings, quoted identifiers
+ * and comments with `replacement(n)`. Copies the SQL in slices between
+ * placeholders and refuses to grow past MAX_INLINED_SQL_LENGTH.
+ */
+const replacePlaceholders = (
+    sql: string,
+    replacement: (index: number) => string,
+): string => {
+    const parts: string[] = [];
+    let outputLength = 0;
+    let state: ScanState = 'sql';
+    let position = 0;
+    let sliceStart = 0;
+    const push = (text: string): void => {
+        outputLength += text.length;
+        if (outputLength > MAX_INLINED_SQL_LENGTH) {
+            throw new PgWireServerError(
+                'statement is too large after parameter substitution',
+                '54000',
+            );
+        }
+        parts.push(text);
+    };
+    while (position < sql.length) {
+        const digits = state === 'sql' ? placeholderAt(sql, position) : null;
+        if (digits !== null) {
+            push(sql.slice(sliceStart, position));
+            push(replacement(Number(digits)));
+            position += 1 + digits.length;
+            sliceStart = position;
+        } else {
+            const step = scanStep(sql, position, state);
+            position += step.length;
+            state = step.state;
+        }
+    }
+    push(sql.slice(sliceStart));
+    return parts.join('');
+};
+
+const checkParameterIndex = (index: number): void => {
+    if (index > MAX_PARAMETERS) {
+        throw new PgWireServerError(
+            `cannot have more than ${MAX_PARAMETERS} parameters in a statement`,
+            '54023',
+        );
+    }
+};
+
+/**
+ * Number of parameters a statement takes: the highest `$n` it references.
+ * Clients may declare fewer (or no) parameter types in Parse than the SQL
+ * uses, exactly as with Postgres, which then infers the rest.
+ */
+export const countParameters = (sql: string): number => {
+    let highest = 0;
+    replacePlaceholders(sql, (index) => {
+        checkParameterIndex(index);
+        highest = Math.max(highest, index);
+        return `$${index}`;
+    });
+    return highest;
+};
+
+/**
+ * Replace `$n` placeholders with literals. The result is compiled to a metric
+ * query and never reaches a warehouse as-is, so literal inlining is safe here.
+ */
+export const inlineParameters = (
+    sql: string,
+    values: (string | null)[],
+    parameterOids: number[],
+): string =>
+    replacePlaceholders(sql, (index) => {
+        checkParameterIndex(index);
+        if (index < 1 || index > values.length) {
+            throw new PgWireServerError(
+                `there is no parameter $${index}`,
+                '42P02',
+            );
+        }
+        return toSqlLiteral(values[index - 1], parameterOids[index - 1] ?? 0);
+    });

--- a/packages/backend/src/ee/postgresWire/lightdashHandlers.test.ts
+++ b/packages/backend/src/ee/postgresWire/lightdashHandlers.test.ts
@@ -1,0 +1,130 @@
+import { type Account } from '@lightdash/common';
+import { describe, expect, it, vi } from 'vitest';
+import type { ServiceRepository } from '../../services/ServiceRepository';
+import {
+    createLightdashPgWireHandlers,
+    type LightdashPgWireSession,
+} from './lightdashHandlers';
+import { type PgWireTable } from './types';
+
+const catalog: PgWireTable[] = [
+    {
+        name: 'orders',
+        fields: [
+            { fieldId: 'orders_status', kind: 'dimension', type: 'string' },
+            { fieldId: 'orders_amount', kind: 'dimension', type: 'number' },
+            {
+                fieldId: 'orders_is_completed',
+                kind: 'dimension',
+                type: 'boolean',
+            },
+            { fieldId: 'orders_order_date', kind: 'dimension', type: 'date' },
+            { fieldId: 'orders_total', kind: 'metric', type: 'sum' },
+            { fieldId: 'orders_count', kind: 'metric', type: 'count' },
+        ],
+    },
+];
+
+const runExploreQuery = vi.fn(async () => ({
+    rows: [
+        {
+            orders_status: { value: { raw: 'completed', formatted: '' } },
+            orders_total: { value: { raw: 2397, formatted: '' } },
+            orders_count: { value: { raw: 12, formatted: '' } },
+        },
+    ],
+}));
+
+const serviceRepository = {
+    getProjectService: () => ({ runExploreQuery }),
+} as unknown as ServiceRepository;
+
+const handlers = createLightdashPgWireHandlers(serviceRepository);
+
+const session: LightdashPgWireSession = {
+    account: { user: { email: 'alice@example.com' } } as unknown as Account,
+    projectUuid: 'project-uuid',
+    catalog,
+};
+
+const EXPLORE_SQL =
+    "SELECT orders_status, orders_total, orders_count FROM orders WHERE orders_status = 'completed' ORDER BY orders_total DESC LIMIT 10";
+
+describe('lightdash pgwire handlers: describe vs query', () => {
+    it('describes an explore query from the catalog without running it', async () => {
+        runExploreQuery.mockClear();
+        const fields = await handlers.describe(session, EXPLORE_SQL);
+        expect(fields).toEqual([
+            { name: 'orders_status', oid: 25 },
+            { name: 'orders_total', oid: 701 },
+            { name: 'orders_count', oid: 20 },
+        ]);
+        expect(runExploreQuery).not.toHaveBeenCalled();
+    });
+
+    it('returns the same fields from describe and query for an explore query', async () => {
+        const described = await handlers.describe(session, EXPLORE_SQL);
+        const result = await handlers.query(session, EXPLORE_SQL);
+        expect(result.type).toBe('rows');
+        if (result.type !== 'rows') {
+            throw new Error('expected rows');
+        }
+        expect(result.fields).toEqual(described);
+        expect(result.rows).toEqual([['completed', '2397', '12']]);
+        expect(runExploreQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it('describes the placeholder shapes Describe(S) produces before Bind', async () => {
+        runExploreQuery.mockClear();
+        await expect(
+            handlers.describe(
+                session,
+                "SELECT orders_status FROM orders WHERE orders_status = '' AND orders_amount > 1 AND orders_is_completed = TRUE LIMIT 1",
+            ),
+        ).resolves.toEqual([{ name: 'orders_status', oid: 25 }]);
+        expect(runExploreQuery).not.toHaveBeenCalled();
+    });
+
+    it('answers session statements, constants and information_schema in memory', async () => {
+        await expect(
+            handlers.describe(session, 'SET x = 1'),
+        ).resolves.toBeNull();
+        await expect(handlers.describe(session, 'BEGIN')).resolves.toBeNull();
+        await expect(handlers.describe(session, 'SELECT 1')).resolves.toEqual([
+            { name: '?column?', oid: 20 },
+        ]);
+        await expect(
+            handlers.describe(
+                session,
+                'SELECT table_name FROM information_schema.tables',
+            ),
+        ).resolves.toEqual([{ name: 'table_name', oid: 25 }]);
+        await expect(handlers.query(session, 'BEGIN')).resolves.toEqual({
+            type: 'command',
+            commandTag: 'BEGIN',
+        });
+        await expect(handlers.query(session, 'discard all;')).resolves.toEqual({
+            type: 'command',
+            commandTag: 'DISCARD ALL',
+        });
+        await expect(handlers.query(session, 'DISCARD PLANS')).resolves.toEqual(
+            {
+                type: 'command',
+                commandTag: 'DISCARD',
+            },
+        );
+        await expect(
+            handlers.query(session, 'SHOW server_version'),
+        ).resolves.toMatchObject({ type: 'rows', commandTag: 'SHOW' });
+    });
+
+    it('surfaces compile errors from describe with the same SQLSTATE as query', async () => {
+        const sql = 'SELECT nope FROM orders';
+        await expect(handlers.describe(session, sql)).rejects.toMatchObject({
+            code: '42703',
+        });
+        await expect(handlers.query(session, sql)).rejects.toMatchObject({
+            code: '42703',
+        });
+    });
+});

--- a/packages/backend/src/ee/postgresWire/lightdashHandlers.ts
+++ b/packages/backend/src/ee/postgresWire/lightdashHandlers.ts
@@ -15,6 +15,7 @@ import Logger from '../../logging/logger';
 import type { ServiceRepository } from '../../services/ServiceRepository';
 import type { ServiceAccountService } from '../services/ServiceAccountService/ServiceAccountService';
 import { tryHandleInformationSchema } from './informationSchema';
+import { PG_OID } from './pgTypes';
 import {
     PgWireServerError,
     type PgWireHandlers,
@@ -22,7 +23,12 @@ import {
     type PgWireResultField,
 } from './PostgresWireServer';
 import { compileSqlToMetricQuery, SqlCompileError } from './sqlToMetricQuery';
-import { type PgWireColumn, type PgWireField, type PgWireTable } from './types';
+import {
+    type PgWireColumn,
+    type PgWireCompiledQuery,
+    type PgWireField,
+    type PgWireTable,
+} from './types';
 
 export type LightdashPgWireSession = {
     account: Account;
@@ -33,28 +39,23 @@ export type LightdashPgWireSession = {
 const VERSION_STRING =
     'PostgreSQL 16.3 (Lightdash semantic layer, wire protocol)';
 
-const TEXT_OID = 25;
-const BOOL_OID = 16;
-const INT8_OID = 20;
-const FLOAT8_OID = 701;
-const DATE_OID = 1082;
-const TIMESTAMP_OID = 1114;
+const TEXT_OID = PG_OID.text;
 
 /** DimensionType / MetricType value -> Postgres type OID */
 const TYPE_OIDS: Record<string, number> = {
-    string: TEXT_OID,
-    number: FLOAT8_OID,
-    boolean: BOOL_OID,
-    date: DATE_OID,
-    timestamp: TIMESTAMP_OID,
-    count: INT8_OID,
-    count_distinct: INT8_OID,
-    sum: FLOAT8_OID,
-    average: FLOAT8_OID,
-    median: FLOAT8_OID,
-    percentile: FLOAT8_OID,
-    min: FLOAT8_OID,
-    max: FLOAT8_OID,
+    string: PG_OID.text,
+    number: PG_OID.float8,
+    boolean: PG_OID.bool,
+    date: PG_OID.date,
+    timestamp: PG_OID.timestamp,
+    count: PG_OID.int8,
+    count_distinct: PG_OID.int8,
+    sum: PG_OID.float8,
+    average: PG_OID.float8,
+    median: PG_OID.float8,
+    percentile: PG_OID.float8,
+    min: PG_OID.float8,
+    max: PG_OID.float8,
 };
 
 const oidForColumn = (column: PgWireColumn): number =>
@@ -106,7 +107,11 @@ const SHOW_PARAMETERS: Record<string, string> = {
  */
 const tryHandleSessionStatement = (sql: string): PgWireQueryResult | null => {
     const trimmed = sql.trim().replace(/;\s*$/, '');
-    const firstWord = trimmed.split(/\s+/)[0]?.toUpperCase() ?? '';
+    const [firstWord = '', secondWord = ''] = (
+        /^(\w+)(?:\s+(\w+))?/.exec(trimmed) ?? []
+    )
+        .slice(1)
+        .map((word) => word?.toUpperCase() ?? '');
     switch (firstWord) {
         case 'BEGIN':
         case 'START':
@@ -122,11 +127,14 @@ const tryHandleSessionStatement = (sql: string): PgWireQueryResult | null => {
         case 'RESET':
             return { type: 'command', commandTag: 'RESET' };
         case 'DISCARD':
-            return { type: 'command', commandTag: 'DISCARD ALL' };
+            return {
+                type: 'command',
+                commandTag: secondWord === 'ALL' ? 'DISCARD ALL' : 'DISCARD',
+            };
         case 'DEALLOCATE':
             return { type: 'command', commandTag: 'DEALLOCATE' };
         case 'SHOW': {
-            const param = trimmed.split(/\s+/)[1]?.toLowerCase() ?? '';
+            const param = secondWord.toLowerCase();
             const value = SHOW_PARAMETERS[param];
             if (value === undefined) {
                 throw new PgWireServerError(
@@ -171,22 +179,22 @@ const tryHandleConstantSelect = (
     for (const col of statement.columns ?? []) {
         const { expr } = col;
         let name = col.alias?.name ?? '?column?';
-        let oid = TEXT_OID;
+        let oid: number = TEXT_OID;
         let value: string | null;
         switch (expr.type) {
             case 'string':
                 value = expr.value;
                 break;
             case 'integer':
-                oid = INT8_OID;
+                oid = PG_OID.int8;
                 value = String(expr.value);
                 break;
             case 'numeric':
-                oid = FLOAT8_OID;
+                oid = PG_OID.float8;
                 value = String(expr.value);
                 break;
             case 'boolean':
-                oid = BOOL_OID;
+                oid = PG_OID.bool;
                 value = expr.value ? 't' : 'f';
                 break;
             case 'null':
@@ -199,7 +207,7 @@ const tryHandleConstantSelect = (
                 else if (fn === 'current_database') value = session.projectUuid;
                 else if (fn === 'current_schema') value = 'public';
                 else if (fn === 'now' || fn === 'current_timestamp') {
-                    oid = TIMESTAMP_OID;
+                    oid = PG_OID.timestamp;
                     value = new Date()
                         .toISOString()
                         .replace('T', ' ')
@@ -233,6 +241,63 @@ const tryHandleConstantSelect = (
 
 const UUID_PATTERN =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Session statements, constant SELECTs and information_schema lookups are
+ * answered in memory; anything else compiles to a metric query that only
+ * `query` runs. `describe` shares this so it always agrees with `query`.
+ */
+type ResolvedStatement =
+    | { kind: 'result'; result: PgWireQueryResult }
+    | { kind: 'explore'; compiled: PgWireCompiledQuery };
+
+const resolveStatement = (
+    session: LightdashPgWireSession,
+    sql: string,
+): ResolvedStatement => {
+    const sessionResult = tryHandleSessionStatement(sql);
+    if (sessionResult) {
+        return { kind: 'result', result: sessionResult };
+    }
+
+    const constantResult = tryHandleConstantSelect(sql, session);
+    if (constantResult) {
+        return { kind: 'result', result: constantResult };
+    }
+
+    // catalog discovery via information_schema.tables / .columns
+    try {
+        const infoResult = tryHandleInformationSchema(
+            parse(sql),
+            session.catalog,
+            session.projectUuid,
+        );
+        if (infoResult) {
+            return { kind: 'result', result: infoResult };
+        }
+    } catch (e) {
+        if (e instanceof PgWireServerError) throw e;
+        // parse errors fall through to the compiler for consistent messages
+    }
+
+    try {
+        return {
+            kind: 'explore',
+            compiled: compileSqlToMetricQuery(sql, session.catalog),
+        };
+    } catch (e) {
+        if (e instanceof SqlCompileError) {
+            throw compileErrorToServerError(e);
+        }
+        throw e;
+    }
+};
+
+const fieldsOf = (compiled: PgWireCompiledQuery): PgWireResultField[] =>
+    compiled.columns.map((column) => ({
+        name: column.name,
+        oid: oidForColumn(column),
+    }));
 
 export const createLightdashPgWireHandlers = (
     serviceRepository: ServiceRepository,
@@ -430,35 +495,22 @@ export const createLightdashPgWireHandlers = (
             return { account, projectUuid, catalog };
         },
 
+        describe: async (session, sql) => {
+            const resolved = resolveStatement(session, sql);
+            if (resolved.kind === 'result') {
+                return resolved.result.type === 'rows'
+                    ? resolved.result.fields
+                    : null;
+            }
+            return fieldsOf(resolved.compiled);
+        },
+
         query: async (session, sql) => {
-            const sessionResult = tryHandleSessionStatement(sql);
-            if (sessionResult) return sessionResult;
-
-            const constantResult = tryHandleConstantSelect(sql, session);
-            if (constantResult) return constantResult;
-
-            // catalog discovery via information_schema.tables / .columns
-            try {
-                const infoResult = tryHandleInformationSchema(
-                    parse(sql),
-                    session.catalog,
-                    session.projectUuid,
-                );
-                if (infoResult) return infoResult;
-            } catch (e) {
-                if (e instanceof PgWireServerError) throw e;
-                // parse errors fall through to the compiler for consistent messages
+            const resolved = resolveStatement(session, sql);
+            if (resolved.kind === 'result') {
+                return resolved.result;
             }
-
-            let compiled;
-            try {
-                compiled = compileSqlToMetricQuery(sql, session.catalog);
-            } catch (e) {
-                if (e instanceof SqlCompileError) {
-                    throw compileErrorToServerError(e);
-                }
-                throw e;
-            }
+            const { compiled } = resolved;
 
             const results = await serviceRepository
                 .getProjectService()
@@ -472,12 +524,7 @@ export const createLightdashPgWireHandlers = (
                     QueryExecutionContext.API,
                 );
 
-            const fields: PgWireResultField[] = compiled.columns.map(
-                (column) => ({
-                    name: column.name,
-                    oid: oidForColumn(column),
-                }),
-            );
+            const fields = fieldsOf(compiled);
             const rows = results.rows.map((row: ResultRow) =>
                 compiled.columns.map((column) =>
                     toTextValue(row[column.source]?.value?.raw, column.type),

--- a/packages/backend/src/ee/postgresWire/pgTypes.ts
+++ b/packages/backend/src/ee/postgresWire/pgTypes.ts
@@ -1,0 +1,23 @@
+/** Postgres type OIDs and wire format codes used by the Metrics SQL API */
+export const PG_OID = {
+    bool: 16,
+    name: 19,
+    int8: 20,
+    int2: 21,
+    int4: 23,
+    text: 25,
+    float4: 700,
+    float8: 701,
+    bpchar: 1042,
+    varchar: 1043,
+    date: 1082,
+    timestamp: 1114,
+    numeric: 1700,
+} as const;
+
+export const TEXT_FORMAT = 0;
+export const BINARY_FORMAT = 1;
+
+/** Text spellings Postgres accepts for boolean input */
+export const TRUE_LITERALS = new Set(['t', 'true', 'y', 'yes', 'on', '1']);
+export const FALSE_LITERALS = new Set(['f', 'false', 'n', 'no', 'off', '0']);

--- a/packages/backend/src/ee/postgresWire/wireEncoding.ts
+++ b/packages/backend/src/ee/postgresWire/wireEncoding.ts
@@ -1,0 +1,39 @@
+/** Big-endian primitives shared by the message writers and the binary codec */
+
+export const cstring = (s: string): Buffer =>
+    // a NUL inside the string would terminate it early on the client
+    Buffer.concat([
+        Buffer.from(s.replace(/\0/g, ''), 'utf8'),
+        Buffer.from([0]),
+    ]);
+
+export const int16 = (n: number): Buffer => {
+    const b = Buffer.alloc(2);
+    b.writeInt16BE(n);
+    return b;
+};
+
+/** Counts on the wire are unsigned (Postgres reads them with pq_getmsgint) */
+export const uint16 = (n: number): Buffer => {
+    const b = Buffer.alloc(2);
+    b.writeUInt16BE(n);
+    return b;
+};
+
+export const int32 = (n: number): Buffer => {
+    const b = Buffer.alloc(4);
+    b.writeInt32BE(n);
+    return b;
+};
+
+export const int64 = (n: bigint): Buffer => {
+    const b = Buffer.alloc(8);
+    b.writeBigInt64BE(n);
+    return b;
+};
+
+export const float64 = (n: number): Buffer => {
+    const b = Buffer.alloc(8);
+    b.writeDoubleBE(n);
+    return b;
+};


### PR DESCRIPTION
## Summary

The Metrics SQL API (Postgres wire server) now speaks the extended query protocol — Parse/Bind/Describe/Execute/Close/Flush/Sync — so pgjdbc-based BI connectors and drivers that never send plain-text queries (Domo's PostgreSQL connector, DBeaver/DataGrip defaults, psycopg3, node-postgres with parameters) can query explores instead of failing after authentication with `0A000 the extended query protocol is not supported`. Closes PROD-10133 / #27405.

Testing against real drivers showed three behaviours the ticket did not anticipate but that the same drivers depend on, so they are in scope: pgjdbc sends `setInt`/`setDouble` parameters **binary** and requests **binary result columns** once a statement passes `prepareThreshold` (five executions — every dashboard refresh); pgjdbc `fetchSize` cursors need named portals to survive `Sync` inside `BEGIN … COMMIT`; psycopg3 describes statements before binding.

## How it works

```
pgjdbc                                   PostgresWireServer
Parse    ("", sql, 0 params)  ────────►  store statement            ◄──  '1' ParseComplete
Bind     ("", "", formats)    ────────►  inline params → portal     ◄──  '2' BindComplete
Describe (P, "")              ────────►  handlers.describe(sql)     ◄──  'T' RowDescription
Execute  ("", maxRows)        ────────►  handlers.query(sql)        ◄──  'D'* + 'C' / 's'
Sync                          ────────►  end implicit txn           ◄──  'Z' ReadyForQuery(I|T)
```

- `PostgresWireServer.ts` — per-connection prepared statements and portals; the extended messages replace the former `0A000` block. Errors set `skipUntilSync` and everything but `Sync`/`Terminate` is ignored until then, exactly like Postgres. `Describe` never touches the warehouse: it asks the new `handlers.describe` for column shapes. `Execute` runs the query once per portal, honours `maxRows` with `PortalSuspended`, and encodes each column in the format the portal asked for. `BEGIN`/`COMMIT`/`ROLLBACK`/`DISCARD ALL` command tags drive the ReadyForQuery status (`T`/`I`) and portal lifetime.
- `extendedQuery.ts` — frontend message decoders (`PayloadReader`, unsigned counts, strict 0/1/n format-code expansion), `$n` counting (clients may declare fewer parameter types than the SQL uses), and parameter inlining as SQL literals by OID. Inlining is safe because the SQL is compiled to a metric query and never reaches a warehouse raw; it copies the SQL in slices and refuses to grow past 1 MB (`54000`).
- `binaryFormat.ts` — binary codec for the OIDs this server emits: parameters bool/int2/int4/int8/float4/float8/date/timestamp/text-like → text; results bool/int4/int8/float8/date/timestamp/text-like ← text. Other OIDs fail with `0A000`; malformed bytes `22P03`; out-of-range ints `22003`; out-of-range dates `22008`.
- `lightdashHandlers.ts` — `describe` shares `resolveStatement` with `query`, so both dispatch identically (session statement → constant SELECT → information_schema → compiled explore query); `describe` stops after `compileSqlToMetricQuery`.
- `pgTypes.ts` (OIDs, format codes, boolean spellings), `wireEncoding.ts` (big-endian primitives), `PgWireServerError.ts` (extracted to avoid an import cycle; re-exported).

Limits added for a public-internet listener: `$n` above 65535 → `54023` before any allocation; 1000 named statements / portals per connection and 16 MB of prepared statement text → `54000`; NUL bytes are stripped from outbound strings; result rows are dropped once a portal completes.

## Regression analysis

| Group | Effect |
|---|---|
| Simple-protocol clients (`psql`, psycopg2, node-postgres without values) | Unchanged wire sequence; `ReadyForQuery` now reports `T` between `BEGIN` and `COMMIT`/`ROLLBACK` (was always `I`). |
| Extended-protocol clients (pgjdbc, psycopg3, node-postgres with values) | Work; text and the common binary formats supported. |
| TLS | Unchanged (extended messages run over the upgraded socket; plaintext still refused when TLS is configured). |
| `pg_catalog` browsing (JDBC `DatabaseMetaData`, GUI schema trees) | Still unsupported (`42601`), as documented — follow-up. |

No API, schema or config changes. `PgWireHandlers` gains a required `describe`; the only implementation is `lightdashHandlers.ts`.

## Test plan

- [x] `pnpm -F backend typecheck` · `pnpm -F backend lint` (oxlint on `src/ee/postgresWire`) · `oxfmt --check` — clean
- [x] `pnpm -F backend exec vitest run src/ee/postgresWire` — 157 tests: raw-socket protocol tests (pgjdbc one-shot flow, Describe-statement-first flow, pipelined batches, portal suspension/resume, error → Sync recovery, statement/portal SQLSTATEs, binary parameters/results incl. mixed per-column formats, transaction-scoped portals, capacity/size limits, TLS + extended), node-postgres driver tests (parameterised, named statements, unicode, `binary: true`, error recovery), decoder/inlining/codec unit tests, and `lightdashHandlers` describe-vs-query tests with a mocked `ProjectService` (describe never calls `runExploreQuery`).
- [x] Manual, local instance with `PGWIRE_PORT` + TLS required, against the demo project:
  - pgjdbc 42.7.7 (default mode, `sslmode=require`, in Docker): parameterless SELECT, string/int/double/bool parameters, `SET`, error + recovery, `information_schema` with a parameter, the same statement 7× (named statement + binary results after `prepareThreshold`), `fetchSize=2` cursor in a transaction — all pass; `getTables()/getColumns()` fail with `42601` (pg_catalog, out of scope).
  - psycopg3: text/int parameters, `prepare=True` twice (Describe-statement path), `binary=True` results incl. float8/date/timestamp, error recovery.
  - `psql \bind` (libpq extended path) with and without parameters; plaintext connection refused with `28000`.
- [ ] Reviewer: DBeaver/DataGrip SQL editor `SELECT` on an explore in default driver mode.

## Follow-ups (separate PRs)

- `pg_catalog` emulation for JDBC `DatabaseMetaData` so GUI schema browsers populate (#27405 out-of-scope note).
- Timestamp columns are declared `timestamp without time zone` but rendered with a `+00` offset in text mode; strict parsers (psycopg3 text mode) reject them. Pre-existing; needs a product decision (naive UTC vs `timestamptz`).
- Docs: PR against `mintlify-docs` updating the Metrics SQL API limitations (opened alongside this).

Closes: PROD-10133
Closes: #27405

🤖 Generated with [Claude Code](https://claude.com/claude-code)
