### PR TITLE
fix(ai): recover interrupted agent streams

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -74,6 +74,7 @@ import {
 import { MessageModelIndicator } from './MessageModelIndicator';
 import { rehypeAiAgentContentLinks } from './rehypeContentLinks';
 import { rehypeMemoryCitationIndices } from './rehypeMemoryCitations';
+import { StreamRecoveryAlert } from './StreamRecoveryAlert';
 import { AiEditDbtProjectToolCall } from './ToolCalls/AiEditDbtProjectToolCall';
 import { AiEditRepoToolCall } from './ToolCalls/AiEditRepoToolCall';
 import {
@@ -345,7 +346,11 @@ const AssistantBubbleContent: FC<{
 
     const isPending = message.status === 'pending';
     const hasError = message.status === 'error';
-    const streamingError = streamingState?.error;
+    const isRecovering = streamingState?.connection.status === 'recovering';
+    const streamingError =
+        streamingState?.connection.status === 'error'
+            ? streamingState.connection.error
+            : null;
     const runSqlTimeoutErrorMessage = getRunSqlTimeoutErrorMessage(message);
     const displayErrorMessage =
         runSqlTimeoutErrorMessage ||
@@ -558,12 +563,17 @@ const AssistantBubbleContent: FC<{
             {/* Reasoning lives inside the LiveActivityCard at all times, so
              *  there is one unified bento for the agent's process. */}
             {(() => {
-                const segments = streamingState?.parts
-                    ? segmentStreamParts(
-                          streamingState.parts,
-                          streamingState.decidedToolCallIds,
-                      )
-                    : [];
+                const shouldUseStreamParts =
+                    isStreaming ||
+                    (streamingState?.connection.status === 'complete' &&
+                        isPending);
+                const segments =
+                    shouldUseStreamParts && streamingState
+                        ? segmentStreamParts(
+                              streamingState.parts,
+                              streamingState.decidedToolCallIds,
+                          )
+                        : [];
 
                 if (segments.length > 0) {
                     // Tool segments are extracted into a single LiveActivityCard
@@ -832,6 +842,7 @@ const AssistantBubbleContent: FC<{
                     </>
                 );
             })()}
+            {isRecovering && isPending && <StreamRecoveryAlert />}
             {/* TypingDots fill the gap until the first visible output lands —
              *  any tool call or text part. Reasoning alone doesn't count: it
              *  collapses by default and would otherwise leave the bubble silent.

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -39,6 +39,7 @@ import {
     useCreateAiAgentThreadMessageSteerMutation,
     useInterruptAiAgentThreadMessageMutation,
 } from '../../hooks/useProjectAiAgents';
+import { isAiAgentThreadStreamActive } from '../../store/aiAgentThreadStreamSlice';
 import { useAiAgentThreadStreamQuery } from '../../streaming/useAiAgentThreadStreamQuery';
 import { AgentSelector } from '../AgentSelector';
 import { type Agent } from '../AgentSelector/AgentSelectorUtils';
@@ -338,11 +339,15 @@ export const AgentChatInput = ({
         });
     }, [editor, threadUuid]);
 
+    const isAgentActive = threadStream
+        ? isAiAgentThreadStreamActive(threadStream.connection)
+        : false;
+
     useEffect(() => {
-        if (hasRequestedInterrupt && !threadStream?.isStreaming) {
+        if (hasRequestedInterrupt && !isAgentActive) {
             setHasRequestedInterrupt(false);
         }
-    }, [hasRequestedInterrupt, threadStream?.isStreaming]);
+    }, [hasRequestedInterrupt, isAgentActive]);
 
     const handleChipClick = useCallback(
         (chip: AgentSuggestion, index: number) => {
@@ -453,14 +458,14 @@ export const AgentChatInput = ({
             onStart: onStartDeepResearch,
         });
     const showSqlModeControl = Boolean(onSqlModeChange && !disabled);
-    const activeMessageUuid = threadStream?.isStreaming
-        ? threadStream.messageUuid
+    const activeMessageUuid = isAgentActive
+        ? threadStream?.messageUuid
         : undefined;
     const canInterrupt = Boolean(
         projectUuid &&
         agentUuid &&
         threadUuid &&
-        threadStream?.isStreaming &&
+        isAgentActive &&
         activeMessageUuid,
     );
     const canSteer = canInterrupt && !disabled && !hasRequestedInterrupt;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ScrollToBottom.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ScrollToBottom.tsx
@@ -76,6 +76,10 @@ const ThreadScrollToBottom = ({
         (sum, r) => sum + r.parts.reduce((acc, part) => acc + part.length, 0),
         0,
     );
+    const streamingError =
+        streamingState?.connection.status === 'error'
+            ? streamingState.connection.error
+            : undefined;
 
     useLayoutEffect(() => {
         return scrollToBottom({
@@ -87,7 +91,7 @@ const ThreadScrollToBottom = ({
         streamingState?.toolCalls?.length,
         totalReasoningPartsCount,
         totalReasoningTextLength,
-        streamingState?.error,
+        streamingError,
         scrollToBottom,
     ]);
 
@@ -95,7 +99,7 @@ const ThreadScrollToBottom = ({
     // streamdown answer, which is taller. The layout shift fires after this
     // effect runs, so we schedule one more scroll on the next frame and then
     // again after Streamdown's animations settle (~360ms).
-    const isStreaming = streamingState?.isStreaming;
+    const isStreaming = streamingState?.connection.status === 'streaming';
     useEffect(() => {
         if (isStreaming !== false) return;
         const raf = requestAnimationFrame(() => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/StreamRecoveryAlert.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/StreamRecoveryAlert.test.tsx
@@ -1,0 +1,23 @@
+import { act, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { StreamRecoveryAlert } from './StreamRecoveryAlert';
+
+describe('StreamRecoveryAlert', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('offers a page refresh when recovery takes too long', async () => {
+        vi.useFakeTimers();
+        renderWithProviders(<StreamRecoveryAlert />);
+
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(10_000);
+        });
+
+        expect(screen.getByRole('button')).toBeVisible();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/StreamRecoveryAlert.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/StreamRecoveryAlert.tsx
@@ -1,0 +1,71 @@
+import { Box, Button, Group, Loader, Text } from '@mantine/core';
+import { useEffect, useState } from 'react';
+
+const RECOVERY_TIMER_INTERVAL_MS = 1_000;
+const RECOVERY_REFRESH_OFFER_DELAY_SECONDS = 10;
+
+export const StreamRecoveryAlert = () => {
+    const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+    useEffect(() => {
+        const startedAt = Date.now();
+        const interval = setInterval(() => {
+            setElapsedSeconds(
+                Math.floor(
+                    (Date.now() - startedAt) / RECOVERY_TIMER_INTERVAL_MS,
+                ),
+            );
+        }, RECOVERY_TIMER_INTERVAL_MS);
+        return () => clearInterval(interval);
+    }, []);
+
+    const showRefresh = elapsedSeconds >= RECOVERY_REFRESH_OFFER_DELAY_SECONDS;
+
+    return (
+        <Box bg="yellow.0" px="sm" py={7} style={{ borderRadius: 10 }}>
+            <Group gap={8} wrap="nowrap" h={22}>
+                <Loader
+                    aria-label="Connection lost. Reconnecting"
+                    color="yellow.7"
+                    size={14}
+                    style={{ flexShrink: 0 }}
+                />
+                <Group gap={6} wrap="nowrap" style={{ flex: 1, minWidth: 0 }}>
+                    <Text
+                        size="xs"
+                        fw={500}
+                        c="yellow.9"
+                        style={{
+                            flexShrink: 0,
+                            fontVariantNumeric: 'tabular-nums',
+                        }}
+                    >
+                        {elapsedSeconds > 0
+                            ? `Connection lost. Reconnecting… ${elapsedSeconds}s`
+                            : 'Connection lost. Reconnecting…'}
+                    </Text>
+                    <Text size="xs" c="dimmed" truncate>
+                        Your agent is still working
+                    </Text>
+                </Group>
+                {showRefresh && (
+                    <Button
+                        color="yellow"
+                        size="compact-xs"
+                        variant="transparent"
+                        px={4}
+                        styles={{
+                            root: {
+                                color: 'var(--mantine-color-yellow-9)',
+                                flexShrink: 0,
+                            },
+                        }}
+                        onClick={() => window.location.reload()}
+                    >
+                        Refresh page
+                    </Button>
+                )}
+            </Group>
+        </Box>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/StreamRecoveryAlert.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/StreamRecoveryAlert.tsx
@@ -22,7 +22,7 @@ export const StreamRecoveryAlert = () => {
     const showRefresh = elapsedSeconds >= RECOVERY_REFRESH_OFFER_DELAY_SECONDS;
 
     return (
-        <Box bg="yellow.0" px="sm" py={7} style={{ borderRadius: 10 }}>
+        <Box bg="yellow.0" px="sm" py={7} bdrs="md">
             <Group gap={8} wrap="nowrap" h={22}>
                 <Loader
                     aria-label="Connection lost. Reconnecting"

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.test.tsx
@@ -1,9 +1,24 @@
+import { type AiAgentMessageAssistant } from '@lightdash/common';
 import { act, renderHook } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    markStreamPolling,
+    stopStreaming,
+} from '../store/aiAgentThreadStreamSlice';
 import { usePendingThreadRefetch } from './usePendingThreadRefetch';
 
+const { dispatchMock, streamState } = vi.hoisted(() => ({
+    dispatchMock: vi.fn(),
+    streamState: { recovering: false, streaming: false },
+}));
+
+vi.mock('../store/hooks', () => ({
+    useAiAgentStoreDispatch: () => dispatchMock,
+}));
+
 vi.mock('../streaming/useAiAgentThreadStreamQuery', () => ({
-    useAiAgentThreadStreaming: () => false,
+    useAiAgentThreadRecoveryActive: () => streamState.recovering,
+    useAiAgentThreadStreaming: () => streamState.streaming,
 }));
 
 const pendingThread = (createdAt: Date | string) =>
@@ -27,7 +42,47 @@ const pendingThread = (createdAt: Date | string) =>
         ],
     }) as Parameters<typeof usePendingThreadRefetch>[0];
 
+const threadWithAssistantStatus = (status: AiAgentMessageAssistant['status']) =>
+    ({
+        uuid: 'thread-1',
+        agentUuid: 'agent-1',
+        createdAt: '2026-08-11T12:00:00.000Z',
+        createdFrom: 'web_app',
+        title: null,
+        titleGeneratedAt: null,
+        firstMessage: { uuid: 'message-1', message: 'Question' },
+        user: { uuid: 'user-1', name: 'User' },
+        compactions: [],
+        messages: [
+            {
+                role: 'assistant',
+                status,
+                uuid: 'message-1',
+                threadUuid: 'thread-1',
+                message: status === 'idle' ? 'Answer' : null,
+                errorMessage: null,
+                interrupted: false,
+                createdAt: '2026-08-11T12:00:00.000Z',
+                humanScore: null,
+                toolCalls: [],
+                toolResults: [],
+                reasoning: [],
+                savedQueryUuid: null,
+                artifacts: null,
+                referencedArtifacts: null,
+                modelConfig: null,
+                tokenUsage: null,
+            },
+        ],
+    }) satisfies NonNullable<Parameters<typeof usePendingThreadRefetch>[0]>;
+
 describe('usePendingThreadRefetch', () => {
+    beforeEach(() => {
+        dispatchMock.mockReset();
+        streamState.recovering = false;
+        streamState.streaming = false;
+    });
+
     afterEach(() => {
         vi.useRealTimers();
     });
@@ -45,6 +100,52 @@ describe('usePendingThreadRefetch', () => {
         );
 
         expect(result.current.isPending).toBe(false);
+    });
+
+    it('polls a pending thread while recovering its connection', async () => {
+        vi.useFakeTimers();
+        streamState.recovering = true;
+        const refetch = vi.fn().mockResolvedValue({ isError: false });
+        const thread = threadWithAssistantStatus('pending');
+
+        renderHook(() => usePendingThreadRefetch(thread, 'thread-1', refetch));
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(5_000);
+        });
+
+        expect(refetch).toHaveBeenCalledOnce();
+        expect(dispatchMock).toHaveBeenCalledWith(
+            markStreamPolling({ threadUuid: 'thread-1' }),
+        );
+    });
+
+    it('keeps showing recovery when polling fails', async () => {
+        vi.useFakeTimers();
+        streamState.recovering = true;
+        const refetch = vi.fn().mockRejectedValue(new Error('Offline'));
+        const thread = threadWithAssistantStatus('pending');
+
+        renderHook(() => usePendingThreadRefetch(thread, 'thread-1', refetch));
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(5_000);
+        });
+
+        expect(dispatchMock).not.toHaveBeenCalledWith(
+            markStreamPolling({ threadUuid: 'thread-1' }),
+        );
+    });
+
+    it('finishes recovery when the persisted response arrives', () => {
+        streamState.recovering = true;
+        const thread = threadWithAssistantStatus('idle');
+
+        renderHook(() => usePendingThreadRefetch(thread, 'thread-1', vi.fn()));
+
+        expect(dispatchMock).toHaveBeenCalledWith(
+            stopStreaming({ threadUuid: 'thread-1' }),
+        );
     });
 
     it('refetches once more before expiring an active writeback', async () => {

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.ts
@@ -4,11 +4,20 @@ import {
     type ApiAiAgentThreadResponse,
 } from '@lightdash/common';
 import { useEffect, useState } from 'react';
-import { useAiAgentThreadStreaming } from '../streaming/useAiAgentThreadStreamQuery';
+import {
+    markStreamPolling,
+    stopStreaming,
+} from '../store/aiAgentThreadStreamSlice';
+import { useAiAgentStoreDispatch } from '../store/hooks';
+import {
+    useAiAgentThreadRecoveryActive,
+    useAiAgentThreadStreaming,
+} from '../streaming/useAiAgentThreadStreamQuery';
 
-const POLL_INTERVAL_MS = 2000;
+const POLL_INTERVAL_MS = 5000;
 
 type Thread = ApiAiAgentThreadResponse['results'] | undefined;
+type ThreadRefetch = () => Promise<{ isError: boolean }>;
 
 const getPendingWritebackExpiresAt = (thread: Thread): number | null => {
     const pendingExpirations =
@@ -41,9 +50,11 @@ const getPendingWritebackExpiresAt = (thread: Thread): number | null => {
 export const usePendingThreadRefetch = (
     thread: Thread,
     threadUuid: string,
-    refetch: () => unknown,
+    refetch: ThreadRefetch,
 ) => {
+    const dispatch = useAiAgentStoreDispatch();
     const isStreaming = useAiAgentThreadStreaming(threadUuid);
+    const isRecoveryActive = useAiAgentThreadRecoveryActive(threadUuid);
     const [expirationClock, setExpirationClock] = useState(0);
     const pendingWritebackExpiresAt = getPendingWritebackExpiresAt(thread);
     const hasPendingWriteback =
@@ -79,9 +90,35 @@ export const usePendingThreadRefetch = (
 
     useEffect(() => {
         if (!isPending || isStreaming) return;
-        const interval = setInterval(() => void refetch(), POLL_INTERVAL_MS);
+
+        const pollThread = async () => {
+            try {
+                const result = await refetch();
+                if (isRecoveryActive && !result.isError) {
+                    dispatch(markStreamPolling({ threadUuid }));
+                }
+            } catch {
+                // Keep showing the recovery alert until a refetch succeeds.
+            }
+        };
+        const interval = setInterval(() => {
+            void pollThread();
+        }, POLL_INTERVAL_MS);
         return () => clearInterval(interval);
-    }, [isPending, isStreaming, refetch]);
+    }, [
+        dispatch,
+        isPending,
+        isRecoveryActive,
+        isStreaming,
+        refetch,
+        threadUuid,
+    ]);
+
+    useEffect(() => {
+        if (thread !== undefined && isRecoveryActive && !isPending) {
+            dispatch(stopStreaming({ threadUuid }));
+        }
+    }, [dispatch, isPending, isRecoveryActive, thread, threadUuid]);
 
     return { isStreaming, isPending };
 };

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.test.ts
@@ -5,9 +5,13 @@ import {
     addToolCall,
     aiAgentThreadStreamSlice,
     appendStepProgress,
+    markStreamPolling,
+    markStreamRecovering,
+    setError,
     setMessage,
     setParts,
     startStreaming,
+    stopStreaming,
 } from './aiAgentThreadStreamSlice';
 
 describe('aiAgentThreadStreamSlice', () => {
@@ -49,6 +53,63 @@ describe('aiAgentThreadStreamSlice', () => {
                 toolName: null,
             }).meta,
         ).toEqual(expectedMeta);
+    });
+
+    it('tracks streaming connection recovery', () => {
+        const streaming = aiAgentThreadStreamSlice.reducer(
+            undefined,
+            startStreaming({
+                threadUuid: 'thread-1',
+                messageUuid: 'message-1',
+            }),
+        );
+        expect(streaming['thread-1']?.connection).toEqual({
+            status: 'streaming',
+        });
+
+        const recovering = aiAgentThreadStreamSlice.reducer(
+            streaming,
+            markStreamRecovering({ threadUuid: 'thread-1' }),
+        );
+        expect(recovering['thread-1']?.connection).toEqual({
+            status: 'recovering',
+        });
+
+        const polling = aiAgentThreadStreamSlice.reducer(
+            recovering,
+            markStreamPolling({ threadUuid: 'thread-1' }),
+        );
+        expect(polling['thread-1']?.connection).toEqual({
+            status: 'polling',
+        });
+
+        const complete = aiAgentThreadStreamSlice.reducer(
+            polling,
+            stopStreaming({ threadUuid: 'thread-1' }),
+        );
+        expect(complete['thread-1']?.connection).toEqual({
+            status: 'complete',
+        });
+    });
+
+    it('keeps terminal stream errors in the connection state', () => {
+        const streaming = aiAgentThreadStreamSlice.reducer(
+            undefined,
+            startStreaming({
+                threadUuid: 'thread-1',
+                messageUuid: 'message-1',
+            }),
+        );
+
+        const failed = aiAgentThreadStreamSlice.reducer(
+            streaming,
+            setError({ threadUuid: 'thread-1', error: 'Failed to connect' }),
+        );
+
+        expect(failed['thread-1']?.connection).toEqual({
+            status: 'error',
+            error: 'Failed to connect',
+        });
     });
 
     it('appends each progress message to the timeline in order', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
@@ -26,6 +26,37 @@ export type StreamPart =
     | { type: 'text'; text: string }
     | (ToolCall & { type: 'toolCall' });
 
+export type AiAgentThreadStreamConnection =
+    | { status: 'streaming' }
+    | { status: 'recovering' }
+    | { status: 'polling' }
+    | { status: 'complete' }
+    | { status: 'error'; error: string };
+
+const activeConnectionStatuses = {
+    streaming: true,
+    recovering: true,
+    polling: true,
+    complete: false,
+    error: false,
+} satisfies Record<AiAgentThreadStreamConnection['status'], boolean>;
+
+const recoveryConnectionStatuses = {
+    streaming: false,
+    recovering: true,
+    polling: true,
+    complete: false,
+    error: false,
+} satisfies Record<AiAgentThreadStreamConnection['status'], boolean>;
+
+export const isAiAgentThreadStreamActive = (
+    connection: AiAgentThreadStreamConnection,
+) => activeConnectionStatuses[connection.status];
+
+export const isAiAgentThreadStreamRecoveryActive = (
+    connection: AiAgentThreadStreamConnection,
+) => recoveryConnectionStatuses[connection.status];
+
 const dedupeStreamParts = (parts: StreamPart[]): StreamPart[] => {
     const dedupedParts: StreamPart[] = [];
     const toolCallIndexById = new Map<string, number>();
@@ -56,7 +87,7 @@ export interface AiAgentThreadStreamingState {
     messageUuid: string;
     content: string;
     parts: StreamPart[];
-    isStreaming: boolean;
+    connection: AiAgentThreadStreamConnection;
     toolCalls: ToolCall[];
     reasoning: Reasoning[];
     decidedToolCallIds: string[];
@@ -74,7 +105,6 @@ export interface AiAgentThreadStreamingState {
      * hover, etc.) without changing the wire protocol.
      */
     stepProgressMessages: StepProgressMessage[];
-    error?: string;
 }
 
 type State = Record<string, AiAgentThreadStreamingState>;
@@ -86,7 +116,7 @@ const initialThread: Omit<
 > = {
     content: '',
     parts: [],
-    isStreaming: true,
+    connection: { status: 'streaming' },
     toolCalls: [],
     reasoning: [],
     decidedToolCallIds: [],
@@ -174,15 +204,31 @@ export const aiAgentThreadStreamSlice = createSlice({
                 toolCallId: string;
             }>(),
         },
+        markStreamRecovering: (
+            state,
+            action: PayloadAction<{ threadUuid: string }>,
+        ) => {
+            const streamingThread = state[action.payload.threadUuid];
+            if (streamingThread?.connection.status === 'streaming') {
+                streamingThread.connection = { status: 'recovering' };
+            }
+        },
+        markStreamPolling: (
+            state,
+            action: PayloadAction<{ threadUuid: string }>,
+        ) => {
+            const streamingThread = state[action.payload.threadUuid];
+            if (streamingThread?.connection.status === 'recovering') {
+                streamingThread.connection = { status: 'polling' };
+            }
+        },
         stopStreaming: (
             state,
             action: PayloadAction<{ threadUuid: string }>,
         ) => {
-            const { threadUuid } = action.payload;
-
-            const streamingThread = state[threadUuid];
+            const streamingThread = state[action.payload.threadUuid];
             if (streamingThread) {
-                streamingThread.isStreaming = false;
+                streamingThread.connection = { status: 'complete' };
             }
         },
         addToolCall: {
@@ -217,8 +263,7 @@ export const aiAgentThreadStreamSlice = createSlice({
 
             const streamingThread = state[threadUuid];
             if (streamingThread) {
-                streamingThread.isStreaming = false;
-                streamingThread.error = error;
+                streamingThread.connection = { status: 'error', error };
             }
         },
         addReasoning: {
@@ -314,6 +359,8 @@ export const {
     setMessage,
     setParts,
     markToolCallDecided,
+    markStreamRecovering,
+    markStreamPolling,
     stopStreaming,
     setError,
     addToolCall,

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/streamInactivityMonitor.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/streamInactivityMonitor.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createStreamInactivityMonitor } from './streamInactivityMonitor';
+
+describe('createStreamInactivityMonitor', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('reports an inactive stream after the timeout', () => {
+        vi.useFakeTimers();
+        const onInactive = vi.fn();
+
+        createStreamInactivityMonitor({ onInactive, timeoutMs: 1_000 });
+
+        vi.advanceTimersByTime(999);
+        expect(onInactive).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(1);
+        expect(onInactive).toHaveBeenCalledOnce();
+    });
+
+    it('restarts the timeout when a chunk arrives', () => {
+        vi.useFakeTimers();
+        const onInactive = vi.fn();
+        const monitor = createStreamInactivityMonitor({
+            onInactive,
+            timeoutMs: 1_000,
+        });
+
+        vi.advanceTimersByTime(900);
+        monitor.reset();
+        vi.advanceTimersByTime(999);
+        expect(onInactive).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(1);
+        expect(onInactive).toHaveBeenCalledOnce();
+    });
+
+    it('stops watching the stream', () => {
+        vi.useFakeTimers();
+        const onInactive = vi.fn();
+        const monitor = createStreamInactivityMonitor({
+            onInactive,
+            timeoutMs: 1_000,
+        });
+
+        monitor.stop();
+        vi.advanceTimersByTime(1_000);
+
+        expect(onInactive).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/streamInactivityMonitor.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/streamInactivityMonitor.ts
@@ -1,0 +1,30 @@
+const AI_AGENT_STREAM_INACTIVITY_TIMEOUT_MS = 30_000;
+
+export const createStreamInactivityMonitor = ({
+    onInactive,
+    timeoutMs = AI_AGENT_STREAM_INACTIVITY_TIMEOUT_MS,
+}: {
+    onInactive: () => void;
+    timeoutMs?: number;
+}) => {
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+
+    const stop = () => {
+        if (timeout !== null) {
+            clearTimeout(timeout);
+            timeout = null;
+        }
+    };
+
+    const reset = () => {
+        stop();
+        timeout = setTimeout(() => {
+            timeout = null;
+            onInactive();
+        }, timeoutMs);
+    };
+
+    reset();
+
+    return { reset, stop };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     getStreamToolCallPart,
     getStepProgressFromChunk,
-    isRecoverableStreamError,
+    readStreamResult,
 } from './useAiAgentThreadStreamMutation';
 
 describe('getStreamToolCallPart', () => {
@@ -63,22 +63,19 @@ describe('getStreamToolCallPart', () => {
     });
 });
 
-describe('isRecoverableStreamError', () => {
-    it.each([
-        new TypeError('Failed to fetch'),
-        new TypeError('Load failed'),
-        new TypeError('terminated'),
-        Object.assign(new Error('Network connection lost'), {
-            name: 'NetworkError',
-        }),
-    ])('recognizes a broken stream transport', (error) => {
-        expect(isRecoverableStreamError(error)).toBe(true);
+describe('readStreamResult', () => {
+    it('returns a successful stream read', async () => {
+        await expect(
+            readStreamResult(() => Promise.resolve('chunk')),
+        ).resolves.toEqual({ status: 'success', value: 'chunk' });
     });
 
-    it('does not recover from an application error', () => {
-        expect(isRecoverableStreamError(new Error('Invalid tool output'))).toBe(
-            false,
-        );
+    it('returns a stream read error without inspecting its message', async () => {
+        const error = new Error('browser-specific message');
+
+        await expect(
+            readStreamResult(() => Promise.reject(error)),
+        ).resolves.toEqual({ status: 'error', error });
     });
 });
 

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     getStreamToolCallPart,
     getStepProgressFromChunk,
+    isRecoverableStreamError,
 } from './useAiAgentThreadStreamMutation';
 
 describe('getStreamToolCallPart', () => {
@@ -59,6 +60,25 @@ describe('getStreamToolCallPart', () => {
             toolResult: output,
             isPreliminary: false,
         });
+    });
+});
+
+describe('isRecoverableStreamError', () => {
+    it.each([
+        new TypeError('Failed to fetch'),
+        new TypeError('Load failed'),
+        new TypeError('terminated'),
+        Object.assign(new Error('Network connection lost'), {
+            name: 'NetworkError',
+        }),
+    ])('recognizes a broken stream transport', (error) => {
+        expect(isRecoverableStreamError(error)).toBe(true);
+    });
+
+    it('does not recover from an application error', () => {
+        expect(isRecoverableStreamError(new Error('Invalid tool output'))).toBe(
+            false,
+        );
     });
 });
 

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -14,6 +14,7 @@ import {
     addReasoning,
     addToolCall,
     appendStepProgress,
+    markStreamRecovering,
     markToolCallDecided,
     setError,
     setMessage,
@@ -29,6 +30,7 @@ import {
     parseStreamRawToolCall,
     parseStreamRawToolResult,
 } from './parseStreamRawToolResult';
+import { createStreamInactivityMonitor } from './streamInactivityMonitor';
 
 export interface AiAgentThreadStreamOptions {
     projectUuid: string;
@@ -42,7 +44,7 @@ export interface AiAgentThreadStreamOptions {
     onError?: (error: string) => void;
     onToolCall?: (toolCall: AiAgentToolCall) => void;
     onToolResult?: (toolResult: AiAgentToolResult) => void;
-    refetchThread?: () => void;
+    refetchThread: () => void;
 }
 
 type StreamToolCallPart = Extract<StreamPart, { type: 'toolCall' }>;
@@ -192,6 +194,13 @@ export const getStreamToolCallPart = (
     } as StreamToolCallPart;
 };
 
+export const isRecoverableStreamError = (error: unknown) =>
+    error instanceof Error &&
+    (error.name === 'TypeError' || error.name === 'NetworkError') &&
+    /failed to fetch|load failed|network(?:error| error| connection)|terminated/i.test(
+        error.message,
+    );
+
 export const getStepProgressFromChunk = (
     chunk: UIMessageChunk,
 ): { message: string; toolName: string | null } | null => {
@@ -236,6 +245,19 @@ export function useAiAgentThreadStreamMutation() {
         }: AiAgentThreadStreamOptions) => {
             const abortController = new AbortController();
             setAbortController(threadUuid, abortController);
+            let isConnected = false;
+            let isRecovering = false;
+            const beginRecovery = () => {
+                if (isRecovering || abortController.signal.aborted) return;
+
+                isRecovering = true;
+                dispatch(markStreamRecovering({ threadUuid }));
+                refetchThread();
+                abortController.abort();
+            };
+            let inactivityMonitor: ReturnType<
+                typeof createStreamInactivityMonitor
+            > | null = null;
 
             try {
                 dispatch(startStreaming({ threadUuid, messageUuid }));
@@ -252,6 +274,11 @@ export function useAiAgentThreadStreamMutation() {
                     },
                 );
 
+                isConnected = true;
+                inactivityMonitor = createStreamInactivityMonitor({
+                    onInactive: beginRecovery,
+                });
+
                 const parser = new ChatStreamParser();
                 const chunkStream = parser.parseStream(response);
                 const [rawChunkStream, uiMessageChunkStream] =
@@ -266,12 +293,18 @@ export function useAiAgentThreadStreamMutation() {
                 const handledToolOutputIds = new Set<string>();
                 const notifiedToolCallIds = new Set<string>();
                 const notifiedToolOutputIds = new Set<string>();
+                let receivedTerminalChunk = false;
 
                 const consumeRawChunks = (async () => {
                     while (true) {
                         const { done, value } = await rawChunkReader.read();
                         if (done) {
                             break;
+                        }
+
+                        inactivityMonitor.reset();
+                        if (value.type === 'finish') {
+                            receivedTerminalChunk = true;
                         }
 
                         const stepProgress = getStepProgressFromChunk(value);
@@ -440,7 +473,7 @@ export function useAiAgentThreadStreamMutation() {
                                             part.toolCallId,
                                         );
 
-                                        void refetchThread?.();
+                                        refetchThread();
                                     }
 
                                     break;
@@ -514,13 +547,26 @@ export function useAiAgentThreadStreamMutation() {
                 }
 
                 await consumeRawChunks;
+                if (!receivedTerminalChunk) {
+                    beginRecovery();
+                    return;
+                }
+
                 onFinish?.();
                 dispatch(stopStreaming({ threadUuid }));
             } catch (error) {
+                if (isRecovering) return;
+
                 if (error instanceof Error && error.name === 'AbortError') {
                     dispatch(stopStreaming({ threadUuid }));
                     return;
                 }
+
+                if (isConnected && isRecoverableStreamError(error)) {
+                    beginRecovery();
+                    return;
+                }
+
                 console.error('Error processing stream:', error);
                 captureException(error, {
                     tags: {
@@ -533,6 +579,8 @@ export function useAiAgentThreadStreamMutation() {
                         : 'Unknown error occurred';
                 dispatch(setError({ threadUuid, error: errorMessage }));
                 onError?.(errorMessage);
+            } finally {
+                inactivityMonitor?.stop();
             }
         },
         [dispatch, setAbortController],

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -194,12 +194,19 @@ export const getStreamToolCallPart = (
     } as StreamToolCallPart;
 };
 
-export const isRecoverableStreamError = (error: unknown) =>
-    error instanceof Error &&
-    (error.name === 'TypeError' || error.name === 'NetworkError') &&
-    /failed to fetch|load failed|network(?:error| error| connection)|terminated/i.test(
-        error.message,
-    );
+type StreamReadResult<T> =
+    | { status: 'success'; value: T }
+    | { status: 'error'; error: unknown };
+
+export const readStreamResult = async <T>(
+    read: () => Promise<T>,
+): Promise<StreamReadResult<T>> => {
+    try {
+        return { status: 'success', value: await read() };
+    } catch (error) {
+        return { status: 'error', error };
+    }
+};
 
 export const getStepProgressFromChunk = (
     chunk: UIMessageChunk,
@@ -245,7 +252,6 @@ export function useAiAgentThreadStreamMutation() {
         }: AiAgentThreadStreamOptions) => {
             const abortController = new AbortController();
             setAbortController(threadUuid, abortController);
-            let isConnected = false;
             let isRecovering = false;
             const beginRecovery = () => {
                 if (isRecovering || abortController.signal.aborted) return;
@@ -274,7 +280,6 @@ export function useAiAgentThreadStreamMutation() {
                     },
                 );
 
-                isConnected = true;
                 inactivityMonitor = createStreamInactivityMonitor({
                     onInactive: beginRecovery,
                 });
@@ -294,10 +299,26 @@ export function useAiAgentThreadStreamMutation() {
                 const notifiedToolCallIds = new Set<string>();
                 const notifiedToolOutputIds = new Set<string>();
                 let receivedTerminalChunk = false;
+                const handleStreamReadError = () => {
+                    if (
+                        !receivedTerminalChunk &&
+                        !abortController.signal.aborted
+                    ) {
+                        beginRecovery();
+                    }
+                };
 
                 const consumeRawChunks = (async () => {
                     while (true) {
-                        const { done, value } = await rawChunkReader.read();
+                        const rawChunkResult = await readStreamResult(() =>
+                            rawChunkReader.read(),
+                        );
+                        if (rawChunkResult.status === 'error') {
+                            handleStreamReadError();
+                            break;
+                        }
+
+                        const { done, value } = rawChunkResult.value;
                         if (done) {
                             break;
                         }
@@ -321,8 +342,18 @@ export function useAiAgentThreadStreamMutation() {
                     }
                 })();
 
-                for await (const uiMessage of stream) {
-                    if (abortController.signal.aborted) return;
+                const uiMessageIterator = stream[Symbol.asyncIterator]();
+                while (true) {
+                    const uiMessageResult = await readStreamResult(() =>
+                        uiMessageIterator.next(),
+                    );
+                    if (uiMessageResult.status === 'error') {
+                        handleStreamReadError();
+                        break;
+                    }
+
+                    const { done, value: uiMessage } = uiMessageResult.value;
+                    if (done || abortController.signal.aborted) break;
 
                     // Extract and combine all text content from the complete message
                     const fullTextContent = uiMessage.parts
@@ -359,7 +390,7 @@ export function useAiAgentThreadStreamMutation() {
 
                     // Process tool calls from the complete message
                     for (const part of uiMessage.parts) {
-                        if (abortController.signal.aborted) return;
+                        if (abortController.signal.aborted) break;
 
                         const toolPart = getStreamToolPart(part);
                         const toolCallPart = getStreamToolCallPart(part);
@@ -544,9 +575,18 @@ export function useAiAgentThreadStreamMutation() {
                                 break;
                         }
                     }
+
+                    if (abortController.signal.aborted) break;
                 }
 
                 await consumeRawChunks;
+                if (abortController.signal.aborted) {
+                    if (!isRecovering) {
+                        dispatch(stopStreaming({ threadUuid }));
+                    }
+                    return;
+                }
+
                 if (!receivedTerminalChunk) {
                     beginRecovery();
                     return;
@@ -559,11 +599,6 @@ export function useAiAgentThreadStreamMutation() {
 
                 if (error instanceof Error && error.name === 'AbortError') {
                     dispatch(stopStreaming({ threadUuid }));
-                    return;
-                }
-
-                if (isConnected && isRecoverableStreamError(error)) {
-                    beginRecovery();
                     return;
                 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamQuery.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamQuery.ts
@@ -1,5 +1,8 @@
 import { shallowEqual } from 'react-redux';
-import { type StreamPart } from '../store/aiAgentThreadStreamSlice';
+import {
+    isAiAgentThreadStreamRecoveryActive,
+    type StreamPart,
+} from '../store/aiAgentThreadStreamSlice';
 import { useAiAgentStoreSelector } from '../store/hooks';
 
 export const useAiAgentThreadStreamQuery = (threadUuid: string) => {
@@ -15,14 +18,25 @@ export const useAiAgentThreadStreamQuery = (threadUuid: string) => {
 export const useAiAgentThreadStreaming = (threadUuid: string) =>
     useAiAgentStoreSelector((state) => {
         const threadStream = state.aiAgentThreadStream[threadUuid];
-        return threadStream?.isStreaming;
+        return threadStream?.connection.status === 'streaming';
+    });
+
+export const useAiAgentThreadRecoveryActive = (threadUuid: string) =>
+    useAiAgentStoreSelector((state) => {
+        const threadStream = state.aiAgentThreadStream[threadUuid];
+        return (
+            threadStream !== undefined &&
+            isAiAgentThreadStreamRecoveryActive(threadStream.connection)
+        );
     });
 
 export const useActiveAiAgentThreadStreamParts = (): StreamPart[] =>
     useAiAgentStoreSelector(
         (state) =>
             Object.values(state.aiAgentThreadStream).flatMap((threadStream) =>
-                threadStream.isStreaming ? threadStream.parts : [],
+                threadStream.connection.status === 'streaming'
+                    ? threadStream.parts
+                    : [],
             ),
         shallowEqual,
     );
@@ -34,7 +48,7 @@ export const useAiAgentThreadMessageStreaming = (
     useAiAgentStoreSelector((state) => {
         const threadStream = state.aiAgentThreadStream[threadUuid];
         return (
-            threadStream?.isStreaming &&
-            threadStream?.messageUuid === messageUuid
+            threadStream?.connection.status === 'streaming' &&
+            threadStream.messageUuid === messageUuid
         );
     });


### PR DESCRIPTION
Closes: ZAP-897

Recover AI agent responses when the live stream closes without a terminal event or stops receiving heartbeats.

- fall back to 5-second persisted-thread polling without replaying the run
- render persisted progress with a compact reconnect and delayed refresh state
- preserve interrupt and scrolling behavior throughout recovery

Tests:
- `pnpm -F frontend typecheck`
- `pnpm -F frontend lint`
- `pnpm -F frontend format`
- targeted Vitest suite: 27 tests