### PR TITLE
fix(frontend): preserve explorer queries in chart builder

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.test.tsx
@@ -1,0 +1,87 @@
+import { ChartType } from '@lightdash/common';
+import { act, waitFor } from '@testing-library/react';
+import type * as ReactRouter from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
+import { ConfigTabs } from './CustomVisConfig';
+
+type CustomChartTypeSectionProps = {
+    onCreateNew: (() => void) | null;
+};
+
+const { locationSearch, navigate, sectionProps } = vi.hoisted(() => ({
+    locationSearch: { current: '' },
+    navigate: vi.fn(),
+    sectionProps: [] as CustomChartTypeSectionProps[],
+}));
+
+vi.mock('react-router', async (importOriginal) => ({
+    ...(await importOriginal<typeof ReactRouter>()),
+    useParams: () => ({ projectUuid: 'project-1' }),
+    useLocation: () => ({ search: locationSearch.current }),
+    useNavigate: () => navigate,
+}));
+vi.mock('../../../../features/apps/hooks/useCanCreateDataApp', () => ({
+    useCanCreateDataApp: () => true,
+}));
+vi.mock('../../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: (featureFlag: string) => ({
+        data: { enabled: featureFlag === 'enable-data-apps' },
+    }),
+}));
+vi.mock('../../../LightdashVisualization/useVisualizationContext', () => ({
+    useVisualizationContext: vi.fn(),
+}));
+vi.mock('../../CustomChartType/CustomChartTypeSection', () => ({
+    default: (props: CustomChartTypeSectionProps) => {
+        sectionProps.push(props);
+        return null;
+    },
+}));
+vi.mock('../../CustomChartType/useSelectProjectChartType', () => ({
+    useCreateProjectChartType: () => vi.fn(),
+    useSelectProjectChartType: () => vi.fn(),
+}));
+vi.mock('../../../MonacoEditor', () => ({
+    default: () => null,
+}));
+vi.mock('./components/CustomVisTemplate', () => ({
+    SelectTemplate: () => null,
+}));
+
+describe('CustomVisConfig', () => {
+    beforeEach(() => {
+        locationSearch.current = '';
+        navigate.mockClear();
+        sectionProps.length = 0;
+        vi.mocked(useVisualizationContext).mockReturnValue({
+            itemsMap: {},
+            visualizationConfig: {
+                chartType: ChartType.CUSTOM,
+                chartConfig: {
+                    validConfig: { spec: {} },
+                    visSpec: '{}',
+                    setVisSpec: vi.fn(),
+                    series: [],
+                    fields: [],
+                },
+            },
+        } as unknown as ReturnType<typeof useVisualizationContext>);
+    });
+
+    it('keeps the Explorer query when opening the chart type builder', async () => {
+        locationSearch.current =
+            '?create_saved_chart_version=serialized-query&fromSpace=space-1';
+
+        renderWithProviders(<ConfigTabs />);
+
+        await waitFor(() => expect(sectionProps.length).toBeGreaterThan(0));
+        act(() => sectionProps[sectionProps.length - 1].onCreateNew?.());
+
+        expect(navigate).toHaveBeenCalledWith({
+            pathname: '/projects/project-1/chart-types/new',
+            search: locationSearch.current,
+        });
+    });
+});

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -10,7 +10,7 @@ import {
 import { useDebouncedValue } from '@mantine/hooks';
 import { type IDisposable, type languages } from 'monaco-editor';
 import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useLocation, useNavigate, useParams } from 'react-router';
 import { useDeepCompareEffect } from 'react-use';
 import { useCanCreateDataApp } from '../../../../features/apps/hooks/useCanCreateDataApp';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
