### PR TITLE
feat: filter AI issues by status

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.test.tsx
@@ -213,4 +213,70 @@ describe('AiAgentAdminReviewItemsTable', () => {
         await user.click(screen.getByRole('button', { name: 'Create PR' }));
         expect(onReviewItemSelect).not.toHaveBeenCalled();
     });
+
+    it('filters issues by status and clears the selection', async () => {
+        const user = userEvent.setup();
+        const rows = [
+            makeReviewItem({
+                uuid: 'triage-review',
+                fingerprint: 'triage-review',
+                source: 'manual',
+                title: 'Triage issue',
+                status: 'triage',
+                latestFinding: null,
+            }),
+            makeReviewItem({
+                uuid: 'open-review',
+                fingerprint: 'open-review',
+                source: 'manual',
+                title: 'To Do issue',
+                status: 'open',
+                latestFinding: null,
+            }),
+            makeReviewItem({
+                uuid: 'in-progress-review',
+                fingerprint: 'in-progress-review',
+                source: 'manual',
+                title: 'In Progress issue',
+                status: 'in_progress',
+                latestFinding: null,
+            }),
+        ];
+        mockUseAiAgentAdminReviewItems.mockImplementation(
+            (
+                _args: unknown,
+                options?: {
+                    select?: (
+                        items: AiAgentReviewItemSummary[],
+                    ) => AiAgentReviewItemSummary[];
+                },
+            ) => ({
+                data: options?.select ? options.select(rows) : rows,
+                isLoading: false,
+            }),
+        );
+
+        renderWithProviders(
+            <MemoryRouter>
+                <AiAgentAdminReviewItemsTable />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText('Triage issue')).toBeInTheDocument();
+        expect(screen.getByText('To Do issue')).toBeInTheDocument();
+        expect(screen.getByText('In Progress issue')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Status' }));
+        await user.click(screen.getByText('Needs triage', { exact: true }));
+
+        expect(screen.getByText('Triage issue')).toBeInTheDocument();
+        expect(screen.queryByText('To Do issue')).not.toBeInTheDocument();
+        expect(screen.queryByText('In Progress issue')).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+        expect(screen.getByText('Triage issue')).toBeInTheDocument();
+        expect(screen.getByText('To Do issue')).toBeInTheDocument();
+        expect(screen.getByText('In Progress issue')).toBeInTheDocument();
+    });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -94,6 +94,15 @@ const ACTIVE_REVIEW_ITEM_STATUSES: AiAgentReviewItemStatus[] = [
     'in_progress',
 ];
 
+const reviewItemStatusLabels: Record<AiAgentReviewItemStatus, string> = {
+    triage: 'Needs triage',
+    open: 'To Do',
+    in_progress: 'In Progress',
+    resolved: 'Resolved',
+    dismissed: 'Dismissed',
+    duplicate: 'Duplicate',
+};
+
 const signalLabels: Record<AiAgentTurnSignal, string> = {
     normal_refinement: 'Normal refinement',
     implicit_correction: 'Implicit correction',
@@ -397,6 +406,9 @@ const AiAgentAdminReviewItemsTable = ({
         [],
     );
     const [selectedAssignees, setSelectedAssignees] = useState<string[]>([]);
+    const [selectedStatuses, setSelectedStatuses] = useState<
+        AiAgentReviewItemStatus[]
+    >([]);
     const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
     const deferredSearch = useDeferredValue(search);
     const updateStatus = useUpdateAiAgentReviewItemStatus();
@@ -548,6 +560,10 @@ const AiAgentAdminReviewItemsTable = ({
 
     const filteredReviewItems = useMemo(() => {
         let items = scopedReviewItems;
+        if (selectedStatuses.length > 0) {
+            const statusSet = new Set(selectedStatuses);
+            items = items.filter((item) => statusSet.has(item.status));
+        }
         if (selectedRootCauses.length > 0) {
             const rootCauseSet = new Set(selectedRootCauses);
             items = items.filter((item) =>
@@ -560,7 +576,12 @@ const AiAgentAdminReviewItemsTable = ({
             );
         }
         return items;
-    }, [scopedReviewItems, selectedRootCauses, selectedAssignees]);
+    }, [
+        scopedReviewItems,
+        selectedStatuses,
+        selectedRootCauses,
+        selectedAssignees,
+    ]);
 
     const filteredReviewSignals = useMemo(() => {
         if (selectedSignals.length === 0) {
@@ -675,6 +696,18 @@ const AiAgentAdminReviewItemsTable = ({
             );
     }, [scopedReviewItems]);
 
+    const statusFacetOptions = useMemo((): FilterFacetOption[] => {
+        const counts = new Map<AiAgentReviewItemStatus, number>();
+        for (const item of scopedReviewItems) {
+            counts.set(item.status, (counts.get(item.status) ?? 0) + 1);
+        }
+        return ACTIVE_REVIEW_ITEM_STATUSES.map((status) => ({
+            value: status,
+            label: reviewItemStatusLabels[status],
+            count: counts.get(status) ?? 0,
+        }));
+    }, [scopedReviewItems]);
+
     const assigneeFacetOptions = useMemo(
         (): FilterFacetOption[] =>
             buildAssigneeFacetOptions({
@@ -712,7 +745,8 @@ const AiAgentAdminReviewItemsTable = ({
         selectedAgentUuids.length > 0 ||
         !hasDefaultRootCauseSelection ||
         selectedSignals.length > 0 ||
-        selectedAssignees.length > 0;
+        selectedAssignees.length > 0 ||
+        selectedStatuses.length > 0;
 
     const clearAllFilters = useCallback(() => {
         setSelectedProjectUuids([]);
@@ -720,6 +754,7 @@ const AiAgentAdminReviewItemsTable = ({
         setSelectedRootCauses(DEFAULT_VISIBLE_ROOT_CAUSES);
         setSelectedSignals([]);
         setSelectedAssignees([]);
+        setSelectedStatuses([]);
     }, []);
 
     const handleRowSelectionChange = useCallback(
@@ -817,6 +852,19 @@ const AiAgentAdminReviewItemsTable = ({
                             }
                             emptyLabel="No root causes in current view"
                             tooltipLabel="Filter by root cause"
+                        />
+                        <FilterFacet
+                            label="Status"
+                            icon={IconListCheck}
+                            options={statusFacetOptions}
+                            selected={selectedStatuses}
+                            onChange={(values) =>
+                                setSelectedStatuses(
+                                    values as AiAgentReviewItemStatus[],
+                                )
+                            }
+                            emptyLabel="No statuses in current view"
+                            tooltipLabel="Filter by status"
                         />
                         <FilterFacet
                             label="Assignee"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
@@ -1,5 +1,6 @@
 import { type AiAgentReviewItemSummary } from '@lightdash/common';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
 import { ReviewKanbanBoard } from './ReviewKanbanBoard';
@@ -132,5 +133,18 @@ describe('ReviewKanbanBoard', () => {
             '[data-tour="reviews-pr"]',
         ) as HTMLButtonElement | null;
         expect(startButton?.disabled).toBe(true);
+    });
+
+    it('filters board cards by status', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<ReviewKanbanBoard onReviewItemSelect={vi.fn()} />);
+
+        await user.click(screen.getByRole('button', { name: 'Status' }));
+        await user.click(screen.getByRole('button', { name: 'Done 1' }));
+
+        expect(
+            screen.queryByText('Triage correction signal'),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText('All done')).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -35,7 +35,13 @@ import {
     type AiAgentRootCause,
 } from '@lightdash/common';
 import { Badge, Box, Button, Group, Stack, Text } from '@mantine/core';
-import { IconBox, IconRobotFace, IconTag, IconUser } from '@tabler/icons-react';
+import {
+    IconBox,
+    IconListCheck,
+    IconRobotFace,
+    IconTag,
+    IconUser,
+} from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { type FC, useDeferredValue, useMemo, useState } from 'react';
 import FilterFacet, {
@@ -195,6 +201,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
         AiAgentRootCause[]
     >(DEFAULT_VISIBLE_ROOT_CAUSES);
     const [selectedAssignees, setSelectedAssignees] = useState<string[]>([]);
+    const [selectedStatuses, setSelectedStatuses] = useState<ReviewLane[]>([]);
     const { data, isLoading } = useAiAgentAdminReviewItems({
         statuses: BOARD_STATUSES,
     });
@@ -279,6 +286,10 @@ export const ReviewKanbanBoard: FC<Props> = ({
 
     const items = useMemo<AiAgentReviewItemSummary[]>(() => {
         let next = scopedItems;
+        if (selectedStatuses.length > 0) {
+            const statusSet = new Set(selectedStatuses);
+            next = next.filter((item) => statusSet.has(getReviewLane(item)));
+        }
         if (selectedRootCauses.length > 0) {
             const rootCauseSet = new Set(selectedRootCauses);
             next = next.filter((item) =>
@@ -291,7 +302,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
             );
         }
         return next;
-    }, [scopedItems, selectedRootCauses, selectedAssignees]);
+    }, [scopedItems, selectedStatuses, selectedRootCauses, selectedAssignees]);
 
     const projectFacetOptions = useMemo((): FilterFacetOption[] => {
         const counts = new Map<string, number>();
@@ -371,6 +382,19 @@ export const ReviewKanbanBoard: FC<Props> = ({
             }),
         [scopedItems, orgUsersByUuid, currentUserUuid],
     );
+
+    const statusFacetOptions = useMemo((): FilterFacetOption[] => {
+        const counts = new Map<ReviewLane, number>();
+        for (const item of scopedItems) {
+            const lane = getReviewLane(item);
+            counts.set(lane, (counts.get(lane) ?? 0) + 1);
+        }
+        return REVIEW_LANES.map((lane) => ({
+            value: lane.id,
+            label: lane.label,
+            count: counts.get(lane.id) ?? 0,
+        }));
+    }, [scopedItems]);
 
     const lanes = useMemo(() => {
         const byLane: Record<ReviewLane, AiAgentReviewItemSummary[]> = {
@@ -562,6 +586,17 @@ export const ReviewKanbanBoard: FC<Props> = ({
                     }
                     emptyLabel="No root causes in current view"
                     tooltipLabel="Filter by root cause"
+                />
+                <FilterFacet
+                    label="Status"
+                    icon={IconListCheck}
+                    options={statusFacetOptions}
+                    selected={selectedStatuses}
+                    onChange={(values) =>
+                        setSelectedStatuses(values as ReviewLane[])
+                    }
+                    emptyLabel="No statuses in current view"
+                    tooltipLabel="Filter by status"
                 />
                 <FilterFacet
                     label="Assignee"


### PR DESCRIPTION
## Summary

- add a counted multi-select Status facet to AI Issues in both Board and Table views
- filter by the visible workflow states (Needs triage, To Do, In Progress, plus Done on the Board)
- include status selection in Table clear/reset behavior
- add focused Board and Table regression coverage

## Requirements

Admins can focus the AI Issues queue on one or more workflow statuses without changing issue state or server-side query behavior. The existing Project, Agent, Cause, Assignee, search, Board, and Table interactions remain available.

## Pre-fix reproduction

1. Start Lightdash and sign in as an organization admin.
2. Open **Settings → AI → Ask AI** and enable **Review AI agent turns**.
3. Create three manual review issues through `POST /api/v1/aiAgents/admin/review-items` for one project.
4. Update one with `PATCH /api/v1/aiAgents/admin/review-items/{fingerprint}` to `triage`, leave one `open`, and update one to `in_progress`.
5. Open **Settings → AI → Issues**.
6. Confirm Board shows one issue in each active lane and switch to Table to confirm all three rows.
7. Observe that the toolbar only offers Project, Agent, Cause, and Assignee; there is no way to filter by status.

## Post-fix validation

Repeat steps 1–6, then:

1. Open **Status** and select **Needs triage**.
2. Confirm Board leaves only the Needs triage card and Table leaves only that row.
3. On Board, also select **In Progress** and confirm exactly those two lanes contain cards.
4. In Table, click **Clear filters** and confirm all three rows return.

The same local fixtures produced Status counts of `1` for Needs triage, To Do, and In Progress.

## Automated checks

- `pnpm --filter frontend exec vitest run src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.test.tsx src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx` — 2 files, 5 tests passed
- focused `oxlint` on the four changed files — 0 warnings/errors
- `pnpm --filter frontend typecheck` — passed
- `oxfmt` on the four changed files — passed
- `git diff --check` — passed

## Screenshots

Before — no Status filter with one issue in each active state:

![Before: no status filter](https://uploads.linear.app/63b56e5e-f571-4fec-a07d-c4fe22d5eef5/17f94946-d64a-4048-83c6-1a8297d2c1e9/e91a4d4f-0264-49ce-82ad-899233e73989)

After — Board filtered to Needs triage:

![After: Board status filter](https://uploads.linear.app/63b56e5e-f571-4fec-a07d-c4fe22d5eef5/009e5d2a-4372-4f41-bd97-3c13aa785829/ce1b9e05-a7cd-4715-bfbe-fcac2384be63)

After — Table filtered to Needs triage:

![After: Table status filter](https://uploads.linear.app/63b56e5e-f571-4fec-a07d-c4fe22d5eef5/12dfde57-95d0-4d74-8d99-930954649bad/b4e35e71-0dba-4fe2-a57a-90fd29dd0bfc)

## Compatibility and security

- local, ephemeral UI filter state only; issue status persistence, saved content, request/response shapes, and public APIs are unchanged
- existing feature-flag behavior, drag/drop status updates, search, and all other facets are unchanged
- fixed local options are the only accepted status values; no new input parsing or execution surface
- no authentication, authorization, permissions, tenant isolation, or sensitive-data behavior changes
- no migration, dependency, feature flag, generated artifact, or generated API/schema change

## Rollout and risk

No rollout step is required. Residual risk is limited to client-side facet interaction and is covered in both views plus the real UI. Confidence: 98%.

Closes: PROD-10118
Closes: #27366
