### PR TITLE
ci: opt-in exe.dev VM development environment for agent sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,12 @@
             "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-okteto-dev.sh\" hook-start",
             "timeout": 1800,
             "statusMessage": "Preparing the Lightdash Okteto development environment"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-exedev-dev.sh\" hook-start",
+            "timeout": 600,
+            "statusMessage": "Provisioning the Lightdash exe.dev VM"
           }
         ]
       }
@@ -30,6 +36,18 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-exedev-dev.sh\" hook-sync",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
@@ -38,6 +56,12 @@
             "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-okteto-dev.sh\" hook-stop",
             "timeout": 1800,
             "statusMessage": "Verifying the Lightdash Okteto development environment"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-exedev-dev.sh\" hook-stop",
+            "timeout": 1800,
+            "statusMessage": "Verifying the Lightdash exe.dev development environment"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,28 @@ again and prevents a final response that omits the URL.
 Leave the Okteto namespace and sync process running so the user can test the
 changes.
 
+## Opt-in Agent exe.dev Development Environment
+
+This workflow is enabled only when `LIGHTDASH_EXEDEV_SSH_KEY` is set. If it is
+not set, skip this section. It is mutually exclusive with the Okteto workflow
+above; only one is configured per session.
+
+When it is set, the `SessionStart` hook (`agent-exedev-dev.sh hook-start`)
+clones a per-session exe.dev VM from a prepared template, syncs the working
+tree, and launches the preview stack in the background; the app may still be
+booting while you work. Do not start it yourself or replace it with a local
+Docker environment. Edits are mirrored to the VM automatically by a
+`PostToolUse` hook. Use `./scripts/agent-exedev-dev.sh ssh '<cmd>'` to inspect
+the server directly (bootstrap log, pm2, docker, psql). Run
+`./scripts/agent-exedev-dev.sh wait` after validating changes and include the
+URL from its `READY:` line in the final response. The `Stop` hook verifies
+health and prevents a final response that omits the URL.
+
+If setup fails, do not make code changes. Follow the reported error and
+`docs/agent-exedev.md`, then resume the session after fixing the setup.
+
+Leave the VM running so the user can test the changes at the public URL.
+
 ## Formula Package Development
 
 The `packages/formula/` package contains a Peggy-based parser that compiles Google Sheets-like formulas to SQL for each warehouse dialect (Postgres, BigQuery, Snowflake, DuckDB).

