### PR TITLE
feat(ai): disclose retention window in agent chat surfaces

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ThreadRetentionNotice.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ThreadRetentionNotice.tsx
@@ -1,0 +1,44 @@
+import {
+    FeatureFlags,
+    getEffectiveRetentionWindowHours,
+    type RetentionWindowHours,
+} from '@lightdash/common';
+import { Group, Text } from '@mantine/core';
+import { IconHourglass } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+import { useAiOrganizationSettings } from '../hooks/useAiOrganizationSettings';
+import { formatRetentionHours } from '../utils/threadRetention';
+
+type Props = {
+    agentThreadRetentionHours: RetentionWindowHours;
+};
+
+export const ThreadRetentionNotice: FC<Props> = ({
+    agentThreadRetentionHours,
+}) => {
+    const flag = useServerFeatureFlag(FeatureFlags.AiThreadRetention);
+    const settingsQuery = useAiOrganizationSettings();
+
+    if (!flag.data?.enabled) return null;
+    // An in-flight ceiling reads as "no ceiling", which would briefly show
+    // an un-capped window — render nothing until the ceiling is known.
+    if (!settingsQuery.isSuccess) return null;
+
+    const effectiveHours = getEffectiveRetentionWindowHours(
+        agentThreadRetentionHours,
+        settingsQuery.data.threadRetentionHours ?? null,
+    );
+    if (effectiveHours === null) return null;
+
+    return (
+        <Group gap={4} wrap="nowrap">
+            <MantineIcon icon={IconHourglass} size={14} color="ldGray.6" />
+            <Text size="xs" c="ldGray.6">
+                Conversations are deleted after{' '}
+                {formatRetentionHours(effectiveHours)} of inactivity
+            </Text>
+        </Group>
+    );
+};

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -14,6 +14,7 @@ import {
     mergeContentMentionSuggestionItems,
 } from '../../features/aiCopilot/components/ChatElements/contentMentions';
 import { ThreadWorkstreamsPanel } from '../../features/aiCopilot/components/ChatElements/ThreadWorkstreamsPanel';
+import { ThreadRetentionNotice } from '../../features/aiCopilot/components/ThreadRetentionNotice';
 import { findRetryableDeepResearchRun } from '../../features/aiCopilot/deepResearch/deepResearchRegistry';
 import { runDeepResearchAgain } from '../../features/aiCopilot/deepResearch/runAgain';
 import {
@@ -406,6 +407,11 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                     {workstreams && workstreams.length > 0 && (
                         <ThreadWorkstreamsPanel workstreams={workstreams} />
                     )}
+                    <ThreadRetentionNotice
+                        agentThreadRetentionHours={
+                            agent.threadRetentionHours ?? null
+                        }
+                    />
                     <AgentChatInput
                         disabled={inputDisabled}
                         disabledReason={inputDisabledReason}

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -27,6 +27,7 @@ import { DefaultAgentButton } from '../../features/aiCopilot/components/DefaultA
 import { usePendingPrompt } from '../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
 import { PinnedContextCard } from '../../features/aiCopilot/components/PinnedContextCard/PinnedContextCard';
 import { SuggestedQuestions } from '../../features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions';
+import { ThreadRetentionNotice } from '../../features/aiCopilot/components/ThreadRetentionNotice';
 import { type StartDeepResearchArgs } from '../../features/aiCopilot/deepResearch/types';
 import { isEmbedAiAgentRoute } from '../../features/aiCopilot/hooks/aiAgentRouting';
 import { emitEmbedAiAgentThreadChange } from '../../features/aiCopilot/hooks/embedAiAgentThreadChange';
@@ -316,6 +317,11 @@ const AiAgentNewThreadPage: FC = () => {
                                 ))}
                             </Group>
                         )}
+                        <ThreadRetentionNotice
+                            agentThreadRetentionHours={
+                                agent.threadRetentionHours ?? null
+                            }
+                        />
                     </Stack>
 
                     {projectUuid && agentUuid && (


### PR DESCRIPTION
Users chatting with a retention-bound agent had no signal that their conversation expires. Shows the agreed static disclosure ("Conversations are deleted after X of inactivity") on the chat and new-thread surfaces, computed from the effective window.

Closes: ZAP-787
Closes: #27087