### PR TITLE
feat(ai): org and agent thread retention settings with ceiling validation

### DIFF
--- a/packages/backend/src/contentAsCode/fieldCoverage/ai_agent.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/ai_agent.test.ts
@@ -14,6 +14,7 @@ describeContentAsCodeSchemaContract({
         'projectUuid',
         'spaceAccess',
         'userAccess',
+        'threadRetentionHours',
         'uuid',
     ],
     documentOnlyFields: [

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -494,6 +494,7 @@ export type DbAiOrganizationSettings = {
     data_app_model_visibility: DataAppModelVisibility | null;
     encrypted_provider_api_keys: Buffer | null;
     provider_api_key_hints: AiProviderApiKeyHints | null;
+    thread_retention_hours: number | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -514,6 +515,7 @@ export type AiOrganizationSettingsTable = Knex.CompositeTableType<
                 | 'data_app_model_visibility'
                 | 'encrypted_provider_api_keys'
                 | 'provider_api_key_hints'
+                | 'thread_retention_hours'
             >
         >,
     Partial<
@@ -530,6 +532,7 @@ export type AiOrganizationSettingsTable = Knex.CompositeTableType<
             | 'data_app_model_visibility'
             | 'encrypted_provider_api_keys'
             | 'provider_api_key_hints'
+            | 'thread_retention_hours'
         >
     >
 >;

--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -35,6 +35,7 @@ export type DbAiAgent = {
      */
     is_system: boolean;
     version: number;
+    thread_retention_hours: number | null;
     created_at: Date;
     updated_at: Date;
 };

--- a/packages/backend/src/ee/database/migrations/20260819140000_add_ai_thread_retention_settings.ts
+++ b/packages/backend/src/ee/database/migrations/20260819140000_add_ai_thread_retention_settings.ts
@@ -1,0 +1,47 @@
+import { Knex } from 'knex';
+
+const AI_ORG_SETTINGS_TABLE = 'ai_organization_settings';
+const AI_AGENT_TABLE = 'ai_agent';
+const COLUMN = 'thread_retention_hours';
+const MIN_HOURS = 1;
+const MAX_HOURS = 876000;
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds nullable integer columns with CHECK constraints to two small tables (one row per org / per agent); no backfill, no reads affected.',
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET lock_timeout = '10s'`);
+    try {
+        await knex.schema.alterTable(AI_ORG_SETTINGS_TABLE, (table) => {
+            table.integer(COLUMN).nullable();
+        });
+        await knex.raw(
+            `ALTER TABLE ${AI_ORG_SETTINGS_TABLE} ADD CONSTRAINT ${AI_ORG_SETTINGS_TABLE}_${COLUMN}_range CHECK (${COLUMN} IS NULL OR (${COLUMN} >= ${MIN_HOURS} AND ${COLUMN} <= ${MAX_HOURS}))`,
+        );
+
+        await knex.schema.alterTable(AI_AGENT_TABLE, (table) => {
+            table.integer(COLUMN).nullable();
+        });
+        await knex.raw(
+            `ALTER TABLE ${AI_AGENT_TABLE} ADD CONSTRAINT ${AI_AGENT_TABLE}_${COLUMN}_range CHECK (${COLUMN} IS NULL OR (${COLUMN} >= ${MIN_HOURS} AND ${COLUMN} <= ${MAX_HOURS}))`,
+        );
+    } finally {
+        await knex.raw('RESET lock_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET lock_timeout = '10s'`);
+    try {
+        await knex.schema.alterTable(AI_AGENT_TABLE, (table) => {
+            table.dropColumn(COLUMN);
+        });
+        await knex.schema.alterTable(AI_ORG_SETTINGS_TABLE, (table) => {
+            table.dropColumn(COLUMN);
+        });
+    } finally {
+        await knex.raw('RESET lock_timeout');
+    }
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -632,6 +632,7 @@ export class AiAgentModel {
                 adminOnly: `${AiAgentTableName}.admin_only`,
                 modelConfig: `${AiAgentTableName}.model_config`,
                 version: `${AiAgentTableName}.version`,
+                threadRetentionHours: `${AiAgentTableName}.thread_retention_hours`,
                 groupAccess: this.database.raw(`
                     COALESCE(
                         (SELECT json_agg(group_uuid)
@@ -771,6 +772,7 @@ export class AiAgentModel {
                 adminOnly: `${AiAgentTableName}.admin_only`,
                 modelConfig: `${AiAgentTableName}.model_config`,
                 version: `${AiAgentTableName}.version`,
+                threadRetentionHours: `${AiAgentTableName}.thread_retention_hours`,
                 groupAccess: this.database.raw(`
                     COALESCE(
                         (SELECT json_agg(group_uuid)
@@ -2050,6 +2052,7 @@ export class AiAgentModel {
             | 'modelConfig'
             | 'version'
             | 'mcpServerUuids'
+            | 'threadRetentionHours'
         > & {
             organizationUuid: string;
             isSystem?: boolean;
@@ -2085,6 +2088,7 @@ export class AiAgentModel {
                     model_config: args.modelConfig ?? null,
                     version: args.version,
                     is_system: args.isSystem ?? false,
+                    thread_retention_hours: args.threadRetentionHours ?? null,
                 })
                 .returning('*');
 
@@ -2189,6 +2193,7 @@ export class AiAgentModel {
                 adminOnly: agent.admin_only,
                 modelConfig: agent.model_config,
                 version: agent.version,
+                threadRetentionHours: agent.thread_retention_hours,
             };
         });
     }
@@ -2317,6 +2322,9 @@ export class AiAgentModel {
                         : {}),
                     ...(args.version !== undefined
                         ? { version: args.version }
+                        : {}),
+                    ...(args.threadRetentionHours !== undefined
+                        ? { thread_retention_hours: args.threadRetentionHours }
                         : {}),
                 })
                 .returning('*');
@@ -2487,6 +2495,7 @@ export class AiAgentModel {
                 adminOnly: agent.admin_only,
                 modelConfig: agent.model_config,
                 version: agent.version,
+                threadRetentionHours: agent.thread_retention_hours,
             };
         });
     }

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -130,6 +130,7 @@ describe('AiDeepResearchRunModel integration', () => {
                 model_config: null,
                 is_system: false,
                 version: 2,
+                thread_retention_hours: null,
             })
             .returning('ai_agent_uuid');
         agentUuid = agent.ai_agent_uuid;

