### PR TITLE
feat(ai): manage thread retention through agent-as-code with flag-off warn-and-drop

### DIFF
--- a/packages/backend/src/contentAsCode/fieldCoverage/ai_agent.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/ai_agent.test.ts
@@ -14,7 +14,6 @@ describeContentAsCodeSchemaContract({
         'projectUuid',
         'spaceAccess',
         'userAccess',
-        'threadRetentionHours',
         'uuid',
     ],
     documentOnlyFields: [

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -433,11 +433,13 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         aiModelCatalog,
                     }),
                 }),
-            aiAgentCoderService: ({ models, context }) =>
+            aiAgentCoderService: ({ models, repository, context }) =>
                 new AiAgentCoderService({
                     lightdashConfig: context.lightdashConfig,
                     aiAgentModel: models.getAiAgentModel(),
                     projectModel: models.getProjectModel(),
+                    aiOrganizationSettingsService:
+                        repository.getAiOrganizationSettingsService(),
                 }),
             aiAgentToolsService: ({ models, repository, context }) =>
                 new AiAgentToolsService({

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -861,6 +861,7 @@ export class AiAgentModel {
                 | 'enableContentTools'
                 | 'enableUserContext'
                 | 'enableSqlMode'
+                | 'threadRetentionHours'
                 | 'modelConfig'
                 | 'updatedAt'
             > & { uuid: string }
@@ -892,6 +893,7 @@ export class AiAgentModel {
                 enableContentTools: `${AiAgentTableName}.enable_content_tools`,
                 enableUserContext: `${AiAgentTableName}.enable_user_context`,
                 enableSqlMode: `${AiAgentTableName}.enable_sql_mode`,
+                threadRetentionHours: `${AiAgentTableName}.thread_retention_hours`,
                 modelConfig: `${AiAgentTableName}.model_config`,
                 updatedAt: `${AiAgentTableName}.updated_at`,
                 instruction: this.database.raw(`

--- a/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.test.ts
@@ -101,9 +101,13 @@ const existingEvaluation = {
 const buildService = ({
     existing = [agentRow],
     evaluations = [],
+    retentionEnabled = false,
+    retentionCeiling = null,
 }: {
-    existing?: (typeof agentRow)[];
+    existing?: (typeof agentRow & { threadRetentionHours?: number | null })[];
     evaluations?: (typeof existingEvaluation)[];
+    retentionEnabled?: boolean;
+    retentionCeiling?: number | null;
 } = {}) => {
     const aiAgentModel = {
         findAgentsForCode: vi.fn(async () => existing),
@@ -122,6 +126,10 @@ const buildService = ({
             })),
         } as never,
         lightdashConfig: lightdashConfigMock,
+        aiOrganizationSettingsService: {
+            isThreadRetentionEnabled: vi.fn(async () => retentionEnabled),
+            getThreadRetentionCeiling: vi.fn(async () => retentionCeiling),
+        } as never,
     });
 
     return { service, aiAgentModel };
@@ -499,5 +507,107 @@ describe('AiAgentCoderService', () => {
         await expect(
             service.upsertAgents(forbiddenUser, projectUuid, [agentAsCode]),
         ).rejects.toThrow('You are not allowed to upload AI agents as code');
+    });
+
+    it('warns and ignores a declared retention window when the org flag is off', async () => {
+        const { service, aiAgentModel } = buildService({
+            retentionEnabled: false,
+        });
+
+        const result = await service.upsertAgents(user, projectUuid, [
+            { ...agentAsCode, threadRetentionHours: 24 },
+        ]);
+
+        expect(result.warnings).toEqual([
+            "AI agent 'revenue-agent': threadRetentionHours was ignored — AI thread retention is not enabled for this organization",
+        ]);
+        // The field is not compared or written, so the agent stays unchanged.
+        expect(result.unchanged).toEqual(['revenue-agent']);
+        expect(aiAgentModel.updateAgent).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when a flag-off upload declares a null retention window', async () => {
+        const { service } = buildService({ retentionEnabled: false });
+
+        const result = await service.upsertAgents(user, projectUuid, [
+            { ...agentAsCode, threadRetentionHours: null },
+        ]);
+
+        expect(result.warnings).toBeUndefined();
+        expect(result.unchanged).toEqual(['revenue-agent']);
+    });
+
+    it('with the flag off, a stored retention value does not make uploads look changed', async () => {
+        const { service, aiAgentModel } = buildService({
+            existing: [{ ...agentRow, threadRetentionHours: 24 }],
+            retentionEnabled: false,
+        });
+
+        const result = await service.upsertAgents(user, projectUuid, [
+            agentAsCode,
+        ]);
+
+        expect(result.unchanged).toEqual(['revenue-agent']);
+        expect(result.warnings).toBeUndefined();
+        expect(aiAgentModel.updateAgent).not.toHaveBeenCalled();
+    });
+
+    it('rejects a retention window above the org ceiling before changing agents', async () => {
+        const { service, aiAgentModel } = buildService({
+            retentionEnabled: true,
+            retentionCeiling: 24,
+        });
+
+        await expect(
+            service.upsertAgents(user, projectUuid, [
+                { ...agentAsCode, threadRetentionHours: 25 },
+            ]),
+        ).rejects.toThrow(
+            "AI agent 'revenue-agent': thread retention cannot exceed the organization limit of 24 hours",
+        );
+        expect(aiAgentModel.updateAgent).not.toHaveBeenCalled();
+        expect(aiAgentModel.createAgent).not.toHaveBeenCalled();
+    });
+
+    it('writes a declared retention window and clears on an explicit null when the flag is on', async () => {
+        const { service, aiAgentModel } = buildService({
+            existing: [{ ...agentRow, threadRetentionHours: null }],
+            retentionEnabled: true,
+        });
+
+        const declared = await service.upsertAgents(user, projectUuid, [
+            { ...agentAsCode, threadRetentionHours: 24 },
+        ]);
+        expect(declared.updated).toEqual(['revenue-agent']);
+        expect(aiAgentModel.updateAgent).toHaveBeenCalledWith(
+            expect.objectContaining({ threadRetentionHours: 24 }),
+        );
+
+        const { service: clearingService, aiAgentModel: clearingModel } =
+            buildService({
+                existing: [{ ...agentRow, threadRetentionHours: 24 }],
+                retentionEnabled: true,
+            });
+        const cleared = await clearingService.upsertAgents(user, projectUuid, [
+            { ...agentAsCode, threadRetentionHours: null },
+        ]);
+        expect(cleared.updated).toEqual(['revenue-agent']);
+        expect(clearingModel.updateAgent).toHaveBeenCalledWith(
+            expect.objectContaining({ threadRetentionHours: null }),
+        );
+    });
+
+    it('leaves a stored retention window untouched when the document omits the field', async () => {
+        const { service, aiAgentModel } = buildService({
+            existing: [{ ...agentRow, threadRetentionHours: 24 }],
+            retentionEnabled: true,
+        });
+
+        const result = await service.upsertAgents(user, projectUuid, [
+            agentAsCode,
+        ]);
+
+        expect(result.unchanged).toEqual(['revenue-agent']);
+        expect(aiAgentModel.updateAgent).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.ts
+++ b/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.ts
@@ -2,8 +2,11 @@ import { subject } from '@casl/ability';
 import {
     CONTENT_AS_CODE_VERSIONS,
     ContentAsCodeType,
+    exceedsRetentionCeiling,
     ForbiddenError,
+    isValidRetentionWindowHours,
     ParameterError,
+    RETENTION_WINDOW_HOURS_ERROR,
     type AgentAsCode,
     type AgentAsCodeEvaluation,
     type AgentAsCodeUpsertChanges,
@@ -16,6 +19,7 @@ import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../../../services/BaseService';
 import { paginateAsCode } from '../../../services/CoderService/pagination';
 import { type AiAgentModel } from '../../models/AiAgentModel';
+import { type AiOrganizationSettingsService } from '../AiOrganizationSettingsService';
 
 const AGENT_AS_CODE_VERSION = CONTENT_AS_CODE_VERSIONS.ai_agent;
 const AGENT_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -70,6 +74,9 @@ const toAgentAsCode = (
     enableContentTools: agent.enableContentTools,
     enableUserContext: agent.enableUserContext,
     enableSqlMode: agent.enableSqlMode,
+    // Omit rather than export null: a dumped `threadRetentionHours: null` in
+    // every YAML would trip the flag-off warning on each re-upload.
+    threadRetentionHours: agent.threadRetentionHours ?? undefined,
     modelConfig: agent.modelConfig,
     evaluations: [...evaluations]
         .sort((left, right) => left.title.localeCompare(right.title))
@@ -77,7 +84,13 @@ const toAgentAsCode = (
     updatedAt: agent.updatedAt,
 });
 
-const getComparableAgent = (agent: AgentAsCode) => ({
+// Retention joins the comparison only when the org flag is on AND the
+// document declares it — an omitted field means "not managed", so a stored
+// value must not look like a diff.
+const getComparableAgent = (
+    agent: AgentAsCode,
+    includeThreadRetention: boolean,
+) => ({
     agentVersion: agent.agentVersion,
     slug: agent.slug,
     name: agent.name,
@@ -90,6 +103,9 @@ const getComparableAgent = (agent: AgentAsCode) => ({
     enableContentTools: agent.enableContentTools,
     enableUserContext: agent.enableUserContext,
     enableSqlMode: agent.enableSqlMode ?? true,
+    ...(includeThreadRetention
+        ? { threadRetentionHours: agent.threadRetentionHours ?? null }
+        : {}),
     modelConfig: agent.modelConfig,
 });
 
@@ -97,6 +113,7 @@ type Dependencies = {
     aiAgentModel: AiAgentModel;
     projectModel: ProjectModel;
     lightdashConfig: LightdashConfig;
+    aiOrganizationSettingsService: AiOrganizationSettingsService;
 };
 
 export class AiAgentCoderService extends BaseService {
@@ -106,11 +123,19 @@ export class AiAgentCoderService extends BaseService {
 
     private readonly lightdashConfig: LightdashConfig;
 
-    constructor({ aiAgentModel, projectModel, lightdashConfig }: Dependencies) {
+    private readonly aiOrganizationSettingsService: AiOrganizationSettingsService;
+
+    constructor({
+        aiAgentModel,
+        projectModel,
+        lightdashConfig,
+        aiOrganizationSettingsService,
+    }: Dependencies) {
         super({ serviceName: 'AiAgentCoderService' });
         this.aiAgentModel = aiAgentModel;
         this.projectModel = projectModel;
         this.lightdashConfig = lightdashConfig;
+        this.aiOrganizationSettingsService = aiOrganizationSettingsService;
     }
 
     private async getProjectOrganizationUuid(
@@ -296,6 +321,45 @@ export class AiAgentCoderService extends BaseService {
             });
         });
 
+        const retentionEnabled =
+            await this.aiOrganizationSettingsService.isThreadRetentionEnabled(
+                user,
+            );
+        const retentionCeiling = retentionEnabled
+            ? await this.aiOrganizationSettingsService.getThreadRetentionCeiling(
+                  organizationUuid,
+              )
+            : null;
+        const warnings: string[] = [];
+        agents.forEach((agent) => {
+            if (agent.threadRetentionHours === undefined) return;
+            if (!retentionEnabled) {
+                // A declared null is a no-op either way — only warn when a
+                // real window is being dropped.
+                if (agent.threadRetentionHours !== null) {
+                    warnings.push(
+                        `AI agent '${agent.slug}': threadRetentionHours was ignored — AI thread retention is not enabled for this organization`,
+                    );
+                }
+                return;
+            }
+            if (!isValidRetentionWindowHours(agent.threadRetentionHours)) {
+                throw new ParameterError(
+                    `AI agent '${agent.slug}': ${RETENTION_WINDOW_HOURS_ERROR}`,
+                );
+            }
+            if (
+                exceedsRetentionCeiling(
+                    agent.threadRetentionHours,
+                    retentionCeiling,
+                )
+            ) {
+                throw new ParameterError(
+                    `AI agent '${agent.slug}': thread retention cannot exceed the organization limit of ${retentionCeiling} hours`,
+                );
+            }
+        });
+
         const existingAgents = await this.aiAgentModel.findAgentsForCode({
             organizationUuid,
             projectUuid,
@@ -348,6 +412,7 @@ export class AiAgentCoderService extends BaseService {
             updated: [],
             unchanged: [],
             deleted: [],
+            ...(warnings.length > 0 ? { warnings } : {}),
         };
 
         for (const agent of agents) {
@@ -357,11 +422,17 @@ export class AiAgentCoderService extends BaseService {
             if (existing) {
                 agentUuid = existing.uuid;
                 const imageUrlChanged = existing.imageUrl !== agent.imageUrl;
+                const retentionDeclared =
+                    retentionEnabled &&
+                    agent.threadRetentionHours !== undefined;
                 const isUnchanged =
                     !force &&
                     isEqual(
-                        getComparableAgent(toAgentAsCode(existing, [])),
-                        getComparableAgent(agent),
+                        getComparableAgent(
+                            toAgentAsCode(existing, []),
+                            retentionDeclared,
+                        ),
+                        getComparableAgent(agent, retentionDeclared),
                     );
 
                 if (!isUnchanged) {
@@ -386,6 +457,13 @@ export class AiAgentCoderService extends BaseService {
                         enableContentTools: agent.enableContentTools,
                         enableUserContext: agent.enableUserContext,
                         enableSqlMode: agent.enableSqlMode ?? true,
+                        ...(retentionEnabled &&
+                        agent.threadRetentionHours !== undefined
+                            ? {
+                                  threadRetentionHours:
+                                      agent.threadRetentionHours,
+                              }
+                            : {}),
                         modelConfig: agent.modelConfig,
                     });
                     agentChanged = true;
@@ -406,6 +484,11 @@ export class AiAgentCoderService extends BaseService {
                     enableContentTools: agent.enableContentTools,
                     enableUserContext: agent.enableUserContext,
                     enableSqlMode: agent.enableSqlMode ?? true,
+                    threadRetentionHours:
+                        retentionEnabled &&
+                        agent.threadRetentionHours !== undefined
+                            ? agent.threadRetentionHours
+                            : null,
                     modelConfig: agent.modelConfig,
                     integrations: [],
                     groupAccess: [],

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -1531,6 +1531,10 @@ const upsertAiAgents = async (
         throw error;
     }
 
+    (results.warnings ?? []).forEach((warning) =>
+        GlobalState.log(styles.warning(`  ⚠ ${warning}`)),
+    );
+
     const counts = {
         'AI agents created': results.created.length,
         'AI agents updated': results.updated.length,

--- a/packages/common/src/ee/AiAgent/coder.ts
+++ b/packages/common/src/ee/AiAgent/coder.ts
@@ -26,6 +26,9 @@ export type AgentAsCode = {
     enableContentTools: boolean;
     enableUserContext: boolean;
     enableSqlMode?: boolean;
+    // Managed only when the org's AI thread retention flag is on (flag-off
+    // uploads warn and ignore it). Omitted = leave unchanged; null = clear.
+    threadRetentionHours?: number | null;
     modelConfig: AiAgentModelConfig | null;
     evaluations?: AgentAsCodeEvaluation[];
     updatedAt?: Date;
@@ -37,6 +40,9 @@ export type AgentAsCodeUpsertChanges = {
     updated: string[];
     unchanged: string[];
     deleted: string[];
+    // Optional so a NEW CLI stays compatible with older servers that never
+    // send the field.
+    warnings?: string[];
 };
 
 export type ApiAgentAsCodeListResponse = {


### PR DESCRIPTION
Agents managed as code could not declare a retention window, so an "ephemeral agent" could not be fully defined in YAML. Adds `threadRetentionHours` to the agent-as-code document with the same guardrails as the API: uploads into an org without the retention flag warn and ignore the field, and values above the org ceiling are rejected before any write.

Relates: ZAP-787
Relates: #27087