### PR TITLE
feat: use dashboard slugs in frontend navigation

### DIFF
--- a/packages/backend/src/contentAsCode/fieldCoverage/chart.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/chart.test.ts
@@ -26,7 +26,6 @@ describeContentAsCodeSchemaContract({
     ],
     documentOnlyFields: [
         'contentType',
-        'dashboardSlug',
         'downloadedAt',
         'spaceSlug',
         'verified',

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -5746,6 +5746,7 @@ export class AiAgentModel {
                     .ref(`${DashboardsTableName}.dashboard_uuid`)
                     .as('content_uuid'),
                 `${DashboardsTableName}.name`,
+                `${DashboardsTableName}.slug`,
                 `${DashboardsTableName}.description`,
                 `${DashboardsTableName}.views_count`,
                 this.database(DashboardVersionsTableName)
@@ -5806,6 +5807,7 @@ export class AiAgentModel {
             (row) => ({
                 ...toBaseItem(row),
                 contentType: ContentType.DASHBOARD,
+                slug: row.slug,
             }),
         );
 

--- a/packages/backend/src/ee/models/PreAggregateDailyStatsModel.ts
+++ b/packages/backend/src/ee/models/PreAggregateDailyStatsModel.ts
@@ -34,6 +34,7 @@ export type PreAggregateDailyStatRow = {
     chartName: string | null;
     dashboardUuid: string | null;
     dashboardName: string | null;
+    dashboardSlug: string | null;
     queryContext: string;
     hitCount: number;
     missCount: number;
@@ -51,6 +52,7 @@ type DbJoinedRow = {
     chart_name: string | null;
     dashboard_uuid: string | null;
     dashboard_name: string | null;
+    dashboard_slug: string | null;
     query_context: string;
     hit_count: number;
     miss_count: number;
@@ -69,6 +71,7 @@ function convertDbRow(row: DbJoinedRow): PreAggregateDailyStatRow {
         chartName: row.chart_name,
         dashboardUuid: row.dashboard_uuid,
         dashboardName: row.dashboard_name,
+        dashboardSlug: row.dashboard_slug,
         queryContext: row.query_context,
         hitCount: row.hit_count,
         missCount: row.miss_count,
@@ -172,6 +175,7 @@ export class PreAggregateDailyStatsModel {
                 this.database.raw('sq.name as chart_name'),
                 `${stats}.dashboard_uuid`,
                 this.database.raw('d.name as dashboard_name'),
+                this.database.raw('d.slug as dashboard_slug'),
                 `${stats}.query_context`,
                 `${stats}.hit_count`,
                 `${stats}.miss_count`,

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -303,6 +303,7 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
                     chartName: row.chartName,
                     dashboardUuid: row.dashboardUuid,
                     dashboardName: row.dashboardName,
+                    dashboardSlug: row.dashboardSlug,
                     queryContext: row.queryContext,
                     hitCount: row.hitCount,
                     missCount: row.missCount,

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -261,6 +261,7 @@ export class AnalyticsModel {
                 first_name: string;
                 last_name: string;
                 dashboard_uuid: string;
+                dashboard_slug: string;
                 dashboard_name: string;
                 count: number;
             }[];
@@ -298,6 +299,7 @@ export class AnalyticsModel {
                     lastName: row.last_name,
                     count: row.count,
                     dashboardUuid: row.dashboard_uuid,
+                    dashboardSlug: row.dashboard_slug,
                     dashboardName: row.dashboard_name,
                 }),
             ),

--- a/packages/backend/src/models/AnalyticsModelSql.ts
+++ b/packages/backend/src/models/AnalyticsModelSql.ts
@@ -223,13 +223,14 @@ export const dashboardViewsSql = (projectUuid: string) => `
 SELECT
   count(dv.dashboard_uuid) as count,
   dv.dashboard_uuid as uuid,
+  d.slug,
   d.name
 FROM public.analytics_dashboard_views dv
   left join ${DashboardsTableName} d  on d.dashboard_uuid  = dv.dashboard_uuid AND d.deleted_at IS NULL
   left join ${SpaceTableName} s on s.space_id  = d.space_id
   left join projects on projects.project_id = s.project_id
 where projects.project_uuid = '${projectUuid}'
-group by dv.dashboard_uuid, d.name
+group by dv.dashboard_uuid, d.slug, d.name
 order by count(dv.dashboard_uuid) desc
 limit 20
 `;
@@ -241,6 +242,7 @@ WITH RankedResults AS (
       u.first_name,
       u.last_name,
       d.dashboard_uuid,
+      d.slug AS dashboard_slug,
       d."name" AS dashboard_name,
       COUNT(dv.dashboard_uuid) AS dashboard_count,
       ROW_NUMBER() OVER (PARTITION BY u.first_name ORDER BY COUNT(dv.dashboard_uuid) DESC) AS rank
@@ -251,13 +253,14 @@ WITH RankedResults AS (
   left join projects on projects.project_id = s.project_id
   WHERE projects.project_uuid = '${projectUuid}'
     AND u.user_uuid IS NOT NULL
-  GROUP BY u.user_uuid, u.first_name, u.last_name, d.dashboard_uuid, d."name"
+  GROUP BY u.user_uuid, u.first_name, u.last_name, d.dashboard_uuid, d.slug, d."name"
 )
 SELECT
   user_uuid,
   first_name,
   last_name,
   dashboard_uuid,
+  dashboard_slug,
   dashboard_name,
   dashboard_count as count
 FROM RankedResults

--- a/packages/backend/src/models/ContentVerificationModel.ts
+++ b/packages/backend/src/models/ContentVerificationModel.ts
@@ -219,6 +219,7 @@ export class ContentVerificationModel {
                 `${ContentVerificationTableName}.content_type`,
                 `${ContentVerificationTableName}.content_uuid`,
                 `${DashboardsTableName}.name`,
+                `${DashboardsTableName}.slug`,
                 `${DashboardsTableName}.description`,
                 `${DashboardsTableName}.views_count`,
                 this.database(DashboardVersionsTableName)
@@ -279,6 +280,7 @@ export class ContentVerificationModel {
             (row) => ({
                 ...toBaseItem(row),
                 contentType: ContentType.DASHBOARD,
+                slug: row.slug,
             }),
         );
 

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -346,6 +346,7 @@ export const expectedAllDashboards: DashboardBasicDetailsWithTileTypes[] = [
         organizationUuid: 'organizationUuid',
         projectUuid: projectEntry.project_uuid,
         uuid: dashboardEntry.dashboard_uuid,
+        slug: dashboardEntry.slug,
         name: dashboardEntry.name,
         description: dashboardEntry.description,
         updatedAt: dashboardVersionEntry.created_at,

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -479,6 +479,7 @@ export class DashboardModel {
                     )
                     .select<GetDashboardDetailsQuery[]>([
                         `${DashboardsTableName}.dashboard_uuid`,
+                        `${DashboardsTableName}.slug`,
                         `${DashboardsTableName}.name`,
                         `${DashboardsTableName}.description`,
                         `${DashboardVersionsTableName}.created_at`,
@@ -561,6 +562,7 @@ export class DashboardModel {
                     name,
                     description,
                     dashboard_uuid,
+                    slug,
                     created_at,
                     project_uuid,
                     user_uuid,
@@ -585,6 +587,7 @@ export class DashboardModel {
                         name,
                         description,
                         uuid: dashboard_uuid,
+                        slug,
                         updatedAt: created_at,
                         projectUuid: project_uuid,
                         updatedByUser: {

--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -155,6 +155,7 @@ const getDashboards = async (
             'pinned_list.pinned_list_uuid',
             `${SpaceTableName}.space_uuid`,
             'pinned_dashboard.dashboard_uuid',
+            `${DashboardsTableName}.slug`,
             'users.user_uuid as updated_by_user_uuid',
             'pinned_dashboard.order',
         )
@@ -168,13 +169,14 @@ const getDashboards = async (
             updated_by_user_last_name: 'users.last_name',
         })
         .orderBy('pinned_dashboard.order', 'asc')
-        .groupBy(1, 2, 3, 4, 5, 6)) as Record<string, AnyType>[];
+        .groupBy(1, 2, 3, 4, 5, 6, 7)) as Record<string, AnyType>[];
     const resourceType: ResourceViewItemType.DASHBOARD =
         ResourceViewItemType.DASHBOARD;
     const items = rows.map((row) => ({
         type: resourceType,
         data: {
             uuid: row.dashboard_uuid,
+            slug: row.slug,
             spaceUuid: row.space_uuid,
             description: row.description,
             name: row.name,

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1784,6 +1784,7 @@ export class SavedChartModel {
                             space_uuid: string;
                             spaceName: string;
                             dashboardName: string | null;
+                            dashboardSlug: string | null;
                             slug: string;
                             deleted_at: Date | null;
                             deleted_by_user_uuid: string | null;
@@ -1799,6 +1800,7 @@ export class SavedChartModel {
                         `${SavedChartsTableName}.dashboard_uuid`,
                         `${SavedChartsTableName}.slug`,
                         `${DashboardsTableName}.name as dashboardName`,
+                        `${DashboardsTableName}.slug as dashboardSlug`,
                         'saved_queries_versions.saved_queries_version_id',
                         'saved_queries_versions.explore_name',
                         'saved_queries_versions.filters',
@@ -2155,6 +2157,7 @@ export class SavedChartModel {
                     pinnedListOrder: null,
                     dashboardUuid: savedQuery.dashboard_uuid,
                     dashboardName: savedQuery.dashboardName,
+                    dashboardSlug: savedQuery.dashboardSlug,
                     colorPalette: resolvedPalette.colors,
                     colorPaletteUuid: savedQuery.color_palette_uuid ?? null,
                     resolvedColorPalette: resolvedPalette,
@@ -2587,6 +2590,7 @@ export class SavedChartModel {
                 chartKind: `${SavedChartsTableName}.last_version_chart_kind`,
                 dashboardUuid: `${DashboardsTableName}.dashboard_uuid`,
                 dashboardName: `${DashboardsTableName}.name`,
+                dashboardSlug: `${DashboardsTableName}.slug`,
                 updatedAt: `${SavedChartsTableName}.last_version_updated_at`,
                 slug: `${SavedChartsTableName}.slug`,
                 viewsCount: `${SavedChartsTableName}.views_count`,

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -755,6 +755,7 @@ export class SearchModel {
                 { uuid: `${DashboardTabsTableName}.uuid` },
                 { name: `${DashboardTabsTableName}.name` },
                 { dashboardUuid: `${DashboardsTableName}.dashboard_uuid` },
+                { dashboardSlug: `${DashboardsTableName}.slug` },
                 { dashboardName: `${DashboardsTableName}.name` },
                 { spaceUuid: `${SpaceTableName}.space_uuid` },
             )

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1381,6 +1381,7 @@ export class SpaceModel {
                 })[]
             >([
                 `${DashboardsTableName}.dashboard_uuid`,
+                `${DashboardsTableName}.slug`,
                 `${DashboardsTableName}.name`,
                 `${DashboardsTableName}.description`,
                 `${ProjectTableName}.project_uuid`,
@@ -1440,6 +1441,7 @@ export class SpaceModel {
                 name,
                 description,
                 dashboard_uuid,
+                slug,
                 created_at,
                 project_uuid,
                 user_uuid,
@@ -1457,6 +1459,7 @@ export class SpaceModel {
                 name,
                 description,
                 uuid: dashboard_uuid,
+                slug,
                 projectUuid: project_uuid,
                 updatedAt: created_at,
                 updatedByUser: {

--- a/packages/backend/src/models/UserFavoritesModel.ts
+++ b/packages/backend/src/models/UserFavoritesModel.ts
@@ -195,6 +195,7 @@ export class UserFavoritesModel {
             .select(
                 `${SpaceTableName}.space_uuid`,
                 `${DashboardsTableName}.dashboard_uuid`,
+                `${DashboardsTableName}.slug`,
                 'users.user_uuid as updated_by_user_uuid',
             )
             .max({
@@ -209,6 +210,7 @@ export class UserFavoritesModel {
             .groupBy(
                 `${SpaceTableName}.space_uuid`,
                 `${DashboardsTableName}.dashboard_uuid`,
+                `${DashboardsTableName}.slug`,
                 'users.user_uuid',
             )) as Record<string, AnyType>[];
 
@@ -216,6 +218,7 @@ export class UserFavoritesModel {
             type: ResourceViewItemType.DASHBOARD as const,
             data: {
                 uuid: row.dashboard_uuid,
+                slug: row.slug,
                 spaceUuid: row.space_uuid,
                 description: row.description,
                 name: row.name,

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -60,6 +60,7 @@ type NormalizedValidationRow = {
     dashboard_uuid: string | null;
     app_uuid: string | null;
     resource_name: string | null;
+    resource_slug: string | null;
     views_count: number | null;
     last_updated_at: Date | null;
     first_name: string | null;
@@ -525,7 +526,10 @@ export class ValidationModel {
             )
             .select<
                 (DbValidationTable &
-                    Pick<DashboardTable['base'], 'name' | 'views_count'> &
+                    Pick<
+                        DashboardTable['base'],
+                        'name' | 'slug' | 'views_count'
+                    > &
                     Pick<UserTable['base'], 'first_name' | 'last_name'> &
                     Pick<DbSpace, 'space_uuid'> & {
                         last_updated_at: Date;
@@ -533,6 +537,7 @@ export class ValidationModel {
             >([
                 `${ValidationTableName}.*`,
                 `${DashboardsTableName}.name`,
+                `${DashboardsTableName}.slug`,
                 `${DashboardVersionsTableName}.created_at as last_updated_at`,
                 `${UserTableName}.first_name`,
                 `${UserTableName}.last_name`,
@@ -567,6 +572,7 @@ export class ValidationModel {
                 return {
                     createdAt: validationError.created_at,
                     dashboardUuid: validationError.dashboard_uuid!,
+                    dashboardSlug: validationError.slug,
                     dashboardViews: validationError.views_count,
                     projectUuid: validationError.project_uuid,
                     error: validationError.error,
@@ -740,6 +746,7 @@ export class ValidationModel {
                 source: ValidationSourceType.Dashboard,
                 fieldName: row.field_name ?? undefined,
                 dashboardUuid: row.dashboard_uuid!,
+                dashboardSlug: row.resource_slug ?? undefined,
                 dashboardViews: row.views_count ?? 0,
                 name: row.resource_name || 'Dashboard does not exist',
                 lastUpdatedBy: row.first_name
@@ -868,6 +875,7 @@ export class ValidationModel {
                 this.database.raw(
                     `COALESCE(${SavedChartsTableName}.name, ${ValidationTableName}.chart_name, 'Chart does not exist') as resource_name`,
                 ),
+                this.database.raw('NULL::text as resource_slug'),
                 `${SavedChartsTableName}.views_count`,
                 this.database.raw(
                     `${SavedChartsTableName}.last_version_updated_at as last_updated_at`,
@@ -924,6 +932,7 @@ export class ValidationModel {
                 this.database.raw(
                     `COALESCE(${DashboardsTableName}.name, ${ValidationTableName}.model_name, 'Dashboard does not exist') as resource_name`,
                 ),
+                `${DashboardsTableName}.slug as resource_slug`,
                 `${DashboardsTableName}.views_count`,
                 this.database.raw(
                     `${DashboardVersionsTableName}.created_at as last_updated_at`,
@@ -960,6 +969,7 @@ export class ValidationModel {
                 this.database.raw(
                     `${ValidationTableName}.model_name as resource_name`,
                 ),
+                this.database.raw('NULL::text as resource_slug'),
                 this.database.raw('NULL::integer as views_count'),
                 this.database.raw('NULL::timestamp as last_updated_at'),
                 this.database.raw('NULL::text as first_name'),
@@ -1089,6 +1099,7 @@ export class ValidationModel {
                 this.database.raw(
                     `COALESCE(${SavedChartsTableName}.name, ${ValidationTableName}.chart_name, 'Chart does not exist') as resource_name`,
                 ),
+                this.database.raw('NULL::text as resource_slug'),
                 `${SavedChartsTableName}.views_count`,
                 this.database.raw(
                     `${SavedChartsTableName}.last_version_updated_at as last_updated_at`,
@@ -1166,6 +1177,7 @@ export class ValidationModel {
                 this.database.raw(
                     `COALESCE(${DashboardsTableName}.name, ${ValidationTableName}.model_name, 'Dashboard does not exist') as resource_name`,
                 ),
+                `${DashboardsTableName}.slug as resource_slug`,
                 `${DashboardsTableName}.views_count`,
                 this.database.raw(
                     `${DashboardVersionsTableName}.created_at as last_updated_at`,
@@ -1220,6 +1232,7 @@ export class ValidationModel {
                 this.database.raw(
                     `${ValidationTableName}.model_name as resource_name`,
                 ),
+                this.database.raw('NULL::text as resource_slug'),
                 this.database.raw('NULL::integer as views_count'),
                 this.database.raw('NULL::timestamp as last_updated_at'),
                 this.database.raw('NULL::text as first_name'),
@@ -1270,6 +1283,7 @@ export class ValidationModel {
                 `${ValidationTableName}.dashboard_uuid`,
                 `${ValidationTableName}.app_uuid`,
                 `${AppsTableName}.name as resource_name`,
+                this.database.raw('NULL::text as resource_slug'),
                 this.database.raw('NULL::integer as views_count'),
                 `${LATEST_APP_VERSION_ALIAS}.created_at as last_updated_at`,
                 `${APP_VERSION_AUTHOR_ALIAS}.first_name`,

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -181,6 +181,7 @@ export const dashboardsDetails: DashboardBasicDetails[] = [
         organizationUuid: user.organizationUuid!,
         projectUuid: dashboard.projectUuid,
         uuid: dashboard.uuid,
+        slug: dashboard.slug,
         name: dashboard.name,
         description: dashboard.description,
         updatedAt: dashboard.updatedAt,

--- a/packages/common/src/types/analytics.ts
+++ b/packages/common/src/types/analytics.ts
@@ -15,6 +15,12 @@ export type ChartActivityViews = {
     name: string;
     slug: string;
 };
+export type DashboardActivityViews = {
+    count: number;
+    uuid: string;
+    name: string;
+    slug: string;
+};
 export type UserActivity = {
     numberUsers: number;
     numberViewers: number;
@@ -35,10 +41,11 @@ export type UserActivity = {
         date: Date;
         average_number_of_weekly_queries_per_user: string;
     }[];
-    dashboardViews: ActivityViews[];
+    dashboardViews: DashboardActivityViews[];
     userMostViewedDashboards: (UserWithCount & {
         dashboardName: string;
         dashboardUuid: string;
+        dashboardSlug: string;
     })[];
     chartViews: ChartActivityViews[];
 };

--- a/packages/common/src/types/contentVerification.ts
+++ b/packages/common/src/types/contentVerification.ts
@@ -36,6 +36,7 @@ export type VerifiedChartListItem = VerifiedContentListItemBase & {
 
 export type VerifiedDashboardListItem = VerifiedContentListItemBase & {
     contentType: ContentType.DASHBOARD;
+    slug: string;
 };
 
 export type VerifiedContentListItem =

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -280,6 +280,7 @@ export type Dashboard = {
 export type DashboardBasicDetails = Pick<
     Dashboard,
     | 'uuid'
+    | 'slug'
     | 'name'
     | 'description'
     | 'updatedAt'

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -343,6 +343,7 @@ export type PreAggregateDailyStatResult = {
     chartName: string | null;
     dashboardUuid: string | null;
     dashboardName: string | null;
+    dashboardSlug: string | null;
     queryContext: string;
     hitCount: number;
     missCount: number;

--- a/packages/common/src/types/resourceViewItem.ts
+++ b/packages/common/src/types/resourceViewItem.ts
@@ -47,6 +47,7 @@ export type ResourceViewDashboardItem = {
     data: Pick<
         DashboardBasicDetails,
         | 'uuid'
+        | 'slug'
         | 'spaceUuid'
         | 'description'
         | 'name'

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -958,6 +958,7 @@ export type SavedChart = {
     pinnedListOrder: number | null;
     dashboardUuid: string | null;
     dashboardName: string | null;
+    dashboardSlug?: string | null;
     /**
      * @deprecated Use `resolvedColorPalette.colors` instead. This field carries
      * only the resolved colors and will be removed once renderers migrate to
@@ -1346,6 +1347,7 @@ export type ChartSummary = Pick<
     | 'pinnedListUuid'
     | 'dashboardUuid'
     | 'dashboardName'
+    | 'dashboardSlug'
     | 'slug'
 > & {
     chartType?: ChartType | undefined;

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -191,6 +191,7 @@ export type DashboardTabResult = {
     uuid: string; // Tab uuid
     name: string; // Tab name
     dashboardUuid: string;
+    dashboardSlug: string;
     dashboardName: string;
     spaceUuid: string;
 };

--- a/packages/common/src/types/validation.ts
+++ b/packages/common/src/types/validation.ts
@@ -31,6 +31,7 @@ export type ValidationErrorChartResponse = ValidationResponseBase & {
 
 export type ValidationErrorDashboardResponse = ValidationResponseBase & {
     dashboardUuid: string | undefined; // NOTE: can be undefined if private content
+    dashboardSlug?: string;
     chartName?: string;
     fieldName?: string;
     tableName?: string; // For dashboard filter errors referencing specific tables

--- a/packages/e2e/cypress/e2e/app/savedDashboards.cy.ts
+++ b/packages/e2e/cypress/e2e/app/savedDashboards.cy.ts
@@ -27,7 +27,7 @@ describe('Dashboard List', () => {
 
         cy.url().should(
             'match',
-            /.*\/projects\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/dashboards\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/,
+            /\/projects\/[0-9a-f-]{36}\/dashboards\/[^/]+\/edit$/,
         );
         cy.findByText('Untitled dashboard').should('exist');
     });

--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -178,6 +178,7 @@ const AddTileButton: FC<Props> = ({
                                         dashboard?.name,
                                         activeTabUuid,
                                         dashboardTabs,
+                                        dashboard?.slug,
                                     );
                                     void navigate(
                                         `/projects/${projectUuid}/tables`,

--- a/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
@@ -47,6 +47,7 @@ const EditChartMenuItem: FC<Props> = ({ tile, chartSlug, ...props }) => {
                         dashboard?.name,
                         activeTab?.uuid,
                         dashboardTabs,
+                        dashboard?.slug,
                     );
                 }
             }}

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/TitleBreadcrumbs.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/TitleBreadcrumbs.tsx
@@ -9,6 +9,7 @@ type Props = {
     spaceUuid: string | null;
     spaceName: string | null;
     dashboardUuid?: string | null;
+    dashboardSlug?: string | null;
     dashboardName?: string | null;
 };
 
@@ -25,6 +26,7 @@ export const TitleBreadCrumbs: FC<Props> = ({
     spaceUuid,
     spaceName,
     dashboardUuid,
+    dashboardSlug,
     dashboardName,
 }) => {
     const isChartWithinDashboard = !!(dashboardUuid && dashboardName);
@@ -51,7 +53,7 @@ export const TitleBreadCrumbs: FC<Props> = ({
                                 <ActionIcon
                                     variant="subtle"
                                     component={Link}
-                                    to={`/projects/${projectUuid}/dashboards/${dashboardUuid}`}
+                                    to={`/projects/${projectUuid}/dashboards/${dashboardSlug ?? dashboardUuid}`}
                                 >
                                     <MantineIcon
                                         color="ldGray.4"
@@ -102,7 +104,7 @@ export const TitleBreadCrumbs: FC<Props> = ({
                             c="ldGray.6"
                             fz="md"
                             component={Link}
-                            to={`/projects/${projectUuid}/dashboards/${dashboardUuid}`}
+                            to={`/projects/${projectUuid}/dashboards/${dashboardSlug ?? dashboardUuid}`}
                             truncate
                             display="inline-block"
                             maw={MAX_WIDTH_TITLE_PX}

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -164,6 +164,7 @@ const SavedChartsHeader: FC = () => {
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
 
     const savedChart = useExplorerSelector(selectSavedChart);
+    const dashboardIdentifier = savedChart?.dashboardSlug ?? dashboardUuid;
 
     const hasUnsavedChanges = useExplorerSelector(selectHasUnsavedChanges);
 
@@ -338,6 +339,9 @@ const SavedChartsHeader: FC = () => {
             ) &&
             !nextLocation.pathname.includes(
                 `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
+            ) &&
+            !nextLocation.pathname.includes(
+                `/projects/${projectUuid}/dashboards/${dashboardIdentifier}`,
             )
         ) {
             return true; //blocks navigation
@@ -434,7 +438,7 @@ const SavedChartsHeader: FC = () => {
 
     const handleGoBackClick = () => {
         void navigate({
-            pathname: `/projects/${savedChart?.projectUuid}/dashboards/${dashboardUuid}`,
+            pathname: `/projects/${savedChart?.projectUuid}/dashboards/${dashboardIdentifier}`,
         });
     };
 
@@ -519,6 +523,7 @@ const SavedChartsHeader: FC = () => {
                                         spaceUuid={savedChart.spaceUuid}
                                         spaceName={savedChart.spaceName}
                                         dashboardUuid={savedChart.dashboardUuid}
+                                        dashboardSlug={savedChart.dashboardSlug}
                                         dashboardName={savedChart.dashboardName}
                                     />
                                 )}
@@ -1053,7 +1058,7 @@ const SavedChartsHeader: FC = () => {
                     onConfirm={() => {
                         if (dashboardUuid) {
                             void navigate(
-                                `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
+                                `/projects/${projectUuid}/dashboards/${dashboardIdentifier}`,
                             );
                         } else {
                             void navigate(`/`);

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/CreateResourceToSpace.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/CreateResourceToSpace.tsx
@@ -26,7 +26,7 @@ const CreateResourceToSpace: FC<Props> = ({ resourceType }) => {
     useEffect(() => {
         if (hasCreatedDashboard && newDashboard) {
             void navigate(
-                `/projects/${projectUuid}/dashboards/${newDashboard.uuid}`,
+                `/projects/${projectUuid}/dashboards/${newDashboard.slug}`,
             );
         }
     }, [navigate, hasCreatedDashboard, newDashboard, projectUuid]);

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -48,7 +48,7 @@ interface Props {
 const getFavoriteItemUrl = (projectUuid: string, item: ResourceViewItem) => {
     switch (item.type) {
         case ResourceViewItemType.DASHBOARD:
-            return `/projects/${projectUuid}/dashboards/${item.data.uuid}/view`;
+            return `/projects/${projectUuid}/dashboards/${item.data.slug}/view`;
         case ResourceViewItemType.CHART:
             return `/projects/${projectUuid}/saved/${item.data.slug}`;
         case ResourceViewItemType.SPACE:

--- a/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
+++ b/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
@@ -22,6 +22,7 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
     const {
         name: dashboardName,
         dashboardUuid,
+        dashboardSlug,
         activeTabUuid,
     } = getEditingDashboardInfo();
 
@@ -78,7 +79,7 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
         // so do not clear the storage here
         setIsCancelling(true);
 
-        let returnUrl = `/projects/${projectUuid}/dashboards/${dashboardUuid}/${
+        let returnUrl = `/projects/${projectUuid}/dashboards/${dashboardSlug ?? dashboardUuid}/${
             savedQueryUuid ? 'view' : 'edit'
         }`;
 
@@ -92,7 +93,14 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
             // Clear the banner after navigating back to dashboard, but only after a delay so that the user can see the banner change
             setIsCancelling(false);
         }, 1000);
-    }, [dashboardUuid, activeTabUuid, navigate, projectUuid, savedQueryUuid]);
+    }, [
+        dashboardSlug,
+        dashboardUuid,
+        activeTabUuid,
+        navigate,
+        projectUuid,
+        savedQueryUuid,
+    ]);
 
     return (
         <>

--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -189,7 +189,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                     onClose={() => setIsCreateDashboardOpen(false)}
                     onConfirm={(dashboard) => {
                         void navigate(
-                            `/projects/${projectUuid}/dashboards/${dashboard.uuid}/edit`,
+                            `/projects/${projectUuid}/dashboards/${dashboard.slug}/edit`,
                         );
 
                         setIsCreateDashboardOpen(false);

--- a/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.tsx
@@ -205,7 +205,7 @@ const PreAggregateStatsTable: FC<Props> = ({
                 Cell: ({ row }) =>
                     row.original.dashboardUuid ? (
                         <Anchor
-                            href={`/projects/${projectUuid}/dashboards/${row.original.dashboardUuid}`}
+                            href={`/projects/${projectUuid}/dashboards/${row.original.dashboardSlug ?? row.original.dashboardUuid}`}
                             target="_blank"
                             size="xs"
                         >

--- a/packages/frontend/src/components/PreAggregateAudit/preAggregateHelpers.ts
+++ b/packages/frontend/src/components/PreAggregateAudit/preAggregateHelpers.ts
@@ -19,6 +19,7 @@ export type AggregatedRow = {
     chartUuid: string | null;
     dashboardName: string | null;
     dashboardUuid: string | null;
+    dashboardSlug: string | null;
     exploreName: string;
     queryContext: string;
     queryType: QueryType;
@@ -59,6 +60,7 @@ export function aggregateStats(
                 chartUuid: stat.chartUuid,
                 dashboardName: stat.dashboardName,
                 dashboardUuid: stat.dashboardUuid,
+                dashboardSlug: stat.dashboardSlug,
                 exploreName: stat.exploreName,
                 queryContext: stat.queryContext,
                 queryType: getQueryType(stat),

--- a/packages/frontend/src/components/SettingsValidator/utils/utils.ts
+++ b/packages/frontend/src/components/SettingsValidator/utils/utils.ts
@@ -16,7 +16,7 @@ export const getLinkToResource = (
         isDashboardValidationError(validationError) &&
         validationError.dashboardUuid
     )
-        return `/projects/${projectUuid}/dashboards/${validationError.dashboardUuid}/view`;
+        return `/projects/${projectUuid}/dashboards/${validationError.dashboardSlug ?? validationError.dashboardUuid}/view`;
 
     if (isDataAppValidationError(validationError) && validationError.appUuid)
         return `/projects/${projectUuid}/apps/${validationError.appUuid}`;

--- a/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
+++ b/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
@@ -81,11 +81,11 @@ const VerifiedContentPanel: FC<Props> = ({ projectUuid }) => {
                 enableSorting: false,
                 size: 250,
                 Cell: ({ row }) => {
-                    const { contentType, contentUuid, name } = row.original;
+                    const { contentType, name } = row.original;
                     const href =
                         contentType === ContentType.CHART
                             ? `/projects/${projectUuid}/saved/${row.original.slug}`
-                            : `/projects/${projectUuid}/dashboards/${contentUuid}`;
+                            : `/projects/${projectUuid}/dashboards/${row.original.slug}`;
                     return (
                         <Anchor
                             component={Link}

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -156,12 +156,12 @@ const DashboardHeader = memo(
         );
         const { search, pathname } = useLocation();
         const navigate = useNavigate();
-        const { projectUuid, dashboardUuid: dashboardIdentifier } = useParams<{
+        const { projectUuid } = useParams<{
             projectUuid: string;
-            dashboardUuid: string;
             organizationUuid: string;
         }>();
         const dashboardUuid = dashboard.uuid;
+        const dashboardIdentifier = dashboard.slug;
 
         const { data: project } = useProject(projectUuid);
 

--- a/packages/frontend/src/components/common/ResourceInfoPopup/DashboardList.tsx
+++ b/packages/frontend/src/components/common/ResourceInfoPopup/DashboardList.tsx
@@ -27,10 +27,10 @@ export const DashboardList: FC<Props> = ({ resourceItemId, projectUuid }) => {
             )}
             {!!relatedDashboards?.length && (
                 <List size="xs">
-                    {relatedDashboards.map(({ uuid, name }) => (
+                    {relatedDashboards.map(({ uuid, slug, name }) => (
                         <List.Item key={uuid}>
                             <Anchor
-                                href={`${window.location.origin}/projects/${projectUuid}/dashboards/${uuid}/view/`}
+                                href={`${window.location.origin}/projects/${projectUuid}/dashboards/${slug}/view/`}
                                 target="_blank"
                                 onClick={(
                                     e: React.MouseEvent<HTMLAnchorElement>,

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -81,7 +81,7 @@ export const getResourceUrl = (projectUuid: string, item: ResourceViewItem) => {
     const itemType = item.type;
     switch (item.type) {
         case ResourceViewItemType.DASHBOARD:
-            return `/projects/${projectUuid}/dashboards/${item.data.uuid}/view`;
+            return `/projects/${projectUuid}/dashboards/${item.data.slug}/view`;
         case ResourceViewItemType.CHART:
             return getChartResourceUrl(projectUuid, item);
         case ResourceViewItemType.SPACE:

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
@@ -141,8 +141,8 @@ export const SaveToDashboard: FC<Props> = ({
             );
             void navigate(
                 activeTabUuid
-                    ? `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit/tabs/${activeTabUuid}`
-                    : `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
+                    ? `/projects/${projectUuid}/dashboards/${selectedDashboard?.slug ?? dashboardUuid}/edit/tabs/${activeTabUuid}`
+                    : `/projects/${projectUuid}/dashboards/${selectedDashboard?.slug ?? dashboardUuid}/edit`,
             );
             showToastSuccess({
                 title: `Success! ${values.name} was added to ${dashboardName}`,
@@ -161,6 +161,7 @@ export const SaveToDashboard: FC<Props> = ({
             showToastSuccess,
             dashboardName,
             selectedDashboard?.tiles,
+            selectedDashboard?.slug,
         ],
     );
     return (

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -412,8 +412,8 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
                 );
                 void navigate(
                     activeTabUuid
-                        ? `/projects/${projectUuid}/dashboards/${originatingDashboard.dashboardUuid}/edit/tabs/${activeTabUuid}`
-                        : `/projects/${projectUuid}/dashboards/${originatingDashboard.dashboardUuid}/edit`,
+                        ? `/projects/${projectUuid}/dashboards/${originatingDashboardData?.slug ?? originatingDashboard.dashboardUuid}/edit/tabs/${activeTabUuid}`
+                        : `/projects/${projectUuid}/dashboards/${originatingDashboardData?.slug ?? originatingDashboard.dashboardUuid}/edit`,
                 );
                 showToastSuccess({
                     title: `Success! ${values.name} was added to ${originatingDashboard.dashboardName}`,

--- a/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
@@ -85,7 +85,7 @@ const ChartDeleteModal: FC<ChartDeleteModalProps> = ({
                                         component={Link}
                                         fz="sm"
                                         target="_blank"
-                                        to={`/projects/${projectUuid}/dashboards/${dashboard.uuid}`}
+                                        to={`/projects/${projectUuid}/dashboards/${dashboard.slug}`}
                                     >
                                         {dashboard.name}
                                     </Anchor>

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -25,7 +25,7 @@ import {
     type FC,
 } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { v4 as uuid4 } from 'uuid';
 import { DASHBOARD_HEADER_HEIGHT } from '../../components/common/Dashboard/dashboard.constants';
 import MantineIcon from '../../components/common/MantineIcon';
@@ -313,11 +313,9 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
 
     const { search } = useLocation();
     const navigate = useNavigate();
-    const { dashboardUuid: dashboardIdentifier } = useParams<{
-        dashboardUuid: string;
-    }>();
-
-    const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
+    const dashboard = useDashboardContext((c) => c.dashboard);
+    const dashboardUuid = dashboard?.uuid;
+    const dashboardIdentifier = dashboard?.slug;
     const projectUuid = useDashboardContext((c) => c.projectUuid);
     const setHaveTabsChanged = useDashboardContext((c) => c.setHaveTabsChanged);
     const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);

--- a/packages/frontend/src/features/omnibar/utils/getSearchItemMap.test.ts
+++ b/packages/frontend/src/features/omnibar/utils/getSearchItemMap.test.ts
@@ -1,0 +1,57 @@
+import { SearchItemType, type SearchResults } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { getSearchItemMap } from './getSearchItemMap';
+
+const emptyResults = {
+    spaces: [],
+    dashboards: [],
+    dashboardTabs: [],
+    savedCharts: [],
+    sqlCharts: [],
+    tables: [],
+    fields: [],
+    pages: [],
+    dataApps: [],
+} as SearchResults;
+
+describe('getSearchItemMap', () => {
+    it('uses dashboard slugs for dashboard and dashboard tab results', () => {
+        const result = getSearchItemMap(
+            {
+                ...emptyResults,
+                dashboards: [
+                    {
+                        uuid: 'dashboard-uuid',
+                        slug: 'dashboard-slug',
+                        name: 'Dashboard',
+                    },
+                ],
+                dashboardTabs: [
+                    {
+                        uuid: 'tab-uuid',
+                        name: 'Tab',
+                        dashboardUuid: 'dashboard-uuid',
+                        dashboardSlug: 'dashboard-slug',
+                        dashboardName: 'Dashboard',
+                        spaceUuid: 'space-uuid',
+                    },
+                ],
+            } as SearchResults,
+            'project-uuid',
+        );
+
+        expect(result.dashboards[0]).toMatchObject({
+            type: SearchItemType.DASHBOARD,
+            location: {
+                pathname: '/projects/project-uuid/dashboards/dashboard-slug',
+            },
+        });
+        expect(result.dashboardTabs[0]).toMatchObject({
+            type: SearchItemType.DASHBOARD_TAB,
+            location: {
+                pathname:
+                    '/projects/project-uuid/dashboards/dashboard-slug/view/tabs/tab-uuid',
+            },
+        });
+    });
+});

--- a/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
+++ b/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
@@ -31,7 +31,7 @@ export const getSearchItemMap = (
         item: item,
         searchRank: item.search_rank,
         location: {
-            pathname: `/projects/${projectUuid}/dashboards/${item.uuid}`,
+            pathname: `/projects/${projectUuid}/dashboards/${item.slug}`,
         },
     }));
 
@@ -41,7 +41,7 @@ export const getSearchItemMap = (
         description: `Dashboard: ${item.dashboardName}`,
         item: item,
         location: {
-            pathname: `/projects/${projectUuid}/dashboards/${item.dashboardUuid}/view/tabs/${item.uuid}`,
+            pathname: `/projects/${projectUuid}/dashboards/${item.dashboardSlug}/view/tabs/${item.uuid}`,
         },
     }));
 

--- a/packages/frontend/src/features/promotion/hooks/usePromoteDashboard.ts
+++ b/packages/frontend/src/features/promotion/hooks/usePromoteDashboard.ts
@@ -30,7 +30,7 @@ export const usePromoteDashboardMutation = () => {
                         icon: IconArrowRight,
                         onClick: () => {
                             window.open(
-                                `/projects/${data.projectUuid}/dashboards/${data.uuid}`,
+                                `/projects/${data.projectUuid}/dashboards/${data.slug}`,
                                 '_blank',
                             );
                         },

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -467,7 +467,13 @@ export const useUpdateDashboard = (
                 await queryClient.invalidateQueries([
                     'dashboards-containing-chart',
                 ]);
-                await queryClient.resetQueries(['saved_dashboard_query', id]);
+                await Promise.all([
+                    queryClient.resetQueries(['saved_dashboard_query', id]),
+                    queryClient.resetQueries([
+                        'saved_dashboard_query',
+                        updatedDashboard.slug,
+                    ]),
+                ]);
                 // Remove stale chart results so navigating back doesn't
                 // show old cache timestamps after a save
                 queryClient.removeQueries({
@@ -496,7 +502,7 @@ export const useUpdateDashboard = (
                               icon: IconArrowRight,
                               onClick: () =>
                                   navigate(
-                                      `/projects/${projectUuid}/dashboards/${id}`,
+                                      `/projects/${projectUuid}/dashboards/${updatedDashboard.slug}`,
                                   ),
                           }
                         : undefined,
@@ -550,7 +556,7 @@ export const useCreateMutation = (
                                   icon: IconArrowRight,
                                   onClick: () =>
                                       navigate(
-                                          `/projects/${projectUuid}/dashboards/${result.uuid}`,
+                                          `/projects/${projectUuid}/dashboards/${result.slug}`,
                                       ),
                               }
                             : undefined,
@@ -598,7 +604,7 @@ export const useCreateDashboardWithChartsMutation = (
                             children: 'Open dashboard',
                             onClick: () =>
                                 navigate(
-                                    `/projects/${projectUuid}/dashboards/${result.uuid}`,
+                                    `/projects/${projectUuid}/dashboards/${result.slug}`,
                                 ),
                         },
                     });
@@ -657,7 +663,7 @@ export const useDuplicateDashboardMutation = (
                               icon: IconArrowRight,
                               onClick: () =>
                                   navigate(
-                                      `/projects/${projectUuid}/dashboards/${data.uuid}`,
+                                      `/projects/${projectUuid}/dashboards/${data.slug}`,
                                   ),
                           }
                         : undefined,

--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.ts
@@ -41,6 +41,7 @@ const useDashboardStorage = () => {
     const clearIsEditingDashboardChart = useCallback(() => {
         sessionStorage.removeItem('fromDashboard');
         sessionStorage.removeItem('dashboardUuid');
+        sessionStorage.removeItem('dashboardSlug');
         // Trigger storage event to update NavBar
         window.dispatchEvent(new Event('storage'));
     }, []);
@@ -50,6 +51,7 @@ const useDashboardStorage = () => {
         return {
             name: sessionStorage.getItem('fromDashboard'),
             dashboardUuid,
+            dashboardSlug: sessionStorage.getItem('dashboardSlug'),
             activeTabUuid: dashboardUuid
                 ? sessionStorage.getItem(activeTabKey(dashboardUuid))
                 : null,
@@ -57,12 +59,24 @@ const useDashboardStorage = () => {
     }, []);
 
     const setDashboardChartInfo = useCallback(
-        (dashboardData: { name: string; dashboardUuid: string }) => {
+        (dashboardData: {
+            name: string;
+            dashboardUuid: string;
+            dashboardSlug?: string;
+        }) => {
             sessionStorage.setItem('fromDashboard', dashboardData.name);
             sessionStorage.setItem(
                 'dashboardUuid',
                 dashboardData.dashboardUuid,
             );
+            if (dashboardData.dashboardSlug) {
+                sessionStorage.setItem(
+                    'dashboardSlug',
+                    dashboardData.dashboardSlug,
+                );
+            } else {
+                sessionStorage.removeItem('dashboardSlug');
+            }
             // Trigger storage event to update NavBar
             window.dispatchEvent(new Event('storage'));
         },
@@ -89,6 +103,7 @@ const useDashboardStorage = () => {
         const dashboardUuid = sessionStorage.getItem('dashboardUuid');
         sessionStorage.removeItem('fromDashboard');
         sessionStorage.removeItem('dashboardUuid');
+        sessionStorage.removeItem('dashboardSlug');
         if (dashboardUuid) {
             sessionStorage.removeItem(tilesKey(dashboardUuid));
             sessionStorage.removeItem(tabsKey(dashboardUuid));
@@ -110,10 +125,16 @@ const useDashboardStorage = () => {
             dashboardName: string | undefined,
             activeTabUuid?: string,
             dashboardTabs?: DashboardTab[],
+            dashboardSlug?: string,
         ) => {
             if (!dashboardUuid) return;
             sessionStorage.setItem('fromDashboard', dashboardName ?? '');
             sessionStorage.setItem('dashboardUuid', dashboardUuid);
+            if (dashboardSlug) {
+                sessionStorage.setItem('dashboardSlug', dashboardSlug);
+            } else {
+                sessionStorage.removeItem('dashboardSlug');
+            }
             sessionStorage.setItem(
                 tilesKey(dashboardUuid),
                 JSON.stringify(dashboardTiles ?? []),

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -342,7 +342,7 @@ export const useUpdateMutation = (
                               icon: IconArrowRight,
                               onClick: () =>
                                   navigate(
-                                      `/projects/${data.projectUuid}/dashboards/${dashboardUuid}`,
+                                      `/projects/${data.projectUuid}/dashboards/${data.dashboardSlug ?? dashboardUuid}`,
                                   ),
                           }
                         : undefined,
@@ -556,7 +556,7 @@ export const useAddVersionMutation = (options?: {
                         icon: IconArrowRight,
                         onClick: () =>
                             navigate(
-                                `/projects/${data.projectUuid}/dashboards/${dashboardUuid}`,
+                                `/projects/${data.projectUuid}/dashboards/${data.dashboardSlug ?? dashboardUuid}`,
                             ),
                     },
                 });

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -54,7 +54,7 @@ const Dashboard: FC = () => {
     const navigate = useNavigate();
     const {
         projectUuid,
-        dashboardUuid: dashboardIdentifier,
+        dashboardUuid: routeDashboardIdentifier,
         mode,
     } = useParams<{
         projectUuid: string;
@@ -68,6 +68,7 @@ const Dashboard: FC = () => {
     const isDashboardLoading = useDashboardContext((c) => c.isDashboardLoading);
     const dashboard = useDashboardContext((c) => c.dashboard);
     const dashboardUuid = dashboard?.uuid;
+    const dashboardIdentifier = dashboard?.slug ?? routeDashboardIdentifier;
 
     const dashboardError = useDashboardContext((c) => c.dashboardError);
     const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);

--- a/packages/frontend/src/pages/DashboardHistory.tsx
+++ b/packages/frontend/src/pages/DashboardHistory.tsx
@@ -37,7 +37,7 @@ import DashboardVersionComparison from './DashboardVersionComparison';
 
 const DashboardHistory = () => {
     const navigate = useNavigate();
-    const { dashboardUuid: dashboardIdentifier, projectUuid } = useParams<{
+    const { dashboardUuid: routeDashboardIdentifier, projectUuid } = useParams<{
         dashboardUuid: string;
         projectUuid: string;
     }>();
@@ -45,10 +45,12 @@ const DashboardHistory = () => {
     const [selectedVersionUuid, setSelectedVersionUuid] = useState<string>();
 
     const dashboardQuery = useDashboardQuery({
-        uuidOrSlug: dashboardIdentifier,
+        uuidOrSlug: routeDashboardIdentifier,
         projectUuid,
     });
     const dashboardUuid = dashboardQuery.data?.uuid;
+    const dashboardIdentifier =
+        dashboardQuery.data?.slug ?? routeDashboardIdentifier;
     const historyQuery = useDashboardHistory(dashboardUuid);
 
     const rollbackMutation = useDashboardVersionRollbackMutation(dashboardUuid);

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -407,8 +407,8 @@ const MinimalDashboard: FC = () => {
 
     const generateTabUrl = useCallback(
         (tabId: string) =>
-            `/minimal/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${tabId}`,
-        [projectUuid, dashboardUuid],
+            `/minimal/projects/${projectUuid}/dashboards/${dashboard?.slug ?? dashboardUuid}/view/tabs/${tabId}`,
+        [projectUuid, dashboard?.slug, dashboardUuid],
     );
 
     const sortedTabs = useMemo(

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -85,7 +85,7 @@ const SavedDashboards = () => {
                     onClose={() => setIsCreateDashboardOpen(false)}
                     onConfirm={(dashboard) => {
                         void navigate(
-                            `/projects/${projectUuid}/dashboards/${dashboard.uuid}/edit`,
+                            `/projects/${projectUuid}/dashboards/${dashboard.slug}/edit`,
                         );
 
                         setIsCreateDashboardOpen(false);

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -73,6 +73,7 @@ const SavedExplorer = () => {
             setDashboardChartInfo({
                 name: data.dashboardName,
                 dashboardUuid: data.dashboardUuid,
+                dashboardSlug: data.dashboardSlug ?? undefined,
             });
         }
     }, [data, setDashboardChartInfo]);

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -468,7 +468,7 @@ const Space: FC = () => {
                         onClose={() => setIsCreateDashboardOpen(false)}
                         onConfirm={(dashboard) => {
                             void navigate(
-                                `/projects/${projectUuid}/dashboards/${dashboard.uuid}/edit`,
+                                `/projects/${projectUuid}/dashboards/${dashboard.slug}/edit`,
                             );
 
                             setIsCreateDashboardOpen(false);

--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -1,6 +1,7 @@
 import {
     type ActivityViews,
     type ChartActivityViews,
+    type DashboardActivityViews,
     type UserActivity as UserActivityResponse,
     type UserWithCount,
 } from '@lightdash/common';
@@ -73,8 +74,8 @@ const BigNumberVis: FC<{ value: number | string; label: string }> = ({
     );
 };
 
-const getDashboardLink = (projectUuid: string, dashboardUuid: string) =>
-    `/projects/${projectUuid}/dashboards/${dashboardUuid}`;
+const getDashboardLink = (projectUuid: string, dashboardSlug: string) =>
+    `/projects/${projectUuid}/dashboards/${dashboardSlug}`;
 
 const getChartLink = (projectUuid: string, chartSlug: string) =>
     `/projects/${projectUuid}/saved/${chartSlug}`;
@@ -448,7 +449,7 @@ const UserActivity: FC = () => {
                                                 component={Link}
                                                 to={getDashboardLink(
                                                     projectUuid,
-                                                    user.dashboardUuid,
+                                                    user.dashboardSlug,
                                                 )}
                                             >
                                                 {user.dashboardName}
@@ -478,10 +479,10 @@ const UserActivity: FC = () => {
                                 {showTableViews({
                                     key: 'dashboard-views',
                                     views: data.dashboardViews,
-                                    getLink: (view) =>
+                                    getLink: (view: DashboardActivityViews) =>
                                         getDashboardLink(
                                             projectUuid,
-                                            view.uuid,
+                                            view.slug,
                                         ),
                                 })}
                             </Table>

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -962,7 +962,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     );
 
     // Apply filters on dashboard load in order of precedence:
-    // 1. Start with base dashboard filters
+    // 1. Start with restored dashboard filters, or the saved filters
     // 2. Apply overrides for iframe embed or replace SDK filters in SDK mode
     // 3. Apply interactivity filtering (embedded dashboards only)
     //
@@ -975,8 +975,32 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         if (dashboardFilters === emptyFilters) {
             let overrides = clone(overridesForSavedDashboardFilters);
 
-            // Step 1: Start with base filters
+            // Step 1: Start with restored filters when returning from the
+            // chart editor. Slug routes only resolve their UUID after the
+            // dashboard loads, so restore the UUID-keyed state here instead
+            // of during the provider's initial mount.
             let updatedDashboardFilters = clone(currentDashboard.filters);
+            const filtersStorageKey = dashboardUuid
+                ? `unsavedDashboardFilters:${dashboardUuid}`
+                : null;
+            const unsavedDashboardFiltersRaw = filtersStorageKey
+                ? sessionStorage.getItem(filtersStorageKey)
+                : null;
+
+            if (unsavedDashboardFiltersRaw && filtersStorageKey) {
+                sessionStorage.removeItem(filtersStorageKey);
+                try {
+                    updatedDashboardFilters = JSON.parse(
+                        unsavedDashboardFiltersRaw,
+                    );
+                } catch {
+                    showToastWarning({
+                        title: 'Could not restore unsaved filters',
+                        subtitle:
+                            'Your previous filter changes could not be loaded',
+                    });
+                }
+            }
 
             let droppedLockedOverrides = 0;
 
@@ -1108,7 +1132,9 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         savedChartUuidsAndTileUuids,
         filterableFieldsByTileUuid,
         showToastInfo,
+        showToastWarning,
         activeTab,
+        dashboardUuid,
     ]);
 
     // Derive the effective temporary filters by stripping any that would
@@ -1288,33 +1314,6 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
 
         // Temp filters
         const tempFilterSearchParam = searchParams.get('tempFilters');
-        const filtersStorageKey = dashboardUuid
-            ? `unsavedDashboardFilters:${dashboardUuid}`
-            : null;
-        const unsavedDashboardFiltersRaw = filtersStorageKey
-            ? sessionStorage.getItem(filtersStorageKey)
-            : null;
-
-        if (filtersStorageKey) {
-            sessionStorage.removeItem(filtersStorageKey);
-        }
-        if (unsavedDashboardFiltersRaw) {
-            try {
-                const unsavedDashboardFilters = JSON.parse(
-                    unsavedDashboardFiltersRaw,
-                );
-                // TODO: this should probably merge with the filters
-                // from the database. This will break if they diverge,
-                // meaning there is a subtle race condition here
-                setDashboardFilters(unsavedDashboardFilters);
-            } catch {
-                showToastWarning({
-                    title: 'Could not restore unsaved filters',
-                    subtitle:
-                        'Your previous filter changes could not be loaded',
-                });
-            }
-        }
         if (tempFilterSearchParam) {
             try {
                 setDashboardTemporaryFilters(


### PR DESCRIPTION
![CleanShot 2026-08-20 at 10.37.08.png](https://app.graphite.com/user-attachments/assets/34311973-0777-4f4f-ba76-53d4eb2d1d24.png)





## Summary

- expose dashboard slugs in existing summary, resource, search, verification, analytics, validation, and audit responses
- use those slugs for active dashboard links across homepage, spaces, favorites, search, tabs, settings, chart breadcrumbs, and create/update flows
- canonicalize dashboard edit, tab, and history navigation while preserving UUID compatibility
- retain UUIDs for API mutations, cache keys, permissions, storage relationships, and dashboard/chart identity

All response changes are additive and use existing joins; no migration or per-dashboard lookup is introduced.

## Testing

- common, backend, and frontend typechecks
- API generation
- focused backend model tests (44 passing)
- focused frontend dashboard storage and search mapping tests (6 passing)
- live-tested homepage/resource links, global search, favorites, verified homepage and settings links, chart-to-dashboard breadcrumbs, UUID-to-slug edit/history canonicalization, and version history
- restored temporary favorite, pin, and verification changes after live testing

Linear: https://linear.app/lightdash/issue/SPK-1132/use-dashboard-slugs-in-frontend-navigation-and-summary-data