### PR TITLE
feat: add space_uuid, space_path, project_uuid to usage analytics export

### DIFF
--- a/packages/backend/src/models/AnalyticsModel.test.ts
+++ b/packages/backend/src/models/AnalyticsModel.test.ts
@@ -78,4 +78,43 @@ describe('AnalyticsModel', () => {
             expect.arrayContaining([expect.stringContaining('/ 0')]),
         );
     });
+
+    describe('getViewsRawData', () => {
+        it('selects the space identifier columns and builds the space_paths recursive CTE', async () => {
+            tracker.on
+                .select(() => true)
+                .response([
+                    {
+                        type: 'chart',
+                        timestamp: '2026-06-15T00:00:00Z',
+                        uuid: 'chart-uuid',
+                        name: 'My Chart',
+                        user_uuid: 'user-uuid',
+                        user_first_name: 'Ada',
+                        user_last_name: 'Lovelace',
+                        space_name: 'Commercial',
+                        space_uuid: 'space-uuid',
+                        space_path: 'LCT / Commercial',
+                        project_uuid: projectUuid,
+                    },
+                ]);
+
+            const results = await model.getViewsRawData(projectUuid);
+
+            expect(results[0]).toEqual(
+                expect.objectContaining({
+                    space_uuid: 'space-uuid',
+                    space_path: 'LCT / Commercial',
+                    project_uuid: projectUuid,
+                }),
+            );
+
+            const sql = tracker.history.select[0].sql.toLowerCase();
+            expect(sql).toContain('with recursive');
+            expect(sql).toContain('space_paths');
+            expect(sql).toContain('space_uuid');
+            expect(sql).toContain('space_path');
+            expect(sql).toContain('project_uuid');
+        });
+    });
 });

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -323,9 +323,30 @@ export class AnalyticsModel {
             user_first_name: string;
             user_last_name: string;
             space_name: string;
+            space_uuid: string;
+            space_path: string;
+            project_uuid: string;
         };
         const results = await this.database.transaction(async (trx) => {
+            const spacePathsCte = this.database.raw(
+                `
+                SELECT s.space_id, s.space_uuid, CAST(s.name AS text) AS path
+                FROM ${SpaceTableName} s
+                INNER JOIN ${ProjectTableName} p ON p.project_id = s.project_id
+                WHERE s.parent_space_uuid IS NULL
+                  AND s.deleted_at IS NULL
+                  AND p.project_uuid = ?
+                UNION ALL
+                SELECT c.space_id, c.space_uuid, sp.path || ' / ' || c.name
+                FROM ${SpaceTableName} c
+                INNER JOIN space_paths sp ON c.parent_space_uuid = sp.space_uuid
+                WHERE c.deleted_at IS NULL
+                `,
+                [projectUuid],
+            );
+
             const chartViews = trx
+                .withRecursive('space_paths', spacePathsCte)
                 .select<RawViewType[]>(
                     this.database.raw(`'chart' as type`),
                     this.database.raw(
@@ -337,6 +358,9 @@ export class AnalyticsModel {
                     `${UserTableName}.first_name as user_first_name`,
                     `${UserTableName}.last_name as user_last_name`,
                     `${SpaceTableName}.name as space_name`,
+                    `${SpaceTableName}.space_uuid as space_uuid`,
+                    `space_paths.path as space_path`,
+                    `${ProjectTableName}.project_uuid as project_uuid`,
                 )
                 .from(AnalyticsChartViewsTableName)
                 .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
@@ -361,6 +385,11 @@ export class AnalyticsModel {
                     `${ProjectTableName}.project_id`,
                     `${SpaceTableName}.project_id`,
                 )
+                .leftJoin(
+                    'space_paths',
+                    `space_paths.space_id`,
+                    `${SpaceTableName}.space_id`,
+                )
                 .where(`${ProjectTableName}.project_uuid`, projectUuid)
                 .whereNull(`${SpaceTableName}.deleted_at`);
 
@@ -376,6 +405,9 @@ export class AnalyticsModel {
                     `${UserTableName}.first_name as user_first_name`,
                     `${UserTableName}.last_name as user_last_name`,
                     `${SpaceTableName}.name as space_name`,
+                    `${SpaceTableName}.space_uuid as space_uuid`,
+                    `space_paths.path as space_path`,
+                    `${ProjectTableName}.project_uuid as project_uuid`,
                 )
                 .from(AnalyticsDashboardViewsTableName)
                 .leftJoin(
@@ -397,6 +429,11 @@ export class AnalyticsModel {
                     ProjectTableName,
                     `${ProjectTableName}.project_id`,
                     `${SpaceTableName}.project_id`,
+                )
+                .leftJoin(
+                    'space_paths',
+                    `space_paths.space_id`,
+                    `${SpaceTableName}.space_id`,
                 )
                 .where(`${ProjectTableName}.project_uuid`, projectUuid)
                 .whereNull(`${SpaceTableName}.deleted_at`);


### PR DESCRIPTION
Closes: PROD-8317

### Description:

Rebased replacement for #24303, which had conflicted with `main` (both branches added `AnalyticsModel.test.ts`).

The Extended Usage Analytics CSV export identified each viewed asset's space only by `space_name` — the flattened leaf name — so two spaces sharing a name in different parts of the tree (a nested `Commercial` under `LCT` and a root-level `Commercial`) collapsed into one bucket with no way to tell them apart, making per-team adoption numbers unreliable.

Adds three columns to `AnalyticsModel.getViewsRawData()`:

- `space_uuid` — stable unique key for joins/dedupe (from the already-joined `spaces` table)
- `space_path` — human-readable ancestor breadcrumb, e.g. `LCT / Commercial`, from a recursive CTE walking down from root spaces accumulating names
- `project_uuid` — for aggregating across projects (from the already-joined `projects` table)

`space_name` is retained, so the change is purely additive. The CSV header is auto-generated from row keys in `AnalyticsService.exportUserActivityRawCsv()`, so no service or controller changes are needed.

The CTE walks the `parent_space_uuid` FK rather than the `path` ltree column, which stores slugs rather than display names and is lossy (hyphens and underscores map to the same label).

Verified: typecheck, oxlint, oxfmt and the `AnalyticsModel` unit tests pass; the test asserts the new columns and the recursive CTE, and I inspected the compiled SQL to confirm the CTE is emitted once at the top of the union and resolves for both the chart and dashboard branches.
