### PR TITLE
fix(bigquery): restore timezone partition pruning

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/timezone_test.sql
+++ b/examples/full-jaffle-shop-demo/dbt/models/timezone_test.sql
@@ -1,3 +1,15 @@
+{% if target.type == 'bigquery' %}
+    {{
+        config(
+            partition_by={
+                "field": "event_timestamp",
+                "data_type": "timestamp",
+                "granularity": "day"
+            }
+        )
+    }}
+{% endif %}
+
 select
     event_id,
     event_timestamp,

--- a/packages/api-tests/tests/queryTimezone.test.ts
+++ b/packages/api-tests/tests/queryTimezone.test.ts
@@ -50,6 +50,7 @@ const HOUR_DIMENSION_KEY = 'timezone_test_event_timestamp_hour';
 const METRIC_KEY = 'timezone_test_count';
 const DIMENSIONS = [DIMENSION_KEY];
 const METRICS = [METRIC_KEY];
+const EXISTING_BIGQUERY_PROJECT_UUID = process.env.BIGQUERY_TEST_PROJECT_UUID;
 
 const HOUR_EQUALS_FILTER = (instant: string) => ({
     dimensions: {
@@ -446,21 +447,25 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
     });
 });
 
-// Warehouse-parity check: the fractional-offset DATE_TRUNC has to be emitted in
-// each dialect's SQL, so re-run the discriminating sub-day assertions against a
+// Warehouse-parity check: execute the discriminating timezone filters against a
 // real BigQuery project. The staging dataset holds the same timezone_test rows
 // as the Postgres seed, so the expected counts are identical.
