### PR TITLE
refactor: share the clarifying round between both builders

### DIFF
--- a/packages/frontend/src/features/apps/builder/BuilderPromptBar.test.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptBar.test.tsx
@@ -7,10 +7,13 @@ import userEvent from '@testing-library/user-event';
 import { forwardRef, useImperativeHandle, useRef, type ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
+import { type ClarificationRound } from '../hooks/useClarificationRound';
 import { type DataAppModelSelection } from '../hooks/useDataAppModelSelection';
-import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
-import { type VizClarification } from '../hooks/useVizClarification';
-import { clarificationStub } from '../testing/vizClarificationStub';
+import {
+    type DataAppVizBuildState,
+    type VizBuildRequest,
+} from '../hooks/useDataAppVizBuild';
+import { clarificationStub } from '../testing/clarificationRoundStub';
 import BuilderPromptBar from './BuilderPromptBar';
 
 // The real composer is TipTap; a text input carries the same handle contract.
@@ -148,7 +151,7 @@ const promptBar = ({
     latestReadyVersion?: number | null;
     model?: DataAppModelSelection;
     onCancelBuild?: (() => void) | null;
-    clarification?: VizClarification;
+    clarification?: ClarificationRound<VizBuildRequest>;
 } = {}) => (
     <BuilderPromptBar
         projectUuid="p1"

--- a/packages/frontend/src/features/apps/builder/BuilderPromptBar.tsx
+++ b/packages/frontend/src/features/apps/builder/BuilderPromptBar.tsx
@@ -29,12 +29,12 @@ import PromptComposer, {
     type PromptComposerHandle,
 } from '../../../components/common/PromptComposer/PromptComposer';
 import { ModelPicker, SelectedAttachmentSection } from '../AppResourcePicker';
+import { type ClarificationRound } from '../hooks/useClarificationRound';
 import { type DataAppModelSelection } from '../hooks/useDataAppModelSelection';
 import {
     type DataAppVizBuildState,
     type VizBuildRequest,
 } from '../hooks/useDataAppVizBuild';
-import { type VizClarification } from '../hooks/useVizClarification';
 import { useVizComposerAttachments } from '../hooks/useVizComposerAttachments';
 import classes from './BuilderPromptBar.module.css';
 import ClarifyingQuestions from './ClarifyingQuestions';
@@ -54,7 +54,7 @@ type Props = {
     onCancelBuild: (() => void) | null;
     modelSelection: DataAppModelSelection;
     /** The pre-build clarifying round every send passes through. */
-    clarification: VizClarification;
+    clarification: ClarificationRound<VizBuildRequest>;
 };
 
 type QueuedPrompt = {

--- a/packages/frontend/src/features/apps/hooks/useClarificationRound.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useClarificationRound.test.ts
@@ -1,9 +1,10 @@
+import { type AppClarification } from '@lightdash/common';
 import { act, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHookWithProviders } from '../../../testing/testUtils';
+import { useClarificationRound } from './useClarificationRound';
 import { useClarifyApp } from './useClarifyApp';
 import { type VizBuildRequest } from './useDataAppVizBuild';
-import { useVizClarification } from './useVizClarification';
 
 vi.mock('./useClarifyApp', () => ({ useClarifyApp: vi.fn() }));
 
@@ -26,15 +27,25 @@ const request = (
     ...overrides,
 });
 
-describe('useVizClarification', () => {
+const toClarifyParams = (item: VizBuildRequest) => ({
+    prompt: item.description,
+    template: 'data_app_viz' as const,
+    fileIds: item.fileIds.length > 0 ? item.fileIds : undefined,
+});
+
+describe('useClarificationRound', () => {
     let clarify: ReturnType<typeof vi.fn>;
-    let onBuild: (request: VizBuildRequest) => void;
+    let onBuild: (
+        request: VizBuildRequest,
+        clarifications: AppClarification[],
+    ) => void;
 
     const setup = (isFirstBuild = true) =>
         renderHookWithProviders(() =>
-            useVizClarification({
+            useClarificationRound<VizBuildRequest>({
                 projectUuid: 'project-1',
                 isFirstBuild,
+                toClarifyParams,
                 onBuild,
             }),
         );
@@ -87,7 +98,7 @@ describe('useVizClarification', () => {
         act(() => result.current.send(request()));
 
         await waitFor(() => expect(result.current.fellThrough).toBe(true));
-        expect(onBuild).toHaveBeenCalledWith(request());
+        expect(onBuild).toHaveBeenCalledWith(request(), []);
     });
 
     it('never asks on a revision', async () => {
@@ -111,16 +122,9 @@ describe('useVizClarification', () => {
         act(() => result.current.answer(0, '  monthly  '));
         act(() => result.current.build(false));
 
-        expect(onBuild).toHaveBeenCalledWith(
-            request({
-                clarifications: [
-                    {
-                        question: 'Over time, or one period?',
-                        answer: 'monthly',
-                    },
-                ],
-            }),
-        );
+        expect(onBuild).toHaveBeenCalledWith(request(), [
+            { question: 'Over time, or one period?', answer: 'monthly' },
+        ]);
         expect(result.current.pending).toBeNull();
     });
 
@@ -134,7 +138,7 @@ describe('useVizClarification', () => {
         act(() => result.current.answer(0, 'monthly'));
         act(() => result.current.build(true));
 
-        expect(onBuild).toHaveBeenCalledWith(request());
+        expect(onBuild).toHaveBeenCalledWith(request(), []);
     });
 
     it('hands the prompt back when the round is abandoned mid-flight', async () => {
@@ -181,6 +185,8 @@ describe('useVizClarification', () => {
             name: 'data_app.clarify_round_resolved',
             properties: {
                 projectId: 'project-1',
+                // Tells the two builders apart on one shared event.
+                template: 'data_app_viz',
                 outcome: 'answered',
                 questionCount: 2,
                 answeredCount: 1,
@@ -200,6 +206,29 @@ describe('useVizClarification', () => {
                     }),
                 }),
             ),
+        );
+    });
+
+    it('builds once when the build itself throws', async () => {
+        // The no-questions path builds from inside the clarify handler. A
+        // throw there must not be read as the clarifier failing and start a
+        // second build.
+        onBuild = vi.fn(() => {
+            throw new Error('generate blew up');
+        });
+        const { result } = setup();
+
+        act(() => result.current.send(request()));
+
+        await waitFor(() => expect(onBuild).toHaveBeenCalledTimes(1));
+        expect(result.current.fellThrough).toBe(false);
+        expect(track).toHaveBeenCalledTimes(1);
+        expect(track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                properties: expect.objectContaining({
+                    outcome: 'no_questions',
+                }),
+            }),
         );
     });
 });

--- a/packages/frontend/src/features/apps/hooks/useClarificationRound.ts
+++ b/packages/frontend/src/features/apps/hooks/useClarificationRound.ts
@@ -1,22 +1,33 @@
 import {
-    DATA_APP_VIZ_TEMPLATE,
+    type AppChartReference,
     type AppClarification,
+    type AppDashboardReference,
+    type DataAppTemplate,
 } from '@lightdash/common';
 import { useCallback, useRef, useState } from 'react';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { useClarifyApp } from './useClarifyApp';
-import { type VizBuildRequest } from './useDataAppVizBuild';
 
-type Args = {
+/** What the clarifier is asked about, derived from the caller's request. */
+export type ClarifyParams = {
+    prompt: string;
+    template?: DataAppTemplate;
+    charts?: AppChartReference[];
+    dashboard?: AppDashboardReference;
+    fileIds?: string[];
+};
+
+type Args<TRequest> = {
     projectUuid: string | undefined;
     /** Only a first build clarifies; a revision is grounded in the version
      *  already on screen. */
     isFirstBuild: boolean;
-    onBuild: (request: VizBuildRequest) => void;
+    toClarifyParams: (request: TRequest) => ClarifyParams;
+    onBuild: (request: TRequest, clarifications: AppClarification[]) => void;
 };
 
-export type VizClarification = {
+export type ClarificationRound<TRequest> = {
     /** The round awaiting answers; null when no questions are on screen. */
     pending: { prompt: string; questions: string[] } | null;
     answers: string[];
@@ -24,7 +35,7 @@ export type VizClarification = {
     clarifyingPrompt: string | null;
     /** The clarifier could not be reached, so the build started as written. */
     fellThrough: boolean;
-    send: (request: VizBuildRequest) => void;
+    send: (request: TRequest) => void;
     answer: (index: number, value: string) => void;
     /** Build with the answers given so far, or with none when skipping. */
     build: (skip: boolean) => void;
@@ -33,21 +44,28 @@ export type VizClarification = {
     reset: () => void;
 };
 
-/** The clarifying round before a first build. The clarifier is advisory, so
- *  every outcome ends in a build; a round id stops a late response reopening
- *  questions the user has already moved past. */
-export const useVizClarification = ({
+/** The clarifying round before a first build, shared by both builders. The
+ *  clarifier is advisory, so every outcome ends in a build; a round id stops a
+ *  late response reopening questions the user has already moved past. */
+export const useClarificationRound = <TRequest>({
     projectUuid,
     isFirstBuild,
+    toClarifyParams,
     onBuild,
-}: Args): VizClarification => {
+}: Args<TRequest>): ClarificationRound<TRequest> => {
     const { mutateAsync: clarify } = useClarifyApp();
     const { track } = useTracking();
     const round = useRef(0);
     const inFlightRequest = useRef<AbortController | null>(null);
-    const [inFlight, setInFlight] = useState<VizBuildRequest | null>(null);
+    const [inFlight, setInFlight] = useState<{
+        request: TRequest;
+        prompt: string;
+        template: DataAppTemplate | undefined;
+    } | null>(null);
     const [pending, setPending] = useState<{
-        request: VizBuildRequest;
+        request: TRequest;
+        prompt: string;
+        template: DataAppTemplate | undefined;
         questions: string[];
     } | null>(null);
     const [answers, setAnswers] = useState<string[]>([]);
@@ -71,6 +89,9 @@ export const useVizClarification = ({
                 | 'answered'
                 | 'skipped'
                 | 'abandoned',
+            // Both builders report here, so the template is what tells the two
+            // surfaces apart — `data_app_viz` is the chart type builder.
+            template: DataAppTemplate | undefined,
             questionCount: number,
             answeredCount: number,
         ) =>
@@ -78,6 +99,7 @@ export const useVizClarification = ({
                 name: EventName.DATA_APP_CLARIFY_ROUND_RESOLVED,
                 properties: {
                     projectId: projectUuid,
+                    template: template ?? null,
                     outcome,
                     questionCount,
                     answeredCount,
@@ -87,47 +109,62 @@ export const useVizClarification = ({
     );
 
     const send = useCallback(
-        (request: VizBuildRequest) => {
+        (request: TRequest) => {
             setFellThrough(false);
             if (!isFirstBuild || !projectUuid) {
-                onBuild(request);
+                onBuild(request, []);
                 return;
             }
+            const params = toClarifyParams(request);
             round.current += 1;
             const current = round.current;
             const controller = new AbortController();
             inFlightRequest.current = controller;
-            setInFlight(request);
+            setInFlight({
+                request,
+                prompt: params.prompt,
+                template: params.template,
+            });
+            // Both handlers go to the same `then` on purpose: a chained
+            // `catch` would also catch a throw from the success path and build
+            // a second time on a round that already built. The terminal catch
+            // only ever sees such a throw, and the build reports its own
+            // failures, so there is nothing left to say about it here.
             void clarify({
                 projectUuid,
-                prompt: request.description,
-                template: DATA_APP_VIZ_TEMPLATE,
-                fileIds:
-                    request.fileIds.length > 0 ? request.fileIds : undefined,
+                ...params,
                 signal: controller.signal,
             })
-                .then(({ questions }) => {
-                    if (current !== round.current) return;
-                    inFlightRequest.current = null;
-                    setInFlight(null);
-                    if (questions.length === 0) {
-                        report('no_questions', 0, 0);
-                        onBuild(request);
-                        return;
-                    }
-                    setPending({ request, questions });
-                    setAnswers(questions.map(() => ''));
-                })
-                .catch(() => {
-                    if (current !== round.current) return;
-                    inFlightRequest.current = null;
-                    setInFlight(null);
-                    setFellThrough(true);
-                    report('unreachable', 0, 0);
-                    onBuild(request);
-                });
+                .then(
+                    ({ questions }) => {
+                        if (current !== round.current) return;
+                        inFlightRequest.current = null;
+                        setInFlight(null);
+                        if (questions.length === 0) {
+                            report('no_questions', params.template, 0, 0);
+                            onBuild(request, []);
+                            return;
+                        }
+                        setPending({
+                            request,
+                            prompt: params.prompt,
+                            template: params.template,
+                            questions,
+                        });
+                        setAnswers(questions.map(() => ''));
+                    },
+                    () => {
+                        if (current !== round.current) return;
+                        inFlightRequest.current = null;
+                        setInFlight(null);
+                        setFellThrough(true);
+                        report('unreachable', params.template, 0, 0);
+                        onBuild(request, []);
+                    },
+                )
+                .catch(() => {});
         },
-        [clarify, isFirstBuild, onBuild, projectUuid, report],
+        [clarify, isFirstBuild, onBuild, projectUuid, report, toClarifyParams],
     );
 
     const answer = useCallback((index: number, value: string) => {
@@ -153,32 +190,30 @@ export const useVizClarification = ({
             reset();
             report(
                 clarifications.length > 0 ? 'answered' : 'skipped',
+                pending.template,
                 pending.questions.length,
                 clarifications.length,
             );
-            onBuild({ ...request, clarifications });
+            onBuild(request, clarifications);
         },
         [answers, onBuild, pending, report, reset],
     );
 
     const abandon = useCallback(() => {
-        const prompt = pending?.request.description ?? inFlight?.description;
-        if (prompt === undefined) return null;
+        const active = pending ?? inFlight;
+        if (!active) return null;
         const questionCount = pending?.questions.length ?? 0;
         reset();
-        report('abandoned', questionCount, 0);
-        return prompt;
+        report('abandoned', active.template, questionCount, 0);
+        return active.prompt;
     }, [inFlight, pending, report, reset]);
 
     return {
         pending: pending
-            ? {
-                  prompt: pending.request.description,
-                  questions: pending.questions,
-              }
+            ? { prompt: pending.prompt, questions: pending.questions }
             : null,
         answers,
-        clarifyingPrompt: inFlight?.description ?? null,
+        clarifyingPrompt: inFlight?.prompt ?? null,
         fellThrough,
         send,
         answer,

--- a/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
@@ -13,7 +13,7 @@ import {
 import { useMutation } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
-type GenerateAppParams = {
+export type GenerateAppParams = {
     projectUuid: string;
     prompt: string;
     template?: DataAppTemplate;

--- a/packages/frontend/src/features/apps/testing/clarificationRoundStub.ts
+++ b/packages/frontend/src/features/apps/testing/clarificationRoundStub.ts
@@ -1,10 +1,11 @@
 import { vi } from 'vitest';
-import { type VizClarification } from '../hooks/useVizClarification';
+import { type ClarificationRound } from '../hooks/useClarificationRound';
+import { type VizBuildRequest } from '../hooks/useDataAppVizBuild';
 
 /** A clarifying round with nothing on screen. */
 export const clarificationStub = (
-    overrides: Partial<VizClarification> = {},
-): VizClarification => ({
+    overrides: Partial<ClarificationRound<VizBuildRequest>> = {},
+): ClarificationRound<VizBuildRequest> => ({
     pending: null,
     answers: [],
     clarifyingPrompt: null,

--- a/packages/frontend/src/features/apps/utils/appBuildRequest.test.ts
+++ b/packages/frontend/src/features/apps/utils/appBuildRequest.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+    toAppClarifyParams,
+    toAppGeneratePayload,
+    type AppBuildRequest,
+} from './appBuildRequest';
+
+const request = (
+    overrides: Partial<AppBuildRequest> = {},
+): AppBuildRequest => ({
+    prompt: 'a dashboard that shows performance',
+    template: 'dashboard',
+    fileIds: ['file-1'],
+    appUuid: 'app-1',
+    charts: [{ uuid: 'chart-1', includeSampleData: true, linkLive: false }],
+    dashboard: { uuid: 'dashboard-1', includeSampleData: false },
+    externalConnections: [
+        { externalConnectionUuid: 'conn-1', alias: 'warehouse' },
+    ],
+    spaceUuid: 'space-1',
+    modelRequest: { claudeModel: 'sonnet' },
+    designUuid: 'design-1',
+    ...overrides,
+});
+
+describe('toAppGeneratePayload', () => {
+    it('carries every snapshotted field onto the generate call', () => {
+        expect(toAppGeneratePayload('project-1', request(), [])).toEqual({
+            projectUuid: 'project-1',
+            prompt: 'a dashboard that shows performance',
+            template: 'dashboard',
+            creationExperience: 'app_builder',
+            fileIds: ['file-1'],
+            appUuid: 'app-1',
+            charts: [
+                { uuid: 'chart-1', includeSampleData: true, linkLive: false },
+            ],
+            dashboard: { uuid: 'dashboard-1', includeSampleData: false },
+            externalConnections: [
+                { externalConnectionUuid: 'conn-1', alias: 'warehouse' },
+            ],
+            clarifications: undefined,
+            spaceUuid: 'space-1',
+            claudeModel: 'sonnet',
+            designUuid: 'design-1',
+        });
+    });
+
+    it('sends answers when the round produced any', () => {
+        const clarifications = [{ question: 'Over time?', answer: 'monthly' }];
+
+        expect(
+            toAppGeneratePayload('project-1', request(), clarifications)
+                .clarifications,
+        ).toEqual(clarifications);
+    });
+
+    it('carries a snapshotted Codex model onto the generate call', () => {
+        expect(
+            toAppGeneratePayload(
+                'project-1',
+                request({ modelRequest: { codexModel: 'gpt-5.6-terra' } }),
+                [],
+            ),
+        ).toMatchObject({ codexModel: 'gpt-5.6-terra' });
+    });
+
+    it('omits an empty round rather than sending an empty array', () => {
+        expect(
+            toAppGeneratePayload('project-1', request(), []).clarifications,
+        ).toBeUndefined();
+    });
+
+    it('keeps an explicit opt-out of a theme distinct from no choice', () => {
+        expect(
+            toAppGeneratePayload('project-1', request({ designUuid: null }), [])
+                .designUuid,
+        ).toBeNull();
+    });
+});
+
+describe('toAppClarifyParams', () => {
+    it('asks the clarifier about the prompt and its attachments', () => {
+        expect(toAppClarifyParams(request())).toEqual({
+            prompt: 'a dashboard that shows performance',
+            template: 'dashboard',
+            charts: [
+                { uuid: 'chart-1', includeSampleData: true, linkLive: false },
+            ],
+            dashboard: { uuid: 'dashboard-1', includeSampleData: false },
+            fileIds: ['file-1'],
+        });
+    });
+
+    it('never leaks build-only choices into the clarify request', () => {
+        const params = toAppClarifyParams(request());
+
+        expect(params).not.toHaveProperty('claudeModel');
+        expect(params).not.toHaveProperty('codexModel');
+        expect(params).not.toHaveProperty('modelRequest');
+        expect(params).not.toHaveProperty('designUuid');
+        expect(params).not.toHaveProperty('spaceUuid');
+        expect(params).not.toHaveProperty('appUuid');
+    });
+});

--- a/packages/frontend/src/features/apps/utils/appBuildRequest.ts
+++ b/packages/frontend/src/features/apps/utils/appBuildRequest.ts
@@ -1,0 +1,56 @@
+import {
+    type AppChartReference,
+    type AppClarification,
+    type AppDashboardReference,
+    type AppExternalConnectionReference,
+    type DataAppTemplate,
+} from '@lightdash/common';
+import { type ClarifyParams } from '../hooks/useClarificationRound';
+import { type DataAppModelSelection } from '../hooks/useDataAppModelSelection';
+import { type GenerateAppParams } from '../hooks/useGenerateApp';
+
+/** Everything the generate call needs, snapshotted at submit time so a
+ *  mid-round model or theme switch cannot change what the build runs against. */
+export type AppBuildRequest = {
+    prompt: string;
+    template: DataAppTemplate | undefined;
+    fileIds: string[] | undefined;
+    appUuid: string;
+    charts: AppChartReference[] | undefined;
+    dashboard: AppDashboardReference | undefined;
+    externalConnections: AppExternalConnectionReference[] | undefined;
+    spaceUuid: string | undefined;
+    modelRequest: DataAppModelSelection['modelRequest'];
+    designUuid: string | null;
+};
+
+export const toAppClarifyParams = (
+    request: AppBuildRequest,
+): ClarifyParams => ({
+    prompt: request.prompt,
+    template: request.template,
+    charts: request.charts,
+    dashboard: request.dashboard,
+    fileIds: request.fileIds,
+});
+
+export const toAppGeneratePayload = (
+    projectUuid: string,
+    request: AppBuildRequest,
+    clarifications: AppClarification[],
+): GenerateAppParams => ({
+    projectUuid,
+    prompt: request.prompt,
+    template: request.template,
+    creationExperience: 'app_builder',
+    fileIds: request.fileIds,
+    appUuid: request.appUuid,
+    charts: request.charts,
+    dashboard: request.dashboard,
+    externalConnections: request.externalConnections,
+    // An empty round is the same as no round at all to the backend.
+    clarifications: clarifications.length > 0 ? clarifications : undefined,
+    spaceUuid: request.spaceUuid,
+    ...request.modelRequest,
+    designUuid: request.designUuid,
+});

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -7,9 +7,7 @@ import {
     isAppVersionInProgress,
     MAX_APP_FILES_PER_VERSION,
     type ApiAppVersionSummary,
-    type AppChartReference,
     type AppClarification,
-    type AppDashboardReference,
     type AppExternalConnectionReference,
     type AppVersionDependencyEntry,
     type DataAppTemplate,
@@ -52,6 +50,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import {
     useCallback,
     useEffect,
+    useLayoutEffect,
     useMemo,
     useRef,
     useState,
@@ -111,11 +110,8 @@ import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
 import { useAppThumbnailUpload } from '../features/apps/hooks/useAppThumbnail';
 import { useBuildNotification } from '../features/apps/hooks/useBuildNotification';
 import { useCancelAppVersion } from '../features/apps/hooks/useCancelAppVersion';
-import { useClarifyApp } from '../features/apps/hooks/useClarifyApp';
-import {
-    useDataAppModelSelection,
-    type DataAppModelSelection,
-} from '../features/apps/hooks/useDataAppModelSelection';
+import { useClarificationRound } from '../features/apps/hooks/useClarificationRound';
+import { useDataAppModelSelection } from '../features/apps/hooks/useDataAppModelSelection';
 import { useGenerateApp } from '../features/apps/hooks/useGenerateApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useIterateApp } from '../features/apps/hooks/useIterateApp';
@@ -127,6 +123,11 @@ import {
 } from '../features/apps/hooks/useTrackedAppQueries';
 import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExternalRequests';
 import { getTemplate } from '../features/apps/templates';
+import {
+    toAppClarifyParams,
+    toAppGeneratePayload,
+    type AppBuildRequest,
+} from '../features/apps/utils/appBuildRequest';
 import {
     getAppFileValidationError,
     isSupportedAppImage,
@@ -548,32 +549,6 @@ const AppGenerate: FC = () => {
         setFocusedQueryUuid(null);
     }, []);
     const [localMessages, setLocalMessages] = useState<ChatMessage[]>([]);
-    // Pre-build clarification round: captured submission args that we need
-    // to fire the actual generate call once the user answers the questions.
-    // Non-null only between "user submitted prompt" and "user clicked Build
-    // on the questions bubble". Always cleared once generate fires.
-    const [pendingClarification, setPendingClarification] = useState<{
-        questions: string[];
-        prompt: string;
-        template: DataAppTemplate | undefined;
-        fileIds: string[] | undefined;
-        appUuid: string;
-        charts: AppChartReference[] | undefined;
-        dashboard: AppDashboardReference | undefined;
-        externalConnections: AppExternalConnectionReference[] | undefined;
-        spaceUuid: string | undefined;
-        // Snapshot of the provider-specific model request at submit time so a mid-clarification
-        // model switch doesn't change which model the build kicks off with —
-        // the user's intent was captured when they pressed send.
-        modelRequest: DataAppModelSelection['modelRequest'];
-        // Same intent-snapshot reasoning as modelRequest — capture the picked
-        // theme at submit time so flipping the picker mid-clarification
-        // doesn't change what the build runs against.
-        designUuid: string | null;
-    } | null>(null);
-    const [clarificationAnswers, setClarificationAnswers] = useState<string[]>(
-        [],
-    );
     // Maps prompt text → image preview URL so the thumbnail survives the
     // local→server message transition (localMessages get cleared when server
     // version data arrives, but the ref persists).
@@ -616,6 +591,23 @@ const AppGenerate: FC = () => {
         },
         [projectUuid, queryClient],
     );
+    // Assigned further down, once the generate mutation and its callbacks are
+    // in scope; only ever called from an event, never during render.
+    const runBuildRef = useRef<
+        (request: AppBuildRequest, clarifications: AppClarification[]) => void
+    >(() => {});
+    const onClarifiedBuild = useCallback(
+        (request: AppBuildRequest, clarifications: AppClarification[]) =>
+            runBuildRef.current(request, clarifications),
+        [],
+    );
+    const clarification = useClarificationRound<AppBuildRequest>({
+        projectUuid,
+        isFirstBuild: !activeAppUuid,
+        toClarifyParams: toAppClarifyParams,
+        onBuild: onClarifiedBuild,
+    });
+    const { reset: resetClarification } = clarification;
     // Track the previous app UUID so we can detect intentional navigation
     // vs. the post-submit URL update (undefined → newUuid).
     const prevUrlAppUuid = useRef(urlAppUuid);
@@ -643,8 +635,7 @@ const AppGenerate: FC = () => {
         setFocusedQueryUuid(null);
         setSelectedTemplate(null);
         setThemeChipOverride(null);
-        setPendingClarification(null);
-        setClarificationAnswers([]);
+        resetClarification();
         setTestVizContext(null);
         setIsChatPanelCollapsed(false);
         versionCacheRef.current.clear();
@@ -654,7 +645,7 @@ const AppGenerate: FC = () => {
         );
         sentImagesByPrompt.current.clear();
         sentFilesByPrompt.current.clear();
-    }, [resetQueries, clearExternalRequests]);
+    }, [resetQueries, clearExternalRequests, resetClarification]);
     useEffect(() => {
         const prev = prevUrlAppUuid.current;
         prevUrlAppUuid.current = urlAppUuid;
@@ -680,8 +671,69 @@ const AppGenerate: FC = () => {
         isLoading: isIterating,
         reset: resetIterate,
     } = useIterateApp();
-    const { mutateAsync: clarifyMutateAsync, isLoading: isClarifying } =
-        useClarifyApp();
+
+    const buildSubmitCallbacks = useCallback(
+        () => ({
+            onSuccess: (data: { appUuid: string; version: number }) => {
+                setActiveAppUuid(data.appUuid);
+                invalidateAppData(data.appUuid);
+                if (!urlAppUuid) {
+                    void navigate(
+                        `/projects/${projectUuid}/apps/${data.appUuid}`,
+                        { replace: true },
+                    );
+                }
+            },
+            onError: (err: unknown) => {
+                // The mutation rejects with an ApiError object (not an Error
+                // instance), so read its message before falling back.
+                const errorMessage = isApiError(err)
+                    ? err.error.message
+                    : err instanceof Error
+                      ? err.message
+                      : 'Failed to generate app';
+                setLocalMessages((prev) => [
+                    ...prev,
+                    {
+                        ...emptyChatMessage(),
+                        role: 'assistant' as const,
+                        status: 'error' as const,
+                        content: errorMessage,
+                        timestamp: new Date(),
+                    },
+                ]);
+            },
+        }),
+        [invalidateAppData, navigate, projectUuid, urlAppUuid],
+    );
+
+    // The generate half of a submit, deferred until the clarifying round (if
+    // any) resolves. Answers ride along and are echoed on the user's bubble.
+    // Assigned in a layout effect, and above the page's early returns, so a
+    // guarded render can neither skip the hook nor leave a stale closure.
+    useLayoutEffect(() => {
+        runBuildRef.current = (request, clarifications) => {
+            if (clarifications.length > 0) {
+                setLocalMessages((prev) => {
+                    const lastUserIdx = prev.findLastIndex(
+                        (m) => m.role === 'user',
+                    );
+                    if (lastUserIdx === -1) return prev;
+                    const next = [...prev];
+                    next[lastUserIdx] = {
+                        ...next[lastUserIdx],
+                        clarifications,
+                    };
+                    return next;
+                });
+            }
+            resetGenerate();
+            generateMutate(
+                toAppGeneratePayload(projectUuid!, request, clarifications),
+                buildSubmitCallbacks(),
+            );
+        };
+    }, [buildSubmitCallbacks, generateMutate, projectUuid, resetGenerate]);
     const { mutate: cancelMutate, isLoading: isCancelling } =
         useCancelAppVersion();
     const {
@@ -805,7 +857,8 @@ const AppGenerate: FC = () => {
     // stays enabled so the next prompt can be drafted), and a pending
     // unanswered clarification keeps send disabled until the user clicks
     // "Build" on the question bubble.
-    const hasPendingClarification = pendingClarification !== null;
+    const hasPendingClarification = clarification.pending !== null;
+    const isClarifying = clarification.clarifyingPrompt !== null;
     // Server-side work that warrants showing a placeholder assistant bubble.
     // Excludes `isSubmitting` (client-side upload — too early to claim
     // generation has started) and `hasPendingClarification` (drives its own
@@ -1474,37 +1527,6 @@ const AppGenerate: FC = () => {
         }
     };
 
-    const buildSubmitCallbacks = () => ({
-        onSuccess: (data: { appUuid: string; version: number }) => {
-            setActiveAppUuid(data.appUuid);
-            invalidateAppData(data.appUuid);
-            if (!urlAppUuid) {
-                void navigate(`/projects/${projectUuid}/apps/${data.appUuid}`, {
-                    replace: true,
-                });
-            }
-        },
-        onError: (err: unknown) => {
-            // The mutation rejects with an ApiError object (not an Error
-            // instance), so read its message before falling back.
-            const errorMessage = isApiError(err)
-                ? err.error.message
-                : err instanceof Error
-                  ? err.message
-                  : 'Failed to generate app';
-            setLocalMessages((prev) => [
-                ...prev,
-                {
-                    ...emptyChatMessage(),
-                    role: 'assistant' as const,
-                    status: 'error' as const,
-                    content: errorMessage,
-                    timestamp: new Date(),
-                },
-            ]);
-        },
-    });
-
     const handleSubmit = async () => {
         const typed = (promptEditorRef.current?.getText() ?? '').trim();
         if (
@@ -1561,11 +1583,11 @@ const AppGenerate: FC = () => {
 
             // For new apps, pre-generate the UUID so the image upload and
             // the generate request both use the same app-scoped S3 path.
-            const newAppUuid = activeAppUuid ? undefined : uuid4();
-            const targetAppUuid = activeAppUuid ?? newAppUuid;
-            if (newAppUuid) {
+            const isFirstBuild = !activeAppUuid;
+            const targetAppUuid = activeAppUuid ?? uuid4();
+            if (isFirstBuild) {
                 setThemeChipOverride({
-                    appUuid: newAppUuid,
+                    appUuid: targetAppUuid,
                     designUuid: selectedThemeUuid,
                 });
             }
@@ -1585,7 +1607,7 @@ const AppGenerate: FC = () => {
                         const result = await uploadFile({
                             projectUuid: projectUuid!,
                             file: att.file,
-                            appUuid: targetAppUuid!,
+                            appUuid: targetAppUuid,
                             kind: att.kind,
                         });
                         ids.push(result.fileId);
@@ -1686,56 +1708,6 @@ const AppGenerate: FC = () => {
             resetGenerate();
             resetIterate();
 
-            // Pre-build clarification: first-build only. The clarifier runs for
-            // every template — the questions adapt to the kind of app being
-            // built (template is passed through). Iteration prompts skip
-            // clarification entirely — by then intent is already grounded in
-            // the existing version.
-            const isFirstBuild = !activeAppUuid;
-            if (isFirstBuild && newAppUuid) {
-                try {
-                    const { questions } = await clarifyMutateAsync({
-                        projectUuid: projectUuid!,
-                        prompt: trimmed,
-                        template: starterTemplate,
-                        charts,
-                        dashboard,
-                        fileIds,
-                    });
-                    if (questions.length > 0) {
-                        setPendingClarification({
-                            questions,
-                            prompt: trimmed,
-                            template: starterTemplate,
-                            fileIds,
-                            appUuid: newAppUuid,
-                            charts,
-                            dashboard,
-                            externalConnections,
-                            spaceUuid: targetSpaceUuid,
-                            modelRequest,
-                            designUuid: selectedThemeUuid,
-                        });
-                        setClarificationAnswers(
-                            new Array(questions.length).fill(''),
-                        );
-                        return;
-                    }
-                    // No questions returned — fall through and build immediately.
-                } catch (err) {
-                    // Clarify failed (model not configured, network, etc.) — fall
-                    // back to the original behavior and just build. We don't want
-                    // a clarifier outage to block the actual feature.
-                    // eslint-disable-next-line no-console
-                    console.warn(
-                        'App clarification failed; proceeding to build',
-                        err,
-                    );
-                }
-            }
-
-            const callbacks = buildSubmitCallbacks();
-
             if (activeAppUuid) {
                 iterateMutate(
                     {
@@ -1749,97 +1721,28 @@ const AppGenerate: FC = () => {
                         ...modelRequest,
                         externalConnections,
                     },
-                    callbacks,
+                    buildSubmitCallbacks(),
                 );
             } else {
-                generateMutate(
-                    {
-                        projectUuid,
-                        prompt: trimmed,
-                        template: starterTemplate,
-                        creationExperience: 'app_builder',
-                        fileIds,
-                        appUuid: newAppUuid,
-                        charts,
-                        dashboard,
-                        spaceUuid: targetSpaceUuid,
-                        ...modelRequest,
-                        designUuid: selectedThemeUuid,
-                        externalConnections,
-                    },
-                    callbacks,
-                );
+                // A first build clarifies before generating; the round calls
+                // back into runBuildRef once it resolves, answered or not.
+                clarification.send({
+                    prompt: trimmed,
+                    template: starterTemplate,
+                    fileIds,
+                    appUuid: targetAppUuid,
+                    charts,
+                    dashboard,
+                    externalConnections,
+                    spaceUuid: targetSpaceUuid,
+                    modelRequest,
+                    designUuid: selectedThemeUuid,
+                });
             }
         } finally {
             isSubmittingRef.current = false;
             setIsSubmitting(false);
         }
-    };
-
-    /**
-     * Submit the user's answers to the clarification questions and start the
-     * actual build. Called by both the "Build" button (which folds answers
-     * into the generate request as `clarifications`) and the "Skip" link
-     * (which fires generate without any clarifications, as if the questions
-     * had never been asked).
-     */
-    const handleSubmitClarification = (skip: boolean) => {
-        if (!pendingClarification) return;
-
-        const clarifications: AppClarification[] = skip
-            ? []
-            : pendingClarification.questions
-                  .map((question, i) => ({
-                      question,
-                      answer: (clarificationAnswers[i] ?? '').trim(),
-                  }))
-                  // Drop empty answers — they don't help the model and just
-                  // make the prompt noisier. Same effect as "Skip" for that
-                  // particular question.
-                  .filter((c) => c.answer.length > 0);
-
-        // Attach the Q&A to the user bubble that handleSubmit just added.
-        // The backend persists the same array on `resources.clarifications`
-        // so the local→server transition is seamless.
-        if (clarifications.length > 0) {
-            setLocalMessages((prev) => {
-                const lastUserIdx = prev.findLastIndex(
-                    (m) => m.role === 'user',
-                );
-                if (lastUserIdx === -1) return prev;
-                const next = [...prev];
-                next[lastUserIdx] = {
-                    ...next[lastUserIdx],
-                    clarifications,
-                };
-                return next;
-            });
-        }
-
-        const captured = pendingClarification;
-        setPendingClarification(null);
-        setClarificationAnswers([]);
-        resetGenerate();
-
-        generateMutate(
-            {
-                projectUuid: projectUuid!,
-                prompt: captured.prompt,
-                template: captured.template,
-                creationExperience: 'app_builder',
-                fileIds: captured.fileIds,
-                appUuid: captured.appUuid,
-                charts: captured.charts,
-                dashboard: captured.dashboard,
-                externalConnections: captured.externalConnections,
-                clarifications:
-                    clarifications.length > 0 ? clarifications : undefined,
-                spaceUuid: captured.spaceUuid,
-                ...captured.modelRequest,
-                designUuid: captured.designUuid,
-            },
-            buildSubmitCallbacks(),
-        );
     };
 
     const handleCancel = () => {
@@ -1959,7 +1862,7 @@ const AppGenerate: FC = () => {
                                 <>
                                     <Box
                                         className={`${classes.chatMessageGroup}${
-                                            pendingClarification
+                                            hasPendingClarification
                                                 ? ` ${classes.dimmedHistory}`
                                                 : ''
                                         }`}
@@ -2390,7 +2293,7 @@ const AppGenerate: FC = () => {
                                             ),
                                         )}
                                     </Box>
-                                    {pendingClarification ? (
+                                    {clarification.pending ? (
                                         <Box
                                             className={classes.clarifyContainer}
                                         >
@@ -2399,27 +2302,18 @@ const AppGenerate: FC = () => {
                                             </Text>
                                             <ClarificationQuestionList
                                                 questions={
-                                                    pendingClarification.questions
+                                                    clarification.pending
+                                                        .questions
                                                 }
-                                                answers={clarificationAnswers}
-                                                onAnswer={(index, value) =>
-                                                    setClarificationAnswers(
-                                                        (current) => {
-                                                            const next = [
-                                                                ...current,
-                                                            ];
-                                                            next[index] = value;
-                                                            return next;
-                                                        },
-                                                    )
-                                                }
+                                                answers={clarification.answers}
+                                                onAnswer={clarification.answer}
                                             />
                                             <Group gap="xs" justify="flex-end">
                                                 <Button
                                                     variant="subtle"
                                                     size="xs"
                                                     onClick={() =>
-                                                        handleSubmitClarification(
+                                                        clarification.build(
                                                             true,
                                                         )
                                                     }
@@ -2429,7 +2323,7 @@ const AppGenerate: FC = () => {
                                                 <Button
                                                     size="xs"
                                                     onClick={() =>
-                                                        handleSubmitClarification(
+                                                        clarification.build(
                                                             false,
                                                         )
                                                     }

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -12,13 +12,14 @@ import {
 } from '../features/apps/hooks/useAppVersionHistory';
 import { useCanCreateDataApp } from '../features/apps/hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
+import { useClarificationRound } from '../features/apps/hooks/useClarificationRound';
 import { useDataAppVisualization } from '../features/apps/hooks/useDataAppVisualization';
 import { useDataAppVizBuild } from '../features/apps/hooks/useDataAppVizBuild';
+import { type VizBuildRequest } from '../features/apps/hooks/useDataAppVizBuild';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
-import { useVizClarification } from '../features/apps/hooks/useVizClarification';
 import { appVersion } from '../features/apps/testing/appVersionHistory';
+import { clarificationStub } from '../features/apps/testing/clarificationRoundStub';
 import { buildStub } from '../features/apps/testing/dataAppVizBuildStub';
-import { clarificationStub } from '../features/apps/testing/vizClarificationStub';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { renderWithProviders } from '../testing/testUtils';
 import ChartTypeBuilder from './ChartTypeBuilder';
@@ -44,8 +45,8 @@ vi.mock('../features/apps/hooks/useDataAppVizBuild', () => ({
 vi.mock('../features/apps/hooks/useDataAppVisualization', () => ({
     useDataAppVisualization: vi.fn(),
 }));
-vi.mock('../features/apps/hooks/useVizClarification', () => ({
-    useVizClarification: vi.fn(),
+vi.mock('../features/apps/hooks/useClarificationRound', () => ({
+    useClarificationRound: vi.fn(),
 }));
 vi.mock('../features/apps/hooks/useAppBuildPoller', () => ({
     useAppBuildPoller: vi.fn(),
@@ -163,6 +164,10 @@ const builderRoutes = (path: string) => (
 const renderBuilder = (path: string) =>
     renderWithProviders(builderRoutes(path));
 
+const mockedClarificationRound = vi.mocked(
+    useClarificationRound<VizBuildRequest>,
+);
+
 describe('ChartTypeBuilder', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -170,7 +175,7 @@ describe('ChartTypeBuilder', () => {
         vi.mocked(useCanCreateDataApp).mockReturnValue(true);
         vi.mocked(useCanEditDataApp).mockReturnValue(true);
         vi.mocked(useDataAppVizBuild).mockReturnValue(buildStub());
-        vi.mocked(useVizClarification).mockReturnValue(clarificationStub());
+        mockedClarificationRound.mockReturnValue(clarificationStub());
         vi.mocked(useDataAppVisualization).mockReturnValue({
             data: undefined,
         } as ReturnType<typeof useDataAppVisualization>);
@@ -591,25 +596,25 @@ describe('ChartTypeBuilder', () => {
 
     it('clarifies a first prompt, but never a revision', () => {
         renderBuilder('/projects/p1/chart-types/new');
-        expect(vi.mocked(useVizClarification).mock.lastCall?.[0]).toMatchObject(
-            { isFirstBuild: true },
-        );
+        expect(mockedClarificationRound.mock.lastCall?.[0]).toMatchObject({
+            isFirstBuild: true,
+        });
 
         setApp(appMeta());
         vi.mocked(useAppVersionHistory).mockReturnValue(
             historyStub([appVersion({ version: 1, status: 'ready' })], 1),
         );
         renderBuilder('/projects/p1/chart-types/viz-1');
-        expect(vi.mocked(useVizClarification).mock.lastCall?.[0]).toMatchObject(
-            { isFirstBuild: false },
-        );
+        expect(mockedClarificationRound.mock.lastCall?.[0]).toMatchObject({
+            isFirstBuild: false,
+        });
     });
 
     it('says when a build started without the clarifier', () => {
         vi.mocked(useDataAppVizBuild).mockReturnValue(
             buildStub({ isBuilding: true, pendingPrompt: 'show revenue' }),
         );
-        vi.mocked(useVizClarification).mockReturnValue(
+        mockedClarificationRound.mockReturnValue(
             clarificationStub({ fellThrough: true }),
         );
         renderBuilder('/projects/p1/chart-types/new');

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -2,6 +2,7 @@ import {
     DATA_APP_VIZ_TEMPLATE,
     FeatureFlags,
     isAppVersionInProgress,
+    type AppClarification,
     type DataAppVizOptionValue,
     type DataAppVizOptionValues,
 } from '@lightdash/common';
@@ -30,12 +31,18 @@ import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppVersionHistory } from '../features/apps/hooks/useAppVersionHistory';
 import { useCanCreateDataApp } from '../features/apps/hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
+import {
+    useClarificationRound,
+    type ClarifyParams,
+} from '../features/apps/hooks/useClarificationRound';
 import { useDataAppModelSelection } from '../features/apps/hooks/useDataAppModelSelection';
 import { useDataAppVisualization } from '../features/apps/hooks/useDataAppVisualization';
-import { useDataAppVizBuild } from '../features/apps/hooks/useDataAppVizBuild';
+import {
+    useDataAppVizBuild,
+    type VizBuildRequest,
+} from '../features/apps/hooks/useDataAppVizBuild';
 import { useElapsedClock } from '../features/apps/hooks/useElapsedClock';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
-import { useVizClarification } from '../features/apps/hooks/useVizClarification';
 import { buildSampleVizContext } from '../features/apps/utils/sampleVizContext';
 import { useResolvedColorPalette } from '../hooks/appearance/useResolvedColorPalette';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
@@ -48,6 +55,12 @@ const noop = () => undefined;
  * (create) and `chart-types/:dataAppVizUuid` (edit); the create flow
  * adopts the new uuid into the URL once the first build is accepted.
  */
+const toVizClarifyParams = (request: VizBuildRequest): ClarifyParams => ({
+    prompt: request.description,
+    template: DATA_APP_VIZ_TEMPLATE,
+    fileIds: request.fileIds.length > 0 ? request.fileIds : undefined,
+});
+
 const ChartTypeBuilder: FC = () => {
     const { projectUuid, dataAppVizUuid: urlVizUuid } = useParams<{
         projectUuid: string;
@@ -74,12 +87,22 @@ const ChartTypeBuilder: FC = () => {
         onCreated: noop,
     });
 
+    // Depend on the send function, not on `build` — that is a fresh object
+    // every render, so the memo would never hold.
+    const sendBuild = build.send;
+    const onClarifiedBuild = useCallback(
+        (request: VizBuildRequest, clarifications: AppClarification[]) =>
+            sendBuild({ ...request, clarifications }),
+        [sendBuild],
+    );
+
     // Questions only before the first build: once a version exists, intent is
     // grounded in what is on screen.
-    const clarification = useVizClarification({
+    const clarification = useClarificationRound<VizBuildRequest>({
         projectUuid,
         isFirstBuild: activeVizUuid === undefined,
-        onBuild: build.send,
+        toClarifyParams: toVizClarifyParams,
+        onBuild: onClarifiedBuild,
     });
     const { reset: resetClarification } = clarification;
 

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -2,6 +2,7 @@ import {
     type AppVersionStatus,
     type AiDeepResearchTerminalStatus,
     type CustomFormatType,
+    type DataAppTemplate,
     type HomepageRecommendedActionKey,
     type SearchItemType,
     type TableCalculationType,
@@ -626,6 +627,9 @@ type DataAppClarifyRoundResolvedEvent = {
     name: EventName.DATA_APP_CLARIFY_ROUND_RESOLVED;
     properties: {
         projectId: string | undefined;
+        /** Which builder the round came from: `data_app_viz` is the chart type
+         *  builder, anything else the app builder. */
+        template: DataAppTemplate | null;
         outcome:
             | 'no_questions'
             | 'unreachable'


### PR DESCRIPTION
### Description:

Stacked on #27555. Frontend only, no behaviour change intended for the chart type builder.

The app builder already had a pre-build clarifying round, written inline in `handleSubmit`. #27555 added a second one for the chart type builder and shared only the question list component, so the state machine existed twice: gate on first build, call clarify, hold the questions, fall through to a build on empty or on error, then trim and filter the answers into `clarifications`.

`useVizClarification` becomes `useClarificationRound<TRequest>`. The caller maps its own request onto the clarify params and gets the answers handed back, so the app builder keeps its fat generate payload and the chart type builder keeps `VizBuildRequest` without either knowing about the other.

The app builder gains what it was missing: a round id, so a late clarify response can no longer reopen a round the user has already answered or walked away from, and an `AbortSignal` so an abandoned round stops the work server-side. It also loses a `console.warn` in favour of the `unreachable` outcome on the event.

https://linear.app/lightdash/issue/PROD-10262
