### PR TITLE
fix: route pre-aggregate time dimensions safely

### DIFF
--- a/docs/pre-aggregates/CONTEXT.md
+++ b/docs/pre-aggregates/CONTEXT.md
@@ -65,8 +65,10 @@ _Avoid_: static filters, pre-filters
 
 **Time dimension / Granularity**:
 The optional time dimension a pre-aggregate is grouped by, and the grain
-(hour–year) it is stored at. Queries at equal or coarser grain can be served;
-finer grain misses.
+(hour–year) it is stored at. Queries can be served only when their requested
+time frame is safely derivable from the stored grain. For example, day can
+serve month, but week cannot serve calendar month because weeks cross month
+boundaries.
 
 **Materialization role**:
 A fixed identity (email plus user attributes) that materialization runs under,

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
@@ -164,6 +164,13 @@ const sourceExplore = (): Explore => ({
                     timeInterval: TimeFrames.WEEK,
                     timeIntervalBaseDimensionName: 'order_date',
                 }),
+                order_date_week_num: makeDimension({
+                    name: 'order_date_week_num',
+                    table: 'orders',
+                    type: DimensionType.NUMBER,
+                    timeInterval: TimeFrames.WEEK_NUM,
+                    timeIntervalBaseDimensionName: 'order_date',
+                }),
                 order_date_month: makeDimension({
                     name: 'order_date_month',
                     table: 'orders',
@@ -177,6 +184,32 @@ const sourceExplore = (): Explore => ({
                     type: DimensionType.STRING,
                     timeInterval: TimeFrames.MONTH_NAME,
                     timeIntervalBaseDimensionName: 'order_date',
+                }),
+                order_date_quarter: makeDimension({
+                    name: 'order_date_quarter',
+                    table: 'orders',
+                    type: DimensionType.DATE,
+                    timeInterval: TimeFrames.QUARTER,
+                    timeIntervalBaseDimensionName: 'order_date',
+                }),
+                order_date_year: makeDimension({
+                    name: 'order_date_year',
+                    table: 'orders',
+                    type: DimensionType.DATE,
+                    timeInterval: TimeFrames.YEAR,
+                    timeIntervalBaseDimensionName: 'order_date',
+                }),
+                created_at: makeDimension({
+                    name: 'created_at',
+                    table: 'orders',
+                    type: DimensionType.TIMESTAMP,
+                }),
+                created_at_day: makeDimension({
+                    name: 'created_at_day',
+                    table: 'orders',
+                    type: DimensionType.TIMESTAMP,
+                    timeInterval: TimeFrames.DAY,
+                    timeIntervalBaseDimensionName: 'created_at',
                 }),
             },
             metrics: {
@@ -362,7 +395,7 @@ describe('buildPreAggregateExplore', () => {
         );
     });
 
-    it('keeps compatible time intervals and drops finer intervals than rollup granularity', () => {
+    it('keeps derivable time frames and drops finer ones', () => {
         const result = buildExplore(
             sourceExplore(),
             sourceExplore().preAggregates![0],
@@ -375,6 +408,41 @@ describe('buildPreAggregateExplore', () => {
             result.tables.orders.dimensions.order_date_month.compiledSql,
         ).toContain('orders.orders_order_date_day');
         expect(result.tables.orders.dimensions.order_date_hour).toBeUndefined();
+    });
+
+    it('does not expose calendar months or week numbers from a week-grain pre-aggregate', () => {
+        const result = buildExplore(sourceExplore(), {
+            ...sourceExplore().preAggregates![0],
+            granularity: TimeFrames.WEEK,
+        });
+
+        expect(result.tables.orders.dimensions.order_date_week).toBeDefined();
+        expect(
+            result.tables.orders.dimensions.order_date_month,
+        ).toBeUndefined();
+        expect(
+            result.tables.orders.dimensions.order_date_quarter,
+        ).toBeUndefined();
+        expect(result.tables.orders.dimensions.order_date_year).toBeUndefined();
+        expect(
+            result.tables.orders.dimensions.order_date_week_num,
+        ).toBeUndefined();
+    });
+
+    it('exposes a raw date but not a raw timestamp from a day-grain pre-aggregate', () => {
+        const explore = sourceExplore();
+        const result = buildExplore(explore, {
+            ...explore.preAggregates![0],
+            dimensions: ['created_at'],
+            timeDimension: 'created_at',
+            granularity: TimeFrames.DAY,
+        });
+
+        expect(result.tables.orders.dimensions.created_at).toBeUndefined();
+        expect(result.tables.orders.dimensions.created_at_day).toBeDefined();
+
+        const dateResult = buildExplore(explore, explore.preAggregates![0]);
+        expect(dateResult.tables.orders.dimensions.order_date).toBeDefined();
     });
 
     it('uses DuckDB-compatible date truncation SQL regardless of source warehouse adapter', () => {

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
@@ -13,7 +13,6 @@ import {
     preAggregateUtils,
     SupportedDbtAdapter,
     timeFrameConfigs,
-    timeFrameOrder,
     type CompiledDimension,
     type CompiledMetric,
     type CompiledTable,
@@ -33,18 +32,6 @@ const {
     getSelectedDimension,
     selectPreAggregateMetrics,
 } = preAggregateMaterialization;
-
-const isFinerGranularity = (
-    candidateGranularity: TimeFrames,
-    targetGranularity: TimeFrames,
-): boolean => {
-    const candidateIndex = timeFrameOrder.indexOf(candidateGranularity);
-    const targetIndex = timeFrameOrder.indexOf(targetGranularity);
-    if (candidateIndex === -1 || targetIndex === -1) {
-        return false;
-    }
-    return candidateIndex < targetIndex;
-};
 
 const getMetricAggregateSql = (
     metricType: MetricType.SUM | MetricType.MIN | MetricType.MAX,
@@ -363,15 +350,16 @@ const getIncludedDimensions = (
         if (
             !preAggregateDef.timeDimension ||
             !preAggregateDef.granularity ||
-            dimensionBaseName !== preAggregateDef.timeDimension ||
-            !dimension.timeInterval
+            dimensionBaseName !== preAggregateDef.timeDimension
         ) {
             return true;
         }
 
-        return !isFinerGranularity(
-            dimension.timeInterval,
-            preAggregateDef.granularity,
+        return (
+            preAggregateUtils.getTimeFrameDerivability(
+                preAggregateUtils.getEffectiveDimensionTimeFrame(dimension),
+                preAggregateDef.granularity,
+            ) === preAggregateUtils.TimeFrameDerivability.DERIVABLE
         );
     });
 };

--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -107,6 +107,18 @@ const baseExplore = (): Explore => ({
                     timeInterval: TimeFrames.QUARTER,
                     timeIntervalBaseDimensionName: 'order_date',
                 }),
+                order_date_week_num: makeDimension({
+                    name: 'order_date_week_num',
+                    type: DimensionType.NUMBER,
+                    timeInterval: TimeFrames.WEEK_NUM,
+                    timeIntervalBaseDimensionName: 'order_date',
+                }),
+                order_date_month_name: makeDimension({
+                    name: 'order_date_month_name',
+                    type: DimensionType.STRING,
+                    timeInterval: TimeFrames.MONTH_NAME,
+                    timeIntervalBaseDimensionName: 'order_date',
+                }),
                 created_at: makeDimension({
                     name: 'created_at',
                     type: DimensionType.TIMESTAMP,
@@ -1869,7 +1881,7 @@ describe('findMatch', () => {
         });
     });
 
-    it('returns granularity_too_fine when query granularity is finer than rollup', () => {
+    it('returns granularity_too_fine when query granularity is finer than the pre-aggregate', () => {
         const explore = {
             ...baseExplore(),
             preAggregates: [
@@ -1900,7 +1912,38 @@ describe('findMatch', () => {
         });
     });
 
-    it('accepts coarser query granularity than rollup', () => {
+    it('does not serve a raw timestamp from a day-grain pre-aggregate', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_daily',
+                    dimensions: [],
+                    metrics: ['order_count'],
+                    timeDimension: 'created_at',
+                    granularity: TimeFrames.DAY,
+                },
+            ],
+        };
+
+        expect(
+            preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_created_at'],
+                    metrics: ['orders_order_count'],
+                }),
+                explore,
+            ).miss,
+        ).toStrictEqual({
+            reason: PreAggregateMissReason.GRANULARITY_TOO_FINE,
+            fieldId: 'orders_created_at',
+            queryGranularity: TimeFrames.RAW,
+            preAggregateGranularity: TimeFrames.DAY,
+            preAggregateTimeDimension: 'created_at',
+        });
+    });
+
+    it('accepts a nesting query granularity from a day-grain pre-aggregate', () => {
         const explore = {
             ...baseExplore(),
             preAggregates: [
@@ -1923,6 +1966,141 @@ describe('findMatch', () => {
         );
 
         expect(result.hit).toBe(true);
+    });
+
+    it('accepts named intervals derivable from a day-grain pre-aggregate', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_daily',
+                    dimensions: ['order_date'],
+                    metrics: ['order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                },
+            ],
+        };
+
+        expect(
+            preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_order_date_month_name'],
+                    metrics: ['orders_order_count'],
+                }),
+                explore,
+            ),
+        ).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_daily',
+            miss: null,
+        });
+    });
+
+    it('does not derive calendar months from a week-grain pre-aggregate', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_weekly',
+                    dimensions: ['order_date'],
+                    metrics: ['order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.WEEK,
+                },
+            ],
+        };
+
+        expect(
+            preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_order_date_month'],
+                    metrics: ['orders_order_count'],
+                }),
+                explore,
+            ).miss,
+        ).toStrictEqual({
+            reason: PreAggregateMissReason.TIME_FRAME_NOT_DERIVABLE,
+            fieldId: 'orders_order_date_month',
+            queryGranularity: TimeFrames.MONTH,
+            preAggregateGranularity: TimeFrames.WEEK,
+            preAggregateTimeDimension: 'order_date',
+        });
+    });
+
+    it('does not derive week numbers from a week-grain pre-aggregate', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_weekly',
+                    dimensions: ['order_date'],
+                    metrics: ['order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.WEEK,
+                },
+            ],
+        };
+
+        expect(
+            preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_order_date_week_num'],
+                    metrics: ['orders_order_count'],
+                }),
+                explore,
+            ).miss,
+        ).toStrictEqual({
+            reason: PreAggregateMissReason.TIME_FRAME_NOT_DERIVABLE,
+            fieldId: 'orders_order_date_week_num',
+            queryGranularity: TimeFrames.WEEK_NUM,
+            preAggregateGranularity: TimeFrames.WEEK,
+            preAggregateTimeDimension: 'order_date',
+        });
+    });
+
+    it('treats a raw date filter as day grain', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_daily',
+                    dimensions: ['order_date'],
+                    metrics: ['order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                },
+            ],
+        };
+
+        expect(
+            preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_order_date_day'],
+                    metrics: ['orders_order_count'],
+                    filters: {
+                        dimensions: {
+                            id: 'date-filter',
+                            and: [
+                                {
+                                    id: 'raw-date-filter',
+                                    target: {
+                                        fieldId: 'orders_order_date',
+                                    },
+                                    operator: FilterOperator.EQUALS,
+                                    values: ['2024-01-01'],
+                                },
+                            ],
+                        },
+                    },
+                }),
+                explore,
+            ),
+        ).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_daily',
+            miss: null,
+        });
     });
 
     it.each([

--- a/packages/cli/src/handlers/preAggregateAudit.ts
+++ b/packages/cli/src/handlers/preAggregateAudit.ts
@@ -66,7 +66,10 @@ function formatMissDetail(
     missFieldLabel: string | null,
 ): string {
     const base = preAggregateMissReasonLabels[miss.reason];
-    if (miss.reason === PreAggregateMissReason.GRANULARITY_TOO_FINE) {
+    if (
+        miss.reason === PreAggregateMissReason.GRANULARITY_TOO_FINE ||
+        miss.reason === PreAggregateMissReason.TIME_FRAME_NOT_DERIVABLE
+    ) {
         return `${base} (query ${miss.queryGranularity}, pre-agg ${miss.preAggregateGranularity})`;
     }
     if (missFieldLabel) {

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -33,7 +33,6 @@ import {
     reduceRequiredDimensionFiltersToFilterRules,
 } from '../../utils/filters';
 import { getItemId } from '../../utils/item';
-import { timeFrameOrder } from '../../utils/timeFrames';
 import {
     getMetricRepresentation,
     PreAggregateMetricRepresentationKind,
@@ -43,22 +42,16 @@ import {
     getDimensionReferences,
     getMetricReferences,
 } from './references';
+import {
+    getEffectiveDimensionTimeFrame,
+    getPreAggregateGranularityRank,
+    getTimeFrameDerivability,
+    TimeFrameDerivability,
+} from './timeFrameDerivability';
 
 export type PreAggregateMatchResult =
     | { hit: true; preAggregateName: string; miss: null }
     | { hit: false; preAggregateName: null; miss: PreAggregateMatchMiss };
-
-const isGranularityCoarserOrEqual = (
-    queryGranularity: TimeFrames,
-    preAggregateGranularity: TimeFrames,
-): boolean => {
-    const queryIndex = timeFrameOrder.indexOf(queryGranularity);
-    const preAggregateIndex = timeFrameOrder.indexOf(preAggregateGranularity);
-    if (queryIndex === -1 || preAggregateIndex === -1) {
-        return false;
-    }
-    return queryIndex >= preAggregateIndex;
-};
 
 const getDimensionsByFieldId = (
     explore: Explore,
@@ -127,17 +120,17 @@ const filterDimensionFieldIdMatchesDef = (
         return false;
     }
 
-    const targetsRollupTimeDimension = getDimensionReferences({
+    const targetsPreAggregateTimeDimension = getDimensionReferences({
         dimension,
         baseTable: explore.baseTable,
     }).includes(preAggregateDef.timeDimension);
 
     return (
-        !targetsRollupTimeDimension ||
-        isGranularityCoarserOrEqual(
-            dimension.timeInterval ?? TimeFrames.RAW,
+        !targetsPreAggregateTimeDimension ||
+        getTimeFrameDerivability(
+            getEffectiveDimensionTimeFrame(dimension),
             preAggregateDef.granularity,
-        )
+        ) === TimeFrameDerivability.DERIVABLE
     );
 };
 
@@ -914,7 +907,11 @@ const getGranularityMissForDef = (
     >,
 ): Extract<
     PreAggregateMatchMiss,
-    { reason: PreAggregateMissReason.GRANULARITY_TOO_FINE }
+    {
+        reason:
+            | PreAggregateMissReason.GRANULARITY_TOO_FINE
+            | PreAggregateMissReason.TIME_FRAME_NOT_DERIVABLE;
+    }
 > | null => {
     if (!preAggregateDef.timeDimension || !preAggregateDef.granularity) {
         return null;
@@ -922,22 +919,39 @@ const getGranularityMissForDef = (
 
     for (const dimensionFieldId of metricQuery.dimensions) {
         const dimension = dimensionsByFieldId.get(dimensionFieldId);
-        const queryGranularity = dimension?.timeInterval;
-        const matchesRollupTimeDimension =
+        const queryGranularity = dimension
+            ? getEffectiveDimensionTimeFrame(dimension)
+            : undefined;
+        const matchesPreAggregateTimeDimension =
             !!dimension &&
             !!queryGranularity &&
-            (dimension.timeIntervalBaseDimensionName ?? dimension.name) ===
-                preAggregateDef.timeDimension;
+            getDimensionBaseName(dimension) === preAggregateDef.timeDimension;
+        const derivability = queryGranularity
+            ? getTimeFrameDerivability(
+                  queryGranularity,
+                  preAggregateDef.granularity,
+              )
+            : TimeFrameDerivability.DERIVABLE;
 
         if (
-            matchesRollupTimeDimension &&
-            !isGranularityCoarserOrEqual(
-                queryGranularity,
-                preAggregateDef.granularity,
-            )
+            matchesPreAggregateTimeDimension &&
+            derivability !== TimeFrameDerivability.DERIVABLE
         ) {
+            if (
+                derivability ===
+                TimeFrameDerivability.QUERY_GRANULARITY_TOO_FINE
+            ) {
+                return {
+                    reason: PreAggregateMissReason.GRANULARITY_TOO_FINE,
+                    fieldId: dimensionFieldId,
+                    queryGranularity,
+                    preAggregateGranularity: preAggregateDef.granularity,
+                    preAggregateTimeDimension: preAggregateDef.timeDimension,
+                };
+            }
+
             return {
-                reason: PreAggregateMissReason.GRANULARITY_TOO_FINE,
+                reason: PreAggregateMissReason.TIME_FRAME_NOT_DERIVABLE,
                 fieldId: dimensionFieldId,
                 queryGranularity,
                 preAggregateGranularity: preAggregateDef.granularity,
@@ -1273,10 +1287,10 @@ export const findMatch = (
         };
     }
 
-    // Defs without a time rollup have no time expansion, so treat them as coarsest.
+    // Defs without a time dimension have no time expansion, so treat them as coarsest.
     const getGranularityCoarseness = (def: PreAggregateDef): number =>
         def.granularity
-            ? timeFrameOrder.indexOf(def.granularity)
+            ? getPreAggregateGranularityRank(def.granularity)
             : Number.MAX_SAFE_INTEGER;
 
     // TODO: Prefer using materialized row count once available.

--- a/packages/common/src/ee/preAggregates/timeFrameDerivability.ts
+++ b/packages/common/src/ee/preAggregates/timeFrameDerivability.ts
@@ -1,0 +1,159 @@
+import { DimensionType, type CompiledDimension } from '../../types/field';
+import { TimeFrames } from '../../types/timeFrames';
+import assertUnreachable from '../../utils/assertUnreachable';
+
+export enum TimeFrameDerivability {
+    DERIVABLE = 'derivable',
+    QUERY_GRANULARITY_TOO_FINE = 'query_granularity_too_fine',
+    NON_NESTING = 'non_nesting',
+}
+
+const NESTING_TIME_FRAMES: readonly TimeFrames[] = [
+    TimeFrames.RAW,
+    TimeFrames.MILLISECOND,
+    TimeFrames.SECOND,
+    TimeFrames.MINUTE,
+    TimeFrames.HOUR,
+    TimeFrames.DAY,
+    TimeFrames.MONTH,
+    TimeFrames.QUARTER,
+    TimeFrames.YEAR,
+];
+
+const PRE_AGGREGATE_GRANULARITY_RANK: Record<TimeFrames, number> = {
+    [TimeFrames.RAW]: 0,
+    [TimeFrames.MILLISECOND]: 1,
+    [TimeFrames.SECOND]: 2,
+    [TimeFrames.MINUTE]: 3,
+    [TimeFrames.MINUTE_OF_HOUR_NUM]: 3,
+    [TimeFrames.HOUR]: 4,
+    [TimeFrames.HOUR_OF_DAY_NUM]: 4,
+    [TimeFrames.DAY]: 5,
+    [TimeFrames.DAY_OF_WEEK_INDEX]: 5,
+    [TimeFrames.DAY_OF_WEEK_NAME]: 5,
+    [TimeFrames.DAY_OF_MONTH_NUM]: 5,
+    [TimeFrames.DAY_OF_YEAR_NUM]: 5,
+    [TimeFrames.WEEK]: 6,
+    [TimeFrames.WEEK_NUM]: 6,
+    [TimeFrames.MONTH]: 7,
+    [TimeFrames.MONTH_NUM]: 7,
+    [TimeFrames.MONTH_NAME]: 7,
+    [TimeFrames.QUARTER]: 8,
+    [TimeFrames.QUARTER_NUM]: 8,
+    [TimeFrames.QUARTER_NAME]: 8,
+    [TimeFrames.YEAR]: 9,
+    [TimeFrames.YEAR_NUM]: 9,
+};
+
+const getNestingIndex = (timeFrame: TimeFrames): number =>
+    NESTING_TIME_FRAMES.indexOf(timeFrame);
+
+const getNestedDerivability = (
+    queryTimeFrame: TimeFrames,
+    storedTimeFrame: TimeFrames,
+): TimeFrameDerivability => {
+    const queryIndex = getNestingIndex(queryTimeFrame);
+    const storedIndex = getNestingIndex(storedTimeFrame);
+
+    if (storedTimeFrame === TimeFrames.WEEK) {
+        return queryIndex <= getNestingIndex(TimeFrames.DAY)
+            ? TimeFrameDerivability.QUERY_GRANULARITY_TOO_FINE
+            : TimeFrameDerivability.NON_NESTING;
+    }
+    if (queryIndex === -1 || storedIndex === -1) {
+        return TimeFrameDerivability.NON_NESTING;
+    }
+    return queryIndex >= storedIndex
+        ? TimeFrameDerivability.DERIVABLE
+        : TimeFrameDerivability.QUERY_GRANULARITY_TOO_FINE;
+};
+
+const getMaximumStoredTimeFrameDerivability = (
+    maximumStoredTimeFrame: TimeFrames,
+    storedTimeFrame: TimeFrames,
+): TimeFrameDerivability => {
+    if (storedTimeFrame === TimeFrames.WEEK) {
+        return TimeFrameDerivability.NON_NESTING;
+    }
+
+    return getNestedDerivability(maximumStoredTimeFrame, storedTimeFrame);
+};
+
+export const getTimeFrameDerivability = (
+    queryTimeFrame: TimeFrames,
+    storedTimeFrame: TimeFrames,
+): TimeFrameDerivability => {
+    if (queryTimeFrame === storedTimeFrame) {
+        return TimeFrameDerivability.DERIVABLE;
+    }
+
+    switch (queryTimeFrame) {
+        case TimeFrames.RAW:
+            return TimeFrameDerivability.QUERY_GRANULARITY_TOO_FINE;
+        case TimeFrames.MILLISECOND:
+        case TimeFrames.SECOND:
+        case TimeFrames.MINUTE:
+        case TimeFrames.HOUR:
+        case TimeFrames.DAY:
+        case TimeFrames.MONTH:
+        case TimeFrames.QUARTER:
+        case TimeFrames.YEAR:
+            return getNestedDerivability(queryTimeFrame, storedTimeFrame);
+        case TimeFrames.WEEK:
+            return getMaximumStoredTimeFrameDerivability(
+                TimeFrames.DAY,
+                storedTimeFrame,
+            );
+        case TimeFrames.DAY_OF_WEEK_INDEX:
+        case TimeFrames.DAY_OF_WEEK_NAME:
+        case TimeFrames.DAY_OF_MONTH_NUM:
+        case TimeFrames.DAY_OF_YEAR_NUM:
+        case TimeFrames.WEEK_NUM:
+            return getMaximumStoredTimeFrameDerivability(
+                TimeFrames.DAY,
+                storedTimeFrame,
+            );
+        case TimeFrames.MONTH_NUM:
+        case TimeFrames.MONTH_NAME:
+            return getMaximumStoredTimeFrameDerivability(
+                TimeFrames.MONTH,
+                storedTimeFrame,
+            );
+        case TimeFrames.QUARTER_NUM:
+        case TimeFrames.QUARTER_NAME:
+            return getMaximumStoredTimeFrameDerivability(
+                TimeFrames.QUARTER,
+                storedTimeFrame,
+            );
+        case TimeFrames.YEAR_NUM:
+            return getMaximumStoredTimeFrameDerivability(
+                TimeFrames.YEAR,
+                storedTimeFrame,
+            );
+        case TimeFrames.HOUR_OF_DAY_NUM:
+            return getMaximumStoredTimeFrameDerivability(
+                TimeFrames.HOUR,
+                storedTimeFrame,
+            );
+        case TimeFrames.MINUTE_OF_HOUR_NUM:
+            return getMaximumStoredTimeFrameDerivability(
+                TimeFrames.MINUTE,
+                storedTimeFrame,
+            );
+        default:
+            return assertUnreachable(
+                queryTimeFrame,
+                `Unsupported query time frame "${queryTimeFrame}"`,
+            );
+    }
+};
+
+export const getEffectiveDimensionTimeFrame = (
+    dimension: Pick<CompiledDimension, 'timeInterval' | 'type'>,
+): TimeFrames =>
+    dimension.timeInterval ??
+    (dimension.type === DimensionType.DATE ? TimeFrames.DAY : TimeFrames.RAW);
+
+export const getPreAggregateGranularityRank = (
+    granularity: TimeFrames,
+): number => PRE_AGGREGATE_GRANULARITY_RANK[granularity];

--- a/packages/common/src/ee/preAggregates/utils.ts
+++ b/packages/common/src/ee/preAggregates/utils.ts
@@ -21,6 +21,12 @@ export {
     supportedMetricTypes,
 } from './metricRepresentation';
 export {
+    getEffectiveDimensionTimeFrame,
+    getPreAggregateGranularityRank,
+    getTimeFrameDerivability,
+    TimeFrameDerivability,
+} from './timeFrameDerivability';
+export {
     getDimensionBaseName,
     getDimensionReferences,
     getMetricReferences,

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -72,6 +72,7 @@ export enum PreAggregateMissReason {
     FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE = 'filter_dimension_not_in_pre_aggregate',
     PRE_AGGREGATE_FILTER_NOT_SATISFIED = 'pre_aggregate_filter_not_satisfied',
     GRANULARITY_TOO_FINE = 'granularity_too_fine',
+    TIME_FRAME_NOT_DERIVABLE = 'time_frame_not_derivable',
     CUSTOM_DIMENSION_PRESENT = 'custom_dimension_present',
     CUSTOM_METRIC_PRESENT = 'custom_metric_present',
     TABLE_CALCULATION_PRESENT = 'table_calculation_present',
@@ -114,6 +115,13 @@ export type PreAggregateMatchMiss =
       }
     | {
           reason: PreAggregateMissReason.GRANULARITY_TOO_FINE;
+          fieldId: FieldId;
+          queryGranularity: TimeFrames;
+          preAggregateGranularity: TimeFrames;
+          preAggregateTimeDimension: string;
+      }
+    | {
+          reason: PreAggregateMissReason.TIME_FRAME_NOT_DERIVABLE;
           fieldId: FieldId;
           queryGranularity: TimeFrames;
           preAggregateGranularity: TimeFrames;
@@ -204,6 +212,8 @@ export const preAggregateMissReasonLabels: Record<
     [PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED]:
         'Pre-aggregate filter not satisfied',
     [PreAggregateMissReason.GRANULARITY_TOO_FINE]: 'Granularity too fine',
+    [PreAggregateMissReason.TIME_FRAME_NOT_DERIVABLE]:
+        'Time frame not derivable',
     [PreAggregateMissReason.CUSTOM_DIMENSION_PRESENT]:
         'Custom dimension detected',
     [PreAggregateMissReason.CUSTOM_METRIC_PRESENT]: 'Custom metric detected',


### PR DESCRIPTION
## What

- Share exhaustive time-frame derivability between matching and generated pre-aggregate explores
- Reject non-nesting week-to-calendar time frames, including week number
- Align raw DATE grouping/filter behavior while rejecting raw TIMESTAMP queries from day-grain pre-aggregates
- Surface a dedicated `time_frame_not_derivable` miss reason
- Update the pre-aggregate time-grain contract

## Why

Week buckets can cross calendar month, quarter, and year boundaries. Treating every apparently coarser time frame as derivable could route a query to a pre-aggregate that returns incorrect totals. Matching and the generated serving shape now use one safety rule.

## Verification

- Backend matcher/build tests: 105 passed
- CLI audit tests: 5 passed
- Common/backend/CLI typechecks passed
- Lint and formatting passed
- Local E2E:
  - External daily pre-aggregate to named month: matched source results and executed via project warehouse
  - Managed daily pre-aggregate to named month: matched source results and executed via DuckDB
  - Weekly pre-aggregate to calendar month: missed with `time_frame_not_derivable` and executed source SQL

Closes: PROD-10248
Closes: #27537