### PR TITLE
feat: add helm install type and chart version to analytics context

### DIFF
--- a/docs/upgrade-telemetry.md
+++ b/docs/upgrade-telemetry.md
@@ -83,5 +83,7 @@ when it matches `[a-z0-9_-]{1,32}`. Missing or invalid values become `unknown`.
 | --- | --- |
 | `boot-winner` | Production image entrypoint before the boot-time migration race. |
 | `compose` | Root Docker Compose `lightdash` service. |
+| `helm-job` | Helm chart migration Job from chart version 2.16.0. |
+| `helm-boot` | Helm chart backend pod entrypoint from chart version 2.16.0. |
 | `unknown` | Fallback when no valid value is supplied. |
 | Other valid value | An external deployment or operator setting the environment variable. |

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -3502,6 +3502,8 @@ export class LightdashAnalytics extends Analytics {
                 installType:
                     process.env.LIGHTDASH_INSTALL_TYPE ||
                     LightdashInstallType.UNKNOWN,
+                installChartVersion:
+                    process.env.LIGHTDASH_HELM_CHART_VERSION || null,
             },
         };
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -653,6 +653,7 @@ export const isLightdashMode = (x: string): x is LightdashMode =>
 export enum LightdashInstallType {
     DOCKER_IMAGE = 'docker_image',
     BASH_INSTALL = 'bash_install',
+    HELM = 'helm',
     HEROKU = 'heroku',
     UNKNOWN = 'unknown',
 }


### PR DESCRIPTION
The chart now identifies itself via environment variables. This lets the server report the install type and chart version, with an explicit null when the chart version is unset.\n\nLinear: SPK-1089