### PR TITLE
feat: role-set management UI for org, project and group access

### DIFF
--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -54,6 +54,16 @@ type DbOrganizationMemberProfile = {
     avatar_content_hash: string | null;
 };
 
+const hasExtraRolesColumn = (db: Knex) =>
+    db.raw(
+        `EXISTS (SELECT 1 FROM ?? AS x WHERE x.organization_id = ??.organization_id AND x.user_id = ??.user_id) AS has_extra_roles`,
+        [
+            OrganizationMembershipCustomRolesTableName,
+            OrganizationMembershipsTableName,
+            OrganizationMembershipsTableName,
+        ],
+    );
+
 const selectColumns = (db: Knex) => [
     `${UserTableName}.user_uuid`,
     `${UserTableName}.user_id`,
@@ -69,14 +79,7 @@ const selectColumns = (db: Knex) => [
     `${UserTableName}.updated_at as user_updated_at`,
     `${UserTableName}.avatar_gradient`,
     `${UserAvatarsTableName}.content_hash as avatar_content_hash`,
-    db.raw(
-        `EXISTS (SELECT 1 FROM ?? AS x WHERE x.organization_id = ??.organization_id AND x.user_id = ??.user_id) AS has_extra_roles`,
-        [
-            OrganizationMembershipCustomRolesTableName,
-            OrganizationMembershipsTableName,
-            OrganizationMembershipsTableName,
-        ],
-    ),
+    hasExtraRolesColumn(db),
 ];
 
 export class OrganizationMemberProfileModel {
@@ -411,6 +414,8 @@ export class OrganizationMemberProfileModel {
                 `${UserTableName}.is_active`,
                 `${EmailTableName}.email`,
                 `${OrganizationTableName}.organization_uuid`,
+                `${OrganizationMembershipsTableName}.organization_id`,
+                `${OrganizationMembershipsTableName}.user_id`,
                 `${OrganizationMembershipsTableName}.role`,
                 `${OrganizationMembershipsTableName}.role_uuid`,
                 `${InviteLinkTableName}.expires_at`,
@@ -432,6 +437,7 @@ export class OrganizationMemberProfileModel {
                 `${UserTableName}.updated_at as user_updated_at`,
                 `${UserTableName}.avatar_gradient`,
                 `${UserAvatarsTableName}.content_hash as avatar_content_hash`,
+                hasExtraRolesColumn(this.database),
             )
             .select<DbOrganizationMemberProfile[]>(
                 this.database.raw(

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -289,6 +289,8 @@ import { type ApiRoadmapResponse } from './roadmap';
 import {
     type ApiCustomRoleAsCodeListResponse,
     type ApiCustomRoleAsCodeUpsertResponse,
+    type ApiOrganizationRoleSetResponse,
+    type ApiProjectRoleSetResponse,
 } from './roles';
 import {
     type ApiCalculateSubtotalsResponse,
@@ -1276,6 +1278,8 @@ type ApiResults =
     | ApiAgentAsCodeUpsertResponse['results']
     | ApiCustomRoleAsCodeListResponse['results']
     | ApiCustomRoleAsCodeUpsertResponse['results']
+    | ApiOrganizationRoleSetResponse['results']
+    | ApiProjectRoleSetResponse['results']
     | ApiUserAsCodeListResponse['results']
     | ApiUserAsCodeUpsertResponse['results']
     | ApiAlertAsCodeListResponse['results']

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -32,6 +32,11 @@ import {
 } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useCallback, useMemo, useState, type FC, type ReactNode } from 'react';
+import { ProjectRoleSetCell } from '../../features/roleSets/components/ProjectRoleSetCell';
+import {
+    useMultipleRolesEnabled,
+    useReplaceProjectUserRoleSetMutation,
+} from '../../features/roleSets/hooks/useRoleSets';
 import { useOrganizationGroups } from '../../hooks/useOrganizationGroups';
 import {
     useOrganizationRoleAssignments,
@@ -217,8 +222,14 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
         useUpsertProjectUserRoleAssignmentMutation(projectUuid);
     const deleteMutation =
         useDeleteProjectUserRoleAssignmentMutation(projectUuid);
+    const replaceRoleSetMutation =
+        useReplaceProjectUserRoleSetMutation(projectUuid);
+    const multipleRolesEnabled = useMultipleRolesEnabled();
 
-    const isMutating = upsertMutation.isLoading || deleteMutation.isLoading;
+    const isMutating =
+        upsertMutation.isLoading ||
+        deleteMutation.isLoading ||
+        replaceRoleSetMutation.isLoading;
 
     const handleRoleChange = useCallback(
         (userUuid: string, newRoleUuid: string | null) => {
@@ -487,40 +498,84 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
                                         )
                                     }
                                 >
-                                    <Select
-                                        id="user-role"
-                                        w={250}
-                                        size="xs"
-                                        disabled={
-                                            isMutating ||
-                                            !canManageProjectAccess
-                                        }
-                                        data={
-                                            u.isMember && !u.hasProjectRole
-                                                ? [
-                                                      {
-                                                          group: 'Organization role',
-                                                          items: [
-                                                              {
-                                                                  value: 'member',
-                                                                  label: 'member (no project access)',
-                                                              },
-                                                          ],
-                                                      },
-                                                      ...groupedRolesData,
-                                                  ]
-                                                : groupedRolesData
-                                        }
-                                        value={
-                                            u.currentRoleUuid || u.highestRole
-                                        }
-                                        onChange={(newRoleUuid) =>
-                                            handleRoleChange(
-                                                u.userUuid,
-                                                newRoleUuid,
-                                            )
-                                        }
-                                    />
+                                    {multipleRolesEnabled ? (
+                                        <Box>
+                                            <ProjectRoleSetCell
+                                                projectUuid={projectUuid}
+                                                assignee={{
+                                                    type: 'user',
+                                                    uuid: u.userUuid,
+                                                    label: u.email,
+                                                }}
+                                                slotRoleId={
+                                                    u.hasProjectRole
+                                                        ? u.projectRole
+                                                        : null
+                                                }
+                                                hasMultipleRoles={
+                                                    u.projectRoleHasMultiple
+                                                }
+                                                organizationRoles={
+                                                    organizationRoles
+                                                }
+                                                disabled={
+                                                    isMutating ||
+                                                    !canManageProjectAccess
+                                                }
+                                                placeholder={
+                                                    u.highestRole ===
+                                                    OrganizationMemberRole.MEMBER
+                                                        ? 'No project access'
+                                                        : `Inherits ${getRoleName(u.highestRole)}`
+                                                }
+                                                onChange={(roleSet) =>
+                                                    replaceRoleSetMutation.mutate(
+                                                        {
+                                                            userUuid:
+                                                                u.userUuid,
+                                                            roleSet,
+                                                        },
+                                                    )
+                                                }
+                                            />
+                                        </Box>
+                                    ) : (
+                                        <Select
+                                            id="user-role"
+                                            w={250}
+                                            size="xs"
+                                            disabled={
+                                                isMutating ||
+                                                !canManageProjectAccess
+                                            }
+                                            data={
+                                                u.isMember && !u.hasProjectRole
+                                                    ? [
+                                                          {
+                                                              group: 'Organization role',
+                                                              items: [
+                                                                  {
+                                                                      value: 'member',
+                                                                      label: 'member (no project access)',
+                                                                  },
+                                                              ],
+                                                          },
+                                                          ...groupedRolesData,
+                                                      ]
+                                                    : groupedRolesData
+                                            }
+                                            value={
+                                                u.currentRoleUuid ||
+                                                u.highestRole
+                                            }
+                                            onChange={(newRoleUuid) =>
+                                                handleRoleChange(
+                                                    u.userUuid,
+                                                    newRoleUuid,
+                                                )
+                                            }
+                                        />
+                                    )}
                                 </Tooltip>
                                 {u.accessWarning && (
                                     <Tooltip label={u.accessWarning}>
@@ -569,6 +624,10 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
             handleDelete,
             isMutating,
             groupedRolesData,
+            multipleRolesEnabled,
+            organizationRoles,
+            projectUuid,
+            replaceRoleSetMutation,
         ]);
 
     const table = useContentTable({

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
@@ -5,6 +5,7 @@ import {
     OrganizationMemberRoleLabels,
     type OrganizationMemberProfile,
     type OrganizationMemberProfileWithGroups,
+    type OrganizationRoleSet,
     type Role,
 } from '@lightdash/common';
 import {
@@ -28,6 +29,11 @@ import {
     useState,
     type FC,
 } from 'react';
+import { OrganizationRoleSetCell } from '../../../features/roleSets/components/OrganizationRoleSetCell';
+import {
+    useMultipleRolesEnabled,
+    useReplaceOrganizationUserRoleSetMutation,
+} from '../../../features/roleSets/hooks/useRoleSets';
 import { useInfiniteScroll } from '../../../hooks/useInfiniteScroll';
 import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
 import {
@@ -51,10 +57,9 @@ import { UsersTopToolbar } from './UsersTopToolbar';
 
 const fetchSize = 50;
 
-type PendingRoleChange = {
-    userId: string;
-    roleId: string;
-};
+type PendingRoleChange =
+    | { userId: string; roleId: string }
+    | { userId: string; roleSet: OrganizationRoleSet };
 
 const UsersTable: FC = () => {
     const theme = useMantineTheme();
@@ -124,6 +129,8 @@ const UsersTable: FC = () => {
     }, [debouncedSearchValue, scrollToTop]);
 
     const updateUserRole = useUpsertOrganizationUserRoleAssignmentMutation();
+    const replaceRoleSet = useReplaceOrganizationUserRoleSetMutation();
+    const multipleRolesEnabled = useMultipleRolesEnabled();
     const organizationRolesQuery = useOrganizationRoles();
 
     const handleRoleChange = useCallback(
@@ -150,17 +157,40 @@ const UsersTable: FC = () => {
         [activeUser.data?.userUuid, updateUserRole],
     );
 
+    const handleRoleSetChange = useCallback(
+        (user: OrganizationMemberProfile, roleSet: OrganizationRoleSet) => {
+            const isCurrentUser = activeUser.data?.userUuid === user.userUuid;
+            const isAdminSelfDowngrade =
+                isCurrentUser &&
+                user.role === OrganizationMemberRole.ADMIN &&
+                roleSet.systemRole !== OrganizationMemberRole.ADMIN;
+
+            if (isAdminSelfDowngrade) {
+                setPendingRoleChange({ userId: user.userUuid, roleSet });
+                return;
+            }
+            replaceRoleSet.mutate({ userUuid: user.userUuid, roleSet });
+        },
+        [activeUser.data?.userUuid, replaceRoleSet],
+    );
+
     const handleConfirmAdminSelfDowngrade = useCallback(() => {
         if (!pendingRoleChange) {
             return;
         }
-
-        updateUserRole.mutate(pendingRoleChange, {
-            onSuccess: () => {
-                setPendingRoleChange(null);
-            },
-        });
-    }, [pendingRoleChange, updateUserRole]);
+        const onSuccess = () => setPendingRoleChange(null);
+        if ('roleSet' in pendingRoleChange) {
+            replaceRoleSet.mutate(
+                {
+                    userUuid: pendingRoleChange.userId,
+                    roleSet: pendingRoleChange.roleSet,
+                },
+                { onSuccess },
+            );
+            return;
+        }
+        updateUserRole.mutate(pendingRoleChange, { onSuccess });
+    }, [pendingRoleChange, updateUserRole, replaceRoleSet]);
 
     const organizationRoleOptions = useMemo(() => {
         const systemRoles = Object.values(OrganizationMemberRole).map(
@@ -284,6 +314,21 @@ const UsersTable: FC = () => {
                 size: 200,
                 Cell: ({ row }) => {
                     const user = row.original;
+                    if (multipleRolesEnabled) {
+                        return (
+                            <OrganizationRoleSetCell
+                                user={user}
+                                organizationRoles={organizationRolesQuery.data}
+                                disabled={
+                                    organizationRolesQuery.isLoading ||
+                                    replaceRoleSet.isLoading
+                                }
+                                onChange={(roleSet) =>
+                                    handleRoleSetChange(user, roleSet)
+                                }
+                            />
+                        );
+                    }
                     return (
                         <Select
                             data={organizationRoleOptions}
@@ -389,7 +434,11 @@ const UsersTable: FC = () => {
         inviteSuccessFor,
         isGroupManagementEnabled,
         handleRoleChange,
+        handleRoleSetChange,
+        multipleRolesEnabled,
+        replaceRoleSet.isLoading,
         organizationRoleOptions,
+        organizationRolesQuery.data,
         organizationRolesQuery.isLoading,
         activeUser.data?.userUuid,
         flatData.length,
@@ -498,7 +547,7 @@ const UsersTable: FC = () => {
             <ContentTable table={table} />
             <ConfirmAdminSelfDowngradeModal
                 opened={pendingRoleChange !== null}
-                loading={updateUserRole.isLoading}
+                loading={updateUserRole.isLoading || replaceRoleSet.isLoading}
                 onClose={() => setPendingRoleChange(null)}
                 onConfirm={handleConfirmAdminSelfDowngrade}
             />

--- a/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
@@ -41,6 +41,11 @@ import { useAbilityContext } from '../../../providers/Ability/useAbilityContext'
 import useApp from '../../../providers/App/useApp';
 import { TrackPage } from '../../../providers/Tracking/TrackingProvider';
 import { CategoryName, PageName, PageType } from '../../../types/Events';
+import { ProjectRoleSetCell } from '../../roleSets/components/ProjectRoleSetCell';
+import {
+    useMultipleRolesEnabled,
+    useReplaceProjectGroupRoleSetMutation,
+} from '../../roleSets/hooks/useRoleSets';
 import AddProjectGroupAccessModal from './AddProjectGroupAccessModal';
 import RevokeProjectGroupAccessModal from './RevokeProjectGroupAccessModal';
 
@@ -147,6 +152,16 @@ const ProjectGroupAccessComponent: FC<ProjectGroupAccessProps> = ({
         );
     }, [projectGroupRoleAssignments, projectUuid]);
 
+    const groupsWithExtraRoles = useMemo(
+        () =>
+            new Set(
+                (projectGroupRoleAssignments ?? [])
+                    .filter((assignment) => assignment.hasMultipleRoles)
+                    .map((assignment) => assignment.assigneeId),
+            ),
+        [projectGroupRoleAssignments],
+    );
+
     const { data: organizationRoles } = useOrganizationRoles();
 
     const rolesData = useMemo(() => {
@@ -204,8 +219,12 @@ const ProjectGroupAccessComponent: FC<ProjectGroupAccessProps> = ({
 
     const { mutateAsync: removeProjectGroupAccess, isLoading: isDeleting } =
         useDeleteProjectGroupRoleAssignmentMutation(projectUuid);
+    const replaceRoleSetMutation =
+        useReplaceProjectGroupRoleSetMutation(projectUuid);
+    const multipleRolesEnabled = useMultipleRolesEnabled();
 
-    const isMutating = isSubmitting || isDeleting;
+    const isMutating =
+        isSubmitting || isDeleting || replaceRoleSetMutation.isLoading;
 
     const handleAddProjectGroupAccess = async (
         formData: CreateProjectGroupAccess,
@@ -319,6 +338,30 @@ const ProjectGroupAccessComponent: FC<ProjectGroupAccessProps> = ({
                 size: 300,
                 Cell: ({ row }) => {
                     const r = row.original;
+                    if (multipleRolesEnabled) {
+                        return (
+                            <ProjectRoleSetCell
+                                projectUuid={projectUuid}
+                                assignee={{
+                                    type: 'group',
+                                    uuid: r.groupUuid,
+                                    label: r.group.name,
+                                }}
+                                slotRoleId={r.currentRoleUuid}
+                                hasMultipleRoles={groupsWithExtraRoles.has(
+                                    r.groupUuid,
+                                )}
+                                organizationRoles={organizationRoles}
+                                disabled={isMutating || !canManageProjectAccess}
+                                onChange={(roleSet) =>
+                                    replaceRoleSetMutation.mutate({
+                                        groupUuid: r.groupUuid,
+                                        roleSet,
+                                    })
+                                }
+                            />
+                        );
+                    }
                     return (
                         <Select
                             id={`group-role-${r.groupUuid}`}
@@ -368,6 +411,11 @@ const ProjectGroupAccessComponent: FC<ProjectGroupAccessProps> = ({
         handleDelete,
         isMutating,
         rolesData,
+        multipleRolesEnabled,
+        organizationRoles,
+        projectUuid,
+        groupsWithExtraRoles,
+        replaceRoleSetMutation,
     ]);
 
     const table = useContentTable({

--- a/packages/frontend/src/features/roleSets/components/OrganizationRoleSetCell.tsx
+++ b/packages/frontend/src/features/roleSets/components/OrganizationRoleSetCell.tsx
@@ -1,0 +1,83 @@
+import {
+    OrganizationMemberRole,
+    OrganizationMemberRoleLabels,
+    type OrganizationMemberProfile,
+    type OrganizationRoleSet,
+    type Role,
+} from '@lightdash/common';
+import { useMemo, type FC } from 'react';
+import {
+    useOrganizationUserRoleSet,
+    useResolvedRoleSet,
+} from '../hooks/useRoleSets';
+import { RoleSetMultiSelect } from './RoleSetMultiSelect';
+
+type Props = {
+    user: Pick<
+        OrganizationMemberProfile,
+        'userUuid' | 'email' | 'role' | 'roleUuid' | 'hasMultipleRoles'
+    >;
+    organizationRoles: Role[] | undefined;
+    disabled?: boolean;
+    onChange: (roleSet: OrganizationRoleSet) => void;
+};
+
+/** Role set derived from the primary slot; exact when the user holds no extras. */
+const roleSetFromSlot = (
+    user: Pick<OrganizationMemberProfile, 'role' | 'roleUuid'>,
+): OrganizationRoleSet =>
+    user.roleUuid
+        ? { systemRole: null, customRoleUuids: [user.roleUuid] }
+        : { systemRole: user.role, customRoleUuids: [] };
+
+export const OrganizationRoleSetCell: FC<Props> = ({
+    user,
+    organizationRoles,
+    disabled,
+    onChange,
+}) => {
+    // Only users flagged with extra roles need the full set fetched
+    const hasMultipleRoles = user.hasMultipleRoles === true;
+    const roleSetQuery = useOrganizationUserRoleSet(user.userUuid, {
+        enabled: hasMultipleRoles,
+    });
+    const slotSet = useMemo(() => roleSetFromSlot(user), [user]);
+    const { value, isPending } = useResolvedRoleSet(
+        slotSet,
+        hasMultipleRoles,
+        roleSetQuery,
+    );
+
+    const systemRoles = useMemo(
+        () =>
+            Object.values(OrganizationMemberRole).map((role) => ({
+                value: role,
+                label: OrganizationMemberRoleLabels[role],
+            })),
+        [],
+    );
+    const customRoles = useMemo(
+        () =>
+            (organizationRoles ?? [])
+                .filter(
+                    (role) =>
+                        role.ownerType === 'user' &&
+                        role.level === 'organization',
+                )
+                .map((role) => ({ value: role.roleUuid, label: role.name })),
+        [organizationRoles],
+    );
+
+    return (
+        <RoleSetMultiSelect<OrganizationMemberRole>
+            id={`user-roles-${user.userUuid}`}
+            systemRoles={systemRoles}
+            customRoles={customRoles}
+            value={value}
+            onChange={onChange}
+            disabled={disabled || isPending}
+            ariaLabel={`Roles for ${user.email}`}
+            w={280}
+        />
+    );
+};

--- a/packages/frontend/src/features/roleSets/components/ProjectRoleSetCell.tsx
+++ b/packages/frontend/src/features/roleSets/components/ProjectRoleSetCell.tsx
@@ -1,0 +1,89 @@
+import {
+    isSystemRole,
+    type ProjectMemberRole,
+    type ProjectRoleSet,
+    type Role,
+} from '@lightdash/common';
+import { useMemo, type FC } from 'react';
+import {
+    useProjectGroupRoleSet,
+    useProjectUserRoleSet,
+    useResolvedRoleSet,
+} from '../hooks/useRoleSets';
+import { RoleSetMultiSelect } from './RoleSetMultiSelect';
+
+type Props = {
+    projectUuid: string;
+    assignee: { type: 'user' | 'group'; uuid: string; label: string };
+    /** Primary-slot role id of the direct assignment (system name or custom uuid), null when none. */
+    slotRoleId: string | null;
+    hasMultipleRoles: boolean;
+    organizationRoles: Role[] | undefined;
+    disabled?: boolean;
+    placeholder?: string;
+    onChange: (roleSet: ProjectRoleSet) => void;
+};
+
+const roleSetFromSlot = (slotRoleId: string | null): ProjectRoleSet => {
+    if (slotRoleId === null) {
+        return { systemRole: null, customRoleUuids: [] };
+    }
+    return isSystemRole(slotRoleId)
+        ? { systemRole: slotRoleId, customRoleUuids: [] }
+        : { systemRole: null, customRoleUuids: [slotRoleId] };
+};
+
+export const ProjectRoleSetCell: FC<Props> = ({
+    projectUuid,
+    assignee,
+    slotRoleId,
+    hasMultipleRoles,
+    organizationRoles,
+    disabled,
+    placeholder,
+    onChange,
+}) => {
+    const userSetQuery = useProjectUserRoleSet(projectUuid, assignee.uuid, {
+        enabled: hasMultipleRoles && assignee.type === 'user',
+    });
+    const groupSetQuery = useProjectGroupRoleSet(projectUuid, assignee.uuid, {
+        enabled: hasMultipleRoles && assignee.type === 'group',
+    });
+    const fetched = assignee.type === 'user' ? userSetQuery : groupSetQuery;
+
+    const slotSet = useMemo(() => roleSetFromSlot(slotRoleId), [slotRoleId]);
+    const { value, isPending } = useResolvedRoleSet(
+        slotSet,
+        hasMultipleRoles,
+        fetched,
+    );
+
+    const { systemRoles, customRoles } = useMemo(() => {
+        const roles = organizationRoles ?? [];
+        return {
+            systemRoles: roles
+                .filter((role) => role.ownerType === 'system')
+                .map((role) => ({ value: role.roleUuid, label: role.name })),
+            customRoles: roles
+                .filter(
+                    (role) =>
+                        role.ownerType === 'user' && role.level === 'project',
+                )
+                .map((role) => ({ value: role.roleUuid, label: role.name })),
+        };
+    }, [organizationRoles]);
+
+    return (
+        <RoleSetMultiSelect<ProjectMemberRole>
+            id={`${assignee.type}-roles-${assignee.uuid}`}
+            systemRoles={systemRoles}
+            customRoles={customRoles}
+            value={value}
+            onChange={onChange}
+            disabled={disabled || isPending}
+            placeholder={placeholder}
+            ariaLabel={`Roles for ${assignee.label}`}
+            w={300}
+        />
+    );
+};

--- a/packages/frontend/src/features/roleSets/components/RoleSetMultiSelect.test.tsx
+++ b/packages/frontend/src/features/roleSets/components/RoleSetMultiSelect.test.tsx
@@ -1,0 +1,115 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { RoleSetMultiSelect } from './RoleSetMultiSelect';
+
+const systemRoles = [
+    { value: 'viewer', label: 'Viewer' },
+    { value: 'editor', label: 'Editor' },
+];
+const customRoles = [
+    { value: 'role-a', label: 'Roadmap viewer' },
+    { value: 'role-b', label: 'SQL runner' },
+];
+
+describe('RoleSetMultiSelect', () => {
+    it('renders the current set as pills', () => {
+        renderWithProviders(
+            <RoleSetMultiSelect
+                systemRoles={systemRoles}
+                customRoles={customRoles}
+                ariaLabel="Roles"
+                value={{ systemRole: 'viewer', customRoleUuids: ['role-a'] }}
+                onChange={vi.fn()}
+            />,
+        );
+        expect(screen.getByText('Viewer')).toBeInTheDocument();
+        expect(screen.getByText('Roadmap viewer')).toBeInTheDocument();
+    });
+
+    it('selecting a system role replaces the existing system role', async () => {
+        const onChange = vi.fn();
+        renderWithProviders(
+            <RoleSetMultiSelect
+                systemRoles={systemRoles}
+                customRoles={customRoles}
+                ariaLabel="Roles"
+                value={{ systemRole: 'viewer', customRoleUuids: ['role-a'] }}
+                onChange={onChange}
+            />,
+        );
+        await userEvent.click(screen.getByRole('textbox', { name: 'Roles' }));
+        await userEvent.click(
+            await screen.findByRole('option', { name: 'Editor' }),
+        );
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith({
+                systemRole: 'editor',
+                customRoleUuids: ['role-a'],
+            }),
+        );
+    });
+
+    it('selecting a custom role adds it on top', async () => {
+        const onChange = vi.fn();
+        renderWithProviders(
+            <RoleSetMultiSelect
+                systemRoles={systemRoles}
+                customRoles={customRoles}
+                ariaLabel="Roles"
+                value={{ systemRole: 'viewer', customRoleUuids: ['role-a'] }}
+                onChange={onChange}
+            />,
+        );
+        await userEvent.click(screen.getByRole('textbox', { name: 'Roles' }));
+        await userEvent.click(
+            await screen.findByRole('option', { name: 'SQL runner' }),
+        );
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith({
+                systemRole: 'viewer',
+                customRoleUuids: ['role-a', 'role-b'],
+            }),
+        );
+    });
+
+    it('does not emit an empty set when the last role is removed', async () => {
+        const onChange = vi.fn();
+        renderWithProviders(
+            <RoleSetMultiSelect
+                systemRoles={systemRoles}
+                customRoles={customRoles}
+                ariaLabel="Roles"
+                value={{ systemRole: null, customRoleUuids: ['role-a'] }}
+                onChange={onChange}
+            />,
+        );
+        const pill = screen
+            .getByText('Roadmap viewer')
+            .closest('.mantine-Pill-root');
+        await userEvent.click(pill!.querySelector('button')!);
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('removing one of several roles keeps the rest', async () => {
+        const onChange = vi.fn();
+        renderWithProviders(
+            <RoleSetMultiSelect
+                systemRoles={systemRoles}
+                customRoles={customRoles}
+                ariaLabel="Roles"
+                value={{ systemRole: 'viewer', customRoleUuids: ['role-a'] }}
+                onChange={onChange}
+            />,
+        );
+        const pill = screen.getByText('Viewer').closest('.mantine-Pill-root');
+        await userEvent.click(pill!.querySelector('button')!);
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith({
+                systemRole: null,
+                customRoleUuids: ['role-a'],
+            }),
+        );
+    });
+});

--- a/packages/frontend/src/features/roleSets/components/RoleSetMultiSelect.tsx
+++ b/packages/frontend/src/features/roleSets/components/RoleSetMultiSelect.tsx
@@ -1,0 +1,123 @@
+import { MultiSelect, Tooltip } from '@mantine/core';
+import { useCallback, useMemo } from 'react';
+
+export type RoleOption = { value: string; label: string };
+
+/** A role set as edited in the UI: at most one system role plus custom roles. */
+export type RoleSetValue<TSystemRole extends string = string> = {
+    systemRole: TSystemRole | null;
+    customRoleUuids: string[];
+};
+
+type Props<TSystemRole extends string> = {
+    systemRoles: RoleOption[];
+    customRoles: RoleOption[];
+    value: RoleSetValue<TSystemRole>;
+    onChange: (next: RoleSetValue<TSystemRole>) => void;
+    disabled?: boolean;
+    /** Shown while the set is empty (e.g. access inherited from the organization). */
+    placeholder?: string;
+    /** Distinguishes rows for assistive tech, e.g. "Roles for jane@acme.com". */
+    ariaLabel: string;
+    id?: string;
+    size?: 'xs' | 'sm' | 'md';
+    w?: number | string;
+};
+
+const toValues = (set: RoleSetValue): string[] => [
+    ...(set.systemRole ? [set.systemRole] : []),
+    ...set.customRoleUuids,
+];
+
+/**
+ * Picker for a complete role set. Selecting a system role replaces any other
+ * system role (roles are nested, so holding two adds nothing); custom roles
+ * accumulate. Permissions are the union of every selected role.
+ */
+export function RoleSetMultiSelect<TSystemRole extends string>({
+    systemRoles,
+    customRoles,
+    value,
+    onChange,
+    disabled,
+    placeholder,
+    ariaLabel,
+    id,
+    size = 'xs',
+    w = 300,
+}: Props<TSystemRole>) {
+    const systemRoleValues = useMemo(
+        () => new Set(systemRoles.map((role) => role.value)),
+        [systemRoles],
+    );
+
+    const data = useMemo(() => {
+        const groups: { group: string; items: RoleOption[] }[] = [];
+        if (systemRoles.length > 0) {
+            groups.push({ group: 'System role', items: systemRoles });
+        }
+        if (customRoles.length > 0) {
+            groups.push({
+                group: 'Custom roles (additive)',
+                items: customRoles,
+            });
+        }
+        return groups;
+    }, [systemRoles, customRoles]);
+
+    const handleChange = useCallback(
+        (selected: string[]) => {
+            const current = toValues(value);
+            const added = selected.find((v) => !current.includes(v));
+            let systemRole = value.systemRole;
+            let customRoleUuids = value.customRoleUuids;
+            if (added !== undefined) {
+                if (systemRoleValues.has(added)) {
+                    systemRole = added as TSystemRole;
+                } else {
+                    customRoleUuids = [...customRoleUuids, added];
+                }
+            } else {
+                // removal
+                systemRole =
+                    systemRole && selected.includes(systemRole)
+                        ? systemRole
+                        : null;
+                customRoleUuids = customRoleUuids.filter((uuid) =>
+                    selected.includes(uuid),
+                );
+            }
+            const next = { systemRole, customRoleUuids };
+            if (toValues(next).length === 0) {
+                return; // a set must keep at least one role
+            }
+            onChange(next);
+        },
+        [value, systemRoleValues, onChange],
+    );
+
+    return (
+        <Tooltip
+            label="Permissions are the union of every selected role. One system role at most; custom roles add on top."
+            openDelay={500}
+            withinPortal
+        >
+            <MultiSelect
+                id={id}
+                size={size}
+                w={w}
+                data={data}
+                value={toValues(value)}
+                onChange={handleChange}
+                disabled={disabled}
+                placeholder={
+                    toValues(value).length === 0 ? placeholder : undefined
+                }
+                searchable
+                hidePickedOptions
+                comboboxProps={{ withinPortal: true }}
+                aria-label={ariaLabel}
+            />
+        </Tooltip>
+    );
+}

--- a/packages/frontend/src/features/roleSets/hooks/useRoleSets.ts
+++ b/packages/frontend/src/features/roleSets/hooks/useRoleSets.ts
@@ -86,13 +86,26 @@ export const useReplaceOrganizationUserRoleSetMutation = () => {
         ApiError,
         { userUuid: string; roleSet: OrganizationRoleSet }
     >(
-        ({ userUuid, roleSet }) =>
-            lightdashApi<ApiOrganizationRoleSetResponse['results']>({
+        ({ userUuid, roleSet }) => {
+            if (!organizationUuid) {
+                const notLoaded: ApiError = {
+                    status: 'error',
+                    error: {
+                        name: 'Error',
+                        statusCode: 400,
+                        message: 'Organization is not loaded yet',
+                        data: {},
+                    },
+                };
+                return Promise.reject(notLoaded);
+            }
+            return lightdashApi<ApiOrganizationRoleSetResponse['results']>({
                 url: `/orgs/${organizationUuid}/roles/assignments/user/${userUuid}/set`,
                 version: 'v2',
                 method: 'PUT',
                 body: JSON.stringify(roleSet),
-            }),
+            });
+        },
         {
             onSuccess: async (_data, { userUuid }) => {
                 await Promise.all([

--- a/packages/frontend/src/features/roleSets/hooks/useRoleSets.ts
+++ b/packages/frontend/src/features/roleSets/hooks/useRoleSets.ts
@@ -1,0 +1,229 @@
+import {
+    CommercialFeatureFlags,
+    type ApiError,
+    type ApiOrganizationRoleSetResponse,
+    type ApiProjectRoleSetResponse,
+    type OrganizationRoleSet,
+    type ProjectRoleSet,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../providers/App/useApp';
+
+export const useMultipleRolesEnabled = (): boolean => {
+    const flag = useServerFeatureFlag(CommercialFeatureFlags.MultipleRoles);
+    return flag.isSuccess && flag.data.enabled;
+};
+
+const ORG_ROLE_SET_KEY = 'organization_user_role_set';
+const PROJECT_USER_ROLE_SET_KEY = 'project_user_role_set';
+const PROJECT_GROUP_ROLE_SET_KEY = 'project_group_role_set';
+
+export const useOrganizationUserRoleSet = (
+    userUuid: string,
+    { enabled = true }: { enabled?: boolean } = {},
+) => {
+    const { user } = useApp();
+    const organizationUuid = user.data?.organizationUuid;
+    return useQuery<OrganizationRoleSet, ApiError>(
+        [ORG_ROLE_SET_KEY, organizationUuid, userUuid],
+        async () =>
+            await lightdashApi<ApiOrganizationRoleSetResponse['results']>({
+                url: `/orgs/${organizationUuid}/roles/assignments/user/${userUuid}/set`,
+                version: 'v2',
+                method: 'GET',
+                body: undefined,
+            }),
+        { enabled: enabled && !!organizationUuid },
+    );
+};
+
+export const useProjectUserRoleSet = (
+    projectUuid: string,
+    userUuid: string,
+    { enabled = true }: { enabled?: boolean } = {},
+) =>
+    useQuery<ProjectRoleSet, ApiError>(
+        [PROJECT_USER_ROLE_SET_KEY, projectUuid, userUuid],
+        () =>
+            lightdashApi<ApiProjectRoleSetResponse['results']>({
+                url: `/projects/${projectUuid}/roles/assignments/user/${userUuid}/set`,
+                version: 'v2',
+                method: 'GET',
+                body: undefined,
+            }),
+        { enabled },
+    );
+
+export const useProjectGroupRoleSet = (
+    projectUuid: string,
+    groupUuid: string,
+    { enabled = true }: { enabled?: boolean } = {},
+) =>
+    useQuery<ProjectRoleSet, ApiError>(
+        [PROJECT_GROUP_ROLE_SET_KEY, projectUuid, groupUuid],
+        () =>
+            lightdashApi<ApiProjectRoleSetResponse['results']>({
+                url: `/projects/${projectUuid}/roles/assignments/group/${groupUuid}/set`,
+                version: 'v2',
+                method: 'GET',
+                body: undefined,
+            }),
+        { enabled },
+    );
+
+export const useReplaceOrganizationUserRoleSetMutation = () => {
+    const { user } = useApp();
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const organizationUuid = user.data?.organizationUuid;
+
+    return useMutation<
+        OrganizationRoleSet,
+        ApiError,
+        { userUuid: string; roleSet: OrganizationRoleSet }
+    >(
+        ({ userUuid, roleSet }) =>
+            lightdashApi<ApiOrganizationRoleSetResponse['results']>({
+                url: `/orgs/${organizationUuid}/roles/assignments/user/${userUuid}/set`,
+                version: 'v2',
+                method: 'PUT',
+                body: JSON.stringify(roleSet),
+            }),
+        {
+            onSuccess: async (_data, { userUuid }) => {
+                await Promise.all([
+                    queryClient.invalidateQueries([
+                        ORG_ROLE_SET_KEY,
+                        organizationUuid,
+                        userUuid,
+                    ]),
+                    queryClient.invalidateQueries([
+                        'organization_role_assignments',
+                    ]),
+                    queryClient.invalidateQueries(['organization_users']),
+                    queryClient.refetchQueries(['user']),
+                ]);
+                showToastSuccess({ title: 'Success! User roles updated.' });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: "Failed to update user's roles",
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
+
+export const useReplaceProjectUserRoleSetMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<
+        ProjectRoleSet,
+        ApiError,
+        { userUuid: string; roleSet: ProjectRoleSet }
+    >(
+        ({ userUuid, roleSet }) =>
+            lightdashApi<ApiProjectRoleSetResponse['results']>({
+                url: `/projects/${projectUuid}/roles/assignments/user/${userUuid}/set`,
+                version: 'v2',
+                method: 'PUT',
+                body: JSON.stringify(roleSet),
+            }),
+        {
+            onSuccess: async (_data, { userUuid }) => {
+                await Promise.all([
+                    queryClient.invalidateQueries([
+                        PROJECT_USER_ROLE_SET_KEY,
+                        projectUuid,
+                        userUuid,
+                    ]),
+                    queryClient.invalidateQueries([
+                        'project_role_assignments',
+                        projectUuid,
+                    ]),
+                ]);
+                showToastSuccess({
+                    title: 'Success! User project roles updated.',
+                });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to update user project roles',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
+
+export const useReplaceProjectGroupRoleSetMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<
+        ProjectRoleSet,
+        ApiError,
+        { groupUuid: string; roleSet: ProjectRoleSet }
+    >(
+        ({ groupUuid, roleSet }) =>
+            lightdashApi<ApiProjectRoleSetResponse['results']>({
+                url: `/projects/${projectUuid}/roles/assignments/group/${groupUuid}/set`,
+                version: 'v2',
+                method: 'PUT',
+                body: JSON.stringify(roleSet),
+            }),
+        {
+            onSuccess: async (_data, { groupUuid }) => {
+                await Promise.all([
+                    queryClient.invalidateQueries([
+                        PROJECT_GROUP_ROLE_SET_KEY,
+                        projectUuid,
+                        groupUuid,
+                    ]),
+                    queryClient.invalidateQueries([
+                        'project_role_assignments',
+                        projectUuid,
+                    ]),
+                    queryClient.invalidateQueries([
+                        'projects',
+                        projectUuid,
+                        'groupAccesses',
+                    ]),
+                ]);
+                showToastSuccess({
+                    title: 'Success! Group project roles updated.',
+                });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to update group project roles',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
+
+/**
+ * Set to edit for a row: the fetched set when the row holds extra roles,
+ * otherwise the set derived from its primary slot. Editing is blocked until
+ * the fetch settles successfully so a partial set is never written back.
+ */
+export const useResolvedRoleSet = <T extends { systemRole: unknown }>(
+    slotSet: T,
+    hasMultipleRoles: boolean,
+    query: { data: T | undefined; isLoading: boolean; isError: boolean },
+): { value: T; isPending: boolean } =>
+    useMemo(
+        () => ({
+            value: hasMultipleRoles && query.data ? query.data : slotSet,
+            isPending: hasMultipleRoles && (query.isLoading || query.isError),
+        }),
+        [slotSet, hasMultipleRoles, query.data, query.isLoading, query.isError],
+    );

--- a/packages/frontend/src/hooks/useProjectUsersWithRolesV2.ts
+++ b/packages/frontend/src/hooks/useProjectUsersWithRolesV2.ts
@@ -9,6 +9,8 @@ import { useProjectRoleAssignments } from './useProjectRoles';
 export type ProjectUserWithRoleV2 = OrganizationMemberProfile & {
     projectUuid: string;
     projectRole: ProjectMemberRole | null;
+    /** True when the direct project assignment holds extra custom roles. */
+    projectRoleHasMultiple: boolean;
 };
 
 export const useProjectUsersWithRoles = (projectUuid: string) => {
@@ -24,12 +26,14 @@ export const useProjectUsersWithRoles = (projectUuid: string) => {
             return {};
 
         return projectRoleAssignmentsQuery.data.reduce<
-            Record<string, ProjectMemberRole>
-        >((acc: Record<string, ProjectMemberRole>, assignment) => {
+            Record<string, { role: ProjectMemberRole; hasMultiple: boolean }>
+        >((acc, assignment) => {
             if (assignment.assigneeType === 'user') {
-                // Convert the role id to ProjectMemberRole
-                acc[assignment.assigneeId] =
-                    assignment.roleId as ProjectMemberRole;
+                acc[assignment.assigneeId] = {
+                    // Convert the role id to ProjectMemberRole
+                    role: assignment.roleId as ProjectMemberRole,
+                    hasMultiple: assignment.hasMultipleRoles === true,
+                };
             }
             return acc;
         }, {});
@@ -44,7 +48,9 @@ export const useProjectUsersWithRoles = (projectUuid: string) => {
         const mappedUsers = organizationUsersQuery.data.map((orgUser) => ({
             ...orgUser,
             projectUuid,
-            projectRole: projectRoles[orgUser.userUuid] || null,
+            projectRole: projectRoles[orgUser.userUuid]?.role ?? null,
+            projectRoleHasMultiple:
+                projectRoles[orgUser.userUuid]?.hasMultiple ?? false,
         }));
 
         // Sort users: project roles first, then alphabetically by firstName


### PR DESCRIPTION
Closes PROD-10217

## What

Behind the `multiple-roles` commercial flag, the single role `Select` on three admin tables becomes a **role-set multi-select** (at most one system role + any number of custom roles; permissions are the union) saved via the role-set endpoints shipped in #27516:

- Org **Users & groups → Users** table → `PUT /api/v2/orgs/{org}/roles/assignments/user/{user}/set`
- **Project access → Users** → `PUT /api/v2/projects/{project}/roles/assignments/user/{user}/set`
- **Project access → Groups** → `PUT /api/v2/projects/{project}/roles/assignments/group/{group}/set`

Rows already flagged `hasMultipleRoles` fetch their full set lazily (one small GET per such row); every other row derives its set from the primary slot, so tables that use no extras make no extra calls. Editing is disabled until a row's fetch settles (loading **or error**) so a partial set is never written back.

Flag off → the existing single-role `Select` code path is unchanged (same DOM, same mutations). Invitation / "add access" modals stay singular.

## Backend fix (small)

`OrganizationMemberProfileModel.getOrganizationMembersAndGroups` — the `includeGroups=` listing the users table actually calls — built its own select list and never emitted `has_extra_roles`, so `hasMultipleRoles` was `undefined` on that path. Extracted `hasExtraRolesColumn(db)` and used it in both listings (added the two membership columns to `GROUP BY`). Additive/optional field only.

## New code

`packages/frontend/src/features/roleSets/`
- `hooks/useRoleSets.ts` — flag hook, GET/PUT hooks per level with invalidations that match the tables' query keys, `useResolvedRoleSet` (fetched-set-or-slot + pending gate)
- `components/RoleSetMultiSelect.tsx` — grouped Mantine `MultiSelect` ("System role" / "Custom roles (additive)"): picking a system role replaces the current one, custom roles accumulate, last role can't be removed; per-row `aria-label`
- `components/OrganizationRoleSetCell.tsx`, `ProjectRoleSetCell.tsx` — thin cells wiring slot/fetch/roles per level

## Verified

- vitest: `RoleSetMultiSelect` (5), plus UsersTable / ProjectAccess / ProjectGroupAccess suites (22 pass); backend `OrganizationMemberProfileModel`/`OrganizationService` (12 pass); frontend typecheck + oxlint + oxfmt clean
- Live on a seeded instance, flag on: org table viewer + custom → toast, persisted, pills after cold reload; project users: inherited-viewer user → custom (moves to direct access) → + Editor → `{editor,[custom]}` persisted; groups: viewer → + custom persisted; inherited-source tooltip and "Inherits X" / "No project access" placeholders; no console errors
- Flag off: legacy read-only `Select` renders as before

## Not in this PR

Docs (PROD-10221), rollout verification with real IdPs (PROD-10218), role bundles (PROD-10223).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
