### PR TITLE
feat: count pre-aggregate execution fallbacks in analytics

### DIFF
--- a/docs/pre-aggregates/CONTEXT.md
+++ b/docs/pre-aggregates/CONTEXT.md
@@ -98,8 +98,8 @@ granularity too fine, non-additive metric).
 A matched query whose pre-aggregate execution failed (unreadable
 materialization, DuckDB error, external table issue), so results were served
 from the source warehouse. Distinct from a miss: the match succeeded but the
-serve did not. Recorded as a fallback reason on query history and exposed on
-results metadata.
+serve did not. Recorded as a fallback reason on query history, exposed on
+results metadata, and counted in pre-aggregate analytics.
 _Avoid_: miss, retry, cache miss
 
 **Ineligible**:

--- a/packages/backend/src/database/migrations/20260818143710_add_fallback_count_to_pre_aggregate_daily_stats.ts
+++ b/packages/backend/src/database/migrations/20260818143710_add_fallback_count_to_pre_aggregate_daily_stats.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+const PreAggregateDailyStatsTableName = 'pre_aggregate_daily_stats';
+const ColumnName = 'fallback_count';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.alterTable(PreAggregateDailyStatsTableName, (table) => {
+        // Matched queries whose pre-aggregate execution failed and were served from the warehouse
+        table.integer(ColumnName).notNullable().defaultTo(0);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.alterTable(PreAggregateDailyStatsTableName, (table) => {
+        table.dropColumn(ColumnName);
+    });
+}

--- a/packages/backend/src/ee/database/entities/preAggregateDailyStats.ts
+++ b/packages/backend/src/ee/database/entities/preAggregateDailyStats.ts
@@ -12,6 +12,7 @@ export type DbPreAggregateDailyStat = {
     query_context: string;
     hit_count: number;
     miss_count: number;
+    fallback_count: number;
     miss_reason: string | null;
     pre_aggregate_name: string | null;
     created_at: Date;

--- a/packages/backend/src/ee/models/PreAggregateDailyStatsModel.ts
+++ b/packages/backend/src/ee/models/PreAggregateDailyStatsModel.ts
@@ -18,6 +18,14 @@ export type PreAggregateDailyStatsUpsertParams = {
     preAggregateName: string | null;
 };
 
+export type PreAggregateDailyStatsFallbackParams = {
+    projectUuid: string;
+    exploreName: string;
+    chartUuid: string | null;
+    dashboardUuid: string | null;
+    queryContext: string;
+};
+
 export type PreAggregateDailyStatRow = {
     projectUuid: string;
     exploreName: string;
@@ -29,6 +37,7 @@ export type PreAggregateDailyStatRow = {
     queryContext: string;
     hitCount: number;
     missCount: number;
+    fallbackCount: number;
     missReason: string | null;
     preAggregateName: string | null;
     updatedAt: Date;
@@ -45,6 +54,7 @@ type DbJoinedRow = {
     query_context: string;
     hit_count: number;
     miss_count: number;
+    fallback_count: number;
     miss_reason: string | null;
     pre_aggregate_name: string | null;
     updated_at: Date;
@@ -62,6 +72,7 @@ function convertDbRow(row: DbJoinedRow): PreAggregateDailyStatRow {
         queryContext: row.query_context,
         hitCount: row.hit_count,
         missCount: row.miss_count,
+        fallbackCount: row.fallback_count,
         missReason: row.miss_reason,
         preAggregateName: row.pre_aggregate_name,
         updatedAt: row.updated_at,
@@ -113,6 +124,35 @@ export class PreAggregateDailyStatsModel {
         );
     }
 
+    async incrementFallback(
+        params: PreAggregateDailyStatsFallbackParams,
+    ): Promise<void> {
+        await this.database.raw(
+            `
+            INSERT INTO ${PreAggregateDailyStatsTableName}
+                (project_uuid, explore_name, date, chart_uuid,
+                 dashboard_uuid, query_context,
+                 hit_count, miss_count, fallback_count)
+            VALUES (?, ?, CURRENT_DATE, ?, ?, ?, 0, 0, 1)
+            ON CONFLICT (
+                project_uuid, explore_name, date, query_context,
+                COALESCE(chart_uuid, '00000000-0000-0000-0000-000000000000'),
+                COALESCE(dashboard_uuid, '00000000-0000-0000-0000-000000000000')
+            )
+            DO UPDATE SET
+                fallback_count = ${PreAggregateDailyStatsTableName}.fallback_count + 1,
+                updated_at = NOW()
+            `,
+            [
+                params.projectUuid,
+                params.exploreName,
+                params.chartUuid,
+                params.dashboardUuid,
+                params.queryContext,
+            ],
+        );
+    }
+
     async getByProject(
         projectUuid: string,
         days: number = 3,
@@ -135,6 +175,7 @@ export class PreAggregateDailyStatsModel {
                 `${stats}.query_context`,
                 `${stats}.hit_count`,
                 `${stats}.miss_count`,
+                `${stats}.fallback_count`,
                 `${stats}.miss_reason`,
                 `${stats}.pre_aggregate_name`,
                 `${stats}.updated_at`,

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -33,6 +33,7 @@ import { type DashboardModel } from '../../../models/DashboardModel/DashboardMod
 import { type SavedChartModel } from '../../../models/SavedChartModel';
 import type {
     PreAggregateStrategy as IPreAggregateStrategy,
+    PreAggregateExecutionFallbackParams,
     PreAggregateExecutionResolution,
     PreAggregateStatsFilters,
     PreAggregationRoutingDecision,
@@ -265,6 +266,17 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
             );
     }
 
+    recordExecutionFallback(params: PreAggregateExecutionFallbackParams): void {
+        void this.statsModel
+            .incrementFallback(params)
+            .catch((e) =>
+                Logger.error(
+                    'Failed to record pre-aggregate execution fallback',
+                    e,
+                ),
+            );
+    }
+
     async cleanupStats(retentionDays: number): Promise<number> {
         return this.statsModel.cleanup(retentionDays);
     }
@@ -294,6 +306,7 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
                     queryContext: row.queryContext,
                     hitCount: row.hitCount,
                     missCount: row.missCount,
+                    fallbackCount: row.fallbackCount,
                     missReason: row.missReason,
                     preAggregateName: row.preAggregateName,
                     updatedAt: row.updatedAt.toISOString(),

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -128,6 +128,7 @@ const makeMockStrategy = (
         () => warehouseClientMock as unknown as WarehouseClient,
     ),
     recordStats: vi.fn(),
+    recordExecutionFallback: vi.fn(),
     cleanupStats: vi.fn(async () => 0),
     getStats: noOpStrategy.getStats.bind(noOpStrategy),
     getResultsStorageClient: vi.fn(() => undefined),
@@ -2476,7 +2477,7 @@ describe('AsyncQueryService', () => {
             displayTimezone: null,
         });
 
-        test('records fallback on query history when execution fails', async () => {
+        test('records fallback on query history and stats when execution fails', async () => {
             const mockStrategy = makeMockStrategy({
                 resolved: true,
                 query: 'SELECT * FROM duckdb_preagg',
@@ -2500,6 +2501,13 @@ describe('AsyncQueryService', () => {
                     user: { id: sessionAccount.user.id },
                 }),
             );
+            expect(mockStrategy.recordExecutionFallback).toHaveBeenCalledWith({
+                projectUuid,
+                exploreName: 'orders',
+                chartUuid: 'chart-uuid',
+                dashboardUuid: 'dashboard-uuid',
+                queryContext: QueryExecutionContext.EXPLORE,
+            });
             expect(runAsyncWarehouseSpy).toHaveBeenCalledTimes(2);
             expect(runAsyncWarehouseSpy.mock.calls[1][0]).toMatchObject({
                 query: 'SELECT * FROM warehouse',
@@ -2529,6 +2537,7 @@ describe('AsyncQueryService', () => {
                 }),
                 expect.anything(),
             );
+            expect(mockStrategy.recordExecutionFallback).not.toHaveBeenCalled();
         });
 
         test('still falls back to the warehouse when the fallback write fails', async () => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2641,6 +2641,16 @@ export class AsyncQueryService extends ProjectService {
                 );
             }
 
+            if (queryTags.explore_name) {
+                this.preAggregateStrategy.recordExecutionFallback({
+                    projectUuid,
+                    exploreName: queryTags.explore_name,
+                    chartUuid: queryTags.chart_uuid ?? null,
+                    dashboardUuid: queryTags.dashboard_uuid ?? null,
+                    queryContext: queryTags.query_context,
+                });
+            }
+
             await this.runAsyncWarehouseQuery({
                 userUuid,
                 organizationUuid,

--- a/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -41,6 +41,15 @@ export type PreAggregationRoutingDecision =
           preAggregateMetadata?: CacheMetadata['preAggregate'];
       };
 
+// Stats context for a matched query whose pre-aggregate failed to serve
+export type PreAggregateExecutionFallbackParams = {
+    projectUuid: string;
+    exploreName: string;
+    chartUuid: string | null;
+    dashboardUuid: string | null;
+    queryContext: string;
+};
+
 export type PreAggregateStatsFilters = {
     exploreName?: string;
     queryType?: 'chart' | 'dashboard' | 'explorer';
@@ -71,6 +80,10 @@ export interface PreAggregateStrategy {
         dashboardUuid: string | null;
         queryContext: string;
     }): void;
+
+    // Called at execution time when a matched pre-aggregate failed to serve
+    // and the query fell back to the source warehouse
+    recordExecutionFallback(params: PreAggregateExecutionFallbackParams): void;
 
     cleanupStats(retentionDays: number): Promise<number>;
 
@@ -125,6 +138,10 @@ export class NoOpPreAggregateStrategy implements PreAggregateStrategy {
     }
 
     recordStats(): void {
+        // no-op
+    }
+
+    recordExecutionFallback(): void {
         // no-op
     }
 

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -346,6 +346,8 @@ export type PreAggregateDailyStatResult = {
     queryContext: string;
     hitCount: number;
     missCount: number;
+    // Matched queries whose pre-aggregate execution failed and were served from the warehouse
+    fallbackCount: number;
     missReason: string | null;
     preAggregateName: string | null;
     updatedAt: string;

--- a/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.tsx
@@ -1,5 +1,5 @@
 import { type PreAggregateDailyStatResult } from '@lightdash/common';
-import { Anchor, Group, Text, useMantineTheme } from '@mantine/core';
+import { Anchor, Group, Text, Tooltip, useMantineTheme } from '@mantine/core';
 import {
     IconAlertTriangle,
     IconChartBar,
@@ -230,7 +230,7 @@ const PreAggregateStatsTable: FC<Props> = ({
                     </Group>
                 ),
                 Cell: ({ row }) => {
-                    const { hitCount, missCount } = row.original;
+                    const { hitCount, missCount, fallbackCount } = row.original;
                     return (
                         <Group gap={8} wrap="nowrap">
                             <Text size="xs" c="green.7" ff="monospace">
@@ -247,6 +247,23 @@ const PreAggregateStatsTable: FC<Props> = ({
                             >
                                 {missCount} uncached
                             </Text>
+                            {fallbackCount > 0 && (
+                                <>
+                                    <Text size="xs" c="ldGray.4" ff="monospace">
+                                        /
+                                    </Text>
+                                    <Tooltip label="Matched a pre-aggregate but execution failed. Results were served from the warehouse">
+                                        <Text
+                                            size="xs"
+                                            ff="monospace"
+                                            c="red.7"
+                                            fw={500}
+                                        >
+                                            {fallbackCount} failed
+                                        </Text>
+                                    </Tooltip>
+                                </>
+                            )}
                         </Group>
                     );
                 },

--- a/packages/frontend/src/components/PreAggregateAudit/preAggregateHelpers.ts
+++ b/packages/frontend/src/components/PreAggregateAudit/preAggregateHelpers.ts
@@ -24,6 +24,7 @@ export type AggregatedRow = {
     queryType: QueryType;
     hitCount: number;
     missCount: number;
+    fallbackCount: number;
     topMissReason: string | null;
     preAggregateName: string | null;
     updatedAt: string;
@@ -47,6 +48,7 @@ export function aggregateStats(
         if (existing) {
             existing.hitCount += stat.hitCount;
             existing.missCount += stat.missCount;
+            existing.fallbackCount += stat.fallbackCount;
             existing.topMissReason ??= stat.missReason;
             if (stat.updatedAt > existing.updatedAt) {
                 existing.updatedAt = stat.updatedAt;
@@ -62,6 +64,7 @@ export function aggregateStats(
                 queryType: getQueryType(stat),
                 hitCount: stat.hitCount,
                 missCount: stat.missCount,
+                fallbackCount: stat.fallbackCount,
                 topMissReason: stat.missReason,
                 preAggregateName: stat.preAggregateName,
                 updatedAt: stat.updatedAt,


### PR DESCRIPTION
Stacked on #27585. Counts pre-aggregate execution fallbacks in pre-aggregate analytics so fleet-wide day-one regressions are visible.

## Changes

- Migration: `fallback_count integer not null default 0` on `pre_aggregate_daily_stats` (additive, rolling-safe).
- `PreAggregateDailyStatsModel.incrementFallback()` — same COALESCE conflict-key upsert as hit/miss recording.
- `PreAggregateStrategy.recordExecutionFallback()` (no-op in OSS, daily-counter increment in EE), called from the `runAsyncPreAggregateQuery` fallback path.
- `PreAggregateDailyStatResult.fallbackCount` on the stats API.
- Analytics table shows `N failed` (red) with tooltip: "Matched a pre-aggregate but execution failed — results were served from the warehouse".

## Semantics

A fallback is counted in addition to the routing-time hit — hits are recorded at match time, before execution. The tooltip makes this explicit rather than decrementing hits (racy, and explorer context has no routing-time hit record to decrement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
