### PR TITLE
fix: support pivoted reusable custom charts

### DIFF
--- a/packages/common/src/ee/apps/sdkFeatures.ts
+++ b/packages/common/src/ee/apps/sdkFeatures.ts
@@ -95,6 +95,13 @@ export const SDK_FEATURES: SdkFeature[] = [
         wiring: 'Declare configOptions (and colorPalette, if the viz colours series) in the viz schema, then read options[name] and colorPalette from useVizContext().',
     },
     {
+        key: 'viz-pivoted-results',
+        label: 'Pivoted results',
+        description:
+            'Render reusable charts and tables from backend-pivoted rows and their complete layout metadata.',
+        wiring: 'When useVizContext().pivotDetails is non-null, use valuesColumns to resolve generated row keys and use indexColumn, groupByColumns, originalColumns, sortBy, totalColumnCount, and passthroughDimensions when the visualization needs their layout semantics. Keep the existing fieldMapping path when pivotDetails is null.',
+    },
+    {
         key: 'follow-host-theme',
         label: 'Follow the host light/dark mode',
         description:

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
+import { type ReadyQueryResultsPage } from '../../types/api';
 import { type ApiSuccess, type ApiSuccessEmpty } from '../../types/api/success';
 import {
     type DashboardConfig,
@@ -1121,5 +1122,6 @@ export type DataAppVizContext = {
     rows: ResultRow[];
     options: Record<string, DataAppVizOptionValue>;
     colorPalette: string[];
+    pivotDetails: ReadyQueryResultsPage['pivotDetails'];
     underlyingData: { enabled: boolean };
 };

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -82,6 +82,7 @@ export * from './dbt/validation';
 export * from './ee';
 export * from './preAggregates';
 export * from './pivot/derivePivotConfigFromChart';
+export * from './pivot/deriveDataAppVizPivotConfig';
 export * from './pivot/pivotConfig';
 export * from './pivot/pivotQueryResults';
 export * from './pivot/utils';

--- a/packages/common/src/pivot/deriveDataAppVizPivotConfig.test.ts
+++ b/packages/common/src/pivot/deriveDataAppVizPivotConfig.test.ts
@@ -1,0 +1,41 @@
+import type { DataAppVizField } from '../ee/apps/types';
+import { deriveDataAppVizPivotConfig } from './deriveDataAppVizPivotConfig';
+
+const fields: DataAppVizField[] = [
+    { name: 'category', label: 'Category', type: 'dimension', required: true },
+    { name: 'value', label: 'Value', type: 'metric', required: true },
+    { name: 'colour', label: 'Colour', type: 'series', required: true },
+    { name: 'facet', label: 'Facet', type: 'series', required: false },
+];
+
+describe('deriveDataAppVizPivotConfig', () => {
+    it('returns mapped series fields in declaration order', () => {
+        expect(
+            deriveDataAppVizPivotConfig(fields, {
+                category: 'orders_created_date',
+                value: 'orders_total',
+                colour: 'orders_status',
+                facet: 'orders_region',
+            }),
+        ).toEqual({ columns: ['orders_status', 'orders_region'] });
+    });
+
+    it('ignores unmapped series fields', () => {
+        expect(
+            deriveDataAppVizPivotConfig(fields, {
+                category: 'orders_created_date',
+                value: 'orders_total',
+                facet: 'orders_region',
+            }),
+        ).toEqual({ columns: ['orders_region'] });
+    });
+
+    it('returns undefined when the chart has no mapped series field', () => {
+        expect(
+            deriveDataAppVizPivotConfig(fields, {
+                category: 'orders_created_date',
+                value: 'orders_total',
+            }),
+        ).toBeUndefined();
+    });
+});

--- a/packages/common/src/pivot/deriveDataAppVizPivotConfig.ts
+++ b/packages/common/src/pivot/deriveDataAppVizPivotConfig.ts
@@ -1,0 +1,27 @@
+import type { DataAppVizField } from '../ee/apps/types';
+import type { DataAppVizFieldMapping, SavedChart } from '../types/savedCharts';
+
+/**
+ * Converts a reusable custom chart's semantic field contract into the
+ * lightweight pivot state persisted with a chart. Keeping this pure makes the
+ * integration removable from callers without coupling schema knowledge to
+ * Explorer state updates.
+ */
+export const deriveDataAppVizPivotConfig = (
+    fields: DataAppVizField[],
+    fieldMapping: DataAppVizFieldMapping,
+): SavedChart['pivotConfig'] => {
+    const columns = fields.reduce<string[]>((mappedSeries, field) => {
+        const fieldId = fieldMapping[field.name];
+        if (
+            field.type === 'series' &&
+            fieldId &&
+            !mappedSeries.includes(fieldId)
+        ) {
+            mappedSeries.push(fieldId);
+        }
+        return mappedSeries;
+    }, []);
+
+    return columns.length > 0 ? { columns } : undefined;
+};

--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -12,6 +12,7 @@ import type { MetricQuery } from '../types/metricQuery';
 import {
     ChartType,
     type CartesianChartConfig,
+    type DataAppVizChart,
     type SavedChartDAO,
 } from '../types/savedCharts';
 import {
@@ -20,7 +21,10 @@ import {
     VizIndexType,
 } from '../visualizations/types';
 // Jest provides describe/it/expect globals
-import { derivePivotConfigurationFromChart } from './derivePivotConfigFromChart';
+import {
+    deriveDataAppVizPivotConfiguration,
+    derivePivotConfigurationFromChart,
+} from './derivePivotConfigFromChart';
 import {
     mockCartesianChartConfig,
     mockItems,
@@ -29,6 +33,130 @@ import {
 } from './derivePivotConfigFromChart.mock';
 
 describe('derivePivotConfigurationFromChart', () => {
+    describe('data app visualizations', () => {
+        const dataAppVizConfig: DataAppVizChart = {
+            dataAppVizUuid: 'viz-uuid',
+            fieldMapping: {
+                category: 'payments_payment_method',
+                value: 'payments_total_revenue',
+                series: 'orders_status',
+            },
+        };
+        const savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'> = {
+            chartConfig: {
+                type: ChartType.DATA_APP_VIZ,
+                config: dataAppVizConfig,
+            },
+            pivotConfig: { columns: ['orders_status'] },
+        };
+
+        it('delegates to the standalone data app pivot derivation', () => {
+            const expected = deriveDataAppVizPivotConfiguration(
+                dataAppVizConfig.fieldMapping,
+                savedChart.pivotConfig,
+                mockMetricQuery,
+                mockItems,
+            );
+
+            expect(
+                derivePivotConfigurationFromChart(
+                    savedChart,
+                    mockMetricQuery,
+                    mockItems,
+                ),
+            ).toEqual(expected);
+        });
+
+        it('derives mapped series, value, and index columns', () => {
+            expect(
+                deriveDataAppVizPivotConfiguration(
+                    dataAppVizConfig.fieldMapping,
+                    savedChart.pivotConfig,
+                    mockMetricQuery,
+                    mockItems,
+                ),
+            ).toEqual({
+                indexColumn: [
+                    {
+                        reference: 'payments_payment_method',
+                        type: VizIndexType.CATEGORY,
+                    },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'payments_total_revenue',
+                        aggregation: VizAggregationOptions.ANY,
+                    },
+                ],
+                groupByColumns: [{ reference: 'orders_status' }],
+                sortBy: [
+                    {
+                        reference: 'payments_payment_method',
+                        direction: SortByDirection.ASC,
+                    },
+                ],
+            });
+        });
+
+        it('stays unpivoted without persisted series columns', () => {
+            expect(
+                deriveDataAppVizPivotConfiguration(
+                    dataAppVizConfig.fieldMapping,
+                    undefined,
+                    mockMetricQuery,
+                    mockItems,
+                ),
+            ).toBeUndefined();
+        });
+
+        it('ignores a stale pivot column that is no longer mapped', () => {
+            expect(
+                deriveDataAppVizPivotConfiguration(
+                    {
+                        category: 'payments_payment_method',
+                        value: 'payments_total_revenue',
+                    },
+                    savedChart.pivotConfig,
+                    mockMetricQuery,
+                    mockItems,
+                ),
+            ).toBeUndefined();
+        });
+
+        it('uses a mapped table calculation as a value column', () => {
+            const tableCalculation: TableCalculation = {
+                name: 'revenue_per_order',
+                displayName: 'Revenue per order',
+                sql: '${payments_total_revenue} / ${orders_count}',
+            };
+            const chartConfig = {
+                dataAppVizUuid: 'viz-uuid',
+                fieldMapping: {
+                    category: 'payments_payment_method',
+                    value: tableCalculation.name,
+                    series: 'orders_status',
+                },
+            };
+
+            expect(
+                deriveDataAppVizPivotConfiguration(
+                    chartConfig.fieldMapping,
+                    savedChart.pivotConfig,
+                    {
+                        ...mockMetricQuery,
+                        tableCalculations: [tableCalculation],
+                    },
+                    mockItems,
+                )?.valuesColumns,
+            ).toEqual([
+                {
+                    reference: tableCalculation.name,
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ]);
+        });
+    });
+
     it('derives pivot configuration for Cartesian charts with pivot config', () => {
         const savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'> = {
             chartConfig: mockCartesianChartConfig,

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -18,6 +18,8 @@ import {
     ChartType,
     getHiddenTableFields,
     isCartesianChartConfig,
+    type DataAppVizFieldMapping,
+    type SavedChart,
     type SavedChartDAO,
 } from '../types/savedCharts';
 import assertUnreachable from '../utils/assertUnreachable';
@@ -495,6 +497,60 @@ function isValid(pivotConfiguration: PivotConfiguration): boolean {
     return true;
 }
 
+/**
+ * Derives the backend pivot shape for a reusable custom chart from its
+ * persisted field bindings and lightweight series columns. This function is
+ * intentionally standalone so DATA_APP_VIZ support remains a removable
+ * delegation from the chart-type dispatcher.
+ */
+export function deriveDataAppVizPivotConfiguration(
+    fieldMapping: DataAppVizFieldMapping | undefined,
+    pivotConfig: SavedChart['pivotConfig'],
+    metricQuery: MetricQuery,
+    fields: ItemsMap,
+): PivotConfiguration | undefined {
+    if (!fieldMapping || !pivotConfig?.columns.length) {
+        return undefined;
+    }
+
+    const mappedFieldIds = new Set(Object.values(fieldMapping));
+    const groupByColumns = pivotConfig.columns
+        .filter(
+            (fieldId) =>
+                mappedFieldIds.has(fieldId) &&
+                metricQuery.dimensions.includes(fieldId),
+        )
+        .map((reference) => ({ reference }));
+    const valuesColumns = [
+        ...metricQuery.metrics,
+        ...(metricQuery.tableCalculations ?? []).map(({ name }) => name),
+    ]
+        .filter((fieldId) => mappedFieldIds.has(fieldId))
+        .map((reference) => ({
+            reference,
+            aggregation: VizAggregationOptions.ANY,
+        }));
+    const indexColumn = getIndexColumn(
+        groupByColumns,
+        valuesColumns,
+        fields,
+        metricQuery,
+    );
+    const partialPivotConfiguration: Omit<PivotConfiguration, 'sortBy'> = {
+        indexColumn,
+        valuesColumns,
+        groupByColumns,
+    };
+    const pivotConfiguration: PivotConfiguration = {
+        ...partialPivotConfiguration,
+        sortBy: getSortByForPivotConfiguration(
+            partialPivotConfiguration,
+            metricQuery,
+        ),
+    };
+
+    return isValid(pivotConfiguration) ? pivotConfiguration : undefined;
+}
 export function derivePivotConfigurationFromChart(
     savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>,
     metricQuery: MetricQuery,
@@ -527,8 +583,15 @@ export function derivePivotConfigurationFromChart(
         case ChartType.BIG_NUMBER:
         case ChartType.MAP:
         case ChartType.SANKEY:
-        case ChartType.DATA_APP_VIZ:
             newConfig = undefined;
+            break;
+        case ChartType.DATA_APP_VIZ:
+            newConfig = deriveDataAppVizPivotConfiguration(
+                chartConfig.config?.fieldMapping,
+                savedChart.pivotConfig,
+                metricQuery,
+                fields,
+            );
             break;
         default:
             return assertUnreachable(type, `Unknown chart type ${type}`);

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -391,7 +391,10 @@ describe('DataAppVizRenderer underlying-data gating', () => {
         (
             mocks.iframePreview.mock.calls.at(-1) as unknown[] | undefined
         )?.[0] as {
-            dataAppVizContext?: { underlyingData: { enabled: boolean } };
+            dataAppVizContext?: {
+                pivotDetails: unknown;
+                underlyingData: { enabled: boolean };
+            };
             rewriteVizUnderlyingDataRequest?: (intent: unknown) => unknown;
         };
 
@@ -416,6 +419,26 @@ describe('DataAppVizRenderer underlying-data gating', () => {
             enabled: true,
         });
         expect(props.rewriteVizUnderlyingDataRequest).toBeTypeOf('function');
+    });
+
+    it('forwards pivot metadata and disables underlying data for pivoted rows', () => {
+        const pivotDetails = {
+            indexColumn: [],
+            valuesColumns: [],
+            groupByColumns: [{ reference: 'orders_status' }],
+        };
+        mocks.vizContextOverrides.current = {
+            resultsData: { ...happyResultsData(), pivotDetails },
+        };
+
+        renderRenderer();
+
+        const props = lastIframeProps();
+        expect(props.dataAppVizContext?.pivotDetails).toBe(pivotDetails);
+        expect(props.dataAppVizContext?.underlyingData).toEqual({
+            enabled: false,
+        });
+        expect(props.rewriteVizUnderlyingDataRequest).toBeUndefined();
     });
 
     it.each([

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -92,6 +92,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     const fieldMapping = config?.fieldMapping;
     const optionValues = config?.optionValues;
     const rows = resultsData?.rows;
+    const pivotDetails = resultsData?.pivotDetails ?? null;
 
     const chartVersionUuid = useChartVersionPreview();
     const renderTarget = useMemo(
@@ -128,7 +129,8 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         canViewUnderlyingData &&
         !hasCustomBinDimension(metricQuery) &&
         !embedToken &&
-        !minimal;
+        !minimal &&
+        !pivotDetails;
 
     const { data: explore } = useExplore(metricQuery?.exploreName, {
         refetchOnMount: false,
@@ -209,6 +211,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
             // Already resolved through the full palette cascade and dark-mode
             // corrected by the visualization context.
             colorPalette,
+            pivotDetails,
             underlyingData: { enabled: underlyingDataEnabled },
         };
     }, [
@@ -217,6 +220,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         configOptions,
         optionValues,
         colorPalette,
+        pivotDetails,
         underlyingDataEnabled,
     ]);
 

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.test.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.test.ts
@@ -1,0 +1,127 @@
+import {
+    ChartType,
+    DimensionType,
+    FieldType,
+    MetricType,
+    type DataAppViz,
+    type ItemsMap,
+} from '@lightdash/common';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSelectProjectChartType } from './useSelectProjectChartType';
+
+const { dispatch } = vi.hoisted(() => ({ dispatch: vi.fn() }));
+
+vi.mock('../../../features/explorer/store', () => ({
+    useExplorerDispatch: () => dispatch,
+    explorerActions: {
+        setChartType: (payload: unknown) => ({ type: 'setChartType', payload }),
+        setChartConfig: (payload: unknown) => ({
+            type: 'setChartConfig',
+            payload,
+        }),
+        setPivotConfig: (payload: unknown) => ({
+            type: 'setPivotConfig',
+            payload,
+        }),
+    },
+}));
+
+const itemsMap = {
+    orders_status: {
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.STRING,
+        name: 'status',
+        label: 'Status',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.status',
+        hidden: false,
+    },
+    orders_region: {
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.STRING,
+        name: 'region',
+        label: 'Region',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.region',
+        hidden: false,
+    },
+    orders_count: {
+        fieldType: FieldType.METRIC,
+        type: MetricType.COUNT,
+        name: 'count',
+        label: 'Count',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.id',
+        hidden: false,
+    },
+} satisfies ItemsMap;
+
+const dataAppViz = {
+    dataAppVizUuid: 'viz-uuid',
+    name: 'Grouped bars',
+    description: 'Groups a metric by a series dimension',
+    projectUuid: 'project-uuid',
+    spaceUuid: null,
+    schema: {
+        fields: [
+            {
+                name: 'category',
+                label: 'Category',
+                type: 'dimension',
+                required: true,
+            },
+            {
+                name: 'value',
+                label: 'Value',
+                type: 'metric',
+                required: true,
+            },
+            {
+                name: 'series',
+                label: 'Series',
+                type: 'series',
+                required: true,
+            },
+        ],
+        configOptions: [],
+        colorPalette: null,
+    },
+    createdAt: new Date('2026-08-19T00:00:00Z'),
+    createdByUserUuid: 'user-uuid',
+} satisfies DataAppViz;
+
+describe('useSelectProjectChartType', () => {
+    beforeEach(() => dispatch.mockClear());
+
+    it('stores mapped series fields in the chart pivot config', () => {
+        const { result } = renderHook(() => useSelectProjectChartType());
+
+        act(() => result.current(dataAppViz, itemsMap));
+
+        expect(dispatch).toHaveBeenLastCalledWith({
+            type: 'setPivotConfig',
+            payload: { columns: ['orders_region'] },
+        });
+        expect(dispatch.mock.calls[1][0]).toEqual({
+            type: 'setChartConfig',
+            payload: {
+                chartConfig: {
+                    type: ChartType.DATA_APP_VIZ,
+                    config: {
+                        dataAppVizUuid: 'viz-uuid',
+                        fieldMapping: {
+                            category: 'orders_status',
+                            value: 'orders_count',
+                            series: 'orders_region',
+                        },
+                        optionValues: {},
+                    },
+                },
+            },
+        });
+    });
+});

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.ts
@@ -1,4 +1,9 @@
-import { ChartType, type DataAppViz, type ItemsMap } from '@lightdash/common';
+import {
+    ChartType,
+    deriveDataAppVizPivotConfig,
+    type DataAppViz,
+    type ItemsMap,
+} from '@lightdash/common';
 import { useCallback } from 'react';
 import { autoMapDataAppVizFields } from '../../../features/chartTypes/utils/autoMapDataAppVizFields';
 import {
@@ -20,6 +25,8 @@ export const useSelectProjectChartType = () => {
 
     return useCallback(
         (dataAppViz: DataAppViz, itemsMap: ItemsMap) => {
+            const fields = dataAppViz.schema?.fields ?? [];
+            const fieldMapping = autoMapDataAppVizFields(fields, itemsMap);
             dispatch(
                 explorerActions.setChartType({
                     chartType: ChartType.DATA_APP_VIZ,
@@ -31,14 +38,16 @@ export const useSelectProjectChartType = () => {
                         type: ChartType.DATA_APP_VIZ,
                         config: {
                             dataAppVizUuid: dataAppViz.dataAppVizUuid,
-                            fieldMapping: autoMapDataAppVizFields(
-                                dataAppViz.schema?.fields ?? [],
-                                itemsMap,
-                            ),
+                            fieldMapping,
                             optionValues: {},
                         },
                     },
                 }),
+            );
+            dispatch(
+                explorerActions.setPivotConfig(
+                    deriveDataAppVizPivotConfig(fields, fieldMapping),
+                ),
             );
         },
         [dispatch],
@@ -70,5 +79,6 @@ export const useCreateProjectChartType = () => {
                 },
             }),
         );
+        dispatch(explorerActions.setPivotConfig(undefined));
     }, [dispatch]);
 };

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -31,10 +31,21 @@ type PickerProps = {
     onSelectProjectType: (dataAppViz: DataAppViz) => void;
 };
 
-const { fieldSelectItems, pickerProps } = vi.hoisted(() => ({
-    fieldSelectItems: [] as Item[][],
-    pickerProps: [] as PickerProps[],
-}));
+type FieldSelectProps = {
+    items: Item[];
+    onChange: (item: Item | null) => void;
+};
+
+const { fieldSelectItems, fieldSelectProps, pickerProps } = vi.hoisted(() => {
+    const fieldSelectItems: Item[][] = [];
+    const fieldSelectProps: FieldSelectProps[] = [];
+    const pickerProps: PickerProps[] = [];
+    return {
+        fieldSelectItems,
+        fieldSelectProps,
+        pickerProps,
+    };
+});
 
 vi.mock('../CustomChartType/CustomChartTypePicker', () => ({
     default: (props: PickerProps) => {
@@ -58,8 +69,9 @@ vi.mock('react-router', async (importOriginal) => ({
     ),
 }));
 vi.mock('../../common/FieldSelect', () => ({
-    default: ({ items }: { items: Item[] }) => {
-        fieldSelectItems.push(items);
+    default: (props: FieldSelectProps) => {
+        fieldSelectItems.push(props.items);
+        fieldSelectProps.push(props);
         return <div data-testid="field-select" />;
     },
 }));
@@ -186,22 +198,26 @@ const queryColumns: ItemsMap = {
 describe('DataAppVizConfigTabs', () => {
     const setOption = vi.fn();
     const setDataAppVizUuid = vi.fn();
+    const setField = vi.fn();
+    const setPivotDimensions = vi.fn();
 
     const mockContext = (
         itemsMap: ItemsMap,
         dataAppVizUuid: string = 'data-app-viz-uuid',
         optionValues: Record<string, boolean | number | string> = {},
+        fieldMapping: Record<string, string> = {},
     ) =>
         vi.mocked(useVisualizationContext).mockReturnValue({
             itemsMap,
+            setPivotDimensions,
             visualizationConfig: {
                 chartType: ChartType.DATA_APP_VIZ,
                 chartConfig: {
                     dataAppVizUuid,
-                    fieldMapping: {},
+                    fieldMapping,
                     optionValues,
                     setDataAppVizUuid,
-                    setField: vi.fn(),
+                    setField,
                     setOption,
                 },
             },
@@ -209,9 +225,12 @@ describe('DataAppVizConfigTabs', () => {
 
     beforeEach(() => {
         fieldSelectItems.length = 0;
+        fieldSelectProps.length = 0;
         pickerProps.length = 0;
         setOption.mockClear();
         setDataAppVizUuid.mockClear();
+        setField.mockClear();
+        setPivotDimensions.mockClear();
         defaultAbility.update([]);
         mockSchema([]);
         mockContext(queryColumns);
@@ -313,6 +332,41 @@ describe('DataAppVizConfigTabs', () => {
             value: 'orders_visible_metric',
             breakdown: 'custom-dimension',
         });
+        expect(setPivotDimensions).toHaveBeenCalledWith(['custom-dimension']);
+    });
+
+    it('updates pivot dimensions when a series mapping changes', () => {
+        const fields: DataAppVizField[] = [
+            ...declaredFields,
+            {
+                name: 'breakdown',
+                label: 'Breakdown',
+                type: 'series',
+                required: false,
+            },
+        ];
+        mockSchema([], null, {
+            schema: { fields, configOptions: [], colorPalette: null },
+        });
+        mockContext(
+            queryColumns,
+            'data-app-viz-uuid',
+            {},
+            {
+                source: 'orders_visible',
+                value: 'orders_visible_metric',
+            },
+        );
+        renderWithProviders(<ConfigTabs />);
+
+        act(() =>
+            fieldSelectProps[fieldSelectProps.length - 1].onChange(
+                customDimension,
+            ),
+        );
+
+        expect(setField).toHaveBeenCalledWith('breakdown', 'custom-dimension');
+        expect(setPivotDimensions).toHaveBeenCalledWith(['custom-dimension']);
     });
 
     it('will not offer the picker before the query has columns', () => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -1,5 +1,6 @@
 import {
     ChartType,
+    deriveDataAppVizPivotConfig,
     getAppDisplayName,
     getEffectiveOptionValues,
     type ItemsMap,
@@ -30,7 +31,7 @@ const NO_COLUMNS: ItemsMap = {};
 export const ConfigTabs: FC = memo(() => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const navigate = useNavigate();
-    const { visualizationConfig, itemsMap, setChartType } =
+    const { visualizationConfig, itemsMap, setChartType, setPivotDimensions } =
         useVisualizationContext();
 
     const isDataAppViz = isDataAppVizVisualizationConfig(visualizationConfig);
@@ -93,6 +94,23 @@ export const ConfigTabs: FC = memo(() => {
         fieldMapping,
     );
 
+    const setMappingPivotDimensions = (
+        nextFields: typeof fields,
+        nextMapping: typeof effectiveMapping,
+    ) =>
+        setPivotDimensions(
+            deriveDataAppVizPivotConfig(nextFields, nextMapping)?.columns,
+        );
+
+    const handleFieldChange = (fieldName: string, fieldId: string | null) => {
+        const nextMapping = { ...effectiveMapping };
+        if (fieldId) nextMapping[fieldName] = fieldId;
+        else delete nextMapping[fieldName];
+
+        setField(fieldName, fieldId);
+        setMappingPivotDimensions(fields, nextMapping);
+    };
+
     const selectedOption: CustomChartTypeOption | null = dataAppVizUuid
         ? { kind: 'projectType', dataAppVizUuid }
         : null;
@@ -104,7 +122,7 @@ export const ConfigTabs: FC = memo(() => {
                 itemsMap={itemsMap ?? NO_COLUMNS}
                 fields={fields}
                 fieldMapping={effectiveMapping}
-                onFieldChange={setField}
+                onFieldChange={handleFieldChange}
             />
             {dataAppViz && (
                 <Box className={classes.typeCard}>
@@ -143,16 +161,19 @@ export const ConfigTabs: FC = memo(() => {
                     selectedDataAppViz={dataAppViz ?? null}
                     hasColumns={hasColumns}
                     onSelectVega={() => setChartType(ChartType.CUSTOM)}
-                    onSelectProjectType={(picked) =>
-                        setDataAppVizUuid(
-                            picked.dataAppVizUuid,
-                            autoMapDataAppVizFields(
-                                picked.schema?.fields ?? [],
-                                itemsMap ?? NO_COLUMNS,
-                            ),
-                        )
-                    }
-                    onClear={() => setDataAppVizUuid('', {})}
+                    onSelectProjectType={(picked) => {
+                        const pickedFields = picked.schema?.fields ?? [];
+                        const pickedMapping = autoMapDataAppVizFields(
+                            pickedFields,
+                            itemsMap ?? NO_COLUMNS,
+                        );
+                        setDataAppVizUuid(picked.dataAppVizUuid, pickedMapping);
+                        setMappingPivotDimensions(pickedFields, pickedMapping);
+                    }}
+                    onClear={() => {
+                        setDataAppVizUuid('', {});
+                        setPivotDimensions(undefined);
+                    }}
                     onCreateNew={
                         canCreateApp
                             ? () =>

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -1179,6 +1179,7 @@ describe('data-app-viz-context push', () => {
         ],
         options: { showLegend: true, barColor: '#ff0000' },
         colorPalette: ['#7162FF', '#1A1B1E'],
+        pivotDetails: null,
         underlyingData: { enabled: false },
     };
 
@@ -1209,6 +1210,7 @@ describe('data-app-viz-context push', () => {
                 rows: dataAppVizContext.rows,
                 options: dataAppVizContext.options,
                 colorPalette: dataAppVizContext.colorPalette,
+                pivotDetails: null,
             }),
             '*',
         );

--- a/packages/frontend/src/features/chartTypes/components/DataAppVizTestPanel.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/DataAppVizTestPanel.test.tsx
@@ -18,9 +18,15 @@ import { renderWithProviders } from '../../../testing/testUtils';
 import DataAppVizTestPanel from './DataAppVizTestPanel';
 import { buildTestMetricQuery, isMappingComplete } from './dataAppVizTestQuery';
 
-const { fieldSelectItems } = vi.hoisted(() => ({
-    fieldSelectItems: [] as Item[][],
-}));
+const { fieldSelectItems, exploreByProjectMock, queryExecutorMock } =
+    vi.hoisted(() => {
+        const fieldSelectItems: Item[][] = [];
+        return {
+            fieldSelectItems,
+            exploreByProjectMock: vi.fn(),
+            queryExecutorMock: vi.fn(),
+        };
+    });
 
 vi.mock('../../../components/common/FieldSelect', () => ({
     default: ({
@@ -67,10 +73,10 @@ vi.mock('../../../hooks/useExplores', () => ({
     useExplores: vi.fn(),
 }));
 vi.mock('../../../hooks/useExplore', () => ({
-    useExploreByProjectUuid: vi.fn(),
+    useExploreByProjectUuid: exploreByProjectMock,
 }));
 vi.mock('../../../providers/Explorer/useQueryExecutor', () => ({
-    useQueryExecutor: vi.fn(),
+    useQueryExecutor: queryExecutorMock,
 }));
 
 import { useColorPalettes } from '../../../hooks/appearance/useOrganizationAppearance';
@@ -269,9 +275,9 @@ describe('DataAppVizTestPanel', () => {
 
     const runSuccessfulPreviewQuery = async () => {
         const user = userEvent.setup();
-        vi.mocked(useExploreByProjectUuid).mockReturnValue({
+        exploreByProjectMock.mockReturnValue({
             data: exploreWithHiddenFields,
-        } as unknown as ReturnType<typeof useExploreByProjectUuid>);
+        });
         vi.mocked(useQueryExecutor).mockReturnValue([
             {
                 query: {
@@ -368,6 +374,7 @@ describe('DataAppVizTestPanel', () => {
                 rows: resultRows,
                 options: { showLegend: true },
                 colorPalette: ['#111111'],
+                pivotDetails: null,
                 underlyingData: { enabled: false },
             }),
         );
@@ -381,6 +388,7 @@ describe('DataAppVizTestPanel', () => {
                 rows: resultRows,
                 options: { showLegend: false },
                 colorPalette: ['#111111'],
+                pivotDetails: null,
                 underlyingData: { enabled: false },
             }),
         );
@@ -403,6 +411,7 @@ describe('DataAppVizTestPanel', () => {
                 rows: resultRows,
                 options: { showLegend: true },
                 colorPalette: ['#111111'],
+                pivotDetails: null,
                 underlyingData: { enabled: false },
             }),
         );
@@ -416,6 +425,7 @@ describe('DataAppVizTestPanel', () => {
                 rows: resultRows,
                 options: { showLegend: true },
                 colorPalette: ['#123456', '#abcdef'],
+                pivotDetails: null,
                 underlyingData: { enabled: false },
             }),
         );
@@ -459,5 +469,125 @@ describe('DataAppVizTestPanel', () => {
             ['orders_visible'],
             ['orders_visible_metric'],
         ]);
+    });
+
+    it('sends mapped series fields through the shared pivot derivation', async () => {
+        const user = userEvent.setup();
+        exploreByProjectMock.mockReturnValue({
+            data: exploreWithHiddenFields,
+        });
+
+        renderWithProviders(
+            <DataAppVizTestPanel
+                projectUuid="p1"
+                schema={{
+                    ...schema,
+                    fields: schema.fields.map((field) => ({
+                        ...field,
+                        required: true,
+                    })),
+                }}
+                onContextChange={vi.fn()}
+            />,
+        );
+
+        await user.click(screen.getByPlaceholderText('Select an explore'));
+        await user.click(await screen.findByText('Orders'));
+        await user.click(screen.getByRole('button', { name: 'Select source' }));
+        await user.click(screen.getByRole('button', { name: 'Select target' }));
+        await user.click(screen.getByRole('button', { name: 'Select value' }));
+        await user.click(
+            screen.getByRole('button', { name: /run test query/i }),
+        );
+
+        expect(useQueryExecutor).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                pivotConfiguration: {
+                    indexColumn: [],
+                    valuesColumns: [
+                        {
+                            reference: 'orders_visible_metric',
+                            aggregation: 'any',
+                        },
+                    ],
+                    groupByColumns: [{ reference: 'orders_visible' }],
+                    sortBy: undefined,
+                },
+            }),
+            [],
+            true,
+        );
+    });
+
+    it('pushes returned pivot metadata into the builder iframe context', async () => {
+        const user = userEvent.setup();
+        const pivotDetails = {
+            indexColumn: [],
+            valuesColumns: [
+                {
+                    referenceField: 'orders_visible_metric',
+                    pivotColumnName: 'orders_visible_metric__visible_retail',
+                    aggregation: 'any',
+                    pivotValues: [
+                        {
+                            referenceField: 'orders_visible',
+                            value: 'Retail',
+                            formatted: 'Retail',
+                        },
+                    ],
+                },
+            ],
+            groupByColumns: [{ reference: 'orders_visible' }],
+        };
+        exploreByProjectMock.mockReturnValue({
+            data: exploreWithHiddenFields,
+        });
+        queryExecutorMock.mockReturnValue([
+            {
+                query: {
+                    data: { queryUuid: 'query-1' },
+                    isFetching: false,
+                    error: null,
+                },
+                queryResults: {
+                    rows: resultRows,
+                    queryUuid: 'query-1',
+                    pivotDetails,
+                    isFetchingFirstPage: false,
+                    error: null,
+                },
+            },
+            vi.fn(),
+        ]);
+        const onContextChange = vi.fn();
+
+        renderWithProviders(
+            <DataAppVizTestPanel
+                projectUuid="p1"
+                schema={{
+                    ...schema,
+                    fields: schema.fields.map((field) => ({
+                        ...field,
+                        required: true,
+                    })),
+                }}
+                onContextChange={onContextChange}
+            />,
+        );
+
+        await user.click(screen.getByPlaceholderText('Select an explore'));
+        await user.click(await screen.findByText('Orders'));
+        await user.click(screen.getByRole('button', { name: 'Select source' }));
+        await user.click(screen.getByRole('button', { name: 'Select target' }));
+        await user.click(screen.getByRole('button', { name: 'Select value' }));
+        await user.click(
+            screen.getByRole('button', { name: /run test query/i }),
+        );
+
+        await waitFor(() =>
+            expect(onContextChange).toHaveBeenLastCalledWith(
+                expect.objectContaining({ pivotDetails }),
+            ),
+        );
     });
 });

--- a/packages/frontend/src/features/chartTypes/hooks/useDataAppVizTestContext.ts
+++ b/packages/frontend/src/features/chartTypes/hooks/useDataAppVizTestContext.ts
@@ -1,4 +1,6 @@
 import {
+    deriveDataAppVizPivotConfig,
+    deriveDataAppVizPivotConfiguration,
     ECHARTS_DEFAULT_COLORS,
     getEffectiveOptionValues,
     getItemMap,
@@ -138,6 +140,7 @@ export const useDataAppVizTestContext = ({
                 rows,
                 options: effectiveOptions,
                 colorPalette,
+                pivotDetails: queryResults.pivotDetails ?? null,
                 underlyingData: { enabled: false },
             });
         }
@@ -146,6 +149,7 @@ export const useDataAppVizTestContext = ({
         run,
         runQueryUuid,
         queryResults.queryUuid,
+        queryResults.pivotDetails,
         effectiveOptions,
         colorPalette,
         onContextChange,
@@ -189,16 +193,31 @@ export const useDataAppVizTestContext = ({
 
     const handleRun = useCallback(() => {
         if (!exploreName || !isMappingComplete(schema, fieldMapping)) return;
+        const metricQuery = buildTestMetricQuery(
+            exploreName,
+            schema,
+            fieldMapping,
+        );
+        const pivotConfig = deriveDataAppVizPivotConfig(
+            schema.fields,
+            fieldMapping,
+        );
         setRun({
             args: {
                 projectUuid,
                 tableId: exploreName,
-                query: buildTestMetricQuery(exploreName, schema, fieldMapping),
+                query: metricQuery,
                 context: QueryExecutionContext.DATA_APP_SAMPLE,
+                pivotConfiguration: deriveDataAppVizPivotConfiguration(
+                    fieldMapping,
+                    pivotConfig,
+                    metricQuery,
+                    itemsMap,
+                ),
             },
             mapping: fieldMapping,
         });
-    }, [exploreName, schema, fieldMapping, projectUuid]);
+    }, [exploreName, schema, fieldMapping, projectUuid, itemsMap]);
 
     const exploreOptions = useMemo(
         () =>

--- a/packages/frontend/src/features/chartTypes/utils/sampleVizContext.ts
+++ b/packages/frontend/src/features/chartTypes/utils/sampleVizContext.ts
@@ -79,6 +79,7 @@ export const buildSampleVizContext = (
         rows,
         options: getEffectiveOptionValues(schema.configOptions, optionValues),
         colorPalette,
+        pivotDetails: null,
         // Sample rows come from no query — there is nothing to drill into.
         underlyingData: { enabled: false },
     };

--- a/packages/frontend/src/hooks/explorer/buildQueryArgs.test.ts
+++ b/packages/frontend/src/hooks/explorer/buildQueryArgs.test.ts
@@ -1,0 +1,113 @@
+import {
+    ChartType,
+    SupportedDbtAdapter,
+    VizAggregationOptions,
+    VizIndexType,
+    type Explore,
+    type ItemsMap,
+    type MetricQuery,
+    type PivotConfiguration,
+    type SavedChartDAO,
+} from '@lightdash/common';
+import type * as LightdashCommon from '@lightdash/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    derivePivotConfigurationFromChart: vi.fn(),
+    getFieldsFromMetricQuery: vi.fn(),
+}));
+
+vi.mock('@lightdash/common', async (importOriginal) => ({
+    ...(await importOriginal<typeof LightdashCommon>()),
+    derivePivotConfigurationFromChart: mocks.derivePivotConfigurationFromChart,
+    getFieldsFromMetricQuery: mocks.getFieldsFromMetricQuery,
+}));
+
+import { buildQueryArgs } from './buildQueryArgs';
+
+const metricQuery: MetricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_created_date', 'orders_status'],
+    metrics: ['orders_total'],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'> = {
+    chartConfig: {
+        type: ChartType.DATA_APP_VIZ,
+        config: {
+            dataAppVizUuid: 'viz-uuid',
+            fieldMapping: {
+                category: 'orders_created_date',
+                value: 'orders_total',
+                series: 'orders_status',
+            },
+        },
+    },
+    pivotConfig: { columns: ['orders_status'] },
+};
+
+const pivotConfiguration: PivotConfiguration = {
+    indexColumn: [
+        { reference: 'orders_created_date', type: VizIndexType.TIME },
+    ],
+    valuesColumns: [
+        {
+            reference: 'orders_total',
+            aggregation: VizAggregationOptions.ANY,
+        },
+    ],
+    groupByColumns: [{ reference: 'orders_status' }],
+    sortBy: undefined,
+};
+
+const itemsMap: ItemsMap = {};
+const explore: Explore = {
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    baseTable: 'orders',
+    joinedTables: [],
+    tables: {},
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+};
+
+describe('buildQueryArgs', () => {
+    beforeEach(() => {
+        mocks.getFieldsFromMetricQuery.mockReturnValue(itemsMap);
+        mocks.derivePivotConfigurationFromChart.mockReturnValue(
+            pivotConfiguration,
+        );
+    });
+
+    it('passes the reusable chart pivot through the v2 metric-query args', () => {
+        const result = buildQueryArgs({
+            activeFields: new Set(['orders_created_date']),
+            tableName: 'orders',
+            projectUuid: 'project-uuid',
+            explore,
+            computedMetricQuery: metricQuery,
+            parameters: undefined,
+            isEditMode: true,
+            minimal: false,
+            savedChart,
+        });
+
+        expect(mocks.derivePivotConfigurationFromChart).toHaveBeenCalledWith(
+            savedChart,
+            metricQuery,
+            {},
+        );
+        expect(result).toEqual(
+            expect.objectContaining({
+                pivotConfiguration,
+                query: expect.objectContaining({
+                    pivotDimensions: ['orders_status'],
+                }),
+            }),
+        );
+    });
+});

--- a/packages/query-sdk/src/features.ts
+++ b/packages/query-sdk/src/features.ts
@@ -95,6 +95,13 @@ export const SDK_FEATURES: SdkFeature[] = [
         wiring: 'Declare configOptions (and colorPalette, if the viz colours series) in the viz schema, then read options[name] and colorPalette from useVizContext().',
     },
     {
+        key: 'viz-pivoted-results',
+        label: 'Pivoted results',
+        description:
+            'Render reusable charts and tables from backend-pivoted rows and their complete layout metadata.',
+        wiring: 'When useVizContext().pivotDetails is non-null, use valuesColumns to resolve generated row keys and use indexColumn, groupByColumns, originalColumns, sortBy, totalColumnCount, and passthroughDimensions when the visualization needs their layout semantics. Keep the existing fieldMapping path when pivotDetails is null.',
+    },
+    {
         key: 'follow-host-theme',
         label: 'Follow the host light/dark mode',
         description:

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -31,6 +31,7 @@ export {
 export type {
     AdditionalMetric,
     Column,
+    ColumnType,
     CustomDimension,
     DownloadResultsFileType,
     DownloadResultsLimit,
@@ -103,6 +104,7 @@ export type {
     VizContext,
     VizContextCell,
     VizContextOptionValue,
+    VizContextPivotDetails,
     VizContextRow,
     VizUnderlyingData,
     DataAppVizContextMessage,

--- a/packages/query-sdk/src/vizContext.test.ts
+++ b/packages/query-sdk/src/vizContext.test.ts
@@ -12,6 +12,7 @@ import {
     toVizContextState,
     type DataAppVizContextMessage,
     type VizContextOptionValue,
+    type VizContextPivotDetails,
     type VizContextRow,
 } from './vizContext';
 
@@ -200,8 +201,55 @@ describe('toVizContextState', () => {
             rows: [],
             options: {},
             colorPalette: [],
+            pivotDetails: null,
             underlyingDataEnabled: false,
         });
+    });
+
+    it('normalizes pivot metadata used to resolve generated columns', () => {
+        const pivotDetails = {
+            totalColumnCount: 2,
+            indexColumn: {
+                reference: 'orders_created_date',
+                type: 'time',
+            },
+            valuesColumns: [
+                {
+                    referenceField: 'orders_total',
+                    pivotColumnName: 'orders_total__status_shipped',
+                    aggregation: 'any',
+                    pivotValues: [
+                        {
+                            referenceField: 'orders_status',
+                            value: 'shipped',
+                            formatted: 'Shipped',
+                        },
+                    ],
+                },
+            ],
+            groupByColumns: [{ reference: 'orders_status' }],
+            sortBy: [
+                {
+                    reference: 'orders_created_date',
+                    direction: 'ASC',
+                },
+            ],
+            originalColumns: {
+                orders_created_date: {
+                    reference: 'orders_created_date',
+                    type: 'date',
+                },
+            },
+            passthroughDimensions: [{ reference: 'orders_image_url' }],
+        } satisfies VizContextPivotDetails;
+
+        expect(
+            toVizContextState(message({ pivotDetails })).pivotDetails,
+        ).toEqual(pivotDetails);
+    });
+
+    it('defaults missing pivot metadata to null', () => {
+        expect(toVizContextState(message({})).pivotDetails).toBeNull();
     });
 });
 

--- a/packages/query-sdk/src/vizContext.ts
+++ b/packages/query-sdk/src/vizContext.ts
@@ -25,6 +25,7 @@ import {
 } from 'react';
 import { useOptionalTransport } from './LightdashProvider';
 import type {
+    ColumnType,
     DownloadResultsOptions,
     DownloadResultsResult,
     Transport,
@@ -47,6 +48,44 @@ export type VizContextRow = Record<string, VizContextCell | undefined>;
 export type VizContextOptionValue = boolean | number | string;
 
 /**
+ * The host's complete backend-pivot layout metadata. This is a structural
+ * mirror because query-sdk is published without a dependency on
+ * `@lightdash/common`.
+ */
+export type VizContextPivotDetails = {
+    totalColumnCount: number | null;
+    indexColumn:
+        | { reference: string; type: 'time' | 'category' }
+        | { reference: string; type: 'time' | 'category' }[]
+        | undefined;
+    valuesColumns: {
+        referenceField: string;
+        pivotColumnName: string;
+        aggregation: string;
+        pivotValues: {
+            referenceField: string;
+            value: unknown;
+            formatted?: string;
+        }[];
+        columnIndex?: number;
+    }[];
+    groupByColumns: { reference: string }[] | undefined;
+    sortBy:
+        | {
+              reference: string;
+              direction: 'ASC' | 'DESC';
+              nullsFirst?: boolean;
+              pivotValues?: {
+                  reference: string;
+                  value: string | number | boolean | null;
+              }[];
+          }[]
+        | undefined;
+    originalColumns: Record<string, { reference: string; type: ColumnType }>;
+    passthroughDimensions?: { reference: string }[];
+};
+
+/**
  * Pushed by the host into the iframe. `fieldMapping` maps each field name the
  * renderer declared to the query field id it resolves to; `rows` are the
  * host-fetched result rows keyed by field id; `options` holds the current
@@ -62,6 +101,8 @@ export type DataAppVizContextMessage = {
     options?: Record<string, VizContextOptionValue>;
     /** Absent when the installed host predates palette delivery. */
     colorPalette?: string[];
+    /** Null for unpivoted rows; absent when the installed host predates pivot metadata delivery. */
+    pivotDetails?: VizContextPivotDetails | null;
     /** Absent when the installed host predates underlying-data delivery. */
     underlyingData?: { enabled?: boolean };
 };
@@ -125,6 +166,8 @@ export type VizContext = {
      * resolved no palette; keep a fallback array in your own code for that.
      */
     colorPalette: string[];
+    /** Metadata that maps generated pivot column names back to their metric and series values. */
+    pivotDetails: VizContextPivotDetails | null;
     /** False until the first context arrives — render a placeholder while false. */
     ready: boolean;
     /** Fetch/export the raw rows behind a clicked data point via the host. */
@@ -136,6 +179,7 @@ type VizContextValue = {
     rows: VizContextRow[];
     options: Record<string, VizContextOptionValue>;
     colorPalette: string[];
+    pivotDetails: VizContextPivotDetails | null;
     underlyingDataEnabled: boolean;
 };
 
@@ -167,10 +211,8 @@ const normalizeOptions = (
 };
 
 /**
- * Normalises an inbound host message into provider state. The payload crosses a
- * postMessage boundary so every key is treated as untrusted; `options` and
- * `colorPalette` are also absent from hosts predating them, and fall back to
- * `{}` / `[]`.
+ * Normalises an inbound host message into provider state. Optional capabilities
+ * are absent from hosts predating them and receive stable fallback values.
  */
 export function toVizContextState(
     message: DataAppVizContextMessage,
@@ -184,6 +226,7 @@ export function toVizContextState(
                   (color): color is string => typeof color === 'string',
               )
             : [],
+        pivotDetails: message.pivotDetails ?? null,
         // Strict boolean check — non-boolean payloads read as disabled.
         underlyingDataEnabled: message.underlyingData?.enabled === true,
     };
@@ -327,6 +370,7 @@ export function useVizContext(): VizContext {
         rows: context?.rows ?? [],
         options: context?.options ?? {},
         colorPalette: context?.colorPalette ?? [],
+        pivotDetails: context?.pivotDetails ?? null,
         ready: context !== null,
         underlyingData,
     };

--- a/sandboxes/data-apps/template/.claude/skills/reusable-visualization/SKILL.md
+++ b/sandboxes/data-apps/template/.claude/skills/reusable-visualization/SKILL.md
@@ -27,8 +27,15 @@ fetch anything yourself; the only host interaction is through the helpers the ho
 returns.
 
 ```tsx
-const { fieldMapping, rows, options, colorPalette, ready, underlyingData } =
-    useVizContext();
+const {
+  fieldMapping,
+  rows,
+  options,
+  colorPalette,
+  pivotDetails,
+  ready,
+  underlyingData,
+} = useVizContext();
 ```
 
 - `fieldMapping` — `Record<string, string>`: the field name you declared → the query field
@@ -39,6 +46,8 @@ const { fieldMapping, rows, options, colorPalette, ready, underlyingData } =
   option you declared (the viewer's choice, else your declared `default`).
 - `colorPalette` — `string[]`: the Lightdash palette resolved for this chart. Always pushed,
   whether or not you declared `colorPalette`. Empty only when the host resolved none.
+- `pivotDetails` — the complete backend-pivot layout, or `null` for ordinary rows. See
+  "Backend-pivoted results" below.
 - `ready` — false until the first context arrives.
 - `underlyingData` — host-mediated access to the raw rows behind a clicked data point.
   See "Data-point actions" below.
@@ -80,6 +89,69 @@ This is the same rule as the sandbox skill's "chart series colors must come from
 palette, delivered differently. An app imports `CHART_COLORS`; a viz reads the resolved
 colours off the hook, because the viewer picks the palette per chart. In a viz, use the
 hook, not `CHART_COLORS`.
+
+## Backend-pivoted results
+
+A mapped `series` field makes Lightdash pivot the results before they reach the viz. In
+that case the mapped metric id is no longer a row key: each series becomes a generated
+column described by `pivotDetails.valuesColumns`.
+
+Match `valuesColumns` whose `referenceField` equals the mapped metric id. For each match,
+use `pivotValues` to identify and label the mapped series value. Generated
+`pivotColumnName` keys contain the same `VizContextCell` objects as ordinary field keys:
+read them with `getRaw(row, column.pivotColumnName)` or
+`getFormatted(row, column.pivotColumnName)`. Never coerce `row[fieldId]` directly with
+`String`, `Number`, or template interpolation; that coerces the cell object rather than
+its value. Preserve the ordinary `fieldMapping` row path when `pivotDetails` is `null`, so
+the same viz works without a mapped series and on older unpivoted charts.
+
+The rest of `pivotDetails` describes the full layout rather than assuming the viz is a
+Cartesian chart:
+
+- `indexColumn` — row-grain fields and their `time`/`category` axis semantics.
+- `groupByColumns` — pivot-header fields in backend layout order.
+- `originalColumns` — original field ids and semantic types before pivoting.
+- `sortBy` — the sort applied to the pivoted result, including anchored pivot values.
+- `totalColumnCount` — the untruncated pivot column count; use it when the viz needs to
+  explain that the returned columns hit a limit.
+- `passthroughDimensions` — hidden dimensions retained on rows for cross-field rendering.
+
+Use these when the visualization's shape benefits from them: a table can build row and
+column headers, while a chart can select a time axis from metadata instead of guessing
+from values. Treat `fieldMapping` as the declared interface; metadata describes how those
+fields were laid out, not permission to render unrelated query fields automatically.
+
+```tsx
+const metricId = fieldMapping['value'];
+const seriesId = fieldMapping['series'];
+const pivotedMetrics =
+  pivotDetails?.valuesColumns.filter(
+    (column) => column.referenceField === metricId,
+  ) ?? [];
+
+const series = pivotedMetrics.map((column) => ({
+  columnId: column.pivotColumnName,
+  label:
+    column.pivotValues.find((value) => value.referenceField === seriesId)
+      ?.formatted ?? 'Unknown',
+}));
+
+const categoryId = fieldMapping['category'];
+const data = rows.map((row) => ({
+  label: getFormatted(row, categoryId),
+  ...Object.fromEntries(
+    series.map(({ columnId }) => [
+      columnId,
+      Number(getRaw(row, columnId) ?? 0),
+    ]),
+  ),
+}));
+```
+
+Use the order of `valuesColumns` for stable colour assignment. A chart with multiple
+declared series fields builds its label from each matching `pivotValues` entry in declared
+field order. Backend-pivoted rows do not have safe one-source-row provenance, so the host
+sets `underlyingData.enabled` to false for them.
 
 ## Data-point actions: underlying data
 

--- a/sandboxes/data-apps/template/.claude/skills/sdk-features/SKILL.md
+++ b/sandboxes/data-apps/template/.claude/skills/sdk-features/SKILL.md
@@ -25,6 +25,7 @@ Users describe features by what they see in the Lightdash editor. Translate:
 | "delivery has all tabs", full data in scheduled deliveries | `delivery-render` | app code opt-in |
 | external API data | `external-fetch` | app code opt-in |
 | runs inside a dashboard tile | `viz-context` | required — see below |
+| reusable chart/table with pivoted results | `viz-pivoted-results` | required — see below |
 | "view underlying data", raw rows behind a point (viz only) | `viz-underlying-data` | app code opt-in |
 | light/dark mode, "matches my Lightdash theme" | `follow-host-theme` | CSS tokens — see below |
 
@@ -82,6 +83,20 @@ one mode:
 For colours CSS can't reach (a chart library's theme object, a logo swap), read
 the mode: `const colorScheme = useColorScheme();` — `'light' | 'dark'`,
 re-rendering on every host toggle.
+
+### `viz-pivoted-results` — reusable visualization pivots
+
+Read `pivotDetails` from `useVizContext()`. When it is non-null, match
+`pivotDetails.valuesColumns` to the mapped metric by `referenceField`, derive series
+labels from `pivotValues`, and read each generated `pivotColumnName` with
+`getRaw(row, pivotColumnName)` or `getFormatted(row, pivotColumnName)`. Generated and
+ordinary row keys both contain `VizContextCell` objects; never coerce `row[fieldId]`
+directly. Use the remaining metadata for the visualization's actual shape: `indexColumn` and
+`originalColumns` provide row-grain/type semantics, `groupByColumns` provides header
+order, `sortBy` describes result ordering, `totalColumnCount` exposes truncation, and
+`passthroughDimensions` identifies hidden fields retained on rows. Preserve the ordinary
+`fieldMapping` path when `pivotDetails` is null. The full contract is in the
+`reusable-visualization` skill.
 
 ### App-code opt-ins (call the API where it fits the app)
 


### PR DESCRIPTION
### Description

Adds backend-pivoted query support for reusable custom chart types through the existing pivot pipeline.

- Derives persisted pivot columns from mapped `series` fields in schema order.
- Adds an isolated `DATA_APP_VIZ` pivot derivation that reuses the existing index, sort, validation, and backend query machinery.
- Applies the same derivation to Explorer, saved/dashboard/merge queries, and builder previews.
- Exposes complete `pivotDetails` metadata through `useVizContext()` for arbitrary reusable charts and tables.
- Disables underlying-data actions for pivoted results until point provenance can be resolved safely.
- Registers the `viz-pivoted-results` SDK capability and documents generation/upgrade wiring.

### Compatibility

Existing saved charts without persisted series pivot columns remain unpivoted. New SDKs treat pivot metadata from older hosts as `null`; older app bundles are detected through the SDK capability manifest and can be upgraded before consuming pivoted results.

The query SDK remains standalone: its pivot metadata is a compile-time-checked structural mirror of the host contract and introduces no runtime dependency on `@lightdash/common`.

### Verification

- Common pivot tests: 40 passed
- Frontend integration tests: 101 passed
- Query SDK registry/context tests: 30 passed
- Common, frontend, and query-sdk typechecks passed
- Changed-file lint/format checks passed
- Pre-merge review: zero blocking findings
