### PR TITLE
fix: serve pre-aggregates when sql_filter references joined fields

### DIFF
--- a/docs/pre-aggregates/adr/0001-external-pre-aggregates-serve-from-project-warehouse.md
+++ b/docs/pre-aggregates/adr/0001-external-pre-aggregates-serve-from-project-warehouse.md
@@ -14,10 +14,21 @@ already skips.
 The external table must expose the **exact generated column names**: metric
 columns named by canonical fieldId, average components as `<fieldId>__sum` /
 `<fieldId>__count`, the time dimension as its granularity-specific fieldId
-(`<dim>_<grain>`), joined dimensions as their plain compiled fieldId, plus any
-columns referenced by `sql_filter` under their raw source names. Columns hold
-partial aggregates at the definition's grain (re-aggregated at serve time), with
-definition filters applied.
+(`<dim>_<grain>`), joined dimensions as their plain compiled fieldId. Columns
+hold partial aggregates at the definition's grain (re-aggregated at serve
+time), with definition filters applied.
+
+`sql_filter` is applied at serve time against the materialization: field
+references (`${field}`, `${joined_table.field}`) are rewritten to the
+materialized fieldId columns, so every referenced field must be one of the
+pre-aggregate's dimensions — otherwise matching records a
+`sql_filter_field_not_in_pre_aggregate` miss and the query runs on the
+warehouse. Non-field references (`${TABLE}.col`, hand-written `table.col`) pass
+through verbatim, so those columns must exist under their raw source names;
+correctness of the resulting grain (notably for non-additive metrics / exact
+match) is the table owner's responsibility. `${lightdash.*}` user attributes
+are substituted with the querying user's values at serve time (fail-closed when
+missing).
 
 ## Considered options
 

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
@@ -939,3 +939,110 @@ describe('buildPreAggregateExplore', () => {
         );
     });
 });
+
+describe('sql_filter (sqlWhere) rewrite', () => {
+    const exploreWithSqlFilter = (uncompiledSqlWhere: string): Explore => {
+        const explore = sourceExplore();
+        return {
+            ...explore,
+            tables: {
+                ...explore.tables,
+                orders: {
+                    ...explore.tables.orders,
+                    uncompiledSqlWhere,
+                    // compiled against source join aliases, unusable on the materialization
+                    sqlWhere: uncompiledSqlWhere.replace(
+                        /\$\{customers\.first_name\}/g,
+                        '("customers".first_name)',
+                    ),
+                },
+            },
+        };
+    };
+
+    const def: PreAggregateDef = {
+        name: 'orders_rollup',
+        dimensions: ['status', 'customers.first_name'],
+        metrics: ['total_order_amount'],
+    };
+
+    it('rewrites joined field references to materialized columns for managed serving', () => {
+        const result = buildExplore(
+            exploreWithSqlFilter(
+                '${customers.first_name} = ${lightdash.attributes.name}',
+            ),
+            def,
+        );
+
+        expect(result.tables.orders.sqlWhere).toBe(
+            'orders.customers_first_name = ${lightdash.attributes.name}',
+        );
+        expect(result.tables.orders.uncompiledSqlWhere).toBe(
+            'orders.customers_first_name = ${lightdash.attributes.name}',
+        );
+    });
+
+    it('rewrites base-table field references to materialized columns', () => {
+        const result = buildExplore(
+            exploreWithSqlFilter("${status} = 'completed'"),
+            def,
+        );
+
+        expect(result.tables.orders.sqlWhere).toBe(
+            "orders.orders_status = 'completed'",
+        );
+    });
+
+    it('applies the same rewrite for external pre-aggregates', () => {
+        const result = buildExplore(
+            exploreWithSqlFilter(
+                '${customers.first_name} = ${lightdash.attributes.name}',
+            ),
+            { ...def, table: '"analytics"."orders_rollup_mv"' },
+        );
+
+        expect(result.tables.orders.sqlWhere).toBe(
+            'orders.customers_first_name = ${lightdash.attributes.name}',
+        );
+        expect(result.tables.orders.uncompiledSqlWhere).toBe(
+            'orders.customers_first_name = ${lightdash.attributes.name}',
+        );
+    });
+
+    it('passes ${TABLE} raw column references through against the base alias', () => {
+        const result = buildExplore(
+            exploreWithSqlFilter('${TABLE}.raw_col = 1'),
+            def,
+        );
+
+        expect(result.tables.orders.sqlWhere).toBe('"orders".raw_col = 1');
+    });
+
+    it('maps a raw time dimension reference to the materialized granularity column', () => {
+        const result = buildExplore(
+            exploreWithSqlFilter("${order_date} >= '2024-01-01'"),
+            {
+                ...def,
+                timeDimension: 'order_date',
+                granularity: TimeFrames.DAY,
+            },
+        );
+
+        expect(result.tables.orders.sqlWhere).toBe(
+            "orders.orders_order_date_day >= '2024-01-01'",
+        );
+    });
+
+    it('rewrites uncovered field references so serving fails closed on a missing column', () => {
+        const result = buildExplore(
+            exploreWithSqlFilter(
+                '${customers.first_name} = ${lightdash.attributes.name}',
+            ),
+            { ...def, dimensions: ['status'] },
+        );
+
+        expect(result.tables.orders.sqlWhere).toBe(
+            'orders.customers_first_name = ${lightdash.attributes.name}',
+        );
+    });
+});

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
@@ -2,9 +2,11 @@ import {
     assertUnreachable,
     ExploreType,
     getItemId,
+    getParsedReference,
     getPreAggregateExploreName,
     getPreAggregateMetricColumnName,
     getPreAggregateMetricComponentColumnName,
+    getReferencedDimension,
     lightdashVariablePattern,
     MetricType,
     PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
@@ -364,6 +366,54 @@ const getIncludedDimensions = (
     });
 };
 
