### PR TITLE
test: add missing Bedrock AI config fixture field

### DIFF
--- a/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.test.ts
+++ b/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.test.ts
@@ -68,6 +68,7 @@ const bedrockConfig: CopilotConfig = aiCopilotConfigSchema.parse({
     enabled: true,
     requiresFeatureFlag: false,
     telemetryEnabled: false,
+    threadDumpEnabled: false,
     debugLoggingEnabled: false,
     askAiButtonEnabled: false,
     embeddingEnabled: false,


### PR DESCRIPTION
### Description

Adds the required `threadDumpEnabled` boolean to the Bedrock AI copilot test
fixture. The field became required in #27552, but this fixture was missed,
causing `OrgAiCopilotConfigResolver.test.ts` to fail during collection on
current `main` and on PRs rebased onto it.

### Validation

- Reproduced the Zod failure before the change
- `pnpm -F backend exec vitest run --config vitest.config.ts src/ee/services/ai/OrgAiCopilotConfigResolver.test.ts` — 43 passed
- Backend formatting and lint pass for the changed file
