### PR TITLE
fix(dashboards): revert date filter auto-mapping across explores

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -16,7 +16,6 @@ import {
     CreateEmbedRequestBody,
     DashboardAvailableFilters,
     DashboardDAO,
-    DashboardFieldTarget,
     DashboardFilters,
     DateGranularity,
     DateZoom,
@@ -37,11 +36,9 @@ import {
     formatRows,
     getAvailableFilterFieldIds,
     getColumnTimezone,
-    getDashboardFieldTarget,
     getDashboardFiltersForTileAndTables,
     getDimensionMapFromTables,
     getDimensions,
-    getExploreDefaultTimeDimension,
     getFilterInteractivityValue,
     getItemId,
     InteractivityOptions,
@@ -728,14 +725,19 @@ export class EmbedService extends BaseService {
         const { dashboardUuids, allowAllDashboards } =
             await this.embedModel.get(projectUuid);
 
-        const hasFilterInteractivity = isFilterInteractivityEnabled(
-            account.access.filtering,
-        );
+        if (!isFilterInteractivityEnabled(account.access.filtering)) {
+            // If dashboard filters interactivity is not enabled, we return an empty list
+            return {
+                savedQueryFilters: {},
+                allFilterableFields: [],
+                allFilterableMetrics: [],
+                savedQueryMetricFilters: {},
+            };
+        }
 
         let allFilters: {
             uuid: string;
             filters: CompiledDimension[];
-            defaultTimeDimension?: DashboardFieldTarget;
         }[] = [];
 
         const savedQueryUuids = savedChartUuidsAndTileUuids.map(
@@ -832,22 +834,13 @@ export class EmbedService extends BaseService {
 
         const filterPromises = savedCharts.map(async (savedChart) => {
             const explore = exploreCache[savedChart.tableName];
-            if (isExploreError(explore)) {
+            if (isExploreError(explore))
                 return { uuid: savedChart.uuid, filters: [] };
-            }
             const filters = getDimensions(explore).filter(
                 (field) => isFilterableDimension(field) && !field.hidden,
             );
-            const defaultTimeDimension =
-                getExploreDefaultTimeDimension(explore);
 
-            return {
-                uuid: savedChart.uuid,
-                filters,
-                defaultTimeDimension: defaultTimeDimension
-                    ? getDashboardFieldTarget(defaultTimeDimension)
-                    : undefined,
-            };
+            return { uuid: savedChart.uuid, filters };
         });
 
         allFilters = await Promise.all(filterPromises);
@@ -883,30 +876,11 @@ export class EmbedService extends BaseService {
             };
         }, {});
 
-        const defaultTimeDimensions = savedChartUuidsAndTileUuids.reduce<
-            DashboardAvailableFilters['defaultTimeDimensions']
-        >((acc, savedChartUuidAndTileUuid) => {
-            const filterResult = allFilters.find(
-                (result) =>
-                    result.uuid === savedChartUuidAndTileUuid.savedChartUuid,
-            );
-            return filterResult?.defaultTimeDimension
-                ? {
-                      ...acc,
-                      [savedChartUuidAndTileUuid.tileUuid]:
-                          filterResult.defaultTimeDimension,
-                  }
-                : acc;
-        }, {});
-
         return {
-            savedQueryFilters: hasFilterInteractivity ? savedQueryFilters : {},
-            allFilterableFields: hasFilterInteractivity
-                ? allFilterableFields
-                : [],
+            savedQueryFilters,
+            allFilterableFields,
             allFilterableMetrics: [],
             savedQueryMetricFilters: {},
-            defaultTimeDimensions,
         };
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -53,7 +53,6 @@ import {
     CustomSqlQueryForbiddenError,
     DashboardAvailableFilters,
     DashboardBasicDetails,
-    DashboardFieldTarget,
     DashboardFilters,
     DatabricksAuthenticationType,
     DatabricksTokenError,
@@ -89,12 +88,10 @@ import {
     getAvailableParametersFromTables,
     getColumnTimezone,
     getCustomSqlFieldKey,
-    getDashboardFieldTarget,
     getDashboardFilterRulesForTables,
     getDbtEnvironmentVariableKeyError,
     getDimensions,
     getErrorMessage,
-    getExploreDefaultTimeDimension,
     getFieldFormatOverrideProps,
     getFields,
     getIntrinsicUserAttributes,
@@ -9293,7 +9290,6 @@ export class ProjectService extends BaseService {
             uuid: string;
             filters: CompiledDimension[];
             metricFilters: Metric[];
-            defaultTimeDimension?: DashboardFieldTarget;
         };
 
         let allFilters: ChartFilters[] = [];
@@ -9360,7 +9356,6 @@ export class ProjectService extends BaseService {
                             uuid: savedChart.uuid,
                             filters: [],
                             metricFilters: [],
-                            defaultTimeDimension: undefined,
                         };
                     }
 
@@ -9377,18 +9372,11 @@ export class ProjectService extends BaseService {
                             (field) => !field.hidden,
                         );
                     }
-                    const defaultTimeDimension =
-                        explore && !isExploreError(explore)
-                            ? getExploreDefaultTimeDimension(explore)
-                            : undefined;
 
                     return {
                         uuid: savedChart.uuid,
                         filters,
                         metricFilters,
-                        defaultTimeDimension: defaultTimeDimension
-                            ? getDashboardFieldTarget(defaultTimeDimension)
-                            : undefined,
                     };
                 });
             },
