### PR TITLE
fix: accept slug URLs in backend unfurls

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
@@ -80,6 +80,7 @@ function createService(
     overrides: Partial<{
         savedSqlModel: Partial<SavedSqlModel>;
         savedChartModel: Partial<SavedChartModel>;
+        dashboardModel: Partial<DashboardModel>;
         headlessBrowser: Record<string, unknown>;
     }> = {},
 ) {
@@ -92,7 +93,8 @@ function createService(
                 ...(overrides.headlessBrowser ?? {}),
             },
         } as unknown as LightdashConfig,
-        dashboardModel: {} as unknown as DashboardModel,
+        dashboardModel: (overrides.dashboardModel ??
+            {}) as unknown as DashboardModel,
         savedChartModel: (overrides.savedChartModel ??
             {}) as unknown as SavedChartModel,
         savedSqlModel: (overrides.savedSqlModel ??
@@ -388,6 +390,93 @@ describe('UnfurlService', () => {
 
             expect(result.isValid).toBe(false);
             expect(getBySlug).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('parseUrl - chart and dashboard slugs', () => {
+        const PROJECT_UUID = '21eef0b9-5bae-40f3-851e-9554588e71a6';
+        const CHART_UUID = '11111111-2222-4333-8444-555555555555';
+        const DASHBOARD_UUID = '66666666-7777-4888-8999-000000000000';
+
+        it.each(['current-chart', 'retired-chart-alias'])(
+            'resolves chart identifier %s to its canonical UUID',
+            async (identifier) => {
+                const get = vi.fn().mockResolvedValue({ uuid: CHART_UUID });
+                const service = createService({
+                    savedChartModel: { get },
+                });
+
+                const result = await service.parseUrl(
+                    `https://app.lightdash.cloud/projects/${PROJECT_UUID}/saved/${identifier}/view`,
+                );
+
+                expect(get).toHaveBeenCalledWith(identifier, undefined, {
+                    projectUuid: PROJECT_UUID,
+                });
+                expect(result).toMatchObject({
+                    isValid: true,
+                    lightdashPage: LightdashPage.CHART,
+                    projectUuid: PROJECT_UUID,
+                    chartUuid: CHART_UUID,
+                    minimalUrl: `http://headless-browser:8080/minimal/projects/${PROJECT_UUID}/saved/${CHART_UUID}`,
+                });
+            },
+        );
+
+        it('resolves a dashboard slug to its canonical UUID', async () => {
+            const getByIdOrSlug = vi
+                .fn()
+                .mockResolvedValue({ uuid: DASHBOARD_UUID });
+            const service = createService({
+                dashboardModel: { getByIdOrSlug },
+            });
+
+            const result = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_UUID}/dashboards/current-dashboard/view?foo=bar`,
+            );
+
+            expect(getByIdOrSlug).toHaveBeenCalledWith('current-dashboard', {
+                projectUuid: PROJECT_UUID,
+            });
+            expect(result).toMatchObject({
+                isValid: true,
+                lightdashPage: LightdashPage.DASHBOARD,
+                projectUuid: PROJECT_UUID,
+                dashboardUuid: DASHBOARD_UUID,
+                minimalUrl: `http://headless-browser:8080/minimal/projects/${PROJECT_UUID}/dashboards/${DASHBOARD_UUID}?foo=bar`,
+            });
+        });
+
+        it('keeps UUID URLs on the existing lookup-free path', async () => {
+            const get = vi.fn();
+            const getByIdOrSlug = vi.fn();
+            const service = createService({
+                savedChartModel: { get },
+                dashboardModel: { getByIdOrSlug },
+            });
+
+            const chartResult = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_UUID}/saved/${CHART_UUID}/view`,
+            );
+            const dashboardResult = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_UUID}/dashboards/${DASHBOARD_UUID}/view`,
+            );
+
+            expect(get).not.toHaveBeenCalled();
+            expect(getByIdOrSlug).not.toHaveBeenCalled();
+            expect(chartResult.chartUuid).toBe(CHART_UUID);
+            expect(dashboardResult.dashboardUuid).toBe(DASHBOARD_UUID);
+        });
+
+        it('returns an invalid result when a slug does not resolve', async () => {
+            const get = vi.fn().mockRejectedValue(new Error('not found'));
+            const service = createService({ savedChartModel: { get } });
+
+            const result = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_UUID}/saved/missing-chart/view`,
+            );
+
+            expect(result.isValid).toBe(false);
         });
     });
 

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -81,6 +81,7 @@ import { countPdfPages } from './countPdfPages';
 
 const uuid = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
 const uuidRegex = new RegExp(uuid, 'g');
+const uuidExactRegex = new RegExp(`^${uuid}$`);
 const nanoid = '[\\w-]{21}';
 const nanoidRegex = new RegExp(nanoid);
 const shareUrlRegex = new RegExp(`/share/(${nanoid})`);
@@ -2549,8 +2550,10 @@ export class UnfurlService extends BaseService {
             ? await this.getSharedUrl(linkUrl)
             : linkUrl;
 
-        const dashboardUrl = new RegExp(`/projects/${uuid}/dashboards/${uuid}`);
-        const chartUrl = new RegExp(`/projects/${uuid}/saved/${uuid}`);
+        const dashboardUrl = new RegExp(
+            `/projects/(${uuid})/dashboards/([^/?#]+)`,
+        );
+        const chartUrl = new RegExp(`/projects/(${uuid})/saved/([^/?#]+)`);
         const exploreUrl = new RegExp(`/projects/${uuid}/tables/`);
         const sqlChartUrl = new RegExp(
             `/projects/(${uuid})/sql-runner/([^/?#]+)`,
@@ -2571,34 +2574,75 @@ export class UnfurlService extends BaseService {
                 appUuid,
             };
         }
-        if (url.match(dashboardUrl) !== null) {
-            const [projectUuid, dashboardUuid] = url.match(uuidRegex) || [];
+        const dashboardMatch = url.match(dashboardUrl);
+        if (dashboardMatch !== null) {
+            const [, projectUuid, encodedIdentifier] = dashboardMatch;
+            try {
+                const dashboardIdentifier =
+                    decodeURIComponent(encodedIdentifier);
+                const dashboardUuid = uuidExactRegex.test(dashboardIdentifier)
+                    ? dashboardIdentifier
+                    : (
+                          await this.dashboardModel.getByIdOrSlug(
+                              dashboardIdentifier,
+                              { projectUuid },
+                          )
+                      ).uuid;
 
-            const { searchParams } = new URL(url);
-            return {
-                isValid: true,
-                lightdashPage: LightdashPage.DASHBOARD,
-                url,
-                minimalUrl: `${
-                    this.lightdashConfig.headlessBrowser.internalLightdashHost
-                }/minimal/projects/${projectUuid}/dashboards/${dashboardUuid}?${searchParams.toString()}`,
-                projectUuid,
-                dashboardUuid,
-            };
+                const { searchParams } = new URL(url);
+                return {
+                    isValid: true,
+                    lightdashPage: LightdashPage.DASHBOARD,
+                    url,
+                    minimalUrl: `${
+                        this.lightdashConfig.headlessBrowser
+                            .internalLightdashHost
+                    }/minimal/projects/${projectUuid}/dashboards/${dashboardUuid}?${searchParams.toString()}`,
+                    projectUuid,
+                    dashboardUuid,
+                };
+            } catch (e) {
+                this.logger.debug(
+                    `Dashboard ${encodedIdentifier} did not resolve in project ${projectUuid}: ${getErrorMessage(
+                        e,
+                    )}`,
+                );
+            }
         }
-        if (url.match(chartUrl) !== null) {
-            const [projectUuid, chartUuid] = url.match(uuidRegex) || [];
-            return {
-                isValid: true,
-                lightdashPage: LightdashPage.CHART,
-                url,
-                minimalUrl: new URL(
-                    `/minimal/projects/${projectUuid}/saved/${chartUuid}`,
-                    this.lightdashConfig.headlessBrowser.internalLightdashHost,
-                ).href,
-                projectUuid,
-                chartUuid,
-            };
+        const chartMatch = url.match(chartUrl);
+        if (chartMatch !== null) {
+            const [, projectUuid, encodedIdentifier] = chartMatch;
+            try {
+                const chartIdentifier = decodeURIComponent(encodedIdentifier);
+                const chartUuid = uuidExactRegex.test(chartIdentifier)
+                    ? chartIdentifier
+                    : (
+                          await this.savedChartModel.get(
+                              chartIdentifier,
+                              undefined,
+                              { projectUuid },
+                          )
+                      ).uuid;
+
+                return {
+                    isValid: true,
+                    lightdashPage: LightdashPage.CHART,
+                    url,
+                    minimalUrl: new URL(
+                        `/minimal/projects/${projectUuid}/saved/${chartUuid}`,
+                        this.lightdashConfig.headlessBrowser
+                            .internalLightdashHost,
+                    ).href,
+                    projectUuid,
+                    chartUuid,
+                };
+            } catch (e) {
+                this.logger.debug(
+                    `Chart ${encodedIdentifier} did not resolve in project ${projectUuid}: ${getErrorMessage(
+                        e,
+                    )}`,
+                );
+            }
         }
         if (url.match(exploreUrl) !== null) {
             const [projectUuid] = url.match(uuidRegex) || [];


### PR DESCRIPTION
Tested locally

<img width="1322" height="806" alt="CleanShot 2026-08-20 at 15 46 59@2x" src="https://github.com/user-attachments/assets/ed70701e-8e63-4ec3-8a6e-f22c121949a0" />


## Summary

- Accept current chart slugs, historical chart aliases, and dashboard slugs in the backend unfurl URL parser.
- Resolve non-UUID identifiers within the project, then continue the existing unfurl and headless flow with canonical UUIDs.
- Preserve the lookup-free UUID path and leave generated links, API contracts, model projections, scheduler behavior, and internal URL formats unchanged.

## Validation

- `pnpm -F backend exec vitest run --config vitest.config.ts src/services/UnfurlService/UnfurlService.test.ts --reporter=dot` — 34 tests passed
- `pnpm -F backend typecheck`
- Targeted backend lint and formatting checks

Closes: SPK-1140