### PR TITLE
feat(ai): hourly retention cleanup job for AI agent threads

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2599,6 +2599,16 @@ export type AiAgentCreatedEvent = BaseTrack & {
     };
 };
 
+export type AiAgentThreadsRetentionCleanedEvent = BaseTrack & {
+    event: 'ai_agent.threads_retention_cleaned';
+    anonymousId: string;
+    properties: {
+        organizationId: string;
+        threadsDeleted: number;
+        memoriesDeleted: number;
+    };
+};
+
 type AiAgentProvisioningFailedEvent = BaseTrack & {
     event: 'ai_agent.provisioning_failed';
     userId: string;
@@ -3434,6 +3444,7 @@ type TypedEvent =
     | SubtotalQueryEvent
     | DeprecatedRouteCalled
     | AiAgentCreatedEvent
+    | AiAgentThreadsRetentionCleanedEvent
     | AiAgentProvisioningFailedEvent
     | AiAgentGithubMcpConnectedEvent
     | AiAgentDeletedEvent

--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -21,6 +21,7 @@ import {
     ApiAiAgentThreadDumpResponse,
     ApiAiOrganizationSettingsResponse,
     ApiAiReviewNotificationSettingsResponse,
+    ApiAiThreadRetentionPreviewResponse,
     ApiErrorPayload,
     ApiMcpActivityResponse,
     ApiMcpActivityStatsResponse,
@@ -971,6 +972,33 @@ export class AiAgentAdminController extends BaseController {
         return {
             status: 'ok',
             results: settings,
+        };
+    }
+
+    /**
+     * Preview what an org-level thread retention window would delete on the
+     * next cleanup run
+     * @summary Preview thread retention impact
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Retrieved thread retention preview')
+    @Get('/settings/thread-retention-preview')
+    @OperationId('getAiThreadRetentionPreview')
+    async getThreadRetentionPreview(
+        @Request() req: express.Request,
+        @Query() retentionHours: number,
+    ): Promise<ApiAiThreadRetentionPreviewResponse> {
+        assertRegisteredAccount(req.account);
+        const results =
+            await this.getAiAgentAdminService().getThreadRetentionPreview(
+                toSessionUser(req.account),
+                retentionHours,
+            );
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results,
         };
     }
 

--- a/packages/backend/src/ee/models/AiAgentModel.threadRetention.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.threadRetention.integration.test.ts
@@ -1,0 +1,452 @@
+import { SEED_ORG_1, SEED_PROJECT } from '@lightdash/common';
+import { type Knex } from 'knex';
+import { getModels, getTestContext } from '../../vitest.setup.integration';
+import {
+    AiAgentToolCallTableName,
+    AiOrganizationSettingsTableName,
+    AiPromptTableName,
+    AiSqlApprovalTableName,
+    AiThreadTableName,
+    AiWritebackRunTableName,
+    type AiPromptTable,
+    type AiThreadTable,
+    type AiWritebackRunTable,
+    type DbAiOrganizationSettings,
+} from '../database/entities/ai';
+import {
+    AiAgentTableName,
+    type AiAgentTable,
+} from '../database/entities/aiAgent';
+import {
+    AiAgentMemoryTableName,
+    type AiAgentMemoryTable,
+} from '../database/entities/aiAgentMemory';
+import { AiDeepResearchRunsTableName } from '../database/entities/aiDeepResearch';
+import { type AiAgentModel } from './AiAgentModel';
+
+describe('AiAgentModel thread retention integration', () => {
+    let database: Knex;
+    let model: AiAgentModel;
+    let userUuid = '';
+    const agentUuids: string[] = [];
+    const agentlessThreadUuids: string[] = [];
+    let hadOrgSettingsRow = false;
+    let previousOrgRetention: number | null = null;
+
+    const createAgent = async (threadRetentionHours: number | null) => {
+        const [agent] = await database<AiAgentTable>(AiAgentTableName)
+            .insert({
+                organization_uuid: SEED_ORG_1.organization_uuid,
+                project_uuid: SEED_PROJECT.project_uuid,
+                name: `retention-test-agent-${agentUuids.length}`,
+                slug: `retention-test-agent-${Date.now()}-${agentUuids.length}`,
+                description: null,
+                image_url: null,
+                image_url_source: null,
+                tags: null,
+                enable_data_access: false,
+                enable_self_improvement: false,
+                enable_content_tools: false,
+                enable_user_context: false,
+                enable_sql_mode: false,
+                admin_only: false,
+                model_config: null,
+                is_system: false,
+                version: 2,
+                thread_retention_hours: threadRetentionHours,
+            })
+            .returning('*');
+        agentUuids.push(agent.ai_agent_uuid);
+        return agent.ai_agent_uuid;
+    };
+
+    const createThread = async (
+        agentUuid: string | null,
+        lastActivityHoursAgo: number,
+    ) => {
+        const [thread] = await database<AiThreadTable>(AiThreadTableName)
+            .insert({
+                organization_uuid: SEED_ORG_1.organization_uuid,
+                project_uuid: SEED_PROJECT.project_uuid,
+                created_from: 'web_app',
+                agent_uuid: agentUuid,
+            })
+            .returning('*');
+        await database.raw(
+            `UPDATE ${AiThreadTableName}
+             SET created_at = now() - make_interval(hours => :hours),
+                 updated_at = now() - make_interval(hours => :hours)
+             WHERE ai_thread_uuid = :threadUuid`,
+            { hours: lastActivityHoursAgo, threadUuid: thread.ai_thread_uuid },
+        );
+        if (agentUuid === null) {
+            agentlessThreadUuids.push(thread.ai_thread_uuid);
+        }
+        return thread.ai_thread_uuid;
+    };
+
+    const addPrompt = async (
+        threadUuid: string,
+        options: { responded: boolean; createdHoursAgo: number },
+    ) => {
+        const [prompt] = await database<AiPromptTable>(AiPromptTableName)
+            .insert({
+                ai_thread_uuid: threadUuid,
+                created_by_user_uuid: userUuid,
+                prompt: 'retention test prompt',
+            })
+            .returning('*');
+        await database.raw(
+            `UPDATE ${AiPromptTableName}
+             SET created_at = now() - make_interval(hours => :hours)
+                 ${options.responded ? ", response = 'done'" : ''}
+             WHERE ai_prompt_uuid = :promptUuid`,
+            {
+                hours: options.createdHoursAgo,
+                promptUuid: prompt.ai_prompt_uuid,
+            },
+        );
+        return prompt.ai_prompt_uuid;
+    };
+
+    const addRunSqlToolCall = async (promptUuid: string) => {
+        const toolCallId = `retention-test-tool-call-${Date.now()}-${Math.random()}`;
+        await database(AiAgentToolCallTableName).insert({
+            ai_prompt_uuid: promptUuid,
+            tool_call_id: toolCallId,
+            tool_name: 'runSql',
+            tool_args: { sql: 'SELECT 1' },
+            ai_mcp_server_uuid: null,
+            parent_tool_call_id: null,
+        });
+        return toolCallId;
+    };
+
+    const addDeepResearchRun = async (
+        agentUuid: string,
+        threadUuid: string,
+        promptUuid: string,
+        options: { status: 'running' | 'completed' },
+    ) => {
+        await database.raw(
+            `INSERT INTO ${AiDeepResearchRunsTableName}
+                (organization_uuid, project_uuid, created_by_user_uuid,
+                 agent_uuid, ai_thread_uuid, prompt_uuid, prompt, entry_point,
+                 budget_snapshot, execution_context_snapshot, status)
+             VALUES
+                (:organizationUuid, :projectUuid, :userUuid, :agentUuid,
+                 :threadUuid, :promptUuid, 'retention test research', 'ask_ai',
+                 '{}'::jsonb, '{}'::jsonb, :status)`,
+            {
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                userUuid,
+                agentUuid,
+                threadUuid,
+                promptUuid,
+                status: options.status,
+            },
+        );
+    };
+
+    const addMemory = async (agentUuid: string, sourceThreadUuid: string) => {
+        await database<AiAgentMemoryTable>(AiAgentMemoryTableName).insert({
+            organization_uuid: SEED_ORG_1.organization_uuid,
+            project_uuid: SEED_PROJECT.project_uuid,
+            agent_uuid: agentUuid,
+            user_uuid: userUuid,
+            source_thread_uuid: sourceThreadUuid,
+            slug: `retention-test-memory-${Date.now()}`,
+            title: 'Retention test memory',
+            raw_memory: 'derived fact',
+            thread_summary: null,
+            generated_at: new Date(),
+            scope: 'user',
+            terms: JSON.stringify([]),
+            objects: JSON.stringify([]),
+            unresolved_objects: JSON.stringify([]),
+        });
+    };
+
+    const threadExists = async (threadUuid: string) => {
+        const row = await database(AiThreadTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .first();
+        return row !== undefined;
+    };
+
+    const setOrgRetention = async (hours: number | null) => {
+        const existing = await database<DbAiOrganizationSettings>(
+            AiOrganizationSettingsTableName,
+        )
+            .where('organization_uuid', SEED_ORG_1.organization_uuid)
+            .first();
+        if (existing) {
+            await database(AiOrganizationSettingsTableName)
+                .where('organization_uuid', SEED_ORG_1.organization_uuid)
+                .update({ thread_retention_hours: hours });
+        } else {
+            await database(AiOrganizationSettingsTableName).insert({
+                organization_uuid: SEED_ORG_1.organization_uuid,
+                ai_agents_visible: true,
+                thread_retention_hours: hours,
+            });
+        }
+    };
+
+    beforeAll(async () => {
+        const ctx = getTestContext();
+        database = ctx.db;
+        model = getModels(ctx.app).aiAgentModel;
+        userUuid = ctx.testUser.userUuid;
+
+        const existingSettings = await database<DbAiOrganizationSettings>(
+            AiOrganizationSettingsTableName,
+        )
+            .where('organization_uuid', SEED_ORG_1.organization_uuid)
+            .first();
+        hadOrgSettingsRow = existingSettings !== undefined;
+        previousOrgRetention = existingSettings?.thread_retention_hours ?? null;
+    });
+
+    afterEach(async () => {
+        await setOrgRetention(null);
+    });
+
+    afterAll(async () => {
+        if (hadOrgSettingsRow) {
+            await database(AiOrganizationSettingsTableName)
+                .where('organization_uuid', SEED_ORG_1.organization_uuid)
+                .update({ thread_retention_hours: previousOrgRetention });
+        } else {
+            await database(AiOrganizationSettingsTableName)
+                .where('organization_uuid', SEED_ORG_1.organization_uuid)
+                .delete();
+        }
+        await database(AiAgentMemoryTableName)
+            .whereIn('agent_uuid', agentUuids)
+            .delete();
+        await database(AiThreadTableName)
+            .whereIn('ai_thread_uuid', agentlessThreadUuids)
+            .delete();
+        // Cascades to any remaining threads/prompts.
+        await database(AiAgentTableName)
+            .whereIn('ai_agent_uuid', agentUuids)
+            .delete();
+    });
+
+    it('deletes threads inactive beyond the agent window, along with derived memories', async () => {
+        const agentUuid = await createAgent(1);
+        const expiredThread = await createThread(agentUuid, 3);
+        await addPrompt(expiredThread, { responded: true, createdHoursAgo: 3 });
+        await addMemory(agentUuid, expiredThread);
+        const activeThread = await createThread(agentUuid, 0);
+        await addPrompt(activeThread, { responded: true, createdHoursAgo: 0 });
+
+        const result = await model.deleteExpiredThreads(
+            SEED_ORG_1.organization_uuid,
+            100,
+        );
+
+        expect(result.deletedThreadUuids).toContain(expiredThread);
+        expect(result.deletedThreadUuids).not.toContain(activeThread);
+        expect(result.deletedMemoriesCount).toBe(1);
+        expect(await threadExists(expiredThread)).toBe(false);
+        expect(await threadExists(activeThread)).toBe(true);
+    });
+
+    it('keeps a thread whose only recent activity is a prompt, even when the thread timestamps are stale', async () => {
+        const agentUuid = await createAgent(1);
+        const threadUuid = await createThread(agentUuid, 48);
+        await addPrompt(threadUuid, { responded: true, createdHoursAgo: 0 });
+
+        const result = await model.deleteExpiredThreads(
+            SEED_ORG_1.organization_uuid,
+            100,
+        );
+
+        expect(result.deletedThreadUuids).not.toContain(threadUuid);
+        expect(await threadExists(threadUuid)).toBe(true);
+    });
+
+    it('keeps an inactive thread with a recent unanswered prompt, but not an abandoned one', async () => {
+        const agentUuid = await createAgent(1);
+        const pendingThread = await createThread(agentUuid, 3);
+        await addPrompt(pendingThread, {
+            responded: false,
+            createdHoursAgo: 2,
+        });
+
+        const abandonedThread = await createThread(agentUuid, 30);
+        await addPrompt(abandonedThread, {
+            responded: false,
+            createdHoursAgo: 30,
+        });
+
+        const result = await model.deleteExpiredThreads(
+            SEED_ORG_1.organization_uuid,
+            100,
+        );
+
+        expect(result.deletedThreadUuids).not.toContain(pendingThread);
+        expect(result.deletedThreadUuids).toContain(abandonedThread);
+    });
+
+    it('keeps a thread waiting on SQL approval no matter how old, and removes the approval decision when the thread is deleted', async () => {
+        const agentUuid = await createAgent(1);
+        const waitingThread = await createThread(agentUuid, 30);
+        const waitingPrompt = await addPrompt(waitingThread, {
+            responded: false,
+            createdHoursAgo: 30,
+        });
+        await addRunSqlToolCall(waitingPrompt);
+
+        const decidedThread = await createThread(agentUuid, 30);
+        const decidedPrompt = await addPrompt(decidedThread, {
+            responded: false,
+            createdHoursAgo: 30,
+        });
+        const decidedToolCallId = await addRunSqlToolCall(decidedPrompt);
+        await database(AiSqlApprovalTableName).insert({
+            tool_call_id: decidedToolCallId,
+            decision: 'approved',
+            decided_by_user_uuid: userUuid,
+        });
+
+        const result = await model.deleteExpiredThreads(
+            SEED_ORG_1.organization_uuid,
+            100,
+        );
+
+        expect(result.deletedThreadUuids).not.toContain(waitingThread);
+        // Approved but never resumed for 30h — the run is dead, not live.
+        expect(result.deletedThreadUuids).toContain(decidedThread);
+        const orphanedApproval = await database(AiSqlApprovalTableName)
+            .where('tool_call_id', decidedToolCallId)
+            .first();
+        expect(orphanedApproval).toBeUndefined();
+    });
+
+    it('keeps a thread with a deep research run in a non-terminal state', async () => {
+        const agentUuid = await createAgent(1);
+
+        const runningThread = await createThread(agentUuid, 30);
+        const runningPrompt = await addPrompt(runningThread, {
+            responded: true,
+            createdHoursAgo: 30,
+        });
+        await addDeepResearchRun(agentUuid, runningThread, runningPrompt, {
+            status: 'running',
+        });
+
+        const finishedThread = await createThread(agentUuid, 30);
+        const finishedPrompt = await addPrompt(finishedThread, {
+            responded: true,
+            createdHoursAgo: 30,
+        });
+        await addDeepResearchRun(agentUuid, finishedThread, finishedPrompt, {
+            status: 'completed',
+        });
+
+        const result = await model.deleteExpiredThreads(
+            SEED_ORG_1.organization_uuid,
+            100,
+        );
+
+        expect(result.deletedThreadUuids).not.toContain(runningThread);
+        expect(result.deletedThreadUuids).toContain(finishedThread);
+    });
+
+    it('keeps a thread with a writeback run in a non-terminal state', async () => {
+        const agentUuid = await createAgent(1);
+        const runningThread = await createThread(agentUuid, 30);
+        await database<AiWritebackRunTable>(AiWritebackRunTableName).insert({
+            organization_uuid: SEED_ORG_1.organization_uuid,
+            project_uuid: SEED_PROJECT.project_uuid,
+            ai_thread_uuid: runningThread,
+            created_by_user_uuid: userUuid,
+            source: 'web',
+            status: 'pending',
+        });
+
+        const finishedThread = await createThread(agentUuid, 30);
+        await database<AiWritebackRunTable>(AiWritebackRunTableName).insert({
+            organization_uuid: SEED_ORG_1.organization_uuid,
+            project_uuid: SEED_PROJECT.project_uuid,
+            ai_thread_uuid: finishedThread,
+            created_by_user_uuid: userUuid,
+            source: 'web',
+            status: 'ready',
+        });
+
+        const result = await model.deleteExpiredThreads(
+            SEED_ORG_1.organization_uuid,
+            100,
+        );
+
+        expect(result.deletedThreadUuids).not.toContain(runningThread);
+        expect(result.deletedThreadUuids).toContain(finishedThread);
+    });
+
+    it('applies the org default to agents without a window and the smaller of the two otherwise', async () => {
+        await setOrgRetention(24);
+        const inheritingAgent = await createAgent(null);
+        const expiredByOrg = await createThread(inheritingAgent, 25);
+        const withinOrgWindow = await createThread(inheritingAgent, 2);
+
+        const tighterAgent = await createAgent(1);
+        const expiredByAgent = await createThread(tighterAgent, 2);
+
+        const result = await model.deleteExpiredThreads(
+            SEED_ORG_1.organization_uuid,
+            100,
+        );
+
+        expect(result.deletedThreadUuids).toContain(expiredByOrg);
+        expect(result.deletedThreadUuids).not.toContain(withinOrgWindow);
+        expect(result.deletedThreadUuids).toContain(expiredByAgent);
+    });
+
+    it('applies the org default to threads with no agent at all', async () => {
+        await setOrgRetention(24);
+        const orphanExpired = await createThread(null, 25);
+        const orphanActive = await createThread(null, 2);
+
+        const result = await model.deleteExpiredThreads(
+            SEED_ORG_1.organization_uuid,
+            100,
+        );
+
+        expect(result.deletedThreadUuids).toContain(orphanExpired);
+        expect(result.deletedThreadUuids).not.toContain(orphanActive);
+    });
+
+    it('deletes nothing when neither agent nor org sets a window', async () => {
+        await setOrgRetention(null);
+        const agentUuid = await createAgent(null);
+        const oldThread = await createThread(agentUuid, 24 * 365);
+
+        const result = await model.deleteExpiredThreads(
+            SEED_ORG_1.organization_uuid,
+            100,
+        );
+
+        expect(result.deletedThreadUuids).not.toContain(oldThread);
+        expect(await threadExists(oldThread)).toBe(true);
+    });
+
+    it('previews the impact of a hypothetical org window without deleting anything', async () => {
+        const agentUuid = await createAgent(null);
+        const oldThread = await createThread(agentUuid, 48);
+        await createThread(agentUuid, 1);
+
+        const preview = await model.countThreadsExpiredByOrgRetention(
+            SEED_ORG_1.organization_uuid,
+            24,
+        );
+
+        expect(preview.threadCount).toBeGreaterThanOrEqual(1);
+        expect(preview.agentCount).toBeGreaterThanOrEqual(1);
+        expect(await threadExists(oldThread)).toBe(true);
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1,6 +1,8 @@
 import {
     AgentToolOutput,
+    AI_DEEP_RESEARCH_TERMINAL_STATUSES,
     AI_WRITEBACK_PENDING_GRACE_MS,
+    AI_WRITEBACK_RUN_TERMINAL_STATUSES,
     AiAgentAdminConversationsSummary,
     AiAgentAdminEvalFilters,
     AiAgentAdminEvalPrompt,
@@ -119,6 +121,7 @@ import {
     AiAgentToolCallErrorTableName,
     AiAgentToolCallTableName,
     AiAgentToolResultTableName,
+    AiOrganizationSettingsTableName,
     AiPromptContextEntityType,
     AiPromptContextTableName,
     AiPromptInterruptTableName,
@@ -174,6 +177,7 @@ import {
     DbAiMcpServerCredential,
     DbAiMcpServerTool,
 } from '../database/entities/aiAgent';
+import { AiAgentMemoryTableName } from '../database/entities/aiAgentMemory';
 import { AiAgentUserPreferencesTableName } from '../database/entities/aiAgentUserPreferences';
 import {
     AiArtifactsTable,
@@ -185,6 +189,7 @@ import {
     DbAiArtifact,
     DbAiArtifactVersion,
 } from '../database/entities/aiArtifacts';
+import { AiDeepResearchRunsTableName } from '../database/entities/aiDeepResearch';
 import {
     AiEvalPromptTableName,
     AiEvalRunResultAssessmentTableName,
@@ -9428,6 +9433,206 @@ export class AiAgentModel {
             // TODO: copy AI reasoning for shared clones when the UI supports it.
 
             return newThreadUuid;
+        });
+    }
+
+    async findOrganizationsWithThreadRetention(): Promise<string[]> {
+        const rows = await this.database
+            .select<{ organization_uuid: string }[]>('organization_uuid')
+            .from(AiOrganizationSettingsTableName)
+            .whereNotNull('thread_retention_hours')
+            .union((builder) =>
+                builder
+                    .select('organization_uuid')
+                    .from(AiAgentTableName)
+                    .whereNotNull('thread_retention_hours'),
+            );
+        return rows.map((row) => row.organization_uuid);
+    }
+
+    /**
+     * Shared predicate for retention sweeps: the effective window (LEAST of
+     * agent/org values — nulls ignored, so agentless threads inherit the org
+     * value) must have elapsed since the last activity, and nothing may be
+     * in flight: an unanswered prompt under 24h old, a runSql call awaiting
+     * human approval at any age, or a non-terminal deep research/writeback
+     * run (their stale-run sweepers guarantee eventual termination).
+     */
+    private static expiredThreadsFilterSql(
+        retentionJoinSql: string,
+        orgRetentionSql: string,
+    ): string {
+        return `
+            FROM ${AiThreadTableName} t
+            LEFT JOIN ${AiAgentTableName} a
+                ON a.ai_agent_uuid = t.agent_uuid
+            ${retentionJoinSql}
+            WHERE t.organization_uuid = :organizationUuid
+                AND LEAST(
+                    a.thread_retention_hours,
+                    ${orgRetentionSql}
+                ) IS NOT NULL
+                AND GREATEST(
+                    t.created_at,
+                    COALESCE(t.updated_at, t.created_at),
+                    COALESCE((
+                        SELECT max(p.created_at)
+                        FROM ${AiPromptTableName} p
+                        WHERE p.ai_thread_uuid = t.ai_thread_uuid
+                    ), t.created_at)
+                ) < now() - make_interval(hours => LEAST(
+                    a.thread_retention_hours,
+                    ${orgRetentionSql}
+                ))
+                AND NOT EXISTS (
+                    SELECT 1 FROM ${AiPromptTableName} p
+                    WHERE p.ai_thread_uuid = t.ai_thread_uuid
+                        AND p.response IS NULL
+                        AND p.error_message IS NULL
+                        AND p.created_at > now() - interval '24 hours'
+                )
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM ${AiPromptTableName} p
+                    JOIN ${AiAgentToolCallTableName} tc
+                        ON tc.ai_prompt_uuid = p.ai_prompt_uuid
+                    LEFT JOIN ${AiAgentToolResultTableName} tr
+                        ON tr.tool_call_id = tc.tool_call_id
+                    LEFT JOIN ${AiSqlApprovalTableName} ap
+                        ON ap.tool_call_id = tc.tool_call_id
+                    WHERE p.ai_thread_uuid = t.ai_thread_uuid
+                        AND t.sql_auto_approved_at IS NULL
+                        AND tc.tool_name = 'runSql'
+                        AND tr.ai_agent_tool_result_uuid IS NULL
+                        AND ap.tool_call_id IS NULL
+                )
+                AND NOT EXISTS (
+                    SELECT 1 FROM ${AiDeepResearchRunsTableName} r
+                    WHERE r.ai_thread_uuid = t.ai_thread_uuid
+                        AND NOT (r.status = ANY(:deepResearchTerminalStatuses))
+                )
+                AND NOT EXISTS (
+                    SELECT 1 FROM ${AiWritebackRunTableName} w
+                    WHERE w.ai_thread_uuid = t.ai_thread_uuid
+                        AND NOT (w.status = ANY(:writebackTerminalStatuses))
+                )
+        `;
+    }
+
+    private static inFlightGuardBindings() {
+        return {
+            deepResearchTerminalStatuses: [
+                ...AI_DEEP_RESEARCH_TERMINAL_STATUSES,
+            ],
+            writebackTerminalStatuses: [...AI_WRITEBACK_RUN_TERMINAL_STATUSES],
+        };
+    }
+
+    /**
+     * Preview for the org settings confirmation dialog: how many threads (and
+     * across how many agents) an org-level window of `orgRetentionHours`
+     * would delete on the next cleanup run.
+     */
+    async countThreadsExpiredByOrgRetention(
+        organizationUuid: string,
+        orgRetentionHours: number,
+    ): Promise<{ threadCount: number; agentCount: number }> {
+        const filterSql = AiAgentModel.expiredThreadsFilterSql(
+            '',
+            'CAST(:orgRetentionHours AS integer)',
+        );
+        const {
+            rows: [row],
+        } = await this.database.raw<{
+            rows: { thread_count: string; agent_count: string }[];
+        }>(
+            `SELECT
+                count(*) AS thread_count,
+                count(DISTINCT t.agent_uuid) AS agent_count
+            ${filterSql}`,
+            {
+                organizationUuid,
+                orgRetentionHours,
+                ...AiAgentModel.inFlightGuardBindings(),
+            },
+        );
+        return {
+            threadCount: Number(row?.thread_count ?? 0),
+            agentCount: Number(row?.agent_count ?? 0),
+        };
+    }
+
+    /**
+     * Deletes one batch of expired threads plus the derived rows the FK
+     * graph does not cascade: memories distilled from a thread, runSql
+     * approval decisions (keyed by tool call id), and pinned-context
+     * references. Everything else is covered by ON DELETE CASCADE.
+     */
+    async deleteExpiredThreads(
+        organizationUuid: string,
+        batchSize: number,
+    ): Promise<{
+        deletedThreadUuids: string[];
+        deletedMemoriesCount: number;
+    }> {
+        const filterSql = AiAgentModel.expiredThreadsFilterSql(
+            `LEFT JOIN ${AiOrganizationSettingsTableName} s
+                ON s.organization_uuid = t.organization_uuid`,
+            's.thread_retention_hours',
+        );
+
+        return this.database.transaction(async (trx) => {
+            const { rows: candidates } = await trx.raw<{
+                rows: { ai_thread_uuid: string }[];
+            }>(
+                `SELECT t.ai_thread_uuid
+                ${filterSql}
+                LIMIT :batchSize
+                FOR UPDATE OF t SKIP LOCKED`,
+                {
+                    organizationUuid,
+                    batchSize,
+                    ...AiAgentModel.inFlightGuardBindings(),
+                },
+            );
+            const deletedThreadUuids = candidates.map(
+                (row) => row.ai_thread_uuid,
+            );
+            if (deletedThreadUuids.length === 0) {
+                return { deletedThreadUuids, deletedMemoriesCount: 0 };
+            }
+
+            await trx(AiSqlApprovalTableName)
+                .whereIn('tool_call_id', (builder) =>
+                    builder
+                        .select(`${AiAgentToolCallTableName}.tool_call_id`)
+                        .from(AiAgentToolCallTableName)
+                        .join(
+                            AiPromptTableName,
+                            `${AiPromptTableName}.ai_prompt_uuid`,
+                            `${AiAgentToolCallTableName}.ai_prompt_uuid`,
+                        )
+                        .whereIn(
+                            `${AiPromptTableName}.ai_thread_uuid`,
+                            deletedThreadUuids,
+                        ),
+                )
+                .delete();
+
+            await trx(AiPromptContextTableName)
+                .where('entity_type', 'thread')
+                .whereIn('entity_uuid', deletedThreadUuids)
+                .delete();
+
+            const deletedMemoriesCount = await trx(AiAgentMemoryTableName)
+                .whereIn('source_thread_uuid', deletedThreadUuids)
+                .delete();
+
+            await trx(AiThreadTableName)
+                .whereIn('ai_thread_uuid', deletedThreadUuids)
+                .delete();
+
+            return { deletedThreadUuids, deletedMemoriesCount };
         });
     }
 }

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -39,6 +39,7 @@ import type { ProjectHomepageService } from '../services/ProjectHomepageService'
 import { sendReviewNotification } from './tasks/sendReviewNotification';
 
 const MCP_TOOL_CALL_RETENTION_DAYS = 90;
+const AI_THREAD_RETENTION_CLEANUP_BATCH_SIZE = 500;
 export const AI_DEEP_RESEARCH_REPORT_CLEANUP_BATCH_SIZE = 100;
 const AI_AGENT_EVAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const AI_AGENT_REVIEW_REMEDIATION_RUN_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
@@ -257,6 +258,14 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     maxAttempts: 3,
                 },
             },