@@ -9456,28 +9444,11 @@ export class ProjectService extends BaseService {
             };
         }, {});
 
-        const defaultTimeDimensions = savedChartUuidsAndTileUuids.reduce<
-            DashboardAvailableFilters['defaultTimeDimensions']
-        >((acc, savedChartUuidAndTileUuid) => {
-            const filterResult = allFilters.find(
-                (result) =>
-                    result.uuid === savedChartUuidAndTileUuid.savedChartUuid,
-            );
-            return filterResult?.defaultTimeDimension
-                ? {
-                      ...acc,
-                      [savedChartUuidAndTileUuid.tileUuid]:
-                          filterResult.defaultTimeDimension,
-                  }
-                : acc;
-        }, {});
-
         return {
             savedQueryFilters,
             allFilterableFields,
             allFilterableMetrics,
             savedQueryMetricFilters,
-            defaultTimeDimensions,
         };
     }
 

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -1,6 +1,6 @@
 import { type ContentVerificationInfo } from './contentVerification';
 import { type FilterableDimension, type Metric } from './field';
-import { type DashboardFieldTarget, type DashboardFilters } from './filter';
+import { type DashboardFilters } from './filter';
 import { type KnexPaginatedData } from './knex-paginate';
 import { type DashboardParameters } from './parameters';
 import {
@@ -335,7 +335,6 @@ export type DashboardAvailableFilters = {
     allFilterableFields: FilterableDimension[];
     allFilterableMetrics: Metric[];
     savedQueryMetricFilters: Record<string, number[]>;
-    defaultTimeDimensions: Record<string, DashboardFieldTarget>;
 };
 
 export type SavedChartsInfoForDashboardAvailableFilters = {

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -18,7 +18,6 @@ import {
     addDashboardFiltersToMetricQuery,
     addFilterRule,
     applyDashboardFiltersForTile,
-    applyDefaultTimeDimensionTileTargets,
     createFilterRuleFromField,
     createFilterRuleFromModelRequiredFilterRule,
     getDashboardFilterRulesForTileAndReferences,
@@ -1492,54 +1491,6 @@ describe('applyDashboardFiltersForTile', () => {
         ).toEqual([]);
     });
 
-    test('maps an unmapped date filter to the explore default time dimension', () => {
-        const exploreWithDefaultTimeDimension = {
-            ...mockExplore,
-            tables: {
-                ...mockExplore.tables,
-                orders: {
-                    ...mockExplore.tables.orders,
-                    defaultTimeDimension: {
-                        field: 'order_date',
-                        interval: TimeFrames.DAY,
-                    },
-                },
-            },
-        };
-        const crossExploreDateRule: DashboardFilterRule = {
-            id: 'f-cross-explore-date',
-            target: {
-                fieldId: 'events_created_at',
-                tableName: 'events',
-                fallbackType: DimensionType.DATE,
-            },
-            operator: FilterOperator.EQUALS,
-            values: ['2026-08-01'],
-            label: 'Date',
-        };
-
-        const { metricQuery, appliedDashboardFilters } =
-            applyDashboardFiltersForTile({
-                tileUuid: 't-1',
-                metricQuery: baseMetricQuery,
-                dashboardFilters: {
-                    dimensions: [crossExploreDateRule],
-                    metrics: [],
-                    tableCalculations: [],
-                },
-                explore: exploreWithDefaultTimeDimension,
-            });
-
-        expect(appliedDashboardFilters.dimensions).toHaveLength(1);
-        expect(appliedDashboardFilters.dimensions[0].target).toMatchObject({
-            fieldId: 'orders_order_date',
-            tableName: 'orders',
-        });
-        expect(
-            (metricQuery.filters.dimensions as AndFilterGroup).and[0],
-        ).toMatchObject({ target: { fieldId: 'orders_order_date' } });
-    });
-
     test('drops rules whose tileTargets disable them for this tile', () => {
         const disabledRule: DashboardFilterRule = {
             ...statusRule,
@@ -1586,129 +1537,6 @@ describe('applyDashboardFiltersForTile', () => {
             target: { fieldId: 'orders_status' },
             values: [true],
         });
-    });
-});
-
-describe('applyDefaultTimeDimensionTileTargets', () => {
-    const sourceDateDimension = {
-        ...mockExplore.tables.orders.dimensions.order_date,
-        name: 'created_at',
-        table: 'events',
-        tableLabel: 'Events',
-    };
-    const defaultTimeDimension =
-        mockExplore.tables.orders.dimensions.order_date;
-
-    test('maps a date filter to each tile default without overriding explicit targets', () => {
-        const filters: DashboardFilters = {
-            dimensions: [
-                {
-                    id: 'date-filter',
-                    target: {
-                        fieldId: 'events_created_at',
-                        tableName: 'events',
-                    },
-                    operator: FilterOperator.EQUALS,
-                    values: ['2026-08-01'],
-                    label: 'Date',
-                    tileTargets: {
-                        excluded: false,
-                        explicit: {
-                            fieldId: 'custom_date',
-                            tableName: 'custom',
-                            fallbackType: DimensionType.DATE,
-                        },
-                    },
-                },
-            ],
-            metrics: [],
-            tableCalculations: [],
-        };
-
-        const result = applyDefaultTimeDimensionTileTargets(
-            filters,
-            {
-                source: [sourceDateDimension],
-                target: [defaultTimeDimension],
-                excluded: [defaultTimeDimension],
-                explicit: [defaultTimeDimension],
-            },
-            {
-                source: {
-                    fieldId: 'events_created_at',
-                    tableName: 'events',
-                    fallbackType: DimensionType.DATE,
-                },
-                target: {
-                    fieldId: 'orders_order_date',
-                    tableName: 'orders',
-                    fallbackType: DimensionType.DATE,
-                },
-                excluded: {
-                    fieldId: 'orders_order_date',
-                    tableName: 'orders',
-                    fallbackType: DimensionType.DATE,
-                },
-                explicit: {
-                    fieldId: 'orders_order_date',
-                    tableName: 'orders',
-                    fallbackType: DimensionType.DATE,
-                },
-            },
-        );
-
-        expect(result.dimensions[0].target.fallbackType).toBe(
-            DimensionType.DATE,
-        );
-        expect(result.dimensions[0].tileTargets).toEqual({
-            excluded: false,
-            explicit: {
-                fieldId: 'custom_date',
-                tableName: 'custom',
-                fallbackType: DimensionType.DATE,
-            },
-            target: {
-                fieldId: 'orders_order_date',
-                tableName: 'orders',
-                fallbackType: DimensionType.DATE,
-            },
-        });
-        expect(result.dimensions[0].tileTargets).not.toHaveProperty('source');
-    });
-
-    test('does not map non-date filters', () => {
-        const filters: DashboardFilters = {
-            dimensions: [
-                {
-                    id: 'status-filter',
-                    target: {
-                        fieldId: 'orders_status',
-                        tableName: 'orders',
-                        fallbackType: DimensionType.STRING,
-                    },
-                    operator: FilterOperator.EQUALS,
-                    values: ['completed'],
-                    label: 'Status',
-                    tileTargets: {},
-                },
-            ],
-            metrics: [],
-            tableCalculations: [],
-        };
-
-        expect(
-            applyDefaultTimeDimensionTileTargets(
-                filters,
-                { target: [defaultTimeDimension] },
-                {
-                    target: {
-                        fieldId: 'orders_order_date',
-                        tableName: 'orders',
-                        fallbackType: DimensionType.DATE,
-                    },
-                },
-            ),
-        ).toEqual(filters);
     });
 });
 

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -16,7 +16,6 @@ import {
     TableCalculationType,
     type CompiledField,
     type CustomSqlDimension,
-    type DashboardFilterableField,
     type Dimension,
     type Field,
     type FilterableDimension,
@@ -517,9 +516,6 @@ const getDefaultTileTargets = (
             [tileUuid]: {
                 fieldId: getItemId(filterableField),
                 tableName: filterableField.table,
-                ...(isDimension(filterableField)
-                    ? { fallbackType: filterableField.type }
-                    : {}),
             },
         };
     }, {});
