### PR TITLE
feat: show chart type build traces

### DIFF
--- a/packages/frontend/src/features/apps/components/AppVersionNarration.tsx
+++ b/packages/frontend/src/features/apps/components/AppVersionNarration.tsx
@@ -1,0 +1,40 @@
+import { Box } from '@mantine/core';
+import { IconHammer } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { ReasoningHistoryRow } from '../../../ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard';
+import {
+    hasVersionNarration,
+    type AppVersionNarrationData,
+} from '../utils/versionNarration';
+
+type Props = {
+    narration: AppVersionNarrationData;
+    isLive: boolean;
+    className?: string;
+};
+
+/** The shared Reasoning/Activity presentation for live and persisted builds. */
+const AppVersionNarration: FC<Props> = ({ narration, isLive, className }) => {
+    if (!hasVersionNarration(narration)) return null;
+
+    return (
+        <Box className={className}>
+            {narration.reasoning.length > 0 && (
+                <ReasoningHistoryRow
+                    texts={narration.reasoning}
+                    isLive={isLive}
+                />
+            )}
+            {narration.activity.length > 0 && (
+                <ReasoningHistoryRow
+                    texts={narration.activity}
+                    isLive={isLive}
+                    icon={IconHammer}
+                    label="Activity"
+                />
+            )}
+        </Box>
+    );
+};
+
+export default AppVersionNarration;

--- a/packages/frontend/src/features/apps/utils/versionNarration.ts
+++ b/packages/frontend/src/features/apps/utils/versionNarration.ts
@@ -1,0 +1,35 @@
+import {
+    type AppVersionStatusHistoryEntry,
+    type AppVersionStatusHistoryEntryKind,
+} from '@lightdash/common';
+
+export type AppVersionNarrationData = {
+    reasoning: string[];
+    activity: string[];
+};
+
+// The null guard exists because the poll worker feeds raw fetch JSON into
+// the query cache; the consecutive dedupe because a retry can restart the
+// generation stream and re-emit the same entry.
+export function versionNarrationTexts(
+    history: AppVersionStatusHistoryEntry[] | undefined,
+    kind: AppVersionStatusHistoryEntryKind,
+): string[] {
+    return (history ?? [])
+        .filter((entry) => entry.kind === kind)
+        .map((entry) => entry.message)
+        .filter((message, index, all) => message !== all[index - 1]);
+}
+
+export const getVersionNarration = (
+    history: AppVersionStatusHistoryEntry[] | undefined,
+): AppVersionNarrationData => ({
+    reasoning: versionNarrationTexts(history, 'thinking'),
+    activity: versionNarrationTexts(history, 'tool'),
+});
+
+export const hasVersionNarration = ({
+    reasoning,
+    activity,
+}: AppVersionNarrationData): boolean =>
+    reasoning.length > 0 || activity.length > 0;

--- a/packages/frontend/src/features/apps/utils/versionsToChatMessages.test.ts
+++ b/packages/frontend/src/features/apps/utils/versionsToChatMessages.test.ts
@@ -1,7 +1,7 @@
 import { type ApiAppVersionSummary } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
+import { versionNarrationTexts } from './versionNarration';
 import {
-    versionNarrationTexts,
     versionsToChatMessages,
     type ChatMessageFallbacks,
 } from './versionsToChatMessages';

