### PR TITLE
fix(frontend): redirect malformed project links

### DIFF
--- a/packages/frontend/src/components/ProjectRoute.test.tsx
+++ b/packages/frontend/src/components/ProjectRoute.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import ProjectRoute from './ProjectRoute';
+
+const state = vi.hoisted(() => ({
+    useActiveProjectUuid: vi.fn(),
+}));
+
+vi.mock('../hooks/useActiveProject', () => ({
+    useActiveProjectUuid: state.useActiveProjectUuid,
+}));
+
+describe('ProjectRoute', () => {
+    beforeEach(() => {
+        state.useActiveProjectUuid.mockReset();
+    });
+
+    it('redirects a malformed project UUID before resolving the project', () => {
+        render(
+            <MemoryRouter
+                initialEntries={['/projects/3675b69e-8324-4110-bdca']}
+            >
+                <Routes>
+                    <Route
+                        path="/projects/:projectUuid"
+                        element={
+                            <ProjectRoute>
+                                <div>project home</div>
+                            </ProjectRoute>
+                        }
+                    />
+                    <Route
+                        path="/projects"
+                        element={<div>project fallback</div>}
+                    />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText('project fallback')).toBeInTheDocument();
+        expect(screen.queryByText('project home')).not.toBeInTheDocument();
+        expect(state.useActiveProjectUuid).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/components/ProjectRoute.tsx
+++ b/packages/frontend/src/components/ProjectRoute.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import React, { type FC } from 'react';
 import { Navigate, useParams } from 'react-router';
+import { validate as isUuidString } from 'uuid';
 import ErrorState from '../components/common/ErrorState';
 import { useActiveProjectUuid } from '../hooks/useActiveProject';
 import { useProject } from '../hooks/useProject';
@@ -8,9 +9,10 @@ import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
 import PageSpinner from './PageSpinner';
 
-const ProjectRoute: FC<React.PropsWithChildren> = ({ children }) => {
+const ResolvedProjectRoute: FC<
+    React.PropsWithChildren<{ projectUuid: string }>
+> = ({ children, projectUuid }) => {
     const { user } = useApp();
-    const { projectUuid } = useParams();
     const { activeProjectUuid, isLoading: isInitialLoading } =
         useActiveProjectUuid({ refetchOnMount: true });
 
@@ -44,6 +46,20 @@ const ProjectRoute: FC<React.PropsWithChildren> = ({ children }) => {
                 );
             }}
         </Can>
+    );
+};
+
+const ProjectRoute: FC<React.PropsWithChildren> = ({ children }) => {
+    const { projectUuid } = useParams();
+
+    if (!projectUuid || !isUuidString(projectUuid)) {
+        return <Navigate to="/projects" replace />;
+    }
+
+    return (
+        <ResolvedProjectRoute projectUuid={projectUuid}>
+            {children}
+        </ResolvedProjectRoute>
     );
 };
 

--- a/packages/frontend/src/hooks/useActiveProject.test.tsx
+++ b/packages/frontend/src/hooks/useActiveProject.test.tsx
@@ -119,7 +119,8 @@ describe('useActiveProjectUuid', () => {
     });
 
     it('persists the active project once when several instances mount together', async () => {
-        routeProjectUuid = 'project-herd';
+        const routeUuid = '6f9d77c3-06b1-4d93-a5ae-3eb68145fc93';
+        routeProjectUuid = routeUuid;
         const setItem = vi.spyOn(Storage.prototype, 'setItem');
         const { wrapper } = createWrapper();
 
@@ -133,7 +134,7 @@ describe('useActiveProjectUuid', () => {
         );
 
         await waitFor(() =>
-            expect(localStorage.getItem(LAST_PROJECT_KEY)).toBe('project-herd'),
+            expect(localStorage.getItem(LAST_PROJECT_KEY)).toBe(routeUuid),
         );
 
         const persistCalls = setItem.mock.calls.filter(
@@ -141,5 +142,19 @@ describe('useActiveProjectUuid', () => {
         );
         expect(persistCalls).toHaveLength(1);
         setItem.mockRestore();
+    });
+
+    it('ignores a malformed project UUID from the route', async () => {
+        const storedProjectUuid = '3675b69e-8324-4110-bdca-059031aa8da3';
+        localStorage.setItem(LAST_PROJECT_KEY, storedProjectUuid);
+        routeProjectUuid = '3675b69e-8324-4110-bdca';
+        const { wrapper } = createWrapper();
+
+        const { result } = renderHook(() => useActiveProjectUuid(), {
+            wrapper,
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        expect(result.current.activeProjectUuid).toBe(storedProjectUuid);
     });
 });

--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -7,6 +7,7 @@ import {
 } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useParams } from 'react-router';
+import { validate as isUuidString } from 'uuid';
 import { useOrganization } from './organization/useOrganization';
 import { useProject } from './useProject';
 import { useProjects } from './useProjects';
@@ -110,6 +111,9 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
     refetchOnMount: boolean;
 }) => {
     const params = useParams<{ projectUuid?: string }>();
+    const paramProjectUuid = isUuidString(params.projectUuid ?? '')
+        ? params.projectUuid
+        : undefined;
     const { data: lastProjectUuid, isFetched: isLastProjectUuidFetched } =
         useActiveProject();
     const { mutate } = useUpdateActiveProjectMutation();
@@ -123,12 +127,12 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
 
     // Priority 1: Project UUID from URL params
     const { data: paramProject, isInitialLoading: isLoadingParamProject } =
-        useProject(params.projectUuid);
+        useProject(paramProjectUuid);
 
     // Priority 2: Last used project from localStorage
     // Only fetch if no param project and we have a lastProjectUuid
     const shouldFetchLastProject =
-        isLoggedIn && !params.projectUuid && !!lastProjectUuid;
+        isLoggedIn && !paramProjectUuid && !!lastProjectUuid;
     const { data: lastProject, isInitialLoading: isLoadingLastProject } =
         useProject(shouldFetchLastProject ? lastProjectUuid : undefined, {
             onError: () => {
@@ -143,7 +147,7 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
     // Only fetch if no param project, no last project, and org has a default
     const shouldFetchDefaultProject =
         isLoggedIn &&
-        !params.projectUuid &&
+        !paramProjectUuid &&
         isLastProjectUuidFetched &&
         !lastProject &&
         !!organization?.defaultProjectUuid;
@@ -159,7 +163,7 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
     // Try to fetch fallback since the last project might have been a preview that was deleted
     const shouldFetchFallbackProjects =
         isLoggedIn &&
-        !params.projectUuid &&
+        !paramProjectUuid &&
         isLastProjectUuidFetched &&
         !lastProject &&
         !isLoadingOrg &&
@@ -186,12 +190,12 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
 
     const isLoading =
         // Still loading if we haven't checked localStorage yet (unless we have URL param)
-        (!params.projectUuid && !isLastProjectUuidFetched) ||
+        (!paramProjectUuid && !isLastProjectUuidFetched) ||
         isLoadingParamProject ||
         (shouldFetchLastProject && isLoadingLastProject) ||
         (shouldFetchDefaultProject && isLoadingDefaultProject) ||
         (shouldFetchFallbackProjects && isLoadingProjects) ||
-        (!params.projectUuid && !lastProjectUuid && isLoadingOrg);
+        (!paramProjectUuid && !lastProjectUuid && isLoadingOrg);
 
     // Determine the active project UUID
     const activeProjectUuid =
@@ -208,8 +212,7 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
             fallbackProject?.projectUuid;
 
         const hasValidLastProject = !!lastProject?.projectUuid;
-        const shouldPersistProject =
-            !!params.projectUuid || !hasValidLastProject;
+        const shouldPersistProject = !!paramProjectUuid || !hasValidLastProject;
 
         if (
             !isLoading &&
@@ -229,7 +232,7 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
         lastProjectUuid,
         mutate,
         paramProject?.projectUuid,
-        params.projectUuid,
+        paramProjectUuid,
     ]);
 
     return {


### PR DESCRIPTION
## Summary

- validate project route parameters before resolving project-scoped content
- ignore malformed project parameters in the shared active-project resolver
- redirect malformed project links through the existing accessible-project fallback
- add focused regression coverage for the route and shared resolver

## Root cause

The `/projects/:projectUuid` route accepted any string. A truncated UUID therefore mounted project-scoped UI, while globally mounted consumers of `useActiveProjectUuid` requested the malformed project identifier. That request returned a 500 and displayed an error even though the user's accessible project remained selected in the navigation.

## User impact

Malformed project links now redirect to the user's accessible active project without issuing a request for the invalid identifier. Valid project UUIDs and the existing permission checks are unchanged.

## Validation

- `pnpm -F frontend test` — 351 files, 2,655 tests passed
- `pnpm -F frontend typecheck`
- focused frontend lint and formatting checks
- `git diff --check`
- browser verification:
  - normal accessible project load shows no alert
  - truncated project UUID redirects to the accessible project home
  - no alert is shown
  - no failed API response occurs
  - no request contains the truncated project UUID
