### PR TITLE
fix: surface miss reason from closest pre-aggregate definition

### DIFF
--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -1556,6 +1556,85 @@ describe('findMatch', () => {
         });
     });
 
+    it('reports the miss from the def that came closest to matching', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'unrelated',
+                    dimensions: ['amount'],
+                    metrics: ['order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                },
+                {
+                    name: 'near_match',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status', 'orders_order_date_day'],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'filter-1',
+                                target: { fieldId: 'orders_amount' },
+                                operator: FilterOperator.EQUALS,
+                                values: [10],
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
+            fieldId: 'orders_amount',
+        });
+    });
+
+    it('keeps YAML definition order between equally close misses', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'first',
+                    dimensions: ['amount'],
+                    metrics: ['order_count'],
+                },
+                {
+                    name: 'second',
+                    dimensions: ['order_date'],
+                    metrics: ['order_count'],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_amount', 'orders_order_date'],
+                metrics: ['orders_order_count'],
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
+            fieldId: 'orders_order_date',
+        });
+    });
+
     it('allows type:number metrics when they are explicitly included in the pre-aggregate definition', () => {
         const explore = {
             ...baseExplore(),

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -845,6 +845,29 @@ const getUnsatisfiedPreAggregateFilterMiss = ({
     };
 };
 
+// Mirrors the check order in getMissForDef: a def that failed a later check
+// came closer to matching, so its miss reason is more actionable.
+const missCloseness: Record<PreAggregateMissReason, number> = {
+    // Query-level reasons resolved before the per-definition loop.
+    [PreAggregateMissReason.NO_PRE_AGGREGATES_DEFINED]: 0,
+    [PreAggregateMissReason.CUSTOM_SQL_METRIC]: 0,
+    [PreAggregateMissReason.CUSTOM_METRIC_PRESENT]: 0,
+    [PreAggregateMissReason.TABLE_CALCULATION_PRESENT]: 0,
+    [PreAggregateMissReason.USER_BYPASS]: 0,
+    [PreAggregateMissReason.EXPLORE_RESOLUTION_ERROR]: 0,
+    [PreAggregateMissReason.NO_ACTIVE_MATERIALIZATION]: 0,
+    [PreAggregateMissReason.METRIC_NOT_IN_PRE_AGGREGATE]: 0,
+    [PreAggregateMissReason.NON_ADDITIVE_METRIC]: 1,
+    [PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH]: 1,
+    [PreAggregateMissReason.CUSTOM_DIMENSION_PRESENT]: 2,
+    [PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE]: 2,
+    [PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE]: 3,
+    [PreAggregateMissReason.SQL_FILTER_FIELD_NOT_IN_PRE_AGGREGATE]: 4,
+    [PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED]: 5,
+    [PreAggregateMissReason.GRANULARITY_TOO_FINE]: 6,
+    [PreAggregateMissReason.TIME_FRAME_NOT_DERIVABLE]: 6,
+};
+
 const isRawTimeInterval = (timeInterval: TimeFrames | undefined): boolean =>
     !timeInterval || timeInterval === TimeFrames.RAW;
 
@@ -1278,10 +1301,10 @@ export const findMatch = (
     const sqlFilterFieldIds = extractSqlFilterFieldIds(explore);
 
     const matchedDefs: PreAggregateDef[] = [];
-    let firstMiss: PreAggregateMatchMiss | null = null;
-    // A miss from a def that covers the queried metrics is more actionable
-    // than "metric not in pre-aggregate" from an unrelated def.
-    let firstSpecificMiss: PreAggregateMatchMiss | null = null;
+    // Surface the miss from the def that came closest to matching; ties keep
+    // YAML definition order.
+    let closestMiss: PreAggregateMatchMiss | null = null;
+    let closestMissRank = -1;
 
     explore.preAggregates.forEach((preAggregateDef) => {
         const miss = getMissForDef({
@@ -1300,14 +1323,10 @@ export const findMatch = (
             return;
         }
 
-        if (!firstMiss) {
-            firstMiss = miss;
-        }
-        if (
-            !firstSpecificMiss &&
-            miss.reason !== PreAggregateMissReason.METRIC_NOT_IN_PRE_AGGREGATE
-        ) {
-            firstSpecificMiss = miss;
+        const missRank = missCloseness[miss.reason];
+        if (missRank > closestMissRank) {
+            closestMiss = miss;
+            closestMissRank = missRank;
         }
     });
 
@@ -1315,14 +1334,13 @@ export const findMatch = (
         return {
             hit: false,
             preAggregateName: null,
-            miss: firstSpecificMiss ??
-                firstMiss ?? {
-                    reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
-                    fieldId:
-                        metricQuery.dimensions[0] ??
-                        metricQuery.metrics[0] ??
-                        'unknown',
-                },
+            miss: closestMiss ?? {
+                reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
+                fieldId:
+                    metricQuery.dimensions[0] ??
+                    metricQuery.metrics[0] ??
+                    'unknown',
+            },
         };
     }
 


### PR DESCRIPTION
## Problem

When a model has several pre-aggregate definitions and a query misses all of them, the surfaced miss reason was the first specific miss in YAML definition order — an unrelated definition's `dimension_not_in_pre_aggregate` could shadow a near-match definition that only failed on a filter, sending the user to investigate the wrong definition.

## Fix

`findMatch` now ranks each definition's miss by how far the definition got through the match checks (metric → non-additive → dimension → filter dimension → sql_filter field → definition filter → granularity) and surfaces the miss from the definition that came closest to matching. Ties keep YAML definition order. Ranks live in a `missCloseness: Record<PreAggregateMissReason, number>` that mirrors the check order in `getMissForDef`.

## Tests

- Repro-shaped test: unrelated def vs near-match def (time dimension + day granularity) with a filter on an uncovered dimension now reports `filter_dimension_not_in_pre_aggregate` from the near-match.
- Tie test: equally close misses keep YAML definition order.
- Existing "specific miss over metric-not-in" behavior unchanged.

Closes: ZAP-881

🤖 Generated with [Claude Code](https://claude.com/claude-code)