--- a/packages/frontend/src/features/apps/utils/versionsToChatMessages.ts
+++ b/packages/frontend/src/features/apps/utils/versionsToChatMessages.ts
@@ -1,8 +1,4 @@
-import {
-    type ApiAppVersionSummary,
-    type AppVersionStatusHistoryEntry,
-    type AppVersionStatusHistoryEntryKind,
-} from '@lightdash/common';
+import { type ApiAppVersionSummary } from '@lightdash/common';
 import { getAppVersionFailureMessage } from '../getAppVersionFailureMessage';
 import {
     emptyChatMessage,
@@ -11,19 +7,7 @@ import {
     type ChatConnection,
     type ChatMessage,
 } from './chatMessage';
-
-// The null guard exists because the poll worker feeds raw fetch JSON into
-// the query cache; the consecutive dedupe because a retry can restart the
-// generation stream and re-emit the same entry.
-export function versionNarrationTexts(
-    history: AppVersionStatusHistoryEntry[] | undefined,
-    kind: AppVersionStatusHistoryEntryKind,
-): string[] {
-    return (history ?? [])
-        .filter((entry) => entry.kind === kind)
-        .map((entry) => entry.message)
-        .filter((message, index, all) => message !== all[index - 1]);
-}
+import { getVersionNarration } from './versionNarration';
 
 /**
  * Session-only attachment fallbacks, keyed by prompt text. Versions persisted
@@ -130,8 +114,7 @@ export function versionsToChatMessages(
             ? new Date(v.statusUpdatedAt).getTime() -
               new Date(v.createdAt).getTime()
             : null;
-        const reasoning = versionNarrationTexts(v.statusHistory, 'thinking');
-        const activity = versionNarrationTexts(v.statusHistory, 'tool');
+        const { reasoning, activity } = getVersionNarration(v.statusHistory);
 
         const msgs: ChatMessage[] = [
             {

--- a/packages/frontend/src/features/chartTypes/builder/BuilderPromptBar.module.css
+++ b/packages/frontend/src/features/chartTypes/builder/BuilderPromptBar.module.css
@@ -90,6 +90,23 @@
     opacity: 0;
 }
 
+/* Narration makes the active build taller than one queue row. Keep the first
+   queued prompt above that card, then fan the remaining prompts behind it. */
+.queue[data-narration] .queuedPrompt:first-child {
+    z-index: 2;
+    transform: none;
+}
+
+.queue[data-narration] .queuedPrompt:nth-child(2) {
+    z-index: 1;
+    opacity: 1;
+    transform: translateY(var(--queue-row-height)) scale(0.982);
+}
+
+.queue[data-narration] .queuedPrompt:nth-child(n + 3) {
+    opacity: 0;
+}
+
 .queue:hover .queueList .stackRow,
 .queue:focus-within .queueList .stackRow {
     opacity: 1;
@@ -120,6 +137,22 @@
 
 .buildingStatus {
     min-width: 0;
+}
+
+.buildingStatus[data-has-narration='true'] {
+    border-radius: 0 0 var(--mantine-radius-lg) var(--mantine-radius-lg);
+}
+
+.liveNarration {
+    position: relative;
+    z-index: 3;
+    padding: 5px 6px;
+    margin-bottom: calc(-1 * var(--queue-row-gap));
+    background: var(--mantine-color-ldGray-0);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-bottom: 0;
+    border-radius: var(--mantine-radius-lg) var(--mantine-radius-lg) 0 0;
+    box-shadow: var(--mantine-shadow-subtle);
 }
 
 .buildingPrompt {

--- a/packages/frontend/src/features/chartTypes/builder/BuilderPromptBar.test.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/BuilderPromptBar.test.tsx
@@ -142,6 +142,7 @@ const promptBar = ({
     latestReadyVersion = null,
     model = modelSelection('sonnet'),
     onCancelBuild = isBuilding ? vi.fn() : null,
+    narration = { reasoning: [], activity: [] },
     // A round with nothing to ask passes the request straight to the build,
     // which is what most of these tests are watching for.
     clarification = clarificationStub({ send: build.send }),
@@ -151,6 +152,7 @@ const promptBar = ({
     latestReadyVersion?: number | null;
     model?: DataAppModelSelection;
     onCancelBuild?: (() => void) | null;
+    narration?: { reasoning: string[]; activity: string[] };
     clarification?: ClarificationRound<VizBuildRequest>;
 } = {}) => (
     <BuilderPromptBar
@@ -164,6 +166,7 @@ const promptBar = ({
         latestReadyVersion={latestReadyVersion}
         build={build}
         onCancelBuild={onCancelBuild}
+        narration={narration}
         modelSelection={model}
         clarification={clarification}
     />
@@ -434,6 +437,91 @@ describe('BuilderPromptBar', () => {
         expect(screen.getByText('Building… 0:07')).toBeInTheDocument();
         expect(screen.getByText('“make it teal”')).toBeInTheDocument();
         expect(screen.getByText('Cancel')).toBeInTheDocument();
+    });
+
+    it('shows live reasoning and activity with the active build', () => {
+        const view = renderWithProviders(
+            promptBar({
+                build: buildState({ isBuilding: true }),
+                isBuilding: true,
+                narration: {
+                    reasoning: ['Choosing a horizontal layout'],
+                    activity: ['Updating Chart.tsx'],
+                },
+            }),
+        );
+
+        expect(screen.getByText('Reasoning')).toBeInTheDocument();
+        expect(
+            screen.getAllByText('Choosing a horizontal layout').length,
+        ).toBeGreaterThan(0);
+        expect(screen.getByText('Activity')).toBeInTheDocument();
+        expect(
+            screen.getAllByText('Updating Chart.tsx').length,
+        ).toBeGreaterThan(0);
+
+        view.rerender(
+            promptBar({
+                build: buildState({ isBuilding: true }),
+                isBuilding: true,
+                narration: {
+                    reasoning: [
+                        'Choosing a horizontal layout',
+                        'Sorting the categories by value',
+                    ],
+                    activity: ['Updating Chart.tsx'],
+                },
+            }),
+        );
+
+        expect(
+            screen.getAllByText('Sorting the categories by value').length,
+        ).toBeGreaterThan(0);
+    });
+
+    it('keeps queued prompts above the active build narration', async () => {
+        renderWithProviders(
+            promptBar({
+                build: buildState({ isBuilding: true }),
+                isBuilding: true,
+                narration: {
+                    reasoning: ['Choosing a horizontal layout'],
+                    activity: [],
+                },
+            }),
+        );
+        const composer = screen.getByPlaceholderText('Ask for another change…');
+
+        await userEvent.type(composer, 'use the brand palette');
+        await userEvent.keyboard('{Enter}');
+        await userEvent.type(composer, 'add a target line');
+        await userEvent.keyboard('{Enter}');
+
+        expect(
+            screen.getByRole('list', { name: '2 queued prompts' }),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Reasoning')).toBeInTheDocument();
+        expect(screen.queryByText('Activity')).not.toBeInTheDocument();
+        expect(screen.getByText('Building… 0:07')).toBeInTheDocument();
+    });
+
+    it('removes live narration when the build settles', () => {
+        const narration = {
+            reasoning: ['Choosing a horizontal layout'],
+            activity: ['Updating Chart.tsx'],
+        };
+        const view = renderWithProviders(
+            promptBar({
+                build: buildState({ isBuilding: true }),
+                isBuilding: true,
+                narration,
+            }),
+        );
+
+        view.rerender(promptBar({ narration }));
+
+        expect(screen.queryByText('Reasoning')).not.toBeInTheDocument();
+        expect(screen.queryByText('Activity')).not.toBeInTheDocument();
     });
 
     it('shows when cancellation is in progress', () => {

--- a/packages/frontend/src/features/chartTypes/builder/BuilderPromptBar.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/BuilderPromptBar.tsx
@@ -32,8 +32,13 @@ import {
     ModelPicker,
     SelectedAttachmentSection,
 } from '../../apps/AppResourcePicker';
+import AppVersionNarration from '../../apps/components/AppVersionNarration';
 import { type ClarificationRound } from '../../apps/hooks/useClarificationRound';
 import { type DataAppModelSelection } from '../../apps/hooks/useDataAppModelSelection';
+import {
+    hasVersionNarration,
+    type AppVersionNarrationData,
+} from '../../apps/utils/versionNarration';
 import {
     type DataAppVizBuildState,
     type VizBuildRequest,
@@ -55,6 +60,7 @@ type Props = {
     latestReadyVersion: number | null;
     build: DataAppVizBuildState;
     onCancelBuild: (() => void) | null;
+    narration: AppVersionNarrationData;
     modelSelection: DataAppModelSelection;
     /** The pre-build clarifying round every send passes through. */
     clarification: ClarificationRound<VizBuildRequest>;
@@ -145,6 +151,7 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
             latestReadyVersion,
             build,
             onCancelBuild,
+            narration,
             modelSelection,
             clarification,
         },
@@ -311,6 +318,7 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
         const queuedStackSize =
             queuedPrompts.length + (visibleSendingPrompt ? 1 : 0);
         const isClarifying = clarification.clarifyingPrompt !== null;
+        const hasNarration = hasVersionNarration(narration);
         const questions = clarification.pending;
         const hasStack = queuedStackSize > 0 || isBuilding || isClarifying;
         // Read-only, not just unsubmittable: text typed here would be lost.
@@ -337,6 +345,9 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                     <Box
                         className={classes.queue}
                         data-building={isBuilding || isClarifying || undefined}
+                        data-narration={
+                            (isBuilding && hasNarration) || undefined
+                        }
                     >
                         {isClarifying && (
                             <Box
@@ -370,6 +381,7 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                         {isBuilding && (
                             <Box
                                 className={`${classes.stackRow} ${classes.buildingStatus}`}
+                                data-has-narration={hasNarration || undefined}
                             >
                                 <Loader size={13} color="ldGray.6" />
                                 <Text fz="xs" fw={600} c="ldGray.9" inherit>
@@ -423,6 +435,13 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                                     </Anchor>
                                 )}
                             </Box>
+                        )}
+                        {isBuilding && hasNarration && (
+                            <AppVersionNarration
+                                narration={narration}
+                                isLive
+                                className={classes.liveNarration}
+                            />
                         )}
                         {queuedStackSize > 0 && (
                             <Box

--- a/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.module.css
+++ b/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.module.css
@@ -1,5 +1,6 @@
 .panel {
-    width: 264px;
+    width: 100%;
+    height: 100%;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
@@ -50,8 +51,14 @@
 
 /* After the hover rule so the viewed version keeps its mark under the cursor. */
 .entry[data-active='true'] {
-    background: var(--mantine-color-ldBrandViolet-0);
-    border-left-color: var(--mantine-color-ldBrandViolet-6);
+    background: light-dark(
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-dark-5)
+    );
+    border-left-color: light-dark(
+        var(--mantine-color-gray-5),
+        var(--mantine-color-gray-6)
+    );
 }
 
 /* The view target: the version line and the prompt that produced it. The
@@ -75,15 +82,11 @@
     color: var(--mantine-color-ldGray-7);
 
     &[data-state='active'] {
-        color: var(--mantine-color-ldBrandViolet-7);
+        color: var(--mantine-color-ldGray-9);
     }
 
     &[data-state='failed'] {
         color: var(--mantine-color-red-7);
-    }
-
-    &[data-state='building'] {
-        color: var(--mantine-color-ldBrandViolet-7);
     }
 }
 
@@ -91,6 +94,33 @@
     background: light-dark(var(--mantine-color-red-0), rgba(224, 49, 49, 0.12));
     border-radius: var(--mantine-radius-sm);
     padding: 6px 8px;
+}
+
+.buildDetails {
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.buildDetailsToggle {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: 100%;
+    padding-top: 7px;
+    color: var(--mantine-color-ldGray-6);
+    text-align: left;
+}
+
+.buildDetailsChevron {
+    flex-shrink: 0;
+    transition: transform 150ms ease;
+}
+
+.buildDetailsChevron[data-open='true'] {
+    transform: rotate(90deg);
+}
+
+.buildDetailsNarration {
+    padding-top: 5px;
 }
 
 .row {

--- a/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.test.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.test.tsx
@@ -108,6 +108,16 @@ describe('VersionHistoryPanel', () => {
         expect(styles).not.toMatch(/animation:\s*ldPulse/);
     });
 
+    it('uses the theme-aware neutral selection surface', () => {
+        const activeEntryStyles = styles.match(
+            /\.entry\[data-active='true'\]\s*\{([^}]*)\}/s,
+        )?.[1];
+
+        expect(activeEntryStyles).toContain('var(--mantine-color-ldGray-1)');
+        expect(activeEntryStyles).toContain('var(--mantine-color-dark-5)');
+        expect(styles).not.toContain('ldBrandViolet');
+    });
+
     it('writes a live entry for a build not yet in history', () => {
         renderWithProviders(
             <VersionHistoryPanel
@@ -147,6 +157,61 @@ describe('VersionHistoryPanel', () => {
 
         fireEvent.click(screen.getByLabelText('View v3'));
         expect(onView).not.toHaveBeenCalled();
+    });
+
+    it.each(['ready', 'error'] as const)(
+        'reveals recorded build details for a %s version',
+        async (status) => {
+            renderWithProviders(
+                <VersionHistoryPanel
+                    {...defaultProps}
+                    versions={[
+                        appVersion({
+                            version: 3,
+                            status,
+                            statusHistory: [
+                                {
+                                    kind: 'thinking',
+                                    message: 'Choosing a horizontal layout',
+                                    timestamp: '2026-05-15T10:00:10Z',
+                                },
+                                {
+                                    kind: 'tool',
+                                    message: 'Updating Chart.tsx',
+                                    timestamp: '2026-05-15T10:00:20Z',
+                                },
+                            ],
+                        }),
+                        ...twoVersions,
+                    ]}
+                />,
+            );
+
+            expect(
+                screen.queryByText('Choosing a horizontal layout'),
+            ).not.toBeInTheDocument();
+
+            fireEvent.click(
+                screen.getByRole('button', {
+                    name: 'Build details for v3',
+                }),
+            );
+
+            expect(
+                screen.getAllByText('Choosing a horizontal layout').length,
+            ).toBeGreaterThan(0);
+            expect(
+                screen.getAllByText('Updating Chart.tsx').length,
+            ).toBeGreaterThan(0);
+        },
+    );
+
+    it('leaves versions without a recorded trace unchanged', () => {
+        renderWithProviders(
+            <VersionHistoryPanel {...defaultProps} versions={twoVersions} />,
+        );
+
+        expect(screen.queryByText('Build details')).not.toBeInTheDocument();
     });
 
     it('loads earlier versions on demand', () => {

--- a/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.tsx
@@ -11,13 +11,18 @@ import {
     Tooltip,
     UnstyledButton,
 } from '@mantine/core';
-import { IconX } from '@tabler/icons-react';
+import { IconChevronRight, IconX } from '@tabler/icons-react';
 import { format } from 'date-fns';
 import { useState, type FC } from 'react';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import AppVersionNarration from '../../apps/components/AppVersionNarration';
 import { getAppVersionFailureMessage } from '../../apps/getAppVersionFailureMessage';
+import {
+    getVersionNarration,
+    hasVersionNarration,
+} from '../../apps/utils/versionNarration';
 import { getVersionAuthorName } from '../../apps/utils/versionsToChatMessages';
 import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
 import RestoreVersionModal from './RestoreVersionModal';
@@ -68,6 +73,43 @@ const AuthorLine: FC<{ version: ApiAppVersionSummary }> = ({ version }) => {
                 {name}
             </Text>
         </>
+    );
+};
+
+const VersionBuildDetails: FC<{ version: ApiAppVersionSummary }> = ({
+    version,
+}) => {
+    const [open, setOpen] = useState(false);
+    const narration = getVersionNarration(version.statusHistory);
+
+    if (!hasVersionNarration(narration)) return null;
+
+    return (
+        <Box className={classes.buildDetails}>
+            <UnstyledButton
+                className={classes.buildDetailsToggle}
+                aria-label={`Build details for v${version.version}`}
+                aria-expanded={open}
+                onClick={() => setOpen((current) => !current)}
+            >
+                <MantineIcon
+                    icon={IconChevronRight}
+                    size={12}
+                    className={classes.buildDetailsChevron}
+                    data-open={open || undefined}
+                />
+                <Text fz={11} fw={600}>
+                    Build details
+                </Text>
+            </UnstyledButton>
+            {open && (
+                <AppVersionNarration
+                    narration={narration}
+                    isLive={false}
+                    className={classes.buildDetailsNarration}
+                />
+            )}
+        </Box>
     );
 };
 
@@ -138,12 +180,12 @@ const VersionHistoryPanel: FC<Props> = ({
                             {label}
                         </Text>
                         {isCurrent && (
-                            <Badge size="xs" variant="outline" color="violet">
+                            <Badge size="xs" variant="outline" color="blue">
                                 Current
                             </Badge>
                         )}
                         {isActive && !isCurrent && (
-                            <Badge size="xs" variant="outline" color="violet">
+                            <Badge size="xs" variant="outline" color="blue">
                                 Viewing
                             </Badge>
                         )}
@@ -153,7 +195,7 @@ const VersionHistoryPanel: FC<Props> = ({
                             </Badge>
                         )}
                         {isBuilding && (
-                            <Badge size="xs" variant="outline" color="violet">
+                            <Badge size="xs" variant="outline" color="blue">
                                 Building…
                             </Badge>
                         )}
@@ -181,6 +223,8 @@ const VersionHistoryPanel: FC<Props> = ({
                         </Text>
                     </Box>
                 )}
+
+                {!isBuilding && <VersionBuildDetails version={version} />}
 
                 <Box className={classes.row}>
                     <AuthorLine version={version} />
@@ -237,11 +281,7 @@ const VersionHistoryPanel: FC<Props> = ({
                                     : `v${build.claimedVersion}`}
                             </Text>
                             {build.claimedVersion !== null && (
-                                <Badge
-                                    size="xs"
-                                    variant="outline"
-                                    color="violet"
-                                >
+                                <Badge size="xs" variant="outline" color="blue">
                                     Building…
                                 </Badge>
                             )}

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -33,7 +33,6 @@ import {
     IconCheck,
     IconArrowUp,
     IconBrush,
-    IconHammer,
     IconExternalLink,
     IconArrowBackUp,
     IconFileDescription,
@@ -77,7 +76,6 @@ import {
 } from '../components/common/PromptComposer';
 import { getChartIcon } from '../components/common/ResourceIcon/utils';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
-import { ReasoningHistoryRow } from '../ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard';
 import { type AppIframePreviewHandle } from '../features/apps/AppIframePreview';
 import AppInspectorPanel from '../features/apps/AppInspectorPanel';
 import {
@@ -99,6 +97,7 @@ import AppBuilderSidebarToggle from '../features/apps/components/AppBuilderSideb
 import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
 import AppPreview from '../features/apps/components/AppPreview';
+import AppVersionNarration from '../features/apps/components/AppVersionNarration';
 import ClarificationQuestionList from '../features/apps/components/ClarificationQuestionList';
 import LoadingDots from '../features/apps/components/LoadingDots';
 import RecentAppSuggestions from '../features/apps/components/RecentAppSuggestions';
@@ -145,10 +144,8 @@ import {
     refToWireString,
     type ElementRef,
 } from '../features/apps/utils/elementRefs';
-import {
-    versionNarrationTexts,
-    versionsToChatMessages,
-} from '../features/apps/utils/versionsToChatMessages';
+import { getVersionNarration } from '../features/apps/utils/versionNarration';
+import { versionsToChatMessages } from '../features/apps/utils/versionsToChatMessages';
 import DataAppVizResultCard from '../features/chartTypes/components/DataAppVizResultCard';
 import DataAppVizTestPanel from '../features/chartTypes/components/DataAppVizTestPanel';
 import { useAppExternalConnections } from '../features/externalConnections/hooks/useAppExternalConnections';
@@ -839,18 +836,8 @@ const AppGenerate: FC = () => {
         return null;
     }, [appData]);
     const isBuilding = latestBuildingVersion !== null;
-    // Accumulated narration for the live build's Reasoning / Activity rows.
-    const reasoningTexts = useMemo<string[]>(
-        () =>
-            versionNarrationTexts(
-                latestBuildingVersion?.statusHistory,
-                'thinking',
-            ),
-        [latestBuildingVersion],
-    );
-    const activityTexts = useMemo<string[]>(
-        () =>
-            versionNarrationTexts(latestBuildingVersion?.statusHistory, 'tool'),
+    const liveNarration = useMemo(
+        () => getVersionNarration(latestBuildingVersion?.statusHistory),
         [latestBuildingVersion],
     );
     // Clarifying counts as loading for the chat input (disable send; typing
@@ -2230,28 +2217,15 @@ const AppGenerate: FC = () => {
                                                             renderVersionDepsChip(
                                                                 msg.version,
                                                             )}
-                                                        {msg.reasoning.length >
-                                                            0 && (
-                                                            <ReasoningHistoryRow
-                                                                texts={
-                                                                    msg.reasoning
-                                                                }
-                                                                isLive={false}
-                                                            />
-                                                        )}
-                                                        {msg.activity.length >
-                                                            0 && (
-                                                            <ReasoningHistoryRow
-                                                                texts={
-                                                                    msg.activity
-                                                                }
-                                                                isLive={false}
-                                                                icon={
-                                                                    IconHammer
-                                                                }
-                                                                label="Activity"
-                                                            />
-                                                        )}
+                                                        <AppVersionNarration
+                                                            narration={{
+                                                                reasoning:
+                                                                    msg.reasoning,
+                                                                activity:
+                                                                    msg.activity,
+                                                            }}
+                                                            isLive={false}
+                                                        />
                                                         {msg.vizSchema ? (
                                                             msg.version !==
                                                                 null &&
@@ -2358,28 +2332,12 @@ const AppGenerate: FC = () => {
                                                             </Text>
                                                         ) : (
                                                             <>
-                                                                {reasoningTexts.length >
-                                                                    0 && (
-                                                                    <ReasoningHistoryRow
-                                                                        texts={
-                                                                            reasoningTexts
-                                                                        }
-                                                                        isLive
-                                                                    />
-                                                                )}
-                                                                {activityTexts.length >
-                                                                    0 && (
-                                                                    <ReasoningHistoryRow
-                                                                        texts={
-                                                                            activityTexts
-                                                                        }
-                                                                        isLive
-                                                                        icon={
-                                                                            IconHammer
-                                                                        }
-                                                                        label="Activity"
-                                                                    />
-                                                                )}
+                                                                <AppVersionNarration
+                                                                    narration={
+                                                                        liveNarration
+                                                                    }
+                                                                    isLive
+                                                                />
                                                                 {latestBuildingVersion?.status ===
                                                                 'generating' ? (
                                                                     // A status line here would duplicate the live

--- a/packages/frontend/src/pages/ChartTypeBuilder.module.css
+++ b/packages/frontend/src/pages/ChartTypeBuilder.module.css
@@ -13,9 +13,38 @@
 }
 
 .content {
+    height: 100%;
     flex: 1;
     min-width: 0;
     position: relative;
     display: flex;
     flex-direction: column;
+}
+
+.historyPanel {
+    min-width: 240px;
+}
+
+.historyResizeHandle {
+    width: 1px;
+    flex: 0 0 1px;
+    cursor: col-resize;
+    background-color: light-dark(
+        var(--mantine-color-ldGray-2),
+        var(--mantine-color-ldDark-4)
+    );
+    transition:
+        background-color 120ms ease,
+        box-shadow 120ms ease;
+}
+
+.historyResizeHandle[data-resize-handle-state='hover'],
+.historyResizeHandle[data-resize-handle-state='drag'],
+.historyResizeHandle:focus-visible {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-4),
+        var(--mantine-color-ldDark-3)
+    );
+    box-shadow: 0 0 0 1px
+        light-dark(var(--mantine-color-ldGray-4), var(--mantine-color-ldDark-3));
 }

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -403,6 +403,47 @@ describe('ChartTypeBuilder', () => {
         ).toBeEnabled();
     });
 
+    it('shows the polled trace when reopening an in-progress build', () => {
+        setApp(appMeta({ latestReadyVersion: 1 }));
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub(
+                [
+                    appVersion({
+                        version: 2,
+                        status: 'generating',
+                        statusHistory: [
+                            {
+                                kind: 'thinking',
+                                message: 'Choosing a horizontal layout',
+                                timestamp: '2026-05-15T10:00:10Z',
+                            },
+                            {
+                                kind: 'tool',
+                                message: 'Updating Chart.tsx',
+                                timestamp: '2026-05-15T10:00:20Z',
+                            },
+                        ],
+                    }),
+                    appVersion({ version: 1 }),
+                ],
+                1,
+            ),
+        );
+
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        expect(screen.getByText('Reasoning')).toBeInTheDocument();
+        expect(
+            screen.getAllByText('Choosing a horizontal layout').length,
+        ).toBeGreaterThan(0);
+        expect(screen.getByText('Activity')).toBeInTheDocument();
+        expect(
+            screen.getAllByText('Updating Chart.tsx').length,
+        ).toBeGreaterThan(0);
+    });
+
     it('renders the current version and lists its history on demand', () => {
         setApp(appMeta());
         vi.mocked(useAppVersionHistory).mockReturnValue(
@@ -427,6 +468,11 @@ describe('ChartTypeBuilder', () => {
 
         fireEvent.click(screen.getByText('History'));
         expect(screen.getByLabelText('Version history')).toBeInTheDocument();
+        expect(
+            screen.getByRole('separator', {
+                name: 'Resize version history',
+            }),
+        ).toBeInTheDocument();
         expect(screen.getByLabelText('View v1')).toBeInTheDocument();
     });
 

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -15,6 +15,7 @@ import {
     useState,
     type FC,
 } from 'react';
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { Link, Navigate, useNavigate, useParams } from 'react-router';
 import { validate as isUuidString } from 'uuid';
 import { DocumentTitle } from '../components/common/DocumentTitle';
@@ -31,6 +32,7 @@ import {
 import { useDataAppModelSelection } from '../features/apps/hooks/useDataAppModelSelection';
 import { useElapsedClock } from '../features/apps/hooks/useElapsedClock';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
+import { getVersionNarration } from '../features/apps/utils/versionNarration';
 import BuilderCanvas from '../features/chartTypes/builder/BuilderCanvas';
 import BuilderPromptBar, {
     type BuilderPromptBarHandle,
@@ -181,6 +183,15 @@ const ChartTypeBuilder: FC = () => {
     }, [urlVizUuid, clearModelPick, resetClarification]);
 
     const isBuilding = build.isBuilding || historyLatestInProgress;
+    const liveNarration = useMemo(
+        () =>
+            getVersionNarration(
+                historyLatestInProgress
+                    ? history.latest?.statusHistory
+                    : undefined,
+            ),
+        [history.latest, historyLatestInProgress],
+    );
 
     // A build started elsewhere needs polling here; a build sent from this
     // page already polls inside useDataAppVizBuild.
@@ -387,63 +398,81 @@ const ChartTypeBuilder: FC = () => {
                     )
                 }
             />
-            <Box className={classes.main}>
-                <Box className={classes.content}>
-                    <BuilderCanvas
-                        projectUuid={projectUuid}
-                        appUuid={activeVizUuid ?? null}
-                        previewVersion={previewVersion}
-                        isBuilding={isBuilding}
-                        failureMessage={failureMessage}
-                        isClarifyRoundOpen={
-                            clarification.clarifyingPrompt !== null ||
-                            clarification.pending !== null
-                        }
-                        clarifierUnavailable={clarification.fellThrough}
-                        previewContext={previewContext}
-                        configurePanel={configurePanel}
-                        onPickExample={
-                            isPromptBarMounted ? handlePickExample : null
-                        }
-                    />
-                    {isPromptBarMounted && (
-                        <BuilderPromptBar
-                            ref={promptBarRef}
-                            sessionKey={promptSessionKey}
+            <PanelGroup direction="horizontal" className={classes.main}>
+                <Panel id="chart-type-builder-canvas" order={1} minSize={50}>
+                    <Box className={classes.content}>
+                        <BuilderCanvas
                             projectUuid={projectUuid}
-                            composerAppUuid={
-                                activeVizUuid ??
-                                build.appUuid ??
-                                build.draftAppUuid
-                            }
-                            hasVersions={history.versions.length > 0}
+                            appUuid={activeVizUuid ?? null}
+                            previewVersion={previewVersion}
                             isBuilding={isBuilding}
-                            buildingPrompt={buildingPrompt}
-                            elapsed={elapsed}
-                            latestReadyVersion={history.latestReadyVersion}
-                            build={build}
-                            onCancelBuild={onCancelBuild}
-                            modelSelection={modelSelection}
-                            clarification={clarification}
+                            failureMessage={failureMessage}
+                            isClarifyRoundOpen={
+                                clarification.clarifyingPrompt !== null ||
+                                clarification.pending !== null
+                            }
+                            clarifierUnavailable={clarification.fellThrough}
+                            previewContext={previewContext}
+                            configurePanel={configurePanel}
+                            onPickExample={
+                                isPromptBarMounted ? handlePickExample : null
+                            }
                         />
-                    )}
-                </Box>
+                        {isPromptBarMounted && (
+                            <BuilderPromptBar
+                                ref={promptBarRef}
+                                sessionKey={promptSessionKey}
+                                projectUuid={projectUuid}
+                                composerAppUuid={
+                                    activeVizUuid ??
+                                    build.appUuid ??
+                                    build.draftAppUuid
+                                }
+                                hasVersions={history.versions.length > 0}
+                                isBuilding={isBuilding}
+                                buildingPrompt={buildingPrompt}
+                                elapsed={elapsed}
+                                latestReadyVersion={history.latestReadyVersion}
+                                build={build}
+                                onCancelBuild={onCancelBuild}
+                                narration={liveNarration}
+                                modelSelection={modelSelection}
+                                clarification={clarification}
+                            />
+                        )}
+                    </Box>
+                </Panel>
                 {hasHistory && isHistoryOpen && (
-                    <VersionHistoryPanel
-                        projectUuid={projectUuid}
-                        appUuid={activeVizUuid}
-                        versions={history.versions}
-                        latestReadyVersion={history.latestReadyVersion}
-                        viewedVersion={effectiveViewedVersion}
-                        onView={handleView}
-                        onClose={handleCloseHistory}
-                        build={build}
-                        hasEarlier={history.hasEarlier}
-                        isFetchingEarlier={history.isFetchingEarlier}
-                        fetchEarlier={history.fetchEarlier}
-                    />
+                    <>
+                        <PanelResizeHandle
+                            className={classes.historyResizeHandle}
+                            aria-label="Resize version history"
+                        />
+                        <Panel
+                            id="chart-type-builder-history"
+                            order={2}
+                            defaultSize={20}
+                            minSize={15}
+                            maxSize={50}
+                            className={classes.historyPanel}
+                        >
+                            <VersionHistoryPanel
+                                projectUuid={projectUuid}
+                                appUuid={activeVizUuid}
+                                versions={history.versions}
+                                latestReadyVersion={history.latestReadyVersion}
+                                viewedVersion={effectiveViewedVersion}
+                                onView={handleView}
+                                onClose={handleCloseHistory}
+                                build={build}
+                                hasEarlier={history.hasEarlier}
+                                isFetchingEarlier={history.isFetchingEarlier}
+                                fetchEarlier={history.fetchEarlier}
+                            />
+                        </Panel>
+                    </>
                 )}
-            </Box>
+            </PanelGroup>
         </Box>
     );
 };


### PR DESCRIPTION
### Description

- Show live Reasoning and Activity rows with the active chart type build while preserving the queued-prompt stack.
- Add collapsed Build details to traced terminal versions in history.
- Share narration extraction and presentation with the Data App builder.

**Chart type builder**
<img width="1247" height="945" alt="CleanShot 2026-08-18 at 17 18 07" src="https://github.com/user-attachments/assets/af74c7d5-e58f-4234-8ad8-3677ff59d822" />
<img width="2060" height="1222" alt="CleanShot 2026-08-18 at 17 18 56" src="https://github.com/user-attachments/assets/fb723b95-29be-425f-a79c-788215877102" />

**Regression (apps)**
<img width="2559" height="1172" alt="CleanShot 2026-08-18 at 17 20 16" src="https://github.com/user-attachments/assets/0c20d7f1-37c4-48d4-b79a-5525ca1e2ba8" />

### Validation

- 71 focused frontend tests
- Frontend typecheck
- Frontend linter
- Production frontend build

Closes: https://linear.app/lightdash/issue/PROD-10263/data-apps-show-live-reasoning-and-activity-while-a-chart-type-builds
Closes: https://linear.app/lightdash/issue/PROD-10264/data-apps-expand-a-chart-type-version-in-history-to-see-how-it-was