+// Recompile sql_filter onto materialized columns (${lightdash.*} kept for
+// query-time substitution); unresolved refs keep a missing column: fail closed.
+const rewriteSqlWhereForPreAggregate = ({
+    sourceExplore,
+    preAggregateDef,
+    servingAdapter,
+}: {
+    sourceExplore: Explore;
+    preAggregateDef: PreAggregateDef;
+    servingAdapter: SupportedDbtAdapter;
+}): string | undefined => {
+    const uncompiledSqlWhere =
+        sourceExplore.tables[sourceExplore.baseTable]?.uncompiledSqlWhere;
+    if (!uncompiledSqlWhere) {
+        return undefined;
+    }
+
+    const quoteChar =
+        warehouseSqlBuilderFromType(servingAdapter).getFieldQuoteChar();
+
+    return uncompiledSqlWhere.replace(
+        lightdashVariablePattern,
+        (_, ref: string) => {
+            if (ref === 'TABLE') {
+                return `${quoteChar}${sourceExplore.baseTable}${quoteChar}`;
+            }
+
+            const { refTable, refName } = getParsedReference(
+                ref,
+                sourceExplore.baseTable,
+            );
+            const dimension = getReferencedDimension<
+                CompiledTable,
+                CompiledDimension
+            >(refTable, refName, sourceExplore.tables);
+            const materializedColumnName = dimension
+                ? getMaterializedDimensionColumnName({
+                      sourceExplore,
+                      dimension,
+                      preAggregateDef,
+                  })
+                : getItemId({ table: refTable, name: refName });
+
+            return `${sourceExplore.baseTable}.${materializedColumnName}`;
+        },
+    );
+};
+
 const getEmptyTable = (
     sourceTable: CompiledTable,
     sqlTable: string,
@@ -416,6 +466,19 @@ export const buildPreAggregateExplore = (
         acc[tableName] = getEmptyTable(sourceTable, sqlTable);
         return acc;
     }, {});
