### PR TITLE
fix(frontend): stop retrying client-side chart processing failures

### DIFF
--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
@@ -17,7 +17,10 @@ import { useQuery } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import getChartDataModel from '../../../components/DataViz/transformers/getChartDataModel';
 import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColorPalette';
-import { useQueryRetryConfig } from '../../../hooks/useQueryRetry';
+import {
+    CHART_RESULTS_ERROR_NAME,
+    useQueryRetryConfig,
+} from '../../../hooks/useQueryRetry';
 import {
     getDashboardSqlChartPivotChartData,
     getEmbedDashboardSqlChartPivotChartData,
@@ -220,7 +223,7 @@ export const useSavedSqlChartResults = (
                 const wrapped: ApiError = {
                     status: 'error',
                     error: {
-                        name: 'ChartResultsError',
+                        name: CHART_RESULTS_ERROR_NAME,
                         statusCode: 500,
                         message,
                         data: {},

--- a/packages/frontend/src/hooks/useQueryRetry.test.ts
+++ b/packages/frontend/src/hooks/useQueryRetry.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { getRetryConfig } from './useQueryRetry';
+import { CHART_RESULTS_ERROR_NAME, getRetryConfig } from './useQueryRetry';
 
 const networkError = { error: { name: 'NetworkError', statusCode: 500 } };
 const serverError = {
     error: { name: 'UnexpectedServerError', statusCode: 500 },
 };
 const notFound = { error: { name: 'NotFoundError', statusCode: 404 } };
+const chartResultsError = {
+    error: { name: CHART_RESULTS_ERROR_NAME, statusCode: 500 },
+};
 
 describe('getRetryConfig', () => {
     it('inherits the global retry config when disabled', () => {
@@ -26,6 +29,12 @@ describe('getRetryConfig', () => {
         expect(retry?.(0, serverError)).toBe(true);
         expect(retry?.(2, serverError)).toBe(true);
         expect(retry?.(3, serverError)).toBe(false);
+    });
+
+    it('does not retry client-side chart processing failures', () => {
+        const { retry } = getRetryConfig(true);
+
+        expect(retry?.(0, chartResultsError)).toBe(false);
     });
 
     it('does not retry 4xx errors when enabled', () => {

--- a/packages/frontend/src/hooks/useQueryRetry.ts
+++ b/packages/frontend/src/hooks/useQueryRetry.ts
@@ -5,10 +5,17 @@ import { shouldRetryQuery } from '../providers/ReactQuery/createQueryClient';
 
 const MAX_SERVER_ERROR_RETRIES = 3;
 
+// Client-side chart processing failures are wrapped as an ApiError with a
+// borrowed 5xx status; they are deterministic, so retrying only delays them.
+export const CHART_RESULTS_ERROR_NAME = 'ChartResultsError';
+
 const is5xxError = (error: unknown): boolean => {
     const statusCode = (error as Partial<ApiError>)?.error?.statusCode;
     return statusCode !== undefined && statusCode >= 500 && statusCode < 600;
 };
+
+const isSynthesizedClientError = (error: unknown): boolean =>
+    (error as Partial<ApiError>)?.error?.name === CHART_RESULTS_ERROR_NAME;
 
 /**
  * Opt-in retry for 5xx responses, layered on top of the global NetworkError
@@ -21,7 +28,8 @@ export const getRetryConfig = (retryEnabled: boolean) =>
               retry: (failureCount: number, error: unknown) =>
                   shouldRetryQuery(failureCount, error) ||
                   (failureCount < MAX_SERVER_ERROR_RETRIES &&
-                      is5xxError(error)),
+                      is5xxError(error) &&
+                      !isSynthesizedClientError(error)),
           }
         : {};
 


### PR DESCRIPTION
## What changed

`useSavedSqlChartResults` wraps client-side chart processing failures (pivot / viz-model / spec generation) as an `ApiError` with a borrowed `statusCode: 500`. With `LIGHTDASH_QUERY_RETRY_ON_TRANSIENT_ERRORS` on, that looked like an overwhelmed backend, so a deterministic failure retried 3 times — roughly 7s of backoff before the user saw the same error, plus 3 duplicate `chartResultsProcessing` captures in Sentry per render.

The 5xx retry now excludes it **by error name**, which is how the global policy already discriminates (`name === 'NetworkError'`) rather than by status code. The name is exported as `CHART_RESULTS_ERROR_NAME` and imported where the error is constructed, so the producer and the retry predicate cannot drift apart.

This deliberately does **not** change the synthesized status code to 4xx. A client-side rendering crash is an app bug, not a bad request, and 400 would misfile it as user error anywhere status codes get bucketed (Sentry grouping, 4xx-vs-5xx alerting). Whether these synthesized errors should borrow an HTTP status at all is a wider question — there are several more in the frontend — and belongs in its own ticket.

## Testing

Extends `useQueryRetry.test.ts` with a case asserting the synthesized error is not retried even while carrying a 5xx status.

## References

Closes: lightdash/lightdash#27564<br>Closes: lightdash/lightdash#27564

Supersedes lightdash/lightdash#27567. Stacked on lightdash/lightdash#27572.