### PR TITLE
feat: show connected user and organization on the MCP OAuth authorize page

### DIFF
--- a/packages/backend/src/models/OAuth2Model.ts
+++ b/packages/backend/src/models/OAuth2Model.ts
@@ -46,6 +46,14 @@ export class OAuth2Model implements AuthorizationCodeModel {
         };
     }
 
+    async findClientName(clientId: string): Promise<string | undefined> {
+        const client = await this.database('oauth2_clients')
+            .select('client_name')
+            .where('client_id', clientId)
+            .first();
+        return client?.client_name;
+    }
+
     async saveAuthorizationCode(
         code: Pick<
             AuthorizationCode,

--- a/packages/backend/src/routers/oauthRouter.ts
+++ b/packages/backend/src/routers/oauthRouter.ts
@@ -31,10 +31,10 @@ function getOAuthService(req: express.Request): OAuthService {
 
 // Get authorization - use OAuth2Server
 oauthRouter.get('/authorize', async (req, res, next) => {
+    const loginUrl = `/login?redirect=${encodeURIComponent(
+        req.originalUrl || req.url,
+    )}`;
     if (!req.user) {
-        const loginUrl = `/login?redirect=${encodeURIComponent(
-            req.originalUrl || req.url,
-        )}`;
         return res.redirect(loginUrl);
     }
     const {
@@ -62,8 +62,10 @@ oauthRouter.get('/authorize', async (req, res, next) => {
             user: {
                 firstName: req.user.firstName,
                 lastName: req.user.lastName,
-                organizationName: req.user.organizationName!,
+                email: req.user.email ?? null,
+                organizationName: req.user.organizationName ?? '',
             },
+            loginUrl,
             hiddenInputs: [
                 {
                     name: 'response_type',

--- a/packages/backend/src/routers/oauthRouter.ts
+++ b/packages/backend/src/routers/oauthRouter.ts
@@ -2,7 +2,6 @@
 import {
     generateOAuthAuthorizePage,
     generateOAuthRedirectPage,
-    getClientName,
     getErrorMessage,
     OAuthIntrospectResponse,
     parseScopeString,
@@ -51,12 +50,15 @@ oauthRouter.get('/authorize', async (req, res, next) => {
 
     // Render authorize page using Handlebars template
     const scopeString = (scope as string) || '';
+    const clientName = await getOAuthService(req).getClientDisplayName(
+        client_id as string,
+    );
     res.set('Content-Type', 'text/html');
     return res.send(
         generateOAuthAuthorizePage({
             action: '/api/v1/oauth/authorize',
             client_id: client_id as string,
-            client_name: getClientName(client_id as string),
+            client_name: clientName,
             scope: scopeString,
             scopes: parseScopeString(scopeString),
             user: {

--- a/packages/backend/src/services/OAuthService/OAuthService.ts
+++ b/packages/backend/src/services/OAuthService/OAuthService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     ForbiddenError,
+    getClientName,
     NotFoundError,
     ParameterError,
     UserWithOrganizationUuid,
@@ -98,6 +99,11 @@ export class OAuthService extends BaseService {
         const refreshToken = await this.oauthModel.getRefreshToken(token);
         if (refreshToken) return this.oauthModel.revokeToken(refreshToken);
         return false;
+    }
+
+    public async getClientDisplayName(clientId: string): Promise<string> {
+        const clientName = await this.oauthModel.findClientName(clientId);
+        return clientName ?? getClientName(clientId);
     }
 
     public async registerClient({

--- a/packages/common/src/utils/oauth.ts
+++ b/packages/common/src/utils/oauth.ts
@@ -115,23 +115,115 @@ const OAUTH_AUTHORIZE_TEMPLATE = `
             }
             .oauth-message {
                 text-align: center;
-                margin-bottom: 24px;
+                margin-bottom: 16px;
                 font-size: 14px;
                 color: #111418;
             }
             .oauth-message strong {
                 font-weight: 600;
             }
-            .oauth-scopes {
+            .oauth-account {
+                border: 1px solid #e9ecef;
+                border-radius: 8px;
+                overflow: hidden;
+                margin-bottom: 20px;
+            }
+            .oauth-account-user {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                padding: 12px 14px;
+            }
+            .oauth-avatar {
+                flex-shrink: 0;
+                width: 36px;
+                height: 36px;
+                border-radius: 50%;
+                background: #111418;
+                color: #f8fafc;
+                font-size: 13px;
+                font-weight: 600;
+                letter-spacing: 0.02em;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                text-transform: uppercase;
+            }
+            .oauth-account-id {
+                flex: 1;
+                min-width: 0;
+            }
+            .oauth-account-name {
+                font-weight: 600;
+                color: #111418;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+            .oauth-account-email {
+                font-size: 12px;
+                color: #6c757d;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+            .oauth-switch-link {
+                flex-shrink: 0;
+                font-size: 12px;
+                font-weight: 500;
+                color: #6c757d;
+                text-decoration: none;
+            }
+            .oauth-switch-link:hover {
+                color: #111418;
+                text-decoration: underline;
+            }
+            .oauth-account-org {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                padding: 8px 14px;
                 border-top: 1px solid #e9ecef;
-                padding-top: 16px;
+                background: #f8fafc;
+            }
+            .oauth-org-icon {
+                flex-shrink: 0;
+                width: 15px;
+                height: 15px;
+                color: #6c757d;
+            }
+            .oauth-account-org-name {
+                flex: 1;
+                min-width: 0;
+                font-size: 13px;
+                font-weight: 500;
+                color: #111418;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+            .oauth-account-org-label {
+                flex-shrink: 0;
+                font-size: 11px;
+                color: #6c757d;
+            }
+            .oauth-scopes {
                 margin-bottom: 16px;
+            }
+            .oauth-scopes-title {
+                font-size: 13px;
+                font-weight: 600;
+                color: #111418;
+                margin: 0 0 4px 0;
             }
             .oauth-scope-item {
                 display: flex;
                 gap: 12px;
                 padding: 12px 0;
                 border-bottom: 1px solid #f8fafc;
+            }
+            .oauth-scope-item:last-child {
+                border-bottom: none;
             }
             .oauth-scope-icon {
                 flex-shrink: 0;
@@ -153,7 +245,9 @@ const OAUTH_AUTHORIZE_TEMPLATE = `
                 line-height: 1.4;
             }
             .oauth-btn-row {
+                /* row-reverse keeps Authorize as the first submit button (Enter approves) while showing Cancel on the left */
                 display: flex;
+                flex-direction: row-reverse;
                 justify-content: center;
                 gap: 12px;
                 margin-top: 24px;
@@ -198,10 +292,35 @@ const OAUTH_AUTHORIZE_TEMPLATE = `
                 </div>
 
                 <p class="oauth-message">
-                    <strong>{{client_name}}</strong> wants to access your Lightdash account <strong>{{user.firstName}} {{user.lastName}}</strong>
+                    <strong>{{client_name}}</strong> wants to access your Lightdash account
                 </p>
 
+                <div class="oauth-account">
+                    <div class="oauth-account-user">
+                        <div class="oauth-avatar" aria-hidden="true">{{user.initials}}</div>
+                        <div class="oauth-account-id">
+                            <div class="oauth-account-name">{{user.firstName}} {{user.lastName}}</div>
+                            {{#if user.email}}
+                            <div class="oauth-account-email">{{user.email}}</div>
+                            {{/if}}
+                        </div>
+                        <a class="oauth-switch-link" id="oauth-switch-account" href="{{loginUrl}}">Switch account</a>
+                    </div>
+                    {{#if user.organizationName}}
+                    <div class="oauth-account-org">
+                        <svg class="oauth-org-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M3 21h18" />
+                            <path d="M9 8h1M9 12h1M9 16h1M14 8h1M14 12h1M14 16h1" />
+                            <path d="M5 21V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16" />
+                        </svg>
+                        <span class="oauth-account-org-name">{{user.organizationName}}</span>
+                        <span class="oauth-account-org-label">Organization</span>
+                    </div>
+                    {{/if}}
+                </div>
+
                 <div class="oauth-scopes">
+                    <p class="oauth-scopes-title">{{client_name}} will be able to:</p>
                     {{#each scopes}}
                     <div class="oauth-scope-item">
                         <svg class="oauth-scope-icon" viewBox="0 0 16 16" fill="currentColor">
@@ -226,6 +345,23 @@ const OAUTH_AUTHORIZE_TEMPLATE = `
                 </div>
             </form>
         </div>
+        <script>
+            (function () {
+                var switchLink = document.getElementById('oauth-switch-account');
+                switchLink.addEventListener('click', function (event) {
+                    event.preventDefault();
+                    var loginUrl = switchLink.href;
+                    // Log out first so the login page doesn't bounce straight back with the same session
+                    fetch('/api/v1/logout', { credentials: 'same-origin' })
+                        .catch(function () {
+                            // Navigate anyway; the login page still lets the user switch accounts
+                        })
+                        .then(function () {
+                            window.location.href = loginUrl;
+                        });
+                });
+            })();
+        </script>
     </body>
 </html>
 `;
@@ -305,6 +441,7 @@ export interface OAuthHiddenInput {
 export interface OAuthUser {
     firstName: string;
     lastName: string;
+    email: string | null;
     organizationName: string;
 }
 
@@ -320,6 +457,8 @@ export interface OAuthAuthorizeParams {
     scope: string;
     scopes: OAuthScopeDescription[];
     user: OAuthUser;
+    /** Where "Switch account" sends the user after logging out */
+    loginUrl: string;
     hiddenInputs: OAuthHiddenInput[];
 }
 
@@ -421,6 +560,12 @@ export const generateOAuthErrorResponse = (
         iconType,
     );
 
+const getUserInitials = (user: OAuthUser): string => {
+    const initials =
+        `${user.firstName.charAt(0)}${user.lastName.charAt(0)}`.trim();
+    return initials || user.email?.charAt(0) || '?';
+};
+
 /**
  * Generates an OAuth authorization page HTML using Handlebars templating
  * This prevents XSS issues by auto-escaping all user content
@@ -432,6 +577,10 @@ export const generateOAuthAuthorizePage = (
         styles: oauthPageStyles,
         logo: LIGHTDASH_LOGO_SVG,
         ...params,
+        user: {
+            ...params.user,
+            initials: getUserInitials(params.user),
+        },
     });
 
 /**


### PR DESCRIPTION
When authorizing an MCP client, the OAuth consent page gave no indication of which account was granting access, so users logged in with the wrong account (e.g. a personal email instead of their company one) had no way to notice or fix it before authorizing. The page now shows the connected user's name, email, and organization, with a switch-account link that logs out and returns to the same authorize request.

Closes: PROD-10316
Closes: #27632


<img width="1088" height="1476" alt="CleanShot 2026-08-19 at 12 51 58@2x" src="https://github.com/user-attachments/assets/561fd535-57e6-473c-8120-92e6b18e5157" />

<img width="886" height="1216" alt="CleanShot 2026-08-19 at 13 01 00@2x" src="https://github.com/user-attachments/assets/a89adbe6-a88c-4fe4-aa28-58e525aece3f" />