@@ -126,6 +126,7 @@ export const ConfigTabs: React.FC = memo(() => {
     const { visualizationConfig } = useVisualizationContext();
     const colorScheme = useComputedColorScheme();
     const { projectUuid } = useParams<{ projectUuid: string }>();
+    const location = useLocation();
     const navigate = useNavigate();
 
     const isCustomConfig = isCustomVisualizationConfig(visualizationConfig);
@@ -266,9 +267,10 @@ export const ConfigTabs: React.FC = memo(() => {
                         onCreateNew={
                             canCreateApp
                                 ? () =>
-                                      void navigate(
-                                          `/projects/${projectUuid}/chart-types/new`,
-                                      )
+                                      void navigate({
+                                          pathname: `/projects/${projectUuid}/chart-types/new`,
+                                          search: location.search,
+                                      })
                                 : null
                         }
                         onBrowseGallery={() =>

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -28,6 +28,7 @@ import { ConfigTabs } from './DataAppVizConfigTabs';
 
 type PickerProps = {
     disabled: boolean;
+    onCreateNew: (() => void) | null;
     onSelectProjectType: (dataAppViz: DataAppViz) => void;
 };
 
@@ -36,16 +37,19 @@ type FieldSelectProps = {
     onChange: (item: Item | null) => void;
 };
 
-const { fieldSelectItems, fieldSelectProps, pickerProps } = vi.hoisted(() => {
-    const fieldSelectItems: Item[][] = [];
-    const fieldSelectProps: FieldSelectProps[] = [];
-    const pickerProps: PickerProps[] = [];
-    return {
-        fieldSelectItems,
-        fieldSelectProps,
-        pickerProps,
-    };
-});
+const {
+    fieldSelectItems,
+    fieldSelectProps,
+    locationSearch,
+    navigate,
+    pickerProps,
+} = vi.hoisted(() => ({
+    fieldSelectItems: [] as Item[][],
+    fieldSelectProps: [] as FieldSelectProps[],
+    locationSearch: { current: '' },
+    navigate: vi.fn(),
+    pickerProps: [] as PickerProps[],
+}));
 
 vi.mock('../CustomChartType/CustomChartTypePicker', () => ({
     default: (props: PickerProps) => {
@@ -60,10 +64,18 @@ vi.mock('../../../features/chartTypes/hooks/useDataAppVisualization', () => ({
 vi.mock('react-router', async (importOriginal) => ({
     ...(await importOriginal<typeof ReactRouter>()),
     useParams: () => ({ projectUuid: 'project-1' }),
+    useLocation: () => ({ search: locationSearch.current }),
     // The panel navigates to the builder; this test does not mount a router.
-    useNavigate: () => vi.fn(),
+    useNavigate: () => navigate,
     Link: ({ to, children, ...rest }: ReactRouter.LinkProps) => (
-        <a href={typeof to === 'string' ? to : ''} {...rest}>
+        <a
+            href={
+                typeof to === 'string'
+                    ? to
+                    : `${to.pathname ?? ''}${to.search ?? ''}`
+            }
+            {...rest}
+        >
             {children}
         </a>
     ),
@@ -227,6 +239,8 @@ describe('DataAppVizConfigTabs', () => {
         fieldSelectItems.length = 0;
         fieldSelectProps.length = 0;
         pickerProps.length = 0;
+        locationSearch.current = '';
+        navigate.mockClear();
         setOption.mockClear();
         setDataAppVizUuid.mockClear();
         setField.mockClear();
@@ -394,6 +408,30 @@ describe('DataAppVizConfigTabs', () => {
         ).toHaveAttribute('href', '/projects/project-1/chart-types/new');
     });
 
+    it('keeps the Explorer query in builder links', async () => {
+        signInAs(OrganizationMemberRole.EDITOR);
+        mockContext(queryColumns, '');
+        locationSearch.current =
+            '?create_saved_chart_version=serialized-query&fromSpace=space-1';
+        vi.mocked(useDataAppVisualization).mockReturnValue({
+            data: undefined,
+        } as unknown as ReturnType<typeof useDataAppVisualization>);
+
+        renderWithProviders(<ConfigTabs />);
+
+        expect(
+            (await screen.findByText('builder')).closest('a'),
+        ).toHaveAttribute(
+            'href',
+            '/projects/project-1/chart-types/new?create_saved_chart_version=serialized-query&fromSpace=space-1',
+        );
+        act(() => pickerProps[pickerProps.length - 1].onCreateNew?.());
+        expect(navigate).toHaveBeenCalledWith({
+            pathname: '/projects/project-1/chart-types/new',
+            search: locationSearch.current,
+        });
+    });
+
     it('offers no builder link to who cannot create chart types', async () => {
         signInAs(OrganizationMemberRole.INTERACTIVE_VIEWER);
         mockContext(queryColumns, '');
@@ -411,6 +449,7 @@ describe('DataAppVizConfigTabs', () => {
 
     it('describes the selected type with a jump into its builder', async () => {
         signInAs(OrganizationMemberRole.EDITOR);
+        locationSearch.current = '?fromDashboard=dashboard-1';
         mockSchema([], null, { description: 'A gauge for KPI progress' });
         renderWithProviders(<ConfigTabs />);
 
@@ -423,7 +462,7 @@ describe('DataAppVizConfigTabs', () => {
             (await screen.findByText('Edit ↗')).closest('a'),
         ).toHaveAttribute(
             'href',
-            '/projects/project-1/chart-types/data-app-viz-uuid',
+            '/projects/project-1/chart-types/data-app-viz-uuid?fromDashboard=dashboard-1',
         );
     });
 

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -7,7 +7,7 @@ import {
 } from '@lightdash/common';
 import { Anchor, Box, Stack, Text } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
-import { Link, useNavigate, useParams } from 'react-router';
+import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualization } from '../../../features/chartTypes/hooks/useDataAppVisualization';
@@ -30,6 +30,7 @@ const NO_COLUMNS: ItemsMap = {};
 
 export const ConfigTabs: FC = memo(() => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
+    const location = useLocation();
     const navigate = useNavigate();
     const { visualizationConfig, itemsMap, setChartType, setPivotDimensions } =
         useVisualizationContext();
@@ -138,7 +139,10 @@ export const ConfigTabs: FC = memo(() => {
                     {canEditSelectedType && (
                         <Anchor
                             component={Link}
-                            to={`/projects/${projectUuid}/chart-types/${dataAppViz.dataAppVizUuid}`}
+                            to={{
+                                pathname: `/projects/${projectUuid}/chart-types/${dataAppViz.dataAppVizUuid}`,
+                                search: location.search,
+                            }}
                             fz="xs"
                             fw={500}
                             mt={4}
@@ -177,9 +181,10 @@ export const ConfigTabs: FC = memo(() => {
                     onCreateNew={
                         canCreateApp
                             ? () =>
-                                  void navigate(
-                                      `/projects/${projectUuid}/chart-types/new`,
-                                  )
+                                  void navigate({
+                                      pathname: `/projects/${projectUuid}/chart-types/new`,
+                                      search: location.search,
+                                  })
                             : null
                     }
                     onBrowseGallery={() =>
@@ -210,7 +215,10 @@ export const ConfigTabs: FC = memo(() => {
                                 , or create a new one in the{' '}
                                 <Anchor
                                     component={Link}
-                                    to={`/projects/${projectUuid}/chart-types/new`}
+                                    to={{
+                                        pathname: `/projects/${projectUuid}/chart-types/new`,
+                                        search: location.search,
+                                    }}
                                     size="xs"
                                 >
                                     builder

--- a/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderHeader.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderHeader.tsx
@@ -18,7 +18,7 @@ import {
     IconPencil,
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
-import { Link } from 'react-router';
+import { Link, type To } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
 import { getVersionAuthorName } from '../../apps/utils/versionsToChatMessages';
@@ -27,6 +27,10 @@ import VersionProvenance from './VersionProvenance';
 
 type Props = {
     projectUuid: string;
+    backLink: {
+        label: string;
+        to: To;
+    };
     /** Null while no app exists yet (create flow before the first build). */
     app: { appUuid: string; name: string; description: string } | null;
     latestReadyVersion: number | null;
@@ -43,6 +47,7 @@ type Props = {
 
 const ChartTypeBuilderHeader: FC<Props> = ({
     projectUuid,
+    backLink,
     app,
     latestReadyVersion,
     provenanceVersion,
@@ -60,13 +65,13 @@ const ChartTypeBuilderHeader: FC<Props> = ({
                 <Button
                     size="xs"
                     component={Link}
-                    to={`/projects/${projectUuid}/gallery`}
+                    to={backLink.to}
                     variant="default"
                     leftSection={
                         <MantineIcon icon={IconChevronLeft} size={15} />
                     }
                 >
-                    Gallery
+                    {backLink.label}
                 </Button>
                 <Box className={classes.divider} />
                 {app ? (

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -1,10 +1,11 @@
 import {
+    ChartType,
     FeatureFlags,
     type ApiAppVersionSummary,
     type ApiGetAppResponse,
 } from '@lightdash/common';
 import { fireEvent, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     useAppVersionHistory,
@@ -87,6 +88,41 @@ vi.mock('../features/chartTypes/hooks/useVizComposerAttachments', () => ({
 
 type AppMeta = ApiGetAppResponse['results'];
 
+const explorerChart = {
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: ['orders_status'],
+        metrics: ['orders_total'],
+        filters: {},
+        sorts: [{ fieldId: 'orders_total', descending: true }],
+        limit: 100,
+        tableCalculations: [],
+    },
+    chartConfig: {
+        type: ChartType.TABLE,
+        config: { showColumnCalculation: false },
+    },
+    tableConfig: { columnOrder: ['orders_status', 'orders_total'] },
+};
+
+const explorerSearch = () => {
+    const searchParams = new URLSearchParams({
+        create_saved_chart_version: JSON.stringify(explorerChart),
+        fromSpace: 'space-1',
+    });
+    return `?${searchParams.toString()}`;
+};
+
+const LocationDisplay = () => {
+    const location = useLocation();
+    return (
+        <div data-testid="location">
+            {`${location.pathname}${location.search}`}
+        </div>
+    );
+};
+
 const appMeta = (overrides: Partial<AppMeta> = {}): AppMeta =>
     ({
         appUuid: 'viz-1',
@@ -136,6 +172,7 @@ const setApp = (meta: AppMeta | null, error: unknown = null) =>
 
 const builderRoutes = (path: string) => (
     <MemoryRouter initialEntries={[path]}>
+        <LocationDisplay />
         <Routes>
             <Route
                 path="/projects/:projectUuid/chart-types/new"
@@ -157,12 +194,22 @@ const builderRoutes = (path: string) => (
                 path="/projects/:projectUuid/apps/:appUuid"
                 element={<div>app-builder</div>}
             />
+            <Route
+                path="/projects/:projectUuid/tables"
+                element={<div>table-picker</div>}
+            />
+            <Route
+                path="/projects/:projectUuid/tables/:tableId"
+                element={<div>explorer</div>}
+            />
         </Routes>
     </MemoryRouter>
 );
 
-const renderBuilder = (path: string) =>
-    renderWithProviders(builderRoutes(path));
+const renderBuilder = (path: string) => {
+    window.history.replaceState({}, '', path);
+    return renderWithProviders(builderRoutes(path));
+};
 
 const mockedClarificationRound = vi.mocked(
     useClarificationRound<VizBuildRequest>,
@@ -326,6 +373,123 @@ describe('ChartTypeBuilder', () => {
         expect(
             screen.getByText('“a stream graph of category share”'),
         ).toBeInTheDocument();
+    });
+
+    it('preserves Explorer search when the create route adopts the app', () => {
+        vi.mocked(useDataAppVizBuild).mockReturnValue(
+            buildStub({
+                isBuilding: true,
+                appUuid: '1e9a3b2c-0000-4000-8000-000000000009',
+                claimedVersion: 1,
+                pendingPrompt: 'a stream graph of category share',
+            }),
+        );
+        const search = explorerSearch();
+
+        renderBuilder(`/projects/p1/chart-types/new${search}`);
+
+        expect(screen.getByTestId('location')).toHaveTextContent(
+            `/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000009${search}`,
+        );
+    });
+
+    it('returns to the Explorer query with the freshly built chart type', () => {
+        const dataAppVizUuid = '1e9a3b2c-0000-4000-8000-000000000001';
+        setApp(appMeta({ appUuid: dataAppVizUuid }));
+        const search = explorerSearch();
+
+        renderBuilder(`/projects/p1/chart-types/${dataAppVizUuid}${search}`);
+
+        const backLink = screen.getByRole('link', { name: 'Explorer' });
+        const destination = new URL(
+            backLink.getAttribute('href') ?? '',
+            'http://lightdash.local',
+        );
+        expect(destination.pathname).toBe('/projects/p1/tables/orders');
+        expect(destination.searchParams.get('fromSpace')).toBe('space-1');
+        expect(
+            JSON.parse(
+                destination.searchParams.get('create_saved_chart_version') ??
+                    '',
+            ),
+        ).toEqual({
+            ...explorerChart,
+            chartConfig: {
+                type: ChartType.DATA_APP_VIZ,
+                config: {
+                    dataAppVizUuid,
+                    fieldMapping: {},
+                    optionValues: {},
+                },
+            },
+        });
+    });
+
+    it('previews the ready chart type with the existing Explorer query', () => {
+        const dataAppVizUuid = '1e9a3b2c-0000-4000-8000-000000000001';
+        setApp(appMeta({ appUuid: dataAppVizUuid }));
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub([appVersion({ version: 1 })], 1),
+        );
+        renderBuilder(
+            `/projects/p1/chart-types/${dataAppVizUuid}${explorerSearch()}`,
+        );
+
+        fireEvent.click(screen.getByText('Preview in explorer'));
+
+        const destination = new URL(
+            screen.getByTestId('location').textContent ?? '',
+            'http://lightdash.local',
+        );
+        expect(destination.pathname).toBe('/projects/p1/tables/orders');
+        expect(destination.searchParams.get('fromSpace')).toBe('space-1');
+        const previewChart = JSON.parse(
+            destination.searchParams.get('create_saved_chart_version') ?? '',
+        );
+        expect(previewChart).toEqual({
+            ...explorerChart,
+            chartConfig: {
+                type: ChartType.DATA_APP_VIZ,
+                config: {
+                    dataAppVizUuid,
+                    fieldMapping: {},
+                    optionValues: {},
+                },
+            },
+        });
+    });
+
+    it('previews a standalone chart type through the table picker', () => {
+        const dataAppVizUuid = '1e9a3b2c-0000-4000-8000-000000000001';
+        setApp(appMeta({ appUuid: dataAppVizUuid }));
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub([appVersion({ version: 1 })], 1),
+        );
+        renderBuilder(`/projects/p1/chart-types/${dataAppVizUuid}`);
+
+        expect(screen.getByRole('link', { name: 'Gallery' })).toHaveAttribute(
+            'href',
+            '/projects/p1/gallery',
+        );
+        fireEvent.click(screen.getByText('Preview in explorer'));
+
+        expect(screen.getByTestId('location')).toHaveTextContent(
+            `/projects/p1/tables?dataAppVizUuid=${dataAppVizUuid}`,
+        );
+        expect(screen.getByText('table-picker')).toBeInTheDocument();
+    });
+
+    it('treats malformed Explorer state as a standalone builder session', () => {
+        setApp(appMeta());
+
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001?create_saved_chart_version=not-json',
+        );
+
+        expect(screen.getByRole('link', { name: 'Gallery' })).toHaveAttribute(
+            'href',
+            '/projects/p1/gallery',
+        );
     });
 
     it('keeps a drafted follow-up when the create route adopts the app', () => {

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -1,4 +1,5 @@
 import {
+    ChartType,
     DATA_APP_VIZ_TEMPLATE,
     FeatureFlags,
     isAppVersionInProgress,
@@ -16,7 +17,13 @@ import {
     type FC,
 } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
-import { Link, Navigate, useNavigate, useParams } from 'react-router';
+import {
+    Link,
+    Navigate,
+    useLocation,
+    useNavigate,
+    useParams,
+} from 'react-router';
 import { validate as isUuidString } from 'uuid';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
@@ -47,6 +54,10 @@ import {
 } from '../features/chartTypes/hooks/useDataAppVizBuild';
 import { buildSampleVizContext } from '../features/chartTypes/utils/sampleVizContext';
 import { useResolvedColorPalette } from '../hooks/appearance/useResolvedColorPalette';
+import {
+    getExplorerUrlFromCreateSavedChartVersion,
+    parseChartFromExplorerSearchParams,
+} from '../hooks/useExplorerRoute';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import classes from './ChartTypeBuilder.module.css';
 
@@ -68,7 +79,16 @@ const ChartTypeBuilder: FC = () => {
         projectUuid: string;
         dataAppVizUuid?: string;
     }>();
+    const location = useLocation();
     const navigate = useNavigate();
+    const explorerChart = useMemo(() => {
+        try {
+            const chart = parseChartFromExplorerSearchParams(location.search);
+            return chart?.tableName ? chart : null;
+        } catch {
+            return null;
+        }
+    }, [location.search]);
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
     const canCreate = useCanCreateDataApp(projectUuid);
 
@@ -138,11 +158,14 @@ const ChartTypeBuilder: FC = () => {
     useEffect(() => {
         if (!urlVizUuid && build.appUuid && projectUuid) {
             void navigate(
-                `/projects/${projectUuid}/chart-types/${build.appUuid}`,
+                {
+                    pathname: `/projects/${projectUuid}/chart-types/${build.appUuid}`,
+                    search: location.search,
+                },
                 { replace: true },
             );
         }
-    }, [urlVizUuid, build.appUuid, projectUuid, navigate]);
+    }, [urlVizUuid, build.appUuid, projectUuid, location.search, navigate]);
 
     // Intentional navigation between vizs resets session state; the
     // post-submit `/new` → uuid replace must not.
@@ -276,6 +299,37 @@ const ChartTypeBuilder: FC = () => {
         (prompt: string) => promptBarRef.current?.setPrompt(prompt),
         [],
     );
+    const explorerDestination = useMemo(() => {
+        if (!explorerChart || !activeVizUuid) return null;
+
+        return getExplorerUrlFromCreateSavedChartVersion(
+            projectUuid,
+            {
+                ...explorerChart,
+                chartConfig: {
+                    type: ChartType.DATA_APP_VIZ,
+                    config: {
+                        dataAppVizUuid: activeVizUuid,
+                        fieldMapping: {},
+                        optionValues: {},
+                    },
+                },
+            },
+            false,
+        );
+    }, [activeVizUuid, explorerChart, projectUuid]);
+    const handlePreviewInExplorer = useCallback(() => {
+        if (!activeVizUuid) return;
+
+        if (explorerDestination) {
+            void navigate(explorerDestination);
+            return;
+        }
+
+        void navigate(
+            `/projects/${projectUuid}/tables?dataAppVizUuid=${activeVizUuid}`,
+        );
+    }, [activeVizUuid, explorerDestination, navigate, projectUuid]);
 
     const canEdit = useCanEditDataApp(projectUuid, {
         spaceUuid: appMeta?.spaceUuid ?? null,
@@ -375,12 +429,25 @@ const ChartTypeBuilder: FC = () => {
     // The composer captures its placeholder at mount, so wait for history
     // before choosing create vs revise wording.
     const isPromptBarMounted = !(activeVizUuid && history.isLoading);
+    const backLink = explorerChart
+        ? {
+              label: 'Explorer',
+              to: explorerDestination ?? {
+                  pathname: `/projects/${projectUuid}/tables/${explorerChart.tableName}`,
+                  search: location.search,
+              },
+          }
+        : {
+              label: 'Gallery',
+              to: `/projects/${projectUuid}/gallery`,
+          };
 
     return (
         <Box className={classes.root}>
             <DocumentTitle title="Chart type builder" />
             <ChartTypeBuilderHeader
                 projectUuid={projectUuid}
+                backLink={backLink}
                 app={appMeta}
                 latestReadyVersion={history.latestReadyVersion}
                 provenanceVersion={provenanceVersion}
@@ -392,11 +459,7 @@ const ChartTypeBuilder: FC = () => {
                         ? handleCloseHistory()
                         : setIsHistoryOpen(true)
                 }
-                onPreviewInExplorer={() =>
-                    void navigate(
-                        `/projects/${projectUuid}/tables?dataAppVizUuid=${activeVizUuid}`,
-                    )
-                }
+                onPreviewInExplorer={handlePreviewInExplorer}
             />
             <PanelGroup direction="horizontal" className={classes.main}>
                 <Panel id="chart-type-builder-canvas" order={1} minSize={50}>


### PR DESCRIPTION
### Description

- carry the active Explorer search string into chart type builder create and edit routes
- preserve it when the create route adopts its generated visualization UUID
- return Back to the parsed Explorer table while preserving the incoming search string exactly
- replace only the serialized chart configuration when previewing in Explorer
- retain Gallery and table-picker behavior for standalone or malformed-query sessions

This is layer 2 of 2 and depends on #27638.

### Tests

- 5 focused frontend test files, 68 tests
- `pnpm -F frontend typecheck`
- changed-file lint and formatting checks
