### PR TITLE
fix: support chart slugs in version history

### DIFF
--- a/packages/frontend/src/pages/ChartHistory.tsx
+++ b/packages/frontend/src/pages/ChartHistory.tsx
@@ -53,11 +53,15 @@ const ChartHistoryContent = memo(() => {
     );
 });
 
-const ChartHistoryExplorer = memo<{ selectedVersionUuid: string | undefined }>(
-    ({ selectedVersionUuid }) => {
-        const { savedQueryUuid } = useParams<{ savedQueryUuid: string }>();
+type ChartHistoryExplorerProps = {
+    chartUuid: string;
+    selectedVersionUuid: string | undefined;
+};
+
+const ChartHistoryExplorer = memo<ChartHistoryExplorerProps>(
+    ({ chartUuid, selectedVersionUuid }) => {
         const chartVersionQuery = useChartVersion(
-            savedQueryUuid,
+            chartUuid,
             selectedVersionUuid,
         );
 
@@ -108,17 +112,18 @@ const ChartHistoryExplorer = memo<{ selectedVersionUuid: string | undefined }>(
 
 const ChartHistory = () => {
     const navigate = useNavigate();
-    const { savedQueryUuid, projectUuid } = useParams<{
+    const { savedQueryUuid: chartIdentifier, projectUuid } = useParams<{
         savedQueryUuid: string;
         projectUuid: string;
     }>();
     const [selectedVersionUuid, selectVersionUuid] = useState<string>();
     const [isRollbackModalOpen, setIsRollbackModalOpen] = useState(false);
     const chartQuery = useSavedQuery({
-        uuidOrSlug: savedQueryUuid,
+        uuidOrSlug: chartIdentifier,
         projectUuid,
     });
-    const historyQuery = useChartHistory(savedQueryUuid);
+    const chartUuid = chartQuery.data?.uuid;
+    const historyQuery = useChartHistory(chartUuid);
 
     useEffect(() => {
         const currentVersion = historyQuery.data?.history[0];
@@ -127,10 +132,10 @@ const ChartHistory = () => {
         }
     }, [selectedVersionUuid, historyQuery.data]);
 
-    const rollbackMutation = useChartVersionRollbackMutation(savedQueryUuid, {
+    const rollbackMutation = useChartVersionRollbackMutation(chartUuid, {
         onSuccess: () => {
             void navigate(
-                `/projects/${projectUuid}/saved/${savedQueryUuid}/view`,
+                `/projects/${projectUuid}/saved/${chartIdentifier}/view`,
             );
         },
     });
@@ -167,7 +172,7 @@ const ChartHistory = () => {
                             items={[
                                 {
                                     title: 'Chart',
-                                    to: `/projects/${projectUuid}/saved/${savedQueryUuid}/view`,
+                                    to: `/projects/${projectUuid}/saved/${chartIdentifier}/view`,
                                 },
                                 { title: 'Version history', active: true },
                             ]}
@@ -295,9 +300,10 @@ const ChartHistory = () => {
                     title="Select a version"
                 />
             )}
-            {selectedVersionUuid && (
+            {selectedVersionUuid && chartUuid && (
                 <ChartHistoryExplorer
                     key={selectedVersionUuid}
+                    chartUuid={chartUuid}
                     selectedVersionUuid={selectedVersionUuid}
                 />
             )}


### PR DESCRIPTION
Before



![CleanShot 2026-08-19 at 12.01.08.png](https://app.graphite.com/user-attachments/assets/e558e58b-2bca-4d56-ba7e-d28099b53f8d.png)



After



![CleanShot 2026-08-19 at 12.02.01.png](https://app.graphite.com/user-attachments/assets/09a1a6cd-2ae1-42bc-8be6-2b4138b0024a.png)





## Summary

- Resolve chart route identifiers through the project-scoped chart endpoint.
- Use the resolved chart UUID for history, version, and rollback requests.
- Preserve the entered UUID, slug, or alias in chart navigation links.

## Validation

- `pnpm -F frontend typecheck`
- `pnpm -F frontend exec oxfmt --check src/pages/ChartHistory.tsx`
- Live-tested chart history with a UUID, current slug, and historical slug alias.

Closes: SPK-1130