### PR TITLE
fix(backend): preserve export filename on streamed downloads

### DIFF
--- a/packages/backend/src/clients/Aws/S3Client.test.ts
+++ b/packages/backend/src/clients/Aws/S3Client.test.ts
@@ -1,0 +1,53 @@
+import { Readable } from 'stream';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { S3Client } from './S3Client';
+
+const createClient = (sendResponse: unknown) => {
+    const client = new S3Client({ lightdashConfig: lightdashConfigMock });
+    // @ts-expect-error `s3` is protected; swapped for a stub to avoid network I/O
+    client.s3 = { send: vi.fn(async () => sendResponse) };
+    return client;
+};
+
+describe('S3Client', () => {
+    describe('getFileStream', () => {
+        it('returns the content disposition stored on the object', async () => {
+            const client = createClient({
+                Body: Readable.from(['hello,world\n']),
+                ContentDisposition:
+                    'attachment; filename="My Chart.csv"; filename*=UTF-8\'\'My%20Chart.csv',
+            });
+
+            const result = await client.getFileStream('csv-my-chart-123.csv');
+
+            expect(result.contentDisposition).toBe(
+                'attachment; filename="My Chart.csv"; filename*=UTF-8\'\'My%20Chart.csv',
+            );
+            expect(result.stream).toBeInstanceOf(Readable);
+        });
+
+        it('returns null when the object has no content disposition', async () => {
+            const client = createClient({
+                Body: Readable.from(['hello,world\n']),
+            });
+
+            const result = await client.getFileStream('csv-my-chart-123.csv');
+
+            expect(result.contentDisposition).toBeNull();
+        });
+
+        it('preserves a non-ASCII content disposition verbatim', async () => {
+            const client = createClient({
+                Body: Readable.from(['hello,world\n']),
+                ContentDisposition:
+                    'attachment; filename="download.csv"; filename*=UTF-8\'\'%E5%A3%B2%E4%B8%8A.csv',
+            });
+
+            const result = await client.getFileStream('csv-123.csv');
+
+            expect(result.contentDisposition).toBe(
+                'attachment; filename="download.csv"; filename*=UTF-8\'\'%E5%A3%B2%E4%B8%8A.csv',
+            );
+        });
+    });
+});

--- a/packages/backend/src/clients/Aws/S3Client.ts
+++ b/packages/backend/src/clients/Aws/S3Client.ts
@@ -25,7 +25,10 @@ import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { createContentDispositionHeader } from '../../utils/FileDownloadUtils/FileDownloadUtils';
 import { writeWithBackpressure } from '../../utils/streamUtils';
-import { type FileStorageClient } from '../FileStorage/FileStorageClient';
+import {
+    type FileStorageClient,
+    type FileStreamResult,
+} from '../FileStorage/FileStorageClient';
 import getContentTypeFromFileType from './getContentTypeFromFileType';
 import { S3BaseClient } from './S3BaseClient';
 
@@ -239,7 +242,7 @@ export class S3Client extends S3BaseClient implements FileStorageClient {
         return onEnd;
     }
 
