### PR TITLE
fix(mcp): expose writeback status tool

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -9005,5 +9005,6 @@ exports[`MCP tool contracts > matches the shared MCP tool definition names snaps
   "get_current_agent",
   "list_verified_content",
   "run_ai_writeback",
+  "get_ai_writeback_status",
 ]
 `;

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
@@ -201,6 +201,7 @@ describe('defineTool', () => {
             .sort();
 
         expect(structuredMcpToolNames).toEqual([
+            'get_ai_writeback_status',
             'get_context',
             'get_metadata',
             'get_query_result',

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -1790,6 +1790,7 @@ export const builtInToolDefinitions: readonly ToolDefinitionInstance[] = [
     getCurrentAgentToolDefinition,
     listVerifiedContentToolDefinition,
     runAiWritebackToolDefinition,
+    getAiWritebackStatusToolDefinition,
 ] as const;
 
 export type BuiltInToolDefinition = ToolDefinitionInstance;

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -416,6 +416,50 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
+            "description": "Tool: get_ai_writeback_status\n\nPurpose:\nCheck the status of a writeback run started by run_ai_writeback, and get the pull request URL once it's ready.\n\nImportant:\n- Poll every 10-15 seconds rather than immediately looping — a run typically takes a few minutes.\n- \"status\" is either \"pending\" (not yet picked up), an in-progress pipeline stage (e.g. \"sandbox\", \"agent\", \"pull_request\"), or a terminal value: \"ready\" (finished — check prUrl), \"error\" (finished — check errorMessage; this also covers the \"more than one dbt source\" case described in run_ai_writeback), or \"cancelled\" (stopped before finishing).\n\nParameters:\n- aiWritebackRunUuid: The id returned by run_ai_writeback.\n\nResponse shape (MCP CallToolResult):\n- content: [{ type: \"text\", text: \"<human-readable status summary>\" }]\n- structuredContent: {\n    status:       string,        // \"pending\" | a pipeline stage | \"ready\" | \"error\" | \"cancelled\"\n    prUrl:        string | null, // set once status is \"ready\" and a PR was opened\n    errorMessage: string | null  // set once status is \"error\"\n  }\n",
+            "inputSchema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                    "aiWritebackRunUuid": {
+                        "description": "The id returned by run_ai_writeback.",
+                        "format": "uuid",
+                        "type": "string"
+                    }
+                },
+                "required": ["aiWritebackRunUuid"],
+                "type": "object"
+            },
+            "name": "get_ai_writeback_status",
+            "outputSchema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                    "errorMessage": {
+                        "description": "Set once status is \"error\"; null otherwise.",
+                        "type": ["string", "null"]
+                    },
+                    "prUrl": {
+                        "description": "URL of the pull request opened from the agent changes, set once status is \"ready\"; null if the agent made no file changes or the run has not finished yet.",
+                        "type": ["string", "null"]
+                    },
+                    "status": {
+                        "description": "\"pending\" | a pipeline stage (e.g. \"sandbox\", \"agent\", \"pull_request\") | \"ready\" | \"error\" | \"cancelled\".",
+                        "type": "string"
+                    }
+                },
+                "required": ["status", "prUrl", "errorMessage"],
+                "type": "object"
+            },
+            "title": "Get AI writeback status"
+        },
+        {
+            "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": false,
+                "readOnlyHint": true
+            },
             "description": "Call this first to discover available projects, the agents you can access in each project, and Lightdash-configured context. Pass the selected projectUuid to every project-scoped tool call and an available agentUuid when agent-specific scope is desired. This tool reports context but does not establish implicit execution state.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
Adds get_ai_writeback_status to the declared MCP tool catalog.

Risk: low — Declares an existing read-only status tool without changing writeback behavior or permissions.