### PR TITLE
feat: use chart slugs in frontend navigation

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -5680,6 +5680,7 @@ export class AiAgentModel {
                     .ref(`${SavedChartsTableName}.saved_query_uuid`)
                     .as('content_uuid'),
                 `${SavedChartsTableName}.name`,
+                `${SavedChartsTableName}.slug`,
                 `${SavedChartsTableName}.description`,
                 `${SavedChartsTableName}.views_count`,
                 `${SavedChartsTableName}.last_version_chart_kind`,
@@ -5796,6 +5797,7 @@ export class AiAgentModel {
         const charts: VerifiedContentListItem[] = chartRows.map((row) => ({
             ...toBaseItem(row),
             contentType: ContentType.CHART,
+            slug: row.slug,
             chartKind: row.last_version_chart_kind,
             exploreName: row.explore_name ?? null,
         }));

--- a/packages/backend/src/models/AnalyticsModelSql.ts
+++ b/packages/backend/src/models/AnalyticsModelSql.ts
@@ -207,13 +207,14 @@ export const chartViewsSql = (projectUuid: string) => `
 SELECT
   count(chart_uuid) as count,
   chart_uuid as uuid,
+  sq.slug,
   sq.name
 FROM public.analytics_chart_views
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid  = chart_uuid AND sq.deleted_at IS NULL
   left join ${SpaceTableName} s on s.space_id  = sq.space_id
   left join projects on projects.project_id = s.project_id
 where projects.project_uuid = '${projectUuid}'
-group by chart_uuid, sq.name
+group by chart_uuid, sq.slug, sq.name
 order by count(chart_uuid) desc
 limit 20
 `;

--- a/packages/backend/src/models/ContentVerificationModel.ts
+++ b/packages/backend/src/models/ContentVerificationModel.ts
@@ -168,6 +168,7 @@ export class ContentVerificationModel {
                 `${ContentVerificationTableName}.content_type`,
                 `${ContentVerificationTableName}.content_uuid`,
                 `${SavedChartsTableName}.name`,
+                `${SavedChartsTableName}.slug`,
                 `${SavedChartsTableName}.description`,
                 `${SavedChartsTableName}.views_count`,
                 `${SavedChartsTableName}.last_version_chart_kind`,
@@ -269,6 +270,7 @@ export class ContentVerificationModel {
         const charts: VerifiedContentListItem[] = chartRows.map((row) => ({
             ...toBaseItem(row),
             contentType: ContentType.CHART,
+            slug: row.slug,
             chartKind: row.last_version_chart_kind,
             exploreName: row.explore_name ?? null,
         }));

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -998,6 +998,7 @@ export class SearchModel {
             )
             .column(
                 { uuid: 'saved_query_uuid' },
+                `${SavedChartsTableName}.slug`,
                 `${SavedChartsTableName}.name`,
                 `${SavedChartsTableName}.description`,
                 {

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -867,6 +867,7 @@ export class CatalogService<
             (chart) => ({
                 name: chart.name,
                 uuid: chart.uuid,
+                slug: chart.slug,
                 description: chart.description,
                 spaceUuid: chart.spaceUuid,
                 spaceName: chart.spaceName,
@@ -909,6 +910,7 @@ export class CatalogService<
             chartSummaries.map((chart) => ({
                 name: chart.name,
                 uuid: chart.uuid,
+                slug: chart.slug,
                 description: chart.description,
                 spaceUuid: chart.spaceUuid,
                 spaceName: chart.spaceName,

--- a/packages/backend/src/services/ContentVerificationService.test.ts
+++ b/packages/backend/src/services/ContentVerificationService.test.ts
@@ -66,6 +66,7 @@ const mockVerifiedItems: VerifiedContentListItem[] = [
         uuid: 'cv-uuid-1',
         contentType: ContentType.CHART,
         contentUuid: 'chart-uuid',
+        slug: 'test-chart',
         name: 'Test Chart',
         description: null,
         chartKind: ChartKind.VERTICAL_BAR,

--- a/packages/common/src/types/analytics.ts
+++ b/packages/common/src/types/analytics.ts
@@ -9,6 +9,12 @@ export type ActivityViews = {
     uuid: string;
     name: string;
 };
+export type ChartActivityViews = {
+    count: number;
+    uuid: string;
+    name: string;
+    slug: string;
+};
 export type UserActivity = {
     numberUsers: number;
     numberViewers: number;
@@ -34,7 +40,7 @@ export type UserActivity = {
         dashboardName: string;
         dashboardUuid: string;
     })[];
-    chartViews: ActivityViews[];
+    chartViews: ChartActivityViews[];
 };
 
 export type ApiUserActivity = {

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -337,6 +337,7 @@ export type CatalogAnalytics = {
     charts: (Pick<
         ChartSummary,
         | 'uuid'
+        | 'slug'
         | 'name'
         | 'description'
         | 'spaceUuid'

--- a/packages/common/src/types/contentVerification.ts
+++ b/packages/common/src/types/contentVerification.ts
@@ -29,6 +29,7 @@ type VerifiedContentListItemBase = {
 
 export type VerifiedChartListItem = VerifiedContentListItemBase & {
     contentType: ContentType.CHART;
+    slug: string;
     chartKind: ChartKind;
     exploreName: string | null;
 };

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -16,7 +16,7 @@ describe('Space', () => {
         const timestamp = new Date().toISOString();
         let privateSpaceUrl: string;
         let privateSpaceUuid: string;
-        let privateChartUuid: string;
+        let privateChartIdentifier: string;
         let privateDashboardUuid: string;
 
         // Create private space
@@ -77,9 +77,9 @@ describe('Space', () => {
 
         cy.contains('Success! Chart was saved.').should('exist');
         cy.url()
-            .should('match', /\/saved\/[0-9a-f-]{36}\/view$/)
+            .should('match', /\/saved\/[^/]+\/view$/)
             .then((url) => {
-                privateChartUuid = url.split('/').at(-2)!;
+                privateChartIdentifier = url.split('/').at(-2)!;
             });
 
         cy.then(() =>
@@ -111,14 +111,18 @@ describe('Space', () => {
 
         return cy.then(() => ({
             privateSpaceUuid,
-            privateChartUuid,
+            privateChartIdentifier,
             privateDashboardUuid,
         }));
     };
 
     it('Another non-admin user cannot see private content', () => {
         createPrivateSpace().then(
-            ({ privateSpaceUuid, privateChartUuid, privateDashboardUuid }) => {
+            ({
+                privateSpaceUuid,
+                privateChartIdentifier,
+                privateDashboardUuid,
+            }) => {
                 cy.loginWithPermissions('member', [
                     {
                         role: 'editor',
@@ -146,7 +150,7 @@ describe('Space', () => {
 
                 for (const url of [
                     `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces/${privateSpaceUuid}`,
-                    `/api/v2/projects/${SEED_PROJECT.project_uuid}/saved/${privateChartUuid}`,
+                    `/api/v2/projects/${SEED_PROJECT.project_uuid}/saved/${privateChartIdentifier}`,
                     `/api/v2/projects/${SEED_PROJECT.project_uuid}/dashboards/${privateDashboardUuid}`,
                 ]) {
                     cy.request({ url, failOnStatusCode: false })

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1525,7 +1525,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                     title={title || chart.name || ''}
                     chartName={chart.name}
                     verification={chart.verification ?? null}
-                    titleHref={`/projects/${projectUuid}/saved/${savedChartUuid}/`}
+                    titleHref={`/projects/${projectUuid}/saved/${chart.slug}/`}
                     description={chart.description}
                     belongsToDashboard={belongsToDashboard}
                     extraMenuItems={
@@ -1550,6 +1550,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                             <Box>
                                                 <EditChartMenuItem
                                                     tile={props.tile}
+                                                    chartSlug={chart.slug}
                                                     disabled={
                                                         isEditMode ||
                                                         !userCanManageChart
@@ -1871,7 +1872,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
     const {
         tile: {
             uuid: tileUuid,
-            properties: { savedChartUuid, hideTitle, title },
+            properties: { hideTitle, title },
         },
         dashboardChartReadyQuery,
         resultsData,
@@ -2011,7 +2012,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         <>
             <TileBase
                 title={title || chart.name || ''}
-                titleHref={`/projects/${projectUuid}/saved/${savedChartUuid}/`}
+                titleHref={`/projects/${projectUuid}/saved/${chart.slug}/`}
                 description={chart.description}
                 isLoading={false}
                 chartKind={chartKind}
@@ -2299,7 +2300,6 @@ export const GenericDashboardChartTile: FC<
             <TileBase
                 isEditMode={isEditMode}
                 chartName={tile.properties.chartName ?? ''}
-                titleHref={`/projects/${projectUuid}/saved/${tile.properties.savedChartUuid}/`}
                 description={''}
                 belongsToDashboard={tile.properties.belongsToDashboard}
                 tile={tile}

--- a/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
@@ -10,9 +10,10 @@ import MantineIcon from '../common/MantineIcon';
 
 type Props = LinkMenuItemProps & {
     tile: DashboardChartTile;
+    chartSlug?: string;
 };
 
-const EditChartMenuItem: FC<Props> = ({ tile, ...props }) => {
+const EditChartMenuItem: FC<Props> = ({ tile, chartSlug, ...props }) => {
     const { user } = useApp();
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const filtersFromContext = useDashboardContext((c) => c.dashboardFilters);
@@ -50,7 +51,7 @@ const EditChartMenuItem: FC<Props> = ({ tile, ...props }) => {
                     );
                 }
             }}
-            href={`/projects/${projectUuid}/saved/${tile.properties.savedChartUuid}/edit?fromDashboard=${dashboardUuid}`}
+            href={`/projects/${projectUuid}/saved/${chartSlug ?? tile.properties.savedChartUuid}/edit?fromDashboard=${dashboardUuid}`}
             {...props}
         >
             Edit chart

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -124,6 +124,17 @@ import SaveChartButton, {
 } from '../SaveChartButton';
 import { TitleBreadCrumbs } from './TitleBreadcrumbs';
 
+const isChartPath = (
+    pathname: string,
+    projectUuid: string | undefined,
+    chartIdentifier: string | undefined,
+) => {
+    if (!projectUuid || !chartIdentifier) return false;
+
+    const chartPath = `/projects/${projectUuid}/saved/${chartIdentifier}`;
+    return pathname.endsWith(chartPath) || pathname.includes(`${chartPath}/`);
+};
+
 const SavedChartsHeader: FC = () => {
     const { data: changeChartExploreFlag } = useServerFeatureFlag(
         FeatureFlags.ChangeChartExplore,
@@ -315,8 +326,15 @@ const SavedChartsHeader: FC = () => {
             hasUnsavedChanges &&
             isEditMode &&
             !isSaveModalOpen &&
-            !nextLocation.pathname.includes(
-                `/projects/${projectUuid}/saved/${savedChart?.uuid}`,
+            !isChartPath(
+                nextLocation.pathname,
+                projectUuid,
+                savedChart?.slug,
+            ) &&
+            !isChartPath(
+                nextLocation.pathname,
+                projectUuid,
+                savedChart?.uuid,
             ) &&
             !nextLocation.pathname.includes(
                 `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
@@ -448,7 +466,7 @@ const SavedChartsHeader: FC = () => {
 
         if (!isFromDashboard)
             void navigate({
-                pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.uuid}/view`,
+                pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.slug}/view`,
             });
     }, [dispatch, isEditMode, savedChart, isFromDashboard, navigate]);
 
@@ -619,7 +637,7 @@ const SavedChartsHeader: FC = () => {
                                                 }
                                                 onClick={() =>
                                                     navigate({
-                                                        pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.uuid}/edit`,
+                                                        pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.slug}/edit`,
                                                     })
                                                 }
                                             >
@@ -826,7 +844,7 @@ const SavedChartsHeader: FC = () => {
                                         }
                                         onClick={() =>
                                             navigate({
-                                                pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.uuid}/history`,
+                                                pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.slug}/history`,
                                             })
                                         }
                                     >
@@ -1085,7 +1103,7 @@ const SavedChartsHeader: FC = () => {
                     onConfirm={() => {
                         clearDashboardStorage();
                         void navigate(
-                            `/projects/${projectUuid}/saved/${savedChart.uuid}/edit`,
+                            `/projects/${projectUuid}/saved/${savedChart.slug}/edit`,
                         );
                     }}
                 />

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -50,7 +50,7 @@ const getFavoriteItemUrl = (projectUuid: string, item: ResourceViewItem) => {
         case ResourceViewItemType.DASHBOARD:
             return `/projects/${projectUuid}/dashboards/${item.data.uuid}/view`;
         case ResourceViewItemType.CHART:
-            return `/projects/${projectUuid}/saved/${item.data.uuid}`;
+            return `/projects/${projectUuid}/saved/${item.data.slug}`;
         case ResourceViewItemType.SPACE:
             return `/projects/${projectUuid}/spaces/${item.data.uuid}`;
         case ResourceViewItemType.DATA_APP:

--- a/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
+++ b/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
@@ -84,7 +84,7 @@ const VerifiedContentPanel: FC<Props> = ({ projectUuid }) => {
                     const { contentType, contentUuid, name } = row.original;
                     const href =
                         contentType === ContentType.CHART
-                            ? `/projects/${projectUuid}/saved/${contentUuid}`
+                            ? `/projects/${projectUuid}/saved/${row.original.slug}`
                             : `/projects/${projectUuid}/dashboards/${contentUuid}`;
                     return (
                         <Anchor

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -68,7 +68,7 @@ const getChartResourceUrl = (
             return `/projects/${projectUuid}/sql-runner/${item.data.slug}`;
         case ChartSourceType.DBT_EXPLORE:
         case undefined:
-            return `/projects/${projectUuid}/saved/${item.data.uuid}`;
+            return `/projects/${projectUuid}/saved/${item.data.slug}`;
         default:
             return assertUnreachable(
                 item.data.source,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
@@ -38,7 +38,7 @@ const ChartList: FC<ChartListProps> = ({
                 <Box
                     key={chart.uuid}
                     component={Link}
-                    to={`/projects/${projectUuid}/saved/${chart.uuid}`}
+                    to={`/projects/${projectUuid}/saved/${chart.slug}`}
                     target="_blank"
                     className={styles.chartRow}
                     onClick={() => onChartClick(chart.uuid)}

--- a/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
+++ b/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
@@ -52,7 +52,7 @@ export const getSearchItemMap = (
         item: item,
         searchRank: item.search_rank,
         location: {
-            pathname: `/projects/${projectUuid}/saved/${item.uuid}`,
+            pathname: `/projects/${projectUuid}/saved/${item.slug}`,
         },
     }));
 

--- a/packages/frontend/src/features/promotion/hooks/usePromoteChart.ts
+++ b/packages/frontend/src/features/promotion/hooks/usePromoteChart.ts
@@ -30,7 +30,7 @@ export const usePromoteMutation = () => {
                         icon: IconArrowRight,
                         onClick: () => {
                             window.open(
-                                `/projects/${data.projectUuid}/saved/${data.uuid}`,
+                                `/projects/${data.projectUuid}/saved/${data.slug}`,
                                 '_blank',
                             );
                         },

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -382,7 +382,7 @@ export const useCreateMutation = ({
         {
             mutationKey: ['saved_query_create', projectUuid],
             onSuccess: (data) => {
-                const navigateUrl = `/projects/${projectUuid}/saved/${data.uuid}/view`;
+                const navigateUrl = `/projects/${projectUuid}/saved/${data.slug}/view`;
                 queryClient.setQueryData(
                     ['saved_query', data.uuid, data.projectUuid],
                     data,
@@ -466,7 +466,7 @@ export const useDuplicateChartMutation = (
                     options?.autoRedirect !== false
                 ) {
                     void navigate(
-                        `/projects/${projectUuid}/saved/${data.uuid}`,
+                        `/projects/${projectUuid}/saved/${data.slug}`,
                     );
                 }
 
@@ -480,7 +480,7 @@ export const useDuplicateChartMutation = (
                               icon: IconArrowRight,
                               onClick: () => {
                                   void navigate(
-                                      `/projects/${projectUuid}/saved/${data.uuid}`,
+                                      `/projects/${projectUuid}/saved/${data.slug}`,
                                   );
                               },
                           }
@@ -566,7 +566,7 @@ export const useAddVersionMutation = (options?: {
                 });
                 if (redirectOnSuccess) {
                     void navigate(
-                        `/projects/${data.projectUuid}/saved/${data.uuid}/view`,
+                        `/projects/${data.projectUuid}/saved/${data.slug}/view`,
                     );
                 }
             }

--- a/packages/frontend/src/pages/ChartHistory.tsx
+++ b/packages/frontend/src/pages/ChartHistory.tsx
@@ -123,6 +123,7 @@ const ChartHistory = () => {
         projectUuid,
     });
     const chartUuid = chartQuery.data?.uuid;
+    const chartSlug = chartQuery.data?.slug ?? chartIdentifier;
     const historyQuery = useChartHistory(chartUuid);
 
     useEffect(() => {
@@ -134,9 +135,7 @@ const ChartHistory = () => {
 
     const rollbackMutation = useChartVersionRollbackMutation(chartUuid, {
         onSuccess: () => {
-            void navigate(
-                `/projects/${projectUuid}/saved/${chartIdentifier}/view`,
-            );
+            void navigate(`/projects/${projectUuid}/saved/${chartSlug}/view`);
         },
     });
 
@@ -172,7 +171,7 @@ const ChartHistory = () => {
                             items={[
                                 {
                                     title: 'Chart',
-                                    to: `/projects/${projectUuid}/saved/${chartIdentifier}/view`,
+                                    to: `/projects/${projectUuid}/saved/${chartSlug}/view`,
                                 },
                                 { title: 'Version history', active: true },
                             ]}

--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -1,5 +1,6 @@
 import {
     type ActivityViews,
+    type ChartActivityViews,
     type UserActivity as UserActivityResponse,
     type UserWithCount,
 } from '@lightdash/common';
@@ -75,27 +76,22 @@ const BigNumberVis: FC<{ value: number | string; label: string }> = ({
 const getDashboardLink = (projectUuid: string, dashboardUuid: string) =>
     `/projects/${projectUuid}/dashboards/${dashboardUuid}`;
 
-const getChartLink = (projectUuid: string, chartUuid: string) =>
-    `/projects/${projectUuid}/saved/${chartUuid}`;
+const getChartLink = (projectUuid: string, chartSlug: string) =>
+    `/projects/${projectUuid}/saved/${chartSlug}`;
 
-const showTableViews = ({
+const showTableViews = <T extends ActivityViews>({
     key,
-    projectUuid,
-    type,
     views,
+    getLink,
 }: {
     key: string;
-    projectUuid: string;
-    type: 'chart' | 'dashboard';
-    views: ActivityViews[];
+    views: T[];
+    getLink: (view: T) => string;
 }) => {
     return (
         <Table.Tbody>
             {views.map((view) => {
-                const to =
-                    type === 'dashboard'
-                        ? getDashboardLink(projectUuid, view.uuid)
-                        : getChartLink(projectUuid, view.uuid);
+                const to = getLink(view);
                 return (
                     <Table.Tr key={`${key}-${view.uuid}`}>
                         <Table.Td>
@@ -481,9 +477,12 @@ const UserActivity: FC = () => {
                                 </Table.Thead>
                                 {showTableViews({
                                     key: 'dashboard-views',
-                                    projectUuid,
-                                    type: 'dashboard',
                                     views: data.dashboardViews,
+                                    getLink: (view) =>
+                                        getDashboardLink(
+                                            projectUuid,
+                                            view.uuid,
+                                        ),
                                 })}
                             </Table>
                         </VisualizationCard>
@@ -500,9 +499,9 @@ const UserActivity: FC = () => {
                                 </Table.Thead>
                                 {showTableViews({
                                     key: 'chart-views',
-                                    projectUuid,
-                                    type: 'chart',
                                     views: data.chartViews,
+                                    getLink: (view: ChartActivityViews) =>
+                                        getChartLink(projectUuid, view.slug),
                                 })}
                             </Table>
                         </VisualizationCard>


### PR DESCRIPTION
## ![CleanShot 2026-08-19 at 15.49.07@2x.png](https://app.graphite.com/user-attachments/assets/e5394156-6672-4473-ae44-e9da0eb7b5ca.png)



## Summary

- use chart slugs in homepage, space, favorites, search, chart header, dashboard tile, activity, verified-content, and metric-usage links
- keep UUIDs for API calls, cache identity, permissions, analytics events, and stored dashboard tile references
- expose slugs through existing search and summary projections without additional requests

## Compatibility

Existing UUID and historical chart-alias URLs continue to resolve. Deleted content and UUID-only admin/error projections remain unchanged; scheduler and AI-generated links are handled by the backend-links ticket later in this stack.

## Testing

- live tested homepage, search, dashboard tile, chart view/edit/history, UUID links, and historical alias links against the local Jaffle Shop project
- `pnpm -F common typecheck`
- `pnpm -F frontend typecheck`
- `pnpm -F backend typecheck`
- `pnpm -F backend test:dev:nowatch` (401 files, 6942 passed)
- `pnpm generate-api`

Linear: https://linear.app/lightdash/issue/SPK-1131/use-chart-slugs-in-frontend-navigation