### PR TITLE
feat: ask clarifying questions before the first chart type build

### DIFF
--- a/packages/frontend/src/features/apps/builder/BuilderCanvas.module.css
+++ b/packages/frontend/src/features/apps/builder/BuilderCanvas.module.css
@@ -84,3 +84,10 @@
 .skeletonBar:nth-child(6) {
     animation-delay: 0.6s;
 }
+
+/* The starter prompts recede while a clarifying round is on screen. */
+.quiet {
+    opacity: 0.3;
+    transition: opacity var(--mantine-other-transitionDuration)
+        var(--mantine-other-transitionTimingFunction);
+}

--- a/packages/frontend/src/features/apps/builder/BuilderCanvas.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderCanvas.tsx
@@ -18,6 +18,10 @@ type Props = {
     isBuilding: boolean;
     /** Why the latest build failed, when there is nothing renderable. */
     failureMessage: string | null;
+    /** A round is waiting or on screen, so the starter prompts recede. */
+    isClarifyRoundOpen: boolean;
+    /** The running build skipped clarifying: the clarifier was unreachable. */
+    clarifierUnavailable: boolean;
     /** Sample data plus configuration from the panel; null renders the app bare. */
     previewContext: DataAppVizContext | null;
     /** The card's configuration column; null until a version declares a schema. */
@@ -73,6 +77,8 @@ const BuilderCanvas: FC<Props> = ({
     previewVersion,
     isBuilding,
     failureMessage,
+    isClarifyRoundOpen,
+    clarifierUnavailable,
     previewContext,
     configurePanel,
     onPickExample,
@@ -102,9 +108,17 @@ const BuilderCanvas: FC<Props> = ({
             ) : isFirstBuild ? (
                 <Stack gap="xl" align="center">
                     <SkeletonBars projectUuid={projectUuid} />
-                    <Text size="md" fw={600} c="ldGray.8">
-                        Building your chart type…
-                    </Text>
+                    <Stack gap={4} align="center">
+                        <Text size="md" fw={600} c="ldGray.8">
+                            Building your chart type…
+                        </Text>
+                        {clarifierUnavailable && (
+                            <Text fz="xs" c="dimmed" ta="center" maw={340}>
+                                Couldn’t reach the clarifier, so this is
+                                building from your prompt as written.
+                            </Text>
+                        )}
+                    </Stack>
                 </Stack>
             ) : failureMessage !== null ? (
                 <Stack gap="xs" align="center">
@@ -119,7 +133,12 @@ const BuilderCanvas: FC<Props> = ({
                     </Text>
                 </Stack>
             ) : (
-                <Stack gap="xl" align="center">
+                <Stack
+                    gap="xl"
+                    align="center"
+                    className={isClarifyRoundOpen ? classes.quiet : undefined}
+                    inert={isClarifyRoundOpen}
+                >
                     <Stack gap="xs" align="center">
                         <Text size="md" fw={600} c="ldGray.8">
                             Start with a prompt

--- a/packages/frontend/src/features/apps/builder/BuilderPromptBar.test.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptBar.test.tsx
@@ -5,6 +5,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import { type DataAppModelSelection } from '../hooks/useDataAppModelSelection';
 import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
+import { type VizClarification } from '../hooks/useVizClarification';
+import { clarificationStub } from '../testing/vizClarificationStub';
 import BuilderPromptBar from './BuilderPromptBar';
 
 // The real composer is TipTap; a text input carries the same handle contract.
@@ -21,9 +23,17 @@ vi.mock('../../../components/common/PromptComposer/PromptComposer', () => ({
             onEmptyChange: (isEmpty: boolean) => void;
             onSubmit: () => void;
             submitDisabled?: boolean;
+            disabled?: boolean;
         }
     >(function MockComposer(
-        { placeholder, toolbarRight, onEmptyChange, onSubmit, submitDisabled },
+        {
+            placeholder,
+            toolbarRight,
+            onEmptyChange,
+            onSubmit,
+            submitDisabled,
+            disabled,
+        },
         ref,
     ) {
         const inputRef = useRef<HTMLInputElement>(null);
@@ -47,6 +57,7 @@ vi.mock('../../../components/common/PromptComposer/PromptComposer', () => ({
                 <input
                     ref={inputRef}
                     placeholder={placeholder}
+                    disabled={disabled}
                     onChange={(event) =>
                         onEmptyChange(event.target.value === '')
                     }
@@ -115,12 +126,16 @@ const promptBar = ({
     latestReadyVersion = null,
     model = modelSelection('sonnet'),
     onCancelBuild = isBuilding ? vi.fn() : null,
+    // A round with nothing to ask passes the request straight to the build,
+    // which is what most of these tests are watching for.
+    clarification = clarificationStub({ send: build.send }),
 }: {
     build?: DataAppVizBuildState;
     isBuilding?: boolean;
     latestReadyVersion?: number | null;
     model?: DataAppModelSelection;
     onCancelBuild?: (() => void) | null;
+    clarification?: VizClarification;
 } = {}) => (
     <BuilderPromptBar
         projectUuid="p1"
@@ -134,6 +149,7 @@ const promptBar = ({
         build={build}
         onCancelBuild={onCancelBuild}
         modelSelection={model}
+        clarification={clarification}
     />
 );
 
@@ -157,6 +173,7 @@ describe('BuilderPromptBar', () => {
             description: 'a funnel of signup steps',
             fileIds: [],
             claudeModel: 'haiku',
+            clarifications: [],
         });
     });
 
@@ -203,6 +220,7 @@ describe('BuilderPromptBar', () => {
                 description: 'hide the axis labels',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
 
@@ -309,6 +327,7 @@ describe('BuilderPromptBar', () => {
                 description: 'group by quarter instead',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
     });
@@ -393,6 +412,113 @@ describe('BuilderPromptBar', () => {
         expect(
             screen.getByRole('button', { name: 'Cancelling generation' }),
         ).toBeDisabled();
+    });
+
+    it('sends a first prompt into the clarifying round rather than the build', async () => {
+        const send = vi.fn();
+        const clarifySend = vi.fn();
+        renderWithProviders(
+            promptBar({
+                build: buildState({ send }),
+                clarification: clarificationStub({ send: clarifySend }),
+            }),
+        );
+
+        await userEvent.type(
+            screen.getByPlaceholderText('Ask for a change…'),
+            'show revenue split by team',
+        );
+        await userEvent.click(screen.getByLabelText('Send'));
+
+        expect(send).not.toHaveBeenCalled();
+        expect(clarifySend).toHaveBeenCalledWith({
+            description: 'show revenue split by team',
+            fileIds: [],
+            claudeModel: 'sonnet',
+            clarifications: [],
+        });
+    });
+
+    it('reports the wait on the clarifier, and hands the prompt back on cancel', async () => {
+        const abandon = vi.fn(() => 'show revenue split by team');
+        renderWithProviders(
+            promptBar({
+                clarification: clarificationStub({
+                    clarifyingPrompt: 'show revenue split by team',
+                    abandon,
+                }),
+            }),
+        );
+
+        expect(screen.getByText('Reading your prompt…')).toBeInTheDocument();
+        expect(
+            screen.getByPlaceholderText('Reading your prompt…'),
+        ).toBeDisabled();
+
+        await userEvent.click(screen.getByText('Cancel'));
+
+        expect(abandon).toHaveBeenCalled();
+        expect(
+            screen.getByDisplayValue('show revenue split by team'),
+        ).toBeInTheDocument();
+    });
+
+    it('locks the composer while the questions are open, and builds with the answers', async () => {
+        const send = vi.fn();
+        const build = vi.fn();
+        const answer = vi.fn();
+        renderWithProviders(
+            promptBar({
+                build: buildState({ send }),
+                clarification: clarificationStub({
+                    pending: {
+                        prompt: 'show revenue split by team',
+                        questions: ['Over time, or one period?'],
+                    },
+                    answers: [''],
+                    answer,
+                    build,
+                }),
+            }),
+        );
+
+        const composer = screen.getByPlaceholderText(
+            'Answer the questions, or skip, to build…',
+        );
+        expect(composer).toBeDisabled();
+        expect(screen.getByLabelText('Send')).toBeDisabled();
+        expect(screen.getByText('0 of 1 answered')).toBeInTheDocument();
+
+        await userEvent.type(
+            screen.getByLabelText('Over time, or one period?'),
+            'monthly',
+        );
+        expect(answer).toHaveBeenCalled();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Build' }));
+
+        expect(build).toHaveBeenCalledWith(false);
+        expect(send).not.toHaveBeenCalled();
+    });
+
+    it('skips the questions and builds anyway', async () => {
+        const build = vi.fn();
+        renderWithProviders(
+            promptBar({
+                clarification: clarificationStub({
+                    pending: {
+                        prompt: 'show revenue split by team',
+                        questions: ['Over time, or one period?'],
+                    },
+                    answers: [''],
+                    build,
+                }),
+            }),
+        );
+
+        await userEvent.click(screen.getByText('Skip and build anyway'));
+
+        expect(build).toHaveBeenCalledWith(true);
     });
 
     it('surfaces a cancellation failure and keeps cancel available', () => {

--- a/packages/frontend/src/features/apps/builder/BuilderPromptBar.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptBar.tsx
@@ -34,8 +34,10 @@ import {
     type DataAppVizBuildState,
     type VizBuildRequest,
 } from '../hooks/useDataAppVizBuild';
+import { type VizClarification } from '../hooks/useVizClarification';
 import { useVizComposerAttachments } from '../hooks/useVizComposerAttachments';
 import classes from './BuilderPromptBar.module.css';
+import ClarifyingQuestions from './ClarifyingQuestions';
 
 type Props = {
     projectUuid: string;
@@ -51,6 +53,8 @@ type Props = {
     build: DataAppVizBuildState;
     onCancelBuild: (() => void) | null;
     modelSelection: DataAppModelSelection;
+    /** The pre-build clarifying round every send passes through. */
+    clarification: VizClarification;
 };
 
 type QueuedPrompt = {
@@ -139,6 +143,7 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
             build,
             onCancelBuild,
             modelSelection,
+            clarification,
         },
         ref,
     ) {
@@ -188,6 +193,7 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                         ? attachments.fileIds
                         : (editing?.request.fileIds ?? []),
                 claudeModel: modelSelection.selectedModel,
+                clarifications: [],
             };
             const queuedPrompt: QueuedPrompt = {
                 id: editing?.id ?? nextQueueId.current++,
@@ -201,7 +207,17 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                 setQueuedPrompts((current) => [...current, queuedPrompt]);
                 return;
             }
-            sendBuild(request);
+            clarification.send(request);
+        };
+
+        // The pencil and Cancel end the same way: prompt back in the composer.
+        const handleReclaimPrompt = () => {
+            const prompt = clarification.abandon();
+            if (prompt === null) return;
+            composerRef.current?.insertContent([
+                { type: 'text', text: prompt },
+            ]);
+            composerRef.current?.focus();
         };
 
         const handleEdit = (item: QueuedPrompt) => {
@@ -289,7 +305,11 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
             !isBuilding && buildError === null ? sendingPrompt : null;
         const queuedStackSize =
             queuedPrompts.length + (visibleSendingPrompt ? 1 : 0);
-        const hasStack = queuedStackSize > 0 || isBuilding;
+        const isClarifying = clarification.clarifyingPrompt !== null;
+        const questions = clarification.pending;
+        const hasStack = queuedStackSize > 0 || isBuilding || isClarifying;
+        // Read-only, not just unsubmittable: text typed here would be lost.
+        const isComposerLocked = isClarifying || questions !== null;
 
         return (
             <Box
@@ -297,11 +317,51 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                 onDragOver={handleDragOver}
                 onDrop={handleDrop}
             >
+                {questions !== null && (
+                    <ClarifyingQuestions
+                        prompt={questions.prompt}
+                        questions={questions.questions}
+                        answers={clarification.answers}
+                        onAnswer={clarification.answer}
+                        onEditPrompt={handleReclaimPrompt}
+                        onSkip={() => clarification.build(true)}
+                        onBuild={() => clarification.build(false)}
+                    />
+                )}
                 {hasStack && (
                     <Box
                         className={classes.queue}
-                        data-building={isBuilding || undefined}
+                        data-building={isBuilding || isClarifying || undefined}
                     >
+                        {isClarifying && (
+                            <Box
+                                className={`${classes.stackRow} ${classes.buildingStatus}`}
+                            >
+                                <Loader size={13} color="ldGray.6" />
+                                <Text fz="xs" fw={600} c="ldGray.9" inherit>
+                                    Reading your prompt…
+                                </Text>
+                                <Text
+                                    className={classes.buildingPrompt}
+                                    fz="xs"
+                                    c="dimmed"
+                                    lineClamp={1}
+                                >
+                                    “{clarification.clarifyingPrompt}”
+                                </Text>
+                                <Anchor
+                                    className={classes.cancelBuild}
+                                    component="button"
+                                    type="button"
+                                    size="xs"
+                                    c="dimmed"
+                                    fw={500}
+                                    onClick={handleReclaimPrompt}
+                                >
+                                    Cancel
+                                </Anchor>
+                            </Box>
+                        )}
                         {isBuilding && (
                             <Box
                                 className={`${classes.stackRow} ${classes.buildingStatus}`}
@@ -410,13 +470,18 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                     ref={composerRef}
                     variant="inline"
                     placeholder={
-                        isBuilding
-                            ? 'Ask for another change…'
-                            : hasVersions
-                              ? 'Ask for a change…'
-                              : 'Describe a new chart type…'
+                        questions !== null
+                            ? 'Answer the questions, or skip, to build…'
+                            : isClarifying
+                              ? 'Reading your prompt…'
+                              : isBuilding
+                                ? 'Ask for another change…'
+                                : hasVersions
+                                  ? 'Ask for a change…'
+                                  : 'Describe a new chart type…'
                     }
-                    submitDisabled={!canSubmit}
+                    disabled={isComposerLocked}
+                    submitDisabled={!canSubmit || isComposerLocked}
                     onEmptyChange={setIsEmpty}
                     onSubmit={handleSubmit}
                     onPaste={handlePaste}
@@ -440,7 +505,15 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                             align="center"
                             wrap="nowrap"
                         >
-                            {isBuilding && !isEmpty ? (
+                            {questions !== null ? (
+                                <Text
+                                    className={classes.queueHint}
+                                    fz="xs"
+                                    c="dimmed"
+                                >
+                                    Answer or skip first
+                                </Text>
+                            ) : isBuilding && !isEmpty ? (
                                 <Text
                                     className={classes.queueHint}
                                     fz="xs"
@@ -502,7 +575,11 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                                         isBuilding ? 'Queue message' : 'Send'
                                     }
                                     size="sm"
-                                    disabled={isEmpty || !canSubmit}
+                                    disabled={
+                                        isEmpty ||
+                                        !canSubmit ||
+                                        isComposerLocked
+                                    }
                                     onClick={handleSubmit}
                                 />
                             )}

--- a/packages/frontend/src/features/apps/builder/ClarifyingQuestions.module.css
+++ b/packages/frontend/src/features/apps/builder/ClarifyingQuestions.module.css
@@ -1,0 +1,32 @@
+/* The composer grown upward: same width and corner as the pill it sits on. */
+.sheet {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: calc(100% + var(--queue-row-gap));
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-xs);
+    padding: var(--mantine-spacing-sm);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-lg);
+    background: var(--mantine-color-background-0);
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.sheetHeader {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    padding: 0 2px 2px;
+}
+
+.sheetPrompt {
+    flex: 1;
+    min-width: 0;
+}
+
+.skipLink {
+    margin-right: auto;
+}

--- a/packages/frontend/src/features/apps/builder/ClarifyingQuestions.tsx
+++ b/packages/frontend/src/features/apps/builder/ClarifyingQuestions.tsx
@@ -1,0 +1,100 @@
+import {
+    ActionIcon,
+    Anchor,
+    Box,
+    Button,
+    Group,
+    Text,
+    Tooltip,
+} from '@mantine/core';
+import { IconPencil, IconSparkles } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import ClarificationQuestionList from '../components/ClarificationQuestionList';
+import classes from './ClarifyingQuestions.module.css';
+
+type Props = {
+    /** The prompt the questions were asked about. */
+    prompt: string;
+    questions: string[];
+    answers: string[];
+    onAnswer: (index: number, value: string) => void;
+    /** Hands the prompt back to the composer, round dropped. */
+    onEditPrompt: () => void;
+    onSkip: () => void;
+    onBuild: () => void;
+};
+
+/** The clarifying round, grown upward out of the composer. Partial answers are
+ *  fine: both Skip and Build lead to the same build. */
+const ClarifyingQuestions: FC<Props> = ({
+    prompt,
+    questions,
+    answers,
+    onAnswer,
+    onEditPrompt,
+    onSkip,
+    onBuild,
+}) => {
+    const answeredCount = answers.filter(
+        (answer) => answer.trim().length > 0,
+    ).length;
+
+    return (
+        <Box
+            className={classes.sheet}
+            role="group"
+            aria-label="Questions before building"
+        >
+            <Box className={classes.sheetHeader}>
+                <MantineIcon icon={IconSparkles} size={14} color="ldGray.6" />
+                <Text
+                    className={classes.sheetPrompt}
+                    fz="xs"
+                    c="ldGray.8"
+                    fw={500}
+                    lineClamp={1}
+                >
+                    {prompt}
+                </Text>
+                <Tooltip withArrow label="Edit the prompt instead">
+                    <ActionIcon
+                        variant="subtle"
+                        color="ldGray"
+                        size="xs"
+                        aria-label="Edit the prompt instead"
+                        onClick={onEditPrompt}
+                    >
+                        <MantineIcon icon={IconPencil} size={13} />
+                    </ActionIcon>
+                </Tooltip>
+            </Box>
+            <ClarificationQuestionList
+                questions={questions}
+                answers={answers}
+                onAnswer={onAnswer}
+            />
+            <Group gap="xs" justify="flex-end" align="center">
+                <Anchor
+                    className={classes.skipLink}
+                    component="button"
+                    type="button"
+                    size="xs"
+                    c="dimmed"
+                    fw={500}
+                    onClick={onSkip}
+                >
+                    Skip and build anyway
+                </Anchor>
+                <Text fz="xs" c="dimmed">
+                    {answeredCount} of {questions.length} answered
+                </Text>
+                <Button size="xs" onClick={onBuild}>
+                    Build
+                </Button>
+            </Group>
+        </Box>
+    );
+};
+
+export default ClarifyingQuestions;

--- a/packages/frontend/src/features/apps/components/ClarificationQuestionList.module.css
+++ b/packages/frontend/src/features/apps/components/ClarificationQuestionList.module.css
@@ -1,0 +1,51 @@
+/* Carries its own elevation: it sits on two differently tinted containers. */
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 6px 10px;
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-md);
+    transition:
+        background-color var(--mantine-other-transitionDuration)
+            var(--mantine-other-transitionTimingFunction),
+        border-color var(--mantine-other-transitionDuration)
+            var(--mantine-other-transitionTimingFunction);
+
+    @mixin light {
+        background-color: var(--mantine-color-white);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-dark-6);
+    }
+}
+
+.field:focus-within {
+    border-color: var(--mantine-color-ldGray-4);
+
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-dark-5);
+    }
+}
+
+/* Answered questions recede so the eye lands on what is still open. */
+.field[data-answered]:not(:focus-within) {
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-dark-7);
+    }
+}
+
+/* The sizing `variant="unstyled"` leaves behind, so the answer reads as
+   flowing text rather than an embedded form field. */
+.input {
+    padding: 0;
+    min-height: 0;
+    font-size: var(--mantine-font-size-sm);
+    line-height: 1.5;
+}

--- a/packages/frontend/src/features/apps/components/ClarificationQuestionList.tsx
+++ b/packages/frontend/src/features/apps/components/ClarificationQuestionList.tsx
@@ -1,0 +1,51 @@
+import { Box, Stack, Text, Textarea } from '@mantine/core';
+import { type FC } from 'react';
+import classes from './ClarificationQuestionList.module.css';
+
+type Props = {
+    questions: string[];
+    /** Answers by question index; a missing entry reads as unanswered. */
+    answers: string[];
+    onAnswer: (index: number, value: string) => void;
+};
+
+/** The pre-build clarifying questions, shared by the app builder's chat panel
+ *  and the chart type builder's composer sheet. Blank answers are dropped. */
+const ClarificationQuestionList: FC<Props> = ({
+    questions,
+    answers,
+    onAnswer,
+}) => (
+    <Stack gap={6}>
+        {questions.map((question, index) => (
+            <Box
+                // Index-keyed: `answers` is too, and questions can repeat.
+                key={index}
+                className={classes.field}
+                data-answered={
+                    (answers[index] ?? '').trim().length > 0 || undefined
+                }
+            >
+                <Text size="sm" c="dimmed" lh={1.4}>
+                    {question}
+                </Text>
+                <Textarea
+                    variant="unstyled"
+                    autosize
+                    minRows={1}
+                    maxRows={4}
+                    placeholder="Your answer"
+                    value={answers[index] ?? ''}
+                    autoFocus={index === 0}
+                    onChange={(event) =>
+                        onAnswer(index, event.currentTarget.value)
+                    }
+                    classNames={{ input: classes.input }}
+                    aria-label={question}
+                />
+            </Box>
+        ))}
+    </Stack>
+);
+
+export default ClarificationQuestionList;

--- a/packages/frontend/src/features/apps/hooks/useClarifyApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useClarifyApp.ts
@@ -15,6 +15,8 @@ type ClarifyAppParams = {
     charts?: AppChartReference[];
     dashboard?: AppDashboardReference;
     fileIds?: string[];
+    /** Drops the request when the round it belongs to is abandoned. */
+    signal?: AbortSignal;
 };
 
 type ClarifyAppResult = ApiClarifyAppResponse['results'];
@@ -26,6 +28,7 @@ const clarifyApp = async ({
     charts,
     dashboard,
     fileIds,
+    signal,
 }: ClarifyAppParams): Promise<ClarifyAppResult> =>
     lightdashApi<ClarifyAppResult>({
         method: 'POST',
@@ -37,6 +40,7 @@ const clarifyApp = async ({
             dashboard,
             fileIds,
         }),
+        signal,
     });
 
 export const useClarifyApp = () =>

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.test.ts
@@ -121,6 +121,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'a donut of orders by status',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
 
@@ -138,12 +139,47 @@ describe('useDataAppVizBuild', () => {
                 description: 'a donut of orders by status',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
 
         expect(generate.mock.lastCall?.[0]).toMatchObject({
             creationExperience: 'chart_type_builder',
         });
+    });
+
+    it('sends clarifying answers with a first build, and nothing when there are none', () => {
+        const { result } = setup();
+
+        act(() =>
+            result.current.send({
+                description: 'show revenue split by team',
+                fileIds: [],
+                claudeModel: 'sonnet',
+                clarifications: [
+                    {
+                        question: 'Over time, or one period?',
+                        answer: 'monthly',
+                    },
+                ],
+            }),
+        );
+        expect(generate.mock.lastCall?.[0]).toMatchObject({
+            clarifications: [
+                { question: 'Over time, or one period?', answer: 'monthly' },
+            ],
+        });
+
+        finishBuild(finishedVersion());
+        act(() =>
+            result.current.send({
+                description: 'a donut of orders by status',
+                fileIds: [],
+                claudeModel: 'sonnet',
+                clarifications: [],
+            }),
+        );
+        expect(generate.mock.lastCall?.[0].clarifications).toBeUndefined();
     });
 
     it('sends the picked model on both a new build and a revision', () => {
@@ -154,6 +190,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'a donut of orders by status',
                 fileIds: [],
                 claudeModel: 'opus',
+                clarifications: [],
             }),
         );
         expect(generate.mock.lastCall?.[0]).toMatchObject({
@@ -170,6 +207,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'make it horizontal',
                 fileIds: [],
                 claudeModel: 'haiku',
+                clarifications: [],
             }),
         );
         expect(iterate.mock.lastCall?.[0]).toMatchObject({
@@ -187,6 +225,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'a donut',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
         const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
@@ -205,6 +244,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'a donut',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
         const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
@@ -229,6 +269,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'a donut',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
         const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
@@ -248,6 +289,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'a donut',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
         const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
@@ -269,6 +311,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'make the bars teal',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
 
@@ -295,6 +338,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'make the bars teal',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
         const handlers = iterate.mock.lastCall?.[1] as GenerateHandlers;
@@ -322,6 +366,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'make a bar chart',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
         act(() =>
@@ -361,6 +406,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'make a bar chart',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
         act(() =>
@@ -382,6 +428,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'make the bars teal',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
         const iterateHandlers = iterate.mock.lastCall?.[1] as GenerateHandlers;
@@ -413,6 +460,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'make the bars teal',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
         const handlers = iterate.mock.lastCall?.[1] as GenerateHandlers;
@@ -434,6 +482,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'a donut',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
         const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
@@ -443,6 +492,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'actually a bar chart',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
 
@@ -457,6 +507,7 @@ describe('useDataAppVizBuild', () => {
                 description: 'a donut',
                 fileIds: [],
                 claudeModel: 'sonnet',
+                clarifications: [],
             }),
         );
         const generateHandlers = generate.mock

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
@@ -2,6 +2,7 @@ import {
     DATA_APP_VIZ_TEMPLATE,
     getErrorMessage,
     type ApiAppVersionSummary,
+    type AppClarification,
     type DataAppClaudeModel,
     type DataAppVizFieldMapping,
     type ItemsMap,
@@ -33,6 +34,9 @@ export type VizBuildRequest = {
     description: string;
     fileIds: string[];
     claudeModel: DataAppClaudeModel;
+    /** Answers to the pre-build clarifying round; empty when it was skipped,
+     *  fell through, or never ran. Only a first build can carry them. */
+    clarifications: AppClarification[];
 };
 
 /** The app claimed by a build before it has a renderable version. */
@@ -175,6 +179,10 @@ export const useDataAppVizBuild = ({
                         appUuid: draftAppUuid,
                         fileIds: files,
                         claudeModel: request.claudeModel,
+                        clarifications:
+                            request.clarifications.length > 0
+                                ? request.clarifications
+                                : undefined,
                     },
                     {
                         onSuccess: ({ appUuid, version }) => {

--- a/packages/frontend/src/features/apps/hooks/useVizClarification.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useVizClarification.test.ts
@@ -1,0 +1,203 @@
+import { act, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHookWithProviders } from '../../../testing/testUtils';
+import { useClarifyApp } from './useClarifyApp';
+import { type VizBuildRequest } from './useDataAppVizBuild';
+import { useVizClarification } from './useVizClarification';
+
+vi.mock('./useClarifyApp', () => ({ useClarifyApp: vi.fn() }));
+
+const track = vi.fn();
+vi.mock('../../../providers/Tracking/useTracking', () => ({
+    default: () => ({ track }),
+}));
+
+const mockedClarify = vi.mocked(useClarifyApp);
+
+const request = (
+    overrides: Partial<VizBuildRequest> = {},
+): VizBuildRequest => ({
+    description: 'show revenue split by team',
+    fileIds: [],
+    claudeModel: 'sonnet',
+    clarifications: [],
+    ...overrides,
+});
+
+describe('useVizClarification', () => {
+    let clarify: ReturnType<typeof vi.fn>;
+    let onBuild: (request: VizBuildRequest) => void;
+
+    const setup = (isFirstBuild = true) =>
+        renderHookWithProviders(() =>
+            useVizClarification({
+                projectUuid: 'project-1',
+                isFirstBuild,
+                onBuild,
+            }),
+        );
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        onBuild = vi.fn();
+        track.mockClear();
+        clarify = vi.fn().mockResolvedValue({ questions: [] });
+        mockedClarify.mockReturnValue({
+            mutateAsync: clarify,
+        } as unknown as ReturnType<typeof useClarifyApp>);
+    });
+
+    it('asks the clarifier before a first build, and holds the build back', async () => {
+        clarify.mockResolvedValue({
+            questions: ['Over time, or one period?', 'Absolute, or share?'],
+        });
+        const { result } = setup();
+
+        act(() => result.current.send(request()));
+
+        await waitFor(() =>
+            expect(result.current.pending?.questions).toHaveLength(2),
+        );
+        expect(clarify).toHaveBeenCalledWith({
+            projectUuid: 'project-1',
+            prompt: 'show revenue split by team',
+            template: 'data_app_viz',
+            fileIds: undefined,
+            signal: expect.any(AbortSignal),
+        });
+        expect(onBuild).not.toHaveBeenCalled();
+    });
+
+    it('builds straight away when the prompt needs no questions', async () => {
+        const { result } = setup();
+
+        act(() => result.current.send(request()));
+
+        await waitFor(() => expect(onBuild).toHaveBeenCalledTimes(1));
+        expect(result.current.pending).toBeNull();
+        expect(result.current.fellThrough).toBe(false);
+    });
+
+    it('builds anyway, and says so, when the clarifier cannot be reached', async () => {
+        clarify.mockRejectedValue(new Error('network'));
+        const { result } = setup();
+
+        act(() => result.current.send(request()));
+
+        await waitFor(() => expect(result.current.fellThrough).toBe(true));
+        expect(onBuild).toHaveBeenCalledWith(request());
+    });
+
+    it('never asks on a revision', async () => {
+        const { result } = setup(false);
+
+        act(() => result.current.send(request()));
+
+        await waitFor(() => expect(onBuild).toHaveBeenCalledTimes(1));
+        expect(clarify).not.toHaveBeenCalled();
+    });
+
+    it('folds answered questions into the build and drops the blanks', async () => {
+        clarify.mockResolvedValue({
+            questions: ['Over time, or one period?', 'Absolute, or share?'],
+        });
+        const { result } = setup();
+
+        act(() => result.current.send(request()));
+        await waitFor(() => expect(result.current.pending).not.toBeNull());
+
+        act(() => result.current.answer(0, '  monthly  '));
+        act(() => result.current.build(false));
+
+        expect(onBuild).toHaveBeenCalledWith(
+            request({
+                clarifications: [
+                    {
+                        question: 'Over time, or one period?',
+                        answer: 'monthly',
+                    },
+                ],
+            }),
+        );
+        expect(result.current.pending).toBeNull();
+    });
+
+    it('skips with no answers at all', async () => {
+        clarify.mockResolvedValue({ questions: ['Over time?'] });
+        const { result } = setup();
+
+        act(() => result.current.send(request()));
+        await waitFor(() => expect(result.current.pending).not.toBeNull());
+
+        act(() => result.current.answer(0, 'monthly'));
+        act(() => result.current.build(true));
+
+        expect(onBuild).toHaveBeenCalledWith(request());
+    });
+
+    it('hands the prompt back when the round is abandoned mid-flight', async () => {
+        let resolveClarify: (value: { questions: string[] }) => void = () => {};
+        clarify.mockReturnValue(
+            new Promise<{ questions: string[] }>((resolve) => {
+                resolveClarify = resolve;
+            }),
+        );
+        const { result } = setup();
+
+        act(() => result.current.send(request()));
+        expect(result.current.clarifyingPrompt).toBe(
+            'show revenue split by team',
+        );
+
+        let abandoned: string | null = null;
+        act(() => {
+            abandoned = result.current.abandon();
+        });
+        expect(abandoned).toBe('show revenue split by team');
+
+        // The request goes with it: nobody is waiting on that answer.
+        expect(clarify.mock.lastCall?.[0].signal.aborted).toBe(true);
+
+        // A late answer cannot reopen a round the user walked away from.
+        await act(async () => {
+            resolveClarify({ questions: ['Over time?'] });
+        });
+        expect(result.current.pending).toBeNull();
+        expect(onBuild).not.toHaveBeenCalled();
+    });
+
+    it('reports how every round ended', async () => {
+        clarify.mockResolvedValue({ questions: ['Over time?', 'Or share?'] });
+        const { result } = setup();
+
+        act(() => result.current.send(request()));
+        await waitFor(() => expect(result.current.pending).not.toBeNull());
+        act(() => result.current.answer(0, 'monthly'));
+        act(() => result.current.build(false));
+
+        expect(track).toHaveBeenCalledWith({
+            name: 'data_app.clarify_round_resolved',
+            properties: {
+                projectId: 'project-1',
+                outcome: 'answered',
+                questionCount: 2,
+                answeredCount: 1,
+            },
+        });
+
+        // An empty question list is the shape a failed clarifier arrives in,
+        // so it has to be visible as its own outcome.
+        track.mockClear();
+        clarify.mockResolvedValue({ questions: [] });
+        act(() => result.current.send(request()));
+        await waitFor(() =>
+            expect(track).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    properties: expect.objectContaining({
+                        outcome: 'no_questions',
+                    }),
+                }),
+            ),
+        );
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useVizClarification.ts
+++ b/packages/frontend/src/features/apps/hooks/useVizClarification.ts
@@ -1,0 +1,189 @@
+import {
+    DATA_APP_VIZ_TEMPLATE,
+    type AppClarification,
+} from '@lightdash/common';
+import { useCallback, useRef, useState } from 'react';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
+import { useClarifyApp } from './useClarifyApp';
+import { type VizBuildRequest } from './useDataAppVizBuild';
+
+type Args = {
+    projectUuid: string | undefined;
+    /** Only a first build clarifies; a revision is grounded in the version
+     *  already on screen. */
+    isFirstBuild: boolean;
+    onBuild: (request: VizBuildRequest) => void;
+};
+
+export type VizClarification = {
+    /** The round awaiting answers; null when no questions are on screen. */
+    pending: { prompt: string; questions: string[] } | null;
+    answers: string[];
+    /** The prompt whose clarify request is in flight. */
+    clarifyingPrompt: string | null;
+    /** The clarifier could not be reached, so the build started as written. */
+    fellThrough: boolean;
+    send: (request: VizBuildRequest) => void;
+    answer: (index: number, value: string) => void;
+    /** Build with the answers given so far, or with none when skipping. */
+    build: (skip: boolean) => void;
+    /** Drop the round and hand its prompt back to the composer. */
+    abandon: () => string | null;
+    reset: () => void;
+};
+
+/** The clarifying round before a first build. The clarifier is advisory, so
+ *  every outcome ends in a build; a round id stops a late response reopening
+ *  questions the user has already moved past. */
+export const useVizClarification = ({
+    projectUuid,
+    isFirstBuild,
+    onBuild,
+}: Args): VizClarification => {
+    const { mutateAsync: clarify } = useClarifyApp();
+    const { track } = useTracking();
+    const round = useRef(0);
+    const inFlightRequest = useRef<AbortController | null>(null);
+    const [inFlight, setInFlight] = useState<VizBuildRequest | null>(null);
+    const [pending, setPending] = useState<{
+        request: VizBuildRequest;
+        questions: string[];
+    } | null>(null);
+    const [answers, setAnswers] = useState<string[]>([]);
+    const [fellThrough, setFellThrough] = useState(false);
+
+    const reset = useCallback(() => {
+        round.current += 1;
+        inFlightRequest.current?.abort();
+        inFlightRequest.current = null;
+        setInFlight(null);
+        setPending(null);
+        setAnswers([]);
+        setFellThrough(false);
+    }, []);
+
+    const report = useCallback(
+        (
+            outcome:
+                | 'no_questions'
+                | 'unreachable'
+                | 'answered'
+                | 'skipped'
+                | 'abandoned',
+            questionCount: number,
+            answeredCount: number,
+        ) =>
+            track({
+                name: EventName.DATA_APP_CLARIFY_ROUND_RESOLVED,
+                properties: {
+                    projectId: projectUuid,
+                    outcome,
+                    questionCount,
+                    answeredCount,
+                },
+            }),
+        [projectUuid, track],
+    );
+
+    const send = useCallback(
+        (request: VizBuildRequest) => {
+            setFellThrough(false);
+            if (!isFirstBuild || !projectUuid) {
+                onBuild(request);
+                return;
+            }
+            round.current += 1;
+            const current = round.current;
+            const controller = new AbortController();
+            inFlightRequest.current = controller;
+            setInFlight(request);
+            void clarify({
+                projectUuid,
+                prompt: request.description,
+                template: DATA_APP_VIZ_TEMPLATE,
+                fileIds:
+                    request.fileIds.length > 0 ? request.fileIds : undefined,
+                signal: controller.signal,
+            })
+                .then(({ questions }) => {
+                    if (current !== round.current) return;
+                    inFlightRequest.current = null;
+                    setInFlight(null);
+                    if (questions.length === 0) {
+                        report('no_questions', 0, 0);
+                        onBuild(request);
+                        return;
+                    }
+                    setPending({ request, questions });
+                    setAnswers(questions.map(() => ''));
+                })
+                .catch(() => {
+                    if (current !== round.current) return;
+                    inFlightRequest.current = null;
+                    setInFlight(null);
+                    setFellThrough(true);
+                    report('unreachable', 0, 0);
+                    onBuild(request);
+                });
+        },
+        [clarify, isFirstBuild, onBuild, projectUuid, report],
+    );
+
+    const answer = useCallback((index: number, value: string) => {
+        setAnswers((current) => {
+            const next = [...current];
+            next[index] = value;
+            return next;
+        });
+    }, []);
+
+    const build = useCallback(
+        (skip: boolean) => {
+            if (!pending) return;
+            const clarifications: AppClarification[] = skip
+                ? []
+                : pending.questions
+                      .map((question, index) => ({
+                          question,
+                          answer: (answers[index] ?? '').trim(),
+                      }))
+                      .filter((item) => item.answer.length > 0);
+            const request = pending.request;
+            reset();
+            report(
+                clarifications.length > 0 ? 'answered' : 'skipped',
+                pending.questions.length,
+                clarifications.length,
+            );
+            onBuild({ ...request, clarifications });
+        },
+        [answers, onBuild, pending, report, reset],
+    );
+
+    const abandon = useCallback(() => {
+        const prompt = pending?.request.description ?? inFlight?.description;
+        if (prompt === undefined) return null;
+        const questionCount = pending?.questions.length ?? 0;
+        reset();
+        report('abandoned', questionCount, 0);
+        return prompt;
+    }, [inFlight, pending, report, reset]);
+
+    return {
+        pending: pending
+            ? {
+                  prompt: pending.request.description,
+                  questions: pending.questions,
+              }
+            : null,
+        answers,
+        clarifyingPrompt: inFlight?.description ?? null,
+        fellThrough,
+        send,
+        answer,
+        build,
+        abandon,
+        reset,
+    };
+};

--- a/packages/frontend/src/features/apps/testing/vizClarificationStub.ts
+++ b/packages/frontend/src/features/apps/testing/vizClarificationStub.ts
@@ -1,0 +1,18 @@
+import { vi } from 'vitest';
+import { type VizClarification } from '../hooks/useVizClarification';
+
+/** A clarifying round with nothing on screen. */
+export const clarificationStub = (
+    overrides: Partial<VizClarification> = {},
+): VizClarification => ({
+    pending: null,
+    answers: [],
+    clarifyingPrompt: null,
+    fellThrough: false,
+    send: vi.fn(),
+    answer: vi.fn(),
+    build: vi.fn(),
+    abandon: vi.fn(() => null),
+    reset: vi.fn(),
+    ...overrides,
+});

--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -476,42 +476,6 @@
     transition: opacity 200ms ease;
 }
 
-.clarifyCard {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    padding: 6px 10px;
-    border-radius: var(--mantine-radius-sm);
-    transition: background-color 100ms ease;
-
-    @mixin light {
-        background-color: var(--mantine-color-white);
-    }
-    @mixin dark {
-        background-color: var(--mantine-color-dark-6);
-    }
-
-    &:focus-within {
-        @mixin light {
-            background-color: var(--mantine-color-ldGray-0);
-        }
-        @mixin dark {
-            background-color: var(--mantine-color-dark-5);
-        }
-    }
-}
-
-/* Strip the default Mantine Textarea framing so the answer reads as flowing
- * chat text inside the card instead of an embedded form field. */
-.clarifyCardInput {
-    padding: 0 !important;
-    min-height: 0 !important;
-    background: transparent !important;
-    border: none !important;
-    font-size: var(--mantine-font-size-sm) !important;
-    line-height: 1.5 !important;
-}
-
 .bubbleClarificationList {
     display: flex;
     flex-direction: column;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -28,7 +28,6 @@ import {
     Menu,
     Stack,
     Text,
-    Textarea,
     Tooltip,
 } from '@mantine/core';
 import {
@@ -102,6 +101,7 @@ import AppBuilderSidebarToggle from '../features/apps/components/AppBuilderSideb
 import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
 import AppPreview from '../features/apps/components/AppPreview';
+import ClarificationQuestionList from '../features/apps/components/ClarificationQuestionList';
 import DataAppVizResultCard from '../features/apps/components/DataAppVizResultCard';
 import DataAppVizTestPanel from '../features/apps/components/DataAppVizTestPanel';
 import LoadingDots from '../features/apps/components/LoadingDots';
@@ -2390,56 +2390,23 @@ const AppGenerate: FC = () => {
                                             <Text size="sm">
                                                 A few quick questions:
                                             </Text>
-                                            <Stack gap={6}>
-                                                {pendingClarification.questions.map(
-                                                    (question, qi) => (
-                                                        <Box
-                                                            key={qi}
-                                                            className={
-                                                                classes.clarifyCard
-                                                            }
-                                                        >
-                                                            <Text
-                                                                size="sm"
-                                                                c="dimmed"
-                                                            >
-                                                                {question}
-                                                            </Text>
-                                                            <Textarea
-                                                                variant="unstyled"
-                                                                autosize
-                                                                minRows={1}
-                                                                maxRows={4}
-                                                                placeholder="Your answer"
-                                                                value={
-                                                                    clarificationAnswers[
-                                                                        qi
-                                                                    ] ?? ''
-                                                                }
-                                                                onChange={(
-                                                                    e,
-                                                                ) => {
-                                                                    const next =
-                                                                        [
-                                                                            ...clarificationAnswers,
-                                                                        ];
-                                                                    next[qi] =
-                                                                        e.currentTarget.value;
-                                                                    setClarificationAnswers(
-                                                                        next,
-                                                                    );
-                                                                }}
-                                                                autoFocus={
-                                                                    qi === 0
-                                                                }
-                                                                classNames={{
-                                                                    input: classes.clarifyCardInput,
-                                                                }}
-                                                            />
-                                                        </Box>
-                                                    ),
-                                                )}
-                                            </Stack>
+                                            <ClarificationQuestionList
+                                                questions={
+                                                    pendingClarification.questions
+                                                }
+                                                answers={clarificationAnswers}
+                                                onAnswer={(index, value) =>
+                                                    setClarificationAnswers(
+                                                        (current) => {
+                                                            const next = [
+                                                                ...current,
+                                                            ];
+                                                            next[index] = value;
+                                                            return next;
+                                                        },
+                                                    )
+                                                }
+                                            />
                                             <Group gap="xs" justify="flex-end">
                                                 <Button
                                                     variant="subtle"

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -15,8 +15,10 @@ import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualization } from '../features/apps/hooks/useDataAppVisualization';
 import { useDataAppVizBuild } from '../features/apps/hooks/useDataAppVizBuild';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
+import { useVizClarification } from '../features/apps/hooks/useVizClarification';
 import { appVersion } from '../features/apps/testing/appVersionHistory';
 import { buildStub } from '../features/apps/testing/dataAppVizBuildStub';
+import { clarificationStub } from '../features/apps/testing/vizClarificationStub';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { renderWithProviders } from '../testing/testUtils';
 import ChartTypeBuilder from './ChartTypeBuilder';
@@ -41,6 +43,9 @@ vi.mock('../features/apps/hooks/useDataAppVizBuild', () => ({
 }));
 vi.mock('../features/apps/hooks/useDataAppVisualization', () => ({
     useDataAppVisualization: vi.fn(),
+}));
+vi.mock('../features/apps/hooks/useVizClarification', () => ({
+    useVizClarification: vi.fn(),
 }));
 vi.mock('../features/apps/hooks/useAppBuildPoller', () => ({
     useAppBuildPoller: vi.fn(),
@@ -165,6 +170,7 @@ describe('ChartTypeBuilder', () => {
         vi.mocked(useCanCreateDataApp).mockReturnValue(true);
         vi.mocked(useCanEditDataApp).mockReturnValue(true);
         vi.mocked(useDataAppVizBuild).mockReturnValue(buildStub());
+        vi.mocked(useVizClarification).mockReturnValue(clarificationStub());
         vi.mocked(useDataAppVisualization).mockReturnValue({
             data: undefined,
         } as ReturnType<typeof useDataAppVisualization>);
@@ -581,5 +587,35 @@ describe('ChartTypeBuilder', () => {
         expect(screen.getByText('Sandbox crashed')).toBeInTheDocument();
         // Nothing is running any more, so the retry has to be typeable.
         expect(screen.getByPlaceholderText('Ask for a change…')).toBeEnabled();
+    });
+
+    it('clarifies a first prompt, but never a revision', () => {
+        renderBuilder('/projects/p1/chart-types/new');
+        expect(vi.mocked(useVizClarification).mock.lastCall?.[0]).toMatchObject(
+            { isFirstBuild: true },
+        );
+
+        setApp(appMeta());
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub([appVersion({ version: 1, status: 'ready' })], 1),
+        );
+        renderBuilder('/projects/p1/chart-types/viz-1');
+        expect(vi.mocked(useVizClarification).mock.lastCall?.[0]).toMatchObject(
+            { isFirstBuild: false },
+        );
+    });
+
+    it('says when a build started without the clarifier', () => {
+        vi.mocked(useDataAppVizBuild).mockReturnValue(
+            buildStub({ isBuilding: true, pendingPrompt: 'show revenue' }),
+        );
+        vi.mocked(useVizClarification).mockReturnValue(
+            clarificationStub({ fellThrough: true }),
+        );
+        renderBuilder('/projects/p1/chart-types/new');
+
+        expect(
+            screen.getByText(/Couldn’t reach the clarifier/),
+        ).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -35,6 +35,7 @@ import { useDataAppVisualization } from '../features/apps/hooks/useDataAppVisual
 import { useDataAppVizBuild } from '../features/apps/hooks/useDataAppVizBuild';
 import { useElapsedClock } from '../features/apps/hooks/useElapsedClock';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
+import { useVizClarification } from '../features/apps/hooks/useVizClarification';
 import { buildSampleVizContext } from '../features/apps/utils/sampleVizContext';
 import { useResolvedColorPalette } from '../hooks/appearance/useResolvedColorPalette';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
@@ -72,6 +73,15 @@ const ChartTypeBuilder: FC = () => {
         dataAppVizUuid: activeVizUuid ?? null,
         onCreated: noop,
     });
+
+    // Questions only before the first build: once a version exists, intent is
+    // grounded in what is on screen.
+    const clarification = useVizClarification({
+        projectUuid,
+        isFirstBuild: activeVizUuid === undefined,
+        onBuild: build.send,
+    });
+    const { reset: resetClarification } = clarification;
 
     const historyUuid = activeVizUuid ?? build.appUuid;
     const history = useAppVersionHistory(projectUuid ?? '', historyUuid);
@@ -141,7 +151,8 @@ const ChartTypeBuilder: FC = () => {
         setColorPaletteUuid(null);
         setIsHistoryOpen(false);
         clearModelPick();
-    }, [urlVizUuid, clearModelPick]);
+        resetClarification();
+    }, [urlVizUuid, clearModelPick, resetClarification]);
 
     const isBuilding = build.isBuilding || historyLatestInProgress;
 
@@ -358,6 +369,11 @@ const ChartTypeBuilder: FC = () => {
                         previewVersion={previewVersion}
                         isBuilding={isBuilding}
                         failureMessage={failureMessage}
+                        isClarifyRoundOpen={
+                            clarification.clarifyingPrompt !== null ||
+                            clarification.pending !== null
+                        }
+                        clarifierUnavailable={clarification.fellThrough}
                         previewContext={previewContext}
                         configurePanel={configurePanel}
                         onPickExample={
@@ -382,6 +398,7 @@ const ChartTypeBuilder: FC = () => {
                             build={build}
                             onCancelBuild={onCancelBuild}
                             modelSelection={modelSelection}
+                            clarification={clarification}
                         />
                     )}
                 </Box>

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -620,6 +620,23 @@ type DataAppRecentSuggestionClickEvent = {
     };
 };
 
+/** `no_questions` doubles as the degraded-clarifier signal: the endpoint
+ *  reports an LLM failure as an empty question list. */
+type DataAppClarifyRoundResolvedEvent = {
+    name: EventName.DATA_APP_CLARIFY_ROUND_RESOLVED;
+    properties: {
+        projectId: string | undefined;
+        outcome:
+            | 'no_questions'
+            | 'unreachable'
+            | 'answered'
+            | 'skipped'
+            | 'abandoned';
+        questionCount: number;
+        answeredCount: number;
+    };
+};
+
 type ThemeToggledEvent = {
     name: EventName.THEME_TOGGLED;
     properties: {
@@ -934,6 +951,7 @@ export type EventData =
     | AiAgentSuggestionImpressionEvent
     | AiAgentSuggestionClickEvent
     | DataAppRecentSuggestionClickEvent
+    | DataAppClarifyRoundResolvedEvent
     | ThemeToggledEvent
     | DashboardUiVersionToggledEvent
     | TableCalculationSaveEvent

--- a/packages/frontend/src/stories/ClarifyingQuestions.stories.tsx
+++ b/packages/frontend/src/stories/ClarifyingQuestions.stories.tsx
@@ -1,0 +1,82 @@
+import { Box } from '@mantine/core';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState, type FC } from 'react';
+import promptBar from '../features/apps/builder/BuilderPromptBar.module.css';
+import ClarifyingQuestions from '../features/apps/builder/ClarifyingQuestions';
+
+const QUESTIONS = [
+    'Should teams be compared side by side, or stacked into one total?',
+    'Is revenue shown over time, or as a single period per team?',
+    'How should teams beyond the top few be handled?',
+    'Absolute revenue, or each team’s share of the total?',
+];
+
+type Props = {
+    prompt: string;
+    questions: string[];
+    initialAnswers: string[];
+};
+
+/** The sheet positions against the composer's host, so the story supplies the
+ *  same host and leaves room above for it to grow into. */
+const Harness: FC<Props> = ({ prompt, questions, initialAnswers }) => {
+    const [answers, setAnswers] = useState(initialAnswers);
+
+    return (
+        <Box pt={360} pb="xl" px="xl">
+            <Box className={promptBar.pillHost} mx="auto">
+                <ClarifyingQuestions
+                    prompt={prompt}
+                    questions={questions}
+                    answers={answers}
+                    onAnswer={(index, value) =>
+                        setAnswers((current) => {
+                            const next = [...current];
+                            next[index] = value;
+                            return next;
+                        })
+                    }
+                    onEditPrompt={() => undefined}
+                    onSkip={() => undefined}
+                    onBuild={() => undefined}
+                />
+            </Box>
+        </Box>
+    );
+};
+
+const meta: Meta<typeof Harness> = {
+    title: 'Data apps/Clarifying questions',
+    component: Harness,
+    parameters: { layout: 'fullscreen' },
+    args: {
+        prompt: 'a chart that shows performance',
+        questions: QUESTIONS.slice(0, 3),
+        initialAnswers: ['', '', ''],
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Harness>;
+
+/** How the round opens: nothing answered, both ways out on the same row. */
+export const Unanswered: Story = {};
+
+/** Partial answers are fine, and answered questions recede. */
+export const PartiallyAnswered: Story = {
+    args: { initialAnswers: ['side by side', '', ''] },
+};
+
+/** The cap, at the longest the clarifier's own prompt allows. */
+export const FourQuestions: Story = {
+    args: { questions: QUESTIONS, initialAnswers: ['', '', '', ''] },
+};
+
+/** One question, where the counter reads oddly if it is not worded per-item. */
+export const SingleQuestion: Story = {
+    args: {
+        questions: ['Over time, or a single period?'],
+        initialAnswers: [''],
+    },
+};

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -91,6 +91,7 @@ export enum EventName {
     HOMEPAGE_RECOMMENDED_ACTION_CLICKED = 'homepage_recommended_action.clicked',
     HOMEPAGE_RECOMMENDED_ACTION_SKIPPED = 'homepage_recommended_action.skipped',
     DATA_APP_RECENT_SUGGESTION_CLICK = 'data_app.recent_suggestion_click',
+    DATA_APP_CLARIFY_ROUND_RESOLVED = 'data_app.clarify_round_resolved',
     REVOKE_INVITES_BUTTON_CLICKED = 'revoke_invites_button.clicked',
     INVITE_BUTTON_CLICKED = 'invite_users_to_organisation_button.clicked',
     RUN_QUERY_BUTTON_CLICKED = 'run_query_button.clicked',


### PR DESCRIPTION
### Description:

The chart type builder never called the viz clarifier, so an under-specified prompt burned a whole build cycle before you found out what was missing. The backend was already there and tested; this wires the call site back up. Frontend only.

Before the first build, the prompt goes to the clarifier and any questions it returns are answered inline above the composer. Answers ride along as `clarifications`, which the backend folds into the prompt and keeps on the version. Revisions never ask.

The clarifier is advisory, so everything ends in a build: no questions, an error, a timeout, or Skip. Only an unreachable clarifier says so on the canvas.

While the questions are up the composer is read-only rather than just unsubmittable, since it is the one input that cannot lead anywhere. Cancel and the pencil both hand the prompt back to it.

The question and answer field already existed inline in `AppGenerate.tsx`; it is now a shared component used by both builders.

A Storybook story under Data apps > Clarifying questions renders the real sheet in its unanswered, partially answered, four-question and single-question states, so the design stays explorable without a second copy of it to keep in sync.

Twelve new tests. The ones that fail against today's behaviour are in `useVizClarification.test.ts`: a first build has to reach the clarifier before the build, a revision must not.

https://linear.app/lightdash/issue/PROD-10262