--- a/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
+++ b/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
@@ -132,6 +132,7 @@ export class AiOrganizationSettingsModel {
                 anthropic: null,
                 openai: null,
             },
+            threadRetentionHours: db.thread_retention_hours,
         };
     }
 
@@ -205,6 +206,7 @@ export class AiOrganizationSettingsModel {
                 data_app_model_visibility: data.dataAppModelVisibility,
                 encrypted_provider_api_keys: this.encryptProviderApiKeys(keys),
                 provider_api_key_hints: buildProviderApiKeyHints(keys),
+                thread_retention_hours: data.threadRetentionHours ?? null,
             })
             .returning('*');
 
@@ -230,6 +232,7 @@ export class AiOrganizationSettingsModel {
                 | 'data_app_model_visibility'
                 | 'encrypted_provider_api_keys'
                 | 'provider_api_key_hints'
+                | 'thread_retention_hours'
             >
         > = {};
         if (data.aiAgentsVisible !== undefined) {
@@ -262,6 +265,9 @@ export class AiOrganizationSettingsModel {
         }
         if (data.dataAppModelVisibility !== undefined) {
             updateData.data_app_model_visibility = data.dataAppModelVisibility;
+        }
+        if (data.threadRetentionHours !== undefined) {
+            updateData.thread_retention_hours = data.threadRetentionHours;
         }
         if (data.providerApiKeys !== undefined) {
             const providerApiKeyUpdates = data.providerApiKeys;
@@ -362,6 +368,7 @@ export class AiOrganizationSettingsModel {
                 modelVisibility: data.modelVisibility ?? null,
                 dataAppModelVisibility: data.dataAppModelVisibility ?? null,
                 providerApiKeys: data.providerApiKeys,
+                threadRetentionHours: data.threadRetentionHours ?? null,
             },
             database,
         );

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
@@ -153,6 +153,7 @@ describe('AI agent memory consolidation integration', () => {
                 model_config: null,
                 is_system: false,
                 version: 1,
+                thread_retention_hours: null,
             })
             .returning<Array<{ ai_agent_uuid: string }>>('ai_agent_uuid');
         agentUuid = agent.ai_agent_uuid;

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryPromotion.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryPromotion.integration.test.ts
@@ -77,6 +77,7 @@ describe('AI agent memory promotion integration', () => {
                 model_config: null,
                 is_system: false,
                 version: 1,
+                thread_retention_hours: null,
             })
             .returning<Array<{ ai_agent_uuid: string }>>('ai_agent_uuid');
         agentUuid = agent.ai_agent_uuid;

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -62,6 +62,7 @@ import {
     derivePivotConfigurationFromChart,
     DownloadFileType,
     EmbedArtifactVersionJobPayload,
+    exceedsRetentionCeiling,
     Explore,
     FeatureFlags,
     ForbiddenError,
@@ -3202,6 +3203,28 @@ export class AiAgentService extends BaseService {
         });
     }
 
+    private async validateThreadRetentionUpdate(
+        user: SessionUser,
+        threadRetentionHours: number | null,
+    ): Promise<void> {
+        if (!user.organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        await this.aiOrganizationSettingsService.assertThreadRetentionWriteAllowed(
+            user,
+            threadRetentionHours,
+        );
+        const ceiling =
+            await this.aiOrganizationSettingsService.getThreadRetentionCeiling(
+                user.organizationUuid,
+            );
+        if (exceedsRetentionCeiling(threadRetentionHours, ceiling)) {
+            throw new ParameterError(
+                `Agent thread retention cannot exceed the organization limit of ${ceiling} hours`,
+            );
+        }
+    }
+
     public async createAgent(
         user: SessionUser,
         body: ApiCreateAiAgent,
@@ -3233,6 +3256,13 @@ export class AiAgentService extends BaseService {
             throw new ForbiddenError();
         }
 
+        if (body.threadRetentionHours != null) {
+            await this.validateThreadRetentionUpdate(
+                user,
+                body.threadRetentionHours,
+            );
+        }
+
         const agent = await this.aiAgentModel.createAgent({
             name: body.name,
             description: body.description,
@@ -3257,6 +3287,7 @@ export class AiAgentService extends BaseService {
             adminOnly: body.adminOnly ?? false,
             modelConfig: body.modelConfig ?? null,
             version: body.version,
+            threadRetentionHours: body.threadRetentionHours ?? null,
         });
 
         this.analytics.track<AiAgentCreatedEvent>({
@@ -4854,6 +4885,16 @@ export class AiAgentService extends BaseService {
             nextImageUrlSource = body.imageUrl ? 'url' : null;
         }
 
+        if (
+            body.threadRetentionHours !== undefined &&
+            body.threadRetentionHours !== agent.threadRetentionHours
+        ) {
+            await this.validateThreadRetentionUpdate(
+                user,
+                body.threadRetentionHours,
+            );
+        }
+
         const updatedAgent = await this.aiAgentModel.updateAgent({
             agentUuid,
             name: body.name,
@@ -4881,6 +4922,7 @@ export class AiAgentService extends BaseService {
             adminOnly: body.adminOnly,
             modelConfig: body.modelConfig,
             version: body.version,
+            threadRetentionHours: body.threadRetentionHours,
         });
 
         this.analytics.track<AiAgentUpdatedEvent>({

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -6,10 +6,13 @@ import {
     BYO_AI_PROVIDERS,
     CommercialFeatureFlags,
     ComputedAiOrganizationSettings,
+    FeatureFlags,
     ForbiddenError,
     getVisibleDataAppClaudeModels,
+    isValidRetentionWindowHours,
     LightdashUser,
     ParameterError,
+    RETENTION_WINDOW_HOURS_ERROR,
     UpdateAiOrganizationSettings,
     UpdateAiProviderApiKeys,
     type AiAgentModelConfig,
@@ -367,6 +370,7 @@ export class AiOrganizationSettingsService extends BaseService {
                 dataAppModelVisibility: null,
                 providerApiKeysSet: { anthropic: false, openai: false },
                 providerApiKeyHints: { anthropic: null, openai: null },
+                threadRetentionHours: null,
                 defaultAiAgentModelOptions: effectiveOptions,
                 configurableModelOptions: configurableOptions,
                 aiAgentReviewsPausedByByok,
@@ -476,6 +480,40 @@ export class AiOrganizationSettingsService extends BaseService {
         return settings?.deepResearchRawSqlEnabled ?? false;
     }
 
+    async isThreadRetentionEnabled(
+        user: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>,
+    ): Promise<boolean> {
+        const flag = await this.commercialFeatureFlagModel.get({
+            user,
+            featureFlagId: FeatureFlags.AiThreadRetention,
+        });
+        return flag.enabled;
+    }
+
+    async assertThreadRetentionWriteAllowed(
+        user: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>,
+        threadRetentionHours: number | null,
+    ): Promise<void> {
+        if (!(await this.isThreadRetentionEnabled(user))) {
+            throw new ForbiddenError(
+                'AI thread retention is not enabled for this organization',
+            );
+        }
+        if (!isValidRetentionWindowHours(threadRetentionHours)) {
+            throw new ParameterError(RETENTION_WINDOW_HOURS_ERROR);
+        }
+    }
+
+    async getThreadRetentionCeiling(
+        organizationUuid: string,
+    ): Promise<number | null> {
+        const settings =
+            await this.aiOrganizationSettingsModel.findByOrganizationUuid(
+                organizationUuid,
+            );
+        return settings?.threadRetentionHours ?? null;
+    }
+
     async upsertSettings(
         user: SessionUser,
         data: UpdateAiOrganizationSettings,
@@ -502,6 +540,19 @@ export class AiOrganizationSettingsService extends BaseService {
 
         if (aiSettingsUpdate.deepResearchLimits !== undefined) {
             validateDeepResearchLimits(aiSettingsUpdate.deepResearchLimits);
+        }
+
+        if (aiSettingsUpdate.threadRetentionHours !== undefined) {
+            // No-op writes stay allowed: clients that round-trip the settings
+            // object must not be rejected while the flag is off.
+            const storedRetention =
+                await this.getThreadRetentionCeiling(organizationUuid);
+            if (aiSettingsUpdate.threadRetentionHours !== storedRetention) {
+                await this.assertThreadRetentionWriteAllowed(
+                    user,
+                    aiSettingsUpdate.threadRetentionHours,
+                );
+            }
         }
 
         // Set when hiding models orphans the org's configured default, so the

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
@@ -125,6 +125,7 @@ const createCandidate = (
     adminOnly: false,
     modelConfig: null,
     version: 1,
+    threadRetentionHours: null,
     context: overrides.context ?? {
         uuid: overrides.uuid,
         projectUuid,

--- a/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
@@ -102,6 +102,7 @@ const selectedAgent: AiAgentWithContext = {
     adminOnly: false,
     modelConfig: null,
     version: 1,
+    threadRetentionHours: null,
     context: {
         uuid: 'agent-uuid',
         projectUuid,

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -421,6 +421,7 @@ export type AiOrganizationSettings = {
     dataAppModelVisibility?: DataAppModelVisibility | null;
     providerApiKeysSet: AiProviderApiKeysSet;
     providerApiKeyHints: AiProviderApiKeyHints;
+    threadRetentionHours?: number | null;
 };
 
 export type CreateAiOrganizationSettings = Omit<
@@ -442,6 +443,7 @@ export type UpdateAiOrganizationSettings = {
     modelVisibility?: AiOrgModelVisibility | null;
     dataAppModelVisibility?: DataAppModelVisibility | null;
     providerApiKeys?: UpdateAiProviderApiKeys;
+    threadRetentionHours?: number | null;
 };
 
 export type ApiAiOrganizationSettingsResponse = ApiSuccess<

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -17,6 +17,10 @@ import type {
     ToolTimeSeriesArgs,
     ToolVerticalBarArgs,
 } from '../..';
+import {
+    MAX_RETENTION_WINDOW_HOURS,
+    MIN_RETENTION_WINDOW_HOURS,
+} from '../../types/dataRetention';
 import assertUnreachable from '../../utils/assertUnreachable';
 import { type AiAgentReviewItemStatus } from './aiAgentReviewClassifierTypes';
 import { type AiEvalRunResultAssessment } from './aiEvalAssessment';
@@ -156,6 +160,12 @@ export const baseAgentSchema = z.object({
     adminOnly: z.boolean(),
     modelConfig: z.custom<AiAgentModelConfig>().nullable(),
     version: z.number(),
+    threadRetentionHours: z
+        .number()
+        .int()
+        .min(MIN_RETENTION_WINDOW_HOURS)
+        .max(MAX_RETENTION_WINDOW_HOURS)
+        .nullable(),
 });
 
 export type BaseAiAgent = z.infer<typeof baseAgentSchema>;
@@ -185,6 +195,7 @@ export type AiAgent = Pick<
     | 'adminOnly'
     | 'modelConfig'
     | 'version'
+    | 'threadRetentionHours'
 >;
 
 export type AiAgentSummary = Pick<
@@ -212,6 +223,7 @@ export type AiAgentSummary = Pick<
     | 'adminOnly'
     | 'modelConfig'
     | 'version'
+    | 'threadRetentionHours'
 >;
 
 // An empty spaceAccess list means the agent is unrestricted (all spaces).
@@ -578,6 +590,7 @@ export type ApiCreateAiAgent = Pick<
     adminOnly?: boolean;
     mcpServerUuids?: string[];
     modelConfig?: AiAgentModelConfig | null;
+    threadRetentionHours?: number | null;
 };
 
 export type ApiUpdateAiAgent = Partial<
@@ -605,6 +618,7 @@ export type ApiUpdateAiAgent = Partial<
     uuid: string;
     enableSqlMode?: boolean;
     mcpServerUuids?: string[];
+    threadRetentionHours?: number | null;
 };
 
 export type ApiCreateAiAgentResponse = {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -131,6 +131,7 @@ export * from './types/errors';
 export * from './types/explore';
 export * from './types/favorites';
 export * from './featureFlags/previewFeatureFlags';
+export * from './types/dataRetention';
 export * from './types/featureFlags';
 export * from './types/impersonationOrganizationSettings';
 export * from './types/previewExpirationProjectSettings';

--- a/packages/common/src/types/dataRetention.test.ts
+++ b/packages/common/src/types/dataRetention.test.ts
@@ -1,0 +1,77 @@
+import {
+    exceedsRetentionCeiling,
+    getEffectiveRetentionWindowHours,
+    isValidRetentionWindowHours,
+    MAX_RETENTION_WINDOW_HOURS,
+} from './dataRetention';
+
+describe('isValidRetentionWindowHours', () => {
+    it('accepts null (keep forever)', () => {
+        expect(isValidRetentionWindowHours(null)).toBe(true);
+    });
+
+    it('accepts whole hours of at least 1', () => {
+        expect(isValidRetentionWindowHours(1)).toBe(true);
+        expect(isValidRetentionWindowHours(720)).toBe(true);
+    });
+
+    it('rejects zero, negatives, and fractions', () => {
+        expect(isValidRetentionWindowHours(0)).toBe(false);
+        expect(isValidRetentionWindowHours(-24)).toBe(false);
+        expect(isValidRetentionWindowHours(1.5)).toBe(false);
+    });
+
+    it('accepts up to 100 years and rejects absurd magnitudes', () => {
+        expect(isValidRetentionWindowHours(MAX_RETENTION_WINDOW_HOURS)).toBe(
+            true,
+        );
+        expect(
+            isValidRetentionWindowHours(MAX_RETENTION_WINDOW_HOURS + 1),
+        ).toBe(false);
+        expect(isValidRetentionWindowHours(2 ** 31)).toBe(false);
+        expect(isValidRetentionWindowHours(Number.MAX_SAFE_INTEGER)).toBe(
+            false,
+        );
+        expect(isValidRetentionWindowHours(Infinity)).toBe(false);
+        expect(isValidRetentionWindowHours(NaN)).toBe(false);
+    });
+});
+
+describe('getEffectiveRetentionWindowHours', () => {
+    it('returns null when neither side sets a window', () => {
+        expect(getEffectiveRetentionWindowHours(null, null)).toBeNull();
+    });
+
+    it('inherits the ceiling when the override is unset', () => {
+        expect(getEffectiveRetentionWindowHours(null, 720)).toBe(720);
+    });
+
+    it('uses the override when there is no ceiling', () => {
+        expect(getEffectiveRetentionWindowHours(24, null)).toBe(24);
+    });
+
+    it('applies the smaller window when both are set', () => {
+        expect(getEffectiveRetentionWindowHours(1, 720)).toBe(1);
+        expect(getEffectiveRetentionWindowHours(720, 24)).toBe(24);
+    });
+});
+
+describe('exceedsRetentionCeiling', () => {
+    it('never exceeds when there is no ceiling', () => {
+        expect(exceedsRetentionCeiling(9999, null)).toBe(false);
+        expect(exceedsRetentionCeiling(null, null)).toBe(false);
+    });
+
+    it('inheriting (null override) never exceeds the ceiling', () => {
+        expect(exceedsRetentionCeiling(null, 24)).toBe(false);
+    });
+
+    it('tightening below or matching the ceiling is allowed', () => {
+        expect(exceedsRetentionCeiling(1, 24)).toBe(false);
+        expect(exceedsRetentionCeiling(24, 24)).toBe(false);
+    });
+
+    it('extending beyond the ceiling exceeds it', () => {
+        expect(exceedsRetentionCeiling(25, 24)).toBe(true);
+    });
+});

--- a/packages/common/src/types/dataRetention.ts
+++ b/packages/common/src/types/dataRetention.ts
@@ -1,0 +1,30 @@
+export type RetentionWindowHours = number | null;
+
+export const MIN_RETENTION_WINDOW_HOURS = 1;
+
+export const MAX_RETENTION_WINDOW_HOURS = 876_000;
+
+export const isValidRetentionWindowHours = (
+    value: RetentionWindowHours,
+): boolean =>
+    value === null ||
+    (Number.isInteger(value) &&
+        value >= MIN_RETENTION_WINDOW_HOURS &&
+        value <= MAX_RETENTION_WINDOW_HOURS);
+
+export const RETENTION_WINDOW_HOURS_ERROR =
+    'Retention must be null (keep forever) or a whole number of hours between 1 and 876,000 (100 years)';
+
+export const getEffectiveRetentionWindowHours = (
+    override: RetentionWindowHours,
+    ceiling: RetentionWindowHours,
+): RetentionWindowHours => {
+    if (override === null) return ceiling;
+    if (ceiling === null) return override;
+    return Math.min(override, ceiling);
+};
+
+export const exceedsRetentionCeiling = (
+    override: RetentionWindowHours,
+    ceiling: RetentionWindowHours,
+): boolean => override !== null && ceiling !== null && override > ceiling;

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -342,6 +342,12 @@ export enum FeatureFlags {
      * is unavailable or the merge needs a pivot. Off by default.
      */
     MergeOnCompose = 'merge-on-compose',
+
+    /**
+     * Configurable retention for AI agent threads. Off by default; enabled
+     * per-org on demand for enterprise customers.
+     */
+    AiThreadRetention = 'ai-thread-retention',
 }
 
 export type FeatureFlag = {


### PR DESCRIPTION
AI agent thread content is retained indefinitely with no way to expire it, which blocks enterprise customers with data-retention/PII requirements from adopting agents over sensitive data. This introduces the org-level retention ceiling and per-agent window (integer hours, null = keep forever), gated behind the `ai-thread-retention` per-org flag and fully dormant until later PRs in the stack enforce and surface it.

Relates: ZAP-787
Relates: #27087