### PR TITLE
fix(pre-aggregates): treat base DATE fields and _day aliases as exact matches 

### DIFF
--- a/docs/pre-aggregates/CONTEXT.md
+++ b/docs/pre-aggregates/CONTEXT.md
@@ -123,7 +123,9 @@ A match where the query's selected dimensions equal the pre-aggregate's
 dimensions, with the time dimension at exactly the pre-aggregate's
 granularity — so each result row is served from a single materialization row
 and no re-aggregation occurs. The only kind of match that can serve
-non-additive metrics. A definition dimension referenced only by a query
+non-additive metrics. Fields that group identically are interchangeable: a
+date-type base field counts as day grain, and the day alias of a date-type
+dimension counts as its stored raw values. A definition dimension referenced only by a query
 filter, or reached through a custom bin, does not count as selected.
 
 **Audit**:

--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -1200,6 +1200,78 @@ describe('findMatch', () => {
             });
         });
 
+        it('hits with the base date field of a day-grain time dimension', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status', 'orders_order_date'],
+                    metrics: ['orders_unique_customers'],
+                }),
+                exploreWithUniqueCustomersDef({
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                }),
+            );
+
+            expect(result).toStrictEqual({
+                hit: true,
+                preAggregateName: 'orders_unique',
+                miss: null,
+            });
+        });
+
+        it('misses with the base timestamp field of a day-grain time dimension', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status', 'orders_created_at'],
+                    metrics: ['orders_unique_customers'],
+                }),
+                exploreWithUniqueCustomersDef({
+                    timeDimension: 'created_at',
+                    granularity: TimeFrames.DAY,
+                }),
+            );
+
+            expect(result.miss).toStrictEqual({
+                reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH,
+                fieldId: 'orders_unique_customers',
+            });
+        });
+
+        it('hits with the day alias of a stored date dimension', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status', 'orders_order_date_day'],
+                    metrics: ['orders_unique_customers'],
+                }),
+                exploreWithUniqueCustomersDef({
+                    dimensions: ['status', 'order_date'],
+                }),
+            );
+
+            expect(result).toStrictEqual({
+                hit: true,
+                preAggregateName: 'orders_unique',
+                miss: null,
+            });
+        });
+
+        it('misses with the day alias of a stored timestamp dimension', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status', 'orders_created_at_day'],
+                    metrics: ['orders_unique_customers'],
+                }),
+                exploreWithUniqueCustomersDef({
+                    dimensions: ['status', 'created_at'],
+                }),
+            );
+
+            expect(result.miss).toStrictEqual({
+                reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH,
+                fieldId: 'orders_unique_customers',
+            });
+        });
+
         it('hits for median metrics on an exact match', () => {
             const result = preAggregateUtils.findMatch(
                 makeMetricQuery({
@@ -1379,24 +1451,6 @@ describe('findMatch', () => {
                 hit: true,
                 preAggregateName: 'orders_unique',
                 miss: null,
-            });
-        });
-
-        it('misses when the raw time dimension is selected instead of the granular one', () => {
-            const result = preAggregateUtils.findMatch(
-                makeMetricQuery({
-                    dimensions: ['orders_status', 'orders_order_date'],
-                    metrics: ['orders_unique_customers'],
-                }),
-                exploreWithUniqueCustomersDef({
-                    timeDimension: 'order_date',
-                    granularity: TimeFrames.DAY,
-                }),
-            );
-
-            expect(result.miss).toStrictEqual({
-                reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH,
-                fieldId: 'orders_unique_customers',
             });
         });
 

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -917,12 +917,28 @@ const isExactDimensionSetMatch = ({
             !!preAggregateDef.granularity &&
             getDimensionBaseName(dimension) === preAggregateDef.timeDimension;
         if (isDefTimeDimension) {
-            if (dimension.timeInterval !== preAggregateDef.granularity) {
+            if (
+                getEffectiveDimensionTimeFrame(dimension) !==
+                preAggregateDef.granularity
+            ) {
                 return false;
             }
         } else if (!isRawTimeInterval(dimension.timeInterval)) {
-            // A truncated variant collapses the stored raw values.
-            return false;
+            // A truncated variant is exact only when truncation is an
+            // identity on the stored raw values (e.g. day alias of a DATE).
+            const baseDimension = dimensionsByFieldId.get(
+                convertFieldRefToFieldId(
+                    `${dimension.table}.${getDimensionBaseName(dimension)}`,
+                    explore.baseTable,
+                ),
+            );
+            if (
+                !baseDimension ||
+                getEffectiveDimensionTimeFrame(dimension) !==
+                    getEffectiveDimensionTimeFrame(baseDimension)
+            ) {
+                return false;
+            }
         }
 
         matchedReferences.forEach((reference) =>


### PR DESCRIPTION
## What

Exact-match serving of non-additive metrics no longer refuses fields that group identically to the stored grain:

1. **Base date field vs day-grain time dimension** — a `DATE`-typed base field (e.g. "Order date") counts as day grain, so it exact-matches a `granularity: day` pre-aggregate the same as the day alias. Previously it missed with `non_additive_metric_requires_exact_match`.
2. **Day alias of a stored date dimension** — a pre-aggregate that stores a `DATE`-typed dimension raw (as a plain dimension) now exact-matches its day alias, since day-truncating a date is an identity. The day alias of a stored `TIMESTAMP` dimension still misses, since there truncation collapses values.

`isExactDimensionSetMatch` now uses `getEffectiveDimensionTimeFrame` (the shared rule from #27538) instead of raw `timeInterval`, comparing against the definition granularity for the time dimension and against the stored base dimension's effective frame otherwise. Also codifies the rule in the pre-aggregates glossary's Exact match entry.

## Why

For a `type: date` column, the base field and the day alias produce identical values, so each result group still maps to exactly one materialization row — the invariant exact match protects. Refusing them caused spurious warehouse misses for `count_distinct`/`median` queries.

## Verification

- Matcher unit tests: base date field → hit; base timestamp field → miss; day alias of stored date dim → hit; day alias of stored timestamp dim → miss (85 passed; removed the test pinning the old miss)
- buildPreAggregateExplore, audit strategy, CLI test suites green; common/backend typecheck + lint clean
- Local E2E on seeded `orders_daily_unique_demo`: base-field query hits and its 126 served rows are identical to `COUNT(DISTINCT order_id)` grouped directly in the warehouse

Closes: ZAP-882

### Risk assessment:

- [ ] This is a high-risk change
