### PR TITLE
fix(backend): name dashboard zip and workbook exports after the dashboard

### DIFF
--- a/packages/backend/src/clients/Aws/S3Client.ts
+++ b/packages/backend/src/clients/Aws/S3Client.ts
@@ -164,9 +164,14 @@ export class S3Client extends S3BaseClient implements FileStorageClient {
         });
     }
 
-    async uploadZip(zip: ReadStream, zipName: string): Promise<string> {
+    async uploadZip(
+        zip: ReadStream,
+        zipName: string,
+        attachmentDownloadName?: string,
+    ): Promise<string> {
         return this.uploadFile(zipName, zip, {
             contentType: 'application/zip',
+            attachmentDownloadName,
         });
     }
 

--- a/packages/backend/src/clients/FileStorage/FileStorageClient.ts
+++ b/packages/backend/src/clients/FileStorage/FileStorageClient.ts
@@ -33,7 +33,11 @@ export interface FileStorageClient {
         attachmentDownloadName?: string,
     ): Promise<string>;
 
-    uploadZip(zip: ReadStream, zipName: string): Promise<string>;
+    uploadZip(
+        zip: ReadStream,
+        zipName: string,
+        attachmentDownloadName?: string,
+    ): Promise<string>;
 
     uploadExcel(
         excel: ReadStream,

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -33,6 +33,7 @@ import {
 import ExecutionContext from 'node-execution-context';
 import type { Mock } from 'vitest';
 import type { ExecutionContextInfo } from '../logging/winston';
+import { WorkbookExportHelper } from '../services/ExcelService/WorkbookExportHelper';
 import SchedulerTask, {
     buildItemMapFromColumns,
     buildSchedulerLogContext,
@@ -3440,6 +3441,7 @@ describe('app delivery target senders', () => {
 describe('dashboard export download filenames', () => {
     afterEach(() => {
         vi.unstubAllGlobals();
+        vi.restoreAllMocks();
     });
 
     const callCreateZipDownloadUrl = (
@@ -3501,9 +3503,73 @@ describe('dashboard export download filenames', () => {
         expect(uploadZip).toHaveBeenCalledTimes(1);
         const [, storageKey, attachmentDownloadName] = uploadZip.mock.calls[0];
         expect(attachmentDownloadName).toBe('Q3 Revenue / Costs.zip');
-        // The key stays storage-safe and timestamped, so it must differ.
         expect(storageKey).not.toContain('/');
         expect(storageKey).toMatch(/\.zip$/);
+        expect(storageKey).not.toBe(attachmentDownloadName);
+    });
+
+    it('uploads the workbook with the dashboard name as the download filename', async () => {
+        vi.spyOn(WorkbookExportHelper, 'createWorkbookFile').mockResolvedValue({
+            worksheetCount: 2,
+            failedFileCount: 0,
+        });
+        const uploadExcel = vi
+            .fn()
+            .mockResolvedValue('https://files.example.com/workbook.xlsx');
+        const task = makeTaskWithDeps({
+            fileStorageClient: asDep<'fileStorageClient'>({
+                isEnabled: () => true,
+                uploadExcel,
+            }),
+            persistentDownloadFileService:
+                asDep<'persistentDownloadFileService'>({
+                    createPersistentUrl: vi
+                        .fn()
+                        .mockResolvedValue(
+                            'https://lightdash.example.com/api/v1/file/abc',
+                        ),
+                }),
+        });
+
+        await (
+            task as unknown as {
+                createWorkbookDownloadUrl: (args: {
+                    files: {
+                        filename: string;
+                        path: string;
+                        localPath: string;
+                        truncated: boolean;
+                    }[];
+                    workbookNameBase: string;
+                    organizationUuid: string;
+                    projectUuid: string;
+                    createdByUserUuid: string;
+                    accessMode: PersistentDownloadFileAccessMode;
+                }) => Promise<{ url: string; numFileFailures: number }>;
+            }
+        ).createWorkbookDownloadUrl({
+            files: [
+                {
+                    filename: 'Revenue',
+                    path: 'https://files.example.com/revenue.xlsx',
+                    localPath: '/tmp/revenue.xlsx',
+                    truncated: false,
+                },
+            ],
+            workbookNameBase: 'Q3 Revenue / Costs',
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            createdByUserUuid: 'user-1',
+            accessMode: PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
+        });
+
+        expect(uploadExcel).toHaveBeenCalledTimes(1);
+        const [, storageKey, attachmentDownloadName] =
+            uploadExcel.mock.calls[0];
+        expect(attachmentDownloadName).toBe('Q3 Revenue / Costs.xlsx');
+        // The key stays storage-safe and timestamped, so it must differ.
+        expect(storageKey).not.toContain('/');
+        expect(storageKey).toMatch(/\.xlsx$/);
         expect(storageKey).not.toBe(attachmentDownloadName);
     });
 });

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -14,6 +14,7 @@ import {
     MetricType,
     NotEnoughResults,
     PartialFailureType,
+    PersistentDownloadFileAccessMode,
     SchedulerFormat,
     sleep,
     ThresholdOperator,
@@ -3433,5 +3434,76 @@ describe('app delivery target senders', () => {
             failures: page.failures,
             notices: page.notices,
         });
+    });
+});
+
+describe('dashboard export download filenames', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    const callCreateZipDownloadUrl = (
+        task: SchedulerTask,
+        zipNameBase: string,
+    ) =>
+        (
+            task as unknown as {
+                createZipDownloadUrl: (args: {
+                    files: { entryNameBase: string; localPath: string }[];
+                    fileType: SchedulerFormat.CSV | SchedulerFormat.XLSX;
+                    zipNameBase: string;
+                    organizationUuid: string;
+                    projectUuid: string;
+                    createdByUserUuid: string | null;
+                    accessMode: PersistentDownloadFileAccessMode;
+                }) => Promise<string>;
+            }
+        ).createZipDownloadUrl({
+            files: [
+                {
+                    entryNameBase: 'Revenue',
+                    localPath: 'https://files.example.com/revenue.csv',
+                },
+            ],
+            fileType: SchedulerFormat.CSV,
+            zipNameBase,
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            createdByUserUuid: 'user-1',
+            accessMode: PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
+        });
+
+    it('uploads the zip with the dashboard name as the download filename', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => new Response('a,b\n1,2\n')),
+        );
+        const uploadZip = vi
+            .fn()
+            .mockResolvedValue('https://files.example.com/export.zip');
+        const task = makeTaskWithDeps({
+            fileStorageClient: asDep<'fileStorageClient'>({
+                isEnabled: () => true,
+                uploadZip,
+            }),
+            persistentDownloadFileService:
+                asDep<'persistentDownloadFileService'>({
+                    createPersistentUrl: vi
+                        .fn()
+                        .mockResolvedValue(
+                            'https://lightdash.example.com/api/v1/file/abc',
+                        ),
+                }),
+        });
+
+        await callCreateZipDownloadUrl(task, 'Q3 Revenue / Costs');
+
+        expect(uploadZip).toHaveBeenCalledTimes(1);
+        const [, storageKey, attachmentDownloadName] = uploadZip.mock.calls[0];
+        expect(attachmentDownloadName).toBe('Q3 Revenue / Costs.zip');
+        // The key stays storage-safe and timestamped, so it must differ.
+        expect(storageKey).not.toContain('/');
+        expect(storageKey).toMatch(/\.zip$/);
+        expect(storageKey).not.toBe(attachmentDownloadName);
     });
 });

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -5854,9 +5854,12 @@ export default class SchedulerTask {
                 zipNameBase,
             )}-${new Date().toISOString().replace(/[:.]/g, '-')}.zip`;
 
+            // The key stays sanitised and timestamped; the download name keeps
+            // the dashboard name as typed.
             await this.fileStorageClient.uploadZip(
                 fsSync.createReadStream(zipPath),
                 zipFileName,
+                `${zipNameBase}.zip`,
             );
         } finally {
             await fs.unlink(zipPath).catch(() => {});
@@ -5959,6 +5962,7 @@ export default class SchedulerTask {
             await this.fileStorageClient.uploadExcel(
                 fsSync.createReadStream(workbookPath),
                 workbookFileName,
+                `${workbookNameBase}.xlsx`,
             );
         } finally {
             await fs.unlink(workbookPath).catch(() => {});


### PR DESCRIPTION
Fixes lightdash/lightdash#27583

Stacked on lightdash/lightdash#27582.

## Problem

"Export all CSVs" (zip) and "Export dashboard" as an XLSX workbook download with a<br>sanitised, timestamped name taken from the storage key:

* `Q3 Revenue / Costs` → `Q3 Revenue _ Costs-2026-08-18T09-14-22-431Z.zip`

Unlike lightdash/lightdash#27568 this is not a regression — these two paths have always used the<br>storage key. lightdash/lightdash#27582 fixes per-chart CSV/XLSX by preferring the<br>`Content-Disposition` stored on the object, but it is provably a **no-op** for<br>these two, because their stored header is byte-identical to the key.

## Root cause

Both uploads omit `attachmentDownloadName`, so `uploadFile` falls back to the key:

```ts
ContentDisposition: createContentDispositionHeader(
    fileOpts.attachmentDownloadName || fileId,
),
```

`uploadZip` had no parameter to pass one at all; `uploadExcel` already accepted one<br>but the workbook call site didn't supply it.

## Change

`uploadZip` gains the `attachmentDownloadName` parameter that `uploadCsv` and<br>`uploadExcel` already have, and both `createZipDownloadUrl` and<br>`createWorkbookDownloadUrl` pass the dashboard name.

The storage keys are deliberately left alone — they need to stay collision-free and<br>storage-safe. Only the download name carries the original name.<br>`createContentDispositionHeader` sanitises and RFC 5987-encodes on the way out, so<br>passing the raw name is safe and gives the best result for non-ASCII dashboards too.

Unlike lightdash/lightdash#27582 this only affects newly created exports; it can't repair the header<br>already written on existing objects.

## Testing

Two tests in `SchedulerTask.test.ts`, one per upload path:

* `createZipDownloadUrl`, driven end to end with a stubbed `fetch`
* `createWorkbookDownloadUrl`, with `WorkbookExportHelper.createWorkbookFile`<br>spied so the path runs without real xlsx inputs

Both assert the upload receives the dashboard name (`Q3 Revenue / Costs.zip` /<br>`.xlsx`) while the storage key stays sanitised, timestamped, and distinct — so a<br>future change that reuses one for the other is caught.

Verified both are load-bearing by removing each `attachmentDownloadName` argument<br>in turn; each fails with `expected undefined to be 'Q3 Revenue / Costs.<ext>'`.

Backend typecheck clean; 457 tests pass across the scheduler, clients, utils,<br>controller and service suites.