### PR TITLE
fix(frontend): restore font-size inheritance for unsized Text/Anchor

### DIFF
--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -255,7 +255,7 @@ const QueryAFiltersCard: FC = memo(() => {
                         filterRule.operator !== FilterOperator.NOT_NULL ? (
                             <>
                                 {' '}
-                                <Text span fw={700} fz="inherit" lh="inherit">
+                                <Text span fw={700} lh="inherit">
                                     {labels.value}
                                 </Text>
                             </>
@@ -310,7 +310,6 @@ const QueryAFiltersCard: FC = memo(() => {
                                                 span
                                                 c="dimmed"
                                                 fw={700}
-                                                fz="inherit"
                                                 lh="inherit"
                                             >
                                                 {expression.operator.toUpperCase()}
@@ -344,7 +343,6 @@ const QueryAFiltersCard: FC = memo(() => {
                             key={`${path}-${index}-operator`}
                             c="dimmed"
                             fw={700}
-                            fz="inherit"
                             lh="inherit"
                             style={{ paddingLeft: itemDepth * 12 }}
                         >

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -255,7 +255,7 @@ const QueryAFiltersCard: FC = memo(() => {
                         filterRule.operator !== FilterOperator.NOT_NULL ? (
                             <>
                                 {' '}
-                                <Text span fw={700} lh="inherit">
+                                <Text span fw={700}>
                                     {labels.value}
                                 </Text>
                             </>
@@ -306,12 +306,7 @@ const QueryAFiltersCard: FC = memo(() => {
                                 <span key={`${path}-${item.id}`}>
                                     {index > 0 ? (
                                         <>
-                                            <Text
-                                                span
-                                                c="dimmed"
-                                                fw={700}
-                                                lh="inherit"
-                                            >
+                                            <Text span c="dimmed" fw={700}>
                                                 {expression.operator.toUpperCase()}
                                             </Text>{' '}
                                         </>
@@ -343,7 +338,6 @@ const QueryAFiltersCard: FC = memo(() => {
                             key={`${path}-${index}-operator`}
                             c="dimmed"
                             fw={700}
-                            lh="inherit"
                             style={{ paddingLeft: itemDepth * 12 }}
                         >
                             {expression.operator.toUpperCase()}

--- a/packages/frontend/src/components/Explorer/QuickFilterMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/QuickFilterMenuItems.tsx
@@ -82,7 +82,7 @@ const QuickFilterMenuItems: FC<Props> = ({ item, value, onAddFilter }) => {
                     onClick={() => handleFilterByValue(operator)}
                 >
                     <Group gap={4} wrap="nowrap">
-                        <Text span fz="inherit" lh="inherit">
+                        <Text span lh="inherit">
                             {label}
                         </Text>
                         <TruncatedText

--- a/packages/frontend/src/components/Explorer/QuickFilterMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/QuickFilterMenuItems.tsx
@@ -82,14 +82,11 @@ const QuickFilterMenuItems: FC<Props> = ({ item, value, onAddFilter }) => {
                     onClick={() => handleFilterByValue(operator)}
                 >
                     <Group gap={4} wrap="nowrap">
-                        <Text span lh="inherit">
-                            {label}
-                        </Text>
+                        <Text span>{label}</Text>
                         <TruncatedText
                             inline
                             fw="bold"
                             fz="inherit"
-                            lh="inherit"
                             maxWidth={MAX_FILTER_VALUE_WIDTH}
                         >
                             {value.formatted}

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -191,7 +191,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                             }}
                         >
                             Filter by{' '}
-                            <Text span fz="inherit" lh="inherit">
+                            <Text span lh="inherit">
                                 "{getItemLabelWithoutTableName(item)}"
                             </Text>
                         </Menu.Item>
@@ -325,7 +325,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                             }}
                         >
                             Filter by{' '}
-                            <Text span fz="inherit" lh="inherit" fw={500}>
+                            <Text span lh="inherit" fw={500}>
                                 {getItemLabelWithoutTableName(item)}
                             </Text>
                         </Menu.Item>
@@ -404,7 +404,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                     }}
                 >
                     Filter by{' '}
-                    <Text span fz="inherit" lh="inherit" fw="semibold">
+                    <Text span lh="inherit" fw="semibold">
                         {getItemLabelWithoutTableName(item)}
                     </Text>
                 </Menu.Item>

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -191,7 +191,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                             }}
                         >
                             Filter by{' '}
-                            <Text span lh="inherit">
+                            <Text span>
                                 "{getItemLabelWithoutTableName(item)}"
                             </Text>
                         </Menu.Item>
@@ -325,7 +325,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                             }}
                         >
                             Filter by{' '}
-                            <Text span lh="inherit" fw={500}>
+                            <Text span fw={500}>
                                 {getItemLabelWithoutTableName(item)}
                             </Text>
                         </Menu.Item>
@@ -404,7 +404,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                     }}
                 >
                     Filter by{' '}
-                    <Text span lh="inherit" fw="semibold">
+                    <Text span fw="semibold">
                         {getItemLabelWithoutTableName(item)}
                     </Text>
                 </Menu.Item>

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderSortMenuOptions.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderSortMenuOptions.tsx
@@ -44,7 +44,7 @@ const ColumnHeaderSortMenuOptions: FC<Props> = ({
                         onClick={() => onSelect(direction)}
                     >
                         Sort{' '}
-                        <Text span lh="inherit" fw="bold">
+                        <Text span fw="bold">
                             {getSortLabel(item, direction)}
                         </Text>
                     </Menu.Item>

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderSortMenuOptions.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderSortMenuOptions.tsx
@@ -44,7 +44,7 @@ const ColumnHeaderSortMenuOptions: FC<Props> = ({
                         onClick={() => onSelect(direction)}
                     >
                         Sort{' '}
-                        <Text span fz="inherit" lh="inherit" fw="bold">
+                        <Text span lh="inherit" fw="bold">
                             {getSortLabel(item, direction)}
                         </Text>
                     </Menu.Item>

--- a/packages/frontend/src/components/MetricQueryData/DrillDownMenuItem.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownMenuItem.tsx
@@ -88,7 +88,7 @@ const DrillDownMenuItem: FC<DrillDownMenuItemProps> = ({
             >
                 <>
                     Drill into{' '}
-                    <Text span fz="inherit" lh="inherit" fw="bold">
+                    <Text span lh="inherit" fw="bold">
                         {value}
                     </Text>
                 </>

--- a/packages/frontend/src/components/MetricQueryData/DrillDownMenuItem.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownMenuItem.tsx
@@ -88,7 +88,7 @@ const DrillDownMenuItem: FC<DrillDownMenuItemProps> = ({
             >
                 <>
                     Drill into{' '}
-                    <Text span lh="inherit" fw="bold">
+                    <Text span fw="bold">
                         {value}
                     </Text>
                 </>

--- a/packages/frontend/src/components/PinnedParameters.tsx
+++ b/packages/frontend/src/components/PinnedParameters.tsx
@@ -100,11 +100,9 @@ const PinnedParameter: FC<PinnedParameterProps> = ({
                         ) : undefined
                     }
                 >
-                    <Text fz="inherit" truncate>
-                        <Text fz="inherit" span>
-                            {parameter.label || parameterKey}:
-                        </Text>{' '}
-                        <Text fz="inherit" fw={700} span>
+                    <Text truncate>
+                        <Text span>{parameter.label || parameterKey}:</Text>{' '}
+                        <Text fw={700} span>
                             {displayValue}
                         </Text>
                     </Text>

--- a/packages/frontend/src/components/SimpleTable/DashboardHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardHeaderContextMenu.tsx
@@ -61,7 +61,7 @@ const ColumnHeaderSortMenuOptions: FC<Props> = ({ item, tileUuid }) => {
                         }}
                     >
                         Sort{' '}
-                        <Text span lh="inherit" fw={500}>
+                        <Text span fw={500}>
                             {getSortLabel(item, sortDirection)}
                         </Text>
                     </Menu.Item>

--- a/packages/frontend/src/components/SimpleTable/DashboardHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardHeaderContextMenu.tsx
@@ -61,7 +61,7 @@ const ColumnHeaderSortMenuOptions: FC<Props> = ({ item, tileUuid }) => {
                         }}
                     >
                         Sort{' '}
-                        <Text span fz="inherit" lh="inherit" fw={500}>
+                        <Text span lh="inherit" fw={500}>
                             {getSortLabel(item, sortDirection)}
                         </Text>
                     </Menu.Item>

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -221,7 +221,7 @@ const SlackSettingsPanel: FC = () => {
                                 color="green"
                                 w="fit-content"
                             >
-                                <Text span fw={500} fz="inherit">
+                                <Text span fw={500}>
                                     {slackInstallation.slackTeamName}
                                 </Text>
                             </Badge>
@@ -232,10 +232,7 @@ const SlackSettingsPanel: FC = () => {
                         Sharing in Slack allows you to unfurl Lightdash URLs and
                         schedule deliveries to specific people or channels
                         within your Slack workspace.{' '}
-                        <Anchor
-                            fz="inherit"
-                            href="https://docs.lightdash.com/references/slack-integration"
-                        >
+                        <Anchor href="https://docs.lightdash.com/references/slack-integration">
                             View docs
                         </Anchor>
                     </Text>
@@ -247,7 +244,7 @@ const SlackSettingsPanel: FC = () => {
                             <SlackChannelSelect
                                 label={
                                     <Group gap="two" mb={2}>
-                                        <Text fz="inherit">
+                                        <Text>
                                             Select a notification channel
                                         </Text>
                                         <Tooltip

--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -202,7 +202,7 @@ const ValueCellMenuDropdownContent: FC<{
                 >
                     <>
                         Drill into{' '}
-                        <Text span lh="inherit" fw={500}>
+                        <Text span fw={500}>
                             {value.formatted}
                         </Text>
                     </>

--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -202,7 +202,7 @@ const ValueCellMenuDropdownContent: FC<{
                 >
                     <>
                         Drill into{' '}
-                        <Text span fz="inherit" lh="inherit" fw={500}>
+                        <Text span lh="inherit" fw={500}>
                             {value.formatted}
                         </Text>
                     </>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -311,12 +311,12 @@ const ReviewConceptHelp = () => (
                 <Stack gap={4}>
                     <Text fz="xs" c="dimmed">
                         A{' '}
-                        <Text span fw={600} c="ldGray.9" fz="inherit">
+                        <Text span fw={600} c="ldGray.9">
                             turn
                         </Text>{' '}
                         is one question and answer. When a turn shows a clear
                         issue, it becomes a{' '}
-                        <Text span fw={600} c="ldGray.9" fz="inherit">
+                        <Text span fw={600} c="ldGray.9">
                             finding
                         </Text>{' '}
                         so you can review it here and decide what to fix next.
@@ -344,12 +344,7 @@ const ReviewConceptHelp = () => (
                             <Text fz="xs" c="dimmed">
                                 {rootCauseHelp[cause].desc}
                                 {rootCauseHelp[cause].opensPr && (
-                                    <Text
-                                        span
-                                        fz="inherit"
-                                        c="ldGray.7"
-                                        fw={600}
-                                    >
+                                    <Text span c="ldGray.7" fw={600}>
                                         {' '}
                                         · fixable here
                                     </Text>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
@@ -571,20 +571,20 @@ export const ReviewRemediationWorkspace = () => {
                     </Group>
                     <Text fz="sm" c="dimmed" mt="sm">
                         We spun up a{' '}
-                        <Text span fw={600} c="bright" fz="inherit">
+                        <Text span fw={600} c="bright">
                             throwaway copy
                         </Text>{' '}
                         of your project with this fix applied.{' '}
-                        <Text span fw={600} c="bright" fz="inherit">
+                        <Text span fw={600} c="bright">
                             {testAgent?.name ?? 'Your agent'}
                         </Text>{' '}
                         re-runs the original question against it, so you can see
                         whether the answer is right{' '}
-                        <Text span fw={600} c="bright" fz="inherit">
+                        <Text span fw={600} c="bright">
                             before you merge
                         </Text>
                         .{' '}
-                        <Text span fw={600} c="bright" fz="inherit">
+                        <Text span fw={600} c="bright">
                             Nothing here touches production.
                         </Text>
                     </Text>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/ReviewsLoopDiagram.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/ReviewsLoopDiagram.tsx
@@ -78,9 +78,9 @@ export const ReviewsLoopDiagram: FC = () => (
         </Box>
         <Box className={styles.loop}>
             <MantineIcon icon={IconReload} size={13} />
-            <Text span fz="inherit" c="inherit" fw="inherit">
+            <Text span c="inherit" fw="inherit">
                 The agent picks this up{' '}
-                <Text span className={styles.loopMuted} fz="inherit">
+                <Text span className={styles.loopMuted}>
                     on its next answer.
                 </Text>
             </Text>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -301,7 +301,6 @@ export const AiGeneralSettingsPage = () => {
                                                 <Anchor
                                                     component={Link}
                                                     to="/generalSettings/ai/issues"
-                                                    fz="inherit"
                                                 >
                                                     Ask AI &gt; Issues
                                                 </Anchor>
@@ -368,7 +367,6 @@ export const AiGeneralSettingsPage = () => {
                                             <Anchor
                                                 component={Link}
                                                 to="/generalSettings/ai/memories"
-                                                fz="inherit"
                                             >
                                                 Ask AI &gt; Memories
                                             </Anchor>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -1859,7 +1859,6 @@ export const AiAgentMcpServersInput = ({
                         <Anchor
                             href="/generalSettings/integrations"
                             target="_blank"
-                            fz="inherit"
                         >
                             Organization settings → Integrations
                         </Anchor>

--- a/packages/frontend/src/ee/features/aiCopilot/components/GithubMcpConnectModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/GithubMcpConnectModal.tsx
@@ -108,7 +108,6 @@ export const GithubMcpConnectModal: FC<Props> = ({
                                 href={GITHUB_FINE_GRAINED_TOKEN_URL}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                fz="inherit"
                             >
                                 GitHub → Fine-grained tokens
                             </Anchor>

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -446,15 +446,11 @@ const Filter: FC<Props> = ({
                                         openDelay={1000}
                                         offset={8}
                                         label={
-                                            <Text fz="inherit">
+                                            <Text>
                                                 {filterRuleTables?.length === 1
                                                     ? 'Table: '
                                                     : 'Tables: '}
-                                                <Text
-                                                    span
-                                                    fw={600}
-                                                    fz="inherit"
-                                                >
+                                                <Text span fw={600}>
                                                     {filterRuleTables?.join(
                                                         ', ',
                                                     )}
@@ -462,12 +458,7 @@ const Filter: FC<Props> = ({
                                             </Text>
                                         }
                                     >
-                                        <Text
-                                            fz="inherit"
-                                            fw={600}
-                                            span
-                                            truncate
-                                        >
+                                        <Text fw={600} span truncate>
                                             {filterRule?.label ||
                                                 filterRuleLabels?.field}{' '}
                                         </Text>
@@ -477,32 +468,17 @@ const Filter: FC<Props> = ({
                                         isEmptyDashboardFilterRule(
                                             filterRule,
                                         )) ? (
-                                        <Text
-                                            span
-                                            fz="inherit"
-                                            c="ldGray.6"
-                                            truncate
-                                        >
+                                        <Text span c="ldGray.6" truncate>
                                             is any value
                                         </Text>
                                     ) : (
                                         <>
-                                            <Text
-                                                span
-                                                fz="inherit"
-                                                c="dimmed"
-                                                truncate
-                                            >
+                                            <Text span c="dimmed" truncate>
                                                 {
                                                     filterRuleLabels?.operator
                                                 }{' '}
                                             </Text>
-                                            <Text
-                                                fw={500}
-                                                fz="inherit"
-                                                span
-                                                truncate
-                                            >
+                                            <Text fw={500} span truncate>
                                                 {truncatedValuesDisplay
                                                     .displayedValues.length > 0
                                                     ? truncatedValuesDisplay.displayedValues.join(

--- a/packages/frontend/src/features/dashboardFilters/DashboardFiltersBarSummary.tsx
+++ b/packages/frontend/src/features/dashboardFilters/DashboardFiltersBarSummary.tsx
@@ -37,7 +37,7 @@ export const DashboardFiltersBarSummary: FC<Props> = ({
                 <Text fz="12" c="dimmed">
                     {hasFilters && (
                         <>
-                            <Text span fw={600} fz="inherit">
+                            <Text span fw={600}>
                                 {filtersCount}{' '}
                             </Text>
                             {filtersCount === 1 ? 'filter' : 'filters'}
@@ -46,7 +46,7 @@ export const DashboardFiltersBarSummary: FC<Props> = ({
                     {hasFilters && hasParameters && ' · '}
                     {hasParameters && (
                         <>
-                            <Text span fw={600} fz="inherit">
+                            <Text span fw={600}>
                                 {parametersCount}{' '}
                             </Text>
                             {parametersCount === 1 ? 'parameter' : 'parameters'}
@@ -55,7 +55,7 @@ export const DashboardFiltersBarSummary: FC<Props> = ({
                     {(hasFilters || hasParameters) && hasDateZoom && ' · '}
                     {hasDateZoom && (
                         <>
-                            <Text span fw={600} fz="inherit">
+                            <Text span fw={600}>
                                 Date Zoom:
                             </Text>{' '}
                             {dateZoomLabel}

--- a/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
@@ -73,7 +73,7 @@ export const FilterDashboardTo: FC<Props> = ({ filters, onAddFilter }) => {
                                 }
                             >
                                 <Group gap={4} wrap="nowrap">
-                                    <Text span fz="inherit" lh="inherit">
+                                    <Text span lh="inherit">
                                         {label}
                                     </Text>
                                     <TruncatedText

--- a/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterDashboardTo.tsx
@@ -73,14 +73,11 @@ export const FilterDashboardTo: FC<Props> = ({ filters, onAddFilter }) => {
                                 }
                             >
                                 <Group gap={4} wrap="nowrap">
-                                    <Text span lh="inherit">
-                                        {label}
-                                    </Text>
+                                    <Text span>{label}</Text>
                                     <TruncatedText
                                         inline
                                         fw={500}
                                         fz="inherit"
-                                        lh="inherit"
                                         maxWidth={MAX_FILTER_VALUE_WIDTH}
                                     >
                                         {valueText}

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -327,10 +327,9 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
                                         />
                                     }
                                 >
-                                    <Text fz="inherit" span>
+                                    <Text span>
                                         <Text
                                             span
-                                            fz="inherit"
                                             fw={600}
                                             c={
                                                 isDefaultInert
@@ -343,7 +342,6 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
                                         {!isEditMode && dateZoomGranularity ? (
                                             <Text
                                                 span
-                                                fz="inherit"
                                                 fw={500}
                                                 c={
                                                     isDefaultInert

--- a/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTile.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTile.tsx
@@ -24,13 +24,13 @@ export const DateZoomInfoOnTile: FC<DateZoomInfoOnTileProps> = ({
                 <>
                     <Text fz="xs">
                         Date zoom:{' '}
-                        <Text span fw={500} fz="inherit">
+                        <Text span fw={500}>
                             {label}
                         </Text>
                     </Text>
                     <Text fz="xs">
                         On:{' '}
-                        <Text span fw={500} fz="inherit">
+                        <Text span fw={500}>
                             {dateDimension?.label}
                         </Text>
                     </Text>

--- a/packages/frontend/src/features/parameters/components/Parameter.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameter.tsx
@@ -192,16 +192,14 @@ const Parameter: FC<Props> = ({
                             }}
                         >
                             <Text fz="xs" truncate>
-                                <Text span fw={600} fz="inherit">
+                                <Text span fw={600}>
                                     {displayLabel}
                                 </Text>
-                                <Text span c="gray.6" fz="inherit">
+                                <Text span c="gray.6">
                                     {' '}
                                     is{' '}
                                 </Text>
-                                <Text span fz="inherit">
-                                    {displayValue}
-                                </Text>
+                                <Text span>{displayValue}</Text>
                             </Text>
                         </Box>
                     </Button>

--- a/packages/frontend/src/stories/TextFontSizeInheritance.module.css
+++ b/packages/frontend/src/stories/TextFontSizeInheritance.module.css
@@ -1,0 +1,3 @@
+.probe {
+    outline: 1px dashed var(--mantine-color-orange-5);
+}

--- a/packages/frontend/src/stories/TextFontSizeInheritance.stories.tsx
+++ b/packages/frontend/src/stories/TextFontSizeInheritance.stories.tsx
@@ -1,0 +1,298 @@
+import {
+    Anchor,
+    Badge,
+    Box,
+    Code,
+    Group,
+    Menu,
+    Paper,
+    Popover,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine/core';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { IconFilter, IconHelpCircle } from '@tabler/icons-react';
+import {
+    useLayoutEffect,
+    useRef,
+    useState,
+    type FC,
+    type ReactNode,
+} from 'react';
+import MantineIcon from '../components/common/MantineIcon';
+import TruncatedText from '../components/common/TruncatedText';
+import styles from './TextFontSizeInheritance.module.css';
+
+/**
+ * Mantine v8 gives Text/Anchor a `md` (16px) fallback font-size instead of
+ * inheriting like v6 did. A rule in styles/global.css restores inheritance as
+ * the fallback. These stories rebuild the production patterns that were
+ * affected and assert the fix by measuring computed styles: the probed
+ * element (dashed outline) must match its parent's font-size, or the
+ * explicitly expected size.
+ */
+
+type Measurement = {
+    actual: string;
+    expected: string;
+    pass: boolean;
+};
+
+const MeasuredExample: FC<{
+    title: string;
+    source: string;
+    /** 'inherit' compares the probe to its parent; a number asserts px */
+    expected: 'inherit' | number;
+    children: ReactNode;
+}> = ({ title, source, expected, children }) => {
+    const ref = useRef<HTMLDivElement>(null);
+    const [measurement, setMeasurement] = useState<Measurement | null>(null);
+
+    useLayoutEffect(() => {
+        const probe = ref.current?.querySelector(`.${styles.probe}`);
+        if (!probe || !probe.parentElement) return;
+        const actual = getComputedStyle(probe).fontSize;
+        const expectedPx =
+            expected === 'inherit'
+                ? getComputedStyle(probe.parentElement).fontSize
+                : `${expected}px`;
+        setMeasurement({
+            actual,
+            expected: expectedPx,
+            pass: actual === expectedPx,
+        });
+    }, [expected]);
+
+    return (
+        <Paper p="md">
+            <Group justify="space-between" align="flex-start" mb="sm">
+                <Box>
+                    <Text fw={600}>{title}</Text>
+                    <Text fz="xs" c="dimmed">
+                        {source}
+                    </Text>
+                </Box>
+                {measurement && (
+                    <Badge
+                        radius="xs"
+                        color={measurement.pass ? 'green' : 'red'}
+                    >
+                        {measurement.pass
+                            ? `${measurement.actual} ✓`
+                            : `${measurement.actual} ✗ expected ${measurement.expected}`}
+                    </Badge>
+                )}
+            </Group>
+            <div ref={ref}>{children}</div>
+        </Paper>
+    );
+};
+
+const meta: Meta = {
+    title: 'Regressions/Text font-size inheritance',
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Unsized Text/Anchor must inherit font-size (and line-height) from context instead of falling back to Mantine v8’s 16px `md`. Each example probes the dashed-outline element and compares its computed font-size to its parent. All badges must be green.',
+            },
+        },
+    },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const NestedSpansInSizedText: Story = {
+    render: () => (
+        <Stack maw={560}>
+            <MeasuredExample
+                title="Bold span inside fz=xs help copy"
+                source="AiAgentAdminReviewItemsTable.tsx — HoverCard concept help"
+                expected={12}
+            >
+                <Text fz="xs" c="dimmed">
+                    A{' '}
+                    <Text span fw={600} c="ldGray.9" className={styles.probe}>
+                        turn
+                    </Text>{' '}
+                    is one question and answer. When a turn shows a clear issue,
+                    it becomes a finding.
+                </Text>
+            </MeasuredExample>
+            <MeasuredExample
+                title="Anchor inside fz=xs Text"
+                source="SlackSettingsPanel/index.tsx — docs link"
+                expected={12}
+            >
+                <Text c="dimmed" fz="xs">
+                    Sharing in Slack allows you to unfurl Lightdash URLs.{' '}
+                    <Anchor
+                        href="https://docs.lightdash.com/references/slack-integration"
+                        className={styles.probe}
+                    >
+                        View docs
+                    </Anchor>
+                </Text>
+            </MeasuredExample>
+            <MeasuredExample
+                title="Value span inside dashboard filter pill"
+                source="dashboardFilters/ActiveFilters/Filter.tsx"
+                expected="inherit"
+            >
+                <Text fz="xs">
+                    Order status{' '}
+                    <Text span c="dimmed" className={styles.probe}>
+                        is any of{' '}
+                    </Text>
+                    <Text fw={500} span>
+                        completed, shipped
+                    </Text>
+                </Text>
+            </MeasuredExample>
+        </Stack>
+    ),
+};
+
+export const MenuItemsAndTooltips: Story = {
+    render: () => (
+        <Stack maw={560}>
+            <MeasuredExample
+                title="Quick filter menu item label + value"
+                source="Explorer/QuickFilterMenuItems.tsx"
+                expected="inherit"
+            >
+                <Menu opened withinPortal={false} position="bottom-start">
+                    <Menu.Target>
+                        <span />
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconFilter} />}
+                        >
+                            <Group gap={4} wrap="nowrap">
+                                <Text span className={styles.probe}>
+                                    Filter by
+                                </Text>
+                                <TruncatedText
+                                    inline
+                                    fw="bold"
+                                    fz="inherit"
+                                    maxWidth={200}
+                                >
+                                    completed
+                                </TruncatedText>
+                            </Group>
+                        </Menu.Item>
+                    </Menu.Dropdown>
+                </Menu>
+            </MeasuredExample>
+            <MeasuredExample
+                title="Tooltip label with bold table names"
+                source="dashboardFilters/ActiveFilters/Filter.tsx"
+                expected={12}
+            >
+                <Tooltip
+                    opened
+                    withinPortal={false}
+                    label={
+                        <Text>
+                            Tables:{' '}
+                            <Text span fw={600} className={styles.probe}>
+                                orders, customers
+                            </Text>
+                        </Text>
+                    }
+                >
+                    <Text span>Order date</Text>
+                </Tooltip>
+            </MeasuredExample>
+            <MeasuredExample
+                title="Text inside a Badge"
+                source="SlackSettingsPanel/index.tsx — workspace badge"
+                expected="inherit"
+            >
+                <Badge radius="xs" size="lg" color="green">
+                    <Text span fw={500} className={styles.probe}>
+                        Lightdash HQ
+                    </Text>
+                </Badge>
+            </MeasuredExample>
+            <MeasuredExample
+                title="Unsized Text in a dropdown inherits the body size"
+                source="ee/aiCopilot — ReviewConceptHelp"
+                expected={14}
+            >
+                <Popover opened withinPortal={false} position="bottom-start">
+                    <Popover.Target>
+                        <Box w="fit-content">
+                            <MantineIcon icon={IconHelpCircle} />
+                        </Box>
+                    </Popover.Target>
+                    <Popover.Dropdown>
+                        <Text className={styles.probe}>
+                            Unsized Text in a dropdown inherits the body size.
+                        </Text>
+                    </Popover.Dropdown>
+                </Popover>
+            </MeasuredExample>
+        </Stack>
+    ),
+};
+
+export const ExplicitSizesStillWin: Story = {
+    render: () => (
+        <Stack maw={560}>
+            <MeasuredExample
+                title="size prop wins over inheritance"
+                source="size='lg' declares --text-fz, so the fallback never applies"
+                expected={18}
+            >
+                <Text fz="xs">
+                    Tiny context{' '}
+                    <Text span size="lg" className={styles.probe}>
+                        stays lg
+                    </Text>
+                </Text>
+            </MeasuredExample>
+            <MeasuredExample
+                title="fz prop wins over inheritance"
+                source="fz='sm' emits an inline font-size"
+                expected={14}
+            >
+                <Text fz="xl">
+                    Large context{' '}
+                    <Text span fz="sm" className={styles.probe}>
+                        stays sm
+                    </Text>
+                </Text>
+            </MeasuredExample>
+            <MeasuredExample
+                title="TruncatedText keeps its own sm default"
+                source="components/common/TruncatedText — deliberate fz='sm'"
+                expected={14}
+            >
+                <Text fz="xs">
+                    <TruncatedText
+                        inline
+                        maxWidth={280}
+                        className={styles.probe}
+                    >
+                        Defaults to sm even in an xs context
+                    </TruncatedText>
+                </Text>
+            </MeasuredExample>
+            <MeasuredExample
+                title="Top-level unsized Text inherits the 14px body size"
+                source="styles/global.css sets body { font-size: 14px }"
+                expected={14}
+            >
+                <Text className={styles.probe}>
+                    Plain paragraph copy is 14px, not Mantine’s 16px{' '}
+                    <Code>md</Code> fallback.
+                </Text>
+            </MeasuredExample>
+        </Stack>
+    ),
+};

--- a/packages/frontend/src/styles/global.css
+++ b/packages/frontend/src/styles/global.css
@@ -20,6 +20,15 @@ body {
     font-size: 14px;
 }
 
+/* Mantine v8 gives Text/Anchor a `md` (16px) fallback font-size instead of
+   inheriting like v6 did. Restore inheritance as the fallback; explicit
+   `size`/`fz` props still win because they set --text-fz / inline styles.
+   Must load after @mantine/core/styles.css to win the cascade tie. */
+.mantine-Text-root,
+.mantine-Anchor-root {
+    font-size: var(--text-fz, inherit);
+}
+
 p {
     margin-bottom: 10px;
     margin-top: 0;

--- a/packages/frontend/src/styles/global.css
+++ b/packages/frontend/src/styles/global.css
@@ -20,13 +20,15 @@ body {
     font-size: 14px;
 }
 
-/* Mantine v8 gives Text/Anchor a `md` (16px) fallback font-size instead of
-   inheriting like v6 did. Restore inheritance as the fallback; explicit
-   `size`/`fz` props still win because they set --text-fz / inline styles.
+/* Mantine v8 gives Text/Anchor `md` fallbacks (16px / 1.55) for font-size and
+   line-height instead of inheriting like v6 did. Restore inheritance as the
+   fallback; explicit `size`/`fz`/`lh` props still win because they set
+   --text-fz/--text-lh or inline styles.
    Must load after @mantine/core/styles.css to win the cascade tie. */
 .mantine-Text-root,
 .mantine-Anchor-root {
     font-size: var(--text-fz, inherit);
+    line-height: var(--text-lh, inherit);
 }
 
 p {


### PR DESCRIPTION
## Problem

Since the Mantine v6 → v8 migration, `Text` (and `Anchor`, built on the same root class) applies `font-size: var(--text-fz, var(--mantine-font-size-md))`. In v6, an unsized `Text` inherited its parent's font-size. In v8 the fallback is `md` (16px), while the app body is 14px — so every `Text` without an explicit size jumps to 16px, most visibly as nested `<Text span>` fragments rendering larger than the 12–14px copy around them (tooltips, menu items, filter pills, badge labels).

We had been patching this per-site with `fz="inherit"` — 53 occurrences across 24 files — with many more affected sites not patched at all.

## Fix

One global CSS rule in `styles/global.css` (loads after `@mantine/core/styles.css`, so it wins the equal-specificity cascade tie) restores inheritance as the *fallback only*:

```css
.mantine-Text-root,
.mantine-Anchor-root {
    font-size: var(--text-fz, inherit);
}
```

Explicit sizing still wins everywhere:
- `size="sm"` declares `--text-fz` as an inline var on the root, so the fallback never applies
- `fz` is a Box style prop that emits inline `font-size` directly, overriding everything
- CSS-module rules load after `global.css` in the bundle and win the tie

With the fallback fixed, the per-site `fz="inherit"` workarounds are dead weight and are removed — except on `TruncatedText` call sites (5 restored), because that component has its own deliberate, pre-migration `fz="sm"` default, so `fz="inherit"` there is a real override, not a workaround. `lh="inherit"` props are untouched (the line-height fallback is unchanged).

## Regression analysis

- **Intended behavior change**: any unsized `Text`/`Anchor` inside a container with a non-14px font-size now inherits that size instead of rendering 16px. This is the v6 behavior and what the copy around it expects, but it is broad — worth an eyeball on a dashboard, the explorer, and an AI agent thread.
- Unsized `Text` at page level inherits the 14px body size (previously 16px), matching pre-migration rendering.
- Every `Text`/`Anchor` with an explicit `size`, `fz`, or a CSS-module font-size is provably unaffected (inline styles / later cascade).
- The removed `fz="inherit"` props are behavior-neutral: inline `font-size: inherit` is replaced by the class fallback `inherit`.
- `TruncatedText` sites keep their overrides, so nothing there changes.
- `List` has the same v8 `--list-fz` md-fallback pattern; left alone since call sites pass `size` explicitly. Same one-line treatment applies if it ever bites.

`pnpm -F frontend run linter` and `pnpm -F frontend typecheck` pass.

## Line-height

The same v8 pattern applies to line-height (`var(--text-lh, var(--mantine-line-height-md))`), so the rule also sets `line-height: var(--text-lh, inherit)`. The 14 now-redundant `lh="inherit"` props are removed; `--text-lh` is only declared by the `size` prop and the `lh` style prop emits inline line-height, so explicit values still win identically.

## Storybook assertions

`src/stories/TextFontSizeInheritance.stories.tsx` rebuilds the affected production patterns (nested spans in xs help copy, anchors in sized Text, menu items, tooltip labels, badge labels, dropdowns) and asserts the fix by measuring computed font sizes at runtime — each example shows a green badge when the probed element matches its parent or the expected px, red on regression. A third story asserts the non-goals: `size`/`fz` props and `TruncatedText`'s deliberate `sm` default still win. All 11 assertions verified green in Storybook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tb8EPCagbaPkTHRSntabBw

