### PR TITLE
fix: support Codex visualization schemas

### DIFF
--- a/packages/common/src/ee/apps/types.test.ts
+++ b/packages/common/src/ee/apps/types.test.ts
@@ -411,14 +411,55 @@ describe('dataAppVizGenerationSchema', () => {
         );
         expect(dataAppVizSchema.safeParse(declaration).success).toBe(true);
     });
+
+    it('normalizes nullable placeholders for optional properties', () => {
+        expect(
+            dataAppVizGenerationSchema.safeParse({
+                ...validFields,
+                configOptions: [
+                    {
+                        name: 'barWidth',
+                        label: 'Bar width',
+                        group: null,
+                        type: 'number',
+                        default: 24,
+                        min: null,
+                        max: null,
+                    },
+                ],
+                colorPalette: { group: null },
+            }),
+        ).toEqual({
+            success: true,
+            data: {
+                ...validFields,
+                configOptions: [
+                    {
+                        name: 'barWidth',
+                        label: 'Bar width',
+                        type: 'number',
+                        default: 24,
+                    },
+                ],
+                colorPalette: {},
+            },
+        });
+    });
 });
 
 describe('dataAppVizJsonSchema', () => {
     // What the generator CLI receives via --json-schema.
     const jsonSchema = dataAppVizJsonSchema as {
+        $schema?: string;
         required?: string[];
         properties?: Record<string, { description?: string }>;
     };
+
+    it('uses the JSON Schema draft supported by both generator CLIs', () => {
+        expect(jsonSchema.$schema).toBe(
+            'http://json-schema.org/draft-07/schema#',
+        );
+    });
 
     it('makes fields, configOptions and colorPalette required', () => {
         expect(jsonSchema.required).toEqual(
@@ -430,5 +471,60 @@ describe('dataAppVizJsonSchema', () => {
         expect(jsonSchema.properties?.fields.description).toBeTruthy();
         expect(jsonSchema.properties?.configOptions.description).toBeTruthy();
         expect(jsonSchema.properties?.colorPalette.description).toBeTruthy();
+    });
+
+    it('uses strict object schemas compatible with Codex structured output', () => {
+        const findMissingRequiredProperties = (
+            value: unknown,
+            path = '$',
+        ): string[] => {
+            if (value === null || typeof value !== 'object') {
+                return [];
+            }
+
+            const schema = value as Record<string, unknown>;
+            const missing: string[] = [];
+            if (
+                schema.properties !== null &&
+                typeof schema.properties === 'object'
+            ) {
+                const propertyNames = Object.keys(schema.properties);
+                const required = Array.isArray(schema.required)
+                    ? schema.required
+                    : [];
+                const missingAtPath = propertyNames.filter(
+                    (property) => !required.includes(property),
+                );
+                if (missingAtPath.length > 0) {
+                    missing.push(`${path}: ${missingAtPath.join(', ')}`);
+                }
+            }
+
+            return Object.entries(schema).reduce<string[]>(
+                (errors, [key, child]) => [
+                    ...errors,
+                    ...findMissingRequiredProperties(child, `${path}.${key}`),
+                ],
+                missing,
+            );
+        };
+
+        expect(findMissingRequiredProperties(jsonSchema)).toEqual([]);
+    });
+
+    it('does not use local JSON Schema references', () => {
+        const findReferences = (value: unknown): string[] => {
+            if (value === null || typeof value !== 'object') {
+                return [];
+            }
+
+            const schema = value as Record<string, unknown>;
+            return [
+                ...(typeof schema.$ref === 'string' ? [schema.$ref] : []),
+                ...Object.values(schema).flatMap(findReferences),
+            ];
+        };
+
+        expect(findReferences(jsonSchema)).toEqual([]);
     });
 });

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -797,7 +797,9 @@ const optionBase = {
         .describe('Human label shown next to the control in the config panel.'),
     group: z
         .string()
+        .nullable()
         .optional()
+        .transform((value) => value ?? undefined)
         .describe(
             'Optional tab name. Options sharing a group are rendered in the same config tab; ungrouped options share a default tab.',
         ),
@@ -864,8 +866,18 @@ const vizConfigOptions = z.array(
             default: z
                 .number()
                 .describe('Value used until the viewer changes it.'),
-            min: z.number().optional().describe('Optional lower bound.'),
-            max: z.number().optional().describe('Optional upper bound.'),
+            min: z
+                .number()
+                .nullable()
+                .optional()
+                .transform((value) => value ?? undefined)
+                .describe('Optional lower bound.'),
+            max: z
+                .number()
+                .nullable()
+                .optional()
+                .transform((value) => value ?? undefined)
+                .describe('Optional upper bound.'),
         }),
         z.object({
             ...optionBase,
@@ -888,7 +900,9 @@ const vizColorPalette = z
     .object({
         group: z
             .string()
+            .nullable()
             .optional()
+            .transform((value) => value ?? undefined)
             .describe(
                 'Optional tab name, matching a config option `group`. The picker gets its own tab when no option shares it.',
             ),
@@ -945,8 +959,18 @@ void dataAppVizGenerationSchemaIsPersistable;
 
 // JSON Schema form of the generation contract for the generator CLI's
 // `--json-schema` flag. Refinements (e.g. unique names) don't survive the
-// conversion and stay enforced by the runtime `safeParse`.
-export const dataAppVizJsonSchema = zodToJsonSchema(dataAppVizGenerationSchema);
+// conversion and stay enforced by the runtime `safeParse`. The OpenAI target
+// represents optional properties as required and nullable for strict structured
+// output. Inline shared schemas because Codex only accepts top-level references,
+// and retain draft-07 because the Claude CLI does not support the OpenAI
+// target's 2019-09 meta-schema.
+export const dataAppVizJsonSchema = {
+    ...zodToJsonSchema(dataAppVizGenerationSchema, {
+        $refStrategy: 'none',
+        target: 'openAi',
+    }),
+    $schema: 'http://json-schema.org/draft-07/schema#',
+};
 
 /** Whether a stored value still has the shape the option declares. */
 const matchesDeclaredType = (


### PR DESCRIPTION
### Description

Makes the data app visualization generation schema compatible with OpenAI strict structured output while preserving the existing persisted optional values.

- use the built-in OpenAI JSON Schema target
- inline shared definitions rejected by Codex
- normalize null placeholders back to omitted optional values
- add regression coverage for strict required fields and references

Ticket: https://linear.app/lightdash/issue/PROD-10288/data-apps-make-visualization-output-schema-codex-compatible

### Tests

- pnpm -F common test
- pnpm -F common lint
- pnpm -F common typecheck
- pnpm -F common build
- live data app visualization generation with Claude and Codex