+
+    const rewrittenSqlWhere = rewriteSqlWhereForPreAggregate({
+        sourceExplore,
+        preAggregateDef,
+        servingAdapter,
+    });
+    if (rewrittenSqlWhere !== undefined) {
+        tables[sourceExplore.baseTable] = {
+            ...tables[sourceExplore.baseTable],
+            sqlWhere: rewrittenSqlWhere,
+            uncompiledSqlWhere: rewrittenSqlWhere,
+        };
+    }
 
     includedDimensions.forEach((dimension) => {
         const compiledSql = buildDimensionSql({

--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -2633,3 +2633,118 @@ describe('findMatch', () => {
         expect(result.hit).toBe(true);
     });
 });
+
+describe('findMatch sql_filter coverage', () => {
+    const makeExploreWithSqlFilter = ({
+        uncompiledSqlWhere,
+        preAggregateDimensions,
+    }: {
+        uncompiledSqlWhere: string;
+        preAggregateDimensions: string[];
+    }): Explore => {
+        const explore = baseExplore();
+        return {
+            ...explore,
+            tables: {
+                ...explore.tables,
+                orders: {
+                    ...explore.tables.orders,
+                    uncompiledSqlWhere,
+                    sqlWhere: uncompiledSqlWhere,
+                },
+            },
+            preAggregates: [
+                {
+                    name: 'orders_summary',
+                    dimensions: preAggregateDimensions,
+                    metrics: ['order_count'],
+                },
+            ],
+        };
+    };
+
+    it('misses when sql_filter references a joined field that is not a definition dimension', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+            }),
+            makeExploreWithSqlFilter({
+                uncompiledSqlWhere:
+                    '${customers.first_name} = ${lightdash.attributes.name}',
+                preAggregateDimensions: ['status'],
+            }),
+        );
+
+        expect(result).toStrictEqual({
+            hit: false,
+            preAggregateName: null,
+            miss: {
+                reason: PreAggregateMissReason.SQL_FILTER_FIELD_NOT_IN_PRE_AGGREGATE,
+                fieldId: 'customers_first_name',
+            },
+        });
+    });
+
+    it('misses when sql_filter references a base-table field that is not a definition dimension', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+            }),
+            makeExploreWithSqlFilter({
+                uncompiledSqlWhere: '${amount} > 10',
+                preAggregateDimensions: ['status'],
+            }),
+        );
+
+        expect(result).toStrictEqual({
+            hit: false,
+            preAggregateName: null,
+            miss: {
+                reason: PreAggregateMissReason.SQL_FILTER_FIELD_NOT_IN_PRE_AGGREGATE,
+                fieldId: 'orders_amount',
+            },
+        });
+    });
+
+    it('hits when the sql_filter field is a definition dimension', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+            }),
+            makeExploreWithSqlFilter({
+                uncompiledSqlWhere:
+                    '${customers.first_name} = ${lightdash.attributes.name}',
+                preAggregateDimensions: ['status', 'customers.first_name'],
+            }),
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_summary',
+            miss: null,
+        });
+    });
+
+    it('ignores ${TABLE} and ${lightdash.*} references in sql_filter', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+            }),
+            makeExploreWithSqlFilter({
+                uncompiledSqlWhere:
+                    "${TABLE}.raw_col = 1 AND ${lightdash.attributes.segment} = 'gold'",
+                preAggregateDimensions: ['status'],
+            }),
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_summary',
+            miss: null,
+        });
+    });
+});

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationSqlFilter.test.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationSqlFilter.test.ts
@@ -1,0 +1,285 @@
+// Serving a model whose sql_filter references a joined table's field: the
+// filter must target the materialized column, not the source join alias.
+import {
+    DEFAULT_SPOTLIGHT_CONFIG,
+    DimensionType,
+    ExploreCompiler,
+    FieldType,
+    MetricType,
+    SupportedDbtAdapter,
+    type MetricQuery,
+    type UncompiledExplore,
+} from '@lightdash/common';
+import { warehouseSqlBuilderFromType } from '@lightdash/warehouses';
+import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
+import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { QueryComposer } from '../../../utils/QueryBuilder/QueryComposer';
+import { buildPreAggregateExplore } from '../../preAggregates/buildPreAggregateExplore';
+import { type ResolvePreAggregationDuckDbArgs } from './PreAggregationDuckDbClient';
+import { PreAggregationExternalResolver } from './PreAggregationExternalResolver';
+
+const EXTERNAL_TABLE = '`analytics`.`orders_rollup_mv`';
+
+const uncompiledSourceExplore = (sqlWhere: string): UncompiledExplore => ({
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    baseTable: 'orders',
+    targetDatabase: SupportedDbtAdapter.BIGQUERY,
+    groupLabel: undefined,
+    warehouse: undefined,
+    sqlPath: undefined,
+    ymlPath: undefined,
+    databricksCompute: undefined,
+    spotlightConfig: DEFAULT_SPOTLIGHT_CONFIG,
+    meta: {},
+    joinedTables: [
+        {
+            table: 'customers',
+            sqlOn: '${orders.customer_id} = ${customers.id}',
+        },
+    ],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: 'db',
+            schema: 'jaffle',
+            sqlTable: '`db`.`jaffle`.`orders`',
+            sqlWhere,
+            lineageGraph: {},
+            dimensions: {
+                customer_id: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.NUMBER,
+                    name: 'customer_id',
+                    label: 'Customer id',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.customer_id',
+                    hidden: false,
+                },
+                status: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'status',
+                    label: 'Status',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.status',
+                    hidden: false,
+                },
+            },
+            metrics: {
+                total_order_amount: {
+                    fieldType: FieldType.METRIC,
+                    type: MetricType.SUM,
+                    name: 'total_order_amount',
+                    label: 'Total order amount',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.amount',
+                    hidden: false,
+                },
+            },
+        },
+        customers: {
+            name: 'customers',
+            label: 'Customers',
+            database: 'db',
+            schema: 'jaffle',
+            sqlTable: '`db`.`jaffle`.`customers`',
+            lineageGraph: {},
+            dimensions: {
+                id: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.NUMBER,
+                    name: 'id',
+                    label: 'Id',
+                    table: 'customers',
+                    tableLabel: 'Customers',
+                    sql: '${TABLE}.id',
+                    hidden: false,
+                },
+                segment: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'segment',
+                    label: 'Segment',
+                    table: 'customers',
+                    tableLabel: 'Customers',
+                    sql: '${TABLE}.segment',
+                    hidden: false,
+                },
+            },
+            metrics: {},
+        },
+    },
+});
+
+const metricQuery: MetricQuery = {
+    exploreName: '__preagg__orders__orders_rollup',
+    dimensions: ['orders_status'],
+    metrics: ['orders_total_order_amount'],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const resolveWithSqlFilter = async (sqlWhere: string) => {
+    const compiler = new ExploreCompiler(
+        warehouseSqlBuilderFromType(SupportedDbtAdapter.BIGQUERY),
+    );
+    const sourceExplore = compiler.compileExplore(
+        uncompiledSourceExplore(sqlWhere),
+    );
+
+    const preAggExplore = buildPreAggregateExplore(
+        sourceExplore,
+        {
+            name: 'orders_rollup',
+            dimensions: ['status', 'customers.segment'],
+            metrics: ['total_order_amount'],
+            table: EXTERNAL_TABLE,
+        },
+        null,
+    );
+
+    const projectModel = {
+        getExploreFromCache: vi.fn().mockResolvedValue(preAggExplore),
+    };
+    const resolver = new PreAggregationExternalResolver({
+        lightdashConfig: {
+            ...lightdashConfigMock,
+            preAggregates: {
+                ...lightdashConfigMock.preAggregates,
+                enabled: true,
+            },
+        },
+        projectModel: projectModel as unknown as ProjectModel,
+    });
+
+    const args: ResolvePreAggregationDuckDbArgs = {
+        projectUuid: 'projectUuid',
+        metricQuery,
+        timezone: 'UTC',
+        dateZoom: undefined,
+        parameters: undefined,
+        preAggregationRoute: {
+            sourceExploreName: 'orders',
+            preAggregateName: 'orders_rollup',
+            mode: 'opportunistic',
+            externalTable: EXTERNAL_TABLE,
+        },
+        fieldsMap: {},
+        pivotConfiguration: undefined,
+        startOfWeek: undefined,
+        userAccessControls: {
+            userAttributes: { segment: ['gold'] },
+            intrinsicUserAttributes: {},
+        },
+        availableParameterDefinitions: {},
+    };
+
+    return resolver.resolve(args);
+};
+
+describe('external pre-aggregate + sql_filter referencing a joined field', () => {
+    test('serves with a user-attribute filter on the materialized column', async () => {
+        const result = await resolveWithSqlFilter(
+            '${customers.segment} = ${lightdash.attributes.segment}',
+        );
+
+        expect(result.resolved).toBe(true);
+        if (!result.resolved) throw new Error('unreachable');
+
+        expect(result.query).toContain(`FROM ${EXTERNAL_TABLE} AS \`orders\``);
+        expect(result.query).toContain('orders.customers_segment');
+        expect(result.query).toContain("'gold'");
+        expect(result.query).not.toContain('JOIN');
+        expect(result.query).not.toMatch(/`customers`\./);
+    });
+
+    test('serves with a static joined-field filter on the materialized column', async () => {
+        const result = await resolveWithSqlFilter(
+            "${customers.segment} = 'gold'",
+        );
+
+        expect(result.resolved).toBe(true);
+        if (!result.resolved) throw new Error('unreachable');
+
+        expect(result.query).toContain(`FROM ${EXTERNAL_TABLE} AS \`orders\``);
+        expect(result.query).toContain("orders.customers_segment = 'gold'");
+        expect(result.query).not.toContain('JOIN');
+        expect(result.query).not.toMatch(/`customers`\./);
+    });
+});
+
+describe('managed pre-aggregate + sql_filter referencing a joined field', () => {
+    test('serves from the materialization with the user-attribute filter', () => {
+        const compiler = new ExploreCompiler(
+            warehouseSqlBuilderFromType(SupportedDbtAdapter.BIGQUERY),
+        );
+        const sourceExplore = compiler.compileExplore(
+            uncompiledSourceExplore(
+                '${customers.segment} = ${lightdash.attributes.segment}',
+            ),
+        );
+
+        const preAggExplore = buildPreAggregateExplore(
+            sourceExplore,
+            {
+                name: 'orders_rollup',
+                dimensions: ['status', 'customers.segment'],
+                metrics: ['total_order_amount'],
+            },
+            null,
+        );
+
+        // Same sqlTable patch PreAggregationDuckDbClient applies before serving
+        const materializationSqlTable =
+            "read_json_auto('s3://bucket/materialization.jsonl')";
+        const patchedExplore = {
+            ...preAggExplore,
+            tables: Object.fromEntries(
+                Object.entries(preAggExplore.tables).map(([name, table]) => [
+                    name,
+                    { ...table, sqlTable: materializationSqlTable },
+                ]),
+            ),
+        };
+
+        const composer = new QueryComposer(
+            {
+                metricQuery,
+                pivotConfiguration: undefined,
+            },
+            {
+                explore: patchedExplore,
+                warehouseSqlBuilder: warehouseSqlBuilderFromType(
+                    SupportedDbtAdapter.DUCKDB,
+                ),
+                intrinsicUserAttributes: {},
+                userAttributes: { segment: ['gold'] },
+                timezone: 'UTC',
+                availableParameterDefinitions: {},
+                parameters: undefined,
+                dateZoom: undefined,
+                pivotDimensions: undefined,
+                pivotItemsMap: {},
+                continueOnError: undefined,
+                useTimezoneAwareDateTrunc: undefined,
+                columnTimezone: undefined,
+                applyDateZoomToFilters: undefined,
+            },
+        );
+
+        const sql = composer.getSql({ columnLimit: 100 });
+
+        expect(sql).toContain(`FROM ${materializationSqlTable} AS "orders"`);
+        expect(sql).toContain("orders.customers_segment = 'gold'");
+        expect(sql).not.toContain('JOIN');
+        expect(sql).not.toMatch(/"customers"\./);
+    });
+});

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -1,3 +1,4 @@
+import { parseAllReferences } from '../../compiler/exploreCompiler';
 import type { Explore } from '../../types/explore';
 import {
     convertFieldRefToFieldId,
@@ -152,6 +153,20 @@ const extractDimensionFilterFieldIds = (
                 typeof target.fieldId === 'string',
         )
         .map((target) => target.fieldId);
+};
+
+// Field ids referenced by the base model's sql_filter. ${TABLE}.col raw
+// references and ${lightdash.*} attributes are not field references.
+const extractSqlFilterFieldIds = (explore: Explore): FieldId[] => {
+    const uncompiledSqlWhere =
+        explore.tables[explore.baseTable]?.uncompiledSqlWhere;
+    if (!uncompiledSqlWhere) {
+        return [];
+    }
+
+    return parseAllReferences(uncompiledSqlWhere, explore.baseTable)
+        .filter((ref) => ref.refName !== 'TABLE')
+        .map((ref) => getItemId({ table: ref.refTable, name: ref.refName }));
 };
 
 const getPreAggregateFilterTargetReferences = (
@@ -971,6 +986,7 @@ const getMissForDef = ({
     metricsByFieldId,
     unoverriddenRequiredFilterTargetFieldIds,
     requiredFilterTargetFieldIds,
+    sqlFilterFieldIds,
 }: {
     metricQuery: MetricQuery;
     explore: Explore;
@@ -982,6 +998,7 @@ const getMissForDef = ({
     metricsByFieldId: ReturnType<typeof getMetricsMapFromTables>;
     unoverriddenRequiredFilterTargetFieldIds: readonly FieldId[];
     requiredFilterTargetFieldIds: ReadonlySet<FieldId>;
+    sqlFilterFieldIds: readonly FieldId[];
 }): PreAggregateMatchMiss | null => {
     const defDimensions = new Set(preAggregateDef.dimensions);
     if (
@@ -1129,6 +1146,25 @@ const getMissForDef = ({
         };
     }
 
+    // The model's sql_filter is applied at serve time against materialized
+    // columns, so every field it references must be a covered dimension.
+    const uncoveredSqlFilterFieldId = sqlFilterFieldIds.find(
+        (fieldId) =>
+            !filterDimensionFieldIdMatchesDef(
+                fieldId,
+                explore,
+                preAggregateDef,
+                defDimensions,
+                dimensionsByFieldId,
+            ),
+    );
+    if (uncoveredSqlFilterFieldId) {
+        return {
+            reason: PreAggregateMissReason.SQL_FILTER_FIELD_NOT_IN_PRE_AGGREGATE,
+            fieldId: uncoveredSqlFilterFieldId,
+        };
+    }
+
     const overlappingRequiredFilter = preAggregateDef.filters?.find((filter) =>
         [...requiredFilterTargetFieldIds].some((fieldId) => {
             const dimension = dimensionsByFieldId.get(fieldId);
@@ -1239,6 +1275,8 @@ export const findMatch = (
         ),
     );
 
+    const sqlFilterFieldIds = extractSqlFilterFieldIds(explore);
+
     const matchedDefs: PreAggregateDef[] = [];
     let firstMiss: PreAggregateMatchMiss | null = null;
     // A miss from a def that covers the queried metrics is more actionable
@@ -1254,6 +1292,7 @@ export const findMatch = (
             metricsByFieldId,
             unoverriddenRequiredFilterTargetFieldIds,
             requiredFilterTargetFieldIds,
+            sqlFilterFieldIds,
         });
 
         if (!miss) {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -68,6 +68,7 @@ export * from './compiler/exploreCompiler';
 export * from './compiler/filtersCompiler';
 export * from './compiler/lightdashModelConverter';
 export * from './compiler/parameters';
+export * from './compiler/referenceLookup';
 export * from './compiler/translator';
 export * from './parameters/reservedParameters';
 export * from './constants/screenshot';

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -70,6 +70,7 @@ export enum PreAggregateMissReason {
     NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH = 'non_additive_metric_requires_exact_match',
     CUSTOM_SQL_METRIC = 'custom_sql_metric',
     FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE = 'filter_dimension_not_in_pre_aggregate',
+    SQL_FILTER_FIELD_NOT_IN_PRE_AGGREGATE = 'sql_filter_field_not_in_pre_aggregate',
     PRE_AGGREGATE_FILTER_NOT_SATISFIED = 'pre_aggregate_filter_not_satisfied',
     GRANULARITY_TOO_FINE = 'granularity_too_fine',
     TIME_FRAME_NOT_DERIVABLE = 'time_frame_not_derivable',
@@ -107,6 +108,10 @@ export type PreAggregateMatchMiss =
       }
     | {
           reason: PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE;
+          fieldId: FieldId;
+      }
+    | {
+          reason: PreAggregateMissReason.SQL_FILTER_FIELD_NOT_IN_PRE_AGGREGATE;
           fieldId: FieldId;
       }
     | {
@@ -209,6 +214,8 @@ export const preAggregateMissReasonLabels: Record<
     [PreAggregateMissReason.CUSTOM_SQL_METRIC]: 'Custom SQL metric',
     [PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE]:
         'Filter dimension not in pre-aggregate',
+    [PreAggregateMissReason.SQL_FILTER_FIELD_NOT_IN_PRE_AGGREGATE]:
+        'sql_filter field not in pre-aggregate',
     [PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED]:
         'Pre-aggregate filter not satisfied',
     [PreAggregateMissReason.GRANULARITY_TOO_FINE]: 'Granularity too fine',


### PR DESCRIPTION
A model's `sql_filter` referencing a joined table's field (e.g. row-level security comparing a user attribute against a joined field) broke pre-aggregate serving: queries matched but resolution threw `Join <table> not found` and silently fell back to the warehouse on every query, with no miss reason recorded.

## Changes

- **Rewrite `sql_filter` onto the materialization** (`buildPreAggregateExplore`): field references — including joined ones like `${customers.segment}` — are recompiled to the pre-aggregate's materialized columns (`orders.customers_segment`) instead of source join aliases. `${lightdash.*}` user attributes keep serve-time substitution with the querying user's attributes (fail-closed when missing). `${TABLE}.col` raw references pass through against the base alias. Applies to managed and external pre-aggregates alike.
- **New miss reason** `sql_filter_field_not_in_pre_aggregate` (with field id): recorded at match time when the `sql_filter` references a field that is not a covered dimension, surfaced in the audit and analytics like other miss reasons. Replaces the silent `resolve_error` fallback; the fix for users is to add the field to the pre-aggregate's dimensions.
- **Fail-closed serving**: unresolved references keep a non-existent column reference, so a gate miss can never turn into unfiltered data.
- **ADR**: external pre-aggregates column-contract wording updated — `sql_filter` field references resolve to materialized fieldId columns; raw references must exist under their raw source names (grain correctness is the table owner's responsibility).

## Tests

- Matcher: miss for uncovered joined/base fields, hit when covered, `${TABLE}`/`${lightdash.*}` ignored
- `buildPreAggregateExplore`: rewrite for managed + external, `${TABLE}` passthrough, time-dimension granularity mapping, fail-closed uncovered refs
- End-to-end serve regression (real explore compiler → pre-aggregate explore builder → resolver): external on BigQuery (attribute-based and static joined-field filters) plus a managed DuckDB equivalent

Product docs rule ("`sql_filter` fields must be pre-aggregate dimensions; raw column references pass through") lands separately in the docs repo.

Closes: ZAP-880
Closes: #27579

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3PQyTRuEdWkkF4r2TSV2Z
