### PR TITLE
feat(ai-agents): view SQL for merged visualizations

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
@@ -3,7 +3,6 @@ import {
     getGroupByDimensions,
     getWebAiChartConfig,
     isAiAgentSqlArtifactVizQuery,
-    isAiMergeChartArtifactConfig,
     isAiSqlChartArtifactConfig,
     parseVizConfig,
     type AiAgentChartTypeOption,
@@ -24,10 +23,12 @@ import { memo, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import TruncatedText from '../../../../../components/common/TruncatedText';
 import useHealth from '../../../../../hooks/health/useHealth';
-import { useCompiledSqlFromMetricQuery } from '../../../../../hooks/useCompiledSql';
 import { useInfiniteQueryResults } from '../../../../../hooks/useQueryResults';
 import { useAiAgentArtifact } from '../../hooks/useAiAgentArtifacts';
-import { useAiMergeCompiledSql } from '../../hooks/useAiMergeCompiledSql';
+import {
+    getAiArtifactChartSource,
+    useAiArtifactCompiledSql,
+} from '../../hooks/useAiArtifactChart';
 import {
     useAiAgentArtifactVizQuery,
     useAiAgentThread,
@@ -108,18 +109,8 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
         const isSqlArtifact = isAiSqlChartArtifactConfig(
             artifactData?.chartConfig,
         );
-        const mergeChartConfig = isAiMergeChartArtifactConfig(
-            artifactData?.chartConfig,
-        )
-            ? artifactData?.chartConfig
-            : null;
-        const isMergeArtifact = mergeChartConfig !== null;
-        const semanticChartConfig =
-            artifactData?.chartConfig?.source === 'semantic'
-                ? artifactData.chartConfig.config
-                : mergeChartConfig
-                  ? mergeChartConfig.config
-                  : null;
+        const { isMergeArtifact, semanticChartConfig } =
+            getAiArtifactChartSource(artifactData?.chartConfig);
 
         const vizConfig = useMemo(() => {
             if (!isFloatingChart || !semanticChartConfig) return null;
@@ -156,22 +147,11 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
             queryUuid,
         );
 
-        const { data: compiledSql } = useCompiledSqlFromMetricQuery({
-            tableName: isMergeArtifact
-                ? undefined
-                : semanticVizQueryData?.query.metricQuery?.exploreName,
+        const compiledSqlQuery = useAiArtifactCompiledSql({
             projectUuid: artifact.projectUuid,
-            metricQuery: isMergeArtifact
-                ? undefined
-                : semanticVizQueryData?.query.metricQuery,
+            isMergeArtifact,
+            vizQueryData: semanticVizQueryData,
         });
-        const { data: mergeCompiledSql } = useAiMergeCompiledSql(
-            artifact.projectUuid,
-            isMergeArtifact ? semanticVizQueryData : undefined,
-        );
-        const compiledSqlQuery = isMergeArtifact
-            ? (mergeCompiledSql?.sql ?? undefined)
-            : compiledSql?.query;
 
         // Same parse the renderer does — needed so the floating pill can
         // show the correct default selection and know whether to render

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
@@ -27,6 +27,7 @@ import useHealth from '../../../../../hooks/health/useHealth';
 import { useCompiledSqlFromMetricQuery } from '../../../../../hooks/useCompiledSql';
 import { useInfiniteQueryResults } from '../../../../../hooks/useQueryResults';
 import { useAiAgentArtifact } from '../../hooks/useAiAgentArtifacts';
+import { useAiMergeCompiledSql } from '../../hooks/useAiMergeCompiledSql';
 import {
     useAiAgentArtifactVizQuery,
     useAiAgentThread,
@@ -164,6 +165,13 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
                 ? undefined
                 : semanticVizQueryData?.query.metricQuery,
         });
+        const { data: mergeCompiledSql } = useAiMergeCompiledSql(
+            artifact.projectUuid,
+            isMergeArtifact ? semanticVizQueryData : undefined,
+        );
+        const compiledSqlQuery = isMergeArtifact
+            ? (mergeCompiledSql?.sql ?? undefined)
+            : compiledSql?.query;
 
         // Same parse the renderer does — needed so the floating pill can
         // show the correct default selection and know whether to render
@@ -339,7 +347,7 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
                             description={description}
                             columns={Object.values(queryResults.columns ?? {})}
                         />
-                    ) : !isMergeArtifact ? (
+                    ) : (
                         <AiChartQuickOptions
                             message={message}
                             projectUuid={artifact.projectUuid}
@@ -350,9 +358,10 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
                                 description: description,
                                 linkToMessage: true,
                             }}
-                            compiledSql={compiledSql?.query}
+                            compiledSql={compiledSqlQuery}
+                            mergeArtifact={isMergeArtifact}
                         />
-                    ) : null}
+                    )}
                     {showCloseButton && (
                         <>
                             <Divider
@@ -404,6 +413,7 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
                         chartConfig={semanticChartConfig}
                         selectedChartType={selectedChartType}
                         headerContent={floatingHead}
+                        loadExplore={!isMergeArtifact}
                     />
                 </div>
                 {shouldShowPill && metricQuery && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -61,6 +61,11 @@ type Props = {
     message: AiAgentMessageAssistant;
     compiledSql?: string;
     artifactData?: AiArtifact;
+    /**
+     * Merged results have no single source explore and cannot be saved as a
+     * chart yet, so only the SQL and verify actions apply.
+     */
+    mergeArtifact?: boolean;
 };
 
 export const AiChartQuickOptions = ({
@@ -70,6 +75,7 @@ export const AiChartQuickOptions = ({
     message,
     compiledSql,
     artifactData,
+    mergeArtifact = false,
 }: Props) => {
     const { track } = useTracking();
     const { user } = useApp();
@@ -355,10 +361,11 @@ export const AiChartQuickOptions = ({
 
     const canVerify = !!artifactData && canManageAgent;
     const hasSavedChartAction = !!message.savedQueryUuid && !isEmbed;
-    const hasSaveActions = !message.savedQueryUuid;
+    const hasSaveActions = !message.savedQueryUuid && !mergeArtifact;
     const canExploreFromEmbed =
         content?.type === 'aiAgent' && content.canExplore === true;
-    const hasExploreAction = !isEmbed || canExploreFromEmbed;
+    const hasExploreAction =
+        (!isEmbed || canExploreFromEmbed) && !mergeArtifact;
     const hasSqlActions = !!compiledSql;
     const hasQuickActions =
         hasSavedChartAction ||
@@ -430,7 +437,7 @@ export const AiChartQuickOptions = ({
                                     )}
                                 </>
                             )
-                        ) : (
+                        ) : hasSaveActions ? (
                             <>
                                 {quickSaveDashboard && (
                                     <Menu.Item
@@ -464,7 +471,7 @@ export const AiChartQuickOptions = ({
                                     </Menu.Item>
                                 )}
                             </>
-                        )}
+                        ) : null}
 
                         {hasExploreAction && (
                             <Menu.Item

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -1,6 +1,5 @@
 import {
     isAiAgentSqlArtifactVizQuery,
-    isAiMergeChartArtifactConfig,
     isAiSqlChartArtifactConfig,
     parseVizConfig,
     type AiAgentChartTypeOption,
@@ -21,9 +20,11 @@ import { useMediaQuery } from '@mantine/hooks';
 import { IconExclamationCircle, IconX } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { useCompiledSqlFromMetricQuery } from '../../../../../hooks/useCompiledSql';
 import { useInfiniteQueryResults } from '../../../../../hooks/useQueryResults';
-import { useAiMergeCompiledSql } from '../../hooks/useAiMergeCompiledSql';
+import {
+    getAiArtifactChartSource,
+    useAiArtifactCompiledSql,
+} from '../../hooks/useAiArtifactChart';
 import { useAiAgentArtifactVizQuery } from '../../hooks/useProjectAiAgents';
 import { clearArtifact } from '../../store/aiArtifactSlice';
 import { useAiAgentStoreDispatch } from '../../store/hooks';
@@ -61,18 +62,9 @@ export const AiChartVisualization: FC<Props> = ({
         useState<AiAgentChartTypeOption | null>(null);
 
     const isSqlArtifact = isAiSqlChartArtifactConfig(artifactData.chartConfig);
-    const mergeChartConfig = isAiMergeChartArtifactConfig(
+    const { isMergeArtifact, semanticChartConfig } = getAiArtifactChartSource(
         artifactData.chartConfig,
-    )
-        ? artifactData.chartConfig
-        : null;
-    const isMergeArtifact = mergeChartConfig !== null;
-    const semanticChartConfig =
-        artifactData.chartConfig?.source === 'semantic'
-            ? artifactData.chartConfig.config
-            : mergeChartConfig
-              ? mergeChartConfig.config
-              : null;
+    );
 
     const vizConfig = useMemo(() => {
         if (!semanticChartConfig) return null;
@@ -105,22 +97,11 @@ export const AiChartVisualization: FC<Props> = ({
         queryExecutionHandle.data?.query.queryUuid,
     );
 
-    const { data: compiledSql } = useCompiledSqlFromMetricQuery({
-        tableName: isMergeArtifact
-            ? undefined
-            : semanticVizQueryData?.query.metricQuery?.exploreName,
+    const compiledSqlQuery = useAiArtifactCompiledSql({
         projectUuid,
-        metricQuery: isMergeArtifact
-            ? undefined
-            : semanticVizQueryData?.query.metricQuery,
+        isMergeArtifact,
+        vizQueryData: semanticVizQueryData,
     });
-    const { data: mergeCompiledSql } = useAiMergeCompiledSql(
-        projectUuid,
-        isMergeArtifact ? semanticVizQueryData : undefined,
-    );
-    const compiledSqlQuery = isMergeArtifact
-        ? (mergeCompiledSql?.sql ?? undefined)
-        : compiledSql?.query;
 
     const isQueryLoading =
         queryExecutionHandle.isLoading ||

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -23,6 +23,7 @@ import { useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useCompiledSqlFromMetricQuery } from '../../../../../hooks/useCompiledSql';
 import { useInfiniteQueryResults } from '../../../../../hooks/useQueryResults';
+import { useAiMergeCompiledSql } from '../../hooks/useAiMergeCompiledSql';
 import { useAiAgentArtifactVizQuery } from '../../hooks/useProjectAiAgents';
 import { clearArtifact } from '../../store/aiArtifactSlice';
 import { useAiAgentStoreDispatch } from '../../store/hooks';
@@ -113,6 +114,13 @@ export const AiChartVisualization: FC<Props> = ({
             ? undefined
             : semanticVizQueryData?.query.metricQuery,
     });
+    const { data: mergeCompiledSql } = useAiMergeCompiledSql(
+        projectUuid,
+        isMergeArtifact ? semanticVizQueryData : undefined,
+    );
+    const compiledSqlQuery = isMergeArtifact
+        ? (mergeCompiledSql?.sql ?? undefined)
+        : compiledSql?.query;
 
     const isQueryLoading =
         queryExecutionHandle.isLoading ||
@@ -216,24 +224,20 @@ export const AiChartVisualization: FC<Props> = ({
                 </Text>
             </Stack>
             <Group gap="sm" display={isMobile ? 'none' : 'flex'}>
-                {!isMergeArtifact && (
-                    <>
-                        <ViewSqlButton sql={compiledSql?.query} />
-                        <AiChartQuickOptions
-                            message={message}
-                            projectUuid={projectUuid}
-                            agentUuid={agentUuid}
-                            artifactData={artifactData}
-                            saveChartOptions={{
-                                name: semanticVizQueryData.metadata.title,
-                                description:
-                                    semanticVizQueryData.metadata.description,
-                                linkToMessage: true,
-                            }}
-                            compiledSql={compiledSql?.query}
-                        />
-                    </>
-                )}
+                <ViewSqlButton sql={compiledSqlQuery} />
+                <AiChartQuickOptions
+                    message={message}
+                    projectUuid={projectUuid}
+                    agentUuid={agentUuid}
+                    artifactData={artifactData}
+                    saveChartOptions={{
+                        name: semanticVizQueryData.metadata.title,
+                        description: semanticVizQueryData.metadata.description,
+                        linkToMessage: true,
+                    }}
+                    compiledSql={compiledSqlQuery}
+                    mergeArtifact={isMergeArtifact}
+                />
                 {showCloseButton && (
                     <ActionIcon
                         size="sm"
@@ -256,6 +260,7 @@ export const AiChartVisualization: FC<Props> = ({
             selectedChartType={selectedChartType}
             onChartTypeChange={setSelectedChartType}
             headerContent={inlineHeaderContent}
+            loadExplore={!isMergeArtifact}
         />
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiArtifactChart.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiArtifactChart.ts
@@ -1,0 +1,51 @@
+import {
+    isAiMergeChartArtifactConfig,
+    type AiChartArtifactConfig,
+    type ApiAiAgentThreadMessageVizQuery,
+} from '@lightdash/common';
+import { useCompiledSqlFromMetricQuery } from '../../../../hooks/useCompiledSql';
+import { useAiMergeCompiledSql } from './useAiMergeCompiledSql';
+
+/** Resolves an artifact's chart config into the shape the renderers consume. */
+export const getAiArtifactChartSource = (
+    chartConfig: AiChartArtifactConfig | null | undefined,
+) => {
+    const mergeChartConfig = isAiMergeChartArtifactConfig(chartConfig)
+        ? chartConfig
+        : null;
+    return {
+        isMergeArtifact: mergeChartConfig !== null,
+        semanticChartConfig:
+            chartConfig?.source === 'semantic'
+                ? chartConfig.config
+                : (mergeChartConfig?.config ?? null),
+    };
+};
+
+/** The SQL behind an artifact's View SQL action, for both query shapes. */
+export const useAiArtifactCompiledSql = ({
+    projectUuid,
+    isMergeArtifact,
+    vizQueryData,
+}: {
+    projectUuid: string | undefined;
+    isMergeArtifact: boolean;
+    vizQueryData: ApiAiAgentThreadMessageVizQuery | undefined;
+}): string | undefined => {
+    const { data: compiledSql } = useCompiledSqlFromMetricQuery({
+        tableName: isMergeArtifact
+            ? undefined
+            : vizQueryData?.query.metricQuery?.exploreName,
+        projectUuid,
+        metricQuery: isMergeArtifact
+            ? undefined
+            : vizQueryData?.query.metricQuery,
+    });
+    const { data: mergeCompiledSql } = useAiMergeCompiledSql(
+        projectUuid,
+        isMergeArtifact ? vizQueryData : undefined,
+    );
+    return isMergeArtifact
+        ? (mergeCompiledSql?.sql ?? undefined)
+        : compiledSql?.query;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiMergeCompiledSql.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiMergeCompiledSql.ts
@@ -1,0 +1,30 @@
+import {
+    type ApiAiAgentThreadMessageVizQuery,
+    type ApiError,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import {
+    compileMergeQuery,
+    type CompiledMergeQuery,
+} from '../../../../features/mergeQuery/hooks/useMergeQuery';
+
+/**
+ * The merged statement for a merge artifact's View SQL action, compiled from
+ * the MergeQuery the viz query executed — the SQL shown is the SQL that ran.
+ */
+export const useAiMergeCompiledSql = (
+    projectUuid: string | undefined,
+    vizQueryData: ApiAiAgentThreadMessageVizQuery | undefined,
+) => {
+    const mergeQuery = vizQueryData?.mergeQuery ?? null;
+    return useQuery<CompiledMergeQuery, ApiError>({
+        queryKey: ['aiMergeCompiledSql', projectUuid, mergeQuery],
+        enabled: !!projectUuid && !!mergeQuery,
+        queryFn: () =>
+            compileMergeQuery(
+                projectUuid!,
+                mergeQuery!,
+                vizQueryData?.query.usedParametersValues,
+            ),
+    });
+};


### PR DESCRIPTION
## What changed

Stacked on #27511 (merge query visualizations for AI agents).

- add a View SQL action for merge artifacts: `useAiMergeCompiledSql` compiles the merged statement from the `MergeQuery` the viz query actually executed, so the SQL shown is the SQL that ran
- show the quick-options menu for merge artifacts, with save/explore still gated off (`mergeArtifact` prop) — those land in the next PR of the stack
- extract the duplicated chart-source derivation and dual compiled-SQL hooks from `AiArtifactPanel` and `AiChartVisualization` into `useAiArtifactChart`

## Why

The base PR renders merge artifacts but hides all quick actions. View SQL is viewer-safe (the `mergeQuery/compile` endpoint enforces viewer-level project access per source) and is the first action users ask for when a result looks surprising.

## Regression analysis

Frontend-only. Non-merge artifacts keep the exact `useCompiledSqlFromMetricQuery` path they had; the extraction is behavior-preserving (verified by the aiCopilot test suite and typecheck on this branch alone).

## Validation

- frontend typecheck, aiCopilot vitest suite (309 tests), oxlint, ts-unused-exports — all on this branch standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fxweiJWtg2XZJ5PNk7u13
