### PR TITLE
fix(upgrade-automation): stop freezing on healthy instances

### DIFF
--- a/examples/upgrade-automation/scripts/verify.sh
+++ b/examples/upgrade-automation/scripts/verify.sh
@@ -92,6 +92,7 @@ deadline=$((started_at + window_seconds))
 consecutive=0
 last_reason=not_started
 verified=false
+superseded=false
 response_body=$(mktemp)
 response_headers=$(mktemp)
 summary_file=$(mktemp)
@@ -132,6 +133,12 @@ if [[ "$DEPLOY_CONCLUSION" == "success" ]]; then
                     consecutive=0
                     if [[ -z "$running_version" ]]; then
                         last_reason=version_header_missing
+                    elif [[ "$running_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+                        && [[ "$pinned_public" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+                        && version_gt "$running_version" "$pinned_public"; then
+                        last_reason="superseded:$(printf '%s' "$running_version" | sanitize_evidence)"
+                        superseded=true
+                        break
                     else
                         last_reason="version_mismatch:$(printf '%s' "$running_version" | sanitize_evidence)"
                     fi
@@ -153,6 +160,8 @@ elapsed=$((finished_at - started_at))
 outcome=failure
 if [[ "$verified" == "true" ]]; then
     outcome=success
+elif [[ "$superseded" == "true" ]]; then
+    outcome=superseded
 fi
 
 cat >"$summary_file" <<EOF
@@ -169,7 +178,23 @@ cat >"$summary_file" <<EOF
 $(jq . <<<"$verdict_json")
 \`\`\`
 EOF
+if [[ "$superseded" == "true" ]]; then
+    gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body-file "$summary_file" \
+        || echo "warning: failed to post the verification summary comment" >&2
+    exit 0
+fi
 if [[ "$verified" == "true" ]]; then
+    if ! marked_freeze_issues=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "$FREEZE_LABEL" --limit 1000 --json number,body --jq '.[] | select(.body | contains("<!-- upgrade-automation:auto-freeze -->")) | .number'); then
+        echo "warning: failed to inspect open upgrade freeze issues" >&2
+        marked_freeze_issues=
+    fi
+    while IFS= read -r freeze_issue_number; do
+        if [[ -z "$freeze_issue_number" ]]; then
+            continue
+        fi
+        gh issue close "$freeze_issue_number" --repo "$GITHUB_REPOSITORY" --comment "Upgrade automation is re-armed after verifying \`$pinned_public\`: $DEPLOY_RUN_URL" \
+            || echo "warning: failed to close upgrade freeze issue #$freeze_issue_number" >&2
+    done <<<"$marked_freeze_issues"
     gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body-file "$summary_file"
     exit 0
 fi

--- a/examples/upgrade-automation/scripts/verify.test.sh
+++ b/examples/upgrade-automation/scripts/verify.test.sh
@@ -185,3 +185,285 @@ run_warning_test migration_parked migration_parked 0
 run_warning_test migration_ledger_unavailable migration_ledger_unavailable 3
 
 printf 'verify readiness warning tests passed\n'
+
+run_version_comparison_test() {
+    local running_version=$1
+    local pinned_version=$2
+    local expected_status=$3
+    local expected_outcome=$4
+    local expected_reason=$5
+    local expect_issue_create=$6
+    local test_name=$7
+    local scenario_dir
+    scenario_dir=$(mktemp -d)
+    mkdir -p "$scenario_dir/bin"
+    printf 'image:\n  tag: %s\n' "$pinned_version" >"$scenario_dir/values.yml"
+    printf '0\n' >"$scenario_dir/time"
+    : >"$scenario_dir/gh.log"
+
+    cat >"$scenario_dir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$TEST_SCENARIO_DIR/gh.log"
+
+case "$*" in
+    *'repos/example/upgrade-test --jq .default_branch'*) printf 'main\n' ;;
+    *'api user --jq .login'*) printf 'test-user\n' ;;
+    *'repos/example/upgrade-test/pulls?'*) printf '123\t0000000000000000000000000000000000000000\n' ;;
+    *'pr view 123'*'--json body --jq .body'*) printf '```json\n{"coveredVersions":["%s"],"direction":"forward","fromVersion":"1.2.2","minPreviousVersion":null,"missingRanges":[],"requiredStops":[],"safe":true,"toVersion":"%s","verdict":true}\n```\n' "$TEST_PINNED_VERSION" "$TEST_PINNED_VERSION" ;;
+    *'pr view 123'*'--json comments'*) printf 'false\n' ;;
+    *'pr view 123'*'--json url'*) printf 'https://example.test/pr/123\n' ;;
+    *'issue list'*) printf '\n' ;;
+    *'issue create'*) printf 'https://example.test/issues/1\n' ;;
+    *'pr comment 123'*)
+        while [[ $# -gt 0 ]]; do
+            if [[ "$1" == '--body-file' ]]; then
+                cp "$2" "$TEST_SCENARIO_DIR/summary"
+                break
+            fi
+            shift
+        done
+        ;;
+    *) ;;
+esac
+EOF
+    cat >"$scenario_dir/bin/git" <<'EOF'
+#!/usr/bin/env bash
+
+if [[ "$1" == 'merge-base' ]]; then
+    exit 0
+fi
+
+exit 1
+EOF
+    cat >"$scenario_dir/bin/date" <<'EOF'
+#!/usr/bin/env bash
+
+cat "$TEST_SCENARIO_DIR/time"
+EOF
+    cat >"$scenario_dir/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+
+current=$(cat "$TEST_SCENARIO_DIR/time")
+printf '%s\n' "$((current + $1))" >"$TEST_SCENARIO_DIR/time"
+EOF
+    cat >"$scenario_dir/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+output=
+write_out=
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output) output=$2; shift 2 ;;
+        --write-out) write_out=$2; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+if [[ -n "$write_out" ]]; then
+    printf '%s\n' '{"status":"ready","warnings":[]}' >"$output"
+    printf '200'
+else
+    printf 'Lightdash-Version: %s\n' "$TEST_RUNNING_VERSION" >"$output"
+fi
+EOF
+    chmod +x "$scenario_dir/bin"/*
+
+    set +e
+    output=$(cd "$scenario_dir" && PATH="$scenario_dir/bin:$PATH" \
+        TEST_SCENARIO_DIR="$scenario_dir" \
+        TEST_RUNNING_VERSION="$running_version" \
+        TEST_PINNED_VERSION="$pinned_version" \
+        GITHUB_REPOSITORY=example/upgrade-test \
+        INSTANCE_URL=https://example.test \
+        BUMP_TARGET=values.yml#image.tag \
+        VERIFY_WINDOW=60s \
+        FREEZE_LABEL=upgrade-freeze \
+        DEPLOY_RUN_URL=https://example.test/run/1 \
+        DEPLOY_CONCLUSION=success \
+        DEPLOYED_SHA=0000000000000000000000000000000000000000 \
+        GH_TOKEN=test-token \
+        "$root/examples/upgrade-automation/scripts/verify.sh" 2>&1)
+    status=$?
+    set -e
+
+    if [[ $status -ne $expected_status ]]; then
+        printf 'expected %s status for %s, got %s:\n%s\n' "$expected_status" "$test_name" "$status" "$output" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+    if ! grep -Fq "Outcome: **$expected_outcome**" "$scenario_dir/summary"; then
+        printf 'expected %s outcome for %s, got:\n' "$expected_outcome" "$test_name" >&2
+        cat "$scenario_dir/summary" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+    if ! grep -Fq "Last readiness reason: \`$expected_reason\`" "$scenario_dir/summary"; then
+        printf 'expected %s as the last readiness reason for %s, got:\n' "$expected_reason" "$test_name" >&2
+        cat "$scenario_dir/summary" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+    if [[ "$expect_issue_create" == "true" ]]; then
+        if ! grep -Fq 'issue create' "$scenario_dir/gh.log"; then
+            printf 'expected %s to create a freeze issue\n' "$test_name" >&2
+            rm -rf "$scenario_dir"
+            exit 1
+        fi
+    elif grep -Fq 'issue create' "$scenario_dir/gh.log"; then
+        printf 'expected %s not to create a freeze issue\n' "$test_name" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+
+    printf 'verify %s test passed\n' "$test_name"
+    rm -rf "$scenario_dir"
+}
+
+run_version_comparison_test 1.2.4 1.2.3 0 superseded superseded:1.2.4 false 'newer version supersession'
+run_version_comparison_test 1.2.2 1.2.3 1 failure version_mismatch:1.2.2 true 'older version mismatch'
+run_version_comparison_test 1.2.4-beta.1 1.2.3 1 failure version_mismatch:1.2.4-beta.1 true 'prerelease version mismatch'
+
+run_freeze_cleanup_test() {
+    local issue_kind=$1
+    local expected_issue_number=$2
+    local test_name=$3
+    local scenario_dir
+    scenario_dir=$(mktemp -d)
+    mkdir -p "$scenario_dir/bin"
+    printf 'image:\n  tag: 1.2.3\n' >"$scenario_dir/values.yml"
+    printf '0\n' >"$scenario_dir/time"
+    : >"$scenario_dir/gh.log"
+
+    cat >"$scenario_dir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$TEST_SCENARIO_DIR/gh.log"
+
+case "$*" in
+    *'repos/example/upgrade-test --jq .default_branch'*) printf 'main\n' ;;
+    *'api user --jq .login'*) printf 'test-user\n' ;;
+    *'repos/example/upgrade-test/pulls?'*) printf '123\t0000000000000000000000000000000000000000\n' ;;
+    *'pr view 123'*'--json body --jq .body'*) printf '```json\n{"coveredVersions":["1.2.3"],"direction":"forward","fromVersion":"1.2.2","minPreviousVersion":null,"missingRanges":[],"requiredStops":[],"safe":true,"toVersion":"1.2.3","verdict":true}\n```\n' ;;
+    *'pr view 123'*'--json comments'*) printf 'false\n' ;;
+    *'pr view 123'*'--json url'*) printf 'https://example.test/pr/123\n' ;;
+    *'issue list'*'upgrade-automation:auto-freeze'*)
+        if [[ "$TEST_ISSUE_KIND" == 'marked' ]]; then
+            printf '17\n'
+        fi
+        ;;
+    *'issue list'*) printf '18\n' ;;
+    *'issue close'*) ;;
+    *'pr comment 123'*)
+        while [[ $# -gt 0 ]]; do
+            if [[ "$1" == '--body-file' ]]; then
+                cp "$2" "$TEST_SCENARIO_DIR/summary"
+                break
+            fi
+            shift
+        done
+        ;;
+    *) ;;
+esac
+EOF
+    cat >"$scenario_dir/bin/git" <<'EOF'
+#!/usr/bin/env bash
+
+if [[ "$1" == 'merge-base' ]]; then
+    exit 0
+fi
+
+exit 1
+EOF
+    cat >"$scenario_dir/bin/date" <<'EOF'
+#!/usr/bin/env bash
+
+cat "$TEST_SCENARIO_DIR/time"
+EOF
+    cat >"$scenario_dir/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+
+current=$(cat "$TEST_SCENARIO_DIR/time")
+printf '%s\n' "$((current + $1))" >"$TEST_SCENARIO_DIR/time"
+EOF
+    cat >"$scenario_dir/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+output=
+write_out=
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output) output=$2; shift 2 ;;
+        --write-out) write_out=$2; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+if [[ -n "$write_out" ]]; then
+    printf '%s\n' '{"status":"ready","warnings":[]}' >"$output"
+    printf '200'
+else
+    printf 'Lightdash-Version: 1.2.3\n' >"$output"
+fi
+EOF
+    chmod +x "$scenario_dir/bin"/*
+
+    set +e
+    output=$(cd "$scenario_dir" && PATH="$scenario_dir/bin:$PATH" \
+        TEST_SCENARIO_DIR="$scenario_dir" \
+        TEST_ISSUE_KIND="$issue_kind" \
+        GITHUB_REPOSITORY=example/upgrade-test \
+        INSTANCE_URL=https://example.test \
+        BUMP_TARGET=values.yml#image.tag \
+        VERIFY_WINDOW=60s \
+        FREEZE_LABEL=upgrade-freeze \
+        DEPLOY_RUN_URL=https://example.test/run/1 \
+        DEPLOY_CONCLUSION=success \
+        DEPLOYED_SHA=0000000000000000000000000000000000000000 \
+        GH_TOKEN=test-token \
+        "$root/examples/upgrade-automation/scripts/verify.sh" 2>&1)
+    status=$?
+    set -e
+
+    if [[ $status -ne 0 ]]; then
+        printf 'expected successful verification for %s, got:\n%s\n' "$test_name" "$output" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+    if ! grep -Fq 'Outcome: **success**' "$scenario_dir/summary"; then
+        printf 'expected successful outcome for %s, got:\n' "$test_name" >&2
+        cat "$scenario_dir/summary" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+    if [[ -n "$expected_issue_number" ]]; then
+        if ! grep -Fq "issue close $expected_issue_number" "$scenario_dir/gh.log"; then
+            printf 'expected %s to close issue %s\n' "$test_name" "$expected_issue_number" >&2
+            rm -rf "$scenario_dir"
+            exit 1
+        fi
+        if ! grep -Fq 'Upgrade automation is re-armed after verifying `1.2.3`: https://example.test/run/1' "$scenario_dir/gh.log"; then
+            printf 'expected %s to explain the verified version and deployment run\n' "$test_name" >&2
+            rm -rf "$scenario_dir"
+            exit 1
+        fi
+    elif grep -Fq 'issue close' "$scenario_dir/gh.log"; then
+        printf 'expected %s not to close an unmarked issue\n' "$test_name" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+
+    printf 'verify %s test passed\n' "$test_name"
+    rm -rf "$scenario_dir"
+}
+
+run_freeze_cleanup_test marked 17 'marked freeze cleanup'
+run_freeze_cleanup_test unmarked '' 'unmarked freeze preservation'


### PR DESCRIPTION
## What breaks

Two internal instances stopped upgrading for 21 hours. Both were healthy the whole time, and both ran 20 releases behind the customer fleet. That inverts the point of a canary.

Two separate bugs in `scripts/verify.sh` caused it.

### A newer running version counted as a failure

Verify compared the running version to the pin with string equality. Releases land every 10 to 30 minutes and `plan` auto-merges, so a later pin often deploys while an earlier verification is still inside its 20 minute window. The instance is then ahead of the version under test. Verify read that as `version_mismatch` and armed the freeze.

One instance froze with `version_mismatch:1.195.0` while verifying 1.193.0. Three later bumps had already merged and rolled out.

### The freeze was one-way

Verify only called `gh issue create`. On a pass it commented on the pull request and exited. Nothing closed an open freeze issue, so a transient failure froze upgrades until a person noticed. One freeze came from attempt 1 of a deploy run whose attempt 2 succeeded 78 minutes later. The freeze stayed armed.

## What changes

A strictly newer running version is now `superseded`, not failed. Verify exits 0, posts the summary comment with `Outcome: **superseded**`, and creates no freeze issue. The comparison applies only when both versions are plain `X.Y.Z`, because `version_gt` parses integer parts and staging tracks pre-release tags.

A verified pass now closes every open issue that carries the freeze label and the `<!-- upgrade-automation:auto-freeze -->` marker, with a comment naming the verified version and the deploy run. The marker check keeps hand-opened freeze issues safe. A close failure warns and does not fail the job.

The superseded path closes nothing. It proves nothing about the pinned version, so it must not disarm a freeze.

## Things worth knowing

- Superseded exits without proving the pinned version was healthy. That version is no longer running anywhere, and the version that replaced it gets its own verification.
- The existing idempotence guard matches `Outcome: **success**`, so a superseded result does not suppress a later re-verification of the same pull request. Repeat runs stay harmless: superseded again, exit 0, no freeze.
- The verify job already declares `issues: write`. No workflow permission change is needed.
- Consumers pin these actions by SHA, so this takes effect only after a repin.

## Tests

`scripts/verify.test.sh` gains five cases: newer version supersedes, older version still freezes, pre-release mismatch still freezes without crashing, a marked freeze issue is closed on a pass, an unmarked one is not.

All suites pass. The new cases fail against the unfixed script, verified by reverting `verify.sh` and re-running.

Linear: SPK-1151