--- a/docs/agent-exedev.md
+++ b/docs/agent-exedev.md
@@ -1,0 +1,124 @@
+# Coding agent development environments on exe.dev
+
+`scripts/agent-exedev-dev.sh` gives a coding agent session (Claude Code on the
+web, the Claude desktop app's Code tab, or local Claude Code) a full disposable
+Lightdash environment on an [exe.dev](https://exe.dev) VM with a public test
+URL. It clones a prepared VM template (copy-on-write, sub-second) and pushes
+git-computed deltas of the working tree over SSH.
+
+The flow is opt-in: every command and hook is a silent no-op unless
+`LIGHTDASH_EXEDEV_SSH_KEY` is set. Configure one environment provider per
+session; do not set it together with `LIGHTDASH_OKTETO_TOKEN`.
+
+## What you need
+
+-   `LIGHTDASH_EXEDEV_SSH_KEY` — an SSH private key (the key material itself,
+    or a path to a key file) for an exe.dev identity that is allowed to `cp`
+    the template, `tag` VMs, and SSH into clones.
+-   A template VM (default `ld-linear-agent-template`, override with
+    `LIGHTDASH_EXEDEV_TEMPLATE`) root-shared with the exe.dev team. The
+    template bakes in the toolchain, a repository checkout with installed
+    dependencies, built shared packages, and pre-pulled Docker images for
+    Postgres, MinIO, Mailpit, and browserless Chromium.
+
+## How a session works
+
+1. **SessionStart hook** (`hook-start`): derives a VM name from the Claude
+   session ID (`ld-cc-<hash>`, short for Lightdash Claude Code), clones the
+   template with `cp <template> <vm> --copy-tags=false`, tags it
+   `lightdash-claude-session` for automated cleanup, root-shares it with the
+   exe.dev team (`share add <vm> team --root`, so session VMs are visible and
+   SSH-able to everyone in the team UI), syncs the working tree, launches the
+   preview stack **in the background**, and publishes the port (`share port`
+   + `share set-public`). It returns in seconds; the app may still be booting
+   when the agent starts working.
+2. **PostToolUse hook** (`hook-sync`): after `Edit`/`Write` it copies exactly
+   that file to the VM (one SSH round trip over a persistent connection);
+   after `Bash` it syncs whatever `git status` reports changed. Vite HMR and
+   pm2 watch pick changes up immediately. Sync failures never block the agent;
+   `wait` is the authoritative sync.
+3. **Stop hook** (`hook-stop`): syncs, blocks until `/api/v1/health` responds,
+   and refuses the final response unless it contains the ready URL.
+
+There is no readiness state machine between those hooks. The agent inspects
+the VM directly over SSH — that is the intended debugging loop:
+
+```bash
+./scripts/agent-exedev-dev.sh ssh 'tail -n 80 /home/exedev/linear-agent/bootstrap.log'
+./scripts/agent-exedev-dev.sh ssh 'pm2 status && pm2 logs --nostream --lines 50'
+./scripts/agent-exedev-dev.sh ssh 'docker compose -f /home/exedev/linear-agent/docker-compose.runner.yml ps'
+curl -fsS "$(./scripts/agent-exedev-dev.sh url)/api/v1/health"
+```
+
+Run `./scripts/agent-exedev-dev.sh wait` after making and validating changes
+and include the URL from its `READY:` line in the final response.
+
+## Sync model
+
+Sync is one-way (session ➞ VM) and git-delta based; nothing ever scans the
+working tree:
+
+-   When the VM's checkout already contains the session's HEAD commit, the
+    ref is set directly with `update-ref` (one SSH round trip). This also
+    sidesteps a git 2.43 `receive-pack` deadlock: empty-pack pushes hang
+    forever on partial-clone (`--filter=blob:none`) repositories.
+-   Otherwise `git push ssh://<vm>/<repo> HEAD:refs/agent/session` transfers
+    only the objects the VM's baked checkout lacks. If the shallow template
+    clone rejects the push (`missing necessary objects`), the VM's history is
+    deepened from GitHub and the sync retried. Either way the VM then
+    force-checkouts the ref (detached).
+-   Uncommitted changes travel as `git diff HEAD --binary` applied on the VM;
+    untracked files are tar-piped. Ignored files (`node_modules`, `.env`,
+    build output) never cross the wire.
+-   If `pnpm-lock.yaml` differs from the template's recorded lockfile hash,
+    `pnpm install` runs on the VM.
+
+Consequences: generate artifacts on the VM only if they are gitignored or you
+copy them back yourself; the session workspace is the single source of truth
+for code. Deleting a locally *untracked* file does not delete it on the VM.
+
+## Commands
+
+```bash
+./scripts/agent-exedev-dev.sh start      # clone + sync + launch preview (background)
+./scripts/agent-exedev-dev.sh wait       # sync, block until healthy, print READY: <url>
+./scripts/agent-exedev-dev.sh sync       # full git-delta sync now
+./scripts/agent-exedev-dev.sh url        # print this session's public URL
+./scripts/agent-exedev-dev.sh ssh <cmd>  # run a command on the session VM
+./scripts/agent-exedev-dev.sh exe <cmd>  # exe.dev control command (ls, share, tag, ...)
+```
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `LIGHTDASH_EXEDEV_SSH_KEY` | — | Opt-in gate; key material or key path |
+| `LIGHTDASH_EXEDEV_TEMPLATE` | `ld-linear-agent-template` | Template VM to clone |
+| `LIGHTDASH_EXEDEV_TEAM_SHARE` | `true` | Root-share session VMs with the team |
+| `LIGHTDASH_EXEDEV_CONTROL_HOST` | `exe.dev` | Control-plane SSH host |
+| `LIGHTDASH_EXEDEV_VM_PREFIX` | `ld-cc-` | Session VM name prefix |
+| `LIGHTDASH_EXEDEV_VM_TAG` | `lightdash-claude-session` | Sweeper tag for clones |
+| `LIGHTDASH_EXEDEV_REMOTE_USER` | `exedev` | SSH user on VMs |
+| `LIGHTDASH_EXEDEV_REMOTE_REPO` | `/opt/linear-agent-template/repository` | Repo checkout path on the VM |
+| `LIGHTDASH_EXEDEV_BOOTSTRAP` | `scripts/agent-exedev-bootstrap.sh` | Local bootstrap script uploaded to the VM |
+| `LIGHTDASH_EXEDEV_REMOTE_LOG` | `/home/exedev/linear-agent/bootstrap.log` | Bootstrap log path on the VM |
+| `LIGHTDASH_EXEDEV_PREVIEW_PORT` | `3000` | Port published via `share port` |
+| `EXEDEV_READY_TIMEOUT_SECONDS` | `900` | `wait`/Stop-hook readiness deadline |
+
+## Claude Code on the web / desktop app
+
+Set `LIGHTDASH_EXEDEV_SSH_KEY` as a secret in the code-session environment
+configuration. Network access must allow outbound SSH (port 22) to `exe.dev`
+and `*.exe.xyz`, and HTTPS to `*.exe.xyz` for health checks.
+
+## Operations
+
+-   Session VMs are tagged and reaped by internal automation; exe.dev
+    auto-suspends idle VMs in the meantime. The VM stays up after the session
+    so the user can test at the public URL and open a PR.
+-   The template is refreshed regularly, so clones start near current `main`.
+-   `share set-public` makes the preview URL world-reachable (demo
+    credentials).
+-   The bootstrap log lives on the VM (`bootstrap.log` next to the workspace);
+    the only local session state is the SSH key and a provisioned marker under
+    `${TMPDIR:-/tmp}/lightdash-agent-exedev/<session-hash>/`.

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,5 +1,21 @@
 # Scripts
 
+## Claude Code exe.dev Environment
+
+### `agent-exedev-dev.sh <start|wait|sync|url|ssh|exe>`
+
+When `LIGHTDASH_EXEDEV_SSH_KEY` is set, clones this session's VM from the
+`ld-linear-agent-template` exe.dev template (copy-on-write), pushes git-computed deltas
+of the working tree over SSH, and launches the preview stack in the background;
+`wait` blocks until the app is healthy and prints the public test URL
+(`READY: https://<vm>.exe.xyz`). Hook commands (`hook-start`, `hook-sync`,
+`hook-stop`) are wired in `.claude/settings.json` and no-op when the key is
+unset. See `docs/agent-exedev.md`.
+
+Use `agent-exedev-dev.sh ssh <cmd>` to run commands on the session VM and
+`agent-exedev-dev.sh exe <cmd>` for exe.dev control commands (`ls`, `share`,
+`tag`, ...) with the session identity already wired up.
+
 ## Claude Code Okteto Environment
 
 ### `agent-okteto-dev.sh <start|wait|url|okteto>`

--- a/scripts/agent-exedev-bootstrap.sh
+++ b/scripts/agent-exedev-bootstrap.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# VM-side preview bootstrap for agent exe.dev sessions: starts the runner
+# containers, builds shared packages, migrates, and serves the app with pm2.
+# Uploaded and launched by agent-exedev-dev.sh; credential-free by design
+# (publishing the port needs exe.dev access and stays on the client side).
+# Usage: agent-exedev-bootstrap.sh [vm-name] | agent-exedev-bootstrap.sh --prepare-template
+set -Eeuo pipefail
+
+template_mode=false
+if [ "${1:-}" = "--prepare-template" ]; then
+    template_mode=true
+    vm_name="$(hostname)"
+else
+    vm_name="${1:-$(hostname)}"
+fi
+workspace="/home/exedev/linear-agent"
+repository_dir="/opt/linear-agent-template/repository"
+preview_prepared_marker="/opt/linear-agent-template/preview-prepared"
+preview_vite_config="$repository_dir/packages/frontend/vite.linear-agent.config.ts"
+preview_url="https://${vm_name}.exe.xyz"
+runner_compose="$workspace/docker-compose.runner.yml"
+preview_ecosystem="$workspace/preview.ecosystem.config.js"
+
+[ -f "$runner_compose" ] || {
+    echo "runner compose file not found: $runner_compose" >&2
+    exit 1
+}
+
+# Template installs node under /opt and pnpm under the workspace npm prefix.
+node_root="$(ls -d /opt/node-v*-linux-* 2>/dev/null | head -1)"
+[ -n "$node_root" ] || { echo "node install root not found under /opt" >&2; exit 1; }
+export PATH="$node_root/bin:$workspace/npm/bin:$workspace/bin:$PATH"
+export npm_config_prefix="$workspace/npm"
+
+set_env_value() {
+    local key="$1" value="$2" file="$3"
+    if grep -q "^${key}=" "$file" 2>/dev/null; then
+        sed -i "s|^${key}=.*|${key}=${value}|" "$file"
+    else
+        printf '%s=%s\n' "$key" "$value" >>"$file"
+    fi
+}
+
+write_preview_vite_config() {
+    cp "$repository_dir/packages/frontend/vite.config.ts" "$preview_vite_config"
+    node - "$preview_vite_config" <<'JS'
+const fs = require('node:fs');
+const path = process.argv[2];
+const source = fs.readFileSync(path, 'utf8');
+const needle = '    server: {\n        port: FE_PORT,';
+const replacement = `    server: {
+        warmup: {
+            clientFiles: [
+                './src/index.tsx',
+                './src/App.tsx',
+                './src/Routes.tsx',
+                './src/pages/Login.tsx',
+                './src/providers/**/*.{ts,tsx}',
+                './src/features/users/**/*.{ts,tsx}',
+                './src/hooks/thirdPartyServices/**/*.{ts,tsx}',
+                './src/components/NavBar/**/*.{ts,tsx}',
+                './src/components/common/DocumentTitle/**/*.{ts,tsx}',
+                './src/components/common/ProjectLayout/**/*.{ts,tsx}',
+                './src/pages/Home.tsx',
+                './src/components/Home/**/*.{ts,tsx}',
+                './src/ee/components/Home/**/*.{ts,tsx}',
+                './src/ee/features/homepageBuilder/**/*.{ts,tsx}',
+                './src/ee/features/managedAgent/ManagedAgentHomeCard.tsx',
+                './src/pages/Explorer.tsx',
+                './src/components/Explorer/**/*.{ts,tsx}',
+                './src/features/explorer/**/*.{ts,tsx}',
+                './src/providers/Explorer/**/*.{ts,tsx}',
+                './src/hooks/explorer/**/*.{ts,tsx}',
+                './src/hooks/useExplorer*.{ts,tsx}',
+                './src/pages/Dashboard.tsx',
+                './src/components/common/Dashboard/**/*.{ts,tsx}',
+                './src/components/DashboardTiles/**/*.{ts,tsx}',
+                './src/features/dashboardFilters/**/*.{ts,tsx}',
+                './src/features/dashboardTabs/**/*.{ts,tsx}',
+                './src/providers/Dashboard/**/*.{ts,tsx}',
+                './src/hooks/dashboard/**/*.{ts,tsx}',
+                '!./src/**/*.{test,spec}.{ts,tsx}',
+                '!./src/**/*.stories.{ts,tsx}',
+                '!./src/**/*.{mock,mocks}.{ts,tsx}',
+                '!./src/**/__tests__/**/*.{ts,tsx}',
+                '!./src/**/__mocks__/**/*.{ts,tsx}',
+            ],
+        },
+        port: FE_PORT,`;
+if (!source.includes(needle)) throw new Error('Vite server configuration shape changed');
+fs.writeFileSync(path, source.replace(needle, replacement));
+JS
+    grep -qxF '/packages/frontend/vite.linear-agent.config.ts' "$repository_dir/.git/info/exclude" || \
+        printf '%s\n' '/packages/frontend/vite.linear-agent.config.ts' >>"$repository_dir/.git/info/exclude"
+}
+
+cd "$repository_dir"
+
+current_commit="$(git rev-parse HEAD)"
+current_lock="$(sha256sum pnpm-lock.yaml | awk '{print $1}')"
+prepared_commit="$(sed -n 's/^commit=//p' "$preview_prepared_marker" 2>/dev/null || true)"
+prepared_lock="$(sed -n 's/^lockfile_sha256=//p' "$preview_prepared_marker" 2>/dev/null || true)"
+seed_required=false
+dbt_required=false
+if [ "$template_mode" = true ] || [ "${PREVIEW_RESEED:-0}" = 1 ] || \
+    [ -z "$prepared_commit" ] || [ -z "$prepared_lock" ]; then
+    seed_required=true
+    dbt_required=true
+elif git cat-file -e "${prepared_commit}^{commit}" 2>/dev/null && \
+    ! git diff --quiet "$prepared_commit" -- examples/full-jaffle-shop-demo/dbt; then
+    dbt_required=true
+fi
+
+echo "== docker =="
+if ! docker info >/dev/null 2>&1; then
+    sudo systemctl start docker.service 2>/dev/null || \
+        sudo sh -c 'nohup dockerd >/tmp/linear-agent-dockerd.log 2>&1 &'
+    for _ in $(seq 1 30); do
+        docker info >/dev/null 2>&1 && break
+        sleep 2
+    done
+    docker info >/dev/null 2>&1 || { echo "dockerd did not come up" >&2; exit 1; }
+fi
+
+# A runner VM owns all of its infrastructure. Lightdash's normal local-dev
+# bootstrap may leave the multi-worktree `ld-shared` project behind if an agent
+# invokes it accidentally. Remove only those legacy containers before starting
+# the runner project so fixed ports remain single-owner resources.
+mapfile -t legacy_shared_containers < <(
+    docker ps -aq --filter label=com.docker.compose.project=ld-shared
+)
+if ((${#legacy_shared_containers[@]} > 0)); then
+    echo "== remove unsupported ld-shared containers =="
+    docker rm -f "${legacy_shared_containers[@]}" >/dev/null
+fi
+
+echo "== ports + env =="
+./scripts/dev-ports.sh claim >/dev/null 2>&1
+eval "$(./scripts/dev-ports.sh env)"
+touch .env.development.local
+set_env_value LD_INSTANCE_ID "$LD_INSTANCE_ID" .env.development.local
+set_env_value PGHOST localhost .env.development.local
+set_env_value PGPORT "$LD_PG_PORT" .env.development.local
+set_env_value PORT "$PORT" .env.development.local
+set_env_value FE_PORT "$FE_PORT" .env.development.local
+set_env_value SCHEDULER_PORT "$SCHEDULER_PORT" .env.development.local
+set_env_value DEBUG_PORT "$DEBUG_PORT" .env.development.local
+set_env_value SDK_TEST_PORT "$SDK_TEST_PORT" .env.development.local
+set_env_value MAPLE_PORT "$MAPLE_PORT" .env.development.local
+set_env_value LIGHTDASH_PROMETHEUS_PORT "$LIGHTDASH_PROMETHEUS_PORT" .env.development.local
+set_env_value SITE_URL "$preview_url" .env.development.local
+set_env_value INTERNAL_LIGHTDASH_HOST "http://localhost:${FE_PORT}" .env.development.local
+set_env_value LIGHTDASH_API_URL "http://localhost:${PORT}" .env.development.local
+set_env_value S3_ENDPOINT http://localhost:9000 .env.development.local
+set_env_value HEADLESS_BROWSER_HOST localhost .env.development.local
+set_env_value HEADLESS_BROWSER_PORT 3001 .env.development.local
+set_env_value EMAIL_SMTP_HOST localhost .env.development.local
+set_env_value EMAIL_SMTP_PORT 1025 .env.development.local
+set_env_value EMAIL_SMTP_SECURE false .env.development.local
+set_env_value EMAIL_SMTP_USE_AUTH false .env.development.local
+set_env_value EMAIL_SMTP_ALLOW_INVALID_CERT true .env.development.local
+set_env_value EMAIL_SMTP_SENDER_NAME Lightdash .env.development.local
+set_env_value EMAIL_SMTP_SENDER_EMAIL noreply@lightdash.local .env.development.local
+set_env_value DBT_DEMO_DIR "$repository_dir/examples/full-jaffle-shop-demo" .env.development.local
+set_env_value LDPAT ldpat_deadbeefdeadbeefdeadbeefdeadbeef .env.development.local
+set_env_value ALLOW_MULTIPLE_ORGS false .env.development.local
+set_env_value RUDDERSTACK_ANALYTICS_DISABLED true .env.development.local
+set_env_value SENTRY_DSN '' .env.development.local
+set_env_value SENTRY_BE_DSN '' .env.development.local
+set_env_value SENTRY_FE_DSN '' .env.development.local
+set_env_value LIGHTDASH_OTEL_TRACES_ENABLED false .env.development.local
+
+echo "== runner compose (postgres/minio/mailpit/browserless) =="
+db_container="${LD_CONTAINER_PREFIX}-db-dev-1"
+# Recreate containers around the persistent named volumes. Docker can leave a
+# container detached from its network after an earlier fixed-port bind failure;
+# a plain `start` reports success without repairing that stale endpoint.
+docker compose -p "$LD_COMPOSE_PROJECT" -f "$runner_compose" up -d --force-recreate
+for _ in $(seq 1 30); do
+    docker exec "$db_container" pg_isready -U postgres >/dev/null 2>&1 && break
+    sleep 2
+done
+docker exec "$db_container" pg_isready -U postgres >/dev/null 2>&1
+for _ in $(seq 1 30); do
+    curl --fail --silent --output /dev/null http://127.0.0.1:3001/json/version && break
+    sleep 2
+done
+curl --fail --silent --output /dev/null http://127.0.0.1:3001/json/version
+
+export PATH="$repository_dir/venv/bin:$PATH"
+
+echo "== build shared packages =="
+pnpm -F common build
+pnpm -F warehouses build
+pnpm -F @lightdash/formula build
+
+echo "== migrate =="
+# Development seeds reference tables owned by the EE migration directory even
+# when the preview app runs unlicensed. A non-secret marker includes the full
+# schema during migration without enabling licensed features in the app.
+LIGHTDASH_LICENSE_KEY=preview-template PGHOST=localhost PGPORT="$LD_PG_PORT" \
+    pnpx dotenv-cli -e .env.development.local -e .env.development -- \
+    pnpm -F backend migrate
+if [ "$seed_required" = true ]; then
+    echo "== seed application data =="
+    PGHOST=localhost PGPORT="$LD_PG_PORT" \
+        pnpx dotenv-cli -e .env.development.local -e .env.development -- \
+        pnpm -F backend seed
+
+fi
+
+if [ "$dbt_required" = true ]; then
+    echo "== dbt seed + run =="
+    PGHOST=localhost PGPORT="$LD_PG_PORT" PGUSER=postgres PGPASSWORD=password PGDATABASE=postgres \
+        "$repository_dir/venv/bin/dbt" seed \
+        --project-dir examples/full-jaffle-shop-demo/dbt \
+        --profiles-dir examples/full-jaffle-shop-demo/profiles
+    PGHOST=localhost PGPORT="$LD_PG_PORT" PGUSER=postgres PGPASSWORD=password PGDATABASE=postgres \
+        "$repository_dir/venv/bin/dbt" run \
+        --project-dir examples/full-jaffle-shop-demo/dbt \
+        --profiles-dir examples/full-jaffle-shop-demo/profiles
+fi
+
+if [ "$seed_required" = false ] && [ "$dbt_required" = false ]; then
+    echo "== seeded data inherited from template =="
+else
+    echo "== seeded data ready =="
+fi
+
+echo "== pm2 (api + frontend, dev mode) =="
+write_preview_vite_config
+cat >"$preview_ecosystem" <<JS
+const base = require('${repository_dir}/ecosystem.config.js');
+const names = new Set(['${LD_INSTANCE_ID}-api', '${LD_INSTANCE_ID}-frontend']);
+const frontendName = '${LD_INSTANCE_ID}-frontend';
+
+module.exports = {
+    apps: base.apps.filter((app) => names.has(app.name)).map((app) => ({
+        ...app,
+        ...(app.name === frontendName
+            ? { args: ((app.args || '') + ' --config ${preview_vite_config}').trim() }
+            : {}),
+        env: {
+            ...app.env,
+            RUDDERSTACK_ANALYTICS_DISABLED: 'true',
+            SENTRY_DSN: '',
+            SENTRY_BE_DSN: '',
+            SENTRY_FE_DSN: '',
+            LIGHTDASH_OTEL_TRACES_ENABLED: 'false',
+        },
+    })),
+};
+JS
+pnpm exec pm2 delete "${LD_INSTANCE_ID}-api" "${LD_INSTANCE_ID}-frontend" \
+    >/dev/null 2>&1 || true
+pnpm exec pm2 start "$preview_ecosystem" >/dev/null
+
+echo "== health check =="
+health_code=""
+for _ in $(seq 1 60); do
+    health_code="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+        "http://localhost:${FE_PORT}/api/v1/health" 2>/dev/null || true)"
+    [ "$health_code" = 200 ] && break
+    sleep 2
+done
+[ "$health_code" = 200 ] || { echo "health check failed (last code: $health_code)" >&2; exit 1; }
+curl --fail --silent --output /dev/null "http://localhost:${FE_PORT}/login"
+
+if [ "$template_mode" = true ]; then
+    printf 'commit=%s\nlockfile_sha256=%s\ncompose_project=%s\n' \
+        "$current_commit" "$current_lock" "$LD_COMPOSE_PROJECT" > "$preview_prepared_marker"
+    pnpm exec pm2 delete "${LD_INSTANCE_ID}-api" "${LD_INSTANCE_ID}-frontend" \
+        >/dev/null 2>&1 || true
+    pnpm exec pm2 kill >/dev/null 2>&1 || true
+    docker compose -p "$LD_COMPOSE_PROJECT" -f "$runner_compose" stop >/dev/null
+    sudo systemctl stop docker.service docker.socket >/dev/null 2>&1 || true
+    echo "TEMPLATE PREVIEW READY: commit=${current_commit} compose=${LD_COMPOSE_PROJECT}"
+    exit 0
+fi
+
+echo "PREVIEW_PORT=${FE_PORT}"
+echo "PREVIEW READY (vm-local): publish port ${FE_PORT} -> ${preview_url}"

--- a/scripts/agent-exedev-dev.sh
+++ b/scripts/agent-exedev-dev.sh
@@ -1,0 +1,617 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+KEY_ENV_VAR="LIGHTDASH_EXEDEV_SSH_KEY"
+CONTROL_HOST="${LIGHTDASH_EXEDEV_CONTROL_HOST:-exe.dev}"
+TEMPLATE_VM="${LIGHTDASH_EXEDEV_TEMPLATE:-ld-linear-agent-template}"
+TEAM_SHARE="${LIGHTDASH_EXEDEV_TEAM_SHARE:-true}"
+VM_PREFIX="${LIGHTDASH_EXEDEV_VM_PREFIX:-ld-cc-}"
+VM_TAG="${LIGHTDASH_EXEDEV_VM_TAG:-lightdash-claude-session}"
+REMOTE_USER="${LIGHTDASH_EXEDEV_REMOTE_USER:-exedev}"
+REMOTE_REPO="${LIGHTDASH_EXEDEV_REMOTE_REPO:-/opt/linear-agent-template/repository}"
+BOOTSTRAP_SCRIPT="${LIGHTDASH_EXEDEV_BOOTSTRAP:-$SCRIPT_DIR/agent-exedev-bootstrap.sh}"
+REMOTE_BOOTSTRAP="/home/exedev/linear-agent/session-bootstrap.sh"
+REMOTE_LOG="${LIGHTDASH_EXEDEV_REMOTE_LOG:-/home/exedev/linear-agent/bootstrap.log}"
+PREVIEW_PORT="${LIGHTDASH_EXEDEV_PREVIEW_PORT:-3000}"
+READY_TIMEOUT_SECONDS="${EXEDEV_READY_TIMEOUT_SECONDS:-900}"
+SSH_TIMEOUT_SECONDS="${EXEDEV_SSH_TIMEOUT_SECONDS:-180}"
+POLL_INTERVAL_SECONDS="${EXEDEV_POLL_INTERVAL_SECONDS:-5}"
+SETUP_DOC="docs/agent-exedev.md"
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/agent-exedev-dev.sh <start|wait|sync|url|ssh|exe>
+
+Requires LIGHTDASH_EXEDEV_SSH_KEY. Commands safely skip when it is unset.
+
+  start          Clone this session's VM from the template, sync the working
+                 tree, and launch the preview stack in the background.
+  wait           Sync, then block until the app is healthy: READY: <url>.
+  sync           Push the full local repository state to the session VM.
+  url            Print the public URL for this Claude session.
+  ssh <args...>  Run a command on the session VM over SSH.
+  exe <args...>  Run an exe.dev control command (ls, cp, tag, share, ...).
+EOF
+}
+
+require_command() {
+    local command_name="$1"
+    command -v "$command_name" >/dev/null 2>&1 ||
+        fail "Missing required command '$command_name'. See $SETUP_DOC."
+}
+
+extract_session_id() {
+    local hook_input="$1" session_id
+
+    session_id="$(
+        printf '%s\n' "$hook_input" |
+            sed -nE 's/.*"session_id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' |
+            head -n 1
+    )"
+
+    [ -n "$session_id" ] || return 1
+    [[ "$session_id" =~ ^[A-Za-z0-9._:-]+$ ]] || return 1
+
+    printf '%s' "$session_id"
+}
+
+extract_json_string() {
+    local hook_input="$1" key="$2"
+
+    printf '%s\n' "$hook_input" |
+        sed -nE 's/.*"'"$key"'"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' |
+        head -n 1
+}
+
+agent_session_id() {
+    local workspace_root
+
+    if [ -n "${LIGHTDASH_AGENT_SESSION_ID:-}" ]; then
+        printf '%s' "$LIGHTDASH_AGENT_SESSION_ID"
+    elif [ -n "${CLAUDE_CODE_REMOTE_SESSION_ID:-}" ]; then
+        printf '%s' "$CLAUDE_CODE_REMOTE_SESSION_ID"
+    else
+        workspace_root="$(git -C "$REPO_ROOT" rev-parse --show-toplevel 2>/dev/null)" ||
+            fail "Agent session and workspace identity are unavailable."
+        printf 'workspace:%s' "$workspace_root"
+    fi
+}
+
+hash_value() {
+    local value="$1"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "$value" | sha256sum | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        printf '%s' "$value" | shasum -a 256 | awk '{print $1}'
+    else
+        fail "Missing sha256sum or shasum. See $SETUP_DOC."
+    fi
+}
+
+file_hash() {
+    local path="$1"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$path" | awk '{print $1}'
+    else
+        shasum -a 256 "$path" | awk '{print $1}'
+    fi
+}
+
+load_session_config() {
+    local id
+
+    id="$(agent_session_id)"
+    SESSION_HASH="$(hash_value "$id")"
+    SESSION_HASH="${SESSION_HASH:0:16}"
+    VM_NAME="${VM_PREFIX}${SESSION_HASH:0:10}"
+    VM_HOST="$VM_NAME.exe.xyz"
+    PUBLIC_URL="https://$VM_HOST"
+    RUN_DIR="${TMPDIR:-/tmp}/lightdash-agent-exedev/$SESSION_HASH"
+    PROVISIONED_FILE="$RUN_DIR/provisioned"
+    printf -v REMOTE_REPO_Q '%q' "$REMOTE_REPO"
+}
+
+require_runtime() {
+    [ -n "${!KEY_ENV_VAR:-}" ] ||
+        fail "$KEY_ENV_VAR is not set. See $SETUP_DOC."
+
+    require_command ssh
+    require_command git
+    require_command curl
+    require_command tar
+}
+
+# The key env var holds either a path to a private key or the key material
+# itself (how Claude code-session environment secrets arrive).
+ensure_key_file() {
+    local key_value="${!KEY_ENV_VAR:-}"
+
+    if [ -f "$key_value" ]; then
+        KEY_FILE="$key_value"
+        return
+    fi
+
+    mkdir -p "$RUN_DIR"
+    KEY_FILE="$RUN_DIR/ssh-key"
+    printf '%s\n' "$key_value" >"$KEY_FILE"
+    chmod 600 "$KEY_FILE"
+}
+
+configure_ssh() {
+    # Control sockets need a short path: unix sockets cap at ~104 bytes and
+    # macOS TMPDIRs alone exceed that.
+    local control_dir="/tmp/ld-exe-cm-$(id -u)"
+
+    ensure_key_file
+    mkdir -p "$RUN_DIR" "$control_dir"
+    chmod 700 "$control_dir"
+    SSH_OPTS=(
+        -i "$KEY_FILE"
+        -o IdentitiesOnly=yes
+        -o IdentityAgent=none
+        -o StrictHostKeyChecking=accept-new
+        -o BatchMode=yes
+        -o ConnectTimeout=15
+        -o ControlMaster=auto
+        -o ControlPath="$control_dir/%C"
+        -o ControlPersist=10m
+    )
+}
+
+git_ssh_command() {
+    local arg out="ssh"
+
+    for arg in "${SSH_OPTS[@]}"; do
+        out+=" $(printf '%q' "$arg")"
+    done
+    printf '%s' "$out"
+}
+
+exe_ctl() {
+    ssh "${SSH_OPTS[@]}" "$CONTROL_HOST" "$@" </dev/null
+}
+
+vm_ssh() {
+    ssh "${SSH_OPTS[@]}" "$REMOTE_USER@$VM_HOST" "$@"
+}
+
+vm_exists() {
+    exe_ctl ls 2>/dev/null | grep -Eq "(^|[[:space:]])${VM_NAME}\.exe\.xyz([[:space:]]|$)"
+}
+
+ensure_vm() {
+    if vm_exists; then
+        return
+    fi
+
+    echo "Cloning $TEMPLATE_VM into $VM_NAME..."
+    exe_ctl cp "$TEMPLATE_VM" "$VM_NAME" --copy-tags=false ||
+        fail "Could not clone $TEMPLATE_VM. Check $KEY_ENV_VAR permissions and see $SETUP_DOC."
+    # Untagged clones escape the sweeper; warn but keep going.
+    exe_ctl tag "$VM_NAME" "$VM_TAG" ||
+        echo "WARNING: could not tag $VM_NAME as $VM_TAG." >&2
+    if [ "$TEAM_SHARE" = "true" ]; then
+        # Make the session VM visible and SSH-able to the whole exe.dev team.
+        exe_ctl share add "$VM_NAME" team --root ||
+            echo "WARNING: could not team-share $VM_NAME." >&2
+    fi
+}
+
+wait_for_vm_ssh() {
+    local deadline=$((SECONDS + SSH_TIMEOUT_SECONDS))
+
+    while ! vm_ssh true </dev/null >/dev/null 2>&1; do
+        ((SECONDS < deadline)) ||
+            fail "Cannot reach $VM_HOST over SSH after ${SSH_TIMEOUT_SECONDS}s."
+        sleep "$POLL_INTERVAL_SECONDS"
+    done
+}
+
+push_session_ref() {
+    GIT_SSH_COMMAND="$(git_ssh_command)" git -C "$REPO_ROOT" push \
+        --quiet --force \
+        "ssh://$REMOTE_USER@$VM_HOST$REMOTE_REPO" \
+        HEAD:refs/agent/session
+}
+
+remote_has_commit() {
+    vm_ssh "git -C $REMOTE_REPO_Q cat-file -e $1 2>/dev/null" </dev/null
+}
+
+set_session_ref() {
+    vm_ssh "git -C $REMOTE_REPO_Q update-ref refs/agent/session $1" </dev/null ||
+        fail "Could not update the session ref on $VM_HOST."
+}
+
+# Full one-way sync: git computes the delta against the template's baked
+# checkout, so nothing ever scans the working tree. Ignored files (node_modules,
+# .env, build output) never cross the wire.
+full_sync() {
+    local diff_file="$RUN_DIR/worktree.diff" untracked_file="$RUN_DIR/untracked.z" head_sha
+
+    mkdir -p "$RUN_DIR"
+    echo "Syncing repository state to $VM_NAME..."
+    head_sha="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+
+    # Empty-pack pushes deadlock git 2.43 receive-pack on partial-clone repos,
+    # so when the commit already exists remotely set the ref directly.
+    if remote_has_commit "$head_sha"; then
+        set_session_ref "$head_sha"
+    else
+        # Knowing the template's tip locally lets push negotiation find the
+        # common base; a stale checkout would pack the entire repository.
+        git -C "$REPO_ROOT" fetch --quiet origin 2>/dev/null || true
+        if ! push_session_ref; then
+            # A shallow template clone rejects pushes of commits that predate
+            # its tip; deepen the VM's history from GitHub and try again. The
+            # deepen itself often brings the commit over, in which case pushing
+            # again would send an empty pack — set the ref directly instead.
+            echo "Push rejected; deepening the VM's git history from origin..."
+            vm_ssh "git -C $REMOTE_REPO_Q fetch --quiet --deepen=1000 origin" </dev/null ||
+                fail "Could not deepen the repository history on $VM_HOST."
+            if remote_has_commit "$head_sha"; then
+                set_session_ref "$head_sha"
+            else
+                push_session_ref ||
+                    fail "git push to $VM_HOST failed. See $SETUP_DOC."
+            fi
+        fi
+    fi
+
+    vm_ssh "git -C $REMOTE_REPO_Q -c advice.detachedHead=false checkout --force --quiet --detach refs/agent/session" </dev/null ||
+        fail "Remote checkout failed on $VM_HOST."
+
+    git -C "$REPO_ROOT" diff HEAD --binary >"$diff_file"
+    if [ -s "$diff_file" ]; then
+        vm_ssh "git -C $REMOTE_REPO_Q apply --whitespace=nowarn" <"$diff_file" ||
+            fail "Applying the working-tree diff failed on $VM_HOST."
+    fi
+
+    git -C "$REPO_ROOT" ls-files -o --exclude-standard -z >"$untracked_file"
+    if [ -s "$untracked_file" ]; then
+        COPYFILE_DISABLE=1 tar -C "$REPO_ROOT" --null -T "$untracked_file" -cf - |
+            vm_ssh "tar --warning=no-unknown-keyword -C $REMOTE_REPO_Q -xf -" ||
+            fail "Copying untracked files failed on $VM_HOST."
+    fi
+}
+
+# Sync only what `git status` reports changed since HEAD. Fast enough for a
+# PostToolUse hook; deletions of tracked files propagate via `rm` on the VM.
+sync_changed() {
+    local changed_file="$RUN_DIR/changed.z" path
+    local -a existing=() deleted=()
+
+    mkdir -p "$RUN_DIR"
+    git -C "$REPO_ROOT" ls-files -m -o --exclude-standard -z >"$changed_file"
+    [ -s "$changed_file" ] || return 0
+
+    while IFS= read -r -d '' path; do
+        if [ -e "$REPO_ROOT/$path" ]; then
+            existing+=("$path")
+        else
+            deleted+=("$path")
+        fi
+    done <"$changed_file"
+
+    if [ "${#existing[@]}" -gt 0 ]; then
+        printf '%s\0' "${existing[@]}" |
+            COPYFILE_DISABLE=1 tar -C "$REPO_ROOT" --null -T - -cf - |
+            vm_ssh "tar --warning=no-unknown-keyword -C $REMOTE_REPO_Q -xf -"
+    fi
+    if [ "${#deleted[@]}" -gt 0 ]; then
+        vm_ssh "cd $REMOTE_REPO_Q && rm -f -- $(printf '%q ' "${deleted[@]}")" </dev/null
+    fi
+}
+
+sync_single_file() {
+    local abs_path="$1" rel_path
+
+    case "$abs_path" in
+        "$REPO_ROOT"/*) rel_path="${abs_path#"$REPO_ROOT"/}" ;;
+        *) return 0 ;;
+    esac
+    git -C "$REPO_ROOT" check-ignore -q "$rel_path" && return 0
+
+    if [ -e "$abs_path" ]; then
+        printf '%s\0' "$rel_path" |
+            COPYFILE_DISABLE=1 tar -C "$REPO_ROOT" --null -T - -cf - |
+            vm_ssh "tar --warning=no-unknown-keyword -C $REMOTE_REPO_Q -xf -"
+    else
+        vm_ssh "cd $REMOTE_REPO_Q && rm -f -- $(printf '%q' "$rel_path")" </dev/null
+    fi
+}
+
+# Template node_modules matches the template's lockfile; install on the VM only
+# when the session's lockfile differs from the recorded template hash.
+maybe_install_dependencies() {
+    local metadata_path local_lock remote_lock
+
+    metadata_path="$(dirname "$REMOTE_REPO")/metadata"
+    local_lock="$(file_hash "$REPO_ROOT/pnpm-lock.yaml")"
+    remote_lock="$(
+        vm_ssh "sed -n 's/^lockfile_sha256=//p' $(printf '%q' "$metadata_path") 2>/dev/null" </dev/null || true
+    )"
+    [ -n "$remote_lock" ] && [ "$local_lock" = "$remote_lock" ] && return 0
+
+    echo "pnpm-lock.yaml changed; installing dependencies on $VM_NAME..."
+    vm_ssh "cd $REMOTE_REPO_Q && CI=true pnpm install --prefer-offline" </dev/null ||
+        fail "pnpm install failed on $VM_HOST. See $SETUP_DOC."
+    vm_ssh "sed -i 's/^lockfile_sha256=.*/lockfile_sha256=$local_lock/' $(printf '%q' "$metadata_path") 2>/dev/null" </dev/null || true
+}
+
+# Require a real 200: unshared VMs answer 307 (exe.dev login redirect), which
+# `curl --fail` would treat as success.
+app_is_healthy() {
+    [ "$(
+        curl --silent --output /dev/null --write-out '%{http_code}' \
+            --max-time 10 "$PUBLIC_URL/api/v1/health" 2>/dev/null
+    )" = "200" ]
+}
+
+# Fire the preview bootstrap on the VM and return immediately; the log stays on
+# the VM so the agent can tail it over SSH.
+launch_bootstrap() {
+    if app_is_healthy; then
+        echo "Preview stack already serving $PUBLIC_URL."
+        return
+    fi
+
+    [ -f "$BOOTSTRAP_SCRIPT" ] ||
+        fail "Bootstrap script not found: $BOOTSTRAP_SCRIPT"
+
+    echo "Launching the preview stack on $VM_NAME (background)..."
+    vm_ssh "cat >$(printf '%q' "$REMOTE_BOOTSTRAP") && chmod +x $(printf '%q' "$REMOTE_BOOTSTRAP")" <"$BOOTSTRAP_SCRIPT" ||
+        fail "Could not upload the preview bootstrap to $VM_HOST."
+
+    # A pidfile guard, not pgrep: the ssh wrapper shell's own command line
+    # contains the script path and would self-match.
+    local pid_file="${REMOTE_LOG}.pid" remote_cmd
+    printf -v remote_cmd \
+        'if kill -0 "$(cat %q 2>/dev/null)" 2>/dev/null; then echo "Bootstrap already running."; else nohup bash %q %q >%q 2>&1 & echo $! >%q; fi' \
+        "$pid_file" "$REMOTE_BOOTSTRAP" "$VM_NAME" "$REMOTE_LOG" "$pid_file"
+    vm_ssh "$remote_cmd" </dev/null ||
+        fail "Could not launch the preview bootstrap on $VM_HOST."
+
+    exe_ctl share port "$VM_NAME" "$PREVIEW_PORT" ||
+        echo "WARNING: could not publish port $PREVIEW_PORT for $VM_NAME." >&2
+    exe_ctl share set-public "$VM_NAME" ||
+        echo "WARNING: could not make $VM_NAME public." >&2
+}
+
+wait_until_healthy() {
+    local deadline last_report now
+
+    deadline=$((SECONDS + READY_TIMEOUT_SECONDS))
+    last_report=$((SECONDS - 30))
+
+    while ((SECONDS < deadline)); do
+        if app_is_healthy; then
+            sleep 2
+            if app_is_healthy; then
+                echo "READY: $PUBLIC_URL"
+                return
+            fi
+        fi
+
+        now=$SECONDS
+        if ((now - last_report >= 30)); then
+            echo "Waiting for application health at $PUBLIC_URL..."
+            last_report=$now
+        fi
+        sleep "$POLL_INTERVAL_SECONDS"
+    done
+
+    echo "Inspect the bootstrap on the VM: ./scripts/agent-exedev-dev.sh ssh 'tail -n 80 $REMOTE_LOG'" >&2
+    fail "Timed out waiting for $PUBLIC_URL."
+}
+
+provision() {
+    require_runtime
+    configure_ssh
+    ensure_vm
+    wait_for_vm_ssh
+    full_sync
+    maybe_install_dependencies
+    launch_bootstrap
+    touch "$PROVISIONED_FILE"
+
+    cat <<EOF
+exe.dev VM $VM_NAME is provisioned; the preview stack is starting in the background.
+Test URL (healthy once /api/v1/health responds): $PUBLIC_URL
+Inspect the server: ./scripts/agent-exedev-dev.sh ssh '<command>' (bootstrap log: $REMOTE_LOG)
+Before the final response, run ./scripts/agent-exedev-dev.sh wait and include the URL from its READY: line.
+EOF
+}
+
+hook_start() {
+    local hook_input hook_output session_id
+
+    [ -n "${!KEY_ENV_VAR:-}" ] || return 0
+
+    hook_input="$(cat)"
+    if [ -z "${CLAUDE_ENV_FILE:-}" ]; then
+        hook_setup_failed "CLAUDE_ENV_FILE is unavailable."
+        return
+    fi
+    if ! session_id="$(extract_session_id "$hook_input")"; then
+        hook_setup_failed "Claude SessionStart input has no usable session_id."
+        return
+    fi
+
+    export LIGHTDASH_AGENT_SESSION_ID="$session_id"
+    if ! printf 'export LIGHTDASH_AGENT_SESSION_ID=%s\n' \
+        "$session_id" >>"$CLAUDE_ENV_FILE"; then
+        hook_setup_failed "Could not persist the Claude session ID."
+        return
+    fi
+
+    load_session_config
+    if ! hook_output="$(provision 2>&1)"; then
+        printf '%s\n' "$hook_output" >&2
+        hook_setup_failed "$(
+            printf '%s\n' "$hook_output" |
+                grep '^ERROR:' |
+                tail -n 1 |
+                sed 's/^ERROR:[[:space:]]*//' ||
+                true
+        )"
+        return
+    fi
+
+    printf '%s\n' "$hook_output"
+}
+
+hook_setup_failed() {
+    local detail="${1:-exe.dev provisioning exited unexpectedly.}"
+
+    printf '%s\n' "$detail" >&2
+    printf '%s\n' \
+        '{"continue":false,"stopReason":"Lightdash exe.dev setup failed before Claude could start. Check the SessionStart hook error and docs/agent-exedev.md, fix the setup, then resume the session."}'
+}
+
+hook_stop() {
+    local hook_input hook_output last_message ready_line ready_url session_id
+
+    [ -n "${!KEY_ENV_VAR:-}" ] || return 0
+
+    hook_input="$(cat)"
+    session_id="$(extract_session_id "$hook_input")" || {
+        echo "Cannot verify Lightdash exe.dev readiness: no usable Claude session ID." >&2
+        exit 2
+    }
+    export LIGHTDASH_AGENT_SESSION_ID="$session_id"
+    load_session_config
+    require_runtime
+    require_command jq
+    configure_ssh
+
+    if ! hook_output="$( (full_sync && maybe_install_dependencies && wait_until_healthy) 2>&1)"; then
+        printf '%s\n' "$hook_output" >&2
+        echo "The Lightdash exe.dev environment must be healthy before the final response." >&2
+        exit 2
+    fi
+
+    ready_line="$(
+        printf '%s\n' "$hook_output" |
+            grep '^READY: https://' |
+            tail -n 1 ||
+            true
+    )"
+    ready_url="${ready_line#READY: }"
+    last_message="$(
+        printf '%s\n' "$hook_input" |
+            jq -r '.last_assistant_message // empty'
+    )" || {
+        echo "Cannot inspect the final response. See $SETUP_DOC." >&2
+        exit 2
+    }
+
+    if [ -z "$ready_line" ] ||
+        ! printf '%s' "$last_message" | grep -Fq "$ready_url"; then
+        echo "The final response must include the ready testing URL: $PUBLIC_URL" >&2
+        exit 2
+    fi
+}
+
+# PostToolUse hook: mirror the edit onto the VM. Never blocks the agent; the
+# `wait` before the final response is the authoritative sync.
+hook_sync() {
+    local hook_input tool_name file_path session_id
+
+    [ -n "${!KEY_ENV_VAR:-}" ] || return 0
+
+    hook_input="$(cat)"
+    session_id="$(extract_session_id "$hook_input")" || return 0
+    export LIGHTDASH_AGENT_SESSION_ID="$session_id"
+    load_session_config
+    [ -f "$PROVISIONED_FILE" ] || return 0
+
+    configure_ssh
+    tool_name="$(extract_json_string "$hook_input" "tool_name")"
+    case "$tool_name" in
+        Edit | Write | MultiEdit | NotebookEdit)
+            file_path="$(extract_json_string "$hook_input" "file_path")"
+            [ -n "$file_path" ] || return 0
+            sync_single_file "$file_path" ||
+                echo "WARNING: could not sync $file_path to $VM_NAME." >&2
+            ;;
+        *)
+            sync_changed ||
+                echo "WARNING: could not sync changed files to $VM_NAME." >&2
+            ;;
+    esac
+    return 0
+}
+
+main() {
+    local command_name="${1:-}"
+
+    case "$command_name" in
+        hook-start)
+            hook_start
+            ;;
+        hook-stop)
+            hook_stop
+            ;;
+        hook-sync)
+            hook_sync
+            ;;
+        ssh | exe)
+            shift || true
+            if [ -z "${!KEY_ENV_VAR:-}" ]; then
+                echo "SKIPPED: $KEY_ENV_VAR is not set."
+                return
+            fi
+            load_session_config
+            configure_ssh
+            case "$command_name" in
+                ssh) vm_ssh "$@" ;;
+                exe) exe_ctl "$@" ;;
+            esac
+            ;;
+        start | wait | sync | url)
+            if [ -z "${!KEY_ENV_VAR:-}" ]; then
+                echo "SKIPPED: $KEY_ENV_VAR is not set."
+                return
+            fi
+
+            load_session_config
+            case "$command_name" in
+                start) provision ;;
+                wait)
+                    require_runtime
+                    configure_ssh
+                    full_sync
+                    maybe_install_dependencies
+                    wait_until_healthy
+                    ;;
+                sync)
+                    require_runtime
+                    configure_ssh
+                    full_sync
+                    ;;
+                url) echo "$PUBLIC_URL" ;;
+            esac
+            ;;
+        -h | --help | help | "")
+            usage
+            ;;
+        *)
+            usage >&2
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/agent-exedev-dev.sh
+++ b/scripts/agent-exedev-dev.sh
@@ -337,7 +337,7 @@ sync_single_file() {
 maybe_install_dependencies() {
     local metadata_path local_lock remote_lock
 
-    metadata_path="$(dirname "$REMOTE_REPO")/metadata"
+    metadata_path="$(dirname "$REMOTE_REPO")/preview-prepared"
     local_lock="$(file_hash "$REPO_ROOT/pnpm-lock.yaml")"
     remote_lock="$(
         vm_ssh "sed -n 's/^lockfile_sha256=//p' $(printf '%q' "$metadata_path") 2>/dev/null" </dev/null || true


### PR DESCRIPTION
### Description:

Adds an opt-in flow that gives a coding agent session a full disposable Lightdash environment on an exe.dev VM with a public test URL, enabled only when `LIGHTDASH_EXEDEV_SSH_KEY` is set. A SessionStart hook clones a per-session VM from a prepared template (copy-on-write, sub-second), syncs the working tree using git-computed deltas over SSH (with `update-ref`/deepen fallbacks for shallow and partial-clone receivers), and launches the preview stack in the background; PostToolUse hooks mirror each edit to the VM and a Stop hook refuses a final response that omits the ready URL. Includes the VM-side bootstrap script (`scripts/agent-exedev-bootstrap.sh`), the session driver (`scripts/agent-exedev-dev.sh`), hook wiring in `.claude/settings.json`, and docs in `docs/agent-exedev.md`. The existing Okteto flow is untouched; both no-op unless their env var is set.

Relates: PROD-10318

🤖 Generated with [Claude Code](https://claude.com/claude-code)