-    async getFileStream(fileId: string): Promise<Readable> {
+    async getFileStream(fileId: string): Promise<FileStreamResult> {
         const command = new GetObjectCommand({
             Bucket: this.lightdashConfig.s3?.bucket,
             Key: fileId,
@@ -250,7 +253,10 @@ export class S3Client extends S3BaseClient implements FileStorageClient {
             if (response === undefined) {
                 throw new S3Error('No response from S3', { fileId });
             }
-            return response.Body as Readable;
+            return {
+                stream: response.Body as Readable,
+                contentDisposition: response.ContentDisposition ?? null,
+            };
         } catch (error) {
             if (error instanceof NoSuchKey || error instanceof NotFound) {
                 throw new NotFoundError('File not found');

--- a/packages/backend/src/clients/FileStorage/FileStorageClient.ts
+++ b/packages/backend/src/clients/FileStorage/FileStorageClient.ts
@@ -2,6 +2,15 @@ import { type WarehouseResults } from '@lightdash/common';
 import { type ReadStream } from 'fs';
 import { type PassThrough, type Readable } from 'stream';
 
+/**
+ * `contentDisposition` is the header stored on the object at upload time, which
+ * carries the friendly download name. Null when the object has none.
+ */
+export type FileStreamResult = {
+    stream: Readable;
+    contentDisposition: string | null;
+};
+
 export interface FileStorageClient {
     readonly expirationDays: number | undefined;
 
@@ -37,7 +46,7 @@ export interface FileStorageClient {
         fileId: string,
     ): Promise<() => Promise<string>>;
 
-    getFileStream(fileId: string): Promise<Readable>;
+    getFileStream(fileId: string): Promise<FileStreamResult>;
 
     createUploadStream(
         fileName: string,

--- a/packages/backend/src/controllers/fileController.test.ts
+++ b/packages/backend/src/controllers/fileController.test.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { validateHeaderValue } from 'node:http';
 import { PassThrough, Readable } from 'stream';
 import { type ServiceRepository } from '../services/ServiceRepository';
 import { FileController } from './fileController';
@@ -27,6 +28,9 @@ const setup = ({
     const res = new PassThrough();
     // @ts-expect-error minimal express.Response stub — only setHeader is used
     res.setHeader = (name: string, value: string) => {
+        // Mirror Node's own validation, so any header we couldn't actually
+        // send fails the test rather than passing silently.
+        validateHeaderValue(name, value);
         headers[name] = value;
     };
     const req = {
@@ -77,6 +81,19 @@ describe('FileController', () => {
             await controller.getFile(FILE_ID, req);
 
             expect(headers['Content-Disposition']).not.toContain('X-Injected');
+            expect(headers['Content-Disposition']).toContain(
+                'csv-my-chart-1755512345678.csv',
+            );
+        });
+
+        it('falls back when the stored content disposition holds raw non-latin-1', async () => {
+            const { controller, req, headers } = setup({
+                s3Key: 'csv-my-chart-1755512345678.csv',
+                contentDisposition: 'attachment; filename="売上.csv"',
+            });
+
+            await controller.getFile(FILE_ID, req);
+
             expect(headers['Content-Disposition']).toContain(
                 'csv-my-chart-1755512345678.csv',
             );

--- a/packages/backend/src/controllers/fileController.test.ts
+++ b/packages/backend/src/controllers/fileController.test.ts
@@ -1,0 +1,111 @@
+import express from 'express';
+import { PassThrough, Readable } from 'stream';
+import { type ServiceRepository } from '../services/ServiceRepository';
+import { FileController } from './fileController';
+
+const FILE_ID = 'test-nanoid-123456789';
+
+const setup = ({
+    s3Key,
+    contentDisposition,
+}: {
+    s3Key: string;
+    contentDisposition: string | null;
+}) => {
+    const services = {
+        getPersistentDownloadFileService: () => ({
+            getFileStream: vi.fn(async () => ({
+                stream: Readable.from(['hello,world\n']),
+                fileType: 'csv',
+                s3Key,
+                contentDisposition,
+            })),
+        }),
+    } as unknown as ServiceRepository;
+
+    const headers: Record<string, string> = {};
+    const res = new PassThrough();
+    // @ts-expect-error minimal express.Response stub — only setHeader is used
+    res.setHeader = (name: string, value: string) => {
+        headers[name] = value;
+    };
+    const req = {
+        res,
+        ip: '127.0.0.1',
+        headers: {},
+    } as unknown as express.Request;
+
+    return { controller: new FileController(services), req, headers };
+};
+
+describe('FileController', () => {
+    describe('getFile', () => {
+        it('uses the content disposition stored on the object', async () => {
+            const { controller, req, headers } = setup({
+                s3Key: 'csv-my-chart-1755512345678.csv',
+                contentDisposition: 'attachment; filename="My Chart.csv"',
+            });
+
+            await controller.getFile(FILE_ID, req);
+
+            expect(headers['Content-Disposition']).toBe(
+                'attachment; filename="My Chart.csv"',
+            );
+            expect(headers['Content-Type']).toBe('text/csv; charset=utf-8');
+        });
+
+        it('falls back to the storage key when the object has no content disposition', async () => {
+            const { controller, req, headers } = setup({
+                s3Key: 'csv-my-chart-1755512345678.csv',
+                contentDisposition: null,
+            });
+
+            await controller.getFile(FILE_ID, req);
+
+            expect(headers['Content-Disposition']).toContain(
+                'csv-my-chart-1755512345678.csv',
+            );
+        });
+
+        it('falls back when the stored content disposition contains CR/LF', async () => {
+            const { controller, req, headers } = setup({
+                s3Key: 'csv-my-chart-1755512345678.csv',
+                contentDisposition:
+                    'attachment; filename="evil.csv"\r\nX-Injected: yes',
+            });
+
+            await controller.getFile(FILE_ID, req);
+
+            expect(headers['Content-Disposition']).not.toContain('X-Injected');
+            expect(headers['Content-Disposition']).toContain(
+                'csv-my-chart-1755512345678.csv',
+            );
+        });
+
+        it('RFC 5987 encodes a non-ASCII storage key on the fallback path', async () => {
+            const { controller, req, headers } = setup({
+                s3Key: 'csv-売上-1755512345678.csv',
+                contentDisposition: null,
+            });
+
+            await controller.getFile(FILE_ID, req);
+
+            expect(headers['Content-Disposition']).toBe(
+                'attachment; filename="csv--1755512345678.csv"; filename*=UTF-8\'\'csv-%E5%A3%B2%E4%B8%8A-1755512345678.csv',
+            );
+        });
+
+        it('passes a non-ASCII stored content disposition through untouched', async () => {
+            const stored =
+                'attachment; filename="download.csv"; filename*=UTF-8\'\'%E5%A3%B2%E4%B8%8A.csv';
+            const { controller, req, headers } = setup({
+                s3Key: 'csv-1755512345678.csv',
+                contentDisposition: stored,
+            });
+
+            await controller.getFile(FILE_ID, req);
+
+            expect(headers['Content-Disposition']).toBe(stored);
+        });
+    });
+});

--- a/packages/backend/src/controllers/fileController.ts
+++ b/packages/backend/src/controllers/fileController.ts
@@ -67,28 +67,35 @@ export class FileController extends BaseController {
             throw new NotFoundError('Cannot find file');
         }
 
-        const { stream, fileType, s3Key } = await this.services
-            .getPersistentDownloadFileService()
-            .getFileStream(fileId, {
-                account: req.account,
-                downloadToken,
-                ip: req.ip,
-                userAgent: req.headers['user-agent'],
-            });
+        const { stream, fileType, s3Key, contentDisposition } =
+            await this.services
+                .getPersistentDownloadFileService()
+                .getFileStream(fileId, {
+                    account: req.account,
+                    downloadToken,
+                    ip: req.ip,
+                    userAgent: req.headers['user-agent'],
+                });
 
         const res = req.res!;
         const contentType =
             FILE_TYPE_TO_MIME[fileType] ?? 'application/octet-stream';
-        const filename = path.basename(s3Key);
+
+        // The header stored at upload time holds the friendly download name;
+        // the storage key is only a fallback. Reject CR/LF so an object written
+        // outside the current upload path can't inject response headers.
+        const storedDisposition =
+            contentDisposition && !/[\r\n]/.test(contentDisposition)
+                ? contentDisposition
+                : null;
 
         res.setHeader('Content-Type', contentType);
-        // Use RFC 5987 encoding so non-ASCII characters in the filename
-        // (em-dashes, accented letters, emojis from dashboard names) don't
-        // make Node throw `ERR_INVALID_CHAR` on setHeader, which would turn
-        // the download into a ~200-byte JSON error response (PROD-7227).
+        // RFC 5987 encoding keeps non-ASCII names (em-dashes, accents, emojis)
+        // from making Node throw `ERR_INVALID_CHAR` on setHeader.
         res.setHeader(
             'Content-Disposition',
-            createContentDispositionHeader(filename),
+            storedDisposition ??
+                createContentDispositionHeader(path.basename(s3Key)),
         );
         res.setHeader('X-Robots-Tag', 'noindex, nofollow');
 

--- a/packages/backend/src/controllers/fileController.ts
+++ b/packages/backend/src/controllers/fileController.ts
@@ -13,7 +13,7 @@ import {
 import express from 'express';
 import path from 'path';
 import { pipeline } from 'stream/promises';
-import { createContentDispositionHeader } from '../utils/FileDownloadUtils/FileDownloadUtils';
+import { getSafeContentDispositionHeader } from '../utils/FileDownloadUtils/FileDownloadUtils';
 import { allowApiKeyAuthentication } from './authentication';
 import { BaseController } from './baseController';
 
@@ -81,21 +81,13 @@ export class FileController extends BaseController {
         const contentType =
             FILE_TYPE_TO_MIME[fileType] ?? 'application/octet-stream';
 
-        // The header stored at upload time holds the friendly download name;
-        // the storage key is only a fallback. Reject CR/LF so an object written
-        // outside the current upload path can't inject response headers.
-        const storedDisposition =
-            contentDisposition && !/[\r\n]/.test(contentDisposition)
-                ? contentDisposition
-                : null;
-
         res.setHeader('Content-Type', contentType);
-        // RFC 5987 encoding keeps non-ASCII names (em-dashes, accents, emojis)
-        // from making Node throw `ERR_INVALID_CHAR` on setHeader.
         res.setHeader(
             'Content-Disposition',
-            storedDisposition ??
-                createContentDispositionHeader(path.basename(s3Key)),
+            getSafeContentDispositionHeader(
+                contentDisposition,
+                path.basename(s3Key),
+            ),
         );
         res.setHeader('X-Robots-Tag', 'noindex, nofollow');
 

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1952,7 +1952,7 @@ export default class SchedulerTask {
             return undefined;
         }
         try {
-            const stream =
+            const { stream } =
                 await this.fileStorageClient.getFileStream(imageS3Key);
             const chunks: Buffer[] = [];
             for await (const chunk of stream) {
@@ -2171,9 +2171,11 @@ export default class SchedulerTask {
                     try {
                         // Add the pdf to the thread
                         const pdfBuffer = this.fileStorageClient.isEnabled()
-                            ? await this.fileStorageClient.getFileStream(
-                                  pdfFile.fileName,
-                              )
+                            ? (
+                                  await this.fileStorageClient.getFileStream(
+                                      pdfFile.fileName,
+                                  )
+                              ).stream
                             : await fs.readFile(pdfFile.source);
 
                         await this.slackClient.postFileToThread({
@@ -2222,9 +2224,11 @@ export default class SchedulerTask {
 
                 // Post PDF file as a separate message
                 const pdfBuffer = this.fileStorageClient.isEnabled()
-                    ? await this.fileStorageClient.getFileStream(
-                          pdfFile.fileName,
-                      )
+                    ? (
+                          await this.fileStorageClient.getFileStream(
+                              pdfFile.fileName,
+                          )
+                      ).stream
                     : await fs.readFile(pdfFile.source);
 
                 await this.slackClient.postFileToThread({

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.test.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.test.ts
@@ -112,7 +112,10 @@ describe('PersistentDownloadFileService', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockModelCreate.mockResolvedValue(undefined);
-        mockS3GetFileStream.mockResolvedValue(Readable.from(['hello,world\n']));
+        mockS3GetFileStream.mockResolvedValue({
+            stream: Readable.from(['hello,world\n']),
+            contentDisposition: null,
+        });
     });
 
     afterEach(() => {
@@ -268,6 +271,38 @@ describe('PersistentDownloadFileService', () => {
                 s3Key: 'exports/test-file.csv',
             });
             expect(mockS3GetFileStream).toHaveBeenCalledOnce();
+        });
+
+        it('returns the content disposition stored on the object', async () => {
+            mockS3GetFileStream.mockResolvedValue({
+                stream: Readable.from(['hello,world\n']),
+                contentDisposition: 'attachment; filename="My Chart.csv"',
+            });
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR),
+            );
+
+            await expect(
+                createService().getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(accountWith()),
+                ),
+            ).resolves.toMatchObject({
+                contentDisposition: 'attachment; filename="My Chart.csv"',
+            });
+        });
+
+        it('returns a null content disposition when the object has none', async () => {
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR),
+            );
+
+            await expect(
+                createService().getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(accountWith()),
+                ),
+            ).resolves.toMatchObject({ contentDisposition: null });
         });
 
         it('denies another project member for a creator-bound export', async () => {

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
@@ -363,6 +363,7 @@ export class PersistentDownloadFileService extends BaseService {
         stream: Readable;
         fileType: string;
         s3Key: string;
+        contentDisposition: string | null;
     }> {
         const file = await this.getAuthorizedFile(fileNanoid, requestContext);
         const requestStartedAt = Date.now();
@@ -385,7 +386,8 @@ export class PersistentDownloadFileService extends BaseService {
             },
         });
 
-        const stream = await this.fileStorageClient.getFileStream(file.s3_key);
+        const { stream, contentDisposition } =
+            await this.fileStorageClient.getFileStream(file.s3_key);
 
         this.analytics.track({
             event: 'persistent_file.url_responded',
@@ -414,6 +416,7 @@ export class PersistentDownloadFileService extends BaseService {
             stream,
             fileType: file.file_type,
             s3Key: file.s3_key,
+            contentDisposition,
         };
     }
 }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -7473,7 +7473,11 @@ export class ProjectService extends BaseService {
             case DownloadFileType.JSONL:
                 return fs.createReadStream(downloadFile.path);
             case DownloadFileType.S3_JSONL:
-                return this.fileStorageClient.getFileStream(downloadFile.path);
+                return (
+                    await this.fileStorageClient.getFileStream(
+                        downloadFile.path,
+                    )
+                ).stream;
             default:
                 throw new ParameterError('File is not a valid JSONL file');
         }

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -458,7 +458,8 @@ export class UnfurlService extends BaseService {
             throw new NotFoundError('Slack unfurl image object missing');
         }
 
-        return this.fileStorageClient.getFileStream(record.s3_key);
+        return (await this.fileStorageClient.getFileStream(record.s3_key))
+            .stream;
     }
 
     async getTitleAndDescription(

--- a/packages/backend/src/utils/FileDownloadUtils/FileDownloadUtils.test.ts
+++ b/packages/backend/src/utils/FileDownloadUtils/FileDownloadUtils.test.ts
@@ -1,5 +1,6 @@
 import {
     createContentDispositionHeader,
+    getSafeContentDispositionHeader,
     sanitizeGenericFileName,
 } from './FileDownloadUtils';
 
@@ -198,6 +199,55 @@ describe('FileDownloadUtils', () => {
             );
             expect(createContentDispositionHeader('test&file.csv')).toContain(
                 "filename*=UTF-8''test%26file.csv",
+            );
+        });
+    });
+
+    describe('getSafeContentDispositionHeader', () => {
+        const FALLBACK = 'csv-storage-key.csv';
+
+        it('preserves a stored attachment filename', () => {
+            const stored = 'attachment; filename="My chart.csv"';
+
+            expect(getSafeContentDispositionHeader(stored, FALLBACK)).toBe(
+                stored,
+            );
+        });
+
+        it('preserves an RFC 5987 percent-encoded filename', () => {
+            const stored =
+                'attachment; filename="download.csv"; filename*=UTF-8\'\'%E5%A3%B2%E4%B8%8A.csv';
+
+            expect(getSafeContentDispositionHeader(stored, FALLBACK)).toBe(
+                stored,
+            );
+        });
+
+        it('preserves latin-1 characters, which Node accepts', () => {
+            const stored = 'attachment; filename="café.csv"';
+
+            expect(getSafeContentDispositionHeader(stored, FALLBACK)).toBe(
+                stored,
+            );
+        });
+
+        it('falls back when nothing was stored', () => {
+            expect(getSafeContentDispositionHeader(null, FALLBACK)).toBe(
+                createContentDispositionHeader(FALLBACK),
+            );
+        });
+
+        // Every class of value setHeader rejects with ERR_INVALID_CHAR.
+        it.each([
+            ['carriage return', 'attachment; filename="a\rb.csv"'],
+            ['line feed', 'attachment; filename="a\nb.csv"'],
+            ['header injection', 'attachment\r\nX-Injected: yes'],
+            ['NUL', 'attachment; filename="a\u0000b.csv"'],
+            ['DEL', 'attachment; filename="a\u007Fb.csv"'],
+            ['raw non-latin-1', 'attachment; filename="売上.csv"'],
+        ])('falls back on a stored header containing %s', (_label, stored) => {
+            expect(getSafeContentDispositionHeader(stored, FALLBACK)).toBe(
+                createContentDispositionHeader(FALLBACK),
             );
         });
     });

--- a/packages/backend/src/utils/FileDownloadUtils/FileDownloadUtils.ts
+++ b/packages/backend/src/utils/FileDownloadUtils/FileDownloadUtils.ts
@@ -8,6 +8,7 @@ import {
     ItemsMap,
 } from '@lightdash/common';
 import moment, { MomentInput } from 'moment/moment';
+import { validateHeaderValue } from 'node:http';
 import { Readable } from 'stream';
 import Logger from '../../logging/logger';
 import { splitJsonlStream } from '../streamUtils';
@@ -62,6 +63,32 @@ export function createContentDispositionHeader(filename: string): string {
 
     // Return both filename (ASCII fallback) and filename* (UTF-8 encoded)
     return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodedFilename}`;
+}
+
+/**
+ * Prefers the Content-Disposition stored on the object, which carries the
+ * friendly download name. Falls back to a header built from `fallbackFilename`
+ * when nothing is stored or when the stored value would make `setHeader` throw
+ * `ERR_INVALID_CHAR` — Node rejects NUL, DEL, CR/LF and any code point above
+ * U+00FF, and that throw would turn the download into a JSON error response.
+ */
+export function getSafeContentDispositionHeader(
+    storedContentDisposition: string | null,
+    fallbackFilename: string,
+): string {
+    if (storedContentDisposition !== null) {
+        try {
+            validateHeaderValue(
+                'Content-Disposition',
+                storedContentDisposition,
+            );
+            return storedContentDisposition;
+        } catch {
+            // Unusable stored header; fall through to the generated one.
+        }
+    }
+
+    return createContentDispositionHeader(fallbackFilename);
 }
 
 export function generateGenericFileId({


### PR DESCRIPTION
Fixes lightdash/lightdash#27568

## Problem

CSV/XLSX files downloaded from the UI are named after the internal storage key<br>(`csv-my-chart-1755512345678.csv`) instead of the chart or dashboard name.

The friendly name is generated correctly and *is* written to the stored object's<br>`Content-Disposition` at upload time — it was being discarded on the read path.

## Root cause

Two changes combined here.

lightdash/lightdash#21870 **introduced the loss** (2026-04-09). Before it, `fileController` redirected<br>to a presigned S3 URL, so S3 served the object's own `Content-Disposition`:

```ts
this.setStatus(302);
this.setHeader('Location', signedUrl);
```

That PR replaced the redirect with backend streaming and rebuilt the header from<br>the storage key instead — but the stored value was never available to the<br>controller, because `S3Client.getFileStream` dropped `response.ContentDisposition`<br>and returned only `response.Body`.

lightdash/lightdash#26914 **made it visible to everyone** (1.92.0, 2026-08-06). Authenticated UI<br>downloads are now created with `AUTHENTICATED_CREATOR` rather than `SIGNED`, so<br>they no longer take the raw-S3 early return in `createPersistentUrl` and always<br>resolve through `/api/v1/file/{id}`. `PERSISTENT_DOWNLOAD_URLS_ENABLED` is not<br>consulted for these downloads at all, so there was no config workaround.

## Change

`FileStorageClient.getFileStream` now returns `{ stream, contentDisposition }`<br>instead of a bare `Readable`. `S3Client` returns the stored header, the service<br>threads it through, and the controller chooses between it and a header built<br>from `path.basename(s3Key)` via a new `getSafeContentDispositionHeader` helper<br>in `FileDownloadUtils`.

Current Lightdash writers always produce a safe RFC 5987 header via<br>`createContentDispositionHeader`, but older or externally written objects may<br>not, and an unusable value would make `setHeader` throw `ERR_INVALID_CHAR` —<br>turning the download into a small JSON error response instead of a file.

The helper validates with Node's own `validateHeaderValue` rather than a CR/LF<br>regex. Node also rejects NUL, DEL, and any code point above U+00FF, so a stored<br>header carrying a raw `filename="売上.csv"` would pass a CR/LF check and then<br>throw at `setHeader`. Verified that `validateHeaderValue` accepts and rejects<br>exactly what `setHeader` does, including latin-1 (`café.csv`), which is allowed.

Widening the existing method was preferred over adding a parallel<br>`getFileStreamWithMetadata()`: there is one implementation and five call sites,<br>so the churn is small and compiler-enforced, and it leaves a single retrieval<br>method for future consumers to find.

No migration, and it fixes already-uploaded files, since the correct name is<br>already on the stored object. It also covers instances running with<br>`PERSISTENT_DOWNLOAD_URLS_ENABLED=true`, which is the older form of this bug.

## Not in this PR

Dashboard **zip** and **workbook** downloads are unchanged by this fix, by<br>design. `uploadZip` and the workbook's `uploadExcel` pass no<br>`attachmentDownloadName`, so the stored header already equals the storage key<br>(`<sanitized-name>-<iso-timestamp>.zip`) and reading it back yields byte-identical<br>output. Those need the name plumbed at *upload* time — a follow-up stacked on<br>this branch.

## Testing

Regression coverage at every boundary:

* `S3Client.test.ts` (new) — stored header retained, null when absent, non-ASCII<br>value preserved verbatim
* `PersistentDownloadFileService.test.ts` — threads the header through, and<br>passes through null
* `fileController.test.ts` (new) — prefers the stored header, falls back when<br>absent / on CR/LF / on raw non-latin-1, and RFC 5987 encodes a non-ASCII<br>storage key on the fallback path
* `FileDownloadUtils.test.ts` — the helper in isolation, covering every class of<br>value Node rejects (CR, LF, header injection, NUL, DEL, raw non-latin-1) plus<br>the values it accepts

The controller test's `setHeader` stub calls `validateHeaderValue` itself, so any<br>header we could not actually send fails the test rather than passing silently.

Both directions were checked by reverting the fix: with the read-path change<br>undone the controller tests fail, and with the CR/LF regex in place of<br>`validateHeaderValue` the NUL, DEL, and raw non-latin-1 cases fail.

Backend typecheck clean; 457 tests pass across the scheduler, clients, utils,<br>controller and service suites.

Credit to lightdash/lightdash#27584 for the `getSafeContentDispositionHeader` extraction, which is<br>cleaner than the inline check this PR originally had.