### PR TITLE
fix(frontend): compose query retry with the global network retry

### DIFF
--- a/packages/frontend/src/hooks/useQueryRetry.test.ts
+++ b/packages/frontend/src/hooks/useQueryRetry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { getRetryConfig } from './useQueryRetry';
+
+const networkError = { error: { name: 'NetworkError', statusCode: 500 } };
+const serverError = {
+    error: { name: 'UnexpectedServerError', statusCode: 500 },
+};
+const notFound = { error: { name: 'NotFoundError', statusCode: 404 } };
+
+describe('getRetryConfig', () => {
+    it('inherits the global retry config when disabled', () => {
+        expect(getRetryConfig(false)).toEqual({});
+    });
+
+    it('keeps the global 5 NetworkError attempts when enabled', () => {
+        const { retry } = getRetryConfig(true);
+
+        expect(retry?.(0, networkError)).toBe(true);
+        expect(retry?.(4, networkError)).toBe(true);
+        expect(retry?.(5, networkError)).toBe(false);
+    });
+
+    it('adds up to 3 attempts for 5xx errors when enabled', () => {
+        const { retry } = getRetryConfig(true);
+
+        expect(retry?.(0, serverError)).toBe(true);
+        expect(retry?.(2, serverError)).toBe(true);
+        expect(retry?.(3, serverError)).toBe(false);
+    });
+
+    it('does not retry 4xx errors when enabled', () => {
+        const { retry } = getRetryConfig(true);
+
+        expect(retry?.(0, notFound)).toBe(false);
+    });
+
+    it('never overrides the global retry delay', () => {
+        expect(getRetryConfig(true)).not.toHaveProperty('retryDelay');
+        expect(getRetryConfig(false)).not.toHaveProperty('retryDelay');
+    });
+});

--- a/packages/frontend/src/hooks/useQueryRetry.ts
+++ b/packages/frontend/src/hooks/useQueryRetry.ts
@@ -1,59 +1,27 @@
 import type { ApiError } from '@lightdash/common';
 import { useMemo } from 'react';
 import useApp from '../providers/App/useApp';
+import { shouldRetryQuery } from '../providers/ReactQuery/createQueryClient';
 
-/**
- * Determines if an API error is retryable (transient database/server issues)
- * @param error The API error from the query
- * @returns true if the error should be retried
- */
-const isRetryableError = (error: ApiError | Partial<ApiError>): boolean => {
-    const statusCode = error.error?.statusCode;
-    const errorName = error.error?.name;
+const MAX_SERVER_ERROR_RETRIES = 3;
 
-    // Retry on network errors (database connection issues, timeouts)
-    if (errorName === 'NetworkError') {
-        return true;
-    }
-
-    // Retry on 5xx server errors (backend/database overwhelmed)
-    if (statusCode && statusCode >= 500 && statusCode < 600) {
-        return true;
-    }
-
-    // Don't retry on 4xx client errors (bad request, not found, unauthorized, etc.)
-    return false;
+const is5xxError = (error: unknown): boolean => {
+    const statusCode = (error as Partial<ApiError>)?.error?.statusCode;
+    return statusCode !== undefined && statusCode >= 500 && statusCode < 600;
 };
 
 /**
- * Calculate exponential backoff delay for retries
- * @param attemptIndex Zero-based retry attempt (0, 1, 2)
- * @returns Delay in milliseconds
+ * Opt-in retry for 5xx responses, layered on top of the global NetworkError
+ * retry rather than replacing it — the global policy is more generous for
+ * transport failures (5 attempts, 8s cap) than this one is for 5xx.
  */
-const getRetryDelay = (attemptIndex: number): number =>
-    // Exponential backoff: 1s, 2s, 4s
-    Math.min(1000 * 2 ** attemptIndex, 4000);
-
-/**
- * Retry configuration for React Query hooks
- * - Max 3 retry attempts
- * - Exponential backoff (1s, 2s, 4s)
- * - Only retry on transient errors (5xx, NetworkError)
- * - Falls back to global query retry defaults when disabled
- */
-const getRetryConfig = (retryEnabled: boolean) =>
+export const getRetryConfig = (retryEnabled: boolean) =>
     retryEnabled
         ? {
-              retry: (
-                  failureCount: number,
-                  error: ApiError | Partial<ApiError>,
-              ) => {
-                  if (failureCount >= 3) {
-                      return false;
-                  }
-                  return isRetryableError(error);
-              },
-              retryDelay: getRetryDelay,
+              retry: (failureCount: number, error: unknown) =>
+                  shouldRetryQuery(failureCount, error) ||
+                  (failureCount < MAX_SERVER_ERROR_RETRIES &&
+                      is5xxError(error)),
           }
         : {};
 


### PR DESCRIPTION
## What changed

`useQueryRetryConfig()` **replaced** the global React Query retry policy instead of extending it, so turning **on** `LIGHTDASH_QUERY_RETRY_ON_TRANSIENT_ERRORS` — the flag whose purpose is to make queries more resilient — made `NetworkError` resilience *worse* than leaving it off:

<!-- linear:table-colwidths:266,266,266 -->
|  | `NetworkError` attempts | Backoff cap |
| -- | -- | -- |
| Flag off (inherits global) | 5 | 8s |
| Flag on (before) | 3 | 4s |
| Flag on (after) | 5 | 8s |

The flag is now purely additive: it layers up to 3 retries for 5xx responses **on top of** the global `shouldRetryQuery`, and no longer overrides `retryDelay`, so the global 8s backoff cap applies in both states.

## Testing

New unit tests in `useQueryRetry.test.ts`, reusing the fixture style already established in `createQueryClient.test.ts`.

## References

Closes: lightdash/lightdash#27563<br>Closes: lightdash/lightdash#27563

Supersedes lightdash/lightdash#27566, which was cut from a pre-lightdash/lightdash#27554 base and re-applied that fix on top of itself.