### PR TITLE
feat(ai): data retention settings UI with org ceiling and agent override

### DIFF
--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -438,6 +438,7 @@ export class AiOrganizationSettingsService extends BaseService {
                 visibleDataAppModels: getVisibleDataAppClaudeModels(
                     dataAppModelVisibility,
                 ),
+                threadRetentionHours: null,
             };
         }
 
@@ -457,6 +458,7 @@ export class AiOrganizationSettingsService extends BaseService {
             visibleDataAppModels: getVisibleDataAppClaudeModels(
                 settings.dataAppModelVisibility,
             ),
+            threadRetentionHours: settings.threadRetentionHours ?? null,
         };
     }
 

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -461,6 +461,9 @@ export type AiOrganizationRuntimeSettings = {
     defaultAiAgentModelOptions: AiModelOption[];
     dataAppCodingAgent: DataAppCodingAgent;
     visibleDataAppModels: DataAppClaudeModel[];
+    // Org retention ceiling, surfaced so agent editors can see what caps
+    // their agent-level window. Optional for backwards compatibility.
+    threadRetentionHours?: number | null;
 };
 
 export type ApiAiOrganizationRuntimeSettingsResponse =

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -37,6 +37,7 @@ import {
 import { AiProvidersCard } from './AiProvidersCard';
 import { AiRouterInstructionsCard } from './AiRouterInstructionsCard';
 import { ReviewNotificationsSettings } from './ReviewNotificationsSettings';
+import { ThreadRetentionCard } from './ThreadRetentionCard';
 
 export const AiGeneralSettingsPage = () => {
     const { data: settings, isInitialLoading: isSettingsLoading } =
@@ -48,6 +49,9 @@ export const AiGeneralSettingsPage = () => {
         FeatureFlags.OrgAiProviderApiKeys,
     );
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const threadRetentionFlag = useServerFeatureFlag(
+        FeatureFlags.AiThreadRetention,
+    );
 
     const aiRouterQuery = useAiRouterConfig();
     const isRouterEnabled = aiRouterQuery.data?.enabled ?? false;
@@ -135,6 +139,12 @@ export const AiGeneralSettingsPage = () => {
                             />
                         </Group>
                     </SettingsCard>
+
+                    {threadRetentionFlag.data?.enabled && (
+                        <ThreadRetentionCard
+                            current={settings.threadRetentionHours ?? null}
+                        />
+                    )}
 
                     <SettingsCard>
                         <Stack gap="md">

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/ThreadRetentionCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/ThreadRetentionCard.tsx
@@ -1,0 +1,110 @@
+import { type RetentionWindowHours } from '@lightdash/common';
+import { Box, Group, Loader, Stack, Text, Title } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import { useState } from 'react';
+import Callout from '../../../../../../components/common/Callout';
+import MantineModal from '../../../../../../components/common/MantineModal';
+import { SettingsCard } from '../../../../../../components/common/Settings/SettingsCard';
+import {
+    useAiThreadRetentionPreview,
+    useUpdateAiOrganizationSettings,
+} from '../../../hooks/useAiOrganizationSettings';
+import { formatRetentionHours } from '../../../utils/threadRetention';
+import { ThreadRetentionSelect } from '../../ThreadRetentionSelect';
+
+export const ThreadRetentionCard = ({
+    current,
+}: {
+    current: RetentionWindowHours;
+}) => {
+    const { mutate: updateSettings, isLoading: isUpdatingSettings } =
+        useUpdateAiOrganizationSettings();
+    // A tightening change is held here until the admin confirms the deletion
+    // it will trigger on the next cleanup run.
+    const [pendingRetentionHours, setPendingRetentionHours] = useState<
+        number | undefined
+    >(undefined);
+    const previewQuery = useAiThreadRetentionPreview(pendingRetentionHours);
+
+    return (
+        <SettingsCard>
+            <Group
+                justify="space-between"
+                wrap="nowrap"
+                align="flex-start"
+                gap="md"
+            >
+                <Box maw={620}>
+                    <Title order={5} mb={4}>
+                        Conversation retention
+                    </Title>
+                    <Text c="ldGray.6" fz="xs">
+                        Automatically delete agent conversations after a period
+                        of inactivity. Agents can shorten this window but not
+                        extend it.
+                    </Text>
+                </Box>
+                <ThreadRetentionSelect
+                    value={current}
+                    disabled={isUpdatingSettings}
+                    onChange={(hours) => {
+                        const tightens =
+                            hours !== null &&
+                            (current === null || hours < current);
+                        if (tightens) {
+                            setPendingRetentionHours(hours);
+                        } else {
+                            updateSettings({ threadRetentionHours: hours });
+                        }
+                    }}
+                />
+            </Group>
+            <MantineModal
+                opened={pendingRetentionHours !== undefined}
+                onClose={() => setPendingRetentionHours(undefined)}
+                title="Reduce conversation retention?"
+                icon={IconAlertTriangle}
+                role="alertdialog"
+                confirmLabel="Reduce retention"
+                onConfirm={() => {
+                    if (pendingRetentionHours !== undefined) {
+                        updateSettings({
+                            threadRetentionHours: pendingRetentionHours,
+                        });
+                    }
+                    setPendingRetentionHours(undefined);
+                }}
+            >
+                <Stack gap="xs">
+                    <Text fz="sm">
+                        Conversations inactive for longer than{' '}
+                        {pendingRetentionHours !== undefined
+                            ? formatRetentionHours(pendingRetentionHours)
+                            : ''}{' '}
+                        will be permanently deleted across all agents in this
+                        organization, starting within the hour. This cannot be
+                        undone.
+                    </Text>
+                    {previewQuery.isInitialLoading ? (
+                        <Group gap="xs">
+                            <Loader size="xs" />
+                            <Text fz="sm" c="dimmed">
+                                Counting affected conversations…
+                            </Text>
+                        </Group>
+                    ) : previewQuery.data &&
+                      previewQuery.data.threadCount > 0 ? (
+                        <Callout
+                            variant="danger"
+                            title={`${previewQuery.data.threadCount} conversation${
+                                previewQuery.data.threadCount === 1 ? '' : 's'
+                            } across ${previewQuery.data.agentCount} agent${
+                                previewQuery.data.agentCount === 1 ? '' : 's'
+                            } will be deleted`}
+                        />
+                    ) : null}
+                </Stack>
+            </MantineModal>
+        </SettingsCard>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -1,5 +1,10 @@
 import { subject } from '@casl/ability';
-import { FeatureFlags, type AiAgentModelConfig } from '@lightdash/common';
+import {
+    FeatureFlags,
+    MAX_RETENTION_WINDOW_HOURS,
+    MIN_RETENTION_WINDOW_HOURS,
+    type AiAgentModelConfig,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Anchor,
@@ -71,6 +76,7 @@ import { AiAgentKnowledgeFilesSection } from './AiAgentKnowledgeFilesSection';
 import { AiAgentMcpServersInput } from './AiAgentMcpServersInput';
 import { InstructionsGuidelines } from './InstructionsSupport';
 import { SpaceAccessSelect } from './SpaceAccessSelect';
+import { ThreadRetentionSelect } from './ThreadRetentionSelect';
 
 const formSchema = z.object({
     name: z.string().min(1),
@@ -96,6 +102,12 @@ const formSchema = z.object({
     adminOnly: z.boolean(),
     modelConfig: z.custom<AiAgentModelConfig>().nullable(),
     version: z.number(),
+    threadRetentionHours: z
+        .number()
+        .int()
+        .min(MIN_RETENTION_WINDOW_HOURS)
+        .max(MAX_RETENTION_WINDOW_HOURS)
+        .nullable(),
 });
 
 type CommitOnBlurTextareaProps = Omit<
@@ -256,6 +268,10 @@ export const AiAgentFormSetup = ({
 
     const userGroupsFeatureFlagQuery = useServerFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
+    );
+
+    const threadRetentionFlagQuery = useServerFeatureFlag(
+        FeatureFlags.AiThreadRetention,
     );
 
     const isGroupsEnabled =
@@ -866,6 +882,35 @@ export const AiAgentFormSetup = ({
                                 .
                             </Text>
                         </AgentSettingsSubsection>
+
+                        {threadRetentionFlagQuery.data?.enabled && (
+                            <>
+                                <Divider />
+                                <AgentSettingsSubsection
+                                    title="Conversation retention"
+                                    description={`Delete this agent's conversations after a period of inactivity. Active conversations are never cut off.${
+                                        aiOrganizationSettings?.threadRetentionHours !=
+                                        null
+                                            ? ' The organization retention policy caps this setting.'
+                                            : ''
+                                    }`}
+                                >
+                                    <ThreadRetentionSelect
+                                        value={form.values.threadRetentionHours}
+                                        ceilingHours={
+                                            aiOrganizationSettings?.threadRetentionHours ??
+                                            null
+                                        }
+                                        onChange={(hours) =>
+                                            form.setFieldValue(
+                                                'threadRetentionHours',
+                                                hours,
+                                            )
+                                        }
+                                    />
+                                </AgentSettingsSubsection>
+                            </>
+                        )}
 
                         <Divider />
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ThreadRetentionSelect.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ThreadRetentionSelect.tsx
@@ -1,0 +1,106 @@
+import {
+    MAX_RETENTION_WINDOW_HOURS,
+    MIN_RETENTION_WINDOW_HOURS,
+    type RetentionWindowHours,
+} from '@lightdash/common';
+import { Group, Select } from '@mantine/core';
+import { useState, type FC } from 'react';
+import { NumberInput } from '../../../../components/common/NumberInput';
+import {
+    formatRetentionHours,
+    THREAD_RETENTION_PRESETS,
+} from '../utils/threadRetention';
+
+type Props = {
+    value: RetentionWindowHours;
+    onChange: (value: RetentionWindowHours) => void;
+    disabled?: boolean;
+    ceilingHours?: RetentionWindowHours;
+};
+
+export const ThreadRetentionSelect: FC<Props> = ({
+    value,
+    onChange,
+    disabled,
+    ceilingHours = null,
+}) => {
+    const [customPicked, setCustomPicked] = useState(false);
+    const [draftHours, setDraftHours] = useState<number | undefined>(undefined);
+
+    const isPreset =
+        value !== null &&
+        THREAD_RETENTION_PRESETS.some((p) => p.hours === value) &&
+        (ceilingHours === null || value <= ceilingHours);
+    const customMode = customPicked || (value !== null && !isPreset);
+
+    const noneLabel =
+        ceilingHours !== null
+            ? `Inherit org default (${formatRetentionHours(ceilingHours)})`
+            : 'Keep forever';
+
+    const presets = THREAD_RETENTION_PRESETS.filter(
+        (p) => ceilingHours === null || p.hours <= ceilingHours,
+    );
+
+    const selectValue = customMode
+        ? 'custom'
+        : value === null
+          ? 'none'
+          : String(value);
+
+    const commitDraft = () => {
+        if (draftHours !== undefined && draftHours !== value) {
+            onChange(draftHours);
+        }
+        setDraftHours(undefined);
+    };
+
+    return (
+        <Group gap="xs" wrap="nowrap">
+            <Select
+                w={200}
+                size="xs"
+                disabled={disabled}
+                value={selectValue}
+                data={[
+                    { value: 'none', label: noneLabel },
+                    ...presets.map((p) => ({
+                        value: String(p.hours),
+                        label: p.label,
+                    })),
+                    { value: 'custom', label: 'Custom…' },
+                ]}
+                onChange={(selected) => {
+                    if (selected === null) return;
+                    if (selected === 'custom') {
+                        setCustomPicked(true);
+                        return;
+                    }
+                    setCustomPicked(false);
+                    setDraftHours(undefined);
+                    onChange(selected === 'none' ? null : Number(selected));
+                }}
+            />
+            {customMode && (
+                <NumberInput
+                    w={120}
+                    size="xs"
+                    min={MIN_RETENTION_WINDOW_HOURS}
+                    max={ceilingHours ?? MAX_RETENTION_WINDOW_HOURS}
+                    disabled={disabled}
+                    value={draftHours ?? value ?? undefined}
+                    placeholder="Hours"
+                    suffix=" h"
+                    onNumberChange={setDraftHours}
+                    onBlur={commitDraft}
+                    onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                            event.preventDefault();
+                            commitDraft();
+                        }
+                    }}
+                />
+            )}
+        </Group>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiOrganizationSettings.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiOrganizationSettings.ts
@@ -1,6 +1,7 @@
 import {
     type ApiAiOrganizationRuntimeSettingsResponse,
     type ApiAiOrganizationSettingsResponse,
+    type ApiAiThreadRetentionPreviewResponse,
     type ApiError,
     type ApiUpdateAiOrganizationSettingsResponse,
     type UpdateAiOrganizationSettings,
@@ -135,3 +136,28 @@ export const useUpdateAiOrganizationSettings = (
         ...mutationOptions,
     });
 };
+
+const getAiThreadRetentionPreview = async (retentionHours: number) => {
+    const params = new URLSearchParams({
+        retentionHours: String(retentionHours),
+    });
+    return lightdashApi<ApiAiThreadRetentionPreviewResponse['results']>({
+        url: `/aiAgents/admin/settings/thread-retention-preview?${params.toString()}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+/**
+ * What an org retention window of `retentionHours` would delete on the next
+ * cleanup run. Backs the confirmation dialog shown before tightening the org
+ * ceiling; only fetched while the dialog needs it (`enabled`).
+ */
+export const useAiThreadRetentionPreview = (
+    retentionHours: number | undefined,
+) =>
+    useQuery<ApiAiThreadRetentionPreviewResponse['results'], ApiError>({
+        queryKey: ['ai-thread-retention-preview', retentionHours],
+        queryFn: () => getAiThreadRetentionPreview(retentionHours!),
+        enabled: retentionHours !== undefined,
+    });

--- a/packages/frontend/src/ee/features/aiCopilot/utils/threadRetention.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/threadRetention.ts
@@ -1,0 +1,13 @@
+export const THREAD_RETENTION_PRESETS: { hours: number; label: string }[] = [
+    { hours: 1, label: '1 hour' },
+    { hours: 24, label: '24 hours' },
+    { hours: 168, label: '7 days' },
+    { hours: 720, label: '30 days' },
+    { hours: 2160, label: '90 days' },
+];
+
+export const formatRetentionHours = (hours: number): string => {
+    const preset = THREAD_RETENTION_PRESETS.find((p) => p.hours === hours);
+    if (preset) return preset.label;
+    return hours % 24 === 0 ? `${hours / 24} days` : `${hours} hours`;
+};

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -1,4 +1,9 @@
-import { ProjectType, type AiAgentModelConfig } from '@lightdash/common';
+import {
+    MAX_RETENTION_WINDOW_HOURS,
+    MIN_RETENTION_WINDOW_HOURS,
+    ProjectType,
+    type AiAgentModelConfig,
+} from '@lightdash/common';
 import {
     AppShell,
     Box,
@@ -107,6 +112,12 @@ const formSchema = z.object({
     adminOnly: z.boolean(),
     modelConfig: z.custom<AiAgentModelConfig>().nullable(),
     version: z.number(),
+    threadRetentionHours: z
+        .number()
+        .int()
+        .min(MIN_RETENTION_WINDOW_HOURS)
+        .max(MAX_RETENTION_WINDOW_HOURS)
+        .nullable(),
 });
 
 type Props = {
@@ -173,6 +184,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             adminOnly: false,
             modelConfig: null,
             version: 2, // INFO: Default to v2 for now
+            threadRetentionHours: null,
         },
         validate: zodResolver(formSchema),
     });
@@ -208,6 +220,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                 adminOnly: agent.adminOnly ?? false,
                 modelConfig: agent.modelConfig ?? null,
                 version: agent.version ?? 2, // INFO: Default to v2 for now
+                threadRetentionHours: agent.threadRetentionHours ?? null,
             };
             form.setValues(values);
             form.resetDirty(values);


### PR DESCRIPTION
Admins had no way to see or configure the retention windows added earlier in the stack. This adds a flag-gated "Conversation retention" card to the org AI General settings page — with a confirmation dialog that shows exactly how many conversations across how many agents a tightened ceiling would delete — and the per-agent retention field, capped by the org ceiling.

Relates: ZAP-787
Relates: #27087