### PR TITLE
fix: make dashboard slug routes safe

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -646,7 +646,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
         const { totalResults, metadata } = resultsData;
         const performance = metadata?.performance;
 
-        const { dashboardUuid } = useParams<{ dashboardUuid: string }>();
+        const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
         const projectUuid = useProjectUuid();
         const { canViewExplore, canViewUnderlyingData, canDrillInto } =
             useContextMenuPermissions({ minimal: false });

--- a/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
@@ -6,7 +6,6 @@ import { Box, Menu, useMantineColorScheme } from '@mantine/core';
 import { IconCopy } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import React, { useCallback, useMemo, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import rehypeExternalLinks from 'rehype-external-links';
 import { v4 as uuid4 } from 'uuid';
 import { DashboardTileComments } from '../../features/comments';
@@ -46,7 +45,7 @@ const MarkdownTile: FC<Props> = (props) => {
     const setHaveTilesChanged = useDashboardContext(
         (c) => c.setHaveTilesChanged,
     );
-    const { dashboardUuid } = useParams<{ dashboardUuid: string }>();
+    const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
 
     const dashboardComments = useMemo(
         () =>

--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -88,10 +88,10 @@ const SqlChartTile: FC<Props> = ({
     ...rest
 }) => {
     const { user } = useApp();
-    const { projectUuid, dashboardUuid } = useParams<{
+    const { projectUuid } = useParams<{
         projectUuid: string;
-        dashboardUuid: string;
     }>();
+    const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
     const effectiveProjectUuid = projectUuidOverride ?? projectUuid;
     const effectiveDashboardUuid = dashboardUuidOverride ?? dashboardUuid;
     const context = useSearchParams('context') || undefined;

--- a/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
@@ -25,9 +25,8 @@ const EditChartMenuItem: FC<Props> = ({ tile, chartSlug, ...props }) => {
 
     const { storeDashboard } = useDashboardStorage();
 
-    const { projectUuid, dashboardUuid } = useParams<{
+    const { projectUuid } = useParams<{
         projectUuid: string;
-        dashboardUuid: string;
     }>();
 
     const userCanManageExplore = user.data?.ability?.can('manage', 'Explore');
@@ -51,7 +50,7 @@ const EditChartMenuItem: FC<Props> = ({ tile, chartSlug, ...props }) => {
                     );
                 }
             }}
-            href={`/projects/${projectUuid}/saved/${chartSlug ?? tile.properties.savedChartUuid}/edit?fromDashboard=${dashboardUuid}`}
+            href={`/projects/${projectUuid}/saved/${chartSlug ?? tile.properties.savedChartUuid}/edit?fromDashboard=${dashboard?.uuid}`}
             {...props}
         >
             Edit chart

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -156,11 +156,12 @@ const DashboardHeader = memo(
         );
         const { search, pathname } = useLocation();
         const navigate = useNavigate();
-        const { projectUuid, dashboardUuid } = useParams<{
+        const { projectUuid, dashboardUuid: dashboardIdentifier } = useParams<{
             projectUuid: string;
             dashboardUuid: string;
             organizationUuid: string;
         }>();
+        const dashboardUuid = dashboard.uuid;
 
         const { data: project } = useProject(projectUuid);
 
@@ -886,7 +887,7 @@ const DashboardHeader = memo(
                                                 }
                                                 onClick={() =>
                                                     navigate(
-                                                        `/projects/${projectUuid}/dashboards/${dashboardUuid}/history`,
+                                                        `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/history`,
                                                     )
                                                 }
                                             >

--- a/packages/frontend/src/features/comments/hooks/useComments.ts
+++ b/packages/frontend/src/features/comments/hooks/useComments.ts
@@ -78,7 +78,7 @@ const getDashboardComments = async ({
 };
 
 const useDashboardComments = (
-    dashboardUuid: string,
+    dashboardUuid: string | undefined,
     projectUuid: string | undefined,
     enabled: boolean,
     resolved: boolean,
@@ -86,6 +86,7 @@ const useDashboardComments = (
     useQuery<ApiGetComments['results'], ApiError>(
         ['comments', dashboardUuid, projectUuid, { resolved }],
         async () => {
+            if (!dashboardUuid) throw new Error('dashboardUuid is required');
             if (!projectUuid) throw new Error('projectUuid is required');
             return getDashboardComments({
                 dashboardUuid,
@@ -97,12 +98,12 @@ const useDashboardComments = (
             // Only poll the active (unresolved) comments
             refetchInterval: resolved ? undefined : 3 * 60 * 1000,
             retry: (_, error) => error.error.statusCode !== 403,
-            enabled: enabled && !!projectUuid,
+            enabled: enabled && !!dashboardUuid && !!projectUuid,
         },
     );
 
 export const useGetComments = (
-    dashboardUuid: string,
+    dashboardUuid: string | undefined,
     projectUuid: string | undefined,
     enabled: boolean,
 ) => useDashboardComments(dashboardUuid, projectUuid, enabled, false);

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -25,7 +25,7 @@ import {
     type FC,
 } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
-import { useLocation, useNavigate } from 'react-router';
+import { useLocation, useNavigate, useParams } from 'react-router';
 import { v4 as uuid4 } from 'uuid';
 import { DASHBOARD_HEADER_HEIGHT } from '../../components/common/Dashboard/dashboard.constants';
 import MantineIcon from '../../components/common/MantineIcon';
@@ -313,6 +313,9 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
 
     const { search } = useLocation();
     const navigate = useNavigate();
+    const { dashboardUuid: dashboardIdentifier } = useParams<{
+        dashboardUuid: string;
+    }>();
 
     const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
     const projectUuid = useDashboardContext((c) => c.projectUuid);
@@ -669,8 +672,8 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
             void navigate(
                 {
                     pathname: isEditMode
-                        ? `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit/tabs/${tab?.uuid}`
-                        : `/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${tab?.uuid}`,
+                        ? `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/edit/tabs/${tab?.uuid}`
+                        : `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/view/tabs/${tab?.uuid}`,
                     search: newParams.toString(),
                 },
                 { replace: true },
@@ -775,7 +778,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
             // If this is the last tab, navigate to the non-tab URL.
             // See `const = sortedTabs` for more context.
             void navigate(
-                `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
+                `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/edit`,
                 { replace: true },
             );
 

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -162,7 +162,7 @@ export const useDashboardQuery = ({
  * @returns The latest dashboard or null if the dashboard is up to date
  */
 export const useDashboardVersionRefresh = (
-    dashboardUuid: string,
+    dashboardUuid: string | undefined,
     projectUuid?: string,
 ) => {
     const queryClient = useQueryClient();
@@ -173,6 +173,9 @@ export const useDashboardVersionRefresh = (
             try {
                 if (!currentDashboard) {
                     throw new Error('Current dashboard is undefined');
+                }
+                if (!dashboardUuid) {
+                    throw new Error('Dashboard UUID is undefined');
                 }
                 if (!projectUuid) {
                     throw new Error('Project UUID is undefined');

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -52,7 +52,11 @@ import '../styles/react-grid.css';
 
 const Dashboard: FC = () => {
     const navigate = useNavigate();
-    const { projectUuid, dashboardUuid, mode } = useParams<{
+    const {
+        projectUuid,
+        dashboardUuid: dashboardIdentifier,
+        mode,
+    } = useParams<{
         projectUuid: string;
         dashboardUuid: string;
         mode?: string;
@@ -63,6 +67,7 @@ const Dashboard: FC = () => {
 
     const isDashboardLoading = useDashboardContext((c) => c.isDashboardLoading);
     const dashboard = useDashboardContext((c) => c.dashboard);
+    const dashboardUuid = dashboard?.uuid;
 
     const dashboardError = useDashboardContext((c) => c.dashboardError);
     const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
@@ -380,18 +385,18 @@ const Dashboard: FC = () => {
             reset();
             if (dashboardTabs.length > 1) {
                 void navigate(
-                    `/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${activeTab?.uuid}`,
+                    `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/view/tabs/${activeTab?.uuid}`,
                     { replace: true },
                 );
             } else {
                 void navigate(
-                    `/projects/${projectUuid}/dashboards/${dashboardUuid}/view`,
+                    `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/view`,
                     { replace: true },
                 );
             }
         }
     }, [
-        dashboardUuid,
+        dashboardIdentifier,
         navigate,
         isSuccess,
         projectUuid,
@@ -609,18 +614,18 @@ const Dashboard: FC = () => {
 
         if (dashboardTabs.length > 0) {
             void navigate(
-                `/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${activeTab?.uuid}`,
+                `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/view/tabs/${activeTab?.uuid}`,
                 { replace: true },
             );
         } else {
             void navigate(
-                `/projects/${projectUuid}/dashboards/${dashboardUuid}/view`,
+                `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/view`,
                 { replace: true },
             );
         }
     }, [
         dashboard,
-        dashboardUuid,
+        dashboardIdentifier,
         navigate,
         projectUuid,
         setDashboardTiles,
@@ -681,8 +686,12 @@ const Dashboard: FC = () => {
             isEditMode &&
             (haveTilesChanged || haveFiltersChanged || haveTabsChanged) &&
             !nextLocation.pathname.includes(
-                `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
+                `/projects/${projectUuid}/dashboards/${dashboardIdentifier}`,
             ) &&
+            (!dashboardUuid ||
+                !nextLocation.pathname.includes(
+                    `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
+                )) &&
             // Allow user to add a new table
             !sessionStorage.getItem(`unsavedDashboardTiles:${dashboardUuid}`)
         ) {
@@ -702,8 +711,8 @@ const Dashboard: FC = () => {
                 {
                     pathname:
                         dashboardTabs.length > 0
-                            ? `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit/tabs/${activeTab?.uuid}`
-                            : `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
+                            ? `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/edit/tabs/${activeTab?.uuid}`
+                            : `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/edit`,
                     search: '',
                 },
                 { replace: true },
@@ -711,7 +720,7 @@ const Dashboard: FC = () => {
         });
     }, [
         projectUuid,
-        dashboardUuid,
+        dashboardIdentifier,
         resetDashboardFilters,
         refreshDashboardVersion,
         navigate,

--- a/packages/frontend/src/pages/DashboardHistory.tsx
+++ b/packages/frontend/src/pages/DashboardHistory.tsx
@@ -37,7 +37,7 @@ import DashboardVersionComparison from './DashboardVersionComparison';
 
 const DashboardHistory = () => {
     const navigate = useNavigate();
-    const { dashboardUuid, projectUuid } = useParams<{
+    const { dashboardUuid: dashboardIdentifier, projectUuid } = useParams<{
         dashboardUuid: string;
         projectUuid: string;
     }>();
@@ -45,9 +45,10 @@ const DashboardHistory = () => {
     const [selectedVersionUuid, setSelectedVersionUuid] = useState<string>();
 
     const dashboardQuery = useDashboardQuery({
-        uuidOrSlug: dashboardUuid,
+        uuidOrSlug: dashboardIdentifier,
         projectUuid,
     });
+    const dashboardUuid = dashboardQuery.data?.uuid;
     const historyQuery = useDashboardHistory(dashboardUuid);
 
     const rollbackMutation = useDashboardVersionRollbackMutation(dashboardUuid);
@@ -86,7 +87,7 @@ const DashboardHistory = () => {
                             items={[
                                 {
                                     title: 'Dashboard',
-                                    to: `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
+                                    to: `/projects/${projectUuid}/dashboards/${dashboardIdentifier}`,
                                 },
                                 { title: 'Version history', active: true },
                             ]}
@@ -193,6 +194,7 @@ const DashboardHistory = () => {
         >
             {selectedVersionUuid ? (
                 <DashboardVersionComparison
+                    dashboard={dashboardQuery.data}
                     dashboardUuid={dashboardUuid}
                     projectUuid={projectUuid}
                     versionUuid={selectedVersionUuid}
@@ -220,7 +222,7 @@ const DashboardHistory = () => {
                                     onSuccess: () => {
                                         setIsRollbackModalOpen(false);
                                         void navigate(
-                                            `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
+                                            `/projects/${projectUuid}/dashboards/${dashboardIdentifier}`,
                                         );
                                     },
                                 });

--- a/packages/frontend/src/pages/DashboardVersionComparison.tsx
+++ b/packages/frontend/src/pages/DashboardVersionComparison.tsx
@@ -8,6 +8,7 @@ import {
     isDashboardLoomTileType,
     isDashboardMarkdownTileType,
     isDashboardSqlChartTile,
+    type Dashboard,
     type DashboardFilterRule,
     type DashboardFilters,
 } from '@lightdash/common';
@@ -43,13 +44,11 @@ import {
 import { EmptyState } from '../components/common/EmptyState';
 import { getConditionalRuleLabel } from '../components/common/Filters/FilterInputs/utils';
 import MantineIcon from '../components/common/MantineIcon';
-import {
-    useDashboardQuery,
-    useDashboardVersion,
-} from '../hooks/dashboard/useDashboard';
+import { useDashboardVersion } from '../hooks/dashboard/useDashboard';
 import NoTableIcon from '../svgs/emptystate-no-table.svg?react';
 
 interface DashboardVersionComparisonProps {
+    dashboard: Dashboard | undefined;
     dashboardUuid: string | undefined;
     projectUuid: string | undefined;
     versionUuid: string | undefined;
@@ -804,23 +803,19 @@ const FiltersTable = ({ data }: { data: any[] }) => {
 };
 
 const DashboardVersionComparison = ({
+    dashboard,
     dashboardUuid,
     projectUuid,
     versionUuid,
 }: DashboardVersionComparisonProps) => {
-    const dashboardQuery = useDashboardQuery({
-        uuidOrSlug: dashboardUuid,
-        projectUuid,
-    });
-
     const versionQuery = useDashboardVersion(dashboardUuid, versionUuid);
 
     const comparison = useMemo(() => {
-        if (!dashboardQuery.data || !versionQuery.data?.dashboard) {
+        if (!dashboard || !versionQuery.data?.dashboard) {
             return null;
         }
 
-        const current = dashboardQuery.data;
+        const current = dashboard;
         const version = versionQuery.data.dashboard;
 
         // Count tiles - diff should be version - current (to show what the selected version has)
@@ -955,7 +950,7 @@ const DashboardVersionComparison = ({
                 if (!versionDiff && currentChart) {
                     currentVersionData = {
                         chartUuid: uuid,
-                        versionUuid: dashboardQuery.data?.versionUuid || '',
+                        versionUuid: dashboard.versionUuid || '',
                         createdAt: new Date(),
                         createdBy: null,
                     };
@@ -1086,7 +1081,7 @@ const DashboardVersionComparison = ({
             alignedCharts,
             tilesData,
         };
-    }, [dashboardQuery.data, versionQuery.data]);
+    }, [dashboard, versionQuery.data]);
 
     if (!versionUuid) {
         return null;
@@ -1117,9 +1112,8 @@ const DashboardVersionComparison = ({
 
     // Check if the selected version is the current version
     // The versionUuid from versionQuery.data is the selected version
-    // The versionUuid from dashboardQuery.data is the current/latest version
-    const isCurrentVersionSelected =
-        versionUuid === dashboardQuery.data?.versionUuid;
+    // The versionUuid from the loaded dashboard is the current/latest version
+    const isCurrentVersionSelected = versionUuid === dashboard?.versionUuid;
 
     if (isCurrentVersionSelected) {
         return (

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -122,7 +122,11 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     const { showToastWarning, showToastInfo } = useToaster();
     const hasNotifiedLockedOverrideRef = useRef(false);
 
-    const { dashboardUuid, tabUuid, mode } = useParams<{
+    const {
+        dashboardUuid: dashboardIdentifier,
+        tabUuid,
+        mode,
+    } = useParams<{
         dashboardUuid: string;
         tabUuid?: string;
         mode?: string;
@@ -136,13 +140,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     // so each dashboard gets a fresh chance to notify the viewer.
     useEffect(() => {
         hasNotifiedLockedOverrideRef.current = false;
-    }, [dashboardUuid]);
+    }, [dashboardIdentifier]);
     const isEditMode = mode === 'edit';
-
-    const {
-        mutateAsync: versionRefresh,
-        isLoading: isRefreshingDashboardVersion,
-    } = useDashboardVersionRefresh(dashboardUuid, projectUuid);
 
     // Embedded dashboards will not be using this query hook to load the dashboard,
     // so we need to set the dashboard manually
@@ -154,7 +153,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         isInitialLoading: isDashboardLoading,
         error: dashboardError,
     } = useDashboardQuery({
-        uuidOrSlug: dashboardUuid,
+        uuidOrSlug: dashboardIdentifier,
         projectUuid,
         useQueryOptions: {
             select: (d) => {
@@ -183,6 +182,11 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             },
         },
     });
+    const dashboardUuid = (dashboard ?? embedDashboard)?.uuid;
+    const {
+        mutateAsync: versionRefresh,
+        isLoading: isRefreshingDashboardVersion,
+    } = useDashboardVersionRefresh(dashboardUuid, projectUuid);
 
     // Embedded dashboards populate `embedDashboard` instead of the query hook,
     // so config-derived state must read from whichever holds the dashboard.


### PR DESCRIPTION
## Summary

- separate the dashboard route identifier (UUID or slug) from the resolved dashboard UUID
- keep browser navigation on the original route identifier while using the resolved UUID for mutations, history, comments, cache keys, and tile actions
- remove a redundant dashboard request from version comparison

## Compatibility

Existing UUID dashboard URLs remain supported. This is a preflight refactor for switching dashboard-generated links to slugs in a follow-up PR.

## Testing

- frontend typecheck
- live-tested slug view/edit navigation, favorite toggle, pin/unpin, version history and version comparison
- live-tested the existing dashboard UUID history URL

Linear: https://linear.app/lightdash/issue/SPK-1149/dashboard-route-safety-preflight-for-slug-url-rollout