@@ -572,7 +568,6 @@ export const createDashboardFilterRuleFromField = ({
                 fieldId: getItemId(field),
                 tableName: field.table,
                 fieldName: field.name,
-                ...(isDimension(field) ? { fallbackType: field.type } : {}),
             },
             tileTargets: getDefaultTileTargets(field, availableTileFilters),
             disabled: !isTemporary,
@@ -1542,85 +1537,6 @@ export const getAvailableFilterFieldIds = (explore: Explore): string[] => [
         .map(([fieldId]) => fieldId),
 ];
 
-export const getExploreDefaultTimeDimension = (
-    explore: Explore,
-): FilterableDimension | undefined => {
-    const baseTable = explore.tables[explore.baseTable];
-    const defaultTimeDimension = baseTable?.defaultTimeDimension;
-    if (!baseTable || !defaultTimeDimension) {
-        return undefined;
-    }
-
-    const fieldId = convertFieldRefToFieldId(
-        defaultTimeDimension.field,
-        baseTable.name,
-    );
-    const dimension = getDimensionMapFromTables(explore.tables)[fieldId];
-    return dimension && isFilterableDimension(dimension)
-        ? dimension
-        : undefined;
-};
-
-export const getDashboardFieldTarget = (
-    field: FilterableDimension,
-): DashboardFieldTarget => ({
-    fieldId: getItemId(field),
-    tableName: field.table,
-    fallbackType: field.type,
-});
-
-const isDateDimensionType = (type: DimensionType | undefined): boolean =>
-    type === DimensionType.DATE || type === DimensionType.TIMESTAMP;
-
-export const applyDefaultTimeDimensionTileTargets = (
-    dashboardFilters: DashboardFilters,
-    filterableFieldsByTileUuid: Record<string, DashboardFilterableField[]>,
-    defaultTimeDimensions: Record<string, DashboardFieldTarget>,
-): DashboardFilters => ({
-    ...dashboardFilters,
-    dimensions: dashboardFilters.dimensions.map((filter) => {
-        const sourceField = Object.values(filterableFieldsByTileUuid)
-            .flat()
-            .find((field) => getItemId(field) === filter.target.fieldId);
-        const filterType =
-            filter.target.fallbackType ??
-            (sourceField && isDimension(sourceField)
-                ? sourceField.type
-                : undefined);
-        if (!isDateDimensionType(filterType)) {
-            return filter;
-        }
-
-        const tileTargets = Object.entries(defaultTimeDimensions).reduce(
-            (targets, [tileUuid, defaultTimeDimensionTarget]) => {
-                if (targets[tileUuid] !== undefined) {
-                    return targets;
-                }
-                const tileHasSourceField = filterableFieldsByTileUuid[
-                    tileUuid
-                ]?.some((field) => getItemId(field) === filter.target.fieldId);
-                if (tileHasSourceField) {
-                    return targets;
-                }
-                return {
-                    ...targets,
-                    [tileUuid]: defaultTimeDimensionTarget,
-                };
-            },
-            { ...filter.tileTargets },
-        );
-
-        return {
-            ...filter,
-            target: {
-                ...filter.target,
-                fallbackType: filterType,
-            },
-            tileTargets,
-        };
-    }),
-});
-
 export const applyDashboardFiltersForTile = ({
     tileUuid,
     metricQuery,
@@ -1635,29 +1551,10 @@ export const applyDashboardFiltersForTile = ({
     metricQuery: MetricQuery;
     appliedDashboardFilters: DashboardFilters;
 } => {
-    const availableFieldIds = getAvailableFilterFieldIds(explore);
-    const defaultTimeDimension = getExploreDefaultTimeDimension(explore);
-    const dimensionFilters = dashboardFilters.dimensions.map((filter) => {
-        const tileTarget = filter.tileTargets?.[tileUuid];
-        if (
-            tileTarget !== undefined ||
-            availableFieldIds.includes(filter.target.fieldId) ||
-            !isDateDimensionType(filter.target.fallbackType) ||
-            !defaultTimeDimension
-        ) {
-            return filter;
-        }
-        return {
-            ...filter,
-            target: {
-                ...getDashboardFieldTarget(defaultTimeDimension),
-            },
-        };
-    });
     const appliedDashboardFilters = getDashboardFiltersForTileAndTables(
         tileUuid,
-        availableFieldIds,
-        { ...dashboardFilters, dimensions: dimensionFilters },
+        getAvailableFilterFieldIds(explore),
+        dashboardFilters,
     );
     return {
         metricQuery: addDashboardFiltersToMetricQuery(

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -1,6 +1,5 @@
 import {
     applyDimensionOverrides,
-    applyDefaultTimeDimensionTileTargets,
     applyMetricOverrides,
     compressDashboardFiltersToParam,
     convertDashboardFiltersParamToDashboardFilters,
@@ -1407,7 +1406,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     }, [dashboardAvailableFiltersData]);
 
     const allFilters = useMemo(() => {
-        const filters = {
+        return {
             dimensions: [
                 ...dashboardFilters.dimensions,
                 ...safeTemporaryFilters?.dimensions,
@@ -1421,19 +1420,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                 ...safeTemporaryFilters?.tableCalculations,
             ],
         };
-        return filterableFieldsByTileUuid && dashboardAvailableFiltersData
-            ? applyDefaultTimeDimensionTileTargets(
-                  filters,
-                  filterableFieldsByTileUuid,
-                  dashboardAvailableFiltersData.defaultTimeDimensions,
-              )
-            : filters;
-    }, [
-        dashboardFilters,
-        safeTemporaryFilters,
-        filterableFieldsByTileUuid,
-        dashboardAvailableFiltersData,
-    ]);
+    }, [dashboardFilters, safeTemporaryFilters]);
 
     // Watch for filter changes and emit events (skip initial render)
     useEffect(() => {


### PR DESCRIPTION
### Description

Reverts #26682 (`fix(dashboards): map date filters across explores`), removing the runtime auto-mapping of dashboard date filters to each explore's `default_time_dimension`.

The feature bypassed filter tile scoping: a tile with no `tileTargets` entry whose explore lacked the filter's field went from "filter does not apply" to "filter silently retargets to the explore's default time dimension" — the state tile scoping produces for out-of-scope cross-explore tiles. Because the generated mapping was runtime-only, it never appeared in the filter bar or the filter's tile configuration, so charts returned wrong or empty results with no visible filter and no way to remove it (#27591). The generated mappings also leaked into persisted scheduler filters when creating a new scheduled delivery (the scheduler form seeds from the augmented filter set), so deliveries created since 1.64.0 on multi-explore dashboards may need a data cleanup — see the issue for details.

Rather than patching the inference (#27598), this removes the feature entirely. The original request will be re-scoped as a UX improvement to dashboard filter setup instead.

**Changes:**

- Revert of commit `a0d96763` (one conflict resolved: an unrelated later import in `ProjectService.ts` kept)
- Removes `applyDefaultTimeDimensionTileTargets()`, `getExploreDefaultTimeDimension()`, `getDashboardFieldTarget()`, the date fallback in `applyDashboardFiltersForTile()`, `fallbackType` population in filter creation, `defaultTimeDimensions` from `DashboardAvailableFilters`, and the provider/service wiring
- Note for reviewers: `defaultTimeDimensions` disappears from the available-filters API response on regeneration (additive field introduced in 1.64.0, consumed only by the frontend)

**Verification (live, seeded Jaffle project, orders tile with `default_time_dimension` on its model; control = 114 rows, correctly applied Jan-2017 date filter = 0 rows):**

| Case | Setup | Before (main) | After revert |
|---|---|---|---|
| Cross-explore filter scoped to a different tile | `tileTargets` maps only another tile | leaked `orders_order_date`, 0 rows (#27591) | no filter, 114 rows ✅ |
| Cross-explore filter, `tileTargets` absent | auto-mapped (the reverted feature) | `orders_order_date`, 0 rows | no filter, 114 rows ✅ (feature removed) |
| Explicit exclusion (`tileTargets: {tile: false}`) | — | no filter | no filter, 114 rows ✅ |
| Explicit mapping to `orders_order_date` | — | applied | applied, 0 rows ✅ |
| Same-explore auto-apply (field exists, defined `tileTargets` without entry for tile) | pre-existing contract | applied | applied, 0 rows ✅ |
| Control, no filters | — | 114 rows | 114 rows ✅ |

**Tests:** `pnpm -F common test src/utils/filters.test.ts` (106 passed), common/backend/frontend typechecks clean.

Closes: PROD-10292
Closes: #27591
Relates: PROD-9427
Relates: #26641

https://claude.ai/code/session_015pJbGAS5Eh4UqzVmcnBSM9