### PR TITLE
fix(pre-aggregates): use `timeFrameConfigs` for named time frame SQL without redundant CAST

### DIFF
--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
@@ -171,6 +171,13 @@ const sourceExplore = (): Explore => ({
                     timeInterval: TimeFrames.MONTH,
                     timeIntervalBaseDimensionName: 'order_date',
                 }),
+                order_date_month_name: makeDimension({
+                    name: 'order_date_month_name',
+                    table: 'orders',
+                    type: DimensionType.STRING,
+                    timeInterval: TimeFrames.MONTH_NAME,
+                    timeIntervalBaseDimensionName: 'order_date',
+                }),
             },
             metrics: {
                 total_order_amount: makeMetric({
@@ -362,11 +369,11 @@ describe('buildPreAggregateExplore', () => {
         );
 
         expect(result.tables.orders.dimensions.order_date_day.compiledSql).toBe(
-            'CAST(orders.orders_order_date_day AS TIMESTAMP)',
+            'orders.orders_order_date_day',
         );
         expect(
             result.tables.orders.dimensions.order_date_month.compiledSql,
-        ).toContain('CAST(orders.orders_order_date_day AS TIMESTAMP)');
+        ).toContain('orders.orders_order_date_day');
         expect(result.tables.orders.dimensions.order_date_hour).toBeUndefined();
     });
 
@@ -381,9 +388,7 @@ describe('buildPreAggregateExplore', () => {
 
         expect(
             result.tables.orders.dimensions.order_date_month.compiledSql,
-        ).toContain(
-            "DATE_TRUNC('MONTH', CAST(orders.orders_order_date_day AS TIMESTAMP))",
-        );
+        ).toContain("DATE_TRUNC('MONTH', orders.orders_order_date_day)");
     });
 
     it('applies startOfWeek to week re-truncation', () => {
@@ -396,7 +401,7 @@ describe('buildPreAggregateExplore', () => {
         expect(
             result.tables.orders.dimensions.order_date_week.compiledSql,
         ).toBe(
-            "(DATE_TRUNC('WEEK', (CAST(orders.orders_order_date_day AS TIMESTAMP) - interval '6 days')) + interval '6 days')",
+            "(DATE_TRUNC('WEEK', (orders.orders_order_date_day - interval '6 days')) + interval '6 days')",
         );
     });
 
@@ -408,9 +413,18 @@ describe('buildPreAggregateExplore', () => {
 
         expect(
             result.tables.orders.dimensions.order_date_week.compiledSql,
-        ).toBe(
-            "DATE_TRUNC('WEEK', CAST(orders.orders_order_date_day AS TIMESTAMP))",
+        ).toBe("DATE_TRUNC('WEEK', orders.orders_order_date_day)");
+    });
+
+    it('derives named time frames with the serving warehouse function', () => {
+        const result = buildExplore(
+            sourceExplore(),
+            sourceExplore().preAggregates![0],
         );
+
+        expect(
+            result.tables.orders.dimensions.order_date_month_name.compiledSql,
+        ).toBe("TO_CHAR(orders.orders_order_date_day, 'FMMonth')");
     });
 
     describe('external pre-aggregates', () => {
@@ -474,9 +488,36 @@ describe('buildPreAggregateExplore', () => {
             // BigQuery argument order, not DuckDB's DATE_TRUNC('MONTH', x)
             expect(
                 result.tables.orders.dimensions.order_date_month.compiledSql,
-            ).toBe(
-                'DATE_TRUNC(CAST(orders.orders_order_date_day AS TIMESTAMP), MONTH)',
+            ).toBe('DATE_TRUNC(orders.orders_order_date_day, MONTH)');
+        });
+
+        it('derives named time frames with the project warehouse function', () => {
+            const result = buildExplore(
+                {
+                    ...sourceExplore(),
+                    targetDatabase: SupportedDbtAdapter.BIGQUERY,
+                },
+                externalDef(),
             );
+
+            expect(
+                result.tables.orders.dimensions.order_date_month_name
+                    .compiledSql,
+            ).toBe("FORMAT_DATE('%B', orders.orders_order_date_day)");
+        });
+
+        it('preserves timestamp materialization types for named time frames', () => {
+            const explore = sourceExplore();
+            explore.targetDatabase = SupportedDbtAdapter.BIGQUERY;
+            explore.tables.orders.dimensions.order_date.type =
+                DimensionType.TIMESTAMP;
+
+            const result = buildExplore(explore, externalDef());
+
+            expect(
+                result.tables.orders.dimensions.order_date_month_name
+                    .compiledSql,
+            ).toBe("FORMAT_DATETIME('%B', orders.orders_order_date_day)");
         });
     });
 
@@ -623,7 +664,7 @@ describe('buildPreAggregateExplore', () => {
 
         expect(result.tables.orders.dimensions.order_date_day).toBeDefined();
         expect(result.tables.orders.dimensions.order_date_day.compiledSql).toBe(
-            'CAST(orders.orders_order_date_day AS TIMESTAMP)',
+            'orders.orders_order_date_day',
         );
         expect(result.tables.orders.dimensions.status).toBeDefined();
     });

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
@@ -5,7 +5,6 @@ import {
     getPreAggregateExploreName,
     getPreAggregateMetricColumnName,
     getPreAggregateMetricComponentColumnName,
-    getSqlForTruncatedDate,
     lightdashVariablePattern,
     MetricType,
     PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
@@ -13,6 +12,7 @@ import {
     PreAggregateMetricRepresentationKind,
     preAggregateUtils,
     SupportedDbtAdapter,
+    timeFrameConfigs,
     timeFrameOrder,
     type CompiledDimension,
     type CompiledMetric,
@@ -268,14 +268,10 @@ const buildDimensionSql = ({
         preAggregateDef,
     });
     const materializedBaseColumnReference = `${sourceExplore.baseTable}.${materializedBaseColumnName}`;
-    const timeDimensionReference =
-        preAggregateDef.timeDimension &&
-        dimensionBaseName === preAggregateDef.timeDimension
-            ? `CAST(${materializedBaseColumnReference} AS TIMESTAMP)`
-            : materializedBaseColumnReference;
+    const baseDimensionType = getBaseDimensionType(sourceExplore, dimension);
 
     if (!dimension.timeInterval) {
-        return timeDimensionReference;
+        return materializedBaseColumnReference;
     }
 
     if (
@@ -284,14 +280,14 @@ const buildDimensionSql = ({
         dimensionBaseName === preAggregateDef.timeDimension &&
         dimension.timeInterval === preAggregateDef.granularity
     ) {
-        return timeDimensionReference;
+        return materializedBaseColumnReference;
     }
 
-    return getSqlForTruncatedDate(
+    return timeFrameConfigs[dimension.timeInterval].getSql(
         servingAdapter,
         dimension.timeInterval,
-        timeDimensionReference,
-        getBaseDimensionType(sourceExplore, dimension),
+        materializedBaseColumnReference,
+        baseDimensionType,
         startOfWeek,
     );
 };


### PR DESCRIPTION
## What

- Compile derived time frames with their configured serving-warehouse function
- Preserve the materialized time grain type instead of forcing `TIMESTAMP`

## Why

Named and extracted time frames were compiled as date truncations. A matching pre-aggregate therefore generated invalid SQL and fell back to the source warehouse.

## Verification

- Managed path: refreshed `orders_daily_avg_demo` from Postgres, then served the new artifact through DuckDB
- DuckDB matrix: day, week, month, month name, day-of-week name, and quarter name all matched the managed pre-aggregate and returned identical source results
- Query history recorded `pre_aggregate_execution=duckdb`; named frames compiled with DuckDB-compatible `TO_CHAR`
- External Postgres: routed to `orders_ext_daily_status_mv`; routed/source results identical
- External BigQuery: all declared tables in `dbt_gbagdavadze` match generated contracts (3/3, 5/5, 4/4 columns)
- BigQuery month-name query matched `events_monthly` and routed to `events_monthly_ext`
- Query history recorded `pre_aggregate_execution=project_warehouse`
- Served SQL uses `FORMAT_DATETIME('%B', events_event_at_month)`; no invalid `DATE_TRUNC(..., MONTH_NAME)`
- Closed-period routed/source results identical
- Focused tests: 31 passed
- Backend typecheck, lint, format, and diff checks passed

Closes: https://linear.app/lightdash/issue/ZAP-841