-describe.skipIf(!hasBigqueryCredentials())(
-    'Query timezone — BigQuery fractional offsets',
+describe.skipIf(!EXISTING_BIGQUERY_PROJECT_UUID && !hasBigqueryCredentials())(
+    'Query timezone — BigQuery filters',
     () => {
         const projectName = 'bigQuery timezone fractional test';
         // Cold BigQuery queries can exceed the default 15s poll window.
         const BIGQUERY_MAX_ATTEMPTS = 120;
         let bqAdmin: ApiClient;
         let bigqueryProjectUuid: string;
+        let ownsBigqueryProject = false;
 
         beforeAll(async () => {
             bqAdmin = await login();
+            if (EXISTING_BIGQUERY_PROJECT_UUID) {
+                bigqueryProjectUuid = EXISTING_BIGQUERY_PROJECT_UUID;
+                return;
+            }
             // Clean up any project leaked by a previously interrupted run
             // before creating a fresh one (names are not unique).
             await deleteProjectsByName(bqAdmin, [projectName]);
@@ -469,13 +474,45 @@ describe.skipIf(!hasBigqueryCredentials())(
                 projectName,
                 bigqueryWarehouseConfig(),
             );
+            ownsBigqueryProject = true;
         }, 420_000);
 
         afterAll(async () => {
-            if (bqAdmin) {
+            if (bqAdmin && ownsBigqueryProject) {
                 await deleteProjectsByName(bqAdmin, [projectName]);
             }
         });
+
+        it.each([
+            {
+                expectedCount: 5,
+                filter: EQUALS_FILTER('2024-01-15'),
+                name: 'equals',
+            },
+            {
+                expectedCount: 9,
+                filter: IN_BETWEEN_FILTER('2024-01-15', '2024-01-16'),
+                name: 'inBetween',
+            },
+            {
+                expectedCount: 5,
+                filter: GREATER_THAN_FILTER('2024-01-15'),
+                name: 'greaterThan',
+            },
+        ])(
+            'Asia/Tokyo day $name preserves local-calendar filter semantics',
+            async ({ expectedCount, filter }) => {
+                const rows = await runTimezoneTestQuery(bqAdmin, {
+                    dimensions: DIMENSIONS,
+                    metrics: METRICS,
+                    timezone: 'Asia/Tokyo',
+                    filters: filter,
+                    projectUuid: bigqueryProjectUuid,
+                    maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+                });
+                expect(getTotalCount(rows, METRIC_KEY)).toBe(expectedCount);
+            },
+        );
 
         it('Asia/Kathmandu (+05:45): groups into 10 hourly buckets', async () => {
             const rows = await runTimezoneTestQuery(bqAdmin, {

--- a/packages/api-tests/tests/queryTimezone.test.ts
+++ b/packages/api-tests/tests/queryTimezone.test.ts
@@ -108,6 +108,20 @@ const GREATER_THAN_FILTER = (day: string) => ({
     },
 });
 
+const CALENDAR_GRAIN_EQUALS_FILTER = (fieldId: string, value: string) => ({
+    dimensions: {
+        id: 'tz-test',
+        and: [
+            {
+                id: `tz-${fieldId}-eq`,
+                target: { fieldId },
+                operator: 'equals',
+                values: [value],
+            },
+        ],
+    },
+});
+
 describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
     beforeAll(async () => {
         admin = await login();
@@ -511,6 +525,42 @@ describe.skipIf(!EXISTING_BIGQUERY_PROJECT_UUID && !hasBigqueryCredentials())(
                     maxAttempts: BIGQUERY_MAX_ATTEMPTS,
                 });
                 expect(getTotalCount(rows, METRIC_KEY)).toBe(expectedCount);
+            },
+        );
+
+        it.each([
+            {
+                dimension: 'timezone_test_event_timestamp_week',
+                name: 'week',
+                value: '2024-01-14',
+            },
+            {
+                dimension: 'timezone_test_event_timestamp_month',
+                name: 'month',
+                value: '2024-01-01',
+            },
+            {
+                dimension: 'timezone_test_event_timestamp_quarter',
+                name: 'quarter',
+                value: '2024-01-01',
+            },
+            {
+                dimension: 'timezone_test_event_timestamp_year',
+                name: 'year',
+                value: '2024-01-01',
+            },
+        ])(
+            'Asia/Tokyo $name equality preserves all 10 interior rows',
+            async ({ dimension, value }) => {
+                const rows = await runTimezoneTestQuery(bqAdmin, {
+                    dimensions: [dimension],
+                    metrics: METRICS,
+                    timezone: 'Asia/Tokyo',
+                    filters: CALENDAR_GRAIN_EQUALS_FILTER(dimension, value),
+                    projectUuid: bigqueryProjectUuid,
+                    maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+                });
+                expect(getTotalCount(rows, METRIC_KEY)).toBe(10);
             },
         );
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -19,6 +19,7 @@ import {
     UnitOfTime,
     VizAggregationOptions,
     VizIndexType,
+    WeekDay,
     type CompiledDimension,
     type CompiledMetric,
     type MetricFilterRule,
@@ -5571,6 +5572,7 @@ describe('Timezone-aware DATE_TRUNC day-or-coarser → DATE cast (GLITCH-452)', 
     const buildDayExplore = (
         baseType: DimensionType = DimensionType.TIMESTAMP,
         adapter: SupportedDbtAdapter = SupportedDbtAdapter.POSTGRES,
+        timestampDomain?: TimestampDomain,
     ): Explore => ({
         targetDatabase: adapter,
         name: 'events',
@@ -5596,6 +5598,7 @@ describe('Timezone-aware DATE_TRUNC day-or-coarser → DATE cast (GLITCH-452)', 
                         fieldType: FieldType.DIMENSION,
                         sql: '${TABLE}.occurred_at',
                         compiledSql: '"events".occurred_at',
+                        timestampDomain,
                         tablesReferences: ['events'],
                         hidden: false,
                     },
@@ -5613,6 +5616,7 @@ describe('Timezone-aware DATE_TRUNC day-or-coarser → DATE cast (GLITCH-452)', 
                         timeInterval: TimeFrames.DAY,
                         timeIntervalBaseDimensionName: 'occurred_at',
                         timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+                        timestampDomain,
                     },
                     occurred_at_month: {
                         type: DimensionType.DATE,
@@ -5628,6 +5632,55 @@ describe('Timezone-aware DATE_TRUNC day-or-coarser → DATE cast (GLITCH-452)', 
                         timeInterval: TimeFrames.MONTH,
                         timeIntervalBaseDimensionName: 'occurred_at',
                         timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+                        timestampDomain,
+                    },
+                    occurred_at_week: {
+                        type: DimensionType.DATE,
+                        name: 'occurred_at_week',
+                        label: 'occurred_at_week',
+                        table: 'events',
+                        tableLabel: 'events',
+                        fieldType: FieldType.DIMENSION,
+                        sql: `DATE_TRUNC('WEEK', \${TABLE}.occurred_at)`,
+                        compiledSql: `DATE_TRUNC('WEEK', "events".occurred_at)`,
+                        tablesReferences: ['events'],
+                        hidden: false,
+                        timeInterval: TimeFrames.WEEK,
+                        timeIntervalBaseDimensionName: 'occurred_at',
+                        timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+                        timestampDomain,
+                    },
+                    occurred_at_quarter: {
+                        type: DimensionType.DATE,
+                        name: 'occurred_at_quarter',
+                        label: 'occurred_at_quarter',
+                        table: 'events',
+                        tableLabel: 'events',
+                        fieldType: FieldType.DIMENSION,
+                        sql: `DATE_TRUNC('QUARTER', \${TABLE}.occurred_at)`,
+                        compiledSql: `DATE_TRUNC('QUARTER', "events".occurred_at)`,
+                        tablesReferences: ['events'],
+                        hidden: false,
+                        timeInterval: TimeFrames.QUARTER,
+                        timeIntervalBaseDimensionName: 'occurred_at',
+                        timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+                        timestampDomain,
+                    },
+                    occurred_at_year: {
+                        type: DimensionType.DATE,
+                        name: 'occurred_at_year',
+                        label: 'occurred_at_year',
+                        table: 'events',
+                        tableLabel: 'events',
+                        fieldType: FieldType.DIMENSION,
+                        sql: `DATE_TRUNC('YEAR', \${TABLE}.occurred_at)`,
+                        compiledSql: `DATE_TRUNC('YEAR', "events".occurred_at)`,
+                        tablesReferences: ['events'],
+                        hidden: false,
+                        timeInterval: TimeFrames.YEAR,
+                        timeIntervalBaseDimensionName: 'occurred_at',
+                        timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+                        timestampDomain,
                     },
                 },
                 metrics: {
@@ -5911,6 +5964,467 @@ describe('Timezone-aware DATE_TRUNC day-or-coarser → DATE cast (GLITCH-452)', 
         );
         expect(where).not.toContain('TIMESTAMP_TRUNC');
     });
+
+    test.each([
+        {
+            operator: FilterOperator.EQUALS,
+            values: ['2024-01-15'],
+            expectedMirror: `TIMESTAMP_TRUNC(("events".occurred_at), DAY, 'Asia/Tokyo') = TIMESTAMP('2024-01-15 00:00:00', 'Asia/Tokyo')`,
+        },
+        {
+            operator: FilterOperator.IN_BETWEEN,
+            values: ['2024-01-15', '2024-01-16'],
+            expectedMirror: `TIMESTAMP_TRUNC(("events".occurred_at), DAY, 'Asia/Tokyo') >= TIMESTAMP('2024-01-15 00:00:00', 'Asia/Tokyo') AND TIMESTAMP_TRUNC(("events".occurred_at), DAY, 'Asia/Tokyo') <= TIMESTAMP('2024-01-16 00:00:00', 'Asia/Tokyo')`,
+        },
+        {
+            operator: FilterOperator.GREATER_THAN,
+            values: ['2024-01-15'],
+            expectedMirror: `TIMESTAMP_TRUNC(("events".occurred_at), DAY, 'Asia/Tokyo') > TIMESTAMP('2024-01-15 00:00:00', 'Asia/Tokyo')`,
+        },
+        {
+            operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+            values: ['2024-01-15'],
+            expectedMirror: `TIMESTAMP_TRUNC(("events".occurred_at), DAY, 'Asia/Tokyo') >= TIMESTAMP('2024-01-15 00:00:00', 'Asia/Tokyo')`,
+        },
+        {
+            operator: FilterOperator.LESS_THAN,
+            values: ['2024-01-15'],
+            expectedMirror: `TIMESTAMP_TRUNC(("events".occurred_at), DAY, 'Asia/Tokyo') < TIMESTAMP('2024-01-15 00:00:00', 'Asia/Tokyo')`,
+        },
+        {
+            operator: FilterOperator.LESS_THAN_OR_EQUAL,
+            values: ['2024-01-15'],
+            expectedMirror: `TIMESTAMP_TRUNC(("events".occurred_at), DAY, 'Asia/Tokyo') <= TIMESTAMP('2024-01-15 00:00:00', 'Asia/Tokyo')`,
+        },
+        {
+            operator: FilterOperator.EQUALS,
+            values: ['2024-01-17', '2024-01-15'],
+            expectedMirror: `TIMESTAMP_TRUNC(("events".occurred_at), DAY, 'Asia/Tokyo') IN (TIMESTAMP('2024-01-17 00:00:00', 'Asia/Tokyo'), TIMESTAMP('2024-01-15 00:00:00', 'Asia/Tokyo'))`,
+        },
+    ])(
+        'BigQuery + non-UTC day-grain $operator keeps the semantic predicate and adds a prunable TIMESTAMP_TRUNC mirror',
+        ({ operator, values, expectedMirror }) => {
+            const { query } = buildQuery({
+                explore: buildDayExplore(
+                    DimensionType.TIMESTAMP,
+                    SupportedDbtAdapter.BIGQUERY,
+                    'aware',
+                ),
+                compiledMetricQuery: {
+                    ...dayQuery,
+                    filters: {
+                        dimensions: {
+                            id: 'root',
+                            and: [
+                                {
+                                    id: 'f1',
+                                    target: {
+                                        fieldId: 'events_occurred_at_day',
+                                    },
+                                    operator,
+                                    values,
+                                },
+                            ],
+                        },
+                    },
+                },
+                warehouseSqlBuilder: bigqueryClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: 'Asia/Tokyo',
+                columnTimezone: 'UTC',
+                useTimezoneAwareDateTrunc: true,
+            });
+            const where = query.slice(query.indexOf('WHERE'));
+
+            expect(where).toContain(
+                `CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP("events".occurred_at), 'Asia/Tokyo'), DAY) AS DATE)`,
+            );
+            expect(where).toContain(expectedMirror);
+        },
+    );
+
+    test('BigQuery + non-UTC month equality adds a prunable month-trunc mirror', () => {
+        const { query } = buildQuery({
+            explore: buildDayExplore(
+                DimensionType.TIMESTAMP,
+                SupportedDbtAdapter.BIGQUERY,
+                'aware',
+            ),
+            compiledMetricQuery: {
+                ...dayQuery,
+                dimensions: ['events_occurred_at_month'],
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'f1',
+                                target: {
+                                    fieldId: 'events_occurred_at_month',
+                                },
+                                operator: FilterOperator.EQUALS,
+                                values: ['2024-05-01'],
+                            },
+                        ],
+                    },
+                },
+            },
+            warehouseSqlBuilder: bigqueryClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            columnTimezone: 'UTC',
+            useTimezoneAwareDateTrunc: true,
+        });
+        const where = query.slice(query.indexOf('WHERE'));
+
+        expect(where).toContain(
+            `TIMESTAMP_TRUNC(("events".occurred_at), MONTH, 'Asia/Tokyo') = TIMESTAMP('2024-05-01 00:00:00', 'Asia/Tokyo')`,
+        );
+    });
+
+    test('BigQuery + non-UTC week equality adds a prunable week-trunc mirror with the default week start', () => {
+        const { query } = buildQuery({
+            explore: buildDayExplore(
+                DimensionType.TIMESTAMP,
+                SupportedDbtAdapter.BIGQUERY,
+                'aware',
+            ),
+            compiledMetricQuery: {
+                ...dayQuery,
+                dimensions: ['events_occurred_at_week'],
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'f1',
+                                target: {
+                                    fieldId: 'events_occurred_at_week',
+                                },
+                                operator: FilterOperator.EQUALS,
+                                values: ['2024-05-05'],
+                            },
+                        ],
+                    },
+                },
+            },
+            warehouseSqlBuilder: bigqueryClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            columnTimezone: 'UTC',
+            useTimezoneAwareDateTrunc: true,
+        });
+        const where = query.slice(query.indexOf('WHERE'));
+
+        expect(where).toContain(
+            `TIMESTAMP_TRUNC(("events".occurred_at), WEEK, 'Asia/Tokyo') = TIMESTAMP('2024-05-05 00:00:00', 'Asia/Tokyo')`,
+        );
+    });
+
+    test('BigQuery + non-UTC quarter equality adds a prunable quarter-trunc mirror', () => {
+        const { query } = buildQuery({
+            explore: buildDayExplore(
+                DimensionType.TIMESTAMP,
+                SupportedDbtAdapter.BIGQUERY,
+                'aware',
+            ),
+            compiledMetricQuery: {
+                ...dayQuery,
+                dimensions: ['events_occurred_at_quarter'],
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'f1',
+                                target: {
+                                    fieldId: 'events_occurred_at_quarter',
+                                },
+                                operator: FilterOperator.EQUALS,
+                                values: ['2024-04-01'],
+                            },
+                        ],
+                    },
+                },
+            },
+            warehouseSqlBuilder: bigqueryClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            columnTimezone: 'UTC',
+            useTimezoneAwareDateTrunc: true,
+        });
+        const where = query.slice(query.indexOf('WHERE'));
+
+        expect(where).toContain(
+            `TIMESTAMP_TRUNC(("events".occurred_at), QUARTER, 'Asia/Tokyo') = TIMESTAMP('2024-04-01 00:00:00', 'Asia/Tokyo')`,
+        );
+    });
+
+    test('BigQuery + non-UTC year equality adds a prunable year-trunc mirror', () => {
+        const { query } = buildQuery({
+            explore: buildDayExplore(
+                DimensionType.TIMESTAMP,
+                SupportedDbtAdapter.BIGQUERY,
+                'aware',
+            ),
+            compiledMetricQuery: {
+                ...dayQuery,
+                dimensions: ['events_occurred_at_year'],
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'f1',
+                                target: {
+                                    fieldId: 'events_occurred_at_year',
+                                },
+                                operator: FilterOperator.EQUALS,
+                                values: ['2024-01-01'],
+                            },
+                        ],
+                    },
+                },
+            },
+            warehouseSqlBuilder: bigqueryClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            columnTimezone: 'UTC',
+            useTimezoneAwareDateTrunc: true,
+        });
+        const where = query.slice(query.indexOf('WHERE'));
+
+        expect(where).toContain(
+            `TIMESTAMP_TRUNC(("events".occurred_at), YEAR, 'Asia/Tokyo') = TIMESTAMP('2024-01-01 00:00:00', 'Asia/Tokyo')`,
+        );
+    });
+
+    test.each([
+        {
+            operator: FilterOperator.GREATER_THAN,
+            expectedOperator: '>',
+        },
+        {
+            operator: FilterOperator.LESS_THAN,
+            expectedOperator: '<',
+        },
+    ])(
+        'BigQuery month $operator mirrors a non-bucket value without rounding',
+        ({ operator, expectedOperator }) => {
+            const { query } = buildQuery({
+                explore: buildDayExplore(
+                    DimensionType.TIMESTAMP,
+                    SupportedDbtAdapter.BIGQUERY,
+                    'aware',
+                ),
+                compiledMetricQuery: {
+                    ...dayQuery,
+                    dimensions: ['events_occurred_at_month'],
+                    filters: {
+                        dimensions: {
+                            id: 'root',
+                            and: [
+                                {
+                                    id: 'f1',
+                                    target: {
+                                        fieldId: 'events_occurred_at_month',
+                                    },
+                                    operator,
+                                    values: ['2024-05-15'],
+                                },
+                            ],
+                        },
+                    },
+                },
+                warehouseSqlBuilder: bigqueryClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: 'Asia/Tokyo',
+                columnTimezone: 'UTC',
+                useTimezoneAwareDateTrunc: true,
+            });
+            const where = query.slice(query.indexOf('WHERE'));
+
+            expect(where).toContain(
+                `TIMESTAMP_TRUNC(("events".occurred_at), MONTH, 'Asia/Tokyo') ${expectedOperator} TIMESTAMP('2024-05-15 00:00:00', 'Asia/Tokyo')`,
+            );
+            expect(where).not.toContain(`2024-06-01 00:00:00`);
+        },
+    );
+
+    test('BigQuery week mirror respects the configured Monday week start', () => {
+        const { query } = buildQuery({
+            explore: buildDayExplore(
+                DimensionType.TIMESTAMP,
+                SupportedDbtAdapter.BIGQUERY,
+                'aware',
+            ),
+            compiledMetricQuery: {
+                ...dayQuery,
+                dimensions: ['events_occurred_at_week'],
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'f1',
+                                target: {
+                                    fieldId: 'events_occurred_at_week',
+                                },
+                                operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+                                values: ['2024-05-08'],
+                            },
+                        ],
+                    },
+                },
+            },
+            warehouseSqlBuilder: {
+                ...bigqueryClientMock,
+                getStartOfWeek: () => WeekDay.MONDAY,
+            },
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            columnTimezone: 'UTC',
+            useTimezoneAwareDateTrunc: true,
+        });
+        const where = query.slice(query.indexOf('WHERE'));
+
+        expect(where).toContain(
+            `TIMESTAMP_TRUNC(("events".occurred_at), WEEK(MONDAY), 'Asia/Tokyo') >= TIMESTAMP('2024-05-08 00:00:00', 'Asia/Tokyo')`,
+        );
+    });
+
+    test('BigQuery partition pruning mirror is not added when the timestamp domain is unknown', () => {
+        const { query } = buildQuery({
+            explore: buildDayExplore(
+                DimensionType.TIMESTAMP,
+                SupportedDbtAdapter.BIGQUERY,
+            ),
+            compiledMetricQuery: {
+                ...dayQuery,
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'f1',
+                                target: {
+                                    fieldId: 'events_occurred_at_day',
+                                },
+                                operator: FilterOperator.EQUALS,
+                                values: ['2024-01-15'],
+                            },
+                        ],
+                    },
+                },
+            },
+            warehouseSqlBuilder: bigqueryClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            columnTimezone: 'UTC',
+            useTimezoneAwareDateTrunc: true,
+        });
+        const where = query.slice(query.indexOf('WHERE'));
+
+        expect(where).not.toContain(
+            `TIMESTAMP_TRUNC(("events".occurred_at), DAY, 'Asia/Tokyo')`,
+        );
+    });
+
+    test('BigQuery partition pruning mirror trusts the base timestamp domain over the generated day dimension', () => {
+        const explore = buildDayExplore(
+            DimensionType.TIMESTAMP,
+            SupportedDbtAdapter.BIGQUERY,
+            'aware',
+        );
+        explore.tables.events.dimensions.occurred_at = {
+            ...explore.tables.events.dimensions.occurred_at,
+            timestampDomain: 'naive',
+        };
+        const { query } = buildQuery({
+            explore,
+            compiledMetricQuery: {
+                ...dayQuery,
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'f1',
+                                target: {
+                                    fieldId: 'events_occurred_at_day',
+                                },
+                                operator: FilterOperator.EQUALS,
+                                values: ['2024-01-15'],
+                            },
+                        ],
+                    },
+                },
+            },
+            warehouseSqlBuilder: bigqueryClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            columnTimezone: 'UTC',
+            useTimezoneAwareDateTrunc: true,
+        });
+        const where = query.slice(query.indexOf('WHERE'));
+
+        expect(where).not.toContain(
+            `TIMESTAMP_TRUNC(("events".occurred_at), DAY, 'Asia/Tokyo')`,
+        );
+    });
+
+    test.each([
+        SupportedDbtAdapter.POSTGRES,
+        SupportedDbtAdapter.REDSHIFT,
+        SupportedDbtAdapter.SNOWFLAKE,
+        SupportedDbtAdapter.DATABRICKS,
+        SupportedDbtAdapter.SPARK,
+        SupportedDbtAdapter.TRINO,
+        SupportedDbtAdapter.ATHENA,
+        SupportedDbtAdapter.CLICKHOUSE,
+        SupportedDbtAdapter.DUCKDB,
+    ])(
+        '%s day filters do not receive the BigQuery partition pruning mirror',
+        (adapter) => {
+            const { query } = buildQuery({
+                explore: buildDayExplore(
+                    DimensionType.TIMESTAMP,
+                    adapter,
+                    'aware',
+                ),
+                compiledMetricQuery: {
+                    ...dayQuery,
+                    filters: {
+                        dimensions: {
+                            id: 'root',
+                            and: [
+                                {
+                                    id: 'f1',
+                                    target: {
+                                        fieldId: 'events_occurred_at_day',
+                                    },
+                                    operator: FilterOperator.EQUALS,
+                                    values: ['2024-01-15'],
+                                },
+                            ],
+                        },
+                    },
+                },
+                warehouseSqlBuilder: {
+                    ...warehouseClientMock,
+                    getAdapterType: () => adapter,
+                },
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: 'Asia/Tokyo',
+                columnTimezone: 'UTC',
+                useTimezoneAwareDateTrunc: true,
+            });
+
+            expect(query).not.toContain(
+                `TIMESTAMP('2024-01-15 00:00:00', 'Asia/Tokyo')`,
+            );
+        },
+    );
 
     test('BigQuery + flag off: dimension compiledSql passes through untouched', () => {
         const { query } = buildQuery({

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    bigqueryDatePart,
     buildTotalFieldRegex,
     CompiledDimension,
     CompiledMetric,
@@ -21,6 +22,7 @@ import {
     FilterGroupItem,
     FilterOperator,
     FilterRule,
+    formatDate,
     getCustomMetricDimensionId,
     getDimensionMapFromTables,
     getDimensions,
@@ -225,6 +227,15 @@ const SOURCE_AGGREGATIONS_CTE_NAME = 'source_aggregations';
 // Prefix for the grain columns of the source-aggregations CTE, so they can't
 // collide with this query's own column aliases.
 const SOURCE_AGGREGATIONS_GRAIN_PREFIX = 'sa_';
+
+const BIGQUERY_PARTITION_PRUNABLE_TIME_FRAMES: ReadonlySet<TimeFrames> =
+    new Set([
+        TimeFrames.DAY,
+        TimeFrames.WEEK,
+        TimeFrames.MONTH,
+        TimeFrames.QUARTER,
+        TimeFrames.YEAR,
+    ]);
 
 const getSourceAggregationSql = (
     aggregation: SourceQueryAggregationFunction,
@@ -1014,6 +1025,103 @@ export class MetricQueryBuilder {
                 lhsMode,
             }),
         };
+    }
+
+    // Mirrors the timezone-aware calendar predicate as
+    // TIMESTAMP_TRUNC(col, <grain>, tz) <op> TIMESTAMP(value, tz) — the same
+    // truncation expressed on the raw column, which BigQuery's partition
+    // pruner supports (the DATETIME()-wrapped form full-scans).
+    private getBigQueryPartitionPruningMirror(
+        dimension: CompiledDimension,
+        filterRule: FilterRule,
+        adapterType: SupportedDbtAdapter,
+        startOfWeek: WeekDay | null | undefined,
+    ): string | undefined {
+        const { timeInterval } = dimension;
+        if (
+            adapterType !== SupportedDbtAdapter.BIGQUERY ||
+            !this.args.useTimezoneAwareDateTrunc ||
+            this.args.timezone === 'UTC' ||
+            !timeInterval ||
+            !BIGQUERY_PARTITION_PRUNABLE_TIME_FRAMES.has(timeInterval) ||
+            filterRule.disabled ||
+            filterRule.includeNull
+        ) {
+            return undefined;
+        }
+
+        const baseDimensionId = dimension.timeIntervalBaseDimensionName
+            ? `${dimension.table}_${dimension.timeIntervalBaseDimensionName}`
+            : undefined;
+        const baseDimension = baseDimensionId
+            ? (this.originalExploreDimensions[baseDimensionId] ??
+              this.exploreDimensions[baseDimensionId])
+            : undefined;
+        if (
+            !baseDimension?.compiledSql ||
+            baseDimension.type !== DimensionType.TIMESTAMP ||
+            baseDimension.timestampDomain !== 'aware'
+        ) {
+            return undefined;
+        }
+
+        const parsedDays = filterRule.values?.map((value) => {
+            if (
+                typeof value !== 'string' &&
+                typeof value !== 'number' &&
+                !(value instanceof Date)
+            ) {
+                return undefined;
+            }
+            const day = formatDate(value);
+            return day === 'NaT' ? undefined : day;
+        });
+        if (!parsedDays || parsedDays.some((day) => day === undefined)) {
+            return undefined;
+        }
+        const days = parsedDays.filter(
+            (day): day is string => day !== undefined,
+        );
+
+        const truncatedColumn = `TIMESTAMP_TRUNC((${
+            baseDimension.compiledSql
+        }), ${bigqueryDatePart(timeInterval, startOfWeek)}, '${
+            this.args.timezone
+        }')`;
+        const timestampLiteral = (day: string): string =>
+            `TIMESTAMP('${day} 00:00:00', '${this.args.timezone}')`;
+        const comparison = (operator: string): string | undefined =>
+            days[0]
+                ? `${truncatedColumn} ${operator} ${timestampLiteral(days[0])}`
+                : undefined;
+
+        switch (filterRule.operator) {
+            case FilterOperator.EQUALS:
+                if (days.length === 1) return comparison('=');
+                return days.length > 1
+                    ? `${truncatedColumn} IN (${days
+                          .map(timestampLiteral)
+                          .join(', ')})`
+                    : undefined;
+            case FilterOperator.IN_BETWEEN: {
+                const [startDay, endDay] = days;
+                return startDay && endDay
+                    ? `${truncatedColumn} >= ${timestampLiteral(
+                          startDay,
+                      )} AND ${truncatedColumn} <= ${timestampLiteral(endDay)}`
+                    : undefined;
+            }
+            case FilterOperator.GREATER_THAN:
+                return comparison('>');
+            case FilterOperator.GREATER_THAN_OR_EQUAL:
+                return comparison('>=');
+            case FilterOperator.LESS_THAN:
+                return comparison('<');
+            case FilterOperator.LESS_THAN_OR_EQUAL:
+                return comparison('<=');
+            default:
+                return undefined;
+        }
     }
 
     /**
@@ -2288,7 +2396,18 @@ export class MetricQueryBuilder {
             finalSqlContainsUpper: /UPPER\s*\(/i.test(renderedFilterSql),
         });
 
-        return renderedFilterSql;
+        const partitionPruningMirror = isDimension(field)
+            ? this.getBigQueryPartitionPruningMirror(
+                  field,
+                  filterRuleWithParamReplacedValues,
+                  adapterType,
+                  startOfWeek,
+              )
+            : undefined;
+
+        return partitionPruningMirror
+            ? `(${renderedFilterSql} AND ${partitionPruningMirror})`
+            : renderedFilterSql;
     }
 
     static getNullsFirstLast(sort: SortField) {

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -469,7 +469,7 @@ const bigqueryStartOfWeekMap: Record<WeekDay, string> = {
     [WeekDay.SUNDAY]: 'SUNDAY',
 };
 
-const bigqueryDatePart = (
+export const bigqueryDatePart = (
     timeFrame: TimeFrames,
     startOfWeek?: WeekDay | null,
 ): string =>


### PR DESCRIPTION
### Status

**Draft research candidate A — not selected for merge.** This PR preserves the existing timezone-aware predicate and adds a second, partition-prunable `TIMESTAMP_TRUNC` predicate. It exists so we can compare this approach with the direct expression swap in #27740.

### Description

- Materialize the existing BigQuery timezone fixture as a day-partitioned table.
- Add API coverage for non-UTC day, week, month, quarter, and year filters.
- For eligible BigQuery filters over catalog-known, timezone-aware `TIMESTAMP` dimensions, retain the current semantic predicate and add an equivalent raw-column mirror:
  - `TIMESTAMP_TRUNC(column, grain, timezone) <operator> TIMESTAMP(value, timezone)`
- Reuse the existing filter operator, values, and shared BigQuery date-part rendering so custom week starts stay aligned.
- Fall back unchanged for sub-day grains, naive or unknown timestamp domains, unsupported operators, UTC, and non-BigQuery adapters.

The current non-UTC predicate wraps the partition column in `DATETIME()`/`CAST`, which prevented pruning in the live fixture and failed BigQuery's `require_partition_filter` check. The added mirror restored pruning and passed that check in the tested day-or-coarser cases.

### Important trade-offs

- The mirror is redundant SQL. If it is exact, the retained predicate adds no semantic protection; if it is too narrow, the mirror can still remove valid rows.
- BigQuery now explicitly documents `TIMESTAMP_TRUNC` as partition-prunable when its additional arguments are constant; the timezone argument here is a literal. A raw-column range is still the simpler documented shape and also matters for clustered-column block pruning.
- Function-wrapped predicates are not the documented shape for clustered-table block pruning.
- This approach adds filter-specific compiler logic and does not help SELECT/GROUP BY expressions or relative-date operators outside its eligibility rules.

### Verification completed on this candidate

- Related backend query-builder tests: 238 passing.
- Common time-frame tests: 131 passing.
- BigQuery API timezone suite: 11 passing against the partitioned fixture.
- Backend/common typecheck, related lint, and formatting passed.
- Live BigQuery bytes processed on a 528-byte day-partitioned fixture:
  - day equals: 144 bytes
  - day between: 208 bytes
  - day greater-than: 496 bytes
  - week: 208 bytes
  - month: 240 bytes
  - quarter: 336 bytes
  - year: 512 bytes
- The same forms passed against a `require_partition_filter = TRUE` copy of the fixture, including DST transition cases in New York and Santiago.
- SQL-shape coverage confirms non-BigQuery adapters remain unchanged.

### Comparison candidate

- #27740 replaces the aware day-or-coarser BigQuery dimension expression with `DATE(column, timezone)` / `DATE_TRUNC(DATE(...), grain)` instead of adding a second predicate.
- The current research preference is a third shape: reuse #27740's DATE-domain expression only while rendering filters, keeping SELECT/GROUP BY unchanged. That removes this PR's duplicate predicate without taking #27740's projection blast radius.

### Risk assessment

- [ ] This is a high-risk change

The implementation is adapter-, grain-, timestamp-domain-, and operator-gated, but this remains an experimental candidate and should not merge until the pruning contract and preferred compiler seam are agreed.
