### PR TITLE
fix(devx): stop shared MinIO expiring dev objects after 1 day

### DIFF
--- a/docker/docker-compose.dev.shared.yml
+++ b/docker/docker-compose.dev.shared.yml
@@ -12,8 +12,12 @@ services:
             - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-minioadmin}
             - MINIO_DEFAULT_BUCKETS=${MINIO_DEFAULT_BUCKETS:-default,results,lightdash-apps}
             - MINIO_BROWSER=${MINIO_BROWSER:-off}
+            # .env.development sets 0 (persist); fallback matches dev.mini/infra
+            - MINIO_EXPIRATION_DAYS=${MINIO_EXPIRATION_DAYS:-1}
         volumes:
-            - minio_data:/minio/data
+            # MinIO serves /data (see init-minio.sh) — mounting elsewhere
+            # leaves objects on an anonymous volume that `compose down` drops
+            - minio_data:/data
             - ./init-minio.sh:/init-minio.sh
         entrypoint: '/init-minio.sh'
 


### PR DESCRIPTION
## Problem

Local MinIO objects (data-app bundles, org images) were wiped whenever the shared dev MinIO container was recreated. Two bugs in `docker/docker-compose.dev.shared.yml`:

1. **`MINIO_EXPIRATION_DAYS` was never forwarded** into the container, so the `.env.development` value of `0` (persist forever) was silently dropped and `init-minio.sh` fell back to its internal 1-day default. Every container recreate re-armed the 1-day lifecycle rule, and MinIO's scavenger then expired every object in every bucket.
2. **The named volume was mounted at `/minio/data`, but MinIO serves `/data`** — so the real objects lived on an anonymous volume that only survived recreates by accident (compose re-attaches anonymous volumes), and a `compose down` would drop them.

This is the same bug #25788 fixed for the `dev.mini` compose; the shared dev compose was missed.

## Fix

- Forward `MINIO_EXPIRATION_DAYS` (fallback `1`, matching dev.mini and infra.yml; `.env.development` pins `0` so dev objects persist).
- Mount `minio_data` at `/data` where MinIO actually serves.

## Note for anyone with an existing shared dev stack

After pulling this, the next `compose up` recreates the minio container with the named volume at `/data`. If your current objects live on the accidental anonymous volume, copy them into `ld-shared_minio_data` first (or accept re-seeding). Verified locally: expiry disabled on all buckets, no ILM rules, bundles served from the named volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
