### PR TITLE
fix(dashboards): respect date filter tile scope

### DIFF
--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -1456,6 +1456,20 @@ describe('applyDashboardFiltersForTile', () => {
         tableCalculations: [],
     };
 
+    const exploreWithDefaultTimeDimension = {
+        ...mockExplore,
+        tables: {
+            ...mockExplore.tables,
+            orders: {
+                ...mockExplore.tables.orders,
+                defaultTimeDimension: {
+                    field: 'order_date',
+                    interval: TimeFrames.DAY,
+                },
+            },
+        },
+    };
+
     const statusRule: DashboardFilterRule = {
         id: 'f-status',
         target: { fieldId: 'orders_status', tableName: 'orders' },
@@ -1493,19 +1507,6 @@ describe('applyDashboardFiltersForTile', () => {
     });
 
     test('maps an unmapped date filter to the explore default time dimension', () => {
-        const exploreWithDefaultTimeDimension = {
-            ...mockExplore,
-            tables: {
-                ...mockExplore.tables,
-                orders: {
-                    ...mockExplore.tables.orders,
-                    defaultTimeDimension: {
-                        field: 'order_date',
-                        interval: TimeFrames.DAY,
-                    },
-                },
-            },
-        };
         const crossExploreDateRule: DashboardFilterRule = {
             id: 'f-cross-explore-date',
             target: {
@@ -1538,6 +1539,45 @@ describe('applyDashboardFiltersForTile', () => {
         expect(
             (metricQuery.filters.dimensions as AndFilterGroup).and[0],
         ).toMatchObject({ target: { fieldId: 'orders_order_date' } });
+    });
+
+    test('does not map a date filter outside its explicit tile scope', () => {
+        const scopedDateRule: DashboardFilterRule = {
+            id: 'f-scoped-date',
+            target: {
+                fieldId: 'events_created_at',
+                tableName: 'events',
+                fallbackType: DimensionType.DATE,
+            },
+            operator: FilterOperator.EQUALS,
+            values: ['2026-08-01'],
+            label: 'Date',
+            tileTargets: {
+                'other-tile': {
+                    fieldId: 'events_created_at',
+                    tableName: 'events',
+                    fallbackType: DimensionType.DATE,
+                },
+            },
+        };
+
+        const { metricQuery, appliedDashboardFilters } =
+            applyDashboardFiltersForTile({
+                tileUuid: 't-1',
+                metricQuery: baseMetricQuery,
+                dashboardFilters: {
+                    dimensions: [scopedDateRule],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+                explore: exploreWithDefaultTimeDimension,
+            });
+
+        expect(appliedDashboardFilters.dimensions).toEqual([]);
+        expect(
+            (metricQuery.filters.dimensions as AndFilterGroup | undefined)
+                ?.and ?? [],
+        ).toEqual([]);
     });
 
     test('drops rules whose tileTargets disable them for this tile', () => {
@@ -1599,7 +1639,58 @@ describe('applyDefaultTimeDimensionTileTargets', () => {
     const defaultTimeDimension =
         mockExplore.tables.orders.dimensions.order_date;
 
-    test('maps a date filter to each tile default without overriding explicit targets', () => {
+    test('does not map a date filter outside its explicit tile scope', () => {
+        const filters: DashboardFilters = {
+            dimensions: [
+                {
+                    id: 'scoped-date-filter',
+                    target: {
+                        fieldId: 'events_created_at',
+                        tableName: 'events',
+                        fallbackType: DimensionType.DATE,
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['2026-08-01'],
+                    label: 'Date',
+                    tileTargets: {
+                        source: {
+                            fieldId: 'events_created_at',
+                            tableName: 'events',
+                            fallbackType: DimensionType.DATE,
+                        },
+                    },
+                },
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+
+        const result = applyDefaultTimeDimensionTileTargets(
+            filters,
+            {
+                source: [sourceDateDimension],
+                target: [defaultTimeDimension],
+            },
+            {
+                source: {
+                    fieldId: 'events_created_at',
+                    tableName: 'events',
+                    fallbackType: DimensionType.DATE,
+                },
+                target: {
+                    fieldId: 'orders_order_date',
+                    tableName: 'orders',
+                    fallbackType: DimensionType.DATE,
+                },
+            },
+        );
+
+        expect(result.dimensions[0].tileTargets).toEqual(
+            filters.dimensions[0].tileTargets,
+        );
+    });
+
+    test('maps an unscoped date filter to each tile default', () => {
         const filters: DashboardFilters = {
             dimensions: [
                 {
@@ -1611,14 +1702,6 @@ describe('applyDefaultTimeDimensionTileTargets', () => {
                     operator: FilterOperator.EQUALS,
                     values: ['2026-08-01'],
                     label: 'Date',
-                    tileTargets: {
-                        excluded: false,
-                        explicit: {
-                            fieldId: 'custom_date',
-                            tableName: 'custom',
-                            fallbackType: DimensionType.DATE,
-                        },
-                    },
                 },
             ],
             metrics: [],
@@ -1661,13 +1744,17 @@ describe('applyDefaultTimeDimensionTileTargets', () => {
             DimensionType.DATE,
         );
         expect(result.dimensions[0].tileTargets).toEqual({
-            excluded: false,
-            explicit: {
-                fieldId: 'custom_date',
-                tableName: 'custom',
+            target: {
+                fieldId: 'orders_order_date',
+                tableName: 'orders',
                 fallbackType: DimensionType.DATE,
             },
-            target: {
+            excluded: {
+                fieldId: 'orders_order_date',
+                tableName: 'orders',
+                fallbackType: DimensionType.DATE,
+            },
+            explicit: {
                 fieldId: 'orders_order_date',
                 tableName: 'orders',
                 fallbackType: DimensionType.DATE,

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -1591,24 +1591,25 @@ export const applyDefaultTimeDimensionTileTargets = (
             return filter;
         }
 
-        const tileTargets = Object.entries(defaultTimeDimensions).reduce(
-            (targets, [tileUuid, defaultTimeDimensionTarget]) => {
-                if (targets[tileUuid] !== undefined) {
-                    return targets;
-                }
-                const tileHasSourceField = filterableFieldsByTileUuid[
-                    tileUuid
-                ]?.some((field) => getItemId(field) === filter.target.fieldId);
-                if (tileHasSourceField) {
-                    return targets;
-                }
-                return {
-                    ...targets,
-                    [tileUuid]: defaultTimeDimensionTarget,
-                };
-            },
-            { ...filter.tileTargets },
-        );
+        const tileTargets = filter.tileTargets
+            ? filter.tileTargets
+            : Object.entries(defaultTimeDimensions).reduce(
+                  (targets, [tileUuid, defaultTimeDimensionTarget]) => {
+                      const tileHasSourceField = filterableFieldsByTileUuid[
+                          tileUuid
+                      ]?.some(
+                          (field) => getItemId(field) === filter.target.fieldId,
+                      );
+                      if (tileHasSourceField) {
+                          return targets;
+                      }
+                      return {
+                          ...targets,
+                          [tileUuid]: defaultTimeDimensionTarget,
+                      };
+                  },
+                  {},
+              );
 
         return {
             ...filter,
@@ -1637,22 +1638,31 @@ export const applyDashboardFiltersForTile = ({
 } => {
     const availableFieldIds = getAvailableFilterFieldIds(explore);
     const defaultTimeDimension = getExploreDefaultTimeDimension(explore);
-    const dimensionFilters = dashboardFilters.dimensions.map((filter) => {
+    const dimensionFilters = dashboardFilters.dimensions.flatMap((filter) => {
         const tileTarget = filter.tileTargets?.[tileUuid];
+        if (
+            filter.tileTargets !== undefined &&
+            tileTarget === undefined &&
+            isDateDimensionType(filter.target.fallbackType)
+        ) {
+            return [];
+        }
         if (
             tileTarget !== undefined ||
             availableFieldIds.includes(filter.target.fieldId) ||
             !isDateDimensionType(filter.target.fallbackType) ||
             !defaultTimeDimension
         ) {
-            return filter;
+            return [filter];
         }
-        return {
-            ...filter,
-            target: {
-                ...getDashboardFieldTarget(defaultTimeDimension),
+        return [
+            {
+                ...filter,
+                target: {
+                    ...getDashboardFieldTarget(defaultTimeDimension),
+                },
             },
-        };
+        ];
     });
     const appliedDashboardFilters = getDashboardFiltersForTileAndTables(
         tileUuid,


### PR DESCRIPTION
Fixes lightdash/lightdash#27591

Linear: lightdash/lightdash#27591

### Description

* Treat a defined dashboard date filter `tileTargets` map as explicit scope.
* Prevent tiles omitted from that map from receiving a cross-explore default-time mapping.
* Preserve automatic default-time mapping when `tileTargets` is absent.
* Keep non-date dashboard filter behavior unchanged.

### Reproduction

On a two-tab dashboard, an Orders date filter was scoped only to the Orders tile while the second tab contained a Visits tile from an unrelated explore. Two uncached v2 dashboard chart queries for the Visits tile both rewrote and applied the filter to `visit_analytics_visit_date`. Setting the Visits tile target explicitly to `false` correctly applied no filter.

### Test plan

- [X] `pnpm -F common test src/utils/filters.test.ts` (111 tests)
- [X] `pnpm -F common typecheck`
- [X] Targeted lint and formatting checks
- [X] `git diff --check`