+            {
+                task: EE_SCHEDULER_TASKS.CLEAN_AI_AGENT_THREADS,
+                pattern: '17 * * * *',
+                options: {
+                    backfillPeriod: 2 * 60 * 60 * 1000,
+                    maxAttempts: 3,
+                },
+            },
         ];
     }
 
@@ -297,6 +306,25 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     cleanupMetrics: this.cleanupMetrics,
                     addJob: helpers.addJob,
                 }),
+            [EE_SCHEDULER_TASKS.CLEAN_AI_AGENT_THREADS]: async (
+                _payload,
+                helpers,
+            ) => {
+                Logger.info('Starting AI thread retention cleanup job');
+                const result = await this.aiAgentService.cleanExpiredThreads(
+                    AI_THREAD_RETENTION_CLEANUP_BATCH_SIZE,
+                );
+                Logger.info(
+                    `AI thread retention cleanup completed. Threads deleted: ${result.threadsDeleted}; derived memories deleted: ${result.memoriesDeleted}`,
+                );
+                if (result.hitBatchLimit) {
+                    await helpers.addJob(
+                        EE_SCHEDULER_TASKS.CLEAN_AI_AGENT_THREADS,
+                        {},
+                        { maxAttempts: 3 },
+                    );
+                }
+            },
             [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: async (
                 payload,
                 _helpers,

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -25,6 +25,7 @@ import {
     AiAgentSummary,
     AiAgentThreadDump,
     AiReviewNotificationSettings,
+    AiThreadRetentionPreview,
     AlreadyExistsError,
     assertUnreachable,
     CreateAiAgentReviewItem,
@@ -36,6 +37,7 @@ import {
     getErrorMessage,
     getReviewItemProjectContextEntry,
     isHiddenAiAgentReviewRootCause,
+    isValidRetentionWindowHours,
     JobStatusType,
     KnexPaginateArgs,
     KnexPaginatedData,
@@ -50,6 +52,7 @@ import {
     PullRequestProvider,
     PullRequestSource,
     RequestMethod,
+    RETENTION_WINDOW_HOURS_ERROR,
     UpdateAiAgentReviewItemPriority,
     UpdateAiAgentReviewItemStatus,
     UpdateAiReviewNotificationSettings,
@@ -3319,5 +3322,47 @@ export class AiAgentAdminService extends BaseService {
             token,
             url: url.href,
         };
+    }
+
+    /**
+     * Powers the org settings confirmation dialog ("threads older than X
+     * across N agents will be deleted") before a retention ceiling is
+     * lowered. Uses the same predicate as the cleanup job, with the given
+     * hours standing in for the org value.
+     */
+    async getThreadRetentionPreview(
+        user: SessionUser,
+        retentionHours: number,
+    ): Promise<AiThreadRetentionPreview> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        if (
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('OrganizationAiAgent', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to manage AI agent settings',
+            );
+        }
+        const flag = await this.featureFlagService.get({
+            user,
+            featureFlagId: FeatureFlags.AiThreadRetention,
+        });
+        if (!flag.enabled) {
+            throw new ForbiddenError(
+                'AI thread retention is not enabled for this organization',
+            );
+        }
+        if (!isValidRetentionWindowHours(retentionHours)) {
+            throw new ParameterError(RETENTION_WINDOW_HOURS_ERROR);
+        }
+        return this.aiAgentModel.countThreadsExpiredByOrgRetention(
+            organizationUuid,
+            retentionHours,
+        );
     }
 }

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -163,6 +163,7 @@ import { EventEmitter } from 'events';
 import fs from 'fs/promises';
 import _ from 'lodash';
 import { nanoid as nanoidGenerator } from 'nanoid';
+import pLimit from 'p-limit';
 import slackifyMarkdown from 'slackify-markdown';
 import { Readable } from 'stream';
 import { z } from 'zod';
@@ -183,6 +184,7 @@ import {
     AiAgentSlackChannelLinkedEvent,
     AiAgentSuggestionsGeneratedEvent,
     AiAgentSuggestionSubmitEvent,
+    AiAgentThreadsRetentionCleanedEvent,
     AiAgentToolCallEvent,
     AiAgentUpdatedEvent,
     ContentVerificationEvent,
@@ -3201,6 +3203,80 @@ export class AiAgentService extends BaseService {
             threadUuid,
             messageUuid,
         });
+    }
+
+    async cleanExpiredThreads(batchSize: number): Promise<{
+        threadsDeleted: number;
+        memoriesDeleted: number;
+        hitBatchLimit: boolean;
+    }> {
+        const organizationUuids =
+            await this.aiAgentModel.findOrganizationsWithThreadRetention();
+
+        const flagLimit = pLimit(5);
+        const flags = await Promise.all(
+            organizationUuids.map((organizationUuid) =>
+                flagLimit(async () => ({
+                    organizationUuid,
+                    flag: await this.featureFlagService.get({
+                        user: { userUuid: 'system', organizationUuid },
+                        featureFlagId: FeatureFlags.AiThreadRetention,
+                    }),
+                })),
+            ),
+        );
+        const enabledOrganizationUuids = flags
+            .filter(({ flag }) => flag.enabled)
+            .map(({ organizationUuid }) => organizationUuid);
+
+        // Each deletion is a transaction cascading a full batch of threads, so
+        // keep the concurrency low to bound the load on the database.
+        const deleteLimit = pLimit(3);
+        const results = await Promise.all(
+            enabledOrganizationUuids.map((organizationUuid) =>
+                deleteLimit(async () => {
+                    const { deletedThreadUuids, deletedMemoriesCount } =
+                        await this.aiAgentModel.deleteExpiredThreads(
+                            organizationUuid,
+                            batchSize,
+                        );
+                    if (deletedThreadUuids.length > 0) {
+                        Logger.info(
+                            `AI thread retention: deleted ${deletedThreadUuids.length} threads and ${deletedMemoriesCount} derived memories for organization ${organizationUuid}`,
+                        );
+                        this.analytics.track<AiAgentThreadsRetentionCleanedEvent>(
+                            {
+                                event: 'ai_agent.threads_retention_cleaned',
+                                anonymousId: LightdashAnalytics.anonymousId,
+                                properties: {
+                                    organizationId: organizationUuid,
+                                    threadsDeleted: deletedThreadUuids.length,
+                                    memoriesDeleted: deletedMemoriesCount,
+                                },
+                            },
+                        );
+                    }
+                    return {
+                        threadsDeleted: deletedThreadUuids.length,
+                        memoriesDeleted: deletedMemoriesCount,
+                    };
+                }),
+            ),
+        );
+
+        return {
+            threadsDeleted: results.reduce(
+                (sum, result) => sum + result.threadsDeleted,
+                0,
+            ),
+            memoriesDeleted: results.reduce(
+                (sum, result) => sum + result.memoriesDeleted,
+                0,
+            ),
+            hitBatchLimit: results.some(
+                (result) => result.threadsDeleted >= batchSize,
+            ),
+        };
     }
 
     private async validateThreadRetentionUpdate(

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -285,6 +285,7 @@ const getTagsForTask: {
     }),
     [SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: () => ({}),
     [SCHEDULER_TASKS.CLEAN_AI_DEEP_RESEARCH_REPORTS]: () => ({}),
+    [SCHEDULER_TASKS.CLEAN_AI_AGENT_THREADS]: () => ({}),
     [SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -468,3 +468,16 @@ export type ApiAiOrganizationRuntimeSettingsResponse =
 
 export type ApiUpdateAiOrganizationSettingsResponse =
     ApiSuccess<AiOrganizationSettings>;
+
+/**
+ * What an org-level retention window of `retentionHours` would delete on the
+ * next cleanup run. Backs the confirmation dialog shown before lowering the
+ * org ceiling.
+ */
+export type AiThreadRetentionPreview = {
+    threadCount: number;
+    agentCount: number;
+};
+
+export type ApiAiThreadRetentionPreviewResponse =
+    ApiSuccess<AiThreadRetentionPreview>;

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -176,6 +176,7 @@ export const EE_SCHEDULER_TASKS = {
     CONSOLIDATE_AI_AGENT_MEMORY_PARTITION: 'consolidateAiAgentMemoryPartition',
     CLEAN_MCP_TOOL_CALLS: 'cleanMcpToolCalls',
     CLEAN_AI_DEEP_RESEARCH_REPORTS: 'cleanAiDeepResearchReports',
+    CLEAN_AI_AGENT_THREADS: 'cleanAiAgentThreads',
     PUBLISH_ANNOUNCEMENT: 'publishAnnouncement',
     SWEEP_DUE_ANNOUNCEMENTS: 'sweepDueAnnouncements',
 } as const;
@@ -288,6 +289,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORY_PARTITION]: AiAgentMemoryConsolidatePartitionJobPayload;
     [SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
     [SCHEDULER_TASKS.CLEAN_AI_DEEP_RESEARCH_REPORTS]: TraceTaskBase;
+    [SCHEDULER_TASKS.CLEAN_AI_AGENT_THREADS]: TraceTaskBase;
     [SCHEDULER_TASKS.PUBLISH_ANNOUNCEMENT]: PublishAnnouncementPayload;
     [SCHEDULER_TASKS.SWEEP_DUE_ANNOUNCEMENTS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
@@ -318,6 +320,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORY_PARTITION]: AiAgentMemoryConsolidatePartitionJobPayload;
     [EE_SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
     [EE_SCHEDULER_TASKS.CLEAN_AI_DEEP_RESEARCH_REPORTS]: TraceTaskBase;
+    [EE_SCHEDULER_TASKS.CLEAN_AI_AGENT_THREADS]: TraceTaskBase;
     [EE_SCHEDULER_TASKS.PUBLISH_ANNOUNCEMENT]: PublishAnnouncementPayload;
     [EE_SCHEDULER_TASKS.SWEEP_DUE_ANNOUNCEMENTS]: TraceTaskBase;
     [EE_SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;


### PR DESCRIPTION
Enforces the retention windows introduced in the previous PR: an hourly job deletes threads inactive past the stricter of the agent/org window — along with derived memories, approval decisions and context references — while never touching threads with work in flight (pending response, pending SQL approval, running deep research or writeback). Also adds the preview count that the settings UI uses to warn admins before tightening the org ceiling.

Relates: ZAP-787
Relates: #27087