### PR TITLE
fix(cli): make slug update path option consistent

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1532,13 +1532,13 @@ program
     .description('Rename a chart slug and update its local references')
     .option('--verbose', 'show verbose output', false)
     .option(
-        '-p, --project <project uuid>',
+        '--project <project uuid>',
         'specify a project UUID',
         parseProjectArgument,
         undefined,
     )
     .option(
-        '--path <path>',
+        '-p, --path <path>',
         'specify the local content-as-code path to update',
         undefined,
     )


### PR DESCRIPTION
## Summary

- make `-p` the short option for the local content-as-code path in `slug-update`
- keep project selection available through the long-form `--project` option
- align `slug-update` with the existing `download` and `upload` conventions

## Testing

- `pnpm -F @lightdash/cli build`
- `pnpm -F @lightdash/cli test src/handlers/slugUpdate.test.ts`
- verified the built CLI help and option parsing
- manually confirmed `slug-update ... -p <path>` updates local content correctly

Closes: SPK-1150
